### PR TITLE
Improve Client Version

### DIFF
--- a/src/Nethermind/Nethermind.Core/ClientVersion.cs
+++ b/src/Nethermind/Nethermind.Core/ClientVersion.cs
@@ -24,31 +24,14 @@ namespace Nethermind.Core
     {
         private static string _gitTag;
 
-        private static string _osName;
         private static string _date;
 
         static ClientVersion()
         {
-            switch (RuntimeInformation.OSDescription.Split(" ")[0])
-            {
-                case "Microsoft":
-                    // Replace "Microsoft Windows" => "Windows"
-                    _osName = "Windows";
-                    break;
-                case "Darwin":
-                    // Replace "Darwin" => "macOS"
-                    _osName = "macOS";
-                    break;
-                default:
-                    // Don't do anything as "Linux" is "Linux", "FreeBSD" is "FreeBSD"...
-                    _osName = RuntimeInformation.OSDescription.Split(" ")[0];
-                    break;
-            }
-
             _date = DateTime.UtcNow.ToString("yyyyMMdd");
             _gitTag = File.Exists(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "git-hash")) ? File.ReadAllText(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "git-hash")).Trim().Replace("g", "") : string.Empty;
 
-            Description = $"Nethermind/v{Version}/{RuntimeInformation.OSArchitecture}-{_osName}/{RuntimeInformation.FrameworkDescription.Trim().Replace(".NET ", "").Replace(" ", "")}";
+            Description = $"Nethermind/v{Version}/{RuntimeInformation.OSArchitecture}-{Nethermind.Core.Platform.GetPlatformName()}/{RuntimeInformation.FrameworkDescription.Trim().Replace(".NET ", "").Replace(" ", "")}";
         }
 
         public static string Version => $"{_gitTag}-{_date}";

--- a/src/Nethermind/Nethermind.Core/ClientVersion.cs
+++ b/src/Nethermind/Nethermind.Core/ClientVersion.cs
@@ -23,26 +23,36 @@ namespace Nethermind.Core
     public static class ClientVersion
     {
         private static string _gitTag;
-        private static string _osDescription;
+
+        private static string _osName;
         private static string _date;
 
         static ClientVersion()
         {
-            _osDescription = RuntimeInformation.OSDescription;
-            if (_osDescription.Contains('#'))
+            switch (RuntimeInformation.OSDescription.Split(" ")[0])
             {
-                int indexOfHash = _osDescription.IndexOf('#');
-                _osDescription = _osDescription.Substring(0, Math.Max(0, indexOfHash - 1));
+                case "Microsoft":
+                    // Replace "Microsoft Windows" => "Windows"
+                    _osName = "Windows";
+                    break;
+                case "Darwin":
+                    // Replace "Darwin" => "macOS"
+                    _osName = "macOS";
+                    break;
+                default:
+                    // Don't do anything as "Linux" is "Linux", "FreeBSD" is "FreeBSD"...
+                    _osName = RuntimeInformation.OSDescription.Split(" ")[0];
+                    break;
             }
-            
+
             _date = DateTime.UtcNow.ToString("yyyyMMdd");
             _gitTag = File.Exists(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "git-hash")) ? File.ReadAllText(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "git-hash")).Trim().Replace("g", "") : string.Empty;
 
-            Description = $"Nethermind/v{Version}/{RuntimeInformation.OSArchitecture}-{_osDescription}/{RuntimeInformation.FrameworkDescription.Trim().Replace(".NET ", "").Replace(" ", "")}";
+            Description = $"Nethermind/v{Version}/{RuntimeInformation.OSArchitecture}-{_osName}/{RuntimeInformation.FrameworkDescription.Trim().Replace(".NET ", "").Replace(" ", "")}";
         }
 
         public static string Version => $"{_gitTag}-{_date}";
-        
+
         public static string Description { get; }
     }
 }

--- a/src/Nethermind/Nethermind.Core/Platform.cs
+++ b/src/Nethermind/Nethermind.Core/Platform.cs
@@ -16,34 +16,6 @@
 
 using System;
 using System.Runtime.InteropServices;
-/*public class NativeLib
-{
-
-    private static OSPlatform GetPlatform()
-    {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            return OSPlatform.Windows;
-        }
-
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-        {
-            return OSPlatform.Linux;
-        }
-
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-        {
-            return OSPlatform.OSX;
-        }
-
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD))
-        {
-            return OSPlatform.Linux;
-        }
-
-        throw new InvalidOperationException("Unsupported platform.");
-    }
-}*/
 
 namespace Nethermind.Core
 {

--- a/src/Nethermind/Nethermind.Core/Platform.cs
+++ b/src/Nethermind/Nethermind.Core/Platform.cs
@@ -1,0 +1,103 @@
+//  Copyright (c) 2020 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Runtime.InteropServices;
+/*public class NativeLib
+{
+
+    private static OSPlatform GetPlatform()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return OSPlatform.Windows;
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            return OSPlatform.Linux;
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return OSPlatform.OSX;
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD))
+        {
+            return OSPlatform.Linux;
+        }
+
+        throw new InvalidOperationException("Unsupported platform.");
+    }
+}*/
+
+namespace Nethermind.Core
+{
+
+    public static class NativeLib
+    {
+        private static OSPlatform GetPlatform()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return OSPlatform.Windows;
+            }
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return OSPlatform.Linux;
+            }
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return OSPlatform.OSX;
+            }
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD))
+            {
+                return OSPlatform.Linux;
+            }
+
+            throw new InvalidOperationException("Unsupported platform.");
+        }
+    }
+
+    public class Platform
+    {
+        public static String GetPlatformName()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return "Linux";
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return "macOS";
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return "Windows";
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD))
+            {
+                return "FreeBSD";
+            }
+
+            throw new InvalidOperationException("Unsupported platform.");
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Core2.Configuration/ClientVersion.cs
+++ b/src/Nethermind/Nethermind.Core2.Configuration/ClientVersion.cs
@@ -72,15 +72,27 @@ namespace Nethermind.Core2.Configuration
             parts.Add(product1);
 
             Architecture osArchiteture = RuntimeInformation.OSArchitecture;
-            string osDescription = RuntimeInformation.OSDescription;
-            if (osDescription.Contains('#'))
+
+            string osName;
+
+            switch (RuntimeInformation.OSDescription.Split(" ")[0])
             {
-                int indexOfHash = osDescription.IndexOf('#');
-                osDescription = osDescription.Substring(0, Math.Max(0, indexOfHash - 1));
+                case "Microsoft":
+                    // Replace "Microsoft Windows" => "Windows"
+                    osName = "Windows";
+                    break;
+                case "Darwin":
+                    // Replace "Darwin" => "macOS"
+                    osName = "macOS";
+                    break;
+                default:
+                    // Don't do anything as "Linux" is "Linux", "FreeBSD" is "FreeBSD"...
+                    osName = RuntimeInformation.OSDescription.Split(" ")[0];
+                    break;
             }
 
             string frameworkDescription = RuntimeInformation.FrameworkDescription;
-            string osFrameworkComment = $"({osArchiteture}-{osDescription}/{frameworkDescription})";
+            string osFrameworkComment = $"({osArchiteture}-{osName}/{frameworkDescription})";
             parts.Add(osFrameworkComment);
 
             if (!string.IsNullOrWhiteSpace(environmentName) && environmentName != Environments.Production)

--- a/src/Nethermind/Nethermind.Core2.Configuration/ClientVersion.cs
+++ b/src/Nethermind/Nethermind.Core2.Configuration/ClientVersion.cs
@@ -73,26 +73,8 @@ namespace Nethermind.Core2.Configuration
 
             Architecture osArchiteture = RuntimeInformation.OSArchitecture;
 
-            string osName;
-
-            switch (RuntimeInformation.OSDescription.Split(" ")[0])
-            {
-                case "Microsoft":
-                    // Replace "Microsoft Windows" => "Windows"
-                    osName = "Windows";
-                    break;
-                case "Darwin":
-                    // Replace "Darwin" => "macOS"
-                    osName = "macOS";
-                    break;
-                default:
-                    // Don't do anything as "Linux" is "Linux", "FreeBSD" is "FreeBSD"...
-                    osName = RuntimeInformation.OSDescription.Split(" ")[0];
-                    break;
-            }
-
             string frameworkDescription = RuntimeInformation.FrameworkDescription;
-            string osFrameworkComment = $"({osArchiteture}-{osName}/{frameworkDescription})";
+            string osFrameworkComment = $"({osArchiteture}-{Nethermind.Core.Platform.GetPlatformName()}/{frameworkDescription})";
             parts.Add(osFrameworkComment);
 
             if (!string.IsNullOrWhiteSpace(environmentName) && environmentName != Environments.Production)

--- a/src/Nethermind/Nethermind.EthStats/Integrations/EthStatsIntegration.cs
+++ b/src/Nethermind/Nethermind.EthStats/Integrations/EthStatsIntegration.cs
@@ -150,7 +150,7 @@ namespace Nethermind.EthStats.Integrations
         private Task SendHelloAsync()
             => _sender.SendAsync(_websocketClient, new HelloMessage(_secret, new Info(_name, _node, _port, _network,
                 _protocol,
-                _api, GetOSName(), RuntimeInformation.OSArchitecture.ToString(), _client,
+                _api, Nethermind.Core.Platform.GetPlatformName(), RuntimeInformation.OSArchitecture.ToString(), _client,
                 _contact, _canUpdateHistory)));
 
         private Task SendBlockAsync(Core.Block block)
@@ -168,26 +168,5 @@ namespace Nethermind.EthStats.Integrations
         private Task SendStatsAsync()
             => _sender.SendAsync(_websocketClient, new StatsMessage(new Messages.Models.Stats(true, true, false, 0,
                 _peerManager.ActivePeers.Count, (long)20.GWei(), 100)));
-
-        private string GetOSName()
-        {
-            string osName;
-            switch (RuntimeInformation.OSDescription.Split(" ")[0])
-            {
-                case "Microsoft":
-                    // Replace "Microsoft Windows" => "Windows"
-                    osName = "Windows";
-                    break;
-                case "Darwin":
-                    // Replace "Darwin" => "macOS"
-                    osName = "macOS";
-                    break;
-                default:
-                    // Don't do anything as "Linux" is "Linux", "FreeBSD" is "FreeBSD"...
-                    osName = RuntimeInformation.OSDescription.Split(" ")[0];
-                    break;
-            }
-            return osName;
-        }
     }
 }

--- a/src/Nethermind/Nethermind.EthStats/Integrations/EthStatsIntegration.cs
+++ b/src/Nethermind/Nethermind.EthStats/Integrations/EthStatsIntegration.cs
@@ -78,7 +78,7 @@ namespace Nethermind.EthStats.Integrations
 
         public async Task InitAsync()
         {
-            _timer = new Timer {Interval = SendStatsInterval};
+            _timer = new Timer { Interval = SendStatsInterval };
             _timer.Elapsed += TimerOnElapsed;
             _blockTree.NewHeadBlock += BlockTreeOnNewHeadBlock;
             _websocketClient = await _ethStatsClient.InitAsync();
@@ -150,13 +150,13 @@ namespace Nethermind.EthStats.Integrations
         private Task SendHelloAsync()
             => _sender.SendAsync(_websocketClient, new HelloMessage(_secret, new Info(_name, _node, _port, _network,
                 _protocol,
-                _api, RuntimeInformation.OSDescription, RuntimeInformation.OSArchitecture.ToString(), _client,
+                _api, GetOSName(), RuntimeInformation.OSArchitecture.ToString(), _client,
                 _contact, _canUpdateHistory)));
 
         private Task SendBlockAsync(Core.Block block)
             => _sender.SendAsync(_websocketClient, new BlockMessage(new Block(block.Number, block.Hash?.ToString(),
                 block.ParentHash?.ToString(),
-                (long) block.Timestamp, (block.Author ?? block.Beneficiary)?.ToString(), block.GasUsed, block.GasLimit,
+                (long)block.Timestamp, (block.Author ?? block.Beneficiary)?.ToString(), block.GasUsed, block.GasLimit,
                 block.Difficulty.ToString(), block.TotalDifficulty?.ToString(),
                 block.Transactions?.Select(t => new Transaction(t.Hash?.ToString())) ?? Enumerable.Empty<Transaction>(),
                 block.TxRoot.ToString(), block.StateRoot.ToString(),
@@ -167,6 +167,27 @@ namespace Nethermind.EthStats.Integrations
 
         private Task SendStatsAsync()
             => _sender.SendAsync(_websocketClient, new StatsMessage(new Messages.Models.Stats(true, true, false, 0,
-                _peerManager.ActivePeers.Count, (long) 20.GWei(), 100)));
+                _peerManager.ActivePeers.Count, (long)20.GWei(), 100)));
+
+        private string GetOSName()
+        {
+            string osName;
+            switch (RuntimeInformation.OSDescription.Split(" ")[0])
+            {
+                case "Microsoft":
+                    // Replace "Microsoft Windows" => "Windows"
+                    osName = "Windows";
+                    break;
+                case "Darwin":
+                    // Replace "Darwin" => "macOS"
+                    osName = "macOS";
+                    break;
+                default:
+                    // Don't do anything as "Linux" is "Linux", "FreeBSD" is "FreeBSD"...
+                    osName = RuntimeInformation.OSDescription.Split(" ")[0];
+                    break;
+            }
+            return osName;
+        }
     }
 }


### PR DESCRIPTION
# *Client Version* Improvements

* Better OS Names ("Windows", "macOS" instead of "Microsoft Windows", "Darwin")
* Display only OS Name. It is generally a good security practice to not disclose OS/Kernel version.

## Before:

```
# Linux
Nethermind/v1.8.61-1-9e6f95184-20200712/X64-Linux 4.19.76-linuxkit/Core3.1.5

# macOS
Nethermind/v1.8.61-1-9e6f95184-20200712/X64-Darwin Kernel Version 19.5.0: Tue May 26 20:41:44 PDT 2020; root:xnu-6153.121.2~2/RELEASE_X86_64 x86_64/Core3.1.5

# Windows
Nethermind/v1.8.61-1-9e6f95184-20200712/X64-Microsoft Windows 6.3.960/Core3.1.5
```

## After
```
# Linux
Nethermind/v1.8.61-1-9e6f95184-20200712/X64-Linux/Core3.1.5

# macOS
Nethermind/v1.8.61-1-9e6f95184-20200712/X64-macOS/Core3.1.5

# Windows
Nethermind/v1.8.61-1-9e6f95184-20200712/X64-Windows/Core3.1.5
```