### PR TITLE
Less allocatey ethash

### DIFF
--- a/src/Nethermind/Nethermind.Core/Crypto/Keccak512.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/Keccak512.cs
@@ -97,6 +97,16 @@ namespace Nethermind.Core.Crypto
             return _hash.ComputeBytesToUint(input);
         }
 
+        public static void ComputeUIntsToUInts(Span<uint> input, Span<uint> output)
+        {
+            if (_hash == null)
+            {
+                LazyInitializer.EnsureInitialized(ref _hash, Init);
+            }
+
+            _hash.ComputeUIntsToUint(input, output);
+        }
+
         public static uint[] ComputeUIntsToUInts(uint[] input)
         {
             if (input == null || input.Length == 0)

--- a/src/Nethermind/Nethermind.Core/Crypto/Keccak512.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/Keccak512.cs
@@ -65,6 +65,11 @@ namespace Nethermind.Core.Crypto
             return InternalCompute(rlp.Bytes);
         }
 
+        public static Keccak512 Compute(Span<byte> input)
+        {
+            return InternalCompute(input);
+        }
+
         public static Keccak512 Compute(byte[] input)
         {
             if (input == null || input.Length == 0)
@@ -112,7 +117,7 @@ namespace Nethermind.Core.Crypto
             return HashFactory.Crypto.SHA3.CreateKeccak512();
         }
         
-        private static Keccak512 InternalCompute(byte[] input)
+        private static Keccak512 InternalCompute(Span<byte> input)
         {
             if (_hash == null)
             {

--- a/src/Nethermind/Nethermind.HashLib/Crypto/SHA3/KeccakBase.cs
+++ b/src/Nethermind/Nethermind.HashLib/Crypto/SHA3/KeccakBase.cs
@@ -77,7 +77,7 @@ namespace Nethermind.HashLib.Crypto.SHA3
             // TODO: review discussions on whether it is always safe (should be)
             ReadOnlySpan<ulong> data = MemoryMarshal.Cast<byte, ulong>(a_data.Slice(a_index, _blockSize));
             //ulong[] data= Converters.ConvertBytesToULongs(a_data, a_index, BlockSize);
-            
+
             for (int j = 0; j < _blockSize / 8; j++)
                 m_state[j] ^= data[j];
 
@@ -150,11 +150,11 @@ namespace Nethermind.HashLib.Crypto.SHA3
             Aso = m_state[23];
             Asu = m_state[24];
 
-            Ca = Aba^Aga^Aka^Ama^Asa;
-            Ce = Abe^Age^Ake^Ame^Ase;
-            Ci = Abi^Agi^Aki^Ami^Asi;
-            Co = Abo^Ago^Ako^Amo^Aso;
-            Cu = Abu^Agu^Aku^Amu^Asu;
+            Ca = Aba ^ Aga ^ Aka ^ Ama ^ Asa;
+            Ce = Abe ^ Age ^ Ake ^ Ame ^ Ase;
+            Ci = Abi ^ Agi ^ Aki ^ Ami ^ Asi;
+            Co = Abo ^ Ago ^ Ako ^ Amo ^ Aso;
+            Cu = Abu ^ Agu ^ Aku ^ Amu ^ Asu;
             Da = Cu ^ (Ce << 1) ^ (Ce >> (64 - 1));
             De = Ca ^ (Ci << 1) ^ (Ci >> (64 - 1));
             Di = Ce ^ (Co << 1) ^ (Co >> (64 - 1));
@@ -2724,6 +2724,11 @@ namespace Nethermind.HashLib.Crypto.SHA3
             Buffer.BlockCopy(m_state, 0, result, 0, HashSize);
             return result;
             //return Converters.ConvertULongsToBytes(m_state).SubArray(0, HashSize);
+        }
+
+        protected override void GetResultUints(Span<uint> result)
+        {
+            m_state.AsSpan(0, HashSize / sizeof(ulong)).CopyTo(MemoryMarshal.Cast<uint, ulong>(result));
         }
 
         protected override uint[] GetResultUInts()

--- a/src/Nethermind/Nethermind.HashLib/Hash.cs
+++ b/src/Nethermind/Nethermind.HashLib/Hash.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using Nethermind.HashLib.Extensions;
@@ -251,6 +252,14 @@ namespace Nethermind.HashLib
             uint[] result = TransformFinalUInts();
             Initialize();
             return result;
+        }
+
+        public virtual void ComputeUIntsToUint(Span<uint> data, Span<uint> output)
+        {
+            Initialize();
+            TransformBytes(MemoryMarshal.AsBytes(data));
+            TransformFinalUInts(output);
+            Initialize();
         }
 
         public void TransformObject(object a_data)
@@ -566,6 +575,11 @@ namespace Nethermind.HashLib
         public abstract HashResult TransformFinal();
 
         public virtual uint[] TransformFinalUInts()
+        {
+            throw new NotSupportedException();
+        }
+        
+        public virtual void TransformFinalUInts(Span<uint> output)
         {
             throw new NotSupportedException();
         }

--- a/src/Nethermind/Nethermind.HashLib/HashCryptoNotBuildIn.cs
+++ b/src/Nethermind/Nethermind.HashLib/HashCryptoNotBuildIn.cs
@@ -117,6 +117,17 @@ namespace Nethermind.HashLib
             return result;
         }
 
+        public override void TransformFinalUInts(Span<uint> output)
+        {
+            Finish();
+
+            Debug.Assert(m_buffer.IsEmpty);
+
+            GetResultUints(output);
+
+            Initialize();
+        }
+
         protected void TransformBuffer()
         {
             Debug.Assert(m_buffer.IsFull);
@@ -137,7 +148,11 @@ namespace Nethermind.HashLib
         protected virtual uint[] GetResultUInts()
         {
             throw new NotSupportedException();
+        }
 
+        protected virtual void GetResultUints(Span<uint> result)
+        {
+            throw new NotSupportedException();
         }
     }
 }

--- a/src/Nethermind/Nethermind.HashLib/Nethermind.HashLib.csproj
+++ b/src/Nethermind/Nethermind.HashLib/Nethermind.HashLib.csproj
@@ -7,6 +7,7 @@
     <Compile Remove="Hash32.cs" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.6.0" />
     <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />
   </ItemGroup>
 </Project>

--- a/src/Nethermind/Nethermind.Mining/Ethash.cs
+++ b/src/Nethermind/Nethermind.Mining/Ethash.cs
@@ -341,7 +341,7 @@ namespace Nethermind.Mining
                 for (uint j = 0; j < hashesInMix; j++)
                 {
                     uint[] item = dataSet.CalcDataSetItem(p + j);
-                    item.AsSpan().CopyTo(newData.Slice((int)(j * item.Length)));
+                    item.CopyTo(newData.Slice((int)(j * item.Length)));
                 }
 
                 Fnv(mixInts, newData);

--- a/src/Nethermind/Nethermind.Mining/Ethash.cs
+++ b/src/Nethermind/Nethermind.Mining/Ethash.cs
@@ -317,14 +317,15 @@ namespace Nethermind.Mining
             }
 
             uint firstOfHeaderAndNonce = GetUInt(headerAndNonceHashed, 0);
+            Span<uint> newData = stackalloc uint[(int)wordsInMix];
             for (uint i = 0; i < Accesses; i++)
             {
                 uint p = Fnv(i ^ firstOfHeaderAndNonce, mixInts[i % wordsInMix]) % (hashesInFull / hashesInMix) * hashesInMix; // since we take 'hashesInMix' consecutive blocks we want only starting indices of such blocks
-                uint[] newData = new uint[wordsInMix];
+                
                 for (uint j = 0; j < hashesInMix; j++)
                 {
                     uint[] item = dataSet.CalcDataSetItem(p + j);
-                    Buffer.BlockCopy(item, 0, newData, (int) (j * item.Length * 4), item.Length * 4);
+                    item.AsSpan().CopyTo(newData.Slice((int)(j * item.Length)));
                 }
 
                 Fnv(mixInts, newData);

--- a/src/Nethermind/Nethermind.Mining/Ethash.cs
+++ b/src/Nethermind/Nethermind.Mining/Ethash.cs
@@ -340,8 +340,7 @@ namespace Nethermind.Mining
 
                 for (uint j = 0; j < hashesInMix; j++)
                 {
-                    uint[] item = dataSet.CalcDataSetItem(p + j);
-                    item.CopyTo(newData.Slice((int)(j * item.Length)));
+                    dataSet.CalcDataSetItem(p + j, newData.Slice((int)(j * 16)));
                 }
 
                 Fnv(mixInts, newData);

--- a/src/Nethermind/Nethermind.Mining/FullDataSet.cs
+++ b/src/Nethermind/Nethermind.Mining/FullDataSet.cs
@@ -14,6 +14,9 @@
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
+using System;
+using Nethermind.Core.Crypto;
+
 namespace Nethermind.Mining
 {
     public class FullDataSet : IEthashDataSet
@@ -27,13 +30,14 @@ namespace Nethermind.Mining
             Data = new uint[(uint)(setSize / Ethash.HashBytes)][];
             for (uint i = 0; i < Data.Length; i++)
             {
-                Data[i] = cache.CalcDataSetItem(i);
+                Data[i] = new uint[16];
+                cache.CalcDataSetItem(i, Data[i]);
             }
         }
 
-        public uint[] CalcDataSetItem(uint i)
+        public void CalcDataSetItem(uint i, Span<uint> output)
         {
-            return Data[i];
+            Data[i].CopyTo(output);
         }
 
         public void Dispose()

--- a/src/Nethermind/Nethermind.Mining/IEthashDataSet.cs
+++ b/src/Nethermind/Nethermind.Mining/IEthashDataSet.cs
@@ -21,6 +21,6 @@ namespace Nethermind.Mining
     public interface IEthashDataSet : IDisposable
     {
         uint Size { get; }
-        uint[] CalcDataSetItem(uint i);
+        void CalcDataSetItem(uint i, Span<uint> output);
     }
 }


### PR DESCRIPTION
An evening play with ethash resulting in the following improvement showed by benchmark

|   Method |     Mean |     Error |   StdDev |Ratio | Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------- |---------:|----------:|---------:|-----:|------:|------:|------:|----------:|
| Before   | 25.07 ms | 0.6110 ms | 1.733 ms | 1.00 |     - |     - |     - | 261.91 KB |
| After changing Hashimoto   | 24.04 ms | 0.4697 ms | 0.8707 ms| 1.00 |     - |     - |     - | 223.91 KB |
| After improving EthashCache | 24.53 ms | 0.4897 ms | 0.8831 ms |  1.00 |     - |     - |     - |   2.84 KB |


The first important improvement was moving the allocation of the array in `Hashimoto` outside of the loop. The second, was improving `Keccak512` to be able to run it on `Span<uint>`, which caused the benchmark to drop allocation 100x.