### PR TITLE
Make PeerManager more resilient to unexpected failure

### DIFF
--- a/src/Nethermind/Nethermind.Network.Stats/INodeStatsManager.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/INodeStatsManager.cs
@@ -14,6 +14,7 @@
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
+using System.Collections.Generic;
 using Nethermind.Stats.Model;
 
 namespace Nethermind.Stats
@@ -43,5 +44,19 @@ namespace Nethermind.Stats
         Headers,
         Bodies,
         Receipts
+    }
+    
+    public static class NodeStatsManagerExtension
+    {
+        public static void UpdateCurrentReputation(this INodeStatsManager nodeStatsManager, IEnumerable<Node> nodes)
+        {
+            foreach (Node node in nodes)
+            {
+                node.CurrentReputation = nodeStatsManager.GetCurrentReputation(node);
+            }
+        }
+
+        public static void UpdateCurrentReputation(this INodeStatsManager nodeStatsManager, params Node[] nodes) =>
+            UpdateCurrentReputation(nodeStatsManager, (IEnumerable<Node>)nodes);
     }
 }

--- a/src/Nethermind/Nethermind.Network.Stats/Model/Node.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/Model/Node.cs
@@ -84,6 +84,7 @@ namespace Nethermind.Stats.Model
         public NodeClientType ClientType { get; private set; } = NodeClientType.Unknown;
         
         public string EthDetails { get; set; }
+        public long CurrentReputation { get; set; }
 
         public Node(PublicKey id, IPEndPoint address)
         {

--- a/src/Nethermind/Nethermind.Network.Test/PeerComparerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/PeerComparerTests.cs
@@ -15,6 +15,7 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
 using System.Collections.Generic;
+using System.Linq;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Stats;
 using Nethermind.Stats.Model;
@@ -34,7 +35,7 @@ namespace Nethermind.Network.Test
         public void SetUp()
         {
             _statsManager = Substitute.For<INodeStatsManager>();
-            _comparer = new PeerComparer(_statsManager);
+            _comparer = new PeerComparer();
         }
 
         [Test]
@@ -52,6 +53,8 @@ namespace Nethermind.Network.Test
             _statsManager.GetCurrentReputation(a).Returns(100);
             _statsManager.GetCurrentReputation(b).Returns(50);
             _statsManager.GetCurrentReputation(c).Returns(200);
+            
+            _statsManager.UpdateCurrentReputation(a, b, c);
 
             Assert.AreEqual(-1, _comparer.Compare(peerA, peerB));
             Assert.AreEqual(1, _comparer.Compare(peerA, peerC));
@@ -83,6 +86,8 @@ namespace Nethermind.Network.Test
             _statsManager.GetCurrentReputation(d).Returns(10);
 
             List<Peer> peers = new List<Peer> {peerA, peerB, peerC, peerD, peerE};
+            
+            _statsManager.UpdateCurrentReputation(peers);
             peers.Sort(_comparer);
             
             Assert.AreEqual(peerC, peers[0]);

--- a/src/Nethermind/Nethermind.Network/NodeStatsManagerExtension.cs
+++ b/src/Nethermind/Nethermind.Network/NodeStatsManagerExtension.cs
@@ -13,34 +13,17 @@
 // 
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
 
 using System.Collections.Generic;
+using System.Linq;
 using Nethermind.Stats;
 
 namespace Nethermind.Network
 {
-    internal class PeerComparer : IComparer<Peer>
+    public static class NodeStatsManagerExtension
     {
-        public int Compare(Peer x, Peer y)
-        {
-            if (x == null)
-            {
-                return y == null ? 0 : 1;
-            }
-
-            if (y == null)
-            {
-                return -1;
-            }
-
-            int staticValue = -x.Node.IsStatic.CompareTo(y.Node.IsStatic);
-            if (staticValue != 0)
-            {
-                return staticValue;
-            }
-
-            int reputation = -x.Node.CurrentReputation.CompareTo(y.Node.CurrentReputation);
-            return reputation;
-        }
+        public static void UpdateCurrentReputation(this INodeStatsManager nodeStatsManager, IEnumerable<Peer> peers) =>
+            nodeStatsManager.UpdateCurrentReputation(peers.Where(p => p?.Node != null).Select(p => p.Node));
     }
 }

--- a/src/Nethermind/Nethermind.Network/PeerComparer.cs
+++ b/src/Nethermind/Nethermind.Network/PeerComparer.cs
@@ -21,11 +21,8 @@ namespace Nethermind.Network
 {
     internal class PeerComparer : IComparer<Peer>
     {
-        private readonly INodeStatsManager _stats;
-
-        public PeerComparer(INodeStatsManager stats)
+        public PeerComparer()
         {
-            _stats = stats;
         }
 
         public int Compare(Peer x, Peer y)
@@ -46,7 +43,7 @@ namespace Nethermind.Network
                 return staticValue;
             }
 
-            int reputation = -_stats.GetCurrentReputation(x.Node).CompareTo(_stats.GetCurrentReputation(y.Node));
+            int reputation = -x.Node.CurrentReputation.CompareTo(y.Node.CurrentReputation);
             return reputation;
         }
     }

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -544,11 +544,7 @@ namespace Nethermind.Network
                 _currentSelection.Candidates.AddRange(staticPeers.Where(sn => !_activePeers.ContainsKey(sn.Node.Id)));
             }
 
-            for (var i = 0; i < _currentSelection.Candidates.Count; i++)
-            {
-                Node node = _currentSelection.Candidates[i].Node;
-                node.CurrentReputation = _stats.GetCurrentReputation(node);
-            }
+            _stats.UpdateCurrentReputation(_currentSelection.Candidates);
             _currentSelection.Candidates.Sort(_peerComparer);
         }
 

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -218,6 +218,7 @@ namespace Nethermind.Network
         {
             int loopCount = 0;
             long previousActivePeersCount = 0;
+            int failCount = 0;
             while (true)
             {
                 try
@@ -335,6 +336,8 @@ namespace Nethermind.Network
                     {
                         _peerUpdateRequested.Set();
                     }
+
+                    failCount = 0;
                 }
                 catch (AggregateException e) when (e.InnerExceptions.Any(inner => inner is OperationCanceledException))
                 {
@@ -349,7 +352,15 @@ namespace Nethermind.Network
                 catch (Exception e)
                 {
                     if (_logger.IsError) _logger.Error("Peer update loop failure", e);
-                    break;
+                    ++failCount;
+                    if (failCount >= 10)
+                    {
+                        break;
+                    }
+                    else
+                    {
+                        await Task.Delay(1000);
+                    }
                 }
             }
         }


### PR DESCRIPTION
2020-12-01 17:10:35.9864|Peer update loop failure System.ArgumentException: Unable to sort because the IComparer.Compare() method returns inconsistent results. Either a value does not compare equal to itself, or one value repeatedly compared to another value yields different results. IComparer: 'Nethermind.Network.PeerComparer'.
   at System.Collections.Generic.IntrospectiveSortUtilities.ThrowOrIgnoreBadComparer(Object comparer)
   at System.Collections.Generic.ArraySortHelper`1.Sort(T[] keys, Int32 index, Int32 length, IComparer`1 comparer)
   at System.Collections.Generic.List`1.Sort(Int32 index, Int32 count, IComparer`1 comparer)
   at Nethermind.Network.PeerManager.SelectAndRankCandidates() in /src/Nethermind/Nethermind.Network/PeerManager.cs:line 540
   at Nethermind.Network.PeerManager.RunPeerUpdateLoop() in /src/Nethermind/Nethermind.Network/PeerManager.cs:line 258