### PR TITLE
Add wildcard routing for RPC

### DIFF
--- a/src/Nethermind/Nethermind.Runner/Controllers/MainController.cs
+++ b/src/Nethermind/Nethermind.Runner/Controllers/MainController.cs
@@ -28,7 +28,7 @@ using Newtonsoft.Json.Serialization;
 
 namespace Nethermind.Runner.Controllers
 {
-    [Route("")]
+    [Route("{*url}")]
     [ApiController]
     public class MainController : ControllerBase
     {


### PR DESCRIPTION
Using the JSON RPC endpoint in a reverse proxy environment was returning 404's as ASP.Net's MVC routing didn't match to the rpc route.

Example: 
1. a request for `http://rpc.example.com/goerli/nethermind` is reverse proxied to `http://<nethermind-client>:8345`
2. the HTTP request will carry the path portion (`/goerli/nethermind`) untouched to nethermind
3. ASP.Net MVC routing in nethermind has no way to route this path and will respond with a `404`

The proposed fix will make the route on `MainController` to act as a "catch-all" route to ignore the path segments.

We would need this fix to run Nethermind in our RPC stack at Slock.it