### PR TITLE
cases when headers are ahead of state nodes and we incorrectly start …

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Synchronization/SyncModeSelectorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Synchronization/SyncModeSelectorTests.cs
@@ -67,6 +67,8 @@ namespace Nethermind.Blockchain.Test.Synchronization
                 (1032, 1000, 0, SyncMode.StateNodes),
                 (1048, 1000, 1000, SyncMode.Headers),
                 (1048, 1016, 1000, SyncMode.StateNodes),
+                (1048, 1016, 1000, SyncMode.StateNodes),
+                (1048, 1032, 1020, SyncMode.StateNodes), // just to check if we always chase headers
                 (1048, 1016, 1016, SyncMode.Full),
                 (1048, 1048, 1048, SyncMode.Full),
                 (1048, 1049, 1049, SyncMode.Full),

--- a/src/Nethermind/Nethermind.Blockchain.Test/Synchronization/SyncThreadTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Synchronization/SyncThreadTests.cs
@@ -229,8 +229,8 @@ namespace Nethermind.Blockchain.Test.Synchronization
         {
             Rlp.RegisterDecoders(typeof(ParityTraceDecoder).Assembly);
 
-            var logManager = NoErrorLimboLogs.Instance;
-//            var logManager = new OneLoggerLogManager(new ConsoleAsyncLogger(LogLevel.Debug, "PEER " + index + " "));
+//            var logManager = NoErrorLimboLogs.Instance;
+            var logManager = new OneLoggerLogManager(new ConsoleAsyncLogger(LogLevel.Debug, "PEER " + index + " "));
             var specProvider = new SingleReleaseSpecProvider(ConstantinopleFix.Instance, MainNetSpecProvider.Instance.ChainId);
 
             MemDb traceDb = new MemDb();

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncModeSelector.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncModeSelector.cs
@@ -63,7 +63,7 @@ namespace Nethermind.Blockchain.Synchronization
             SyncMode newSyncMode;
             if (maxBlockNumberAmongPeers - bestFullState <= FullSyncThreshold)
             {
-                newSyncMode = SyncMode.Full;
+                newSyncMode = bestFullState >= bestHeader ? SyncMode.Full : SyncMode.StateNodes;
             }
             else if (maxBlockNumberAmongPeers - bestHeader <= FullSyncThreshold)
             {


### PR DESCRIPTION
…full sync