### PR TITLE
add Address to the AccountProof

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc/Data/ProofConverter.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Data/ProofConverter.cs
@@ -71,9 +71,10 @@ namespace Nethermind.JsonRpc.Data
             writer.WriteStartArray();
             for (int i = 0; i < value.Proof.Length; i++)
             {
-                writer.WriteValue(value.Proof[i].ToHexString(true));    
+                writer.WriteValue(value.Proof[i].ToHexString(true));
             }
             writer.WriteEnd();
+            writer.WriteProperty("address", value.Address, serializer);
             writer.WriteProperty("balance", value.Balance, serializer);
             writer.WriteProperty("codeHash", value.CodeHash, serializer);
             writer.WriteProperty("nonce", value.Nonce, serializer);
@@ -88,7 +89,7 @@ namespace Nethermind.JsonRpc.Data
                 writer.WriteStartArray();
                 for (int ip = 0; ip < value.StorageProofs[i].Proof.Length; ip++)
                 {
-                    writer.WriteValue(value.StorageProofs[i].Proof[ip].ToHexString(true));    
+                    writer.WriteValue(value.StorageProofs[i].Proof[ip].ToHexString(true));
                 }
                 writer.WriteEnd();
                 writer.WriteProperty("value", value.StorageProofs[i].Value, serializer);
@@ -96,7 +97,7 @@ namespace Nethermind.JsonRpc.Data
             }
             writer.WriteEnd();
             writer.WriteEnd();
-            
+
         }
 
         public override AccountProof ReadJson(JsonReader reader, Type objectType, AccountProof existingValue, bool hasExistingValue, JsonSerializer serializer)

--- a/src/Nethermind/Nethermind.Store/Proofs/AccountProof.cs
+++ b/src/Nethermind/Nethermind.Store/Proofs/AccountProof.cs
@@ -14,6 +14,7 @@
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
+using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Dirichlet.Numerics;
 
@@ -24,16 +25,18 @@ namespace Nethermind.Store.Proofs
     /// </summary>
     public class AccountProof
     {
+        public Address Address { get; set; }
+
         public byte[][] Proof { get; set; }
-        
+
         public UInt256 Balance { get; set; }
-        
+
         public Keccak CodeHash { get; set; }
-        
+
         public UInt256 Nonce { get; set; }
-        
+
         public Keccak StorageRoot { get; set; }
-        
+
         public StorageProof[] StorageProofs { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.Store/Proofs/AccountProofCollector.cs
+++ b/src/Nethermind/Nethermind.Store/Proofs/AccountProofCollector.cs
@@ -58,7 +58,7 @@ namespace Nethermind.Store.Proofs
         {
             return Keccak.Compute(index);
         }
-        
+
         private static Keccak ToKey(UInt256 index)
         {
             return new Keccak(StorageTree.GetKey(index).ToArray());
@@ -68,12 +68,12 @@ namespace Nethermind.Store.Proofs
             : this(address, Array.Empty<Keccak>())
         {
         }
-        
+
         public AccountProofCollector(Address address, UInt256[] storageKeys)
             : this(address, storageKeys.Select(ToKey).ToArray())
         {
         }
-        
+
         public AccountProofCollector(Address address, byte[][] storageKeys)
             : this(address, storageKeys.Select(ToKey).ToArray())
         {
@@ -86,6 +86,7 @@ namespace Nethermind.Store.Proofs
 
             _accountProof = new AccountProof();
             _accountProof.StorageProofs = new StorageProof[localStorageKeys.Length];
+            _accountProof.Address = _address;
 
             _storagePrefixes = new Nibble[localStorageKeys.Length][];
             _storageProofBits = new List<byte[]>[localStorageKeys.Length];
@@ -139,14 +140,14 @@ namespace Nethermind.Store.Proofs
 
             if (trieVisitContext.IsStorage)
             {
-//                Console.WriteLine($"Visiting BRANCH {node.Keccak} at {_pathIndex}");
+                //                Console.WriteLine($"Visiting BRANCH {node.Keccak} at {_pathIndex}");
                 foreach (int storageIndex in _nodeInfos[node.Keccak].StorageIndices)
                 {
-                    Keccak childHash = node.GetChildHash((byte) _storagePrefixes[storageIndex][_pathIndex]);
+                    Keccak childHash = node.GetChildHash((byte)_storagePrefixes[storageIndex][_pathIndex]);
                     if (childHash == null)
                     {
                         Console.WriteLine($"Empty at {storageIndex}");
-                        
+
                         AddEmpty(node, trieVisitContext);
                     }
                     else
@@ -158,7 +159,7 @@ namespace Nethermind.Store.Proofs
 
                         _nodeInfos[childHash].PathIndex = _pathIndex + 1;
                         _nodeInfos[childHash].StorageIndices.Add(storageIndex);
-//                        Console.WriteLine($"For BRANCH {storageIndex} will visit {childHash} at {_pathIndex + 1}");
+                        //                        Console.WriteLine($"For BRANCH {storageIndex} will visit {childHash} at {_pathIndex + 1}");
 
                         _visitingFilter.Add(childHash);
                     }
@@ -166,7 +167,7 @@ namespace Nethermind.Store.Proofs
             }
             else
             {
-                _visitingFilter.Add(node.GetChildHash((byte) _prefix[_pathIndex]));
+                _visitingFilter.Add(node.GetChildHash((byte)_prefix[_pathIndex]));
             }
 
             _pathIndex++;
@@ -180,13 +181,13 @@ namespace Nethermind.Store.Proofs
             Keccak childHash = node.GetChildHash(0);
             if (trieVisitContext.IsStorage)
             {
-//                Console.WriteLine($"Visiting EXT {node.Keccak} at {_pathIndex}");
-//                Console.WriteLine($"Node {node.Keccak} has storage indices {string.Join(';', _nodeInfos[node.Keccak].StorageIndices)} at {_pathIndex + node.Path.Length}");
+                //                Console.WriteLine($"Visiting EXT {node.Keccak} at {_pathIndex}");
+                //                Console.WriteLine($"Node {node.Keccak} has storage indices {string.Join(';', _nodeInfos[node.Keccak].StorageIndices)} at {_pathIndex + node.Path.Length}");
                 _nodeInfos[childHash] = new NodeInfo();
                 _nodeInfos[childHash].PathIndex = _pathIndex + node.Path.Length;
                 _nodeInfos[childHash].StorageIndices.AddRange(_nodeInfos[node.Keccak].StorageIndices);
 
-//                Console.WriteLine($"For EXT {string.Join(';', _nodeInfos[node.Keccak].StorageIndices)} will visit {childHash} at {_pathIndex + node.Path.Length}");
+                //                Console.WriteLine($"For EXT {string.Join(';', _nodeInfos[node.Keccak].StorageIndices)} will visit {childHash} at {_pathIndex + node.Path.Length}");
             }
 
             _visitingFilter.Add(childHash); // always accept so can optimize
@@ -237,10 +238,10 @@ namespace Nethermind.Store.Proofs
 
             if (trieVisitContext.IsStorage)
             {
-//                Console.WriteLine($"Visiting LEAF {node.Keccak} at {_pathIndex} - node value is {node.Value.ToHexString()}");
+                //                Console.WriteLine($"Visiting LEAF {node.Keccak} at {_pathIndex} - node value is {node.Value.ToHexString()}");
                 foreach (int storageIndex in _nodeInfos[node.Keccak].StorageIndices)
                 {
-//                    Console.WriteLine($"Setting LEAF value for {storageIndex} {node.Keccak} at {_pathIndex} - node value is {node.Value.ToHexString()}");
+                    //                    Console.WriteLine($"Setting LEAF value for {storageIndex} {node.Keccak} at {_pathIndex} - node value is {node.Value.ToHexString()}");
                     _accountProof.StorageProofs[storageIndex].Value = new RlpStream(node.Value).DecodeByteArray();
                 }
             }


### PR DESCRIPTION
currently `proof_call` delivers a array of AccountProofs, but we don't know the address of the proof.
So adding the address fixes this issue