### PR TITLE
Adds support for null ID to match JSON-RPC specification.

### DIFF
--- a/src/Nethermind/Nethermind.Serialization.Json/IdConverter.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/IdConverter.cs
@@ -39,7 +39,7 @@ namespace Nethermind.Serialization.Json
                     writer.WriteValue(typedValue);
                     break;
                 case null:
-                    writer.WriteValue(null);
+                    writer.WriteNull();
                     break;
                 default:
                     throw new NotSupportedException();

--- a/src/Nethermind/Nethermind.Serialization.Json/IdConverter.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/IdConverter.cs
@@ -38,6 +38,9 @@ namespace Nethermind.Serialization.Json
                 case string typedValue:
                     writer.WriteValue(typedValue);
                     break;
+                case null:
+                    writer.WriteValue(null);
+                    break;
                 default:
                     throw new NotSupportedException();
             }
@@ -51,6 +54,8 @@ namespace Nethermind.Serialization.Json
                     return reader.Value;
                 case JsonToken.String:
                     return reader.Value as string;
+                case JsonToken.Null:
+                    return null;
                 default:
                     throw new NotSupportedException($"{reader.TokenType}");
             }


### PR DESCRIPTION
There is an incredibly high probability that this won't work with only these changes, but I thought I would give it a try and help kickstart an actual fix.

https://www.jsonrpc.org/specification#request_object

Note that according to the JSON-RPC specification, `null` is an allowed value for `id`.  The server should be blindly returning whatever value the client gives, as long as it is a number, string, or null.

I actually believe there is a secondary problem here in that you are using `Integer` during the `ReadJson` process and while discouraged, doubles are supported for the `id` field.  Similarly, you are returning `BigInteger` values for the ID, but BigIntegers are not supported in JSON, only doubles are, so any situation in which you are returning a `long` or `BigInteger` (rather than an `int` or `double`) is going to be an error.  However, I haven't fixed these, because I'm not running into a problem with them in my app at the moment.  😄