### PR TITLE
Hexprefix - optimizations

### DIFF
--- a/src/Nethermind/Ethereum.HexPrefix.Test/HexPrefixTests.cs
+++ b/src/Nethermind/Ethereum.HexPrefix.Test/HexPrefixTests.cs
@@ -41,7 +41,7 @@ namespace Ethereum.HexPrefix.Test
         public void Test(HexPrefixTest test)
         {
             Nethermind.Store.HexPrefix result =
-                new Nethermind.Store.HexPrefix(test.IsTerm, test.Sequence);
+                Nethermind.Store.HexPrefix.Create(test.IsTerm, test.Sequence);
             byte[] bytes = result.ToBytes();
             string resultHex = bytes.ToHexString(false);
             Assert.AreEqual(test.Output, resultHex);

--- a/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
@@ -121,6 +121,11 @@ namespace Nethermind.Core.Extensions
         {
             return a1.SequenceEqual(a2);
         }
+        
+        public static bool AreEqual(ReadOnlySpan<byte> a1, ReadOnlySpan<byte> a2)
+        {
+            return a1.SequenceEqual(a2);
+        }
 
         public static bool IsZero(this byte[] bytes)
         {

--- a/src/Nethermind/Nethermind.Store.Test/HexPrefixTests.cs
+++ b/src/Nethermind/Nethermind.Store.Test/HexPrefixTests.cs
@@ -25,7 +25,7 @@ namespace Nethermind.Store.Test
         [TestCase(true, (byte)3, (byte)51)]
         public void Encode_gives_correct_output_when_one(bool flag, byte nibble1, byte byte1)
         {
-            HexPrefix hexPrefix = new HexPrefix(flag, nibble1);
+            HexPrefix hexPrefix = HexPrefix.Create(flag, nibble1);
             byte[] output = hexPrefix.ToBytes();
             Assert.AreEqual(1, output.Length);
             Assert.AreEqual(byte1, output[0]);
@@ -35,7 +35,7 @@ namespace Nethermind.Store.Test
         [TestCase(true, (byte)3, (byte)7, (byte)13, (byte)51, (byte)125)]
         public void Encode_gives_correct_output_when_odd(bool flag, byte nibble1, byte nibble2, byte nibble3, byte byte1, byte byte2)
         {
-            HexPrefix hexPrefix = new HexPrefix(flag, nibble1, nibble2, nibble3);
+            HexPrefix hexPrefix = HexPrefix.Create(flag, nibble1, nibble2, nibble3);
             byte[] output = hexPrefix.ToBytes();
             Assert.AreEqual(2, output.Length);
             Assert.AreEqual(byte1, output[0]);
@@ -46,7 +46,7 @@ namespace Nethermind.Store.Test
         [TestCase(true, (byte)3, (byte)7, (byte)32, (byte)55)]
         public void Encode_gives_correct_output_when_even(bool flag, byte nibble1, byte nibble2, byte byte1, byte byte2)
         {
-            HexPrefix hexPrefix = new HexPrefix(flag, nibble1, nibble2);
+            HexPrefix hexPrefix = HexPrefix.Create(flag, nibble1, nibble2);
             byte[] output = hexPrefix.ToBytes();
             Assert.AreEqual(2, output.Length);
             Assert.AreEqual(byte1, output[0]);

--- a/src/Nethermind/Nethermind.Store.Test/HexPrefixTests.cs
+++ b/src/Nethermind/Nethermind.Store.Test/HexPrefixTests.cs
@@ -35,7 +35,7 @@ namespace Nethermind.Store.Test
         [TestCase(true, (byte)3, (byte)7, (byte)13, (byte)51, (byte)125)]
         public void Encode_gives_correct_output_when_odd(bool flag, byte nibble1, byte nibble2, byte nibble3, byte byte1, byte byte2)
         {
-            HexPrefix hexPrefix = HexPrefix.Create(flag, nibble1, nibble2, nibble3);
+            HexPrefix hexPrefix = HexPrefix.Create(flag, new[] { nibble1, nibble2, nibble3 });
             byte[] output = hexPrefix.ToBytes();
             Assert.AreEqual(2, output.Length);
             Assert.AreEqual(byte1, output[0]);
@@ -46,7 +46,7 @@ namespace Nethermind.Store.Test
         [TestCase(true, (byte)3, (byte)7, (byte)32, (byte)55)]
         public void Encode_gives_correct_output_when_even(bool flag, byte nibble1, byte nibble2, byte byte1, byte byte2)
         {
-            HexPrefix hexPrefix = HexPrefix.Create(flag, nibble1, nibble2);
+            HexPrefix hexPrefix = HexPrefix.Create(flag, new[] { nibble1, nibble2 });
             byte[] output = hexPrefix.ToBytes();
             Assert.AreEqual(2, output.Length);
             Assert.AreEqual(byte1, output[0]);

--- a/src/Nethermind/Nethermind.Store.Test/TrieNodeTests.cs
+++ b/src/Nethermind/Nethermind.Store.Test/TrieNodeTests.cs
@@ -30,11 +30,11 @@ namespace Nethermind.Store.Test
         public TrieNodeTests()
         {
             _tiniestLeaf = new TrieNode(NodeType.Leaf);
-            _tiniestLeaf.Key = new HexPrefix(true, 5);
+            _tiniestLeaf.Key = HexPrefix.Create(true, 5);
             _tiniestLeaf.Value = new byte[] {10};
             
             _heavyLeaf = new TrieNode(NodeType.Leaf);
-            _heavyLeaf.Key = new HexPrefix(true, 5);
+            _heavyLeaf.Key = HexPrefix.Create(true, 5);
             _heavyLeaf.Value = Keccak.EmptyTreeHash.Bytes.Concat(Keccak.EmptyTreeHash.Bytes).ToArray();
         }
         
@@ -74,7 +74,7 @@ namespace Nethermind.Store.Test
         public void Can_encode_decode_tiny_extension()
         {
             TrieNode trieNode = new TrieNode(NodeType.Extension);
-            trieNode.Key = new HexPrefix(false, 5);
+            trieNode.Key = HexPrefix.Create(false, 5);
             trieNode.SetChild(0, _tiniestLeaf);
 
             Rlp rlp = trieNode.RlpEncode();
@@ -92,7 +92,7 @@ namespace Nethermind.Store.Test
         public void Can_encode_decode_heavy_extension()
         {
             TrieNode trieNode = new TrieNode(NodeType.Extension);
-            trieNode.Key = new HexPrefix(false, 5);
+            trieNode.Key = HexPrefix.Create(false, 5);
             trieNode.SetChild(0, _heavyLeaf);
 
             Rlp rlp = trieNode.RlpEncode();
@@ -108,7 +108,7 @@ namespace Nethermind.Store.Test
         public void Can_set_and_get_children_using_indexer()
         {
             TrieNode tiniest = new TrieNode(NodeType.Leaf);
-            tiniest.Key = new HexPrefix(true, 5);
+            tiniest.Key = HexPrefix.Create(true, 5);
             tiniest.Value = new byte[] {10};
 
             TrieNode trieNode = new TrieNode(NodeType.Branch);
@@ -146,7 +146,7 @@ namespace Nethermind.Store.Test
         {
             TrieNode trieNode = new TrieNode(NodeType.Extension);
             trieNode[0] = _heavyLeaf;
-            trieNode.Key = new HexPrefix(false, 5);
+            trieNode.Key = HexPrefix.Create(false, 5);
             Rlp rlp = trieNode.RlpEncode();
             TrieNode decoded = new TrieNode(NodeType.Extension, rlp);
             
@@ -159,7 +159,7 @@ namespace Nethermind.Store.Test
         {
             TrieNode trieNode = new TrieNode(NodeType.Extension);
             trieNode[0] = _tiniestLeaf;
-            trieNode.Key = new HexPrefix(false, 5);
+            trieNode.Key = HexPrefix.Create(false, 5);
             Rlp rlp = trieNode.RlpEncode();
             TrieNode decoded = new TrieNode(NodeType.Extension, rlp);
             

--- a/src/Nethermind/Nethermind.Store/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Store/PatriciaTree.cs
@@ -292,7 +292,7 @@ namespace Nethermind.Store
                     return null;
                 }
 
-                RootRef = TreeNodeFactory.CreateLeaf(new HexPrefix(true, updatePath.Slice(0, nibblesCount).ToArray()), updateValue);
+                RootRef = TreeNodeFactory.CreateLeaf(HexPrefix.Create(true, updatePath.Slice(0, nibblesCount).ToArray()), updateValue);
                 RootRef.IsDirty = true;
                 return updateValue;
             }
@@ -352,7 +352,7 @@ namespace Nethermind.Store
                     {
                         if (node.Value.Length != 0)
                         {
-                            TrieNode leafFromBranch = TreeNodeFactory.CreateLeaf(new HexPrefix(true), node.Value);
+                            TrieNode leafFromBranch = TreeNodeFactory.CreateLeaf(HexPrefix.Create(true), node.Value);
                             leafFromBranch.IsDirty = true;
                             nextNode = leafFromBranch;
                         }
@@ -377,19 +377,19 @@ namespace Nethermind.Store
                             childNode.ResolveNode(this);
                             if (childNode.IsBranch)
                             {
-                                TrieNode extensionFromBranch = TreeNodeFactory.CreateExtension(new HexPrefix(false, (byte) childNodeIndex), childNode);
+                                TrieNode extensionFromBranch = TreeNodeFactory.CreateExtension(HexPrefix.Create(false, (byte) childNodeIndex), childNode);
                                 extensionFromBranch.IsDirty = true;
                                 nextNode = extensionFromBranch;
                             }
                             else if (childNode.IsExtension)
                             {
-                                childNode.Key = new HexPrefix(false, Bytes.Concat((byte) childNodeIndex, childNode.Path));
+                                childNode.Key = HexPrefix.Create(false, Bytes.Concat((byte) childNodeIndex, childNode.Path));
                                 childNode.IsDirty = true;
                                 nextNode = childNode;
                             }
                             else if (childNode.IsLeaf)
                             {
-                                childNode.Key = new HexPrefix(true, Bytes.Concat((byte) childNodeIndex, childNode.Path));
+                                childNode.Key = HexPrefix.Create(true, Bytes.Concat((byte) childNodeIndex, childNode.Path));
                                 childNode.IsDirty = true;
                                 nextNode = childNode;
                             }
@@ -404,12 +404,12 @@ namespace Nethermind.Store
                 {
                     if (nextNode.IsLeaf)
                     {
-                        nextNode.Key = new HexPrefix(true, Bytes.Concat(node.Path, nextNode.Path));
+                        nextNode.Key = HexPrefix.Create(true, Bytes.Concat(node.Path, nextNode.Path));
                     }
                     else if (nextNode.IsExtension)
                     {
                         nextNode.IsDirty = true;
-                        nextNode.Key = new HexPrefix(false, Bytes.Concat(node.Path, nextNode.Path));
+                        nextNode.Key = HexPrefix.Create(false, Bytes.Concat(node.Path, nextNode.Path));
                     }
                     else if (nextNode.IsBranch)
                     {
@@ -488,7 +488,7 @@ namespace Nethermind.Store
                 }
 
                 byte[] leafPath = traverseContext.UpdatePath.Slice(traverseContext.CurrentIndex, traverseContext.UpdatePath.Length - traverseContext.CurrentIndex).ToArray();
-                TrieNode leaf = TreeNodeFactory.CreateLeaf(new HexPrefix(true, leafPath), traverseContext.UpdateValue);
+                TrieNode leaf = TreeNodeFactory.CreateLeaf(HexPrefix.Create(true, leafPath), traverseContext.UpdateValue);
                 leaf.IsDirty = true;
                 ConnectNodes(leaf);
 
@@ -577,7 +577,7 @@ namespace Nethermind.Store
             if (extensionLength != 0)
             {
                 Span<byte> extensionPath = longerPath.Slice(0, extensionLength);
-                TrieNode extension = TreeNodeFactory.CreateExtension(new HexPrefix(false, extensionPath.ToArray()));
+                TrieNode extension = TreeNodeFactory.CreateExtension(HexPrefix.Create(false, extensionPath.ToArray()));
                 extension.IsDirty = true;
                 _nodeStack.Push(new StackedNode(extension, 0));
             }
@@ -591,7 +591,7 @@ namespace Nethermind.Store
             else
             {
                 Span<byte> shortLeafPath = shorterPath.Slice(extensionLength + 1, shorterPath.Length - extensionLength - 1);
-                TrieNode shortLeaf = TreeNodeFactory.CreateLeaf(new HexPrefix(true, shortLeafPath.ToArray()), shorterPathValue);
+                TrieNode shortLeaf = TreeNodeFactory.CreateLeaf(HexPrefix.Create(true, shortLeafPath.ToArray()), shorterPathValue);
                 shortLeaf.IsDirty = true;
                 branch.SetChild(shorterPath[extensionLength], shortLeaf);
             }
@@ -600,7 +600,7 @@ namespace Nethermind.Store
 
 
             node.IsDirty = true;
-            node.Key = new HexPrefix(true, leafPath.ToArray());
+            node.Key = HexPrefix.Create(true, leafPath.ToArray());
             node.Value = longerPathValue;
 
             _nodeStack.Push(new StackedNode(branch, longerPath[extensionLength]));
@@ -649,7 +649,7 @@ namespace Nethermind.Store
             if (extensionLength != 0)
             {
                 byte[] extensionPath = node.Path.Slice(0, extensionLength);
-                node.Key = new HexPrefix(false, extensionPath);
+                node.Key = HexPrefix.Create(false, extensionPath);
                 node.IsDirty = true;
                 _nodeStack.Push(new StackedNode(node, 0));
             }
@@ -663,7 +663,7 @@ namespace Nethermind.Store
             else
             {
                 byte[] path = remaining.Slice(extensionLength + 1, remaining.Length - extensionLength - 1).ToArray();
-                TrieNode shortLeaf = TreeNodeFactory.CreateLeaf(new HexPrefix(true, path), traverseContext.UpdateValue);
+                TrieNode shortLeaf = TreeNodeFactory.CreateLeaf(HexPrefix.Create(true, path), traverseContext.UpdateValue);
                 shortLeaf.IsDirty = true;
                 branch.SetChild(remaining[extensionLength], shortLeaf);
             }
@@ -671,7 +671,7 @@ namespace Nethermind.Store
             if (pathBeforeUpdate.Length - extensionLength > 1)
             {
                 byte[] extensionPath = pathBeforeUpdate.Slice(extensionLength + 1, pathBeforeUpdate.Length - extensionLength - 1);
-                TrieNode secondExtension = TreeNodeFactory.CreateExtension(new HexPrefix(false, extensionPath), node.GetChild(0));
+                TrieNode secondExtension = TreeNodeFactory.CreateExtension(HexPrefix.Create(false, extensionPath), node.GetChild(0));
                 secondExtension.IsDirty = true;
                 branch.SetChild(pathBeforeUpdate[extensionLength], secondExtension);
             }

--- a/src/Nethermind/Nethermind.Store/TrieNode.cs
+++ b/src/Nethermind/Nethermind.Store/TrieNode.cs
@@ -105,7 +105,7 @@ namespace Nethermind.Store
         public bool IsBranch => NodeType == NodeType.Branch;
         public bool IsExtension => NodeType == NodeType.Extension;
 
-        public byte[] Path => Key.Path;
+        public ReadOnlySpan<byte> Path => Key.Path;
 
         internal HexPrefix Key
         {


### PR DESCRIPTION
This is an **experimental PR**, created for a discussion and is not ready to be merged.

Currently, we allocate a byte array `byte[]` for every `HexPrefix`. This makes the HexPrefix a simple structure, a wrapper around the mentioned array. If we switched to `ReadOnlySpan<byte>` we could provide different implementations of `HexPrefix` and by introducing a cost of a virtual dispatch and span creation possibly allocate less. 

The PR introduced two kinds of `HexPrefix`, one based on an array, another on the `long` field. The second, if it's sufficiently frequently created, could provide some gains in terms of allocating less litter. 

The conditions that I see, to make it worth it, are:

1. the number of HexPrefixes with Length less than 8 is much much greater that the number of HexPrefixes  with length equal or greater than 8.

