### PR TITLE
allow for subnet

### DIFF
--- a/src/Nethermind/Nethermind.Network.Test/EnodeTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/EnodeTests.cs
@@ -18,6 +18,7 @@
 using System;
 using System.Linq;
 using System.Net;
+using DotNetty.Common.Utilities;
 using FluentAssertions;
 using Nethermind.Blockchain;
 using Nethermind.Core.Crypto;
@@ -43,7 +44,7 @@ namespace Nethermind.Network.Test
             var publicKey = new PublicKey("0x000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f");
             string domain = "www.google.com";
             Enode enode = new Enode($"enode://{publicKey.ToString(false)}@{domain}:{1234}");
-            enode.HostIp.Should().BeEquivalentTo(Dns.GetHostAddresses(domain).First());
+            enode.HostIp.GetAddressBytes().Slice(3).Should().BeEquivalentTo(Dns.GetHostAddresses(domain).First().GetAddressBytes().Slice(0, 3));
             enode.Port.Should().Be(1234);
             enode.PublicKey.Should().BeEquivalentTo(publicKey);
         }


### PR DESCRIPTION
testing only the first 3 bytes since the dns is load balancing google.com