### PR TITLE
Remove excessive "Staying on sync mode Full" logs after fast sync

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncModeSelector.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncModeSelector.cs
@@ -131,7 +131,7 @@ namespace Nethermind.Blockchain.Synchronization
                 if (_logger.IsInfo) _logger.Info($"Switching sync mode from {Current} to {newSyncMode} {BuildStateString(bestHeader, bestFullBlock, bestFullState, maxBlockNumberAmongPeers)}");
                 ChangeSyncMode(newSyncMode);
             }
-            else
+            else if (Current != SyncMode.Full)
             {
                 if (_logger.IsInfo) _logger.Info($"Staying on sync mode {Current} {BuildStateString(bestHeader, bestFullBlock, bestFullState, maxBlockNumberAmongPeers)}");
             }


### PR DESCRIPTION
Logs before:

`2019-12-30 12:45:26.0875|DEBUG Full Sync | Processed    1912329 |   14 150ms, mgasps    0,00 total    0,00, tps    0,00 total    0,00, bps    0,07 total    0,06, recv queue 0, proc queue 0|
2019-12-30 12:45:26.2826|Discovered a new block   1912329 11:45:24 (0x7fdc4e...87f020), tx count: 2 sealed by roninkaizen, sent by 13.93.54.137:30303|
2019-12-30 12:45:26.4223|Staying on sync mode Full |best header:1912329|best full block:1912329|best state:1912329|best peer block:1912329|
2019-12-30 12:45:27.4234|Staying on sync mode Full |best header:1912329|best full block:1912329|best state:1912329|best peer block:1912329|
2019-12-30 12:45:28.4388|Staying on sync mode Full |best header:1912329|best full block:1912329|best state:1912329|best peer block:1912329|
2019-12-30 12:45:29.4518|Staying on sync mode Full |best header:1912329|best full block:1912329|best state:1912329|best peer block:1912329|
2019-12-30 12:45:30.4523|Staying on sync mode Full |best header:1912329|best full block:1912329|best state:1912329|best peer block:1912329|
2019-12-30 12:45:31.4601|Staying on sync mode Full |best header:1912329|best full block:1912329|best state:1912329|best peer block:1912329|
2019-12-30 12:45:32.4698|Sync peers - Initialized: 2 | All: 2 | Max: 50|
2019-12-30 12:45:32.4698|Staying on sync mode Full |best header:1912329|best full block:1912329|best state:1912329|best peer block:1912329|
2019-12-30 12:45:32.4698|   [Peer|13.93.54.137:30303|1912329|Parity-Ethereum/v2.6.5-beta-753b923-20191112/x86_64-linux-gnu/rustc1.39.0][1047]|
2019-12-30 12:45:32.4698|   [Peer|94.237.54.114:30313|1912329|Nethermind/v1.3.8-14-gffddb0d-20191227/X64-Linux 4.4.0-141-generic/Core3.0.1][228]|
2019-12-30 12:45:33.4775|Staying on sync mode Full |best header:1912329|best full block:1912329|best state:1912329|best peer block:1912329|
2019-12-30 12:45:34.4914|Staying on sync mode Full |best header:1912329|best full block:1912329|best state:1912329|best peer block:1912329|
2019-12-30 12:45:35.4990|Staying on sync mode Full |best header:1912329|best full block:1912329|best state:1912329|best peer block:1912329|
2019-12-30 12:45:36.5095|Staying on sync mode Full |best header:1912329|best full block:1912329|best state:1912329|best peer block:1912329|
2019-12-30 12:45:37.5199|Staying on sync mode Full |best header:1912329|best full block:1912329|best state:1912329|best peer block:1912329|
2019-12-30 12:45:38.5226|Staying on sync mode Full |best header:1912329|best full block:1912329|best state:1912329|best peer block:1912329|
2019-12-30 12:45:39.5364|Staying on sync mode Full |best header:1912329|best full block:1912329|best state:1912329|best peer block:1912329|
2019-12-30 12:45:40.5467|Staying on sync mode Full |best header:1912329|best full block:1912329|best state:1912329|best peer block:1912329|
2019-12-30 12:45:41.5626|Staying on sync mode Full |best header:1912329|best full block:1912329|best state:1912329|best peer block:1912329|
2019-12-30 12:45:41.5626|Discovered a new block   1912330 11:45:39 (0xffb201...c734c8), tx count: 3 sealed by Infura, sent by 13.93.54.137:30303|
2019-12-30 12:45:41.5832|DEBUG Full Sync | Processed    1912330 |   15 495ms, mgasps    0,03 total    0,00, tps    0,19 total    0,00, bps    0,06 total    0,06, recv queue 0, proc queue 0|
2019-12-30 12:45:41.7892|Discovered a new block   1912330 11:45:39 (0x44325a...ee203e), tx count: 2 sealed by roninkaizen, sent by 13.93.54.137:30303|
2019-12-30 12:45:42.5780|Staying on sync mode Full |best header:1912330|best full block:1912330|best state:1912330|best peer block:1912330|
2019-12-30 12:45:43.5805|Staying on sync mode Full |best header:1912330|best full block:1912330|best state:1912330|best peer block:1912330|
2019-12-30 12:45:44.5967|Staying on sync mode Full |best header:1912330|best full block:1912330|best state:1912330|best peer block:1912330|
2019-12-30 12:45:45.6100|Staying on sync mode Full |best header:1912330|best full block:1912330|best state:1912330|best peer block:1912330|
2019-12-30 12:45:46.6246|Staying on sync mode Full |best header:1912330|best full block:1912330|best state:1912330|best peer block:1912330|
2019-12-30 12:45:47.6318|Staying on sync mode Full |best header:1912330|best full block:1912330|best state:1912330|best peer block:1912330|
2019-12-30 12:45:48.6398|Staying on sync mode Full |best header:1912330|best full block:1912330|best state:1912330|best peer block:1912330|
2019-12-30 12:45:49.6490|Staying on sync mode Full |best header:1912330|best full block:1912330|best state:1912330|best peer block:1912330|
2019-12-30 12:45:50.6569|Staying on sync mode Full |best header:1912330|best full block:1912330|best state:1912330|best peer block:1912330|
2019-12-30 12:45:51.6659|Staying on sync mode Full |best header:1912330|best full block:1912330|best state:1912330|best peer block:1912330|
2019-12-30 12:45:52.6764|Staying on sync mode Full |best header:1912330|best full block:1912330|best state:1912330|best peer block:1912330|
2019-12-30 12:45:53.6924|Staying on sync mode Full |best header:1912330|best full block:1912330|best state:1912330|best peer block:1912330|
2019-12-30 12:45:54.7072|Staying on sync mode Full |best header:1912330|best full block:1912330|best state:1912330|best peer block:1912330|
2019-12-30 12:45:55.6711|Discovered a new block   1912331 11:45:54 (0xe47ab1...86051a), tx count: 1 sealed by Pantheon, sent by 13.93.54.137:30303|
2019-12-30 12:45:55.6761|DEBUG Full Sync | Processed    1912331 |   14 093ms, mgasps    0,02 total    0,00, tps    0,07 total    0,00, bps    0,07 total    0,06, recv queue 0, proc queue 0|
2019-12-30 12:45:55.7185|Staying on sync mode Full |best header:1912331|best full block:1912331|best state:1912331|best peer block:1912331|
2019-12-30 12:45:56.3327|Discovered a new block   1912331 11:45:54 (0x6237b9...cd3e1b), tx count: 1 sealed by roninkaizen, sent by 13.93.54.137:30303|
2019-12-30 12:45:56.7258|Staying on sync mode Full |best header:1912331|best full block:1912331|best state:1912331|best peer block:1912331|
2019-12-30 12:45:57.7331|Staying on sync mode Full |best header:1912331|best full block:1912331|best state:1912331|best peer block:1912331|
2019-12-30 12:45:58.7351|Staying on sync mode Full |best header:1912331|best full block:1912331|best state:1912331|best peer block:1912331|
2019-12-30 12:45:59.7412|Staying on sync mode Full |best header:1912331|best full block:1912331|best state:1912331|best peer block:1912331|
2019-12-30 12:46:00.7445|Staying on sync mode Full |best header:1912331|best full block:1912331|best state:1912331|best peer block:1912331|
2019-12-30 12:46:01.7494|Staying on sync mode Full |best header:1912331|best full block:1912331|best state:1912331|best peer block:1912331|
2019-12-30 12:46:02.7551|Staying on sync mode Full |best header:1912331|best full block:1912331|best state:1912331|best peer block:1912331|
2019-12-30 12:46:03.7691|Staying on sync mode Full |best header:1912331|best full block:1912331|best state:1912331|best peer block:1912331|
2019-12-30 12:46:04.7814|Staying on sync mode Full |best header:1912331|best full block:1912331|best state:1912331|best peer block:1912331|
2019-12-30 12:46:05.7819|Staying on sync mode Full |best header:1912331|best full block:1912331|best state:1912331|best peer block:1912331|`

Logs after 
`2019-12-30 12:48:40.4565|DEBUG Full Sync | Processed    1912332 |    1 388ms, mgasps    1,58 total    1,58, tps    5,04 total    5,04, bps    0,00 total    0,00, recv queue 0, proc queue 9|
2019-12-30 12:48:42.3266|Discovered a new block   1912342 11:48:39 (0xa2f839...817bd2), tx count: 5 sealed by Dapowerplay, sent by 94.237.54.114:30313|
2019-12-30 12:48:42.6825|DEBUG Full Sync | Processed    1912342 |    2 226ms, mgasps    2,04 total    1,86, tps    6,74 total    6,09, bps    4,49 total    2,77, recv queue 0, proc queue 0|
2019-12-30 12:48:43.5742|Discovered a new block   1912342 11:48:39 (0x3f3c4d...d9000a), tx count: 1 sealed by Parity, sent by 13.93.54.137:30303|
2019-12-30 12:48:56.1662|Discovered a new block   1912343 11:48:54 (0xc6d47b...2e39a2), tx count: 1 sealed by roninkaizen, sent by 94.237.54.114:30313|
2019-12-30 12:48:56.1789|DEBUG Full Sync | Processed    1912343 |   13 496ms, mgasps    0,03 total    0,42, tps    0,07 total    1,34, bps    0,07 total    0,64, recv queue 0, proc queue 0|
2019-12-30 12:49:10.6937|Discovered a new block   1912344 11:49:09 (0x2aebb4...e293f1), tx count: 3 sealed by Infura, sent by 13.93.54.137:30303|
2019-12-30 12:49:10.6937|DEBUG Full Sync | Processed    1912344 |   14 523ms, mgasps    0,02 total    0,23, tps    0,21 total    0,82, bps    0,07 total    0,38, recv queue 0, proc queue 0|
2019-12-30 12:49:27.0154|Discovered a new block   1912345 11:49:24 (0x1123ce...890a52), tx count: 2 sealed by Prysm Labs, sent by 13.93.54.137:30303|
2019-12-30 12:49:27.0154|DEBUG Full Sync | Processed    1912345 |   16 322ms, mgasps    0,02 total    0,16, tps    0,12 total    0,58, bps    0,06 total    0,27, recv queue 0, proc queue 0|
2019-12-30 12:49:40.7306|Discovered a new block   1912346 11:49:39 (0x608c71...6355f7), tx count: 0 sealed by POA, sent by 13.93.54.137:30303|
2019-12-30 12:49:40.7306|DEBUG Full Sync | Processed    1912346 |   13 708ms, mgasps    0,00 total    0,13, tps    0,00 total    0,45, bps    0,07 total    0,23, recv queue 0, proc queue 0|
`