### PR TITLE
Moves WebSocketsManager instantiation to API Builder.

### DIFF
--- a/src/Nethermind/Nethermind.Api/IApiWithNetwork.cs
+++ b/src/Nethermind/Nethermind.Api/IApiWithNetwork.cs
@@ -52,6 +52,6 @@ namespace Nethermind.Api
         ISynchronizer? Synchronizer { get; set; }
         ISyncPeerPool? SyncPeerPool { get; set; }
         ISyncServer? SyncServer { get; set; }
-        IWebSocketsManager? WebSocketsManager { get; set; }
+        IWebSocketsManager WebSocketsManager { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.Runner/Ethereum/Api/NethermindApi.cs
+++ b/src/Nethermind/Nethermind.Runner/Ethereum/Api/NethermindApi.cs
@@ -168,7 +168,7 @@ namespace Nethermind.Runner.Ethereum.Api
         public ITxPool? TxPool { get; set; }
         public ITxPoolInfoProvider? TxPoolInfoProvider { get; set; }
         public IWallet? Wallet { get; set; }
-        public IWebSocketsManager? WebSocketsManager { get; set; }
+        public IWebSocketsManager WebSocketsManager { get; set; } = new WebSocketsManager();
 
         public ProtectedPrivateKey? NodeKey { get; set; }
         public ProtectedPrivateKey? OriginalSignerKey { get; set; } // TODO: please explain what it does

--- a/src/Nethermind/Nethermind.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Runner/Program.cs
@@ -175,7 +175,6 @@ namespace Nethermind.Runner
                     }
                 }
                 
-                nethermindApi.WebSocketsManager = new WebSocketsManager();
                 EthereumRunner ethereumRunner = new EthereumRunner(nethermindApi);
                 await ethereumRunner.Start(_processCloseCancellationSource.Token).ContinueWith(x =>
                 {


### PR DESCRIPTION
This makes it so `Api.WebSocketsManager` can be non-null, which makes it easier to use in plugins who want to use it.  Previously, this was unconditionally instantiated and assigned immediately after the builder finished and there aren't any code paths that set it to null, so it was *effectively* not null but in a way the static analyzer couldn't follow.