### PR TITLE
byte[] directly

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Proofs/ReceiptTrieTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Proofs/ReceiptTrieTests.cs
@@ -60,7 +60,7 @@ namespace Nethermind.Blockchain.Test.Proofs
         
         private void VerifyProof(byte[][] proof, Keccak receiptRoot)
         {
-            TrieNode node = new TrieNode(NodeType.Unknown, new Rlp(proof.Last()));
+            TrieNode node = new TrieNode(NodeType.Unknown, proof.Last());
             node.ResolveNode(null);
             TxReceipt receipt = new ReceiptMessageDecoder().Decode(node.Value.AsRlpStream());
             Assert.NotNull(receipt.Bloom);

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/FastSync/NodeDataFeed.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/FastSync/NodeDataFeed.cs
@@ -595,7 +595,7 @@ namespace Nethermind.Blockchain.Synchronization.FastSync
         private void HandleTrieNode(StateSyncItem currentStateSyncItem, byte[] currentResponseItem, ref int invalidNodes)
         {
             NodeDataType nodeDataType = currentStateSyncItem.NodeDataType;
-            TrieNode trieNode = new TrieNode(NodeType.Unknown, new Rlp(currentResponseItem));
+            TrieNode trieNode = new TrieNode(NodeType.Unknown, currentResponseItem);
             trieNode.ResolveNode(null);
             switch (trieNode.NodeType)
             {

--- a/src/Nethermind/Nethermind.Runner/configs/goerli.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/goerli.cfg
@@ -10,7 +10,6 @@
     "LogFileName": "goerli.logs.txt"
   },
   "Network": {
-    "ActivePeersMaxCount": 256,
     "DiscoveryPort": 30303,
     "P2PPort": 30303,
     "NettyArenaOrder": 11

--- a/src/Nethermind/Nethermind.Runner/configs/goerli.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/goerli.cfg
@@ -10,6 +10,7 @@
     "LogFileName": "goerli.logs.txt"
   },
   "Network": {
+    "ActivePeersMaxCount": 256,
     "DiscoveryPort": 30303,
     "P2PPort": 30303,
     "NettyArenaOrder": 11

--- a/src/Nethermind/Nethermind.State.Test/Proofs/AccountProofCollectorTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/Proofs/AccountProofCollectorTests.cs
@@ -651,7 +651,7 @@ storage: 10075208144087594565017167249218046892267736431914869828855077415926031
 
             for (int j = 0; j < accountProof.StorageProofs.Length; j++)
             {
-                TrieNode node = new TrieNode(NodeType.Unknown, new Rlp(accountProof.StorageProofs[j].Proof.Last()));
+                TrieNode node = new TrieNode(NodeType.Unknown, accountProof.StorageProofs[j].Proof.Last());
                 node.ResolveNode(null);
                 if (node.Value.Length != 1)
                 {
@@ -728,7 +728,7 @@ storage: 10075208144087594565017167249218046892267736431914869828855077415926031
                     addressesWithStorage[i].StorageCells[j].Index.ToBigEndian(indexBytes.AsSpan());
                     accountProof.StorageProofs[j].Key.ToHexString().Should().Be(indexBytes.ToHexString(), $"{i} {j}");
 
-                    TrieNode node = new TrieNode(NodeType.Unknown, new Rlp(accountProof.StorageProofs[j].Proof.Last()));
+                    TrieNode node = new TrieNode(NodeType.Unknown, accountProof.StorageProofs[j].Proof.Last());
                     node.ResolveNode(null);
                     // TestContext.Write($"|[{i},{j}]");
                     if (node.Value.Length != 1)

--- a/src/Nethermind/Nethermind.State.Test/TrieNodeTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/TrieNodeTests.cs
@@ -65,7 +65,7 @@ namespace Nethermind.Store.Test
         [Test]
         public void Throws_trie_exception_on_unexpected_format()
         {
-            TrieNode trieNode = new TrieNode(NodeType.Unknown, new Rlp(new byte[42]));
+            TrieNode trieNode = new TrieNode(NodeType.Unknown, new byte[42]);
             Assert.Throws<TrieException>(() => trieNode.ResolveNode(new PatriciaTree()));
         }
 
@@ -140,7 +140,7 @@ namespace Nethermind.Store.Test
                 }
 
                 Rlp rlp = trieNode.RlpEncode();
-                TrieNode restoredNode = new TrieNode(NodeType.Branch, rlp);
+                TrieNode restoredNode = new TrieNode(NodeType.Branch, rlp.Bytes);
 
                 for (int childIndex = 0; childIndex < 16; childIndex++)
                 {
@@ -166,7 +166,7 @@ namespace Nethermind.Store.Test
 
             Rlp rlp = trieNode.RlpEncode();
 
-            TrieNode decoded = new TrieNode(NodeType.Unknown, rlp);
+            TrieNode decoded = new TrieNode(NodeType.Unknown, rlp.Bytes);
             decoded.ResolveNode(null);
             TrieNode decodedTiniest = decoded.GetChild(11);
             decodedTiniest.ResolveNode(null);
@@ -183,7 +183,7 @@ namespace Nethermind.Store.Test
 
             Rlp rlp = trieNode.RlpEncode();
 
-            TrieNode decoded = new TrieNode(NodeType.Unknown, rlp);
+            TrieNode decoded = new TrieNode(NodeType.Unknown, rlp.Bytes);
             decoded.ResolveNode(null);
             TrieNode decodedTiniest = decoded.GetChild(11);
 
@@ -199,7 +199,7 @@ namespace Nethermind.Store.Test
 
             Rlp rlp = trieNode.RlpEncode();
 
-            TrieNode decoded = new TrieNode(NodeType.Unknown, rlp);
+            TrieNode decoded = new TrieNode(NodeType.Unknown, rlp.Bytes);
             decoded.ResolveNode(null);
             TrieNode decodedTiniest = decoded.GetChild(0);
             decodedTiniest.ResolveNode(null);
@@ -217,7 +217,7 @@ namespace Nethermind.Store.Test
 
             Rlp rlp = trieNode.RlpEncode();
 
-            TrieNode decoded = new TrieNode(NodeType.Unknown, rlp);
+            TrieNode decoded = new TrieNode(NodeType.Unknown, rlp.Bytes);
             decoded.ResolveNode(null);
             TrieNode decodedTiniest = decoded.GetChild(0);
 
@@ -243,7 +243,7 @@ namespace Nethermind.Store.Test
             TrieNode trieNode = new TrieNode(NodeType.Branch);
             trieNode[11] = _heavyLeaf;
             Rlp rlp = trieNode.RlpEncode();
-            TrieNode decoded = new TrieNode(NodeType.Branch, rlp);
+            TrieNode decoded = new TrieNode(NodeType.Branch, rlp.Bytes);
 
             Keccak getResult = decoded.GetChildHash(11);
             Assert.NotNull(getResult);
@@ -255,7 +255,7 @@ namespace Nethermind.Store.Test
             TrieNode trieNode = new TrieNode(NodeType.Branch);
             trieNode[11] = _tiniestLeaf;
             Rlp rlp = trieNode.RlpEncode();
-            TrieNode decoded = new TrieNode(NodeType.Branch, rlp);
+            TrieNode decoded = new TrieNode(NodeType.Branch, rlp.Bytes);
 
             Keccak getResult = decoded.GetChildHash(11);
             Assert.Null(getResult);
@@ -268,7 +268,7 @@ namespace Nethermind.Store.Test
             trieNode[0] = _heavyLeaf;
             trieNode.Key = new HexPrefix(false, 5);
             Rlp rlp = trieNode.RlpEncode();
-            TrieNode decoded = new TrieNode(NodeType.Extension, rlp);
+            TrieNode decoded = new TrieNode(NodeType.Extension, rlp.Bytes);
 
             Keccak getResult = decoded.GetChildHash(0);
             Assert.NotNull(getResult);
@@ -281,7 +281,7 @@ namespace Nethermind.Store.Test
             trieNode[0] = _tiniestLeaf;
             trieNode.Key = new HexPrefix(false, 5);
             Rlp rlp = trieNode.RlpEncode();
-            TrieNode decoded = new TrieNode(NodeType.Extension, rlp);
+            TrieNode decoded = new TrieNode(NodeType.Extension, rlp.Bytes);
 
             Keccak getResult = decoded.GetChildHash(0);
             Assert.Null(getResult);
@@ -507,7 +507,7 @@ namespace Nethermind.Store.Test
 
             Rlp rlp = node.RlpEncode();
 
-            TrieNode restoredNode = new TrieNode(NodeType.Branch, rlp);
+            TrieNode restoredNode = new TrieNode(NodeType.Branch, rlp.Bytes);
 
             restoredNode.RlpEncode();
         }

--- a/src/Nethermind/Nethermind.State/Proofs/AccountProofCollector.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/AccountProofCollector.cs
@@ -217,13 +217,13 @@ namespace Nethermind.State.Proofs
                 {
                     foreach (int storageIndex in _storageNodeInfos[node.Keccak].StorageIndices)
                     {
-                        _storageProofItems[storageIndex].Add(node.FullRlp.Bytes);
+                        _storageProofItems[storageIndex].Add(node.FullRlp);
                     }
                 }
             }
             else
             {
-                _accountProofItems.Add(node.FullRlp.Bytes);
+                _accountProofItems.Add(node.FullRlp);
             }
         }
 

--- a/src/Nethermind/Nethermind.State/Proofs/ProofCollector.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/ProofCollector.cs
@@ -84,7 +84,7 @@ namespace Nethermind.State.Proofs
 
         private void AddProofBits(TrieNode node)
         {
-            _proofBits.Add(node.FullRlp.Bytes);
+            _proofBits.Add(node.FullRlp);
         }
 
         public void VisitLeaf(TrieNode node, TrieVisitContext trieVisitContext, byte[] value)

--- a/src/Nethermind/Nethermind.State/Proofs/ProofVerifier.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/ProofVerifier.cs
@@ -31,7 +31,7 @@ namespace Nethermind.State.Proofs
                 return null;
             }
 
-            TrieNode trieNode = new TrieNode(NodeType.Unknown, new Rlp(proof.Last()));
+            TrieNode trieNode = new TrieNode(NodeType.Unknown, proof.Last());
             trieNode.ResolveNode(null);
             for (int i = proof.Length; i > 0; i--)
             {

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -30,7 +30,7 @@ namespace Nethermind.Trie
     [DebuggerDisplay("{RootHash}")]
     public class PatriciaTree
     {
-        public static readonly LruCache<Keccak, Rlp> NodeCache = new LruCache<Keccak, Rlp>(256 * 1024);
+        public static readonly LruCache<Keccak, byte[]> NodeCache = new LruCache<Keccak, byte[]>(256 * 1024);
 
         /// <summary>
         ///     0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421
@@ -118,7 +118,7 @@ namespace Nethermind.Trie
                         throw new ArgumentNullException($"Threading issue at {nameof(_currentCommit)} - should not happen unless we use static objects somewhere here.");
                     }
 
-                    _keyValueStore[node.Keccak.Bytes] = node.FullRlp.Bytes;
+                    _keyValueStore[node.Keccak.Bytes] = node.FullRlp;
                 }
 
                 // reset objects
@@ -253,14 +253,14 @@ namespace Nethermind.Trie
             Set(rawKey, value == null ? new byte[0] : value.Bytes);
         }
 
-        internal Rlp GetNode(Keccak keccak, bool allowCaching)
+        internal byte[] GetNode(Keccak keccak, bool allowCaching)
         {
             if (!allowCaching)
             {
-                return new Rlp(_keyValueStore[keccak.Bytes]);
+                return _keyValueStore[keccak.Bytes];
             }
 
-            Rlp cachedRlp = NodeCache.Get(keccak);
+            byte[] cachedRlp = NodeCache.Get(keccak);
             if (cachedRlp == null)
             {
                 byte[] dbValue = _keyValueStore[keccak.Bytes];
@@ -269,7 +269,7 @@ namespace Nethermind.Trie
                     throw new TrieException($"Node {keccak} is missing from the DB");
                 }
                 
-                return new Rlp(dbValue);
+                return dbValue;
             }
 
             return cachedRlp;

--- a/src/Nethermind/Nethermind.Trie/TreeDumper.cs
+++ b/src/Nethermind/Nethermind.Trie/TreeDumper.cs
@@ -60,12 +60,12 @@ namespace Nethermind.Trie
 
         public void VisitBranch(TrieNode node, TrieVisitContext trieVisitContext)
         {
-            _builder.AppendLine($"{GetPrefix(trieVisitContext)}BRANCH | -> {(node.Keccak?.Bytes ?? node.FullRlp?.Bytes)?.ToHexString()}");
+            _builder.AppendLine($"{GetPrefix(trieVisitContext)}BRANCH | -> {(node.Keccak?.Bytes ?? node.FullRlp)?.ToHexString()}");
         }
 
         public void VisitExtension(TrieNode node, TrieVisitContext trieVisitContext)
         {
-            _builder.AppendLine($"{GetPrefix(trieVisitContext)}EXTENSION {Nibbles.FromBytes(node.Path).ToPackedByteArray().ToHexString(false)} -> {(node.Keccak?.Bytes ?? node.FullRlp?.Bytes)?.ToHexString()}");
+            _builder.AppendLine($"{GetPrefix(trieVisitContext)}EXTENSION {Nibbles.FromBytes(node.Path).ToPackedByteArray().ToHexString(false)} -> {(node.Keccak?.Bytes ?? node.FullRlp)?.ToHexString()}");
         }
 
         private AccountDecoder decoder = new AccountDecoder();
@@ -73,7 +73,7 @@ namespace Nethermind.Trie
         public void VisitLeaf(TrieNode node, TrieVisitContext trieVisitContext, byte[] value = null)
         {
             string leafDescription = trieVisitContext.IsStorage ? "LEAF " : "ACCOUNT ";
-            _builder.AppendLine($"{GetPrefix(trieVisitContext)}{leafDescription} {Nibbles.FromBytes(node.Path).ToPackedByteArray().ToHexString(false)} -> {(node.Keccak?.Bytes ?? node.FullRlp?.Bytes)?.ToHexString()}");
+            _builder.AppendLine($"{GetPrefix(trieVisitContext)}{leafDescription} {Nibbles.FromBytes(node.Path).ToPackedByteArray().ToHexString(false)} -> {(node.Keccak?.Bytes ?? node.FullRlp)?.ToHexString()}");
             if (!trieVisitContext.IsStorage)
             {
                 Account account = decoder.Decode(new RlpStream(value));


### PR DESCRIPTION
just replacing Rlp wrapper with byte[] directly on trie node
Rlp account for around of 10% objects in memory after 24h run on Goerli (and around 100MB memory which is around 15% of .NET memory). This will be even more where RPC caches are used.