### PR TITLE
Potentially cheaper array based LRU cache

### DIFF
--- a/src/Nethermind/Nethermind.Benchmark/Core/LruCacheAddAtCapacityBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Core/LruCacheAddAtCapacityBenchmarks.cs
@@ -20,15 +20,22 @@ using Nethermind.Core.Caching;
 namespace Nethermind.Benchmarks.Core
 {
     [MemoryDiagnoser]
-    [SimpleJob]
     public class LruCacheAddAtCapacityBenchmarks
     {
+        const int Capacity = 16;
         private object _object = new object();
+        private LruCache<int, object> shared;
         
-        [Benchmark]
-        public ICache<int, object> No_recycling()
+        [GlobalSetup]
+        public void Setup()
         {
-            LruCache<int, object> cache = new LruCache<int, object>(16, 16, string.Empty);
+            shared = new LruCache<int, object>(Capacity, Capacity, string.Empty);
+        }
+
+        [Benchmark]
+        public ICache<int, object> WithRecreation()
+        {
+            LruCache<int, object> cache = new LruCache<int, object>(Capacity, Capacity, string.Empty);
             for (int j = 0; j < 1024 * 64; j++)
             {
                 cache.Set(j, _object);
@@ -36,17 +43,16 @@ namespace Nethermind.Benchmarks.Core
 
             return cache;
         }
-        
+
         [Benchmark]
-        public ICache<int, object> With_recycling()
+        public void WithClear()
         {
-            LruCache<int, object> cache = new LruCache<int, object>(16, 16, string.Empty);
             for (int j = 0; j < 1024 * 64; j++)
             {
-                cache.Set(j, _object);
+                shared.Set(j, _object);
             }
 
-            return cache;
+            shared.Clear();
         }
     }
 }

--- a/src/Nethermind/Nethermind.Core.Test/Caching/LruCacheTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Caching/LruCacheTests.cs
@@ -1,4 +1,4 @@
-﻿//  Copyright (c) 2018 Demerzel Solutions Limited
+//  Copyright (c) 2018 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
 // 
 //  The Nethermind library is free software: you can redistribute it and/or modify
@@ -14,6 +14,7 @@
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
+using System;
 using FluentAssertions;
 using Nethermind.Core.Caching;
 using Nethermind.Core.Test.Builders;
@@ -22,12 +23,12 @@ using NUnit.Framework;
 
 namespace Nethermind.Core.Test.Caching
 {
-    [TestFixture]
-    public class LruCacheTests
+    [TestFixture(typeof(LruCache<Address, Account>))]
+    public class LruCacheTests<TCache>
     {
-        private ICache<Address, Account> Create()
+        private static ICache<Address, Account> Create()
         {
-            return new LruCache<Address, Account>(Capacity, "test");
+            return (ICache<Address, Account>) Activator.CreateInstance(typeof(TCache), Capacity, "test");
         }
         
         private const int Capacity = 16;

--- a/src/Nethermind/Nethermind.Core.Test/Caching/LruCacheTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Caching/LruCacheTests.cs
@@ -20,6 +20,7 @@ using Nethermind.Core.Caching;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Int256;
 using NUnit.Framework;
+using Org.BouncyCastle.Bcpg.OpenPgp;
 
 namespace Nethermind.Core.Test.Caching
 {
@@ -115,6 +116,32 @@ namespace Nethermind.Core.Test.Caching
             cache.Set(_addresses[0], _accounts[0]);
             cache.Delete(_addresses[0]);
             cache.Get(_addresses[0]).Should().Be(null);
+        }
+
+        [Test]
+        public void Clear_should_free_all_capacity()
+        {
+            ICache<Address, Account> cache = Create();
+            for (int i = 0; i < Capacity; i++)
+            {
+                cache.Set(_addresses[i], _accounts[i]);
+            }
+
+            cache.Clear();
+
+            static int MapForRefill (int index) => (index + 1) % Capacity;
+
+            // fill again
+            for (int i = 0; i < Capacity; i++)
+            {
+                cache.Set(_addresses[i], _accounts[MapForRefill(i)]);
+            }
+
+            // validate
+            for (int i = 0; i < Capacity; i++)
+            {
+                cache.Get(_addresses[i]).Should().Be(_accounts[MapForRefill(i)]);
+            }
         }
     }
 }

--- a/src/Nethermind/Nethermind.Core/Caching/LruCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/LruCache.cs
@@ -49,6 +49,7 @@ namespace Nethermind.Core.Caching
         {
             _cacheMap?.Clear();
             _list = new Node[MinimumListCapacity];
+            _head = Node.Null;
         }
 
         public LruCache(int maxCapacity, int startCapacity, string name)
@@ -175,15 +176,15 @@ namespace Nethermind.Core.Caching
 
         private void Replace(TKey key, TValue value)
         {
-            int node = _head;
-            NodeRemove(node);
-            _cacheMap.Remove(_list[node].Key);
+            int i = _head;
+            ref Node node = ref NodeRemove(i);
+            _cacheMap.Remove(node.Key);
 
-            _list[node].Value = value;
-            _list[node].Key = key;
-            NodeAddLast(node);
+            node.Value = value;
+            node.Key = key;
+            NodeAddLast(i);
 
-            _cacheMap.Add(key, node);
+            _cacheMap.Add(key, i);
         }
 
         private int _head = Node.Null;

--- a/src/Nethermind/Nethermind.Core/Caching/LruCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/LruCache.cs
@@ -1,4 +1,4 @@
-﻿//  Copyright (c) 2018 Demerzel Solutions Limited
+//  Copyright (c) 2018 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
 // 
 //  The Nethermind library is free software: you can redistribute it and/or modify
@@ -14,6 +14,7 @@
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
+using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Nethermind.Core.Extensions;
@@ -21,27 +22,42 @@ using Nethermind.Core.Extensions;
 namespace Nethermind.Core.Caching
 {
     /// <summary>
-    /// https://stackoverflow.com/questions/754233/is-it-there-any-lru-implementation-of-idictionary
+    /// A custom array based LRU cache.
     /// </summary>
+    /// <remarks>
+    /// The array based solution is preferred to lower the overall memory management overhead. The <see cref="LinkedListNode{T}"/> based approach is very costly.
+    /// </remarks>
     public class LruCache<TKey, TValue> : ICache<TKey, TValue> where TKey : notnull
     {
         private readonly int _maxCapacity;
-        private readonly Dictionary<TKey, LinkedListNode<LruCacheItem>> _cacheMap;
-        private readonly LinkedList<LruCacheItem> _lruList;
+        private readonly Dictionary<TKey, int> _cacheMap;
+        private Node[] _list;
+
+        private const int MinimumListCapacity = 16;
+
+        struct Node
+        {
+            public const int Null = -1;
+
+            public int Prev;
+            public int Next;
+            public TValue Value;
+            public TKey Key;
+        }
 
         public void Clear()
         {
             _cacheMap?.Clear();
-            _lruList?.Clear();
+            _list = new Node[MinimumListCapacity];
         }
 
         public LruCache(int maxCapacity, int startCapacity, string name)
         {
             _maxCapacity = maxCapacity;
             _cacheMap = typeof(TKey) == typeof(byte[])
-                ? new Dictionary<TKey, LinkedListNode<LruCacheItem>>((IEqualityComparer<TKey>) Bytes.EqualityComparer)
-                : new Dictionary<TKey, LinkedListNode<LruCacheItem>>(startCapacity); // do not initialize it at the full capacity
-            _lruList = new LinkedList<LruCacheItem>();
+                ? new Dictionary<TKey, int>((IEqualityComparer<TKey>)Bytes.EqualityComparer)
+                : new Dictionary<TKey, int>(startCapacity); // do not initialize it at the full capacity
+            _list = new Node[Math.Max(startCapacity, MinimumListCapacity)];
         }
 
         public LruCache(int maxCapacity, string name)
@@ -52,11 +68,13 @@ namespace Nethermind.Core.Caching
         [MethodImpl(MethodImplOptions.Synchronized)]
         public TValue Get(TKey key)
         {
-            if (_cacheMap.TryGetValue(key, out LinkedListNode<LruCacheItem>? node))
+            if (_cacheMap.TryGetValue(key, out int node))
             {
-                TValue value = node.Value.Value;
-                _lruList.Remove(node);
-                _lruList.AddLast(node);
+                TValue value = _list[node].Value;
+
+                NodeRemove(node);
+                NodeAddLast(node);
+
                 return value;
             }
 
@@ -69,11 +87,13 @@ namespace Nethermind.Core.Caching
         [MethodImpl(MethodImplOptions.Synchronized)]
         public bool TryGet(TKey key, out TValue value)
         {
-            if (_cacheMap.TryGetValue(key, out LinkedListNode<LruCacheItem>? node))
+            if (_cacheMap.TryGetValue(key, out int node))
             {
-                value = node.Value.Value;
-                _lruList.Remove(node);
-                _lruList.AddLast(node);
+                value = _list[node].Value;
+
+                NodeRemove(node);
+                NodeAddLast(node);
+
                 return true;
             }
 
@@ -93,11 +113,12 @@ namespace Nethermind.Core.Caching
                 return;
             }
 
-            if (_cacheMap.TryGetValue(key, out LinkedListNode<LruCacheItem>? node))
+            if (_cacheMap.TryGetValue(key, out int node))
             {
-                node.Value.Value = val;
-                _lruList.Remove(node);
-                _lruList.AddLast(node);
+                _list[node].Value = val;
+
+                NodeRemove(node);
+                NodeAddLast(node);
             }
             else
             {
@@ -107,10 +128,18 @@ namespace Nethermind.Core.Caching
                 }
                 else
                 {
-                    LruCacheItem cacheItem = new LruCacheItem(key, val);
-                    LinkedListNode<LruCacheItem> newNode = new LinkedListNode<LruCacheItem>(cacheItem);
-                    _lruList.AddLast(newNode);
-                    _cacheMap.Add(key, newNode);    
+                    int newNode = _cacheMap.Count;
+
+                    if (newNode >= _list.Length)
+                    {
+                        Array.Resize(ref _list, _list.Length * 2);
+                    }
+
+                    _list[newNode].Value = val;
+                    _list[newNode].Key = key;
+
+                    NodeAddLast(newNode);
+                    _cacheMap.Add(key, newNode);
                 }
             }
         }
@@ -118,10 +147,26 @@ namespace Nethermind.Core.Caching
         [MethodImpl(MethodImplOptions.Synchronized)]
         public void Delete(TKey key)
         {
-            if (_cacheMap.TryGetValue(key, out LinkedListNode<LruCacheItem>? node))
+            if (_cacheMap.Remove(key, out int node))
             {
-                _lruList.Remove(node);
-                _cacheMap.Remove(key);
+                int nextFree = _cacheMap.Count;
+
+                ref Node removed = ref NodeRemove(node, true);
+
+                if (nextFree == 0)
+                {
+                    // head is null, nothing to remove
+                }
+                else if (nextFree == node)
+                {
+                    // nothing to do, the last node was removed
+                }
+                else
+                {
+                    removed = _list[nextFree];
+                    _list[removed.Prev].Next = node;
+                    _list[removed.Next].Prev = node;
+                }
             }
         }
 
@@ -130,26 +175,73 @@ namespace Nethermind.Core.Caching
 
         private void Replace(TKey key, TValue value)
         {
-            LinkedListNode<LruCacheItem>? node = _lruList.First;
-            _lruList.RemoveFirst();
-            _cacheMap.Remove(node.Value.Key);
-            
-            node.Value.Value = value;
-            node.Value.Key = key;
-            _lruList.AddLast(node);
+            int node = _head;
+            NodeRemove(node);
+            _cacheMap.Remove(_list[node].Key);
+
+            _list[node].Value = value;
+            _list[node].Key = key;
+            NodeAddLast(node);
+
             _cacheMap.Add(key, node);
         }
 
-        private class LruCacheItem
+        private int _head = Node.Null;
+
+        private ref Node NodeRemove(int i, bool cleanValues = false)
         {
-            public LruCacheItem(TKey k, TValue v)
+            ref Node node = ref _list[i];
+
+            if (node.Next == i)
             {
-                Key = k;
-                Value = v;
+                _head = Node.Null;
+            }
+            else
+            {
+                _list[node.Next].Prev = node.Prev;
+                _list[node.Prev].Next = node.Next;
+
+                if (_head == i)
+                {
+                    _head = node.Next;
+                }
             }
 
-            public TKey Key;
-            public TValue Value;
+            if (cleanValues)
+            {
+                node.Value = default!;
+                node.Key = default!;
+            }
+
+            return ref node;
+        }
+
+        private void NodeAddLast(int i)
+        {
+            if (_head == Node.Null)
+                NodeInsertToEmptyList(i);
+            else
+                NodeInsertBefore(_head, i);
+        }
+
+        private void NodeInsertToEmptyList(int i)
+        {
+            ref Node node = ref _list[i];
+
+            node.Next = i;
+            node.Prev = i;
+            _head = i;
+        }
+
+        private void NodeInsertBefore(int n, int @new)
+        {
+            ref Node node = ref _list[n];
+            ref Node newNode = ref _list[@new];
+
+            newNode.Next = n;
+            newNode.Prev = node.Prev;
+            _list[node.Prev].Next = @new;
+            node.Prev = @new;
         }
 
         public int MemorySize => CalculateMemorySize(0, _cacheMap.Count);
@@ -157,7 +249,7 @@ namespace Nethermind.Core.Caching
         public static int CalculateMemorySize(int keyPlusValueSize, int currentItemsCount)
         {
             // it may actually be different if the initial capacity not equal to max (depending on the dictionary growth path)
-            
+
             const int preInit = 48 /* LinkedList */ + 80 /* Dictionary */ + 24;
             int postInit = 52 /* lazy init of two internal dictionary arrays + dictionary size times (entry size + int) */ + MemorySizes.FindNextPrime(currentItemsCount) * 28 + currentItemsCount * 80 /* LinkedListNode and CacheItem times items count */;
             return MemorySizes.Align(preInit + postInit + keyPlusValueSize * currentItemsCount);


### PR DESCRIPTION
This is a speculative PR proposing changes for the implementation of the LRU cache.

Previous version was based on `LinkedList<T>`,  `LinkedListNode<T>` and `LruCacheItem`. It had following properties:

- each of this types is a class, therefore it allocates an object header
- `LinkedListNode<T>` contains three references: `previous`, `next` and the `list`. The value is stored in the `item`
- `LruCacheItem` contains the key (needed for `.Replace` operation) and the actual value.

When profiling a runner, I found large amounts of objects allocated for the purpose of `LinkedListNode<T>` and `LruCacheItem`.

This PR changes the approach to use an **array of structs** and implementing a linked list on to of it. It removes some memory overhead as a single array item consist of:

- `prev` and `next` implemented as 32bit ints, no references needed
- `TValue` and `TKey` like in the previously existing `LruCacheItem`
- no reference to the list in a struct (not needed).

**This is an exploratory work and requires more testing and benchmarking**. Initial memory profiling looked possibly promising (I'm trying to use soft language to do not overpromise here), showing removal of a lot of objects' litter.

### Gains estimations

#### LinkedList based approach

|  Item | Description  | 32-bit | 64-bit  |
|---|---|---|---|
| LinkedListNode | class overhead (object header)  |  8  | 16  |
| LinkedListNode.prev |  an object reference  | 4  | 8  |
| LinkedListNode.next  |  an object reference  | 4  | 8  |
| LinkedListNode.list  | an object reference  | 4  | 8  |
| LruCacheItem  | class overhead (object header)  | 8  | 16  |
|  **Sum** |   | 24  | 48  |

#### Array of structs based approach

|  Item | Description  | 32-bit | 64-bit  |
|---|---|---|---|
| Cell.prev | an int32  |  4  | 4  |
| Cell.next | an int32  |  4  | 4  |
|  **Sum** |   | 8  | 8  |

#### Difference

|  Approach | 32-bit | 64-bit  |
|---|---|---|
| LinkedList |  24  | 48  |
| Array of structs |  8 | 8 |
| **Gain** |  16 | 40 |

This just a size estimation for a single item. It does not take into consideration GC overhead for keeping a lot of objects alive.

### Benchmarks

I used and modified `LruCacheAddAtCapacityBenchmarks`

#### Before

|         Method |     Mean |     Error |    StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------- |---------:|----------:|----------:|------:|------:|------:|----------:|
| WithRecreation | 4.736 ms | 0.0930 ms | 0.0955 ms |     - |     - |     - |   1.92 KB |
|      WithClear | 4.661 ms | 0.1011 ms | 0.0946 ms |     - |     - |     - |   1.26 KB |

#### After

|         Method |     Mean |     Error |    StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------- |---------:|----------:|----------:|------:|------:|------:|----------:|
| WithRecreation | 3.625 ms | 0.0672 ms | 0.0628 ms |     - |     - |     - |     917 B |
|      WithClear | 3.573 ms | 0.0620 ms | 0.0580 ms |     - |     - |     - |     430 B |