### PR TITLE
Automate file header maintenance by putting it to %Header% file templ…

### DIFF
--- a/src/Nethermind/Nethermind.sln.DotSettings
+++ b/src/Nethermind/Nethermind.sln.DotSettings
@@ -1,4 +1,20 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/FileHeader/FileHeaderText/@EntryValue"> Copyright (c) 2018 Demerzel Solutions Limited&#xD;
+ This file is part of the Nethermind library.&#xD;
+ &#xD;
+ The Nethermind library is free software: you can redistribute it and/or modify&#xD;
+ it under the terms of the GNU Lesser General Public License as published by&#xD;
+ the Free Software Foundation, either version 3 of the License, or&#xD;
+ (at your option) any later version.&#xD;
+ &#xD;
+ The Nethermind library is distributed in the hope that it will be useful,&#xD;
+ but WITHOUT ANY WARRANTY; without even the implied warranty of&#xD;
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the&#xD;
+ GNU Lesser General Public License for more details.&#xD;
+ &#xD;
+ You should have received a copy of the GNU Lesser General Public License&#xD;
+ along with the Nethermind. If not, see &lt;http://www.gnu.org/licenses/&gt;.&#xD;
+&#xD;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=CTR/@EntryIndexedValue">CTR</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=EIP/@EntryIndexedValue">EIP</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IV/@EntryIndexedValue">IV</s:String>


### PR DESCRIPTION
…ate for Rider

Only downside is that rider adds headers with // comments, contrary to current format of /* */ But it looks similar enough that I would prefer not having to think about it.