### PR TITLE
Fix StateSyncFeed deadlock by locking _handleWatch & _stateDbLock alw…

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization/FastSync/StateSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/StateSyncFeed.cs
@@ -710,21 +710,24 @@ namespace Nethermind.Synchronization.FastSync
                     return EmptyBatch!;
                 }
 
-                lock (_stateDbLock)
+                lock (_handleWatch)
                 {
-                    // if finished downloading
-                    try
+                    lock (_stateDbLock)
                     {
-                        if (_stateDb.KeyExists(_rootNode))
+                        // if finished downloading
+                        try
                         {
-                            VerifyPostSyncCleanUp();
-                            FinishThisSyncRound();
+                            if (_stateDb.KeyExists(_rootNode))
+                            {
+                                VerifyPostSyncCleanUp();
+                                FinishThisSyncRound();
+                                return EmptyBatch!;
+                            }
+                        }
+                        catch (ObjectDisposedException)
+                        {
                             return EmptyBatch!;
                         }
-                    }
-                    catch (ObjectDisposedException)
-                    {
-                        return EmptyBatch!;
                     }
                 }
 


### PR DESCRIPTION
…ays in same order:

They were in different order:
https://github.com/NethermindEth/nethermind/blob/ce989c4a2238c086d8063b033a24410f8[…]Nethermind/Nethermind.Synchronization/FastSync/StateSyncFeed.cs
with:
https://github.com/NethermindEth/nethermind/blob/ce989c4a2238c086d8063b033a24410f8[…]Nethermind/Nethermind.Synchronization/FastSync/StateSyncFeed.cs
vs
https://github.com/NethermindEth/nethermind/blob/ce989c4a2238c086d8063b033a24410f8[…]Nethermind/Nethermind.Synchronization/FastSync/StateSyncFeed.cs
with:
https://github.com/NethermindEth/nethermind/blob/ce989c4a2238c086d8063b033a24410f8[…]Nethermind/Nethermind.Synchronization/FastSync/StateSyncFeed.cs