### PR TITLE
Update dappnode-update.yml to dispatch events to nethermind repo

### DIFF
--- a/.github/workflows/dappnode-update.yml
+++ b/.github/workflows/dappnode-update.yml
@@ -6,13 +6,19 @@ on:
     - '*'
 
 jobs:
-  dappnode-update:
-    name: Updating DAppNode package
+  dappnode-update-netethermind:
+    name: Trigger the beacon-chain DAppNodePackage update
     runs-on: ubuntu-latest
     steps:
-    - name: Send dispatch event to DAppNodePackage-nethermind repo
+    - name: Get the tag
+      id: get_tag
+      run: echo ::set-output name=TAG::${GITHUB_REF/refs\/tags\//}
+    - name: Send dispatch event to nethermind DAppNodePackage repository
+      env: 
+        DISPATCH_REPO: dappnode/DAppNodePackage-nethermind
       run: |
-        curl -v -X POST -u "${{ secrets.PAT_USERNAME }}:${{ secrets.PAT_TOKEN }}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" --data '{"event_type":"dappnode_update"}' https://api.github.com/repos/nethermindeth/nethermind/dispatches
-    
-
-
+        curl -v -X POST -u "${{ secrets.PAT_GITHUB }}" \
+        -H "Accept: application/vnd.github.everest-preview+json" \
+        -H "Content-Type: application/json" \
+        --data '{"event_type":"new_release", "client_payload": { "tag":"${{ steps.get_tag.outputs.TAG }}"}}' \
+        https://api.github.com/repos/$DISPATCH_REPO/dispatches


### PR DESCRIPTION
We did some changes on our repo and this allows us to have an auto-generated DAppNodePackage every time that you tag a new release.
 