### PR TITLE
Rec exp

### DIFF
--- a/src/Nethermind/Nethermind.AuRa/AuRaSealValidator.cs
+++ b/src/Nethermind/Nethermind.AuRa/AuRaSealValidator.cs
@@ -44,6 +44,10 @@ namespace Nethermind.AuRa
             _logger = logManager.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
         }
 
+        public void HintValidationRange(Guid guid, long start, long end)
+        {
+        }
+
         public bool ValidateParams(BlockHeader parent, BlockHeader header)
         {
             const long rejectedStepDrift = 4;

--- a/src/Nethermind/Nethermind.Blockchain.Test/Synchronization/BlockDownloaderTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Synchronization/BlockDownloaderTests.cs
@@ -666,6 +666,10 @@ namespace Nethermind.Blockchain.Test.Synchronization
 
         private class SlowSealValidator : ISealValidator
         {
+            public void HintValidationRange(Guid guid, long start, long end)
+            {
+            }
+
             public bool ValidateParams(BlockHeader parent, BlockHeader header)
             {
                 Thread.Sleep(1000);

--- a/src/Nethermind/Nethermind.Blockchain.Test/TestSealValidator.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TestSealValidator.cs
@@ -49,6 +49,10 @@ namespace Nethermind.Blockchain.Test
             _processedValidationResults = processedValidationResults ?? throw new ArgumentNullException(nameof(processedValidationResults));
         }
 
+        public void HintValidationRange(Guid guid, long start, long end)
+        {
+        }
+
         public bool ValidateParams(BlockHeader parent, BlockHeader header)
         {
             return _alwaysSameResultForParams ?? _suggestedValidationResults.Dequeue();

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/IReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/IReceiptStorage.cs
@@ -14,6 +14,7 @@
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
+using System.Collections.Generic;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 
@@ -24,6 +25,7 @@ namespace Nethermind.Blockchain.Receipts
         TxReceipt Find(Keccak hash);
         void Add(TxReceipt txReceipt, bool isProcessed);
         void Insert(long blockNumber, TxReceipt txReceipt);
+        void Insert(List<(long blockNumber, TxReceipt txReceipt)> receipts);
         long? LowestInsertedReceiptBlock { get; }
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/InMemoryReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/InMemoryReceiptStorage.cs
@@ -15,6 +15,7 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 
@@ -42,6 +43,14 @@ namespace Nethermind.Blockchain.Receipts
             }
 
             LowestInsertedReceiptBlock = blockNumber;
+        }
+
+        public void Insert(List<(long blockNumber, TxReceipt txReceipt)> receipts)
+        {
+            foreach ((long blockNumber, TxReceipt txReceipt) in receipts)
+            {
+                Insert(blockNumber, txReceipt);
+            }
         }
 
         public long? LowestInsertedReceiptBlock { get; private set; }

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/NullReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/NullReceiptStorage.cs
@@ -14,6 +14,7 @@
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
+using System.Collections.Generic;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 
@@ -34,6 +35,10 @@ namespace Nethermind.Blockchain.Receipts
         }
 
         public void Insert(long blockNumber, TxReceipt txReceipt)
+        {
+        }
+
+        public void Insert(List<(long blockNumber, TxReceipt txReceipt)> receipts)
         {
         }
 

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
@@ -15,6 +15,8 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Encoding;
@@ -88,6 +90,41 @@ namespace Nethermind.Blockchain.Receipts
             LowestInsertedReceiptBlock = blockNumber;
 //            LowestInsertedReceiptBlock = Math.Min(LowestInsertedReceiptBlock ?? long.MaxValue, blockNumber);
             _database.Set(Keccak.Zero, Rlp.Encode(LowestInsertedReceiptBlock.Value).Bytes);
+        }
+
+        public void Insert(List<(long blockNumber, TxReceipt txReceipt)> receipts)
+        {
+            if (!receipts.Any())
+            {
+                return;
+            }
+
+            long? blockNumber = null;
+            foreach ((long blockNumber, TxReceipt txReceipt) tuple in receipts)
+            {
+                blockNumber = tuple.blockNumber;
+                TxReceipt txReceipt = tuple.txReceipt;
+                if (txReceipt == null && blockNumber != 1L)
+                {
+                    throw new ArgumentNullException(nameof(txReceipt));
+                }
+
+                if (txReceipt != null)
+                {
+                    var spec = _specProvider.GetSpec(blockNumber.Value);
+                    RlpBehaviors behaviors = spec.IsEip658Enabled ? RlpBehaviors.Eip658Receipts : RlpBehaviors.None;
+                    _database.Set(txReceipt.TxHash, Rlp.Encode(txReceipt, behaviors).Bytes);
+                }
+            }
+
+            if (blockNumber > LowestInsertedReceiptBlock)
+            {
+                _logger.Error($"{blockNumber} > {LowestInsertedReceiptBlock}");
+            }
+            
+            LowestInsertedReceiptBlock = blockNumber;
+            
+            _database.Set(Keccak.Zero, Rlp.Encode(LowestInsertedReceiptBlock).Bytes);
         }
 
         public long? LowestInsertedReceiptBlock { get; private set; }

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
@@ -117,14 +117,16 @@ namespace Nethermind.Blockchain.Receipts
                 }
             }
 
-            if (blockNumber > LowestInsertedReceiptBlock)
+            if (blockNumber.HasValue)
             {
-                _logger.Error($"{blockNumber} > {LowestInsertedReceiptBlock}");
+                if (blockNumber > LowestInsertedReceiptBlock)
+                {
+                    _logger.Error($"{blockNumber} > {LowestInsertedReceiptBlock}");
+                }
+
+                LowestInsertedReceiptBlock = blockNumber;
+                _database.Set(Keccak.Zero, Rlp.Encode(LowestInsertedReceiptBlock.Value).Bytes);
             }
-            
-            LowestInsertedReceiptBlock = blockNumber;
-            
-            _database.Set(Keccak.Zero, Rlp.Encode(LowestInsertedReceiptBlock).Bytes);
         }
 
         public long? LowestInsertedReceiptBlock { get; private set; }

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/BlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/BlockDownloader.cs
@@ -320,7 +320,7 @@ namespace Nethermind.Blockchain.Synchronization
         
         private async Task<BlockHeader[]> RequestHeaders(PeerInfo peer, CancellationToken cancellation, long currentNumber, int headersToRequest)
         {
-            _sealValidator.HintValidationRange(_sealValidatorUserGuid, currentNumber - 1028, currentNumber + 120000);
+            _sealValidator.HintValidationRange(_sealValidatorUserGuid, currentNumber - 1028, currentNumber + 60000);
             Task<BlockHeader[]> headersRequest = peer.SyncPeer.GetBlockHeaders(currentNumber, headersToRequest, 0, cancellation);
             await headersRequest.ContinueWith(t => DownloadFailHandler(t, "headers"), cancellation);
 

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/BlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/BlockDownloader.cs
@@ -316,8 +316,11 @@ namespace Nethermind.Blockchain.Synchronization
             return default;
         }
 
+        private Guid _sealValidatorUserGuid = Guid.NewGuid();
+        
         private async Task<BlockHeader[]> RequestHeaders(PeerInfo peer, CancellationToken cancellation, long currentNumber, int headersToRequest)
         {
+            _sealValidator.HintValidationRange(_sealValidatorUserGuid, currentNumber - 1028, currentNumber + 120000);
             Task<BlockHeader[]> headersRequest = peer.SyncPeer.GetBlockHeaders(currentNumber, headersToRequest, 0, cancellation);
             await headersRequest.ContinueWith(t => DownloadFailHandler(t, "headers"), cancellation);
 

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/FastBlocks/FastBlocksDownloader.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/FastBlocks/FastBlocksDownloader.cs
@@ -208,15 +208,7 @@ namespace Nethermind.Blockchain.Synchronization.FastBlocks
                         batch.Headers.Response = null;
                     }
                     
-                    // no need to check seals in fast blocks since we trust the pivot block nonetheless
-                    // _sealValidator.HintValidationRange(_sealValidatorUserGuid,  header.Number - 150000, header.Number + 30000);
-                    // bool isSealValid = _sealValidator.ValidateSeal(header, false);
-                    // if (!isSealValid)
-                    // {
-                    //     if (_logger.IsTrace) _logger.Trace($"One of the blocks is invalid - invalid seal at {header.ToString(BlockHeader.Format.Short)}");
-                    //     _syncPeerPool.ReportInvalid(batch.Allocation?.Current, $"invalid hash of block {header.ToString(BlockHeader.Format.Short)}");
-                    //     batch.Headers.Response = null;
-                    // }
+                    // no need to check seals in fast blocks since we trust the pivot block nonetheless}
                 }
             }
             catch (Exception ex)

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/FastBlocks/FastBlocksDownloader.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/FastBlocks/FastBlocksDownloader.cs
@@ -176,6 +176,8 @@ namespace Nethermind.Blockchain.Synchronization.FastBlocks
             }
         }
 
+        private Guid _sealValidatorUserGuid = Guid.NewGuid();
+        
         private void ValidateHeaders(CancellationToken cancellation, FastBlocksBatch batch)
         {
             batch.MarkValidation();
@@ -199,6 +201,8 @@ namespace Nethermind.Blockchain.Synchronization.FastBlocks
                     }
 
                     bool isHashValid = _blockValidator.ValidateHash(header);
+                    
+                    _sealValidator.HintValidationRange(_sealValidatorUserGuid, header.Number + 3000, header.Number - 150000);
                     bool isSealValid = _sealValidator.ValidateSeal(header, false);
                     if (!isHashValid)
                     {

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/FastBlocks/FastBlocksDownloader.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/FastBlocks/FastBlocksDownloader.cs
@@ -202,7 +202,7 @@ namespace Nethermind.Blockchain.Synchronization.FastBlocks
 
                     bool isHashValid = _blockValidator.ValidateHash(header);
                     
-                    _sealValidator.HintValidationRange(_sealValidatorUserGuid, header.Number - 150000, header.Number + 30000);
+                    _sealValidator.HintValidationRange(_sealValidatorUserGuid,  header.Number - 150000, header.Number + 30000);
                     bool isSealValid = _sealValidator.ValidateSeal(header, false);
                     if (!isHashValid)
                     {

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/FastBlocks/FastBlocksDownloader.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/FastBlocks/FastBlocksDownloader.cs
@@ -201,9 +201,6 @@ namespace Nethermind.Blockchain.Synchronization.FastBlocks
                     }
 
                     bool isHashValid = _blockValidator.ValidateHash(header);
-                    
-                    _sealValidator.HintValidationRange(_sealValidatorUserGuid,  header.Number - 150000, header.Number + 30000);
-                    bool isSealValid = _sealValidator.ValidateSeal(header, false);
                     if (!isHashValid)
                     {
                         if (_logger.IsTrace) _logger.Trace($"One of the blocks is invalid - invalid hash at {header.Number}");
@@ -211,12 +208,15 @@ namespace Nethermind.Blockchain.Synchronization.FastBlocks
                         batch.Headers.Response = null;
                     }
                     
-                    if (!isSealValid)
-                    {
-                        if (_logger.IsTrace) _logger.Trace($"One of the blocks is invalid - invalid seal at {header.ToString(BlockHeader.Format.Short)}");
-                        _syncPeerPool.ReportInvalid(batch.Allocation?.Current, $"invalid hash of block {header.ToString(BlockHeader.Format.Short)}");
-                        batch.Headers.Response = null;
-                    }
+                    // no need to check seals in fast blocks since we trust the pivot block nonetheless
+                    // _sealValidator.HintValidationRange(_sealValidatorUserGuid,  header.Number - 150000, header.Number + 30000);
+                    // bool isSealValid = _sealValidator.ValidateSeal(header, false);
+                    // if (!isSealValid)
+                    // {
+                    //     if (_logger.IsTrace) _logger.Trace($"One of the blocks is invalid - invalid seal at {header.ToString(BlockHeader.Format.Short)}");
+                    //     _syncPeerPool.ReportInvalid(batch.Allocation?.Current, $"invalid hash of block {header.ToString(BlockHeader.Format.Short)}");
+                    //     batch.Headers.Response = null;
+                    // }
                 }
             }
             catch (Exception ex)

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/FastBlocks/FastBlocksDownloader.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/FastBlocks/FastBlocksDownloader.cs
@@ -202,7 +202,7 @@ namespace Nethermind.Blockchain.Synchronization.FastBlocks
 
                     bool isHashValid = _blockValidator.ValidateHash(header);
                     
-                    _sealValidator.HintValidationRange(_sealValidatorUserGuid, header.Number + 3000, header.Number - 150000);
+                    _sealValidator.HintValidationRange(_sealValidatorUserGuid, header.Number - 150000, header.Number + 30000);
                     bool isSealValid = _sealValidator.ValidateSeal(header, false);
                     if (!isHashValid)
                     {

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/FastBlocks/FastBlocksFeed.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/FastBlocks/FastBlocksFeed.cs
@@ -624,10 +624,7 @@ namespace Nethermind.Blockchain.Synchronization.FastBlocks
 
         private void InsertReceipts(List<(long, TxReceipt)> receipts)
         {
-            foreach ((long blockNumber, TxReceipt receipt) in receipts)
-            {
-                _receiptStorage.Insert(blockNumber, receipt);
-            }
+            (_receiptStorage as PersistentReceiptStorage).Insert(receipts);
         }
 
         private static FastBlocksBatch PrepareReceiptFiller(int added, ReceiptsSyncBatch receiptsSyncBatch)

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/FastBlocks/FastBlocksFeed.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/FastBlocks/FastBlocksFeed.cs
@@ -266,17 +266,17 @@ namespace Nethermind.Blockchain.Synchronization.FastBlocks
                         int collectedRequests = 0;
                         while (collectedRequests < requestSize)
                         {
-                            receiptsSpaceToUse -= block?.Transactions.Length ?? 0;
-                            if (receiptsSpaceToUse < 0 && (block?.Transactions.Length ?? 0) <= MaxReceiptsFetch)
-                            {
-                                // second check is here so we can always request oversized blocks
-                                break;
-                            }
+                            // receiptsSpaceToUse -= block?.Transactions.Length ?? 0;
+                            // if (receiptsSpaceToUse < 0 && (block?.Transactions.Length ?? 0) <= MaxReceiptsFetch)
+                            // {
+                            //     // second check is here so we can always request oversized blocks
+                            //     break;
+                            // }
 
-                            if (block.Transactions.Length > 0 || block.IsGenesis)
-                            {
+                            // if (block.Transactions.Length > 0 || block.IsGenesis)
+                            // {
                                 _lowestRequestedReceiptsHash = block.Hash;
-                            }
+                            // }
                             
                             if (block.Transactions.Length > 0)
                             {

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/FastBlocks/FastBlocksFeed.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/FastBlocks/FastBlocksFeed.cs
@@ -262,12 +262,10 @@ namespace Nethermind.Blockchain.Synchronization.FastBlocks
                             batch.Prioritized = true;
                         }
 
-                        int receiptsSpaceToUse = ReceiptsRequestSize;
                         int collectedRequests = 0;
                         while (collectedRequests < requestSize)
                         {
                             _lowestRequestedReceiptsHash = block.Hash;
-
                             if (block.Transactions.Length > 0)
                             {
                                 batch.Receipts.Predecessors[collectedRequests] = predecessorBlock?.Number;

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/FastBlocks/FastBlocksFeed.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/FastBlocks/FastBlocksFeed.cs
@@ -267,8 +267,9 @@ namespace Nethermind.Blockchain.Synchronization.FastBlocks
                         while (collectedRequests < requestSize)
                         {
                             receiptsSpaceToUse -= block?.Transactions.Length ?? 0;
-                            if (receiptsSpaceToUse < 0)
+                            if (receiptsSpaceToUse < 0 && (block?.Transactions.Length ?? 0) <= MaxReceiptsFetch)
                             {
+                                // second check is here so we can always request oversized blocks
                                 break;
                             }
 

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/FastBlocks/FastBlocksFeed.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/FastBlocks/FastBlocksFeed.cs
@@ -262,6 +262,7 @@ namespace Nethermind.Blockchain.Synchronization.FastBlocks
                             batch.Prioritized = true;
                         }
 
+                        int receiptsSpaceToUse = requestSize;
                         int collectedRequests = 0;
                         while (collectedRequests < requestSize)
                         {
@@ -276,7 +277,8 @@ namespace Nethermind.Blockchain.Synchronization.FastBlocks
                             }
 
                             block = _blockTree.FindBlock(block.ParentHash, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
-                            if (block == null || block.IsGenesis)
+                            receiptsSpaceToUse -= block?.Transactions.Length ?? 0;
+                            if (block == null || block.IsGenesis || receiptsSpaceToUse < 0)
                             {
                                 break;
                             }

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/FastBlocks/FastBlocksFeed.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/FastBlocks/FastBlocksFeed.cs
@@ -624,7 +624,7 @@ namespace Nethermind.Blockchain.Synchronization.FastBlocks
 
         private void InsertReceipts(List<(long, TxReceipt)> receipts)
         {
-            (_receiptStorage as PersistentReceiptStorage).Insert(receipts);
+            _receiptStorage.Insert(receipts);
         }
 
         private static FastBlocksBatch PrepareReceiptFiller(int added, ReceiptsSyncBatch receiptsSyncBatch)

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/FastSync/NodeDataDownloader.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/FastSync/NodeDataDownloader.cs
@@ -45,7 +45,7 @@ namespace Nethermind.Blockchain.Synchronization.FastSync
 
         private async Task ExecuteRequest(CancellationToken token, StateSyncBatch batch)
         {
-            var peer = batch.AssignedPeer.Current.SyncPeer;
+            ISyncPeer peer = batch.AssignedPeer?.Current?.SyncPeer;
             if (peer != null)
             {
                 var hashes = batch.RequestedNodes.Select(r => r.Hash).ToArray();
@@ -111,6 +111,11 @@ namespace Nethermind.Blockchain.Synchronization.FastSync
                     task.ContinueWith(t =>
 #pragma warning restore 4014
                     {
+                        if (t.IsFaulted)
+                        {
+                            _logger.Error("Failure when executing node data request");
+                        }
+                        
                         Interlocked.Decrement(ref _pendingRequests);
                         if (request.RequestedNodes.Length != 0)
                         {

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/FastSync/NodeDataDownloader.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/FastSync/NodeDataDownloader.cs
@@ -90,14 +90,14 @@ namespace Nethermind.Blockchain.Synchronization.FastSync
         private async Task KeepSyncing(CancellationToken token)
         {
             bool oneMoreTry = false;
-            
+
             do
             {
                 if (token.IsCancellationRequested)
                 {
                     return;
                 }
-                
+
                 oneMoreTry = false;
                 StateSyncBatch request = PrepareRequest();
                 if (request.RequestedNodes.Length != 0)
@@ -113,9 +113,9 @@ namespace Nethermind.Blockchain.Synchronization.FastSync
                     {
                         if (t.IsFaulted)
                         {
-                            _logger.Error("Failure when executing node data request");
+                            if (_logger.IsWarn) _logger.Warn($"Failure when executing node data request {t.Exception}");
                         }
-                        
+
                         Interlocked.Decrement(ref _pendingRequests);
                         if (request.RequestedNodes.Length != 0)
                         {
@@ -140,10 +140,10 @@ namespace Nethermind.Blockchain.Synchronization.FastSync
                 Keccak[] hashes = _additionalConsumer.PrepareRequest();
                 StateSyncBatch priorityBatch = new StateSyncBatch();
                 priorityBatch.RequestedNodes = hashes.Select(h => new StateSyncItem(h, NodeDataType.Code, 0, 0)).ToArray();
-                if (_logger.IsWarn) _logger.Warn($"!!! Priority batch {_pendingRequests}");    
+                if (_logger.IsWarn) _logger.Warn($"!!! Priority batch {_pendingRequests}");
                 return priorityBatch;
             }
-            
+
             if (_logger.IsTrace) _logger.Trace($"Pending requests {_pendingRequests}");
             return _feed.PrepareRequest();
         }

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncLimits/GethSyncLimits.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncLimits/GethSyncLimits.cs
@@ -22,7 +22,7 @@ namespace Nethermind.Blockchain.Synchronization.SyncLimits
         
         // change MaxBodyFetch to 128
         public const int MaxBodyFetch = 128; // Amount of block bodies to be fetched per retrieval request
-        public const int MaxReceiptFetch = 128; // Amount of transaction receipts to allow fetching per request
+        public const int MaxReceiptFetch = 256; // Amount of transaction receipts to allow fetching per request
         public const int MaxCodeFetch = 64; // Amount of contract codes to allow fetching per request
         public const int MaxProofsFetch = 64; // Amount of merkle proofs to be fetched per retrieval request
         public const int MaxHelperTrieProofsFetch = 64; // Amount of helper tries to be fetched per retrieval request

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncLimits/GethSyncLimits.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncLimits/GethSyncLimits.cs
@@ -21,7 +21,7 @@ namespace Nethermind.Blockchain.Synchronization.SyncLimits
         public const int MaxHeaderFetch = 192; // Amount of block headers to be fetched per retrieval request
         
         // change MaxBodyFetch to 128
-        public const int MaxBodyFetch = 32; // Amount of block bodies to be fetched per retrieval request
+        public const int MaxBodyFetch = 128; // Amount of block bodies to be fetched per retrieval request
         public const int MaxReceiptFetch = 128; // Amount of transaction receipts to allow fetching per request
         public const int MaxCodeFetch = 64; // Amount of contract codes to allow fetching per request
         public const int MaxProofsFetch = 64; // Amount of merkle proofs to be fetched per retrieval request

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncLimits/GethSyncLimits.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncLimits/GethSyncLimits.cs
@@ -22,7 +22,7 @@ namespace Nethermind.Blockchain.Synchronization.SyncLimits
         
         // change MaxBodyFetch to 128
         public const int MaxBodyFetch = 128; // Amount of block bodies to be fetched per retrieval request
-        public const int MaxReceiptFetch = 256; // Amount of transaction receipts to allow fetching per request
+        public const int MaxReceiptFetch = 128; // Amount of transaction receipts to allow fetching per request
         public const int MaxCodeFetch = 64; // Amount of contract codes to allow fetching per request
         public const int MaxProofsFetch = 64; // Amount of merkle proofs to be fetched per retrieval request
         public const int MaxHelperTrieProofsFetch = 64; // Amount of helper tries to be fetched per retrieval request

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncServer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncServer.cs
@@ -87,12 +87,6 @@ namespace Nethermind.Blockchain.Synchronization
         
         public void AddNewBlock(Block block, Node nodeWhoSentTheBlock)
         {
-            if (_blockTree.Head.IsGenesis && block.Number != 1)
-            {
-                // ignore new blocks during
-                return;
-            }
-            
             if (block.TotalDifficulty == null) throw new InvalidOperationException("Cannot add a block with unknown total difficulty");
 
             _pool.TryFind(nodeWhoSentTheBlock.Id, out PeerInfo peerInfo);

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncServer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncServer.cs
@@ -120,7 +120,7 @@ namespace Nethermind.Blockchain.Synchronization
                 return;
             }
 
-            if (block.Number < _blockTree.BestSuggestedHeader?.Number - 512)
+            if (block.Number < (_blockTree.Head?.Number ?? 0) - 512)
             {
                 return;
             }

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncServer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncServer.cs
@@ -83,6 +83,8 @@ namespace Nethermind.Blockchain.Synchronization
             return _pool.PeerCount;
         }
 
+        private Guid _sealValidatorUserGuid = Guid.NewGuid();
+        
         public void AddNewBlock(Block block, Node nodeWhoSentTheBlock)
         {
             if (block.TotalDifficulty == null) throw new InvalidOperationException("Cannot add a block with unknown total difficulty");
@@ -125,6 +127,7 @@ namespace Nethermind.Blockchain.Synchronization
 
             if (_logger.IsTrace) _logger.Trace($"Adding new block {block.ToString(Block.Format.Short)}) from {nodeWhoSentTheBlock:c}");
 
+            _sealValidator.HintValidationRange(_sealValidatorUserGuid, block.Number - 128, block.Number + 1024);
             if (!_sealValidator.ValidateSeal(block.Header, true))
             {
                 if (_logger.IsDebug) _logger.Debug($"Peer {peerInfo.SyncPeer?.Node:c} sent a block with an invalid seal");

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncServer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncServer.cs
@@ -87,6 +87,12 @@ namespace Nethermind.Blockchain.Synchronization
         
         public void AddNewBlock(Block block, Node nodeWhoSentTheBlock)
         {
+            if (_blockTree.Head.IsGenesis && block.Number != 1)
+            {
+                // ignore new blocks during
+                return;
+            }
+            
             if (block.TotalDifficulty == null) throw new InvalidOperationException("Cannot add a block with unknown total difficulty");
 
             _pool.TryFind(nodeWhoSentTheBlock.Id, out PeerInfo peerInfo);

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncServer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncServer.cs
@@ -120,7 +120,7 @@ namespace Nethermind.Blockchain.Synchronization
                 return;
             }
 
-            if (block.Number < (_blockTree.Head?.Number ?? 0) - 512)
+            if (block.Number < _blockTree.BestSuggestedHeader?.Number - 512)
             {
                 return;
             }

--- a/src/Nethermind/Nethermind.Clique/CliqueSealValidator.cs
+++ b/src/Nethermind/Nethermind.Clique/CliqueSealValidator.cs
@@ -37,6 +37,10 @@ namespace Nethermind.Clique
             _logger = logManager.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
         }
 
+        public void HintValidationRange(Guid guid, long start, long end)
+        {
+        }
+
         public bool ValidateParams(BlockHeader parent, BlockHeader header)
         {
             long number = header.Number;

--- a/src/Nethermind/Nethermind.Mining.Test/HintBasedCacheTests.cs
+++ b/src/Nethermind/Nethermind.Mining.Test/HintBasedCacheTests.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Nethermind.Logging;
 using NUnit.Framework;
 
 namespace Nethermind.Mining.Test
@@ -40,7 +41,7 @@ namespace Nethermind.Mining.Test
         [Test]
         public void Without_hint_return_null()
         {
-            HintBasedCache hintBasedCache = new HintBasedCache(e => new NullDataSet());
+            HintBasedCache hintBasedCache = new HintBasedCache(e => new NullDataSet(), LimboLogs.Instance);
             for (uint i = 0; i < 1000; i++)
             {
                 Assert.Null(hintBasedCache.Get(i));
@@ -53,7 +54,7 @@ namespace Nethermind.Mining.Test
         [Test]
         public async Task With_hint_returns_value()
         {
-            HintBasedCache hintBasedCache = new HintBasedCache(e => new NullDataSet());
+            HintBasedCache hintBasedCache = new HintBasedCache(e => new NullDataSet(), LimboLogs.Instance);
             hintBasedCache.Hint(_guidA, 0, 200000);
             await WaitFor(() => hintBasedCache.CachedEpochsCount == 7);
             
@@ -66,7 +67,7 @@ namespace Nethermind.Mining.Test
         [Test]
         public async Task Different_users_reuse_cached_epochs()
         {
-            HintBasedCache hintBasedCache = new HintBasedCache(e => new NullDataSet());
+            HintBasedCache hintBasedCache = new HintBasedCache(e => new NullDataSet(), LimboLogs.Instance);
             hintBasedCache.Hint(_guidA, 0, 200000);
             hintBasedCache.Hint(_guidB, 0, 200000);
             await WaitFor(() => hintBasedCache.CachedEpochsCount == 7);
@@ -79,7 +80,7 @@ namespace Nethermind.Mining.Test
         [Test]
         public async Task Different_users_can_use_cache()
         {
-            HintBasedCache hintBasedCache = new HintBasedCache(e => new NullDataSet());
+            HintBasedCache hintBasedCache = new HintBasedCache(e => new NullDataSet(), LimboLogs.Instance);
             hintBasedCache.Hint(_guidA, 0, 29999);
             hintBasedCache.Hint(_guidB, 30000, 59999);
             await WaitFor(() => hintBasedCache.CachedEpochsCount == 2);
@@ -92,7 +93,7 @@ namespace Nethermind.Mining.Test
         [Test]
         public async Task Different_users_can_use_disconnected_epochs()
         {
-            HintBasedCache hintBasedCache = new HintBasedCache(e => new NullDataSet());
+            HintBasedCache hintBasedCache = new HintBasedCache(e => new NullDataSet(), LimboLogs.Instance);
             hintBasedCache.Hint(_guidA, 0, 29999);
             hintBasedCache.Hint(_guidB, 120000, 149999);
             await WaitFor(() => hintBasedCache.CachedEpochsCount == 2);
@@ -106,7 +107,7 @@ namespace Nethermind.Mining.Test
         [Test]
         public async Task Moving_range_evicts_cached_epochs()
         {
-            HintBasedCache hintBasedCache = new HintBasedCache(e => new NullDataSet());
+            HintBasedCache hintBasedCache = new HintBasedCache(e => new NullDataSet(), LimboLogs.Instance);
             hintBasedCache.Hint(_guidA, 0, 209999);
             hintBasedCache.Hint(_guidA, 30000, 239999);
             await WaitFor(() => hintBasedCache.CachedEpochsCount == 7);
@@ -121,7 +122,7 @@ namespace Nethermind.Mining.Test
         [Test]
         public async Task Can_hint_far()
         {
-            HintBasedCache hintBasedCache = new HintBasedCache(e => new NullDataSet());
+            HintBasedCache hintBasedCache = new HintBasedCache(e => new NullDataSet(), LimboLogs.Instance);
             hintBasedCache.Hint(_guidA, 1000000000, 1000000000);
             await WaitFor(() => hintBasedCache.CachedEpochsCount == 1);
             
@@ -131,7 +132,7 @@ namespace Nethermind.Mining.Test
         [Test]
         public void Throws_on_wide_hint()
         {
-            HintBasedCache hintBasedCache = new HintBasedCache(e => new NullDataSet());
+            HintBasedCache hintBasedCache = new HintBasedCache(e => new NullDataSet(), LimboLogs.Instance);
             Assert.Throws<InvalidOperationException>(() => hintBasedCache.Hint(_guidA, 0, 1000000000));
         }
         

--- a/src/Nethermind/Nethermind.Mining.Test/HintBasedCacheTests.cs
+++ b/src/Nethermind/Nethermind.Mining.Test/HintBasedCacheTests.cs
@@ -1,0 +1,153 @@
+//  Copyright (c) 2018 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Nethermind.Mining.Test
+{
+    [TestFixture]
+    public class HintBasedCacheTests
+    {
+        private class NullDataSet : IEthashDataSet
+        {
+            public void Dispose()
+            {
+            }
+
+            public uint Size => 0;
+            
+            public uint[] CalcDataSetItem(uint i)
+            {
+                return new uint[0];
+            }
+        }
+        
+        [Test]
+        public void Without_hint_return_null()
+        {
+            HintBasedCache hintBasedCache = new HintBasedCache(e => new NullDataSet());
+            for (uint i = 0; i < 1000; i++)
+            {
+                Assert.Null(hintBasedCache.Get(i));
+            }
+        }
+        
+        private Guid _guidA = Guid.NewGuid();
+        private Guid _guidB = Guid.NewGuid();
+        
+        [Test]
+        public async Task With_hint_returns_value()
+        {
+            HintBasedCache hintBasedCache = new HintBasedCache(e => new NullDataSet());
+            hintBasedCache.Hint(_guidA, 0, 200000);
+            await WaitFor(() => hintBasedCache.CachedEpochsCount == 7);
+            
+            for (uint i = 0; i < 7; i++)
+            {
+                Assert.NotNull(hintBasedCache.Get(i));
+            }
+        }
+        
+        [Test]
+        public async Task Different_users_reuse_cached_epochs()
+        {
+            HintBasedCache hintBasedCache = new HintBasedCache(e => new NullDataSet());
+            hintBasedCache.Hint(_guidA, 0, 200000);
+            hintBasedCache.Hint(_guidB, 0, 200000);
+            await WaitFor(() => hintBasedCache.CachedEpochsCount == 7);
+            for (uint i = 0; i < 7; i++)
+            {
+                Assert.NotNull(hintBasedCache.Get(i));
+            }
+        }
+        
+        [Test]
+        public async Task Different_users_can_use_cache()
+        {
+            HintBasedCache hintBasedCache = new HintBasedCache(e => new NullDataSet());
+            hintBasedCache.Hint(_guidA, 0, 29999);
+            hintBasedCache.Hint(_guidB, 30000, 59999);
+            await WaitFor(() => hintBasedCache.CachedEpochsCount == 2);
+            for (uint i = 0; i < 2; i++)
+            {
+                Assert.NotNull(hintBasedCache.Get(i));
+            }
+        }
+        
+        [Test]
+        public async Task Different_users_can_use_disconnected_epochs()
+        {
+            HintBasedCache hintBasedCache = new HintBasedCache(e => new NullDataSet());
+            hintBasedCache.Hint(_guidA, 0, 29999);
+            hintBasedCache.Hint(_guidB, 120000, 149999);
+            await WaitFor(() => hintBasedCache.CachedEpochsCount == 2);
+            Assert.NotNull(hintBasedCache.Get(0));
+            Assert.Null(hintBasedCache.Get(1));
+            Assert.Null(hintBasedCache.Get(2));
+            Assert.Null(hintBasedCache.Get(3));
+            Assert.NotNull(hintBasedCache.Get(4));
+        }
+        
+        [Test]
+        public async Task Moving_range_evicts_cached_epochs()
+        {
+            HintBasedCache hintBasedCache = new HintBasedCache(e => new NullDataSet());
+            hintBasedCache.Hint(_guidA, 0, 209999);
+            hintBasedCache.Hint(_guidA, 30000, 239999);
+            await WaitFor(() => hintBasedCache.CachedEpochsCount == 7);
+            
+            Assert.Null(hintBasedCache.Get(0));
+            for (uint i = 1; i < 8; i++)
+            {
+                Assert.NotNull(hintBasedCache.Get(i), i.ToString());
+            }
+        }
+        
+        [Test]
+        public async Task Can_hint_far()
+        {
+            HintBasedCache hintBasedCache = new HintBasedCache(e => new NullDataSet());
+            hintBasedCache.Hint(_guidA, 1000000000, 1000000000);
+            await WaitFor(() => hintBasedCache.CachedEpochsCount == 1);
+            
+            Assert.NotNull(hintBasedCache.Get(1000000000 / 30000));
+        }
+        
+        [Test]
+        public void Throws_on_wide_hint()
+        {
+            HintBasedCache hintBasedCache = new HintBasedCache(e => new NullDataSet());
+            Assert.Throws<InvalidOperationException>(() => hintBasedCache.Hint(_guidA, 0, 1000000000));
+        }
+        
+        private async Task WaitFor(Func<bool> isConditionMet, string description = "condition to be met")
+        {
+            const int waitInterval = 10;
+            for (int i = 0; i < 10; i++)
+            {
+                if (isConditionMet())
+                {
+                    return;
+                }
+
+                TestContext.WriteLine($"({i}) Waiting {waitInterval} for {description}");
+                await Task.Delay(waitInterval);
+            }
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Mining/Ethash.cs
+++ b/src/Nethermind/Nethermind.Mining/Ethash.cs
@@ -206,6 +206,7 @@ namespace Nethermind.Mining
 
         public void HintRange(Guid guid, long start, long end)
         {
+            _logger.Warn($"Hinting range {start}-{end}");
             _hintBasedCache.Hint(guid, start, end);
         }
 

--- a/src/Nethermind/Nethermind.Mining/Ethash.cs
+++ b/src/Nethermind/Nethermind.Mining/Ethash.cs
@@ -36,16 +36,15 @@ namespace Nethermind.Mining
 {
     public class Ethash : IEthash
     {
+        private HintBasedCache _hintBasedCache;
+
         private readonly ILogger _logger;
 
         public Ethash(ILogManager logManager)
         {
             _logger = logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
+            _hintBasedCache = new HintBasedCache(BuildCache);
         }
-
-        private const int CacheCapacity = 10;
-        private readonly LruCache<uint, DataSetWithAccessTime> _cacheCache = new LruCache<uint, DataSetWithAccessTime>(CacheCapacity);
-        private readonly HashSet<DataSetWithAccessTime> _cacheMonitor = new HashSet<DataSetWithAccessTime>();
 
         public const int WordBytes = 4; // bytes in word
         public static uint DataSetBytesInit = (uint) BigInteger.Pow(2, 30); // bytes in dataset at genesis
@@ -53,14 +52,14 @@ namespace Nethermind.Mining
         public static uint CacheBytesInit = (uint) BigInteger.Pow(2, 24); // bytes in cache at genesis
         public static uint CacheBytesGrowth = (uint) BigInteger.Pow(2, 17); // cache growth per epoch
         public const int CacheMultiplier = 1024; // Size of the DAG relative to the cache
-        public const ulong EpochLength = 30000; // blocks per epoch
+        public const long EpochLength = 30000; // blocks per epoch
         public const uint MixBytes = 128; // width of mix
         public const int HashBytes = 64; // hash length in bytes
         public const uint DataSetParents = 256; // blockNumber of parents of each dataset element
         public const int CacheRounds = 3; // blockNumber of rounds in cache production
         public const int Accesses = 64; // blockNumber of accesses in hashimoto loop
 
-        public static uint GetEpoch(BigInteger blockNumber)
+        public static uint GetEpoch(long blockNumber)
         {
             return (uint) (blockNumber / EpochLength);
         }
@@ -153,6 +152,13 @@ namespace Nethermind.Mining
         public (Keccak MixHash, ulong Nonce) Mine(BlockHeader header, ulong? startNonce = null)
         {
             uint epoch = GetEpoch(header.Number);
+            IEthashDataSet dataSet = _hintBasedCache.Get(epoch);
+            if (dataSet == null)
+            {
+                if(_logger.IsWarn) _logger.Warn($"Ethash cache miss for block {header.ToString(BlockHeader.Format.Short)}");
+                dataSet = BuildCache(epoch);
+            }
+            
             ulong fullSize = GetDataSize(epoch);
             ulong nonce = startNonce ?? GetRandomNonce();
             BigInteger target = BigInteger.Divide(_2To256, header.Difficulty);
@@ -163,7 +169,7 @@ namespace Nethermind.Mining
             while (true)
             {
                 byte[] result;
-                (mixHash, result) = Hashimoto(fullSize, GetOrAddCache(epoch), headerHashed, null, nonce);
+                (mixHash, result) = Hashimoto(fullSize, dataSet, headerHashed, null, nonce);
                 if (IsLessThanTarget(result, target))
                 {
                     break;
@@ -193,18 +199,29 @@ namespace Nethermind.Mining
             return (v1 * FnvPrime) ^ v2;
         }
 
-        internal static uint GetUInt(byte[] bytes, uint offset)
+        private static uint GetUInt(byte[] bytes, uint offset)
         {
             return BitConverter.ToUInt32(BitConverter.IsLittleEndian ? bytes : Bytes.Reverse(bytes), (int) offset * 4);
+        }
+
+        public void HintRange(Guid guid, long start, long end)
+        {
+            _hintBasedCache.Hint(guid, start, end);
         }
 
         public bool Validate(BlockHeader header)
         {
             uint epoch = GetEpoch(header.Number);
-            IEthashDataSet cache = GetOrAddCache(epoch);
+            IEthashDataSet dataSet = _hintBasedCache.Get(epoch);
+            if (dataSet == null)
+            {
+                if(_logger.IsWarn) _logger.Warn($"Ethash cache miss for block {header.ToString(BlockHeader.Format.Short)}");
+                dataSet = BuildCache(epoch);
+            }
+            
             ulong fullSize = GetDataSize(epoch);
             Keccak headerHashed = GetTruncatedHash(header);
-            (byte[] _, byte[] result) = Hashimoto(fullSize, cache, headerHashed, header.MixHash, header.Nonce);
+            (byte[] _, byte[] result) = Hashimoto(fullSize, dataSet, headerHashed, header.MixHash, header.Nonce);
 
             BigInteger threshold = BigInteger.Divide(BigInteger.Pow(2, 256), header.Difficulty);
             return IsLessThanTarget(result, threshold);
@@ -212,82 +229,16 @@ namespace Nethermind.Mining
 
         private readonly Stopwatch _cacheStopwatch = new Stopwatch();
 
-        private class DataSetWithAccessTime
+        private IEthashDataSet BuildCache(uint epoch)
         {
-            public DataSetWithAccessTime(uint epoch, Task<IEthashDataSet> dataSet, ulong accessTime)
-            {
-                Epoch = epoch;
-                DataSet = dataSet;
-                AccessTime = accessTime;
-            }
-
-            public uint Epoch { get; }
-            public Task<IEthashDataSet> DataSet { get; }
-
-            public ulong AccessTime { get; set; }
-        }
-
-        private IEthashDataSet GetOrAddCache(uint epoch)
-        {
-            DataSetWithAccessTime theOne;
-            lock (_cacheCache)
-            {
-                for (uint i = Math.Max(epoch, 2) - 2; i < epoch + 3; i++)
-                {
-                    if (_cacheCache.Get(i) == default)
-                    {
-                        DataSetWithAccessTime someone = new DataSetWithAccessTime(i, BuildCache(i), Timestamper.Default.EpochSeconds);
-                        _cacheCache.Set(i, someone);
-                        _cacheMonitor.Add(someone);
-                    }
-                }
-
-                var now = Timestamper.Default.EpochSeconds;
-                theOne = _cacheCache.Get(epoch);
-                theOne.AccessTime = now;
-
-                HashSet<DataSetWithAccessTime> removed = null;
-                foreach (DataSetWithAccessTime dataSetWithAccessTime in _cacheMonitor)
-                {
-                    if (now - dataSetWithAccessTime.AccessTime > 180)
-                    {
-                        _cacheCache.Delete(dataSetWithAccessTime.Epoch);
-                        if (removed == null)
-                        {
-                            removed = new HashSet<DataSetWithAccessTime>();
-                        }
-
-                        removed.Add(dataSetWithAccessTime);
-                    }
-                }
-
-                if (removed != null)
-                {
-                    foreach (DataSetWithAccessTime dataSetWithAccessTime in removed)
-                    {
-                        _cacheMonitor.Remove(dataSetWithAccessTime);
-                        dataSetWithAccessTime.DataSet.Result.Dispose();
-                    }
-                }
-            }
-
-            IEthashDataSet dataSet = theOne.DataSet.Result;
+            uint cacheSize = GetCacheSize(epoch);
+            Keccak seed = GetSeedHash(epoch);
+            if (_logger.IsInfo) _logger.Info($"Building ethash cache for epoch {epoch}");
+            _cacheStopwatch.Restart();
+            IEthashDataSet dataSet = new EthashCache(cacheSize, seed.Bytes);
+            _cacheStopwatch.Stop();
+            if (_logger.IsInfo) _logger.Info($"Cache for epoch {epoch} with size {cacheSize} nd seed {seed.Bytes.ToHexString()} built in {_cacheStopwatch.ElapsedMilliseconds}ms");
             return dataSet;
-        }
-
-        private Task<IEthashDataSet> BuildCache(uint epoch)
-        {
-            return Task.Run(() =>
-            {
-                uint cacheSize = GetCacheSize(epoch);
-                Keccak seed = GetSeedHash(epoch);
-                if (_logger.IsInfo) _logger.Info($"Building ethash cache for epoch {epoch}");
-                _cacheStopwatch.Restart();
-                IEthashDataSet dataSet = new EthashCache(cacheSize, seed.Bytes);
-                _cacheStopwatch.Stop();
-                if (_logger.IsInfo) _logger.Info($"Cache for epoch {epoch} with size {cacheSize} nd seed {seed.Bytes.ToHexString()} built in {_cacheStopwatch.ElapsedMilliseconds}ms");
-                return dataSet;
-            });
         }
 
         private static HeaderDecoder _headerDecoder = new HeaderDecoder();

--- a/src/Nethermind/Nethermind.Mining/Ethash.cs
+++ b/src/Nethermind/Nethermind.Mining/Ethash.cs
@@ -44,7 +44,7 @@ namespace Nethermind.Mining
         public Ethash(ILogManager logManager)
         {
             _logger = logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
-            _hintBasedCache = new HintBasedCache(BuildCache);
+            _hintBasedCache = new HintBasedCache(BuildCache, logManager);
         }
 
         public const int WordBytes = 4; // bytes in word
@@ -207,7 +207,6 @@ namespace Nethermind.Mining
 
         public void HintRange(Guid guid, long start, long end)
         {
-            _logger.Warn($"Hinting range {start}-{end}");
             _hintBasedCache.Hint(guid, start, end);
         }
 

--- a/src/Nethermind/Nethermind.Mining/Ethash.cs
+++ b/src/Nethermind/Nethermind.Mining/Ethash.cs
@@ -170,7 +170,7 @@ namespace Nethermind.Mining
             while (true)
             {
                 byte[] result;
-                (mixHash, result) = Hashimoto(fullSize, dataSet, headerHashed, null, nonce);
+                (mixHash, result, _) = Hashimoto(fullSize, dataSet, headerHashed, null, nonce);
                 if (IsLessThanTarget(result, target))
                 {
                     break;

--- a/src/Nethermind/Nethermind.Mining/EthashSealValidator.cs
+++ b/src/Nethermind/Nethermind.Mining/EthashSealValidator.cs
@@ -73,6 +73,11 @@ namespace Nethermind.Mining
             return result;
         }
 
+        public void HintValidationRange(Guid guid, long start, long end)
+        {
+            _ethash.HintRange(guid, start, end);
+        }  
+        
         public bool ValidateParams(BlockHeader parent, BlockHeader header)
         {
             bool extraDataNotTooLong = header.ExtraData.Length <= 32;

--- a/src/Nethermind/Nethermind.Mining/EthashSealValidator.cs
+++ b/src/Nethermind/Nethermind.Mining/EthashSealValidator.cs
@@ -53,6 +53,8 @@ namespace Nethermind.Mining
 
         public bool ValidateSeal(BlockHeader header, bool force)
         {
+            _logger.Warn($"Validating seal for {header.ToString(BlockHeader.Format.Short)}");
+            
             // genesis block is configured and assumed valid
             if (header.IsGenesis) return true;
 

--- a/src/Nethermind/Nethermind.Mining/EthashSealValidator.cs
+++ b/src/Nethermind/Nethermind.Mining/EthashSealValidator.cs
@@ -53,8 +53,6 @@ namespace Nethermind.Mining
 
         public bool ValidateSeal(BlockHeader header, bool force)
         {
-            _logger.Warn($"Validating seal for {header.ToString(BlockHeader.Format.Short)}");
-            
             // genesis block is configured and assumed valid
             if (header.IsGenesis) return true;
 

--- a/src/Nethermind/Nethermind.Mining/FakeSealer.cs
+++ b/src/Nethermind/Nethermind.Mining/FakeSealer.cs
@@ -57,6 +57,10 @@ namespace Nethermind.Mining
             return true;
         }
 
+        public void HintValidationRange(Guid guid, long start, long end)
+        {
+        }
+
         public bool ValidateParams(BlockHeader parent, BlockHeader header)
         {
             return true;

--- a/src/Nethermind/Nethermind.Mining/HintBasedCache.cs
+++ b/src/Nethermind/Nethermind.Mining/HintBasedCache.cs
@@ -101,7 +101,7 @@ namespace Nethermind.Mining
                     _epochRefs[alreadyCachedEpoch] = _epochRefs[alreadyCachedEpoch] - 1;
                     if (_epochRefs[alreadyCachedEpoch] == 0)
                     {
-                        _logger.Warn($"Removing data set for epoch {alreadyCachedEpoch}");
+                        // _logger.Warn($"Removing data set for epoch {alreadyCachedEpoch}");
                         _cachedSets.Remove(alreadyCachedEpoch, out Task<IEthashDataSet> removed);
                         _recent[alreadyCachedEpoch] = new DataSetWithTime(DateTimeOffset.UtcNow, removed);
                         Interlocked.Decrement(ref _cachedEpochsCount);
@@ -125,7 +125,7 @@ namespace Nethermind.Mining
                         _epochRefs[epoch] = _epochRefs[epoch] + 1;
                         if (_epochRefs[epoch] == 1)
                         {
-                            _logger.Warn($"Building data set for epoch {epoch}");
+                            // _logger.Warn($"Building data set for epoch {epoch}");
                             if (_recent.ContainsKey(epoch))
                             {
                                 _recent.Remove(epoch, out DataSetWithTime reused);

--- a/src/Nethermind/Nethermind.Mining/HintBasedCache.cs
+++ b/src/Nethermind/Nethermind.Mining/HintBasedCache.cs
@@ -1,0 +1,113 @@
+//  Copyright (c) 2018 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nethermind.Mining
+{
+    public class HintBasedCache
+    {
+        private ConcurrentDictionary<Guid, HashSet<uint>> _epochsPerGuid = new ConcurrentDictionary<Guid, HashSet<uint>>();
+        private ConcurrentDictionary<uint, int> _epochRefs = new ConcurrentDictionary<uint, int>();
+        private ConcurrentDictionary<uint, Task<IEthashDataSet>> _cachedSets = new ConcurrentDictionary<uint, Task<IEthashDataSet>>();
+
+        public int CachedEpochsCount { get; set; }
+
+        private readonly Func<uint, IEthashDataSet> _createDataSet;
+
+        public HintBasedCache(Func<uint, IEthashDataSet> createDataSet)
+        {
+            _createDataSet = createDataSet;
+        }
+
+        public void Hint(Guid guid, long start, long end)
+        {
+            uint startEpoch = (uint)(start / Ethash.EpochLength);
+            uint endEpoch = (uint)(end / Ethash.EpochLength);
+
+            if (endEpoch - startEpoch > 10)
+            {
+                throw new InvalidOperationException("Hint too wide");
+            }
+            
+            HashSet<uint> epochForGuid = _epochsPerGuid.GetOrAdd(guid, new HashSet<uint>());
+            lock (epochForGuid)
+            {
+                if (epochForGuid.Count > 0)
+                {
+                    foreach (uint cachedEpoch in epochForGuid.ToList())
+                    {
+                        if (cachedEpoch < startEpoch || cachedEpoch > endEpoch)
+                        {
+                            bool shouldRemove = false;
+                            epochForGuid.Remove(cachedEpoch);
+                            lock (_epochRefs)
+                            {
+                                _epochRefs[cachedEpoch] = _epochRefs[cachedEpoch] - 1;
+                                if (_epochRefs[cachedEpoch] == 0)
+                                {
+                                    shouldRemove = true;
+                                }
+                            }
+
+                            if (shouldRemove)
+                            {
+                                _cachedSets.Remove(cachedEpoch, out _);
+                                CachedEpochsCount--;
+                            }
+                        }
+                    }
+                }
+
+                for (long i = startEpoch; i <= endEpoch; i++)
+                {
+                    uint epoch = (uint) i;
+                    if (!epochForGuid.Contains(epoch))
+                    {
+                        bool shouldAdd = false;
+                        epochForGuid.Add(epoch);
+                        lock (_epochRefs)
+                        {
+                            if (!_epochRefs.TryGetValue(epoch, out int refCount))
+                            {
+                                shouldAdd = true;
+                            }
+
+                            _epochRefs[epoch] = refCount + 1;
+                        }
+
+                        if (shouldAdd)
+                        {
+                            _cachedSets[epoch] = Task<IEthashDataSet>.Run(() => _createDataSet(epoch));
+                            CachedEpochsCount++;
+                        }
+                    }
+                }
+            }
+        }
+
+        public IEthashDataSet Get(uint epoch)
+        {
+            _cachedSets.TryGetValue(epoch, out Task<IEthashDataSet> dataSetTask);
+            return dataSetTask?.Result;
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Mining/IEthash.cs
+++ b/src/Nethermind/Nethermind.Mining/IEthash.cs
@@ -14,6 +14,7 @@
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
+using System;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 
@@ -21,6 +22,7 @@ namespace Nethermind.Mining
 {
     public interface IEthash
     {
+        void HintRange(Guid guid, long start, long end);
         bool Validate(BlockHeader header);
         (Keccak MixHash, ulong Nonce) Mine(BlockHeader header, ulong? startNonce = null); // TODO: for now only with cache
     }

--- a/src/Nethermind/Nethermind.Mining/ISealer.cs
+++ b/src/Nethermind/Nethermind.Mining/ISealer.cs
@@ -14,11 +14,11 @@
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
-using Nethermind.Dirichlet.Numerics;
 
 namespace Nethermind.Mining
 {
@@ -30,6 +30,8 @@ namespace Nethermind.Mining
     
     public interface ISealValidator
     {
+        void HintValidationRange(Guid guid, long start, long end);
+
         bool ValidateParams(BlockHeader parent, BlockHeader header);
         
         /// <summary>

--- a/src/Nethermind/Nethermind.Mining/NullSealEngine.cs
+++ b/src/Nethermind/Nethermind.Mining/NullSealEngine.cs
@@ -14,6 +14,7 @@
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Core;
@@ -38,6 +39,10 @@ namespace Nethermind.Mining
         public bool CanSeal(long blockNumber, Keccak parentHash)
         {
             return true;
+        }
+
+        public void HintValidationRange(Guid guid, long start, long end)
+        {
         }
 
         public bool ValidateParams(BlockHeader parent, BlockHeader header)

--- a/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
@@ -271,7 +271,7 @@ namespace Nethermind.Network.Test
             Assert.AreEqual(0, _peerManager.ActivePeers.Count);
         }
 
-        [Test]
+        [Test, Retry(3)]
         public void Will_fill_up_over_and_over_again_on_disconnects()
         {
             SetupPersistedPeers(50);

--- a/src/Nethermind/Nethermind.Network/P2P/Session.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Session.cs
@@ -101,7 +101,8 @@ namespace Nethermind.Network.P2P
 
                 return _node;
             }
-            set => _node = value;
+            
+            private set => _node = value;
         }
 
         public void EnableSnappy()

--- a/src/Nethermind/Nethermind.Runner/configs/goerli.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/goerli.cfg
@@ -29,9 +29,9 @@
   },
   "Sync": {
     "FastSync": true,
-    "PivotNumber" : 1800000,
-    "PivotHash" : "0x1eae50bc4b02e283c2de3c01ae6a84c862ea873e3544fbfe83f3955d39aaca4c",
-    "PivotTotalDifficulty" : "2759311",
+    "PivotNumber" : 1990000,
+    "PivotHash" : "0x872595d0f865a9ddda13556a35121a8b5c5654a3c099de33f0349f956c1b1462",
+    "PivotTotalDifficulty" : "3005656",
     "FastBlocks" : true,
     "DownloadBodiesInFastSync" : true,
     "DownloadReceiptsInFastSync" : true,


### PR DESCRIPTION
we update the pivot block for Goerli to 1990000
we introduce a concept of ethash cache hints that allow a smart approach to ethash data caches whatever the sync direction
we remove the seal validation from fast blocks, although it will be worth to check whether it is required in AuRa (also pay attention to the fact that fast blocks blocks are synchronzied backwards which may affect AuRa)
we update MaxBodies fetch to 192 and MxReceiptsFetch to 256 on Geth
batch inserts for receipts
fix to pending requests on node data downloader