### PR TITLE
Neth neth 755

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
@@ -410,6 +410,21 @@ namespace Nethermind.Blockchain.Test
             BlockHeader[] blocks = blockTree.FindHeaders(block0.Hash, 0, 0, false);
             Assert.AreEqual(0, blocks.Length);
         }
+        
+        [Test]
+        public void Find_sequence_one_block()
+        {
+            BlockTree blockTree = BuildBlockTree();
+            Block block0 = Build.A.Block.WithNumber(0).TestObject;
+            Block block1 = Build.A.Block.WithNumber(1).WithParent(block0).TestObject;
+            Block block2 = Build.A.Block.WithNumber(2).WithParent(block1).TestObject;
+            AddToMain(blockTree, block0);
+            AddToMain(blockTree, block1);
+            AddToMain(blockTree, block2);
+
+            BlockHeader[] blocks = blockTree.FindHeaders(block2.Hash, 1, 0, false);
+            Assert.AreEqual(1, blocks.Length);
+        }
 
         [Test]
         public void Find_sequence_basic_skip()

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
@@ -352,7 +352,7 @@ namespace Nethermind.Blockchain.Test
             AddToMain(blockTree, block1);
             AddToMain(blockTree, block2);
 
-            Block[] headers = blockTree.FindBlocks(block0.Hash, 100, 0, false);
+            BlockHeader[] headers = blockTree.FindHeaders(block0.Hash, 100, 0, false);
             Assert.AreEqual(100, headers.Length);
             Assert.AreEqual(block0.Hash, headers[0].Hash);
             Assert.Null(headers[3]);
@@ -371,10 +371,10 @@ namespace Nethermind.Blockchain.Test
             AddToMain(blockTree, block1);
             AddToMain(blockTree, block2);
 
-            Block[] blocks = blockTree.FindBlocks(block0.Hash, 3, 0, false);
+            BlockHeader[] blocks = blockTree.FindHeaders(block0.Hash, 3, 0, false);
             Assert.AreEqual(3, blocks.Length);
-            Assert.AreEqual(block0.Hash, BlockHeader.CalculateHash(blocks[0].Header));
-            Assert.AreEqual(block2.Hash, BlockHeader.CalculateHash(blocks[2].Header));
+            Assert.AreEqual(block0.Hash, BlockHeader.CalculateHash(blocks[0]));
+            Assert.AreEqual(block2.Hash, BlockHeader.CalculateHash(blocks[2]));
         }
 
         [Test]
@@ -388,12 +388,13 @@ namespace Nethermind.Blockchain.Test
             AddToMain(blockTree, block1);
             AddToMain(blockTree, block2);
 
-            Block[] blocks = blockTree.FindBlocks(block2.Hash, 3, 0, true);
+            BlockHeader[] blocks = blockTree.FindHeaders(block2.Hash, 3, 0, true);
             Assert.AreEqual(3, blocks.Length);
 
-            Assert.AreEqual(block2.Hash, BlockHeader.CalculateHash(blocks[0].Header));
-            Assert.AreEqual(block0.Hash, BlockHeader.CalculateHash(blocks[2].Header));
+            Assert.AreEqual(block2.Hash, BlockHeader.CalculateHash(blocks[0]));
+            Assert.AreEqual(block0.Hash, BlockHeader.CalculateHash(blocks[2]));
         }
+
 
         [Test]
         public void Find_sequence_zero_blocks()
@@ -406,7 +407,7 @@ namespace Nethermind.Blockchain.Test
             AddToMain(blockTree, block1);
             AddToMain(blockTree, block2);
 
-            Block[] blocks = blockTree.FindBlocks(block0.Hash, 0, 0, false);
+            BlockHeader[] blocks = blockTree.FindHeaders(block0.Hash, 0, 0, false);
             Assert.AreEqual(0, blocks.Length);
         }
 
@@ -421,10 +422,10 @@ namespace Nethermind.Blockchain.Test
             AddToMain(blockTree, block1);
             AddToMain(blockTree, block2);
 
-            Block[] blocks = blockTree.FindBlocks(block0.Hash, 2, 1, false);
+            BlockHeader[] blocks = blockTree.FindHeaders(block0.Hash, 2, 1, false);
             Assert.AreEqual(2, blocks.Length, "length");
-            Assert.AreEqual(block0.Hash, BlockHeader.CalculateHash(blocks[0].Header));
-            Assert.AreEqual(block2.Hash, BlockHeader.CalculateHash(blocks[1].Header));
+            Assert.AreEqual(block0.Hash, BlockHeader.CalculateHash(blocks[0]));
+            Assert.AreEqual(block2.Hash, BlockHeader.CalculateHash(blocks[1]));
         }
 
         [Test]
@@ -438,7 +439,7 @@ namespace Nethermind.Blockchain.Test
             AddToMain(blockTree, block1);
             AddToMain(blockTree, block2);
 
-            Block[] blocks = blockTree.FindBlocks(block0.Hash, 4, 0, false);
+            BlockHeader[] blocks = blockTree.FindHeaders(block0.Hash, 4, 0, false);
             Assert.AreEqual(4, blocks.Length);
             Assert.IsNull(blocks[3]);
         }

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
@@ -361,6 +361,43 @@ namespace Nethermind.Blockchain.Test
         }
 
         [Test]
+        public void Find_sequence_basic_longer()
+        {
+            BlockTree blockTree = BuildBlockTree();
+            Block block0 = Build.A.Block.WithNumber(0).TestObject;
+            Block block1 = Build.A.Block.WithNumber(1).WithParent(block0).TestObject;
+            Block block2 = Build.A.Block.WithNumber(2).WithParent(block1).TestObject;
+            AddToMain(blockTree, block0);
+            AddToMain(blockTree, block1);
+            AddToMain(blockTree, block2);
+
+            int length = 256;
+            BlockHeader[] blocks = blockTree.FindHeaders(block0.Hash, length, 0, false);
+            Assert.AreEqual(length, blocks.Length);
+            Assert.AreEqual(block0.Hash, BlockHeader.CalculateHash(blocks[0]));
+            Assert.AreEqual(block1.Hash, BlockHeader.CalculateHash(blocks[1]));
+            Assert.AreEqual(block2.Hash, BlockHeader.CalculateHash(blocks[2]));
+        }
+        
+        [Test]
+        public void Find_sequence_basic_shorter()
+        {
+            BlockTree blockTree = BuildBlockTree();
+            Block block0 = Build.A.Block.WithNumber(0).TestObject;
+            Block block1 = Build.A.Block.WithNumber(1).WithParent(block0).TestObject;
+            Block block2 = Build.A.Block.WithNumber(2).WithParent(block1).TestObject;
+            AddToMain(blockTree, block0);
+            AddToMain(blockTree, block1);
+            AddToMain(blockTree, block2);
+
+            int length = 2;
+            BlockHeader[] blocks = blockTree.FindHeaders(block1.Hash, length, 0, false);
+            Assert.AreEqual(length, blocks.Length);
+            Assert.AreEqual(block1.Hash, BlockHeader.CalculateHash(blocks[0]));
+            Assert.AreEqual(block2.Hash, BlockHeader.CalculateHash(blocks[1]));
+        }
+        
+        [Test]
         public void Find_sequence_basic()
         {
             BlockTree blockTree = BuildBlockTree();
@@ -371,9 +408,11 @@ namespace Nethermind.Blockchain.Test
             AddToMain(blockTree, block1);
             AddToMain(blockTree, block2);
 
-            BlockHeader[] blocks = blockTree.FindHeaders(block0.Hash, 3, 0, false);
-            Assert.AreEqual(3, blocks.Length);
+            int length = 3;
+            BlockHeader[] blocks = blockTree.FindHeaders(block0.Hash, length, 0, false);
+            Assert.AreEqual(length, blocks.Length);
             Assert.AreEqual(block0.Hash, BlockHeader.CalculateHash(blocks[0]));
+            Assert.AreEqual(block1.Hash, BlockHeader.CalculateHash(blocks[1]));
             Assert.AreEqual(block2.Hash, BlockHeader.CalculateHash(blocks[2]));
         }
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
@@ -39,7 +39,10 @@ namespace Nethermind.Blockchain.Test
     {
         private BlockTree BuildBlockTree()
         {
-            return new BlockTree(new MemDb(), new MemDb(), new MemDb(), MainNetSpecProvider.Instance, NullTxPool.Instance, LimboLogs.Instance);
+            _blocksDb = new MemDb();
+            _headersDb = new MemDb();
+            _blocksInfosDb = new MemDb();
+            return new BlockTree(_blocksDb, _headersDb, _blocksInfosDb, MainNetSpecProvider.Instance, NullTxPool.Instance, LimboLogs.Instance);
         }
 
         private static void AddToMain(BlockTree blockTree, Block block0)
@@ -202,7 +205,7 @@ namespace Nethermind.Blockchain.Test
             AddToMain(blockTree, block1);
             AddToMain(blockTree, block2);
 
-            Block found = blockTree.FindBlock(2);
+            Block found = blockTree.FindBlock(2, BlockTreeLookupOptions.None);
             Assert.AreEqual(block2.Hash, BlockHeader.CalculateHash(found.Header));
         }
 
@@ -217,7 +220,7 @@ namespace Nethermind.Blockchain.Test
             AddToMain(blockTree, block1);
             AddToMain(blockTree, block2);
 
-            Block found = blockTree.FindBlock(1920000);
+            Block found = blockTree.FindBlock(1920000, BlockTreeLookupOptions.None);
             Assert.Null(found);
         }
 
@@ -230,7 +233,7 @@ namespace Nethermind.Blockchain.Test
             AddToMain(blockTree, block0);
             AddToMain(blockTree, block1);
 
-            Block found = blockTree.FindBlock(5);
+            Block found = blockTree.FindBlock(5, BlockTreeLookupOptions.None);
             Assert.IsNull(found);
         }
 
@@ -317,6 +320,44 @@ namespace Nethermind.Blockchain.Test
             Assert.AreEqual(2, headers.Length);
             Assert.AreEqual(block0.Hash, headers[0].Hash);
             Assert.Null(headers[1]);
+        }
+        
+        [Test]
+        public void When_finding_headers_does_not_find_a_header_it_breaks_the_loop()
+        {
+            BlockTree blockTree = BuildBlockTree();
+            Block block0 = Build.A.Block.WithNumber(0).TestObject;
+            Block block1 = Build.A.Block.WithNumber(1).WithParent(block0).TestObject;
+            Block block2 = Build.A.Block.WithNumber(2).WithParent(block1).TestObject;
+            AddToMain(blockTree, block0);
+            AddToMain(blockTree, block1);
+            AddToMain(blockTree, block2);
+
+            BlockHeader[] headers = blockTree.FindHeaders(block0.Hash, 100, 0, false);
+            Assert.AreEqual(100, headers.Length);
+            Assert.AreEqual(block0.Hash, headers[0].Hash);
+            Assert.Null(headers[3]);
+            
+            Assert.AreEqual(0, _headersDb.ReadsCount);
+        }
+        
+        [Test]
+        public void When_finding_blocks_does_not_find_a_block_it_breaks_the_loop()
+        {
+            BlockTree blockTree = BuildBlockTree();
+            Block block0 = Build.A.Block.WithNumber(0).TestObject;
+            Block block1 = Build.A.Block.WithNumber(1).WithParent(block0).TestObject;
+            Block block2 = Build.A.Block.WithNumber(2).WithParent(block1).TestObject;
+            AddToMain(blockTree, block0);
+            AddToMain(blockTree, block1);
+            AddToMain(blockTree, block2);
+
+            Block[] headers = blockTree.FindBlocks(block0.Hash, 100, 0, false);
+            Assert.AreEqual(100, headers.Length);
+            Assert.AreEqual(block0.Hash, headers[0].Hash);
+            Assert.Null(headers[3]);
+            
+            Assert.AreEqual(0, _headersDb.ReadsCount);
         }
 
         [Test]
@@ -539,7 +580,7 @@ namespace Nethermind.Blockchain.Test
                 BlockTree testTree = Build.A.BlockTree(genesisBlock).OfChainLength(chainLength).TestObject;
                 for (int i = 0; i < testTree.Head.Number + 1; i++)
                 {
-                    Block ithBlock = testTree.FindBlock(i);
+                    Block ithBlock = testTree.FindBlock(i, BlockTreeLookupOptions.None);
                     blocksDb.Set(ithBlock.Hash, Rlp.Encode(ithBlock).Bytes);
 
                     ChainLevelInfo ithLevel = new ChainLevelInfo(true, new BlockInfo[1] {new BlockInfo(ithBlock.Hash, ithBlock.TotalDifficulty.Value)});
@@ -569,14 +610,14 @@ namespace Nethermind.Blockchain.Test
                 BlockTree testTree = Build.A.BlockTree(genesisBlock).OfChainLength(chainLength).TestObject;
                 for (int i = 0; i < testTree.Head.Number + 1; i++)
                 {
-                    Block ithBlock = testTree.FindBlock(i);
+                    Block ithBlock = testTree.FindBlock(i, BlockTreeLookupOptions.None);
                     blocksDb.Set(ithBlock.Hash, Rlp.Encode(ithBlock).Bytes);
 
                     ChainLevelInfo ithLevel = new ChainLevelInfo(true, new BlockInfo[1] {new BlockInfo(ithBlock.Hash, ithBlock.TotalDifficulty.Value)});
                     blockInfosDb.Set(i, Rlp.Encode(ithLevel).Bytes);
                 }
 
-                blocksDb.Set(Keccak.Zero, Rlp.Encode(testTree.FindBlock(1)).Bytes);
+                blocksDb.Set(Keccak.Zero, Rlp.Encode(testTree.FindBlock(1, BlockTreeLookupOptions.None)).Bytes);
 
                 BlockTree blockTree = new BlockTree(blocksDb, headersDb, blockInfosDb, OlympicSpecProvider.Instance, Substitute.For<ITxPool>(), LimboLogs.Instance);
                 await blockTree.LoadBlocksFromDb(CancellationToken.None);
@@ -1252,5 +1293,9 @@ namespace Nethermind.Blockchain.Test
             new object[] {728000, 0L},
             new object[] {7280000L, 1L}
         };
+
+        private MemDb _blocksInfosDb;
+        private MemDb _headersDb;
+        private MemDb _blocksDb;
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockhashProviderTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockhashProviderTests.cs
@@ -37,7 +37,7 @@ namespace Nethermind.Blockchain.Test
             BlockTree tree = Build.A.BlockTree(genesis).OfHeadersOnly.OfChainLength(chainLength).TestObject;
 
             BlockhashProvider provider = new BlockhashProvider(tree, LimboLogs.Instance);
-            BlockHeader head = tree.FindHeader(chainLength - 1);
+            BlockHeader head = tree.FindHeader(chainLength - 1, BlockTreeLookupOptions.None);
             Block current = Build.A.Block.WithParent(head).TestObject;
             Keccak result = provider.GetBlockhash(current.Header, chainLength - 1);
             Assert.AreEqual(head.Hash, result);
@@ -52,10 +52,10 @@ namespace Nethermind.Blockchain.Test
             BlockTree tree = Build.A.BlockTree(genesis).OfHeadersOnly.OfChainLength(chainLength).TestObject;
 
             BlockhashProvider provider = new BlockhashProvider(tree, LimboLogs.Instance);
-            BlockHeader head = tree.FindHeader(chainLength - 1);
+            BlockHeader head = tree.FindHeader(chainLength - 1, BlockTreeLookupOptions.None);
             Block current = Build.A.Block.WithParent(head).TestObject;
             Keccak result = provider.GetBlockhash(current.Header, chainLength - 256);
-            Assert.AreEqual(tree.FindHeader(256).Hash, result);
+            Assert.AreEqual(tree.FindHeader(256, BlockTreeLookupOptions.None).Hash, result);
         }
 
         [Test]
@@ -123,7 +123,7 @@ namespace Nethermind.Blockchain.Test
             BlockTree tree = Build.A.BlockTree(genesis).OfChainLength(chainLength).TestObject;
 
             BlockhashProvider provider = new BlockhashProvider(tree, LimboLogs.Instance);
-            BlockHeader head = tree.FindHeader(chainLength - 1);
+            BlockHeader head = tree.FindHeader(chainLength - 1, BlockTreeLookupOptions.None);
             Block current = Build.A.Block.WithParent(head).TestObject;
             Keccak result = provider.GetBlockhash(current.Header, chainLength - 1);
             Assert.AreEqual(head.Hash, result);
@@ -138,7 +138,7 @@ namespace Nethermind.Blockchain.Test
             BlockTree tree = Build.A.BlockTree(genesis).OfChainLength(chainLength).TestObject;
 
             BlockhashProvider provider = new BlockhashProvider(tree, LimboLogs.Instance);
-            BlockHeader head = tree.FindHeader(chainLength - 1);
+            BlockHeader head = tree.FindHeader(chainLength - 1, BlockTreeLookupOptions.None);
             Block current = Build.A.Block.WithParent(head).TestObject;
             Keccak result = provider.GetBlockhash(current.Header, chainLength);
             Assert.Null(result);
@@ -153,7 +153,7 @@ namespace Nethermind.Blockchain.Test
             BlockTree tree = Build.A.BlockTree(genesis).OfChainLength(chainLength).TestObject;
 
             BlockhashProvider provider = new BlockhashProvider(tree, LimboLogs.Instance);
-            BlockHeader head = tree.FindHeader(chainLength - 1);
+            BlockHeader head = tree.FindHeader(chainLength - 1, BlockTreeLookupOptions.None);
             Block current = Build.A.Block.WithParent(head).TestObject;
             Keccak result = provider.GetBlockhash(current.Header, chainLength + 1);
             Assert.Null(result);
@@ -168,10 +168,10 @@ namespace Nethermind.Blockchain.Test
             BlockTree tree = Build.A.BlockTree(genesis).OfChainLength(chainLength).TestObject;
 
             BlockhashProvider provider = new BlockhashProvider(tree, LimboLogs.Instance);
-            BlockHeader head = tree.FindHeader(chainLength - 1);
+            BlockHeader head = tree.FindHeader(chainLength - 1, BlockTreeLookupOptions.None);
             Block current = Build.A.Block.WithParent(head).TestObject;
             Keccak result = provider.GetBlockhash(current.Header, chainLength - 256);
-            Assert.AreEqual(tree.FindHeader(256).Hash, result);
+            Assert.AreEqual(tree.FindHeader(256, BlockTreeLookupOptions.None).Hash, result);
         }
 
         [Test]
@@ -183,7 +183,7 @@ namespace Nethermind.Blockchain.Test
             BlockTree tree = Build.A.BlockTree(genesis).OfChainLength(chainLength).TestObject;
 
             BlockhashProvider provider = new BlockhashProvider(tree, LimboLogs.Instance);
-            BlockHeader head = tree.FindHeader(chainLength - 1);
+            BlockHeader head = tree.FindHeader(chainLength - 1, BlockTreeLookupOptions.None);
             Block current = Build.A.Block.WithParent(head).TestObject;
             Keccak result = provider.GetBlockhash(current.Header, chainLength - 257);
             Assert.Null(result);
@@ -198,7 +198,7 @@ namespace Nethermind.Blockchain.Test
             BlockTree tree = Build.A.BlockTree(genesis).OfChainLength(chainLength).TestObject;
 
             BlockhashProvider provider = new BlockhashProvider(tree, LimboLogs.Instance);
-            BlockHeader head = tree.FindHeader(chainLength - 1);
+            BlockHeader head = tree.FindHeader(chainLength - 1, BlockTreeLookupOptions.None);
             Block current = Build.A.Block.WithParent(head).TestObject;
             Keccak result = provider.GetBlockhash(current.Header, 127);
             Assert.AreEqual(head.Hash, result);

--- a/src/Nethermind/Nethermind.Blockchain.Test/IntegrationTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/IntegrationTests.cs
@@ -134,7 +134,7 @@ namespace Nethermind.Blockchain.Test
             int totalTx = 0;
             for (int i = 0; i < 6; i++)
             {
-                Block block = blockTree.FindBlock(i);
+                Block block = blockTree.FindBlock(i, BlockTreeLookupOptions.None);
                 logger.Info($"Block {i} with {block.Transactions.Length} txs");
 
                 ManualResetEventSlim blockProcessedEvent = new ManualResetEventSlim(false);

--- a/src/Nethermind/Nethermind.Blockchain.Test/Synchronization/FastBlocks/FastBlocksFeedTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Synchronization/FastBlocks/FastBlocksFeedTests.cs
@@ -931,7 +931,7 @@ namespace Nethermind.Blockchain.Test.Synchronization.FastBlocks
                     TestContext.WriteLine($"{_time,6} | SYNC PEER {syncPeer.Node:s} WILL SEND SHIFTED MESSAGES ({startNumber} INSTEAD OF {headersSyncBatch.StartNumber})");
                 }
 
-                Keccak hash = tree.FindHeader(startNumber)?.Hash;
+                Keccak hash = tree.FindHash(startNumber);
 
                 if (hash == null)
                 {

--- a/src/Nethermind/Nethermind.Blockchain.Test/Synchronization/FastBlocks/FastBlocksFeedTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Synchronization/FastBlocks/FastBlocksFeedTests.cs
@@ -153,7 +153,7 @@ namespace Nethermind.Blockchain.Test.Synchronization.FastBlocks
             _localBlockTree = new BlockTree(new MemDb(), new MemDb(), new MemDb(), MainNetSpecProvider.Instance, NullTxPool.Instance, _syncConfig, LimboLogs.Instance);
             for (int i = 0; i < length; i++)
             {
-                _localBlockTree.SuggestBlock(_validTree2048.FindBlock(i));
+                _localBlockTree.SuggestBlock(_validTree2048.FindBlock(i, BlockTreeLookupOptions.None));
             }
         }
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/Synchronization/OldStyleFullSynchronizerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Synchronization/OldStyleFullSynchronizerTests.cs
@@ -341,8 +341,8 @@ namespace Nethermind.Blockchain.Test.Synchronization
         public void Can_retrieve_empty_receipts()
         {
             _blockTree = Build.A.BlockTree(_genesisBlock).OfChainLength(2).TestObject;
-            Block block0 = _blockTree.FindBlock(0);
-            Block block1 = _blockTree.FindBlock(1);
+            Block block0 = _blockTree.FindBlock(0, BlockTreeLookupOptions.None);
+            Block block1 = _blockTree.FindBlock(1, BlockTreeLookupOptions.None);
 
             TxReceipt[][] txReceipts = _syncServer.GetReceipts(new[] {block0.Hash, block1.Hash, TestItem.KeccakA});
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/Synchronization/SyncPeerMock.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Synchronization/SyncPeerMock.cs
@@ -103,7 +103,7 @@ namespace Nethermind.Blockchain.Test.Synchronization
             
             for (int i = 0; i < maxBlocks; i++)
             {
-                result[i] = _remoteTree.FindHeader(firstNumber.Value + i + skip);
+                result[i] = _remoteTree.FindHeader(firstNumber.Value + i + skip, BlockTreeLookupOptions.RequireCanonical);
             }
             
             return Task.FromResult(result);
@@ -112,7 +112,7 @@ namespace Nethermind.Blockchain.Test.Synchronization
         public Task<BlockHeader[]> GetBlockHeaders(long number, int maxBlocks, int skip, CancellationToken token)
         {
             BlockHeader[] result = new BlockHeader[maxBlocks];
-            long? firstNumber = _remoteTree.FindHeader(number)?.Number;
+            long? firstNumber = _remoteTree.FindHeader(number, BlockTreeLookupOptions.RequireCanonical)?.Number;
             if (!firstNumber.HasValue)
             {
                 return Task.FromResult(result);

--- a/src/Nethermind/Nethermind.Blockchain.Test/Synchronization/SyncPeerMock.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Synchronization/SyncPeerMock.cs
@@ -127,7 +127,7 @@ namespace Nethermind.Blockchain.Test.Synchronization
                 }
                 else
                 {
-                    result[i] = _remoteTree.FindBlock(blockNumber).Header;
+                    result[i] = _remoteTree.FindBlock(blockNumber, BlockTreeLookupOptions.None).Header;
                 }
             }
             

--- a/src/Nethermind/Nethermind.Blockchain.Test/Synchronization/SyncServerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Synchronization/SyncServerTests.cs
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2018 Demerzel Solutions Limited
+ * This file is part of the Nethermind library.
+ *
+ * The Nethermind library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Nethermind library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+using Nethermind.Blockchain.Receipts;
+using Nethermind.Blockchain.Synchronization;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Logging;
+using Nethermind.Store;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Blockchain.Test.Synchronization
+{
+    [TestFixture]
+    public class SyncServerTests
+    {
+        private IBlockTree _blockTree;
+        private IEthSyncPeerPool _peerPool;
+        private ISynchronizer _synchronizer;
+        private SyncServer _syncServer;
+
+        [SetUp]
+        public void Setup()
+        {
+            _blockTree = Substitute.For<IBlockTree>();
+            _peerPool = Substitute.For<IEthSyncPeerPool>();
+            _synchronizer = Substitute.For<ISynchronizer>();
+            _syncServer = new SyncServer(new StateDb(), new StateDb(), _blockTree, NullReceiptStorage.Instance, TestSealValidator.AlwaysValid, _peerPool, _synchronizer, new SyncConfig(), LimboLogs.Instance);
+        }
+        
+        [Test]
+        public void _When_finding_hash_it_does_not_load_headers()
+        {
+            _blockTree.FindHash(123).Returns(TestItem.KeccakA);
+            Keccak result = _syncServer.FindHash(123);
+
+            _blockTree.DidNotReceive().FindHeader(Arg.Any<long>(), Arg.Any<BlockTreeLookupOptions>());
+            _blockTree.DidNotReceive().FindHeader(Arg.Any<Keccak>(), Arg.Any<BlockTreeLookupOptions>());
+            _blockTree.DidNotReceive().FindBlock(Arg.Any<Keccak>(), Arg.Any<BlockTreeLookupOptions>());
+            Assert.AreEqual(TestItem.KeccakA, result);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -668,33 +668,12 @@ namespace Nethermind.Blockchain
             return GetBlockHashOnMainOrOnlyHash(number);
         }
 
-        public Block[] FindBlocks(Keccak blockHash, int numberOfBlocks, int skip, bool reverse)
-        {
-            if (blockHash == null) throw new ArgumentNullException(nameof(blockHash));
-
-            Block[] result = new Block[numberOfBlocks];
-            Block startBlock = FindBlock(blockHash, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
-            if (startBlock == null)
-            {
-                return result;
-            }
-
-            for (int i = 0; i < numberOfBlocks; i++)
-            {
-                int blockNumber = (int) startBlock.Number + (reverse ? -1 : 1) * (i + i * skip);
-                Block ithBlock = FindBlock(blockNumber, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
-                result[i] = ithBlock;
-            }
-
-            return result;
-        }
-
         public BlockHeader[] FindHeaders(Keccak blockHash, int numberOfBlocks, int skip, bool reverse)
         {
             if (blockHash == null) throw new ArgumentNullException(nameof(blockHash));
 
             BlockHeader[] result = new BlockHeader[numberOfBlocks];
-            BlockHeader startBlock = FindHeader(blockHash, BlockTreeLookupOptions.TotalDifficultyNotNeeded | BlockTreeLookupOptions.RequireCanonical);
+            BlockHeader startBlock = FindHeader(blockHash, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
             if (startBlock == null)
             {
                 return result;
@@ -713,7 +692,7 @@ namespace Nethermind.Blockchain
                     break;
                 }
 
-                current = FindHeader(nextNumber, BlockTreeLookupOptions.TotalDifficultyNotNeeded | BlockTreeLookupOptions.RequireCanonical);
+                current = FindHeader(nextNumber, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
             } while (current != null && responseIndex < numberOfBlocks);
 
             return result;

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -671,13 +671,23 @@ namespace Nethermind.Blockchain
         public BlockHeader[] FindHeaders(Keccak blockHash, int numberOfBlocks, int skip, bool reverse)
         {
             if (blockHash == null) throw new ArgumentNullException(nameof(blockHash));
+            if (numberOfBlocks == 0)
+            {
+                return Array.Empty<BlockHeader>();
+            }
 
+            BlockHeader startHeader = FindHeader(blockHash, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
+            if (startHeader == null)
+            {
+                return new BlockHeader[numberOfBlocks];
+            }
+            
             if (skip == 0)
             {
                 /* if we do not skip and we have the last block then we can assume that all the blocks are there
                    and we can use the fact that we can use parent hash and that searching by hash is much faster
                    as it does not require the step of resolving number -> hash */
-                BlockHeader endHeader = FindHeader(blockHash, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
+                BlockHeader endHeader = FindHeader(startHeader.Number + numberOfBlocks - 1, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
                 if (endHeader != null)
                 {
                     return FindHeadersReversedFull(endHeader, numberOfBlocks);
@@ -685,12 +695,6 @@ namespace Nethermind.Blockchain
             }
 
             BlockHeader[] result = new BlockHeader[numberOfBlocks];
-            BlockHeader startHeader = FindHeader(blockHash, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
-            if (startHeader == null)
-            {
-                return result;
-            }
-
             BlockHeader current = startHeader;
             int directionMultiplier = reverse ? -1 : 1;
             int responseIndex = 0;

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -681,7 +681,12 @@ namespace Nethermind.Blockchain
             {
                 return new BlockHeader[numberOfBlocks];
             }
-            
+
+            if (numberOfBlocks == 1)
+            {
+                return new[] {startHeader};
+            }
+
             if (skip == 0)
             {
                 /* if we do not skip and we have the last block then we can assume that all the blocks are there
@@ -713,22 +718,27 @@ namespace Nethermind.Blockchain
 
             return result;
         }
-        
+
         private BlockHeader[] FindHeadersReversedFull(BlockHeader startHeader, int numberOfBlocks)
         {
             if (startHeader == null) throw new ArgumentNullException(nameof(startHeader));
+            if (numberOfBlocks == 1)
+            {
+                return new[] {startHeader};
+            }
+
             BlockHeader[] result = new BlockHeader[numberOfBlocks];
-            
+
             BlockHeader current = startHeader;
             int responseIndex = numberOfBlocks - 1;
             do
             {
                 result[responseIndex] = current;
                 responseIndex--;
-                
+
                 current = FindHeader(current.ParentHash, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
             } while (current != null && responseIndex < numberOfBlocks);
-            
+
             return result;
         }
 
@@ -1217,7 +1227,7 @@ namespace Nethermind.Blockchain
                 throw new InvalidOperationException(
                     $"Not able to retrieve block number for an unknown block {blockHash}");
             }
-            
+
             return header.Number;
         }
 

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -1207,21 +1207,13 @@ namespace Nethermind.Blockchain
 
         private long LoadNumberOnly(Keccak blockHash)
         {
-            BlockHeader header = _headerCache.Get(blockHash);
-            if (header != null)
-            {
-                return header.Number;
-            }
-
-            byte[] headerData = _headerDb.Get(blockHash);
-            if (headerData == null)
+            BlockHeader header = FindHeader(blockHash, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
+            if (header == null)
             {
                 throw new InvalidOperationException(
                     $"Not able to retrieve block number for an unknown block {blockHash}");
             }
-
-            header = _headerDecoder.Decode(headerData.AsRlpValueContext(), RlpBehaviors.AllowExtraData);
-            _headerCache.Set(blockHash, header);
+            
             return header.Number;
         }
 

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -739,7 +739,11 @@ namespace Nethermind.Blockchain
             {
                 result[responseIndex] = current;
                 responseIndex--;
-
+                if (responseIndex < 0)
+                {
+                    break;
+                }
+                
                 current = FindHeader(current.ParentHash, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
             } while (current != null && responseIndex < numberOfBlocks);
 

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -670,10 +670,14 @@ namespace Nethermind.Blockchain
 
         public BlockHeader[] FindHeaders(Keccak blockHash, int numberOfBlocks, int skip, bool reverse)
         {
-            if (blockHash == null) throw new ArgumentNullException(nameof(blockHash));
             if (numberOfBlocks == 0)
             {
                 return Array.Empty<BlockHeader>();
+            }
+            
+            if (blockHash == null)
+            {
+                return new BlockHeader[numberOfBlocks]; 
             }
 
             BlockHeader startHeader = FindHeader(blockHash, BlockTreeLookupOptions.TotalDifficultyNotNeeded);

--- a/src/Nethermind/Nethermind.Blockchain/BlockTreeLookupOptions.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTreeLookupOptions.cs
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2018 Demerzel Solutions Limited
+ * This file is part of the Nethermind library.
+ *
+ * The Nethermind library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Nethermind library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+using System;
+
+namespace Nethermind.Blockchain
+{
+    /// <summary>
+    /// This class has been introduced for performance reasons only (in order to minimize expensive DB lookups where not necessary).
+    /// </summary>
+    [Flags]
+    public enum BlockTreeLookupOptions
+    {
+        None = 0,
+        TotalDifficultyNotNeeded = 1,
+        RequireCanonical = 2,
+        All = 3
+    }
+}

--- a/src/Nethermind/Nethermind.Blockchain/BlockhashProvider.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockhashProvider.cs
@@ -60,7 +60,7 @@ namespace Nethermind.Blockchain
                 {
                     try
                     {
-                        header = _blockTree.FindHeader(number);
+                        header = _blockTree.FindHeader(number, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
                     }
                     catch (InvalidOperationException) // fast sync during the first 256 blocks after the transition
                     {

--- a/src/Nethermind/Nethermind.Blockchain/IBlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/IBlockTree.cs
@@ -141,9 +141,7 @@ namespace Nethermind.Blockchain
         BlockHeader FindHeader(long blockNumber, BlockTreeLookupOptions options);
         
         Keccak FindHash(long blockNumber);
-        
-        Block[] FindBlocks(Keccak blockHash, int numberOfBlocks, int skip, bool reverse);
-        
+
         BlockHeader[] FindHeaders(Keccak hash, int numberOfBlocks, int skip, bool reverse);
         
         void DeleteInvalidBlock(Block invalidBlock);

--- a/src/Nethermind/Nethermind.Blockchain/IBlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/IBlockTree.cs
@@ -138,7 +138,9 @@ namespace Nethermind.Blockchain
         
         Block FindBlock(long blockNumber);
 
-        BlockHeader FindHeader(long blockNumber);
+        BlockHeader FindHeader(long blockNumber, BlockTreeLookupOptions options);
+        
+        Keccak FindHash(long blockNumber);
         
         Block[] FindBlocks(Keccak blockHash, int numberOfBlocks, int skip, bool reverse);
         

--- a/src/Nethermind/Nethermind.Blockchain/IBlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/IBlockTree.cs
@@ -136,7 +136,7 @@ namespace Nethermind.Blockchain
         
         BlockHeader FindHeader(Keccak blockHash, BlockTreeLookupOptions options);
         
-        Block FindBlock(long blockNumber);
+        Block FindBlock(long blockNumber, BlockTreeLookupOptions options);
 
         BlockHeader FindHeader(long blockNumber, BlockTreeLookupOptions options);
         

--- a/src/Nethermind/Nethermind.Blockchain/ReadOnlyBlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/ReadOnlyBlockTree.cs
@@ -104,9 +104,9 @@ namespace Nethermind.Blockchain
             return _wrapped.FindHeaders(hash, numberOfBlocks, skip, reverse);
         }
 
-        public Block FindBlock(long blockNumber)
+        public Block FindBlock(long blockNumber, BlockTreeLookupOptions options)
         {
-            return _wrapped.FindBlock(blockNumber);
+            return _wrapped.FindBlock(blockNumber, options);
         }
 
         public void DeleteInvalidBlock(Block invalidBlock)

--- a/src/Nethermind/Nethermind.Blockchain/ReadOnlyBlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/ReadOnlyBlockTree.cs
@@ -93,12 +93,7 @@ namespace Nethermind.Blockchain
         {
             return _wrapped.FindHash(blockNumber);
         }
-
-        public Block[] FindBlocks(Keccak blockHash, int numberOfBlocks, int skip, bool reverse)
-        {
-            return _wrapped.FindBlocks(blockHash, numberOfBlocks, skip, reverse);
-        }
-
+        
         public BlockHeader[] FindHeaders(Keccak hash, int numberOfBlocks, int skip, bool reverse)
         {
             return _wrapped.FindHeaders(hash, numberOfBlocks, skip, reverse);

--- a/src/Nethermind/Nethermind.Blockchain/ReadOnlyBlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/ReadOnlyBlockTree.cs
@@ -84,9 +84,14 @@ namespace Nethermind.Blockchain
             return _wrapped.FindHeader(blockHash, options);
         }
 
-        public BlockHeader FindHeader(long blockNumber)
+        public BlockHeader FindHeader(long blockNumber, BlockTreeLookupOptions options)
         {
-            return _wrapped.FindHeader(blockNumber);
+            return _wrapped.FindHeader(blockNumber, options);
+        }
+
+        public Keccak FindHash(long blockNumber)
+        {
+            return _wrapped.FindHash(blockNumber);
         }
 
         public Block[] FindBlocks(Keccak blockHash, int numberOfBlocks, int skip, bool reverse)

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/BlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/BlockDownloader.cs
@@ -145,9 +145,6 @@ namespace Nethermind.Blockchain.Synchronization
             return headersSynced;
         }
 
-        public static int emptyRequested = 0;
-        public static int allRequested = 0;
-
         public async Task<long> DownloadBlocks(PeerInfo bestPeer, int newBlocksToSkip, CancellationToken cancellation, bool shouldProcess = true)
         {
             if (bestPeer == null)

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/BlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/BlockDownloader.cs
@@ -40,7 +40,7 @@ namespace Nethermind.Blockchain.Synchronization
         private readonly ISealValidator _sealValidator;
         private readonly ISyncReport _syncReport;
         private readonly ILogger _logger;
-        
+
         private SyncBatchSize _syncBatchSize;
         private int _sinceLastTimeout;
 
@@ -121,7 +121,7 @@ namespace Nethermind.Blockchain.Synchronization
                     }
 
                     if (_logger.IsTrace) _logger.Trace($"Received {currentHeader} from {bestPeer:s}");
-                    bool isValid = i > 1 ? _blockValidator.ValidateHeader(currentHeader, headers[i - 1], false) : _blockValidator.ValidateHeader(currentHeader, false); 
+                    bool isValid = i > 1 ? _blockValidator.ValidateHeader(currentHeader, headers[i - 1], false) : _blockValidator.ValidateHeader(currentHeader, false);
                     if (!isValid)
                     {
                         throw new EthSynchronizationException($"{bestPeer} sent a block {currentHeader.ToString(BlockHeader.Format.Short)} with an invalid header");
@@ -144,6 +144,9 @@ namespace Nethermind.Blockchain.Synchronization
 
             return headersSynced;
         }
+
+        public static int emptyRequested = 0;
+        public static int allRequested = 0;
 
         public async Task<long> DownloadBlocks(PeerInfo bestPeer, int newBlocksToSkip, CancellationToken cancellation, bool shouldProcess = true)
         {
@@ -176,9 +179,11 @@ namespace Nethermind.Blockchain.Synchronization
 
                 if (_logger.IsTrace) _logger.Trace($"Full sync request {currentNumber}+{blocksToRequest} to peer {bestPeer} with {bestPeer.HeadNumber} blocks. Got {currentNumber} and asking for {blocksToRequest} more.");
                 var headers = await RequestHeaders(bestPeer, cancellation, currentNumber, blocksToRequest);
+                Block[] blocks = new Block[headers.Length - 1];
 
                 List<Keccak> hashes = new List<Keccak>();
-                Dictionary<Keccak, BlockHeader> headersByHash = new Dictionary<Keccak, BlockHeader>();
+                Dictionary<int, int> indexMapping = new Dictionary<int, int>();
+                int currentBodyIndex = 0;
                 for (int i = 1; i < headers.Length; i++)
                 {
                     if (headers[i] == null)
@@ -186,11 +191,20 @@ namespace Nethermind.Blockchain.Synchronization
                         break;
                     }
 
-                    hashes.Add(headers[i].Hash);
-                    headersByHash[headers[i].Hash] = headers[i];
+                    if (headers[i].HasBody)
+                    {
+                        blocks[i - 1] = new Block(headers[i], (BlockBody) null);
+                        indexMapping.Add(currentBodyIndex, i - 1);
+                        currentBodyIndex++;
+                        hashes.Add(headers[i].Hash);
+                    }
+                    else
+                    {
+                        blocks[i - 1] = new Block(headers[i], BlockBody.Empty);
+                    }
                 }
-
-                Task<BlockBody[]> bodiesTask = bestPeer.SyncPeer.GetBlocks(hashes.ToArray(), cancellation);
+                
+                Task<BlockBody[]> bodiesTask = hashes.Count == 0 ? Task.FromResult(new BlockBody[0]) : bestPeer.SyncPeer.GetBlocks(hashes.ToArray(), cancellation);
                 await bodiesTask.ContinueWith(t =>
                 {
                     if (t.IsFaulted)
@@ -218,7 +232,6 @@ namespace Nethermind.Blockchain.Synchronization
                 }
 
                 BlockBody[] bodies = bodiesTask.Result;
-                Block[] blocks = new Block[bodies.Length];
                 for (int i = 0; i < bodies.Length; i++)
                 {
                     BlockBody body = bodies[i];
@@ -227,8 +240,14 @@ namespace Nethermind.Blockchain.Synchronization
                         // TODO: this is how it used to be... I do not want to touch it without extensive testing 
                         throw new EthSynchronizationException($"{bestPeer} sent an empty body for {blocks[i].ToString(Block.Format.Short)}.");
                     }
-                    
-                    blocks[i] = new Block(null, body);
+
+                    Block block = blocks[indexMapping[i]];
+                    if (block == null || block.Body != null)
+                    {
+                        throw new InvalidOperationException("Invalid state of blocks placeholders during sync");
+                    }
+
+                    blocks[indexMapping[i]].Body = body;
                 }
 
                 _sinceLastTimeout++;
@@ -237,12 +256,20 @@ namespace Nethermind.Blockchain.Synchronization
                     _syncBatchSize.Expand();
                 }
 
+                int fullDataBlocksCount = 0;
                 for (int i = 0; i < blocks.Length; i++)
                 {
-                    blocks[i].Header = headersByHash[hashes[i]];
+                    if (blocks[i]?.Body != null)
+                    {
+                        fullDataBlocksCount++;
+                    }
+                    else
+                    {
+                        break;
+                    }
                 }
 
-                if (blocks.Length > 0)
+                if (fullDataBlocksCount > 0)
                 {
                     bool parentIsKnown = _blockTree.IsKnownBlock(blocks[0].Number - 1, blocks[0].ParentHash);
                     if (!parentIsKnown)
@@ -253,7 +280,7 @@ namespace Nethermind.Blockchain.Synchronization
                     }
                 }
 
-                for (int i = 0; i < blocks.Length; i++)
+                for (int i = 0; i < fullDataBlocksCount; i++)
                 {
                     if (cancellation.IsCancellationRequested)
                     {
@@ -396,6 +423,7 @@ namespace Nethermind.Blockchain.Synchronization
                         throw new EthSynchronizationException(message);
                     }
                 }
+
                 case AddBlockResult.CannotAccept:
                     throw new EthSynchronizationException("Block tree rejected block/header");
                 case AddBlockResult.InvalidBlock:

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/FastBlocks/FastBlocksFeed.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/FastBlocks/FastBlocksFeed.cs
@@ -708,7 +708,7 @@ namespace Nethermind.Blockchain.Synchronization.FastBlocks
             _startNumber = lowestInserted?.Number ?? _pivotNumber;
             _startBodyHash = lowestInsertedBody?.Hash ?? _pivotHash;
             _startHeaderHash = lowestInserted?.Hash ?? _pivotHash;
-            _startReceiptsHash = _blockTree.FindBlock(_receiptStorage.LowestInsertedReceiptBlock ?? long.MaxValue)?.Hash ?? _pivotHash;
+            _startReceiptsHash = _blockTree.FindHash(_receiptStorage.LowestInsertedReceiptBlock ?? long.MaxValue) ?? _pivotHash;
             _startTotalDifficulty = lowestInserted?.TotalDifficulty ?? _pivotDifficulty;
 
             _nextHeaderHash = _startHeaderHash;

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncServer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncServer.cs
@@ -16,10 +16,8 @@
  * along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
  */
 
-using System;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
-using Nethermind.Dirichlet.Numerics;
 using Nethermind.Stats.Model;
 
 namespace Nethermind.Blockchain.Synchronization
@@ -31,7 +29,6 @@ namespace Nethermind.Blockchain.Synchronization
         TxReceipt[][] GetReceipts(Keccak[] blockHashes);
         Block Find(Keccak hash);
         Keccak FindHash(long number);
-        Block[] FindBlocks(Keccak hash, int numberOfBlocks, int skip, bool reverse);
         BlockHeader[] FindHeaders(Keccak hash, int numberOfBlocks, int skip, bool reverse);
         byte[][] GetNodeData(Keccak[] keys);
         int GetPeerCount();

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncServer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncServer.cs
@@ -30,7 +30,7 @@ namespace Nethermind.Blockchain.Synchronization
         void AddNewBlock(Block block, Node node);
         TxReceipt[][] GetReceipts(Keccak[] blockHashes);
         Block Find(Keccak hash);
-        BlockHeader FindHeader(long number);
+        Keccak FindHash(long number);
         Block[] FindBlocks(Keccak hash, int numberOfBlocks, int skip, bool reverse);
         BlockHeader[] FindHeaders(Keccak hash, int numberOfBlocks, int skip, bool reverse);
         byte[][] GetNodeData(Keccak[] keys);

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncServer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncServer.cs
@@ -17,7 +17,6 @@
  */
 
 using System;
-using System.Threading.Tasks;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
@@ -221,9 +220,9 @@ namespace Nethermind.Blockchain.Synchronization
             return _blockTree.FindBlock(hash, BlockTreeLookupOptions.None);
         }
 
-        public BlockHeader FindHeader(long number)
+        public Keccak FindHash(long number)
         {
-            return _blockTree.FindHeader(number);
+            return _blockTree.FindHash(number);
         }
 
         public Block[] FindBlocks(Keccak hash, int numberOfBlocks, int skip, bool reverse)

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncServer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncServer.cs
@@ -225,11 +225,6 @@ namespace Nethermind.Blockchain.Synchronization
             return _blockTree.FindHash(number);
         }
 
-        public Block[] FindBlocks(Keccak hash, int numberOfBlocks, int skip, bool reverse)
-        {
-            return _blockTree.FindBlocks(hash, numberOfBlocks, skip, reverse);
-        }
-
         [Todo(Improve.Refactor, "This may not be desired if the other node is just syncing now too")]
         private void OnNewHeadBlock(object sender, BlockEventArgs blockEventArgs)
         {

--- a/src/Nethermind/Nethermind.Blockchain/Tracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracer.cs
@@ -64,7 +64,7 @@ namespace Nethermind.Blockchain
                 return null;
             }
             
-            Block block = _blockTree.FindBlock(txReceipt.BlockNumber);
+            Block block = _blockTree.FindBlock(txReceipt.BlockNumber, BlockTreeLookupOptions.RequireCanonical);
             if (block == null)
             {
                 return null;
@@ -75,7 +75,7 @@ namespace Nethermind.Blockchain
 
         public GethLikeTxTrace Trace(long blockNumber, int txIndex, GethTraceOptions options)
         {
-            Block block = _blockTree.FindBlock(blockNumber);
+            Block block = _blockTree.FindBlock(blockNumber, BlockTreeLookupOptions.RequireCanonical);
             if (block == null) throw new InvalidOperationException("Only historical blocks");
 
             if (txIndex > block.Transactions.Length - 1) throw new InvalidOperationException($"Block {blockNumber} has only {block.Transactions.Length} transactions and the requested tx index was {txIndex}");
@@ -85,7 +85,7 @@ namespace Nethermind.Blockchain
 
         public GethLikeTxTrace Trace(long blockNumber, Transaction tx, GethTraceOptions options)
         {
-            Block block = _blockTree.FindBlock(blockNumber);
+            Block block = _blockTree.FindBlock(blockNumber, BlockTreeLookupOptions.RequireCanonical);
             if (block == null) throw new InvalidOperationException("Only historical blocks");
             block.Body = new BlockBody(new[] {tx}, new BlockHeader[]{});
             GethLikeBlockTracer blockTracer = new GethLikeBlockTracer(tx.Hash, options);
@@ -101,7 +101,7 @@ namespace Nethermind.Blockchain
 
         public GethLikeTxTrace[] TraceBlock(long blockNumber, GethTraceOptions options)
         {
-            Block block = _blockTree.FindBlock(blockNumber);
+            Block block = _blockTree.FindBlock(blockNumber, BlockTreeLookupOptions.RequireCanonical);
             return TraceBlock(block, options);
         }
         
@@ -125,7 +125,7 @@ namespace Nethermind.Blockchain
             }
             
             TxReceipt txReceipt = _receiptStorage.Find(txHash);
-            Block block = _blockTree.FindBlock(txReceipt.BlockNumber);
+            Block block = _blockTree.FindBlock(txReceipt.BlockNumber, BlockTreeLookupOptions.RequireCanonical);
             if (block == null) throw new InvalidOperationException("Only historical blocks");
 
             return ParityTrace(block, txHash, traceTypes);
@@ -133,7 +133,7 @@ namespace Nethermind.Blockchain
 
         public ParityLikeTxTrace[] ParityTraceBlock(long blockNumber, ParityTraceTypes traceTypes)
         {
-            Block block = _blockTree.FindBlock(blockNumber);
+            Block block = _blockTree.FindBlock(blockNumber, BlockTreeLookupOptions.RequireCanonical);
             bool loadedFromDb = true;
             
             List<ParityLikeTxTrace> result = new List<ParityLikeTxTrace>();

--- a/src/Nethermind/Nethermind.Clique.Test/CliqueBlockProducerTests.cs
+++ b/src/Nethermind/Nethermind.Clique.Test/CliqueBlockProducerTests.cs
@@ -289,7 +289,7 @@ namespace Nethermind.Clique.Test
             public On AssertHeadBlockTimestamp(PrivateKey nodeKey)
             {
                 if (_logger.IsInfo) _logger.Info($"ASSERTING HEAD BLOCK TIMESTAMP ON {nodeKey.Address}");
-                Assert.LessOrEqual(_blockTrees[nodeKey].FindBlock(_blockTrees[nodeKey].Head.Number - 1).Timestamp + _cliqueConfig.BlockPeriod, _blockTrees[nodeKey].Head.Timestamp + 1);
+                Assert.LessOrEqual(_blockTrees[nodeKey].FindBlock(_blockTrees[nodeKey].Head.Number - 1, BlockTreeLookupOptions.None).Timestamp + _cliqueConfig.BlockPeriod, _blockTrees[nodeKey].Head.Timestamp + 1);
                 return this;
             }
 
@@ -297,8 +297,8 @@ namespace Nethermind.Clique.Test
             {
                 WaitForNumber(nodeKey, number);
                 if (_logger.IsInfo) _logger.Info($"ASSERTING {vote} VOTE ON {address} AT BLOCK {number}");
-                Assert.AreEqual(vote ? Clique.NonceAuthVote : Clique.NonceDropVote, _blockTrees[nodeKey].FindBlock(number).Header.Nonce, nodeKey + " vote nonce");
-                Assert.AreEqual(address, _blockTrees[nodeKey].FindBlock(number).Beneficiary, nodeKey.Address + " vote nonce");
+                Assert.AreEqual(vote ? Clique.NonceAuthVote : Clique.NonceDropVote, _blockTrees[nodeKey].FindBlock(number, BlockTreeLookupOptions.None).Header.Nonce, nodeKey + " vote nonce");
+                Assert.AreEqual(address, _blockTrees[nodeKey].FindBlock(number, BlockTreeLookupOptions.None).Beneficiary, nodeKey.Address + " vote nonce");
                 return this;
             }
 
@@ -306,7 +306,7 @@ namespace Nethermind.Clique.Test
             {
                 WaitForNumber(nodeKey, number);
                 if (_logger.IsInfo) _logger.Info($"ASSERTING {count} SIGNERS AT BLOCK {number}");
-                var header = _blockTrees[nodeKey].FindBlock(number).Header;
+                var header = _blockTrees[nodeKey].FindBlock(number, BlockTreeLookupOptions.None).Header;
                 Assert.AreEqual(count, _snapshotManager[nodeKey].GetOrCreateSnapshot(header.Number, header.Hash).Signers.Count, nodeKey + " signers count");
                 return this;
             }
@@ -316,7 +316,7 @@ namespace Nethermind.Clique.Test
             {
                 WaitForNumber(nodeKey, number);
                 if (_logger.IsInfo) _logger.Info($"ASSERTING EMPTY TALLY FOR {privateKeyB.Address} EMPTY AT {number}");
-                var header = _blockTrees[nodeKey].FindBlock(number).Header;
+                var header = _blockTrees[nodeKey].FindBlock(number, BlockTreeLookupOptions.None).Header;
                 Assert.AreEqual(false, _snapshotManager[nodeKey].GetOrCreateSnapshot(header.Number, header.Hash).Tally.ContainsKey(privateKeyB.Address), nodeKey + " tally empty");
                 return this;
             }
@@ -355,7 +355,7 @@ namespace Nethermind.Clique.Test
 
             public Block GetBlock(PrivateKey privateKey, long number)
             {
-                Block block = _blockTrees[privateKey].FindBlock(number);
+                Block block = _blockTrees[privateKey].FindBlock(number, BlockTreeLookupOptions.None);
                 if (block == null)
                 {
                     throw new InvalidOperationException($"Cannot find block {number}");

--- a/src/Nethermind/Nethermind.Clique/CliqueBridge.cs
+++ b/src/Nethermind/Nethermind.Clique/CliqueBridge.cs
@@ -93,7 +93,7 @@ namespace Nethermind.Clique
 
         public Address[] GetSigners(long number)
         {
-            BlockHeader header = _blockTree.FindHeader(number);
+            BlockHeader header = _blockTree.FindHeader(number, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
             return _snapshotManager.GetOrCreateSnapshot(header.Number, header.Hash).Signers.Select(s => s.Key).ToArray();
         }
 

--- a/src/Nethermind/Nethermind.Core.Test/Builders/BlockTreeExtensions.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Builders/BlockTreeExtensions.cs
@@ -30,7 +30,7 @@ namespace Nethermind.Core.Test.Builders
             List<Block> blocks = new List<Block>();
             for (int i = splitBlockNumber + 1; i < branchLength; i++)
             {
-                Block block = alternative.FindBlock(i);
+                Block block = alternative.FindBlock(i, BlockTreeLookupOptions.RequireCanonical);
                 blockTree.SuggestBlock(block);
                 blocks.Add(block);
             }

--- a/src/Nethermind/Nethermind.Core.Test/OmmersValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/OmmersValidatorTests.cs
@@ -49,7 +49,7 @@ namespace Nethermind.Core.Test
         public OmmersValidatorTests()
         {
             _blockTree = Build.A.BlockTree().OfChainLength(1).TestObject;
-            _grandgrandparent = _blockTree.FindBlock(0);
+            _grandgrandparent = _blockTree.FindBlock(0, BlockTreeLookupOptions.None);
             _grandparent = Build.A.Block.WithParent(_grandgrandparent).TestObject;
             _duplicateOmmer = Build.A.Block.WithParent(_grandgrandparent).TestObject;
             _parent = Build.A.Block.WithParent(_grandparent).WithOmmers(_duplicateOmmer).TestObject;

--- a/src/Nethermind/Nethermind.Core/BlockBody.cs
+++ b/src/Nethermind/Nethermind.Core/BlockBody.cs
@@ -34,5 +34,7 @@ namespace Nethermind.Core
 
         public Transaction[] Transactions { get; set; }
         public BlockHeader[] Ommers { get; set; }
+        
+        public static BlockBody Empty = new BlockBody(); 
     }
 }

--- a/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
@@ -102,7 +102,7 @@ namespace Nethermind.Facade
         
         public Block FindBlock(Keccak blockHash) => _blockTree.FindBlock(blockHash, BlockTreeLookupOptions.None);
         
-        public Block FindBlock(long blockNumber) => _blockTree.FindBlock(blockNumber);
+        public Block FindBlock(long blockNumber) => _blockTree.FindBlock(blockNumber, BlockTreeLookupOptions.RequireCanonical);
         
         public Block FindGenesisBlock() => _blockTree.FindBlock(_blockTree.Genesis.Hash, BlockTreeLookupOptions.RequireCanonical);
         

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugBridge.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugBridge.cs
@@ -109,13 +109,13 @@ namespace Nethermind.JsonRpc.Modules.DebugModule
 
         public byte[] GetBlockRlp(long number)
         {
-            BlockHeader header = _blockTree.FindHeader(number);
-            if (header == null)
+            Keccak hash = _blockTree.FindHash(number);
+            if (hash == null)
             {
                 return null;
             }
 
-            return _dbMappings[DbNames.Blocks].Get(header.Hash);
+            return _dbMappings[DbNames.Blocks].Get(hash);
         }
 
         public string GetConfigValue(string category, string name)

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/NullModuleProvider.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/NullModuleProvider.cs
@@ -35,11 +35,11 @@ namespace Nethermind.JsonRpc.Modules
         {
         }
 
-        public IReadOnlyCollection<JsonConverter> Converters => ArraySegment<JsonConverter>.Empty;
+        public IReadOnlyCollection<JsonConverter> Converters => Array.Empty<JsonConverter>();
         
-        public IReadOnlyCollection<ModuleType> Enabled => ArraySegment<ModuleType>.Empty;
+        public IReadOnlyCollection<ModuleType> Enabled => Array.Empty<ModuleType>();
         
-        public IReadOnlyCollection<ModuleType> All => ArraySegment<ModuleType>.Empty;
+        public IReadOnlyCollection<ModuleType> All => Array.Empty<ModuleType>();
         
         public ModuleResolution Check(string methodName)
         {

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/Eth62ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/Eth62ProtocolHandlerTests.cs
@@ -105,7 +105,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth
             
             handler.HandleMessage(new Packet(Protocol.Eth, statusMsg.PacketType, svc.Serialize(statusMsg)));
             handler.HandleMessage(new Packet(Protocol.Eth, msg.PacketType, svc.Serialize(msg)));
-            syncManager.Received().FindHeader(1920000);
+            syncManager.Received().FindHash(1920000);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/Eth62ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/Eth62ProtocolHandlerTests.cs
@@ -80,7 +80,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth
             var session = Substitute.For<ISession>();
             var syncManager = Substitute.For<ISyncServer>();
             var transactionPool = Substitute.For<ITxPool>();
-            syncManager.FindBlocks(null, Arg.Any<int>(), Arg.Any<int>(), Arg.Any<bool>()).Throws(new ArgumentNullException());
+            syncManager.FindHeaders(null, Arg.Any<int>(), Arg.Any<int>(), Arg.Any<bool>()).Throws(new ArgumentNullException());
             Block genesisBlock = Build.A.Block.Genesis.TestObject;
             syncManager.Head.Returns(genesisBlock.Header);
             syncManager.Genesis.Returns(genesisBlock.Header);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/Eth62ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/Eth62ProtocolHandler.cs
@@ -18,6 +18,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Timers;
@@ -340,6 +341,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth
 
         private void Handle(GetBlockBodiesMessage request)
         {
+            Stopwatch stopwatch = Stopwatch.StartNew();
             Keccak[] hashes = request.BlockHashes;
             Block[] blocks = new Block[hashes.Length];
 
@@ -349,12 +351,14 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth
             }
 
             Interlocked.Increment(ref _counter);
-            if (Logger.IsTrace) Logger.Trace($"OUT {_counter:D5} BlockBodies to {Node:s}");
             Send(new BlockBodiesMessage(blocks));
+            stopwatch.Stop();
+            if (Logger.IsTrace) Logger.Trace($"OUT {_counter:D5} BlockBodies to {Node:s} in {stopwatch.Elapsed.TotalMilliseconds}ms");
         }
 
         private void Handle(GetBlockHeadersMessage getBlockHeadersMessage)
         {
+            Stopwatch stopwatch = Stopwatch.StartNew();
             if (Logger.IsTrace)
             {
                 Logger.Trace($"GetBlockHeaders.MaxHeaders: {getBlockHeadersMessage.MaxHeaders}");
@@ -364,12 +368,16 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth
                 Logger.Trace($"GetBlockHeaders.StartingBlockNumber: {getBlockHeadersMessage.StartingBlockNumber}");
             }
 
-            // to clearly state that this client is an ETH client (and avoid disconnections on reversed sync)
+            Interlocked.Increment(ref _counter);
+            
+            // to clearly state that this client is an ETH client and not ETC (and avoid disconnections on reversed sync)
             // also to improve performance as this is the most common request
             if (getBlockHeadersMessage.StartingBlockNumber == 1920000 && getBlockHeadersMessage.MaxHeaders == 1)
             {
+                // hardcoded response
                 Packet packet = new Packet(ProtocolCode, Eth62MessageCode.BlockHeaders, Bytes.FromHexString("f90210f9020da0a218e2c611f21232d857e3c8cecdcdf1f65f25a4477f98f6f47e4063807f2308a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d4934794bcdfc35b86bedf72f0cda046a3c16829a2ef41d1a0c5e389416116e3696cce82ec4533cce33efccb24ce245ae9546a4b8f0d5e9a75a07701df8e07169452554d14aadd7bfa256d4a1d0355c1d174ab373e3e2d0a3743a026cf9d9422e9dd95aedc7914db690b92bab6902f5221d62694a2fa5d065f534bb90100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008638c3bf2616aa831d4c008347e7c08301482084578f7aa88d64616f2d686172642d666f726ba05b5acbf4bf305f948bd7be176047b20623e1417f75597341a059729165b9239788bede87201de42426"));
                 Session.DeliverMessage(packet);
+                if (Logger.IsTrace) Logger.Trace($"OUT {_counter:D5} hardcoded 1920000 BlockHeaders to {Node:s}");
                 return;
             }
 
@@ -381,12 +389,12 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth
 
             BlockHeader[] headers =
                 startingHash == null
-                    ? new BlockHeader[0]
+                    ? Array.Empty<BlockHeader>()
                     : SyncServer.FindHeaders(startingHash, (int) getBlockHeadersMessage.MaxHeaders, (int) getBlockHeadersMessage.Skip, getBlockHeadersMessage.Reverse == 1);
 
-            Interlocked.Increment(ref _counter);
-            if (Logger.IsTrace) Logger.Trace($"OUT {_counter:D5} BlockHeaders to {Node:s}");
             Send(new BlockHeadersMessage(headers));
+            stopwatch.Stop();
+            if (Logger.IsTrace) Logger.Trace($"OUT {_counter:D5} BlockHeaders to {Node:s} in {stopwatch.Elapsed.TotalMilliseconds}ms");
         }
 
         private void Handle(BlockBodiesMessage message)

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/Eth62ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/Eth62ProtocolHandler.cs
@@ -390,7 +390,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth
             Keccak startingHash = getBlockHeadersMessage.StartingBlockHash;
             if (startingHash == null)
             {
-                startingHash = SyncServer.FindHeader(getBlockHeadersMessage.StartingBlockNumber)?.Hash;
+                startingHash = SyncServer.FindHash(getBlockHeadersMessage.StartingBlockNumber);
             }
 
             BlockHeader[] headers =

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/Eth62ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/Eth62ProtocolHandler.cs
@@ -341,6 +341,11 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth
 
         private void Handle(GetBlockBodiesMessage request)
         {
+            if (Logger.IsTrace)
+            {
+                Logger.Trace($"Received bodies request of length {request.BlockHashes.Length} from {Session.Node:c}:");
+            }
+            
             Stopwatch stopwatch = Stopwatch.StartNew();
             Keccak[] hashes = request.BlockHashes;
             Block[] blocks = new Block[hashes.Length];
@@ -361,11 +366,12 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth
             Stopwatch stopwatch = Stopwatch.StartNew();
             if (Logger.IsTrace)
             {
-                Logger.Trace($"GetBlockHeaders.MaxHeaders: {getBlockHeadersMessage.MaxHeaders}");
-                Logger.Trace($"GetBlockHeaders.Reverse: {getBlockHeadersMessage.Reverse}");
-                Logger.Trace($"GetBlockHeaders.Skip: {getBlockHeadersMessage.Skip}");
-                Logger.Trace($"GetBlockHeaders.StartingBlockhash: {getBlockHeadersMessage.StartingBlockHash}");
-                Logger.Trace($"GetBlockHeaders.StartingBlockNumber: {getBlockHeadersMessage.StartingBlockNumber}");
+                Logger.Trace($"Received headers request from {Session.Node:c}:");
+                Logger.Trace($"  MaxHeaders: {getBlockHeadersMessage.MaxHeaders}");
+                Logger.Trace($"  Reverse: {getBlockHeadersMessage.Reverse}");
+                Logger.Trace($"  Skip: {getBlockHeadersMessage.Skip}");
+                Logger.Trace($"  StartingBlockhash: {getBlockHeadersMessage.StartingBlockHash}");
+                Logger.Trace($"  StartingBlockNumber: {getBlockHeadersMessage.StartingBlockNumber}");
             }
 
             Interlocked.Increment(ref _counter);
@@ -458,12 +464,12 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth
 
             if (Logger.IsTrace)
             {
-                Logger.Trace("Sending headers request:");
-                Logger.Trace($"Starting blockhash: {message.StartingBlockHash}");
-                Logger.Trace($"Starting number: {message.StartingBlockNumber}");
-                Logger.Trace($"Skip: {message.Skip}");
-                Logger.Trace($"Reverse: {message.Reverse}");
-                Logger.Trace($"Max headers: {message.MaxHeaders}");
+                Logger.Trace($"Sending headers request to {Session.Node:c}:");
+                Logger.Trace($"  Starting blockhash: {message.StartingBlockHash}");
+                Logger.Trace($"  Starting number: {message.StartingBlockNumber}");
+                Logger.Trace($"  Skip: {message.Skip}");
+                Logger.Trace($"  Reverse: {message.Reverse}");
+                Logger.Trace($"  Max headers: {message.MaxHeaders}");
             }
 
             var request = new Request<GetBlockHeadersMessage, BlockHeader[]>(message);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/Eth62ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/Eth62ProtocolHandler.cs
@@ -117,7 +117,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth
 
         public void Init()
         {
-            if (Logger.IsTrace) Logger.Trace($"{Session.RemoteNodeId} {ProtocolCode} v{ProtocolVersion} subprotocol initializing");
+            if (Logger.IsTrace) Logger.Trace($"{ProtocolCode} v{ProtocolVersion} subprotocol initializing with {Session.Node:c}");
             if (SyncServer.Head == null)
             {
                 throw new InvalidOperationException($"Cannot initialize {ProtocolCode} v{ProtocolVersion} protocol without the head block set");
@@ -155,12 +155,12 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth
         {
             if (Logger.IsTrace)
             {
-                Logger.Trace($"{Session.RemoteNodeId} {nameof(Eth62ProtocolHandler)} handling a message with code {message.PacketType}.");
+                Logger.Trace($"Handling {message} message from {Session.Node:c}.");
             }
 
             if (message.PacketType != Eth62MessageCode.Status && !_statusReceived)
             {
-                throw new SubprotocolException($"{Session.RemoteNodeId} No {nameof(StatusMessage)} received prior to communication.");
+                throw new SubprotocolException($"No {nameof(StatusMessage)} received prior to communication with {Session.Node:c}.");
             }
 
             switch (message.PacketType)
@@ -171,7 +171,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth
                     break;
                 case Eth62MessageCode.NewBlockHashes:
                     Interlocked.Increment(ref _counter);
-                    if (Logger.IsTrace) Logger.Trace($"{_counter:D5} NewBlockHashes from {Node:s}");
+                    if (Logger.IsTrace) Logger.Trace($"{_counter:D5} NewBlockHashes from {Node:c}");
                     Metrics.Eth62NewBlockHashesReceived++;
                     Handle(Deserialize<NewBlockHashesMessage>(message.Data));
                     break;
@@ -186,31 +186,31 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth
                     break;
                 case Eth62MessageCode.GetBlockHeaders:
                     Interlocked.Increment(ref _counter);
-                    if (Logger.IsTrace) Logger.Trace($"{_counter:D5} GetBlockHeaders from {Node:s}");
+                    if (Logger.IsTrace) Logger.Trace($"{_counter:D5} GetBlockHeaders from {Node:c}");
                     Metrics.Eth62GetBlockHeadersReceived++;
                     Handle(Deserialize<GetBlockHeadersMessage>(message.Data));
                     break;
                 case Eth62MessageCode.BlockHeaders:
                     Interlocked.Increment(ref _counter);
-                    if (Logger.IsTrace) Logger.Trace($"{_counter:D5} BlockHeaders from {Node:s}");
+                    if (Logger.IsTrace) Logger.Trace($"{_counter:D5} BlockHeaders from {Node:c}");
                     Metrics.Eth62BlockHeadersReceived++;
                     Handle(Deserialize<BlockHeadersMessage>(message.Data));
                     break;
                 case Eth62MessageCode.GetBlockBodies:
                     Interlocked.Increment(ref _counter);
-                    if (Logger.IsTrace) Logger.Trace($"{_counter:D5} GetBlockBodies from {Node:s}");
+                    if (Logger.IsTrace) Logger.Trace($"{_counter:D5} GetBlockBodies from {Node:c}");
                     Metrics.Eth62GetBlockBodiesReceived++;
                     Handle(Deserialize<GetBlockBodiesMessage>(message.Data));
                     break;
                 case Eth62MessageCode.BlockBodies:
                     Interlocked.Increment(ref _counter);
-                    if (Logger.IsTrace) Logger.Trace($"{_counter:D5} BlockBodies from {Node:s}");
+                    if (Logger.IsTrace) Logger.Trace($"{_counter:D5} BlockBodies from {Node:c}");
                     Metrics.Eth62BlockBodiesReceived++;
                     Handle(Deserialize<BlockBodiesMessage>(message.Data));
                     break;
                 case Eth62MessageCode.NewBlock:
                     Interlocked.Increment(ref _counter);
-                    if (Logger.IsTrace) Logger.Trace($"{_counter:D5} NewBlock from {Node:s}");
+                    if (Logger.IsTrace) Logger.Trace($"{_counter:D5} NewBlock from {Node:c}");
                     Metrics.Eth62NewBlockReceived++;
                     Handle(Deserialize<NewBlockMessage>(message.Data));
                     break;
@@ -240,7 +240,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth
 
         public void SendNewBlock(Block block)
         {
-            if (Logger.IsTrace) Logger.Trace($"OUT {_counter:D5} NewBlock to {Node:s}");
+            if (Logger.IsTrace) Logger.Trace($"OUT {_counter:D5} NewBlock to {Node:c}");
             if (block.TotalDifficulty == null)
             {
                 throw new InvalidOperationException($"Trying to send a block {block.Hash} with null total difficulty");
@@ -290,7 +290,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth
 
             _statusReceived = true;
             if (Logger.IsTrace)
-                Logger.Trace($"{Session.RemoteNodeId} ETH received status with" +
+                Logger.Trace($"ETH received status from {Session.Node:c} with" +
                              Environment.NewLine + $" prot version\t{status.ProtocolVersion}" +
                              Environment.NewLine + $" network ID\t{status.ChainId}," +
                              Environment.NewLine + $" genesis hash\t{status.GenesisHash}," +
@@ -335,7 +335,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth
                     _notAcceptedTxsSinceLastCheck++;
                 }
 
-                if (Logger.IsTrace) Logger.Trace($"{Node.Id} sent {transaction.Hash} and it was {result} (chain ID = {transaction.Signature.GetChainId})");
+                if (Logger.IsTrace) Logger.Trace($"{Node:c} sent {transaction.Hash} tx and it was {result} (chain ID = {transaction.Signature.GetChainId})");
             }
         }
 
@@ -353,7 +353,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth
             Interlocked.Increment(ref _counter);
             Send(new BlockBodiesMessage(blocks));
             stopwatch.Stop();
-            if (Logger.IsTrace) Logger.Trace($"OUT {_counter:D5} BlockBodies to {Node:s} in {stopwatch.Elapsed.TotalMilliseconds}ms");
+            if (Logger.IsTrace) Logger.Trace($"OUT {_counter:D5} BlockBodies to {Node:c} in {stopwatch.Elapsed.TotalMilliseconds}ms");
         }
 
         private void Handle(GetBlockHeadersMessage getBlockHeadersMessage)
@@ -377,7 +377,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth
                 // hardcoded response
                 Packet packet = new Packet(ProtocolCode, Eth62MessageCode.BlockHeaders, Bytes.FromHexString("f90210f9020da0a218e2c611f21232d857e3c8cecdcdf1f65f25a4477f98f6f47e4063807f2308a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d4934794bcdfc35b86bedf72f0cda046a3c16829a2ef41d1a0c5e389416116e3696cce82ec4533cce33efccb24ce245ae9546a4b8f0d5e9a75a07701df8e07169452554d14aadd7bfa256d4a1d0355c1d174ab373e3e2d0a3743a026cf9d9422e9dd95aedc7914db690b92bab6902f5221d62694a2fa5d065f534bb90100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008638c3bf2616aa831d4c008347e7c08301482084578f7aa88d64616f2d686172642d666f726ba05b5acbf4bf305f948bd7be176047b20623e1417f75597341a059729165b9239788bede87201de42426"));
                 Session.DeliverMessage(packet);
-                if (Logger.IsTrace) Logger.Trace($"OUT {_counter:D5} hardcoded 1920000 BlockHeaders to {Node:s}");
+                if (Logger.IsTrace) Logger.Trace($"OUT {_counter:D5} hardcoded 1920000 BlockHeaders to {Node:c}");
                 return;
             }
 
@@ -394,7 +394,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth
 
             Send(new BlockHeadersMessage(headers));
             stopwatch.Stop();
-            if (Logger.IsTrace) Logger.Trace($"OUT {_counter:D5} BlockHeaders to {Node:s} in {stopwatch.Elapsed.TotalMilliseconds}ms");
+            if (Logger.IsTrace) Logger.Trace($"OUT {_counter:D5} BlockHeaders to {Node:c} in {stopwatch.Elapsed.TotalMilliseconds}ms");
         }
 
         private void Handle(BlockBodiesMessage message)
@@ -566,7 +566,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth
 
         public void Disconnect(DisconnectReason reason, string details)
         {
-            if (Logger.IsDebug) Logger.Debug($"Disconnecting {Node:s} bacause of the {details}");
+            if (Logger.IsDebug) Logger.Debug($"Disconnecting {Node:c} bacause of the {details}");
             Session.InitiateDisconnect(reason, details);
         }
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V63/Eth63ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V63/Eth63ProtocolHandler.cs
@@ -64,25 +64,25 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V63
             {
                 case Eth63MessageCode.GetReceipts:
                     Interlocked.Increment(ref _counter);
-                    if(Logger.IsTrace) Logger.Trace($"{_counter:D5} GetReceipts from {Node:s}");
+                    if(Logger.IsTrace) Logger.Trace($"{_counter:D5} GetReceipts from {Node:c}");
                     Metrics.Eth63GetReceiptsReceived++;
                     Handle(Deserialize<GetReceiptsMessage>(message.Data));
                     break;
                 case Eth63MessageCode.Receipts:
                     Interlocked.Increment(ref _counter);
-                    if(Logger.IsTrace) Logger.Trace($"{_counter:D5} Receipts from {Node:s}");
+                    if(Logger.IsTrace) Logger.Trace($"{_counter:D5} Receipts from {Node:c}");
                     Metrics.Eth63ReceiptsReceived++;
                     Handle(Deserialize<ReceiptsMessage>(message.Data));
                     break;
                 case Eth63MessageCode.GetNodeData:
                     Interlocked.Increment(ref _counter);
-                    if(Logger.IsTrace) Logger.Trace($"{_counter:D5} GetNodeData from {Node:s}");
+                    if(Logger.IsTrace) Logger.Trace($"{_counter:D5} GetNodeData from {Node:c}");
                     Metrics.Eth63GetNodeDataReceived++;
                     Handle(Deserialize<GetNodeDataMessage>(message.Data));
                     break;
                 case Eth63MessageCode.NodeData:
                     Interlocked.Increment(ref _counter);
-                    if(Logger.IsTrace) Logger.Trace($"{_counter:D5} NodeData from {Node:s}");
+                    if(Logger.IsTrace) Logger.Trace($"{_counter:D5} NodeData from {Node:c}");
                     Metrics.Eth63NodeDataReceived++;
                     Handle(Deserialize<NodeDataMessage>(message.Data));
                     break;
@@ -96,7 +96,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V63
             Interlocked.Increment(ref _counter);
             Send(new ReceiptsMessage(txReceipts));
             stopwatch.Stop();
-            if(Logger.IsTrace) Logger.Trace($"OUT {_counter:D5} Receipts to {Node:s} in {stopwatch.Elapsed.TotalMilliseconds}ms");
+            if(Logger.IsTrace) Logger.Trace($"OUT {_counter:D5} Receipts to {Node:c} in {stopwatch.Elapsed.TotalMilliseconds}ms");
         }
 
         private void Handle(ReceiptsMessage msg)
@@ -115,7 +115,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V63
             Interlocked.Increment(ref _counter);
             Send(new NodeDataMessage(nodeData));
             stopwatch.Stop();
-            if(Logger.IsTrace) Logger.Trace($"OUT {_counter:D5} NodeData to {Node:s} in {stopwatch.Elapsed.TotalMilliseconds}ms");
+            if(Logger.IsTrace) Logger.Trace($"OUT {_counter:D5} NodeData to {Node:c} in {stopwatch.Elapsed.TotalMilliseconds}ms");
         }
 
         private void Handle(NodeDataMessage msg)

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V63/Eth63ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V63/Eth63ProtocolHandler.cs
@@ -18,6 +18,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Blockchain.Synchronization;
@@ -90,10 +91,12 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V63
         
         private void Handle(GetReceiptsMessage msg)
         {
+            Stopwatch stopwatch = Stopwatch.StartNew();
             TxReceipt[][] txReceipts = SyncServer.GetReceipts(msg.BlockHashes);
             Interlocked.Increment(ref _counter);
-            if(Logger.IsTrace) Logger.Trace($"OUT {_counter:D5} Receipts to {Node:s}");
             Send(new ReceiptsMessage(txReceipts));
+            stopwatch.Stop();
+            if(Logger.IsTrace) Logger.Trace($"OUT {_counter:D5} Receipts to {Node:s} in {stopwatch.Elapsed.TotalMilliseconds}ms");
         }
 
         private void Handle(ReceiptsMessage msg)
@@ -107,10 +110,12 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V63
 
         private void Handle(GetNodeDataMessage msg)
         {
+            Stopwatch stopwatch = Stopwatch.StartNew();
             byte[][] nodeData = SyncServer.GetNodeData(msg.Keys);
             Interlocked.Increment(ref _counter);
-            if(Logger.IsTrace) Logger.Trace($"OUT {_counter:D5} NodeData to {Node:s}");
             Send(new NodeDataMessage(nodeData));
+            stopwatch.Stop();
+            if(Logger.IsTrace) Logger.Trace($"OUT {_counter:D5} NodeData to {Node:s} in {stopwatch.Elapsed.TotalMilliseconds}ms");
         }
 
         private void Handle(NodeDataMessage msg)

--- a/src/Nethermind/Nethermind.Network/Rlpx/Packet.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/Packet.cs
@@ -40,5 +40,10 @@ namespace Nethermind.Network.Rlpx
         public int PacketType { get; set; }
 
         public string Protocol { get; set; }
+
+        public override string ToString()
+        {
+            return $"{Protocol ?? "???"}.{PacketType}";
+        }
     }
 }

--- a/src/Nethermind/Nethermind.PerfTest/Program.cs
+++ b/src/Nethermind/Nethermind.PerfTest/Program.cs
@@ -129,9 +129,14 @@ namespace Nethermind.PerfTest
                 return _blockTree.FindHeader(blockHash, options);
             }
 
-            public BlockHeader FindHeader(long number)
+            public Block FindBlock(long blockNumber, BlockTreeLookupOptions options)
             {
-                return _blockTree.FindHeader(number);
+                return _blockTree.FindBlock(blockNumber, options);
+            }
+
+            public BlockHeader FindHeader(long blockNumber, BlockTreeLookupOptions options)
+            {
+                return _blockTree.FindHeader(blockNumber, options);
             }
 
             public Keccak FindHash(long blockNumber)
@@ -147,11 +152,6 @@ namespace Nethermind.PerfTest
             public BlockHeader[] FindHeaders(Keccak hash, int numberOfBlocks, int skip, bool reverse)
             {
                 return _blockTree.FindHeaders(hash, numberOfBlocks, skip, reverse);
-            }
-
-            public Block FindBlock(long blockNumber)
-            {
-                return _blockTree.FindBlock(blockNumber);
             }
 
             public void DeleteInvalidBlock(Block invalidBlock)

--- a/src/Nethermind/Nethermind.PerfTest/Program.cs
+++ b/src/Nethermind/Nethermind.PerfTest/Program.cs
@@ -144,11 +144,6 @@ namespace Nethermind.PerfTest
                 return _blockTree.FindHash(blockNumber);
             }
 
-            public Block[] FindBlocks(Keccak blockHash, int numberOfBlocks, int skip, bool reverse)
-            {
-                return _blockTree.FindBlocks(blockHash, numberOfBlocks, skip, reverse);
-            }
-
             public BlockHeader[] FindHeaders(Keccak hash, int numberOfBlocks, int skip, bool reverse)
             {
                 return _blockTree.FindHeaders(hash, numberOfBlocks, skip, reverse);

--- a/src/Nethermind/Nethermind.PerfTest/Program.cs
+++ b/src/Nethermind/Nethermind.PerfTest/Program.cs
@@ -134,6 +134,11 @@ namespace Nethermind.PerfTest
                 return _blockTree.FindHeader(number);
             }
 
+            public Keccak FindHash(long blockNumber)
+            {
+                return _blockTree.FindHash(blockNumber);
+            }
+
             public Block[] FindBlocks(Keccak blockHash, int numberOfBlocks, int skip, bool reverse)
             {
                 return _blockTree.FindBlocks(blockHash, numberOfBlocks, skip, reverse);


### PR DESCRIPTION
The changes include:

1) slight relaxation of canonical chain requirements when serving sync requests (in most cases we will send canonical chain and in other we are ok to be dropped as a sync peer)
2) more thorough selection of when to load TotalDifficulty from the database resulting in 3x BlockInfo db hit decrease
3) improved tracing with measurements for sync requests handling
4) BlockDownloader doe snot send requests for bodies of blocks that clearly state in the headers that bodies are empty