### PR TITLE
Additional fixes for bloom migration and searching logs

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Find/LogFinderTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Find/LogFinderTests.cs
@@ -28,6 +28,7 @@ using Nethermind.Core;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
+using Nethermind.Logging;
 using Nethermind.Store;
 using Nethermind.Store.Bloom;
 using NSubstitute;
@@ -52,7 +53,7 @@ namespace Nethermind.Blockchain.Test.Find
             _blockTree = Build.A.BlockTree().WithTransactions(_receiptStorage, specProvider, LogsForBlockBuilder).OfChainLength(5).TestObject;
             _bloomStorage = new BloomStorage(new BloomConfig(), new MemDb(), new InMemoryDictionaryFileStoreFactory());
             _receiptsRecovery = Substitute.For<IReceiptsRecovery>();
-            _logFinder = new LogFinder(_blockTree, _receiptStorage, _bloomStorage, _receiptsRecovery);
+            _logFinder = new LogFinder(_blockTree, _receiptStorage, _bloomStorage, _receiptsRecovery, NullLogManager.Instance);
         }
 
         private IEnumerable<LogEntry> LogsForBlockBuilder(Block block, Transaction transaction)
@@ -106,7 +107,7 @@ namespace Nethermind.Blockchain.Test.Find
         {
             StoreTreeBlooms(withBloomDb);
             _receiptStorage = NullReceiptStorage.Instance;
-            _logFinder = new LogFinder(_blockTree, _receiptStorage, _bloomStorage, _receiptsRecovery);
+            _logFinder = new LogFinder(_blockTree, _receiptStorage, _bloomStorage, _receiptsRecovery, NullLogManager.Instance);
             
             var logFilter = AllBlockFilter().Build();
             var logs = _logFinder.FindLogs(logFilter);
@@ -118,7 +119,7 @@ namespace Nethermind.Blockchain.Test.Find
         {
             StoreTreeBlooms(withBloomDb);
             var blockFinder = Substitute.For<IBlockFinder>();
-            _logFinder = new LogFinder(blockFinder, _receiptStorage, _bloomStorage, _receiptsRecovery);
+            _logFinder = new LogFinder(blockFinder, _receiptStorage, _bloomStorage, _receiptsRecovery, NullLogManager.Instance);
             var logFilter = AllBlockFilter().Build();
             var action = new Func<IEnumerable<FilterLog>>(() =>_logFinder.FindLogs(logFilter));
             action.Should().Throw<ArgumentException>();
@@ -220,7 +221,7 @@ namespace Nethermind.Blockchain.Test.Find
         public void filter_by_blocks_with_limit([ValueSource(nameof(WithBloomValues))]bool withBloomDb)
         {
             StoreTreeBlooms(withBloomDb);
-            _logFinder = new LogFinder(_blockTree,  _receiptStorage, _bloomStorage, _receiptsRecovery, 2);
+            _logFinder = new LogFinder(_blockTree,  _receiptStorage, _bloomStorage, _receiptsRecovery, NullLogManager.Instance, 2);
             var filter = FilterBuilder.New().FromLatestBlock().ToLatestBlock().Build();
             var logs = _logFinder.FindLogs(filter).ToArray();
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/Find/LogFinderTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Find/LogFinderTests.cs
@@ -53,7 +53,7 @@ namespace Nethermind.Blockchain.Test.Find
             _blockTree = Build.A.BlockTree().WithTransactions(_receiptStorage, specProvider, LogsForBlockBuilder).OfChainLength(5).TestObject;
             _bloomStorage = new BloomStorage(new BloomConfig(), new MemDb(), new InMemoryDictionaryFileStoreFactory());
             _receiptsRecovery = Substitute.For<IReceiptsRecovery>();
-            _logFinder = new LogFinder(_blockTree, _receiptStorage, _bloomStorage, _receiptsRecovery, NullLogManager.Instance);
+            _logFinder = new LogFinder(_blockTree, _receiptStorage, _bloomStorage, _receiptsRecovery, LimboLogs.Instance);
         }
 
         private IEnumerable<LogEntry> LogsForBlockBuilder(Block block, Transaction transaction)
@@ -107,7 +107,7 @@ namespace Nethermind.Blockchain.Test.Find
         {
             StoreTreeBlooms(withBloomDb);
             _receiptStorage = NullReceiptStorage.Instance;
-            _logFinder = new LogFinder(_blockTree, _receiptStorage, _bloomStorage, _receiptsRecovery, NullLogManager.Instance);
+            _logFinder = new LogFinder(_blockTree, _receiptStorage, _bloomStorage, _receiptsRecovery, LimboLogs.Instance);
             
             var logFilter = AllBlockFilter().Build();
             var logs = _logFinder.FindLogs(logFilter);
@@ -119,7 +119,7 @@ namespace Nethermind.Blockchain.Test.Find
         {
             StoreTreeBlooms(withBloomDb);
             var blockFinder = Substitute.For<IBlockFinder>();
-            _logFinder = new LogFinder(blockFinder, _receiptStorage, _bloomStorage, _receiptsRecovery, NullLogManager.Instance);
+            _logFinder = new LogFinder(blockFinder, _receiptStorage, _bloomStorage, _receiptsRecovery, LimboLogs.Instance);
             var logFilter = AllBlockFilter().Build();
             var action = new Func<IEnumerable<FilterLog>>(() =>_logFinder.FindLogs(logFilter));
             action.Should().Throw<ArgumentException>();
@@ -221,7 +221,7 @@ namespace Nethermind.Blockchain.Test.Find
         public void filter_by_blocks_with_limit([ValueSource(nameof(WithBloomValues))]bool withBloomDb)
         {
             StoreTreeBlooms(withBloomDb);
-            _logFinder = new LogFinder(_blockTree,  _receiptStorage, _bloomStorage, _receiptsRecovery, NullLogManager.Instance, 2);
+            _logFinder = new LogFinder(_blockTree,  _receiptStorage, _bloomStorage, _receiptsRecovery, LimboLogs.Instance, 2);
             var filter = FilterBuilder.New().FromLatestBlock().ToLatestBlock().Build();
             var logs = _logFinder.FindLogs(filter).ToArray();
 

--- a/src/Nethermind/Nethermind.DataMarketplace.Consumers.Test/Services/Deposits/BlockchainBridgeBuilder.cs
+++ b/src/Nethermind/Nethermind.DataMarketplace.Consumers.Test/Services/Deposits/BlockchainBridgeBuilder.cs
@@ -53,7 +53,7 @@ namespace Nethermind.DataMarketplace.Consumers.Test.Services.Deposits
             VirtualMachine virtualMachine = new VirtualMachine(stateProvider, storageProvider, new BlockhashProvider(blockTree, LimboLogs.Instance), MainNetSpecProvider.Instance, LimboLogs.Instance);
             TransactionProcessor processor = new TransactionProcessor(MainNetSpecProvider.Instance, stateProvider, storageProvider, virtualMachine, LimboLogs.Instance);
 
-            BlockchainBridge blockchainBridge = new BlockchainBridge(stateReader, stateProvider, storageProvider, blockTree, txPool, new InMemoryReceiptStorage(), NullFilterStore.Instance, NullFilterManager.Instance, wallet, processor, ecdsa, NullBloomStorage.Instance, new ReceiptsRecovery(), NullLogManager.Instance);
+            BlockchainBridge blockchainBridge = new BlockchainBridge(stateReader, stateProvider, storageProvider, blockTree, txPool, new InMemoryReceiptStorage(), NullFilterStore.Instance, NullFilterManager.Instance, wallet, processor, ecdsa, NullBloomStorage.Instance, new ReceiptsRecovery(), LimboLogs.Instance);
             return new NdmBlockchainBridge(blockchainBridge, txPool);
         }
     }

--- a/src/Nethermind/Nethermind.DataMarketplace.Consumers.Test/Services/Deposits/BlockchainBridgeBuilder.cs
+++ b/src/Nethermind/Nethermind.DataMarketplace.Consumers.Test/Services/Deposits/BlockchainBridgeBuilder.cs
@@ -53,7 +53,7 @@ namespace Nethermind.DataMarketplace.Consumers.Test.Services.Deposits
             VirtualMachine virtualMachine = new VirtualMachine(stateProvider, storageProvider, new BlockhashProvider(blockTree, LimboLogs.Instance), MainNetSpecProvider.Instance, LimboLogs.Instance);
             TransactionProcessor processor = new TransactionProcessor(MainNetSpecProvider.Instance, stateProvider, storageProvider, virtualMachine, LimboLogs.Instance);
 
-            BlockchainBridge blockchainBridge = new BlockchainBridge(stateReader, stateProvider, storageProvider, blockTree, txPool, new InMemoryReceiptStorage(), NullFilterStore.Instance, NullFilterManager.Instance, wallet, processor, ecdsa, NullBloomStorage.Instance, new ReceiptsRecovery());
+            BlockchainBridge blockchainBridge = new BlockchainBridge(stateReader, stateProvider, storageProvider, blockTree, txPool, new InMemoryReceiptStorage(), NullFilterStore.Instance, NullFilterManager.Instance, wallet, processor, ecdsa, NullBloomStorage.Instance, new ReceiptsRecovery(), NullLogManager.Instance);
             return new NdmBlockchainBridge(blockchainBridge, txPool);
         }
     }

--- a/src/Nethermind/Nethermind.DataMarketplace.Infrastructure/Modules/NdmModule.cs
+++ b/src/Nethermind/Nethermind.DataMarketplace.Infrastructure/Modules/NdmModule.cs
@@ -66,6 +66,7 @@ namespace Nethermind.DataMarketplace.Infrastructure.Modules
                 services.Ecdsa,
                 services.BloomStorage,
                 new ReceiptsRecovery(),
+                logManager,
                 jsonRpcConfig.FindLogBlockDepthLimit);
             var dataAssetRlpDecoder = new DataAssetDecoder();
             var encoder = new AbiEncoder();

--- a/src/Nethermind/Nethermind.Facade.Test/BlockChainBridgeTests.cs
+++ b/src/Nethermind/Nethermind.Facade.Test/BlockChainBridgeTests.cs
@@ -25,6 +25,7 @@ using Nethermind.Crypto;
 using Nethermind.Dirichlet.Numerics;
 using Nethermind.Evm;
 using Nethermind.Evm.Tracing;
+using Nethermind.Logging;
 using Nethermind.State;
 using Nethermind.Store;
 using Nethermind.Store.Bloom;
@@ -81,7 +82,8 @@ namespace Nethermind.Facade.Test
                 _transactionProcessor,
                 _ethereumEcdsa,
                 _bloomStorage,
-                _receiptsRecovery);
+                _receiptsRecovery,
+                NullLogManager.Instance);
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Facade.Test/BlockChainBridgeTests.cs
+++ b/src/Nethermind/Nethermind.Facade.Test/BlockChainBridgeTests.cs
@@ -83,7 +83,7 @@ namespace Nethermind.Facade.Test
                 _ethereumEcdsa,
                 _bloomStorage,
                 _receiptsRecovery,
-                NullLogManager.Instance);
+                LimboLogs.Instance);
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
@@ -29,6 +29,7 @@ using Nethermind.Crypto;
 using Nethermind.Dirichlet.Numerics;
 using Nethermind.Evm;
 using Nethermind.Evm.Tracing;
+using Nethermind.Logging;
 using Nethermind.State;
 using Nethermind.Store;
 using Nethermind.Store.Bloom;
@@ -70,6 +71,7 @@ namespace Nethermind.Facade
             IEthereumEcdsa ecdsa,
             IBloomStorage bloomStorage, 
             IReceiptsRecovery receiptsRecovery,
+            ILogManager logManager,
             int findLogBlockDepthLimit = 1000)
         {
             _stateReader = stateReader ?? throw new ArgumentNullException(nameof(stateReader));
@@ -83,7 +85,7 @@ namespace Nethermind.Facade
             _wallet = wallet ?? throw new ArgumentException(nameof(wallet));
             _transactionProcessor = transactionProcessor ?? throw new ArgumentException(nameof(transactionProcessor));
             _ecdsa = ecdsa ?? throw new ArgumentNullException(nameof(ecdsa));
-            _logFinder = new LogFinder(_blockTree, _receiptStorage, bloomStorage, receiptsRecovery, findLogBlockDepthLimit);
+            _logFinder = new LogFinder(_blockTree, _receiptStorage, bloomStorage, receiptsRecovery, logManager, findLogBlockDepthLimit);
         }
 
         public IReadOnlyCollection<Address> GetWalletAccounts()

--- a/src/Nethermind/Nethermind.JsonRpc.Benchmark/EthModuleBenchmarks.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Benchmark/EthModuleBenchmarks.cs
@@ -107,7 +107,8 @@ namespace Nethermind.JsonRpc.Benchmark
                 transactionProcessor, 
                 new EthereumEcdsa(MainNetSpecProvider.Instance, LimboLogs.Instance),
                 bloomStorage, 
-                new ReceiptsRecovery());
+                new ReceiptsRecovery(),
+                LimboLogs.Instance);
             
             _ethModule = new EthModule(new JsonRpcConfig(), LimboLogs.Instance, bridge);
         }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/EthModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/EthModuleTests.cs
@@ -101,7 +101,7 @@ namespace Nethermind.JsonRpc.Test.Modules
 
             IFilterStore filterStore = new FilterStore();
             IFilterManager filterManager = new FilterManager(filterStore, blockProcessor, txPool, LimboLogs.Instance);
-            _blockchainBridge = new BlockchainBridge(stateReader, stateProvider, storageProvider, blockTree, txPool, receiptStorage, filterStore, filterManager, NullWallet.Instance, txProcessor, ethereumEcdsa, NullBloomStorage.Instance, new ReceiptsRecovery());
+            _blockchainBridge = new BlockchainBridge(stateReader, stateProvider, storageProvider, blockTree, txPool, receiptStorage, filterStore, filterManager, NullWallet.Instance, txProcessor, ethereumEcdsa, NullBloomStorage.Instance, new ReceiptsRecovery(), LimboLogs.Instance);
 
             BlockchainProcessor blockchainProcessor = new BlockchainProcessor(blockTree, blockProcessor, new TxSignaturesRecoveryStep(ethereumEcdsa, txPool, LimboLogs.Instance), LimboLogs.Instance, true);
             blockchainProcessor.Start();

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthModuleFactory.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthModuleFactory.cs
@@ -95,6 +95,7 @@ namespace Nethermind.JsonRpc.Modules.Eth
                 _ethereumEcdsa,
                 _bloomStorage,
                 new ReceiptsRecovery(),
+                _logManager,
                 _rpcConfig.FindLogBlockDepthLimit);
             
             return new EthModule(_rpcConfig, _logManager, blockchainBridge);

--- a/src/Nethermind/Nethermind.Runner.Test/EthereumRunnerTest.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/EthereumRunnerTest.cs
@@ -20,6 +20,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using log4net.Core;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Config;
 using Nethermind.DataMarketplace.Channels;
@@ -130,17 +131,21 @@ namespace Nethermind.Runner.Test
             Console.WriteLine(type7.Name);
             Console.WriteLine(type8.Name);
             Console.WriteLine(type9.Name);
+
+            // To eliminate file locks on index files.
+            configProvider.GetConfig<IBloomConfig>().Index = false;
             
             EthereumRunner runner = new EthereumRunner(
                 new RpcModuleProvider(new JsonRpcConfig(), LimboLogs.Instance),
                 configProvider,
-                LimboLogs.Instance, 
+                NUnitLogManager.Instance, 
                 Substitute.For<IGrpcServer>(),
                 Substitute.For<INdmConsumerChannelManager>(),
                 Substitute.For<INdmDataPublisher>(),
                 Substitute.For<INdmInitializer>(),
                 Substitute.For<IWebSocketsManager>(),
-                new EthereumJsonSerializer(), Substitute.For<IMonitoringService>());
+                new EthereumJsonSerializer(), 
+                Substitute.For<IMonitoringService>());
 
             await runner.Start();
             await runner.StopAsync();

--- a/src/Nethermind/Nethermind.Runner.Test/NUnitLogManager.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/NUnitLogManager.cs
@@ -1,0 +1,110 @@
+﻿//  Copyright (c) 2018 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using Nethermind.Logging;
+using NUnit.Framework;
+
+namespace Nethermind.Runner.Test
+{
+    public class NUnitLogManager : ILogManager
+    {
+        public static readonly NUnitLogManager Instance = new NUnitLogManager();
+        
+        private readonly LogLevel _level;
+        
+        public NUnitLogManager(LogLevel level = LogLevel.Info)
+        {
+            _level = level;
+        }
+
+        public ILogger GetClassLogger(Type type) => GetClassLogger();
+
+        public ILogger GetClassLogger<T>() => GetClassLogger();
+
+        public ILogger GetClassLogger() => new NUnitLogger(_level);
+
+        public ILogger GetLogger(string loggerName) => GetClassLogger();
+
+        public class NUnitLogger : ILogger
+        {
+            private readonly LogLevel _level;
+
+            public NUnitLogger(LogLevel level)
+            {
+                _level = level;
+            }
+
+            public void Info(string text)
+            {
+                if (IsInfo)
+                {
+                    Log(text);
+                }
+            }
+
+            public void Warn(string text)
+            {
+                if (IsWarn)
+                {
+                    Log(text);
+                }
+            }
+
+            public void Debug(string text)
+            {
+                if (IsDebug)
+                {
+                    Log(text);
+                }
+            }
+
+            public void Trace(string text)
+            {
+                if (IsTrace)
+                {
+                    Log(text);
+                }
+            }
+
+            public void Error(string text, Exception ex = null)
+            {
+                if (IsError)
+                {
+                    Log(text, ex);
+                }
+            }
+
+            public bool IsInfo => CheckLevel(LogLevel.Info);
+            public bool IsWarn => CheckLevel(LogLevel.Warn);
+            public bool IsDebug => CheckLevel(LogLevel.Debug);
+            public bool IsTrace => CheckLevel(LogLevel.Trace);
+            public bool IsError => CheckLevel(LogLevel.Error);
+                
+            private bool CheckLevel(LogLevel logLevel) => _level >= logLevel;
+                
+            private static void Log(string text, Exception ex = null)
+            {
+                TestContext.Out.WriteLine(text);
+                    
+                if (ex != null)
+                {
+                    TestContext.Out.WriteLine(ex.ToString());
+                }
+            }
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Runner/Ethereum/Steps/DatabaseMigrations.cs
+++ b/src/Nethermind/Nethermind.Runner/Ethereum/Steps/DatabaseMigrations.cs
@@ -47,7 +47,7 @@ namespace Nethermind.Runner.Ethereum.Steps
         private Task? _bloomDbMigrationTask;
         private Average[]? _averages;
         private readonly StringBuilder _builder = new StringBuilder();
-        private IBloomConfig _bloomConfig;
+        private readonly IBloomConfig _bloomConfig;
 
         public DatabaseMigrations(EthereumRunnerContext context)
         {
@@ -152,6 +152,12 @@ namespace Nethermind.Runner.Ethereum.Steps
 
         private void RunBloomMigration(CancellationToken token)
         {
+            BlockHeader GetMissingBLockHeader(long i)
+            {
+                if (_logger.IsWarn) _logger.Warn(GetLogMessage("warning", $"Header for block {i} not found. Database might be corrupted and BloomDb will not be correct."));
+                return new BlockHeader(Keccak.Zero, Keccak.Zero, Address.Zero, UInt256.Zero, 0L, 0L, UInt256.Zero, Bytes.Empty);
+            }
+
             if (_context.BloomStorage == null) throw new StepDependencyException(nameof(_context.BloomStorage));
             if (_context.BlockTree == null) throw new StepDependencyException(nameof(_context.BlockTree));
             
@@ -162,6 +168,7 @@ namespace Nethermind.Runner.Ethereum.Steps
             long from = synced;
             _migrateCount = to + 1;
             _averages = _context.BloomStorage.Averages.ToArray();
+            var chainLevelInfoRepository = _context.ChainLevelInfoRepository;
 
             _progress.Update(synced);
 
@@ -195,11 +202,27 @@ namespace Nethermind.Runner.Ethereum.Steps
                             yield break;
                         }
 
-                        var header = blockTree.FindHeader(i);
-                        yield return header ?? new BlockHeader(Keccak.Zero, Keccak.Zero, Address.Zero, UInt256.Zero, 0L, 0L, UInt256.Zero, Bytes.Empty);
+                        var level = chainLevelInfoRepository.LoadLevel(i);
+                        if (level == null)
+                        {
+                            yield return GetMissingBLockHeader(i);
+                        }
+                        else
+                        {
+                            if (!level.HasBlockOnMainChain)
+                            {
+                                if (level.BlockInfos.Length > 0)
+                                {
+                                    level.HasBlockOnMainChain = true;
+                                    chainLevelInfoRepository.PersistLevel(i, level);
+                                }
+                            }
+                        
+                            var header = blockTree.FindHeader(level.MainChainBlock.BlockHash, BlockTreeLookupOptions.None);
+                            yield return header ?? GetMissingBLockHeader(i);
+                        }
 
-                        synced++;
-                        _progress.Update(synced);
+                        _progress.Update(++synced);
                     }
                 }
             }

--- a/src/Nethermind/Nethermind.Runner/Ethereum/Steps/DatabaseMigrations.cs
+++ b/src/Nethermind/Nethermind.Runner/Ethereum/Steps/DatabaseMigrations.cs
@@ -38,6 +38,8 @@ namespace Nethermind.Runner.Ethereum.Steps
     [RunnerStepDependencies(typeof(InitRlp), typeof(InitDatabase), typeof(InitializeBlockchain), typeof(InitializeNetwork))]
     public class DatabaseMigrations : IStep, IAsyncDisposable
     {
+        private static BlockHeader EmptyHeader = new BlockHeader(Keccak.Zero, Keccak.Zero, Address.Zero, UInt256.Zero, 0L, 0L, UInt256.Zero, Bytes.Empty);
+        
         private readonly EthereumRunnerContext _context;
         private readonly ILogger _logger;
         private Stopwatch? _stopwatch;
@@ -154,8 +156,8 @@ namespace Nethermind.Runner.Ethereum.Steps
         {
             BlockHeader GetMissingBLockHeader(long i)
             {
-                if (_logger.IsWarn) _logger.Warn(GetLogMessage("warning", $"Header for block {i} not found. Database might be corrupted and BloomDb will not be correct."));
-                return new BlockHeader(Keccak.Zero, Keccak.Zero, Address.Zero, UInt256.Zero, 0L, 0L, UInt256.Zero, Bytes.Empty);
+                if (_logger.IsWarn) _logger.Warn(GetLogMessage("warning", $"Header for block {i} not found. Logs will not be searchable for this block."));
+                return EmptyHeader;
             }
 
             if (_context.BloomStorage == null) throw new StepDependencyException(nameof(_context.BloomStorage));


### PR DESCRIPTION
1. Change bloom migration to include ChainLevelInfo.HasBlockOnMainChain for old blocks.
2. Add warnings to logs when nbloom migration cannot find header.
3. Add errors to logs when LogFinder cannot find block.
4. Add NUnitLogManager to Initialize runner smoke tests for better diagnostics of failures in this test