### PR TITLE
Makes the API produce a reference assembly.

### DIFF
--- a/src/Nethermind/Nethermind.Abi/Nethermind.Abi.csproj
+++ b/src/Nethermind/Nethermind.Abi/Nethermind.Abi.csproj
@@ -4,6 +4,8 @@
         <TargetFramework>net5.0</TargetFramework>
         <LangVersion>8</LangVersion>
         <Nullable>enable</Nullable>
+        <Deterministic>true</Deterministic>
+        <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Nethermind/Nethermind.Blockchain/Nethermind.Blockchain.csproj
+++ b/src/Nethermind/Nethermind.Blockchain/Nethermind.Blockchain.csproj
@@ -3,6 +3,8 @@
     <TargetFramework>net5.0</TargetFramework>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <LangVersion>8.0</LangVersion>
+    <Deterministic>true</Deterministic>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Nethermind.Abi\Nethermind.Abi.csproj" />

--- a/src/Nethermind/Nethermind.Config/Nethermind.Config.csproj
+++ b/src/Nethermind/Nethermind.Config/Nethermind.Config.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
+    <Deterministic>true</Deterministic>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/src/Nethermind/Nethermind.Consensus/Nethermind.Consensus.csproj
+++ b/src/Nethermind/Nethermind.Consensus/Nethermind.Consensus.csproj
@@ -2,6 +2,8 @@
 
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
+        <Deterministic>true</Deterministic>
+        <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Nethermind/Nethermind.Core/Nethermind.Core.csproj
+++ b/src/Nethermind/Nethermind.Core/Nethermind.Core.csproj
@@ -4,6 +4,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
+    <Deterministic>true</Deterministic>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/Nethermind/Nethermind.Crypto/Nethermind.Crypto.csproj
+++ b/src/Nethermind/Nethermind.Crypto/Nethermind.Crypto.csproj
@@ -3,6 +3,8 @@
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <Deterministic>true</Deterministic>
+        <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Nethermind/Nethermind.Db/Nethermind.Db.csproj
+++ b/src/Nethermind/Nethermind.Db/Nethermind.Db.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
+    <Deterministic>true</Deterministic>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Nethermind.Config\Nethermind.Config.csproj" />

--- a/src/Nethermind/Nethermind.Evm/Nethermind.Evm.csproj
+++ b/src/Nethermind/Nethermind.Evm/Nethermind.Evm.csproj
@@ -3,6 +3,8 @@
     <TargetFramework>net5.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Deterministic>true</Deterministic>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Nethermind.Core\Nethermind.Core.csproj" />

--- a/src/Nethermind/Nethermind.Facade/Nethermind.Facade.csproj
+++ b/src/Nethermind/Nethermind.Facade/Nethermind.Facade.csproj
@@ -3,6 +3,8 @@
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
         <LangVersion>8.0</LangVersion>
+        <Deterministic>true</Deterministic>
+        <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Nethermind/Nethermind.Grpc/Nethermind.Grpc.csproj
+++ b/src/Nethermind/Nethermind.Grpc/Nethermind.Grpc.csproj
@@ -3,6 +3,8 @@
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
         <LangVersion>latest</LangVersion>
+        <Deterministic>true</Deterministic>
+        <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Nethermind/Nethermind.JsonRpc/Nethermind.JsonRpc.csproj
+++ b/src/Nethermind/Nethermind.JsonRpc/Nethermind.JsonRpc.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
+    <Deterministic>true</Deterministic>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/src/Nethermind/Nethermind.KeyStore/Nethermind.KeyStore.csproj
+++ b/src/Nethermind/Nethermind.KeyStore/Nethermind.KeyStore.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
+    <Deterministic>true</Deterministic>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <NoWarn>NU1701;NU1702</NoWarn>

--- a/src/Nethermind/Nethermind.Logging/Nethermind.Logging.csproj
+++ b/src/Nethermind/Nethermind.Logging/Nethermind.Logging.csproj
@@ -3,6 +3,8 @@
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
         <LangVersion>8.0</LangVersion>
+        <Deterministic>true</Deterministic>
+        <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Nethermind/Nethermind.Monitoring/Nethermind.Monitoring.csproj
+++ b/src/Nethermind/Nethermind.Monitoring/Nethermind.Monitoring.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
+    <Deterministic>true</Deterministic>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Nethermind/Nethermind.Network.Stats/Nethermind.Network.Stats.csproj
+++ b/src/Nethermind/Nethermind.Network.Stats/Nethermind.Network.Stats.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>net5.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <RootNamespace>Nethermind.Stats</RootNamespace>
+    <Deterministic>true</Deterministic>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Nethermind/Nethermind.Network/Nethermind.Network.csproj
+++ b/src/Nethermind/Nethermind.Network/Nethermind.Network.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
+    <Deterministic>true</Deterministic>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Nethermind.Blockchain\Nethermind.Blockchain.csproj">

--- a/src/Nethermind/Nethermind.PubSub/Nethermind.PubSub.csproj
+++ b/src/Nethermind/Nethermind.PubSub/Nethermind.PubSub.csproj
@@ -3,6 +3,8 @@
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
         <LangVersion>8.0</LangVersion>
+        <Deterministic>true</Deterministic>
+        <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Nethermind/Nethermind.Serialization.Json/Nethermind.Serialization.Json.csproj
+++ b/src/Nethermind/Nethermind.Serialization.Json/Nethermind.Serialization.Json.csproj
@@ -2,6 +2,8 @@
 
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
+        <Deterministic>true</Deterministic>
+        <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Nethermind/Nethermind.Specs/Nethermind.Specs.csproj
+++ b/src/Nethermind/Nethermind.Specs/Nethermind.Specs.csproj
@@ -2,6 +2,8 @@
 
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
+        <Deterministic>true</Deterministic>
+        <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Nethermind/Nethermind.State/Nethermind.State.csproj
+++ b/src/Nethermind/Nethermind.State/Nethermind.State.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
+    <Deterministic>true</Deterministic>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Nethermind.Core\Nethermind.Core.csproj">

--- a/src/Nethermind/Nethermind.Synchronization/Nethermind.Synchronization.csproj
+++ b/src/Nethermind/Nethermind.Synchronization/Nethermind.Synchronization.csproj
@@ -3,6 +3,8 @@
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
         <Nullable>enable</Nullable>
+        <Deterministic>true</Deterministic>
+        <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Nethermind/Nethermind.Trie/Nethermind.Trie.csproj
+++ b/src/Nethermind/Nethermind.Trie/Nethermind.Trie.csproj
@@ -3,6 +3,8 @@
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
         <Nullable>annotations</Nullable>
+        <Deterministic>true</Deterministic>
+        <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Nethermind/Nethermind.TxPool/Nethermind.TxPool.csproj
+++ b/src/Nethermind/Nethermind.TxPool/Nethermind.TxPool.csproj
@@ -2,6 +2,8 @@
 
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
+        <Deterministic>true</Deterministic>
+        <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Nethermind/Nethermind.Wallet/Nethermind.Wallet.csproj
+++ b/src/Nethermind/Nethermind.Wallet/Nethermind.Wallet.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
+    <Deterministic>true</Deterministic>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Nethermind.Core\Nethermind.Core.csproj" />

--- a/src/Nethermind/Nethermind.WebSockets/Nethermind.WebSockets.csproj
+++ b/src/Nethermind/Nethermind.WebSockets/Nethermind.WebSockets.csproj
@@ -3,6 +3,8 @@
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
         <LangVersion>8.0</LangVersion>
+        <Deterministic>true</Deterministic>
+        <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
A reference assembly is one that has all implementation and dependencies stripped out.  This is very useful for plugin authors because it means they can just reference this file in their plugin and get IDE support, auto-complete, comment documentation, etc.

`Deterministic` should *probably* be applied to this entire repository (helps with auditing final build artifacts), but specifically it is recommended for ReferenceAssemblies which is why I have enabled it here.

Upon building after this change `src\Nethermind\Nethermind.Api\bin\Release\net5.0\ref` will contain a `Nethermind.Api.dll` that is 24KB large.  Users can then reference it in their Plugin projects with:
```xml
<Project Sdk="Microsoft.NET.Sdk">
	<PropertyGroup>
		<TargetFramework>net5.0</TargetFramework>
		<Nullable>enable</Nullable>
	</PropertyGroup>
	<ItemGroup>
		<Reference Include="Nethermind.Api">
			<HintPath>.\Nethermind.Api.dll</HintPath>
			<Private>false</Private>
		</Reference>
	</ItemGroup>
</Project>
```

Note, for complete API support I think most projects will need to have this flag set.  This is the bare minimum required to get access to the API, but you'll also need to do something similar for other projects like `Nethermind.Blockchain`, `Nethermind.State`, `Nethermind.TxPool`, etc. which the user will need to bring in depending on their needs.

Ideally, every project would be configured to generate reference assemblies and CI would package those up and add them to the GitHub release assets as a .zip file so plugin authors can grab the whole set and pull out the pieces they need.

If there is a desire to apply these settings project wide, let me know and I can probably throw together a quick find and replace to do the job.