### PR TITLE
adding parity_netPeers

### DIFF
--- a/src/Nethermind/Nethermind.Cli/Modules/ParityCliModule.cs
+++ b/src/Nethermind/Nethermind.Cli/Modules/ParityCliModule.cs
@@ -44,7 +44,7 @@ namespace Nethermind.Cli.Modules
         [CliFunction("parity", "setEngineSignerSecret", Description = "Sets an authority account for signing consensus messages.")]
         public bool SetEngineSignerSecret(string privateKey) => NodeManager.Post<bool>("parity_setEngineSignerSecret", privateKey).Result;
         
-        [CliFunction("parity", "netPeers", Description = "Returns connected peers. Peers with non-empty protocols have completed handshake.")]
+        [CliProperty("parity", "netPeers", Description = "Returns connected peers. Peers with non-empty protocols have completed handshake.")]
         public JsValue NetPeers() => NodeManager.PostJint("parity_netPeers").Result;
     }
 }

--- a/src/Nethermind/Nethermind.Cli/Modules/ParityCliModule.cs
+++ b/src/Nethermind/Nethermind.Cli/Modules/ParityCliModule.cs
@@ -43,5 +43,8 @@ namespace Nethermind.Cli.Modules
         
         [CliFunction("parity", "setEngineSignerSecret", Description = "Sets an authority account for signing consensus messages.")]
         public bool SetEngineSignerSecret(string privateKey) => NodeManager.Post<bool>("parity_setEngineSignerSecret", privateKey).Result;
+        
+        [CliFunction("parity", "netPeers", Description = "Returns connected peers. Peers with non-empty protocols have completed handshake.")]
+        public JsValue NetPeers() => NodeManager.PostJint("parity_netPeers").Result;
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/ParityModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/ParityModuleTests.cs
@@ -14,6 +14,7 @@
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
+using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -34,7 +35,9 @@ using Nethermind.State;
 using Nethermind.State.Repositories;
 using Nethermind.Db.Blooms;
 using Nethermind.KeyStore;
+using Nethermind.Network;
 using Nethermind.Specs.Forks;
+using Nethermind.Stats.Model;
 using Nethermind.Trie.Pruning;
 using Nethermind.TxPool;
 using Nethermind.TxPool.Storages;
@@ -58,6 +61,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             var specProvider = MainnetSpecProvider.Instance;
             var ethereumEcdsa = new EthereumEcdsa(specProvider.ChainId, logger);
             var txStorage = new InMemoryTxStorage();
+            IPeerManager peerManager = Substitute.For<IPeerManager>();
 
             var txPool = new TxPool.TxPool(txStorage, ethereumEcdsa, specProvider, new TxPoolConfig(),
                 new StateProvider(new TrieStore(new StateDb(), LimboLogs.Instance), new StateDb(), LimboLogs.Instance),  LimboLogs.Instance);
@@ -72,7 +76,7 @@ namespace Nethermind.JsonRpc.Test.Modules
 
             _signerStore = new Signer(specProvider.ChainId, TestItem.PrivateKeyB, logger);
             _parityModule = new ParityModule(ethereumEcdsa, txPool, blockTree, receiptStorage, new Enode(TestItem.PublicKeyA, IPAddress.Loopback, 8545), 
-                _signerStore, new MemKeyStore(new[] {TestItem.PrivateKeyA}),  logger);
+                _signerStore, new MemKeyStore(new[] {TestItem.PrivateKeyA}),  logger, peerManager);
             
             var blockNumber = 2;
             var pendingTransaction = Build.A.Transaction.Signed(ethereumEcdsa, TestItem.PrivateKeyD, false)

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Parity/EthProtocolInfo.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Parity/EthProtocolInfo.cs
@@ -15,8 +15,8 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 // 
 
-using Nethermind.Core.Crypto;
 using Nethermind.Int256;
+using Nethermind.Network;
 using Newtonsoft.Json;
 
 namespace Nethermind.JsonRpc.Modules.Parity
@@ -30,6 +30,13 @@ namespace Nethermind.JsonRpc.Modules.Parity
         public UInt256 Difficulty { get; set; }
         
         [JsonProperty("head", Order = 2)]
-        public Keccak HeadHash { get; set; }
+        public string HeadHash { get; set; }
+
+        public EthProtocolInfo(Peer peer)
+        {
+            Version = peer.InSession?.Node.EthProtocolVersion ?? peer.OutSession?.Node.EthProtocolVersion ?? 0;
+            Difficulty = peer.InSession?.Node.Difficulty ?? peer.OutSession?.Node.Difficulty ?? 0;
+            HeadHash = peer.InSession?.Node.HeadHash?.ToString() ?? peer.OutSession?.Node.HeadHash?.ToString();
+        }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Parity/EthProtocolInfo.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Parity/EthProtocolInfo.cs
@@ -15,8 +15,8 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 // 
 
+using Nethermind.Core.Crypto;
 using Nethermind.Int256;
-using Nethermind.Network;
 using Newtonsoft.Json;
 
 namespace Nethermind.JsonRpc.Modules.Parity
@@ -30,13 +30,6 @@ namespace Nethermind.JsonRpc.Modules.Parity
         public UInt256 Difficulty { get; set; }
         
         [JsonProperty("head", Order = 2)]
-        public string HeadHash { get; set; }
-
-        public EthProtocolInfo(Peer peer)
-        {
-            Version = peer.InSession?.Node.EthProtocolVersion ?? peer.OutSession?.Node.EthProtocolVersion ?? 0;
-            Difficulty = peer.InSession?.Node.Difficulty ?? peer.OutSession?.Node.Difficulty ?? 0;
-            HeadHash = peer.InSession?.Node.HeadHash?.ToString() ?? peer.OutSession?.Node.HeadHash?.ToString();
-        }
+        public Keccak HeadHash { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Parity/EthProtocolInfo.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Parity/EthProtocolInfo.cs
@@ -15,31 +15,21 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 // 
 
-using Nethermind.Network;
-using Nethermind.Network.P2P;
+using Nethermind.Core.Crypto;
+using Nethermind.Int256;
 using Newtonsoft.Json;
 
 namespace Nethermind.JsonRpc.Modules.Parity
 {
-    public class PeerNetworkInfo
+    public class EthProtocolInfo
     {
-        [JsonProperty("localAddress", Order = 0)]
-        public string LocalAddress { get; set; }
+        [JsonProperty("version", Order = 0)]
+        public byte Version { get; set; }
         
-        [JsonProperty("remoteAddress", Order = 1)]
-        public string RemoteAddress { get; set; }
-
-        public PeerNetworkInfo(Peer peer)
-        {
-            LocalAddress = peer.Node.Host;
-            RemoteAddress = peer.InSession != null ? GetRemoteAddress(peer.InSession)
-                : peer.OutSession != null ? GetRemoteAddress(peer.OutSession)
-                : null;
-        }
+        [JsonProperty("difficulty", Order = 1)]
+        public UInt256 Difficulty { get; set; }
         
-        private string GetRemoteAddress(ISession session)
-        {
-            return session.State != SessionState.New ? session.RemoteHost : "Handshake";
-        }
+        [JsonProperty("head", Order = 2)]
+        public Keccak HeadHash { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Parity/IParityModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Parity/IParityModule.cs
@@ -40,5 +40,8 @@ namespace Nethermind.JsonRpc.Modules.Parity
 
         [JsonRpcMethod(Description = "", IsImplemented = true)]
         ResultWrapper<bool> parity_clearEngineSigner();
+        
+        [JsonRpcMethod(Description = "Returns connected peers. Peers with non-empty protocols have completed handshake.", IsImplemented = true)]
+        ResultWrapper<ParityNetPeers> parity_netPeers();
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Parity/ParityModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Parity/ParityModule.cs
@@ -111,7 +111,13 @@ namespace Nethermind.JsonRpc.Modules.Parity
         }
 
         public ResultWrapper<string> parity_enode() => ResultWrapper<string>.Success(_enode.ToString());
-        
-        public ResultWrapper<ParityNetPeers> parity_netPeers() => ResultWrapper<ParityNetPeers>.Success(new ParityNetPeers(_peerManager));
+
+        public ResultWrapper<ParityNetPeers> parity_netPeers()
+        {
+            IReadOnlyCollection<Peer> activePeers = _peerManager.ActivePeers;
+            IReadOnlyCollection<Peer> connectedPeers = _peerManager.ConnectedPeers;
+            int maxActivePeers = _peerManager.MaxActivePeers;
+            return ResultWrapper<ParityNetPeers>.Success(new ParityNetPeers(activePeers, connectedPeers, maxActivePeers));
+        }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Parity/ParityModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Parity/ParityModule.cs
@@ -42,6 +42,7 @@ namespace Nethermind.JsonRpc.Modules.Parity
         private readonly ISignerStore _signerStore;
         private readonly IKeyStore _keyStore;
         private readonly IPeerManager _peerManager;
+        private ParityNetPeers _parityNetPeers;
 
         public ParityModule(
             IEcdsa ecdsa,
@@ -114,10 +115,12 @@ namespace Nethermind.JsonRpc.Modules.Parity
 
         public ResultWrapper<ParityNetPeers> parity_netPeers()
         {
-            IReadOnlyCollection<Peer> activePeers = _peerManager.ActivePeers;
-            IReadOnlyCollection<Peer> connectedPeers = _peerManager.ConnectedPeers;
-            int maxActivePeers = _peerManager.MaxActivePeers;
-            return ResultWrapper<ParityNetPeers>.Success(new ParityNetPeers(activePeers, connectedPeers, maxActivePeers));
+            _parityNetPeers = new ParityNetPeers();
+            _parityNetPeers.Active = _peerManager.ActivePeers.Count;
+            _parityNetPeers.Connected = _peerManager.ConnectedPeers.Count;
+            _parityNetPeers.Max = _peerManager.MaxActivePeers;
+            _parityNetPeers.Peers = _peerManager.ActivePeers.Select(p => new PeerInfo(p)).ToArray();
+            return ResultWrapper<ParityNetPeers>.Success(_parityNetPeers);
         }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Parity/ParityModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Parity/ParityModule.cs
@@ -28,6 +28,7 @@ using Nethermind.KeyStore;
 using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
 using Nethermind.TxPool;
+using Nethermind.Network;
 
 namespace Nethermind.JsonRpc.Modules.Parity
 {
@@ -40,6 +41,7 @@ namespace Nethermind.JsonRpc.Modules.Parity
         private readonly IEnode _enode;
         private readonly ISignerStore _signerStore;
         private readonly IKeyStore _keyStore;
+        private readonly IPeerManager _peerManager;
 
         public ParityModule(
             IEcdsa ecdsa,
@@ -49,7 +51,8 @@ namespace Nethermind.JsonRpc.Modules.Parity
             IEnode enode,
             ISignerStore signerStore,
             IKeyStore keyStore,
-            ILogManager logManager)
+            ILogManager logManager,
+            IPeerManager peerManager)
         {
             _ecdsa = ecdsa ?? throw new ArgumentNullException(nameof(ecdsa));
             _txPool = txPool ?? throw new ArgumentNullException(nameof(txPool));
@@ -58,6 +61,7 @@ namespace Nethermind.JsonRpc.Modules.Parity
             _enode = enode ?? throw new ArgumentNullException(nameof(enode));
             _signerStore = signerStore ?? throw new ArgumentNullException(nameof(signerStore));
             _keyStore = keyStore ?? throw new ArgumentNullException(nameof(keyStore));
+            _peerManager = peerManager ?? throw new ArgumentNullException(nameof(peerManager));
         }
 
         public ResultWrapper<ParityTransaction[]> parity_pendingTransactions()
@@ -107,5 +111,7 @@ namespace Nethermind.JsonRpc.Modules.Parity
         }
 
         public ResultWrapper<string> parity_enode() => ResultWrapper<string>.Success(_enode.ToString());
+        
+        public ResultWrapper<ParityNetPeers> parity_netPeers() => ResultWrapper<ParityNetPeers>.Success(new ParityNetPeers(_peerManager));
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Parity/ParityNetPeers.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Parity/ParityNetPeers.cs
@@ -15,25 +15,26 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 // 
 
-using System.Collections.Generic;
-using System.Linq;
-using Nethermind.Network;
+using Newtonsoft.Json;
 
 namespace Nethermind.JsonRpc.Modules.Parity
 {
     public class ParityNetPeers
     {
+        [JsonProperty("active", Order = 0)]
         public int Active { get; set; }
+        
+        [JsonProperty("connected", Order = 1)]
         public int Connected { get; set; }
+        
+        [JsonProperty("max", Order = 2)]
         public int Max { get; set; }
+        
+        [JsonProperty("peers", Order = 3)]
         public PeerInfo[] Peers { get; set; }
         
-        public ParityNetPeers(IReadOnlyCollection<Peer> activePeers, IReadOnlyCollection<Peer> connectedPeers, int maxActivePeers)
+        public ParityNetPeers()
         {
-            Active = activePeers.Count;
-            Connected = connectedPeers.Count;
-            Max = maxActivePeers;
-            Peers = activePeers.Select(p => new PeerInfo(p)).ToArray();
         }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Parity/ParityNetPeers.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Parity/ParityNetPeers.cs
@@ -1,4 +1,4 @@
-﻿//  Copyright (c) 2021 Demerzel Solutions Limited
+//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
 // 
 //  The Nethermind library is free software: you can redistribute it and/or modify
@@ -13,22 +13,26 @@
 // 
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
 
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using Nethermind.Config;
+using System.Linq;
+using Nethermind.Network;
 
-namespace Nethermind.Network
+namespace Nethermind.JsonRpc.Modules.Parity
 {
-    public interface IPeerManager
+    public class ParityNetPeers
     {
-        void Init();
-        void Start();
-        Task StopAsync();
-        IReadOnlyCollection<Peer> ActivePeers { get; }
-        IReadOnlyCollection<Peer> ConnectedPeers { get; }
-        int MaxActivePeers { get; }
-        void AddPeer(NetworkNode node);
-        bool RemovePeer(NetworkNode node);
+        public int Active { get; set; }
+        public int Connected { get; set; }
+        public int Max { get; set; }
+        public PeerInfo[] Peers { get; set; }
+        
+        public ParityNetPeers(IPeerManager peerManager)
+        {
+            Active = peerManager.ActivePeers.Count;
+            Connected = peerManager.ConnectedPeers.Count;
+            Max = peerManager.MaxActivePeers;
+            Peers = peerManager.ActivePeers.Select(p => new PeerInfo(p)).ToArray();
+        }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Parity/ParityNetPeers.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Parity/ParityNetPeers.cs
@@ -15,6 +15,7 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 // 
 
+using System.Collections.Generic;
 using System.Linq;
 using Nethermind.Network;
 
@@ -27,12 +28,12 @@ namespace Nethermind.JsonRpc.Modules.Parity
         public int Max { get; set; }
         public PeerInfo[] Peers { get; set; }
         
-        public ParityNetPeers(IPeerManager peerManager)
+        public ParityNetPeers(IReadOnlyCollection<Peer> activePeers, IReadOnlyCollection<Peer> connectedPeers, int maxActivePeers)
         {
-            Active = peerManager.ActivePeers.Count;
-            Connected = peerManager.ConnectedPeers.Count;
-            Max = peerManager.MaxActivePeers;
-            Peers = peerManager.ActivePeers.Select(p => new PeerInfo(p)).ToArray();
+            Active = activePeers.Count;
+            Connected = connectedPeers.Count;
+            Max = maxActivePeers;
+            Peers = activePeers.Select(p => new PeerInfo(p)).ToArray();
         }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Parity/PeerInfo.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Parity/PeerInfo.cs
@@ -15,29 +15,32 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 // 
 
-using System;
 using System.Collections.Generic;
 using Nethermind.Network;
 using Nethermind.Stats.Model;
+using Newtonsoft.Json;
 
 namespace Nethermind.JsonRpc.Modules.Parity
 {
     public class PeerInfo
     {
+        [JsonProperty("id", Order = 0)]
         public string Id { get; set; }
+        
+        [JsonProperty("name", Order = 1)]
         public string Name { get; set; }
+        
+        [JsonProperty("caps", Order = 2)]
         public List<Capability> Caps { get; set; }
+        
+        [JsonProperty("network", Order = 3)]
         public PeerNetworkInfo Network { get; set; }
-        public string Protocols { get; set; }
+        
+        [JsonProperty("protocols", Order = 4)]
+        public Dictionary<string, EthProtocolInfo> Protocols { get; set; }
         
         public PeerInfo(Peer peer)
         {
-            if (peer.Node == null)
-            {
-                throw new ArgumentException(
-                    $"{nameof(PeerInfo)} cannot be created for a {nameof(Peer)} with an unknown {peer.Node}");
-            }
-            
             Id = peer.InSession?.RemoteNodeId.ToString() ?? peer.OutSession?.RemoteNodeId.ToString();
             Name = peer.Node.ClientId;
             Network = new PeerNetworkInfo(peer);

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Parity/PeerInfo.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Parity/PeerInfo.cs
@@ -44,6 +44,11 @@ namespace Nethermind.JsonRpc.Modules.Parity
             Id = peer.InSession?.RemoteNodeId.ToString() ?? peer.OutSession?.RemoteNodeId.ToString();
             Name = peer.Node.ClientId;
             Network = new PeerNetworkInfo(peer);
+
+            Caps = peer.InSession?.Node.AgreedCapabilities ?? peer.OutSession?.Node.AgreedCapabilities;
+          
+            Protocols = new Dictionary<string, EthProtocolInfo>();
+            Protocols.Add("eth", new EthProtocolInfo(peer));
         }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Parity/PeerInfo.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Parity/PeerInfo.cs
@@ -1,0 +1,46 @@
+//  Copyright (c) 2021 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
+
+using System;
+using System.Collections.Generic;
+using Nethermind.Network;
+using Nethermind.Stats.Model;
+
+namespace Nethermind.JsonRpc.Modules.Parity
+{
+    public class PeerInfo
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public List<Capability> Caps { get; set; }
+        public PeerNetworkInfo Network { get; set; }
+        public string Protocols { get; set; }
+        
+        public PeerInfo(Peer peer)
+        {
+            if (peer.Node == null)
+            {
+                throw new ArgumentException(
+                    $"{nameof(PeerInfo)} cannot be created for a {nameof(Peer)} with an unknown {peer.Node}");
+            }
+            
+            Id = peer.InSession?.RemoteNodeId.ToString() ?? peer.OutSession?.RemoteNodeId.ToString();
+            Name = peer.Node.ClientId;
+            Network = new PeerNetworkInfo(peer);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Parity/PeerNetworkInfo.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Parity/PeerNetworkInfo.cs
@@ -28,11 +28,14 @@ namespace Nethermind.JsonRpc.Modules.Parity
         public PeerNetworkInfo(Peer peer)
         {
             LocalAddress = peer.Node.Host;
-            RemoteAddress = peer.InSession != null ? peer.InSession.State != SessionState.New
-                    ? peer.InSession.RemoteHost : "Handshake"
-                : peer.OutSession != null ? peer.OutSession.State != SessionState.New
-                    ? peer.OutSession.RemoteHost : "Handshake"
+            RemoteAddress = peer.InSession != null ? GetRemoteAdress(peer.InSession)
+                : peer.OutSession != null ? GetRemoteAdress(peer.OutSession)
                 : null;
+        }
+        
+        private string GetRemoteAdress(ISession session)
+        {
+            return session.State != SessionState.New ? session.RemoteHost : "Handshake";
         }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Parity/PeerNetworkInfo.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Parity/PeerNetworkInfo.cs
@@ -15,8 +15,6 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 // 
 
-using Nethermind.Network;
-using Nethermind.Network.P2P;
 using Newtonsoft.Json;
 
 namespace Nethermind.JsonRpc.Modules.Parity
@@ -28,18 +26,5 @@ namespace Nethermind.JsonRpc.Modules.Parity
         
         [JsonProperty("remoteAddress", Order = 1)]
         public string RemoteAddress { get; set; }
-
-        public PeerNetworkInfo(Peer peer)
-        {
-            LocalAddress = peer.Node.Host;
-            RemoteAddress = peer.InSession != null ? GetRemoteAddress(peer.InSession)
-                : peer.OutSession != null ? GetRemoteAddress(peer.OutSession)
-                : null;
-        }
-        
-        private string GetRemoteAddress(ISession session)
-        {
-            return session.State != SessionState.New ? session.RemoteHost : "Handshake";
-        }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Parity/PeerNetworkInfo.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Parity/PeerNetworkInfo.cs
@@ -1,4 +1,4 @@
-﻿//  Copyright (c) 2021 Demerzel Solutions Limited
+//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
 // 
 //  The Nethermind library is free software: you can redistribute it and/or modify
@@ -13,22 +13,26 @@
 // 
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
 
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using Nethermind.Config;
+using Nethermind.Network;
+using Nethermind.Network.P2P;
 
-namespace Nethermind.Network
+namespace Nethermind.JsonRpc.Modules.Parity
 {
-    public interface IPeerManager
+    public class PeerNetworkInfo
     {
-        void Init();
-        void Start();
-        Task StopAsync();
-        IReadOnlyCollection<Peer> ActivePeers { get; }
-        IReadOnlyCollection<Peer> ConnectedPeers { get; }
-        int MaxActivePeers { get; }
-        void AddPeer(NetworkNode node);
-        bool RemovePeer(NetworkNode node);
+        public string LocalAddress { get; set; }
+        public string RemoteAddress { get; set; }
+
+        public PeerNetworkInfo(Peer peer)
+        {
+            LocalAddress = peer.Node.Host;
+            RemoteAddress = peer.InSession != null ? peer.InSession.State != SessionState.New
+                    ? peer.InSession.RemoteHost : "Handshake"
+                : peer.OutSession != null ? peer.OutSession.State != SessionState.New
+                    ? peer.OutSession.RemoteHost : "Handshake"
+                : null;
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Network.Stats/Model/Node.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/Model/Node.cs
@@ -15,9 +15,11 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
 using System;
+using System.Collections.Generic;
 using System.Net;
 using Nethermind.Core.Crypto;
 using Nethermind.Crypto;
+using Nethermind.Int256;
 
 namespace Nethermind.Stats.Model
 {
@@ -84,6 +86,10 @@ namespace Nethermind.Stats.Model
         public NodeClientType ClientType { get; private set; } = NodeClientType.Unknown;
         
         public string EthDetails { get; set; }
+        public byte EthProtocolVersion { get; set; }
+        public UInt256 Difficulty { get; set; }
+        public Keccak HeadHash { get; set; }
+        public List<Capability> AgreedCapabilities { get; set; }
         public long CurrentReputation { get; set; }
 
         public Node(PublicKey id, IPEndPoint address)

--- a/src/Nethermind/Nethermind.Network.Stats/Model/Node.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/Model/Node.cs
@@ -15,11 +15,9 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
 using System;
-using System.Collections.Generic;
 using System.Net;
 using Nethermind.Core.Crypto;
 using Nethermind.Crypto;
-using Nethermind.Int256;
 
 namespace Nethermind.Stats.Model
 {
@@ -86,10 +84,6 @@ namespace Nethermind.Stats.Model
         public NodeClientType ClientType { get; private set; } = NodeClientType.Unknown;
         
         public string EthDetails { get; set; }
-        public byte EthProtocolVersion { get; set; }
-        public UInt256 Difficulty { get; set; }
-        public Keccak HeadHash { get; set; }
-        public List<Capability> AgreedCapabilities { get; set; }
         public long CurrentReputation { get; set; }
 
         public Node(PublicKey id, IPEndPoint address)

--- a/src/Nethermind/Nethermind.Network/P2P/ISession.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ISession.cs
@@ -49,7 +49,9 @@ namespace Nethermind.Network.P2P
         IPingSender PingSender { get; set; }
         
         void AddProtocolHandler(IProtocolHandler handler);
-        
+
+        bool TryGetProtocolHandler(string protocolCode, out IProtocolHandler handler);
+
         void Init(byte p2PVersion, IChannelHandlerContext context, IPacketSender packetSender);
 
         /// <summary>

--- a/src/Nethermind/Nethermind.Network/P2P/Session.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Session.cs
@@ -255,6 +255,11 @@ namespace Nethermind.Network.P2P
             }
         }
 
+        public bool TryGetProtocolHandler(string protocolCode, out IProtocolHandler handler)
+        {
+            return _protocols.TryGetValue(protocolCode, out handler);
+        }
+
         public void Init(byte p2PVersion, IChannelHandlerContext context, IPacketSender packetSender)
         {
             if (_logger.IsTrace) _logger.Trace($"{nameof(Init)} called on {this}");

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -96,8 +96,9 @@ namespace Nethermind.Network
 
         public IReadOnlyCollection<Peer> ActivePeers => _activePeers.Values.ToList().AsReadOnly();
         public IReadOnlyCollection<Peer> CandidatePeers => _peerPool.CandidatePeers.ToList();
+        public IReadOnlyCollection<Peer> ConnectedPeers => _activePeers.Values.Where(IsConnected).ToList().AsReadOnly();
         private int AvailableActivePeersCount => MaxActivePeers - _activePeers.Count;
-        private int MaxActivePeers => _networkConfig.ActivePeersMaxCount + _peerPool.StaticPeerCount;
+        public int MaxActivePeers => _networkConfig.ActivePeersMaxCount + _peerPool.StaticPeerCount;
 
         public void Init()
         {

--- a/src/Nethermind/Nethermind.Network/ProtocolsManager.cs
+++ b/src/Nethermind/Nethermind.Network/ProtocolsManager.cs
@@ -267,8 +267,6 @@ namespace Nethermind.Network
 
         private void InitP2PProtocol(ISession session, P2PProtocolHandler handler)
         {
-            session.Node.EthProtocolVersion = handler.ProtocolVersion;
-            session.Node.AgreedCapabilities = handler.AgreedCapabilities;
             handler.ProtocolInitialized += (sender, args) =>
             {
                 P2PProtocolInitializedEventArgs typedArgs = (P2PProtocolInitializedEventArgs) args;
@@ -304,9 +302,6 @@ namespace Nethermind.Network
         private void InitSyncPeerProtocol(ISession session, SyncPeerProtocolHandlerBase handler)
         {
             session.Node.EthDetails = handler.Name;
-            session.Node.EthProtocolVersion = handler.ProtocolVersion;
-            session.Node.Difficulty = handler.TotalDifficulty;
-            session.Node.HeadHash = handler.HeadHash;
             handler.ProtocolInitialized += (sender, args) =>
             {
                 if (!RunBasicChecks(session, handler.ProtocolCode, handler.ProtocolVersion)) return;

--- a/src/Nethermind/Nethermind.Network/ProtocolsManager.cs
+++ b/src/Nethermind/Nethermind.Network/ProtocolsManager.cs
@@ -267,6 +267,8 @@ namespace Nethermind.Network
 
         private void InitP2PProtocol(ISession session, P2PProtocolHandler handler)
         {
+            session.Node.EthProtocolVersion = handler.ProtocolVersion;
+            session.Node.AgreedCapabilities = handler.AgreedCapabilities;
             handler.ProtocolInitialized += (sender, args) =>
             {
                 P2PProtocolInitializedEventArgs typedArgs = (P2PProtocolInitializedEventArgs) args;
@@ -302,6 +304,9 @@ namespace Nethermind.Network
         private void InitSyncPeerProtocol(ISession session, SyncPeerProtocolHandlerBase handler)
         {
             session.Node.EthDetails = handler.Name;
+            session.Node.EthProtocolVersion = handler.ProtocolVersion;
+            session.Node.Difficulty = handler.TotalDifficulty;
+            session.Node.HeadHash = handler.HeadHash;
             handler.ProtocolInitialized += (sender, args) =>
             {
                 if (!RunBasicChecks(session, handler.ProtocolCode, handler.ProtocolVersion)) return;

--- a/src/Nethermind/Nethermind.Runner/Ethereum/Steps/RegisterRpcModules.cs
+++ b/src/Nethermind/Nethermind.Runner/Ethereum/Steps/RegisterRpcModules.cs
@@ -72,6 +72,7 @@ namespace Nethermind.Runner.Ethereum.Steps
             if (_api.SpecProvider == null) throw new StepDependencyException(nameof(_api.SpecProvider));
             if (_api.TxSender == null) throw new StepDependencyException(nameof(_api.TxSender));
             if (_api.StateReader == null) throw new StepDependencyException(nameof(_api.StateReader));
+            if (_api.PeerManager == null) throw new StepDependencyException(nameof(_api.PeerManager));
 
             if (jsonRpcConfig.Enabled)
             {
@@ -181,7 +182,8 @@ namespace Nethermind.Runner.Ethereum.Steps
                 _api.Enode,
                 _api.EngineSignerStore,
                 _api.KeyStore,
-                _api.LogManager);
+                _api.LogManager,
+                _api.PeerManager);
             _api.RpcModuleProvider.Register(new SingletonModulePool<IParityModule>(parityModule, true));
 
             Web3Module web3Module = new Web3Module(_api.LogManager);


### PR DESCRIPTION
# Implemented:
* JsonRpc response
* CLI response
* returning number of active peers
* returning number of connected peers
* returning max number of active peers
* returning PeerInfo[] object (array of all active peers)
	* returning peer id
	* returning peer name
	* returning list of capabilities
	* returning PeerNetworkInfo object
		* returning peer local address
		* returning peer remote address
	* returning EthProtocolInfo
		* returning protocol version
		* returning difficulty
		* returning head (headhash)
* test for standard case, Node=null, Session=null