### PR TITLE
threadlocal ripemd

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/RipemdTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/RipemdTests.cs
@@ -31,12 +31,5 @@ namespace Nethermind.Core.Test
             string result = Ripemd.ComputeString(new byte[] { });
             Assert.AreEqual(RipemdOfEmptyString, result);
         }
-
-        [Test]
-        public void Empty_string()
-        {
-            string result = Ripemd.ComputeString(string.Empty);
-            Assert.AreEqual(RipemdOfEmptyString, result);
-        }
     }
 }

--- a/src/Nethermind/Nethermind.Evm/Precompiles/Ripemd160PrecompiledContract.cs
+++ b/src/Nethermind/Nethermind.Evm/Precompiles/Ripemd160PrecompiledContract.cs
@@ -14,13 +14,10 @@
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
-using System.Numerics;
 using Nethermind.Core;
-using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Crypto;
-using Nethermind.Specs;
 
 namespace Nethermind.Evm.Precompiles
 {


### PR DESCRIPTION
Important in two cases:
1) it actually sometimes fails during the ethereum tests
2) unlikely scenario of this being executed at the same time in JSON RPC and block processor (which means it will happen)