### PR TITLE
refresh tasks added

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Synchronization/EthSyncPeerPoolTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Synchronization/EthSyncPeerPoolTests.cs
@@ -285,7 +285,7 @@ namespace Nethermind.Blockchain.Test.Synchronization
             var syncPeer = Substitute.For<ISyncPeer>();
             syncPeer.Node.Returns(new Node(TestItem.PublicKeyA, "127.0.0.1", 30303));
             _pool.AddPeer(syncPeer);
-            _pool.Refresh(TestItem.PublicKeyA);
+            _pool.Refresh(new PeerInfo(syncPeer), null);
             await Task.Delay(100);
 
             await syncPeer.Received(2).GetHeadBlockHeader(Arg.Any<Keccak>(), Arg.Any<CancellationToken>());

--- a/src/Nethermind/Nethermind.Blockchain.Test/Synchronization/FastSync/NodeDataDownloaderTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Synchronization/FastSync/NodeDataDownloaderTests.cs
@@ -573,7 +573,7 @@ namespace Nethermind.Blockchain.Test.Synchronization.FastSync
         {
             DbContext dbContext = new DbContext(_logger);
             BlockTree blockTree = Build.A.BlockTree().OfChainLength((int) BlockTree.BestSuggestedHeader.Number).TestObject;
-            _pool = new EthSyncPeerPool(blockTree, new NodeStatsManager(new StatsConfig(), LimboLogs.Instance), new SyncConfig {FastSync = true}, 25, LimboLogs.Instance);
+            _pool = new EthSyncPeerPool(blockTree, new NodeStatsManager(new StatsConfig(), LimboLogs.Instance), 25, LimboLogs.Instance);
             _pool.Start();
             _pool.AddPeer(syncPeer);
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/Synchronization/OldStyleFullSynchronizerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Synchronization/OldStyleFullSynchronizerTests.cs
@@ -56,7 +56,7 @@ namespace Nethermind.Blockchain.Test.Synchronization
             ITxValidator txValidator = Build.A.TransactionValidator.ThatAlwaysReturnsTrue.TestObject;
 
             var stats = new NodeStatsManager(new StatsConfig(), LimboLogs.Instance);
-            _pool = new EthSyncPeerPool(_blockTree, stats, quickConfig, 25, LimboLogs.Instance);
+            _pool = new EthSyncPeerPool(_blockTree, stats, 25, LimboLogs.Instance);
             _synchronizer = new Synchronizer(MainNetSpecProvider.Instance, _blockTree, NullReceiptStorage.Instance, blockValidator, sealValidator, _pool, quickConfig, Substitute.For<INodeDataDownloader>(), Substitute.For<INodeStatsManager>(), LimboLogs.Instance);
             _syncServer = new SyncServer(_stateDb, _codeDb, _blockTree, _receiptStorage, blockValidator, sealValidator, _pool, _synchronizer, quickConfig, LimboLogs.Instance);
         }

--- a/src/Nethermind/Nethermind.Blockchain.Test/Synchronization/SyncThreadTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Synchronization/SyncThreadTests.cs
@@ -283,7 +283,7 @@ namespace Nethermind.Blockchain.Test.Synchronization
             var processor = new BlockchainProcessor(tree, blockProcessor, step, logManager, true);
 
             var nodeStatsManager = new NodeStatsManager(new StatsConfig(), logManager);
-            var syncPeerPool = new EthSyncPeerPool(tree, nodeStatsManager, syncConfig, 25, logManager);
+            var syncPeerPool = new EthSyncPeerPool(tree, nodeStatsManager, 25, logManager);
 
             StateProvider devState = new StateProvider(stateDb, codeDb, logManager);
             StorageProvider devStorage = new StorageProvider(stateDb, devState, logManager);

--- a/src/Nethermind/Nethermind.Blockchain.Test/Synchronization/SynchronizerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Synchronization/SynchronizerTests.cs
@@ -277,8 +277,8 @@ namespace Nethermind.Blockchain.Test.Synchronization
 
             private IEthSyncPeerPool SyncPeerPool { get; set; }
 
-            ILogManager _logManager = LimboLogs.Instance;
-//            ILogManager _logManager = new OneLoggerLogManager(new ConsoleAsyncLogger(LogLevel.Debug));
+//            ILogManager _logManager = LimboLogs.Instance;
+            ILogManager _logManager = new OneLoggerLogManager(new ConsoleAsyncLogger(LogLevel.Debug));
 
             private ILogger _logger;
 
@@ -292,7 +292,7 @@ namespace Nethermind.Blockchain.Test.Synchronization
                 MemDb blockInfoDb = new MemDb();
                 BlockTree = new BlockTree(new MemDb(), new MemDb(), blockInfoDb, new ChainLevelInfoRepository(blockInfoDb), new SingleReleaseSpecProvider(Constantinople.Instance, 1), NullTxPool.Instance, _logManager);
                 NodeStatsManager stats = new NodeStatsManager(new StatsConfig(), _logManager);
-                SyncPeerPool = new EthSyncPeerPool(BlockTree, stats, syncConfig, 25, _logManager);
+                SyncPeerPool = new EthSyncPeerPool(BlockTree, stats, 25, _logManager);
 
                 NodeDataFeed feed = new NodeDataFeed(codeDb, stateDb, _logManager);
 

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/FastBlocks/FastBlocksDownloader.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/FastBlocks/FastBlocksDownloader.cs
@@ -230,7 +230,7 @@ namespace Nethermind.Blockchain.Synchronization.FastBlocks
                 FastBlocksBatch request = PrepareRequest();
                 if (request != null)
                 {
-                    request.Allocation = await _syncPeerPool.BorrowAsync(BorrowOptions.DoNotReplace | (request.Prioritized ? BorrowOptions.None : BorrowOptions.LowPriority), "fast blocks", request.MinNumber, 1000);
+                    request.Allocation = await _syncPeerPool.BorrowAsync(PeerSelectionOptions.DoNotReplace | (request.Prioritized ? PeerSelectionOptions.None : PeerSelectionOptions.LowPriority), "fast blocks", request.MinNumber, 1000);
                     
                     Interlocked.Increment(ref _pendingRequests);
                     Task task = ExecuteRequest(token, request);

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/FastSync/NodeDataDownloader.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/FastSync/NodeDataDownloader.cs
@@ -130,7 +130,7 @@ namespace Nethermind.Blockchain.Synchronization.FastSync
             StateSyncBatch request = PrepareRequest(forAdditionalConsumers);
             if (request.RequestedNodes.Length != 0)
             {
-                request.AssignedPeer = await _syncPeerPool.BorrowAsync(BorrowOptions.DoNotReplace, "node sync", null, 1000);
+                request.AssignedPeer = await _syncPeerPool.BorrowAsync(PeerSelectionOptions.DoNotReplace, "node sync", null, 1000);
 
                 Interlocked.Increment(ref _pendingRequests);
                 // if (_logger.IsWarn) _logger.Warn($"Creating new request with {request.RequestedNodes.Length} nodes");

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/IEthSyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/IEthSyncPeerPool.cs
@@ -49,7 +49,7 @@ namespace Nethermind.Blockchain.Synchronization
         
         int PeerMaxCount { get; }
         
-        void Refresh(PublicKey nodeId);
+        void Refresh(PeerInfo peerInfo, Keccak hash);
         
         void RemovePeer(ISyncPeer syncPeer);
         

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/IEthSyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/IEthSyncPeerPool.cs
@@ -25,7 +25,7 @@ namespace Nethermind.Blockchain.Synchronization
     {
         bool TryFind(PublicKey nodeId, out PeerInfo peerInfo);
         
-        Task<SyncPeerAllocation> BorrowAsync(BorrowOptions borrowOptions = BorrowOptions.None, string description = "", long? minNumber = null, int timeoutMilliseconds = 0);
+        Task<SyncPeerAllocation> BorrowAsync(PeerSelectionOptions peerSelectionOptions = PeerSelectionOptions.None, string description = "", long? minNumber = null, int timeoutMilliseconds = 0);
         
         void Free(SyncPeerAllocation syncPeerAllocation);
         
@@ -58,8 +58,6 @@ namespace Nethermind.Blockchain.Synchronization
         void Start();
         
         Task StopAsync();
-        
-        void EnsureBest();
         
         void ReportBadPeer(SyncPeerAllocation batchAssignedPeer);
         

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/PeerSelectionOptions.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/PeerSelectionOptions.cs
@@ -19,10 +19,24 @@ using System;
 namespace Nethermind.Blockchain.Synchronization
 {
     [Flags]
-    public enum BorrowOptions
+    public enum PeerSelectionOptions
     {
         None = 0,
-        DoNotReplace = 1,
-        LowPriority = 2
+        
+        /// <summary>
+        /// Try to allocate a peer with high latency / low quality first
+        /// </summary>
+        LowPriority = 1,
+        
+        /// <summary>
+        /// Require only peers with higher total difficulty to be allocated
+        /// </summary>
+        HigherTotalDiff = 2,
+        
+        /// <summary>
+        /// Do not try to upgrade this peer allocation before it is freed or cancelled.
+        /// </summary>
+        DoNotReplace = 4,
+        All = 7,
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/PeerSelectionOptionsExtensions.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/PeerSelectionOptionsExtensions.cs
@@ -1,0 +1,36 @@
+//  Copyright (c) 2018 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+
+namespace Nethermind.Blockchain.Synchronization
+{
+    public static class PeerSelectionOptionsExtensions
+    {
+        public static bool IsLowPriority(this PeerSelectionOptions options)
+        {
+            return (options & PeerSelectionOptions.LowPriority) == PeerSelectionOptions.LowPriority;
+        }
+        
+        public static bool RequiresHigherDifficulty(this PeerSelectionOptions options)
+        {
+            return (options & PeerSelectionOptions.HigherTotalDiff) == PeerSelectionOptions.HigherTotalDiff;
+        }
+        
+        public static bool ShouldNotBeReplaced(this PeerSelectionOptions options)
+        {
+            return (options & PeerSelectionOptions.DoNotReplace) == PeerSelectionOptions.DoNotReplace;
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncPeerAllocation.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncPeerAllocation.cs
@@ -118,20 +118,5 @@ namespace Nethermind.Blockchain.Synchronization
         {
             return string.Concat("[Allocation|", Description, "]");
         }
-
-        public void FinishSync()
-        {
-            PeerInfo current = Current;
-            if (current == null)
-            {
-                return;
-            }
-            
-            lock (_allocationLock)
-            {
-                current.IsAllocated = false;
-                Current = null;
-            }
-        }
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncServer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncServer.cs
@@ -178,9 +178,12 @@ namespace Nethermind.Blockchain.Synchronization
                         result = _blockTree.SuggestBlock(block, true);
                         if (_logger.IsTrace) _logger.Trace($"{block.Hash} ({block.Number}) adding result is {result}");
                     }
-
                     
-                    if (result == AddBlockResult.UnknownParent) _synchronizer.RequestSynchronization(SyncTriggerType.Reorganization);
+                    if (result == AddBlockResult.UnknownParent)
+                    {
+                        _pool.Refresh(peerInfo, block.ParentHash);
+                        _synchronizer.RequestSynchronization(SyncTriggerType.Reorganization);
+                    }
                 }
             }
             else
@@ -213,7 +216,7 @@ namespace Nethermind.Blockchain.Synchronization
                     /* do not add as this is a hint only */
                 }
 
-                _pool.Refresh(node.Id);
+                _pool.Refresh(peerInfo, null);
             }
         }
 

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/Synchronizer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/Synchronizer.cs
@@ -258,7 +258,6 @@ namespace Nethermind.Blockchain.Synchronization
                 if (_blocksSyncAllocation != null)
                 {
                     UInt256 ourTotalDifficulty = _blockTree.BestSuggestedHeader?.TotalDifficulty ?? 0;
-                    _syncPeerPool.EnsureBest();
                     bestPeer = _blocksSyncAllocation?.Current;
                     if (bestPeer == null || bestPeer.TotalDifficulty <= ourTotalDifficulty)
                     {
@@ -401,7 +400,7 @@ namespace Nethermind.Blockchain.Synchronization
             if (_blocksSyncAllocation == null)
             {
                 if (_logger.IsDebug) _logger.Debug("Allocating block sync.");
-                _blocksSyncAllocation = await _syncPeerPool.BorrowAsync(BorrowOptions.None, "synchronizer");
+                _blocksSyncAllocation = await _syncPeerPool.BorrowAsync(PeerSelectionOptions.HigherTotalDiff, "synchronizer");
                 _blocksSyncAllocation.Replaced += AllocationOnReplaced;
                 _blocksSyncAllocation.Cancelled += AllocationOnCancelled;
                 _blocksSyncAllocation.Refreshed += AllocationOnRefreshed;

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/Synchronizer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/Synchronizer.cs
@@ -249,10 +249,6 @@ namespace Nethermind.Blockchain.Synchronization
                         }
                     }
                 }
-                else
-                {
-                    FreeBlocksSyncAllocation();
-                }
 
                 PeerInfo bestPeer = null;
                 if (_blocksSyncAllocation != null)
@@ -336,7 +332,7 @@ namespace Nethermind.Blockchain.Synchronization
                         }
                     }
 
-                    _blocksSyncAllocation?.FinishSync();
+                    FreeBlocksSyncAllocation();
                 }
 
                 var source = _peerSyncCancellation;

--- a/src/Nethermind/Nethermind.Runner/Ethereum/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Runner/Ethereum/Steps/InitializeNetwork.cs
@@ -76,7 +76,7 @@ namespace Nethermind.Runner.Ethereum.Steps
             }
 
             int maxPeersCount = _context.NetworkConfig.ActivePeersMaxCount;
-            _context.SyncPeerPool = new EthSyncPeerPool(_context.BlockTree, _context.NodeStatsManager, _context.Config<ISyncConfig>(), maxPeersCount, _context.LogManager);
+            _context.SyncPeerPool = new EthSyncPeerPool(_context.BlockTree, _context.NodeStatsManager, maxPeersCount, _context.LogManager);
             NodeDataFeed feed = new NodeDataFeed(_context.DbProvider.CodeDb, _context.DbProvider.StateDb, _context.LogManager);
             NodeDataDownloader nodeDataDownloader = new NodeDataDownloader(_context.SyncPeerPool, feed, _context.NodeDataConsumer, _context.LogManager);
             _context.Synchronizer = new Synchronizer(_context.SpecProvider, _context.BlockTree, _context.ReceiptStorage, _context.BlockValidator, _context.SealValidator, _context.SyncPeerPool, _context.Config<ISyncConfig>(), nodeDataDownloader, _context.NodeStatsManager, _context.LogManager);


### PR DESCRIPTION
Changes the concept of peer refresh to a broader idea of refresh task - short sync tasks that are executed in a queue outside of a syn peer allocation pool.The queue already existed but was not reacting to hint block and may have lead to delayed execution of reorgs.

Removes the sticky synchronize blocks allocation that was using a different 'free' approach - finish sync. Simplified it by always freeing it the same way as any non-replacable allocation is.

Passes the BorrowOptions further down and renames to PeerSelectionOptions.

Removes non-obvious EnsureBest invocations as the Best peer should be always assigned when borrow is called.

