### PR TITLE
estimator taking into account stipend and gas pressure and refunds

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Builders/TransactionBuilder.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Builders/TransactionBuilder.cs
@@ -58,12 +58,14 @@ namespace Nethermind.Core.Test.Builders
         
         public TransactionBuilder WithData(byte[] data)
         {
+            TestObjectInternal.Init = null;
             TestObjectInternal.Data = data;
             return this;
         }
         
         public TransactionBuilder WithInit(byte[] initCode)
         {
+            TestObjectInternal.Data = null;
             TestObjectInternal.Init = initCode;
             return this;
         }

--- a/src/Nethermind/Nethermind.DataMarketplace.Test/ContractInteractionTest.cs
+++ b/src/Nethermind/Nethermind.DataMarketplace.Test/ContractInteractionTest.cs
@@ -262,7 +262,7 @@ namespace Nethermind.DataMarketplace.Test
                 return new Facade.BlockchainBridge.CallOutput(tracer.ReturnValue, tracer.GasSpent, tracer.Error);
             }
 
-            public Facade.BlockchainBridge.CallOutput EstimateGas(BlockHeader header, Transaction transaction)
+            public Facade.BlockchainBridge.CallOutput EstimateGas(BlockHeader header, Transaction tx)
             {
                 throw new NotImplementedException();
             }

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/EstimateGasTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/EstimateGasTracerTests.cs
@@ -17,6 +17,7 @@
 using FluentAssertions;
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
+using Nethermind.Core.Test.Builders;
 using Nethermind.Evm.Tracing;
 using NUnit.Framework;
 
@@ -41,7 +42,7 @@ namespace Nethermind.Evm.Test.Tracing
             tracer.ReportAction(1000, 0, Address.Zero, Address.Zero, Bytes.Empty, ExecutionType.Call, true);
             tracer.ReportActionEnd(400, Bytes.Empty); // this would not happen but we want to ensure that precompiles are ignored
             tracer.ReportActionEnd(600, Bytes.Empty);
-            tracer.AdditionalGasRequired.Should().Be(0);
+            tracer.CalculateEstimate(Build.A.Transaction.WithGasLimit(1000).TestObject).Should().Be(0);
         }
 
         [Test]
@@ -64,7 +65,7 @@ namespace Nethermind.Evm.Test.Tracing
             EstimateGasTracer tracer = new EstimateGasTracer();
             tracer.ReportAction(1000, 0, Address.Zero, Address.Zero, Bytes.Empty, ExecutionType.Transaction, false);
             tracer.ReportActionEnd(600, Bytes.Empty);
-            tracer.AdditionalGasRequired.Should().Be(0);
+            tracer.CalculateEstimate(Build.A.Transaction.WithGasLimit(1000).TestObject).Should().Be(0);
         }
 
         [Test]
@@ -86,7 +87,7 @@ namespace Nethermind.Evm.Test.Tracing
                 tracer.ReportActionEnd(300, Bytes.Empty); // should not happen
             }
 
-            tracer.AdditionalGasRequired.Should().Be(18);
+            tracer.CalculateEstimate(Build.A.Transaction.WithGasLimit(1000).TestObject).Should().Be(14L);
         }
 
         [Test]
@@ -110,7 +111,7 @@ namespace Nethermind.Evm.Test.Tracing
                 tracer.ReportActionEnd(500, Bytes.Empty); // should not happen
             }
 
-            tracer.AdditionalGasRequired.Should().Be(8);
+            tracer.CalculateEstimate(Build.A.Transaction.WithGasLimit(1000).TestObject).Should().Be(24L);
         }
 
         [Test]
@@ -123,7 +124,7 @@ namespace Nethermind.Evm.Test.Tracing
             tracer.ReportActionEnd(63, Bytes.Empty); // second level
             tracer.ReportActionEnd(65, Bytes.Empty);
 
-            tracer.AdditionalGasRequired.Should().Be(1);
+            tracer.CalculateEstimate(Build.A.Transaction.WithGasLimit(128).TestObject).Should().Be(1);
         }
 
         [Test]
@@ -147,7 +148,7 @@ namespace Nethermind.Evm.Test.Tracing
                 tracer.ReportActionEnd(500, Bytes.Empty); // should not happen
             }
 
-            tracer.AdditionalGasRequired.Should().Be(18);
+            tracer.CalculateEstimate(Build.A.Transaction.WithGasLimit(1000).TestObject).Should().Be(18);
         }
 
         [Test]
@@ -171,7 +172,7 @@ namespace Nethermind.Evm.Test.Tracing
                 tracer.ReportActionEnd(500, Bytes.Empty); // should not happen
             }
 
-            tracer.AdditionalGasRequired.Should().Be(17);
+            tracer.CalculateEstimate(Build.A.Transaction.WithGasLimit(1000).TestObject).Should().Be(17);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Evm.Test/TransactionProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/TransactionProcessorTests.cs
@@ -15,24 +15,23 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
 using System;
-using System.Buffers.Binary;
+using System.Runtime.CompilerServices;
 using FluentAssertions;
 using Nethermind.Core;
 using Nethermind.Core.Attributes;
-using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Specs;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Crypto;
 using Nethermind.Db;
-using Nethermind.Evm.Precompiles;
 using Nethermind.Evm.Tracing;
+using Nethermind.Evm.Tracing.GethStyle;
 using Nethermind.Evm.Tracing.ParityStyle;
 using Nethermind.Logging;
+using Nethermind.Serialization.Json;
 using Nethermind.Specs.Forks;
 using Nethermind.State;
-using Nethermind.Store;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -217,9 +216,146 @@ namespace Nethermind.Evm.Test
 
             EstimateGasTracer tracer = new EstimateGasTracer();
             _transactionProcessor.CallAndRestore(tx, block.Header, tracer);
+
+            tracer.GasSpent.Should().Be(21000);
+            tracer.CalculateEstimate(tx).Should().Be(21000);
+        }
+
+        [Test]
+        public void Can_estimate_with_refund()
+        {
+            byte[] initByteCode = Prepare.EvmCode
+                .PushData(1)
+                .PushData(1)
+                .Op(Instruction.SSTORE)
+                .PushData(0)
+                .PushData(1)
+                .Op(Instruction.SSTORE)
+                .Op(Instruction.STOP)
+                .Done;
+
+            long gasLimit = 100000;
+
+            Transaction tx = Build.A.Transaction.SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA, 1).WithInit(initByteCode).WithGasLimit(gasLimit).TestObject;
+            Block block = Build.A.Block.WithNumber(MainNetSpecProvider.MuirGlacierBlockNumber).WithTransactions(tx).WithGasLimit(2 * gasLimit).TestObject;
+
+            IntrinsicGasCalculator gasCalculator = new IntrinsicGasCalculator();
+            long intrinsic = gasCalculator.Calculate(tx, MuirGlacier.Instance);
+
+            GethLikeTxTracer gethTracer = new GethLikeTxTracer(GethTraceOptions.Default);
+            _transactionProcessor.CallAndRestore(tx, block.Header, gethTracer);
+            TestContext.WriteLine(new EthereumJsonSerializer().Serialize(gethTracer.BuildResult(), true));
+
+            EstimateGasTracer tracer = new EstimateGasTracer();
+            _transactionProcessor.CallAndRestore(tx, block.Header, tracer);
+
+            long actualIntrinsic = tx.GasLimit - tracer.IntrinsicGasAt;
+            actualIntrinsic.Should().Be(intrinsic);
+            tracer.CalculateAdditionalGasRequired(tx).Should().Be(RefundOf.SSetReversedEip2200 + GasCostOf.CallStipend - GasCostOf.SStoreNetMeteredEip2200 + 1);
+            tracer.GasSpent.Should().Be(54764L);
+            long estimate = tracer.CalculateEstimate(tx);
+            estimate.Should().Be(75465L);
+
+            ConfirmEnoughEstimate(tx, block, estimate);
+        }
+
+        [Test(Description = "Since the second call is a CREATE operation it has intrinsic gas of 21000 + 32000 + data")]
+        public void Can_estimate_with_destroy_refund_and_below_intrinsic()
+        {
+            byte[] initByteCode = Prepare.EvmCode.ForInitOf(Prepare.EvmCode.PushData(Address.Zero).Op(Instruction.SELFDESTRUCT).Done).Done;
+            Address contractAddress = ContractAddress.From(TestItem.PrivateKeyA.Address, 0);
+
+            byte[] byteCode = Prepare.EvmCode
+                .Call(contractAddress, 46179)
+                .Op(Instruction.STOP).Done;
+
+            long gasLimit = 100000;
+
+            Transaction initTx = Build.A.Transaction.SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA, 1).WithInit(initByteCode).WithGasLimit(gasLimit).TestObject;
+            Transaction tx = Build.A.Transaction.SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA, 1).WithInit(byteCode).WithGasLimit(gasLimit).WithNonce(1).TestObject;
+            Block block = Build.A.Block.WithNumber(MainNetSpecProvider.MuirGlacierBlockNumber).WithTransactions(tx).WithGasLimit(2 * gasLimit).TestObject;
+
+            IntrinsicGasCalculator gasCalculator = new IntrinsicGasCalculator();
+            long intrinsic = gasCalculator.Calculate(tx, MuirGlacier.Instance);
+
+            _transactionProcessor.Execute(initTx, block.Header, NullTxTracer.Instance);
+
+            EstimateGasTracer tracer = new EstimateGasTracer();
+            GethLikeTxTracer gethTracer = new GethLikeTxTracer(GethTraceOptions.Default);
+            _transactionProcessor.CallAndRestore(tx, block.Header, tracer);
+            _transactionProcessor.CallAndRestore(tx, block.Header, gethTracer);
+            TestContext.WriteLine(new EthereumJsonSerializer().Serialize(gethTracer.BuildResult(), true));
+
+            long actualIntrinsic = tx.GasLimit - tracer.IntrinsicGasAt;
+            actualIntrinsic.Should().Be(intrinsic);
+            tracer.CalculateAdditionalGasRequired(tx).Should().Be(24080);
+            tracer.GasSpent.Should().Be(35228L);
+            long estimate = tracer.CalculateEstimate(tx);
+            estimate.Should().Be(59308);
+
+            ConfirmEnoughEstimate(tx, block, estimate);
+        }
+
+        private void ConfirmEnoughEstimate(Transaction tx, Block block, long estimate)
+        {
+            CallOutputTracer outputTracer = new CallOutputTracer();
+            tx.GasLimit = estimate;
+            TestContext.WriteLine(tx.GasLimit);
+
+            GethLikeTxTracer gethTracer = new GethLikeTxTracer(GethTraceOptions.Default);
+            _transactionProcessor.CallAndRestore(tx, block.Header, gethTracer);
+            string traceEnoughGas = new EthereumJsonSerializer().Serialize(gethTracer.BuildResult(), true);
+
+            _transactionProcessor.CallAndRestore(tx, block.Header, outputTracer);
+            traceEnoughGas.Should().NotContain("OutOfGas");
+
+            outputTracer = new CallOutputTracer();
+            tx.GasLimit = Math.Min(estimate - 1, estimate * 63 / 64);
+            TestContext.WriteLine(tx.GasLimit);
             
-            Assert.AreEqual(21000, tracer.GasSpent);
-            Assert.AreEqual(0, tracer.AdditionalGasRequired);
+            gethTracer = new GethLikeTxTracer(GethTraceOptions.Default);
+            _transactionProcessor.CallAndRestore(tx, block.Header, gethTracer);
+
+            string traceOutOfGas = new EthereumJsonSerializer().Serialize(gethTracer.BuildResult(), true);
+            TestContext.WriteLine(traceOutOfGas);
+            
+            _transactionProcessor.CallAndRestore(tx, block.Header, outputTracer);
+
+            bool failed = traceEnoughGas.Contains("failed") || traceEnoughGas.Contains("OutOfGas");
+            failed.Should().BeTrue();
+        }
+
+        [Test]
+        public void Can_estimate_with_stipend()
+        {
+            byte[] initByteCode = Prepare.EvmCode
+                .CallWithValue(Address.Zero, 0, 1)
+                .Op(Instruction.STOP)
+                .Done;
+
+            long gasLimit = 100000;
+
+            Transaction tx = Build.A.Transaction.SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA, 1).WithInit(initByteCode).WithGasLimit(gasLimit).TestObject;
+            Block block = Build.A.Block.WithNumber(MainNetSpecProvider.MuirGlacierBlockNumber).WithTransactions(tx).WithGasLimit(2 * gasLimit).TestObject;
+
+            IntrinsicGasCalculator gasCalculator = new IntrinsicGasCalculator();
+            long intrinsic = gasCalculator.Calculate(tx, MuirGlacier.Instance);
+
+            GethLikeTxTracer gethTracer = new GethLikeTxTracer(GethTraceOptions.Default);
+            _transactionProcessor.CallAndRestore(tx, block.Header, gethTracer);
+            TestContext.WriteLine(new EthereumJsonSerializer().Serialize(gethTracer.BuildResult(), true));
+
+            EstimateGasTracer tracer = new EstimateGasTracer();
+            _transactionProcessor.CallAndRestore(tx, block.Header, tracer);
+
+            long actualIntrinsic = tx.GasLimit - tracer.IntrinsicGasAt;
+            actualIntrinsic.Should().Be(intrinsic);
+            tracer.CalculateAdditionalGasRequired(tx).Should().Be(2300);
+            tracer.GasSpent.Should().Be(85669L);
+            long estimate = tracer.CalculateEstimate(tx);
+            estimate.Should().Be(87969L);
+
+            ConfirmEnoughEstimate(tx, block, estimate);
         }
 
         [Test]
@@ -246,13 +382,15 @@ namespace Nethermind.Evm.Test
 
             EstimateGasTracer tracer = new EstimateGasTracer();
             _transactionProcessor.CallAndRestore(tx, block.Header, tracer);
-            
+
             long actualIntrinsic = tx.GasLimit - tracer.IntrinsicGasAt;
-            actualIntrinsic.Should().Be(53000);
-            tracer.AdditionalGasRequired.Should().Be(1);
-            tracer.GasSpent.Should().Be(53724);
-            long estimate = tracer.GasSpent + tracer.AdditionalGasRequired;
-            estimate.Should().Be(53725);
+            actualIntrinsic.Should().Be(intrinsic);
+            tracer.CalculateAdditionalGasRequired(tx).Should().Be(1);
+            tracer.GasSpent.Should().Be(54224L);
+            long estimate = tracer.CalculateEstimate(tx);
+            estimate.Should().Be(54225L);
+
+            ConfirmEnoughEstimate(tx, block, estimate);
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Evm/RefundHelper.cs
+++ b/src/Nethermind/Nethermind.Evm/RefundHelper.cs
@@ -14,15 +14,17 @@
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
+using System;
+using System.Runtime.CompilerServices;
+
 namespace Nethermind.Evm
 {
-    public static class RefundOf
+    public static class RefundHelper
     {
-        public const long SSetReversedEip1283 = 19800;
-        public const long SClearReversedEip1283 = 4800;
-        public const long SSetReversedEip2200 = 19200;
-        public const long SClearReversedEip2200 = 4200;
-        public const long SClear = 15000;
-        public const long Destroy = 24000;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static long CalculateClaimableRefund(long spentGas, long totalRefund)
+        {
+            return Math.Min(spentGas / 2L, totalRefund);
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Evm/Tracing/BlockReceiptsTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/BlockReceiptsTracer.cs
@@ -33,6 +33,7 @@ namespace Nethermind.Evm.Tracing
         public bool IsTracingOpLevelStorage => _currentTxTracer.IsTracingOpLevelStorage;
         public bool IsTracingMemory => _currentTxTracer.IsTracingMemory;
         public bool IsTracingInstructions => _currentTxTracer.IsTracingInstructions;
+        public bool IsTracingRefunds => _currentTxTracer.IsTracingRefunds;
         public bool IsTracingCode => _currentTxTracer.IsTracingCode;
         public bool IsTracingStack => _currentTxTracer.IsTracingStack;
         public bool IsTracingState => _currentTxTracer.IsTracingState;
@@ -204,14 +205,19 @@ namespace Nethermind.Evm.Tracing
             _currentTxTracer.ReportByteCode(byteCode);
         }
 
-        public void ReportRefundForVmTrace(long refund, long gasAvailable)
+        public void ReportGasUpdateForVmTrace(long refund, long gasAvailable)
         {
-            _currentTxTracer.ReportRefundForVmTrace(refund, gasAvailable);
+            _currentTxTracer.ReportGasUpdateForVmTrace(refund, gasAvailable);
         }
 
         public void ReportRefund(long refund)
         {
             _currentTxTracer.ReportRefund(refund);
+        }
+
+        public void ReportExtraGasPressure(long extraGasPressure)
+        {
+            _currentTxTracer.ReportExtraGasPressure(extraGasPressure);
         }
 
         public void SetOperationStack(List<string> stackTrace)

--- a/src/Nethermind/Nethermind.Evm/Tracing/CallOutputTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/CallOutputTracer.cs
@@ -31,6 +31,7 @@ namespace Nethermind.Evm.Tracing
         public bool IsTracingOpLevelStorage => false;
         public bool IsTracingMemory => false;
         public bool IsTracingInstructions => false;
+        public bool IsTracingRefunds => false;
         public bool IsTracingCode => false;
         public bool IsTracingStack => false;
         public bool IsTracingState => false;
@@ -169,7 +170,7 @@ namespace Nethermind.Evm.Tracing
             throw new NotSupportedException();
         }
 
-        public void ReportRefundForVmTrace(long refund, long gasAvailable)
+        public void ReportGasUpdateForVmTrace(long refund, long gasAvailable)
         {
             throw new NotSupportedException();
         }
@@ -177,6 +178,11 @@ namespace Nethermind.Evm.Tracing
         public void ReportRefund(long refund)
         {
             throw new NotSupportedException();
+        }
+
+        public void ReportExtraGasPressure(long extraGasPressure)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/GethLikeTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/GethLikeTxTracer.cs
@@ -43,6 +43,7 @@ namespace Nethermind.Evm.Tracing.GethStyle
         public bool IsTracingOpLevelStorage { get; }
         public bool IsTracingMemory { get; }
         bool ITxTracer.IsTracingInstructions => true;
+        public bool IsTracingRefunds => false;
         public bool IsTracingCode => false;
         public bool IsTracingStack { get; }
         bool ITxTracer.IsTracingState => false;
@@ -210,12 +211,18 @@ namespace Nethermind.Evm.Tracing.GethStyle
             throw new NotSupportedException();
         }
 
-        public void ReportRefundForVmTrace(long refund, long gasAvailable)
+        public void ReportGasUpdateForVmTrace(long refund, long gasAvailable)
         {
         }
 
         public void ReportRefund(long refund)
         {
+            throw new NotSupportedException();
+        }
+
+        public void ReportExtraGasPressure(long extraGasPressure)
+        {
+            throw new NotImplementedException();
         }
 
         public void SetOperationStack(List<string> stackTrace)

--- a/src/Nethermind/Nethermind.Evm/Tracing/ITxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/ITxTracer.cs
@@ -45,6 +45,10 @@ namespace Nethermind.Evm.Tracing
         bool IsTracingMemory { get; }
         bool IsTracingInstructions { get; }
         /// <summary>
+        /// Updates of refund counter
+        /// </summary>
+        bool IsTracingRefunds { get; }
+        /// <summary>
         /// Code deployment
         /// </summary>
         bool IsTracingCode { get; }
@@ -100,8 +104,14 @@ namespace Nethermind.Evm.Tracing
 
         void ReportByteCode(byte[] byteCode);
 
-        void ReportRefundForVmTrace(long refund, long gasAvailable);
+        /// <summary>
+        /// Special case for VM trace in Parity but we consider removing support for it
+        /// </summary>
+        /// <param name="refund"></param>
+        /// <param name="gasAvailable"></param>
+        void ReportGasUpdateForVmTrace(long refund, long gasAvailable);
 
         void ReportRefund(long refund);
+        void ReportExtraGasPressure(long extraGasPressure);
     }
 }

--- a/src/Nethermind/Nethermind.Evm/Tracing/NullTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/NullTxTracer.cs
@@ -44,6 +44,7 @@ namespace Nethermind.Evm.Tracing
         public bool IsTracingOpLevelStorage => false;
         public bool IsTracingMemory => false;
         public bool IsTracingInstructions => false;
+        public bool IsTracingRefunds => false;
         public bool IsTracingCode => false;
         public bool IsTracingStack => false;
         public bool IsTracingState => false;
@@ -93,7 +94,11 @@ namespace Nethermind.Evm.Tracing
         public void ReportBlockHash(Keccak blockHash) => throw new InvalidOperationException(ErrorMessage);
 
         public void ReportByteCode(byte[] byteCode) => throw new InvalidOperationException(ErrorMessage);
-        public void ReportRefundForVmTrace(long refund, long gasAvailable)=> throw new InvalidOperationException(ErrorMessage);
+        public void ReportGasUpdateForVmTrace(long refund, long gasAvailable)=> throw new InvalidOperationException(ErrorMessage);
         public void ReportRefund(long refund) => throw new InvalidOperationException(ErrorMessage);
+        public void ReportExtraGasPressure(long extraGasPressure)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Evm/Tracing/ParityStyle/ParityLikeTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/ParityStyle/ParityLikeTxTracer.cs
@@ -80,10 +80,10 @@ namespace Nethermind.Evm.Tracing.ParityStyle
         public bool IsTracingOpLevelStorage => false;
         public bool IsTracingMemory => false;
         public bool IsTracingInstructions { get; }
+        public bool IsTracingRefunds => false;
         public bool IsTracingCode { get; }
         public bool IsTracingStack => false;
         public bool IsTracingState { get; }
-        
         public bool IsTracingBlockHash => false;
         
         private static string GetCallType(ExecutionType executionType)
@@ -463,13 +463,19 @@ namespace Nethermind.Evm.Tracing.ParityStyle
             _currentVmTrace.VmTrace.Code = byteCode;
         }
 
-        public void ReportRefundForVmTrace(long refund, long gasAvailable)
+        public void ReportGasUpdateForVmTrace(long refund, long gasAvailable)
         {
             _currentOperation.Used = gasAvailable;
         }
 
         public void ReportRefund(long refund)
         {
+            throw new NotSupportedException();
+        }
+
+        public void ReportExtraGasPressure(long extraGasPressure)
+        {
+            throw new NotSupportedException();
         }
     }
 }

--- a/src/Nethermind/Nethermind.Evm/Tracing/Proofs/ProofTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/Proofs/ProofTxTracer.cs
@@ -47,6 +47,7 @@ namespace Nethermind.Evm.Tracing.Proofs
         public bool IsTracingOpLevelStorage => false;
         public bool IsTracingMemory => false;
         public bool IsTracingInstructions => false;
+        public bool IsTracingRefunds => false;
         public bool IsTracingCode => false;
         public bool IsTracingStack => false;
         public bool IsTracingState => true;
@@ -66,12 +67,17 @@ namespace Nethermind.Evm.Tracing.Proofs
             throw new NotSupportedException();
         }
 
-        public void ReportRefundForVmTrace(long refund, long gasAvailable)
+        public void ReportGasUpdateForVmTrace(long refund, long gasAvailable)
         {
             throw new NotSupportedException();
         }
 
         public void ReportRefund(long refund)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void ReportExtraGasPressure(long extraGasPressure)
         {
             throw new NotSupportedException();
         }

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessor.cs
@@ -50,7 +50,7 @@ namespace Nethermind.Evm
             _storageProvider = storageProvider ?? throw new ArgumentNullException(nameof(storageProvider));
             _ecdsa = new EthereumEcdsa(specProvider, logManager);
         }
-        
+
         public void CallAndRestore(Transaction transaction, BlockHeader block, ITxTracer txTracer)
         {
             Execute(transaction, block, txTracer, true);
@@ -65,7 +65,7 @@ namespace Nethermind.Evm
         {
             block.GasUsed += tx.GasLimit;
             Address recipient = tx.To ?? ContractAddress.From(tx.SenderAddress, _stateProvider.GetNonce(tx.SenderAddress));
-            
+
             _stateProvider.RecalculateStateRoot();
             Keccak stateRoot = _specProvider.GetSpec(block.Number).IsEip658Enabled ? null : _stateProvider.StateRoot;
             if (txTracer.IsTracingReceipt) txTracer.MarkAsFailed(recipient, tx.GasLimit, Bytes.Empty, reason ?? "invalid", stateRoot);
@@ -81,7 +81,7 @@ namespace Nethermind.Evm
             {
                 spec = new SystemTransactionReleaseSpec(spec);
             }
-            
+
             Address recipient = transaction.To;
             UInt256 value = transaction.Value;
             UInt256 gasPrice = transaction.GasPrice;
@@ -127,10 +127,10 @@ namespace Nethermind.Evm
                 {
                     transaction.SenderAddress = _ecdsa.RecoverAddress(transaction, block.Number);
                 }
-                
+
                 if (sender != transaction.SenderAddress)
                 {
-                    if(_logger.IsWarn) _logger.Warn($"TX recovery issue fixed - tx was coming with sender {sender} and the now it recovers to {transaction.SenderAddress}");
+                    if (_logger.IsWarn) _logger.Warn($"TX recovery issue fixed - tx was coming with sender {sender} and the now it recovers to {transaction.SenderAddress}");
                     sender = transaction.SenderAddress;
                 }
                 else
@@ -139,7 +139,7 @@ namespace Nethermind.Evm
                     if (gasPrice == UInt256.Zero)
                     {
                         _stateProvider.CreateAccount(sender, UInt256.Zero);
-                    }                    
+                    }
                 }
             }
 
@@ -163,9 +163,9 @@ namespace Nethermind.Evm
                 _stateProvider.IncrementNonce(sender);
             }
 
-            _stateProvider.SubtractFromBalance(sender, (ulong) gasLimit * gasPrice, spec);
-
-            // TODO: I think we can skip this commit and decrease the tree operations this way
+            UInt256 senderReservedGasPayment = (ulong) gasLimit * gasPrice;
+            
+            _stateProvider.SubtractFromBalance(sender, senderReservedGasPayment, spec);
             _stateProvider.Commit(spec, txTracer.IsTracingState ? txTracer : null);
 
             long unspentGas = gasLimit - intrinsicGas;
@@ -187,7 +187,7 @@ namespace Nethermind.Evm
                     {
                         recipient = transaction.SenderAddress;
                     }
-                    
+
                     if (_stateProvider.AccountExists(recipient))
                     {
                         if ((_virtualMachine.GetCachedCodeInfo(recipient)?.MachineCode?.Length ?? 0) != 0 || _stateProvider.GetNonce(recipient) != 0)
@@ -255,6 +255,7 @@ namespace Nethermind.Evm
                     {
                         if (_logger.IsTrace) _logger.Trace($"Destroying account {toBeDestroyed}");
                         _stateProvider.DeleteAccount(toBeDestroyed);
+                        if (txTracer.IsTracingRefunds) txTracer.ReportRefund(RefundOf.Destroy);
                     }
 
                     statusCode = StatusCode.Success;
@@ -296,6 +297,10 @@ namespace Nethermind.Evm
             {
                 _storageProvider.Reset();
                 _stateProvider.Reset();
+                
+                _stateProvider.AddToBalance(sender, senderReservedGasPayment, spec);
+                _stateProvider.DecrementNonce(sender);
+                _stateProvider.Commit(spec);
             }
 
             if (!isCall && notSystemTransaction)
@@ -310,9 +315,9 @@ namespace Nethermind.Evm
                 if (!eip658Enabled)
                 {
                     _stateProvider.RecalculateStateRoot();
-                    stateRoot = _stateProvider.StateRoot;    
+                    stateRoot = _stateProvider.StateRoot;
                 }
-                
+
                 if (statusCode == StatusCode.Failure)
                 {
                     txTracer.MarkAsFailed(recipient, spentGas, (substate?.ShouldRevert ?? false) ? substate.Output : Bytes.Empty, substate?.Error, stateRoot);
@@ -328,14 +333,14 @@ namespace Nethermind.Evm
         {
             if (_logger.IsTrace) _logger.Trace($"Invalid tx {transaction.Hash} ({reason})");
         }
-
+        
         private long Refund(long gasLimit, long unspentGas, TransactionSubstate substate, Address sender, UInt256 gasPrice, IReleaseSpec spec)
         {
             long spentGas = gasLimit;
             if (!substate.IsError)
             {
                 spentGas -= unspentGas;
-                long refund = substate.ShouldRevert ? 0 : Math.Min(spentGas / 2L, substate.Refund + substate.DestroyList.Count * RefundOf.Destroy);
+                long refund = substate.ShouldRevert ? 0 : RefundHelper.CalculateClaimableRefund(spentGas, substate.Refund + substate.DestroyList.Count * RefundOf.Destroy);
 
                 if (_logger.IsTrace) _logger.Trace("Refunding unused gas of " + unspentGas + " and refund of " + refund);
                 _stateProvider.AddToBalance(sender, (ulong) (unspentGas + refund) * gasPrice, spec);

--- a/src/Nethermind/Nethermind.Evm/TransactionSubstate.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionSubstate.cs
@@ -29,9 +29,10 @@ namespace Nethermind.Evm
         private static List<Address> _emptyDestroyList = new List<Address>(0);
         private static List<LogEntry> _emptyLogs = new List<LogEntry>(0);
 
-        public TransactionSubstate(string error)
+        
+        public TransactionSubstate(EvmExceptionType exceptionType)
         {
-            Error = error;
+            Error = exceptionType.ToString();
             Refund = 0;
             DestroyList = _emptyDestroyList;
             Logs = _emptyLogs;

--- a/src/Nethermind/Nethermind.Facade.Test/BlockChainBridgeTests.cs
+++ b/src/Nethermind/Nethermind.Facade.Test/BlockChainBridgeTests.cs
@@ -139,10 +139,10 @@ namespace Nethermind.Facade.Test
         {
             BlockHeader header = Build.A.BlockHeader.WithNumber(10).TestObject;
             Transaction tx = new Transaction();
-            tx.GasLimit = 1000;
+            tx.GasLimit = Transaction.BaseTxGasCost;
             
             var gas = _blockchainBridge.EstimateGas(header, tx);
-            gas.GasSpent.Should().Be(0);
+            gas.GasSpent.Should().Be(Transaction.BaseTxGasCost);
             
             _transactionProcessor.Received().CallAndRestore(
                 tx,

--- a/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
@@ -206,11 +206,12 @@ namespace Nethermind.Facade
             return new CallOutput {Error = callOutputTracer.Error, GasSpent = callOutputTracer.GasSpent, OutputData = callOutputTracer.ReturnValue};
         }
 
-        public CallOutput EstimateGas(BlockHeader header, Transaction transaction)
+        public CallOutput EstimateGas(BlockHeader header, Transaction tx)
         {
             EstimateGasTracer estimateGasTracer = new EstimateGasTracer();
-            CallAndRestore(header, transaction, estimateGasTracer);
-            return new CallOutput {Error = estimateGasTracer.Error, GasSpent = estimateGasTracer.GasSpent + estimateGasTracer.AdditionalGasRequired};
+            CallAndRestore(header, tx, estimateGasTracer);
+            long estimate = estimateGasTracer.CalculateEstimate(tx);
+            return new CallOutput {Error = estimateGasTracer.Error, GasSpent = estimate};
         }
 
         private void CallAndRestore(BlockHeader blockHeader, Transaction transaction, ITxTracer tracer)

--- a/src/Nethermind/Nethermind.Facade/IBlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/IBlockchainBridge.cs
@@ -43,7 +43,7 @@ namespace Nethermind.Facade
         Keccak SendTransaction(Transaction tx, TxHandlingOptions txHandlingOptions);
         TxReceipt GetReceipt(Keccak txHash);
         BlockchainBridge.CallOutput Call(BlockHeader blockHeader, Transaction transaction);
-        BlockchainBridge.CallOutput EstimateGas(BlockHeader header, Transaction transaction);
+        BlockchainBridge.CallOutput EstimateGas(BlockHeader header, Transaction tx);
         long GetChainId();
         byte[] GetCode(Address address);
         byte[] GetCode(Keccak codeHash);

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/EthModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/EthModuleTests.cs
@@ -415,14 +415,14 @@ namespace Nethermind.JsonRpc.Test.Modules
         }
 
         [Test]
-        public void Eth_call_no_recipient()
+        public void Eth_call_no_recipient_should_work_as_init()
         {
             var transaction = new TransactionForRpc(Keccak.Zero, 1L, 1, new Transaction());
             transaction.From = TestItem.AddressA;
             transaction.Data = new byte[] {1, 2, 3};
 
             string serialized = RpcTest.TestSerializedRequest(EthModuleFactory.Converters, _ethModule, "eth_call", _ethSerializer.Serialize(transaction), "latest");
-            Assert.AreEqual("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32015,\"message\":\"VM execution error.\",\"data\":\"Error\"},\"id\":67}", serialized);
+            Assert.AreEqual("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32015,\"message\":\"VM execution error.\",\"data\":\"StackUnderflow\"},\"id\":67}", serialized);
         }
 
         [Test]


### PR DESCRIPTION
Gas estimator needs to take account multiple events:
* refunds
* gas barriers when the gas level is checked but not used (with stipend or SSTORE with stipend)
* refunds from SELFDESTRUCT
* various types of nesting