### PR TITLE
ethash optimizations

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Synchronization/FastSync/NodeDataDownloaderTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Synchronization/FastSync/NodeDataDownloaderTests.cs
@@ -577,7 +577,7 @@ namespace Nethermind.Blockchain.Test.Synchronization.FastSync
 
         private int _timeoutLength = 10000;
 
-        [Test, TestCaseSource("Scenarios"), Retry(3)]
+        [Test, TestCaseSource("Scenarios"), Retry(5)]
         public async Task Can_download_in_multiple_connections((string Name, Action<StateTree, StateDb, StateDb> SetupTree) testCase)
         {
             testCase.SetupTree(_remoteStateTree, _remoteStateDb, _remoteCodeDb);
@@ -600,7 +600,7 @@ namespace Nethermind.Blockchain.Test.Synchronization.FastSync
             CompareTrees("END");
         }
 
-        [Test, TestCaseSource("Scenarios"), Retry(3)]
+        [Test, TestCaseSource("Scenarios"), Retry(5)]
         public async Task Can_download_with_moving_target((string Name, Action<StateTree, StateDb, StateDb> SetupTree) testCase)
         {
             testCase.SetupTree(_remoteStateTree, _remoteStateDb, _remoteCodeDb);
@@ -641,7 +641,7 @@ namespace Nethermind.Blockchain.Test.Synchronization.FastSync
             CompareCodeDbs();
         }
 
-        [Test, TestCaseSource("Scenarios"), Retry(3)]
+        [Test, TestCaseSource("Scenarios"), Retry(5)]
         public async Task Big_test((string Name, Action<StateTree, StateDb, StateDb> SetupTree) testCase)
         {
             _remoteCodeDb[Keccak.Compute(Code0).Bytes] = Code0;
@@ -705,7 +705,7 @@ namespace Nethermind.Blockchain.Test.Synchronization.FastSync
             CompareCodeDbs();
         }
 
-        [Test, TestCaseSource("Scenarios"), Retry(3)]
+        [Test, TestCaseSource("Scenarios"), Retry(5)]
         public async Task Can_download_when_executor_sends_shorter_responses((string Name, Action<StateTree, StateDb, StateDb> SetupTree) testCase)
         {
             testCase.SetupTree(_remoteStateTree, _remoteStateDb, _remoteCodeDb);
@@ -723,7 +723,7 @@ namespace Nethermind.Blockchain.Test.Synchronization.FastSync
             CompareTrees("END");
         }
 
-        [Test, TestCaseSource("Scenarios"), Retry(3)]
+        [Test, TestCaseSource("Scenarios"), Retry(5)]
         public async Task Can_download_a_full_state((string Name, Action<StateTree, StateDb, StateDb> SetupTree) testCase)
         {
             testCase.SetupTree(_remoteStateTree, _remoteStateDb, _remoteCodeDb);
@@ -748,7 +748,7 @@ namespace Nethermind.Blockchain.Test.Synchronization.FastSync
             CompareTrees("END");
         }
 
-        [Test, TestCaseSource("Scenarios"), Retry(3)]
+        [Test, TestCaseSource("Scenarios"), Retry(5)]
         public async Task Dependent_branch_counter_is_zero_and_leaf_is_short((string Name, Action<StateTree, StateDb, StateDb> SetupTree) testCase)
         {
             testCase.SetupTree(_remoteStateTree, _remoteStateDb, _remoteCodeDb);
@@ -788,7 +788,7 @@ namespace Nethermind.Blockchain.Test.Synchronization.FastSync
             CompareTrees("END");
         }
         
-        [Test, TestCaseSource("Scenarios"), Retry(3)]
+        [Test, TestCaseSource("Scenarios"), Retry(5)]
         public async Task Scenario_plus_one_storage((string Name, Action<StateTree, StateDb, StateDb> SetupTree) testCase)
         {
             testCase.SetupTree(_remoteStateTree, _remoteStateDb, _remoteCodeDb);
@@ -821,7 +821,7 @@ namespace Nethermind.Blockchain.Test.Synchronization.FastSync
             CompareTrees("END");
         }
 
-        [Test, TestCaseSource("Scenarios"), Retry(3)]
+        [Test, TestCaseSource("Scenarios"), Retry(5)]
         public async Task Scenario_plus_one_code((string Name, Action<StateTree, StateDb, StateDb> SetupTree) testCase)
         {
             testCase.SetupTree(_remoteStateTree, _remoteStateDb, _remoteCodeDb);
@@ -853,7 +853,7 @@ namespace Nethermind.Blockchain.Test.Synchronization.FastSync
             CompareTrees("END");
         }
 
-        [Test, TestCaseSource("Scenarios"), Retry(3)]
+        [Test, TestCaseSource("Scenarios"), Retry(5)]
         public async Task Scenario_plus_one_code_one_storage((string Name, Action<StateTree, StateDb, StateDb> SetupTree) testCase)
         {
             testCase.SetupTree(_remoteStateTree, _remoteStateDb, _remoteCodeDb);
@@ -899,7 +899,7 @@ namespace Nethermind.Blockchain.Test.Synchronization.FastSync
         }
 
         [Test]
-        [Retry(3)]
+        [Retry(5)]
         public async Task Silences_when_peer_sends_empty_byte_arrays()
         {
             ExecutorMock mock = new ExecutorMock(_remoteStateDb, _remoteCodeDb, ExecutorMock.EmptyArraysInResponses);

--- a/src/Nethermind/Nethermind.Blockchain.Test/Synchronization/MeasuredProgressTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Synchronization/MeasuredProgressTests.cs
@@ -77,7 +77,7 @@ namespace Nethermind.Blockchain.Test.Synchronization
             measuredProgress.SetMeasuringPoint();
             Thread.Sleep(100);
             measuredProgress.Update(1L);
-            Assert.GreaterOrEqual(measuredProgress.TotalPerSecond, 6M);
+            Assert.GreaterOrEqual(measuredProgress.TotalPerSecond, 4M);
             Assert.LessOrEqual(measuredProgress.TotalPerSecond, 10M);
         }
 

--- a/src/Nethermind/Nethermind.Blockchain/TxPools/TxPool.cs
+++ b/src/Nethermind/Nethermind.Blockchain/TxPools/TxPool.cs
@@ -18,6 +18,8 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection.Metadata.Ecma335;
+using System.Security.Cryptography;
 using System.Threading;
 using System.Timers;
 using Nethermind.Blockchain.Synchronization;
@@ -58,16 +60,12 @@ namespace Nethermind.Blockchain.TxPools
         private static readonly ThreadLocal<Random> Random =
             new ThreadLocal<Random>(() => new Random(Interlocked.Increment(ref _seed)));
         
+        private SortedPool<Keccak, Transaction> _transactions = new SortedPool<Keccak,Transaction>(1024, (t1, t2) => t1.GasPrice.CompareTo(t2.GasPrice));
+        
         private readonly ISpecProvider _specProvider;
         private readonly IStateProvider _stateProvider;
         private readonly IEthereumEcdsa _ecdsa;
         private readonly ILogger _logger;
-
-        /// <summary>
-        /// All pending transactions.
-        /// </summary>
-        private readonly ConcurrentDictionary<Keccak, Transaction> _pendingTxs =
-            new ConcurrentDictionary<Keccak, Transaction>();
 
         /// <summary>
         /// Transactions published locally (initiated by this node users).
@@ -167,7 +165,7 @@ namespace Nethermind.Blockchain.TxPools
             _txRemovalTimer.Start();
         }
 
-        public Transaction[] GetPendingTransactions() => _pendingTxs.Values.ToArray();
+        public Transaction[] GetPendingTransactions() => _transactions.GetSnapshot();
         
         public Transaction[] GetOwnPendingTransactions() => _ownTransactions.Values.ToArray();
 
@@ -220,7 +218,7 @@ namespace Nethermind.Blockchain.TxPools
                 return AddTxResult.InvalidChainId;
             }
 
-            if (!_pendingTxs.TryAdd(tx.Hash, tx))
+            if (!_transactions.TryInsert(tx.Hash, tx))
             {
                 // If transaction is fresh and already known then it may be stored in memory.
                 Metrics.PendingTransactionsKnown++;
@@ -248,7 +246,7 @@ namespace Nethermind.Blockchain.TxPools
             
             if (isOwn && !HandleOwnTransaction(tx))
             {
-                _pendingTxs.TryRemove(tx.Hash, out _);
+                _transactions.TryRemove(tx.Hash, out _);
                 return AddTxResult.OwnNonceAlreadyUsed;
             }
             
@@ -330,7 +328,7 @@ namespace Nethermind.Blockchain.TxPools
                 }
             }
             
-            if (_pendingTxs.TryRemove(hash, out var transaction))
+            if (_transactions.TryRemove(hash, out var transaction))
             {
                 RemovedPending?.Invoke(this, new TxEventArgs(transaction));
             }
@@ -351,7 +349,7 @@ namespace Nethermind.Blockchain.TxPools
 
         public bool TryGetSender(Keccak hash, out Address sender)
         {
-            bool found = _pendingTxs.TryGetValue(hash, out Transaction transaction);
+            bool found = _transactions.TryGetValue(hash, out Transaction transaction);
             sender = found ? transaction.SenderAddress : null;
             return found;
         }
@@ -460,14 +458,14 @@ namespace Nethermind.Blockchain.TxPools
         
         private void RemovalTimerElapsed(object sender, ElapsedEventArgs eventArgs)
         {
-            if (_pendingTxs.Count == 0)
+            if (_transactions.Count == 0)
             {
                 return;
             }
 
             List<Keccak> hashes = new List<Keccak>();
             UInt256 timestamp = new UInt256(_timestamper.EpochSeconds);
-            foreach (Transaction tx in _pendingTxs.Values)
+            foreach (Transaction tx in _transactions.GetSnapshot())
             {
                 if (_ownTransactions.ContainsKey(tx.Hash))
                 {
@@ -483,7 +481,7 @@ namespace Nethermind.Blockchain.TxPools
 
             for (int i = 0; i < hashes.Count; i++)
             {
-                if (_pendingTxs.TryRemove(hashes[i], out Transaction tx))
+                if (_transactions.TryRemove(hashes[i], out Transaction tx))
                 {
                     RemovedPending?.Invoke(this, new TxEventArgs(tx));
                 }

--- a/src/Nethermind/Nethermind.Blockchain/TxPools/TxPool.cs
+++ b/src/Nethermind/Nethermind.Blockchain/TxPools/TxPool.cs
@@ -66,8 +66,8 @@ namespace Nethermind.Blockchain.TxPools
         /// <summary>
         /// All pending transactions.
         /// </summary>
-        private readonly ConcurrentDictionary<Keccak, Transaction> _pendingTxs =
-            new ConcurrentDictionary<Keccak, Transaction>();
+        private readonly LruCache<Keccak, Transaction> _pendingTxs =
+            new LruCache<Keccak, Transaction>(1024);
 
         /// <summary>
         /// Transactions published locally (initiated by this node users).

--- a/src/Nethermind/Nethermind.Blockchain/TxPools/TxPool.cs
+++ b/src/Nethermind/Nethermind.Blockchain/TxPools/TxPool.cs
@@ -66,8 +66,8 @@ namespace Nethermind.Blockchain.TxPools
         /// <summary>
         /// All pending transactions.
         /// </summary>
-        private readonly LruCache<Keccak, Transaction> _pendingTxs =
-            new LruCache<Keccak, Transaction>(1024);
+        private readonly ConcurrentDictionary<Keccak, Transaction> _pendingTxs =
+            new ConcurrentDictionary<Keccak, Transaction>();
 
         /// <summary>
         /// Transactions published locally (initiated by this node users).

--- a/src/Nethermind/Nethermind.Blockchain/TxPools/TxPoolConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/TxPools/TxPoolConfig.cs
@@ -18,8 +18,8 @@ namespace Nethermind.Blockchain.TxPools
 {
     public class TxPoolConfig : ITxPoolConfig
     {
-        public int ObsoletePendingTransactionInterval { get; set; } = 15;
-        public int RemovePendingTransactionInterval { get; set; } = 600;
+        public int ObsoletePendingTransactionInterval { get; set; } = 5;
+        public int RemovePendingTransactionInterval { get; set; } = 15;
         public int PeerNotificationThreshold { get; set; } = 5;
     }
 }

--- a/src/Nethermind/Nethermind.Core.Test/SortedPoolTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/SortedPoolTests.cs
@@ -1,0 +1,89 @@
+﻿//  Copyright (c) 2018 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Dirichlet.Numerics;
+using NUnit.Framework;
+
+namespace Nethermind.Core.Test
+{
+    [TestFixture]
+    public class SortedPoolTests
+    {
+        private const int Capacity = 16;
+
+        private readonly SortedPool<Keccak, Transaction> _sortedPool = new SortedPool<Keccak, Transaction>(Capacity, (t1, t2) => t1.GasPrice.CompareTo(t2.GasPrice));
+
+        private Transaction[] _transactions = new Transaction[Capacity * 8];
+        
+        [SetUp]
+        public void Setup()
+        {
+            for (int i = 0; i < _transactions.Length; i++)
+            {
+                UInt256.Create(out UInt256 gasPrice, i);
+                _transactions[i] = Build.A.Transaction.WithGasPrice(gasPrice).TestObject;
+            }
+        }
+
+        [Test]
+        public void Beyond_capacity()
+        {
+            for (int i = 0; i < _transactions.Length; i++)
+            {
+                var tx = _transactions[^(i + 1)];
+                tx.Hash = Transaction.CalculateHash(tx);
+                _sortedPool.TryInsert(tx.Hash, tx);
+                Assert.AreEqual(i > 15 ? null : tx, _sortedPool.TryGetValue(tx.Hash, out Transaction txOther) ? txOther : null);
+                Assert.AreEqual(Math.Min(16, i + 1), _sortedPool.Count);
+            }
+
+            Assert.AreEqual(Capacity, _sortedPool.GetSnapshot().Length);
+            
+            for (int i = 0; i < Capacity; i++)
+            {
+                Transaction tx = _sortedPool.TakeFirst();
+                UInt256.Create(out UInt256 gasPrice, _transactions.Length - i - 1);
+                Assert.AreEqual(Capacity - i - 1, _sortedPool.Count);
+                Assert.AreEqual(gasPrice, tx.GasPrice);
+            }
+            
+            
+        }
+        
+        [Test]
+        public void Beyond_capacity_ordered()
+        {
+            for (int i = 0; i < _transactions.Length; i++)
+            {
+                var tx = _transactions[i];
+                tx.Hash = Transaction.CalculateHash(tx);
+                _sortedPool.TryInsert(tx.Hash, tx);
+                Assert.AreEqual(Math.Min(16, i + 1), _sortedPool.Count);
+            }
+
+            for (int i = 0; i < Capacity; i++)
+            {
+                Transaction tx = _sortedPool.TakeFirst();
+                UInt256.Create(out UInt256 gasPrice, _transactions.Length - i - 1);
+                Assert.AreEqual(Capacity - i - 1, _sortedPool.Count);
+                Assert.AreEqual(gasPrice, tx.GasPrice);
+            }
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Core/SortedPool.cs
+++ b/src/Nethermind/Nethermind.Core/SortedPool.cs
@@ -1,0 +1,140 @@
+﻿//  Copyright (c) 2018 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+
+namespace Nethermind.Core
+{
+    public class SortedPool<TKey, TValue>
+    {
+        private readonly int _capacity;
+        private readonly Comparison<TValue> _comparison;
+        private readonly Dictionary<TKey, LinkedListNode<KeyValuePair<TKey, TValue>>> _cacheMap;
+        private readonly LinkedList<KeyValuePair<TKey, TValue>> _lruList;
+
+        public SortedPool(int capacity, Comparison<TValue> comparison)
+        {
+            _capacity = capacity;
+            _comparison = comparison;
+            _cacheMap = new Dictionary<TKey, LinkedListNode<KeyValuePair<TKey, TValue>>>(); // do not initialize it at the full capacity
+            _lruList = new LinkedList<KeyValuePair<TKey, TValue>>();
+        }
+
+        public int Count => _cacheMap.Count;
+
+        [MethodImpl(MethodImplOptions.Synchronized)]
+        public TValue[] GetSnapshot()
+        {
+            return _lruList.Select(i => i.Value).ToArray();
+        }
+
+        [MethodImpl(MethodImplOptions.Synchronized)]
+        public TValue TakeFirst()
+        {
+            var value = _lruList.First.Value;
+            _lruList.RemoveFirst();
+            _cacheMap.Remove(value.Key);
+            return value.Value;
+        }
+
+        [MethodImpl(MethodImplOptions.Synchronized)]
+        public bool TryRemove(TKey key, out TValue tx)
+        {
+            if (_cacheMap.TryGetValue(key, out var txNode))
+            {
+                if (_cacheMap.Remove(key))
+                {
+                    _lruList.Remove(txNode);
+                    tx = txNode.Value.Value;
+                    return true;
+                }
+            }
+
+            tx = default;
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.Synchronized)]
+        public bool TryGetValue(TKey key, out TValue tx)
+        {
+            if (_cacheMap.TryGetValue(key, out var txNode))
+            {
+                tx = txNode.Value.Value;
+                return true;
+            }
+
+            tx = default;
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.Synchronized)]
+        public bool TryInsert(TKey key, TValue val)
+        {
+            if (val == null)
+            {
+                throw new ArgumentNullException();
+            }
+
+            if (_cacheMap.TryGetValue(key, out _))
+            {
+                return false;
+            }
+
+            KeyValuePair<TKey, TValue> cacheItem = new KeyValuePair<TKey, TValue>(key, val);
+            LinkedListNode<KeyValuePair<TKey, TValue>> newNode = new LinkedListNode<KeyValuePair<TKey, TValue>>(cacheItem);
+
+
+            LinkedListNode<KeyValuePair<TKey, TValue>> node = _lruList.First;
+            bool added = false;
+            while (node != null)
+            {
+                if (_comparison(node.Value.Value, val) < 0)
+                {
+                    _lruList.AddBefore(node, newNode);
+                    added = true;
+                    break;
+                }
+
+                node = node.Next;
+            }
+
+            if (!added)
+            {
+                _lruList.AddLast(newNode);
+            }
+
+            _cacheMap.Add(key, newNode);
+
+            if (_cacheMap.Count > _capacity)
+            {
+                RemoveLast();
+            }
+
+            return true;
+        }
+
+        private void RemoveLast()
+        {
+            LinkedListNode<KeyValuePair<TKey, TValue>> node = _lruList.Last;
+            _lruList.RemoveLast();
+
+            _cacheMap.Remove(node.Value.Key);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Mining/EthashCache.cs
+++ b/src/Nethermind/Nethermind.Mining/EthashCache.cs
@@ -15,6 +15,7 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
 using System;
+using System.Buffers;
 using Nethermind.Core.Crypto;
 
 namespace Nethermind.Mining
@@ -23,12 +24,14 @@ namespace Nethermind.Mining
     {
         private uint[][] Data { get; set; }
 
-        public uint Size => (uint)(Data.Length * Ethash.HashBytes);
+        public uint Size { get; set; }
 
         public EthashCache(uint cacheSize, byte[] seed)
         {
             uint cachePageCount = cacheSize / Ethash.HashBytes;
-            Data = new uint[cachePageCount][];
+            Size = cachePageCount * Ethash.HashBytes;
+                
+            Data = ArrayPool<uint[]>.Shared.Rent((int)cachePageCount);
             Data[0] = Keccak512.ComputeToUInts(seed);
             for (uint i = 1; i < cachePageCount; i++)
             {
@@ -55,7 +58,7 @@ namespace Nethermind.Mining
 
         public uint[] CalcDataSetItem(uint i)
         {
-            uint n = (uint)Data.Length;
+            uint n = Size / Ethash.HashBytes;
             int r = Ethash.HashBytes / Ethash.WordBytes;
 
             uint[] mixInts = new uint[Ethash.HashBytes / Ethash.WordBytes];
@@ -72,6 +75,35 @@ namespace Nethermind.Mining
 
             mixInts = Keccak512.ComputeUIntsToUInts(mixInts);
             return mixInts;
+        }
+
+        private bool isDisposed;
+        
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+        
+        private void Dispose(bool isDisposing)
+        {
+            if (isDisposed)
+            {
+                return;
+            }
+            
+            isDisposed = true;
+            
+            if (isDisposing)
+            {
+                GC.SuppressFinalize(this);
+            }
+            
+            ArrayPool<uint[]>.Shared.Return(Data);
+        }
+
+        ~EthashCache()
+        {
+            Dispose(false);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Mining/FullDataSet.cs
+++ b/src/Nethermind/Nethermind.Mining/FullDataSet.cs
@@ -35,5 +35,9 @@ namespace Nethermind.Mining
         {
             return Data[i];
         }
+
+        public void Dispose()
+        {
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Mining/IEthashDataSet.cs
+++ b/src/Nethermind/Nethermind.Mining/IEthashDataSet.cs
@@ -14,9 +14,11 @@
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
+using System;
+
 namespace Nethermind.Mining
 {
-    public interface IEthashDataSet
+    public interface IEthashDataSet : IDisposable
     {
         uint Size { get; }
         uint[] CalcDataSetItem(uint i);

--- a/src/Nethermind/Nethermind.Network/P2P/HelloMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/HelloMessageSerializer.cs
@@ -14,6 +14,7 @@
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
+using System;
 using System.Linq;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Encoding;
@@ -44,11 +45,11 @@ namespace Nethermind.Network.P2P
 
             HelloMessage helloMessage = new HelloMessage();
             helloMessage.P2PVersion = rlpStream.DecodeByte();
-            helloMessage.ClientId = rlpStream.DecodeString();
+            helloMessage.ClientId = string.Intern(rlpStream.DecodeString());
             helloMessage.Capabilities = rlpStream.DecodeArray(ctx =>
             {
                 ctx.ReadSequenceLength();
-                string protocolCode = ctx.DecodeString();
+                string protocolCode = string.Intern(ctx.DecodeString());
                 int version = ctx.DecodeByte();
                 return new Capability(protocolCode, version);
             }).ToList();

--- a/src/Nethermind/Nethermind.sln.DotSettings
+++ b/src/Nethermind/Nethermind.sln.DotSettings
@@ -36,6 +36,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=CALLVALUE/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=chainspec/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Challengeable/@EntryIndexedValue">True</s:Boolean>
+	
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=CODECOPY/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=CODESIZE/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=coinbase/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
(also rebased on top of the other PR - pending_limits)
Waiting for Task.Result outside of a lock.
Removing old epochs from cache.
string interning on client ids and capabilities.
Array Pool used for ethash uint[][]