### PR TITLE
Aura fixes for ReadOnly state

### DIFF
--- a/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
@@ -109,6 +109,8 @@ namespace Ethereum.Test.Base
             {
                 stateProvider.CreateAccount(test.CurrentCoinbase, 0);
             }
+            
+            stateProvider.RecalculateStateRoot();
 
             List<string> differences = RunAssertions(test, stateProvider);
             EthereumTestResult testResult = new EthereumTestResult();

--- a/src/Nethermind/Nethermind.AuRa.Test/AuRaAdditionalBlockProcessorFactoryTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/AuRaAdditionalBlockProcessorFactoryTests.cs
@@ -45,6 +45,7 @@ namespace Nethermind.AuRa.Test
             var factory = new AuRaAdditionalBlockProcessorFactory(Substitute.For<IStateProvider>(),
                 Substitute.For<IAbiEncoder>(), 
                 Substitute.For<ITransactionProcessor>(),
+                Substitute.For<ITransactionProcessorFactory>(),
                 Substitute.For<IBlockTree>(),
                 Substitute.For<IReceiptStorage>(),
                 Substitute.For<IValidatorStore>(),

--- a/src/Nethermind/Nethermind.AuRa.Test/AuRaAdditionalBlockProcessorFactoryTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/AuRaAdditionalBlockProcessorFactoryTests.cs
@@ -45,7 +45,7 @@ namespace Nethermind.AuRa.Test
             var factory = new AuRaAdditionalBlockProcessorFactory(Substitute.For<IStateProvider>(),
                 Substitute.For<IAbiEncoder>(), 
                 Substitute.For<ITransactionProcessor>(),
-                Substitute.For<ITransactionProcessorFactory>(),
+                Substitute.For<IReadOnlyTransactionProcessorSource>(),
                 Substitute.For<IBlockTree>(),
                 Substitute.For<IReceiptStorage>(),
                 Substitute.For<IValidatorStore>(),

--- a/src/Nethermind/Nethermind.AuRa.Test/AuRaBlockProducerTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/AuRaBlockProducerTests.cs
@@ -37,7 +37,7 @@ namespace Nethermind.AuRa.Test
 {
     public class AuRaBlockProducerTests
     {
-        private IPendingTransactionSelector _pendingTransactionSelector;
+        private IPendingTxSelector _pendingTxSelector;
         private IBlockchainProcessor _blockchainProcessor;
         private ISealer _sealer;
         private IBlockTree _blockTree;
@@ -55,7 +55,7 @@ namespace Nethermind.AuRa.Test
         {
             _stepDelay = TimeSpan.FromMilliseconds(10);
             
-            _pendingTransactionSelector = Substitute.For<IPendingTransactionSelector>();
+            _pendingTxSelector = Substitute.For<IPendingTxSelector>();
             _blockchainProcessor = Substitute.For<IBlockchainProcessor>();
             _sealer = Substitute.For<ISealer>();
             _blockTree = Substitute.For<IBlockTree>();
@@ -66,7 +66,7 @@ namespace Nethermind.AuRa.Test
             _auraConfig = Substitute.For<IAuraConfig>();
             _nodeAddress = TestItem.AddressA;
             _auRaBlockProducer = new AuRaBlockProducer(
-                _pendingTransactionSelector,
+                _pendingTxSelector,
                 _blockchainProcessor,
                 _sealer,
                 _blockTree,
@@ -79,7 +79,7 @@ namespace Nethermind.AuRa.Test
                 _nodeAddress);
 
             _auraConfig.ForceSealing.Returns(true);
-            _pendingTransactionSelector.SelectTransactions(Arg.Any<long>()).Returns(Array.Empty<Transaction>());
+            _pendingTxSelector.SelectTransactions(Arg.Any<long>()).Returns(Array.Empty<Transaction>());
             _sealer.CanSeal(Arg.Any<long>(), Arg.Any<Keccak>()).Returns(true);
             _sealer.SealBlock(Arg.Any<Block>(), Arg.Any<CancellationToken>()).Returns(c => Task.FromResult(c.Arg<Block>()));
             _blockProcessingQueue.IsEmpty.Returns(true);
@@ -125,7 +125,7 @@ namespace Nethermind.AuRa.Test
         public async Task Produces_block_when_ForceSealing_is_false_and_there_are_transactions()
         {
             _auraConfig.ForceSealing.Returns(false);
-            _pendingTransactionSelector.SelectTransactions(Arg.Any<long>()).Returns(new[] {Build.A.Transaction.TestObject});
+            _pendingTxSelector.SelectTransactions(Arg.Any<long>()).Returns(new[] {Build.A.Transaction.TestObject});
             (await StartStop()).ShouldProduceBlocks(Quantity.AtLeastOne());
         }
         

--- a/src/Nethermind/Nethermind.AuRa.Test/AuRaBlockProducerTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/AuRaBlockProducerTests.cs
@@ -81,6 +81,7 @@ namespace Nethermind.AuRa.Test
             _sealer.SealBlock(Arg.Any<Block>(), Arg.Any<CancellationToken>()).Returns(c => Task.FromResult(c.Arg<Block>()));
             _blockProcessingQueue.IsEmpty.Returns(true);
             _auRaStepCalculator.TimeToNextStep.Returns(_stepDelay);
+            _blockTree.BestKnownNumber.Returns(1);
             _blockTree.Head.Returns(Build.A.BlockHeader.WithAura(10, Bytes.Empty).TestObject);
             _blockchainProcessor.Process(Arg.Any<Block>(), ProcessingOptions.ProducingBlock, Arg.Any<IBlockTracer>()).Returns(c => c.Arg<Block>());
         }
@@ -95,6 +96,13 @@ namespace Nethermind.AuRa.Test
         public async Task Does_not_produce_block_when_ProcessingQueueEmpty_not_raised()
         {
             (await StartStop(false)).ShouldProduceBlocks(Quantity.None());
+        }
+        
+        [Test]
+        public async Task Produces_block_when_ProcessingQueueEmpty_not_raised_but_BestKnownNumber_is_0()
+        {
+            _blockTree.BestKnownNumber.Returns(0);
+            (await StartStop(false)).ShouldProduceBlocks(Quantity.AtLeastOne());
         }
         
         [Test]

--- a/src/Nethermind/Nethermind.AuRa.Test/AuRaBlockProducerTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/AuRaBlockProducerTests.cs
@@ -68,15 +68,12 @@ namespace Nethermind.AuRa.Test
             _auRaBlockProducer = new AuRaBlockProducer(
                 _pendingTxSelector,
                 _blockchainProcessor,
+                _stateProvider,
                 _sealer,
                 _blockTree,
                 _blockProcessingQueue,
-                _stateProvider,
                 _timestamper,
-                NullLogManager.Instance,
-                _auRaStepCalculator,
-                _auraConfig,
-                _nodeAddress);
+                NullLogManager.Instance, _auRaStepCalculator, _auraConfig, _nodeAddress);
 
             _auraConfig.ForceSealing.Returns(true);
             _pendingTxSelector.SelectTransactions(Arg.Any<long>()).Returns(Array.Empty<Transaction>());

--- a/src/Nethermind/Nethermind.AuRa.Test/AuRaSealerTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/AuRaSealerTests.cs
@@ -43,7 +43,6 @@ namespace Nethermind.AuRa.Test
         private IBlockTree _blockTree;
         private int _headStep;
         private IAuRaStepCalculator _auRaStepCalculator;
-        private IAuRaValidator _auRaValidator;
         private Address _address;
         private IValidatorStore _validatorStore;
         private IValidSealerStrategy _validSealerStrategy;
@@ -56,7 +55,6 @@ namespace Nethermind.AuRa.Test
             _blockTree.Head.Returns(Build.A.BlockHeader.WithHash(Keccak.Compute("hash")).WithAura(_headStep, Bytes.Empty).TestObject);
 
             _auRaStepCalculator = Substitute.For<IAuRaStepCalculator>();
-            _auRaValidator = Substitute.For<IAuRaValidator>();
             _validatorStore = Substitute.For<IValidatorStore>();
             _validSealerStrategy = Substitute.For<IValidSealerStrategy>();
             var wallet = new DevWallet(new WalletConfig(), NullLogManager.Instance);
@@ -64,7 +62,6 @@ namespace Nethermind.AuRa.Test
             
             _auRaSealer = new AuRaSealer(
                 _blockTree,
-                _auRaValidator,
                 _validatorStore,
                 _auRaStepCalculator,
                 _address,

--- a/src/Nethermind/Nethermind.AuRa.Test/Validators/ContractValidatorTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/Validators/ContractValidatorTests.cs
@@ -58,7 +58,7 @@ namespace Nethermind.AuRa.Test.Validators
         private IReceiptStorage _receiptsStorage;
         private IValidatorStore _validatorStore;
         private IValidSealerStrategy _validSealerStrategy;
-        private ITransactionProcessorFactory _transactionProcessorFactory;
+        private IReadOnlyTransactionProcessorSource _readOnlyTransactionProcessorSource;
 
 
         [SetUp]
@@ -80,9 +80,9 @@ namespace Nethermind.AuRa.Test.Validators
             
             _block = new Block( Build.A.BlockHeader.WithNumber(1).WithAura(1, Bytes.Empty).TestObject, new BlockBody());
             
-            _transactionProcessor = Substitute.For<ITransactionProcessor>();
-            _transactionProcessorFactory = Substitute.For<ITransactionProcessorFactory>();
-            _transactionProcessorFactory.Create(Arg.Any<Keccak>()).Returns(_transactionProcessor);
+            _transactionProcessor = Substitute.For<IReadOnlyTransactionProcessor>();
+            _readOnlyTransactionProcessorSource = Substitute.For<IReadOnlyTransactionProcessorSource>();
+            _readOnlyTransactionProcessorSource.Get(Arg.Any<Keccak>()).Returns(_transactionProcessor);
             _stateProvider.StateRoot.Returns(TestItem.KeccakA);
             
             _abiEncoder
@@ -97,56 +97,56 @@ namespace Nethermind.AuRa.Test.Validators
         [Test]
         public void throws_ArgumentNullException_on_empty_validator()
         {
-            Action act = () => new ContractValidator(null, _stateProvider, _abiEncoder, _transactionProcessor, _transactionProcessorFactory, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
+            Action act = () => new ContractValidator(null, _stateProvider, _abiEncoder, _transactionProcessor, _readOnlyTransactionProcessorSource, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
             act.Should().Throw<ArgumentNullException>();
         }
         
         [Test]
         public void throws_ArgumentNullException_on_empty_validatorStore()
         {
-            Action act = () => new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _transactionProcessorFactory, _blockTree, _receiptsStorage, null, _validSealerStrategy, _logManager, 1);
+            Action act = () => new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _readOnlyTransactionProcessorSource, _blockTree, _receiptsStorage, null, _validSealerStrategy, _logManager, 1);
             act.Should().Throw<ArgumentNullException>();
         }
         
         [Test]
         public void throws_ArgumentNullException_on_empty_validSealearStrategy()
         {
-            Action act = () => new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _transactionProcessorFactory, _blockTree, _receiptsStorage, _validatorStore, null, _logManager, 1);
+            Action act = () => new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _readOnlyTransactionProcessorSource, _blockTree, _receiptsStorage, _validatorStore, null, _logManager, 1);
             act.Should().Throw<ArgumentNullException>();
         }
         
         [Test]
         public void throws_ArgumentNullException_on_empty_stateProvider()
         {
-            Action act = () => new ContractValidator(_validator, null, _abiEncoder, _transactionProcessor, _transactionProcessorFactory, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
+            Action act = () => new ContractValidator(_validator, null, _abiEncoder, _transactionProcessor, _readOnlyTransactionProcessorSource, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
             act.Should().Throw<ArgumentNullException>();
         }
         
         [Test]
         public void throws_ArgumentNullException_on_empty_abiEncoder()
         {
-            Action act = () => new ContractValidator(_validator, _stateProvider, null, _transactionProcessor, _transactionProcessorFactory, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
+            Action act = () => new ContractValidator(_validator, _stateProvider, null, _transactionProcessor, _readOnlyTransactionProcessorSource, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
             act.Should().Throw<ArgumentNullException>();
         }
 
         [Test]
         public void throws_ArgumentNullException_on_empty_transactionProcessor()
         {
-            Action act = () => new ContractValidator(_validator, _stateProvider, _abiEncoder, null, _transactionProcessorFactory, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
+            Action act = () => new ContractValidator(_validator, _stateProvider, _abiEncoder, null, _readOnlyTransactionProcessorSource, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
             act.Should().Throw<ArgumentNullException>();
         }
         
         [Test]
         public void throws_ArgumentNullException_on_empty_blockTree()
         {
-            Action act = () => new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _transactionProcessorFactory, null, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
+            Action act = () => new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _readOnlyTransactionProcessorSource, null, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
             act.Should().Throw<ArgumentNullException>();
         }
         
         [Test]
         public void throws_ArgumentNullException_on_empty_logManager()
         {
-            Action act = () => new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _transactionProcessorFactory, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, null, 1);
+            Action act = () => new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _readOnlyTransactionProcessorSource, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, null, 1);
             act.Should().Throw<ArgumentNullException>();
         }
 
@@ -154,7 +154,7 @@ namespace Nethermind.AuRa.Test.Validators
         public void throws_ArgumentNullException_on_empty_contractAddress()
         {
             _validator.Addresses = new Address[0];
-            Action act = () => new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _transactionProcessorFactory, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
+            Action act = () => new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _readOnlyTransactionProcessorSource, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
             act.Should().Throw<ArgumentException>();
         }
 
@@ -164,7 +164,7 @@ namespace Nethermind.AuRa.Test.Validators
             var initialValidator = Address.FromNumber(2000);
             SetupInitialValidators(initialValidator);
             _block.Header.Beneficiary = initialValidator;
-            var validator = new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _transactionProcessorFactory, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
+            var validator = new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _readOnlyTransactionProcessorSource, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
             
             validator.PreProcess(_block);
             
@@ -183,7 +183,7 @@ namespace Nethermind.AuRa.Test.Validators
             var pendingValidators = new PendingValidators(blockNumber, blockHash, validators);
             _validatorStore.PendingValidators.Returns(pendingValidators);
             
-            IAuRaValidatorProcessor validator = new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _transactionProcessorFactory, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
+            IAuRaValidatorProcessor validator = new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _readOnlyTransactionProcessorSource, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
             
             validator.SetFinalizationManager(_blockFinalizationManager);
             _blockFinalizationManager.BlocksFinalized +=
@@ -199,7 +199,7 @@ namespace Nethermind.AuRa.Test.Validators
             var initialValidator = TestItem.AddressA;
             SetupInitialValidators(initialValidator);
             var startBlockNumber = 1;
-            IAuRaValidatorProcessor validator = new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _transactionProcessorFactory, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, startBlockNumber);
+            IAuRaValidatorProcessor validator = new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _readOnlyTransactionProcessorSource, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, startBlockNumber);
             validator.SetFinalizationManager(_blockFinalizationManager);
 
             _block.Header.Number = 1;
@@ -507,7 +507,7 @@ namespace Nethermind.AuRa.Test.Validators
             var currentValidators = GenerateValidators(1);
             SetupInitialValidators(currentValidators);
             
-            IAuRaValidatorProcessor validator = new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _transactionProcessorFactory, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, test.StartBlockNumber);
+            IAuRaValidatorProcessor validator = new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _readOnlyTransactionProcessorSource, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, test.StartBlockNumber);
             validator.SetFinalizationManager(_blockFinalizationManager);
             
             test.TryDoReorganisations(test.StartBlockNumber, out _);
@@ -583,7 +583,7 @@ namespace Nethermind.AuRa.Test.Validators
             
             var blockTree = blockTreeBuilder.TestObject;
             SetupInitialValidators(blockTree.Head, validators);
-            IAuRaValidatorProcessor validator = new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _transactionProcessorFactory, blockTree, inMemoryReceiptStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
+            IAuRaValidatorProcessor validator = new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _readOnlyTransactionProcessorSource, blockTree, inMemoryReceiptStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
             validator.SetFinalizationManager(_blockFinalizationManager);
 
             _abiEncoder.Decode(ValidatorContract.Definition.addressArrayResult, Arg.Any<byte[]>())

--- a/src/Nethermind/Nethermind.AuRa.Test/Validators/ContractValidatorTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/Validators/ContractValidatorTests.cs
@@ -58,6 +58,7 @@ namespace Nethermind.AuRa.Test.Validators
         private IReceiptStorage _receiptsStorage;
         private IValidatorStore _validatorStore;
         private IValidSealerStrategy _validSealerStrategy;
+        private ITransactionProcessorFactory _transactionProcessorFactory;
 
 
         [SetUp]
@@ -71,6 +72,7 @@ namespace Nethermind.AuRa.Test.Validators
             _blockTree = Substitute.For<IBlockTree>();
             _blockFinalizationManager = Substitute.For<IBlockFinalizationManager>();
             _receiptsStorage = Substitute.For<IReceiptStorage>();
+            _transactionProcessorFactory = Substitute.For<ITransactionProcessorFactory>();
             _validator = new AuRaParameters.Validator()
             {
                 Addresses = new[] {_contractAddress},
@@ -93,56 +95,56 @@ namespace Nethermind.AuRa.Test.Validators
         [Test]
         public void throws_ArgumentNullException_on_empty_validator()
         {
-            Action act = () => new ContractValidator(null, _stateProvider, _abiEncoder, _transactionProcessor, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
+            Action act = () => new ContractValidator(null, _stateProvider, _abiEncoder, _transactionProcessor, _transactionProcessorFactory, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
             act.Should().Throw<ArgumentNullException>();
         }
         
         [Test]
         public void throws_ArgumentNullException_on_empty_validatorStore()
         {
-            Action act = () => new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _blockTree, _receiptsStorage, null, _validSealerStrategy, _logManager, 1);
+            Action act = () => new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _transactionProcessorFactory, _blockTree, _receiptsStorage, null, _validSealerStrategy, _logManager, 1);
             act.Should().Throw<ArgumentNullException>();
         }
         
         [Test]
         public void throws_ArgumentNullException_on_empty_validSealearStrategy()
         {
-            Action act = () => new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _blockTree, _receiptsStorage, _validatorStore, null, _logManager, 1);
+            Action act = () => new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _transactionProcessorFactory, _blockTree, _receiptsStorage, _validatorStore, null, _logManager, 1);
             act.Should().Throw<ArgumentNullException>();
         }
         
         [Test]
         public void throws_ArgumentNullException_on_empty_stateProvider()
         {
-            Action act = () => new ContractValidator(_validator, null, _abiEncoder, _transactionProcessor, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
+            Action act = () => new ContractValidator(_validator, null, _abiEncoder, _transactionProcessor, _transactionProcessorFactory, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
             act.Should().Throw<ArgumentNullException>();
         }
         
         [Test]
         public void throws_ArgumentNullException_on_empty_abiEncoder()
         {
-            Action act = () => new ContractValidator(_validator, _stateProvider, null, _transactionProcessor, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
+            Action act = () => new ContractValidator(_validator, _stateProvider, null, _transactionProcessor, _transactionProcessorFactory, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
             act.Should().Throw<ArgumentNullException>();
         }
 
         [Test]
         public void throws_ArgumentNullException_on_empty_transactionProcessor()
         {
-            Action act = () => new ContractValidator(_validator, _stateProvider, _abiEncoder, null, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
+            Action act = () => new ContractValidator(_validator, _stateProvider, _abiEncoder, null, _transactionProcessorFactory, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
             act.Should().Throw<ArgumentNullException>();
         }
         
         [Test]
         public void throws_ArgumentNullException_on_empty_blockTree()
         {
-            Action act = () => new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, null, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
+            Action act = () => new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _transactionProcessorFactory, null, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
             act.Should().Throw<ArgumentNullException>();
         }
         
         [Test]
         public void throws_ArgumentNullException_on_empty_logManager()
         {
-            Action act = () => new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, null, 1);
+            Action act = () => new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _transactionProcessorFactory, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, null, 1);
             act.Should().Throw<ArgumentNullException>();
         }
 
@@ -150,7 +152,7 @@ namespace Nethermind.AuRa.Test.Validators
         public void throws_ArgumentNullException_on_empty_contractAddress()
         {
             _validator.Addresses = new Address[0];
-            Action act = () => new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
+            Action act = () => new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _transactionProcessorFactory, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
             act.Should().Throw<ArgumentException>();
         }
 
@@ -160,7 +162,7 @@ namespace Nethermind.AuRa.Test.Validators
             var initialValidator = Address.FromNumber(2000);
             SetupInitialValidators(initialValidator);
             _block.Header.Beneficiary = initialValidator;
-            var validator = new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
+            var validator = new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _transactionProcessorFactory, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
             
             validator.PreProcess(_block);
             
@@ -179,7 +181,7 @@ namespace Nethermind.AuRa.Test.Validators
             var pendingValidators = new PendingValidators(blockNumber, blockHash, validators);
             _validatorStore.PendingValidators.Returns(pendingValidators);
             
-            IAuRaValidatorProcessor validator = new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
+            IAuRaValidatorProcessor validator = new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _transactionProcessorFactory, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
             
             validator.SetFinalizationManager(_blockFinalizationManager);
             _blockFinalizationManager.BlocksFinalized +=
@@ -195,7 +197,7 @@ namespace Nethermind.AuRa.Test.Validators
             var initialValidator = TestItem.AddressA;
             SetupInitialValidators(initialValidator);
             var startBlockNumber = 1;
-            IAuRaValidatorProcessor validator = new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, startBlockNumber);
+            IAuRaValidatorProcessor validator = new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _transactionProcessorFactory, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, startBlockNumber);
             validator.SetFinalizationManager(_blockFinalizationManager);
 
             _block.Header.Number = 1;
@@ -503,7 +505,7 @@ namespace Nethermind.AuRa.Test.Validators
             var currentValidators = GenerateValidators(1);
             SetupInitialValidators(currentValidators);
             
-            IAuRaValidatorProcessor validator = new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, test.StartBlockNumber);
+            IAuRaValidatorProcessor validator = new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _transactionProcessorFactory, _blockTree, _receiptsStorage, _validatorStore, _validSealerStrategy, _logManager, test.StartBlockNumber);
             validator.SetFinalizationManager(_blockFinalizationManager);
             
             test.TryDoReorganisations(test.StartBlockNumber, out _);
@@ -579,7 +581,7 @@ namespace Nethermind.AuRa.Test.Validators
             
             var blockTree = blockTreeBuilder.TestObject;
             SetupInitialValidators(blockTree.Head, validators);
-            IAuRaValidatorProcessor validator = new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, blockTree, inMemoryReceiptStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
+            IAuRaValidatorProcessor validator = new ContractValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _transactionProcessorFactory, blockTree, inMemoryReceiptStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
             validator.SetFinalizationManager(_blockFinalizationManager);
 
             _abiEncoder.Decode(ValidatorContract.Definition.addressArrayResult, Arg.Any<byte[]>())

--- a/src/Nethermind/Nethermind.AuRa.Test/Validators/ContractValidatorTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/Validators/ContractValidatorTests.cs
@@ -72,7 +72,6 @@ namespace Nethermind.AuRa.Test.Validators
             _blockTree = Substitute.For<IBlockTree>();
             _blockFinalizationManager = Substitute.For<IBlockFinalizationManager>();
             _receiptsStorage = Substitute.For<IReceiptStorage>();
-            _transactionProcessorFactory = Substitute.For<ITransactionProcessorFactory>();
             _validator = new AuRaParameters.Validator()
             {
                 Addresses = new[] {_contractAddress},
@@ -82,6 +81,9 @@ namespace Nethermind.AuRa.Test.Validators
             _block = new Block( Build.A.BlockHeader.WithNumber(1).WithAura(1, Bytes.Empty).TestObject, new BlockBody());
             
             _transactionProcessor = Substitute.For<ITransactionProcessor>();
+            _transactionProcessorFactory = Substitute.For<ITransactionProcessorFactory>();
+            _transactionProcessorFactory.Create(Arg.Any<Keccak>()).Returns(_transactionProcessor);
+            _stateProvider.StateRoot.Returns(TestItem.KeccakA);
             
             _abiEncoder
                 .Encode(AbiEncodingStyle.IncludeSignature, Arg.Is<AbiSignature>(s => s.Name == "getValidators"), Arg.Any<object[]>())

--- a/src/Nethermind/Nethermind.AuRa/AuRaAdditionalBlockProcessorFactory.cs
+++ b/src/Nethermind/Nethermind.AuRa/AuRaAdditionalBlockProcessorFactory.cs
@@ -44,6 +44,7 @@ namespace Nethermind.AuRa
         private readonly IStateProvider _stateProvider;
         private readonly IAbiEncoder _abiEncoder;
         private readonly ITransactionProcessor _transactionProcessor;
+        private readonly ITransactionProcessorFactory _readOnlyTransactionProcessorFactory;
         private readonly IBlockTree _blockTree;
         private readonly IReceiptStorage _receiptStorage;
         private readonly IValidatorStore _validatorStore;
@@ -52,6 +53,7 @@ namespace Nethermind.AuRa
         public AuRaAdditionalBlockProcessorFactory(IStateProvider stateProvider,
             IAbiEncoder abiEncoder,
             ITransactionProcessor transactionProcessor,
+            ITransactionProcessorFactory readOnlyTransactionProcessorFactory,
             IBlockTree blockTree,
             IReceiptStorage receiptStorage,
             IValidatorStore validatorStore,
@@ -60,6 +62,7 @@ namespace Nethermind.AuRa
             _stateProvider = stateProvider;
             _abiEncoder = abiEncoder;
             _transactionProcessor = transactionProcessor;
+            _readOnlyTransactionProcessorFactory = readOnlyTransactionProcessorFactory;
             _blockTree = blockTree;
             _receiptStorage = receiptStorage;
             _validatorStore = validatorStore;
@@ -75,9 +78,9 @@ namespace Nethermind.AuRa
                 case AuRaParameters.ValidatorType.List:
                     return new ListValidator(validator, auRaSealerValidator, _logManager);
                 case AuRaParameters.ValidatorType.Contract:
-                    return new ContractValidator(validator, _stateProvider, _abiEncoder, _transactionProcessor, _blockTree, _receiptStorage, _validatorStore, auRaSealerValidator, _logManager, startBlockNumber);
+                    return new ContractValidator(validator, _stateProvider, _abiEncoder, _transactionProcessor, _readOnlyTransactionProcessorFactory, _blockTree, _receiptStorage, _validatorStore, auRaSealerValidator, _logManager, startBlockNumber);
                 case AuRaParameters.ValidatorType.ReportingContract:
-                    return new ReportingContractValidator(validator, _stateProvider, _abiEncoder, _transactionProcessor, _blockTree, _receiptStorage, _validatorStore, auRaSealerValidator, _logManager, startBlockNumber);
+                    return new ReportingContractValidator(validator, _stateProvider, _abiEncoder, _transactionProcessor, _readOnlyTransactionProcessorFactory, _blockTree, _receiptStorage, _validatorStore, auRaSealerValidator, _logManager, startBlockNumber);
                 case AuRaParameters.ValidatorType.Multi:
                     return new MultiValidator(validator, this, _blockTree, _validatorStore, _logManager);
                 default:

--- a/src/Nethermind/Nethermind.AuRa/AuRaAdditionalBlockProcessorFactory.cs
+++ b/src/Nethermind/Nethermind.AuRa/AuRaAdditionalBlockProcessorFactory.cs
@@ -44,7 +44,7 @@ namespace Nethermind.AuRa
         private readonly IStateProvider _stateProvider;
         private readonly IAbiEncoder _abiEncoder;
         private readonly ITransactionProcessor _transactionProcessor;
-        private readonly ITransactionProcessorFactory _readOnlyTransactionProcessorFactory;
+        private readonly IReadOnlyTransactionProcessorSource _readOnlyReadOnlyTransactionProcessorSource;
         private readonly IBlockTree _blockTree;
         private readonly IReceiptStorage _receiptStorage;
         private readonly IValidatorStore _validatorStore;
@@ -53,7 +53,7 @@ namespace Nethermind.AuRa
         public AuRaAdditionalBlockProcessorFactory(IStateProvider stateProvider,
             IAbiEncoder abiEncoder,
             ITransactionProcessor transactionProcessor,
-            ITransactionProcessorFactory readOnlyTransactionProcessorFactory,
+            IReadOnlyTransactionProcessorSource readOnlyTransactionProcessorSource,
             IBlockTree blockTree,
             IReceiptStorage receiptStorage,
             IValidatorStore validatorStore,
@@ -62,7 +62,7 @@ namespace Nethermind.AuRa
             _stateProvider = stateProvider;
             _abiEncoder = abiEncoder;
             _transactionProcessor = transactionProcessor;
-            _readOnlyTransactionProcessorFactory = readOnlyTransactionProcessorFactory;
+            _readOnlyReadOnlyTransactionProcessorSource = readOnlyTransactionProcessorSource;
             _blockTree = blockTree;
             _receiptStorage = receiptStorage;
             _validatorStore = validatorStore;
@@ -78,9 +78,9 @@ namespace Nethermind.AuRa
                 case AuRaParameters.ValidatorType.List:
                     return new ListValidator(validator, auRaSealerValidator, _logManager);
                 case AuRaParameters.ValidatorType.Contract:
-                    return new ContractValidator(validator, _stateProvider, _abiEncoder, _transactionProcessor, _readOnlyTransactionProcessorFactory, _blockTree, _receiptStorage, _validatorStore, auRaSealerValidator, _logManager, startBlockNumber);
+                    return new ContractValidator(validator, _stateProvider, _abiEncoder, _transactionProcessor, _readOnlyReadOnlyTransactionProcessorSource, _blockTree, _receiptStorage, _validatorStore, auRaSealerValidator, _logManager, startBlockNumber);
                 case AuRaParameters.ValidatorType.ReportingContract:
-                    return new ReportingContractValidator(validator, _stateProvider, _abiEncoder, _transactionProcessor, _readOnlyTransactionProcessorFactory, _blockTree, _receiptStorage, _validatorStore, auRaSealerValidator, _logManager, startBlockNumber);
+                    return new ReportingContractValidator(validator, _stateProvider, _abiEncoder, _transactionProcessor, _readOnlyReadOnlyTransactionProcessorSource, _blockTree, _receiptStorage, _validatorStore, auRaSealerValidator, _logManager, startBlockNumber);
                 case AuRaParameters.ValidatorType.Multi:
                     return new MultiValidator(validator, this, _blockTree, _validatorStore, _logManager);
                 default:

--- a/src/Nethermind/Nethermind.AuRa/AuRaBlockProducer.cs
+++ b/src/Nethermind/Nethermind.AuRa/AuRaBlockProducer.cs
@@ -45,10 +45,10 @@ namespace Nethermind.AuRa
 
         public AuRaBlockProducer(IPendingTxSelector pendingTxSelector,
             IBlockchainProcessor processor,
+            IStateProvider stateProvider,
             ISealer sealer,
             IBlockTree blockTree,
             IBlockProcessingQueue blockProcessingQueue,
-            IStateProvider stateProvider,
             ITimestamper timestamper,
             ILogManager logManager,
             IAuRaStepCalculator auRaStepCalculator,

--- a/src/Nethermind/Nethermind.AuRa/AuRaBlockProducer.cs
+++ b/src/Nethermind/Nethermind.AuRa/AuRaBlockProducer.cs
@@ -43,7 +43,7 @@ namespace Nethermind.AuRa
         private readonly IAuraConfig _config;
         private readonly Address _nodeAddress;
 
-        public AuRaBlockProducer(IPendingTransactionSelector pendingTransactionSelector,
+        public AuRaBlockProducer(IPendingTxSelector pendingTxSelector,
             IBlockchainProcessor processor,
             ISealer sealer,
             IBlockTree blockTree,
@@ -54,7 +54,7 @@ namespace Nethermind.AuRa
             IAuRaStepCalculator auRaStepCalculator,
             IAuraConfig config,
             Address nodeAddress) 
-            : base(pendingTransactionSelector, processor, sealer, blockTree, blockProcessingQueue, stateProvider, timestamper, logManager, "AuRa")
+            : base(pendingTxSelector, processor, sealer, blockTree, blockProcessingQueue, stateProvider, timestamper, logManager, "AuRa")
         {
             _auRaStepCalculator = auRaStepCalculator ?? throw new ArgumentNullException(nameof(auRaStepCalculator));
             _config = config ?? throw new ArgumentNullException(nameof(config));

--- a/src/Nethermind/Nethermind.AuRa/AuRaSealer.cs
+++ b/src/Nethermind/Nethermind.AuRa/AuRaSealer.cs
@@ -76,8 +76,8 @@ namespace Nethermind.AuRa
                 return null;
             }
 
-            var headerHash = block.Header.CalculateHash(RlpBehaviors.ForSealing);
-            var signature = _wallet.Sign(headerHash, _nodeAddress);
+            Keccak headerHash = block.Header.CalculateHash(RlpBehaviors.ForSealing);
+            Signature signature = _wallet.Sign(headerHash, _nodeAddress);
             block.Header.AuRaSignature = signature.BytesWithRecovery;
             
             return block;
@@ -89,11 +89,11 @@ namespace Nethermind.AuRa
                 ? throw new InvalidOperationException("Head block doesn't have AuRaStep specified.'")
                 : _blockTree.Head.AuRaStep.Value < step;
 
-            bool IsThisNodeTurn(long blockLevel, long step) => _validSealerStrategy.IsValidSealer(_validatorStore.GetValidators(), _nodeAddress, step);
+            bool IsThisNodeTurn(long step) => _validSealerStrategy.IsValidSealer(_validatorStore.GetValidators(), _nodeAddress, step);
 
-            var currentStep = _auRaStepCalculator.CurrentStep;
-            var stepNotYetProduced = StepNotYetProduced(currentStep);
-            var isThisNodeTurn = IsThisNodeTurn(blockNumber, currentStep);
+            long currentStep = _auRaStepCalculator.CurrentStep;
+            bool stepNotYetProduced = StepNotYetProduced(currentStep);
+            bool isThisNodeTurn = IsThisNodeTurn(currentStep);
             if (isThisNodeTurn)
             {
                 if (_logger.IsWarn && !stepNotYetProduced) _logger.Warn($"Cannot seal block {blockNumber}: AuRa step {currentStep} already produced.");

--- a/src/Nethermind/Nethermind.AuRa/AuRaSealer.cs
+++ b/src/Nethermind/Nethermind.AuRa/AuRaSealer.cs
@@ -32,7 +32,6 @@ namespace Nethermind.AuRa
     {
         private readonly IBlockTree _blockTree;
         private readonly IValidatorStore _validatorStore;
-        private readonly IAuRaValidator _validator;
         private readonly IAuRaStepCalculator _auRaStepCalculator;
         private readonly Address _nodeAddress;
         private readonly IBasicWallet _wallet;
@@ -41,7 +40,6 @@ namespace Nethermind.AuRa
         
         public AuRaSealer(
             IBlockTree blockTree,
-            IAuRaValidator validator,
             IValidatorStore validatorStore,
             IAuRaStepCalculator auRaStepCalculator,
             Address nodeAddress,
@@ -51,7 +49,6 @@ namespace Nethermind.AuRa
         {
             _blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
             _validatorStore = validatorStore ?? throw new ArgumentNullException(nameof(validatorStore));
-            _validator = validator ?? throw new ArgumentNullException(nameof(validator));
             _auRaStepCalculator = auRaStepCalculator ?? throw new ArgumentNullException(nameof(auRaStepCalculator));
             _nodeAddress = nodeAddress ?? throw new ArgumentNullException(nameof(nodeAddress));
             _wallet = wallet ?? throw new ArgumentNullException(nameof(wallet));

--- a/src/Nethermind/Nethermind.AuRa/Rewards/AuRaRewardCalculator.cs
+++ b/src/Nethermind/Nethermind.AuRa/Rewards/AuRaRewardCalculator.cs
@@ -37,7 +37,7 @@ namespace Nethermind.AuRa.Rewards
         private readonly RewardContract _contract;
         private readonly CallOutputTracer _tracer = new CallOutputTracer();
 
-        public AuRaRewardCalculator(AuRaParameters auRaParameters, IAbiEncoder abiEncoder,  ITransactionProcessor transactionProcessor)
+        public AuRaRewardCalculator(AuRaParameters auRaParameters, IAbiEncoder abiEncoder, ITransactionProcessor transactionProcessor)
         {
             if (auRaParameters == null) throw new ArgumentNullException(nameof(AuRaParameters));
             _transactionProcessor = transactionProcessor ?? throw new ArgumentNullException(nameof(transactionProcessor));
@@ -121,6 +121,22 @@ namespace Nethermind.AuRa.Rewards
             }
 
             return RewardContract.Definition.BenefactorKind.ToBlockRewardType(kind);
+        }
+
+        public static IRewardCalculatorSource GetSource(AuRaParameters auRaParameters, IAbiEncoder abiEncoder) => new AuRaRewardCalculatorSource(auRaParameters, abiEncoder);
+
+        private class AuRaRewardCalculatorSource : IRewardCalculatorSource
+        {
+            private readonly AuRaParameters _auRaParameters;
+            private readonly IAbiEncoder _abiEncoder;
+
+            public AuRaRewardCalculatorSource(AuRaParameters auRaParameters, IAbiEncoder abiEncoder)
+            {
+                _auRaParameters = auRaParameters;
+                _abiEncoder = abiEncoder;
+            }
+
+            public IRewardCalculator Get(ITransactionProcessor processor) => new AuRaRewardCalculator(_auRaParameters, _abiEncoder, processor);
         }
     }
 }

--- a/src/Nethermind/Nethermind.AuRa/Validators/ContractValidator.cs
+++ b/src/Nethermind/Nethermind.AuRa/Validators/ContractValidator.cs
@@ -43,7 +43,7 @@ namespace Nethermind.AuRa.Validators
         private readonly ILogger _logger;
         private readonly IStateProvider _stateProvider;
         private readonly ITransactionProcessor _transactionProcessor;
-        private readonly ITransactionProcessorFactory _readOnlyTransactionProcessorFactory;
+        private readonly IReadOnlyTransactionProcessorSource _readOnlyReadOnlyTransactionProcessorSource;
 
         private ValidatorContract _validatorContract;
         private PendingValidators _currentPendingValidators;
@@ -67,7 +67,7 @@ namespace Nethermind.AuRa.Validators
             IStateProvider stateProvider,
             IAbiEncoder abiEncoder,
             ITransactionProcessor transactionProcessor,
-            ITransactionProcessorFactory readOnlyTransactionProcessorFactory,
+            IReadOnlyTransactionProcessorSource readOnlyTransactionProcessorSource,
             IBlockTree blockTree,
             IReceiptStorage receiptStorage,
             IValidatorStore validatorStore,
@@ -79,7 +79,7 @@ namespace Nethermind.AuRa.Validators
             ContractAddress = validator.Addresses?.FirstOrDefault() ?? throw new ArgumentException("Missing contract address for AuRa validator.", nameof(validator.Addresses));
             _stateProvider = stateProvider ?? throw new ArgumentNullException(nameof(stateProvider));
             _transactionProcessor = transactionProcessor ?? throw new ArgumentNullException(nameof(transactionProcessor));
-            _readOnlyTransactionProcessorFactory = readOnlyTransactionProcessorFactory ?? throw new ArgumentNullException(nameof(readOnlyTransactionProcessorFactory));
+            _readOnlyReadOnlyTransactionProcessorSource = readOnlyTransactionProcessorSource ?? throw new ArgumentNullException(nameof(readOnlyTransactionProcessorSource));
             _receiptStorage = receiptStorage ?? throw new ArgumentNullException(nameof(receiptStorage));
             _validatorStore = validatorStore ?? throw new ArgumentNullException(nameof(validatorStore));
             _logger = logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
@@ -239,7 +239,8 @@ namespace Nethermind.AuRa.Validators
 
         private Address[] LoadValidatorsFromContract(BlockHeader blockHeader)
         {
-            ValidatorContract.InvokeTransaction(blockHeader, _readOnlyTransactionProcessorFactory.Create(_stateProvider.StateRoot), ValidatorContract.GetValidators(), Output);
+            using var readOnlyTransactionProcessor = _readOnlyReadOnlyTransactionProcessorSource.Get(_stateProvider.StateRoot);
+            ValidatorContract.InvokeTransaction(blockHeader, readOnlyTransactionProcessor, ValidatorContract.GetValidators(), Output);
 
             if (Output.ReturnValue.Length == 0)
             {

--- a/src/Nethermind/Nethermind.AuRa/Validators/ReportingContractValidator.cs
+++ b/src/Nethermind/Nethermind.AuRa/Validators/ReportingContractValidator.cs
@@ -30,14 +30,14 @@ namespace Nethermind.AuRa.Validators
             IStateProvider stateProvider,
             IAbiEncoder abiEncoder,
             ITransactionProcessor transactionProcessor,
-            ITransactionProcessorFactory readOnlyTransactionProcessorFactory,
+            IReadOnlyTransactionProcessorSource readOnlyTransactionProcessorSource,
             IBlockTree blockTree,
             IReceiptStorage receiptStorage,
             IValidatorStore validatorStore,
             IValidSealerStrategy validSealerStrategy,
             ILogManager logManager,
             long startBlockNumber) 
-            : base(validator, stateProvider, abiEncoder, transactionProcessor, readOnlyTransactionProcessorFactory, blockTree, receiptStorage, validatorStore, validSealerStrategy, logManager, startBlockNumber)
+            : base(validator, stateProvider, abiEncoder, transactionProcessor, readOnlyTransactionProcessorSource, blockTree, receiptStorage, validatorStore, validSealerStrategy, logManager, startBlockNumber)
         {
         }
     }

--- a/src/Nethermind/Nethermind.AuRa/Validators/ReportingContractValidator.cs
+++ b/src/Nethermind/Nethermind.AuRa/Validators/ReportingContractValidator.cs
@@ -30,13 +30,14 @@ namespace Nethermind.AuRa.Validators
             IStateProvider stateProvider,
             IAbiEncoder abiEncoder,
             ITransactionProcessor transactionProcessor,
+            ITransactionProcessorFactory readOnlyTransactionProcessorFactory,
             IBlockTree blockTree,
             IReceiptStorage receiptStorage,
             IValidatorStore validatorStore,
             IValidSealerStrategy validSealerStrategy,
             ILogManager logManager,
             long startBlockNumber) 
-            : base(validator, stateProvider, abiEncoder, transactionProcessor, blockTree, receiptStorage, validatorStore, validSealerStrategy, logManager, startBlockNumber)
+            : base(validator, stateProvider, abiEncoder, transactionProcessor, readOnlyTransactionProcessorFactory, blockTree, receiptStorage, validatorStore, validSealerStrategy, logManager, startBlockNumber)
         {
         }
     }

--- a/src/Nethermind/Nethermind.Blockchain.Test/IntegrationTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/IntegrationTests.cs
@@ -119,7 +119,7 @@ namespace Nethermind.Blockchain.Test
             blockTree.SuggestBlock(chainSpec.Genesis);
             blockchainProcessor.Start();
 
-            var transactionSelector = new PendingTransactionSelector(txPool, stateProvider, logManager);
+            var transactionSelector = new PendingTxSelector(txPool, stateProvider, logManager);
             MinedBlockProducer minedBlockProducer = new MinedBlockProducer(transactionSelector, blockchainProcessor, sealer, blockTree, blockchainProcessor, stateProvider, timestamper, NullLogManager.Instance, difficultyCalculator);
             minedBlockProducer.Start();
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/Synchronization/SyncThreadTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Synchronization/SyncThreadTests.cs
@@ -292,7 +292,7 @@ namespace Nethermind.Blockchain.Test.Synchronization
             var devBlockProcessor = new BlockProcessor(specProvider, blockValidator, rewardCalculator, devTxProcessor, stateDb, codeDb, devState, devStorage, txPool, receiptStorage, logManager);
             var devChainProcessor = new BlockchainProcessor(tree, devBlockProcessor, step, logManager, false);
             var transactionSelector = new PendingTxSelector(txPool, stateProvider, logManager);
-            var producer = new DevBlockProducer(transactionSelector, devChainProcessor, tree, processor, stateProvider, new Timestamper(), logManager, txPool);
+            var producer = new DevBlockProducer(transactionSelector, devChainProcessor, stateProvider, tree, processor, txPool, new Timestamper(), logManager);
 
             NodeDataFeed feed = new NodeDataFeed(codeDb, stateDb, logManager);
             NodeDataDownloader downloader = new NodeDataDownloader(syncPeerPool, feed, NullDataConsumer.Instance,  logManager);

--- a/src/Nethermind/Nethermind.Blockchain.Test/Synchronization/SyncThreadTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Synchronization/SyncThreadTests.cs
@@ -291,7 +291,7 @@ namespace Nethermind.Blockchain.Test.Synchronization
             var devTxProcessor = new TransactionProcessor(specProvider, devState, devStorage, devEvm, logManager);
             var devBlockProcessor = new BlockProcessor(specProvider, blockValidator, rewardCalculator, devTxProcessor, stateDb, codeDb, devState, devStorage, txPool, receiptStorage, logManager);
             var devChainProcessor = new BlockchainProcessor(tree, devBlockProcessor, step, logManager, false);
-            var transactionSelector = new PendingTransactionSelector(txPool, stateProvider, logManager);
+            var transactionSelector = new PendingTxSelector(txPool, stateProvider, logManager);
             var producer = new DevBlockProducer(transactionSelector, devChainProcessor, tree, processor, stateProvider, new Timestamper(), logManager, txPool);
 
             NodeDataFeed feed = new NodeDataFeed(codeDb, stateDb, logManager);

--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionSelectorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionSelectorTests.cs
@@ -129,7 +129,7 @@ namespace Nethermind.Blockchain.Test
             transactionPool.GetPendingTransactions().Returns(testCase.Transactions.ToArray());
             SetAccountStates();
 
-            var selector = new PendingTransactionSelector(transactionPool, stateProvider, NullLogManager.Instance, testCase.MinGasPriceForMining);
+            var selector = new PendingTxSelector(transactionPool, stateProvider, NullLogManager.Instance, testCase.MinGasPriceForMining);
 
             var selectedTransactions = selector.SelectTransactions(testCase.GasLimit);
             selectedTransactions.Should().BeEquivalentTo(testCase.ExpectedSelectedTransactions);

--- a/src/Nethermind/Nethermind.Blockchain/IPendingTransactionSelector.cs
+++ b/src/Nethermind/Nethermind.Blockchain/IPendingTransactionSelector.cs
@@ -19,7 +19,7 @@ using Nethermind.Core;
 
 namespace Nethermind.Blockchain
 {
-    public interface IPendingTransactionSelector
+    public interface IPendingTxSelector
     {
         IEnumerable<Transaction> SelectTransactions(long gasLimit);
     }

--- a/src/Nethermind/Nethermind.Blockchain/PendingTransactionSelector.cs
+++ b/src/Nethermind/Nethermind.Blockchain/PendingTransactionSelector.cs
@@ -25,18 +25,18 @@ using Nethermind.Store;
 
 namespace Nethermind.Blockchain
 {
-    public class PendingTransactionSelector : IPendingTransactionSelector
+    public class PendingTxSelector : IPendingTxSelector
     {
         private readonly ITxPool _transactionPool;
         private readonly IStateProvider _stateProvider;
         private readonly long _minGasPriceForMining;
         private readonly ILogger _logger;
 
-        public PendingTransactionSelector(ITxPool transactionPool, IStateProvider stateProvider, ILogManager logManager, long minGasPriceForMining = 1)
+        public PendingTxSelector(ITxPool transactionPool, IStateProvider stateProvider, ILogManager logManager, long minGasPriceForMining = 1)
         {
             _transactionPool = transactionPool ?? throw new ArgumentNullException(nameof(transactionPool));
             _stateProvider = stateProvider ?? throw new ArgumentNullException(nameof(stateProvider));
-            _logger = logManager?.GetClassLogger<PendingTransactionSelector>() ?? throw new ArgumentNullException(nameof(logManager));
+            _logger = logManager?.GetClassLogger<PendingTxSelector>() ?? throw new ArgumentNullException(nameof(logManager));
             _minGasPriceForMining = minGasPriceForMining;
         }
         

--- a/src/Nethermind/Nethermind.Blockchain/Producers/BaseBlockProducer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Producers/BaseBlockProducer.cs
@@ -38,11 +38,11 @@ namespace Nethermind.Blockchain.Producers
         private readonly ISealer _sealer;
         private readonly IStateProvider _stateProvider;
         private readonly ITimestamper _timestamper;
-        private readonly IPendingTransactionSelector _pendingTransactionSelector;
+        private readonly IPendingTxSelector _pendingTxSelector;
         protected ILogger Logger { get; }
 
         protected BaseBlockProducer(
-            IPendingTransactionSelector pendingTransactionSelector,
+            IPendingTxSelector pendingTxSelector,
             IBlockchainProcessor processor,
             ISealer sealer,
             IBlockTree blockTree,
@@ -51,7 +51,7 @@ namespace Nethermind.Blockchain.Producers
             ITimestamper timestamper,
             ILogManager logManager)
         {
-            _pendingTransactionSelector = pendingTransactionSelector ?? throw new ArgumentNullException(nameof(pendingTransactionSelector));
+            _pendingTxSelector = pendingTxSelector ?? throw new ArgumentNullException(nameof(pendingTxSelector));
             Processor = processor ?? throw new ArgumentNullException(nameof(processor));
             _sealer = sealer ?? throw new ArgumentNullException(nameof(sealer));
             BlockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
@@ -151,7 +151,7 @@ namespace Nethermind.Blockchain.Producers
 
             if (Logger.IsDebug) Logger.Debug($"Setting total difficulty to {parent.TotalDifficulty} + {difficulty}.");
 
-            Block block = new Block(header, _pendingTransactionSelector.SelectTransactions(header.GasLimit), new BlockHeader[0]);
+            Block block = new Block(header, _pendingTxSelector.SelectTransactions(header.GasLimit), new BlockHeader[0]);
             header.TxRoot = new TxTrie(block.Transactions).RootHash;
             return block;
         }

--- a/src/Nethermind/Nethermind.Blockchain/Producers/BaseLoopBlockProducer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Producers/BaseLoopBlockProducer.cs
@@ -34,7 +34,7 @@ namespace Nethermind.Blockchain.Producers
         private bool _canProduce;
 
         protected BaseLoopBlockProducer(
-            IPendingTransactionSelector pendingTransactionSelector,
+            IPendingTxSelector pendingTxSelector,
             IBlockchainProcessor processor,
             ISealer sealer,
             IBlockTree blockTree,
@@ -43,7 +43,7 @@ namespace Nethermind.Blockchain.Producers
             ITimestamper timestamper,
             ILogManager logManager,
             string name) 
-            : base(pendingTransactionSelector, processor, sealer, blockTree, blockProcessingQueue, stateProvider, timestamper, logManager)
+            : base(pendingTxSelector, processor, sealer, blockTree, blockProcessingQueue, stateProvider, timestamper, logManager)
         {
             _name = name;
         }

--- a/src/Nethermind/Nethermind.Blockchain/Producers/BaseLoopBlockProducer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Producers/BaseLoopBlockProducer.cs
@@ -82,7 +82,7 @@ namespace Nethermind.Blockchain.Producers
         
         protected virtual async ValueTask ProducerLoop()
         {
-            bool CanProduce() => _canProduce ?? BlockTree.BestKnownNumber == 0 && BlockProcessingQueue.IsEmpty;
+            bool CanProduce() => (_canProduce ?? BlockTree.BestKnownNumber == 0) && BlockProcessingQueue.IsEmpty;
 
             while (!_loopCancellationTokenSource.IsCancellationRequested)
             {

--- a/src/Nethermind/Nethermind.Blockchain/Producers/BaseLoopBlockProducer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Producers/BaseLoopBlockProducer.cs
@@ -31,7 +31,7 @@ namespace Nethermind.Blockchain.Producers
         private Task _producerTask;
         private readonly CancellationTokenSource _loopCancellationTokenSource = new CancellationTokenSource();
         private readonly CancellationTokenSource _stepCancellationTokenSource = new CancellationTokenSource();
-        private bool _canProduce;
+        private bool? _canProduce;
 
         protected BaseLoopBlockProducer(
             IPendingTxSelector pendingTxSelector,
@@ -82,9 +82,11 @@ namespace Nethermind.Blockchain.Producers
         
         protected virtual async ValueTask ProducerLoop()
         {
+            bool CanProduce() => _canProduce ?? BlockTree.BestKnownNumber == 0 && BlockProcessingQueue.IsEmpty;
+
             while (!_loopCancellationTokenSource.IsCancellationRequested)
             {
-                if (_canProduce && BlockProcessingQueue.IsEmpty)
+                if (CanProduce())
                 {
                     await ProducerLoopStep(_stepCancellationTokenSource.Token);
                 }

--- a/src/Nethermind/Nethermind.Blockchain/Producers/DevBackgroundBlockProducer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Producers/DevBackgroundBlockProducer.cs
@@ -32,13 +32,13 @@ namespace Nethermind.Blockchain.Producers
         private const int DelayBetweenBlocks = 5_000;
 
         public DevBackgroundBlockProducer(
-            IPendingTransactionSelector pendingTransactionSelector,
+            IPendingTxSelector pendingTxSelector,
             IBlockchainProcessor processor,
             IBlockTree blockTree,
             IBlockProcessingQueue blockProcessingQueue,
             IStateProvider stateProvider,
             ITimestamper timestamper,
-            ILogManager logManager) : base(pendingTransactionSelector, processor, NullSealEngine.Instance, blockTree, blockProcessingQueue, stateProvider, timestamper, logManager, "Dev")
+            ILogManager logManager) : base(pendingTxSelector, processor, NullSealEngine.Instance, blockTree, blockProcessingQueue, stateProvider, timestamper, logManager, "Dev")
         {
         }
 

--- a/src/Nethermind/Nethermind.Blockchain/Producers/DevBlockProducer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Producers/DevBlockProducer.cs
@@ -32,12 +32,12 @@ namespace Nethermind.Blockchain.Producers
 
         public DevBlockProducer(IPendingTxSelector pendingTxSelector,
             IBlockchainProcessor processor,
+            IStateProvider stateProvider,
             IBlockTree blockTree,
             IBlockProcessingQueue blockProcessingQueue,
-            IStateProvider stateProvider,
+            ITxPool txPool,
             ITimestamper timestamper,
-            ILogManager logManager, 
-            ITxPool txPool) 
+            ILogManager logManager) 
             : base(pendingTxSelector, processor, NullSealEngine.Instance, blockTree, blockProcessingQueue, stateProvider, timestamper, logManager)
         {
             _txPool = txPool ?? throw new ArgumentNullException(nameof(txPool));

--- a/src/Nethermind/Nethermind.Blockchain/Producers/DevBlockProducer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Producers/DevBlockProducer.cs
@@ -30,7 +30,7 @@ namespace Nethermind.Blockchain.Producers
     {
         private readonly ITxPool _txPool;
 
-        public DevBlockProducer(IPendingTransactionSelector pendingTransactionSelector,
+        public DevBlockProducer(IPendingTxSelector pendingTxSelector,
             IBlockchainProcessor processor,
             IBlockTree blockTree,
             IBlockProcessingQueue blockProcessingQueue,
@@ -38,7 +38,7 @@ namespace Nethermind.Blockchain.Producers
             ITimestamper timestamper,
             ILogManager logManager, 
             ITxPool txPool) 
-            : base(pendingTransactionSelector, processor, NullSealEngine.Instance, blockTree, blockProcessingQueue, stateProvider, timestamper, logManager)
+            : base(pendingTxSelector, processor, NullSealEngine.Instance, blockTree, blockProcessingQueue, stateProvider, timestamper, logManager)
         {
             _txPool = txPool ?? throw new ArgumentNullException(nameof(txPool));
         }

--- a/src/Nethermind/Nethermind.Blockchain/Producers/MinedBlockProducer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Producers/MinedBlockProducer.cs
@@ -33,7 +33,7 @@ namespace Nethermind.Blockchain.Producers
         private CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
 
         public MinedBlockProducer(
-            IPendingTransactionSelector pendingTransactionSelector,
+            IPendingTxSelector pendingTxSelector,
             IBlockchainProcessor processor,
             ISealer sealer,
             IBlockTree blockTree,
@@ -42,7 +42,7 @@ namespace Nethermind.Blockchain.Producers
             ITimestamper timestamper,
             ILogManager logManager,
             IDifficultyCalculator difficultyCalculator) 
-            : base(pendingTransactionSelector, processor, sealer, blockTree, blockProcessingQueue, stateProvider, timestamper, logManager)
+            : base(pendingTxSelector, processor, sealer, blockTree, blockProcessingQueue, stateProvider, timestamper, logManager)
         {
             _difficultyCalculator = difficultyCalculator ?? throw new ArgumentNullException(nameof(difficultyCalculator));
         }

--- a/src/Nethermind/Nethermind.Blockchain/ReadOnlyChain.cs
+++ b/src/Nethermind/Nethermind.Blockchain/ReadOnlyChain.cs
@@ -38,7 +38,7 @@ namespace Nethermind.Blockchain
 
         public ReadOnlyChain(ReadOnlyBlockTree readOnlyTree,
             IBlockValidator blockValidator,
-            IRewardCalculator rewardCalculator,
+            Func<ITransactionProcessor, IRewardCalculator> rewardCalculatorFactory,
             ISpecProvider specProvider,
             IReadOnlyDbProvider dbProvider,
             IBlockDataRecoveryStep recoveryStep,
@@ -54,7 +54,7 @@ namespace Nethermind.Blockchain
             ITransactionProcessor transactionProcessor = new TransactionProcessor(specProvider, ReadOnlyStateProvider, storageProvider, virtualMachine, logManager);
             ITxPool txPool = customTxPool;
             AdditionalBlockProcessors = additionalBlockProcessorsFactory?.Invoke(dbProvider.StateDb, ReadOnlyStateProvider, readOnlyTree, transactionProcessor, logManager);
-            BlockProcessor = new BlockProcessor(specProvider, blockValidator, rewardCalculator, transactionProcessor, dbProvider.StateDb, dbProvider.CodeDb, ReadOnlyStateProvider, storageProvider, txPool, receiptStorage, logManager, AdditionalBlockProcessors);
+            BlockProcessor = new BlockProcessor(specProvider, blockValidator, rewardCalculatorFactory(transactionProcessor), transactionProcessor, dbProvider.StateDb, dbProvider.CodeDb, ReadOnlyStateProvider, storageProvider, txPool, receiptStorage, logManager, AdditionalBlockProcessors);
             Processor = new OneTimeChainProcessor(dbProvider, new BlockchainProcessor(readOnlyTree, BlockProcessor, recoveryStep, logManager, false));
         }
     }

--- a/src/Nethermind/Nethermind.Blockchain/ReadOnlyChain.cs
+++ b/src/Nethermind/Nethermind.Blockchain/ReadOnlyChain.cs
@@ -14,15 +14,15 @@
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
-using System.Collections.Generic;
 using Nethermind.Store;
 
 namespace Nethermind.Blockchain
 {
-    public class ReadOnlyChain
+    public class BlockProducerContext
     {
         public IBlockchainProcessor ChainProcessor { get; set; }
         public IStateProvider ReadOnlyStateProvider { get; set; }
         public IBlockProcessor BlockProcessor { get; set; }
+        public IPendingTxSelector PendingTxSelector { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/ReadOnlyChain.cs
+++ b/src/Nethermind/Nethermind.Blockchain/ReadOnlyChain.cs
@@ -14,48 +14,15 @@
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
-using System;
 using System.Collections.Generic;
-using Nethermind.Blockchain.Receipts;
-using Nethermind.Blockchain.Rewards;
-using Nethermind.Blockchain.TxPools;
-using Nethermind.Blockchain.Validators;
-using Nethermind.Core.Attributes;
-using Nethermind.Core.Specs;
-using Nethermind.Evm;
-using Nethermind.Logging;
 using Nethermind.Store;
 
 namespace Nethermind.Blockchain
 {
-    [Todo("Review how it compares with ReadOnlyChainProcessingEnv")]
     public class ReadOnlyChain
     {
-        public IBlockchainProcessor Processor { get; }
-        public IStateProvider ReadOnlyStateProvider { get; }
-        public IEnumerable<IAdditionalBlockProcessor> AdditionalBlockProcessors { get; }
-        public IBlockProcessor BlockProcessor { get; }
-
-        public ReadOnlyChain(ReadOnlyBlockTree readOnlyTree,
-            IBlockValidator blockValidator,
-            Func<ITransactionProcessor, IRewardCalculator> rewardCalculatorFactory,
-            ISpecProvider specProvider,
-            IReadOnlyDbProvider dbProvider,
-            IBlockDataRecoveryStep recoveryStep,
-            ILogManager logManager,
-            ITxPool customTxPool,
-            IReceiptStorage receiptStorage,
-            Func<IDb, IStateProvider, IBlockTree, ITransactionProcessor, ILogManager, IEnumerable<IAdditionalBlockProcessor>> additionalBlockProcessorsFactory)
-        {
-            ReadOnlyStateProvider = new StateProvider(dbProvider.StateDb, dbProvider.CodeDb, logManager);
-            StorageProvider storageProvider = new StorageProvider(dbProvider.StateDb, ReadOnlyStateProvider, logManager);
-            BlockhashProvider blockhashProvider = new BlockhashProvider(readOnlyTree, logManager);
-            VirtualMachine virtualMachine = new VirtualMachine(ReadOnlyStateProvider, storageProvider, blockhashProvider, specProvider, logManager);
-            ITransactionProcessor transactionProcessor = new TransactionProcessor(specProvider, ReadOnlyStateProvider, storageProvider, virtualMachine, logManager);
-            ITxPool txPool = customTxPool;
-            AdditionalBlockProcessors = additionalBlockProcessorsFactory?.Invoke(dbProvider.StateDb, ReadOnlyStateProvider, readOnlyTree, transactionProcessor, logManager);
-            BlockProcessor = new BlockProcessor(specProvider, blockValidator, rewardCalculatorFactory(transactionProcessor), transactionProcessor, dbProvider.StateDb, dbProvider.CodeDb, ReadOnlyStateProvider, storageProvider, txPool, receiptStorage, logManager, AdditionalBlockProcessors);
-            Processor = new OneTimeChainProcessor(dbProvider, new BlockchainProcessor(readOnlyTree, BlockProcessor, recoveryStep, logManager, false));
-        }
+        public IBlockchainProcessor ChainProcessor { get; set; }
+        public IStateProvider ReadOnlyStateProvider { get; set; }
+        public IBlockProcessor BlockProcessor { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/ReadOnlyReadOnlyTransactionProcessorSource.cs
+++ b/src/Nethermind/Nethermind.Blockchain/ReadOnlyReadOnlyTransactionProcessorSource.cs
@@ -22,26 +22,19 @@ using Nethermind.Store;
 
 namespace Nethermind.Blockchain
 {
-    public class ReadOnlyTransactionProcessorFactory : ITransactionProcessorFactory
+    public class ReadOnlyReadOnlyTransactionProcessorSource : IReadOnlyTransactionProcessorSource
     {
-        private readonly IReadOnlyDbProvider _readOnlyDbProvider;
-        private readonly ISpecProvider _specProvider;
-        private readonly ILogManager _logManager;
-        private readonly ReadOnlyBlockTree _blockTree;
+        private readonly ReadOnlyTxProcessingEnv _environment;
 
-        public ReadOnlyTransactionProcessorFactory(IReadOnlyDbProvider readOnlyDbProvider, IBlockTree blockTree, ISpecProvider specProvider, ILogManager logManager)
+        public ReadOnlyReadOnlyTransactionProcessorSource(IDbProvider dbProvider, IBlockTree blockTree, ISpecProvider specProvider, ILogManager logManager)
         {
-            _readOnlyDbProvider = readOnlyDbProvider;
-            _specProvider = specProvider;
-            _logManager = logManager;
-            _blockTree = new ReadOnlyBlockTree(blockTree);
+            _environment = new ReadOnlyTxProcessingEnv(new ReadOnlyDbProvider(dbProvider, false), new ReadOnlyBlockTree(blockTree), specProvider, logManager);
         }
         
-        public ITransactionProcessor Create(Keccak stateRoot)
+        public IReadOnlyTransactionProcessor Get(Keccak stateRoot)
         {
-            ReadOnlyTxProcessingEnv environment = new ReadOnlyTxProcessingEnv(_readOnlyDbProvider, _blockTree, _specProvider, _logManager);
-            environment.StateProvider.StateRoot = stateRoot;
-            return environment.TransactionProcessor;
+            _environment.StateProvider.StateRoot = stateRoot;
+            return new ReadOnlyTransactionProcessor(_environment.TransactionProcessor, _environment.StateProvider);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/ReadOnlyTransactionProcessorFactory.cs
+++ b/src/Nethermind/Nethermind.Blockchain/ReadOnlyTransactionProcessorFactory.cs
@@ -1,0 +1,47 @@
+﻿//  Copyright (c) 2018 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Specs;
+using Nethermind.Evm;
+using Nethermind.Logging;
+using Nethermind.Store;
+
+namespace Nethermind.Blockchain
+{
+    public class ReadOnlyTransactionProcessorFactory : ITransactionProcessorFactory
+    {
+        private readonly IReadOnlyDbProvider _readOnlyDbProvider;
+        private readonly ISpecProvider _specProvider;
+        private readonly ILogManager _logManager;
+        private readonly ReadOnlyBlockTree _blockTree;
+
+        public ReadOnlyTransactionProcessorFactory(IReadOnlyDbProvider readOnlyDbProvider, IBlockTree blockTree, ISpecProvider specProvider, ILogManager logManager)
+        {
+            _readOnlyDbProvider = readOnlyDbProvider;
+            _specProvider = specProvider;
+            _logManager = logManager;
+            _blockTree = new ReadOnlyBlockTree(blockTree);
+        }
+        
+        public ITransactionProcessor Create(Keccak stateRoot)
+        {
+            ReadOnlyTxProcessingEnv environment = new ReadOnlyTxProcessingEnv(_readOnlyDbProvider, _blockTree, _specProvider, _logManager);
+            environment.StateProvider.StateRoot = stateRoot;
+            return environment.TransactionProcessor;
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Blockchain/Rewards/IRewardCalculatorSource.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Rewards/IRewardCalculatorSource.cs
@@ -1,4 +1,4 @@
-//  Copyright (c) 2018 Demerzel Solutions Limited
+﻿//  Copyright (c) 2018 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
 // 
 //  The Nethermind library is free software: you can redistribute it and/or modify
@@ -14,23 +14,12 @@
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
-using System;
-using Nethermind.Core;
+using Nethermind.Evm;
 
 namespace Nethermind.Blockchain.Rewards
 {
-    public class NoBlockRewards : IRewardCalculator
-    {   
-        private NoBlockRewards()
-        {
-        }
-
-        public static NoBlockRewards Instance { get; } = new NoBlockRewards();
-        
-        public static IRewardCalculatorSource Source { get; } = new InstanceRewardCalculatorSource(Instance); 
-        
-        private static BlockReward[] _noRewards = Array.Empty<BlockReward>();
-
-        public BlockReward[] CalculateRewards(Block block) => _noRewards;
+    public interface IRewardCalculatorSource
+    {
+        IRewardCalculator Get(ITransactionProcessor processor);
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Rewards/InstanceRewardCalculatorSource.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Rewards/InstanceRewardCalculatorSource.cs
@@ -14,19 +14,22 @@
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
-using Nethermind.Core.Crypto;
+using Nethermind.Evm;
 
-namespace Nethermind.Evm
+namespace Nethermind.Blockchain.Rewards
 {
-    public class SingletonTransactionProcessorFactory : ITransactionProcessorFactory
+    public class InstanceRewardCalculatorSource : IRewardCalculatorSource
     {
-        private readonly ITransactionProcessor _instance;
+        private readonly IRewardCalculator _calculator;
 
-        public SingletonTransactionProcessorFactory(ITransactionProcessor instance)
+        public InstanceRewardCalculatorSource(IRewardCalculator calculator)
         {
-            _instance = instance;
+            _calculator = calculator;
         }
-            
-        public ITransactionProcessor Create(Keccak stateRoot) => _instance;
+
+        public IRewardCalculator Get(ITransactionProcessor processor)
+        {
+            return _calculator;
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Rewards/RewardCalculator.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Rewards/RewardCalculator.cs
@@ -63,5 +63,7 @@ namespace Nethermind.Blockchain.Rewards
         {
             return blockReward - ((uint) (blockHeader.Number - ommer.Number) * blockReward >> 3);
         }
+
+        public static IRewardCalculatorSource GetSource(ISpecProvider specProvider) => new InstanceRewardCalculatorSource(new RewardCalculator(specProvider));
     }
 }

--- a/src/Nethermind/Nethermind.Clique.Test/CliqueBlockProducerTests.cs
+++ b/src/Nethermind/Nethermind.Clique.Test/CliqueBlockProducerTests.cs
@@ -139,7 +139,7 @@ namespace Nethermind.Clique.Test
                 }
 
                 PendingTxSelector pendingTxSelector = new PendingTxSelector(txPool, stateProvider, nodeLogManager);
-                CliqueBlockProducer blockProducer = new CliqueBlockProducer(pendingTxSelector, minerProcessor, blockTree, _timestamper, new CryptoRandom(), minerStateProvider, snapshotManager, cliqueSealer, privateKey.Address, _cliqueConfig, nodeLogManager);
+                CliqueBlockProducer blockProducer = new CliqueBlockProducer(pendingTxSelector, minerProcessor, minerStateProvider, blockTree, _timestamper, new CryptoRandom(), snapshotManager, cliqueSealer, privateKey.Address, _cliqueConfig, nodeLogManager);
                 blockProducer.Start();
 
                 _producers.Add(privateKey, blockProducer);

--- a/src/Nethermind/Nethermind.Clique.Test/CliqueBlockProducerTests.cs
+++ b/src/Nethermind/Nethermind.Clique.Test/CliqueBlockProducerTests.cs
@@ -138,8 +138,8 @@ namespace Nethermind.Clique.Test
                     ProcessGenesis(privateKey);
                 }
 
-                PendingTransactionSelector pendingTransactionSelector = new PendingTransactionSelector(txPool, stateProvider, nodeLogManager);
-                CliqueBlockProducer blockProducer = new CliqueBlockProducer(pendingTransactionSelector, minerProcessor, blockTree, _timestamper, new CryptoRandom(), minerStateProvider, snapshotManager, cliqueSealer, privateKey.Address, _cliqueConfig, nodeLogManager);
+                PendingTxSelector pendingTxSelector = new PendingTxSelector(txPool, stateProvider, nodeLogManager);
+                CliqueBlockProducer blockProducer = new CliqueBlockProducer(pendingTxSelector, minerProcessor, blockTree, _timestamper, new CryptoRandom(), minerStateProvider, snapshotManager, cliqueSealer, privateKey.Address, _cliqueConfig, nodeLogManager);
                 blockProducer.Start();
 
                 _producers.Add(privateKey, blockProducer);

--- a/src/Nethermind/Nethermind.Clique.Test/CliqueBridgeTests.cs
+++ b/src/Nethermind/Nethermind.Clique.Test/CliqueBridgeTests.cs
@@ -37,7 +37,7 @@ namespace Nethermind.Clique.Test
             CliqueConfig cliqueConfig = new CliqueConfig();
             IBlockTree blockTree = Substitute.For<IBlockTree>();
             CliqueBlockProducer producer = new CliqueBlockProducer(
-                Substitute.For<IPendingTransactionSelector>(),
+                Substitute.For<IPendingTxSelector>(),
                 Substitute.For<IBlockchainProcessor>(),
                 blockTree,
                 Substitute.For<ITimestamper>(),

--- a/src/Nethermind/Nethermind.Clique.Test/CliqueBridgeTests.cs
+++ b/src/Nethermind/Nethermind.Clique.Test/CliqueBridgeTests.cs
@@ -39,15 +39,12 @@ namespace Nethermind.Clique.Test
             CliqueBlockProducer producer = new CliqueBlockProducer(
                 Substitute.For<IPendingTxSelector>(),
                 Substitute.For<IBlockchainProcessor>(),
+                Substitute.For<IStateProvider>(),
                 blockTree,
                 Substitute.For<ITimestamper>(),
                 Substitute.For<ICryptoRandom>(),
-                Substitute.For<IStateProvider>(),
                 Substitute.For<ISnapshotManager>(),
-                new CliqueSealer(new BasicWallet(TestItem.PrivateKeyA), cliqueConfig, Substitute.For<ISnapshotManager>(), TestItem.PrivateKeyA.Address, NullLogManager.Instance),
-                TestItem.AddressA,
-                cliqueConfig,
-                NullLogManager.Instance);
+                new CliqueSealer(new BasicWallet(TestItem.PrivateKeyA), cliqueConfig, Substitute.For<ISnapshotManager>(), TestItem.PrivateKeyA.Address, NullLogManager.Instance), TestItem.AddressA, cliqueConfig, NullLogManager.Instance);
             
             SnapshotManager snapshotManager = new SnapshotManager(CliqueConfig.Default, new MemDb(), Substitute.For<IBlockTree>(), NullEthereumEcdsa.Instance, LimboLogs.Instance);
             

--- a/src/Nethermind/Nethermind.Clique/CliqueBlockProducer.cs
+++ b/src/Nethermind/Nethermind.Clique/CliqueBlockProducer.cs
@@ -47,7 +47,7 @@ namespace Nethermind.Clique
         private readonly ICryptoRandom _cryptoRandom;
         private readonly WiggleRandomizer _wiggle;
 
-        private readonly IPendingTransactionSelector _pendingTransactionSelector;
+        private readonly IPendingTxSelector _pendingTxSelector;
         private readonly IBlockchainProcessor _processor;
         private readonly ISealer _sealer;
         private readonly ISnapshotManager _snapshotManager;
@@ -59,7 +59,7 @@ namespace Nethermind.Clique
         private readonly System.Timers.Timer _timer = new System.Timers.Timer();
 
         public CliqueBlockProducer(
-            IPendingTransactionSelector pendingTransactionSelector,
+            IPendingTxSelector pendingTxSelector,
             IBlockchainProcessor blockchainProcessor,
             IBlockTree blockTree,
             ITimestamper timestamper,
@@ -72,7 +72,7 @@ namespace Nethermind.Clique
             ILogManager logManager)
         {
             _logger = logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
-            _pendingTransactionSelector = pendingTransactionSelector ?? throw new ArgumentNullException(nameof(pendingTransactionSelector));
+            _pendingTxSelector = pendingTxSelector ?? throw new ArgumentNullException(nameof(pendingTxSelector));
             _processor = blockchainProcessor ?? throw new ArgumentNullException(nameof(blockchainProcessor));
             _blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
             _stateProvider = stateProvider ?? throw new ArgumentNullException(nameof(stateProvider));
@@ -380,7 +380,7 @@ namespace Nethermind.Clique
 
             _stateProvider.StateRoot = parentHeader.StateRoot;
 
-            var selectedTxs = _pendingTransactionSelector.SelectTransactions(header.GasLimit);
+            var selectedTxs = _pendingTxSelector.SelectTransactions(header.GasLimit);
             Block block = new Block(header, selectedTxs, new BlockHeader[0]);
             header.TxRoot = new TxTrie(block.Transactions).RootHash;
             block.Header.Author = _address;

--- a/src/Nethermind/Nethermind.Clique/CliqueBlockProducer.cs
+++ b/src/Nethermind/Nethermind.Clique/CliqueBlockProducer.cs
@@ -58,13 +58,12 @@ namespace Nethermind.Clique
         private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
         private readonly System.Timers.Timer _timer = new System.Timers.Timer();
 
-        public CliqueBlockProducer(
-            IPendingTxSelector pendingTxSelector,
+        public CliqueBlockProducer(IPendingTxSelector pendingTxSelector,
             IBlockchainProcessor blockchainProcessor,
+            IStateProvider stateProvider,
             IBlockTree blockTree,
             ITimestamper timestamper,
             ICryptoRandom cryptoRandom,
-            IStateProvider stateProvider,
             ISnapshotManager snapshotManager,
             ISealer cliqueSealer,
             Address address,

--- a/src/Nethermind/Nethermind.Evm/IReadOnlyTransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/IReadOnlyTransactionProcessor.cs
@@ -14,12 +14,12 @@
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
-using Nethermind.Core.Crypto;
+using System;
 
 namespace Nethermind.Evm
 {
-    public interface ITransactionProcessorFactory
+    public interface IReadOnlyTransactionProcessor : ITransactionProcessor, IDisposable
     {
-        ITransactionProcessor Create(Keccak stateRoot);
+        
     }
 }

--- a/src/Nethermind/Nethermind.Evm/IReadOnlyTransactionProcessorSource.cs
+++ b/src/Nethermind/Nethermind.Evm/IReadOnlyTransactionProcessorSource.cs
@@ -1,4 +1,4 @@
-//  Copyright (c) 2018 Demerzel Solutions Limited
+﻿//  Copyright (c) 2018 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
 // 
 //  The Nethermind library is free software: you can redistribute it and/or modify
@@ -14,23 +14,12 @@
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
-using System;
-using Nethermind.Core;
+using Nethermind.Core.Crypto;
 
-namespace Nethermind.Blockchain.Rewards
+namespace Nethermind.Evm
 {
-    public class NoBlockRewards : IRewardCalculator
-    {   
-        private NoBlockRewards()
-        {
-        }
-
-        public static NoBlockRewards Instance { get; } = new NoBlockRewards();
-        
-        public static IRewardCalculatorSource Source { get; } = new InstanceRewardCalculatorSource(Instance); 
-        
-        private static BlockReward[] _noRewards = Array.Empty<BlockReward>();
-
-        public BlockReward[] CalculateRewards(Block block) => _noRewards;
+    public interface IReadOnlyTransactionProcessorSource
+    {
+        IReadOnlyTransactionProcessor Get(Keccak stateRoot);
     }
 }

--- a/src/Nethermind/Nethermind.Evm/ITransactionProcessorFactory.cs
+++ b/src/Nethermind/Nethermind.Evm/ITransactionProcessorFactory.cs
@@ -1,0 +1,25 @@
+﻿//  Copyright (c) 2018 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+
+using Nethermind.Core.Crypto;
+
+namespace Nethermind.Evm
+{
+    public interface ITransactionProcessorFactory
+    {
+        ITransactionProcessor Create(Keccak stateRoot);
+    }
+}

--- a/src/Nethermind/Nethermind.Evm/ReadOnlyTransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/ReadOnlyTransactionProcessor.cs
@@ -1,0 +1,49 @@
+﻿//  Copyright (c) 2018 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+
+using Nethermind.Core;
+using Nethermind.Evm.Tracing;
+using Nethermind.Store;
+
+namespace Nethermind.Evm
+{
+    public class ReadOnlyTransactionProcessor : IReadOnlyTransactionProcessor
+    {
+        private readonly ITransactionProcessor _transactionProcessor;
+        private readonly IStateProvider _stateProvider;
+
+        public ReadOnlyTransactionProcessor(ITransactionProcessor transactionProcessor, IStateProvider stateProvider)
+        {
+            _transactionProcessor = transactionProcessor;
+            _stateProvider = stateProvider;
+        }
+        
+        public void Execute(Transaction transaction, BlockHeader block, ITxTracer txTracer)
+        {
+            _transactionProcessor.Execute(transaction, block, txTracer);
+        }
+
+        public void CallAndRestore(Transaction transaction, BlockHeader block, ITxTracer txTracer)
+        {
+            _transactionProcessor.CallAndRestore(transaction, block, txTracer);
+        }
+
+        public void Dispose()
+        {
+            _stateProvider.Reset();
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Evm/SingletonTransactionProcessorFactory.cs
+++ b/src/Nethermind/Nethermind.Evm/SingletonTransactionProcessorFactory.cs
@@ -1,0 +1,32 @@
+﻿//  Copyright (c) 2018 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+
+using Nethermind.Core.Crypto;
+
+namespace Nethermind.Evm
+{
+    public class SingletonTransactionProcessorFactory : ITransactionProcessorFactory
+    {
+        private readonly ITransactionProcessor _instance;
+
+        public SingletonTransactionProcessorFactory(ITransactionProcessor instance)
+        {
+            _instance = instance;
+        }
+            
+        public ITransactionProcessor Create(Keccak stateRoot) => _instance;
+    }
+}

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugModuleFactory.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugModuleFactory.cs
@@ -35,7 +35,7 @@ namespace Nethermind.JsonRpc.Modules.DebugModule
         private readonly IBlockTree _blockTree;
         private readonly IDbProvider _dbProvider;
         private readonly IBlockValidator _blockValidator;
-        private readonly IRewardCalculator _rewardCalculator;
+        private readonly IRewardCalculatorSource _rewardCalculatorSource;
         private readonly IReceiptStorage _receiptStorage;
         private readonly IConfigProvider _configProvider;
         private readonly ISpecProvider _specProvider;
@@ -48,7 +48,7 @@ namespace Nethermind.JsonRpc.Modules.DebugModule
             IBlockTree blockTree,
             IBlockValidator blockValidator,
             IBlockDataRecoveryStep recoveryStep,
-            IRewardCalculator rewardCalculator,
+            IRewardCalculatorSource rewardCalculator,
             IReceiptStorage receiptStorage,
             IConfigProvider configProvider,
             ISpecProvider specProvider,
@@ -58,7 +58,7 @@ namespace Nethermind.JsonRpc.Modules.DebugModule
             _blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
             _blockValidator = blockValidator ?? throw new ArgumentNullException(nameof(blockValidator));
             _recoveryStep = recoveryStep ?? throw new ArgumentNullException(nameof(recoveryStep));
-            _rewardCalculator = rewardCalculator ?? throw new ArgumentNullException(nameof(rewardCalculator));
+            _rewardCalculatorSource = rewardCalculator ?? throw new ArgumentNullException(nameof(rewardCalculator));
             _receiptStorage = receiptStorage ?? throw new ArgumentNullException(nameof(receiptStorage));
             _configProvider = configProvider ?? throw new ArgumentNullException(nameof(configProvider));
             _specProvider = specProvider ?? throw new ArgumentNullException(nameof(specProvider));
@@ -71,7 +71,7 @@ namespace Nethermind.JsonRpc.Modules.DebugModule
             IReadOnlyDbProvider readOnlyDbProvider = new ReadOnlyDbProvider(_dbProvider, false);
             ReadOnlyBlockTree readOnlyTree = new ReadOnlyBlockTree(_blockTree);
             ReadOnlyTxProcessingEnv txEnv = new ReadOnlyTxProcessingEnv(readOnlyDbProvider, readOnlyTree, _specProvider, _logManager);
-            ReadOnlyChainProcessingEnv readOnlyChainProcessingEnv = new ReadOnlyChainProcessingEnv(txEnv, _blockValidator, _recoveryStep, _rewardCalculator, _receiptStorage, readOnlyDbProvider, _specProvider, _logManager);
+            ReadOnlyChainProcessingEnv readOnlyChainProcessingEnv = new ReadOnlyChainProcessingEnv(txEnv, _blockValidator, _recoveryStep, _rewardCalculatorSource.Get(txEnv.TransactionProcessor), _receiptStorage, readOnlyDbProvider, _specProvider, _logManager);
             IGethStyleTracer tracer = new GethStyleTracer(readOnlyChainProcessingEnv.ChainProcessor, _receiptStorage, new ReadOnlyBlockTree(_blockTree));
 
             DebugBridge debugBridge = new DebugBridge(_configProvider, readOnlyDbProvider, tracer, readOnlyChainProcessingEnv.BlockProcessingQueue, _blockTree);

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Trace/TraceModuleFactory.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Trace/TraceModuleFactory.cs
@@ -41,7 +41,7 @@ namespace Nethermind.JsonRpc.Modules.Trace
         private readonly IDbProvider _dbProvider;
         private readonly IBlockValidator _blockValidator;
         private readonly IEthereumEcdsa _ethereumEcdsa;
-        private readonly IRewardCalculator _rewardCalculator;
+        private readonly IRewardCalculatorSource _rewardCalculatorSource;
         private readonly IReceiptStorage _receiptStorage;
         private readonly ISpecProvider _specProvider;
         private readonly IJsonRpcConfig _jsonRpcConfig;
@@ -56,7 +56,7 @@ namespace Nethermind.JsonRpc.Modules.Trace
             IBlockValidator blockValidator,
             IEthereumEcdsa ethereumEcdsa,
             IBlockDataRecoveryStep recoveryStep,
-            IRewardCalculator rewardCalculator,
+            IRewardCalculatorSource rewardCalculatorSource,
             IReceiptStorage receiptStorage,
             ISpecProvider specProvider,
             IJsonRpcConfig rpcConfig,
@@ -68,7 +68,7 @@ namespace Nethermind.JsonRpc.Modules.Trace
             _blockValidator = blockValidator ?? throw new ArgumentNullException(nameof(blockValidator));
             _ethereumEcdsa = ethereumEcdsa ?? throw new ArgumentNullException(nameof(ethereumEcdsa));
             _recoveryStep = recoveryStep ?? throw new ArgumentNullException(nameof(recoveryStep));
-            _rewardCalculator = rewardCalculator ?? throw new ArgumentNullException(nameof(rewardCalculator));
+            _rewardCalculatorSource = rewardCalculatorSource ?? throw new ArgumentNullException(nameof(rewardCalculatorSource));
             _receiptStorage = receiptStorage ?? throw new ArgumentNullException(nameof(receiptStorage));
             _specProvider = specProvider ?? throw new ArgumentNullException(nameof(specProvider));
             _jsonRpcConfig = rpcConfig ?? throw new ArgumentNullException(nameof(rpcConfig));
@@ -97,7 +97,7 @@ namespace Nethermind.JsonRpc.Modules.Trace
                 _jsonRpcConfig.FindLogBlockDepthLimit
                 );
             
-            ReadOnlyChainProcessingEnv chainEnv = new ReadOnlyChainProcessingEnv(txEnv, _blockValidator, _recoveryStep, _rewardCalculator, _receiptStorage, readOnlyDbProvider, _specProvider, _logManager);
+            ReadOnlyChainProcessingEnv chainEnv = new ReadOnlyChainProcessingEnv(txEnv, _blockValidator, _recoveryStep, _rewardCalculatorSource.Get(txEnv.TransactionProcessor), _receiptStorage, readOnlyDbProvider, _specProvider, _logManager);
             IParityStyleTracer tracer = new ParityStyleTracer(chainEnv.ChainProcessor, _receiptStorage, new ReadOnlyBlockTree(_blockTree));
             
             return new TraceModule(blockchainBridge, tracer);

--- a/src/Nethermind/Nethermind.PerfTest/Program.cs
+++ b/src/Nethermind/Nethermind.PerfTest/Program.cs
@@ -297,7 +297,7 @@ namespace Nethermind.PerfTest
             {
                 var abiEncoder = new AbiEncoder();
                 _validatorStore = new ValidatorStore(dbProvider.StateDb);
-                var validatorProcessor = new AuRaAdditionalBlockProcessorFactory(stateProvider, abiEncoder, processor, new SingletonTransactionProcessorFactory(processor), blockTree, receiptStorage, _validatorStore, _logManager)
+                var validatorProcessor = new AuRaAdditionalBlockProcessorFactory(stateProvider, abiEncoder, processor, new ReadOnlyReadOnlyTransactionProcessorSource(dbProvider, blockTree, specProvider, _logManager), blockTree, receiptStorage, _validatorStore, _logManager)
                     .CreateValidatorProcessor(chainSpec.AuRa.Validators);
                     
                 sealValidator = new AuRaSealValidator(chainSpec.AuRa, new AuRaStepCalculator(chainSpec.AuRa.StepDuration, new Timestamper()), _validatorStore, ethereumSigner, _logManager);

--- a/src/Nethermind/Nethermind.PerfTest/Program.cs
+++ b/src/Nethermind/Nethermind.PerfTest/Program.cs
@@ -297,7 +297,7 @@ namespace Nethermind.PerfTest
             {
                 var abiEncoder = new AbiEncoder();
                 _validatorStore = new ValidatorStore(dbProvider.StateDb);
-                var validatorProcessor = new AuRaAdditionalBlockProcessorFactory(stateProvider, abiEncoder, processor, blockTree, receiptStorage, _validatorStore, _logManager)
+                var validatorProcessor = new AuRaAdditionalBlockProcessorFactory(stateProvider, abiEncoder, processor, new SingletonTransactionProcessorFactory(processor), blockTree, receiptStorage, _validatorStore, _logManager)
                     .CreateValidatorProcessor(chainSpec.AuRa.Validators);
                     
                 sealValidator = new AuRaSealValidator(chainSpec.AuRa, new AuRaStepCalculator(chainSpec.AuRa.StepDuration, new Timestamper()), _validatorStore, ethereumSigner, _logManager);

--- a/src/Nethermind/Nethermind.Runner.Test/Ethereum/ContextWithMocks.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Ethereum/ContextWithMocks.cs
@@ -50,7 +50,7 @@ namespace Nethermind.Runner.Test.Ethereum
             context.BlockProcessor = Substitute.For<IBlockProcessor>();
             context.ReceiptStorage = Substitute.For<IReceiptStorage>();
             context.BlockValidator = Substitute.For<IBlockValidator>();
-            context.RewardCalculator = Substitute.For<IRewardCalculator>();
+            context.RewardCalculatorSource = Substitute.For<IRewardCalculatorSource>();
             context.RecoveryStep = Substitute.For<IBlockDataRecoveryStep>();
             context.TxPoolInfoProvider = Substitute.For<ITxPoolInfoProvider>();
             context.StaticNodesManager = Substitute.For<IStaticNodesManager>();

--- a/src/Nethermind/Nethermind.Runner/Ethereum/EthereumRunnerContext.cs
+++ b/src/Nethermind/Nethermind.Runner/Ethereum/EthereumRunnerContext.cs
@@ -99,7 +99,7 @@ namespace Nethermind.Runner.Ethereum
         public IHeaderValidator HeaderValidator;
         public IBlockDataRecoveryStep RecoveryStep;
         public IBlockProcessor BlockProcessor;
-        public IRewardCalculator RewardCalculator;
+        public IRewardCalculatorSource RewardCalculatorSource;
         public ISpecProvider SpecProvider;
         public IStateProvider StateProvider;
         public ISealer Sealer;

--- a/src/Nethermind/Nethermind.Runner/Ethereum/Steps/InitializeBlockchain.cs
+++ b/src/Nethermind/Nethermind.Runner/Ethereum/Steps/InitializeBlockchain.cs
@@ -246,7 +246,8 @@ namespace Nethermind.Runner.Ethereum.Steps
                 case SealEngineType.AuRa:
                     AbiEncoder abiEncoder = new AbiEncoder();
                     _context.ValidatorStore = new ValidatorStore(_context.DbProvider.BlockInfosDb);
-                    IAuRaValidatorProcessor validatorProcessor = new AuRaAdditionalBlockProcessorFactory(_context.StateProvider, abiEncoder, _context.TransactionProcessor, _context.BlockTree, _context.ReceiptStorage, _context.ValidatorStore, _context.LogManager)
+                    ITransactionProcessorFactory readOnlyTransactionProcessorFactory = new ReadOnlyTransactionProcessorFactory(new ReadOnlyDbProvider(_context.DbProvider, false), _context.BlockTree, _context.SpecProvider, _context.LogManager);
+                    IAuRaValidatorProcessor validatorProcessor = new AuRaAdditionalBlockProcessorFactory(_context.StateProvider, abiEncoder, _context.TransactionProcessor, readOnlyTransactionProcessorFactory, _context.BlockTree, _context.ReceiptStorage, _context.ValidatorStore, _context.LogManager)
                         .CreateValidatorProcessor(_context.ChainSpec.AuRa.Validators);
                     
                     AuRaStepCalculator auRaStepCalculator = new AuRaStepCalculator(_context.ChainSpec.AuRa.StepDuration, _context.Timestamper);    

--- a/src/Nethermind/Nethermind.Runner/Ethereum/Steps/InitializeBlockchain.cs
+++ b/src/Nethermind/Nethermind.Runner/Ethereum/Steps/InitializeBlockchain.cs
@@ -155,7 +155,7 @@ namespace Nethermind.Runner.Ethereum.Steps
             _context.BlockProcessor = new BlockProcessor(
                 _context.SpecProvider,
                 _context.BlockValidator,
-                _context.RewardCalculator,
+                _context.RewardCalculatorSource.Get(_context.TransactionProcessor),
                 _context.TransactionProcessor,
                 _context.DbProvider.StateDb,
                 _context.DbProvider.CodeDb,
@@ -204,10 +204,10 @@ namespace Nethermind.Runner.Ethereum.Steps
                 case SealEngineType.None:
                     _context.Sealer = NullSealEngine.Instance;
                     _context.SealValidator = NullSealEngine.Instance;
-                    _context.RewardCalculator = NoBlockRewards.Instance;
+                    _context.RewardCalculatorSource = NoBlockRewards.Source;
                     break;
                 case SealEngineType.Clique:
-                    _context.RewardCalculator = NoBlockRewards.Instance;
+                    _context.RewardCalculatorSource = NoBlockRewards.Source;
                     CliqueConfig cliqueConfig = new CliqueConfig();
                     cliqueConfig.BlockPeriod = _context.ChainSpec.Clique.Period;
                     cliqueConfig.Epoch = _context.ChainSpec.Clique.Epoch;
@@ -227,10 +227,10 @@ namespace Nethermind.Runner.Ethereum.Steps
                 case SealEngineType.NethDev:
                     _context.Sealer = NullSealEngine.Instance;
                     _context.SealValidator = NullSealEngine.Instance;
-                    _context.RewardCalculator = NoBlockRewards.Instance;
+                    _context.RewardCalculatorSource = NoBlockRewards.Source;
                     break;
                 case SealEngineType.Ethash:
-                    _context.RewardCalculator = new RewardCalculator(_context.SpecProvider);
+                    _context.RewardCalculatorSource = RewardCalculator.GetSource(_context.SpecProvider);
                     DifficultyCalculator difficultyCalculator = new DifficultyCalculator(_context.SpecProvider);
                     if (_context.Config<IInitConfig>().IsMining)
                     {
@@ -246,13 +246,13 @@ namespace Nethermind.Runner.Ethereum.Steps
                 case SealEngineType.AuRa:
                     AbiEncoder abiEncoder = new AbiEncoder();
                     _context.ValidatorStore = new ValidatorStore(_context.DbProvider.BlockInfosDb);
-                    ITransactionProcessorFactory readOnlyTransactionProcessorFactory = new ReadOnlyTransactionProcessorFactory(new ReadOnlyDbProvider(_context.DbProvider, false), _context.BlockTree, _context.SpecProvider, _context.LogManager);
-                    IAuRaValidatorProcessor validatorProcessor = new AuRaAdditionalBlockProcessorFactory(_context.StateProvider, abiEncoder, _context.TransactionProcessor, readOnlyTransactionProcessorFactory, _context.BlockTree, _context.ReceiptStorage, _context.ValidatorStore, _context.LogManager)
+                    IReadOnlyTransactionProcessorSource readOnlyTransactionProcessorSource = new ReadOnlyReadOnlyTransactionProcessorSource(_context.DbProvider, _context.BlockTree, _context.SpecProvider, _context.LogManager);
+                    IAuRaValidatorProcessor validatorProcessor = new AuRaAdditionalBlockProcessorFactory(_context.StateProvider, abiEncoder, _context.TransactionProcessor, readOnlyTransactionProcessorSource, _context.BlockTree, _context.ReceiptStorage, _context.ValidatorStore, _context.LogManager)
                         .CreateValidatorProcessor(_context.ChainSpec.AuRa.Validators);
                     
                     AuRaStepCalculator auRaStepCalculator = new AuRaStepCalculator(_context.ChainSpec.AuRa.StepDuration, _context.Timestamper);    
                     _context.SealValidator = new AuRaSealValidator(_context.ChainSpec.AuRa, auRaStepCalculator, _context.ValidatorStore, _context.EthereumEcdsa, _context.LogManager);
-                    _context.RewardCalculator = new AuRaRewardCalculator(_context.ChainSpec.AuRa, abiEncoder, _context.TransactionProcessor);
+                    _context.RewardCalculatorSource = AuRaRewardCalculator.GetSource(_context.ChainSpec.AuRa, abiEncoder);
                     _context.Sealer = new AuRaSealer(_context.BlockTree, _context.ValidatorStore, auRaStepCalculator, _context.NodeKey.Address, new BasicWallet(_context.NodeKey), new ValidSealerStrategy(), _context.LogManager);
                     blockProcessors.Add(validatorProcessor);
                     break;

--- a/src/Nethermind/Nethermind.Runner/Ethereum/Steps/InitializeBlockchain.cs
+++ b/src/Nethermind/Nethermind.Runner/Ethereum/Steps/InitializeBlockchain.cs
@@ -253,7 +253,7 @@ namespace Nethermind.Runner.Ethereum.Steps
                     AuRaStepCalculator auRaStepCalculator = new AuRaStepCalculator(_context.ChainSpec.AuRa.StepDuration, _context.Timestamper);    
                     _context.SealValidator = new AuRaSealValidator(_context.ChainSpec.AuRa, auRaStepCalculator, _context.ValidatorStore, _context.EthereumEcdsa, _context.LogManager);
                     _context.RewardCalculator = new AuRaRewardCalculator(_context.ChainSpec.AuRa, abiEncoder, _context.TransactionProcessor);
-                    _context.Sealer = new AuRaSealer(_context.BlockTree, validatorProcessor, _context.ValidatorStore, auRaStepCalculator, _context.NodeKey.Address, new BasicWallet(_context.NodeKey), new ValidSealerStrategy(), _context.LogManager);
+                    _context.Sealer = new AuRaSealer(_context.BlockTree, _context.ValidatorStore, auRaStepCalculator, _context.NodeKey.Address, new BasicWallet(_context.NodeKey), new ValidSealerStrategy(), _context.LogManager);
                     blockProcessors.Add(validatorProcessor);
                     break;
                 default:

--- a/src/Nethermind/Nethermind.Runner/Ethereum/Steps/RegisterRpcModules.cs
+++ b/src/Nethermind/Nethermind.Runner/Ethereum/Steps/RegisterRpcModules.cs
@@ -74,10 +74,10 @@ namespace Nethermind.Runner.Ethereum.Steps
             ProofModuleFactory proofModuleFactory = new ProofModuleFactory(_context.DbProvider, _context.BlockTree, _context.RecoveryStep, _context.ReceiptStorage, _context.SpecProvider,  _context.LogManager);
             _context.RpcModuleProvider.Register(new BoundedModulePool<IProofModule>(2, proofModuleFactory));
             
-            DebugModuleFactory debugModuleFactory = new DebugModuleFactory(_context.DbProvider, _context.BlockTree, _context.BlockValidator, _context.RecoveryStep, _context.RewardCalculator, _context.ReceiptStorage, _context.ConfigProvider, _context.SpecProvider, _context.LogManager);
+            DebugModuleFactory debugModuleFactory = new DebugModuleFactory(_context.DbProvider, _context.BlockTree, _context.BlockValidator, _context.RecoveryStep, _context.RewardCalculatorSource, _context.ReceiptStorage, _context.ConfigProvider, _context.SpecProvider, _context.LogManager);
             _context.RpcModuleProvider.Register(new BoundedModulePool<IDebugModule>(8, debugModuleFactory));
 
-            TraceModuleFactory traceModuleFactory = new TraceModuleFactory(_context.DbProvider, _context.TxPool, _context.BlockTree, _context.BlockValidator, _context.EthereumEcdsa, _context.RecoveryStep, _context.RewardCalculator, _context.ReceiptStorage, _context.SpecProvider, rpcConfig, _context.LogManager);
+            TraceModuleFactory traceModuleFactory = new TraceModuleFactory(_context.DbProvider, _context.TxPool, _context.BlockTree, _context.BlockValidator, _context.EthereumEcdsa, _context.RecoveryStep, _context.RewardCalculatorSource, _context.ReceiptStorage, _context.SpecProvider, rpcConfig, _context.LogManager);
             _context.RpcModuleProvider.Register(new BoundedModulePool<ITraceModule>(8, traceModuleFactory));
 
             if (_context.SealValidator is CliqueSealValidator)

--- a/src/Nethermind/Nethermind.State.Test.Runner/Nethermind.State.Test.Runner.csproj
+++ b/src/Nethermind/Nethermind.State.Test.Runner/Nethermind.State.Test.Runner.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
       <PackageReference Include="CommandLineParser" Version="2.6.0" />
-      <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+      <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Nethermind/Nethermind.State.Test.Runner/StateTestTxTracer.cs
+++ b/src/Nethermind/Nethermind.State.Test.Runner/StateTestTxTracer.cs
@@ -20,6 +20,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Nethermind.Core;
+using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Dirichlet.Numerics;
 using Nethermind.Evm;
@@ -42,14 +43,15 @@ namespace Nethermind.State.Test.Runner
         public bool IsTracingCode => false;
         public bool IsTracingStack { get; set; } = true;
         bool ITxTracer.IsTracingState => false;
-        
-        public void MarkAsSuccess(Address recipient, long gasSpent, byte[] output, LogEntry[] logs)
+        public bool IsTracingBlockHash { get; } = false;
+
+        public void MarkAsSuccess(Address recipient, long gasSpent, byte[] output, LogEntry[] logs, Keccak stateRoot = null)
         {
             _trace.Result.Output = output;
             _trace.Result.GasUsed = gasSpent;
         }
 
-        public void MarkAsFailed(Address recipient, long gasSpent, byte[] output, string error)
+        public void MarkAsFailed(Address recipient, long gasSpent, byte[] output, string error, Keccak stateRoot = null)
         {
             _trace.Result.Error = _traceEntry?.Error ?? error;
             _trace.Result.Output = output ?? Bytes.Empty;
@@ -201,6 +203,11 @@ namespace Nethermind.State.Test.Runner
         public void ReportActionEnd(long gas, Address deploymentAddress, byte[] deployedCode)
         {
             throw new NotSupportedException();
+        }
+
+        public void ReportBlockHash(Keccak blockHash)
+        {
+            throw new NotImplementedException();
         }
 
         public void ReportByteCode(byte[] byteCode)

--- a/src/Nethermind/Nethermind.Store.Test/StateProviderTests.cs
+++ b/src/Nethermind/Nethermind.Store.Test/StateProviderTests.cs
@@ -27,6 +27,7 @@ using Nethermind.Evm.Tracing;
 using Nethermind.Evm.Tracing.ParityStyle;
 using Nethermind.Logging;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using NUnit.Framework;
 
 namespace Nethermind.Store.Test
@@ -196,6 +197,19 @@ namespace Nethermind.Store.Test
             provider.GetBalance(_address1); // justcache
             provider.AddToBalance(_address1, 0, SpuriousDragon.Instance); // touch
             Assert.DoesNotThrow(() => provider.Commit(SpuriousDragon.Instance, tracer));
+        }
+
+        [Test]
+        public void Does_not_require_recalculation_after_reset()
+        {
+            StateProvider provider = new StateProvider(new StateDb(new MemDb()), Substitute.For<IDb>(), Logger);
+            provider.CreateAccount(TestItem.AddressA, 5);
+            
+            Action action = () => { var x = provider.StateRoot; };
+            action.Should().Throw<InvalidOperationException>();
+            
+            provider.Reset();
+            action.Should().NotThrow<InvalidOperationException>();
         }
     }
 }

--- a/src/Nethermind/Nethermind.Store/StateProvider.cs
+++ b/src/Nethermind/Nethermind.Store/StateProvider.cs
@@ -360,6 +360,7 @@ namespace Nethermind.Store
 
         public void CreateAccount(Address address, in UInt256 balance)
         {
+            _needsStateRootUpdate = true;
             if (_logger.IsTrace) _logger.Trace($"Creating account: {address} with balance {balance}");
             Account account = balance.IsZero ? Account.TotallyEmpty : new Account(balance);
             PushNew(address, account);

--- a/src/Nethermind/Nethermind.Store/StateProvider.cs
+++ b/src/Nethermind/Nethermind.Store/StateProvider.cs
@@ -722,6 +722,7 @@ namespace Nethermind.Store
             _nullReadsForTracing.Clear();
             _currentPosition = -1;
             Array.Clear(_changes, 0, _changes.Length);
+            _needsStateRootUpdate = false;
         }
 
         public void CommitTree()


### PR DESCRIPTION
1. Move GetValidators to ReadOnly states as they shouldn't change them. This is done in order not to touch state and have to recalculate StateRoot when invoking GetValidators. This is also in-line with Parity implementation.

2. Create separate AuRaRewardCalculator for producing blocks to move it to ReadOnly state. This caused state hash missmatch on POA Core (interestingly not on other networks).