### PR TITLE
use magenta colour for tracing

### DIFF
--- a/src/Nethermind/Nethermind.Network/Discovery/DiscoveryManager.cs
+++ b/src/Nethermind/Nethermind.Network/Discovery/DiscoveryManager.cs
@@ -155,6 +155,8 @@ namespace Nethermind.Network.Discovery
 
         public void SendMessage(DiscoveryMessage discoveryMessage)
         {
+            if (_logger.IsTrace) _logger.Trace($"Sending msg: {discoveryMessage}");
+            
             try
             {
                 if (discoveryMessage is PingMessage pingMessage)

--- a/src/Nethermind/Nethermind.Runner/NLog.config
+++ b/src/Nethermind/Nethermind.Runner/NLog.config
@@ -2,7 +2,7 @@
 
 <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="http://www.nlog-project.org/schemas/NLog.xsd NLog.xsd"
+      xsi:schemaLocation="http://www.nlog-project.org/schemas/NLog.xsd"
       autoReload="true" throwExceptions="false">
 
     <extensions>
@@ -23,7 +23,7 @@
         <target xsi:type="ColoredConsole"
                 autoFlush="true"
                 name="auto-colored-console-async"
-                useDefaultRowHighlightingRules="False"
+                useDefaultRowHighlightingRules="false"
                 layout="${longdate}|${message} ${exception:format=toString}">
             <!-- layout="${longdate}|${threadid}|${message} ${exception:format=toString}"> -->
             <highlight-row backgroundColor="NoChange" condition="level == LogLevel.Fatal" foregroundColor="Red" />
@@ -31,7 +31,7 @@
             <highlight-row backgroundColor="NoChange" condition="level == LogLevel.Warn" foregroundColor="Yellow" />
             <highlight-row backgroundColor="NoChange" condition="level == LogLevel.Info" foregroundColor="Cyan" />
             <highlight-row backgroundColor="NoChange" condition="level == LogLevel.Debug" foregroundColor="Gray" />
-            <highlight-row backgroundColor="NoChange" condition="level == LogLevel.Trace" foregroundColor="DarkGray" />
+            <highlight-row backgroundColor="NoChange" condition="level == LogLevel.Trace" foregroundColor="Magenta" />
         </target>
         <target xsi:type="BufferingWrapper" name="seq" bufferSize="1000" flushTimeout="2000">
             <target xsi:type="Seq" serverUrl="http://localhost:5341" apiKey="">
@@ -63,7 +63,7 @@
         <!-- <logger name="Synchronization.Peers.*" minlevel="Warn" writeTo="file-async"/> -->
         <!-- <logger name="Synchronization.Peers.*" minlevel="Warn" writeTo="auto-colored-console-async"/> -->
         <!-- <logger name="Synchronization.Peers.*" final="true"/> -->
-
+        
         <!-- if sync get stuck this is the best thing to enable the Trace on -->
         <!-- <logger name="Synchronization.ParallelSync.MultiSyncModeSelector" minlevel="Trace" writeTo="file-async"/> -->
         <!-- <logger name="Synchronization.ParallelSync.MultiSyncModeSelector" minlevel="Trace" writeTo="auto-colored-console-async"/> -->


### PR DESCRIPTION
Changes trace log from dark gray to magenta as dark gray is not visible on some terminals.