### PR TITLE
IdConverter and serialization changes

### DIFF
--- a/src/Nethermind/Nethermind.Core/IJsonSerializer.cs
+++ b/src/Nethermind/Nethermind.Core/IJsonSerializer.cs
@@ -16,20 +16,12 @@
  * along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
  */
 
-using System.Collections.Generic;
 using Newtonsoft.Json;
-using NLog;
 
 namespace Nethermind.Core
 {
     public interface IJsonSerializer
     {
-        [Todo(Improve.Refactor, "Move this method to a IRpcJsonSerializer")]
-        T DeserializeAnonymousType<T>(string json, T definition);
-        
-        [Todo(Improve.Refactor, "Move this method to a IRpcJsonSerializer")]
-        (T Model, List<T> Collection) DeserializeObjectOrArray<T>(string json);
-        
         T Deserialize<T>(string json);
         string Serialize<T>(T value, bool indented = false); // TODO: support serializing to stream
         void RegisterConverter(JsonConverter converter);

--- a/src/Nethermind/Nethermind.Core/IJsonSerializer.cs
+++ b/src/Nethermind/Nethermind.Core/IJsonSerializer.cs
@@ -16,6 +16,7 @@
  * along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
  */
 
+using System.IO;
 using Newtonsoft.Json;
 
 namespace Nethermind.Core
@@ -23,7 +24,8 @@ namespace Nethermind.Core
     public interface IJsonSerializer
     {
         T Deserialize<T>(string json);
-        string Serialize<T>(T value, bool indented = false); // TODO: support serializing to stream
+        string Serialize<T>(T value, bool indented = false);
+        void Serialize<T>(Stream stream, T value, bool indented = false);
         void RegisterConverter(JsonConverter converter);
     }
 }

--- a/src/Nethermind/Nethermind.Core/Json/EthereumJsonSerializer.cs
+++ b/src/Nethermind/Nethermind.Core/Json/EthereumJsonSerializer.cs
@@ -86,7 +86,6 @@ namespace Nethermind.Core.Json
             return _internalSerializer.Deserialize<T>(jsonReader);
         }
 
-        [Todo(Improve.Performance, "Seems that we create new JsonSerializer each time unnecessrily")]
         public string Serialize<T>(T value, bool indented = false)
         {
             StringWriter stringWriter = new StringWriter(new StringBuilder(256), CultureInfo.InvariantCulture);

--- a/src/Nethermind/Nethermind.Core/Json/EthereumJsonSerializer.cs
+++ b/src/Nethermind/Nethermind.Core/Json/EthereumJsonSerializer.cs
@@ -21,6 +21,7 @@ using System.Globalization;
 using System.IO;
 using System.Text;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 
 namespace Nethermind.Core.Json
 {
@@ -67,6 +68,7 @@ namespace Nethermind.Core.Json
 
         private static JsonSerializerSettings _settings = new JsonSerializerSettings
         {
+            ContractResolver = new CamelCasePropertyNamesContractResolver(),
             NullValueHandling = NullValueHandling.Ignore,
             Formatting = Formatting.None,
             Converters = BasicConverters
@@ -74,6 +76,7 @@ namespace Nethermind.Core.Json
 
         private static JsonSerializerSettings _readableSettings = new JsonSerializerSettings
         {
+            ContractResolver = new CamelCasePropertyNamesContractResolver(),
             NullValueHandling = NullValueHandling.Ignore,
             Formatting = Formatting.Indented,
             Converters = ReadableConverters
@@ -104,6 +107,22 @@ namespace Nethermind.Core.Json
             }
             
             return stringWriter.ToString();
+        }
+        
+        public void Serialize<T>(Stream stream, T value, bool indented = false)
+        {
+            StreamWriter streamWriter = new StreamWriter(stream);
+            using JsonTextWriter jsonTextWriter = new JsonTextWriter(streamWriter);
+            if (indented)
+            {
+                jsonTextWriter.Formatting = _internalReadableSerializer.Formatting;
+                _internalReadableSerializer.Serialize(jsonTextWriter, value, typeof(T));
+            }
+            else
+            {
+                jsonTextWriter.Formatting = _internalSerializer.Formatting;
+                _internalSerializer.Serialize(jsonTextWriter, value, typeof(T));    
+            }
         }
 
         public void RegisterConverter(JsonConverter converter)

--- a/src/Nethermind/Nethermind.Core/Json/EthereumJsonSerializer.cs
+++ b/src/Nethermind/Nethermind.Core/Json/EthereumJsonSerializer.cs
@@ -16,19 +16,23 @@
  * along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
  */
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
+using System.Globalization;
+using System.IO;
+using System.Text;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Nethermind.Core.Json
 {
     public class EthereumJsonSerializer : IJsonSerializer
     {
+        private JsonSerializer _internalSerializer;
+        private JsonSerializer _internalReadableSerializer;
+
         public EthereumJsonSerializer()
         {
-            _serializer = JsonSerializer.Create(_settings);
+            _internalSerializer = JsonSerializer.Create(_settings);
+            _internalReadableSerializer = JsonSerializer.Create(_readableSettings);
         }
 
         public static IList<JsonConverter> BasicConverters { get; } = new List<JsonConverter>
@@ -74,66 +78,33 @@ namespace Nethermind.Core.Json
             Formatting = Formatting.Indented,
             Converters = ReadableConverters
         };
-
-        public T DeserializeAnonymousType<T>(string json, T definition)
-        {
-            throw new NotSupportedException();
-        }
-
+        
         public T Deserialize<T>(string json)
         {
-            return JsonConvert.DeserializeObject<T>(json, _settings);
+            using StringReader reader = new StringReader(json);
+            using JsonReader jsonReader = new JsonTextReader(reader);
+            return _internalSerializer.Deserialize<T>(jsonReader);
         }
 
-        private JsonSerializer _serializer;
-
-        public (T Model, List<T> Collection) DeserializeObjectOrArray<T>(string json)
-        {
-            var token = JToken.Parse(json);
-            if (token is JArray array)
-            {
-                foreach (var tokenElement in array)
-                {
-                    UpdateParams(tokenElement);
-                }
-
-                return (default, array.ToObject<List<T>>(_serializer));
-            }
-
-            UpdateParams(token);
-            return (token.ToObject<T>(_serializer), null);
-        }
-
-        private void UpdateParams(JToken token)
-        {
-            var paramsToken = token.SelectToken("params");
-            if (paramsToken == null)
-            {
-                paramsToken = token.SelectToken("Params");
-                if (paramsToken == null)
-                {
-                    return;
-                }
-
-//                if (paramsToken == null)
-//                {
-//                    throw new FormatException("Missing 'params' token");
-//                }
-            }
-            
-            JArray arrayToken = (JArray)paramsToken;
-            for (int i = 0; i < arrayToken.Count; i++)
-            {
-                if (arrayToken[i].Type == JTokenType.Array || arrayToken[i].Type == JTokenType.Object)
-                {
-                    arrayToken[i].Replace(JToken.Parse(Serialize(arrayToken[i].Value<object>().ToString())));
-                }
-            }
-        }
-
+        [Todo(Improve.Performance, "Seems that we create new JsonSerializer each time unnecessrily")]
         public string Serialize<T>(T value, bool indented = false)
         {
-            return JsonConvert.SerializeObject(value, indented ? _readableSettings : _settings);
+            StringWriter stringWriter = new StringWriter(new StringBuilder(256), CultureInfo.InvariantCulture);
+            using (JsonTextWriter jsonTextWriter = new JsonTextWriter(stringWriter))
+            {
+                if (indented)
+                {
+                    jsonTextWriter.Formatting = _internalReadableSerializer.Formatting;
+                    _internalReadableSerializer.Serialize(jsonTextWriter, value, typeof(T));
+                }
+                else
+                {
+                    jsonTextWriter.Formatting = _internalSerializer.Formatting;
+                    _internalSerializer.Serialize(jsonTextWriter, value, typeof(T));    
+                }
+            }
+            
+            return stringWriter.ToString();
         }
 
         public void RegisterConverter(JsonConverter converter)
@@ -154,6 +125,9 @@ namespace Nethermind.Core.Json
                 Formatting = Formatting.None,
                 Converters = BasicConverters
             };
+
+            _internalSerializer = JsonSerializer.Create(_settings);
+            _internalReadableSerializer = JsonSerializer.Create(_readableSettings);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Core/Json/IdConverter.cs
+++ b/src/Nethermind/Nethermind.Core/Json/IdConverter.cs
@@ -1,0 +1,65 @@
+//  Copyright (c) 2018 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Numerics;
+using Nethermind.Dirichlet.Numerics;
+using Newtonsoft.Json;
+
+namespace Nethermind.Core.Json
+{
+    public class IdConverter : JsonConverter
+    {
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            switch (value)
+            {
+                case int typedValue:
+                    writer.WriteRawValue(typedValue.ToString());
+                    break;
+                case long typedValue:
+                    writer.WriteRawValue(typedValue.ToString());
+                    break;
+                case BigInteger typedValue:
+                    writer.WriteRawValue(typedValue.ToString());
+                    break;
+                case string typedValue:
+                    writer.WriteRawValue(typedValue);
+                    break;
+                default:
+                    throw new NotSupportedException();
+            }
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            switch (reader.TokenType)
+            {
+                case JsonToken.Integer:
+                    return reader.Value;
+                case JsonToken.String:
+                    return reader.Value as string;
+                default:
+                    throw new NotSupportedException($"{reader.TokenType}");
+            }
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return true;
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Core/Json/UnforgivingJsonSerializer.cs
+++ b/src/Nethermind/Nethermind.Core/Json/UnforgivingJsonSerializer.cs
@@ -18,6 +18,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -37,6 +38,11 @@ namespace Nethermind.Core.Json
                 NullValueHandling = NullValueHandling.Ignore,
                 Formatting = indented ? Formatting.Indented : Formatting.None
             });
+        }
+
+        public void Serialize<T>(Stream stream, T value, bool indented = false)
+        {
+            throw new NotSupportedException();
         }
 
         public void RegisterConverter(JsonConverter converter)

--- a/src/Nethermind/Nethermind.Core/Json/UnforgivingJsonSerializer.cs
+++ b/src/Nethermind/Nethermind.Core/Json/UnforgivingJsonSerializer.cs
@@ -25,70 +25,9 @@ namespace Nethermind.Core.Json
 {
     public class UnforgivingJsonSerializer : IJsonSerializer
     {
-        public T DeserializeAnonymousType<T>(string json, T definition)
-        {
-            return JsonConvert.DeserializeAnonymousType(json, definition);
-        }
-
         public T Deserialize<T>(string json)
         {
             return JsonConvert.DeserializeObject<T>(json);
-        }
-
-        public (T Model, List<T> Collection) DeserializeObjectOrArray<T>(string json)
-        {
-            var token = JToken.Parse(json);
-            if (token is JArray array)
-            {
-                foreach (var tokenElement in array)
-                {
-                    UpdateParams(tokenElement);
-                }
-
-                return (default, array.ToObject<List<T>>());
-            }
-            UpdateParams(token);
-
-            return (token.ToObject<T>(), null);
-        }
-        
-        private void UpdateParams(JToken token)
-        {
-            var paramsToken = token.SelectToken("params");
-            if (paramsToken == null)
-            {
-                paramsToken = token.SelectToken("Params");
-                if (paramsToken == null)
-                {
-                    return;
-                }
-
-//                if (paramsToken == null)
-//                {
-//                    throw new FormatException("Missing 'params' token");
-//                }
-            }
-            
-            var values = new List<string>();
-            foreach (var value in paramsToken.Value<IEnumerable<object>>())
-            {
-                var valueString = value?.ToString();
-                if (valueString == null)
-                {
-                    values.Add($"\"null\"");
-                    continue;
-                }
-                
-                if (valueString.StartsWith("{") || valueString.StartsWith("["))
-                {
-                    values.Add(Serialize(valueString));
-                    continue;
-                }
-                values.Add($"\"{valueString}\"");
-            }
-
-            var json = $"[{string.Join(",", values)}]";
-            paramsToken.Replace(JToken.Parse(json));
         }
 
         public string Serialize<T>(T value, bool indented = false)

--- a/src/Nethermind/Nethermind.JsonRpc.Test/RpcTest.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/RpcTest.cs
@@ -61,13 +61,7 @@ namespace Nethermind.JsonRpc.Test
             IJsonRpcService service = new JsonRpcService(moduleProvider, NullLogManager.Instance);
             return service;
         }
-        
-        //{
-        //    "jsonrpc": "2.0",
-        //    "method": "eth_getBlockByNumber",
-        //    "params": [ "0x1b4", true ],
-        //    "id": 67
-        //}
+
         public static JsonRpcRequest GetJsonRequest(string method, params string[] parameters)
         {
             var request = new JsonRpcRequest()

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
@@ -26,25 +26,27 @@ using System.Threading.Tasks;
 using Nethermind.Core;
 using Nethermind.Logging;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 
 namespace Nethermind.JsonRpc
 {
     public class JsonRpcProcessor : IJsonRpcProcessor
     {
-        private readonly IJsonRpcService _jsonRpcService;
-        private readonly IJsonSerializer _jsonSerializer;
+        private IJsonRpcService _jsonRpcService;
+        private IJsonSerializer _jsonSerializer;
         private JsonSerializer _traceSerializer;
-        private readonly ILogger _logger;
-        private readonly IJsonRpcConfig _jsonRpcConfig;
+        private IJsonRpcConfig _jsonRpcConfig;
+        private ILogger _logger;
+
         private Recorder _recorder;
 
         public JsonRpcProcessor(IJsonRpcService jsonRpcService, IJsonSerializer jsonSerializer, IJsonRpcConfig jsonRpcConfig, ILogManager logManager)
         {
-            _jsonRpcService = jsonRpcService ?? throw new ArgumentNullException(nameof(jsonRpcService));
-            _jsonSerializer = jsonSerializer ?? throw new ArgumentNullException(nameof(jsonSerializer));
             _logger = logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
             _jsonRpcConfig = jsonRpcConfig ?? throw new ArgumentNullException(nameof(jsonRpcConfig));
+            _jsonRpcService = jsonRpcService ?? throw new ArgumentNullException(nameof(jsonRpcService));
+            _jsonSerializer = jsonSerializer ?? throw new ArgumentNullException(nameof(jsonSerializer));
 
             if (_jsonRpcConfig.RpcRecorderEnabled)
             {
@@ -74,7 +76,48 @@ namespace Nethermind.JsonRpc
 
             _traceSerializer = JsonSerializer.Create(jsonSettings);
         }
-        
+
+        private JsonSerializer _obsoleteBasicJsonSerializer = new JsonSerializer();
+
+        private (JsonRpcRequest Model, List<JsonRpcRequest> Collection) DeserializeObjectOrArray(string json)
+        {  
+            var token = JToken.Parse(json);
+            if (token is JArray array)
+            {
+                foreach (var tokenElement in array)
+                {
+                    UpdateParams(tokenElement);
+                }
+
+                return (default, array.ToObject<List<JsonRpcRequest>>(_obsoleteBasicJsonSerializer));
+            }
+
+            UpdateParams(token);
+            return (token.ToObject<JsonRpcRequest>(_obsoleteBasicJsonSerializer), null);
+        }
+
+        private void UpdateParams(JToken token)
+        {
+            var paramsToken = token.SelectToken("params");
+            if (paramsToken == null)
+            {
+                paramsToken = token.SelectToken("Params");
+                if (paramsToken == null)
+                {
+                    return;
+                }
+            }
+
+            JArray arrayToken = (JArray) paramsToken;
+            for (int i = 0; i < arrayToken.Count; i++)
+            {
+                if (arrayToken[i].Type == JTokenType.Array || arrayToken[i].Type == JTokenType.Object)
+                {
+                    arrayToken[i].Replace(JToken.Parse(_jsonSerializer.Serialize(arrayToken[i].Value<object>().ToString())));
+                }
+            }
+        }
+
         public async Task<JsonRpcResult> ProcessAsync(string request)
         {
             if (_jsonRpcConfig.RpcRecorderEnabled)
@@ -86,7 +129,7 @@ namespace Nethermind.JsonRpc
             (JsonRpcRequest Model, List<JsonRpcRequest> Collection) rpcRequest;
             try
             {
-                rpcRequest = _jsonSerializer.DeserializeObjectOrArray<JsonRpcRequest>(request);
+                rpcRequest = DeserializeObjectOrArray(request);
             }
             catch (Exception ex)
             {
@@ -106,8 +149,7 @@ namespace Nethermind.JsonRpc
                 JsonRpcErrorResponse localErrorResponse = response as JsonRpcErrorResponse;
                 if (localErrorResponse != null)
                 {
-                    if (_logger.IsError)
-                        _logger.Error($"Failed to respond to {rpcRequest.Model.Method} {localErrorResponse.Error.Message}");
+                    if (_logger.IsError) _logger.Error($"Failed to respond to {rpcRequest.Model.Method} {localErrorResponse.Error.Message}");
                     Metrics.JsonRpcErrors++;
                 }
                 else
@@ -138,8 +180,7 @@ namespace Nethermind.JsonRpc
                     JsonRpcErrorResponse localErrorResponse = response as JsonRpcErrorResponse;
                     if (localErrorResponse != null)
                     {
-                        if (_logger.IsError)
-                            _logger.Error($"Failed to respond to {jsonRpcRequest.Method} {localErrorResponse.Error.Message}");
+                        if (_logger.IsError) _logger.Error($"Failed to respond to {jsonRpcRequest.Method} {localErrorResponse.Error.Message}");
                         Metrics.JsonRpcErrors++;
                     }
                     else
@@ -172,11 +213,9 @@ namespace Nethermind.JsonRpc
             if (_logger.IsTrace)
             {
                 StringBuilder builder = new StringBuilder();
-                using (StringWriter stringWriter = new StringWriter(builder))
-                using (JsonTextWriter jsonWriter = new JsonTextWriter(stringWriter))
-                {
-                    _traceSerializer.Serialize(jsonWriter, response);
-                }
+                using StringWriter stringWriter = new StringWriter(builder);
+                using JsonTextWriter jsonWriter = new JsonTextWriter(stringWriter);
+                _traceSerializer.Serialize(jsonWriter, response);
 
                 _logger.Trace($"Sending JSON RPC response: {builder}");
             }
@@ -186,12 +225,10 @@ namespace Nethermind.JsonRpc
         {
             if (_logger.IsTrace)
             {
-                var builder = new StringBuilder();
-                using (StringWriter stringWriter = new StringWriter(builder))
-                using (JsonTextWriter jsonWriter = new JsonTextWriter(stringWriter))
-                {
-                    _traceSerializer.Serialize(jsonWriter, responses);
-                }
+                StringBuilder builder = new StringBuilder();
+                using StringWriter stringWriter = new StringWriter(builder);
+                using JsonTextWriter jsonWriter = new JsonTextWriter(stringWriter);
+                _traceSerializer.Serialize(jsonWriter, responses);
 
                 _logger.Trace($"Sending JSON RPC response: {builder}");
             }
@@ -233,9 +270,9 @@ namespace Nethermind.JsonRpc
             {
                 if (!_isEnabled)
                 {
-                    return;;
+                    return;
                 }
-                
+
                 lock (_recorderSync)
                 {
                     _currentRecorderFileLength += request.Length;
@@ -244,7 +281,7 @@ namespace Nethermind.JsonRpc
                         CreateNewRecorderFile();
                     }
 
-                    var singleLineRequest = request.Replace(Environment.NewLine, "");
+                    string singleLineRequest = request.Replace(Environment.NewLine, "");
                     File.AppendAllText(_currentRecorderFilePath, singleLineRequest + Environment.NewLine);
                 }
             }

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcRequest.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcRequest.cs
@@ -16,7 +16,7 @@
  * along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
  */
 
-using Nethermind.Dirichlet.Numerics;
+using Nethermind.Core.Json;
 using Newtonsoft.Json;
 
 namespace Nethermind.JsonRpc
@@ -28,7 +28,9 @@ namespace Nethermind.JsonRpc
         
         [JsonProperty(Required = Required.Default)]
         public string[] Params { get; set; }
-        public UInt256 Id { get; set; }
+        
+        [JsonConverter(typeof(IdConverter))]
+        public object Id { get; set; }
 
         public override string ToString()
         {

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcResponse.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcResponse.cs
@@ -17,7 +17,6 @@
  */
 
 using Nethermind.Core.Json;
-using Nethermind.Dirichlet.Numerics;
 using Newtonsoft.Json;
 
 namespace Nethermind.JsonRpc
@@ -29,10 +28,10 @@ namespace Nethermind.JsonRpc
 
         [JsonProperty(PropertyName = "result", NullValueHandling = NullValueHandling.Include, Order = 2)]
         public object Result { get; set; }
-
-        [JsonConverter(typeof(UInt256Converter), NumberConversion.Decimal)]
+        
+        [JsonConverter(typeof(IdConverter))]
         [JsonProperty(PropertyName = "id", Order = 0)]
-        public UInt256 Id { get; set; }
+        public object Id { get; set; }
     }
     
     public class JsonRpcErrorResponse : JsonRpcResponse
@@ -54,9 +53,9 @@ namespace Nethermind.JsonRpc
 
         [JsonProperty(PropertyName = "error", NullValueHandling = NullValueHandling.Ignore, Order = 3)]
         public Error Error { get; set; }
-
-        [JsonConverter(typeof(UInt256Converter), NumberConversion.Decimal)]
+        
+        [JsonConverter(typeof(IdConverter))]
         [JsonProperty(PropertyName = "id", Order = 0)]
-        public UInt256 Id { get; set; }
+        public object Id { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
@@ -258,7 +258,7 @@ namespace Nethermind.JsonRpc
             }
         }
 
-        private JsonRpcResponse GetSuccessResponse(object result, UInt256 id)
+        private JsonRpcResponse GetSuccessResponse(object result, object id)
         {
             var response = new JsonRpcResponse
             {
@@ -277,7 +277,7 @@ namespace Nethermind.JsonRpc
 
         public IList<JsonConverter> Converters { get; } = new List<JsonConverter>();
 
-        private JsonRpcErrorResponse GetErrorResponse(ErrorType errorType, string message, UInt256 id, string methodName, object result = null)
+        private JsonRpcErrorResponse GetErrorResponse(ErrorType errorType, string message, object id, string methodName, object result = null)
         {
             if (_logger.IsDebug) _logger.Debug($"Sending error response, method: {methodName ?? "none"}, id: {id}, errorType: {errorType}, message: {message}");
             var response = new JsonRpcErrorResponse

--- a/src/Nethermind/Nethermind.Runner/RunnerAppBase.cs
+++ b/src/Nethermind/Nethermind.Runner/RunnerAppBase.cs
@@ -104,7 +104,7 @@ namespace Nethermind.Runner
                 Console.Title = initConfig.LogFileName;
                 Console.CancelKeyPress += ConsoleOnCancelKeyPress;
 
-                var serializer = new UnforgivingJsonSerializer();
+                var serializer = new EthereumJsonSerializer();
                 if (Logger.IsInfo)
                 {
                     Logger.Info($"Nethermind config:\n{serializer.Serialize(initConfig, true)}\n");

--- a/src/Nethermind/Nethermind.Runner/Startup.cs
+++ b/src/Nethermind/Nethermind.Runner/Startup.cs
@@ -26,6 +26,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Nethermind.Config;
+using Nethermind.Core;
 using Nethermind.JsonRpc;
 using Nethermind.Runner.Config;
 using Nethermind.WebSockets;
@@ -50,6 +51,7 @@ namespace Nethermind.Runner
                 p => p.AllowAnyMethod().AllowAnyHeader().WithOrigins(corsOrigins)));
         }
 
+        [Todo(Improve.Performance, "Can we write immediatelly to the stream instead of calling ToString on the entire JSON content?")]
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env, IJsonRpcProcessor jsonRpcProcessor,
             IJsonRpcService jsonRpcService)
         {
@@ -90,6 +92,7 @@ namespace Nethermind.Runner
                 using var reader = new StreamReader(ctx.Request.Body, Encoding.UTF8);
                 var request = await reader.ReadToEndAsync();
                 var result = await jsonRpcProcessor.ProcessAsync(request);
+                
                 await ctx.Response.WriteAsync(result.IsCollection
                     ? JsonConvert.SerializeObject(result.Responses, JsonSettings)
                     : JsonConvert.SerializeObject(result.Response, JsonSettings));


### PR DESCRIPTION
It adds support for JSON RPC requests in the form of "67" or 67 or "0x1234" or 2312423415552531523423423423424 or "some-long-guid-here".

It makes one more step towards getting rid of the UnforgivingJsonSerializer.

It simplifies the IJsonSerializer API.

It optimizes the serialize / deserialize calls from EthereumJsonSerializer so they reuse serializers.

Fixes #983