### PR TITLE
Evm stack improvements

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Benchmark/EvmPushPopByteBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/EvmPushPopByteBenchmarks.cs
@@ -15,47 +15,11 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
 using System;
-using System.Collections.Generic;
-using System.Numerics;
 using BenchmarkDotNet.Attributes;
-using Nethermind.Core;
-using Nethermind.Core.Crypto;
-using Nethermind.Core.Extensions;
-using Nethermind.Core.Specs;
-using Nethermind.Dirichlet.Numerics;
 using Nethermind.Evm.Tracing;
-using Nethermind.Logging;
-using Nethermind.Store;
 
 namespace Nethermind.Evm.Benchmark
 {
-    [MemoryDiagnoser]
-    public class EvmPushSignedIntBenchmarks
-    {
-        [ParamsSource(nameof(ValueSource))]
-        public BigInteger value;
-
-        // public property
-        public IEnumerable<BigInteger> ValueSource => new[] { BigInteger.Parse("-125124123718263172357123"), BigInteger.Parse("-1"), BigInteger.Parse("1"), UInt256.MaxValue, UInt256.MinValue};
-        
-        private byte[] stackBytes;
-        private ITxTracer _tracer = NullTxTracer.Instance;
-
-        [GlobalSetup]
-        public void GlobalSetup()
-        {
-            stackBytes = new byte[(EvmStack.MaxStackSize + EvmStack.RegisterLength) * 1024];
-        }
-
-        [Benchmark(Baseline = true)]
-        public void Current()
-        {
-            EvmStack stack = new EvmStack(stackBytes.AsSpan(), 0, _tracer);
-            stack.PushSignedInt(in value);
-            stack.PopLimbo();
-        }
-    }
-
     public class EvmPushPopByteBenchmarks
     {
         [MemoryDiagnoser]
@@ -70,10 +34,20 @@ namespace Nethermind.Evm.Benchmark
                 stackBytes = new byte[(EvmStack.MaxStackSize + EvmStack.RegisterLength) * 1024];
             }
 
-            [Benchmark(Baseline = true)]
+            [Benchmark(Baseline = true, OperationsPerInvoke = 4)]
             public void Current()
             {
                 EvmStack stack = new EvmStack(stackBytes.AsSpan(), 0, _tracer);
+
+                stack.PushByte(1);
+                stack.PopByte();
+                
+                stack.PushByte(1);
+                stack.PopByte();
+                
+                stack.PushByte(1);
+                stack.PopByte();
+                
                 stack.PushByte(1);
                 stack.PopByte();
             }

--- a/src/Nethermind/Nethermind.Evm.Benchmark/EvmPushSignedIntBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/EvmPushSignedIntBenchmarks.cs
@@ -55,28 +55,4 @@ namespace Nethermind.Evm.Benchmark
             stack.PopLimbo();
         }
     }
-
-    public class EvmPushPopByteBenchmarks
-    {
-        [MemoryDiagnoser]
-        public class EvmPushSignedIntBenchmarks
-        {
-            private byte[] stackBytes;
-            private ITxTracer _tracer = NullTxTracer.Instance;
-
-            [GlobalSetup]
-            public void GlobalSetup()
-            {
-                stackBytes = new byte[(EvmStack.MaxStackSize + EvmStack.RegisterLength) * 1024];
-            }
-
-            [Benchmark(Baseline = true)]
-            public void Current()
-            {
-                EvmStack stack = new EvmStack(stackBytes.AsSpan(), 0, _tracer);
-                stack.PushByte(1);
-                stack.PopByte();
-            }
-        }
-    }
 }

--- a/src/Nethermind/Nethermind.Evm.Benchmark/EvmPushUInt256Benchmarks.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/EvmPushUInt256Benchmarks.cs
@@ -18,25 +18,19 @@ using System;
 using System.Collections.Generic;
 using System.Numerics;
 using BenchmarkDotNet.Attributes;
-using Nethermind.Core;
-using Nethermind.Core.Crypto;
-using Nethermind.Core.Extensions;
-using Nethermind.Core.Specs;
 using Nethermind.Dirichlet.Numerics;
 using Nethermind.Evm.Tracing;
-using Nethermind.Logging;
-using Nethermind.Store;
 
 namespace Nethermind.Evm.Benchmark
 {
     [MemoryDiagnoser]
-    public class EvmPushSignedIntBenchmarks
+    public class EvmPushUInt256Benchmarks
     {
         [ParamsSource(nameof(ValueSource))]
-        public BigInteger value;
+        public UInt256 value;
 
         // public property
-        public IEnumerable<BigInteger> ValueSource => new[] { BigInteger.Parse("-125124123718263172357123"), BigInteger.Parse("-1"), BigInteger.Parse("1"), UInt256.MaxValue, UInt256.MinValue};
+        public IEnumerable<UInt256> ValueSource => new[] { UInt256.One, UInt256.MaxValue};
         
         private byte[] stackBytes;
         private ITxTracer _tracer = NullTxTracer.Instance;
@@ -47,36 +41,22 @@ namespace Nethermind.Evm.Benchmark
             stackBytes = new byte[(EvmStack.MaxStackSize + EvmStack.RegisterLength) * 1024];
         }
 
-        [Benchmark(Baseline = true)]
+        [Benchmark(Baseline = true, OperationsPerInvoke = 4)]
         public void Current()
         {
             EvmStack stack = new EvmStack(stackBytes.AsSpan(), 0, _tracer);
-            stack.PushSignedInt(in value);
+            
+            stack.PushUInt256(ref value);
             stack.PopLimbo();
-        }
-    }
-
-    public class EvmPushPopByteBenchmarks
-    {
-        [MemoryDiagnoser]
-        public class EvmPushSignedIntBenchmarks
-        {
-            private byte[] stackBytes;
-            private ITxTracer _tracer = NullTxTracer.Instance;
-
-            [GlobalSetup]
-            public void GlobalSetup()
-            {
-                stackBytes = new byte[(EvmStack.MaxStackSize + EvmStack.RegisterLength) * 1024];
-            }
-
-            [Benchmark(Baseline = true)]
-            public void Current()
-            {
-                EvmStack stack = new EvmStack(stackBytes.AsSpan(), 0, _tracer);
-                stack.PushByte(1);
-                stack.PopByte();
-            }
+            
+            stack.PushUInt256(ref value);
+            stack.PopLimbo();
+            
+            stack.PushUInt256(ref value);
+            stack.PopLimbo();
+            
+            stack.PushUInt256(ref value);
+            stack.PopLimbo();
         }
     }
 }

--- a/src/Nethermind/Nethermind.Evm/EvmStack.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmStack.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Numerics;
+using System.Runtime.CompilerServices;
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
 using Nethermind.Dirichlet.Numerics;
@@ -63,8 +64,7 @@ namespace Nethermind.Evm
 
             if (++Head >= MaxStackSize)
             {
-                Metrics.EvmExceptions++;
-                throw new EvmStackOverflowException();
+                ThrowOverflow();
             }
         }
 
@@ -78,8 +78,7 @@ namespace Nethermind.Evm
 
             if (++Head >= MaxStackSize)
             {
-                Metrics.EvmExceptions++;
-                throw new EvmStackOverflowException();
+                ThrowOverflow();
             }
         }
 
@@ -94,8 +93,7 @@ namespace Nethermind.Evm
 
             if (++Head >= MaxStackSize)
             {
-                Metrics.EvmExceptions++;
-                throw new EvmStackOverflowException();
+                ThrowOverflow();
             }
         }
 
@@ -107,8 +105,7 @@ namespace Nethermind.Evm
 
             if (++Head >= MaxStackSize)
             {
-                Metrics.EvmExceptions++;
-                throw new EvmStackOverflowException();
+                ThrowOverflow();
             }
         }
 
@@ -121,8 +118,7 @@ namespace Nethermind.Evm
 
             if (++Head >= MaxStackSize)
             {
-                Metrics.EvmExceptions++;
-                throw new EvmStackOverflowException();
+                ThrowOverflow();
             }
         }
 
@@ -156,8 +152,7 @@ namespace Nethermind.Evm
 
             if (++Head >= MaxStackSize)
             {
-                Metrics.EvmExceptions++;
-                throw new EvmStackOverflowException();
+               ThrowOverflow();
             }
         }
 
@@ -165,8 +160,7 @@ namespace Nethermind.Evm
         {
             if (Head-- == 0)
             {
-                Metrics.EvmExceptions++;
-                throw new EvmStackUnderflowException();
+                ThrowUnderflow();
             }
         }
 
@@ -189,20 +183,19 @@ namespace Nethermind.Evm
         {
             if (Head-- == 0)
             {
-                Metrics.EvmExceptions++;
-                throw new EvmStackUnderflowException();
+                ThrowUnderflow();
             }
 
             return new Address(_bytes.Slice(Head * 32 + 12, 20).ToArray());
         }
 
         // ReSharper disable once ImplicitlyCapturedClosure
+
         public Span<byte> PopBytes()
         {
             if (Head-- == 0)
             {
-                Metrics.EvmExceptions++;
-                throw new EvmStackUnderflowException();
+                ThrowUnderflow();
             }
 
             return _bytes.Slice(Head * 32, 32);
@@ -212,8 +205,7 @@ namespace Nethermind.Evm
         {
             if (Head-- == 0)
             {
-                Metrics.EvmExceptions++;
-                throw new EvmStackUnderflowException();
+                ThrowUnderflow();
             }
 
             return _bytes[Head * 32 + 31];
@@ -232,8 +224,7 @@ namespace Nethermind.Evm
 
             if (++Head >= MaxStackSize)
             {
-                Metrics.EvmExceptions++;
-                throw new EvmStackOverflowException();
+                ThrowOverflow();
             }
         }
 
@@ -241,8 +232,7 @@ namespace Nethermind.Evm
         {
             if (Head < depth)
             {
-                Metrics.EvmExceptions++;
-                throw new EvmStackUnderflowException();
+                ThrowUnderflow();
             }
 
             _bytes.Slice((Head - depth) * 32, 32).CopyTo(_bytes.Slice(Head * 32, 32));
@@ -256,8 +246,7 @@ namespace Nethermind.Evm
 
             if (++Head >= MaxStackSize)
             {
-                Metrics.EvmExceptions++;
-                throw new EvmStackOverflowException();
+                ThrowOverflow();
             }
         }
 
@@ -267,8 +256,7 @@ namespace Nethermind.Evm
 
             if (Head < depth)
             {
-                Metrics.EvmExceptions++;
-                throw new EvmStackUnderflowException();
+               ThrowUnderflow();
             }
 
             Span<byte> bottomSpan = _bytes.Slice((Head - depth) * 32, 32);
@@ -331,9 +319,22 @@ namespace Nethermind.Evm
 
             if (++Head >= MaxStackSize)
             {
-                Metrics.EvmExceptions++;
-                throw new EvmStackOverflowException();
+                ThrowOverflow();
             }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ThrowOverflow()
+        {
+            Metrics.EvmExceptions++;
+            throw new EvmStackOverflowException();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ThrowUnderflow()
+        {
+            Metrics.EvmExceptions++;
+            throw new EvmStackUnderflowException();
         }
     }
 }

--- a/src/Nethermind/Nethermind.Evm/EvmState.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmState.cs
@@ -48,19 +48,17 @@ namespace Nethermind.Evm
 
             public byte[] RentBytesOnStack()
             {
-                if (_bytesOnStackPool.Count == 0)
+                if (_bytesOnStackPool.TryPop(out byte[] result))
                 {
-                    Interlocked.Increment(ref _bytesOnStackCreated);
-                    if (_bytesOnStackCreated > _capacity)
-                    {
-                        throw new Exception();
-                    }
-
-                    _bytesOnStackPool.Push(new byte[(EvmStack.MaxStackSize + EvmStack.RegisterLength) * 32]);
+                    return result;
                 }
 
-                _bytesOnStackPool.TryPop(out byte[] result);
-                return result;
+                if (Interlocked.Increment(ref _bytesOnStackCreated) > _capacity)
+                {
+                    throw new Exception();
+                }
+
+                return new byte[(EvmStack.MaxStackSize + EvmStack.RegisterLength) * 32];
             }
         }
 


### PR DESCRIPTION
This is a draft. Please do not review nor merge it.

This PR tries to improve Evm stack behavior by:

1. Moving throwing overflow/underflow exceptions to separate methods, that should make EvmStack methods much easier to inline for JIT
1. Treating data once as `Span<byte>` and once as 32 bytes word
1. Benchmarking it with a few new benchmarks

``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.17134.1069 (1803/April2018Update/Redstone4)
Intel Core i7-6700HQ CPU 2.60GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
Frequency=2531252 Hz, Resolution=395.0614 ns, Timer=TSC
.NET Core SDK=3.1.100
  [Host]     : .NET Core 3.0.1 (CoreCLR 4.700.19.51502, CoreFX 4.700.19.51609), X64 RyuJIT
  DefaultJob : .NET Core 3.0.1 (CoreCLR 4.700.19.51502, CoreFX 4.700.19.51609), X64 RyuJIT
```

#### Nethermind.Evm.Benchmark.EvmPopIntBenchmarks

|  Method |     Mean |   Error |  StdDev | Ratio |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------- |---------:|--------:|--------:|------:|-------:|------:|------:|----------:|
| Current | 192.6 ns | 2.12 ns | 1.98 ns |  1.00 | 0.0305 |     - |     - |      96 B |
| After   | 230.7 ns | 3.59 ns | 3.35 ns |  1.00 | 0.0305 |     - |     - |      96 B |

#### Nethermind.Evm.Benchmark.EvmPushPopByteBenchmarks

|  Method |     Mean |    Error |   StdDev | Ratio | Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------- |---------:|---------:|---------:|------:|------:|------:|------:|----------:|
| Current | 16.05 ns | 0.250 ns | 0.209 ns |  1.00 |     - |     - |     - |         - |
| After   | 13.66 ns | 0.278 ns | 0.330 ns |  1.00 |     - |     - |     - |         - |

#### Nethermind.Evm.Benchmark.EvmPushUInt256Benchmarks

|  Method |                value |     Mean |    Error |   StdDev | Ratio | Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------- |--------------------- |---------:|---------:|---------:|------:|------:|------:|------:|----------:|
| Current |                    1 | 12.48 ns | 0.251 ns | 0.210 ns |  1.00 |     - |     - |     - |         - |
| After   |                    1 | 13.96 ns | 0.164 ns | 0.145 ns |  1.00 |     - |     - |     - |         - |
| Current | 11579(...)39935 [78] | 12.55 ns | 0.133 ns | 0.124 ns |  1.00 |     - |     - |     - |         - |
| After   | 11579(...)39935 [78] | 13.84 ns | 0.245 ns | 0.229 ns |  1.00 |     - |     - |     - |         - |