### PR TITLE
Memory play

### DIFF
--- a/src/Nethermind/Nethermind.AuRa.Test/AuRaBlockProducerTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/AuRaBlockProducerTests.cs
@@ -76,7 +76,7 @@ namespace Nethermind.AuRa.Test
             _blockProcessingQueue.IsEmpty.Returns(true);
             _auRaStepCalculator.TimeToNextStep.Returns(_stepDelay);
             _blockTree.BestKnownNumber.Returns(1);
-            _blockTree.Head.Returns(Build.A.BlockHeader.WithAura(10, Bytes.Empty).TestObject);
+            _blockTree.Head.Returns(Build.A.Block.WithHeader(Build.A.BlockHeader.WithAura(10, Bytes.Empty).TestObject).TestObject);
             _blockchainProcessor.Process(Arg.Any<Block>(), ProcessingOptions.ProducingBlock, Arg.Any<IBlockTracer>()).Returns(c => c.Arg<Block>());
         }
 
@@ -179,7 +179,7 @@ namespace Nethermind.AuRa.Test
         [Test]
         public async Task Does_not_produce_block_when_head_is_null()
         {
-            _blockTree.Head.Returns((BlockHeader) null);
+            _blockTree.Head.Returns((Block) null);
             (await StartStop()).ShouldProduceBlocks(Quantity.None());
         }
         

--- a/src/Nethermind/Nethermind.AuRa.Test/AuRaSealerTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/AuRaSealerTests.cs
@@ -52,7 +52,7 @@ namespace Nethermind.AuRa.Test
         {
             _blockTree = Substitute.For<IBlockTree>();
             _headStep = 10;
-            _blockTree.Head.Returns(Build.A.BlockHeader.WithHash(Keccak.Compute("hash")).WithAura(_headStep, Bytes.Empty).TestObject);
+            _blockTree.Head.Returns(Build.A.Block.WithHeader(Build.A.BlockHeader.WithHash(Keccak.Compute("hash")).WithAura(_headStep, Bytes.Empty).TestObject).TestObject);
 
             _auRaStepCalculator = Substitute.For<IAuRaStepCalculator>();
             _validatorStore = Substitute.For<IValidatorStore>();

--- a/src/Nethermind/Nethermind.AuRa.Test/Validators/ContractValidatorTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/Validators/ContractValidatorTests.cs
@@ -584,7 +584,7 @@ namespace Nethermind.AuRa.Test.Validators
                 .OfChainLength(9, 0, 0, validators);
             
             var blockTree = blockTreeBuilder.TestObject;
-            SetupInitialValidators(blockTree.Head, validators);
+            SetupInitialValidators(blockTree.Head?.Header, validators);
             IAuRaValidatorProcessorExtension validator = new ContractBasedValidator(_validator, _stateProvider, _abiEncoder, _transactionProcessor, _readOnlyTransactionProcessorSource, blockTree, inMemoryReceiptStorage, _validatorStore, _validSealerStrategy, _logManager, 1);
             validator.SetFinalizationManager(_blockFinalizationManager);
 

--- a/src/Nethermind/Nethermind.Benchmark/Core/LruCacheBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Core/LruCacheBenchmarks.cs
@@ -14,10 +14,33 @@
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
-namespace Nethermind.Trie
+using System;
+using BenchmarkDotNet.Attributes;
+using Nethermind.Core.Caching;
+
+namespace Nethermind.Benchmarks.Core
 {
-    public static class MemoryAllowance
+    [EvaluateOverhead(false)]
+    [MemoryDiagnoser]
+    [SimpleJob(1, 1, 1, 1)]
+    public class LruCacheBenchmarks
     {
-        public static int TrieNodeCacheSize { get; set; } = 1 << 19;
+        [Params(0, 4, 16, 32)]
+        public int StartCapacity { get; set; }
+        
+        [Params(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20)]
+        public int ItemsCount { get; set; }
+
+        [Benchmark]
+        public LruCache<int, object> WithItems()
+        {
+            LruCache<int, object> cache = new LruCache<int, object>(16, StartCapacity, string.Empty);
+            for (int j = 0; j < ItemsCount; j++)
+            {
+                cache.Set(j, new object());
+            }
+
+            return cache;
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Benchmark/Core/LruCacheKeccakBytesBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Core/LruCacheKeccakBytesBenchmarks.cs
@@ -1,0 +1,60 @@
+//  Copyright (c) 2018 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using BenchmarkDotNet.Attributes;
+using Nethermind.Core.Caching;
+using Nethermind.Core.Crypto;
+
+namespace Nethermind.Benchmarks.Core
+{
+    [EvaluateOverhead(false)]
+    [MemoryDiagnoser]
+    [SimpleJob(1, 1, 1, 1)]
+    public class LruCacheKeccakBytesBenchmarks
+    {
+        [GlobalSetup]
+        public void InitKeccaks()
+        {
+            for (int i = 0; i < Keys.Length; i++)
+            {
+                Keys[i] = Keccak.Compute(i.ToString());
+            }
+        }
+
+        [Params(0, 2, 4, 8, 16, 32)]
+        public int StartCapacity { get; set; }
+
+        [Params(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28)]
+        public int ItemsCount { get; set; }
+
+        public Keccak[] Keys { get; set; } = new Keccak[28];
+
+        public byte[] Value { get; set; } = new byte[0];
+
+        [Benchmark]
+        public LruCache<Keccak, byte[]> WithItems()
+        {
+            LruCache<Keccak, byte[]> cache = new LruCache<Keccak, byte[]>(128, StartCapacity, String.Empty);
+            for (int j = 0; j < ItemsCount; j++)
+            {
+                cache.Set(Keys[j], Value);
+            }
+
+            return cache;
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Benchmark/Program.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Program.cs
@@ -14,12 +14,10 @@
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
+using System.Diagnostics;
+using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Running;
 using Nethermind.Benchmarks.Core;
-using Nethermind.Benchmarks.Evm;
-using Nethermind.Benchmarks.Mining;
-using Nethermind.Benchmarks.Rlp;
-using Nethermind.Benchmarks.Store;
 
 namespace Nethermind.Benchmarks
 {
@@ -27,48 +25,10 @@ namespace Nethermind.Benchmarks
     {
         public static void Main(string[] args)
         {
-            BenchmarkRunner.Run<ByteArrayToHexBenchmarks>();
-//            BenchmarkRunner.Run<FromHexBenchmarks>();
-//            BenchmarkRunner.Run<BytesCompare>();
-//            BenchmarkRunner.Run<BytesIsZero>();
-//            BenchmarkRunner.Run<BytesPad>();
-//            BenchmarkRunner.Run<Keccak256>();
-//            BenchmarkRunner.Run<Keccak512>();
-//            
-//            BenchmarkRunner.Run<Bn128AddPrecompile>(); // complex, may require experimenting with other libraries
-//            BenchmarkRunner.Run<Bn128MulPrecompile>(); // complex, may require experimenting with other libraries
-//            BenchmarkRunner.Run<Bn128PairingPrecompile>(); // complex, may require experimenting with other libraries
-//            BenchmarkRunner.Run<CalculateJumpDestinations>(); // less important now, since mainly cached
-//            BenchmarkRunner.Run<CalculateMemoryCost>();
-//            BenchmarkRunner.Run<IntrinsicGasCalculator>(); // less important but might be simple and fun
-//            BenchmarkRunner.Run<PrecompileEcRecover>();
-//            BenchmarkRunner.Run<PrecompileModExp>();
-//            BenchmarkRunner.Run<PrecompileSha2>();
-//            BenchmarkRunner.Run<PrecompileRipemd>();
-//            BenchmarkRunner.Run<SimpleTransferProcessing>();
-//            
-//            BenchmarkRunner.Run<EthashHashimoto>();
-//            
-//            // here we can try some structural changes to RLP design where allocations are limited and performance improved
-//            BenchmarkRunner.Run<RlpDecodeAccount>();
-//            BenchmarkRunner.Run<RlpEncodeAccount>();
-//            BenchmarkRunner.Run<RlpDecodeBlock>();
-//            BenchmarkRunner.Run<RlpEncodeBlockBenchmark>();
-//            BenchmarkRunner.Run<RlpEncodeHeader>();
-//            BenchmarkRunner.Run<RlpEncodeTransaction>();
-//              BenchmarkRunner.Run<RlpEncodeLong>();
-//              BenchmarkRunner.Run<RlpDecodeLong>();
-//              BenchmarkRunner.Run<RlpDecodeInt>();
-//              BenchmarkRunner.Run<SignExtend>();
-//            BenchmarkRunner.Run<BitwiseOr>();
-//            BenchmarkRunner.Run<BitwiseAnd>();
-//            BenchmarkRunner.Run<BitwiseNot>();
-//            BenchmarkRunner.Run<BitwiseXor>();
-
-//              BenchmarkRunner.Run<PatriciaTree>();
-//            
-//            BenchmarkRunner.Run<HexPrefixFromBytes>();
-//            BenchmarkRunner.Run<PatriciaTree>(); // potentially a bigger rewrite
+            IConfig config = Debugger.IsAttached ? new DebugInProcessConfig() : null;
+            BenchmarkRunner.Run<LruCacheBenchmarks>(config);
+            BenchmarkRunner.Run<LruCacheKeccakBytesBenchmarks>(config);
+            // BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, config);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
@@ -846,7 +846,7 @@ namespace Nethermind.Blockchain.Test
             tree.DeleteInvalidBlock(block2);
 
             Assert.AreEqual(block1.Number, tree.BestKnownNumber);
-            Assert.AreEqual(block1.Header, tree.Head);
+            Assert.AreEqual(block1.Header, tree.Head?.Header);
             Assert.AreEqual(block1.Header, tree.BestSuggestedHeader);
         }
 
@@ -1000,7 +1000,7 @@ namespace Nethermind.Blockchain.Test
             Assert.Null(blockInfosDb.Get(5), "level 5");
 
             Assert.AreEqual(2L, tree.BestKnownNumber, "best known");
-            Assert.AreEqual(block2.Header, tree.Head, "head");
+            Assert.AreEqual(block2.Header, tree.Head?.Header, "head");
             Assert.AreEqual(block2.Hash, tree.BestSuggestedHeader.Hash, "suggested");
         }
 
@@ -1033,7 +1033,7 @@ namespace Nethermind.Blockchain.Test
             tree.DeleteInvalidBlock(block3bad);
 
             Assert.AreEqual(5L, tree.BestKnownNumber, "best known");
-            Assert.AreEqual(block5.Header, tree.Head, "head");
+            Assert.AreEqual(block5.Header, tree.Head?.Header, "head");
             Assert.AreEqual(block5.Hash, tree.BestSuggestedHeader.Hash, "suggested");
         }
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
@@ -659,7 +659,7 @@ namespace Nethermind.Blockchain.Test
                     blockInfosDb.Set(i, Rlp.Encode(ithLevel).Bytes);
                 }
 
-                blockInfosDb.Set(Keccak.Zero, Rlp.Encode(genesisBlock.Header).Bytes);
+                blockInfosDb.Set(Keccak.Zero, genesisBlock.Header.Hash.Bytes);
                 headersDb.Set(genesisBlock.Header.Hash, Rlp.Encode(genesisBlock.Header).Bytes);
 
                 BlockTree blockTree = new BlockTree(blocksDb, headersDb, blockInfosDb, new ChainLevelInfoRepository(blockInfosDb), OlympicSpecProvider.Instance, NullTxPool.Instance, NullBloomStorage.Instance, LimboLogs.Instance);
@@ -693,7 +693,7 @@ namespace Nethermind.Blockchain.Test
                     blockInfosDb.Set(i, Rlp.Encode(ithLevel).Bytes);
                 }
 
-                blockInfosDb.Set(Keccak.Zero, Rlp.Encode(genesisBlock.Header).Bytes);
+                blockInfosDb.Set(Keccak.Zero, genesisBlock.Header.Hash.Bytes);
                 headersDb.Set(genesisBlock.Header.Hash, Rlp.Encode(genesisBlock.Header).Bytes);
 
                 BlockTree blockTree = new BlockTree(blocksDb, headersDb, blockInfosDb, new ChainLevelInfoRepository(blockInfosDb), OlympicSpecProvider.Instance, Substitute.For<ITxPool>(), NullBloomStorage.Instance, LimboLogs.Instance);

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
@@ -614,30 +614,6 @@ namespace Nethermind.Blockchain.Test
         }
 
         [Test]
-        public void Can_init_head_block_from_db_by_header()
-        {
-            Block genesisBlock = Build.A.Block.Genesis.TestObject;
-            Block headBlock = genesisBlock;
-
-            MemDb blocksDb = new MemDb();
-            MemDb headersDb = new MemDb();
-            blocksDb.Set(genesisBlock.Hash, Rlp.Encode(genesisBlock).Bytes);
-            headersDb.Set(genesisBlock.Hash, Rlp.Encode(genesisBlock.Header).Bytes);
-
-            MemDb blockInfosDb = new MemDb();
-            blockInfosDb.Set(Keccak.Zero, Rlp.Encode(genesisBlock.Header).Bytes);
-
-            ChainLevelInfo level = new ChainLevelInfo(true, new BlockInfo[1] {new BlockInfo(headBlock.Hash, headBlock.Difficulty)});
-            level.BlockInfos[0].WasProcessed = true;
-
-            blockInfosDb.Set(0, Rlp.Encode(level).Bytes);
-
-            BlockTree blockTree = new BlockTree(blocksDb, headersDb, blockInfosDb, new ChainLevelInfoRepository(blockInfosDb), OlympicSpecProvider.Instance, Substitute.For<ITxPool>(), NullBloomStorage.Instance, LimboLogs.Instance);
-            Assert.AreEqual(headBlock.Hash, blockTree.Head?.Hash, "head");
-            Assert.AreEqual(headBlock.Hash, blockTree.Genesis?.Hash, "genesis");
-        }
-
-        [Test]
         public void Can_init_head_block_from_db_by_hash()
         {
             Block genesisBlock = Build.A.Block.Genesis.TestObject;

--- a/src/Nethermind/Nethermind.Blockchain.Test/ReadOnlyBlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/ReadOnlyBlockTreeTests.cs
@@ -49,7 +49,7 @@ namespace Nethermind.Blockchain.Test
         [TestCase(10, 20, 15, 16, false, TestName = "Allow deletion.")]
         public void DeleteChainSlice_throws_when_corrupted_blocks_not_found(long? head, long bestKnown, long start, long? corruptedBlock, bool throws)
         {
-            _innerBlockTree.Head.Returns(head == null ? null : Build.A.BlockHeader.WithNumber(head.Value).TestObject);
+            _innerBlockTree.Head.Returns(head == null ? null : Build.A.Block.WithHeader(Build.A.BlockHeader.WithNumber(head.Value).TestObject).TestObject);
             _innerBlockTree.BestKnownNumber.Returns(bestKnown);
             _innerBlockTree.FindHeader(Arg.Any<long>(), Arg.Any<BlockTreeLookupOptions>())
                 .Returns(c => c.Arg<long>() == corruptedBlock ? null : Build.A.BlockHeader.WithNumber(c.Arg<long>()).TestObject);

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -45,8 +45,8 @@ namespace Nethermind.Blockchain
     public class BlockTree : IBlockTree
     {
         private const int CacheSize = 64;
-        private readonly LruCache<Keccak, Block> _blockCache = new LruCache<Keccak, Block>(CacheSize);
-        private readonly LruCache<Keccak, BlockHeader> _headerCache = new LruCache<Keccak, BlockHeader>(CacheSize);
+        private readonly LruCache<Keccak, Block> _blockCache = new LruCache<Keccak, Block>(CacheSize, "blocks");
+        private readonly LruCache<Keccak, BlockHeader> _headerCache = new LruCache<Keccak, BlockHeader>(CacheSize, "headers");
 
         private const int BestKnownSearchLimit = 256_000_000;
         public const int DbLoadBatchSize = 4000;
@@ -59,7 +59,7 @@ namespace Nethermind.Blockchain
         private readonly IDb _headerDb;
         private readonly IDb _blockInfoDb;
 
-        private LruCache<long, HashSet<Keccak>> _invalidBlocks = new LruCache<long, HashSet<Keccak>>(128);
+        private LruCache<long, HashSet<Keccak>> _invalidBlocks = new LruCache<long, HashSet<Keccak>>(128, "invalid blocks");
         private readonly BlockDecoder _blockDecoder = new BlockDecoder();
         private readonly HeaderDecoder _headerDecoder = new HeaderDecoder();
         private readonly ILogger _logger;

--- a/src/Nethermind/Nethermind.Blockchain/Find/IBlockFinder.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Find/IBlockFinder.cs
@@ -28,7 +28,7 @@ namespace Nethermind.Blockchain.Find
         
         Keccak PendingHash { get; }
         
-        BlockHeader Head { get; }
+        Block Head { get; }
         
         Block FindBlock(Keccak blockHash, BlockTreeLookupOptions options);
         
@@ -60,7 +60,7 @@ namespace Nethermind.Blockchain.Find
         
         public Block FindGenesisBlock() => FindBlock(GenesisHash, BlockTreeLookupOptions.RequireCanonical);
         
-        public Block FindHeadBlock() => FindBlock(HeadHash, BlockTreeLookupOptions.None);
+        public Block FindHeadBlock() => Head;
         
         public Block FindEarliestBlock() => FindGenesisBlock();
         
@@ -76,7 +76,7 @@ namespace Nethermind.Blockchain.Find
 
         public BlockHeader FindEarliestHeader() => FindGenesisHeader();
         
-        public BlockHeader FindLatestHeader() => Head;
+        public BlockHeader FindLatestHeader() => Head?.Header;
 
         public BlockHeader FindPendingHeader() => FindHeader(PendingHash, BlockTreeLookupOptions.None);
         

--- a/src/Nethermind/Nethermind.Blockchain/Processing/BlockchainProcessor.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Processing/BlockchainProcessor.cs
@@ -275,7 +275,7 @@ namespace Nethermind.Blockchain.Processing
             
             if (!shouldProcess)
             {
-                if (_logger.IsDebug) _logger.Debug($"Skipped processing of {suggestedBlock.ToString(Block.Format.FullHashAndNumber)}, Head = {_blockTree.Head?.ToString(BlockHeader.Format.Short)}, total diff = {totalDifficulty}, head total diff = {_blockTree.Head?.TotalDifficulty}");
+                if (_logger.IsDebug) _logger.Debug($"Skipped processing of {suggestedBlock.ToString(Block.Format.FullHashAndNumber)}, Head = {_blockTree.Head?.Header?.ToString(BlockHeader.Format.Short)}, total diff = {totalDifficulty}, head total diff = {_blockTree.Head?.TotalDifficulty}");
                 return null;
             }
 
@@ -381,7 +381,7 @@ namespace Nethermind.Blockchain.Processing
                     break;
                 }
 
-                bool isFastSyncTransition = _blockTree.Head == _blockTree.Genesis && toBeProcessed.Number > 1;
+                bool isFastSyncTransition = _blockTree.Head?.Header == _blockTree.Genesis && toBeProcessed.Number > 1;
                 if (!isFastSyncTransition)
                 {
                     if (_logger.IsTrace) _logger.Trace($"Finding parent of {toBeProcessed.ToString(Block.Format.Short)}");
@@ -402,7 +402,7 @@ namespace Nethermind.Blockchain.Processing
 
             if (branchingPoint != null && branchingPoint.Hash != _blockTree.Head?.Hash)
             {
-                if (_logger.IsTrace) _logger.Trace($"Head block was: {_blockTree.Head?.ToString(BlockHeader.Format.Short)}");
+                if (_logger.IsTrace) _logger.Trace($"Head block was: {_blockTree.Head?.Header?.ToString(BlockHeader.Format.Short)}");
                 if (_logger.IsTrace) _logger.Trace($"Branching from: {branchingPoint.ToString(BlockHeader.Format.Short)}");
             }
             else

--- a/src/Nethermind/Nethermind.Blockchain/Producers/BaseBlockProducer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Producers/BaseBlockProducer.cs
@@ -72,7 +72,7 @@ namespace Nethermind.Blockchain.Producers
         {
             lock (_newBlockLock)
             {
-                BlockHeader parentHeader = BlockTree.Head;
+                BlockHeader parentHeader = BlockTree.Head?.Header;
                 if (parentHeader == null)
                 {
                     if (Logger.IsWarn) Logger.Warn($"Preparing new block - parent header is null");

--- a/src/Nethermind/Nethermind.Blockchain/ReadOnlyBlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/ReadOnlyBlockTree.cs
@@ -40,7 +40,7 @@ namespace Nethermind.Blockchain
         public Block LowestInsertedBody => _wrapped.LowestInsertedBody;
         public Block BestSuggestedBody => _wrapped.BestSuggestedBody;
         public long BestKnownNumber => _wrapped.BestKnownNumber;
-        public BlockHeader Head => _wrapped.Head;
+        public Block Head => _wrapped.Head;
         public bool CanAcceptNewBlocks { get; } = false;
 
         public Task LoadBlocksFromDb(CancellationToken cancellationToken, long? startBlockNumber, int batchSize = BlockTree.DbLoadBatchSize, int maxBlocksToLoad = Int32.MaxValue) => throw new InvalidOperationException($"{nameof(ReadOnlyBlockTree)} does not expect {nameof(LoadBlocksFromDb)} calls");

--- a/src/Nethermind/Nethermind.Consensus.AuRa/AuRaBlockFinalizationManager.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/AuRaBlockFinalizationManager.cs
@@ -71,7 +71,7 @@ namespace Nethermind.Consensus.AuRa
             // This is needed if processing was stopped between processing last block and running finalization logic 
             if (hasHead)
             {
-                FinalizeBlocks(_blockTree.Head);
+                FinalizeBlocks(_blockTree.Head?.Header);
             }
         }
 

--- a/src/Nethermind/Nethermind.Consensus.AuRa/AuRaSealer.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/AuRaSealer.cs
@@ -85,9 +85,9 @@ namespace Nethermind.Consensus.AuRa
 
         public bool CanSeal(long blockNumber, Keccak parentHash)
         {
-            bool StepNotYetProduced(long step) => !_blockTree.Head.AuRaStep.HasValue
+            bool StepNotYetProduced(long step) => !_blockTree.Head.Header.AuRaStep.HasValue
                 ? throw new InvalidOperationException("Head block doesn't have AuRaStep specified.'")
-                : _blockTree.Head.AuRaStep.Value < step;
+                : _blockTree.Head.Header.AuRaStep.Value < step;
 
             bool IsThisNodeTurn(long step)
             {

--- a/src/Nethermind/Nethermind.Consensus.AuRa/Validators/ContractBasedValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/Validators/ContractBasedValidator.cs
@@ -99,7 +99,7 @@ namespace Nethermind.Consensus.AuRa.Validators
                 _blockFinalizationManager.BlocksFinalized += OnBlocksFinalized;
                 if (_blockTree.Head != null)
                 {
-                    Validators = LoadValidatorsFromContract(_blockTree.Head);
+                    Validators = LoadValidatorsFromContract(_blockTree.Head?.Header);
                 }
             }
         }

--- a/src/Nethermind/Nethermind.Consensus.Clique/CliqueBridge.cs
+++ b/src/Nethermind/Nethermind.Consensus.Clique/CliqueBridge.cs
@@ -59,7 +59,7 @@ namespace Nethermind.Consensus.Clique
 
         public Snapshot GetSnapshot()
         {
-            BlockHeader head = _blockTree.Head;
+            Block head = _blockTree.Head;
             return _snapshotManager.GetOrCreateSnapshot(head.Number, head.Hash);
         }
 
@@ -83,7 +83,7 @@ namespace Nethermind.Consensus.Clique
 
         public Address[] GetSigners()
         {
-            BlockHeader head = _blockTree.Head;
+            Block head = _blockTree.Head;
             return _snapshotManager.GetOrCreateSnapshot(head.Number, head.Hash).Signers.Select(s => s.Key).ToArray();
         }
 
@@ -95,7 +95,7 @@ namespace Nethermind.Consensus.Clique
 
         public string[] GetSignersAnnotated()
         {
-            BlockHeader header = _blockTree.Head;
+            Block header = _blockTree.Head;
             return _snapshotManager.GetOrCreateSnapshot(header.Number, header.Hash).Signers.Select(s => string.Concat(s.Key, $" ({KnownAddresses.GetDescription(s.Key)})")).ToArray();
         }
         

--- a/src/Nethermind/Nethermind.Consensus.Clique/SnapshotManager.cs
+++ b/src/Nethermind/Nethermind.Consensus.Clique/SnapshotManager.cs
@@ -47,7 +47,7 @@ namespace Nethermind.Consensus.Clique
         {
             _logger = logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
             _cliqueConfig = cliqueConfig ?? throw new ArgumentNullException(nameof(cliqueConfig));
-            _signatures = new LruCache<Keccak, Address>(Clique.InMemorySignatures, "signatures");
+            _signatures = new LruCache<Keccak, Address>(Clique.InMemorySignatures, Clique.InMemorySignatures, "signatures");
             _ecdsa = ecdsa ?? throw new ArgumentNullException(nameof(ecdsa));
             _blocksDb = blocksDb ?? throw new ArgumentNullException(nameof(blocksDb));
             _blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));

--- a/src/Nethermind/Nethermind.Consensus.Clique/SnapshotManager.cs
+++ b/src/Nethermind/Nethermind.Consensus.Clique/SnapshotManager.cs
@@ -41,13 +41,13 @@ namespace Nethermind.Consensus.Clique
         private readonly ICache<Keccak, Address> _signatures;
         private readonly IEthereumEcdsa _ecdsa;
         private IDb _blocksDb;
-        private ICache<Keccak, Snapshot> _snapshotCache = new LruCache<Keccak, Snapshot>(Clique.InMemorySnapshots);
+        private ICache<Keccak, Snapshot> _snapshotCache = new LruCache<Keccak, Snapshot>(Clique.InMemorySnapshots, "clique snapshots");
 
         public SnapshotManager(ICliqueConfig cliqueConfig, IDb blocksDb, IBlockTree blockTree, IEthereumEcdsa ecdsa, ILogManager logManager)
         {
             _logger = logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
             _cliqueConfig = cliqueConfig ?? throw new ArgumentNullException(nameof(cliqueConfig));
-            _signatures = new LruCache<Keccak, Address>(Clique.InMemorySignatures);
+            _signatures = new LruCache<Keccak, Address>(Clique.InMemorySignatures, "signatures");
             _ecdsa = ecdsa ?? throw new ArgumentNullException(nameof(ecdsa));
             _blocksDb = blocksDb ?? throw new ArgumentNullException(nameof(blocksDb));
             _blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
@@ -350,7 +350,7 @@ namespace Nethermind.Consensus.Clique
             
             // was this needed?
 //            snapshot.Hash = headers[headers.Count - 1].CalculateHash();
-            snapshot.Hash = headers[headers.Count - 1].Hash;
+            snapshot.Hash = headers[^1].Hash;
             return snapshot;
         }
 

--- a/src/Nethermind/Nethermind.Consensus.Ethash/EthashSealValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus.Ethash/EthashSealValidator.cs
@@ -31,7 +31,7 @@ namespace Nethermind.Consensus.Ethash
         private IEthash _ethash;
         private ILogger _logger;
 
-        private LruCache<Keccak, bool> _sealCache = new LruCache<Keccak, bool>(2048, "ethash seals");
+        private LruCache<Keccak, bool> _sealCache = new LruCache<Keccak, bool>(2048, 2048, "ethash seals");
         private const int SealValidationIntervalConstantComponent = 1024;
         private int sealValidationInterval = SealValidationIntervalConstantComponent;
 

--- a/src/Nethermind/Nethermind.Consensus.Ethash/EthashSealValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus.Ethash/EthashSealValidator.cs
@@ -31,7 +31,7 @@ namespace Nethermind.Consensus.Ethash
         private IEthash _ethash;
         private ILogger _logger;
 
-        private LruCache<Keccak, bool> _sealCache = new LruCache<Keccak, bool>(2048);
+        private LruCache<Keccak, bool> _sealCache = new LruCache<Keccak, bool>(2048, "ethash seals");
         private const int SealValidationIntervalConstantComponent = 1024;
         private int sealValidationInterval = SealValidationIntervalConstantComponent;
 

--- a/src/Nethermind/Nethermind.Core.Test/LruCacheTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/LruCacheTests.cs
@@ -41,7 +41,7 @@ namespace Nethermind.Core.Test
         [Test]
         public void Beyond_capacity()
         {
-            LruCache<Address, Account> cache = new LruCache<Address, Account>(Capacity);
+            LruCache<Address, Account> cache = new LruCache<Address, Account>(Capacity, "test");
             for (int i = 0; i < Capacity; i++)
             {
                 cache.Set(_addresses[i], _accounts[i]);

--- a/src/Nethermind/Nethermind.Core/Caching/LruCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/LruCache.cs
@@ -38,8 +38,6 @@ namespace Nethermind.Core.Caching
 
         public LruCache(int maxCapacity, int startCapacity, string name)
         {
-            Console.WriteLine($"INITIALIZING CACHE {name} WITH MAX CAPACITY {maxCapacity} AND START CAPACITY {startCapacity}");
-            
             _maxCapacity = maxCapacity;
             _cacheMap = typeof(TKey) == typeof(byte[])
                 ? new Dictionary<TKey, LinkedListNode<LruCacheItem>>((IEqualityComparer<TKey>) Bytes.EqualityComparer)

--- a/src/Nethermind/Nethermind.Core/Caching/LruCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/LruCache.cs
@@ -14,6 +14,7 @@
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
+using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Nethermind.Core.Extensions;
@@ -25,7 +26,7 @@ namespace Nethermind.Core.Caching
     /// </summary>
     public class LruCache<TKey, TValue> : ICache<TKey, TValue>
     {
-        private readonly int _capacity;
+        private readonly int _maxCapacity;
         private readonly Dictionary<TKey, LinkedListNode<LruCacheItem>> _cacheMap;
         private readonly LinkedList<LruCacheItem> _lruList;
 
@@ -34,14 +35,21 @@ namespace Nethermind.Core.Caching
             _cacheMap?.Clear();
             _lruList?.Clear();
         }
-        
-        public LruCache(int capacity)
+
+        public LruCache(int maxCapacity, int startCapacity, string name)
         {
-            _capacity = capacity;
+            Console.WriteLine($"INITIALIZING CACHE {name} WITH MAX CAPACITY {maxCapacity} AND START CAPACITY {startCapacity}");
+            
+            _maxCapacity = maxCapacity;
             _cacheMap = typeof(TKey) == typeof(byte[])
-                ? new Dictionary<TKey, LinkedListNode<LruCacheItem>>((IEqualityComparer<TKey>)Bytes.EqualityComparer)
-                : new Dictionary<TKey, LinkedListNode<LruCacheItem>>(); // do not initialize it at the full capacity
+                ? new Dictionary<TKey, LinkedListNode<LruCacheItem>>((IEqualityComparer<TKey>) Bytes.EqualityComparer)
+                : new Dictionary<TKey, LinkedListNode<LruCacheItem>>(startCapacity); // do not initialize it at the full capacity
             _lruList = new LinkedList<LruCacheItem>();
+        }
+
+        public LruCache(int maxCapacity, string name)
+            : this(maxCapacity, 0, name)
+        {
         }
 
         [MethodImpl(MethodImplOptions.Synchronized)]
@@ -74,7 +82,7 @@ namespace Nethermind.Core.Caching
             }
             else
             {
-                if (_cacheMap.Count >= _capacity)
+                if (_cacheMap.Count >= _maxCapacity)
                 {
                     RemoveFirst();
                 }
@@ -114,6 +122,17 @@ namespace Nethermind.Core.Caching
 
             public readonly TKey Key;
             public TValue Value;
+        }
+
+        public int MemorySize => CalculateMemorySize(0, _cacheMap.Count);
+
+        public static int CalculateMemorySize(int keyPlusValueSize, int currentItemsCount)
+        {
+            // it may actually be different if the initial capacity not equal to max (depending on the dictionary growth path)
+            
+            const int preInit = 48 /* LinkedList */ + 80 /* Dictionary */ + 24;
+            int postInit = 52 /* lazy init of two internal dictionary arrays + dictionary size times (entry size + int) */ + MemorySizes.FindNextPrime(currentItemsCount) * 28 + currentItemsCount * 80 /* LinkedListNode and CacheItem times items count */;
+            return MemorySizes.Align(preInit + postInit + keyPlusValueSize * currentItemsCount);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Core/MemorySizes.cs
+++ b/src/Nethermind/Nethermind.Core/MemorySizes.cs
@@ -14,6 +14,8 @@
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
+using System;
+using System.Collections;
 using System.Runtime.CompilerServices;
 
 namespace Nethermind.Core
@@ -28,10 +30,57 @@ namespace Nethermind.Core
         {
             return unalignedSize + (-unalignedSize & AlignmentMask);
         }
-        
+
         public const int RefSize = 8;
+
         public const int SmallObjectOverhead = 24;
+
         // public const int LargeObjectOverhead = 32; // just guessing, 20 on 32bit
         public const int ArrayOverhead = 20;
+
+        private static BitArray _isPrime = ESieve(1024 * 1024); // 1MB in memory
+
+        public static int FindNextPrime(int number)
+        {
+            number++;
+            for (; number < _isPrime.Length; number++)
+                //found a prime return that number
+                if (_isPrime[number])
+                    return number;
+            //no prime return error code
+            return -1;
+        }
+
+        /// <summary>
+        /// https://stackoverflow.com/questions/23644479/find-next-prime-number
+        /// </summary>
+        /// <param name="upperLimit"></param>
+        /// <returns></returns>
+        public static BitArray ESieve(int upperLimit)
+        {
+            int sieveBound = (int) (upperLimit - 1);
+            int upperSqrt = (int) Math.Sqrt(sieveBound);
+            BitArray primeBits = new BitArray(sieveBound + 1, true);
+            primeBits[0] = false;
+            primeBits[1] = false;
+            for (int j = 4; j <= sieveBound; j += 2)
+            {
+                primeBits[j] = false;
+            }
+
+            for (int i = 3; i <= upperSqrt; i += 2)
+            {
+                if (primeBits[i])
+                {
+                    int inc = i * 2;
+                    for (int j = i * i; j <= sieveBound; j += inc)
+                    {
+                        primeBits[j] = false;
+                    }
+                }
+            }
+
+            return primeBits;
+        }
     }
 }

--- a/src/Nethermind/Nethermind.DataMarketplace.Core/Services/NdmBlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.DataMarketplace.Core/Services/NdmBlockchainBridge.cs
@@ -52,7 +52,7 @@ namespace Nethermind.DataMarketplace.Core.Services
 
         public Task<Block?> GetLatestBlockAsync()
         {
-            BlockHeader head = _blockchainBridge.Head;
+            Block head = _blockchainBridge.Head;
             return head is null
                 ? Task.FromResult<Block?>(null)
                 : Task.FromResult<Block?>(_blockchainBridge.FindBlock(head.Hash));
@@ -81,7 +81,7 @@ namespace Nethermind.DataMarketplace.Core.Services
 
         public Task<byte[]> CallAsync(Transaction transaction)
         {
-            var callOutput = _blockchainBridge.Call(_blockchainBridge.Head, transaction);
+            var callOutput = _blockchainBridge.Call(_blockchainBridge.Head?.Header, transaction);
             return Task.FromResult(callOutput.OutputData ?? new byte[] {0});
         }
 

--- a/src/Nethermind/Nethermind.DataMarketplace.Test/ContractInteractionTest.cs
+++ b/src/Nethermind/Nethermind.DataMarketplace.Test/ContractInteractionTest.cs
@@ -199,7 +199,7 @@ namespace Nethermind.DataMarketplace.Test
             private Transaction _tx;
             private Block _headBlock;
 
-            public BlockHeader Head => _headBlock.Header;
+            public Block Head => _headBlock;
             public long BestKnown { get; }
             public bool IsSyncing { get; }
             public bool IsMining { get; }
@@ -252,7 +252,7 @@ namespace Nethermind.DataMarketplace.Test
                 tx.Hash = tx.CalculateHash();
                 _headBlock.Transactions[_txIndex++] = tx;
                 _receiptsTracer.StartNewTxTrace(tx.Hash);
-                _processor.Execute(tx, Head, _receiptsTracer);
+                _processor.Execute(tx, Head?.Header, _receiptsTracer);
                 _receiptsTracer.EndTxTrace();
                 return tx.CalculateHash();
             }
@@ -264,7 +264,7 @@ namespace Nethermind.DataMarketplace.Test
             public Facade.BlockchainBridge.CallOutput Call(BlockHeader blockHeader, Transaction transaction)
             {
                 CallOutputTracer tracer = new CallOutputTracer();
-                _processor.Execute(transaction, Head, tracer);
+                _processor.Execute(transaction, Head?.Header, tracer);
                 return new Facade.BlockchainBridge.CallOutput(tracer.ReturnValue, tracer.GasSpent, tracer.Error);
             }
 

--- a/src/Nethermind/Nethermind.DataMarketplace.Test/Services/NdmBlockchainBridgeTests.cs
+++ b/src/Nethermind/Nethermind.DataMarketplace.Test/Services/NdmBlockchainBridgeTests.cs
@@ -65,7 +65,7 @@ namespace Nethermind.DataMarketplace.Test.Services
         [Test]
         public async Task get_latest_block_number_should_return_head_number()
         {
-            var header = Build.A.BlockHeader.TestObject;
+            var header = Build.A.Block.TestObject;
             _blockchainBridge.Head.Returns(header);
             var result = await _ndmBridge.GetLatestBlockNumberAsync();
             result.Should().Be(_blockchainBridge.Head.Number);
@@ -113,12 +113,11 @@ namespace Nethermind.DataMarketplace.Test.Services
         public async Task get_latest_block_should_return_head_number()
         {
             var block = Build.A.Block.TestObject;
-            var header = Build.A.BlockHeader.TestObject;
-            _blockchainBridge.Head.Returns(header);
-            _blockchainBridge.FindBlock(header.Hash).Returns(block);
+            _blockchainBridge.Head.Returns(block);
+            _blockchainBridge.FindBlock(block.Hash).Returns(block);
             var result = await _ndmBridge.GetLatestBlockAsync();
             result.Should().Be(block);
-            _blockchainBridge.Received().FindBlock(header.Hash);
+            _blockchainBridge.Received().FindBlock(block.Hash);
         }
         
         [Test]
@@ -182,14 +181,14 @@ namespace Nethermind.DataMarketplace.Test.Services
         [Test]
         public async Task call_should_invoke_blockchain_bridge_call_and_return_data()
         {
-            var head = Build.A.BlockHeader.TestObject;
+            var head = Build.A.Block.TestObject;
             var transaction = Build.A.Transaction.TestObject;
             var data = new byte[] {0, 1, 2};
             _blockchainBridge.Head.Returns(head);
             var output = new BlockchainBridge.CallOutput(data, 0, null);
-            _blockchainBridge.Call(head, transaction).Returns(output);
+            _blockchainBridge.Call(head?.Header, transaction).Returns(output);
             var result = await _ndmBridge.CallAsync(transaction);
-            _blockchainBridge.Received().Call(head, transaction);
+            _blockchainBridge.Received().Call(head?.Header, transaction);
             result.Should().BeSameAs(data);
         }
         

--- a/src/Nethermind/Nethermind.Evm/MemoryAllowance.cs
+++ b/src/Nethermind/Nethermind.Evm/MemoryAllowance.cs
@@ -18,6 +18,6 @@ namespace Nethermind.Evm
 {
     public static class MemoryAllowance
     {
-        public static int CodeCacheSize { get; set; } = 2 << 12;
+        public static int CodeCacheSize { get; } = 1 << 13;
     }
 }

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -71,7 +71,7 @@ namespace Nethermind.Evm
 
         private readonly IBlockhashProvider _blockhashProvider;
         private readonly ISpecProvider _specProvider;
-        private readonly LruCache<Keccak, CodeInfo> _codeCache = new LruCache<Keccak, CodeInfo>(MemoryAllowance.CodeCacheSize);
+        private readonly LruCache<Keccak, CodeInfo> _codeCache = new LruCache<Keccak, CodeInfo>(MemoryAllowance.CodeCacheSize, "VM bytecodes");
         private readonly ILogger _logger;
         private readonly IStateProvider _state;
         private readonly Stack<EvmState> _stateStack = new Stack<EvmState>();

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -71,7 +71,7 @@ namespace Nethermind.Evm
 
         private readonly IBlockhashProvider _blockhashProvider;
         private readonly ISpecProvider _specProvider;
-        private readonly LruCache<Keccak, CodeInfo> _codeCache = new LruCache<Keccak, CodeInfo>(MemoryAllowance.CodeCacheSize, "VM bytecodes");
+        private static readonly LruCache<Keccak, CodeInfo> _codeCache = new LruCache<Keccak, CodeInfo>(MemoryAllowance.CodeCacheSize, "VM bytecodes");
         private readonly ILogger _logger;
         private readonly IStateProvider _state;
         private readonly Stack<EvmState> _stateStack = new Stack<EvmState>();

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -71,7 +71,7 @@ namespace Nethermind.Evm
 
         private readonly IBlockhashProvider _blockhashProvider;
         private readonly ISpecProvider _specProvider;
-        private static readonly LruCache<Keccak, CodeInfo> _codeCache = new LruCache<Keccak, CodeInfo>(MemoryAllowance.CodeCacheSize, "VM bytecodes");
+        private static readonly LruCache<Keccak, CodeInfo> _codeCache = new LruCache<Keccak, CodeInfo>(MemoryAllowance.CodeCacheSize, MemoryAllowance.CodeCacheSize, "VM bytecodes");
         private readonly ILogger _logger;
         private readonly IStateProvider _state;
         private readonly Stack<EvmState> _stateStack = new Stack<EvmState>();

--- a/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
@@ -104,7 +104,7 @@ namespace Nethermind.Facade
             _wallet.Sign(tx, _blockTree.ChainId);
         }
 
-        public BlockHeader Head => _blockTree.Head;
+        public Block Head => _blockTree.Head;
 
         public long BestKnown => _blockTree.BestKnownNumber;
 

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/EthModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/EthModuleTests.cs
@@ -212,7 +212,7 @@ namespace Nethermind.JsonRpc.Test.Modules
         public async Task Eth_get_balance_internal_error()
         {
             IBlockchainBridge bridge = Substitute.For<IBlockchainBridge>();
-            bridge.Head.Returns((BlockHeader) null);
+            bridge.Head.Returns((Block) null);
 
             _test = await TestRpcBlockchain.ForTest(SealEngineType.NethDev).WithBlockchainBridge(bridge).Build();
             string serialized = _test.TestEthRpc("eth_getBalance", TestItem.AddressA.Bytes.ToHexString(true), "0x01");
@@ -232,7 +232,7 @@ namespace Nethermind.JsonRpc.Test.Modules
         {
             IBlockchainBridge bridge = Substitute.For<IBlockchainBridge>();
             bridge.IsSyncing.Returns(false);
-            bridge.Head.Returns(Build.A.BlockHeader.WithNumber(900).TestObject);
+            bridge.Head.Returns(Build.A.Block.WithHeader(Build.A.BlockHeader.WithNumber(900).TestObject).TestObject);
             bridge.BestKnown.Returns(1000L);
             bridge.IsSyncing.Returns(true);
 
@@ -247,7 +247,7 @@ namespace Nethermind.JsonRpc.Test.Modules
         {
             IBlockchainBridge bridge = Substitute.For<IBlockchainBridge>();
             bridge.IsSyncing.Returns(false);
-            bridge.Head.Returns(Build.A.BlockHeader.WithNumber(900).TestObject);
+            bridge.Head.Returns(Build.A.Block.WithHeader(Build.A.BlockHeader.WithNumber(900).TestObject).TestObject);
             bridge.BestKnown.Returns(1000L);
 
             _test = await TestRpcBlockchain.ForTest(SealEngineType.NethDev).WithBlockchainBridge(bridge).Build();
@@ -597,7 +597,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             IBlockchainBridge bridge = Substitute.For<IBlockchainBridge>();
             bridge.IsSyncing.Returns(true);
             bridge.BestKnown.Returns(6178000L);
-            bridge.Head.Returns(Build.A.BlockHeader.WithNumber(6170000L).TestObject);
+            bridge.Head.Returns(Build.A.Block.WithHeader(Build.A.BlockHeader.WithNumber(6170000L).TestObject).TestObject);
 
             _test = await TestRpcBlockchain.ForTest(SealEngineType.NethDev).WithBlockchainBridge(bridge).Build();
             string serialized = _test.TestEthRpc("eth_syncing");

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Proof/ProofModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Proof/ProofModuleTests.cs
@@ -219,7 +219,7 @@ namespace Nethermind.JsonRpc.Test.Modules.Proof
         [Test]
         public void Can_call_by_hash_canonical()
         {
-            BlockHeader lastHead = _blockTree.Head;
+            Block lastHead = _blockTree.Head;
             Block block = Build.A.Block.WithParent(lastHead).TestObject;
             Block newBlockOnMain = Build.A.Block.WithParent(lastHead).WithDifficulty(block.Difficulty + 1).TestObject;
             BlockTreeBuilder.AddBlock(_blockTree, block);

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/TxPool/TxPoolModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/TxPool/TxPoolModule.cs
@@ -34,7 +34,7 @@ namespace Nethermind.JsonRpc.Modules.TxPool
 
         public ResultWrapper<TxPoolStatus> txpool_status()
         {
-            var poolInfo = _txPoolInfoProvider.GetInfo(_blockFinder.Head);
+            var poolInfo = _txPoolInfoProvider.GetInfo(_blockFinder.Head?.Header);
             var poolStatus = new TxPoolStatus(poolInfo);
          
             return ResultWrapper<TxPoolStatus>.Success(poolStatus);
@@ -42,13 +42,13 @@ namespace Nethermind.JsonRpc.Modules.TxPool
 
         public ResultWrapper<TxPoolContent> txpool_content()
         {
-            var poolInfo = _txPoolInfoProvider.GetInfo(_blockFinder.Head);
+            var poolInfo = _txPoolInfoProvider.GetInfo(_blockFinder.Head?.Header);
             return ResultWrapper<TxPoolContent>.Success(new TxPoolContent(poolInfo));
         }
 
         public ResultWrapper<TxPoolInspection> txpool_inspect()
         {
-            var poolInfo = _txPoolInfoProvider.GetInfo(_blockFinder.Head);
+            var poolInfo = _txPoolInfoProvider.GetInfo(_blockFinder.Head?.Header);
             return ResultWrapper<TxPoolInspection>.Success(new TxPoolInspection(poolInfo));
         }
     }

--- a/src/Nethermind/Nethermind.Network.Stats/StatsConfig.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/StatsConfig.cs
@@ -22,10 +22,8 @@ namespace Nethermind.Stats
     {
         public StatsConfig()
         {
-            FailedConnectionDelays = new []{ 100, 100, 100, 500, 500, 500, 1000, 5000, 1000 * 60 * 10 };
-            DisconnectDelays =       new []{ 100, 100, 100, 500, 500, 500, 1000, 5000, 1000 * 60 * 5 };
-//            FailedConnectionDelays = new []{ 100, 100, 100, 100, 100, 500, 500, 500, 500, 500, 1000, 1000, 1000, 1000, 1000, 5000, 10000, 1000 * 60, 1000 * 60 * 5, 1000 * 60 * 10 };
-//            DisconnectDelays = new []{ 100, 100, 100, 100, 100, 500, 500, 500, 500, 500, 1000, 1000, 1000, 1000, 1000, 5000, 10000, 1000 * 60, 1000 * 60 * 5 };
+            FailedConnectionDelays = new []{ 100, 200, 500, 1000, 2000, 5000, 10000, 15000, 30000, 60000, 60000 * 5 };
+            DisconnectDelays =       new []{ 100, 200, 500, 1000, 2000, 5000, 10000, 15000, 30000, 60000, 60000 * 5 };
         }
         
         public bool CaptureNodeStatsEventHistory { get; set; } = false;

--- a/src/Nethermind/Nethermind.Network/IP/SocketIPSource.cs
+++ b/src/Nethermind/Nethermind.Network/IP/SocketIPSource.cs
@@ -18,6 +18,7 @@ using System;
 using System.Net;
 using System.Net.Sockets;
 using Nethermind.Logging;
+using Nethermind.Network.Config;
 
 namespace Nethermind.Network.IP
 {
@@ -43,7 +44,7 @@ namespace Nethermind.Network.IP
             }
             catch (SocketException e)
             {
-                if(_logger.IsError) _logger.Error($"Error while getting local ip from socket.", e);
+                if(_logger.IsError) _logger.Error($"Error while getting local ip from socket. You can set a manual override via config {nameof(NetworkConfig)}.{nameof(NetworkConfig.LocalIp)}");
                 ipAddress = null;
                 return false;
             }

--- a/src/Nethermind/Nethermind.Network/IP/WebIPSource.cs
+++ b/src/Nethermind/Nethermind.Network/IP/WebIPSource.cs
@@ -14,7 +14,9 @@
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
+using System;
 using System.Net;
+using System.Net.Http;
 using Nethermind.Logging;
 
 namespace Nethermind.Network.IP
@@ -34,14 +36,16 @@ namespace Nethermind.Network.IP
         {
             try
             {
+                HttpClient httpClient = new HttpClient();
+                httpClient.Timeout = TimeSpan.FromSeconds(3);
                 if(_logger.IsInfo) _logger.Info($"Using {_url} to get external ip");
-                string ip = new WebClient().DownloadString(_url).Trim();
+                string ip = httpClient.GetStringAsync(_url).Result.Trim();
                 if(_logger.IsDebug) _logger.Debug($"External ip: {ip}");
                 return IPAddress.TryParse(ip, out ipAddress);
             }
-            catch (WebException e)
+            catch (Exception e)
             {
-                if(_logger.IsError) _logger.Error($"Error while getting external ip from {_url}", e);
+                if(_logger.IsDebug) _logger.Error($"Error while getting external ip from {_url}", e);
                 ipAddress = null;
                 return false;
             }

--- a/src/Nethermind/Nethermind.Network/Timeouts.cs
+++ b/src/Nethermind/Nethermind.Network/Timeouts.cs
@@ -20,19 +20,19 @@ namespace Nethermind.Network
 {
     public static class Timeouts
     {
-        public static readonly TimeSpan InitialConnection = TimeSpan.FromSeconds(5);
+        public static readonly TimeSpan InitialConnection = TimeSpan.FromSeconds(2);
         public static readonly TimeSpan TcpClose = TimeSpan.FromSeconds(5);
-        public static readonly TimeSpan Eth = TimeSpan.FromSeconds(5);
-        public static readonly TimeSpan P2PPing = TimeSpan.FromSeconds(5);
-        public static readonly TimeSpan P2PHello = TimeSpan.FromSeconds(5);
-        public static readonly TimeSpan Eth62Status = TimeSpan.FromSeconds(5);
-        public static readonly TimeSpan Les3Status = TimeSpan.FromSeconds(5);
-        public static readonly TimeSpan NdmHi = TimeSpan.FromSeconds(10);
-        public static readonly TimeSpan NdmDeliveryReceipt = TimeSpan.FromSeconds(5);
-        public static readonly TimeSpan NdmDepositApproval = TimeSpan.FromSeconds(5);
-        public static readonly TimeSpan NdmEthRequest = TimeSpan.FromSeconds(5);
-        public static readonly TimeSpan NdmDataRequestResult = TimeSpan.FromSeconds(5);
-        public static readonly TimeSpan Handshake = TimeSpan.FromSeconds(5);
+        public static readonly TimeSpan Eth = TimeSpan.FromSeconds(3);
+        public static readonly TimeSpan P2PPing = TimeSpan.FromSeconds(3);
+        public static readonly TimeSpan P2PHello = TimeSpan.FromSeconds(3);
+        public static readonly TimeSpan Eth62Status = TimeSpan.FromSeconds(3);
+        public static readonly TimeSpan Les3Status = TimeSpan.FromSeconds(3);
+        public static readonly TimeSpan NdmHi = TimeSpan.FromSeconds(3);
+        public static readonly TimeSpan NdmDeliveryReceipt = TimeSpan.FromSeconds(3);
+        public static readonly TimeSpan NdmDepositApproval = TimeSpan.FromSeconds(3);
+        public static readonly TimeSpan NdmEthRequest = TimeSpan.FromSeconds(3);
+        public static readonly TimeSpan NdmDataRequestResult = TimeSpan.FromSeconds(3);
+        public static readonly TimeSpan Handshake = TimeSpan.FromSeconds(3);
         public static readonly TimeSpan Disconnection = TimeSpan.FromSeconds(1);
     }
 }

--- a/src/Nethermind/Nethermind.PerfTest/Program.cs
+++ b/src/Nethermind/Nethermind.PerfTest/Program.cs
@@ -89,7 +89,7 @@ namespace Nethermind.PerfTest
             public Block LowestInsertedBody => _blockTree.LowestInsertedBody;
             public Block BestSuggestedBody => _blockTree.BestSuggestedBody;
             public long BestKnownNumber => _blockTree.BestKnownNumber;
-            public BlockHeader Head => _blockTree.Head;
+            public Block Head => _blockTree.Head;
             public bool CanAcceptNewBlocks { get; } = true;
 
             public async Task LoadBlocksFromDb(CancellationToken cancellationToken, long? startBlockNumber, int batchSize = BlockTree.DbLoadBatchSize, int maxBlocksToLoad = int.MaxValue)

--- a/src/Nethermind/Nethermind.Runner/Ethereum/Steps/InitializeBlockchain.cs
+++ b/src/Nethermind/Nethermind.Runner/Ethereum/Steps/InitializeBlockchain.cs
@@ -25,6 +25,8 @@ using Nethermind.Blockchain.Validators;
 using Nethermind.Consensus;
 using Nethermind.Core;
 using Nethermind.Core.Attributes;
+using Nethermind.Core.Caching;
+using Nethermind.Core.Crypto;
 using Nethermind.Crypto;
 using Nethermind.Db;
 using Nethermind.Evm;
@@ -122,7 +124,7 @@ namespace Nethermind.Runner.Ethereum.Steps
             {
                 _context.StateProvider.StateRoot = _context.BlockTree.Head.StateRoot;
             }
-            
+
             _context.ReceiptStorage = initConfig.StoreReceipts ? (IReceiptStorage?) new PersistentReceiptStorage(_context.DbProvider.ReceiptsDb, _context.SpecProvider, new ReceiptsRecovery()) : NullReceiptStorage.Instance;
             _context.ReceiptFinder = new FullInfoReceiptFinder(_context.ReceiptStorage, new ReceiptsRecovery(), _context.BlockTree);
 
@@ -205,7 +207,7 @@ namespace Nethermind.Runner.Ethereum.Steps
                     _context.BlockProcessingQueue);
             }
 
-            ThisNodeInfo.AddInfo("Mem est trie :", $"{Trie.MemoryAllowance.TrieNodeCacheSize * 400 / 1024 / 1024}MB".PadLeft(8));
+            ThisNodeInfo.AddInfo("Mem est trie :", $"{LruCache<Keccak, byte[]>.CalculateMemorySize(52 + 320, Trie.MemoryAllowance.TrieNodeCacheSize) / 1024 / 1024}MB".PadLeft(8));
 
             return Task.CompletedTask;
         }

--- a/src/Nethermind/Nethermind.Runner/Ethereum/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Runner/Ethereum/Steps/InitializeNetwork.cs
@@ -288,7 +288,7 @@ namespace Nethermind.Runner.Ethereum.Steps
                 return Task.CompletedTask;
             }
 
-            if (_logger.IsDebug) _logger.Debug($"Starting synchronization from block {_ctx.BlockTree.Head.ToString(BlockHeader.Format.Short)}.");
+            if (_logger.IsDebug) _logger.Debug($"Starting synchronization from block {_ctx.BlockTree.Head?.Header?.ToString(BlockHeader.Format.Short)}.");
 
             _ctx.SyncPeerPool.Start();
             _ctx.Synchronizer.Start();

--- a/src/Nethermind/Nethermind.Runner/Hive/HiveRunner.cs
+++ b/src/Nethermind/Nethermind.Runner/Hive/HiveRunner.cs
@@ -161,7 +161,7 @@ namespace Nethermind.Runner.Hive
             try
             {
                 _blockTree.SuggestBlock(block);
-                if (_logger.IsInfo) _logger.Info($"HIVE suggested {block.ToString(Block.Format.Short)}, now best suggested header {_blockTree.BestSuggestedHeader}, head {_blockTree.Head.ToString(BlockHeader.Format.Short)}");
+                if (_logger.IsInfo) _logger.Info($"HIVE suggested {block.ToString(Block.Format.Short)}, now best suggested header {_blockTree.BestSuggestedHeader}, head {_blockTree.Head?.Header?.ToString(BlockHeader.Format.Short)}");
             }
             catch (InvalidBlockException e)
             {

--- a/src/Nethermind/Nethermind.State/Repositories/ChainLevelInfoRepository.cs
+++ b/src/Nethermind/Nethermind.State/Repositories/ChainLevelInfoRepository.cs
@@ -27,7 +27,7 @@ namespace Nethermind.State.Repositories
         private const int CacheSize = 64;
         
         private readonly object _writeLock = new object();
-        private readonly LruCache<long, ChainLevelInfo> _blockInfoCache = new LruCache<long, ChainLevelInfo>(CacheSize,  "chain level infos");
+        private readonly LruCache<long, ChainLevelInfo> _blockInfoCache = new LruCache<long, ChainLevelInfo>(CacheSize, CacheSize,  "chain level infos");
         
         private readonly IDb _blockInfoDb;
         

--- a/src/Nethermind/Nethermind.State/Repositories/ChainLevelInfoRepository.cs
+++ b/src/Nethermind/Nethermind.State/Repositories/ChainLevelInfoRepository.cs
@@ -27,7 +27,7 @@ namespace Nethermind.State.Repositories
         private const int CacheSize = 64;
         
         private readonly object _writeLock = new object();
-        private readonly LruCache<long, ChainLevelInfo> _blockInfoCache = new LruCache<long, ChainLevelInfo>(CacheSize);
+        private readonly LruCache<long, ChainLevelInfo> _blockInfoCache = new LruCache<long, ChainLevelInfo>(CacheSize,  "chain level infos");
         
         private readonly IDb _blockInfoDb;
         

--- a/src/Nethermind/Nethermind.Store.Bloom/BloomStorage.cs
+++ b/src/Nethermind/Nethermind.Store.Bloom/BloomStorage.cs
@@ -261,7 +261,7 @@ namespace Nethermind.Store.Bloom
                 LevelElementSize = levelElementSize;
                 LevelMultiplier = levelMultiplier;
                 _migrationStatistics = migrationStatistics;
-                _cache = new LruCache<long, Core.Bloom>(levelMultiplier);
+                _cache = new LruCache<long, Core.Bloom>(levelMultiplier, "blooms");
             }
 
             public void Store(long blockNumber, Core.Bloom bloom)

--- a/src/Nethermind/Nethermind.Store.Bloom/BloomStorage.cs
+++ b/src/Nethermind/Nethermind.Store.Bloom/BloomStorage.cs
@@ -261,7 +261,7 @@ namespace Nethermind.Store.Bloom
                 LevelElementSize = levelElementSize;
                 LevelMultiplier = levelMultiplier;
                 _migrationStatistics = migrationStatistics;
-                _cache = new LruCache<long, Core.Bloom>(levelMultiplier, "blooms");
+                _cache = new LruCache<long, Core.Bloom>(levelMultiplier, levelMultiplier, "blooms");
             }
 
             public void Store(long blockNumber, Core.Bloom bloom)

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
@@ -212,7 +212,7 @@ namespace Nethermind.Synchronization.Test.FastSync
 
             public Task<BlockHeader> GetHeadBlockHeader(Keccak hash, CancellationToken token)
             {
-                return Task.FromResult(BlockTree.Head);
+                return Task.FromResult(BlockTree.Head?.Header);
             }
 
             public void SendNewBlock(Block block)

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerMock.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerMock.cs
@@ -135,7 +135,7 @@ namespace Nethermind.Synchronization.Test
 
         public Task<BlockHeader> GetHeadBlockHeader(Keccak hash, CancellationToken token)
         {
-            return Task.FromResult(_remoteTree.Head);
+            return Task.FromResult(_remoteTree.Head?.Header);
         }
 
         private BlockingCollection<Action> _sendQueue = new BlockingCollection<Action>();

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncProgressResolverTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncProgressResolverTests.cs
@@ -69,7 +69,7 @@ namespace Nethermind.Synchronization.Test
             syncConfig.PivotNumber = "1";
 
             SyncProgressResolver syncProgressResolver = new SyncProgressResolver(blockTree, receiptStorage, stateDb, syncConfig, LimboLogs.Instance);
-            var head = Build.A.BlockHeader.WithNumber(5).WithStateRoot(TestItem.KeccakA).TestObject;
+            var head = Build.A.Block.WithHeader(Build.A.BlockHeader.WithNumber(5).WithStateRoot(TestItem.KeccakA).TestObject).TestObject;
             blockTree.Head.Returns(head);
             stateDb.Get(head.StateRoot).Returns(new byte[] {1});
             Assert.AreEqual(head.Number, syncProgressResolver.FindBestFullState());
@@ -85,11 +85,11 @@ namespace Nethermind.Synchronization.Test
             syncConfig.PivotNumber = "1";
 
             SyncProgressResolver syncProgressResolver = new SyncProgressResolver(blockTree, receiptStorage, stateDb, syncConfig, LimboLogs.Instance);
-            var head = Build.A.BlockHeader.WithNumber(5).WithStateRoot(TestItem.KeccakA).TestObject;
+            var head = Build.A.Block.WithHeader(Build.A.BlockHeader.WithNumber(5).WithStateRoot(TestItem.KeccakA).TestObject).TestObject;
             var suggested = Build.A.BlockHeader.WithNumber(6).WithStateRoot(TestItem.KeccakB).TestObject;
             blockTree.Head.Returns(head);
             blockTree.BestSuggestedHeader.Returns(suggested);
-            blockTree.FindHeader(Arg.Any<Keccak>(), BlockTreeLookupOptions.TotalDifficultyNotNeeded).Returns(head);
+            blockTree.FindHeader(Arg.Any<Keccak>(), BlockTreeLookupOptions.TotalDifficultyNotNeeded).Returns(head.Header);
             stateDb.Get(head.StateRoot).Returns(new byte[] {1});
             stateDb.Get(suggested.StateRoot).Returns(new byte[] {1});
             Assert.AreEqual(suggested.Number, syncProgressResolver.FindBestFullState());
@@ -105,11 +105,11 @@ namespace Nethermind.Synchronization.Test
             syncConfig.PivotNumber = "1";
 
             SyncProgressResolver syncProgressResolver = new SyncProgressResolver(blockTree, receiptStorage, stateDb, syncConfig, LimboLogs.Instance);
-            var head = Build.A.BlockHeader.WithNumber(5).WithStateRoot(TestItem.KeccakA).TestObject;
+            var head =  Build.A.Block.WithHeader(Build.A.BlockHeader.WithNumber(5).WithStateRoot(TestItem.KeccakA).TestObject).TestObject;
             var suggested = Build.A.BlockHeader.WithNumber(6).WithStateRoot(TestItem.KeccakB).TestObject;
             blockTree.Head.Returns(head);
             blockTree.BestSuggestedHeader.Returns(suggested);
-            blockTree.FindHeader(Arg.Any<Keccak>(), BlockTreeLookupOptions.TotalDifficultyNotNeeded).Returns(head);
+            blockTree.FindHeader(Arg.Any<Keccak>(), BlockTreeLookupOptions.TotalDifficultyNotNeeded).Returns(head?.Header);
             stateDb.Get(head.StateRoot).Returns(new byte[] {1});
             stateDb.Get(suggested.StateRoot).Returns((byte[]) null);
             Assert.AreEqual(head.Number, syncProgressResolver.FindBestFullState());

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/StateSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/StateSyncFeed.cs
@@ -112,7 +112,7 @@ namespace Nethermind.Synchronization.FastSync
         
         private ConcurrentDictionary<StateSyncBatch, object> _pendingRequests = new ConcurrentDictionary<StateSyncBatch, object>();
         private Dictionary<Keccak, HashSet<DependentItem>> _dependencies = new Dictionary<Keccak, HashSet<DependentItem>>();
-        private LruCache<Keccak, object> _alreadySaved = new LruCache<Keccak, object>(_alreadySavedCapacity);
+        private LruCache<Keccak, object> _alreadySaved = new LruCache<Keccak, object>(_alreadySavedCapacity, "saved nodes");
 
         public StateSyncFeed(ISnapshotableDb codeDb, ISnapshotableDb stateDb, IDb tempDb, ISyncModeSelector syncModeSelector, IBlockTree blockTree, ILogManager logManager)
         {
@@ -384,7 +384,7 @@ namespace Nethermind.Synchronization.FastSync
                 }
                 
                 _dependencies = new Dictionary<Keccak, HashSet<DependentItem>>();
-                _alreadySaved = new LruCache<Keccak, object>(_alreadySavedCapacity);
+                _alreadySaved = new LruCache<Keccak, object>(_alreadySavedCapacity, "saved nodes");
             }
 
             if (TotalNodesPending != 0)

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncProgressResolver.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncProgressResolver.cs
@@ -64,7 +64,7 @@ namespace Nethermind.Synchronization.ParallelSync
              when it causes a full sync vs node sync race at every block.*/
 
             BlockHeader bestSuggested = _blockTree.BestSuggestedHeader;
-            BlockHeader head = _blockTree.Head;
+            Block head = _blockTree.Head;
             long bestFullState = head?.Number ?? 0;
             long maxLookup = Math.Min(_maxLookup * 2, (bestSuggested?.Number ?? 0L) - bestFullState);
 

--- a/src/Nethermind/Nethermind.Synchronization/SyncServer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SyncServer.cs
@@ -110,7 +110,7 @@ namespace Nethermind.Synchronization
                     }
                 }
 
-                return headIsGenesis ? _pivotHeader ?? _blockTree.Genesis : _blockTree.Head;
+                return headIsGenesis ? _pivotHeader ?? _blockTree.Genesis : _blockTree.Head?.Header;
             }
         }
 

--- a/src/Nethermind/Nethermind.Synchronization/SyncServer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SyncServer.cs
@@ -52,7 +52,7 @@ namespace Nethermind.Synchronization
         private readonly ISynchronizer _synchronizer;
         private readonly ISyncConfig _syncConfig;
         private object _dummyValue = new object();
-        private LruCache<Keccak, object> _recentlySuggested = new LruCache<Keccak, object>(128, "recently suggested blocks");
+        private LruCache<Keccak, object> _recentlySuggested = new LruCache<Keccak, object>(128, 128, "recently suggested blocks");
         private long _pivotNumber;
 
         public SyncServer(

--- a/src/Nethermind/Nethermind.Synchronization/SyncServer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SyncServer.cs
@@ -52,7 +52,7 @@ namespace Nethermind.Synchronization
         private readonly ISynchronizer _synchronizer;
         private readonly ISyncConfig _syncConfig;
         private object _dummyValue = new object();
-        private LruCache<Keccak, object> _recentlySuggested = new LruCache<Keccak, object>(128);
+        private LruCache<Keccak, object> _recentlySuggested = new LruCache<Keccak, object>(128, "recently suggested blocks");
         private long _pivotNumber;
 
         public SyncServer(

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -30,7 +30,7 @@ namespace Nethermind.Trie
     [DebuggerDisplay("{RootHash}")]
     public class PatriciaTree
     {
-        public static readonly LruCache<Keccak, byte[]> NodeCache = new LruCache<Keccak, byte[]>(MemoryAllowance.TrieNodeCacheSize, "trie nodes");
+        public static readonly LruCache<Keccak, byte[]> NodeCache = new LruCache<Keccak, byte[]>(MemoryAllowance.TrieNodeCacheSize, MemoryAllowance.TrieNodeCacheSize, "trie nodes");
 
         /// <summary>
         ///     0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -30,7 +30,7 @@ namespace Nethermind.Trie
     [DebuggerDisplay("{RootHash}")]
     public class PatriciaTree
     {
-        public static readonly LruCache<Keccak, byte[]> NodeCache = new LruCache<Keccak, byte[]>(MemoryAllowance.TrieNodeCacheSize);
+        public static readonly LruCache<Keccak, byte[]> NodeCache = new LruCache<Keccak, byte[]>(MemoryAllowance.TrieNodeCacheSize, "trie nodes");
 
         /// <summary>
         ///     0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421
@@ -269,6 +269,7 @@ namespace Nethermind.Trie
                     throw new TrieException($"Node {keccak} is missing from the DB");
                 }
                 
+                NodeCache.Set(keccak, dbValue);
                 return dbValue;
             }
 

--- a/src/Nethermind/Nethermind.Trie/TrieNode.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.cs
@@ -186,7 +186,6 @@ namespace Nethermind.Trie
         {
             try
             {
-
                 if (NodeType == NodeType.Unknown)
                 {
                     if (FullRlp == null)

--- a/src/Nethermind/Nethermind.TxPool/MemoryAllowance.cs
+++ b/src/Nethermind/Nethermind.TxPool/MemoryAllowance.cs
@@ -18,7 +18,7 @@ namespace Nethermind.TxPool
 {
     public static class MemoryAllowance
     {
-        public static int MemPoolSize { get; set; } = 2 << 10;
-        public static int TxHashCacheSize { get; set; } = 2 << 18;
+        public static int MemPoolSize { get; set; } = 1 << 11;
+        public static int TxHashCacheSize { get; } = 1 << 19;
     }
 }

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -43,7 +43,7 @@ namespace Nethermind.TxPool
 
         private readonly ConcurrentDictionary<Address, AddressNonces> _nonces = new ConcurrentDictionary<Address, AddressNonces>();
 
-        private LruCache<Keccak, object> _hashCache = new LruCache<Keccak, object>(MemoryAllowance.TxHashCacheSize, "tx hashes");
+        private LruCache<Keccak, object> _hashCache = new LruCache<Keccak, object>(MemoryAllowance.TxHashCacheSize, MemoryAllowance.TxHashCacheSize, "tx hashes");
 
         /// <summary>
         /// Number of blocks after which own transaction will not be resurrected any more
@@ -146,7 +146,7 @@ namespace Nethermind.TxPool
             _stateProvider = stateProvider ?? throw new ArgumentNullException(nameof(stateProvider));
 
             MemoryAllowance.MemPoolSize = txPoolConfig.Size;
-            ThisNodeInfo.AddInfo("Mem est tx   :", $"{(MemoryAllowance.TxHashCacheSize * 64 + MemoryAllowance.MemPoolSize * 4096) / 1024 / 1024}MB".PadLeft(8));
+            ThisNodeInfo.AddInfo("Mem est tx   :", $"{(LruCache<Keccak, object>.CalculateMemorySize(32, MemoryAllowance.TxHashCacheSize) + LruCache<Keccak, Transaction>.CalculateMemorySize(4096, MemoryAllowance.MemPoolSize)) / 1024 / 1024}MB".PadLeft(8));
             _transactions = new DistinctValueSortedPool<Keccak, Transaction>(MemoryAllowance.MemPoolSize, (t1, t2) => t1.GasPrice.CompareTo(t2.GasPrice), PendingTransactionComparer.Default);
             _peerNotificationThreshold = txPoolConfig.PeerNotificationThreshold;
 

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -43,7 +43,7 @@ namespace Nethermind.TxPool
 
         private readonly ConcurrentDictionary<Address, AddressNonces> _nonces = new ConcurrentDictionary<Address, AddressNonces>();
 
-        private LruCache<Keccak, object> _hashCache = new LruCache<Keccak, object>(MemoryAllowance.TxHashCacheSize);
+        private LruCache<Keccak, object> _hashCache = new LruCache<Keccak, object>(MemoryAllowance.TxHashCacheSize, "tx hashes");
 
         /// <summary>
         /// Number of blocks after which own transaction will not be resurrected any more


### PR DESCRIPTION
VirtualMachines will now share static bytecode LruCache
BlockTree holds a Head block reference now instead of HeadeHeader
TImeouts changed for connections to imporve speed at which peer manager establishes new connections
LruCache detailed memory calculation has been added