### PR TITLE
Introduce config parameter JsonRpc.MaxRequestBodySize

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc/IJsonRpcConfig.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/IJsonRpcConfig.cs
@@ -84,5 +84,10 @@ namespace Nethermind.JsonRpc
             Description = "A path to a file that contains a list of new-line separated approved JSON RPC calls",
             DefaultValue = "Data/jsonrpc.filter")]
         string CallsFilterFilePath { get; set; }
+
+        [ConfigItem(
+            Description = "Max HTTP request body size",
+            DefaultValue = "30000000")]
+        long? MaxRequestBodySize { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcConfig.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcConfig.cs
@@ -42,5 +42,6 @@ namespace Nethermind.JsonRpc
         public int ReportIntervalSeconds { get; set; } = 300;
         public bool BufferResponses { get; set; }
         public string CallsFilterFilePath { get; set; } = "Data/jsonrpc.filter";
+        public long? MaxRequestBodySize { get; set; } = 30000000;
     }
 }

--- a/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
+++ b/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
@@ -42,7 +42,14 @@ namespace Nethermind.Runner
 
         public void ConfigureServices(IServiceCollection services)
         {
-            services.Configure<KestrelServerOptions>(options => { options.AllowSynchronousIO = true; });
+            var sp = services.BuildServiceProvider();
+            IConfigProvider configProvider = sp.GetService<IConfigProvider>();
+            IJsonRpcConfig jsonRpcConfig = configProvider.GetConfig<IJsonRpcConfig>();
+
+            services.Configure<KestrelServerOptions>(options => {
+                options.AllowSynchronousIO = true;
+                options.Limits.MaxRequestBodySize = jsonRpcConfig.MaxRequestBodySize;
+            });
             Bootstrap.Instance.RegisterJsonRpcServices(services);
             string corsOrigins = Environment.GetEnvironmentVariable("NETHERMIND_CORS_ORIGINS") ?? "*";
             services.AddCors(c => c.AddPolicy("Cors",


### PR DESCRIPTION
This should allow increase the maximum body size (default ~28.8 MiB) for JSON RPC requests. 