### PR TITLE
Vector based VM bitwise operators and benchmarks for #713

### DIFF
--- a/src/Nethermind/Nethermind.Benchmarks/Evm/BitwiseAnd.cs
+++ b/src/Nethermind/Nethermind.Benchmarks/Evm/BitwiseAnd.cs
@@ -1,0 +1,58 @@
+﻿/*
+ * Copyright (c) 2018 Demerzel Solutions Limited
+ * This file is part of the Nethermind library.
+ *
+ * The Nethermind library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Nethermind library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+using System;
+using System.Numerics;
+using BenchmarkDotNet.Attributes;
+
+namespace Nethermind.Benchmarks.Evm
+{
+    [MemoryDiagnoser]
+    [CoreJob(baseline: true)]
+    public class BitwiseAnd
+    {
+        [GlobalSetup]
+        public void Setup()
+        {
+            a[31] = 3;
+            b[31] = 7;
+        }
+
+        private byte[] a = new byte[32];
+        private byte[] b = new byte[32];
+        private byte[] c = new byte[32];
+        
+        [Benchmark(Baseline = true)]
+        public void Current()
+        {
+            for (int i = 0; i < 32; i++)
+            {
+                c[i] = (byte)(a[i] & b[i]);
+            }
+        }
+        
+        [Benchmark]
+        public void Improved()
+        {
+            Vector<byte> aVec = new Vector<byte>(a);
+            Vector<byte> bVec = new Vector<byte>(b);
+
+            Vector.BitwiseAnd(aVec, bVec).CopyTo(c);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Benchmarks/Evm/BitwiseNot.cs
+++ b/src/Nethermind/Nethermind.Benchmarks/Evm/BitwiseNot.cs
@@ -34,6 +34,14 @@ namespace Nethermind.Benchmarks.Evm
         private byte[] a = new byte[32];
         private byte[] c = new byte[32];
         
+        internal readonly byte[] BytesMax32 =
+        {
+            255, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255, 255
+        };
+        
         [Benchmark(Baseline = true)]
         public void Current()
         {
@@ -47,7 +55,7 @@ namespace Nethermind.Benchmarks.Evm
         public void Improved()
         {
             Vector<byte> aVec = new Vector<byte>(a);
-            Vector.Negate(aVec).CopyTo(c);
+            Vector.Xor(aVec, new Vector<byte>(BytesMax32)).CopyTo(c);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Benchmarks/Evm/BitwiseNot.cs
+++ b/src/Nethermind/Nethermind.Benchmarks/Evm/BitwiseNot.cs
@@ -1,0 +1,53 @@
+﻿/*
+ * Copyright (c) 2018 Demerzel Solutions Limited
+ * This file is part of the Nethermind library.
+ *
+ * The Nethermind library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Nethermind library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+using System.Numerics;
+using BenchmarkDotNet.Attributes;
+
+namespace Nethermind.Benchmarks.Evm
+{
+    [MemoryDiagnoser]
+    [CoreJob(baseline: true)]
+    public class BitwiseNot
+    {
+        [GlobalSetup]
+        public void Setup()
+        {
+            a[31] = 3;
+        }
+
+        private byte[] a = new byte[32];
+        private byte[] c = new byte[32];
+        
+        [Benchmark(Baseline = true)]
+        public void Current()
+        {
+            for (int i = 0; i < 32; i++)
+            {
+                c[i] = (byte)(~a[i]);
+            }
+        }
+        
+        [Benchmark]
+        public void Improved()
+        {
+            Vector<byte> aVec = new Vector<byte>(a);
+            Vector.Negate(aVec).CopyTo(c);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Benchmarks/Evm/BitwiseOr.cs
+++ b/src/Nethermind/Nethermind.Benchmarks/Evm/BitwiseOr.cs
@@ -1,0 +1,56 @@
+﻿/*
+ * Copyright (c) 2018 Demerzel Solutions Limited
+ * This file is part of the Nethermind library.
+ *
+ * The Nethermind library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Nethermind library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+using System.Numerics;
+using BenchmarkDotNet.Attributes;
+
+namespace Nethermind.Benchmarks.Evm
+{
+    [MemoryDiagnoser]
+    [CoreJob(baseline: true)]
+    public class BitwiseOr
+    {
+        [GlobalSetup]
+        public void Setup()
+        {
+            a[31] = 3;
+            b[31] = 7;
+        }
+
+        private byte[] a = new byte[32];
+        private byte[] b = new byte[32];
+        private byte[] c = new byte[32];
+        
+        [Benchmark(Baseline = true)]
+        public void Current()
+        {
+            for (int i = 0; i < 32; i++)
+            {
+                c[i] = (byte)(a[i] | b[i]);
+            }
+        }
+        
+        [Benchmark]
+        public void Improved()
+        {
+            Vector<byte> aVec = new Vector<byte>(a);
+            Vector<byte> bVec = new Vector<byte>(b);
+            Vector.BitwiseOr(aVec, bVec).CopyTo(c);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Benchmarks/Evm/BitwiseXor.cs
+++ b/src/Nethermind/Nethermind.Benchmarks/Evm/BitwiseXor.cs
@@ -1,0 +1,56 @@
+﻿/*
+ * Copyright (c) 2018 Demerzel Solutions Limited
+ * This file is part of the Nethermind library.
+ *
+ * The Nethermind library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Nethermind library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+using System.Numerics;
+using BenchmarkDotNet.Attributes;
+
+namespace Nethermind.Benchmarks.Evm
+{
+    [MemoryDiagnoser]
+    [CoreJob(baseline: true)]
+    public class BitwiseXor
+    {
+        [GlobalSetup]
+        public void Setup()
+        {
+            a[31] = 3;
+            b[31] = 7;
+        }
+
+        private byte[] a = new byte[32];
+        private byte[] b = new byte[32];
+        private byte[] c = new byte[32];
+        
+        [Benchmark(Baseline = true)]
+        public void Current()
+        {
+            for (int i = 0; i < 32; i++)
+            {
+                c[i] = (byte)(a[i] ^ b[i]);
+            }
+        }
+        
+        [Benchmark]
+        public void Improved()
+        {
+            Vector<byte> aVec = new Vector<byte>(a);
+            Vector<byte> bVec = new Vector<byte>(b);
+            Vector.Xor(aVec, bVec).CopyTo(c);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Benchmarks/Program.cs
+++ b/src/Nethermind/Nethermind.Benchmarks/Program.cs
@@ -66,7 +66,11 @@ namespace Nethermind.Benchmarks
 //            BenchmarkRunner.Run<RlpEncodeTransaction>();
 //              BenchmarkRunner.Run<RlpEncodeLong>();
 //              BenchmarkRunner.Run<RlpDecodeLong>();
-              BenchmarkRunner.Run<RlpDecodeInt>();
+//              BenchmarkRunner.Run<RlpDecodeInt>();
+            BenchmarkRunner.Run<BitwiseOr>();
+            BenchmarkRunner.Run<BitwiseAnd>();
+            BenchmarkRunner.Run<BitwiseNot>();
+            BenchmarkRunner.Run<BitwiseXor>();
 
 //              BenchmarkRunner.Run<PatriciaTree>();
 //            

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -58,6 +58,14 @@ namespace Nethermind.Evm
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         };
+        
+        internal readonly byte[] BytesMax32 =
+        {
+            255, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255, 255
+        };
 
         private readonly IBlockhashProvider _blockhashProvider;
         private readonly LruCache<Keccak, CodeInfo> _codeCache = new LruCache<Keccak, CodeInfo>(4 * 1024);
@@ -1308,8 +1316,9 @@ namespace Nethermind.Evm
                         Span<byte> a = PopBytes(bytesOnStack);
 
                         Vector<byte> aVec = new Vector<byte>(a);
+                        Vector<byte> negVec = Vector.Xor(aVec, new Vector<byte>(BytesMax32));
 
-                        Vector.Negate(aVec).CopyTo(wordBufferArray);
+                        negVec.CopyTo(wordBufferArray);
 
                         PushBytes(wordBufferArray, bytesOnStack);
                         break;

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -725,7 +725,8 @@ namespace Nethermind.Evm
                 }
             }
 
-            Span<byte> wordBuffer = new byte[32].AsSpan();
+            byte[] wordBufferArray = new byte[32];
+            Span<byte> wordBuffer = wordBufferArray.AsSpan();
 
             void Swap(int depth, Span<byte> stack, Span<byte> buffer)
             {
@@ -1249,12 +1250,13 @@ namespace Nethermind.Evm
 
                         Span<byte> a = PopBytes(bytesOnStack);
                         Span<byte> b = PopBytes(bytesOnStack);
-                        for (int i = 0; i < 32; i++)
-                        {
-                            wordBuffer[i] = (byte)(a[i] & b[i]);
-                        }
+        
+                        Vector<byte> aVec = new Vector<byte>(a);
+                        Vector<byte> bVec = new Vector<byte>(b);
+                        
+                        Vector.BitwiseAnd(aVec, bVec).CopyTo(wordBufferArray);
 
-                        PushBytes(wordBuffer, bytesOnStack);
+                        PushBytes(wordBufferArray, bytesOnStack);
                         break;
                     }
                     case Instruction.OR:
@@ -1267,12 +1269,13 @@ namespace Nethermind.Evm
 
                         Span<byte> a = PopBytes(bytesOnStack);
                         Span<byte> b = PopBytes(bytesOnStack);
-                        for (int i = 0; i < 32; i++)
-                        {
-                            wordBuffer[i] = (byte)(a[i] | b[i]);
-                        }
+        
+                        Vector<byte> aVec = new Vector<byte>(a);
+                        Vector<byte> bVec = new Vector<byte>(b);
+                        
+                        Vector.BitwiseOr(aVec, bVec).CopyTo(wordBufferArray);
 
-                        PushBytes(wordBuffer, bytesOnStack);
+                        PushBytes(wordBufferArray, bytesOnStack);
                         break;
                     }
                     case Instruction.XOR:
@@ -1285,12 +1288,13 @@ namespace Nethermind.Evm
 
                         Span<byte> a = PopBytes(bytesOnStack);
                         Span<byte> b = PopBytes(bytesOnStack);
-                        for (int i = 0; i < 32; i++)
-                        {
-                            wordBuffer[i] = (byte)(a[i] ^ b[i]);
-                        }
+        
+                        Vector<byte> aVec = new Vector<byte>(a);
+                        Vector<byte> bVec = new Vector<byte>(b);
+                        
+                        Vector.Xor(aVec, bVec).CopyTo(wordBufferArray);
 
-                        PushBytes(wordBuffer, bytesOnStack);
+                        PushBytes(wordBufferArray, bytesOnStack);
                         break;
                     }
                     case Instruction.NOT:
@@ -1301,13 +1305,13 @@ namespace Nethermind.Evm
                             return CallResult.OutOfGasException;
                         }
 
-                        Span<byte> bytes = PopBytes(bytesOnStack);
-                        for (int i = 0; i < 32; ++i)
-                        {
-                            bytes[i] = (byte)~bytes[i];
-                        }
+                        Span<byte> a = PopBytes(bytesOnStack);
 
-                        PushBytes(bytes, bytesOnStack);
+                        Vector<byte> aVec = new Vector<byte>(a);
+
+                        Vector.Negate(aVec).CopyTo(wordBufferArray);
+
+                        PushBytes(wordBufferArray, bytesOnStack);
                         break;
                     }
                     case Instruction.BYTE:


### PR DESCRIPTION
|   Method |       Mean |     Error |    StdDev | Ratio | Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------- |-----------:|----------:|----------:|------:|------:|------:|------:|----------:|
|  Current | 28.5806 ns | 0.1132 ns | 0.0945 ns |  1.00 |     - |     - |     - |         - |
| Improved |  0.6117 ns | 0.0220 ns | 0.0195 ns |  0.02 |     - |     - |     - |         - |

|   Method |       Mean |     Error |    StdDev | Ratio | Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------- |-----------:|----------:|----------:|------:|------:|------:|------:|----------:|
|  Current | 22.9990 ns | 0.4591 ns | 0.4714 ns |  1.00 |     - |     - |     - |         - |
| Improved |  0.3141 ns | 0.0114 ns | 0.0096 ns |  0.01 |     - |     - |     - |         - |

|   Method |       Mean |     Error |    StdDev | Ratio | Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------- |-----------:|----------:|----------:|------:|------:|------:|------:|----------:|
|  Current | 29.2991 ns | 0.2257 ns | 0.2001 ns |  1.00 |     - |     - |     - |         - |
| Improved |  0.6152 ns | 0.0261 ns | 0.0218 ns |  0.02 |     - |     - |     - |         - |


|   Method |       Mean |     Error |    StdDev | Ratio | Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------- |-----------:|----------:|----------:|------:|------:|------:|------:|----------:|
|  Current | 29.2271 ns | 0.5382 ns | 0.4771 ns |  1.00 |     - |     - |     - |         - |
| Improved |  0.5984 ns | 0.0102 ns | 0.0090 ns |  0.02 |     - |     - |     - |         - |

