### PR TITLE
add macro expansion of PX opcode for pushing hex values

### DIFF
--- a/src/Nethermind/Nethermind.EvmPlayground/Program.cs
+++ b/src/Nethermind/Nethermind.EvmPlayground/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Text;
 
 namespace Nethermind.EvmPlayground
 {
@@ -35,9 +36,38 @@ namespace Nethermind.EvmPlayground
             }
         }
 
+        public static string HexStringToDecString(string hex)
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.AppendFormat("{0:x2}", hex);
+            return sb.ToString();
+        }
+
+        private static string ExpandPushHex(string input)
+        {
+            string[] expansion = input.Split(' ').ToArray();
+            string ret;
+
+            for (int i = 0; i < expansion.Length - 1; i++) {
+                if (expansion[i] == "PX") {
+                    if (expansion[i+1].Length <= 64) {
+                        expansion[i] = (96 + (expansion[i+1].Length / 2) - 1).ToString();
+                        string decimals = String.Join(" ", Bytes.FromHexString(expansion[i+1]).Select(x => x.ToString()));
+                        Console.WriteLine($"PX {expansion[i+1]} expanded to: {expansion[i]} {decimals}");
+                        expansion[i+1] = decimals;
+                    }
+                    else {
+                        Console.WriteLine($"PX operand {expansion[i+1]} is greater than 32 bytes");
+                    }
+                }
+            }
+            ret = String.Join(" ", expansion);
+            return ret;
+        }
+
         private static string RunMacros(string input)
         {
-            return input.Replace("PZ1", "96 0");
+            return ExpandPushHex(input.Replace("PZ1", "96 0"));
         }
     }
 }


### PR DESCRIPTION
This allows pushing of variable length hexadecimal values, e.g.:

    PX 0a
    PX 8e21a363dce22ff6057deef7c074062037f571

Case is insensitive, but an even number of nibbles must be provided.  A maximum of 32 bytes (64 nibbles) are allowed, since the longest `PUSH` opcode available in EVM is `PUSH32`.