### PR TITLE
AuRa validator store

### DIFF
--- a/src/Nethermind/Chains/AuRaTest.json
+++ b/src/Nethermind/Chains/AuRaTest.json
@@ -13,18 +13,16 @@
               "list": ["0x557abc72a6594d1bd9a655a1cb58a595526416c8"]
             },
             "4" : {
-              "list": ["0x557abc72a6594d1bd9a655a1cb58a595526416c8", "0x69399093be61566a1c86b09bd02612c6bf31214f"]
+              "list": ["0x69399093be61566a1c86b09bd02612c6bf31214f"]
             },
             "8" : {
-              "list": ["0x557abc72a6594d1bd9a655a1cb58a595526416c8", "0x7e99aceb5d3dba8c79732c6cf49f184b00cff69b"]
+              "list": ["0x7e99aceb5d3dba8c79732c6cf49f184b00cff69b"]
             },
             "12" : {
               "safeContract": "0x8bf38d4764929064f2d4d3a56520a76ab3df415b"
             }
           }
-        },
-        "blockRewardContractAddress": "0x3145197AD50D7083D0222DE4fCCf67d9BD05C30D",
-        "blockRewardContractTransition": 4639000
+        }
       }
     }
   },
@@ -70,7 +68,6 @@
     "0000000000000000000000000000000000000005": { "builtin": { "name": "modexp", "activate_at": "0x0", "pricing": { "modexp": { "divisor": 20 } } } },
     "0000000000000000000000000000000000000006": { "builtin": { "name": "alt_bn128_add", "activate_at": "0x0", "pricing": { "linear": { "base": 500, "word": 0 } } } },
     "0000000000000000000000000000000000000007": { "builtin": { "name": "alt_bn128_mul", "activate_at": "0x0", "pricing": { "linear": { "base": 40000, "word": 0 } } } },
-    "0000000000000000000000000000000000000008": { "builtin": { "name": "alt_bn128_pairing", "activate_at": "0x0", "pricing": { "alt_bn128_pairing": { "base": 100000, "pair": 80000, "eip1108_transition_base": 0, "eip1108_transition_pair": 0 } } } },
 
     "0x0000000000000000000000000000000000000001": {
       "balance": "1",

--- a/src/Nethermind/Nethermind.AuRa.Test/AuRaAdditionalBlockProcessorFactoryTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/AuRaAdditionalBlockProcessorFactoryTests.cs
@@ -42,13 +42,12 @@ namespace Nethermind.AuRa.Test
             var stateDb = Substitute.For<IDb>();
             stateDb[Arg.Any<byte[]>()].Returns((byte[]) null);
             
-            var factory = new AuRaAdditionalBlockProcessorFactory(
-                stateDb,
-                Substitute.For<IStateProvider>(),
+            var factory = new AuRaAdditionalBlockProcessorFactory(Substitute.For<IStateProvider>(),
                 Substitute.For<IAbiEncoder>(), 
                 Substitute.For<ITransactionProcessor>(),
                 Substitute.For<IBlockTree>(),
                 Substitute.For<IReceiptStorage>(),
+                Substitute.For<IValidatorStore>(),
                 Substitute.For<ILogManager>());
 
             var validator = new AuRaParameters.Validator()

--- a/src/Nethermind/Nethermind.AuRa.Test/AuRaSealValidatorTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/AuRaSealValidatorTests.cs
@@ -60,7 +60,7 @@ namespace Nethermind.AuRa.Test
             
             _sealValidator = new AuRaSealValidator(_auRaParameters, 
                 _auRaStepCalculator,
-                Substitute.For<IAuRaValidator>(),
+                Substitute.For<IValidatorStore>(),
                 _ethereumEcdsa, 
                 _logManager);
         }

--- a/src/Nethermind/Nethermind.AuRa.Test/AuRaSealerTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/AuRaSealerTests.cs
@@ -44,6 +44,8 @@ namespace Nethermind.AuRa.Test
         private IAuRaStepCalculator _auRaStepCalculator;
         private IAuRaValidator _auRaValidator;
         private Address _address;
+        private IValidatorStore _validatorStore;
+        private IValidSealerStrategy _validSealerStrategy;
 
         [SetUp]
         public void Setup()
@@ -54,15 +56,19 @@ namespace Nethermind.AuRa.Test
 
             _auRaStepCalculator = Substitute.For<IAuRaStepCalculator>();
             _auRaValidator = Substitute.For<IAuRaValidator>();
+            _validatorStore = Substitute.For<IValidatorStore>();
+            _validSealerStrategy = Substitute.For<IValidSealerStrategy>();
             var wallet = new DevWallet(new WalletConfig(), NullLogManager.Instance);
             _address = wallet.NewAccount(new NetworkCredential(string.Empty, "AAA").SecurePassword);
             
             _auRaSealer = new AuRaSealer(
                 _blockTree,
                 _auRaValidator,
+                _validatorStore,
                 _auRaStepCalculator,
                 _address,
                 wallet,
+                _validSealerStrategy,
                 NullLogManager.Instance);
         }
 
@@ -73,7 +79,7 @@ namespace Nethermind.AuRa.Test
         public bool can_seal(long auRaStep, bool validSealer)
         {
             _auRaStepCalculator.CurrentStep.Returns(auRaStep);
-            _auRaValidator.IsValidSealer(_address, auRaStep).Returns(validSealer);
+            _validSealerStrategy.IsValidSealer(Arg.Any<IList<Address>>(), _address, auRaStep).Returns(validSealer);
             return _auRaSealer.CanSeal(10, _blockTree.Head.Hash);
         }
 
@@ -81,7 +87,7 @@ namespace Nethermind.AuRa.Test
         public async Task seal_can_recover_address()
         {
             _auRaStepCalculator.CurrentStep.Returns(11);
-            _auRaValidator.IsValidSealer(_address, 11).Returns(true);
+            _validSealerStrategy.IsValidSealer(Arg.Any<IList<Address>>(), _address, 11).Returns(true);
             var block = Build.A.Block.WithHeader(Build.A.BlockHeader.WithBeneficiary(_address).WithAura(11, null).TestObject).TestObject;
             
             block = await _auRaSealer.SealBlock(block, CancellationToken.None);

--- a/src/Nethermind/Nethermind.AuRa.Test/Validators/ContractValidatorTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/Validators/ContractValidatorTests.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography;
 using FluentAssertions;
 using Nethermind.Abi;
 using Nethermind.AuRa.Contracts;
@@ -46,7 +47,6 @@ namespace Nethermind.AuRa.Test.Validators
 {
     public class ContractValidatorTests
     {
-        private IDb _db;
         private IStateProvider _stateProvider;
         private IAbiEncoder _abiEncoder;
         private ILogManager _logManager;
@@ -54,19 +54,21 @@ namespace Nethermind.AuRa.Test.Validators
         private Block _block;
         private ITransactionProcessor _transactionProcessor;
         private IBlockFinalizationManager _blockFinalizationManager;
-        private Address _contractAddress = Address.FromNumber(1000);
-        private byte[] _getValidatorsData = new byte[] {0, 1, 2};
-        private byte[] _finalizeChangeData= new byte[] {3, 4, 5};
+        private static Address _contractAddress = Address.FromNumber(1000);
+        private (Address Sender, byte[] TransactionData) _getValidatorsData = (_contractAddress, new byte[] {0, 1, 2});
+        private (Address Sender, byte[] TransactionData) _finalizeChangeData = (Address.SystemUser, new byte[] {3, 4, 5});
         private Address[] _initialValidators;
         private IBlockTree _blockTree;
         private IReceiptStorage _receiptsStorage;
+        private IValidatorStore _validatorStore;
+        private IValidSealerStrategy _validSealerStrategy;
 
 
         [SetUp]
         public void SetUp()
         {
-            _db = Substitute.For<IDb>();
-            _db[ContractValidator.PendingValidatorsKey.Bytes].Returns((byte[]) null);
+            _validatorStore = new ValidatorStore(new MemDb());
+            _validSealerStrategy = new ValidSealerStrategy();
             _stateProvider = Substitute.For<IStateProvider>();
             _abiEncoder = Substitute.For<IAbiEncoder>();
             _logManager = Substitute.For<ILogManager>();
@@ -85,59 +87,66 @@ namespace Nethermind.AuRa.Test.Validators
             
             _abiEncoder
                 .Encode(AbiEncodingStyle.IncludeSignature, Arg.Is<AbiSignature>(s => s.Name == "getValidators"), Arg.Any<object[]>())
-                .Returns(_getValidatorsData);
+                .Returns(_getValidatorsData.TransactionData);
             
             _abiEncoder
                 .Encode(AbiEncodingStyle.IncludeSignature, Arg.Is<AbiSignature>(s => s.Name == "finalizeChange"), Arg.Any<object[]>())
-                .Returns(_finalizeChangeData);
+                .Returns(_finalizeChangeData.TransactionData);
         }
 
         [Test]
         public void throws_ArgumentNullException_on_empty_validator()
         {
-            Action act = () => new ContractValidator(null, _db, _stateProvider, _abiEncoder, _transactionProcessor, _blockTree, _receiptsStorage, _logManager, 1);
+            Action act = () => new ContractValidator(null, _stateProvider, _abiEncoder, _transactionProcessor, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
             act.Should().Throw<ArgumentNullException>();
         }
         
         [Test]
-        public void throws_ArgumentNullException_on_empty_stateDb()
+        public void throws_ArgumentNullException_on_empty_validatorStore()
         {
-            Action act = () => new ContractValidator(_validator, null, _stateProvider, _abiEncoder, _transactionProcessor, _blockTree, _receiptsStorage, _logManager, 1);
+            Action act = () => new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _blockTree, _receiptsStorage, null, _validSealerStrategy, _logManager, 1);
+            act.Should().Throw<ArgumentNullException>();
+        }
+        
+        [Test]
+        public void throws_ArgumentNullException_on_empty_validSealearStrategy()
+        {
+            Action act = () => new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _blockTree, _receiptsStorage, _validatorStore, null, _logManager, 1);
             act.Should().Throw<ArgumentNullException>();
         }
         
         [Test]
         public void throws_ArgumentNullException_on_empty_stateProvider()
         {
-            Action act = () => new ContractValidator(_validator, _db, null, _abiEncoder, _transactionProcessor, _blockTree, _receiptsStorage, _logManager, 1);
+            Action act = () => new ContractValidator(_validator, null, _abiEncoder, _transactionProcessor, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
             act.Should().Throw<ArgumentNullException>();
         }
         
         [Test]
         public void throws_ArgumentNullException_on_empty_abiEncoder()
         {
-            Action act = () => new ContractValidator(_validator, _db, _stateProvider, null, _transactionProcessor, _blockTree, _receiptsStorage, _logManager, 1);
+            Action act = () => new ContractValidator(_validator, _stateProvider, null, _transactionProcessor, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
             act.Should().Throw<ArgumentNullException>();
         }
 
         [Test]
         public void throws_ArgumentNullException_on_empty_transactionProcessor()
         {
-            Action act = () => new ContractValidator(_validator, _db, _stateProvider, _abiEncoder, null, _blockTree, _receiptsStorage, _logManager, 1);
+            Action act = () => new ContractValidator(_validator, _stateProvider, _abiEncoder, null, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
             act.Should().Throw<ArgumentNullException>();
         }
         
         [Test]
         public void throws_ArgumentNullException_on_empty_blockTree()
         {
-            Action act = () => new ContractValidator(_validator, _db, _stateProvider, _abiEncoder, _transactionProcessor, null, _receiptsStorage, _logManager, 1);
+            Action act = () => new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, null, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
             act.Should().Throw<ArgumentNullException>();
         }
         
         [Test]
         public void throws_ArgumentNullException_on_empty_logManager()
         {
-            Action act = () => new ContractValidator(_validator, _db, _stateProvider, _abiEncoder, _transactionProcessor, _blockTree, _receiptsStorage, null, 1);
+            Action act = () => new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, null, 1);
             act.Should().Throw<ArgumentNullException>();
         }
 
@@ -145,7 +154,7 @@ namespace Nethermind.AuRa.Test.Validators
         public void throws_ArgumentNullException_on_empty_contractAddress()
         {
             _validator.Addresses = new Address[0];
-            Action act = () => new ContractValidator(_validator, _db, _stateProvider, _abiEncoder, _transactionProcessor, _blockTree, _receiptsStorage, _logManager, 1);
+            Action act = () => new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
             act.Should().Throw<ArgumentException>();
         }
 
@@ -155,7 +164,7 @@ namespace Nethermind.AuRa.Test.Validators
             var initialValidator = Address.FromNumber(2000);
             SetupInitialValidators(initialValidator);
             _block.Beneficiary = initialValidator;
-            var validator = new ContractValidator(_validator, _db, _stateProvider, _abiEncoder, _transactionProcessor, _blockTree, _receiptsStorage, _logManager, 1);
+            var validator = new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
             
             validator.PreProcess(_block);
             
@@ -166,32 +175,33 @@ namespace Nethermind.AuRa.Test.Validators
         [Test]
         public void initializes_pendingValidators_from_db()
         {
+            _validatorStore = Substitute.For<IValidatorStore>();
+            
             var blockNumber = 10;
             var validators = TestItem.Addresses.Take(10).ToArray();
             var blockHash = Keccak.Compute("Test");
-            var pendingValidators = new ContractValidator.PendingValidators(blockNumber, blockHash, validators);
-            var rlp = Rlp.Encode(pendingValidators);
-            _db[ContractValidator.PendingValidatorsKey.Bytes].Returns(rlp.Bytes);
+            var pendingValidators = new PendingValidators(blockNumber, blockHash, validators);
+            _validatorStore.PendingValidators.Returns(pendingValidators);
             
-            IAuRaValidatorProcessor validator = new ContractValidator(_validator, _db, _stateProvider, _abiEncoder, _transactionProcessor, _blockTree, _receiptsStorage, _logManager, 1);
+            IAuRaValidatorProcessor validator = new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
             
             validator.SetFinalizationManager(_blockFinalizationManager);
             _blockFinalizationManager.BlocksFinalized +=
                 Raise.EventWith(new FinalizeEventArgs(_block.Header,
                     Build.A.BlockHeader.WithNumber(blockNumber).WithHash(blockHash).TestObject));
-            
-            validators.Select((v, i) => validator.IsValidSealer(v, i)).Should().AllBeEquivalentTo(true);
+
+            validator.Validators.Should().BeEquivalentTo(validators, o => o.WithStrictOrdering());
         }
             
 
-        [TestCase(1L, false, Description = "on initialize")]
-        [TestCase(10L, true, Description = "when producing block")]
+        [TestCase(1L, false, TestName = "on initialize")]
+        [TestCase(10L, true, TestName = "when producing block")]
         public void loads_initial_validators_from_contract(long blockNumber, bool producingBlock)
         {
             var initialValidator = TestItem.AddressA;
             SetupInitialValidators(initialValidator);
             var startBlockNumber = 1;
-            IAuRaValidatorProcessor validator = new ContractValidator(_validator, new MemDb(), _stateProvider, _abiEncoder, _transactionProcessor, _blockTree, _receiptsStorage, _logManager, startBlockNumber);
+            IAuRaValidatorProcessor validator = new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, startBlockNumber);
 
             _block.Number = blockNumber;
             _block.Beneficiary = initialValidator;
@@ -214,26 +224,7 @@ namespace Nethermind.AuRa.Test.Validators
             }
 
             // initial validator should be true
-            validator.IsValidSealer(initialValidator, 5).Should().BeTrue();
-        }
-
-        [Test]
-        public void loads_initial_validators_from_contract_on_demand()
-        {
-            var validator = new ContractValidator(_validator, _db, _stateProvider, _abiEncoder, _transactionProcessor, _blockTree, _receiptsStorage, _logManager, 1);
-            var initialValidator = TestItem.AddressA;
-            SetupInitialValidators(initialValidator);
-            _block.Number = 3;
-            _blockTree.Head.Returns(_block.Header);
-
-            validator.IsValidSealer(initialValidator, 10);
-            
-            // getValidators should have been called
-            _transactionProcessor.Received(1)
-                .Execute(
-                    Arg.Is<Transaction>(t => CheckTransaction(t, _getValidatorsData)),
-                    _block.Header,
-                    Arg.Is<ITxTracer>(t => t is CallOutputTracer));
+            validator.Validators.Should().BeEquivalentTo(new Address[] { initialValidator }, o => o.WithStrictOrdering());
         }
 
         public static IEnumerable<TestCaseData> ConsecutiveInitiateChangeData
@@ -480,12 +471,11 @@ namespace Nethermind.AuRa.Test.Validators
                                         FinalizeBlock = 3
                                     },
                                     new ConsecutiveInitiateChangeTestParameters.ValidatorsInfo()
-                                        // this will not be finalized even with reorganisation
-                                        {
-                                            Addresses = GenerateValidators(2),
-                                            InitializeBlock = 5,
-                                            FinalizeBlock = 7
-                                        },
+                                    {
+                                        Addresses = GenerateValidators(2),
+                                        InitializeBlock = 5,
+                                        FinalizeBlock = 7
+                                    },
                                 }
                             }
                         },
@@ -521,7 +511,7 @@ namespace Nethermind.AuRa.Test.Validators
             var currentValidators = GenerateValidators(1);
             SetupInitialValidators(currentValidators);
             
-            IAuRaValidatorProcessor validator = new ContractValidator(_validator, new MemDb(), _stateProvider, _abiEncoder, _transactionProcessor, _blockTree, _receiptsStorage, _logManager, test.StartBlockNumber);
+            IAuRaValidatorProcessor validator = new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, test.StartBlockNumber);
             validator.SetFinalizationManager(_blockFinalizationManager);
             
             test.TryDoReorganisations(test.StartBlockNumber, out _);
@@ -546,15 +536,13 @@ namespace Nethermind.AuRa.Test.Validators
                 Action preProcess = () => validator.PreProcess(_block);
                 preProcess.Should().NotThrow<InvalidOperationException>(test.TestName);
                 validator.PostProcess(_block, txReceipts);
-                var finalizedNumber = blockNumber - validator.MinSealersForFinalization + 1;
+                var finalizedNumber = blockNumber - validator.Validators.MinSealersForFinalization() + 1;
                 _blockFinalizationManager.BlocksFinalized += Raise.EventWith(
                     new FinalizeEventArgs(_block.Header, Build.A.BlockHeader.WithNumber(finalizedNumber)
                             .WithHash(Keccak.Compute(finalizedNumber.ToString())).TestObject));
                 
                 currentValidators = test.GetCurrentValidators(blockNumber);
-                var nextValidators = test.GetNextValidators(blockNumber);
-                currentValidators.Select((a, index) => validator.IsValidSealer(a, index)).Should().AllBeEquivalentTo(true, $"Validator address is not recognized in block {blockNumber}");
-                nextValidators?.Except(currentValidators).Select((a, index) => validator.IsValidSealer(a, index)).Should().AllBeEquivalentTo(false);
+                validator.Validators.Should().BeEquivalentTo(currentValidators, o => o.WithStrictOrdering(), $"Validator address should be recognized in block {blockNumber}");
             }
             
             ValidateFinalizationForChain(test.Current);
@@ -580,7 +568,7 @@ namespace Nethermind.AuRa.Test.Validators
                     block = bt.FindBlock(block.ParentHash, BlockTreeLookupOptions.None);
                 }
             }
-
+            
             var validators = TestItem.Addresses[initialValidatorsIndex * 10];
             var inMemoryReceiptStorage = new InMemoryReceiptStorage();
             var blockTreeBuilder = Build.A.BlockTree().WithTransactions(inMemoryReceiptStorage,
@@ -599,7 +587,7 @@ namespace Nethermind.AuRa.Test.Validators
             
             var blockTree = blockTreeBuilder.TestObject;
             SetupInitialValidators(blockTree.Head, validators);
-            IAuRaValidatorProcessor validator = new ContractValidator(_validator, _db, _stateProvider, _abiEncoder, _transactionProcessor, blockTree, inMemoryReceiptStorage, _logManager, 1);
+            IAuRaValidatorProcessor validator = new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, blockTree, inMemoryReceiptStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
             validator.SetFinalizationManager(_blockFinalizationManager);
 
             _abiEncoder.Decode(ValidatorContract.Definition.addressArrayResult, Arg.Any<byte[]>())
@@ -613,15 +601,14 @@ namespace Nethermind.AuRa.Test.Validators
 
             validator.PreProcess(blockTree.FindBlock(blockTree.Head.Hash, BlockTreeLookupOptions.None));
 
-            byte[] expectedPendingValidatorsBytes =  Rlp.OfEmptySequence.Bytes;
+            PendingValidators pendingValidators = null;
             if (expectedBlockValidators.HasValue)
             {
                 var block = GetAllBlocks(blockTree).First(b => b.Number == expectedBlockValidators.Value);
-                var pendingValidators = new ContractValidator.PendingValidators(block.Number, block.Hash, new [] {TestItem.Addresses[block.Number*10]});
-                expectedPendingValidatorsBytes = Rlp.Encode(pendingValidators).Bytes;
+                pendingValidators = new PendingValidators(block.Number, block.Hash, new [] {TestItem.Addresses[block.Number*10]});
             }
-
-            _db.Received()[ContractValidator.PendingValidatorsKey.Bytes] = Arg.Is<byte[]>(r => r.SequenceEqual(expectedPendingValidatorsBytes));
+            
+            _validatorStore.PendingValidators.Should().BeEquivalentTo(pendingValidators);
         }
 
 
@@ -671,9 +658,9 @@ namespace Nethermind.AuRa.Test.Validators
             return data;
         }
         
-        private bool CheckTransaction(Transaction t, byte[] transactionData)
+        private bool CheckTransaction(Transaction t, (Address Sender, byte[] TransactionData) transactionInfo)
         {
-            return t.SenderAddress == Address.SystemUser && t.To == _contractAddress && t.Data == transactionData;
+            return t.SenderAddress == transactionInfo.Sender && t.To == _contractAddress && t.Data == transactionInfo.TransactionData;
         }
         
         public class ConsecutiveInitiateChangeTestParameters
@@ -687,7 +674,7 @@ namespace Nethermind.AuRa.Test.Validators
             public IDictionary<long, ChainInfo> Reorganisations { get; set; }
             
             public string TestName { get; set; }
-
+            
             public override string ToString() => JsonConvert.SerializeObject(this);
 
             public bool TryDoReorganisations(int blockNumber, out ChainInfo last)
@@ -731,17 +718,13 @@ namespace Nethermind.AuRa.Test.Validators
                 }
             }
 
-            public Address[] GetNextValidators(int blockNumber) => 
-                Current.Validators?.FirstOrDefault(v => v.FinalizeBlock > blockNumber)?.Addresses;
-
             public Address[] GetCurrentValidators(int blockNumber)
             {
-                ValidatorsInfo LastFinalizedInitChange(ChainInfo chainInfo)
-                {
-                    return chainInfo.Validators?.LastOrDefault(v => v.FinalizeBlock <= blockNumber);
-                }
+                ValidatorsInfo LastFinalizedInitChange(ChainInfo chainInfo, int maxInitializeBlockNumber = int.MaxValue) => chainInfo?.Validators?.LastOrDefault(v => v.FinalizeBlock <= blockNumber && v.InitializeBlock < maxInitializeBlockNumber);
 
-                var lastFinalizedInitChange = LastFinalizedInitChange(Current) ?? LastFinalizedInitChange(_last);
+                var finalizedInitChange = LastFinalizedInitChange(Current);
+                var previousReorgFinalizedInitChange = LastFinalizedInitChange(_last, Current.BlockNumber);
+                var lastFinalizedInitChange = finalizedInitChange ?? previousReorgFinalizedInitChange;
                 return lastFinalizedInitChange?.Addresses;
             }
 

--- a/src/Nethermind/Nethermind.AuRa.Test/Validators/ValidatorInfoDecoderTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/Validators/ValidatorInfoDecoderTests.cs
@@ -1,4 +1,4 @@
-//  Copyright (c) 2018 Demerzel Solutions Limited
+﻿//  Copyright (c) 2018 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
 // 
 //  The Nethermind library is free software: you can redistribute it and/or modify
@@ -14,13 +14,23 @@
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
-using System.Collections.Generic;
-using Nethermind.Core;
+using FluentAssertions;
+using Nethermind.AuRa.Validators;
+using Nethermind.Core.Encoding;
+using Nethermind.Core.Test.Builders;
+using NUnit.Framework;
 
-namespace Nethermind.AuRa.Validators
+namespace Nethermind.AuRa.Test.Validators
 {
-    internal static class AuRaValidatorsCollectionExtensions
+    public class ValidatorInfoDecoderTests
     {
-        public static int MinSealersForFinalization(this IList<Address> validators) => validators.Count / 2 + 1;
+        [Test]
+        public void Can_decode_previously_encoded()
+        {
+            var info = new ValidatorInfo(10, 5, new[] {TestItem.AddressA, TestItem.AddressC});
+            var rlp = Rlp.Encode(info);
+            var decoded = Rlp.Decode<ValidatorInfo>(rlp);
+            decoded.Should().BeEquivalentTo(info);
+        }
     }
 }

--- a/src/Nethermind/Nethermind.AuRa.Test/Validators/ValidatorStoreTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/Validators/ValidatorStoreTests.cs
@@ -1,0 +1,175 @@
+﻿//  Copyright (c) 2018 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using FluentAssertions;
+using Nethermind.AuRa.Validators;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Encoding;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Store;
+using NUnit.Framework;
+
+namespace Nethermind.AuRa.Test.Validators
+{
+    public class ValidatorStoreTests
+    {
+        public static IEnumerable ValidatorsTests
+        {
+            get
+            {
+                yield return new TestCaseData(CreateMemDbWithValidators(), null, null, Array.Empty<Address>()).SetCategory("InitializedDb").SetName("EmptyDb");
+
+                var db = CreateMemDbWithValidators(new []
+                {
+                    (10L, new[] {TestItem.AddressA})
+                });
+
+                yield return new TestCaseData(db, null, null, new[] {TestItem.AddressA}).SetCategory("InitializedDb").SetName("Db1 latest");
+                yield return new TestCaseData(db, 11L, null, new[] {TestItem.AddressA}).SetCategory("InitializedDb").SetName("Db1 11");
+                yield return new TestCaseData(db, 10L, null, Array.Empty<Address>()).SetCategory("InitializedDb").SetName("Db1 10");
+                yield return new TestCaseData(db, 1L, null, Array.Empty<Address>()).SetCategory("InitializedDb").SetName("Db1 1");
+
+                db = CreateMemDbWithValidators(new []
+                {
+                    (1L, new[] {TestItem.AddressA}),
+                    (5L, new[] {TestItem.AddressA, TestItem.AddressB}),
+                    (10L, new[] {TestItem.AddressA, TestItem.AddressC})
+                });
+
+                yield return new TestCaseData(db, null, null, new[] {TestItem.AddressA, TestItem.AddressC}).SetCategory("InitializedDb").SetName("Db2 latest");
+                yield return new TestCaseData(db, 11L, null, new[] {TestItem.AddressA, TestItem.AddressC}).SetCategory("InitializedDb").SetName("Db2 11");
+                yield return new TestCaseData(db, 10L, null, new[] {TestItem.AddressA, TestItem.AddressB}).SetCategory("InitializedDb").SetName("Db2 10");
+                yield return new TestCaseData(db, 6L, null, new[] {TestItem.AddressA, TestItem.AddressB}).SetCategory("InitializedDb").SetName("Db2 6");
+                yield return new TestCaseData(db, 5L, null, new[] {TestItem.AddressA}).SetCategory("InitializedDb").SetName("Db2 5");
+                yield return new TestCaseData(db, 2L, null, new[] {TestItem.AddressA}).SetCategory("InitializedDb").SetName("Db2 2");
+                yield return new TestCaseData(db, 1L, null, Array.Empty<Address>()).SetCategory("InitializedDb").SetName("Db2 1");
+
+                yield return new TestCaseData(CreateMemDbWithValidators(), null, new []
+                {
+                    (5L, new [] {TestItem.AddressB})
+                }, new [] {TestItem.AddressB}).SetCategory("Add one").SetName("AddToStore");
+
+                yield return new TestCaseData(CreateMemDbWithValidators(), null, new []
+                {
+                    (5L, new [] {TestItem.AddressB}),
+                    (10L, new [] {TestItem.AddressC}),
+                    (15L, new [] {TestItem.AddressC, TestItem.AddressA})
+                }, new [] {TestItem.AddressC, TestItem.AddressA}).SetCategory("Add multiple, check latest").SetName("AddToStore");
+
+                yield return new TestCaseData(CreateMemDbWithValidators(), 12L, new []
+                {
+                    (5L, new [] {TestItem.AddressB}),
+                    (10L, new [] {TestItem.AddressC}),
+                    (15L, new [] {TestItem.AddressC, TestItem.AddressA})
+                }, new [] {TestItem.AddressC}).SetCategory("Add multiple, check history").SetName("AddToStore");
+
+                yield return new TestCaseData(db, null, new []
+                {
+                    (20L, new [] {TestItem.AddressB}),
+                    (25L, new [] {TestItem.AddressC}),
+                }, new[] {TestItem.AddressC}).SetCategory("Add multiple, initialized db, check latest").SetName("AddToStore");
+
+                yield return new TestCaseData(db, 12L, new []
+                {
+                    (20L, new [] {TestItem.AddressB}),
+                    (25L, new [] {TestItem.AddressC}),
+                }, new[] {TestItem.AddressA, TestItem.AddressC}).SetCategory("Add multiple, initialized db, check history").SetName("AddToStore");
+            }
+        }
+
+        [TestCaseSource(nameof(ValidatorsTests))]
+        public void validators_return_as_expected(IDb db, long? blockNumber, IEnumerable<(long FinalizingBlock, Address[] Validators)> validatorsToAdd, Address[] expectedValidators)
+        {
+            var store = new ValidatorStore(db);
+            if (validatorsToAdd != null)
+            {
+                foreach (var validator in validatorsToAdd.OrderBy(v => v.FinalizingBlock))
+                {
+                    store.SetValidators(validator.FinalizingBlock, validator.Validators);
+                }
+            }
+
+            store.GetValidators(blockNumber).Should().BeEquivalentTo(expectedValidators);
+        }
+
+        public static IEnumerable PendingValidatorsTests
+        {
+            get
+            {
+                yield return new TestCaseData(new MemDb(), null, false, null);
+                yield return new TestCaseData(new MemDb(), null, true, null);
+
+                var validators = new PendingValidators(100, Keccak.EmptyTreeHash, TestItem.Addresses.Take(5).ToArray());
+                yield return new TestCaseData(new MemDb(), validators, true, validators);
+
+                var db = new MemDb();
+                db.Set(ValidatorStore.PendingValidatorsKey, Rlp.Encode(validators).Bytes);
+                yield return new TestCaseData(db, null, false, validators);
+                yield return new TestCaseData(db, null, true, null);
+
+                db.Set(ValidatorStore.PendingValidatorsKey, Rlp.Encode(validators).Bytes);
+                validators = new PendingValidators(10, Keccak.Zero, Array.Empty<Address>());
+                yield return new TestCaseData(db, validators, true, validators);
+            }
+        }
+
+        [TestCaseSource(nameof(PendingValidatorsTests))]
+        public void pending_validators_return_as_expected(IDb db, PendingValidators validators, bool setValidators, PendingValidators expectedValidators)
+        {
+            var store = new ValidatorStore(db);
+            if (setValidators)
+            {
+                store.PendingValidators = validators;
+            }
+
+            store.PendingValidators.Should().BeEquivalentTo(expectedValidators);
+        }
+
+
+        private static MemDb CreateMemDbWithValidators(IEnumerable<(long FinalizingBlock, Address[] Validators)> validators = null)
+        {
+            Keccak GetKey(in long blockNumber) => Keccak.Compute("Validators" + blockNumber);
+
+            validators ??= Array.Empty<(long FinalizingBlock, Address[] Validators)>();
+            var ordered = validators.OrderByDescending(v => v.FinalizingBlock).ToArray();
+
+            var memDb = new MemDb();
+
+            for (int i = 0; i < ordered.Length; i++)
+            {
+                var current = ordered[i];
+                var next = i + 1 < ordered.Length ? ordered[i + 1] : (-1, Array.Empty<Address>());
+                var validatorInfo = new ValidatorInfo(current.FinalizingBlock, next.FinalizingBlock, current.Validators);
+
+                if (i == 0)
+                {
+                    memDb.Set(ValidatorStore.LatestFinalizedValidatorsBlockNumberKey, current.FinalizingBlock.ToBigEndianByteArrayWithoutLeadingZeros());
+                }
+
+                memDb.Set(GetKey(current.FinalizingBlock), Rlp.Encode(validatorInfo).Bytes);
+            }
+
+            return memDb;
+        }
+    }
+} 

--- a/src/Nethermind/Nethermind.AuRa/AuRaSealValidator.cs
+++ b/src/Nethermind/Nethermind.AuRa/AuRaSealValidator.cs
@@ -85,7 +85,7 @@ namespace Nethermind.AuRa
 
             if (header.AuRaStep > currentStep)
             {
-                if (_logger.IsWarn) _logger.Warn($"Block {header.Number}, hash {header.Hash} step {header.AuRaStep} is too early. Current step is {currentStep}.");
+                if (_logger.IsWarn) _logger.Warn($"Block {header.Number}, hash {header.Hash} step {header.AuRaStep} is {_stepCalculator.TimeToStep(header.AuRaStep.Value):g} too early. Current step is {currentStep}.");
             }
 
             if (header.AuRaStep - parent.AuRaStep != 1)

--- a/src/Nethermind/Nethermind.AuRa/AuRaStepCalculator.cs
+++ b/src/Nethermind/Nethermind.AuRa/AuRaStepCalculator.cs
@@ -40,6 +40,10 @@ namespace Nethermind.AuRa
         public long CurrentStep => _timestamper.EpochSecondsLong / _stepDuration;
 
         public TimeSpan TimeToNextStep => new TimeSpan(TimeToNextStepInTicks);
+        public TimeSpan TimeToStep(long step)
+        {
+            return new TimeSpan(TimeToNextStep.Ticks + (step - CurrentStep - 1) * _stepDurationMilliseconds * TimeSpan.TicksPerMillisecond);
+        }
 
         private long TimeToNextStepInTicks => (_stepDurationMilliseconds - _timestamper.EpochMillisecondsLong % _stepDurationMilliseconds) * TimeSpan.TicksPerMillisecond;
     }

--- a/src/Nethermind/Nethermind.AuRa/Contracts/RewardContract.cs
+++ b/src/Nethermind/Nethermind.AuRa/Contracts/RewardContract.cs
@@ -117,7 +117,7 @@ namespace Nethermind.AuRa.Contracts
         /// 101-106 - Uncle - Reward attributed to uncles, with distance 1 to 6 (Ethash engine)
         /// </param>
         public Transaction Reward(Address[] benefactors, ushort[] kind)
-            => GenerateTransaction(_abiEncoder.Encode(Definition.reward, benefactors, kind));
+            => GenerateTransaction(_abiEncoder.Encode(Definition.reward, benefactors, kind), Address.SystemUser);
         
         public (Address[] Addresses, BigInteger[] Rewards) DecodeRewards(byte[] data)
         {

--- a/src/Nethermind/Nethermind.AuRa/Contracts/SystemContract.cs
+++ b/src/Nethermind/Nethermind.AuRa/Contracts/SystemContract.cs
@@ -27,21 +27,21 @@ namespace Nethermind.AuRa.Contracts
 {
     public class SystemContract
     {
-        private readonly Address _contractAddress;
+        protected Address ContractAddress { get; }
 
         public SystemContract(Address contractAddress)
         {
-            _contractAddress = contractAddress ?? throw new ArgumentNullException(nameof(contractAddress));
+            ContractAddress = contractAddress ?? throw new ArgumentNullException(nameof(contractAddress));
         }
         
-        protected Transaction GenerateTransaction(byte[] transactionData, long gasLimit = long.MaxValue, UInt256? nonce = null)
+        protected Transaction GenerateTransaction(byte[] transactionData, Address sender, long gasLimit = long.MaxValue, UInt256? nonce = null)
         {
             var transaction = new Transaction(true)
             {
                 Value = UInt256.Zero,
                 Data = transactionData,
-                To = _contractAddress,
-                SenderAddress = Address.SystemUser,
+                To = ContractAddress,
+                SenderAddress = sender,
                 GasLimit = gasLimit,
                 GasPrice = UInt256.Zero,
                 Nonce = nonce ?? UInt256.Zero,
@@ -77,6 +77,7 @@ namespace Nethermind.AuRa.Contracts
             try
             {
                 transactionProcessor.Execute(transaction, header, tracer);
+                
                 return tracer.StatusCode == StatusCode.Success;
             }
             catch (Exception)

--- a/src/Nethermind/Nethermind.AuRa/Contracts/ValidatorContract.cs
+++ b/src/Nethermind/Nethermind.AuRa/Contracts/ValidatorContract.cs
@@ -83,9 +83,9 @@ namespace Nethermind.AuRa.Contracts
             _getValidatorsTransactionData = _abiEncoder.Encode(Definition.getValidators);
         }
 
-        public Transaction FinalizeChange() => GenerateTransaction(_finalizeChangeTransactionData);
+        public Transaction FinalizeChange() => GenerateTransaction(_finalizeChangeTransactionData, Address.SystemUser);
 
-        public Transaction GetValidators() => GenerateTransaction(_getValidatorsTransactionData);
+        public Transaction GetValidators() => GenerateTransaction(_getValidatorsTransactionData, ContractAddress);
 
         public bool CheckInitiateChangeEvent(Address contractAddress, BlockHeader blockHeader, TxReceipt[] receipts, out Address[] addresses)
         {

--- a/src/Nethermind/Nethermind.AuRa/IAuRaStepCalculator.cs
+++ b/src/Nethermind/Nethermind.AuRa/IAuRaStepCalculator.cs
@@ -22,5 +22,6 @@ namespace Nethermind.AuRa
     {
         long CurrentStep { get; }
         TimeSpan TimeToNextStep { get; }
+        TimeSpan TimeToStep(long step);
     }
 }

--- a/src/Nethermind/Nethermind.AuRa/Validators/ContractValidator.cs
+++ b/src/Nethermind/Nethermind.AuRa/Validators/ContractValidator.cs
@@ -102,7 +102,7 @@ namespace Nethermind.AuRa.Validators
             if (!forSealing && _blockFinalizationManager != null)
             {
                 _blockFinalizationManager.BlocksFinalized += OnBlocksFinalized;
-                if (_blockTree.Head?.IsGenesis == false)
+                if (_blockTree.Head != null)
                 {
                     Validators = LoadValidatorsFromContract(_blockTree.Head);
                 }

--- a/src/Nethermind/Nethermind.AuRa/Validators/ContractValidator.cs
+++ b/src/Nethermind/Nethermind.AuRa/Validators/ContractValidator.cs
@@ -115,7 +115,8 @@ namespace Nethermind.AuRa.Validators
             
             if (shouldLoadValidators)
             {
-                Validators = LoadValidatorsFromContract(block.Header);
+                Validators = isInitBlock ? LoadValidatorsFromContract(block.Header) : _validatorStore.GetValidators();
+
                 if (mainChainProcessing)
                 {
                     if (_logger.IsInfo) _logger.Info($"{(isInitBlock ? "Initial" : "Current")} contract validators ({Validators.Length}): [{string.Join<Address>(", ", Validators)}].");

--- a/src/Nethermind/Nethermind.AuRa/Validators/ContractValidator.cs
+++ b/src/Nethermind/Nethermind.AuRa/Validators/ContractValidator.cs
@@ -102,6 +102,10 @@ namespace Nethermind.AuRa.Validators
             if (!forSealing && _blockFinalizationManager != null)
             {
                 _blockFinalizationManager.BlocksFinalized += OnBlocksFinalized;
+                if (_blockTree.Head?.IsGenesis == false)
+                {
+                    Validators = LoadValidatorsFromContract(_blockTree.Head);
+                }
             }
         }
 

--- a/src/Nethermind/Nethermind.AuRa/Validators/IAuRaValidator.cs
+++ b/src/Nethermind/Nethermind.AuRa/Validators/IAuRaValidator.cs
@@ -21,9 +21,7 @@ namespace Nethermind.AuRa.Validators
 {
     public interface IAuRaValidator
     {
-        int MinSealersForFinalization { get; }
-        int CurrentSealersCount { get; }
-        bool IsValidSealer(Address address, long step);
+        Address[] Validators { get; }
         void SetFinalizationManager(IBlockFinalizationManager finalizationManager, bool forProducing = false);
     }
 }

--- a/src/Nethermind/Nethermind.AuRa/Validators/IValidSealerStrategy.cs
+++ b/src/Nethermind/Nethermind.AuRa/Validators/IValidSealerStrategy.cs
@@ -1,4 +1,4 @@
-//  Copyright (c) 2018 Demerzel Solutions Limited
+﻿//  Copyright (c) 2018 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
 // 
 //  The Nethermind library is free software: you can redistribute it and/or modify
@@ -19,8 +19,8 @@ using Nethermind.Core;
 
 namespace Nethermind.AuRa.Validators
 {
-    internal static class AuRaValidatorsCollectionExtensions
+    public interface IValidSealerStrategy
     {
-        public static int MinSealersForFinalization(this IList<Address> validators) => validators.Count / 2 + 1;
+        bool IsValidSealer(IList<Address> validators, Address address, long step);
     }
 }

--- a/src/Nethermind/Nethermind.AuRa/Validators/IValidatorStore.cs
+++ b/src/Nethermind/Nethermind.AuRa/Validators/IValidatorStore.cs
@@ -1,4 +1,4 @@
-//  Copyright (c) 2018 Demerzel Solutions Limited
+﻿//  Copyright (c) 2018 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
 // 
 //  The Nethermind library is free software: you can redistribute it and/or modify
@@ -14,13 +14,14 @@
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
-using System.Collections.Generic;
 using Nethermind.Core;
 
 namespace Nethermind.AuRa.Validators
 {
-    internal static class AuRaValidatorsCollectionExtensions
+    public interface IValidatorStore
     {
-        public static int MinSealersForFinalization(this IList<Address> validators) => validators.Count / 2 + 1;
+        void SetValidators(long finalizingBlockNumber, Address[] validators);
+        Address[] GetValidators(long? blockNumber = null);
+        PendingValidators PendingValidators { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.AuRa/Validators/ListValidator.cs
+++ b/src/Nethermind/Nethermind.AuRa/Validators/ListValidator.cs
@@ -28,7 +28,7 @@ namespace Nethermind.AuRa.Validators
 {
     public sealed class ListValidator : AuRaValidatorProcessorBase
     {
-        public ListValidator(AuRaParameters.Validator validator, ILogManager logManager) : base(validator, logManager)
+        public ListValidator(AuRaParameters.Validator validator, IValidSealerStrategy validSealerStrategy, ILogManager logManager) : base(validator, validSealerStrategy, logManager)
         {
             Validators = validator.Addresses?.Length > 0
                 ? validator.Addresses

--- a/src/Nethermind/Nethermind.AuRa/Validators/MultiValidator.cs
+++ b/src/Nethermind/Nethermind.AuRa/Validators/MultiValidator.cs
@@ -150,7 +150,7 @@ namespace Nethermind.AuRa.Validators
                 if (validator.ValidatorType.CanChangeImmediately())
                 {
                     SetCurrentValidator(block.Number, validator);
-                    if (_logger.IsInfo && notProducing) _logger.Info($"Immediately applying chainspec validator change signalled at block at block {block.ToString(Block.Format.Short)} to {validator.ValidatorType}.");
+                    if (_logger.IsInfo && notProducing) _logger.Info($"Immediately applying chainspec validator change signalled at block {block.ToString(Block.Format.Short)} to {validator.ValidatorType}.");
                 }
                 else if (_logger.IsInfo && notProducing) _logger.Info($"Signal for switch to chainspec {validator.ValidatorType} based validator set at block {block.ToString(Block.Format.Short)}.");
             }
@@ -171,7 +171,10 @@ namespace Nethermind.AuRa.Validators
             if (_blockFinalizationManager != null)
             {
                 _blockFinalizationManager.BlocksFinalized += OnBlocksFinalized;
-                InitCurrentValidator(_blockFinalizationManager.LastFinalizedBlockLevel);
+                if (_blockFinalizationManager.LastFinalizedBlockLevel != 0)
+                {
+                    InitCurrentValidator(_blockFinalizationManager.LastFinalizedBlockLevel);
+                }
             }
 
             _currentValidator?.SetFinalizationManager(finalizationManager, forProducing);

--- a/src/Nethermind/Nethermind.AuRa/Validators/MultiValidator.cs
+++ b/src/Nethermind/Nethermind.AuRa/Validators/MultiValidator.cs
@@ -191,8 +191,7 @@ namespace Nethermind.AuRa.Validators
                 _currentValidator.SetFinalizationManager(_blockFinalizationManager, _validatorUsedForSealing);
                 _currentValidatorPrototype = validatorPrototype;
                 
-                // TODO: Check if we can produce blocks after switching to ContractValidator
-                if (validatorPrototype.ValidatorType.CanChangeImmediately())
+                if (!_validatorUsedForSealing)
                 {
                     _validatorStore.SetValidators(finalizedAtBlockNumber, _currentValidator.Validators);
                 }

--- a/src/Nethermind/Nethermind.AuRa/Validators/MultiValidator.cs
+++ b/src/Nethermind/Nethermind.AuRa/Validators/MultiValidator.cs
@@ -29,6 +29,7 @@ namespace Nethermind.AuRa.Validators
     {
         private readonly IAuRaAdditionalBlockProcessorFactory _validatorFactory;
         private readonly IBlockTree _blockTree;
+        private readonly IValidatorStore _validatorStore;
         private IBlockFinalizationManager _blockFinalizationManager;
         private readonly IDictionary<long, AuRaParameters.Validator> _validators;
         private readonly ILogger _logger;
@@ -37,18 +38,21 @@ namespace Nethermind.AuRa.Validators
         private bool _validatorUsedForSealing;
         private long _lastProcessedBlock = 0;
         
-        public MultiValidator(AuRaParameters.Validator validator, IAuRaAdditionalBlockProcessorFactory validatorFactory, IBlockTree blockTree, ILogManager logManager)
+        public MultiValidator(AuRaParameters.Validator validator, IAuRaAdditionalBlockProcessorFactory validatorFactory, IBlockTree blockTree, IValidatorStore validatorStore, ILogManager logManager)
         {
             if (validator == null) throw new ArgumentNullException(nameof(validator));
             if (validator.ValidatorType != AuRaParameters.ValidatorType.Multi) throw new ArgumentException("Wrong validator type.", nameof(validator));
             _validatorFactory = validatorFactory ?? throw new ArgumentNullException(nameof(validatorFactory));
             _blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
+            _validatorStore = validatorStore ?? throw new ArgumentNullException(nameof(validatorStore));
             _logger = logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
             
             _validators = validator.Validators?.Count > 0
                 ? validator.Validators
                 : throw new ArgumentException("Multi validator cannot be empty.", nameof(validator.Validators));
         }
+        
+        public Address[] Validators => _currentValidator?.Validators;
 
         private void InitCurrentValidator(long blockNumber)
         {
@@ -60,18 +64,18 @@ namespace Nethermind.AuRa.Validators
             _lastProcessedBlock = blockNumber;
         }
 
-        private bool TryGetLastValidator(long blockNum, out KeyValuePair<long, AuRaParameters.Validator> val)
+        private bool TryGetLastValidator(long blockNum, out KeyValuePair<long, AuRaParameters.Validator> validator)
         {
             var headNumber = _blockTree.Head?.Number ?? 0;
             
-            val = default;
+            validator = default;
             bool found = false;
             
             foreach (var kvp in _validators)
             {
                 if (kvp.Key <= blockNum || kvp.Key <= headNumber && kvp.Value.ValidatorType.CanChangeImmediately())
                 {
-                    val = kvp;
+                    validator = kvp;
                     found = true;
                 }
             }
@@ -153,11 +157,6 @@ namespace Nethermind.AuRa.Validators
 
             _lastProcessedBlock = block.Number;
         }
-        
-        public bool IsValidSealer(Address address, long step) => _currentValidator?.IsValidSealer(address, step) == true;
-
-        public int MinSealersForFinalization => _currentValidator.MinSealersForFinalization;
-        public int CurrentSealersCount => _currentValidator.CurrentSealersCount;
 
         void IAuRaValidator.SetFinalizationManager(IBlockFinalizationManager finalizationManager, bool forProducing)
         {
@@ -191,6 +190,12 @@ namespace Nethermind.AuRa.Validators
                 _currentValidator = CreateValidator(finalizedAtBlockNumber, validatorPrototype);
                 _currentValidator.SetFinalizationManager(_blockFinalizationManager, _validatorUsedForSealing);
                 _currentValidatorPrototype = validatorPrototype;
+                
+                // TODO: Check if we can produce blocks after switching to ContractValidator
+                if (validatorPrototype.ValidatorType.CanChangeImmediately())
+                {
+                    _validatorStore.SetValidators(finalizedAtBlockNumber, _currentValidator.Validators);
+                }
             }
         }
 

--- a/src/Nethermind/Nethermind.AuRa/Validators/MultiValidator.cs
+++ b/src/Nethermind/Nethermind.AuRa/Validators/MultiValidator.cs
@@ -171,10 +171,7 @@ namespace Nethermind.AuRa.Validators
             if (_blockFinalizationManager != null)
             {
                 _blockFinalizationManager.BlocksFinalized += OnBlocksFinalized;
-                if (_blockFinalizationManager.LastFinalizedBlockLevel != 0)
-                {
-                    InitCurrentValidator(_blockFinalizationManager.LastFinalizedBlockLevel);
-                }
+                InitCurrentValidator(_blockFinalizationManager.LastFinalizedBlockLevel);
             }
 
             _currentValidator?.SetFinalizationManager(finalizationManager, forProducing);

--- a/src/Nethermind/Nethermind.AuRa/Validators/PendingValidators.cs
+++ b/src/Nethermind/Nethermind.AuRa/Validators/PendingValidators.cs
@@ -1,4 +1,4 @@
-//  Copyright (c) 2018 Demerzel Solutions Limited
+﻿//  Copyright (c) 2018 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
 // 
 //  The Nethermind library is free software: you can redistribute it and/or modify
@@ -14,12 +14,29 @@
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
-using System.Collections.Generic;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Encoding;
 
-namespace Nethermind.Core.Extensions
+namespace Nethermind.AuRa.Validators
 {
-    public static class ArrayExtensions
+    public class PendingValidators
     {
-        public static T GetItemRoundRobin<T>(this T[] array, long index) => array[index % array.Length];
+        static PendingValidators()
+        {
+            Rlp.Decoders[typeof(PendingValidators)] = new PendingValidatorsDecoder();
+        }
+
+        public PendingValidators(long blockNumber, Keccak blockHash, Address[] addresses)
+        {
+            BlockNumber = blockNumber;
+            BlockHash = blockHash;
+            Addresses = addresses;
+        }
+
+        public Address[] Addresses { get; }
+        public long BlockNumber { get; }
+        public Keccak BlockHash { get; }
+        public bool AreFinalized { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.AuRa/Validators/PendingValidatorsDecoder.cs
+++ b/src/Nethermind/Nethermind.AuRa/Validators/PendingValidatorsDecoder.cs
@@ -1,0 +1,117 @@
+﻿//  Copyright (c) 2018 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Nethermind.Core;
+using Nethermind.Core.Encoding;
+
+namespace Nethermind.AuRa.Validators
+{
+    internal class PendingValidatorsDecoder : IRlpDecoder<PendingValidators>
+    {
+        public PendingValidators Decode(RlpStream rlpStream, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+        {
+            if (rlpStream.IsNextItemNull())
+            {
+                rlpStream.ReadByte();
+                return null;
+            }
+
+            var sequenceLength = rlpStream.ReadSequenceLength();
+            var pendingValidatorsCheck = rlpStream.Position + sequenceLength;
+
+            var blockNumber = rlpStream.DecodeLong();
+            var blockHash = rlpStream.DecodeKeccak();
+
+            var addressSequenceLength = rlpStream.ReadSequenceLength();
+            var addressCheck = rlpStream.Position + addressSequenceLength;
+            List<Address> addresses = new List<Address>();
+            while (rlpStream.Position < addressCheck)
+            {
+                addresses.Add(rlpStream.DecodeAddress());
+            }
+            rlpStream.Check(addressCheck);
+
+            var result = new PendingValidators(blockNumber, blockHash, addresses.ToArray())
+            {
+                AreFinalized = rlpStream.DecodeBool()
+            };
+
+            rlpStream.Check(pendingValidatorsCheck);
+
+            return result;
+        }
+
+        public Rlp Encode(PendingValidators item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+        {
+            if (item == null)
+            {
+                return Rlp.OfEmptySequence;
+            }
+
+            RlpStream rlpStream = new RlpStream(GetLength(item, rlpBehaviors));
+            Encode(rlpStream, item, rlpBehaviors);
+            return new Rlp(rlpStream.Data);
+        }
+
+        public void Encode(MemoryStream stream, PendingValidators item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+        {
+            (int contentLength, int addressesLength) = GetContentLength(item, rlpBehaviors);
+            Rlp.StartSequence(stream, contentLength);
+            Rlp.Encode(stream, item.BlockNumber);
+            Rlp.Encode(stream, item.BlockHash);
+            Rlp.StartSequence(stream, addressesLength);
+            for (int i = 0; i < item.Addresses.Length; i++)
+            {
+                Rlp.Encode(stream, item.Addresses[i]);
+            }
+            Rlp.Encode(stream, item.AreFinalized);
+        }
+
+        public void Encode(RlpStream rlpStream, PendingValidators item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+        {
+            (int contentLength, int addressesLength) = GetContentLength(item, rlpBehaviors);
+            rlpStream.StartSequence(contentLength);
+            rlpStream.Encode(item.BlockNumber);
+            rlpStream.Encode(item.BlockHash);
+            rlpStream.StartSequence(addressesLength);
+            for (int i = 0; i < item.Addresses.Length; i++)
+            {
+                rlpStream.Encode(item.Addresses[i]);
+            }
+            rlpStream.Encode(item.AreFinalized);
+        }
+
+        public int GetLength(PendingValidators item, RlpBehaviors rlpBehaviors) =>
+            item == null ? 1 : Rlp.LengthOfSequence(GetContentLength(item, rlpBehaviors).Total);
+
+        private (int Total, int Addresses) GetContentLength(PendingValidators item, RlpBehaviors rlpBehaviors)
+        {
+            int contentLength = Rlp.LengthOf(item.BlockNumber) 
+                                + Rlp.LengthOf(item.BlockHash) 
+                                + Rlp.LengthOf(item.AreFinalized); 
+
+            var addressesLength = GetAddressesLength(item.Addresses);
+            contentLength += Rlp.LengthOfSequence(addressesLength);
+
+            return (contentLength, addressesLength);
+        }
+
+        private int GetAddressesLength(Address[] addresses) => addresses.Sum(Rlp.LengthOf);
+    }
+} 

--- a/src/Nethermind/Nethermind.AuRa/Validators/ReportingContractValidator.cs
+++ b/src/Nethermind/Nethermind.AuRa/Validators/ReportingContractValidator.cs
@@ -27,15 +27,16 @@ namespace Nethermind.AuRa.Validators
     public class ReportingContractValidator : ContractValidator
     {
         public ReportingContractValidator(AuRaParameters.Validator validator,
-            IDb stateDb,
             IStateProvider stateProvider,
             IAbiEncoder abiEncoder,
             ITransactionProcessor transactionProcessor,
             IBlockTree blockTree,
             IReceiptStorage receiptStorage,
+            IValidatorStore validatorStore,
+            IValidSealerStrategy validSealerStrategy,
             ILogManager logManager,
             long startBlockNumber) 
-            : base(validator, stateDb, stateProvider, abiEncoder, transactionProcessor, blockTree, receiptStorage, logManager, startBlockNumber)
+            : base(validator, stateProvider, abiEncoder, transactionProcessor, blockTree, receiptStorage, validatorStore, validSealerStrategy, logManager, startBlockNumber)
         {
         }
     }

--- a/src/Nethermind/Nethermind.AuRa/Validators/ValidSealerStrategy.cs
+++ b/src/Nethermind/Nethermind.AuRa/Validators/ValidSealerStrategy.cs
@@ -1,4 +1,4 @@
-//  Copyright (c) 2018 Demerzel Solutions Limited
+﻿//  Copyright (c) 2018 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
 // 
 //  The Nethermind library is free software: you can redistribute it and/or modify
@@ -16,11 +16,12 @@
 
 using System.Collections.Generic;
 using Nethermind.Core;
+using Nethermind.Core.Extensions;
 
 namespace Nethermind.AuRa.Validators
 {
-    internal static class AuRaValidatorsCollectionExtensions
+    public class ValidSealerStrategy : IValidSealerStrategy
     {
-        public static int MinSealersForFinalization(this IList<Address> validators) => validators.Count / 2 + 1;
+        public bool IsValidSealer(IList<Address> validators, Address address, long step) => validators.GetItemRoundRobin(step) == address;
     }
 }

--- a/src/Nethermind/Nethermind.AuRa/Validators/ValidatorInfo.cs
+++ b/src/Nethermind/Nethermind.AuRa/Validators/ValidatorInfo.cs
@@ -1,4 +1,4 @@
-//  Copyright (c) 2018 Demerzel Solutions Limited
+﻿//  Copyright (c) 2018 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
 // 
 //  The Nethermind library is free software: you can redistribute it and/or modify
@@ -14,13 +14,27 @@
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
-using System.Collections.Generic;
 using Nethermind.Core;
+using Nethermind.Core.Encoding;
 
 namespace Nethermind.AuRa.Validators
 {
-    internal static class AuRaValidatorsCollectionExtensions
+    public class ValidatorInfo
     {
-        public static int MinSealersForFinalization(this IList<Address> validators) => validators.Count / 2 + 1;
+        static ValidatorInfo()
+        {
+            Rlp.Decoders[typeof(ValidatorInfo)] = new ValidatorInfoDecoder();
+        }
+
+        public ValidatorInfo(long finalizingBlockNumber, long previousFinalizingBlockNumber, Address[] validators)
+        {
+            FinalizingBlockNumber = finalizingBlockNumber;
+            PreviousFinalizingBlockNumber = previousFinalizingBlockNumber;
+            Validators = validators;
+        }
+
+        public long FinalizingBlockNumber { get; }
+        public long PreviousFinalizingBlockNumber { get; }
+        public Address[] Validators { get; }
     }
 }

--- a/src/Nethermind/Nethermind.AuRa/Validators/ValidatorInfoDecoder.cs
+++ b/src/Nethermind/Nethermind.AuRa/Validators/ValidatorInfoDecoder.cs
@@ -1,0 +1,104 @@
+﻿//  Copyright (c) 2018 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+
+using System.IO;
+using Nethermind.Core;
+using Nethermind.Core.Encoding;
+
+namespace Nethermind.AuRa.Validators
+{
+    internal class ValidatorInfoDecoder : IRlpDecoder<ValidatorInfo>
+    {
+        public ValidatorInfo Decode(RlpStream rlpStream, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+        {
+            if (rlpStream.IsNextItemNull())
+            {
+                rlpStream.ReadByte();
+                return null;
+            }
+
+            var length = rlpStream.ReadSequenceLength();
+            int check = rlpStream.Position + length;
+            var finalizingBlockNumber = rlpStream.DecodeLong();
+            var previousFinalizingBlockNumber= rlpStream.DecodeLong();
+
+            int addressesSequenceLength = rlpStream.ReadSequenceLength();
+            int addressesCheck = rlpStream.Position + addressesSequenceLength;
+            Address[] addresses = new Address[addressesSequenceLength / Rlp.LengthOfAddressRlp];
+            int i = 0;
+            while (rlpStream.Position < addressesCheck)
+            {
+                addresses[i++] = rlpStream.DecodeAddress();                
+            }
+            rlpStream.Check(addressesCheck);
+            rlpStream.Check(check);
+
+            return new ValidatorInfo(finalizingBlockNumber, previousFinalizingBlockNumber, addresses);
+        }
+
+        public Rlp Encode(ValidatorInfo item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+        {
+            if (item == null)
+            {
+                return Rlp.OfEmptySequence;
+            }
+
+            RlpStream rlpStream = new RlpStream(GetLength(item, rlpBehaviors));
+            Encode(rlpStream, item, rlpBehaviors);
+            return new Rlp(rlpStream.Data);
+        }
+
+        public void Encode(RlpStream stream, ValidatorInfo item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+        {
+            if (item == null)
+            {
+                stream.EncodeNullObject();
+                return;
+            }
+
+            var (contentLength, validatorLength)  = GetContentLength(item, rlpBehaviors);
+            stream.StartSequence(contentLength);
+            stream.Encode(item.FinalizingBlockNumber);
+            stream.Encode(item.PreviousFinalizingBlockNumber);
+            stream.StartSequence(validatorLength);
+            for (int i = 0; i < item.Validators.Length; i++)
+            {
+                stream.Encode(item.Validators[i]);
+            }
+        }
+
+        public void Encode(MemoryStream stream, ValidatorInfo item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+        {
+            var (contentLength, validatorLength) = GetContentLength(item, rlpBehaviors);
+            Rlp.StartSequence(stream, contentLength);
+            Rlp.Encode(stream, item.FinalizingBlockNumber);
+            Rlp.Encode(stream, item.PreviousFinalizingBlockNumber);
+            Rlp.StartSequence(stream, validatorLength);
+            for (int i = 0; i < item.Validators.Length; i++)
+            {
+                Rlp.Encode(stream, item.Validators[i]);
+            }
+        }
+
+        public int GetLength(ValidatorInfo item, RlpBehaviors rlpBehaviors) => item == null ? 1 : Rlp.LengthOfSequence(GetContentLength(item, rlpBehaviors).Total);
+
+        private static (int Total, int Validators) GetContentLength(ValidatorInfo item, RlpBehaviors rlpBehaviors)
+        {
+            var validatorsLength = Rlp.LengthOfAddressRlp * item.Validators.Length;
+            return (Rlp.LengthOf(item.FinalizingBlockNumber) + Rlp.LengthOf(item.PreviousFinalizingBlockNumber) + Rlp.GetSequenceRlpLength(validatorsLength), validatorsLength);
+        }
+    }
+} 

--- a/src/Nethermind/Nethermind.AuRa/Validators/ValidatorStore.cs
+++ b/src/Nethermind/Nethermind.AuRa/Validators/ValidatorStore.cs
@@ -1,0 +1,98 @@
+﻿//  Copyright (c) 2018 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Encoding;
+using Nethermind.Core.Extensions;
+using Nethermind.Store;
+
+namespace Nethermind.AuRa.Validators
+{
+    public class ValidatorStore : IValidatorStore
+    {
+        internal static readonly Keccak LatestFinalizedValidatorsBlockNumberKey = Keccak.Compute("LatestFinalizedValidatorsBlockNumber");
+        internal static readonly Keccak PendingValidatorsKey = Keccak.Compute("PendingValidators");
+        private static readonly PendingValidatorsDecoder PendingValidatorsDecoder = new PendingValidatorsDecoder();
+
+        private readonly IDb _db;
+        private long _latestFinalizedValidatorsBlockNumber;
+        private ValidatorInfo _latestValidatorInfo;
+        private static readonly int EmptyBlockNumber = -1;
+        private static readonly ValidatorInfo EmptyValidatorInfo = new ValidatorInfo(-1, -1, Array.Empty<Address>());
+
+        public ValidatorStore(IDb db)
+        {
+            _db = db;
+            _latestFinalizedValidatorsBlockNumber = _db.Get(LatestFinalizedValidatorsBlockNumberKey)?.ToLongFromBigEndianByteArrayWithoutLeadingZeros() ?? EmptyBlockNumber;
+        }
+
+        public void SetValidators(long finalizingBlockNumber, Address[] validators)
+        {
+            if (finalizingBlockNumber > _latestFinalizedValidatorsBlockNumber)
+            {
+                var validatorInfo = new ValidatorInfo(finalizingBlockNumber, _latestFinalizedValidatorsBlockNumber, validators);
+                var rlp = Rlp.Encode(validatorInfo);
+                _db.Set(GetKey(finalizingBlockNumber), rlp.Bytes);
+                _db.Set(LatestFinalizedValidatorsBlockNumberKey, finalizingBlockNumber.ToBigEndianByteArrayWithoutLeadingZeros());
+                _latestFinalizedValidatorsBlockNumber = finalizingBlockNumber;
+                _latestValidatorInfo = validatorInfo;
+            }
+        }
+
+        private Keccak GetKey(in long blockNumber) => Keccak.Compute("Validators" + blockNumber);
+
+
+        public Address[] GetValidators(long? blockNumber = null)
+        {
+            return blockNumber == null || blockNumber > _latestFinalizedValidatorsBlockNumber ? GetLatestValidatorInfo().Validators : FindValidatorInfo(blockNumber.Value);
+        }
+
+        public PendingValidators PendingValidators {
+            get
+            {
+                var rlpStream = new RlpStream(_db.Get(PendingValidatorsKey) ?? Rlp.OfEmptySequence.Bytes);
+                return PendingValidatorsDecoder.Decode(rlpStream);
+            }
+            set => _db.Set(PendingValidatorsKey,  PendingValidatorsDecoder.Encode(value).Bytes);
+        }
+
+        private Address[] FindValidatorInfo(in long blockNumber)
+        {
+            var currentValidatorInfo = GetLatestValidatorInfo();
+            while (currentValidatorInfo.FinalizingBlockNumber >= blockNumber)
+            {
+                currentValidatorInfo = LoadValidatorInfo(currentValidatorInfo.PreviousFinalizingBlockNumber);
+            }
+
+            return currentValidatorInfo.Validators;
+        }
+
+        private ValidatorInfo GetLatestValidatorInfo() => _latestValidatorInfo ??= LoadValidatorInfo(_latestFinalizedValidatorsBlockNumber);
+
+        private ValidatorInfo LoadValidatorInfo(in long blockNumber)
+        {
+            if (blockNumber > EmptyBlockNumber)
+            {
+                var bytes = _db.Get(GetKey(blockNumber));
+                return bytes != null ? Rlp.Decode<ValidatorInfo>(bytes) : null;
+            }
+
+            return EmptyValidatorInfo;
+        }
+    }
+} 

--- a/src/Nethermind/Nethermind.Core/Extensions/IListExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/IListExtensions.cs
@@ -15,12 +15,11 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
 using System.Collections.Generic;
-using Nethermind.Core;
 
-namespace Nethermind.AuRa.Validators
+namespace Nethermind.Core.Extensions
 {
-    internal static class AuRaValidatorsCollectionExtensions
+    public static class IListExtensions
     {
-        public static int MinSealersForFinalization(this IList<Address> validators) => validators.Count / 2 + 1;
+        public static T GetItemRoundRobin<T>(this IList<T> array, long index) => array[(int) (index % array.Count)];
     }
 }

--- a/src/Nethermind/Nethermind.Core/Extensions/IListExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/IListExtensions.cs
@@ -20,6 +20,6 @@ namespace Nethermind.Core.Extensions
 {
     public static class IListExtensions
     {
-        public static T GetItemRoundRobin<T>(this IList<T> array, long index) => array[(int) (index % array.Count)];
+        public static T GetItemRoundRobin<T>(this IList<T> array, long index) => array.Count == 0 ? default : array[(int) (index % array.Count)];
     }
 }

--- a/src/Nethermind/Nethermind.Core/Extensions/Int64Extensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/Int64Extensions.cs
@@ -123,5 +123,19 @@ namespace Nethermind.Core.Extensions
                 return bytes;    
             }
         }
+
+        public static long ToLongFromBigEndianByteArrayWithoutLeadingZeros(this byte[] bytes)
+        {
+            long value = 0;
+            var length = bytes.Length;
+            
+            for (int i = 0; i < length; i++)
+            {
+                value += bytes[length - 1 - i] << 8 * i;
+            }
+
+            return value;
+
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Core/Specs/ChainSpecStyle/AuRaParameters.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/ChainSpecStyle/AuRaParameters.cs
@@ -55,12 +55,12 @@ namespace Nethermind.Core.Specs.ChainSpecStyle
         
         public Address BlockRewardContractAddress { get; set; }
         
-        public long BlockRewardContractTransition { get; set; }
+        public long? BlockRewardContractTransition { get; set; }
         
         public long ValidateScoreTransition { get; set; }
         
         public long ValidateStepTransition { get; set; }
-
+		
         public Validator Validators { get; set; }
         
         public enum ValidatorType

--- a/src/Nethermind/Nethermind.Core/Specs/ChainSpecStyle/ChainSpecLoader.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/ChainSpecStyle/ChainSpecLoader.cs
@@ -179,6 +179,8 @@ namespace Nethermind.Core.Specs.ChainSpecStyle
                     BlockReward = chainSpecJson.Engine.AuthorityRound.BlockReward,
                     BlockRewardContractAddress = chainSpecJson.Engine.AuthorityRound.BlockRewardContractAddress,
                     BlockRewardContractTransition = chainSpecJson.Engine.AuthorityRound.BlockRewardContractTransition,
+                    ValidateScoreTransition = chainSpecJson.Engine.AuthorityRound.ValidateScoreTransition,
+                    ValidateStepTransition = chainSpecJson.Engine.AuthorityRound.ValidateStepTransition,
                     Validators = LoadValidator(chainSpecJson.Engine.AuthorityRound.Validator)
                 };
             }

--- a/src/Nethermind/Nethermind.Core/Specs/ChainSpecStyle/Json/ChainSpecJson.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/ChainSpecStyle/Json/ChainSpecJson.cs
@@ -92,8 +92,12 @@ namespace Nethermind.Core.Specs.ChainSpecStyle.Json
             
             public Address BlockRewardContractAddress { get; set; }
             
-            public long BlockRewardContractTransition { get; set; }
+            public long? BlockRewardContractTransition { get; set; }
             
+            public long ValidateScoreTransition { get; set; }
+        
+            public long ValidateStepTransition { get; set; }
+		
             public AuRaValidatorJson Validators { get; set; }
         }
 
@@ -141,8 +145,12 @@ namespace Nethermind.Core.Specs.ChainSpecStyle.Json
             
             public Address BlockRewardContractAddress => Params.BlockRewardContractAddress;
             
-            public long BlockRewardContractTransition => Params.BlockRewardContractTransition;
-            
+            public long? BlockRewardContractTransition => Params.BlockRewardContractTransition;
+
+            public long ValidateScoreTransition => Params.ValidateScoreTransition;
+
+            public long ValidateStepTransition => Params.ValidateStepTransition;
+
             public AuRaValidatorJson Validator => Params.Validators;
             
             public AuraEngineParamsJson Params { get; set; }

--- a/src/Nethermind/Nethermind.Runner/RunnerAppBase.cs
+++ b/src/Nethermind/Nethermind.Runner/RunnerAppBase.cs
@@ -89,6 +89,7 @@ namespace Nethermind.Runner
                 var initConfig = configProvider.GetConfig<IInitConfig>();
                 LogManager.Configuration = new XmlLoggingConfiguration("NLog.config".GetApplicationResourcePath());
                 _logger = new NLogLogger(initConfig.LogFileName, initConfig.LogDirectory);
+                if (_logger.IsInfo) _logger.Info($"Nethermind version: {ClientVersion.Description}");
                 LogMemoryConfiguration();
 
                 var pathDbPath = getDbBasePath();
@@ -103,10 +104,7 @@ namespace Nethermind.Runner
                 Console.CancelKeyPress += ConsoleOnCancelKeyPress;
 
                 var serializer = new EthereumJsonSerializer();
-                if (_logger.IsInfo)
-                {
-                    _logger.Info($"Nethermind config:\n{serializer.Serialize(initConfig, true)}\n");
-                }
+                if (_logger.IsInfo) _logger.Info($"Nethermind config:\n{serializer.Serialize(initConfig, true)}\n");
 
                 _cancelKeySource = new TaskCompletionSource<object>();
 

--- a/src/Nethermind/Nethermind.Runner/Runners/EthereumRunner.cs
+++ b/src/Nethermind/Nethermind.Runner/Runners/EthereumRunner.cs
@@ -180,6 +180,7 @@ namespace Nethermind.Runner.Runners
         private IJsonRpcClientProxy _jsonRpcClientProxy;
         private IEthJsonRpcClientProxy _ethJsonRpcClientProxy;
         private IHttpClient _httpClient;
+        private IValidatorStore _validatorStore;
         public const string DiscoveryNodesDbPath = "discoveryNodes";
         public const string PeersDbPath = "peers";
 
@@ -617,8 +618,13 @@ namespace Nethermind.Runner.Runners
             switch (_chainSpec.SealEngineType)
             {
                 case SealEngineType.AuRa:
-                    return new AuRaBlockFinalizationManager(_blockTree, _chainLevelInfoRepository, _blockProcessor, 
-                            blockPreProcessors.OfType<IAuRaValidator>().First(), _logManager);
+                    var finalizationManager = new AuRaBlockFinalizationManager(_blockTree, _chainLevelInfoRepository, _blockProcessor, _validatorStore, new ValidSealerStrategy(), _logManager);
+                    foreach (IAuRaValidator auRaValidator in blockPreProcessors.OfType<IAuRaValidator>())
+                    {
+                        auRaValidator.SetFinalizationManager(finalizationManager);
+                    }
+
+                    return finalizationManager;
                 default:
                     return null;
             }
@@ -667,7 +673,8 @@ namespace Nethermind.Runner.Runners
                     case SealEngineType.AuRa:
                     {
                         IAuRaValidatorProcessor validator = null;
-                        ReadOnlyChain producerChain = GetProducerChain((db, s, b, t, l)  => new[] {validator = new AuRaAdditionalBlockProcessorFactory(db, s, new AbiEncoder(), t, b, _receiptStorage, l).CreateValidatorProcessor(_chainSpec.AuRa.Validators)});
+                        ReadOnlyChain producerChain = GetProducerChain((db, s, b, t, l)  => 
+                            new[] {validator = new AuRaAdditionalBlockProcessorFactory(s, new AbiEncoder(), t, b, _receiptStorage, _validatorStore, l).CreateValidatorProcessor(_chainSpec.AuRa.Validators)});
                         PendingTransactionSelector pendingTransactionSelector = new PendingTransactionSelector(_txPool, producerChain.ReadOnlyStateProvider, _logManager);
                         if (_logger.IsWarn) _logger.Warn("Starting AuRa block producer & sealer");
                         _blockProducer = new AuRaBlockProducer(pendingTransactionSelector, producerChain.Processor, _sealer, _blockTree, producerChain.ReadOnlyStateProvider, _timestamper, _logManager, new AuRaStepCalculator(_chainSpec.AuRa.StepDuration, _timestamper), _configProvider.GetConfig<IAuraConfig>(), _nodeKey.Address);
@@ -731,13 +738,14 @@ namespace Nethermind.Runner.Runners
                     break;
                 case SealEngineType.AuRa:
                     var abiEncoder = new AbiEncoder();
-                    var validatorProcessor = new AuRaAdditionalBlockProcessorFactory(_dbProvider.StateDb, _stateProvider, abiEncoder, _transactionProcessor, _blockTree, _receiptStorage, _logManager)
+                    _validatorStore = new ValidatorStore(_dbProvider.StateDb);
+                    var validatorProcessor = new AuRaAdditionalBlockProcessorFactory(_stateProvider, abiEncoder, _transactionProcessor, _blockTree, _receiptStorage, _validatorStore, _logManager)
                         .CreateValidatorProcessor(_chainSpec.AuRa.Validators);
                     
                     var auRaStepCalculator = new AuRaStepCalculator(_chainSpec.AuRa.StepDuration, _timestamper);    
-                    _sealValidator = new AuRaSealValidator(_chainSpec.AuRa, auRaStepCalculator, validatorProcessor, _ethereumEcdsa, _logManager);
+                    _sealValidator = new AuRaSealValidator(_chainSpec.AuRa, auRaStepCalculator, _validatorStore, _ethereumEcdsa, _logManager);
                     _rewardCalculator = new AuRaRewardCalculator(_chainSpec.AuRa, abiEncoder, _transactionProcessor);
-                    _sealer = new AuRaSealer(_blockTree, validatorProcessor, auRaStepCalculator, _nodeKey.Address, new BasicWallet(_nodeKey), _logManager);
+                    _sealer = new AuRaSealer(_blockTree, validatorProcessor, _validatorStore, auRaStepCalculator, _nodeKey.Address, new BasicWallet(_nodeKey), new ValidSealerStrategy(), _logManager);
                     blockPreProcessors.Add(validatorProcessor);
                     break;
                 default:

--- a/src/Nethermind/Nethermind.Runner/Runners/EthereumRunner.cs
+++ b/src/Nethermind/Nethermind.Runner/Runners/EthereumRunner.cs
@@ -554,14 +554,14 @@ namespace Nethermind.Runner.Runners
                 _initConfig.StoreReceipts,
                 _initConfig.StoreTraces);
 
-            _finalizationManager = InitFinalizationManager(additionalBlockProcessors);
-
             // create shared objects between discovery and peer manager
             IStatsConfig statsConfig = _configProvider.GetConfig<IStatsConfig>();
             _nodeStatsManager = new NodeStatsManager(statsConfig, _logManager);
 
             _blockchainProcessor.Start();
             LoadGenesisBlock(string.IsNullOrWhiteSpace(_initConfig.GenesisHash) ? null : new Keccak(_initConfig.GenesisHash));
+            
+            _finalizationManager = InitFinalizationManager(additionalBlockProcessors);
             
             InitBlockProducers();
             
@@ -738,7 +738,7 @@ namespace Nethermind.Runner.Runners
                     break;
                 case SealEngineType.AuRa:
                     var abiEncoder = new AbiEncoder();
-                    _validatorStore = new ValidatorStore(_dbProvider.StateDb);
+                    _validatorStore = new ValidatorStore(_dbProvider.BlockInfosDb);
                     var validatorProcessor = new AuRaAdditionalBlockProcessorFactory(_stateProvider, abiEncoder, _transactionProcessor, _blockTree, _receiptStorage, _validatorStore, _logManager)
                         .CreateValidatorProcessor(_chainSpec.AuRa.Validators);
                     


### PR DESCRIPTION
Created a separate store for Validator collection transitions. This is needed as Parity works like this.
THis solves issues #1235 and #1181 and also makes for better responsibility split, allowing loading current Validator collection without instantiating (Contract/Multi/List)Validator class.

There will be separate PR in some near future simplifying naming, usage and setup.