### PR TITLE
Will not try to refund consumed deposit

### DIFF
--- a/src/Nethermind/Nethermind.DataMarketplace.Consumers.Infrastructure/NdmConsumersModule.cs
+++ b/src/Nethermind/Nethermind.DataMarketplace.Consumers.Infrastructure/NdmConsumersModule.cs
@@ -258,7 +258,7 @@ namespace Nethermind.DataMarketplace.Consumers.Infrastructure
                         daiPriceService,
                         _api.GasPriceService,
                         _api.MainBlockProcessor,
-                        depositRepository,
+                        depositManager,
                         consumerNotifier,
                         logManager,
                         useDepositTimer,

--- a/src/Nethermind/Nethermind.DataMarketplace.Consumers.Infrastructure/NdmConsumersModule.cs
+++ b/src/Nethermind/Nethermind.DataMarketplace.Consumers.Infrastructure/NdmConsumersModule.cs
@@ -258,7 +258,7 @@ namespace Nethermind.DataMarketplace.Consumers.Infrastructure
                         daiPriceService,
                         _api.GasPriceService,
                         _api.MainBlockProcessor,
-                        depositManager,
+                        depositRepository,
                         consumerNotifier,
                         logManager,
                         useDepositTimer,

--- a/src/Nethermind/Nethermind.DataMarketplace.Consumers.Infrastructure/Persistence/InMemory/Repositories/DepositDetailsInMemoryRepository.cs
+++ b/src/Nethermind/Nethermind.DataMarketplace.Consumers.Infrastructure/Persistence/InMemory/Repositories/DepositDetailsInMemoryRepository.cs
@@ -75,15 +75,16 @@ namespace Nethermind.DataMarketplace.Consumers.Infrastructure.Persistence.InMemo
 
             if (query.EligibleToRefund)
             {
-                foreach (var deposit in deposits)
+                foreach (var deposit in filteredDeposits)
                 {
                     uint consumedUnits = await _depositUnitsCalculator.GetConsumedAsync(deposit);
                     deposit.SetConsumedUnits(consumedUnits);
                 }
                 
-                filteredDeposits = filteredDeposits.Where(d => !d.RefundClaimed && (d.ConsumedUnits < d.Deposit.Units) &&
+                filteredDeposits = filteredDeposits.Where(d => !d.RefundClaimed &&
+                                                               (d.ConsumedUnits < d.Deposit.Units) &&
                                                                (!(d.EarlyRefundTicket is null) ||
-                                                                query.CurrentBlockTimestamp >= d.Deposit.ExpiryTime));
+                                                               query.CurrentBlockTimestamp >= d.Deposit.ExpiryTime));
             }
 
             return filteredDeposits.OrderByDescending(d => d.Timestamp).ToArray().Paginate(query);

--- a/src/Nethermind/Nethermind.DataMarketplace.Consumers.Infrastructure/Persistence/Rocks/Repositories/DepositDetailsRocksRepository.cs
+++ b/src/Nethermind/Nethermind.DataMarketplace.Consumers.Infrastructure/Persistence/Rocks/Repositories/DepositDetailsRocksRepository.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Nethermind.Core.Crypto;
+using Nethermind.DataMarketplace.Consumers.Deposits;
 using Nethermind.DataMarketplace.Consumers.Deposits.Domain;
 using Nethermind.DataMarketplace.Consumers.Deposits.Queries;
 using Nethermind.DataMarketplace.Consumers.Deposits.Repositories;
@@ -33,6 +34,7 @@ namespace Nethermind.DataMarketplace.Consumers.Infrastructure.Persistence.Rocks.
     {
         private readonly IDb _database;
         private readonly IRlpDecoder<DepositDetails> _rlpDecoder;
+        private readonly IDepositUnitsCalculator _depositUnitsCalculator;
 
         public DepositDetailsRocksRepository(IDb database, IRlpDecoder<DepositDetails> rlpDecoder)
         {
@@ -53,7 +55,7 @@ namespace Nethermind.DataMarketplace.Consumers.Infrastructure.Persistence.Rocks.
             return Decode(bytes);
         }
 
-        public Task<PagedResult<DepositDetails>> BrowseAsync(GetDeposits query)
+        public async Task<PagedResult<DepositDetails>> BrowseAsync(GetDeposits query)
         {
             if (query is null)
             {
@@ -63,7 +65,7 @@ namespace Nethermind.DataMarketplace.Consumers.Infrastructure.Persistence.Rocks.
             var depositsBytes = _database.GetAllValues().ToArray();
             if (depositsBytes.Length == 0)
             {
-                return Task.FromResult(PagedResult<DepositDetails>.Empty);
+                return PagedResult<DepositDetails>.Empty;
             }
 
             DepositDetails[] deposits = new DepositDetails[depositsBytes.Length];
@@ -94,12 +96,19 @@ namespace Nethermind.DataMarketplace.Consumers.Infrastructure.Persistence.Rocks.
 
             if (query.EligibleToRefund)
             {
-                filteredDeposits = filteredDeposits.Where(d => !d.RefundClaimed &&
+
+                foreach (var deposit in deposits)
+                {
+                    uint consumedUnits = await _depositUnitsCalculator.GetConsumedAsync(deposit);
+                    deposit.SetConsumedUnits(consumedUnits);
+                }
+
+                filteredDeposits = filteredDeposits.Where(d => !d.RefundClaimed && (d.ConsumedUnits < d.Deposit.Units) &&
                                                                (!(d.EarlyRefundTicket is null) ||
                                                                 query.CurrentBlockTimestamp >= d.Deposit.ExpiryTime));
             }
 
-            return Task.FromResult(filteredDeposits.OrderByDescending(d => d.Timestamp).ToArray().Paginate(query));
+            return filteredDeposits.OrderByDescending(d => d.Timestamp).ToArray().Paginate(query);
         }
 
         public Task AddAsync(DepositDetails deposit) => AddOrUpdateAsync(deposit);

--- a/src/Nethermind/Nethermind.DataMarketplace.Consumers.Infrastructure/Persistence/Rocks/Repositories/DepositDetailsRocksRepository.cs
+++ b/src/Nethermind/Nethermind.DataMarketplace.Consumers.Infrastructure/Persistence/Rocks/Repositories/DepositDetailsRocksRepository.cs
@@ -95,8 +95,7 @@ namespace Nethermind.DataMarketplace.Consumers.Infrastructure.Persistence.Rocks.
             if (query.EligibleToRefund)
             {
                 filteredDeposits = filteredDeposits.Where(d => !d.RefundClaimed &&
-                                                               (!(d.EarlyRefundTicket is null) &&
-                                                               (d.ConsumedUnits < d.Deposit.Units) ||
+                                                               (!(d.EarlyRefundTicket is null) ||
                                                                 query.CurrentBlockTimestamp >= d.Deposit.ExpiryTime));
             }
 

--- a/src/Nethermind/Nethermind.DataMarketplace.Consumers.Infrastructure/Persistence/Rocks/Repositories/DepositDetailsRocksRepository.cs
+++ b/src/Nethermind/Nethermind.DataMarketplace.Consumers.Infrastructure/Persistence/Rocks/Repositories/DepositDetailsRocksRepository.cs
@@ -95,7 +95,8 @@ namespace Nethermind.DataMarketplace.Consumers.Infrastructure.Persistence.Rocks.
             if (query.EligibleToRefund)
             {
                 filteredDeposits = filteredDeposits.Where(d => !d.RefundClaimed &&
-                                                               (!(d.EarlyRefundTicket is null) ||
+                                                               (!(d.EarlyRefundTicket is null) &&
+                                                               (d.ConsumedUnits < d.Deposit.Units) ||
                                                                 query.CurrentBlockTimestamp >= d.Deposit.ExpiryTime));
             }
 

--- a/src/Nethermind/Nethermind.DataMarketplace.Consumers.Infrastructure/Persistence/Rocks/Repositories/DepositDetailsRocksRepository.cs
+++ b/src/Nethermind/Nethermind.DataMarketplace.Consumers.Infrastructure/Persistence/Rocks/Repositories/DepositDetailsRocksRepository.cs
@@ -36,10 +36,11 @@ namespace Nethermind.DataMarketplace.Consumers.Infrastructure.Persistence.Rocks.
         private readonly IRlpDecoder<DepositDetails> _rlpDecoder;
         private readonly IDepositUnitsCalculator _depositUnitsCalculator;
 
-        public DepositDetailsRocksRepository(IDb database, IRlpDecoder<DepositDetails> rlpDecoder)
+        public DepositDetailsRocksRepository(IDb database, IRlpDecoder<DepositDetails> rlpDecoder, IDepositUnitsCalculator depositUnitsCalculator)
         {
             _database = database;
             _rlpDecoder = rlpDecoder;
+            _depositUnitsCalculator = depositUnitsCalculator;
         }
 
         public async Task<DepositDetails?> GetAsync(Keccak id)

--- a/src/Nethermind/Nethermind.DataMarketplace.Consumers.Test/Infrastructure/Persistence/DepositDetailsRocksRepositoryTests.cs
+++ b/src/Nethermind/Nethermind.DataMarketplace.Consumers.Test/Infrastructure/Persistence/DepositDetailsRocksRepositoryTests.cs
@@ -255,7 +255,7 @@ namespace Nethermind.DataMarketplace.Consumers.Test.Infrastructure.Persistence
             IDb db = new MemDb();
             IDepositUnitsCalculator depositUnitsCalculator = Substitute.For<IDepositUnitsCalculator>();
             DepositDetailsRocksRepository repository = new DepositDetailsRocksRepository(db, new DepositDetailsDecoder(), depositUnitsCalculator);
-            Assert.Throws<ArgumentNullException>(() => repository.BrowseAsync(null));
+            Assert.ThrowsAsync<ArgumentNullException>(() => repository.BrowseAsync(null));
         }
     }
 }

--- a/src/Nethermind/Nethermind.DataMarketplace.Consumers.Test/Infrastructure/Persistence/DepositDetailsRocksRepositoryTests.cs
+++ b/src/Nethermind/Nethermind.DataMarketplace.Consumers.Test/Infrastructure/Persistence/DepositDetailsRocksRepositoryTests.cs
@@ -21,6 +21,7 @@ using FluentAssertions;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Test.Builders;
+using Nethermind.DataMarketplace.Consumers.Deposits;
 using Nethermind.DataMarketplace.Consumers.Deposits.Domain;
 using Nethermind.DataMarketplace.Consumers.Deposits.Queries;
 using Nethermind.DataMarketplace.Consumers.Infrastructure.Persistence.Rocks.Repositories;
@@ -28,6 +29,7 @@ using Nethermind.DataMarketplace.Consumers.Infrastructure.Rlp;
 using Nethermind.DataMarketplace.Core.Domain;
 using Nethermind.DataMarketplace.Infrastructure.Rlp;
 using Nethermind.Db;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Nethermind.DataMarketplace.Consumers.Test.Infrastructure.Persistence
@@ -119,7 +121,8 @@ namespace Nethermind.DataMarketplace.Consumers.Test.Infrastructure.Persistence
         public async Task Add_get(DepositDetails details)
         {
             IDb db = new MemDb();
-            DepositDetailsRocksRepository repository = new DepositDetailsRocksRepository(db, new DepositDetailsDecoder());
+            IDepositUnitsCalculator depositUnitsCalculator = Substitute.For<IDepositUnitsCalculator>();
+            DepositDetailsRocksRepository repository = new DepositDetailsRocksRepository(db, new DepositDetailsDecoder(), depositUnitsCalculator);
             await repository.AddAsync(details);
             DepositDetails retrieved = await repository.GetAsync(details.Id);
             retrieved.Should().BeEquivalentTo(details);
@@ -129,7 +132,8 @@ namespace Nethermind.DataMarketplace.Consumers.Test.Infrastructure.Persistence
         public async Task Get_null()
         {
             IDb db = new MemDb();
-            DepositDetailsRocksRepository repository = new DepositDetailsRocksRepository(db, new DepositDetailsDecoder());
+            IDepositUnitsCalculator depositUnitsCalculator = Substitute.For<IDepositUnitsCalculator>();
+            DepositDetailsRocksRepository repository = new DepositDetailsRocksRepository(db, new DepositDetailsDecoder(), depositUnitsCalculator);
             DepositDetails retrieved = await repository.GetAsync(Keccak.Zero);
             retrieved.Should().BeNull();
         }
@@ -138,7 +142,8 @@ namespace Nethermind.DataMarketplace.Consumers.Test.Infrastructure.Persistence
         public async Task Update_get(DepositDetails details)
         {
             IDb db = new MemDb();
-            DepositDetailsRocksRepository repository = new DepositDetailsRocksRepository(db, new DepositDetailsDecoder());
+            IDepositUnitsCalculator depositUnitsCalculator = Substitute.For<IDepositUnitsCalculator>();
+            DepositDetailsRocksRepository repository = new DepositDetailsRocksRepository(db, new DepositDetailsDecoder(), depositUnitsCalculator);
             await repository.UpdateAsync(details);
             DepositDetails retrieved = await repository.GetAsync(details.Id);
             retrieved.Should().BeEquivalentTo(details);
@@ -148,7 +153,8 @@ namespace Nethermind.DataMarketplace.Consumers.Test.Infrastructure.Persistence
         public async Task Add_update_get(DepositDetails details)
         {
             IDb db = new MemDb();
-            DepositDetailsRocksRepository repository = new DepositDetailsRocksRepository(db, new DepositDetailsDecoder());
+            IDepositUnitsCalculator depositUnitsCalculator = Substitute.For<IDepositUnitsCalculator>();
+            DepositDetailsRocksRepository repository = new DepositDetailsRocksRepository(db, new DepositDetailsDecoder(), depositUnitsCalculator);
             await repository.AddAsync(_cases[0]);
             await repository.UpdateAsync(details);
             DepositDetails retrieved = await repository.GetAsync(details.Id);
@@ -159,7 +165,8 @@ namespace Nethermind.DataMarketplace.Consumers.Test.Infrastructure.Persistence
         public async Task Browse_by_eligible_to_refund()
         {
             IDb db = new MemDb();
-            DepositDetailsRocksRepository repository = new DepositDetailsRocksRepository(db, new DepositDetailsDecoder());
+            IDepositUnitsCalculator depositUnitsCalculator = Substitute.For<IDepositUnitsCalculator>();
+            DepositDetailsRocksRepository repository = new DepositDetailsRocksRepository(db, new DepositDetailsDecoder(), depositUnitsCalculator);
             foreach (DepositDetails details in _cases)
             {
                 await repository.AddAsync(details);
@@ -173,7 +180,8 @@ namespace Nethermind.DataMarketplace.Consumers.Test.Infrastructure.Persistence
         public async Task Browse_pending_only()
         {
             IDb db = new MemDb();
-            DepositDetailsRocksRepository repository = new DepositDetailsRocksRepository(db, new DepositDetailsDecoder());
+            IDepositUnitsCalculator depositUnitsCalculator = Substitute.For<IDepositUnitsCalculator>();
+            DepositDetailsRocksRepository repository = new DepositDetailsRocksRepository(db, new DepositDetailsDecoder(), depositUnitsCalculator);
             foreach (DepositDetails details in _cases)
             {
                 await repository.AddAsync(details);
@@ -187,7 +195,8 @@ namespace Nethermind.DataMarketplace.Consumers.Test.Infrastructure.Persistence
         public async Task Browse_not_rejected_only()
         {
             IDb db = new MemDb();
-            DepositDetailsRocksRepository repository = new DepositDetailsRocksRepository(db, new DepositDetailsDecoder());
+            IDepositUnitsCalculator depositUnitsCalculator = Substitute.For<IDepositUnitsCalculator>();
+            DepositDetailsRocksRepository repository = new DepositDetailsRocksRepository(db, new DepositDetailsDecoder(), depositUnitsCalculator);
             foreach (DepositDetails details in _cases)
             {
                 await repository.AddAsync(details);
@@ -201,7 +210,8 @@ namespace Nethermind.DataMarketplace.Consumers.Test.Infrastructure.Persistence
         public async Task Browse_unconfirmed_only()
         {
             IDb db = new MemDb();
-            DepositDetailsRocksRepository repository = new DepositDetailsRocksRepository(db, new DepositDetailsDecoder());
+            IDepositUnitsCalculator depositUnitsCalculator = Substitute.For<IDepositUnitsCalculator>();
+            DepositDetailsRocksRepository repository = new DepositDetailsRocksRepository(db, new DepositDetailsDecoder(), depositUnitsCalculator);
             foreach (DepositDetails details in _cases)
             {
                 await repository.AddAsync(details);
@@ -215,13 +225,17 @@ namespace Nethermind.DataMarketplace.Consumers.Test.Infrastructure.Persistence
         public async Task Browse_empty()
         {
             IDb db = new MemDb();
-            DepositDetailsRocksRepository repository = new DepositDetailsRocksRepository(db, new DepositDetailsDecoder());
+            IDepositUnitsCalculator depositUnitsCalculator = Substitute.For<IDepositUnitsCalculator>();
+            DepositDetailsRocksRepository repository = new DepositDetailsRocksRepository(db, new DepositDetailsDecoder(), depositUnitsCalculator);
             foreach (DepositDetails details in _cases)
             {
                 await repository.AddAsync(details);
             }
 
-            PagedResult<DepositDetails> result = await repository.BrowseAsync(new GetDeposits {EligibleToRefund = true});
+            PagedResult<DepositDetails> result = await repository.BrowseAsync(new GetDeposits
+            {
+                EligibleToRefund = true
+            });
             result.Items.Should().HaveCount(0);
         }
 
@@ -229,7 +243,8 @@ namespace Nethermind.DataMarketplace.Consumers.Test.Infrastructure.Persistence
         public async Task Browse_empty_database()
         {
             IDb db = new MemDb();
-            DepositDetailsRocksRepository repository = new DepositDetailsRocksRepository(db, new DepositDetailsDecoder());
+            IDepositUnitsCalculator depositUnitsCalculator = Substitute.For<IDepositUnitsCalculator>();
+            DepositDetailsRocksRepository repository = new DepositDetailsRocksRepository(db, new DepositDetailsDecoder(), depositUnitsCalculator);
             PagedResult<DepositDetails> result = await repository.BrowseAsync(new GetDeposits());
             result.Items.Should().HaveCount(0);
         }
@@ -238,7 +253,8 @@ namespace Nethermind.DataMarketplace.Consumers.Test.Infrastructure.Persistence
         public void Null_query_throws()
         {
             IDb db = new MemDb();
-            DepositDetailsRocksRepository repository = new DepositDetailsRocksRepository(db, new DepositDetailsDecoder());
+            IDepositUnitsCalculator depositUnitsCalculator = Substitute.For<IDepositUnitsCalculator>();
+            DepositDetailsRocksRepository repository = new DepositDetailsRocksRepository(db, new DepositDetailsDecoder(), depositUnitsCalculator);
             Assert.Throws<ArgumentNullException>(() => repository.BrowseAsync(null));
         }
     }

--- a/src/Nethermind/Nethermind.DataMarketplace.Consumers.Test/Infrastructure/Persistence/Mongo/DepositDetailsMongoRepositoryTests.cs
+++ b/src/Nethermind/Nethermind.DataMarketplace.Consumers.Test/Infrastructure/Persistence/Mongo/DepositDetailsMongoRepositoryTests.cs
@@ -4,10 +4,12 @@ using FluentAssertions;
 using MongoDB.Driver;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Test.Builders;
+using Nethermind.DataMarketplace.Consumers.Deposits;
 using Nethermind.DataMarketplace.Consumers.Deposits.Domain;
 using Nethermind.DataMarketplace.Consumers.Deposits.Queries;
 using Nethermind.DataMarketplace.Consumers.Infrastructure.Persistence.Mongo.Repositories;
 using Nethermind.DataMarketplace.Core.Domain;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Nethermind.DataMarketplace.Consumers.Test.Infrastructure.Persistence.Mongo
@@ -25,7 +27,8 @@ namespace Nethermind.DataMarketplace.Consumers.Test.Infrastructure.Persistence.M
         public async Task Can_add_async()
         {
             IMongoDatabase database = MongoForTest.TempDb.GetDatabase();
-            var repo = new DepositDetailsMongoRepository(database);
+            IDepositUnitsCalculator depositUnitsCalculator = Substitute.For<IDepositUnitsCalculator>();
+            var repo = new DepositDetailsMongoRepository(database, depositUnitsCalculator);
             DepositDetails depositDetails = BuildDummyDepositDetails();
             await repo.AddAsync(depositDetails);
         }
@@ -34,7 +37,8 @@ namespace Nethermind.DataMarketplace.Consumers.Test.Infrastructure.Persistence.M
         public async Task Can_get_by_id()
         {
             IMongoDatabase database = MongoForTest.TempDb.GetDatabase();
-            var repo = new DepositDetailsMongoRepository(database);
+            IDepositUnitsCalculator depositUnitsCalculator = Substitute.For<IDepositUnitsCalculator>();
+            var repo = new DepositDetailsMongoRepository(database, depositUnitsCalculator);
             DepositDetails depositDetails = BuildDummyDepositDetails();
             await repo.AddAsync(depositDetails);
             DepositDetails result = await repo.GetAsync(depositDetails.Id);
@@ -71,7 +75,8 @@ namespace Nethermind.DataMarketplace.Consumers.Test.Infrastructure.Persistence.M
         public async Task Can_browse()
         {
             IMongoDatabase database = MongoForTest.TempDb.GetDatabase();
-            var repo = new DepositDetailsMongoRepository(database);
+            IDepositUnitsCalculator depositUnitsCalculator = Substitute.For<IDepositUnitsCalculator>();
+            var repo = new DepositDetailsMongoRepository(database, depositUnitsCalculator);
             DepositDetails depositDetails = BuildDummyDepositDetails();
             await repo.AddAsync(depositDetails);
             await repo.BrowseAsync(new GetDeposits());
@@ -81,7 +86,8 @@ namespace Nethermind.DataMarketplace.Consumers.Test.Infrastructure.Persistence.M
         public async Task Can_browse_with_query_and_pagination()
         {
             IMongoDatabase database = MongoForTest.TempDb.GetDatabase();
-            var repo = new DepositDetailsMongoRepository(database);
+            IDepositUnitsCalculator depositUnitsCalculator = Substitute.For<IDepositUnitsCalculator>();
+            var repo = new DepositDetailsMongoRepository(database, depositUnitsCalculator);
             DepositDetails depositDetails = BuildDummyDepositDetails();
             await repo.AddAsync(depositDetails);
             GetDeposits query = new GetDeposits();

--- a/src/Nethermind/Nethermind.DataMarketplace.Consumers.Test/Infrastructure/Persistence/ProviderRocksRepositoryTests.cs
+++ b/src/Nethermind/Nethermind.DataMarketplace.Consumers.Test/Infrastructure/Persistence/ProviderRocksRepositoryTests.cs
@@ -17,10 +17,12 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Nethermind.DataMarketplace.Consumers.Deposits;
 using Nethermind.DataMarketplace.Consumers.Deposits.Domain;
 using Nethermind.DataMarketplace.Consumers.Infrastructure.Persistence.Rocks.Repositories;
 using Nethermind.DataMarketplace.Consumers.Infrastructure.Rlp;
 using Nethermind.Db;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Nethermind.DataMarketplace.Consumers.Test.Infrastructure.Persistence
@@ -37,7 +39,8 @@ namespace Nethermind.DataMarketplace.Consumers.Test.Infrastructure.Persistence
         public async Task Get_providers(DepositDetails depositDetails)
         {
             IDb db = new MemDb();
-            DepositDetailsRocksRepository detailsRocksRepository = new DepositDetailsRocksRepository(db, new DepositDetailsDecoder());
+            IDepositUnitsCalculator depositUnitsCalculator = Substitute.For<IDepositUnitsCalculator>();
+            DepositDetailsRocksRepository detailsRocksRepository = new DepositDetailsRocksRepository(db, new DepositDetailsDecoder(), depositUnitsCalculator);
             await detailsRocksRepository.AddAsync(depositDetails);
             
             ProviderRocksRepository repository = new ProviderRocksRepository(db, new DepositDetailsDecoder());
@@ -50,7 +53,8 @@ namespace Nethermind.DataMarketplace.Consumers.Test.Infrastructure.Persistence
         public async Task Get_assets(DepositDetails depositDetails)
         {
             IDb db = new MemDb();
-            DepositDetailsRocksRepository detailsRocksRepository = new DepositDetailsRocksRepository(db, new DepositDetailsDecoder());
+            IDepositUnitsCalculator depositUnitsCalculator = Substitute.For<IDepositUnitsCalculator>();
+            DepositDetailsRocksRepository detailsRocksRepository = new DepositDetailsRocksRepository(db, new DepositDetailsDecoder(), depositUnitsCalculator);
             await detailsRocksRepository.AddAsync(depositDetails);
             
             ProviderRocksRepository repository = new ProviderRocksRepository(db, new DepositDetailsDecoder());
@@ -63,7 +67,8 @@ namespace Nethermind.DataMarketplace.Consumers.Test.Infrastructure.Persistence
         public async Task Get_providers_empty_db()
         {
             IDb db = new MemDb();
-            DepositDetailsRocksRepository detailsRocksRepository = new DepositDetailsRocksRepository(db, new DepositDetailsDecoder());
+            IDepositUnitsCalculator depositUnitsCalculator = Substitute.For<IDepositUnitsCalculator>();
+            DepositDetailsRocksRepository detailsRocksRepository = new DepositDetailsRocksRepository(db, new DepositDetailsDecoder(), depositUnitsCalculator);
             ProviderRocksRepository repository = new ProviderRocksRepository(db, new DepositDetailsDecoder());
 
             var retrieved = await repository.GetProvidersAsync();
@@ -74,7 +79,8 @@ namespace Nethermind.DataMarketplace.Consumers.Test.Infrastructure.Persistence
         public async Task Get_assets_empty_db()
         {
             IDb db = new MemDb();
-            DepositDetailsRocksRepository detailsRocksRepository = new DepositDetailsRocksRepository(db, new DepositDetailsDecoder());
+            IDepositUnitsCalculator depositUnitsCalculator = Substitute.For<IDepositUnitsCalculator>();
+            DepositDetailsRocksRepository detailsRocksRepository = new DepositDetailsRocksRepository(db, new DepositDetailsDecoder(), depositUnitsCalculator);
             ProviderRocksRepository repository = new ProviderRocksRepository(db, new DepositDetailsDecoder());
 
             var retrieved = await repository.GetDataAssetsAsync();

--- a/src/Nethermind/Nethermind.DataMarketplace.Consumers.Test/Services/Deposits/DepositManagerTests.cs
+++ b/src/Nethermind/Nethermind.DataMarketplace.Consumers.Test/Services/Deposits/DepositManagerTests.cs
@@ -81,6 +81,7 @@ namespace Nethermind.DataMarketplace.Consumers.Test.Services.Deposits
             IProviderRepository providerRepository = new ProviderInMemoryRepository(depositsInMemoryDb);
             IConsumerNotifier notifier = new ConsumerNotifier(Substitute.For<INdmNotifier>());
             DataAssetService dataAssetService = new DataAssetService(providerRepository, notifier, LimboLogs.Instance);
+            IDepositUnitsCalculator depositUnitsCalculator = Substitute.For<IDepositUnitsCalculator>();
             INdmPeer peer = Substitute.For<INdmPeer>();
             peer.NodeId.Returns(TestItem.PublicKeyB);
             peer.ProviderAddress.Returns(_providerAddress);
@@ -94,7 +95,7 @@ namespace Nethermind.DataMarketplace.Consumers.Test.Services.Deposits
             ProviderService providerService = new ProviderService(providerRepository, notifier, LimboLogs.Instance);
             providerService.Add(peer);
 
-            _depositManager = new DepositManager(depositService, unitsCalculator, dataAssetService, _kycVerifier, providerService, new AbiEncoder(), new CryptoRandom(), _wallet, Substitute.For<IGasPriceService>(), new DepositDetailsInMemoryRepository(depositsInMemoryDb), Timestamper.Default, LimboLogs.Instance, 6, false);
+            _depositManager = new DepositManager(depositService, unitsCalculator, dataAssetService, _kycVerifier, providerService, new AbiEncoder(), new CryptoRandom(), _wallet, Substitute.For<IGasPriceService>(), new DepositDetailsInMemoryRepository(depositsInMemoryDb, depositUnitsCalculator), Timestamper.Default, LimboLogs.Instance, 6, false);
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.DataMarketplace.Consumers.Test/Services/Deposits/DepositProviderTests.cs
+++ b/src/Nethermind/Nethermind.DataMarketplace.Consumers.Test/Services/Deposits/DepositProviderTests.cs
@@ -19,12 +19,14 @@ using FluentAssertions;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
+using Nethermind.DataMarketplace.Consumers.Deposits;
 using Nethermind.DataMarketplace.Consumers.Deposits.Domain;
 using Nethermind.DataMarketplace.Consumers.Deposits.Services;
 using Nethermind.DataMarketplace.Consumers.Infrastructure.Persistence.InMemory.Databases;
 using Nethermind.DataMarketplace.Consumers.Infrastructure.Persistence.InMemory.Repositories;
 using Nethermind.DataMarketplace.Core.Domain;
 using Nethermind.Logging;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Nethermind.DataMarketplace.Consumers.Test.Services.Deposits
@@ -42,12 +44,12 @@ namespace Nethermind.DataMarketplace.Consumers.Test.Services.Deposits
         public void Setup()
         {
             DataAssetProvider provider = new DataAssetProvider(_providerAddress, "provider");
+            IDepositUnitsCalculator depositUnitsCalculator = Substitute.For<IDepositUnitsCalculator>();
             _asset = new DataAsset(Keccak.Compute("1"), "name", "desc", 1, DataAssetUnitType.Unit, 1000, 10000, new DataAssetRules(new DataAssetRule(1)), provider, state: DataAssetState.Published);
-
             _deposit = new Deposit(Keccak.Zero, 1, 2, 3);
             _details = new DepositDetails(_deposit, _asset, Address.Zero, new byte[0], 1, new TransactionInfo[0]);
 
-            DepositDetailsInMemoryRepository repository = new DepositDetailsInMemoryRepository(new DepositsInMemoryDb());
+            DepositDetailsInMemoryRepository repository = new DepositDetailsInMemoryRepository(new DepositsInMemoryDb(), depositUnitsCalculator);
             repository.AddAsync(_details);
 
             ConsumerSessionInMemoryRepository sessionInMemoryRepository = new ConsumerSessionInMemoryRepository();

--- a/src/Nethermind/Nethermind.DataMarketplace.Consumers.Test/Services/Deposits/DepositReportServiceTests.cs
+++ b/src/Nethermind/Nethermind.DataMarketplace.Consumers.Test/Services/Deposits/DepositReportServiceTests.cs
@@ -26,6 +26,7 @@ using Nethermind.DataMarketplace.Consumers.Infrastructure.Persistence.InMemory.D
 using Nethermind.DataMarketplace.Consumers.Infrastructure.Persistence.InMemory.Repositories;
 using Nethermind.DataMarketplace.Core.Domain;
 using Nethermind.Wallet;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Nethermind.DataMarketplace.Consumers.Test.Services.Deposits
@@ -51,7 +52,8 @@ namespace Nethermind.DataMarketplace.Consumers.Test.Services.Deposits
         [Test]
         public void Can_get_a_single_item_report()
         {
-            DepositDetailsInMemoryRepository repository = new DepositDetailsInMemoryRepository(new DepositsInMemoryDb());
+            IDepositUnitsCalculator depositUnitsCalculator = Substitute.For<IDepositUnitsCalculator>();
+            DepositDetailsInMemoryRepository repository = new DepositDetailsInMemoryRepository(new DepositsInMemoryDb(), depositUnitsCalculator);
             repository.AddAsync(_details);
             ConsumerSessionInMemoryRepository sessionInMemoryRepository = new ConsumerSessionInMemoryRepository();
             DepositReportService reportService = new DepositReportService(repository, new DepositUnitsCalculator(sessionInMemoryRepository, Timestamper.Default), new ReceiptInMemoryRepository(), new ConsumerSessionInMemoryRepository(), Timestamper.Default);

--- a/src/Nethermind/Nethermind.DataMarketplace.Consumers.Test/Services/Shared/ConsumerServiceBackgroundProcessorTests.cs
+++ b/src/Nethermind/Nethermind.DataMarketplace.Consumers.Test/Services/Shared/ConsumerServiceBackgroundProcessorTests.cs
@@ -15,6 +15,8 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
 using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Processing;
 using Nethermind.Core;
@@ -22,6 +24,7 @@ using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
 using Nethermind.DataMarketplace.Consumers.Deposits;
 using Nethermind.DataMarketplace.Consumers.Deposits.Domain;
+using Nethermind.DataMarketplace.Consumers.Deposits.Queries;
 using Nethermind.DataMarketplace.Consumers.Deposits.Repositories;
 using Nethermind.DataMarketplace.Consumers.Infrastructure.Persistence.InMemory.Databases;
 using Nethermind.DataMarketplace.Consumers.Infrastructure.Persistence.InMemory.Repositories;
@@ -30,6 +33,7 @@ using Nethermind.DataMarketplace.Consumers.Notifiers.Services;
 using Nethermind.DataMarketplace.Consumers.Refunds;
 using Nethermind.DataMarketplace.Consumers.Shared;
 using Nethermind.DataMarketplace.Consumers.Shared.Services;
+using Nethermind.DataMarketplace.Consumers.Shared.Services.Models;
 using Nethermind.DataMarketplace.Core.Domain;
 using Nethermind.DataMarketplace.Core.Services;
 using Nethermind.Logging;
@@ -47,6 +51,10 @@ namespace Nethermind.DataMarketplace.Consumers.Test.Services.Shared
         private Deposit _deposit;
         private Address _providerAddress = TestItem.AddressA;
         private DepositDetails _details;
+        private IDepositManager _depositManager;
+        IConsumerNotifier _consumerNotifier;
+        IAccountService _accountService;
+        IRefundClaimant _refundClaimant;
 
         [SetUp]
         public void Setup()
@@ -56,17 +64,18 @@ namespace Nethermind.DataMarketplace.Consumers.Test.Services.Shared
             _deposit = new Deposit(Keccak.Zero, 1, 2, 3);
             _details = new DepositDetails(_deposit, _asset, Address.Zero, new byte[0], 1, new TransactionInfo[0]);
 
-            IAccountService accountService = Substitute.For<IAccountService>();
-            IRefundClaimant refundClaimant = Substitute.For<IRefundClaimant>();
+            _accountService = Substitute.For<IAccountService>();
+            _refundClaimant = Substitute.For<IRefundClaimant>();
             IDepositConfirmationService depositConfirmationService = Substitute.For<IDepositConfirmationService>();
             IEthPriceService ethPriceService = Substitute.For<IEthPriceService>();
             IDaiPriceService daiPriceService = Substitute.For<IDaiPriceService>();
             IGasPriceService gasPriceService = Substitute.For<IGasPriceService>();
+            _depositManager = Substitute.For<IDepositManager>();
             _blockProcessor = Substitute.For<IBlockProcessor>();
-            IConsumerNotifier notifier = new ConsumerNotifier(Substitute.For<INdmNotifier>());
+            _consumerNotifier = Substitute.For<IConsumerNotifier>();
             IDepositDetailsRepository repository = new DepositDetailsInMemoryRepository(new DepositsInMemoryDb());
             repository.AddAsync(_details);
-            _processor = new ConsumerServicesBackgroundProcessor(accountService, refundClaimant, depositConfirmationService, ethPriceService, daiPriceService, gasPriceService, _blockProcessor, repository, notifier, LimboLogs.Instance);
+            _processor = new ConsumerServicesBackgroundProcessor(_accountService, _refundClaimant, depositConfirmationService, ethPriceService, daiPriceService, gasPriceService, _blockProcessor, _depositManager, _consumerNotifier, LimboLogs.Instance);
         }
 
         [TearDown]
@@ -86,6 +95,67 @@ namespace Nethermind.DataMarketplace.Consumers.Test.Services.Shared
         {
             _processor.Init();
             _blockProcessor.BlockProcessed += Raise.EventWith(new BlockProcessedEventArgs(Build.A.Block.TestObject, Array.Empty<TxReceipt>()));
+        }
+
+        [Test]
+        // If deposits are eligable to refund (deposit is expired / consumer hasn't consumed all units yet etc.)
+        // background proccessor will try to refund them every single block proccesed. 
+        public void Will_try_to_refund_deposit_while_expired_and_not_consumed()
+        {
+            _processor.Init();
+            var blockProccesed = Build.A.Block.TestObject;
+            _accountService.GetAddress().Returns(TestItem.AddressB);
+
+            var dataAsset = new DataAsset(Keccak.OfAnEmptyString, "test", "test", 1,
+                DataAssetUnitType.Unit, 0, 10, new DataAssetRules(new DataAssetRule(1)),
+                new DataAssetProvider(Address.Zero, "test"));
+
+            _refundClaimant.TryClaimEarlyRefundAsync(Arg.Any<DepositDetails>(), TestItem.AddressB)
+                .Returns(new RefundClaimStatus(Keccak.Zero, true));
+
+            var consumedDeposit = new Deposit(Keccak.Zero, 10, 1, 1);
+            var consumedDepositDetails = new DepositDetails(consumedDeposit, dataAsset, null, null, 1, null);
+            consumedDepositDetails.SetConsumedUnits(9);
+
+            var refundsResult = PagedResult<DepositDetails>.Create(
+                new List<DepositDetails> { consumedDepositDetails }, 
+                1, 
+                1, 
+                1, 
+                1);
+
+            _depositManager.BrowseAsync(Arg.Any<GetDeposits>()).Returns(Task.FromResult(refundsResult));
+
+            _blockProcessor.BlockProcessed += Raise.EventWith(new BlockProcessedEventArgs(blockProccesed, Array.Empty<TxReceipt>()));
+
+            _consumerNotifier.Received().SendClaimedEarlyRefundAsync(Arg.Any<Keccak>(), Arg.Any<string>(), Arg.Any<Keccak>());
+        }
+
+        [Test]
+        // If all units are consumed, background processor should not try to refund this deposit.
+        // Consumed units are not set in databases - they are calculated by DepositUnitsCalculator,
+        // so we need to remember to always calculate consumed units after reading them from DB
+        public void Will_not_try_to_refund_consumed_deposit()
+        {
+            _processor.Init();
+            var blockProccesed = Build.A.Block.TestObject;
+
+            var consumedDeposit = new Deposit(Keccak.Zero, 10, 1, 1);
+            var consumedDepositDetails = new DepositDetails(consumedDeposit, null, null, null, 1, null);
+            consumedDepositDetails.SetConsumedUnits(10);
+
+            var refundsResult = PagedResult<DepositDetails>.Create(
+                new List<DepositDetails> { consumedDepositDetails }, 
+                1, 
+                1, 
+                1, 
+                1);
+
+            _depositManager.BrowseAsync(Arg.Any<GetDeposits>()).Returns(Task.FromResult(refundsResult));
+
+            _blockProcessor.BlockProcessed += Raise.EventWith(new BlockProcessedEventArgs(blockProccesed, Array.Empty<TxReceipt>()));
+
+            _consumerNotifier.DidNotReceive().SendClaimedRefundAsync(Arg.Any<Keccak>(), Arg.Any<string>(), Arg.Any<Keccak>());
         }
     }
 }

--- a/src/Nethermind/Nethermind.DataMarketplace.Consumers.Test/Services/Shared/ConsumerServiceBackgroundProcessorTests.cs
+++ b/src/Nethermind/Nethermind.DataMarketplace.Consumers.Test/Services/Shared/ConsumerServiceBackgroundProcessorTests.cs
@@ -68,10 +68,11 @@ namespace Nethermind.DataMarketplace.Consumers.Test.Services.Shared
             IEthPriceService ethPriceService = Substitute.For<IEthPriceService>();
             IDaiPriceService daiPriceService = Substitute.For<IDaiPriceService>();
             IGasPriceService gasPriceService = Substitute.For<IGasPriceService>();
+            IDepositUnitsCalculator depositUnitsCalculator = Substitute.For<IDepositUnitsCalculator>();
             _depositRepository = Substitute.For<IDepositDetailsRepository>();
             _blockProcessor = Substitute.For<IBlockProcessor>();
             _consumerNotifier = Substitute.For<IConsumerNotifier>();
-            IDepositDetailsRepository repository = new DepositDetailsInMemoryRepository(new DepositsInMemoryDb());
+            IDepositDetailsRepository repository = new DepositDetailsInMemoryRepository(new DepositsInMemoryDb(), depositUnitsCalculator);
             repository.AddAsync(_details);
             _processor = new ConsumerServicesBackgroundProcessor(_accountService, _refundClaimant, depositConfirmationService, ethPriceService, daiPriceService, gasPriceService, _blockProcessor, _depositRepository, _consumerNotifier, LimboLogs.Instance);
         }

--- a/src/Nethermind/Nethermind.DataMarketplace.Consumers/Deposits/Domain/DepositDetails.cs
+++ b/src/Nethermind/Nethermind.DataMarketplace.Consumers/Deposits/Domain/DepositDetails.cs
@@ -58,6 +58,8 @@ namespace Nethermind.DataMarketplace.Consumers.Deposits.Domain
         public TransactionInfo? ClaimedRefundTransaction { get; private set; }
         public bool RefundCancelled { get; private set; }
         public bool RefundClaimed { get; private set; }
+
+        // Consumed units are set by DepositUnitsCalculator - not readable from DB
         public uint ConsumedUnits { get; private set; }
         public string? Kyc { get; private set; }
         public uint Confirmations { get; private set; }


### PR DESCRIPTION
There was a bug with `ConsumerServiceBackgroundProcessor` - it was trying to refund deposit even if all of the units was consumed. 

It was caused by reading deposits from `DepositRepository` and not from `DepositManager`.
While reading from repo - there was always 0 consumed units since we need to calculate consumed units with `DepositUnitsCalculator` used in reading with manager. 