### PR TITLE
feature/eth2 in process validator

### DIFF
--- a/src/Nethermind/Nethermind.BeaconNode.Host/Nethermind.BeaconNode.Host.csproj
+++ b/src/Nethermind/Nethermind.BeaconNode.Host/Nethermind.BeaconNode.Host.csproj
@@ -29,6 +29,7 @@
     <ProjectReference Include="..\Nethermind.BeaconNode\Nethermind.BeaconNode.csproj" />
     <ProjectReference Include="..\Nethermind.BeaconNode.Storage\Nethermind.BeaconNode.Storage.csproj" />
     <ProjectReference Include="..\Nethermind.Core2.Cryptography\Nethermind.Core2.Cryptography.csproj" />
+    <ProjectReference Include="..\Nethermind.HonestValidator\Nethermind.HonestValidator.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Nethermind/Nethermind.BeaconNode.Host/Program.cs
+++ b/src/Nethermind/Nethermind.BeaconNode.Host/Program.cs
@@ -26,6 +26,8 @@ using Nethermind.BeaconNode.Peering;
 using Nethermind.BeaconNode.Storage;
 using Nethermind.Core2.Configuration;
 using Nethermind.Core2.Cryptography;
+using Nethermind.HonestValidator;
+using Nethermind.HonestValidator.MockedStart;
 
 namespace Nethermind.BeaconNode.Host
 {
@@ -89,6 +91,12 @@ namespace Nethermind.BeaconNode.Host
                     if (hostContext.Configuration.GetValue<ulong>("QuickStart:GenesisTime") > 0)
                     {
                         services.AddBeaconNodeQuickStart(hostContext.Configuration);
+                    }
+                    
+                    if (hostContext.Configuration.GetSection("QuickStart:ValidatorStartIndex").Exists())
+                    {
+                        services.AddHonestValidator(hostContext.Configuration);
+                        services.AddHonestValidatorQuickStart(hostContext.Configuration);
                     }
                 })
                 .ConfigureWebHostDefaults(webBuilder =>

--- a/src/Nethermind/Nethermind.BeaconNode.Host/README.md
+++ b/src/Nethermind/Nethermind.BeaconNode.Host/README.md
@@ -25,7 +25,7 @@ To run the unit tests:
 dotnet test src/Nethermind/Nethermind.BeaconNode.Test
 ```
 
-To run with default Development settings (minimal config), with mocked quick start:
+To run the beacon node with default Development settings (minimal config), with mocked quick start:
 
 ```
 dotnet run --project src/Nethermind/Nethermind.BeaconNode.Host --QuickStart:GenesisTime 1578009600 --QuickStart:ValidatorCount 64
@@ -44,9 +44,19 @@ Other GET queries:
 
 Note: With QuickStart validator count 64, validators index 20, with public key 0xa1c76af1..., is the validator for slot 1. The corresponding randao signature for fork 0x00000000, at epoch 0, that must be used is 0xa3426b63... (other values will fail validation).
 
-### Test the Honest Validator
+### Test with an in-process Honest Validator
 
-Using the quick start clock, you want to synchronise the clock offset of the node and validator. The following will set genesis to occur at the next full minute. 
+This will run both the beacon node and an in-process honest validator, both using quick start mocked keys. For testing and devleopment it is easiest to run both components in a single host:
+
+```
+dotnet run --project src/Nethermind/Nethermind.BeaconNode.Host --QuickStart:GenesisTime 1578009600 --QuickStart:ValidatorCount 64 --QuickStart:ValidatorStartIndex 0 --QuickStart:NumberOfValidators 32
+```
+
+### Test with separate processes for node and validator
+
+This will run the Beacon Node and Honest Validator in separate host processes, communicating via the REST API.
+
+When using the quick start clock (to mock a specific genesis time), you need to synchronise the clock offset of the node and validator. The following will set genesis to occur at the next full minute. 
 
 First, build both the required hosts:
 
@@ -64,9 +74,10 @@ $offset = [Math]::Floor((1578009600 - [DateTimeOffset]::UtcNow.ToUnixTimeSeconds
 And the validator host in a separate shell (which connects to the node):
 
 ```
-$offset = [Math]::Floor((1578009600 - [DateTimeOffset]::UtcNow.ToUnixTimeSeconds())/60) * 60; $offset; dotnet run --no-build --project src/Nethermind/Nethermind.HonestValidator.Host --QuickStart:ValidatorStartIndex 0 --QuickStart:NumberOfValidators 32 --QuickStart:ClockOffset $offset
+$offset = [Math]::Floor((1578009600 - [DateTimeOffset]::UtcNow.ToUnixTimeSeconds())/60) * 60; $offset; dotnet run --no-build --project src/Nethermind/Nethermind.HonestValidator.Host --QuickStart:ValidatorStartIndex 32 --QuickStart:NumberOfValidators 32 --QuickStart:ClockOffset $offset
 ```
 
+Note that it is possible to run ranges of validators both in-process and as separate validator processes, or even have multiple validator ranges in multiple validator processes.
 
 ### Optional requirements
 

--- a/src/Nethermind/Nethermind.BeaconNode.Host/README.md
+++ b/src/Nethermind/Nethermind.BeaconNode.Host/README.md
@@ -79,6 +79,20 @@ $offset = [Math]::Floor((1578009600 - [DateTimeOffset]::UtcNow.ToUnixTimeSeconds
 
 Note that it is possible to run ranges of validators both in-process and as separate validator processes, or even have multiple validator ranges in multiple validator processes.
 
+### Quick start clock
+
+For a network to interact it is important that their clocks are synchronised (the specifications allow for limited tolerance). Normally this is provided by the system clock, synchronised to real time.
+
+To test genesis, the genesis time parameter could then be adjusted to just ahead of the current system clock time, however every time the system was tested this would be different (with a different genesis block).
+
+Whilst we could use a different genesis block each time, Nethermind also has a mock clock that can run at a specific offset, but at realtime speed. 
+
+For example, with genesis time 1,578,009,600 this clock can be set to start at a test time slightly before 1,578,009,600 every time it is run. (The snippets above calculate the offset to use to start at the next minute boundary, so will work if node and validator are started during the same minute.)
+
+Note that the different processess (nodes and validators) need to use the same offset to be synchronised. 
+
+The clock will also be useful in future testing to reproduce specific scenarios starting from particular states at past clock dates (using a negative offset).
+
 ### Optional requirements
 
 * PowerShell Core, to run build scripts

--- a/src/Nethermind/Nethermind.BeaconNode.Peering/BeaconNodePeeringServiceCollectionExtensions.cs
+++ b/src/Nethermind/Nethermind.BeaconNode.Peering/BeaconNodePeeringServiceCollectionExtensions.cs
@@ -24,7 +24,7 @@ namespace Nethermind.BeaconNode.Peering
     {
         public static void AddBeaconNodePeering(this IServiceCollection services, IConfiguration configuration)
         {
-            services.AddScoped<INetworkPeering, NetworkPeering>();
+            services.AddSingleton<INetworkPeering, NetworkPeering>();
             services.AddHostedService<PeeringWorker>();
         }
     }

--- a/src/Nethermind/Nethermind.BeaconNode/BeaconNodeServiceCollectionExtensions.cs
+++ b/src/Nethermind/Nethermind.BeaconNode/BeaconNodeServiceCollectionExtensions.cs
@@ -34,12 +34,11 @@ namespace Nethermind.BeaconNode
             services.AddSingleton<BeaconStateTransition>();
             services.AddSingleton<BeaconStateMutator>();
             services.AddSingleton<ForkChoice>();
+            services.AddSingleton<ValidatorAssignments>();
+            services.AddSingleton<BlockProducer>();
+            services.AddSingleton<IBeaconNodeApi, BeaconNodeFacade>();
 
             services.AddHostedService<BeaconNodeWorker>();
-            
-            services.AddScoped<ValidatorAssignments>();
-            services.AddScoped<BlockProducer>();
-            services.AddScoped<IBeaconNodeApi, BeaconNodeFacade>();
         }
     }
 }

--- a/src/Nethermind/Nethermind.HonestValidator/Log.cs
+++ b/src/Nethermind/Nethermind.HonestValidator/Log.cs
@@ -77,6 +77,14 @@ namespace Nethermind.HonestValidator
 
         // 4bxx warning
         
+        public static readonly Action<ILogger, Exception?> WaitingForNodeVersion =
+            LoggerMessage.Define(LogLevel.Warning,
+                new EventId(4450, nameof(WaitingForNodeVersion)),
+                "Waiting for node version to succeed.");
+        public static readonly Action<ILogger, Exception?> WaitingForGenesisTime =
+            LoggerMessage.Define(LogLevel.Warning,
+                new EventId(4451, nameof(WaitingForGenesisTime)),
+                "Waiting for node genesis time to succeed.");
         // FIXME: Duplicate of beacon node
         public static readonly Action<ILogger, long, Exception?> QuickStartClockCreated =
             LoggerMessage.Define<long>(LogLevel.Warning,


### PR DESCRIPTION
Configure to run the honest validator in-process with the beacon node host, so that you only need to run one executable for development/test.

Most of this is simply a configuration change. The validator is decoupled/independent of the node, just accessing the IBeaconNodeApi directly, rather than via REST. But it does make running it for dev/test a bit easier.

A small tweak with additional error handling so the first call to get genesis doesn't crash due to timing issues (the node isn't up and running). For the network version, this is handled along with network connection errors in the OAPI client, but for in-process the node is always available (once initialised).


