### PR TITLE
JsonRPC performance improvements

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/BoundedModulePoolTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/BoundedModulePoolTests.cs
@@ -76,95 +76,90 @@ namespace Nethermind.JsonRpc.Test.Modules
         }
 
         [Test]
-        public void Ensure_concurrency()
+        public async Task Ensure_concurrency()
         {
-            _modulePool.GetModule(false);
+            await _modulePool.GetModule(false);
         }
 
         [Test]
-        public void Ensure_limited_exclusive()
+        public async Task Ensure_limited_exclusive()
         {
-            _modulePool.GetModule(false);
-            Assert.Throws<TimeoutException>(() => _modulePool.GetModule(false));
+            await _modulePool.GetModule(false);
+            Assert.ThrowsAsync<TimeoutException>(() => _modulePool.GetModule(false));
         }
         
         [Test]
-        public void Ensure_returning_shared_does_not_change_concurrency()
+        public async Task Ensure_returning_shared_does_not_change_concurrency()
         {
-            IEthModule shared = _modulePool.GetModule(true);
+            IEthModule shared = await _modulePool.GetModule(true);
             _modulePool.ReturnModule(shared);
-            _modulePool.GetModule(false);
-            Assert.Throws<TimeoutException>(() => _modulePool.GetModule(false));
+            await _modulePool.GetModule(false);
+            Assert.ThrowsAsync<TimeoutException>(() => _modulePool.GetModule(false));
         }
 
         [Test]
-        public void Ensure_unlimited_shared()
+        public async Task Ensure_unlimited_shared()
         {
             for (int i = 0; i < 1000; i++)
             {
-                _modulePool.GetModule(true);
+                await _modulePool.GetModule(true);
             }
         }
 
         [Test]
         public async Task Ensure_that_shared_is_never_returned_as_exclusive()
         {
-            IEthModule sharedModule = _modulePool.GetModule(true);
+            IEthModule sharedModule = await _modulePool.GetModule(true);
             _modulePool.ReturnModule(sharedModule);
 
             const int iterations = 1000;
-            Action rentReturnShared = () =>
+            Func<Task> rentReturnShared = async () =>
             {
                 for (int i = 0; i < iterations; i++)
                 {
                     TestContext.Out.WriteLine($"Rent shared {i}");
-                    IEthModule ethModule = _modulePool.GetModule(true);
+                    IEthModule ethModule = await _modulePool.GetModule(true);
                     Assert.AreSame(sharedModule, ethModule);
                     _modulePool.ReturnModule(ethModule);
                     TestContext.Out.WriteLine($"Return shared {i}");
                 }
             };
 
-            Action rentReturnExclusive = () =>
+            Func<Task> rentReturnExclusive = async () =>
             {
                 for (int i = 0; i < iterations; i++)
                 {
                     TestContext.Out.WriteLine($"Rent exclusive {i}");
-                    IEthModule ethModule = _modulePool.GetModule(false);
+                    IEthModule ethModule = await _modulePool.GetModule(false);
                     Assert.AreNotSame(sharedModule, ethModule);
                     _modulePool.ReturnModule(ethModule);
                     TestContext.Out.WriteLine($"Return exclusive {i}");
                 }
             };
 
-            Task a = new Task(rentReturnExclusive);
-            Task b = new Task(rentReturnExclusive);
-            Task c = new Task(rentReturnShared);
-            Task d = new Task(rentReturnShared);
-
-            a.Start();
-            b.Start();
-            c.Start();
-            d.Start();
+            Task a = Task.Run(rentReturnExclusive);
+            Task b = Task.Run(rentReturnExclusive);
+            Task c = Task.Run(rentReturnShared);
+            Task d = Task.Run(rentReturnShared);
 
             await Task.WhenAll(a, b, c, d);
         }
 
         [TestCase(true)]
         [TestCase(false)]
-        public void Can_rent_and_return(bool canBeShared)
+        public async Task Can_rent_and_return(bool canBeShared)
         {
-            IEthModule ethModule = _modulePool.GetModule(canBeShared);
+            IEthModule ethModule = await _modulePool.GetModule(canBeShared);
             _modulePool.ReturnModule(ethModule);
         }
 
         [TestCase(true)]
         [TestCase(false)]
-        public void Can_rent_and_return_in_a_loop(bool canBeShared)
+        public async Task Can_rent_and_return_in_a_loop(bool canBeShared)
         {
             for (int i = 0; i < 1000; i++)
             {
-                IEthModule ethModule = _modulePool.GetModule(canBeShared);
+                IEthModule ethModule = await _modulePool.GetModule(canBeShared);
                 _modulePool.ReturnModule(ethModule);
             }
         }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TestRpcModuleProvider.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TestRpcModuleProvider.cs
@@ -1,4 +1,4 @@
-﻿//  Copyright (c) 2018 Demerzel Solutions Limited
+//  Copyright (c) 2018 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
 // 
 //  The Nethermind library is free software: you can redistribute it and/or modify
@@ -17,6 +17,7 @@
 using System.Collections.Generic;
 using System.IO.Abstractions;
 using System.Reflection;
+using System.Threading.Tasks;
 using Nethermind.JsonRpc.Modules;
 using Nethermind.JsonRpc.Modules.DebugModule;
 using Nethermind.JsonRpc.Modules.Eth;
@@ -62,7 +63,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             return _provider.Resolve(methodName);
         }
 
-        public IModule Rent(string methodName, bool readOnly)
+        public Task<IModule> Rent(string methodName, bool readOnly)
         {
             return _provider.Rent(methodName, readOnly);
         }

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
@@ -1,4 +1,4 @@
-﻿//  Copyright (c) 2018 Demerzel Solutions Limited
+//  Copyright (c) 2018 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
 // 
 //  The Nethermind library is free software: you can redistribute it and/or modify
@@ -153,7 +153,7 @@ namespace Nethermind.JsonRpc
 
             //execute method
             IResultWrapper resultWrapper = null;
-            IModule module = _rpcModuleProvider.Rent(methodName, method.ReadOnly);
+            IModule module = await _rpcModuleProvider.Rent(methodName, method.ReadOnly);
             bool returnImmediately = methodName != "eth_getLogs";
             Action returnAction = returnImmediately ? (Action) null : () => _rpcModuleProvider.Return(methodName, module);
             try

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/IRpcModulePool.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/IRpcModulePool.cs
@@ -14,11 +14,13 @@
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
+using System.Threading.Tasks;
+
 namespace Nethermind.JsonRpc.Modules
 {
     public interface IRpcModulePool<T> where T : IModule
     {
-        T GetModule(bool canBeShared);
+        Task<T> GetModule(bool canBeShared);
         
         void ReturnModule(T module);
 

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/IRpcModuleProvider.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/IRpcModuleProvider.cs
@@ -1,4 +1,4 @@
-﻿//  Copyright (c) 2018 Demerzel Solutions Limited
+//  Copyright (c) 2018 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
 // 
 //  The Nethermind library is free software: you can redistribute it and/or modify
@@ -16,6 +16,7 @@
 
 using System.Collections.Generic;
 using System.Reflection;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 
 namespace Nethermind.JsonRpc.Modules
@@ -34,7 +35,7 @@ namespace Nethermind.JsonRpc.Modules
         
         (MethodInfo MethodInfo, bool ReadOnly) Resolve(string methodName);
         
-        IModule Rent(string methodName, bool canBeShared);
+        Task<IModule> Rent(string methodName, bool canBeShared);
         
         void Return(string methodName, IModule module);
     }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/NullModuleProvider.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/NullModuleProvider.cs
@@ -1,4 +1,4 @@
-﻿//  Copyright (c) 2018 Demerzel Solutions Limited
+//  Copyright (c) 2018 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
 // 
 //  The Nethermind library is free software: you can redistribute it and/or modify
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 
 namespace Nethermind.JsonRpc.Modules
@@ -24,6 +25,7 @@ namespace Nethermind.JsonRpc.Modules
     public class NullModuleProvider : IRpcModuleProvider
     {
         public static NullModuleProvider Instance = new NullModuleProvider();
+        private static Task<IModule> Null = Task.FromResult(default(IModule));
 
         private NullModuleProvider()
         {
@@ -49,9 +51,9 @@ namespace Nethermind.JsonRpc.Modules
             return (null, false);
         }
 
-        public IModule Rent(string methodName, bool canBeShared)
+        public Task<IModule> Rent(string methodName, bool canBeShared)
         {
-            return null;
+            return Null;
         }
 
         public void Return(string methodName, IModule module)

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/RpcModuleProvider.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/RpcModuleProvider.cs
@@ -1,4 +1,4 @@
-﻿//  Copyright (c) 2018 Demerzel Solutions Limited
+//  Copyright (c) 2018 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
 // 
 //  The Nethermind library is free software: you can redistribute it and/or modify
@@ -20,6 +20,7 @@ using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 using Nethermind.Logging;
 using Newtonsoft.Json;
 
@@ -36,8 +37,8 @@ namespace Nethermind.JsonRpc.Modules
         private Dictionary<string, ResolvedMethodInfo> _methods
             = new Dictionary<string, ResolvedMethodInfo>(StringComparer.InvariantCulture);
         
-        private Dictionary<ModuleType, (Func<bool, IModule> RentModule, Action<IModule> ReturnModule)> _pools
-            = new Dictionary<ModuleType, (Func<bool, IModule> RentModule, Action<IModule> ReturnModule)>();
+        private Dictionary<ModuleType, (Func<bool, Task<IModule>> RentModule, Action<IModule> ReturnModule)> _pools
+            = new Dictionary<ModuleType, (Func<bool, Task<IModule>> RentModule, Action<IModule> ReturnModule)>();
         
         private IRpcMethodFilter _filter = NullRpcMethodFilter.Instance;
 
@@ -70,7 +71,7 @@ namespace Nethermind.JsonRpc.Modules
             
             ModuleType moduleType = attribute.ModuleType;
 
-            _pools[moduleType] = (canBeShared => pool.GetModule(canBeShared), m => pool.ReturnModule((T) m));
+            _pools[moduleType] = (async canBeShared => await pool.GetModule(canBeShared), m => pool.ReturnModule((T) m));
             _modules.Add(moduleType);
 
             ((List<JsonConverter>) Converters).AddRange(pool.Factory.GetConverters());
@@ -106,7 +107,7 @@ namespace Nethermind.JsonRpc.Modules
             return (result.MethodInfo, result.ReadOnly);
         }
 
-        public IModule Rent(string methodName, bool canBeShared)
+        public Task<IModule> Rent(string methodName, bool canBeShared)
         {
             if (!_methods.ContainsKey(methodName)) return null;
 

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/RpcModuleProvider.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/RpcModuleProvider.cs
@@ -93,34 +93,30 @@ namespace Nethermind.JsonRpc.Modules
 
         public ModuleResolution Check(string methodName)
         {
-            if (!_methods.ContainsKey(methodName)) return ModuleResolution.Unknown;
+            if (!_methods.TryGetValue(methodName, out ResolvedMethodInfo result)) return ModuleResolution.Unknown;
 
-            ResolvedMethodInfo result = _methods[methodName];
             return _enabledModules.Contains(result.ModuleType) ? ModuleResolution.Enabled : ModuleResolution.Disabled;
         }
 
         public (MethodInfo, bool) Resolve(string methodName)
         {
-            if (!_methods.ContainsKey(methodName)) return (null, false);
+            if (!_methods.TryGetValue(methodName, out ResolvedMethodInfo result)) return (null, false);
 
-            ResolvedMethodInfo result = _methods[methodName];
             return (result.MethodInfo, result.ReadOnly);
         }
 
         public Task<IModule> Rent(string methodName, bool canBeShared)
         {
-            if (!_methods.ContainsKey(methodName)) return null;
+            if (!_methods.TryGetValue(methodName, out ResolvedMethodInfo result)) return null;
 
-            ResolvedMethodInfo result = _methods[methodName];
             return _pools[result.ModuleType].RentModule(canBeShared);
         }
 
         public void Return(string methodName, IModule module)
         {
-            if (!_methods.ContainsKey(methodName))
+            if (!_methods.TryGetValue(methodName, out ResolvedMethodInfo result))
                 throw new InvalidOperationException("Not possible to return an unresolved module");
 
-            ResolvedMethodInfo result = _methods[methodName];
             _pools[result.ModuleType].ReturnModule(module);
         }
 

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/SingletonModulePool.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/SingletonModulePool.cs
@@ -15,18 +15,21 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
 using System;
+using System.Threading.Tasks;
 
 namespace Nethermind.JsonRpc.Modules
 {
     public class SingletonModulePool<T> : IRpcModulePool<T> where T : IModule
     {
         private readonly T _onlyInstance;
+        private readonly Task<T> _onlyInstanceAsTask;
         private readonly bool _allowExclusive;
 
         public SingletonModulePool(T module, bool allowExclusive = true)
         {
             Factory = new SingletonFactory<T>(module);
             _onlyInstance = module;
+            _onlyInstanceAsTask = Task.FromResult(_onlyInstance);
             _allowExclusive = allowExclusive;
         }
 
@@ -37,14 +40,14 @@ namespace Nethermind.JsonRpc.Modules
             _allowExclusive = allowExclusive;
         }
         
-        public T GetModule(bool canBeShared)
+        public Task<T> GetModule(bool canBeShared)
         {
             if (!canBeShared && !_allowExclusive)
             {
                 throw new InvalidOperationException($"{nameof(SingletonModulePool<T>)} can only return shareable modules");
             }
             
-            return _onlyInstance;
+            return _onlyInstanceAsTask;
         }
 
         public void ReturnModule(T module)

--- a/src/Nethermind/Nethermind.JsonRpc/WebSockets/JsonRpcWebSocketsClient.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/WebSockets/JsonRpcWebSocketsClient.cs
@@ -57,7 +57,7 @@ namespace Nethermind.JsonRpc.WebSockets
             }
 
             Stopwatch stopwatch = Stopwatch.StartNew();
-            using JsonRpcResult result = await _jsonRpcProcessor.ProcessAsync(Encoding.UTF8.GetString(data.ToArray()));
+            using JsonRpcResult result = await _jsonRpcProcessor.ProcessAsync(Encoding.UTF8.GetString(data.Span));
 
             string resultData;
 


### PR DESCRIPTION
The aim of this PR is to improve performance of JsonRPC in Nethermind. The potential improvements that are considered after an inital review are listed below. They are grouped by a performance opportunity and followed by more nested action points.

### Plan of Action

- [x] make things async-fiendly
  - [x] `BoundedModulePool`  should be made async friendly by making `GetModule` Task/ValueTask-returning
- [x] better usage for data structures
  - [x] replace in `BoundedModulePool` the currently used `ConcurrentBag` with a better alternative
  - [x] `RpcModuleProvider` could use `Dictionary.TryGetValue` for lookups
- [ ] `Encoding.Utf8.GetBytes` should use a pooled buffer
  - [ ] `WebSocketsClient.SendRawAsync`
  - [ ] ~`BasicJsonRpcClient.Base64Encode`~ not needed as it's called once in the `.ctor` of the client
  - [ ] `JsonRpcProcessor.ProcessAsync` should use a non-string parameter as an input that would enable pooling
- [ ] J* objects into `JsonTextReader`/`JsonTextWriter`
  - [ ] `JsonRpcProcessor.DeserializeObjectOrArray`
  - [ ] `JsonRpcProcessor.UpdateParams `
- [ ] non-string serialization
  - [ ] `JsonRpcService.DeserializeParameters` could use a non-string deserialization


