### PR TITLE
Get proof 741

### DIFF
--- a/src/Nethermind/Nethermind.Cli/Modules/EthCliModule.cs
+++ b/src/Nethermind/Nethermind.Cli/Modules/EthCliModule.cs
@@ -16,6 +16,7 @@
  * along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
  */
 
+using System.Linq;
 using System.Numerics;
 using Jint.Native;
 using Nethermind.Core;
@@ -52,6 +53,12 @@ namespace Nethermind.Cli.Modules
             return NodeManager.Post<object>("eth_getBlockByHash", CliParseHash(hash), returnFullTransactionObjects).Result;
         }
         
+        [CliFunction("eth", "getProof")]
+        public object GetProof(string address, string[] storage, string blockParameter)
+        {
+            return NodeManager.Post<object>("eth_getProof", CliParseAddress(address), storage, blockParameter).Result;
+        }
+
         [CliFunction("eth", "getStorageAt")]
         public object GetStorageAt(string address, string positionIndex, string blockParameter)
         {

--- a/src/Nethermind/Nethermind.DataMarketplace.Test/ContractInteractionTest.cs
+++ b/src/Nethermind/Nethermind.DataMarketplace.Test/ContractInteractionTest.cs
@@ -375,6 +375,11 @@ namespace Nethermind.DataMarketplace.Test
                 throw new System.NotImplementedException();
             }
 
+            public void RunTreeVisitor(ITreeVisitor treeVisitor, Keccak stateRoot)
+            {
+                throw new NotImplementedException();
+            }
+
             public TxPoolInfo GetTxPoolInfo()
             {
                 throw new System.NotImplementedException();

--- a/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
@@ -256,6 +256,11 @@ namespace Nethermind.Facade
             return new FilterLog[0];
         }
 
+        public void RunTreeVisitor(ITreeVisitor treeVisitor)
+        {
+            _stateReader.RunTreeVisitor(treeVisitor);
+        }
+        
         public int NewFilter(FilterBlock fromBlock, FilterBlock toBlock,
             object address = null, IEnumerable<object> topics = null)
         {

--- a/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
@@ -256,9 +256,9 @@ namespace Nethermind.Facade
             return new FilterLog[0];
         }
 
-        public void RunTreeVisitor(ITreeVisitor treeVisitor)
+        public void RunTreeVisitor(ITreeVisitor treeVisitor, Keccak stateRoot)
         {
-            _stateReader.RunTreeVisitor(treeVisitor);
+            _stateReader.RunTreeVisitor(stateRoot, treeVisitor);
         }
         
         public int NewFilter(FilterBlock fromBlock, FilterBlock toBlock,

--- a/src/Nethermind/Nethermind.Facade/IBlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/IBlockchainBridge.cs
@@ -24,6 +24,7 @@ using Nethermind.Blockchain.TxPools;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Dirichlet.Numerics;
+using Nethermind.Store;
 using Block = Nethermind.Core.Block;
 
 namespace Nethermind.Facade
@@ -91,5 +92,6 @@ namespace Nethermind.Facade
 
         FilterLog[] GetLogs(FilterBlock fromBlock, FilterBlock toBlock, object address = null,
             IEnumerable<object> topics = null);
+        void RunTreeVisitor(ITreeVisitor treeVisitor);
     }
 }

--- a/src/Nethermind/Nethermind.Facade/IBlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/IBlockchainBridge.cs
@@ -92,6 +92,6 @@ namespace Nethermind.Facade
 
         FilterLog[] GetLogs(FilterBlock fromBlock, FilterBlock toBlock, object address = null,
             IEnumerable<object> topics = null);
-        void RunTreeVisitor(ITreeVisitor treeVisitor);
+        void RunTreeVisitor(ITreeVisitor treeVisitor, Keccak stateRoot);
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Data/SerializationTestBase.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Data/SerializationTestBase.cs
@@ -24,6 +24,7 @@ using Nethermind.Blockchain;
 using Nethermind.Core.Json;
 using Nethermind.Facade;
 using Nethermind.JsonRpc.Modules;
+using Nethermind.JsonRpc.Modules.Eth;
 using Nethermind.JsonRpc.Modules.Trace;
 using Nethermind.Logging;
 using Newtonsoft.Json;
@@ -68,6 +69,11 @@ namespace Nethermind.JsonRpc.Test.Data
             TraceModule module = new TraceModule(Substitute.For<IBlockchainBridge>(), NullLogManager.Instance, Substitute.For<ITracer>());
 
             JsonSerializer serializer = new JsonSerializer();
+            foreach (JsonConverter converter in EthModuleFactory.Converters)
+            {
+                serializer.Converters.Add(converter);
+            }
+            
             foreach (JsonConverter converter in TraceModuleFactory.Converters)
             {
                 serializer.Converters.Add(converter);

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Eip1186/ProofCollectorTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Eip1186/ProofCollectorTests.cs
@@ -19,6 +19,8 @@
 using System;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Encoding;
+using Nethermind.Core.Extensions;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Dirichlet.Numerics;
 using Nethermind.JsonRpc.Eip1186;
@@ -44,7 +46,7 @@ namespace Nethermind.JsonRpc.Test.Eip1186
             tree.Accept(proofCollector, new MemDb());
             AccountProof proof = proofCollector.BuildResult();
             Assert.AreEqual(UInt256.One, proof.Balance);
-            
+
             ProofCollector proofCollector2 = new ProofCollector(TestItem.AddressB);
             tree.Accept(proofCollector2, new MemDb());
             AccountProof proof2 = proofCollector2.BuildResult();
@@ -67,13 +69,13 @@ namespace Nethermind.JsonRpc.Test.Eip1186
             tree.Accept(proofCollector, new MemDb());
             AccountProof proof = proofCollector.BuildResult();
             Assert.AreEqual(account1.CodeHash, proof.CodeHash);
-            
+
             ProofCollector proofCollector2 = new ProofCollector(TestItem.AddressB);
             tree.Accept(proofCollector2, new MemDb());
             AccountProof proof2 = proofCollector2.BuildResult();
             Assert.AreEqual(Keccak.OfAnEmptyString, proof2.CodeHash);
         }
-        
+
         [Test]
         public void Nonce_is_correct()
         {
@@ -90,13 +92,13 @@ namespace Nethermind.JsonRpc.Test.Eip1186
             tree.Accept(proofCollector, new MemDb());
             AccountProof proof = proofCollector.BuildResult();
             Assert.AreEqual(account1.Nonce, proof.Nonce);
-            
+
             ProofCollector proofCollector2 = new ProofCollector(TestItem.AddressB);
             tree.Accept(proofCollector2, new MemDb());
             AccountProof proof2 = proofCollector2.BuildResult();
             Assert.AreEqual(UInt256.Zero, proof2.Nonce);
         }
-        
+
         [Test]
         public void Storage_root_is_correct()
         {
@@ -113,13 +115,13 @@ namespace Nethermind.JsonRpc.Test.Eip1186
             tree.Accept(proofCollector, new MemDb());
             AccountProof proof = proofCollector.BuildResult();
             Assert.AreEqual(TestItem.KeccakA, proof.StorageRoot);
-            
+
             ProofCollector proofCollector2 = new ProofCollector(TestItem.AddressB);
             tree.Accept(proofCollector2, new MemDb());
             AccountProof proof2 = proofCollector2.BuildResult();
             Assert.AreEqual(Keccak.EmptyTreeHash, proof2.StorageRoot);
         }
-        
+
         [Test]
         public void Proof_path_is_filled()
         {
@@ -137,7 +139,7 @@ namespace Nethermind.JsonRpc.Test.Eip1186
             AccountProof proof = proofCollector.BuildResult();
             Assert.AreEqual(3, proof.Proof.Length);
         }
-        
+
         [Test]
         public void Storage_proofs_length_is_as_expected()
         {
@@ -150,28 +152,272 @@ namespace Nethermind.JsonRpc.Test.Eip1186
             tree.Set(TestItem.AddressB, account2);
             tree.Commit();
 
-            ProofCollector proofCollector = new ProofCollector(TestItem.AddressA, UInt256.One, UInt256.Zero);
+            ProofCollector proofCollector = new ProofCollector(TestItem.AddressA, Bytes.FromHexString("0x0000000000000000000000000000000000000000000000000000000000000000"), Bytes.FromHexString("0x0000000000000000000000000000000000000000000000000000000000000001"));
             tree.Accept(proofCollector, new MemDb());
             AccountProof proof = proofCollector.BuildResult();
             Assert.AreEqual(2, proof.StorageProofs.Length);
         }
-        
+
         [Test]
-        public void Storage_proofs_are_filled()
+        public void Storage_proofs_have_values_set()
         {
-            StateTree tree = new StateTree();
+            IDb memDb = new MemDb();
+            StateTree tree = new StateTree(memDb);
+            StorageTree storageTree = new StorageTree(memDb);
+            storageTree.Set(UInt256.Zero, Bytes.FromHexString("0xab12000000000000000000000000000000000000000000000000000000000000000000000000000000"));
+            storageTree.Set(UInt256.One, Bytes.FromHexString("0xab34000000000000000000000000000000000000000000000000000000000000000000000000000000"));
+            storageTree.Commit();
 
             byte[] code = new byte[] {1, 2, 3};
-            Account account1 = Build.An.Account.WithBalance(1).WithStorageRoot(TestItem.KeccakA).TestObject;
+            Account account1 = Build.An.Account.WithBalance(1).WithStorageRoot(storageTree.RootHash).TestObject;
             Account account2 = Build.An.Account.WithBalance(2).TestObject;
             tree.Set(TestItem.AddressA, account1);
             tree.Set(TestItem.AddressB, account2);
             tree.Commit();
 
-            ProofCollector proofCollector = new ProofCollector(TestItem.AddressA, UInt256.One, UInt256.Zero);
-            tree.Accept(proofCollector, new MemDb());
+            ProofCollector proofCollector = new ProofCollector(TestItem.AddressA, Bytes.FromHexString("0x0000000000000000000000000000000000000000000000000000000000000000"), Bytes.FromHexString("0x0000000000000000000000000000000000000000000000000000000000000001"));
+            tree.Accept(proofCollector, memDb);
             AccountProof proof = proofCollector.BuildResult();
-            throw new NotImplementedException();
+            Assert.AreEqual("0xab12000000000000000000000000000000000000000000000000000000000000000000000000000000", proof.StorageProofs[0].Value.ToHexString(true));
+            Assert.AreEqual("0xab34000000000000000000000000000000000000000000000000000000000000000000000000000000", proof.StorageProofs[1].Value.ToHexString(true));
+        }
+
+        [Test]
+        public void Storage_proofs_have_keys_set()
+        {
+            IDb memDb = new MemDb();
+            StateTree tree = new StateTree(memDb);
+            StorageTree storageTree = new StorageTree(memDb);
+            storageTree.Set(UInt256.Zero, Bytes.FromHexString("0xab12000000000000000000000000000000000000000000000000000000000000000000000000000000"));
+            storageTree.Set(UInt256.One, Bytes.FromHexString("0xab34000000000000000000000000000000000000000000000000000000000000000000000000000000"));
+            storageTree.Commit();
+
+            byte[] code = new byte[] {1, 2, 3};
+            Account account1 = Build.An.Account.WithBalance(1).WithStorageRoot(storageTree.RootHash).TestObject;
+            Account account2 = Build.An.Account.WithBalance(2).TestObject;
+            tree.Set(TestItem.AddressA, account1);
+            tree.Set(TestItem.AddressB, account2);
+            tree.Commit();
+
+            ProofCollector proofCollector = new ProofCollector(TestItem.AddressA, Bytes.FromHexString("0x0000000000000000000000000000000000000000000000000000000000000000"), Bytes.FromHexString("0x0000000000000000000000000000000000000000000000000000000000000001"));
+            tree.Accept(proofCollector, memDb);
+            AccountProof proof = proofCollector.BuildResult();
+            Assert.AreEqual("0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563", proof.StorageProofs[0].Key.Bytes.ToHexString(true));
+            Assert.AreEqual("0xb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6", proof.StorageProofs[1].Key.Bytes.ToHexString(true));
+        }
+
+        [Test]
+        public void Storage_proofs_have_values_set_complex_setup()
+        {
+            Keccak a = new Keccak("0x000000000000000000000000000000000000000000aaaaaaaaaaaaaaaaaaaaaa");
+            Keccak b = new Keccak("0x0000000000000000000000000bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+            Keccak c = new Keccak("0x0000000000cccccccccccccccccccccccccccccccccccccccccccccccccccccc");
+
+            IDb memDb = new MemDb();
+            StateTree tree = new StateTree(memDb);
+            StorageTree storageTree = new StorageTree(memDb);
+            storageTree.Set(a.Bytes, Rlp.Encode(Bytes.FromHexString("0xab12000000000000000000000000000000000000000000000000000000000000000000000000000000")));
+            storageTree.Set(b.Bytes, Rlp.Encode(Bytes.FromHexString("0xab34000000000000000000000000000000000000000000000000000000000000000000000000000000")));
+            storageTree.Set(c.Bytes, Rlp.Encode(Bytes.FromHexString("0xab56000000000000000000000000000000000000000000000000000000000000000000000000000000")));
+            storageTree.Commit();
+
+            byte[] code = new byte[] {1, 2, 3};
+            Account account1 = Build.An.Account.WithBalance(1).WithStorageRoot(storageTree.RootHash).TestObject;
+            Account account2 = Build.An.Account.WithBalance(2).TestObject;
+            tree.Set(TestItem.AddressA, account1);
+            tree.Set(TestItem.AddressB, account2);
+            tree.Commit();
+
+            TreeDumper dumper = new TreeDumper();
+            tree.Accept(dumper, memDb);
+            Console.WriteLine(dumper.ToString());
+
+            ProofCollector proofCollector = new ProofCollector(TestItem.AddressA, new Keccak[] {a, b, c});
+            tree.Accept(proofCollector, memDb);
+            AccountProof proof = proofCollector.BuildResult();
+            Assert.AreEqual("0xab12000000000000000000000000000000000000000000000000000000000000000000000000000000", proof.StorageProofs[0].Value.ToHexString(true));
+            Assert.AreEqual("0xab34000000000000000000000000000000000000000000000000000000000000000000000000000000", proof.StorageProofs[1].Value.ToHexString(true));
+            Assert.AreEqual("0xab56000000000000000000000000000000000000000000000000000000000000000000000000000000", proof.StorageProofs[2].Value.ToHexString(true));
+        }
+
+        [Test]
+        public void Storage_proofs_have_values_set_complex_2_setup()
+        {
+            Keccak a = new Keccak("0x000000000000000000000000000000000000000000aaaaaaaaaaaaaaaaaaaaaa");
+            Keccak b = new Keccak("0x0000000000000000000000000bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+            Keccak c = new Keccak("0x0000000000cccccccccccccccccccccccccccccccccccccccccccccccccccccc");
+            Keccak d = new Keccak("0x0000000000dddddddddddddddddddddddddddddddddddddddddddddddddddddd");
+            Keccak e = new Keccak("0x0000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
+
+            IDb memDb = new MemDb();
+            StateTree tree = new StateTree(memDb);
+            StorageTree storageTree = new StorageTree(memDb);
+            storageTree.Set(a.Bytes, Rlp.Encode(Bytes.FromHexString("0xab12000000000000000000000000000000000000000000000000000000000000000000000000000000")));
+            storageTree.Set(b.Bytes, Rlp.Encode(Bytes.FromHexString("0xab34000000000000000000000000000000000000000000000000000000000000000000000000000000")));
+            storageTree.Set(c.Bytes, Rlp.Encode(Bytes.FromHexString("0xab56000000000000000000000000000000000000000000000000000000000000000000000000000000")));
+            storageTree.Set(d.Bytes, Rlp.Encode(Bytes.FromHexString("0xab78000000000000000000000000000000000000000000000000000000000000000000000000000000")));
+            storageTree.Set(e.Bytes, Rlp.Encode(Bytes.FromHexString("0xab9a000000000000000000000000000000000000000000000000000000000000000000000000000000")));
+            storageTree.Commit();
+
+            byte[] code = new byte[] {1, 2, 3};
+            Account account1 = Build.An.Account.WithBalance(1).WithStorageRoot(storageTree.RootHash).TestObject;
+            Account account2 = Build.An.Account.WithBalance(2).TestObject;
+            tree.Set(TestItem.AddressA, account1);
+            tree.Set(TestItem.AddressB, account2);
+            tree.Commit();
+
+            TreeDumper dumper = new TreeDumper();
+            tree.Accept(dumper, memDb);
+            Console.WriteLine(dumper.ToString());
+
+            ProofCollector proofCollector = new ProofCollector(TestItem.AddressA, new Keccak[] {a, b, c, d, e});
+            tree.Accept(proofCollector, memDb);
+            AccountProof proof = proofCollector.BuildResult();
+            Assert.AreEqual("0xab12000000000000000000000000000000000000000000000000000000000000000000000000000000", proof.StorageProofs[0].Value.ToHexString(true));
+            Assert.AreEqual("0xab34000000000000000000000000000000000000000000000000000000000000000000000000000000", proof.StorageProofs[1].Value.ToHexString(true));
+            Assert.AreEqual("0xab56000000000000000000000000000000000000000000000000000000000000000000000000000000", proof.StorageProofs[2].Value.ToHexString(true));
+            Assert.AreEqual("0xab78000000000000000000000000000000000000000000000000000000000000000000000000000000", proof.StorageProofs[3].Value.ToHexString(true));
+            Assert.AreEqual("0xab9a000000000000000000000000000000000000000000000000000000000000000000000000000000", proof.StorageProofs[4].Value.ToHexString(true));
+        }
+
+        [Test]
+        public void Storage_proofs_have_values_set_complex_3_setup()
+        {
+            Keccak a = new Keccak("0x000000000000000000000000000000000000000000aaaaaaaaaaaaaaaaaaaaaa");
+            Keccak b = new Keccak("0x0000000000000000000000000bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+            Keccak c = new Keccak("0x00000000001ccccccccccccccccccccccccccccccccccccccccccccccccccccc");
+            Keccak d = new Keccak("0x00000000001ddddddddddddddddddddddddddddddddddddddddddddddddddddd");
+            Keccak e = new Keccak("0x00000000001eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
+
+            IDb memDb = new MemDb();
+            StateTree tree = new StateTree(memDb);
+            StorageTree storageTree = new StorageTree(memDb);
+            storageTree.Set(a.Bytes, Rlp.Encode(Bytes.FromHexString("0xab12000000000000000000000000000000000000000000000000000000000000000000000000000000")));
+            storageTree.Set(b.Bytes, Rlp.Encode(Bytes.FromHexString("0xab34000000000000000000000000000000000000000000000000000000000000000000000000000000")));
+            storageTree.Set(c.Bytes, Rlp.Encode(Bytes.FromHexString("0xab56000000000000000000000000000000000000000000000000000000000000000000000000000000")));
+            storageTree.Set(d.Bytes, Rlp.Encode(Bytes.FromHexString("0xab78000000000000000000000000000000000000000000000000000000000000000000000000000000")));
+            storageTree.Set(e.Bytes, Rlp.Encode(Bytes.FromHexString("0xab9a000000000000000000000000000000000000000000000000000000000000000000000000000000")));
+            storageTree.Commit();
+
+            byte[] code = new byte[] {1, 2, 3};
+            Account account1 = Build.An.Account.WithBalance(1).WithStorageRoot(storageTree.RootHash).TestObject;
+            Account account2 = Build.An.Account.WithBalance(2).TestObject;
+            tree.Set(TestItem.AddressA, account1);
+            tree.Set(TestItem.AddressB, account2);
+            tree.Commit();
+
+            TreeDumper dumper = new TreeDumper();
+            tree.Accept(dumper, memDb);
+            Console.WriteLine(dumper.ToString());
+
+            ProofCollector proofCollector = new ProofCollector(TestItem.AddressA, new Keccak[] {a, b, c, d, e});
+            tree.Accept(proofCollector, memDb);
+            AccountProof proof = proofCollector.BuildResult();
+            Assert.AreEqual("0xab12000000000000000000000000000000000000000000000000000000000000000000000000000000", proof.StorageProofs[0].Value.ToHexString(true));
+            Assert.AreEqual("0xab34000000000000000000000000000000000000000000000000000000000000000000000000000000", proof.StorageProofs[1].Value.ToHexString(true));
+            Assert.AreEqual("0xab56000000000000000000000000000000000000000000000000000000000000000000000000000000", proof.StorageProofs[2].Value.ToHexString(true));
+            Assert.AreEqual("0xab78000000000000000000000000000000000000000000000000000000000000000000000000000000", proof.StorageProofs[3].Value.ToHexString(true));
+            Assert.AreEqual("0xab9a000000000000000000000000000000000000000000000000000000000000000000000000000000", proof.StorageProofs[4].Value.ToHexString(true));
+        }
+
+        [Test]
+        public void Storage_proofs_when_values_are_missing_setup()
+        {
+            Keccak a = new Keccak("0x000000000000000000000000000000000000000000aaaaaaaaaaaaaaaaaaaaaa");
+            Keccak b = new Keccak("0x0000000000000000000000000bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+            Keccak c = new Keccak("0x00000000001ccccccccccccccccccccccccccccccccccccccccccccccccccccc");
+            Keccak d = new Keccak("0x00000000001ddddddddddddddddddddddddddddddddddddddddddddddddddddd");
+            Keccak e = new Keccak("0x00000000001eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
+
+            IDb memDb = new MemDb();
+            StateTree tree = new StateTree(memDb);
+            StorageTree storageTree = new StorageTree(memDb);
+            storageTree.Set(a.Bytes, Rlp.Encode(Bytes.FromHexString("0xab12000000000000000000000000000000000000000000000000000000000000000000000000000000")));
+            storageTree.Set(c.Bytes, Rlp.Encode(Bytes.FromHexString("0xab56000000000000000000000000000000000000000000000000000000000000000000000000000000")));
+            storageTree.Set(e.Bytes, Rlp.Encode(Bytes.FromHexString("0xab9a000000000000000000000000000000000000000000000000000000000000000000000000000000")));
+            storageTree.Commit();
+
+            byte[] code = new byte[] {1, 2, 3};
+            Account account1 = Build.An.Account.WithBalance(1).WithStorageRoot(storageTree.RootHash).TestObject;
+            Account account2 = Build.An.Account.WithBalance(2).TestObject;
+            tree.Set(TestItem.AddressA, account1);
+            tree.Set(TestItem.AddressB, account2);
+            tree.Commit();
+
+            TreeDumper dumper = new TreeDumper();
+            tree.Accept(dumper, memDb);
+            Console.WriteLine(dumper.ToString());
+
+            ProofCollector proofCollector = new ProofCollector(TestItem.AddressA, new Keccak[] {a, b, c, d, e});
+            tree.Accept(proofCollector, memDb);
+            AccountProof proof = proofCollector.BuildResult();
+            Assert.AreEqual("0xab12000000000000000000000000000000000000000000000000000000000000000000000000000000", proof.StorageProofs[0].Value?.ToHexString(true) ?? "0x");
+            Assert.AreEqual("0xab12000000000000000000000000000000000000000000000000000000000000000000000000000000", proof.StorageProofs[1].Value?.ToHexString(true) ?? "0x");
+            Assert.AreEqual("0xab56000000000000000000000000000000000000000000000000000000000000000000000000000000", proof.StorageProofs[2].Value?.ToHexString(true) ?? "0x");
+            Assert.AreEqual("0x", proof.StorageProofs[3].Value?.ToHexString(true) ?? "0x");
+            Assert.AreEqual("0xab9a000000000000000000000000000000000000000000000000000000000000000000000000000000", proof.StorageProofs[4].Value?.ToHexString(true) ?? "0x");
+        }
+
+        [Test]
+        public void Shows_empty_values_when_account_is_missing()
+        {
+            IDb memDb = new MemDb();
+            StateTree tree = new StateTree(memDb);
+
+            byte[] code = new byte[] {1, 2, 3};
+            Account account2 = Build.An.Account.WithBalance(2).TestObject;
+            tree.Set(TestItem.AddressB, account2);
+            tree.Commit();
+
+            TreeDumper dumper = new TreeDumper();
+            tree.Accept(dumper, memDb);
+            Console.WriteLine(dumper.ToString());
+
+            ProofCollector proofCollector = new ProofCollector(TestItem.AddressA);
+            tree.Accept(proofCollector, memDb);
+            AccountProof proof = proofCollector.BuildResult();
+            Assert.AreEqual((UInt256)2, proof.Balance);
+            Assert.AreEqual(UInt256.Zero, proof.Nonce);
+            Assert.AreEqual(Keccak.OfAnEmptyString, proof.CodeHash);
+            Assert.AreEqual(Keccak.EmptyTreeHash, proof.StorageRoot);
+        }
+
+        [Test]
+        public void Storage_proofs_have_values_set_selective_setup()
+        {
+            Keccak a = new Keccak("0x000000000000000000000000000000000000000000aaaaaaaaaaaaaaaaaaaaaa");
+            Keccak b = new Keccak("0x0000000000000000000000000bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+            Keccak c = new Keccak("0x00000000001ccccccccccccccccccccccccccccccccccccccccccccccccccccc");
+            Keccak d = new Keccak("0x00000000001ddddddddddddddddddddddddddddddddddddddddddddddddddddd");
+            Keccak e = new Keccak("0x00000000001eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
+
+            IDb memDb = new MemDb();
+            StateTree tree = new StateTree(memDb);
+            StorageTree storageTree = new StorageTree(memDb);
+            storageTree.Set(a.Bytes, Rlp.Encode(Bytes.FromHexString("0xab12000000000000000000000000000000000000000000000000000000000000000000000000000000")));
+            storageTree.Set(b.Bytes, Rlp.Encode(Bytes.FromHexString("0xab34000000000000000000000000000000000000000000000000000000000000000000000000000000")));
+            storageTree.Set(c.Bytes, Rlp.Encode(Bytes.FromHexString("0xab56000000000000000000000000000000000000000000000000000000000000000000000000000000")));
+            storageTree.Set(d.Bytes, Rlp.Encode(Bytes.FromHexString("0xab78000000000000000000000000000000000000000000000000000000000000000000000000000000")));
+            storageTree.Set(e.Bytes, Rlp.Encode(Bytes.FromHexString("0xab9a000000000000000000000000000000000000000000000000000000000000000000000000000000")));
+            storageTree.Commit();
+
+            byte[] code = new byte[] {1, 2, 3};
+            Account account1 = Build.An.Account.WithBalance(1).WithStorageRoot(storageTree.RootHash).TestObject;
+            Account account2 = Build.An.Account.WithBalance(2).TestObject;
+            tree.Set(TestItem.AddressA, account1);
+            tree.Set(TestItem.AddressB, account2);
+            tree.Commit();
+
+            TreeDumper dumper = new TreeDumper();
+            tree.Accept(dumper, memDb);
+            Console.WriteLine(dumper.ToString());
+
+            ProofCollector proofCollector = new ProofCollector(TestItem.AddressA, new Keccak[] {a, c, e});
+            tree.Accept(proofCollector, memDb);
+            AccountProof proof = proofCollector.BuildResult();
+            Assert.AreEqual("0xab12000000000000000000000000000000000000000000000000000000000000000000000000000000", proof.StorageProofs[0].Value.ToHexString(true));
+            Assert.AreEqual("0xab56000000000000000000000000000000000000000000000000000000000000000000000000000000", proof.StorageProofs[1].Value.ToHexString(true));
+            Assert.AreEqual("0xab9a000000000000000000000000000000000000000000000000000000000000000000000000000000", proof.StorageProofs[2].Value.ToHexString(true));
         }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Eip1186/ProofCollectorTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Eip1186/ProofCollectorTests.cs
@@ -16,6 +16,7 @@
  * along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
  */
 
+using System;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
@@ -24,7 +25,7 @@ using Nethermind.JsonRpc.Eip1186;
 using Nethermind.Store;
 using NUnit.Framework;
 
-namespace Nethermind.JsonRpc.Test
+namespace Nethermind.JsonRpc.Test.Eip1186
 {
     public class ProofCollectorTests
     {
@@ -135,6 +136,42 @@ namespace Nethermind.JsonRpc.Test
             tree.Accept(proofCollector, new MemDb());
             AccountProof proof = proofCollector.BuildResult();
             Assert.AreEqual(3, proof.Proof.Length);
+        }
+        
+        [Test]
+        public void Storage_proofs_length_is_as_expected()
+        {
+            StateTree tree = new StateTree();
+
+            byte[] code = new byte[] {1, 2, 3};
+            Account account1 = Build.An.Account.WithBalance(1).WithStorageRoot(TestItem.KeccakA).TestObject;
+            Account account2 = Build.An.Account.WithBalance(2).TestObject;
+            tree.Set(TestItem.AddressA, account1);
+            tree.Set(TestItem.AddressB, account2);
+            tree.Commit();
+
+            ProofCollector proofCollector = new ProofCollector(TestItem.AddressA, UInt256.One, UInt256.Zero);
+            tree.Accept(proofCollector, new MemDb());
+            AccountProof proof = proofCollector.BuildResult();
+            Assert.AreEqual(2, proof.StorageProofs.Length);
+        }
+        
+        [Test]
+        public void Storage_proofs_are_filled()
+        {
+            StateTree tree = new StateTree();
+
+            byte[] code = new byte[] {1, 2, 3};
+            Account account1 = Build.An.Account.WithBalance(1).WithStorageRoot(TestItem.KeccakA).TestObject;
+            Account account2 = Build.An.Account.WithBalance(2).TestObject;
+            tree.Set(TestItem.AddressA, account1);
+            tree.Set(TestItem.AddressB, account2);
+            tree.Commit();
+
+            ProofCollector proofCollector = new ProofCollector(TestItem.AddressA, UInt256.One, UInt256.Zero);
+            tree.Accept(proofCollector, new MemDb());
+            AccountProof proof = proofCollector.BuildResult();
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Eip1186/ProofConverterTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Eip1186/ProofConverterTests.cs
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2018 Demerzel Solutions Limited
+ * This file is part of the Nethermind library.
+ *
+ * The Nethermind library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Nethermind library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+using System;
+using System.IO;
+using System.Text;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Encoding;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Dirichlet.Numerics;
+using Nethermind.JsonRpc.Eip1186;
+using Nethermind.JsonRpc.Test.Data;
+using Nethermind.Store;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace Nethermind.JsonRpc.Test.Eip1186
+{
+    public class ProofConverterTests : SerializationTestBase
+    {
+        [Test]
+        public void Storage_proofs_have_values_set_complex_3_setup()
+        {
+            Keccak a = new Keccak("0x000000000000000000000000000000000000000000aaaaaaaaaaaaaaaaaaaaaa");
+            Keccak b = new Keccak("0x0000000000000000000000000bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+            Keccak c = new Keccak("0x00000000001ccccccccccccccccccccccccccccccccccccccccccccccccccccc");
+            Keccak d = new Keccak("0x00000000001ddddddddddddddddddddddddddddddddddddddddddddddddddddd");
+            Keccak e = new Keccak("0x00000000001eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
+
+            IDb memDb = new MemDb();
+            StateTree tree = new StateTree(memDb);
+            StorageTree storageTree = new StorageTree(memDb);
+            storageTree.Set(a.Bytes, Rlp.Encode(Bytes.FromHexString("0xab12000000000000000000000000000000000000000000000000000000000000000000000000000000")));
+            storageTree.Set(b.Bytes, Rlp.Encode(Bytes.FromHexString("0xab34000000000000000000000000000000000000000000000000000000000000000000000000000000")));
+            storageTree.Set(c.Bytes, Rlp.Encode(Bytes.FromHexString("0xab56000000000000000000000000000000000000000000000000000000000000000000000000000000")));
+            storageTree.Set(d.Bytes, Rlp.Encode(Bytes.FromHexString("0xab78000000000000000000000000000000000000000000000000000000000000000000000000000000")));
+            storageTree.Set(e.Bytes, Rlp.Encode(Bytes.FromHexString("0xab9a000000000000000000000000000000000000000000000000000000000000000000000000000000")));
+            storageTree.Commit();
+
+            byte[] code = new byte[] {1, 2, 3};
+            Account account1 = Build.An.Account.WithBalance(1).WithStorageRoot(storageTree.RootHash).TestObject;
+            Account account2 = Build.An.Account.WithBalance(2).TestObject;
+            tree.Set(TestItem.AddressA, account1);
+            tree.Set(TestItem.AddressB, account2);
+            tree.Commit();
+
+            ProofCollector proofCollector = new ProofCollector(TestItem.AddressA, new Keccak[] {a, b, c, d, e});
+            tree.Accept(proofCollector, memDb);
+            AccountProof proof = proofCollector.BuildResult();
+
+            TestOneWaySerialization(proof, "{\"accountProof\":[\"0xe215a0e2a0cd25c7c043b502d300690d497d07c90503cf48575d7c4d9df48c3239c3f4\",\"0xf8518080808080a064c7ecf7af3f0cd537929398725a611310f6d5190a097aca9c03a3d21ce061128080808080808080a02352504a0cd6095829b18bae394d0c882d84eead7be5b6ad0a87daaff9d2fb4a8080\",\"0xf869a020227dead52ea912e013e7641ccd6b3b174498e55066b0c174a09c8c3cc4bf5eb846f8448001a0afc6e7c1c13f18c0ee2a94c64c0855a03d1dd26afe5f6b2c2a99eb065223ca39a0c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470\"],\"balance\":\"0x1\",\"codeHash\":\"0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470\",\"nonce\":\"0x0\",\"storageHash\":\"0xafc6e7c1c13f18c0ee2a94c64c0855a03d1dd26afe5f6b2c2a99eb065223ca39\",\"storageProof\":[{\"key\":\"0x000000000000000000000000000000000000000000aaaaaaaaaaaaaaaaaaaaaa\",\"proof\":[\"0xe886000000000000a0830818307108fb62adbcdd1d9b869a4cf8955dc211a286503febdf17ac599b2e\",\"0xf851a020be9ddd30723181a87b18a6d2bfa2b3323f30f1d0646aa9c7eea06af9e31c57a06da0dc6a9169f5f35fd7d057065203ba2c9fb225d8d6b4bb35f2dc1d2ba693b6808080808080808080808080808080\",\"0xea880000000000000000a0c0f54c2d3456184a7bc418ec5b534a9a136ed3b5627caced8bed3732264b3fed\",\"0xf851a034c4b62df64d959a98788985227a6c0ab009d7db955547d0be790c1ce553ed4980808080808080808080a0b43c9841efec2ea2b85472f8883b77a2669cc8ed0c86a422d4114b9e17f115918080808080\"],\"value\":\"0xab12000000000000000000000000000000000000000000000000000000000000000000000000000000\"},{\"key\":\"0x0000000000000000000000000bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\",\"proof\":[\"0xe886000000000000a0830818307108fb62adbcdd1d9b869a4cf8955dc211a286503febdf17ac599b2e\",\"0xf851a020be9ddd30723181a87b18a6d2bfa2b3323f30f1d0646aa9c7eea06af9e31c57a06da0dc6a9169f5f35fd7d057065203ba2c9fb225d8d6b4bb35f2dc1d2ba693b6808080808080808080808080808080\",\"0xea880000000000000000a0c0f54c2d3456184a7bc418ec5b534a9a136ed3b5627caced8bed3732264b3fed\",\"0xf851a034c4b62df64d959a98788985227a6c0ab009d7db955547d0be790c1ce553ed4980808080808080808080a0b43c9841efec2ea2b85472f8883b77a2669cc8ed0c86a422d4114b9e17f115918080808080\"],\"value\":\"0xab34000000000000000000000000000000000000000000000000000000000000000000000000000000\"},{\"key\":\"0x00000000001ccccccccccccccccccccccccccccccccccccccccccccccccccccc\",\"proof\":[\"0xe886000000000000a0830818307108fb62adbcdd1d9b869a4cf8955dc211a286503febdf17ac599b2e\",\"0xf851a020be9ddd30723181a87b18a6d2bfa2b3323f30f1d0646aa9c7eea06af9e31c57a06da0dc6a9169f5f35fd7d057065203ba2c9fb225d8d6b4bb35f2dc1d2ba693b6808080808080808080808080808080\",\"0xf871808080808080808080808080a0d05f5bbfc8b0cf084848efcdd079e280384c937c8f30e5fe86dea0b4c3e23ebaa0ed9e169336203e22c92423e552c29f717f1024954239f90ee6940d9546149ad3a06841d65c5f2d895812aa6b18874d0aeae1cca5d73d3ee9277dc00bc84bee6ca78080\",\"0xf8479b20ccccccccccccccccccccccccccccccccccccccccccccccccccccaaa9ab56000000000000000000000000000000000000000000000000000000000000000000000000000000\"],\"value\":\"0xab56000000000000000000000000000000000000000000000000000000000000000000000000000000\"},{\"key\":\"0x00000000001ddddddddddddddddddddddddddddddddddddddddddddddddddddd\",\"proof\":[\"0xe886000000000000a0830818307108fb62adbcdd1d9b869a4cf8955dc211a286503febdf17ac599b2e\",\"0xf851a020be9ddd30723181a87b18a6d2bfa2b3323f30f1d0646aa9c7eea06af9e31c57a06da0dc6a9169f5f35fd7d057065203ba2c9fb225d8d6b4bb35f2dc1d2ba693b6808080808080808080808080808080\",\"0xf871808080808080808080808080a0d05f5bbfc8b0cf084848efcdd079e280384c937c8f30e5fe86dea0b4c3e23ebaa0ed9e169336203e22c92423e552c29f717f1024954239f90ee6940d9546149ad3a06841d65c5f2d895812aa6b18874d0aeae1cca5d73d3ee9277dc00bc84bee6ca78080\",\"0xf8479b20ddddddddddddddddddddddddddddddddddddddddddddddddddddaaa9ab78000000000000000000000000000000000000000000000000000000000000000000000000000000\"],\"value\":\"0xab78000000000000000000000000000000000000000000000000000000000000000000000000000000\"},{\"key\":\"0x00000000001eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\",\"proof\":[\"0xe886000000000000a0830818307108fb62adbcdd1d9b869a4cf8955dc211a286503febdf17ac599b2e\",\"0xf851a020be9ddd30723181a87b18a6d2bfa2b3323f30f1d0646aa9c7eea06af9e31c57a06da0dc6a9169f5f35fd7d057065203ba2c9fb225d8d6b4bb35f2dc1d2ba693b6808080808080808080808080808080\",\"0xf871808080808080808080808080a0d05f5bbfc8b0cf084848efcdd079e280384c937c8f30e5fe86dea0b4c3e23ebaa0ed9e169336203e22c92423e552c29f717f1024954239f90ee6940d9546149ad3a06841d65c5f2d895812aa6b18874d0aeae1cca5d73d3ee9277dc00bc84bee6ca78080\",\"0xf8479b20eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeaaa9ab9a000000000000000000000000000000000000000000000000000000000000000000000000000000\"],\"value\":\"0xab9a000000000000000000000000000000000000000000000000000000000000000000000000000000\"}]}");
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.JsonRpc.Test/ProofCollectorTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/ProofCollectorTests.cs
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2018 Demerzel Solutions Limited
+ * This file is part of the Nethermind library.
+ *
+ * The Nethermind library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Nethermind library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Dirichlet.Numerics;
+using Nethermind.Store;
+using NUnit.Framework;
+
+namespace Nethermind.JsonRpc.Test
+{
+    public class ProofCollectorTests
+    {
+        [Test]
+        public void Balance_is_correct()
+        {
+            ProofCollector proofCollector = new ProofCollector(TestItem.AddressA);
+            StateTree tree = new StateTree();
+
+            Account account1 = Build.An.Account.WithBalance(1).TestObject;
+            Account account2 = Build.An.Account.WithBalance(2).TestObject;
+            tree.Set(TestItem.AddressA, account1);
+            tree.Set(TestItem.AddressB, account2);
+
+            tree.Accept(proofCollector, new MemDb());
+
+            AccountProof proof = proofCollector.AccountProof;
+
+            Assert.AreEqual(UInt256.One, proof.Balance);
+        }
+
+        [Test]
+        public void Code_hash_is_correct()
+        {
+            ProofCollector proofCollector = new ProofCollector(TestItem.AddressA);
+            StateTree tree = new StateTree();
+
+            byte[] code = new byte[] {1, 2, 3};
+            Account account1 = Build.An.Account.WithBalance(1).WithCode(code).TestObject;
+            Account account2 = Build.An.Account.WithBalance(2).TestObject;
+            tree.Set(TestItem.AddressA, account1);
+            tree.Set(TestItem.AddressB, account2);
+
+            tree.Accept(proofCollector, new MemDb());
+
+            AccountProof proof = proofCollector.AccountProof;
+
+            Assert.AreEqual(Keccak.Compute(code), proof.CodeHash);
+        }
+        
+        [Test]
+        public void Nonce_is_correct()
+        {
+            ProofCollector proofCollector = new ProofCollector(TestItem.AddressA);
+            StateTree tree = new StateTree();
+
+            byte[] code = new byte[] {1, 2, 3};
+            Account account1 = Build.An.Account.WithBalance(1).WithNonce(UInt256.One).TestObject;
+            Account account2 = Build.An.Account.WithBalance(2).TestObject;
+            tree.Set(TestItem.AddressA, account1);
+            tree.Set(TestItem.AddressB, account2);
+
+            tree.Accept(proofCollector, new MemDb());
+
+            AccountProof proof = proofCollector.AccountProof;
+
+            Assert.AreEqual(account1.Nonce, proof.Nonce);
+        }
+        
+        [Test]
+        public void Storage_root_is_correct()
+        {
+            ProofCollector proofCollector = new ProofCollector(TestItem.AddressA);
+            StateTree tree = new StateTree();
+
+            byte[] code = new byte[] {1, 2, 3};
+            Account account1 = Build.An.Account.WithBalance(1).WithStorageRoot(TestItem.KeccakA).TestObject;
+            Account account2 = Build.An.Account.WithBalance(2).TestObject;
+            tree.Set(TestItem.AddressA, account1);
+            tree.Set(TestItem.AddressB, account2);
+
+            tree.Accept(proofCollector, new MemDb());
+
+            AccountProof proof = proofCollector.AccountProof;
+
+            Assert.AreEqual(TestItem.KeccakA, proof.StorageRoot);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.JsonRpc.Test/ProofCollectorTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/ProofCollectorTests.cs
@@ -37,10 +37,11 @@ namespace Nethermind.JsonRpc.Test
             Account account2 = Build.An.Account.WithBalance(2).TestObject;
             tree.Set(TestItem.AddressA, account1);
             tree.Set(TestItem.AddressB, account2);
+            tree.Commit();
 
             tree.Accept(proofCollector, new MemDb());
 
-            AccountProof proof = proofCollector.AccountProof;
+            AccountProof proof = proofCollector.BuildResult();
 
             Assert.AreEqual(UInt256.One, proof.Balance);
         }
@@ -56,10 +57,11 @@ namespace Nethermind.JsonRpc.Test
             Account account2 = Build.An.Account.WithBalance(2).TestObject;
             tree.Set(TestItem.AddressA, account1);
             tree.Set(TestItem.AddressB, account2);
+            tree.Commit();
 
             tree.Accept(proofCollector, new MemDb());
 
-            AccountProof proof = proofCollector.AccountProof;
+            AccountProof proof = proofCollector.BuildResult();
 
             Assert.AreEqual(Keccak.Compute(code), proof.CodeHash);
         }
@@ -75,10 +77,11 @@ namespace Nethermind.JsonRpc.Test
             Account account2 = Build.An.Account.WithBalance(2).TestObject;
             tree.Set(TestItem.AddressA, account1);
             tree.Set(TestItem.AddressB, account2);
+            tree.Commit();
 
             tree.Accept(proofCollector, new MemDb());
 
-            AccountProof proof = proofCollector.AccountProof;
+            AccountProof proof = proofCollector.BuildResult();
 
             Assert.AreEqual(account1.Nonce, proof.Nonce);
         }
@@ -94,10 +97,11 @@ namespace Nethermind.JsonRpc.Test
             Account account2 = Build.An.Account.WithBalance(2).TestObject;
             tree.Set(TestItem.AddressA, account1);
             tree.Set(TestItem.AddressB, account2);
+            tree.Commit();
 
             tree.Accept(proofCollector, new MemDb());
 
-            AccountProof proof = proofCollector.AccountProof;
+            AccountProof proof = proofCollector.BuildResult();
 
             Assert.AreEqual(TestItem.KeccakA, proof.StorageRoot);
         }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/ProofCollectorTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/ProofCollectorTests.cs
@@ -20,6 +20,7 @@ using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Dirichlet.Numerics;
+using Nethermind.JsonRpc.Eip1186;
 using Nethermind.Store;
 using NUnit.Framework;
 

--- a/src/Nethermind/Nethermind.JsonRpc/Eip1186/AccountProof.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Eip1186/AccountProof.cs
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2018 Demerzel Solutions Limited
+ * This file is part of the Nethermind library.
+ *
+ * The Nethermind library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Nethermind library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+using Nethermind.Core.Crypto;
+using Nethermind.Dirichlet.Numerics;
+
+namespace Nethermind.JsonRpc.Eip1186
+{
+    public class AccountProof
+    {
+        public byte[][] Proof { get; set; }
+        
+        public UInt256 Balance { get; set; }
+        
+        public Keccak CodeHash { get; set; }
+        
+        public UInt256 Nonce { get; set; }
+        
+        public Keccak StorageRoot { get; set; }
+        
+        public StorageProof[] StorageProofs { get; set; }
+    }
+}

--- a/src/Nethermind/Nethermind.JsonRpc/Eip1186/ProofCollector.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Eip1186/ProofCollector.cs
@@ -21,11 +21,9 @@ using System.Collections.Generic;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Encoding;
-using Nethermind.Core.Extensions;
-using Nethermind.Dirichlet.Numerics;
 using Nethermind.Store;
 
-namespace Nethermind.JsonRpc
+namespace Nethermind.JsonRpc.Eip1186
 {
     /// <summary>
     ///{
@@ -148,27 +146,5 @@ namespace Nethermind.JsonRpc
         {
             throw new InvalidOperationException($"{nameof(ProofCollector)} does never expect to visit code");
         }
-    }
-
-    public class AccountProof
-    {
-        public byte[][] Proof { get; set; }
-        
-        public UInt256 Balance { get; set; }
-        
-        public Keccak CodeHash { get; set; }
-        
-        public UInt256 Nonce { get; set; }
-        
-        public Keccak StorageRoot { get; set; }
-        
-        public StorageProof[] StorageProofs { get; set; }
-    }
-
-    public class StorageProof
-    {
-        public byte[][] Proof { get; set; }
-        public Keccak Key { get; set; }
-        public byte[] Value { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Eip1186/StorageProof.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Eip1186/StorageProof.cs
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2018 Demerzel Solutions Limited
+ * This file is part of the Nethermind library.
+ *
+ * The Nethermind library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Nethermind library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+using Nethermind.Core.Crypto;
+
+namespace Nethermind.JsonRpc.Eip1186
+{
+    public class StorageProof
+    {
+        public byte[][] Proof { get; set; }
+        public Keccak Key { get; set; }
+        public byte[] Value { get; set; }
+    }
+}

--- a/src/Nethermind/Nethermind.JsonRpc/Eip1186/SyncingResultConverter.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Eip1186/SyncingResultConverter.cs
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2018 Demerzel Solutions Limited
+ * This file is part of the Nethermind library.
+ *
+ * The Nethermind library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Nethermind library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+using System;
+using Nethermind.Core.Extensions;
+using Nethermind.JsonRpc.Modules.Trace;
+using Newtonsoft.Json;
+
+namespace Nethermind.JsonRpc.Eip1186
+{
+    /// <summary>
+    ///{
+    ///  "id": 1,
+    ///  "jsonrpc": "2.0",
+    ///  "method": "eth_getProof",
+    ///  "params": [
+    ///    "0x7F0d15C7FAae65896648C8273B6d7E43f58Fa842",
+    ///    [  "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421" ],
+    ///    "latest"
+    ///  ]
+    ///}
+    ///  
+    ///{
+    ///  "id": 1,
+    ///  "jsonrpc": "2.0",
+    ///  "result": {
+    ///    "accountProof": [
+    ///    "0xf90211a...0701bc80",
+    ///    "0xf90211a...0d832380",
+    ///    "0xf90211a...5fb20c80",
+    ///    "0xf90211a...0675b80",
+    ///    "0xf90151a0...ca08080"
+    ///    ],
+    ///  "balance": "0x0",
+    ///  "codeHash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+    ///  "nonce": "0x0",
+    ///  "storageHash": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+    ///  "storageProof": [
+    ///  {
+    ///    "key": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+    ///    "proof": [
+    ///    "0xf90211a...0701bc80",
+    ///    "0xf90211a...0d832380"
+    ///    ],
+    ///    "value": "0x1"
+    ///  }
+    ///  ]
+    ///  }
+    ///}
+    /// </summary>
+    public class ProofConverter : JsonConverter<AccountProof>
+    {
+        public override void WriteJson(JsonWriter writer, AccountProof value, JsonSerializer serializer)
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName("accountProof");
+            writer.WriteStartArray();
+            for (int i = 0; i < value.Proof.Length; i++)
+            {
+                writer.WriteValue(value.Proof[i].ToHexString(true));    
+            }
+            writer.WriteEnd();
+            writer.WriteProperty("balance", value.Balance, serializer);
+            writer.WriteProperty("codeHash", value.CodeHash, serializer);
+            writer.WriteProperty("nonce", value.Nonce, serializer);
+            writer.WriteProperty("storageHash", value.StorageRoot, serializer);
+            writer.WritePropertyName("storageProof");
+            writer.WriteStartArray();
+            for (int i = 0; i < value.StorageProofs.Length; i++)
+            {
+                writer.WriteStartObject();
+                writer.WriteProperty("key", value.StorageProofs[i].Key, serializer);
+                writer.WritePropertyName("proof");
+                writer.WriteStartArray();
+                for (int ip = 0; ip < value.StorageProofs[ip].Proof.Length; ip++)
+                {
+                    writer.WriteValue(value.StorageProofs[i].Proof[ip].ToHexString(true));    
+                }
+                writer.WriteEnd();
+                writer.WriteProperty("value", value.StorageProofs[i].Value, serializer);
+                writer.WriteEnd();
+            }
+            writer.WriteEnd();
+            writer.WriteEnd();
+            
+        }
+
+        public override AccountProof ReadJson(JsonReader reader, Type objectType, AccountProof existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthModule.cs
@@ -610,10 +610,20 @@ namespace Nethermind.JsonRpc.Modules.Eth
         }
 
         // https://github.com/ethereum/EIPs/issues/1186
-        public ResultWrapper<AccountProof> eth_getProof(Address accountAddress, Keccak[] hashRate, BlockParameter blockParameter)
+        public ResultWrapper<AccountProof> eth_getProof(Address accountAddress, byte[][] storageKeys, BlockParameter blockParameter)
         {
-            ProofCollector proofCollector = new ProofCollector(accountAddress);
-            _blockchainBridge.RunTreeVisitor(proofCollector);
+            Block block;
+            try
+            {
+                block = _blockchainBridge.GetBlock(blockParameter);
+            }
+            catch (JsonRpcException ex)
+            {
+                return ResultWrapper<AccountProof>.Fail(ex.Message, ex.ErrorType, null);
+            }
+            
+            ProofCollector proofCollector = new ProofCollector(accountAddress, storageKeys);
+            _blockchainBridge.RunTreeVisitor(proofCollector, block.StateRoot);
 
             return ResultWrapper<AccountProof>.Success(proofCollector.BuildResult());
         }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthModule.cs
@@ -30,6 +30,7 @@ using Nethermind.Core.Model;
 using Nethermind.Dirichlet.Numerics;
 using Nethermind.Facade;
 using Nethermind.JsonRpc.Data;
+using Nethermind.JsonRpc.Eip1186;
 using Nethermind.Logging;
 
 namespace Nethermind.JsonRpc.Modules.Eth

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthModule.cs
@@ -608,6 +608,15 @@ namespace Nethermind.JsonRpc.Modules.Eth
             return ResultWrapper<bool?>.Fail("eth_submitHashrate not supported", ErrorType.MethodNotFound, null);
         }
 
+        // https://github.com/ethereum/EIPs/issues/1186
+        public ResultWrapper<AccountProof> eth_getProof(Address accountAddress, Keccak[] hashRate, BlockParameter blockParameter)
+        {
+            ProofCollector proofCollector = new ProofCollector(accountAddress);
+            _blockchainBridge.RunTreeVisitor(proofCollector);
+
+            return ResultWrapper<AccountProof>.Success(proofCollector.AccountProof);
+        }
+
         private ResultWrapper<BigInteger?> GetOmmersCount(BlockParameter blockParameter)
         {
             Block block;

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthModule.cs
@@ -614,7 +614,7 @@ namespace Nethermind.JsonRpc.Modules.Eth
             ProofCollector proofCollector = new ProofCollector(accountAddress);
             _blockchainBridge.RunTreeVisitor(proofCollector);
 
-            return ResultWrapper<AccountProof>.Success(proofCollector.AccountProof);
+            return ResultWrapper<AccountProof>.Success(proofCollector.BuildResult());
         }
 
         private ResultWrapper<BigInteger?> GetOmmersCount(BlockParameter blockParameter)

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthModuleFactory.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthModuleFactory.cs
@@ -25,6 +25,7 @@ using Nethermind.Blockchain.TxPools;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.Facade;
+using Nethermind.JsonRpc.Eip1186;
 using Nethermind.Logging;
 using Nethermind.Store;
 using Nethermind.Wallet;
@@ -99,7 +100,8 @@ namespace Nethermind.JsonRpc.Modules.Eth
         
         public static List<JsonConverter> Converters = new List<JsonConverter>
         {
-            new SyncingResultConverter()
+            new SyncingResultConverter(),
+            new ProofConverter()
         };
 
         public override IReadOnlyCollection<JsonConverter> GetConverters() => Converters;

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/IEthModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/IEthModule.cs
@@ -77,6 +77,6 @@ namespace Nethermind.JsonRpc.Modules.Eth
         ResultWrapper<bool?> eth_submitHashrate(string hashRate, string id);
         
         // https://github.com/ethereum/EIPs/issues/1186
-        ResultWrapper<AccountProof> eth_getProof(Address accountAddress, Keccak[] hashRate, BlockParameter blockParameter);
+        ResultWrapper<AccountProof> eth_getProof(Address accountAddress, byte[][] hashRate, BlockParameter blockParameter);
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/IEthModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/IEthModule.cs
@@ -74,5 +74,8 @@ namespace Nethermind.JsonRpc.Modules.Eth
         
         [JsonRpcMethod(Description = "", IsImplemented = false)]
         ResultWrapper<bool?> eth_submitHashrate(string hashRate, string id);
+        
+        // https://github.com/ethereum/EIPs/issues/1186
+        ResultWrapper<AccountProof> eth_getProof(Address accountAddress, Keccak[] hashRate, BlockParameter blockParameter);
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/IEthModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/IEthModule.cs
@@ -22,6 +22,7 @@ using Nethermind.Blockchain.Filters;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.JsonRpc.Data;
+using Nethermind.JsonRpc.Eip1186;
 
 namespace Nethermind.JsonRpc.Modules.Eth
 {

--- a/src/Nethermind/Nethermind.JsonRpc/ProofCollector.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/ProofCollector.cs
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2018 Demerzel Solutions Limited
+ * This file is part of the Nethermind library.
+ *
+ * The Nethermind library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Nethermind library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Encoding;
+using Nethermind.Dirichlet.Numerics;
+using Nethermind.Store;
+
+namespace Nethermind.JsonRpc
+{
+    /// <summary>
+    ///{
+    ///  "id": 1,
+    ///  "jsonrpc": "2.0",
+    ///  "method": "eth_getProof",
+    ///  "params": [
+    ///    "0x7F0d15C7FAae65896648C8273B6d7E43f58Fa842",
+    ///    [  "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421" ],
+    ///    "latest"
+    ///  ]
+    ///}
+    ///  
+    ///{
+    ///  "id": 1,
+    ///  "jsonrpc": "2.0",
+    ///  "result": {
+    ///    "accountProof": [
+    ///    "0xf90211a...0701bc80",
+    ///    "0xf90211a...0d832380",
+    ///    "0xf90211a...5fb20c80",
+    ///    "0xf90211a...0675b80",
+    ///    "0xf90151a0...ca08080"
+    ///    ],
+    ///  "balance": "0x0",
+    ///  "codeHash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+    ///  "nonce": "0x0",
+    ///  "storageHash": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+    ///  "storageProof": [
+    ///  {
+    ///    "key": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+    ///    "proof": [
+    ///    "0xf90211a...0701bc80",
+    ///    "0xf90211a...0d832380"
+    ///    ],
+    ///    "value": "0x1"
+    ///  }
+    ///  ]
+    ///  }
+    ///}
+    /// </summary>
+    public class ProofCollector : ITreeVisitor
+    {
+        private Keccak _nextNodeToVisit;
+        
+        private readonly Address _address;
+
+        public ProofCollector(Address address)
+        {
+            _address = address;
+        }
+        
+        public AccountProof AccountProof { get; set; }
+
+        public bool ShouldVisit(Keccak nextNode)
+        {
+            return true;
+        }
+
+        public void VisitTree(Keccak rootHash, VisitContext context)
+        {
+            AccountProof = new AccountProof();
+        }
+
+        public void VisitMissingNode(Keccak nodeHash, VisitContext context)
+        {
+        }
+
+        public void VisitBranch(byte[] hashOrRlp, VisitContext context)
+        {
+            TrieNode node = new TrieNode(NodeType.Branch, new Rlp(hashOrRlp));
+        }
+
+        public void VisitExtension(byte[] hashOrRlp, VisitContext context)
+        {
+            TrieNode node = new TrieNode(NodeType.Extension, new Rlp(hashOrRlp));
+        }
+
+        public void VisitLeaf(byte[] hashOrRlp, VisitContext context)
+        {
+            TrieNode node = new TrieNode(NodeType.Leaf, new Rlp(hashOrRlp));
+            
+            if (context.IsStorage)
+            {
+            }
+            else
+            {
+                new TrieNode(NodeType.Unknown, new Rlp(hashOrRlp));
+            }
+        }
+
+        public void VisitCode(Keccak codeHash, byte[] code, VisitContext context)
+        {
+        }
+    }
+
+    public class AccountProof
+    {
+        public byte[][] Proof { get; set; }
+        public UInt256 Balance { get; set; }
+        public Keccak CodeHash { get; set; }
+        
+        public UInt256 Nonce { get; set; }
+        public Keccak StorageRoot { get; set; }
+        public StorageProof[] StorageProofs { get; set; }
+    }
+
+    public class StorageProof
+    {
+        public byte[][] Proof { get; set; }
+        public Keccak Key { get; set; }
+        public byte[] Value { get; set; }
+    }
+}

--- a/src/Nethermind/Nethermind.Store/IStateReader.cs
+++ b/src/Nethermind/Nethermind.Store/IStateReader.cs
@@ -43,5 +43,7 @@ namespace Nethermind.Store
         byte[] GetCode(Keccak stateRoot, Address address);
 
         byte[] GetCode(Keccak codeHash);
+        
+        void RunTreeVisitor(ITreeVisitor treeVisitor);
     }
 }

--- a/src/Nethermind/Nethermind.Store/IStateReader.cs
+++ b/src/Nethermind/Nethermind.Store/IStateReader.cs
@@ -44,6 +44,6 @@ namespace Nethermind.Store
 
         byte[] GetCode(Keccak codeHash);
         
-        void RunTreeVisitor(ITreeVisitor treeVisitor);
+        void RunTreeVisitor(Keccak stateRoot, ITreeVisitor treeVisitor);
     }
 }

--- a/src/Nethermind/Nethermind.Store/ITreeVisitor.cs
+++ b/src/Nethermind/Nethermind.Store/ITreeVisitor.cs
@@ -37,11 +37,11 @@ namespace Nethermind.Store
         
         void VisitMissingNode(Keccak nodeHash, VisitContext context);
         
-        void VisitBranch(byte[] hashOrRlp, VisitContext context);
+        void VisitBranch(TrieNode node, VisitContext context);
         
-        void VisitExtension(byte[] hashOrRlp, VisitContext context);
+        void VisitExtension(TrieNode node, VisitContext context);
         
-        void VisitLeaf(byte[] hashOrRlp, VisitContext context);
+        void VisitLeaf(TrieNode node, VisitContext context);
         
         void VisitCode(Keccak codeHash, byte[] code, VisitContext context);
     }

--- a/src/Nethermind/Nethermind.Store/ITreeVisitor.cs
+++ b/src/Nethermind/Nethermind.Store/ITreeVisitor.cs
@@ -31,6 +31,8 @@ namespace Nethermind.Store
     
     public interface ITreeVisitor
     {
+        bool ShouldVisit(Keccak nextNode);
+        
         void VisitTree(Keccak rootHash, VisitContext context);
         
         void VisitMissingNode(Keccak nodeHash, VisitContext context);

--- a/src/Nethermind/Nethermind.Store/StateReader.cs
+++ b/src/Nethermind/Nethermind.Store/StateReader.cs
@@ -101,6 +101,11 @@ namespace Nethermind.Store
             return _codeDb[codeHash.Bytes];
         }
 
+        public void RunTreeVisitor(ITreeVisitor treeVisitor)
+        {
+            _state.Accept(treeVisitor, _codeDb);
+        }
+
         public byte[] GetCode(Keccak rootHash, Address address)
         {
             Account account = GetState(rootHash, address);

--- a/src/Nethermind/Nethermind.Store/StateReader.cs
+++ b/src/Nethermind/Nethermind.Store/StateReader.cs
@@ -101,8 +101,9 @@ namespace Nethermind.Store
             return _codeDb[codeHash.Bytes];
         }
 
-        public void RunTreeVisitor(ITreeVisitor treeVisitor)
+        public void RunTreeVisitor(Keccak rootHash, ITreeVisitor treeVisitor)
         {
+            _state.RootHash = rootHash;
             _state.Accept(treeVisitor, _codeDb);
         }
 
@@ -119,7 +120,6 @@ namespace Nethermind.Store
 
         private Account GetState(Keccak rootHash, Address address)
         {
-            Metrics.StateTreeReads++;
             _state.RootHash = rootHash;
             Account account = _state.Get(address);
             return account;

--- a/src/Nethermind/Nethermind.Store/TreeDumper.cs
+++ b/src/Nethermind/Nethermind.Store/TreeDumper.cs
@@ -58,20 +58,20 @@ namespace Nethermind.Store
             _builder.AppendLine($"{GetIndent(context.Level) }{GetChildIndex(context)}MISSING {nodeHash}");
         }
 
-        public void VisitBranch(byte[] hashOrRlp, VisitContext context)
+        public void VisitBranch(TrieNode node, VisitContext context)
         {
-            _builder.AppendLine($"{GetPrefix(context)}BRANCH {hashOrRlp?.ToHexString()}");
+            _builder.AppendLine($"{GetPrefix(context)}BRANCH {(node.Keccak?.Bytes ?? node.FullRlp?.Bytes)?.ToHexString()}");
         }
 
-        public void VisitExtension(byte[] hashOrRlp, VisitContext context)
+        public void VisitExtension(TrieNode node, VisitContext context)
         {
-            _builder.AppendLine($"{GetPrefix(context)}EXTENSION {hashOrRlp?.ToHexString()}");
+            _builder.AppendLine($"{GetPrefix(context)}EXTENSION {(node.Keccak?.Bytes ?? node.FullRlp?.Bytes)?.ToHexString()}");
         }
 
-        public void VisitLeaf(byte[] hashOrRlp, VisitContext context)
+        public void VisitLeaf(TrieNode node, VisitContext context)
         {
             string leafDescription = context.IsStorage ? "LEAF " : "ACCOUNT ";
-            _builder.AppendLine($"{GetPrefix(context)}{leafDescription}{hashOrRlp?.ToHexString()}");
+            _builder.AppendLine($"{GetPrefix(context)}{leafDescription}{(node.Keccak?.Bytes ?? node.FullRlp?.Bytes)?.ToHexString()}");
         }
 
         public void VisitCode(Keccak codeHash, byte[] code, VisitContext context)

--- a/src/Nethermind/Nethermind.Store/TreeDumper.cs
+++ b/src/Nethermind/Nethermind.Store/TreeDumper.cs
@@ -30,7 +30,12 @@ namespace Nethermind.Store
         {
             _builder.Clear();
         }
-        
+
+        public bool ShouldVisit(Keccak nextNode)
+        {
+            return true;
+        }
+
         public void VisitTree(Keccak rootHash, VisitContext context)
         {
             if (rootHash == Keccak.EmptyTreeHash)

--- a/src/Nethermind/Nethermind.Store/TrieNode.cs
+++ b/src/Nethermind/Nethermind.Store/TrieNode.cs
@@ -404,6 +404,9 @@ namespace Nethermind.Store
 
             if (NodeType == NodeType.Extension)
             {
+                context.Position = 0;
+                context.ReadSequenceLength();
+                context.DecodeByteArraySpan();
                 return context.DecodeKeccak();
             }
 
@@ -553,7 +556,8 @@ namespace Nethermind.Store
                     throw new NotImplementedException();
                 case NodeType.Branch:
                 {
-                    visitor.VisitBranch(Keccak?.Bytes ?? FullRlp?.Bytes, context);
+                    BuildLookupTable();
+                    visitor.VisitBranch(this, context);
                     context.Level++;
                     for (int i = 0; i < 16; i++)
                     {
@@ -571,7 +575,7 @@ namespace Nethermind.Store
                 }
                 case NodeType.Extension:
                 {
-                    visitor.VisitExtension(Keccak?.Bytes ?? FullRlp?.Bytes, context);
+                    visitor.VisitExtension(this, context);
                     TrieNode child = GetChild(0);
                     if (child != null && visitor.ShouldVisit(child.Keccak))
                     {
@@ -585,7 +589,7 @@ namespace Nethermind.Store
                 }
                 case NodeType.Leaf:
                 {
-                    visitor.VisitLeaf(Keccak?.Bytes ?? FullRlp?.Bytes, context);
+                    visitor.VisitLeaf(this, context);
                     if (!context.IsStorage)
                     {
                         Account account = _decoder.Decode(Value.AsRlpContext());

--- a/src/Nethermind/Nethermind.Store/TrieStatsCollector.cs
+++ b/src/Nethermind/Nethermind.Store/TrieStatsCollector.cs
@@ -56,7 +56,7 @@ namespace Nethermind.Store
             }
         }
 
-        public void VisitBranch(byte[] hashOrRlp, VisitContext context)
+        public void VisitBranch(TrieNode node, VisitContext context)
         {
             if (context.IsStorage)
             {
@@ -68,8 +68,8 @@ namespace Nethermind.Store
             }
         }
 
-        public void VisitExtension(byte[] hashOrRlp, VisitContext context)
-        {
+        public void VisitExtension(TrieNode node, VisitContext context)
+                 {
             if (context.IsStorage)
             {
                 Stats.StorageExtensionCount++;
@@ -80,7 +80,7 @@ namespace Nethermind.Store
             }
         }
         
-        public void VisitLeaf(byte[] hashOrRlp, VisitContext context)
+        public void VisitLeaf(TrieNode node, VisitContext context)
         {
             if (Stats.NodesCount - _lastAccountNodeCount > 100000)
             {

--- a/src/Nethermind/Nethermind.Store/TrieStatsCollector.cs
+++ b/src/Nethermind/Nethermind.Store/TrieStatsCollector.cs
@@ -16,6 +16,7 @@
  * along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
  */
 
+using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Logging;
 
@@ -33,7 +34,12 @@ namespace Nethermind.Store
         }
         
         public TrieStats Stats { get; } = new TrieStats();
-        
+
+        public bool ShouldVisit(Keccak nextNode)
+        {
+            return true;
+        }
+
         public void VisitTree(Keccak rootHash, VisitContext context)
         {
         }


### PR DESCRIPTION
Adds an implementation of EIP-1186

We are using a Tree Visitor implementation that collects the information to build a proof for the account and storage values. We use the fact that the state and storage DBs are together.