### PR TITLE
LargeArrayPool introduced

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Buffers/LargerArrayPoolTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Buffers/LargerArrayPoolTests.cs
@@ -1,0 +1,127 @@
+//  Copyright (c) 2018 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
+
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using Nethermind.Core.Buffers;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using NUnit.Framework;
+
+namespace Nethermind.Core.Test.Buffers
+{
+    public class LargerArrayPoolTests
+    {
+        private static readonly SingleArrayPool s_shared = new SingleArrayPool();
+        private readonly ArrayPool<byte> _thrower;
+        private const int ArrayPoolLimit = 16;
+        private const int LargeBufferSize = 32;
+
+        public LargerArrayPoolTests()
+        {
+            _thrower = Substitute.For<ArrayPool<byte>>();
+            _thrower.Rent(Arg.Any<int>()).ThrowsForAnyArgs(new Exception());
+        }
+
+        [Test]
+        public void Renting_small_goes_to_Small_Buffer_Pool()
+        {
+            LargerArrayPool pool = new LargerArrayPool(ArrayPoolLimit, LargeBufferSize, 1, s_shared);
+            byte[] array = pool.Rent(ArrayPoolLimit);
+
+            try
+            {
+                Assert.AreEqual(s_shared._bytes, array);
+            }
+            finally
+            {
+                pool.Return(array);
+            }
+        }
+
+        [Test]
+        public void Renting_bigger_uses_Larger_Pool()
+        {
+            const int middleSize = (ArrayPoolLimit + LargeBufferSize) / 2;
+
+            LargerArrayPool pool = new LargerArrayPool(ArrayPoolLimit, LargeBufferSize, 1, _thrower);
+
+            byte[] array1 = pool.Rent(middleSize);
+            pool.Return(array1);
+
+            byte[] array2 = pool.Rent(middleSize);
+
+            Assert.True(ReferenceEquals(array1, array2));
+        }
+
+        [Test]
+        public void Renting_above_Large_Buffer_Size_just_allocates()
+        {
+            const int tooBig = LargeBufferSize + 1;
+
+            LargerArrayPool pool = new LargerArrayPool(ArrayPoolLimit, LargeBufferSize, 1, _thrower);
+            byte[] array1 = pool.Rent(tooBig);
+            pool.Return(array1);
+
+            byte[] array2 = pool.Rent(tooBig);
+
+            Assert.False(ReferenceEquals(array1, array2));
+        }
+
+        [Test]
+        public void Renting_too_many_just_allocates()
+        {
+            const int middleSize = (ArrayPoolLimit + LargeBufferSize) / 2;
+
+            const int size = 1;
+            const int additional = 2;
+
+            LargerArrayPool pool = new LargerArrayPool(ArrayPoolLimit, LargeBufferSize, size, _thrower);
+
+            HashSet<byte[]> arrays = new HashSet<byte[]>();
+
+            // rent first size + additional
+            for (int i = 0; i < size + additional; i++)
+            {
+                arrays.Add(pool.Rent(middleSize));
+            }
+
+            // return all
+            foreach (byte[] bytes in arrays)
+            {
+                pool.Return(bytes);
+            }
+
+            // try to train it all
+            while (arrays.Remove(pool.Rent(middleSize)))
+            {
+            }
+
+            Assert.AreEqual(additional, arrays.Count);
+        }
+
+        class SingleArrayPool : ArrayPool<byte>
+        {
+            public readonly byte[] _bytes = new byte[0];
+
+            public override byte[] Rent(int minimumLength) => _bytes;
+
+            public override void Return(byte[] array, bool clearArray = false) => Assert.AreEqual(_bytes, array);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Core/Buffers/LargerArrayPool.cs
+++ b/src/Nethermind/Nethermind.Core/Buffers/LargerArrayPool.cs
@@ -1,0 +1,80 @@
+//  Copyright (c) 2018 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
+
+using System;
+using System.Buffers;
+using System.Threading;
+
+namespace Nethermind.Core.Buffers
+{
+    public sealed class LargerArrayPool : ArrayPool<byte>
+    {
+        static readonly LargerArrayPool instance = new LargerArrayPool();
+
+        public static new ArrayPool<byte> Shared => instance;
+
+        public const int LargeBufferSize = 8 * 1024 * 1024;
+        const int ArrayPoolLimit = 1024 * 1024;
+
+        private static byte[]? s_buffer1;
+        private static byte[]? s_buffer2;
+
+        static byte[] RentLarge()
+        {
+            return Interlocked.Exchange(ref s_buffer1, null) ??
+                   Interlocked.Exchange(ref s_buffer2, null) ??
+                   new byte[LargeBufferSize];
+        }
+
+        static void ReturnLarge(byte[] array, bool clearArray)
+        {
+            if (clearArray)
+            {
+                Array.Clear(array, 0, array.Length);
+            }
+
+            if (Interlocked.CompareExchange(ref s_buffer1, array, null) != null)
+            {
+                Interlocked.CompareExchange(ref s_buffer2, array, null);
+            }
+        }
+
+        public override byte[] Rent(int minimumLength)
+        {
+            if (ArrayPoolLimit < minimumLength && minimumLength <= LargeBufferSize)
+            {
+                return RentLarge();
+            }
+
+            // any other case delegated to the shared
+            return ArrayPool<byte>.Shared.Rent(minimumLength);
+        }
+
+        public override void Return(byte[] array, bool clearArray = false)
+        {
+            if (array.Length == LargeBufferSize)
+            {
+                ReturnLarge(array, clearArray);
+            }
+            else
+            {
+                // any other case delegated to the shared
+                ArrayPool<byte>.Shared.Return(array, clearArray);
+            }
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Core/Buffers/LargerArrayPool.cs
+++ b/src/Nethermind/Nethermind.Core/Buffers/LargerArrayPool.cs
@@ -35,7 +35,19 @@ namespace Nethermind.Core.Buffers
         private static readonly int s_maxLargeBufferCount = Environment.ProcessorCount + 2;
         
         private readonly Stack<byte[]> _pool = new Stack<byte[]>(s_maxLargeBufferCount);
-        
+        private readonly int _largeBufferSize;
+        private readonly int _arrayPoolLimit;
+        private readonly ArrayPool<byte> _smallPool;
+        private readonly int _maxBufferCount;
+
+        public LargerArrayPool(int arrayPoolLimit = ArrayPoolLimit, int largeBufferSize = LargeBufferSize, int? maxBufferCount = default, ArrayPool<byte>? smallPool = null)
+        {
+            _smallPool = smallPool ?? ArrayPool<byte>.Shared;
+            _arrayPoolLimit = arrayPoolLimit;
+            _largeBufferSize = largeBufferSize;
+            _maxBufferCount = maxBufferCount.GetValueOrDefault(s_maxLargeBufferCount);
+        }
+
         byte[] RentLarge()
         {
             lock (_pool)
@@ -46,7 +58,7 @@ namespace Nethermind.Core.Buffers
                 }
             }
 
-            return new byte[LargeBufferSize];
+            return new byte[_largeBufferSize];
         }
 
         void ReturnLarge(byte[] array, bool clearArray)
@@ -58,7 +70,7 @@ namespace Nethermind.Core.Buffers
 
             lock (_pool)
             {
-                if (_pool.Count < s_maxLargeBufferCount)
+                if (_pool.Count < _maxBufferCount)
                 {
                     _pool.Push(array);
                 }
@@ -67,12 +79,12 @@ namespace Nethermind.Core.Buffers
 
         public override byte[] Rent(int minimumLength)
         {
-            if (minimumLength <= ArrayPoolLimit)
+            if (minimumLength <= _arrayPoolLimit)
             {
-                return ArrayPool<byte>.Shared.Rent(minimumLength);
+                return _smallPool.Rent(minimumLength);
             }
 
-            if (minimumLength <= LargeBufferSize)
+            if (minimumLength <= _largeBufferSize)
             {
                 return RentLarge();
             }
@@ -84,12 +96,11 @@ namespace Nethermind.Core.Buffers
         public override void Return(byte[] array, bool clearArray = false)
         {
             int length = array.Length;
-            if (length <= ArrayPoolLimit)
+            if (length <= _arrayPoolLimit)
             {
-                ArrayPool<byte>.Shared.Return(array, clearArray);
-
+                _smallPool.Return(array, clearArray);
             }
-            else if (length <= LargeBufferSize)
+            else if (length <= _largeBufferSize)
             {
                 ReturnLarge(array, clearArray);
             }

--- a/src/Nethermind/Nethermind.Core/Buffers/LargerArrayPool.cs
+++ b/src/Nethermind/Nethermind.Core/Buffers/LargerArrayPool.cs
@@ -30,17 +30,17 @@ namespace Nethermind.Core.Buffers
         public const int LargeBufferSize = 8 * 1024 * 1024;
         const int ArrayPoolLimit = 1024 * 1024;
 
-        private static byte[]? s_buffer1;
-        private static byte[]? s_buffer2;
+        private byte[]? s_buffer1;
+        private byte[]? s_buffer2;
 
-        static byte[] RentLarge()
+        byte[] RentLarge()
         {
             return Interlocked.Exchange(ref s_buffer1, null) ??
                    Interlocked.Exchange(ref s_buffer2, null) ??
                    new byte[LargeBufferSize];
         }
 
-        static void ReturnLarge(byte[] array, bool clearArray)
+        void ReturnLarge(byte[] array, bool clearArray)
         {
             if (clearArray)
             {

--- a/src/Nethermind/Nethermind.Evm/EvmPooledMemory.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmPooledMemory.cs
@@ -1,4 +1,4 @@
-﻿//  Copyright (c) 2018 Demerzel Solutions Limited
+//  Copyright (c) 2018 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
 // 
 //  The Nethermind library is free software: you can redistribute it and/or modify
@@ -17,6 +17,7 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using Nethermind.Core.Buffers;
 using Nethermind.Core.Extensions;
 using Nethermind.Int256;
 
@@ -25,7 +26,7 @@ namespace Nethermind.Evm
     public class EvmPooledMemory : IEvmMemory
     {
         public const int WordSize = 32;
-        private static readonly ArrayPool<byte> Pool = ArrayPool<byte>.Shared;
+        private static readonly ArrayPool<byte> Pool = LargerArrayPool.Shared;
 
         private int _lastZeroedSize;
 


### PR DESCRIPTION
This PR introduces a limited in size `LargeArrayPool` that should be able to help with large buffers used from time to time. The assumptions are as follows:

1. for small arrays, less than 1MB `ArrayPool<byte>.Shared` is used with its default bucketing behavior
1. for arrays bigger than 1MB but less than 8MB, one of two buffers provided in `LargeArrayPool` is used. No bucketing, just using 8MB chunks
1. for arrays bigger that 8MB, the default `ArrayPool<byte>.Shared` is used again. This will probably allocate but it's highly unlikely that it'll be used by any real-world evm example.

