### PR TITLE
ByteArrayToHexViaLookup32Safe made faster

### DIFF
--- a/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
@@ -619,28 +619,27 @@ namespace Nethermind.Core.Extensions
 
                 int toProcess = state.Bytes.Length;
 
-                const int unroll = 8;
-
-                while (toProcess > unroll)
+                var lookup32 = Lookup32;
+                while (toProcess > 8)
                 {
-                    output = Lookup32[input];
-                    Unsafe.Add(ref output, 1) = Lookup32[Unsafe.Add(ref input, 1)];
-                    Unsafe.Add(ref output, 2) = Lookup32[Unsafe.Add(ref input, 2)];
-                    Unsafe.Add(ref output, 3) = Lookup32[Unsafe.Add(ref input, 3)];
-                    Unsafe.Add(ref output, 4) = Lookup32[Unsafe.Add(ref input, 4)];
-                    Unsafe.Add(ref output, 5) = Lookup32[Unsafe.Add(ref input, 5)];
-                    Unsafe.Add(ref output, 6) = Lookup32[Unsafe.Add(ref input, 6)];
-                    Unsafe.Add(ref output, 7) = Lookup32[Unsafe.Add(ref input, 7)];
+                    output = lookup32[input];
+                    Unsafe.Add(ref output, 1) = lookup32[Unsafe.Add(ref input, 1)];
+                    Unsafe.Add(ref output, 2) = lookup32[Unsafe.Add(ref input, 2)];
+                    Unsafe.Add(ref output, 3) = lookup32[Unsafe.Add(ref input, 3)];
+                    Unsafe.Add(ref output, 4) = lookup32[Unsafe.Add(ref input, 4)];
+                    Unsafe.Add(ref output, 5) = lookup32[Unsafe.Add(ref input, 5)];
+                    Unsafe.Add(ref output, 6) = lookup32[Unsafe.Add(ref input, 6)];
+                    Unsafe.Add(ref output, 7) = lookup32[Unsafe.Add(ref input, 7)];
 
-                    output = ref Unsafe.Add(ref output, unroll);
-                    input = ref Unsafe.Add(ref input, unroll);
+                    output = ref Unsafe.Add(ref output, 8);
+                    input = ref Unsafe.Add(ref input, 8);
                     
-                    toProcess -= unroll;
+                    toProcess -= 8;
                 }
 
                 while (toProcess > 0)
                 {
-                    output = Lookup32[input];
+                    output = lookup32[input];
 
                     output = ref Unsafe.Add(ref output, 1);
                     input = ref Unsafe.Add(ref input, 1);

--- a/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
@@ -611,7 +611,7 @@ namespace Nethermind.Core.Extensions
                 {
                     charsRef = '0';
                     Unsafe.Add(ref charsRef, 1) = 'x';
-                    charsRef = Unsafe.Add(ref charsRef, 2);
+                    charsRef = ref Unsafe.Add(ref charsRef, 2);
                 }
 
                 ref var input = ref state.Bytes[0];


### PR DESCRIPTION
This PR makes `ByteArrayToHexViaLookup32Safe` a bit faster (~20-25%) by:

1. unrolling the loop with `ref` arithmetic
1. skipping redundant length checks

It potentially shows how this optimization can be done in other places

### Benchmarks

Before

|     Method |      Mean |    Error |   StdDev | Ratio | RatioSD | Allocated |
|----------- |----------:|---------:|---------:|------:|--------:|----------:|
| SafeLookup | 121.43 ns | 1.760 ns | 1.646 ns |  1.84 |    0.09 |     280 B |
|   HexMateA |  71.45 ns | 2.265 ns | 6.608 ns |  1.00 |    0.00 |     280 B |

After

|     Method |     Mean |    Error |   StdDev | Ratio | RatioSD | Allocated |
|----------- |---------:|---------:|---------:|------:|--------:|----------:|
| SafeLookup | 97.17 ns | 2.011 ns | 4.198 ns |  1.46 |    0.09 |     280 B |
|   HexMateA | 67.01 ns | 1.452 ns | 2.504 ns |  1.00 |    0.00 |     280 B |