### PR TITLE
proofs with system accounts

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/ProofTxTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/ProofTxTracerTests.cs
@@ -23,9 +23,17 @@ using NUnit.Framework;
 
 namespace Nethermind.Evm.Test.Tracing
 {
-    [TestFixture]
+    [TestFixture(true)]
+    [TestFixture(false)]
     public class ProofTxTracerTests : VirtualMachineTestsBase
     {
+        private readonly bool _treatSystemAccountDifferently;
+
+        public ProofTxTracerTests(bool treatSystemAccountDifferently)
+        {
+            _treatSystemAccountDifferently = treatSystemAccountDifferently;
+        }
+    
         [Test]
         public void Can_trace_sender_recipient_miner()
         {
@@ -274,7 +282,7 @@ namespace Nethermind.Evm.Test.Tracing
         protected (ProofTxTracer trace, Block block, Transaction transaction) ExecuteAndTraceProofCall(SenderRecipientAndMiner addresses, params byte[] code)
         {
             (Block block, Transaction transaction) = PrepareTx(BlockNumber, 100000, code, addresses);
-            ProofTxTracer tracer = new ProofTxTracer();
+            ProofTxTracer tracer = new ProofTxTracer(_treatSystemAccountDifferently);
             _processor.Execute(transaction, block.Header, tracer);
             return (tracer, block, transaction);
         }

--- a/src/Nethermind/Nethermind.Evm/Tracing/CallOutputTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/CallOutputTracer.cs
@@ -130,6 +130,11 @@ namespace Nethermind.Evm.Tracing
             throw new NotSupportedException();
         }
 
+        public void ReportAccountRead(Address address)
+        {
+            throw new NotSupportedException();
+        }
+
         public void ReportStorageChange(StorageCell storageCell, byte[] before, byte[] after)
         {
             throw new NotSupportedException();

--- a/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/GethLikeTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/GethLikeTxTracer.cs
@@ -171,6 +171,11 @@ namespace Nethermind.Evm.Tracing.GethStyle
             throw new NotSupportedException();
         }
 
+        public void ReportAccountRead(Address address)
+        {
+            throw new NotSupportedException();
+        }
+
         public void ReportStorageChange(StorageCell storageCell, byte[] before, byte[] after)
         {
             throw new NotSupportedException();

--- a/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/GethLikeTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/GethLikeTxTracer.cs
@@ -173,7 +173,6 @@ namespace Nethermind.Evm.Tracing.GethStyle
 
         public void ReportAccountRead(Address address)
         {
-            throw new NotSupportedException();
         }
 
         public void ReportStorageChange(StorageCell storageCell, byte[] before, byte[] after)

--- a/src/Nethermind/Nethermind.Evm/Tracing/NullTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/NullTxTracer.cs
@@ -79,6 +79,8 @@ namespace Nethermind.Evm.Tracing
         public void ReportCodeChange(Address address, byte[] before, byte[] after) => throw new InvalidOperationException(ErrorMessage);
 
         public void ReportNonceChange(Address address, UInt256? before, UInt256? after) => throw new InvalidOperationException(ErrorMessage);
+        
+        public void ReportAccountRead(Address address) => throw new InvalidOperationException(ErrorMessage);
 
         public void ReportStorageChange(StorageCell storageCell, byte[] before, byte[] after) => throw new InvalidOperationException(ErrorMessage);
 

--- a/src/Nethermind/Nethermind.Evm/Tracing/ParityStyle/ParityLikeTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/ParityStyle/ParityLikeTxTracer.cs
@@ -374,6 +374,11 @@ namespace Nethermind.Evm.Tracing.ParityStyle
             _trace.StateChanges[address].Nonce = new ParityStateChange<UInt256?>(before, after);
         }
 
+        public void ReportAccountRead(Address address)
+        {
+            throw new NotSupportedException();
+        }
+
         public void ReportStorageChange(StorageCell storageCell, byte[] before, byte[] after)
         {
             Dictionary<UInt256, ParityStateChange<byte[]>> storage = null;

--- a/src/Nethermind/Nethermind.Evm/Tracing/ParityStyle/ParityLikeTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/ParityStyle/ParityLikeTxTracer.cs
@@ -376,7 +376,6 @@ namespace Nethermind.Evm.Tracing.ParityStyle
 
         public void ReportAccountRead(Address address)
         {
-            throw new NotSupportedException();
         }
 
         public void ReportStorageChange(StorageCell storageCell, byte[] before, byte[] after)

--- a/src/Nethermind/Nethermind.Evm/Tracing/Proofs/ProofBlockTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/Proofs/ProofBlockTracer.cs
@@ -22,15 +22,17 @@ namespace Nethermind.Evm.Tracing.Proofs
 {
     public class ProofBlockTracer : BlockTracerBase<ProofTxTracer, ProofTxTracer>, IBlockTracer
     {
+        private readonly bool _treatSystemAccountDifferently;
         private ProofTxTracer _txTracer;
 
-        public ProofBlockTracer(Keccak txHash) : base(txHash)
+        public ProofBlockTracer(Keccak txHash, bool treatSystemAccountDifferently) : base(txHash)
         {
+            _treatSystemAccountDifferently = treatSystemAccountDifferently;
         }
         
         protected override ProofTxTracer OnStart(Keccak txHash)
         {
-            return _txTracer = new ProofTxTracer();
+            return _txTracer = new ProofTxTracer(_treatSystemAccountDifferently);
         }
 
         /// <summary>

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Proof/ProofModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Proof/ProofModule.cs
@@ -95,7 +95,7 @@ namespace Nethermind.JsonRpc.Modules.Proof
 
             Block block = new Block(header, new[] {transaction}, Enumerable.Empty<BlockHeader>());
 
-            ProofBlockTracer proofBlockTracer = new ProofBlockTracer(null);
+            ProofBlockTracer proofBlockTracer = new ProofBlockTracer(null, transaction.SenderAddress == Address.SystemUser);
             _tracer.Trace(block, proofBlockTracer);
 
             CallResultWithProof callResultWithProof = new CallResultWithProof();

--- a/src/Nethermind/Nethermind.Store/IStateTracer.cs
+++ b/src/Nethermind/Nethermind.Store/IStateTracer.cs
@@ -24,8 +24,6 @@ namespace Nethermind.Store
         void ReportBalanceChange(Address address, UInt256? before, UInt256? after);
         void ReportCodeChange(Address address, byte[] before, byte[] after);
         void ReportNonceChange(Address address, UInt256? before, UInt256? after);
-        void ReportAccountRead(Address address)
-        {
-        }
+        void ReportAccountRead(Address address);
     }
 }


### PR DESCRIPTION
Removes the system account from the proof list unless the system account was actually referred to in some way beyond the SENDER read.

an account will included if one of these conditions are true:
- the account is the sender and gasPrice>0
- the account code or storage is used in one of these opcodes BALANCE, CREATE, CALL, CALLCODE, DELEGATECALL, STATICCALL, EXTCODECOPY, EXTCODESIZE or EXTCODEHASH
- the accounts storage is used in an SLOAD
