### PR TITLE
resize responses from receipt requests so they are not filled with nulls

### DIFF
--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V63/Eth63ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V63/Eth63ProtocolHandlerTests.cs
@@ -14,6 +14,23 @@
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Logging;
+using Nethermind.Network.P2P;
+using Nethermind.Network.P2P.Subprotocols.Eth.V62;
+using Nethermind.Network.P2P.Subprotocols.Eth.V63;
+using Nethermind.Network.Rlpx;
+using Nethermind.Specs;
+using Nethermind.Stats;
+using Nethermind.Synchronization;
+using Nethermind.TxPool;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V63
@@ -21,5 +38,121 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V63
     [TestFixture]
     public class Eth63ProtocolHandlerTests
     {
+        [Test]
+        public async Task Can_request_and_handle_receipts()
+        {
+            StatusMessageSerializer statusMessageSerializer = new StatusMessageSerializer();
+            ReceiptsMessageSerializer receiptMessageSerializer
+                = new ReceiptsMessageSerializer(MainnetSpecProvider.Instance);
+            MessageSerializationService serializationService = new MessageSerializationService();
+            serializationService.Register(statusMessageSerializer);
+            serializationService.Register(receiptMessageSerializer);
+
+            Eth63ProtocolHandler protocolHandler = new Eth63ProtocolHandler(
+                Substitute.For<ISession>(),
+                serializationService,
+                Substitute.For<INodeStatsManager>(),
+                Substitute.For<ISyncServer>(),
+                Substitute.For<ITxPool>(),
+                LimboLogs.Instance);
+
+            var receipts = Enumerable.Repeat(
+                Enumerable.Repeat(Build.A.Receipt.WithAllFieldsFilled.TestObject, 100).ToArray(),
+                1000).ToArray(); // TxReceipt[1000][100]
+
+            StatusMessage statusMessage = new StatusMessage();
+            Packet statusPacket =
+                new Packet("eth", Eth62MessageCode.Status, statusMessageSerializer.Serialize(statusMessage));
+
+            ReceiptsMessage receiptsMsg = new ReceiptsMessage(receipts);
+            Packet receiptsPacket =
+                new Packet("eth", Eth63MessageCode.Receipts, receiptMessageSerializer.Serialize(receiptsMsg));
+
+            protocolHandler.HandleMessage(statusPacket);
+            Task<TxReceipt[][]> task = protocolHandler.GetReceipts(
+                Enumerable.Repeat(Keccak.Zero, 1000).ToArray(),
+                CancellationToken.None);
+
+            protocolHandler.HandleMessage(receiptsPacket);
+
+            var result = await task;
+            result.Should().HaveCount(1000);
+        }
+
+        [Test]
+        public void Will_not_serve_receipts_requests_above_512()
+        {
+            StatusMessageSerializer statusMessageSerializer = new StatusMessageSerializer();
+            ReceiptsMessageSerializer receiptMessageSerializer
+                = new ReceiptsMessageSerializer(MainnetSpecProvider.Instance);
+            GetReceiptsMessageSerializer getReceiptMessageSerializer
+                = new GetReceiptsMessageSerializer();
+            MessageSerializationService serializationService = new MessageSerializationService();
+            serializationService.Register(statusMessageSerializer);
+            serializationService.Register(receiptMessageSerializer);
+            serializationService.Register(getReceiptMessageSerializer);
+
+            ISession session = Substitute.For<ISession>();
+            ISyncServer syncServer = Substitute.For<ISyncServer>();
+            Eth63ProtocolHandler protocolHandler = new Eth63ProtocolHandler(
+                session,
+                serializationService,
+                Substitute.For<INodeStatsManager>(),
+                syncServer,
+                Substitute.For<ITxPool>(),
+                LimboLogs.Instance);
+
+            StatusMessage statusMessage = new StatusMessage();
+            Packet statusPacket =
+                new Packet("eth", Eth62MessageCode.Status, statusMessageSerializer.Serialize(statusMessage));
+
+            GetReceiptsMessage getReceiptsMessage = new GetReceiptsMessage(
+                Enumerable.Repeat(Keccak.Zero, 513).ToArray());
+            Packet getReceiptsPacket =
+                new Packet("eth", Eth63MessageCode.GetReceipts, getReceiptMessageSerializer.Serialize(getReceiptsMessage));
+
+            protocolHandler.HandleMessage(statusPacket);
+            Assert.Throws<EthSyncException>(() =>protocolHandler.HandleMessage(getReceiptsPacket));
+        }
+
+        [Test]
+        public void Will_not_send_messages_larger_than_2MB()
+        {
+            StatusMessageSerializer statusMessageSerializer = new StatusMessageSerializer();
+            ReceiptsMessageSerializer receiptMessageSerializer
+                = new ReceiptsMessageSerializer(MainnetSpecProvider.Instance);
+            GetReceiptsMessageSerializer getReceiptMessageSerializer
+                = new GetReceiptsMessageSerializer();
+            MessageSerializationService serializationService = new MessageSerializationService();
+            serializationService.Register(statusMessageSerializer);
+            serializationService.Register(receiptMessageSerializer);
+            serializationService.Register(getReceiptMessageSerializer);
+
+            ISession session = Substitute.For<ISession>();
+            ISyncServer syncServer = Substitute.For<ISyncServer>();
+            Eth63ProtocolHandler protocolHandler = new Eth63ProtocolHandler(
+                session,
+                serializationService,
+                Substitute.For<INodeStatsManager>(),
+                syncServer,
+                Substitute.For<ITxPool>(),
+                LimboLogs.Instance);
+
+            syncServer.GetReceipts(Arg.Any<Keccak>()).Returns(
+                Enumerable.Repeat(Build.A.Receipt.WithAllFieldsFilled.TestObject, 512).ToArray());
+
+            StatusMessage statusMessage = new StatusMessage();
+            Packet statusPacket =
+                new Packet("eth", Eth62MessageCode.Status, statusMessageSerializer.Serialize(statusMessage));
+
+            GetReceiptsMessage getReceiptsMessage = new GetReceiptsMessage(
+                Enumerable.Repeat(Keccak.Zero, 512).ToArray());
+            Packet getReceiptsPacket =
+                new Packet("eth", Eth63MessageCode.GetReceipts, getReceiptMessageSerializer.Serialize(getReceiptsMessage));
+
+            protocolHandler.HandleMessage(statusPacket);
+            protocolHandler.HandleMessage(getReceiptsPacket);
+            session.Received().DeliverMessage(Arg.Is<ReceiptsMessage>(r => r.TxReceipts.Length == 60));
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V63/Eth63ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V63/Eth63ProtocolHandlerTests.cs
@@ -28,6 +28,7 @@ using Nethermind.Network.P2P.Subprotocols.Eth.V63;
 using Nethermind.Network.Rlpx;
 using Nethermind.Specs;
 using Nethermind.Stats;
+using Nethermind.Stats.Model;
 using Nethermind.Synchronization;
 using Nethermind.TxPool;
 using NSubstitute;
@@ -38,6 +39,15 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V63
     [TestFixture]
     public class Eth63ProtocolHandlerTests
     {
+        private ISession _session = Substitute.For<ISession>();
+        
+        [SetUp]
+        public void Setup()
+        {
+            _session.Node.Returns(new Node("127.0.0.1", 1000, true));
+            NetworkDiagTracer.IsEnabled = true;
+        }
+        
         [Test]
         public async Task Can_request_and_handle_receipts()
         {
@@ -49,7 +59,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V63
             serializationService.Register(receiptMessageSerializer);
 
             Eth63ProtocolHandler protocolHandler = new Eth63ProtocolHandler(
-                Substitute.For<ISession>(),
+                _session,
                 serializationService,
                 Substitute.For<INodeStatsManager>(),
                 Substitute.For<ISyncServer>(),
@@ -91,11 +101,10 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V63
             serializationService.Register(statusMessageSerializer);
             serializationService.Register(receiptMessageSerializer);
             serializationService.Register(getReceiptMessageSerializer);
-
-            ISession session = Substitute.For<ISession>();
+            
             ISyncServer syncServer = Substitute.For<ISyncServer>();
             Eth63ProtocolHandler protocolHandler = new Eth63ProtocolHandler(
-                session,
+                _session,
                 serializationService,
                 Substitute.For<INodeStatsManager>(),
                 syncServer,
@@ -127,11 +136,10 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V63
             serializationService.Register(statusMessageSerializer);
             serializationService.Register(receiptMessageSerializer);
             serializationService.Register(getReceiptMessageSerializer);
-
-            ISession session = Substitute.For<ISession>();
+            
             ISyncServer syncServer = Substitute.For<ISyncServer>();
             Eth63ProtocolHandler protocolHandler = new Eth63ProtocolHandler(
-                session,
+                _session,
                 serializationService,
                 Substitute.For<INodeStatsManager>(),
                 syncServer,
@@ -152,7 +160,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V63
 
             protocolHandler.HandleMessage(statusPacket);
             protocolHandler.HandleMessage(getReceiptsPacket);
-            session.Received().DeliverMessage(Arg.Is<ReceiptsMessage>(r => r.TxReceipts.Length == 14));
+            _session.Received().DeliverMessage(Arg.Is<ReceiptsMessage>(r => r.TxReceipts.Length == 14));
         }
     }
 }

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V63/Eth63ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V63/Eth63ProtocolHandlerTests.cs
@@ -152,7 +152,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V63
 
             protocolHandler.HandleMessage(statusPacket);
             protocolHandler.HandleMessage(getReceiptsPacket);
-            session.Received().DeliverMessage(Arg.Is<ReceiptsMessage>(r => r.TxReceipts.Length == 60));
+            session.Received().DeliverMessage(Arg.Is<ReceiptsMessage>(r => r.TxReceipts.Length == 14));
         }
     }
 }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V63/Eth63ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V63/Eth63ProtocolHandler.cs
@@ -209,7 +209,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V63
                 return task.Result;
             }
 
-            StatsManager.ReportTransferSpeedEvent(Session.Node, TransferSpeedType.Receipts,0L);
+            StatsManager.ReportTransferSpeedEvent(Session.Node, TransferSpeedType.Receipts, 0L);
 
             throw new TimeoutException($"{Session} Request timeout in {nameof(GetReceiptsMessage)}");
         }

--- a/src/Nethermind/Nethermind.Network/P2P/SyncPeerProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/SyncPeerProtocolHandlerBase.cs
@@ -373,6 +373,7 @@ namespace Nethermind.Network.P2P
 
                 if (sizeEstimate > SoftOutgoingMessageSizeLimit)
                 {
+                    Array.Resize(ref txReceipts, i + 1);
                     break;
                 }
             }

--- a/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
@@ -972,7 +972,7 @@ namespace Nethermind.Synchronization.Test
 
         [TestCase(32)]
         [TestCase(1)]
-        public async Task Throws_on_transaction_count_different_than_receipts_count_in_block(int threshold)
+        public async Task Does_not_throw_on_transaction_count_different_than_receipts_count_in_block(int threshold)
         {
             InMemoryReceiptStorage inMemoryReceiptStorage = new InMemoryReceiptStorage();
             BlockDownloader downloader = new BlockDownloader(_feed, _peerPool, _blockTree, Always.Valid, Always.Valid, NullSyncReport.Instance, inMemoryReceiptStorage, RopstenSpecProvider.Instance, LimboLogs.Instance);
@@ -998,7 +998,7 @@ namespace Nethermind.Synchronization.Test
             syncPeer.HeadNumber.Returns(2);
 
             Func<Task> action = async () => await downloader.DownloadBlocks(peerInfo, new BlocksRequest(DownloaderOptions.WithReceipts), CancellationToken.None);
-            action.Should().Throw<EthSyncException>();
+            action.Should().NotThrow();
         }
 
         [TestCase(32)]

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloadContext.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloadContext.cs
@@ -106,26 +106,25 @@ namespace Nethermind.Synchronization.Blocks
             block.Body = body;
         }
 
-        public void SetReceipts(int index, TxReceipt[] receipts)
+        public bool TrySetReceipts(int index, TxReceipt[] receipts)
         {
             if (!_downloadReceipts)
             {
-                throw new InvalidOperationException($"Unexpected call to {nameof(SetReceipts)} when not downloading receipts");
+                throw new InvalidOperationException($"Unexpected call to {nameof(TrySetReceipts)} when not downloading receipts");
             }
 
             int mappedIndex = _indexMapping[index];
             Block block = Blocks[_indexMapping[index]];
             receipts ??= Array.Empty<TxReceipt>();
 
-            if (_receiptsRecovery.TryRecover(block, receipts))
+            bool result = _receiptsRecovery.TryRecover(block, receipts); 
+            if (result)
             {
                 ValidateReceipts(block, receipts);
                 ReceiptsForBlocks![mappedIndex] = receipts;
             }
-            else
-            {
-                throw new EthSyncException($"Missing receipts for block {block.ToString(Block.Format.Short)}.");
-            }
+
+            return result;
         }
 
         private void ValidateReceipts(Block block, TxReceipt[] blockReceipts)

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
@@ -419,9 +419,18 @@ namespace Nethermind.Synchronization.Blocks
                 await request.ContinueWith(t => DownloadFailHandler(request, "bodies"));
 
                 TxReceipt[][] result = request.Result;
+                
+                int validResponsesCount = 0;
                 for (int i = 0; i < result.Length; i++)
                 {
-                    context.SetReceipts(i + offset, result[i]);
+                    if(context.TrySetReceipts(i + offset, result[i]))
+                    {
+                        validResponsesCount++;
+                    }
+                    else
+                    {
+                        break;
+                    }
                 }
 
                 if (result.Length == 0)


### PR DESCRIPTION
If the response can only send receipts for 50 blocks due to soft message size limit and the request is for 512 blocks then we should respond with TxReceipt[52][] and not TxReceipt[512][] where null is set for each value beyond 52.