### PR TITLE
check max peers again

### DIFF
--- a/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
@@ -43,7 +43,6 @@ namespace Nethermind.Network.Test
 {
     [Parallelizable(ParallelScope.Self)]
     [TestFixture]
-    // [Explicit("Repeatedly fails on Travis")]
     public class PeerManagerTests
     {
         private RlpxMock _rlpxPeer;
@@ -356,7 +355,7 @@ namespace Nethermind.Network.Test
             {
                 DiscoverNew(25);
                 Thread.Sleep(_travisDelay);
-                Assert.AreEqual(25 * (i + 1), _peerManager.ActivePeers.Count);
+                Assert.AreEqual(25, _peerManager.ActivePeers.Count);
             }
         }
 

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -808,7 +808,7 @@ namespace Nethermind.Network
             }
 
             _stats.ReportEvent(nodeEventArgs.Node, NodeStatsEventType.NodeDiscovered);
-            // if (_pending < AvailableActivePeersCount)
+            if (_pending < AvailableActivePeersCount)
             {
 #pragma warning disable 4014
                 // fire and forget - all the surrounding logic will be executed


### PR DESCRIPTION
It changes the eagerness of looking for now peers. To avoid resource usage I rbing it back to old behaviour. Both behaviours are correct and both are passing tests so no tests changes required.