### PR TITLE
Feature/1539 validator sync status

### DIFF
--- a/src/Nethermind/Nethermind.BeaconNode.Host/README.md
+++ b/src/Nethermind/Nethermind.BeaconNode.Host/README.md
@@ -125,6 +125,29 @@ Note that the different processess (nodes and validators) need to use the same o
 
 The clock will also be useful in future testing to reproduce specific scenarios starting from particular states at past clock dates (using a negative offset).
 
+#### Example: Slot catch up when a test net is missing time
+
+The default quickstart clock offset starts the effective clock at genesis time. You can run the host with a past genesis time and offset = 0 (current time clock) to simulate what might happen if a test net is missing some time.
+
+e.g. To simulate the first test validator starting 120 seconds after genesis:
+
+```
+dotnet run --project src/Nethermind/Nethermind.BeaconNode.Host --QuickStart:GenesisTime ([DateTimeOffset]::UtcNow.ToUnixTimeSeconds() - 120) --QuickStart:ClockOffset 0 --QuickStart:ValidatorCount 64 --QuickStart:ValidatorStartIndex 0 --QuickStart:NumberOfValidators 32
+```
+
+Normally other nodes would have produced blocks and the chain head will match the clock time; if it is behind the clock time, it would simply mean that the node needs to sync to catch up.
+
+However, with a test network there might have been no nodes/validators active, e.g. if the entire network was stopped. This means no blocks would have been produced (by anyone) and the head will be old.
+
+If nodes only checked based on clock time, and the head was too many epochs in the past, then every node would simply get 406 DutiesNotAvailableForRequestedEpoch errors.
+
+e.g. If a test network was stopped at slot 100 (epoch 12), and restarted at clock time slot 150 (epoch 18) then if validators used the clock time to start requesting duties and they all requested for epoch 18, they would all get 406 errors.
+
+The Nethermind validator client will start at whatever head the beacon node has, i.e. slot 101, even if it is in the past (compared to the clock).
+
+If it was only one node that was stopped, i.e. it is simply out of date and needs to sync, then it might produce some useless blocks (but there is no penalty to this), and once the beacon node has updated the head, the validator will know which duties to check next.
+
+
 ### Optional requirements
 
 * PowerShell Core, to run build scripts

--- a/src/Nethermind/Nethermind.BeaconNode.Host/README.md
+++ b/src/Nethermind/Nethermind.BeaconNode.Host/README.md
@@ -33,6 +33,8 @@ dotnet run --project src/Nethermind/Nethermind.BeaconNode.Host -- --QuickStart:G
 
 ### Test it works
 
+**NOTE: OpenAPI not currently fixed after upgrade to 0.10.1, so this section is not working (yet)** 
+
 Run, as above, then open a browser to ```https://localhost:8230/node/version``` and it should respond with the name and version.
 
 Other GET queries:

--- a/src/Nethermind/Nethermind.BeaconNode/BeaconNodeFacade.cs
+++ b/src/Nethermind/Nethermind.BeaconNode/BeaconNodeFacade.cs
@@ -189,7 +189,7 @@ namespace Nethermind.BeaconNode
         }
 
         public async Task<ApiResponse<IList<ValidatorDuty>>> ValidatorDutiesAsync(IList<BlsPublicKey> validatorPublicKeys,
-            Epoch? epoch, [EnumeratorCancellation] CancellationToken cancellationToken)
+            Epoch? epoch, CancellationToken cancellationToken)
         {
             if (validatorPublicKeys.Count < 1)
             {

--- a/src/Nethermind/Nethermind.BeaconNode/BeaconNodeFacade.cs
+++ b/src/Nethermind/Nethermind.BeaconNode/BeaconNodeFacade.cs
@@ -16,7 +16,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -66,7 +65,7 @@ namespace Nethermind.BeaconNode
                     // Beacon chain is currently syncing or waiting for genesis.
                     return ApiResponse.Create<ulong>(StatusCode.InternalError);
                 }
-                
+
                 BeaconState state = await GetHeadStateAsync().ConfigureAwait(false);
                 return ApiResponse.Create(StatusCode.Success, state.GenesisTime);
             }
@@ -139,7 +138,8 @@ namespace Nethermind.BeaconNode
         {
             try
             {
-                BeaconBlock unsignedBlock = await _blockProducer.NewBlockAsync(slot, randaoReveal).ConfigureAwait(false);
+                BeaconBlock unsignedBlock =
+                    await _blockProducer.NewBlockAsync(slot, randaoReveal).ConfigureAwait(false);
                 return ApiResponse.Create(StatusCode.Success, unsignedBlock);
             }
             catch (Exception ex)
@@ -149,7 +149,8 @@ namespace Nethermind.BeaconNode
             }
         }
 
-        public async Task<ApiResponse> PublishBlockAsync(SignedBeaconBlock signedBlock, CancellationToken cancellationToken)
+        public async Task<ApiResponse> PublishBlockAsync(SignedBeaconBlock signedBlock,
+            CancellationToken cancellationToken)
         {
             try
             {
@@ -188,19 +189,21 @@ namespace Nethermind.BeaconNode
             }
         }
 
-        public async Task<ApiResponse<IList<ValidatorDuty>>> ValidatorDutiesAsync(IList<BlsPublicKey> validatorPublicKeys,
+        public async Task<ApiResponse<IList<ValidatorDuty>>> ValidatorDutiesAsync(
+            IList<BlsPublicKey> validatorPublicKeys,
             Epoch? epoch, CancellationToken cancellationToken)
         {
             if (validatorPublicKeys.Count < 1)
             {
                 return ApiResponse.Create<IList<ValidatorDuty>>(StatusCode.InvalidRequest);
             }
+
             if (!_store.IsInitialized)
             {
                 // Beacon chain is currently syncing or waiting for genesis.
                 return ApiResponse.Create<IList<ValidatorDuty>>(StatusCode.CurrentlySyncing);
             }
-            
+
             // TODO: Rather than check one by one (each of which loops through potentially all slots for the epoch), optimise by either checking multiple, or better possibly caching or pre-calculating
             IList<ValidatorDuty> validatorDuties = new List<ValidatorDuty>();
             foreach (BlsPublicKey validatorPublicKey in validatorPublicKeys)
@@ -224,7 +227,7 @@ namespace Nethermind.BeaconNode
 
                 validatorDuties.Add(validatorDuty);
             }
-            
+
             ApiResponse<IList<ValidatorDuty>> response = ApiResponse.Create(StatusCode.Success, validatorDuties);
             return response;
         }

--- a/src/Nethermind/Nethermind.Core2.Abstractions/Api/SyncingStatus.cs
+++ b/src/Nethermind/Nethermind.Core2.Abstractions/Api/SyncingStatus.cs
@@ -20,6 +20,8 @@ namespace Nethermind.Core2.Api
 {
     public class SyncingStatus
     {
+        public static SyncingStatus Zero = new SyncingStatus(Slot.Zero, Slot.Zero, Slot.Zero);
+
         public SyncingStatus(Slot startingSlot, Slot currentSlot, Slot highestSlot)
         {
             StartingSlot = startingSlot;

--- a/src/Nethermind/Nethermind.Core2.Abstractions/Containers/Fork.cs
+++ b/src/Nethermind/Nethermind.Core2.Abstractions/Containers/Fork.cs
@@ -20,6 +20,8 @@ namespace Nethermind.Core2.Containers
 {
     public struct Fork
     {
+        public static Fork Zero = new Fork(ForkVersion.Zero, ForkVersion.Zero, Epoch.Zero);
+
         public Fork(ForkVersion previousVersion, ForkVersion currentVersion, Epoch epoch)
         {
             PreviousVersion = previousVersion;
@@ -27,13 +29,14 @@ namespace Nethermind.Core2.Containers
             Epoch = epoch;
         }
 
-        public ForkVersion PreviousVersion { get; }
         public ForkVersion CurrentVersion { get; }
 
         /// <summary>
         ///     Gets the epoch of the latest fork
         /// </summary>
         public Epoch Epoch { get; }
+
+        public ForkVersion PreviousVersion { get; }
 
         public override string ToString()
         {

--- a/src/Nethermind/Nethermind.Core2.Abstractions/Types/ForkVersion.cs
+++ b/src/Nethermind/Nethermind.Core2.Abstractions/Types/ForkVersion.cs
@@ -22,32 +22,24 @@ namespace Nethermind.Core2.Types
     public struct ForkVersion : IEquatable<ForkVersion>
     {
         public const int Length = sizeof(uint);
-        
+        public static ForkVersion Zero = new ForkVersion();
+
         private readonly uint _number;
 
-        public ReadOnlySpan<byte> AsSpan()
-        {
-            return MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref this, 1));
-        }
-        
         public ForkVersion(Span<byte> span)
         {
             if (span.Length != sizeof(uint))
             {
-                throw new ArgumentOutOfRangeException(nameof(span), span.Length, $"{nameof(ForkVersion)} must have exactly {sizeof(uint)} bytes");
+                throw new ArgumentOutOfRangeException(nameof(span), span.Length,
+                    $"{nameof(ForkVersion)} must have exactly {sizeof(uint)} bytes");
             }
-            
+
             _number = MemoryMarshal.Cast<byte, uint>(span)[0];
         }
 
-        public static bool operator ==(ForkVersion a, ForkVersion b)
+        public ReadOnlySpan<byte> AsSpan()
         {
-            return a._number == b._number;
-        }
-
-        public static bool operator !=(ForkVersion a, ForkVersion b)
-        {
-            return !(a == b);
+            return MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref this, 1));
         }
 
         public bool Equals(ForkVersion other)
@@ -63,6 +55,16 @@ namespace Nethermind.Core2.Types
         public override int GetHashCode()
         {
             return _number.GetHashCode();
+        }
+
+        public static bool operator ==(ForkVersion a, ForkVersion b)
+        {
+            return a._number == b._number;
+        }
+
+        public static bool operator !=(ForkVersion a, ForkVersion b)
+        {
+            return !(a == b);
         }
 
         public override string ToString()

--- a/src/Nethermind/Nethermind.HonestValidator.Test/ValidatorClientTest.cs
+++ b/src/Nethermind/Nethermind.HonestValidator.Test/ValidatorClientTest.cs
@@ -161,9 +161,9 @@ namespace Nethermind.HonestValidator.Test
             IValidatorKeyProvider validatorKeyProvider = testServiceProvider.GetService<IValidatorKeyProvider>();
             
             ValidatorClient validatorClient = testServiceProvider.GetService<ValidatorClient>();
-            BeaconChain beaconChain = testServiceProvider.GetService<BeaconChain>();
+            BeaconChainInformation beaconChainInformation = testServiceProvider.GetService<BeaconChainInformation>();
             
-            await validatorClient.OnTickAsync(beaconChain, 7, new CancellationToken());
+            await validatorClient.OnTickAsync(beaconChainInformation, 7, new CancellationToken());
             
             // Assert
             List<ICall> clientReceived = beaconNodeOApiClient.ReceivedCalls().ToList();

--- a/src/Nethermind/Nethermind.HonestValidator/HonestValidatorServiceCollectionExtensions.cs
+++ b/src/Nethermind/Nethermind.HonestValidator/HonestValidatorServiceCollectionExtensions.cs
@@ -29,7 +29,7 @@ namespace Nethermind.HonestValidator
         public static void AddHonestValidator(this IServiceCollection services, IConfiguration configuration)
         {
             services.AddSingleton<IClock, SystemClock>();
-            services.AddSingleton<BeaconChain>();
+            services.AddSingleton<BeaconChainInformation>();
             services.AddSingleton<ValidatorClient>();
             
             services.AddHostedService<HonestValidatorWorker>();

--- a/src/Nethermind/Nethermind.HonestValidator/Log.cs
+++ b/src/Nethermind/Nethermind.HonestValidator/Log.cs
@@ -96,7 +96,27 @@ namespace Nethermind.HonestValidator
         public static readonly Action<ILogger, int, StatusCode, Exception?> ErrorGettingValidatorDuties =
             LoggerMessage.Define<int, StatusCode>(LogLevel.Error,
                 new EventId(5451, nameof(ErrorGettingValidatorDuties)),
-                "Error getting updated validator duties from bacon node, response: {StatusCodeNumeric} {StatusCode}.");
+                "Error getting updated validator duties from beacon node, response: {StatusCodeNumeric} {StatusCode}.");
+        public static readonly Action<ILogger, int, StatusCode, Exception?> ErrorGettingForkVersion =
+            LoggerMessage.Define<int, StatusCode>(LogLevel.Error,
+                new EventId(5452, nameof(ErrorGettingForkVersion)),
+                "Error getting updated fork version from beacon node, response: {StatusCodeNumeric} {StatusCode}.");
+        public static readonly Action<ILogger, int, StatusCode, Exception?> ErrorGettingSyncStatus =
+            LoggerMessage.Define<int, StatusCode>(LogLevel.Error,
+                new EventId(5453, nameof(ErrorGettingSyncStatus)),
+                "Error getting updated sync status from beacon node, response: {StatusCodeNumeric} {StatusCode}.");
+        public static readonly Action<ILogger, string, Exception?> ExceptionGettingValidatorDuties =
+            LoggerMessage.Define<string>(LogLevel.Error,
+                new EventId(5454, nameof(ErrorGettingValidatorDuties)),
+                "Exception getting updated validator duties from beacon node, error message: {ErrorMessage}");
+        public static readonly Action<ILogger, string, Exception?> ExceptionGettingForkVersion =
+            LoggerMessage.Define<string>(LogLevel.Error,
+                new EventId(5455, nameof(ErrorGettingForkVersion)),
+                "Exception getting updated fork version from beacon node, error message: {ErrorMessage}");
+        public static readonly Action<ILogger, string, Exception?> ExceptionGettingSyncStatus =
+            LoggerMessage.Define<string>(LogLevel.Error,
+                new EventId(5456, nameof(ErrorGettingSyncStatus)),
+                "Exception getting updated sync status from beacon node, error message: {ErrorMessage}");
 
         // 8bxx finalization
 

--- a/src/Nethermind/Nethermind.HonestValidator/Log.cs
+++ b/src/Nethermind/Nethermind.HonestValidator/Log.cs
@@ -16,6 +16,7 @@
 
 using System;
 using Microsoft.Extensions.Logging;
+using Nethermind.Core2.Api;
 using Nethermind.Core2.Crypto;
 using Nethermind.Core2.Types;
 
@@ -92,6 +93,10 @@ namespace Nethermind.HonestValidator
             LoggerMessage.Define(LogLevel.Error,
                 new EventId(5450, nameof(HonestValidatorWorkerLoopError)),
                 "Unexpected error caught in honest validator worker, loop continuing.");
+        public static readonly Action<ILogger, int, StatusCode, Exception?> ErrorGettingValidatorDuties =
+            LoggerMessage.Define<int, StatusCode>(LogLevel.Error,
+                new EventId(5451, nameof(ErrorGettingValidatorDuties)),
+                "Error getting updated validator duties from bacon node, response: {StatusCodeNumeric} {StatusCode}.");
 
         // 8bxx finalization
 

--- a/src/Nethermind/Nethermind.HonestValidator/LogDebug.cs
+++ b/src/Nethermind/Nethermind.HonestValidator/LogDebug.cs
@@ -55,6 +55,10 @@ namespace Nethermind.HonestValidator
             LoggerMessage.Define<BlsPublicKey, Epoch, Slot, Shard>(LogLevel.Debug,
                 new EventId(6455, nameof(ValidatorDutyAttestationChanged)),
                 "Validator {PublicKey} epoch {Epoch} duty attestation slot {Slot} for shard {Shard}.");
+        public static readonly Action<ILogger, Slot, Slot, Slot, Exception?> ProcessingSlot =
+            LoggerMessage.Define<Slot, Slot, Slot>(LogLevel.Debug,
+                new EventId(6455, nameof(ProcessingSlot)),
+                "Processing slot {CheckSlot}, at clock time slot {ClockSlot}, with last sync status current (head) slot {NodeCurrentSlot}.");
 
     }
 }

--- a/src/Nethermind/Nethermind.HonestValidator/Services/BeaconChainInformation.cs
+++ b/src/Nethermind/Nethermind.HonestValidator/Services/BeaconChainInformation.cs
@@ -15,19 +15,30 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
 using System.Threading.Tasks;
-using Nethermind.Core2.Configuration;
+using Nethermind.Core2.Api;
 using Nethermind.Core2.Containers;
 using Nethermind.Core2.Types;
 
 namespace Nethermind.HonestValidator.Services
 {
-    public class BeaconChain
+    public class BeaconChainInformation
     {
-        public ulong GenesisTime { get; private set;  }
+        public Fork Fork { get; private set; } = Fork.Zero;
+        public ulong GenesisTime { get; private set; }
 
-        public ulong Time { get; private set;  }
+        public Slot LastSlotChecked { get; private set; }
 
-        public Fork Fork { get; private set; }
+        public bool NodeIsSyncing { get; private set; }
+
+        public SyncingStatus SyncStatus { get; private set; } = SyncingStatus.Zero;
+
+        public ulong Time { get; private set; }
+
+        public Task SetForkAsync(Fork fork)
+        {
+            Fork = fork;
+            return Task.CompletedTask;
+        }
 
         public Task SetGenesisTimeAsync(ulong time)
         {
@@ -35,15 +46,26 @@ namespace Nethermind.HonestValidator.Services
             return Task.CompletedTask;
         }
 
-        public Task SetTimeAsync(ulong time)
+        public Task SetLastSlotChecked(Slot slot)
         {
-            Time = time;
+            LastSlotChecked = slot;
             return Task.CompletedTask;
         }
 
-        public Task SetForkAsync(Fork fork)
+        public Task SetSyncStatus(Syncing syncing)
         {
-            Fork = fork;
+            NodeIsSyncing = syncing.IsSyncing;
+            if (syncing.SyncStatus != null)
+            {
+                SyncStatus = syncing.SyncStatus;
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task SetTimeAsync(ulong time)
+        {
+            Time = time;
             return Task.CompletedTask;
         }
     }

--- a/src/Nethermind/Nethermind.HonestValidator/ValidatorClient.cs
+++ b/src/Nethermind/Nethermind.HonestValidator/ValidatorClient.cs
@@ -16,17 +16,15 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Nethermind.Core2.Configuration;
 using Nethermind.Core2;
 using Nethermind.Core2.Api;
+using Nethermind.Core2.Configuration;
 using Nethermind.Core2.Containers;
 using Nethermind.Core2.Crypto;
-using Nethermind.Core2.Json;
 using Nethermind.Core2.Types;
 using Nethermind.HonestValidator.Services;
 using Nethermind.Logging.Microsoft;
@@ -35,16 +33,16 @@ namespace Nethermind.HonestValidator
 {
     public class ValidatorClient
     {
-        private readonly ILogger _logger;
-        private readonly IOptionsMonitor<MiscellaneousParameters> _miscellaneousParameterOptions;
-        private readonly IOptionsMonitor<InitialValues> _initialValueOptions;
-        private readonly IOptionsMonitor<TimeParameters> _timeParameterOptions;
-        private readonly IOptionsMonitor<MaxOperationsPerBlock> _maxOperationsPerBlockOptions;
-        private readonly IOptionsMonitor<SignatureDomains> _signatureDomainOptions;
-        private readonly ICryptographyService _cryptographyService;
+        private readonly BeaconChainInformation _beaconChainInformation;
         private readonly IBeaconNodeApi _beaconNodeApi;
+        private readonly ICryptographyService _cryptographyService;
+        private readonly IOptionsMonitor<InitialValues> _initialValueOptions;
+        private readonly ILogger _logger;
+        private readonly IOptionsMonitor<MaxOperationsPerBlock> _maxOperationsPerBlockOptions;
+        private readonly IOptionsMonitor<MiscellaneousParameters> _miscellaneousParameterOptions;
+        private readonly IOptionsMonitor<SignatureDomains> _signatureDomainOptions;
+        private readonly IOptionsMonitor<TimeParameters> _timeParameterOptions;
         private readonly IValidatorKeyProvider _validatorKeyProvider;
-        private readonly BeaconChain _beaconChain;
         private readonly ValidatorState _validatorState;
 
         public ValidatorClient(ILogger<ValidatorClient> logger,
@@ -56,7 +54,7 @@ namespace Nethermind.HonestValidator
             ICryptographyService cryptographyService,
             IBeaconNodeApi beaconNodeApi,
             IValidatorKeyProvider validatorKeyProvider,
-            BeaconChain beaconChain)
+            BeaconChainInformation beaconChainInformation)
         {
             _logger = logger;
             _miscellaneousParameterOptions = miscellaneousParameterOptions;
@@ -67,106 +65,60 @@ namespace Nethermind.HonestValidator
             _cryptographyService = cryptographyService;
             _beaconNodeApi = beaconNodeApi;
             _validatorKeyProvider = validatorKeyProvider;
-            _beaconChain = beaconChain;
-            
+            _beaconChainInformation = beaconChainInformation;
+
             _validatorState = new ValidatorState();
         }
-        
-        public Slot GetCurrentSlot(BeaconChain beaconChain)
-        {
-            ulong slotValue = (beaconChain.Time - beaconChain.GenesisTime) / _timeParameterOptions.CurrentValue.SecondsPerSlot;
-            return new Slot(slotValue);
-        }
-        
-        public async Task OnTickAsync(BeaconChain beaconChain, ulong time, CancellationToken cancellationToken)
-        {
-            // update time
-            Slot previousSlot = GetCurrentSlot(beaconChain);
-            await beaconChain.SetTimeAsync(time).ConfigureAwait(false);
-            Slot currentSlot = GetCurrentSlot(beaconChain);
-            
-            // TODO: attestation is done 1/3 way through slot
 
-            // Not a new slot, return
-            bool isNewSlot = currentSlot > previousSlot;
-            if (!isNewSlot)
+        /// <summary>
+        /// Returns the domain for the 'domain_type' and 'fork_version'
+        /// </summary>
+        public Domain ComputeDomain(DomainType domainType, ForkVersion? forkVersion)
+        {
+            // TODO: Duplicate of BeaconChainUtility
+
+            if (forkVersion == null)
             {
-                return;
+                forkVersion = _initialValueOptions.CurrentValue.GenesisForkVersion;
             }
 
-            await UpdateForkVersion(cancellationToken).ConfigureAwait(false);
-            
-            Epoch currentEpoch = ComputeEpochAtSlot(currentSlot);
-            await UpdateDutiesAsync(currentEpoch, cancellationToken).ConfigureAwait(false);
-
-            await ProcessProposalDutiesAsync(currentSlot, cancellationToken).ConfigureAwait(false);
-            
-            // If upcoming attester, join (or change) topics
-            // Subscribe to topics
-
-            // Attest 1/3 way through slot
+            Span<byte> combined = stackalloc byte[Domain.Length];
+            domainType.AsSpan().CopyTo(combined);
+            forkVersion.Value.AsSpan().CopyTo(combined.Slice(DomainType.Length));
+            return new Domain(combined);
         }
 
-        public async Task UpdateForkVersion(CancellationToken cancellationToken)
+//        public async Task ProcessProposerDutiesAsync(ulong time)
+//        {
+//            throw new System.NotSupportedException();
+//        }
+
+        /// <summary>
+        /// Return the epoch number of ``slot``.
+        /// </summary>
+        public Epoch ComputeEpochAtSlot(Slot slot)
         {
-            var forkResponse = await _beaconNodeApi.GetNodeForkAsync(cancellationToken).ConfigureAwait(false);
-            if (forkResponse.StatusCode == StatusCode.Success)
-            {
-                var fork = forkResponse.Content;
-                await _beaconChain.SetForkAsync(fork).ConfigureAwait(false);
-            }
-            else
-            {
-                throw new Exception($"Error response from get fork: {(int)forkResponse.StatusCode} {forkResponse.StatusCode}.");
-            }
+            // TODO: Duplicate of BeaconChainUtility
+
+            return new Epoch(slot / _timeParameterOptions.CurrentValue.SlotsPerEpoch);
         }
 
-        public async Task ProcessProposalDutiesAsync(Slot slot, CancellationToken cancellationToken)
+        /// <summary>
+        /// Return the signing root of an object by calculating the root of the object-domain tree.
+        /// </summary>
+        public Root ComputeSigningRoot(Root objectRoot, Domain domain)
         {
-            // If proposer, get block, sign block, return to node
-            // Retry if not successful; need to queue this up to send immediately if connection issue. (or broadcast?)
+            // TODO: Duplicate of BeaconChainUtility
 
-            BlsPublicKey? blsPublicKey = _validatorState.GetProposalDutyForSlot(slot);
-            if (!(blsPublicKey is null))
-            {
-                if (_logger.IsInfo()) Log.ProposalDutyFor(_logger, slot, _beaconChain.Time, blsPublicKey, null);
-                
-                BlsSignature randaoReveal = GetEpochSignature(slot, blsPublicKey);
-
-                if (_logger.IsDebug()) LogDebug.RequestingBlock(_logger, slot, blsPublicKey.ToShortString(), randaoReveal.ToString().Substring(0, 10), null);
-
-                ApiResponse<BeaconBlock> newBlockResponse = await _beaconNodeApi.NewBlockAsync(slot, randaoReveal, cancellationToken).ConfigureAwait(false);
-                if (newBlockResponse.StatusCode == StatusCode.Success)
-                {
-                    BeaconBlock unsignedBlock = newBlockResponse.Content;
-                    BlsSignature blockSignature = GetBlockSignature(unsignedBlock, blsPublicKey);
-                    SignedBeaconBlock signedBlock = new SignedBeaconBlock(unsignedBlock, blockSignature);
-
-                    if (_logger.IsDebug())
-                        LogDebug.PublishingSignedBlock(_logger, slot, blsPublicKey.ToShortString(),
-                            randaoReveal.ToString().Substring(0, 10), signedBlock.Message,
-                            signedBlock.Signature.ToString().Substring(0, 10), null);
-
-                    ApiResponse publishBlockResponse = await _beaconNodeApi.PublishBlockAsync(signedBlock, cancellationToken)
-                        .ConfigureAwait(false);
-                    if (publishBlockResponse.StatusCode != StatusCode.Success && publishBlockResponse.StatusCode !=
-                        StatusCode.BroadcastButFailedValidation)
-                    {
-                        throw new Exception($"Error response from publish: {(int)publishBlockResponse.StatusCode} {publishBlockResponse.StatusCode}.");
-                    }
-
-                    bool nodeAccepted = publishBlockResponse.StatusCode == StatusCode.Success;
-                    // TODO: Log warning if not accepted? Not sure what else we could do.
-                    _validatorState.ClearProposalDutyForSlot(slot);
-                }
-            }
+            SigningRoot domainWrappedObject = new SigningRoot(objectRoot, domain);
+            return _cryptographyService.HashTreeRoot(domainWrappedObject);
         }
 
         public BlsSignature GetBlockSignature(BeaconBlock block, BlsPublicKey blsPublicKey)
         {
-            var fork = _beaconChain.Fork;
+            var fork = _beaconChainInformation.Fork;
             var epoch = ComputeEpochAtSlot(block.Slot);
-            
+
             ForkVersion forkVersion;
             if (epoch < fork.Epoch)
             {
@@ -179,7 +131,7 @@ namespace Nethermind.HonestValidator
 
             var domainType = _signatureDomainOptions.CurrentValue.BeaconProposer;
             var proposerDomain = ComputeDomain(domainType, forkVersion);
-            
+
             /*
             JsonSerializerOptions options = new System.Text.Json.JsonSerializerOptions { WriteIndented = true };
             options.ConfigureNethermindCore2();
@@ -190,15 +142,22 @@ namespace Nethermind.HonestValidator
             var signingRoot = ComputeSigningRoot(blockRoot, proposerDomain);
 
             var signature = _validatorKeyProvider.SignRoot(blsPublicKey, signingRoot);
-            
+
             return signature;
         }
-        
+
+        public Slot GetCurrentSlot(BeaconChainInformation beaconChainInformation)
+        {
+            ulong slotValue = (beaconChainInformation.Time - beaconChainInformation.GenesisTime) /
+                              _timeParameterOptions.CurrentValue.SecondsPerSlot;
+            return new Slot(slotValue);
+        }
+
         public BlsSignature GetEpochSignature(Slot slot, BlsPublicKey blsPublicKey)
         {
-            var fork = _beaconChain.Fork;
+            var fork = _beaconChainInformation.Fork;
             var epoch = ComputeEpochAtSlot(slot);
-            
+
             ForkVersion forkVersion;
             if (epoch < fork.Epoch)
             {
@@ -211,7 +170,7 @@ namespace Nethermind.HonestValidator
 
             var domainType = _signatureDomainOptions.CurrentValue.Randao;
             var randaoDomain = ComputeDomain(domainType, forkVersion);
-            
+
             var epochRoot = _cryptographyService.HashTreeRoot(epoch);
             var signingRoot = ComputeSigningRoot(epochRoot, randaoDomain);
 
@@ -220,92 +179,215 @@ namespace Nethermind.HonestValidator
             return randaoReveal;
         }
 
-        public async Task UpdateDutiesAsync(Epoch epoch, CancellationToken cancellationToken)
+        public async Task OnTickAsync(BeaconChainInformation beaconChainInformation, ulong time,
+            CancellationToken cancellationToken)
         {
-            IList<BlsPublicKey> publicKeys = _validatorKeyProvider.GetPublicKeys();
+            // update time
+            await beaconChainInformation.SetTimeAsync(time).ConfigureAwait(false);
+            Slot currentSlot = GetCurrentSlot(beaconChainInformation);
 
-            ApiResponse<IList<ValidatorDuty>> validatorDutiesResponse = await _beaconNodeApi.ValidatorDutiesAsync(publicKeys, epoch, cancellationToken);
-            if (validatorDutiesResponse.StatusCode != StatusCode.Success)
+            // TODO: attestation is done 1/3 way through slot
+
+            // Not a new slot (clock is still the same as the slot we just checked), return
+            bool shouldCheckSlot = currentSlot > beaconChainInformation.LastSlotChecked;
+            if (!shouldCheckSlot)
             {
-                Log.ErrorGettingValidatorDuties(_logger, (int) validatorDutiesResponse.StatusCode,
-                    validatorDutiesResponse.StatusCode, null);
                 return;
             }
-            
-            IList<ValidatorDuty> validatorDuties = validatorDutiesResponse.Content;
 
-            foreach (ValidatorDuty validatorDuty in validatorDuties)
+            await UpdateForkVersion(cancellationToken).ConfigureAwait(false);
+            
+            // TODO: For beacon nodes that don't report SyncingStatus (which is nullable/optional),
+            // then need a different strategy to determine the current head known by the beacon node.
+            // The current code (2020-03-15) will simply start from slot 0 and process 1/second until
+            // caught up with clock slot; at 6 seconds/slot, this is 6x faster, i.e. 1 day still takes 4 hours.
+            // (okay for testing).
+            // Alternative 1: see if the node supports /beacon/head, and use that slot
+            // Alternative 2: try UpdateDuties, and if you get 406 DutiesNotAvailableForRequestedEpoch then use a
+            // divide & conquer algorithm to determine block to check. (Could be a back off x1, x2, x4, x8, etc if 406)
+            
+            await UpdateSyncStatus(cancellationToken).ConfigureAwait(false);
+
+            // Need to have an anchor block (will provide the genesis time) before can do anything
+            // Absolutely no point in generating blocks < anchor slot
+            // Irrespective of clock time, can't check duties >= 2 epochs ahead of current (head), as don't have data
+            //  - actually, validator only cares about what they need to sign this slot
+            //  - the beacon node takes care of subscribing to topics an epoch in advance, etc
+            // While signing a block < highest (seen) slot may be a waste, there is no penalty for doing so
+
+            // Generally no point in generating blocks <= current (head) slot
+            Slot slotToCheck =
+                Slot.Max(beaconChainInformation.LastSlotChecked, beaconChainInformation.SyncStatus.CurrentSlot) +
+                Slot.One;
+
+            LogDebug.ProcessingSlot(_logger, slotToCheck, currentSlot, beaconChainInformation.SyncStatus.CurrentSlot,
+                null);
+
+            // Slot is set before processing; if there is an error (in process; update duties has a try/catch), it will skip to the next slot
+            // (maybe the error will be resolved; trade off of whether error can be fixed by retrying, e.g. network error,
+            // but potentially getting stuck in a slot, vs missing a slot)
+            // TODO: Maybe add a retry policy/retry count when to advance last slot checked regardless
+            await beaconChainInformation.SetLastSlotChecked(slotToCheck);
+
+            // TODO: Attestations should run checks one epoch ahead, for topic subscriptions, although this is more a beacon node thing to do.
+
+            // Note that UpdateDuties will continue even if there is an error/issue (i.e. assume no change and process what we have)
+            Epoch epochToCheck = ComputeEpochAtSlot(slotToCheck);
+            await UpdateDutiesAsync(epochToCheck, cancellationToken).ConfigureAwait(false);
+
+            await ProcessProposalDutiesAsync(slotToCheck, cancellationToken).ConfigureAwait(false);
+
+            // If upcoming attester, join (or change) topics
+            // Subscribe to topics
+
+            // Attest 1/3 way through slot
+        }
+
+        public async Task ProcessProposalDutiesAsync(Slot slot, CancellationToken cancellationToken)
+        {
+            // If proposer, get block, sign block, return to node
+            // Retry if not successful; need to queue this up to send immediately if connection issue. (or broadcast?)
+
+            BlsPublicKey? blsPublicKey = _validatorState.GetProposalDutyForSlot(slot);
+            if (!(blsPublicKey is null))
             {
-                Slot? currentAttestationSlot =
-                    _validatorState.AttestationSlot.GetValueOrDefault(validatorDuty.ValidatorPublicKey);
-                Shard? currentAttestationShard =
-                    _validatorState.AttestationShard.GetValueOrDefault(validatorDuty.ValidatorPublicKey);
-                if (validatorDuty.AttestationSlot != currentAttestationSlot ||
-                    validatorDuty.AttestationShard != currentAttestationShard)
+                if (_logger.IsInfo())
+                    Log.ProposalDutyFor(_logger, slot, _beaconChainInformation.Time, blsPublicKey, null);
+
+                BlsSignature randaoReveal = GetEpochSignature(slot, blsPublicKey);
+
+                if (_logger.IsDebug())
+                    LogDebug.RequestingBlock(_logger, slot, blsPublicKey.ToShortString(),
+                        randaoReveal.ToString().Substring(0, 10), null);
+
+                ApiResponse<BeaconBlock> newBlockResponse = await _beaconNodeApi
+                    .NewBlockAsync(slot, randaoReveal, cancellationToken).ConfigureAwait(false);
+                if (newBlockResponse.StatusCode == StatusCode.Success)
                 {
-                    _validatorState.SetAttestationDuty(validatorDuty.ValidatorPublicKey, validatorDuty.AttestationSlot,
-                        validatorDuty.AttestationShard);
+                    BeaconBlock unsignedBlock = newBlockResponse.Content;
+                    BlsSignature blockSignature = GetBlockSignature(unsignedBlock, blsPublicKey);
+                    SignedBeaconBlock signedBlock = new SignedBeaconBlock(unsignedBlock, blockSignature);
+
                     if (_logger.IsDebug())
-                        LogDebug.ValidatorDutyAttestationChanged(_logger, validatorDuty.ValidatorPublicKey, epoch,
-                            validatorDuty.AttestationSlot, validatorDuty.AttestationShard, null);
+                        LogDebug.PublishingSignedBlock(_logger, slot, blsPublicKey.ToShortString(),
+                            randaoReveal.ToString().Substring(0, 10), signedBlock.Message,
+                            signedBlock.Signature.ToString().Substring(0, 10), null);
+
+                    ApiResponse publishBlockResponse = await _beaconNodeApi
+                        .PublishBlockAsync(signedBlock, cancellationToken)
+                        .ConfigureAwait(false);
+                    if (publishBlockResponse.StatusCode != StatusCode.Success && publishBlockResponse.StatusCode !=
+                        StatusCode.BroadcastButFailedValidation)
+                    {
+                        throw new Exception(
+                            $"Error response from publish: {(int) publishBlockResponse.StatusCode} {publishBlockResponse.StatusCode}.");
+                    }
+
+                    bool nodeAccepted = publishBlockResponse.StatusCode == StatusCode.Success;
+                    // TODO: Log warning if not accepted? Not sure what else we could do.
+                    _validatorState.ClearProposalDutyForSlot(slot);
                 }
             }
+        }
 
-            foreach (ValidatorDuty validatorDuty in validatorDuties)
+        public async Task UpdateDutiesAsync(Epoch epoch, CancellationToken cancellationToken)
+        {
+            try
             {
-                Slot? currentProposalSlot = _validatorState.ProposalSlot.GetValueOrDefault(validatorDuty.ValidatorPublicKey);
-                if (validatorDuty.BlockProposalSlot != Slot.None &&
-                    validatorDuty.BlockProposalSlot != currentProposalSlot)
+                IList<BlsPublicKey> publicKeys = _validatorKeyProvider.GetPublicKeys();
+
+                ApiResponse<IList<ValidatorDuty>> validatorDutiesResponse =
+                    await _beaconNodeApi.ValidatorDutiesAsync(publicKeys, epoch, cancellationToken);
+                if (validatorDutiesResponse.StatusCode != StatusCode.Success)
                 {
-                    _validatorState.SetProposalDuty(validatorDuty.ValidatorPublicKey, validatorDuty.BlockProposalSlot);
-                    if (_logger.IsInfo())
-                        Log.ValidatorDutyProposalChanged(_logger, validatorDuty.ValidatorPublicKey, epoch,
-                            validatorDuty.BlockProposalSlot, null);
+                    Log.ErrorGettingValidatorDuties(_logger, (int) validatorDutiesResponse.StatusCode,
+                        validatorDutiesResponse.StatusCode, null);
+                    return;
+                }
+
+                // Record proposal duties first, in case there is an error
+                foreach (ValidatorDuty validatorDuty in validatorDutiesResponse.Content)
+                {
+                    Slot? currentProposalSlot =
+                        _validatorState.ProposalSlot.GetValueOrDefault(validatorDuty.ValidatorPublicKey);
+                    if (validatorDuty.BlockProposalSlot != Slot.None &&
+                        validatorDuty.BlockProposalSlot != currentProposalSlot)
+                    {
+                        _validatorState.SetProposalDuty(validatorDuty.ValidatorPublicKey,
+                            validatorDuty.BlockProposalSlot);
+                        if (_logger.IsInfo())
+                            Log.ValidatorDutyProposalChanged(_logger, validatorDuty.ValidatorPublicKey, epoch,
+                                validatorDuty.BlockProposalSlot, null);
+                    }
+                }
+
+                foreach (ValidatorDuty validatorDuty in validatorDutiesResponse.Content)
+                {
+                    Slot? currentAttestationSlot =
+                        _validatorState.AttestationSlot.GetValueOrDefault(validatorDuty.ValidatorPublicKey);
+                    Shard? currentAttestationShard =
+                        _validatorState.AttestationShard.GetValueOrDefault(validatorDuty.ValidatorPublicKey);
+                    if (validatorDuty.AttestationSlot != currentAttestationSlot ||
+                        validatorDuty.AttestationShard != currentAttestationShard)
+                    {
+                        _validatorState.SetAttestationDuty(validatorDuty.ValidatorPublicKey,
+                            validatorDuty.AttestationSlot,
+                            validatorDuty.AttestationShard);
+                        if (_logger.IsDebug())
+                            LogDebug.ValidatorDutyAttestationChanged(_logger, validatorDuty.ValidatorPublicKey, epoch,
+                                validatorDuty.AttestationSlot, validatorDuty.AttestationShard, null);
+                    }
                 }
             }
-        }
-
-//        public async Task ProcessProposerDutiesAsync(ulong time)
-//        {
-//            throw new System.NotSupportedException();
-//        }
-        
-        /// <summary>
-        /// Return the epoch number of ``slot``.
-        /// </summary>
-        public Epoch ComputeEpochAtSlot(Slot slot)
-        {
-            // TODO: Duplicate of BeaconChainUtility
-            
-            return new Epoch(slot / _timeParameterOptions.CurrentValue.SlotsPerEpoch);
-        }
-
-        /// <summary>
-        /// Returns the domain for the 'domain_type' and 'fork_version'
-        /// </summary>
-        public Domain ComputeDomain(DomainType domainType, ForkVersion? forkVersion)
-        {
-            // TODO: Duplicate of BeaconChainUtility
-            
-            if (forkVersion == null)
+            catch (Exception ex)
             {
-                forkVersion = _initialValueOptions.CurrentValue.GenesisForkVersion;
+                Log.ExceptionGettingValidatorDuties(_logger, ex.Message, ex);
             }
-            Span<byte> combined = stackalloc byte[Domain.Length];
-            domainType.AsSpan().CopyTo(combined);
-            forkVersion.Value.AsSpan().CopyTo(combined.Slice(DomainType.Length));
-            return new Domain(combined);
         }
-        
-        /// <summary>
-        /// Return the signing root of an object by calculating the root of the object-domain tree.
-        /// </summary>
-        public Root ComputeSigningRoot(Root objectRoot, Domain domain)
+
+        public async Task UpdateForkVersion(CancellationToken cancellationToken)
         {
-            // TODO: Duplicate of BeaconChainUtility
-            
-            SigningRoot domainWrappedObject = new SigningRoot(objectRoot, domain);
-            return _cryptographyService.HashTreeRoot(domainWrappedObject);
+            // TODO: Should we be validating this?  i.e. check against config that it is the chain ID we are expecting?
+            // TODO: At least for prior to cutover epoch (allows operation when fork epoch has not yet been reached and only one side is updated)
+            // TODO: Once version is different for the current epoch, should disconnect.
+
+            try
+            {
+                var forkResponse = await _beaconNodeApi.GetNodeForkAsync(cancellationToken).ConfigureAwait(false);
+                if (forkResponse.StatusCode == StatusCode.Success)
+                {
+                    await _beaconChainInformation.SetForkAsync(forkResponse.Content).ConfigureAwait(false);
+                }
+                else
+                {
+                    Log.ErrorGettingForkVersion(_logger, (int) forkResponse.StatusCode, forkResponse.StatusCode, null);
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.ExceptionGettingForkVersion(_logger, ex.Message, ex);
+            }
+        }
+
+        public async Task UpdateSyncStatus(CancellationToken cancellationToken)
+        {
+            try
+            {
+                var syncingResponse = await _beaconNodeApi.GetSyncingAsync(cancellationToken).ConfigureAwait(false);
+                if (syncingResponse.StatusCode == StatusCode.Success)
+                {
+                    await _beaconChainInformation.SetSyncStatus(syncingResponse.Content).ConfigureAwait(false);
+                }
+                else
+                {
+                    Log.ErrorGettingForkVersion(_logger, (int) syncingResponse.StatusCode, syncingResponse.StatusCode,
+                        null);
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.ExceptionGettingSyncStatus(_logger, ex.Message, ex);
+            }
         }
     }
 }

--- a/src/Nethermind/Nethermind.HonestValidator/ValidatorClient.cs
+++ b/src/Nethermind/Nethermind.HonestValidator/ValidatorClient.cs
@@ -225,6 +225,13 @@ namespace Nethermind.HonestValidator
             IList<BlsPublicKey> publicKeys = _validatorKeyProvider.GetPublicKeys();
 
             ApiResponse<IList<ValidatorDuty>> validatorDutiesResponse = await _beaconNodeApi.ValidatorDutiesAsync(publicKeys, epoch, cancellationToken);
+            if (validatorDutiesResponse.StatusCode != StatusCode.Success)
+            {
+                Log.ErrorGettingValidatorDuties(_logger, (int) validatorDutiesResponse.StatusCode,
+                    validatorDutiesResponse.StatusCode, null);
+                return;
+            }
+            
             IList<ValidatorDuty> validatorDuties = validatorDutiesResponse.Content;
 
             foreach (ValidatorDuty validatorDuty in validatorDuties)

--- a/src/Nethermind/Nethermind.HonestValidator/ValidatorState.cs
+++ b/src/Nethermind/Nethermind.HonestValidator/ValidatorState.cs
@@ -15,7 +15,6 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using Nethermind.Core2.Crypto;
 using Nethermind.Core2.Types;
 
@@ -25,13 +24,23 @@ namespace Nethermind.HonestValidator
     {
         private readonly Dictionary<BlsPublicKey, Shard> _attestationShard = new Dictionary<BlsPublicKey, Shard>();
         private readonly Dictionary<BlsPublicKey, Slot> _attestationSlot = new Dictionary<BlsPublicKey, Slot>();
-        private readonly Dictionary<BlsPublicKey, Slot> _proposalSlot = new Dictionary<BlsPublicKey, Slot>();
 
         private readonly Dictionary<Slot, BlsPublicKey> _proposalDutyBySlot = new Dictionary<Slot, BlsPublicKey>();
+        private readonly Dictionary<BlsPublicKey, Slot> _proposalSlot = new Dictionary<BlsPublicKey, Slot>();
 
         public IReadOnlyDictionary<BlsPublicKey, Shard> AttestationShard => _attestationShard;
         public IReadOnlyDictionary<BlsPublicKey, Slot> AttestationSlot => _attestationSlot;
         public IReadOnlyDictionary<BlsPublicKey, Slot> ProposalSlot => _proposalSlot;
+
+        public void ClearProposalDutyForSlot(Slot slot)
+        {
+            _proposalDutyBySlot.Remove(slot);
+        }
+
+        public BlsPublicKey? GetProposalDutyForSlot(Slot slot)
+        {
+            return _proposalDutyBySlot.GetValueOrDefault(slot);
+        }
 
         public void SetAttestationDuty(BlsPublicKey key, Slot slot, Shard shard)
         {
@@ -44,16 +53,6 @@ namespace Nethermind.HonestValidator
         {
             _proposalSlot[key] = slot;
             _proposalDutyBySlot[slot] = key;
-        }
-
-        public BlsPublicKey? GetProposalDutyForSlot(Slot slot)
-        {
-            return _proposalDutyBySlot.GetValueOrDefault(slot);
-        }
-
-        public void ClearProposalDutyForSlot(Slot slot)
-        {
-            _proposalDutyBySlot.Remove(slot);
         }
     }
 }


### PR DESCRIPTION
Update validator to call the sync status API and request duties / generate blocks based on the last known head block, even if in the past compared to the clock.

This helps a test network catch up if the entire network is down for longer than the look ahead (2 epochs). The old code used the clock time, and would fail with everyone getting 406 errors.

Note that if the known head < clock time, it could simply mean that the node is out of date (if only one node was down) and needs to sync to catch up. In these cases, it would produce useless blocks based on the old head (they won't win fork choice), however there is no penalty for producing old blocks. (Provided the other restrictions, like no duplicate signed blocks, are followed)

Closes #1539 