### PR TITLE
Add option to expose Prometheus metrics for pulling

### DIFF
--- a/src/Nethermind/Nethermind.Monitoring/Config/IMetricsConfig.cs
+++ b/src/Nethermind/Nethermind.Monitoring/Config/IMetricsConfig.cs
@@ -18,17 +18,20 @@ using Nethermind.Config;
 
 namespace Nethermind.Monitoring.Config
 {
-    [ConfigCategory(Description = "Configuration of the Prometheus + Grafana metrics publication. Documentation of the required setup is not yet ready (but the metrics do work and are used by the dev team)")]
+    [ConfigCategory(Description = "Configuration of the Prometheus metrics publication. Documentation of the required setup is not yet ready (but the metrics do work and are used by the dev team)")]
     public interface IMetricsConfig : IConfig
     {
-        [ConfigItem(Description = "If 'true' then the node publishes various metrics to Prometheus at the given interval.", DefaultValue = "false")]
+        [ConfigItem(Description = "If set, the node exposes Prometheus metrics on the given port.", DefaultValue = "null")]
+        int? ExposePort { get; }
+
+        [ConfigItem(Description = "If 'true',the node publishes various metrics to Prometheus Pushgateway at given interval.", DefaultValue = "false")]
         bool Enabled { get; }
         
-        [ConfigItem(Description = "Prometheus URL.", DefaultValue = "\"http://localhost:9091/metrics\"")]
-        string PushGatewayUrl {get; }
+        [ConfigItem(Description = "Prometheus Pushgateway URL.", DefaultValue = "\"http://localhost:9091/metrics\"")]
+        string PushGatewayUrl { get; }
         
         [ConfigItem(DefaultValue = "5", Description = "Defines how often metrics are pushed to Prometheus")]
-        int IntervalSeconds {get; }
+        int IntervalSeconds { get; }
         
         [ConfigItem(Description = "Name displayed in the Grafana dashboard", DefaultValue = "\"Nethermind\"")]
         string NodeName { get; }

--- a/src/Nethermind/Nethermind.Monitoring/Config/MetricsConfig.cs
+++ b/src/Nethermind/Nethermind.Monitoring/Config/MetricsConfig.cs
@@ -18,8 +18,9 @@ namespace Nethermind.Monitoring.Config
 {
     public class MetricsConfig : IMetricsConfig
     {
+        public int? ExposePort { get; set; } = null;
         public bool Enabled { get; set; } = false;
-        public string PushGatewayUrl {get; set; } =  "http://localhost:9091/metrics";
+        public string PushGatewayUrl {get; set; } = "http://localhost:9091/metrics";
         public int IntervalSeconds {get; set; } = 5;
         public string NodeName { get; set;} = "Nethermind";
     }


### PR DESCRIPTION
This adds a configurable `ExposePort` to expose Prometheus metrics via HTTP port. This functionality is disabled if not configured.

Prometheus is generally set up with polling from services and PushGateway is more intended as a workaround and for very short-lived processes.

Let me know what you think and if you want any structural changes in the config - opting for keeping backwards compatibility without making the config too messy.