### PR TITLE
Bitwise speed up for execution in a non vectorized environments

### DIFF
--- a/src/Nethermind/Nethermind.Benchmark/Evm/BitwiseAndBenchmark.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Evm/BitwiseAndBenchmark.cs
@@ -18,6 +18,8 @@
 
 using System;
 using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using BenchmarkDotNet.Attributes;
 
 namespace Nethermind.Benchmarks.Evm
@@ -40,10 +42,14 @@ namespace Nethermind.Benchmarks.Evm
         [Benchmark(Baseline = true)]
         public void Current()
         {
-            for (int i = 0; i < 32; i++)
-            {
-                c[i] = (byte)(a[i] & b[i]);
-            }
+            ref var refA = ref MemoryMarshal.AsRef<ulong>(a);
+            ref var refB = ref MemoryMarshal.AsRef<ulong>(b);
+            ref var refBuffer = ref MemoryMarshal.AsRef<ulong>(c);
+
+            refBuffer = refA & refB;
+            Unsafe.Add(ref refBuffer, 1) = Unsafe.Add(ref refA, 1) & Unsafe.Add(ref refB, 1);
+            Unsafe.Add(ref refBuffer, 2) = Unsafe.Add(ref refA, 2) & Unsafe.Add(ref refB, 2);
+            Unsafe.Add(ref refBuffer, 3) = Unsafe.Add(ref refA, 3) & Unsafe.Add(ref refB, 3);
         }
         
         [Benchmark]

--- a/src/Nethermind/Nethermind.Benchmark/Evm/BitwiseNotBenchmark.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Evm/BitwiseNotBenchmark.cs
@@ -17,6 +17,8 @@
  */
 
 using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using BenchmarkDotNet.Attributes;
 
 namespace Nethermind.Benchmarks.Evm
@@ -45,10 +47,13 @@ namespace Nethermind.Benchmarks.Evm
         [Benchmark(Baseline = true)]
         public void Current()
         {
-            for (int i = 0; i < 32; i++)
-            {
-                c[i] = (byte)(~a[i]);
-            }
+            ref var refA = ref MemoryMarshal.AsRef<ulong>(a);
+            ref var refBuffer = ref MemoryMarshal.AsRef<ulong>(c);
+
+            refBuffer = ~refA;
+            Unsafe.Add(ref refBuffer, 1) = ~Unsafe.Add(ref refA, 1);
+            Unsafe.Add(ref refBuffer, 2) = ~Unsafe.Add(ref refA, 2);
+            Unsafe.Add(ref refBuffer, 3) = ~Unsafe.Add(ref refA, 3);
         }
         
         [Benchmark]

--- a/src/Nethermind/Nethermind.Benchmark/Evm/BitwiseOrBenchmark.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Evm/BitwiseOrBenchmark.cs
@@ -17,6 +17,8 @@
  */
 
 using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using BenchmarkDotNet.Attributes;
 
 namespace Nethermind.Benchmarks.Evm
@@ -39,10 +41,14 @@ namespace Nethermind.Benchmarks.Evm
         [Benchmark(Baseline = true)]
         public void Current()
         {
-            for (int i = 0; i < 32; i++)
-            {
-                c[i] = (byte)(a[i] | b[i]);
-            }
+            ref var refA = ref MemoryMarshal.AsRef<ulong>(a);
+            ref var refB = ref MemoryMarshal.AsRef<ulong>(b);
+            ref var refBuffer = ref MemoryMarshal.AsRef<ulong>(c);
+
+            refBuffer = refA | refB;
+            Unsafe.Add(ref refBuffer, 1) = Unsafe.Add(ref refA, 1) | Unsafe.Add(ref refB, 1);
+            Unsafe.Add(ref refBuffer, 2) = Unsafe.Add(ref refA, 2) | Unsafe.Add(ref refB, 2);
+            Unsafe.Add(ref refBuffer, 3) = Unsafe.Add(ref refA, 3) | Unsafe.Add(ref refB, 3);
         }
         
         [Benchmark]

--- a/src/Nethermind/Nethermind.Benchmark/Evm/BitwiseXorBenchmark.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Evm/BitwiseXorBenchmark.cs
@@ -17,6 +17,8 @@
  */
 
 using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using BenchmarkDotNet.Attributes;
 
 namespace Nethermind.Benchmarks.Evm
@@ -39,10 +41,14 @@ namespace Nethermind.Benchmarks.Evm
         [Benchmark(Baseline = true)]
         public void Current()
         {
-            for (int i = 0; i < 32; i++)
-            {
-                c[i] = (byte)(a[i] ^ b[i]);
-            }
+            ref var refA = ref MemoryMarshal.AsRef<ulong>(a);
+            ref var refB = ref MemoryMarshal.AsRef<ulong>(b);
+            ref var refBuffer = ref MemoryMarshal.AsRef<ulong>(c);
+
+            refBuffer = refA ^ refB;
+            Unsafe.Add(ref refBuffer, 1) = Unsafe.Add(ref refA, 1) ^ Unsafe.Add(ref refB, 1);
+            Unsafe.Add(ref refBuffer, 2) = Unsafe.Add(ref refA, 2) ^ Unsafe.Add(ref refB, 2);
+            Unsafe.Add(ref refBuffer, 3) = Unsafe.Add(ref refA, 3) ^ Unsafe.Add(ref refB, 3);
         }
         
         [Benchmark]

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -17,11 +17,13 @@
  */
 
 using System;
+using System.Buffers;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel.Design;
 using System.Numerics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
@@ -1287,10 +1289,14 @@ namespace Nethermind.Evm
                         }
                         else
                         {
-                            for (int i = 0; i < 32; i++)
-                            {
-                                wordBuffer[i] = (byte)(a[i] & b[i]);
-                            }
+                            ref var refA = ref MemoryMarshal.AsRef<ulong>(a);
+                            ref var refB = ref MemoryMarshal.AsRef<ulong>(b);
+                            ref var refBuffer = ref MemoryMarshal.AsRef<ulong>(wordBuffer);
+
+                            refBuffer = refA & refB;
+                            Unsafe.Add(ref refBuffer, 1) = Unsafe.Add(ref refA, 1) & Unsafe.Add(ref refB, 1);
+                            Unsafe.Add(ref refBuffer, 2) = Unsafe.Add(ref refA, 2) & Unsafe.Add(ref refB, 2);
+                            Unsafe.Add(ref refBuffer, 3) = Unsafe.Add(ref refA, 3) & Unsafe.Add(ref refB, 3);
                         }
 
                         PushBytes(wordBuffer, bytesOnStack);
@@ -1316,10 +1322,14 @@ namespace Nethermind.Evm
                         }
                         else
                         {
-                            for (int i = 0; i < 32; i++)
-                            {
-                                wordBuffer[i] = (byte)(a[i] | b[i]);
-                            }
+                            ref var refA = ref MemoryMarshal.AsRef<ulong>(a);
+                            ref var refB = ref MemoryMarshal.AsRef<ulong>(b);
+                            ref var refBuffer = ref MemoryMarshal.AsRef<ulong>(wordBuffer);
+
+                            refBuffer = refA | refB;
+                            Unsafe.Add(ref refBuffer, 1) = Unsafe.Add(ref refA, 1) | Unsafe.Add(ref refB, 1);
+                            Unsafe.Add(ref refBuffer, 2) = Unsafe.Add(ref refA, 2) | Unsafe.Add(ref refB, 2);
+                            Unsafe.Add(ref refBuffer, 3) = Unsafe.Add(ref refA, 3) | Unsafe.Add(ref refB, 3);
                         }
 
                         PushBytes(wordBuffer, bytesOnStack);
@@ -1345,10 +1355,14 @@ namespace Nethermind.Evm
                         }
                         else
                         {
-                            for (int i = 0; i < 32; i++)
-                            {
-                                wordBuffer[i] = (byte)(a[i] ^ b[i]);
-                            }
+                            ref var refA = ref MemoryMarshal.AsRef<ulong>(a);
+                            ref var refB = ref MemoryMarshal.AsRef<ulong>(b);
+                            ref var refBuffer = ref MemoryMarshal.AsRef<ulong>(wordBuffer);
+
+                            refBuffer = refA ^ refB;
+                            Unsafe.Add(ref refBuffer, 1) = Unsafe.Add(ref refA, 1) ^ Unsafe.Add(ref refB, 1);
+                            Unsafe.Add(ref refBuffer, 2) = Unsafe.Add(ref refA, 2) ^ Unsafe.Add(ref refB, 2);
+                            Unsafe.Add(ref refBuffer, 3) = Unsafe.Add(ref refA, 3) ^ Unsafe.Add(ref refB, 3);
                         }
 
                         PushBytes(wordBuffer, bytesOnStack);
@@ -1373,10 +1387,13 @@ namespace Nethermind.Evm
                         }
                         else
                         {
-                            for (int i = 0; i < 32; ++i)
-                            {
-                                wordBuffer[i] = (byte)~a[i];
-                            }
+                            ref var refA = ref MemoryMarshal.AsRef<ulong>(a);
+                            ref var refBuffer = ref MemoryMarshal.AsRef<ulong>(wordBuffer);
+
+                            refBuffer = ~refA;
+                            Unsafe.Add(ref refBuffer, 1) = ~Unsafe.Add(ref refA, 1);
+                            Unsafe.Add(ref refBuffer, 2) = ~Unsafe.Add(ref refA, 2);
+                            Unsafe.Add(ref refBuffer, 3) = ~Unsafe.Add(ref refA, 3) ;
                         }
 
                         PushBytes(wordBuffer, bytesOnStack);


### PR DESCRIPTION
This PR provides an improvement over bitwise operations for non SIMD-enabled executions. It shows a tremendous gain for non-vectorized (up to 10-15 times faster).

### Details

It does it by treating `Span<byte>` as `ref ulong` and then using ref arithmetic and the fact that the size of the span is known up front, to batch computation and skip boundary checks.

### BitwiseAndBenchmark

Before

|   Method |       Mean |     Error |    StdDev | Ratio | Allocated |
|--------- |-----------:|----------:|----------:|------:|----------:|
|  Current | 38.3080 ns | 0.8547 ns | 2.1285 ns |  1.00 |         - |
| Improved |  0.7642 ns | 0.0574 ns | 0.1237 ns |  0.02 |         - |

After

|   Method |      Mean |     Error |    StdDev | Ratio | RatioSD | Allocated |
|--------- |----------:|----------:|----------:|------:|--------:|----------:|
|  Current | 2.7912 ns | 0.0882 ns | 0.1498 ns |  1.00 |    0.00 |         - |
| Improved | 0.8369 ns | 0.0587 ns | 0.1103 ns |  0.30 |    0.04 |         - |

### BitwiseNotBenchmark

Before

|   Method |       Mean |     Error |    StdDev | Ratio |  Allocated |
|--------- |-----------:|----------:|----------:|------:|------:|
|  Current | 34.7140 ns | 0.7003 ns | 0.8857 ns |  1.00 |          - |
| Improved |  0.7860 ns | 0.0562 ns | 0.0859 ns |  0.02 |         - |

After

|   Method |     Mean |     Error |    StdDev | Ratio | RatioSD | Allocated |
|--------- |---------:|----------:|----------:|------:|--------:|----------:|
|  Current | 1.578 ns | 0.0707 ns | 0.0757 ns |  1.00 |    0.00 |         - |
| Improved | 1.030 ns | 0.0611 ns | 0.1086 ns |  0.66 |    0.07 |         - |

### BitwiseOrBenchmark

Before

|   Method |       Mean |     Error |    StdDev | Ratio | Allocated |
|--------- |-----------:|----------:|----------:|------:|----------:|
|  Current | 36.5179 ns | 0.7490 ns | 0.7356 ns |  1.00 |         - |
| Improved |  0.6491 ns | 0.0549 ns | 0.0675 ns |  0.02 |         - |

After

|   Method |      Mean |     Error |    StdDev |    Median | Ratio | RatioSD | Allocated |
|--------- |----------:|----------:|----------:|----------:|------:|--------:|----------:|
|  Current | 2.6616 ns | 0.0949 ns | 0.1939 ns | 2.5941 ns |  1.00 |    0.00 |         - |
| Improved | 0.8948 ns | 0.0588 ns | 0.1487 ns | 0.8456 ns |  0.35 |    0.06 |         - |

### BitwiseXorBenchmark

Before

|   Method |       Mean |     Error |    StdDev | Ratio | Allocated |
|--------- |-----------:|----------:|----------:|------:|----------:|
|  Current | 36.6601 ns | 0.7728 ns | 1.2911 ns |  1.00 |         - |
| Improved |  0.9368 ns | 0.0571 ns | 0.1389 ns |  0.02 |         - |

After

|   Method |      Mean |     Error |    StdDev | Ratio | RatioSD | Allocated |
|--------- |----------:|----------:|----------:|------:|--------:|----------:|
|  Current | 2.7754 ns | 0.0955 ns | 0.1369 ns |  1.00 |    0.00 |         - |
| Improved | 0.7530 ns | 0.0529 ns | 0.0495 ns |  0.27 |    0.02 |         - |