### PR TITLE
Tri stage transition

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/IBlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/IBlockTree.cs
@@ -37,7 +37,7 @@ namespace Nethermind.Blockchain
         BlockHeader Genesis { get; }
         
         /// <summary>
-        /// Best header that has been suggested
+        /// Best header that has been suggested (suggested for processing in the fast sync mode)
         /// </summary>
         BlockHeader BestSuggestedHeader { get; }
 
@@ -57,7 +57,7 @@ namespace Nethermind.Blockchain
         Block LowestInsertedBody { get; }
         
         /// <summary>
-        /// Best downloaded block number
+        /// Best downloaded block number (highest number of chain level on the chain)
         /// </summary>
         long BestKnownNumber { get; }
 
@@ -69,7 +69,7 @@ namespace Nethermind.Blockchain
         AddBlockResult Insert(BlockHeader header);
         
         /// <summary>
-        /// Inserts a disconnected block body
+        /// Inserts a disconnected block body (not for processing).
         /// </summary>
         /// <param name="block">Block to add</param>
         /// <returns>Result of the operation, eg. Added, AlreadyKnown, etc.</returns>

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugBridge.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugBridge.cs
@@ -38,7 +38,6 @@ namespace Nethermind.JsonRpc.Modules.DebugModule
 
         public DebugBridge(IConfigProvider configProvider, IReadOnlyDbProvider dbProvider, IGethStyleTracer tracer, IBlockProcessingQueue receiptsBlockQueue, IBlockTree blockTree)
         {
-            receiptsBlockQueue.ProcessingQueueEmpty += (sender, args) => _receiptProcessedEvent.Set();
             _configProvider = configProvider ?? throw new ArgumentNullException(nameof(configProvider));
             _tracer = tracer ?? throw new ArgumentNullException(nameof(tracer));
             _blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
@@ -133,7 +132,5 @@ namespace Nethermind.JsonRpc.Modules.DebugModule
         {
             return _configProvider.GetRawValue(category, name);
         }
-
-        private AutoResetEvent _receiptProcessedEvent = new AutoResetEvent(false);
     }
 }

--- a/src/Nethermind/Nethermind.Runner/Ethereum/Steps/InitializeBlockchain.cs
+++ b/src/Nethermind/Nethermind.Runner/Ethereum/Steps/InitializeBlockchain.cs
@@ -201,6 +201,7 @@ namespace Nethermind.Runner.Ethereum.Steps
                     _context.RecoveryStep,
                     _context.RewardCalculatorSource,
                     _context.BlockProcessingQueue,
+                    _context.BlockchainProcessor,
                     _context.SyncModeSelector);
             }
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/BeamSync/BeamBlockchainProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BeamSync/BeamBlockchainProcessorTests.cs
@@ -46,6 +46,7 @@ namespace Nethermind.Synchronization.Test.BeamSync
         private BlockValidator _validator;
         private IBlockProcessingQueue _blockchainProcessingQueue;
         private IBlockchainProcessor _blockchainProcessor;
+        private BeamBlockchainProcessor _beamBlockchainProcessor;
 
         [SetUp]
         public void SetUp()
@@ -55,6 +56,13 @@ namespace Nethermind.Synchronization.Test.BeamSync
             _blockTree = Build.A.BlockTree().OfChainLength(10).TestObject;
             HeaderValidator headerValidator = new HeaderValidator(_blockTree, NullSealEngine.Instance, MainnetSpecProvider.Instance, LimboLogs.Instance);
             _validator = new BlockValidator(Always.Valid, headerValidator, Always.Valid, MainnetSpecProvider.Instance, LimboLogs.Instance);
+        }
+        
+        [TearDown]
+        public void TearDown()
+        {
+            _beamBlockchainProcessor.Dispose();
+            _blockchainProcessor.Dispose();
         }
 
         [Test, Retry(3)]
@@ -125,8 +133,6 @@ namespace Nethermind.Synchronization.Test.BeamSync
             _blockchainProcessingQueue.Received().Enqueue(newBlock2, ProcessingOptions.StoreReceipts);
             _blockchainProcessingQueue.Received().Enqueue(newBlock3, ProcessingOptions.StoreReceipts);
             _blockchainProcessingQueue.Received().Enqueue(newBlock4, ProcessingOptions.StoreReceipts);
-            
-            _blockchainProcessor.Dispose();
         }
         
         [Test, Retry(3)]
@@ -161,7 +167,7 @@ namespace Nethermind.Synchronization.Test.BeamSync
         private void SetupBeamProcessor(ISyncModeSelector syncModeSelector = null)
         {
             MemDbProvider memDbProvider = new MemDbProvider();
-            _ = new BeamBlockchainProcessor(
+            _beamBlockchainProcessor  = new BeamBlockchainProcessor(
                 new ReadOnlyDbProvider(memDbProvider, false),
                 _blockTree,
                 MainnetSpecProvider.Instance,

--- a/src/Nethermind/Nethermind.Synchronization.Test/BeamSync/BeamBlockchainProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BeamSync/BeamBlockchainProcessorTests.cs
@@ -14,7 +14,9 @@
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
+using System;
 using System.Threading;
+using System.Threading.Tasks;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Processing;
 using Nethermind.Blockchain.Rewards;
@@ -50,29 +52,41 @@ namespace Nethermind.Synchronization.Test.BeamSync
             _blockTree = Build.A.BlockTree().OfChainLength(10).TestObject;
             HeaderValidator headerValidator = new HeaderValidator(_blockTree, NullSealEngine.Instance, MainnetSpecProvider.Instance, LimboLogs.Instance);
             _validator = new BlockValidator(Always.Valid, headerValidator, Always.Valid, MainnetSpecProvider.Instance, LimboLogs.Instance);
-            SetupBeamProcessor();
         }
 
         [Test, Retry(3)]
         public void Valid_block_makes_it_all_the_way()
         {
+            SetupBeamProcessor(SyncMode.Beam);
             Block newBlock = Build.A.Block.WithParent(_blockTree.Head).WithTotalDifficulty(_blockTree.Head.TotalDifficulty + 1).TestObject;
             _blockTree.SuggestBlock(newBlock);
             Thread.Sleep(1000);
-            _blockchainProcessor.Received().Enqueue(newBlock, ProcessingOptions.IgnoreParentNotOnMainChain);
+            _blockchainProcessor.Received().Enqueue(newBlock, ProcessingOptions.Beam);
         }
 
         [Test, Retry(3)]
         public void Valid_block_with_transactions_makes_it_all_the_way()
         {
+            SetupBeamProcessor(SyncMode.Beam);
             EthereumEcdsa ethereumEcdsa = new EthereumEcdsa(MainnetSpecProvider.Instance, LimboLogs.Instance);
             Block newBlock = Build.A.Block.WithParent(_blockTree.Head).WithReceiptsRoot(new Keccak("0xeb82c315eaf2c2a5dfc1766b075263d80e8b3ab9cb690d5304cdf114fff26939")).WithTransactions(Build.A.Transaction.SignedAndResolved(ethereumEcdsa, TestItem.PrivateKeyA, 10000000).TestObject, Build.A.Transaction.SignedAndResolved(ethereumEcdsa, TestItem.PrivateKeyB, 10000000).TestObject).WithGasUsed(42000).WithTotalDifficulty(_blockTree.Head.TotalDifficulty + 1).TestObject;
             _blockTree.SuggestBlock(newBlock);
             Thread.Sleep(1000);
-            _blockchainProcessor.Received().Enqueue(newBlock, ProcessingOptions.IgnoreParentNotOnMainChain);
+            _blockchainProcessor.Received().Enqueue(newBlock, ProcessingOptions.Beam);
+        }
+        
+        [Test, Retry(3)]
+        public void Valid_block_with_transactions_makes_it_is_processed_normally_if_beam_syncing_finished()
+        {
+            SetupBeamProcessor(SyncMode.None);
+            EthereumEcdsa ethereumEcdsa = new EthereumEcdsa(MainnetSpecProvider.Instance, LimboLogs.Instance);
+            Block newBlock = Build.A.Block.WithParent(_blockTree.Head).WithReceiptsRoot(new Keccak("0xeb82c315eaf2c2a5dfc1766b075263d80e8b3ab9cb690d5304cdf114fff26939")).WithTransactions(Build.A.Transaction.SignedAndResolved(ethereumEcdsa, TestItem.PrivateKeyA, 10000000).TestObject, Build.A.Transaction.SignedAndResolved(ethereumEcdsa, TestItem.PrivateKeyB, 10000000).TestObject).WithGasUsed(42000).WithTotalDifficulty(_blockTree.Head.TotalDifficulty + 1).TestObject;
+            _blockTree.SuggestBlock(newBlock);
+            Thread.Sleep(1000);
+            _blockchainProcessor.Received().Enqueue(newBlock, ProcessingOptions.StoreReceipts);
         }
 
-        private void SetupBeamProcessor()
+        private void SetupBeamProcessor(SyncMode syncMode = SyncMode.Beam)
         {
             MemDbProvider memDbProvider = new MemDbProvider();
             _ = new BeamBlockchainProcessor(
@@ -91,6 +105,7 @@ namespace Nethermind.Synchronization.Test.BeamSync
         [Test]
         public void Invalid_block_will_never_reach_actual_processor()
         {
+            SetupBeamProcessor(SyncMode.Beam);
             Block newBlock = Build.A.Block.WithParent(_blockTree.Head).WithTotalDifficulty(_blockTree.Head.TotalDifficulty + 1).TestObject;
             newBlock.Header.Hash = Keccak.Zero;
             _blockTree.SuggestBlock(newBlock);
@@ -100,10 +115,26 @@ namespace Nethermind.Synchronization.Test.BeamSync
         [Test]
         public void Valid_block_that_would_be_skipped_will_never_reach_actual_processor()
         {
+            SetupBeamProcessor(SyncMode.Beam);
             // setting same difficulty as head to make sure the block will be ignored
             Block newBlock = Build.A.Block.WithParent(_blockTree.Head).WithTotalDifficulty(_blockTree.Head.TotalDifficulty).TestObject;
             _blockTree.SuggestBlock(newBlock);
             _blockchainProcessor.DidNotReceiveWithAnyArgs().Enqueue(newBlock, ProcessingOptions.None);
+        }
+        
+        private async Task WaitFor(Func<bool> isConditionMet, string description = "condition to be met")
+        {
+            const int waitInterval = 10;
+            for (int i = 0; i < 100; i++)
+            {
+                if (isConditionMet())
+                {
+                    return;
+                }
+
+                TestContext.WriteLine($"({i}) Waiting {waitInterval} for {description}");
+                await Task.Delay(waitInterval);
+            }
         }
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization.Test/BeamSync/BeamSyncDbTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BeamSync/BeamSyncDbTests.cs
@@ -19,6 +19,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
 using Nethermind.Logging;
@@ -282,8 +283,8 @@ namespace Nethermind.Synchronization.Test.BeamSync
             BeamSyncDb beamSyncDb = new BeamSyncDb(stateDB, tempDb, StaticSelector.Beam, LimboLogs.Instance);
 
             byte[] bytes = new byte[] {1, 2, 3};
-            beamSyncDb.Set(TestItem.KeccakA, bytes);
-            byte[] retrievedFromTemp = stateDB.Get(TestItem.KeccakA);
+            beamSyncDb.Set(Keccak.Compute(bytes), bytes);
+            byte[] retrievedFromTemp = stateDB.Get(Keccak.Compute(bytes));
             retrievedFromTemp.Should().BeNull();
         }
 
@@ -295,9 +296,9 @@ namespace Nethermind.Synchronization.Test.BeamSync
             BeamSyncDb beamSyncDb = new BeamSyncDb(stateDB, tempDb, StaticSelector.Beam, LimboLogs.Instance);
 
             byte[] bytes = new byte[] {1, 2, 3};
-            tempDb.Set(TestItem.KeccakA, bytes);
+            tempDb.Set(Keccak.Compute(bytes), bytes);
 
-            byte[] retrievedFromTemp = beamSyncDb.Get(TestItem.KeccakA);
+            byte[] retrievedFromTemp = beamSyncDb.Get(Keccak.Compute(bytes));
             retrievedFromTemp.Should().BeEquivalentTo(bytes);
         }
 
@@ -309,9 +310,9 @@ namespace Nethermind.Synchronization.Test.BeamSync
             BeamSyncDb beamSyncDb = new BeamSyncDb(stateDB, tempDb, StaticSelector.Beam, LimboLogs.Instance);
 
             byte[] bytes = new byte[] {1, 2, 3};
-            stateDB.Set(TestItem.KeccakA, bytes);
+            stateDB.Set(Keccak.Compute(bytes), bytes);
 
-            byte[] retrievedFromTemp = beamSyncDb.Get(TestItem.KeccakA);
+            byte[] retrievedFromTemp = beamSyncDb.Get(Keccak.Compute(bytes));
             retrievedFromTemp.Should().BeEquivalentTo(bytes);
         }
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorTests.cs
@@ -1001,6 +1001,16 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                 .IfThisNodeJustFinishedFastBlocksAndFastSync()
                 .AndPeersMovedSlightlyForward()
                 .WhenBeamSyncIsConfigured()
+                .TheSyncModeShouldBe(SyncMode.StateNodes | SyncMode.FastSync | SyncMode.Beam);
+        }
+        
+        [Test]
+        public void When_peers_move_slightly_forward_when_state_syncing_without_beam()
+        {
+            Scenario.GoesLikeThis()
+                .IfThisNodeJustFinishedFastBlocksAndFastSync()
+                .AndPeersMovedSlightlyForward()
+                .WhenFastSyncWithFastBlocksIsConfigured()
                 .TheSyncModeShouldBe(SyncMode.StateNodes | SyncMode.FastSync);
         }
         

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorTests.cs
@@ -90,7 +90,6 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                     SyncProgressResolver.ChainDifficulty.Returns(ValidGenesis.TotalDifficulty ?? 0);
                     SyncProgressResolver.FindBestHeader().Returns(0);
                     SyncProgressResolver.FindBestFullBlock().Returns(0);
-                    SyncProgressResolver.FindBestBeamState().Returns(0);
                     SyncProgressResolver.FindBestFullState().Returns(0);
                     SyncProgressResolver.IsLoadingBlocksFromDb().Returns(false);
                     SyncProgressResolver.IsFastBlocksFinished().Returns(false);
@@ -145,7 +144,6 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                         {
                             SyncProgressResolver.FindBestHeader().Returns(ChainHead.Number);
                             SyncProgressResolver.FindBestFullBlock().Returns(ChainHead.Number);
-                            SyncProgressResolver.FindBestBeamState().Returns(ChainHead.Number);
                             SyncProgressResolver.FindBestFullState().Returns(ChainHead.Number);
                             SyncProgressResolver.FindBestProcessedBlock().Returns(ChainHead.Number);
                             SyncProgressResolver.IsFastBlocksFinished().Returns(true);
@@ -163,7 +161,6 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                         {
                             SyncProgressResolver.FindBestHeader().Returns(ChainHead.Number);
                             SyncProgressResolver.FindBestFullBlock().Returns(ChainHead.Number);
-                            SyncProgressResolver.FindBestBeamState().Returns(ChainHead.Number);
                             SyncProgressResolver.FindBestFullState().Returns(ChainHead.Number - FastSyncCatchUpHeightDelta + 1);
                             SyncProgressResolver.FindBestProcessedBlock().Returns(ChainHead.Number - FastSyncCatchUpHeightDelta + 1);
                             SyncProgressResolver.IsFastBlocksFinished().Returns(true);
@@ -181,7 +178,6 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                         {
                             SyncProgressResolver.FindBestHeader().Returns(Pivot.Number + 16);
                             SyncProgressResolver.FindBestFullBlock().Returns(0);
-                            SyncProgressResolver.FindBestBeamState().Returns(0);
                             SyncProgressResolver.FindBestFullState().Returns(0);
                             SyncProgressResolver.FindBestProcessedBlock().Returns(0);
                             SyncProgressResolver.IsFastBlocksFinished().Returns(false);
@@ -199,7 +195,6 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                         {
                             SyncProgressResolver.FindBestHeader().Returns(Pivot.Number + 16);
                             SyncProgressResolver.FindBestFullBlock().Returns(0);
-                            SyncProgressResolver.FindBestBeamState().Returns(0);
                             SyncProgressResolver.FindBestFullState().Returns(0);
                             SyncProgressResolver.FindBestProcessedBlock().Returns(0);
                             SyncProgressResolver.IsFastBlocksFinished().Returns(true);
@@ -217,7 +212,6 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                         {
                             SyncProgressResolver.FindBestHeader().Returns(ChainHead.Number);
                             SyncProgressResolver.FindBestFullBlock().Returns(ChainHead.Number);
-                            SyncProgressResolver.FindBestBeamState().Returns(ChainHead.Number - FastSyncCatchUpHeightDelta - 1);
                             SyncProgressResolver.FindBestFullState().Returns(ChainHead.Number - FastSyncCatchUpHeightDelta - 1);
                             SyncProgressResolver.FindBestProcessedBlock().Returns(ChainHead.Number - FastSyncCatchUpHeightDelta - 1);
                             SyncProgressResolver.IsFastBlocksFinished().Returns(true);
@@ -235,7 +229,6 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                         {
                             SyncProgressResolver.FindBestHeader().Returns(ChainHead.Number - MultiSyncModeSelector.FastSyncLag);
                             SyncProgressResolver.FindBestFullBlock().Returns(0);
-                            SyncProgressResolver.FindBestBeamState().Returns(0);
                             SyncProgressResolver.FindBestFullState().Returns(0);
                             SyncProgressResolver.FindBestProcessedBlock().Returns(0);
                             SyncProgressResolver.IsFastBlocksFinished().Returns(false);
@@ -253,7 +246,6 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                         {
                             SyncProgressResolver.FindBestHeader().Returns(ChainHead.Number - MultiSyncModeSelector.FastSyncLag);
                             SyncProgressResolver.FindBestFullBlock().Returns(0);
-                            SyncProgressResolver.FindBestBeamState().Returns(0);
                             SyncProgressResolver.FindBestFullState().Returns(ChainHead.Number - MultiSyncModeSelector.FastSyncLag);
                             SyncProgressResolver.FindBestProcessedBlock().Returns(0);
                             SyncProgressResolver.IsFastBlocksFinished().Returns(false);
@@ -271,7 +263,6 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                         {
                             SyncProgressResolver.FindBestHeader().Returns(ChainHead.Number - MultiSyncModeSelector.FastSyncLag);
                             SyncProgressResolver.FindBestFullBlock().Returns(0);
-                            SyncProgressResolver.FindBestBeamState().Returns(0);
                             SyncProgressResolver.FindBestFullState().Returns(ChainHead.Number - MultiSyncModeSelector.FastSyncLag);
                             SyncProgressResolver.FindBestProcessedBlock().Returns(0);
                             SyncProgressResolver.IsFastBlocksFinished().Returns(true);
@@ -289,7 +280,6 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                         {
                             SyncProgressResolver.FindBestHeader().Returns(ChainHead.Number - MultiSyncModeSelector.FastSyncLag);
                             SyncProgressResolver.FindBestFullBlock().Returns(0);
-                            SyncProgressResolver.FindBestBeamState().Returns(0);
                             SyncProgressResolver.FindBestFullState().Returns(ChainHead.Number - MultiSyncModeSelector.FastSyncLag - 7);
                             SyncProgressResolver.FindBestProcessedBlock().Returns(0);
                             SyncProgressResolver.IsFastBlocksFinished().Returns(true);
@@ -307,7 +297,6 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                         {
                             SyncProgressResolver.FindBestHeader().Returns(ChainHead.Number);
                             SyncProgressResolver.FindBestFullBlock().Returns(ChainHead.Number);
-                            SyncProgressResolver.FindBestBeamState().Returns(ChainHead.Number - MultiSyncModeSelector.FastSyncLag);
                             SyncProgressResolver.FindBestFullState().Returns(ChainHead.Number - MultiSyncModeSelector.FastSyncLag);
                             SyncProgressResolver.FindBestProcessedBlock().Returns(0);
                             SyncProgressResolver.IsFastBlocksFinished().Returns(true);
@@ -325,7 +314,6 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                         {
                             SyncProgressResolver.FindBestHeader().Returns(ChainHead.Number - MultiSyncModeSelector.FastSyncLag);
                             SyncProgressResolver.FindBestFullBlock().Returns(0);
-                            SyncProgressResolver.FindBestBeamState().Returns(0);
                             SyncProgressResolver.FindBestFullState().Returns(0);
                             SyncProgressResolver.FindBestProcessedBlock().Returns(0);
                             SyncProgressResolver.IsFastBlocksFinished().Returns(true);
@@ -344,7 +332,6 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                         {
                             SyncProgressResolver.FindBestHeader().Returns(currentBlock);
                             SyncProgressResolver.FindBestFullBlock().Returns(currentBlock);
-                            SyncProgressResolver.FindBestBeamState().Returns(0);
                             SyncProgressResolver.FindBestFullState().Returns(currentBlock);
                             SyncProgressResolver.FindBestProcessedBlock().Returns(0);
                             SyncProgressResolver.IsFastBlocksFinished().Returns(true);
@@ -363,7 +350,6 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                         {
                             SyncProgressResolver.FindBestHeader().Returns(ChainHead.Number);
                             SyncProgressResolver.FindBestFullBlock().Returns(ChainHead.Number);
-                            SyncProgressResolver.FindBestBeamState().Returns(0);
                             SyncProgressResolver.FindBestFullState().Returns(currentBlock);
                             SyncProgressResolver.FindBestProcessedBlock().Returns(currentBlock);
                             SyncProgressResolver.IsFastBlocksFinished().Returns(true);
@@ -382,7 +368,6 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                         {
                             SyncProgressResolver.FindBestHeader().Returns(currentBlock);
                             SyncProgressResolver.FindBestFullBlock().Returns(currentBlock);
-                            SyncProgressResolver.FindBestBeamState().Returns(0);
                             SyncProgressResolver.FindBestFullState().Returns(currentBlock);
                             SyncProgressResolver.FindBestProcessedBlock().Returns(currentBlock);
                             SyncProgressResolver.IsFastBlocksFinished().Returns(true);
@@ -403,7 +388,6 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                         {
                             SyncProgressResolver.FindBestHeader().Returns(ChainHead.Number);
                             SyncProgressResolver.FindBestFullBlock().Returns(ChainHead.Number);
-                            SyncProgressResolver.FindBestBeamState().Returns(0);
                             SyncProgressResolver.FindBestFullState().Returns(0);
                             SyncProgressResolver.FindBestProcessedBlock().Returns(currentBlock);
                             SyncProgressResolver.IsFastBlocksFinished().Returns(true);
@@ -422,7 +406,6 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                         {
                             SyncProgressResolver.FindBestHeader().Returns(currentBlock);
                             SyncProgressResolver.FindBestFullBlock().Returns(currentBlock);
-                            SyncProgressResolver.FindBestBeamState().Returns(0);
                             SyncProgressResolver.FindBestFullState().Returns(currentBlock);
                             SyncProgressResolver.FindBestProcessedBlock().Returns(currentBlock);
                             SyncProgressResolver.IsFastBlocksFinished().Returns(true);
@@ -440,7 +423,7 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                         {
                             SyncProgressResolver.FindBestHeader().Returns(ChainHead.Number);
                             SyncProgressResolver.FindBestFullBlock().Returns(ChainHead.Number);
-                            SyncProgressResolver.FindBestBeamState().Returns(0);
+                            
                             SyncProgressResolver.FindBestFullState().Returns(ChainHead.Number - 1);
                             SyncProgressResolver.FindBestProcessedBlock().Returns(ChainHead.Number);
                             SyncProgressResolver.IsFastBlocksFinished().Returns(true);

--- a/src/Nethermind/Nethermind.Synchronization/BeamSync/BeamBlockchainProcessor.cs
+++ b/src/Nethermind/Nethermind.Synchronization/BeamSync/BeamBlockchainProcessor.cs
@@ -122,6 +122,7 @@ namespace Nethermind.Synchronization.BeamSync
                     }
 
                     _isAfterBeam = true;
+                    if(_logger.IsInfo) _logger.Info($"Setting block action to shelving.");
                     _blockAction = Shelve;
                 }
 
@@ -138,10 +139,10 @@ namespace Nethermind.Synchronization.BeamSync
         {
             if ((e.Current & SyncMode.Full) == SyncMode.Full)
             {
+                if(_logger.IsInfo) _logger.Info($"Setting block action to standard processing.");
                 _blockAction = EnqueueForStandardProcessing;
+                UnregisterListeners();
             }
-
-            UnregisterListeners();
         }
 
         /// <summary>
@@ -366,6 +367,7 @@ namespace Nethermind.Synchronization.BeamSync
 
         private void UnregisterListeners()
         {
+            if(_logger.IsDebug) _logger.Debug($"Unregistering sync mode listeners.");
             _syncModeSelector.Preparing -= SyncModeSelectorOnPreparing;
             _syncModeSelector.Changing -= SyncModeSelectorOnChanging;
             _syncModeSelector.Changed -= SyncModeSelectorOnChanged;

--- a/src/Nethermind/Nethermind.Synchronization/BeamSync/BeamBlockchainProcessor.cs
+++ b/src/Nethermind/Nethermind.Synchronization/BeamSync/BeamBlockchainProcessor.cs
@@ -310,7 +310,7 @@ namespace Nethermind.Synchronization.BeamSync
                     Transaction tx = block.Transactions[i];
                     BeamSyncContext.Description.Value = $"[tx prefetch {i}]";
                     BeamSyncContext.LastFetchUtc.Value = DateTime.UtcNow;
-                    stateReader.GetAccount(stateRoot, tx.To);
+                    stateReader.GetAccount(stateRoot, tx.SenderAddress);
                 }
 
                 return BeamSyncContext.ResolvedInContext.Value;
@@ -352,7 +352,7 @@ namespace Nethermind.Synchronization.BeamSync
                     {
                         BeamSyncContext.Description.Value = $"[code prefetch {i}]";
                         BeamSyncContext.LastFetchUtc.Value = DateTime.UtcNow;
-                        stateReader.GetCode(stateRoot, tx.SenderAddress);
+                        stateReader.GetCode(stateRoot, tx.To);
                     }
                 }
 

--- a/src/Nethermind/Nethermind.Synchronization/BeamSync/BeamSyncDb.cs
+++ b/src/Nethermind/Nethermind.Synchronization/BeamSync/BeamSyncDb.cs
@@ -48,8 +48,6 @@ namespace Nethermind.Synchronization.BeamSync
 
         private readonly ISyncModeSelector _syncModeSelector;
 
-        private readonly Func<bool> _writeThrough;
-
         private ILogger _logger;
 
         private IDb _targetDbForSaves;
@@ -72,6 +70,7 @@ namespace Nethermind.Synchronization.BeamSync
         {
             // the beam processor either already switched or is about ti switch to the full sync mode
             // we should be already switched to the new database
+            Finish();
         }
 
         private void SyncModeSelectorOnPreparing(object sender, SyncModeChangedEventArgs e)

--- a/src/Nethermind/Nethermind.Synchronization/BeamSync/BeamSyncDb.cs
+++ b/src/Nethermind/Nethermind.Synchronization/BeamSync/BeamSyncDb.cs
@@ -147,7 +147,6 @@ namespace Nethermind.Synchronization.BeamSync
                 // if we keep timing out then we would finally reject the block (but only shelve it instead of marking invalid)
 
                 bool wasInDb = true;
-                var fromMem = _stateDb[key];
                 while (true)
                 {
                     if (BeamSyncContext.Cancelled.Value.IsCancellationRequested)
@@ -170,7 +169,7 @@ namespace Nethermind.Synchronization.BeamSync
                         }
                     }
 
-                    fromMem ??= _tempDb[key] ?? _stateDb[key];
+                    var fromMem = _tempDb[key] ?? _stateDb[key];
                     if (fromMem == null)
                     {
                         if (_logger.IsTrace) _logger.Trace($"Beam sync miss - {key.ToHexString()} - retrieving");
@@ -217,6 +216,11 @@ namespace Nethermind.Synchronization.BeamSync
                         }
 
                         BeamSyncContext.LastFetchUtc.Value = DateTime.UtcNow;
+                        
+                        // if (!Bytes.AreEqual(Keccak.Compute(fromMem).Bytes, key))
+                        // {
+                        //     throw new Exception("DB had an entry with a hash mismatch {key}");
+                        // }
 
                         return fromMem;
                     }

--- a/src/Nethermind/Nethermind.Synchronization/BeamSync/CompositeStateSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/BeamSync/CompositeStateSyncFeed.cs
@@ -33,9 +33,9 @@ namespace Nethermind.Synchronization.BeamSync
         {
             _logger = logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
             _subFeeds = subFeeds;
-            foreach (ISyncFeed<T> dataConsumer in _subFeeds)
+            foreach (ISyncFeed<T> syncFeed in _subFeeds)
             {
-                dataConsumer.StateChanged += OnSubFeedStateChanged;
+                syncFeed.StateChanged += OnSubFeedStateChanged;
             }
         }
 
@@ -45,6 +45,22 @@ namespace Nethermind.Synchronization.BeamSync
             if (child.CurrentState == SyncFeedState.Active)
             {
                 Activate();
+                return;
+            }
+
+            bool areAllFinished = true;
+            foreach (ISyncFeed<T> subFeed in _subFeeds)
+            {
+                if (subFeed.CurrentState != SyncFeedState.Finished)
+                {
+                    areAllFinished = false;
+                    break;
+                }
+            }
+
+            if (areAllFinished)
+            {
+                Finish();
             }
         }
 

--- a/src/Nethermind/Nethermind.Synchronization/BeamSync/CompositeStateSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/BeamSync/CompositeStateSyncFeed.cs
@@ -66,11 +66,12 @@ namespace Nethermind.Synchronization.BeamSync
 
         public override Task<T> PrepareRequest()
         {
-            foreach (ISyncFeed<T> syncFeed in _subFeeds)
+            for (int subFeedIndex = 0; subFeedIndex < _subFeeds.Length; subFeedIndex++)
             {
-                if (syncFeed.CurrentState == SyncFeedState.Active)
+                ISyncFeed<T> subFeed = _subFeeds[subFeedIndex];
+                if (subFeed.CurrentState == SyncFeedState.Active)
                 {
-                    T batch = syncFeed.PrepareRequest().Result;
+                    T batch = subFeed.PrepareRequest().Result;
                     if (batch != null)
                     {
                         return Task.FromResult(batch);
@@ -83,14 +84,15 @@ namespace Nethermind.Synchronization.BeamSync
 
         public override SyncResponseHandlingResult HandleResponse(T batch)
         {
-            foreach (ISyncFeed<T> subFeed in _subFeeds)
+            for (int subFeedIndex = 0; subFeedIndex < _subFeeds.Length; subFeedIndex++)
             {
+                ISyncFeed<T> subFeed = _subFeeds[subFeedIndex];
                 if (subFeed.FeedId == batch.ConsumerId)
                 {
                     subFeed.HandleResponse(batch);
                 }
             }
-            
+
             return SyncResponseHandlingResult.OK;
         }
 

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
@@ -630,12 +630,7 @@ namespace Nethermind.Synchronization.Blocks
             
             allocationWithCancellation.Cancel();
         }
-
-        private void AllocationOnRefreshed(object sender, EventArgs e)
-        {
-            Feed.Activate();
-        }
-
+        
         private void AllocationOnReplaced(object sender, AllocationChangeEventArgs e)
         {
             if (e.Previous == null)

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/ISyncModeSelector.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/ISyncModeSelector.cs
@@ -21,7 +21,9 @@ namespace Nethermind.Synchronization.ParallelSync
     public interface ISyncModeSelector
     {
         SyncMode Current { get; }
-
+        
+        event EventHandler<SyncModeChangedEventArgs> Preparing;
+        
         event EventHandler<SyncModeChangedEventArgs> Changing;
         
         event EventHandler<SyncModeChangedEventArgs> Changed;

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/ISyncModeSelector.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/ISyncModeSelector.cs
@@ -22,6 +22,8 @@ namespace Nethermind.Synchronization.ParallelSync
     {
         SyncMode Current { get; }
 
+        event EventHandler<SyncModeChangedEventArgs> Changing;
+        
         event EventHandler<SyncModeChangedEventArgs> Changed;
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/ISyncProgressResolver.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/ISyncProgressResolver.cs
@@ -23,9 +23,7 @@ namespace Nethermind.Synchronization.ParallelSync
     public interface ISyncProgressResolver
     {
         long FindBestFullState();
-        
-        long FindBestBeamState();
-        
+
         long FindBestHeader();
         
         long FindBestFullBlock();

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
@@ -329,32 +329,17 @@ namespace Nethermind.Synchronization.ParallelSync
         private bool ShouldBeInBeamSyncMode(Snapshot best)
         {
             bool beamSyncEnabled = BeamSyncEnabled;
-            bool fastSyncHasBeenActive = best.Header >= PivotNumber;
-            bool hasAnyPostPivotPeer = AnyPostPivotPeerKnown(best.PeerBlock);
-            bool inStateNodesSync = best.IsInStateSync;
-            bool notInFastSync = !best.IsInFastSync;
-            bool notInAStickyFullSync = !IsInAStickyFullSyncMode(best);
-            bool notHasJustStartedFullSync = !HasJustStartedFullSync(best);
+            bool isInStateSync = best.IsInStateSync;
 
             if (_logger.IsTrace)
             {
                 _logger.Trace("======================== BEAM");
                 _logger.Trace("beamSyncEnabled " + beamSyncEnabled);
-                _logger.Trace("fastSyncHasBeenActive " + beamSyncEnabled);
-                _logger.Trace("hasAnyPostPivotPeer " + beamSyncEnabled);
-                _logger.Trace("inStateNodesSync " + inStateNodesSync);
-                _logger.Trace("notInFastSync " + beamSyncEnabled);
-                _logger.Trace("notInAStickyFullSync " + notInAStickyFullSync);
-                _logger.Trace("notHasJustStartedFullSync " + notHasJustStartedFullSync);
+                _logger.Trace("isInStateSync " + isInStateSync);
             }
 
             return beamSyncEnabled &&
-                   fastSyncHasBeenActive &&
-                   hasAnyPostPivotPeer &&
-                   inStateNodesSync &&
-                   notInAStickyFullSync &&
-                   notHasJustStartedFullSync &&
-                   notInFastSync;
+                   isInStateSync;
         }
 
         private bool HasJustStartedFullSync(Snapshot best)

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
@@ -192,6 +192,7 @@ namespace Nethermind.Synchronization.ParallelSync
             // Changing is invoked here so we can block until all the subsystems are ready to switch
             // for example when switching to Full sync we need to ensure that we safely transition
             // the beam sync DB and beam processor
+            Preparing?.Invoke(this, args);
             Changing?.Invoke(this, args);
             Current = newModes;
             Changed?.Invoke(this, args);
@@ -220,7 +221,6 @@ namespace Nethermind.Synchronization.ParallelSync
         }
 
         public SyncMode Current { get; private set; } = SyncMode.None;
-        public event EventHandler<SyncModeChangedEventArgs> Changing;
 
         private bool IsInAStickyFullSyncMode(Snapshot best)
         {
@@ -435,6 +435,8 @@ namespace Nethermind.Synchronization.ParallelSync
             }
         }
 
+        public event EventHandler<SyncModeChangedEventArgs> Preparing;
+        public event EventHandler<SyncModeChangedEventArgs> Changing;
         public event EventHandler<SyncModeChangedEventArgs> Changed;
 
         private struct Snapshot

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
@@ -225,7 +225,7 @@ namespace Nethermind.Synchronization.ParallelSync
         private bool IsInAStickyFullSyncMode(Snapshot best)
         {
             bool hasEverBeenInFullSync = best.Processed > PivotNumber && best.State > PivotNumber;
-            long heightDelta = best.PeerBlock - best.Header;
+            long heightDelta = best.PeerBlock - best.Processed;
             return hasEverBeenInFullSync && heightDelta < FastSyncCatchUpHeightDelta;
         }
 

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
@@ -30,7 +30,7 @@ namespace Nethermind.Synchronization.ParallelSync
         /// Number of blocks before the best peer's head when we switch from fast sync to full sync
         /// </summary>
         public const int FastSyncLag = 32;
-        
+
         /// <summary>
         /// How many blocks can fast sync stay behind while state nodes is still syncing
         /// </summary>
@@ -155,7 +155,7 @@ namespace Nethermind.Synchronization.ParallelSync
             {
                 newModes |= SyncMode.StateNodes;
             }
-            
+
             if (IsTheModeSwitchWorthMentioning(newModes))
             {
                 string stateString = BuildStateString(best);
@@ -184,11 +184,11 @@ namespace Nethermind.Synchronization.ParallelSync
                     if (_logger.IsTrace) _logger.Trace(message);
                 }
             }
-            
+
             SyncMode previous = Current;
 
             SyncModeChangedEventArgs args = new SyncModeChangedEventArgs(previous, Current);
-            
+
             // Changing is invoked here so we can block until all the subsystems are ready to switch
             // for example when switching to Full sync we need to ensure that we safely transition
             // the beam sync DB and beam processor
@@ -204,7 +204,7 @@ namespace Nethermind.Synchronization.ParallelSync
         /// <param name="best">Snapshot of the best known states</param>
         /// <returns>A string describing the state of sync</returns>
         private static string BuildStateString(Snapshot best) =>
-            $"processed:{best.Processed}|beam state:{best.BeamState}|state:{best.State}|block:{best.Block}|header:{best.Header}|peer block:{best.PeerBlock}";
+            $"processed:{best.Processed}|state:{best.State}|block:{best.Block}|header:{best.Header}|peer block:{best.PeerBlock}";
 
         private void TimerOnElapsed(object sender, ElapsedEventArgs e)
         {
@@ -268,7 +268,7 @@ namespace Nethermind.Synchronization.ParallelSync
 
         private bool ShouldBeInFullSyncMode(Snapshot best)
         {
-            bool higherDiffPeerKnown = AnyPeerWithHigherDifficultyKnown(best.PeerDifficulty);
+            bool desiredPeerKnown = AnyDesiredPeerKnown(best);
             bool postPivotPeerAvailable = AnyPostPivotPeerKnown(best.PeerBlock);
             bool hasFastSyncBeenActive = best.Header >= PivotNumber;
             bool notInBeamSync = !best.IsInBeamSync;
@@ -278,7 +278,7 @@ namespace Nethermind.Synchronization.ParallelSync
             if (_logger.IsTrace)
             {
                 _logger.Trace("======================== FULL");
-                _logger.Trace("higherDiffPeerKnown " + higherDiffPeerKnown);
+                _logger.Trace("higherDiffPeerKnown " + desiredPeerKnown);
                 _logger.Trace("postPivotPeerAvailable " + postPivotPeerAvailable);
                 _logger.Trace("hasFastSyncBeenActive " + hasFastSyncBeenActive);
                 _logger.Trace("notInBeamSync " + notInBeamSync);
@@ -286,7 +286,7 @@ namespace Nethermind.Synchronization.ParallelSync
                 _logger.Trace("notInStateSync " + notInStateSync);
             }
 
-            return higherDiffPeerKnown &&
+            return desiredPeerKnown &&
                    postPivotPeerAvailable &&
                    hasFastSyncBeenActive &&
                    notInBeamSync &&
@@ -357,10 +357,12 @@ namespace Nethermind.Synchronization.ParallelSync
                    && best.Processed < best.State; // not processed the block yet
         }
 
-        private bool AnyPeerWithHigherDifficultyKnown(UInt256 bestPeerDiff)
+        private bool AnyDesiredPeerKnown(Snapshot best)
         {
-            if (_logger.IsTrace) _logger.Trace($"Is best peer diff {bestPeerDiff} > local total diff {_syncProgressResolver.ChainDifficulty}");
-            return bestPeerDiff > _syncProgressResolver.ChainDifficulty;
+            UInt256 localChainDifficulty = _syncProgressResolver.ChainDifficulty;
+            if (_logger.IsTrace) _logger.Trace($"Best peer [{best.PeerBlock},{best.PeerDifficulty}] > local [{best.Header},{localChainDifficulty}]");
+            return best.PeerDifficulty > localChainDifficulty ||
+                   best.PeerDifficulty == localChainDifficulty && best.PeerBlock > best.Header;
         }
 
         private bool AnyPostPivotPeerKnown(long bestPeerBlock)
@@ -400,11 +402,10 @@ namespace Nethermind.Synchronization.ParallelSync
             // and think that we have an invalid snapshot
             long processed = _syncProgressResolver.FindBestProcessedBlock();
             long state = _syncProgressResolver.FindBestFullState();
-            long beamState = BeamSyncEnabled ? _syncProgressResolver.FindBestBeamState() : state;
             long block = _syncProgressResolver.FindBestFullBlock();
             long header = _syncProgressResolver.FindBestHeader();
 
-            Snapshot best = new Snapshot(processed, beamState, state, block, header, peerBlock, peerDifficulty);
+            Snapshot best = new Snapshot(processed, state, block, header, peerBlock, peerDifficulty);
             VerifySnapshot(best);
             return best;
         }
@@ -441,7 +442,7 @@ namespace Nethermind.Synchronization.ParallelSync
 
         private struct Snapshot
         {
-            public Snapshot(long processed, long beamState, long state, long block, long header, long peerBlock, UInt256 peerDifficulty)
+            public Snapshot(long processed, long state, long block, long header, long peerBlock, UInt256 peerDifficulty)
             {
                 Processed = processed;
                 State = state;
@@ -449,7 +450,6 @@ namespace Nethermind.Synchronization.ParallelSync
                 Header = header;
                 PeerBlock = peerBlock;
                 PeerDifficulty = peerDifficulty;
-                BeamState = beamState;
 
                 IsInFastBlocks = IsInFastSync = IsInBeamSync = IsInFullSync = IsInStateSync = false;
             }
@@ -469,11 +469,6 @@ namespace Nethermind.Synchronization.ParallelSync
             /// Best full block state in the state trie (may not be processed if we just finished state trie download)
             /// </summary>
             public long State { get; }
-
-            /// <summary>
-            /// Best beam block state in the state trie (may not be processed if we just finished state trie download)
-            /// </summary>
-            public long BeamState { get; }
 
             /// <summary>
             /// Best block body

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/PendingSyncModeSelector.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/PendingSyncModeSelector.cs
@@ -26,8 +26,14 @@ namespace Nethermind.Synchronization.ParallelSync
         public void SetActual(ISyncModeSelector syncModeSelector)
         {
             _syncModeSelector = syncModeSelector ?? throw new ArgumentNullException(nameof(syncModeSelector));
-            _syncModeSelector.Changed += SyncModeSelectorOnChanged;
+            _syncModeSelector.Preparing +=SyncModeSelectorOnPreparing;
             _syncModeSelector.Changing += SyncModeSelectorOnChanging;
+            _syncModeSelector.Changed += SyncModeSelectorOnChanged;
+        }
+
+        private void SyncModeSelectorOnPreparing(object? sender, SyncModeChangedEventArgs e)
+        {
+            Preparing?.Invoke(this, e);
         }
 
         private void SyncModeSelectorOnChanging(object? sender, SyncModeChangedEventArgs e)
@@ -41,6 +47,7 @@ namespace Nethermind.Synchronization.ParallelSync
         }
 
         public SyncMode Current => _syncModeSelector?.Current ?? SyncMode.None;
+        public event EventHandler<SyncModeChangedEventArgs> Preparing;
         public event EventHandler<SyncModeChangedEventArgs> Changing;
         public event EventHandler<SyncModeChangedEventArgs> Changed;
     }

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/PendingSyncModeSelector.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/PendingSyncModeSelector.cs
@@ -27,6 +27,12 @@ namespace Nethermind.Synchronization.ParallelSync
         {
             _syncModeSelector = syncModeSelector ?? throw new ArgumentNullException(nameof(syncModeSelector));
             _syncModeSelector.Changed += SyncModeSelectorOnChanged;
+            _syncModeSelector.Changing += SyncModeSelectorOnChanging;
+        }
+
+        private void SyncModeSelectorOnChanging(object? sender, SyncModeChangedEventArgs e)
+        {
+            Changing?.Invoke(this, e);
         }
 
         private void SyncModeSelectorOnChanged(object sender, SyncModeChangedEventArgs e)
@@ -35,6 +41,7 @@ namespace Nethermind.Synchronization.ParallelSync
         }
 
         public SyncMode Current => _syncModeSelector?.Current ?? SyncMode.None;
+        public event EventHandler<SyncModeChangedEventArgs> Changing;
         public event EventHandler<SyncModeChangedEventArgs> Changed;
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/StaticSelector.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/StaticSelector.cs
@@ -40,6 +40,12 @@ namespace Nethermind.Synchronization.ParallelSync
         public static StaticSelector FullWithFastBlocks { get; } = new StaticSelector(SyncMode.Full | SyncMode.FastBlocks);
 
         public SyncMode Current { get; }
+        
+        public event EventHandler<SyncModeChangedEventArgs> Preparing
+        {
+            add { }
+            remove { }
+        }
 
         public event EventHandler<SyncModeChangedEventArgs> Changed
         {

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/StaticSelector.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/StaticSelector.cs
@@ -46,5 +46,11 @@ namespace Nethermind.Synchronization.ParallelSync
             add { }
             remove { }
         }
+        
+        public event EventHandler<SyncModeChangedEventArgs> Changing
+        {
+            add { }
+            remove { }
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncProgressResolver.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncProgressResolver.cs
@@ -125,35 +125,6 @@ namespace Nethermind.Synchronization.ParallelSync
             return bestFullState;
         }
 
-        public long FindBestBeamState()
-        {
-            BlockHeader bestSuggested = _blockTree.BestSuggestedHeader;
-            Block head = _blockTree.Head;
-            long bestFullState = head?.Number ?? 0;
-            for (int i = 0; i < _maxLookupBack; i++)
-            {
-                if (bestSuggested == null)
-                {
-                    break;
-                }
-
-                if (bestSuggested.Number < _syncConfig.PivotNumberParsed)
-                {
-                    break;
-                }
-
-                if (IsBeamSynced(bestSuggested.StateRoot))
-                {
-                    bestFullState = bestSuggested.Number;
-                    break;
-                }
-
-                bestSuggested = _blockTree.FindHeader(bestSuggested.ParentHash, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
-            }
-
-            return bestFullState;
-        }
-
         public long FindBestHeader() => _blockTree.BestSuggestedHeader?.Number ?? 0;
 
         public long FindBestFullBlock() => Math.Min(FindBestHeader(), _blockTree.BestSuggestedBody?.Number ?? 0); // avoiding any potential concurrency issue

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncProgressResolver.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncProgressResolver.cs
@@ -28,7 +28,10 @@ namespace Nethermind.Synchronization.ParallelSync
 {
     public class SyncProgressResolver : ISyncProgressResolver
     {
-        private const int _maxLookupBack = 128; // not that we will be doing that every second or so
+        // TODO: we can search 1024 back and confirm 128 deep header and start using it as Max(0, confirmed)
+        // then we will never have to look 128 back again
+        // note that we will be doing that every second or so
+        private const int _maxLookupBack = 128;
 
         private readonly IBlockTree _blockTree;
         private readonly IReceiptStorage _receiptStorage;


### PR DESCRIPTION
to avoid BeamProcessor to write to a wrong DB and ensure a safe switch for the target write database in the beam sync DB we introduce a three step lock

SyncModeSelector invokes three events - Preparing, Changing and Changed, thus allowing the listeners to synchronize with each other

![image](https://user-images.githubusercontent.com/498913/80330038-f8fd0180-883b-11ea-81ff-24c891414951.png)
