### PR TITLE
to prevent setup is correct from failing

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncThreadTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncThreadTests.cs
@@ -51,7 +51,7 @@ using BlockTree = Nethermind.Blockchain.BlockTree;
 
 namespace Nethermind.Synchronization.Test
 {
-    [Parallelizable(ParallelScope.Self)]
+    [Parallelizable(ParallelScope.None)]
     [TestFixture(SynchronizerType.Fast)]
     [TestFixture(SynchronizerType.Full)]
     public class SyncThreadsTests


### PR DESCRIPTION
The test sometimes fails, probably because of parallel runs