### PR TITLE
Paged memory mapped DB

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/RocksDbFactory.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/RocksDbFactory.cs
@@ -14,6 +14,7 @@
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
+using System.IO;
 using Nethermind.Db.Rocks.Config;
 using Nethermind.Logging;
 
@@ -37,6 +38,13 @@ namespace Nethermind.Db.Rocks
                 rocksDbSettings,
                 _dbConfig, 
                 _logManager);
+        }
+
+        public IDb CreateMemoryMappedDb(RocksDbSettings rocksDbSettings)
+        {
+            MemoryMappedKeyValueStore store = new(Path.Combine(_basePath, rocksDbSettings.DbName), pageSize: 4096);
+            store.Initialize();
+            return new MemoryMappedDb(rocksDbSettings.DbPath, store);
         }
 
         public IColumnsDb<T> CreateColumnsDb<T>(RocksDbSettings rocksDbSettings) where T : notnull

--- a/src/Nethermind/Nethermind.Db.Rocks/RocksDbFactory.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/RocksDbFactory.cs
@@ -33,18 +33,18 @@ namespace Nethermind.Db.Rocks
         }
 
         public IDb CreateDb(RocksDbSettings rocksDbSettings)
-        { 
-            return new SimpleRocksDb(_basePath, 
+        {
+            return new SimpleRocksDb(_basePath,
                 rocksDbSettings,
-                _dbConfig, 
+                _dbConfig,
                 _logManager);
         }
 
         public IDb CreateMemoryMappedDb(RocksDbSettings rocksDbSettings)
         {
-            MemoryMappedKeyValueStore store = new(Path.Combine(_basePath, rocksDbSettings.DbName), pageSize: 4096);
+            MemoryMappedKeyValueStore<Config3BytesPrefix4KbPage> store = new(Path.Combine(_basePath, rocksDbSettings.DbName));
             store.Initialize();
-            return new MemoryMappedDb(rocksDbSettings.DbPath, store);
+            return new MemoryMappedDb<Config3BytesPrefix4KbPage>(rocksDbSettings.DbPath, store);
         }
 
         public IColumnsDb<T> CreateColumnsDb<T>(RocksDbSettings rocksDbSettings) where T : notnull
@@ -53,6 +53,12 @@ namespace Nethermind.Db.Rocks
                 rocksDbSettings,
                 _dbConfig,
                 _logManager);
+        }
+
+        struct Config3BytesPrefix4KbPage : IMemoryMappedStoreConfig
+        {
+            public int PrefixByteCount => 3;
+            public int PageSize => 4 * 1024;
         }
     }
 }

--- a/src/Nethermind/Nethermind.Db.Rpc/RpcDbFactory.cs
+++ b/src/Nethermind/Nethermind.Db.Rpc/RpcDbFactory.cs
@@ -42,6 +42,11 @@ namespace Nethermind.Db.Rpc
             _logManager = logManager;
         }
 
+        public IDb CreateMemoryMappedDb(RocksDbSettings rocksDbSettings)
+        {
+            throw new System.NotImplementedException();
+        }
+
         public IColumnsDb<T> CreateColumnsDb<T>(RocksDbSettings rocksDbSettings)
         {
             var rocksDb = _wrappedRocksDbFactory.CreateColumnsDb<T>(rocksDbSettings);

--- a/src/Nethermind/Nethermind.Db.Test/MemoryMappedKeyValueStoreTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/MemoryMappedKeyValueStoreTests.cs
@@ -99,6 +99,11 @@ namespace Nethermind.Db.Test
                 Assert.True(expected.AsSpan().SequenceEqual(actual), "Value is different from the expected one for index {0}", j);
                 j++;
             }
+
+            byte[] nonExistent = new byte[MemoryMappedKeyValueStore<TestConfig>.KeyLength];
+            random.NextBytes(nonExistent);
+            
+            Assert.IsFalse(store.TryGet(nonExistent, out _ ));
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Db.Test/MemoryMappedKeyValueStoreTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/MemoryMappedKeyValueStoreTests.cs
@@ -1,0 +1,133 @@
+//  Copyright (c) 2018 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+using NUnit.Framework;
+
+namespace Nethermind.Db.Test
+{
+    [Explicit("Disk IO ")]
+    public class MemoryMappedKeyValueStoreTests
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            // lazy IO makes these tests hard on shared file names. Let's sleep it through.
+            Thread.Sleep(TimeSpan.FromSeconds(5));
+            
+            string dir = TestContext.CurrentContext.WorkDirectory;
+            foreach (string file in Directory.GetFiles(dir, MemoryMappedKeyValueStore.Prefix + "*"))
+            {
+                File.Delete(file);
+            }
+
+            string jumps = Path.Combine(dir, MemoryMappedKeyValueStore.JumpsFileName);
+            if (File.Exists(jumps))
+            {
+                File.Delete(jumps);
+            }
+        }
+
+        [TestCase(1000_000, 10000)]
+        public void Test(int size, int batchSize)
+        {
+            const int minLength = 50;
+            const int maxLength = 500;
+
+            Console.WriteLine("Working directory {0}", TestContext.CurrentContext.WorkDirectory);
+
+            using MemoryMappedKeyValueStore store = new MemoryMappedKeyValueStore(TestContext.CurrentContext.WorkDirectory);
+            store.Initialize();
+
+            Random random = new Random(size);
+
+            List<(byte[] key, byte[] value)> pairs = new List<(byte[] key, byte[] value)>();
+
+            MemoryMappedKeyValueStore.IWriteBatch batch = store.StartBatch();
+            int batchCount = 0;
+            
+            for (int i = 0; i < size; i++)
+            {
+                int length = random.Next(minLength, maxLength);
+
+                byte[] value = new byte[length];
+                byte[] key = new byte[MemoryMappedKeyValueStore.KeyLength];
+
+                value.AsSpan().Fill((byte)i);
+
+                Span<int> k = MemoryMarshal.Cast<byte, int>(key);
+                k[0] = random.Next();
+                k[^1] = i;
+
+                pairs.Add((key, value));
+
+                batch.Put(key, value);
+                if (batchCount++ == batchSize)
+                {
+                    batch.Commit();
+                    batch.Dispose();
+                    batch = store.StartBatch();
+                    batchCount = 0;
+                }
+            }
+
+            batch.Commit();
+            batch.Dispose();
+
+            SpinWait.SpinUntil(() => store.HasNoEntriesToFlush);
+
+            int j = 0;
+            foreach ((byte[] key, byte[] expected) in pairs)
+            {
+                Assert.True(store.TryGet(key, out MemoryMappedKeyValueStore.Slice actual), "Key was not found");
+                Assert.AreEqual(expected.Length, actual.Span.Length, "Value lengths are different for value index {0}",
+                    j);
+                Assert.True(expected.AsSpan().SequenceEqual(actual.Span),
+                    "Value is different from the expected one for index {0}", j);
+                j++;
+            }
+        }
+
+        [Test]
+        public void Deletes()
+        {
+            using MemoryMappedKeyValueStore store = new MemoryMappedKeyValueStore(TestContext.CurrentContext.WorkDirectory, 16 * 1024);
+            store.Initialize();
+
+            byte[] key = new byte[MemoryMappedKeyValueStore.KeyLength];
+            key.AsSpan().Fill(13);
+
+            byte[] value = new byte[] { 47 };
+
+            store.Set(key, value);
+
+            SpinWait.SpinUntil(() => store.HasNoEntriesToFlush);
+
+            store.Delete(key);
+
+            Assert.False(store.TryGet(key, out _));
+
+            SpinWait.SpinUntil(() => store.HasNoEntriesToFlush);
+
+            Assert.False(store.TryGet(key, out _));
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Db.Test/MemoryMappedKeyValueStoreTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/MemoryMappedKeyValueStoreTests.cs
@@ -128,7 +128,7 @@ namespace Nethermind.Db.Test
         struct TestConfig : IMemoryMappedStoreConfig
         {
             public int PrefixByteCount => 2;
-            public int PageSize => 16 * 1024;
+            public int PageSize => 32 * 1024;
         }
     }
 }

--- a/src/Nethermind/Nethermind.Db/IRocksDbFactory.cs
+++ b/src/Nethermind/Nethermind.Db/IRocksDbFactory.cs
@@ -20,6 +20,8 @@ namespace Nethermind.Db
     {
         IDb CreateDb(RocksDbSettings rocksDbSettings);
         
+        IDb CreateMemoryMappedDb(RocksDbSettings rocksDbSettings);
+        
         IColumnsDb<T> CreateColumnsDb<T>(RocksDbSettings rocksDbSettings);
     }
 }

--- a/src/Nethermind/Nethermind.Db/MemoryMappedDb.cs
+++ b/src/Nethermind/Nethermind.Db/MemoryMappedDb.cs
@@ -77,7 +77,7 @@ namespace Nethermind.Db
 
         public void Remove(byte[] key) => _store.Delete(key);
 
-        private byte[] Get(byte[] key) => _store.TryGet(key, out MemoryMappedKeyValueStore.Slice value) ? value.ToArray() : null;
+        private byte[] Get(byte[] key) => _store.TryGet(key, out Span<byte> value) ? value.ToArray() : null;
 
         public bool KeyExists(byte[] key) => _store.TryGet(key, out _);
 
@@ -135,7 +135,7 @@ namespace Nethermind.Db
 
         public void Clear() { }
 
-        public Span<byte> GetSpan(byte[] key) => _store.TryGet(key, out MemoryMappedKeyValueStore.Slice slice) ? slice.Span : Span<byte>.Empty;
+        public Span<byte> GetSpan(byte[] key) => _store.TryGet(key, out Span<byte> span) ? span: Span<byte>.Empty;
 
         public void DangerousReleaseMemory(in Span<byte> span) { }
     }

--- a/src/Nethermind/Nethermind.Db/MemoryMappedDb.cs
+++ b/src/Nethermind/Nethermind.Db/MemoryMappedDb.cs
@@ -21,12 +21,13 @@ using Nethermind.Core;
 
 namespace Nethermind.Db
 {
-    public class MemoryMappedDb : IDbWithSpan
+    public class MemoryMappedDb<TConfig> : IDbWithSpan
+        where TConfig : struct, IMemoryMappedStoreConfig
     {
-        private readonly MemoryMappedKeyValueStore _store;
+        private readonly MemoryMappedKeyValueStore<TConfig> _store;
         private bool _isDisposed;
 
-        public MemoryMappedDb(string name, MemoryMappedKeyValueStore store)
+        public MemoryMappedDb(string name, MemoryMappedKeyValueStore<TConfig> store)
         {
             _store = store;
             Name = name;
@@ -87,11 +88,11 @@ namespace Nethermind.Db
 
         internal class MemoryMappedBatch : IBatch
         {
-            private readonly MemoryMappedDb _db;
+            private readonly MemoryMappedDb<TConfig> _db;
 
-            internal readonly MemoryMappedKeyValueStore.IWriteBatch _batch;
+            internal readonly MemoryMappedKeyValueStore<TConfig>.IWriteBatch _batch;
 
-            public MemoryMappedBatch(MemoryMappedDb db)
+            public MemoryMappedBatch(MemoryMappedDb<TConfig> db)
             {
                 _db = db;
 

--- a/src/Nethermind/Nethermind.Db/MemoryMappedDb.cs
+++ b/src/Nethermind/Nethermind.Db/MemoryMappedDb.cs
@@ -1,0 +1,142 @@
+//  Copyright (c) 2018 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
+
+using System;
+using System.Collections.Generic;
+using Nethermind.Core;
+
+namespace Nethermind.Db
+{
+    public class MemoryMappedDb : IDbWithSpan
+    {
+        private readonly MemoryMappedKeyValueStore _store;
+        private bool _isDisposed;
+
+        public MemoryMappedDb(string name, MemoryMappedKeyValueStore store)
+        {
+            _store = store;
+            Name = name;
+        }
+
+        public byte[] this[byte[] key]
+        {
+            get
+            {
+                if (_isDisposed)
+                {
+                    throw new ObjectDisposedException($"Attempted to read form a disposed database {Name}");
+                }
+
+                return Get(key);
+            }
+            set
+            {
+                if (_isDisposed)
+                {
+                    throw new ObjectDisposedException($"Attempted to write to a disposed database {Name}");
+                }
+
+                if (value == null)
+                {
+                    Remove(key);
+                }
+                else
+                {
+                    _store.Set(key, value);
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            _isDisposed = true;
+            _store.Dispose();
+        }
+
+        public string Name { get; }
+
+        public KeyValuePair<byte[], byte[]>[] this[byte[][] keys] => throw new NotImplementedException();
+
+        public IEnumerable<KeyValuePair<byte[], byte[]>> GetAll(bool ordered = false) => throw new NotImplementedException();
+
+        public IEnumerable<byte[]> GetAllValues(bool ordered = false) => throw new NotImplementedException("");
+
+        public void Remove(byte[] key) => _store.Delete(key);
+
+        private byte[] Get(byte[] key) => _store.TryGet(key, out MemoryMappedKeyValueStore.Slice value) ? value.ToArray() : null;
+
+        public bool KeyExists(byte[] key) => _store.TryGet(key, out _);
+
+        public IDb Innermost => this;
+
+        public IBatch StartBatch() => new MemoryMappedBatch(this);
+
+        internal class MemoryMappedBatch : IBatch
+        {
+            private readonly MemoryMappedDb _db;
+
+            internal readonly MemoryMappedKeyValueStore.IWriteBatch _batch;
+
+            public MemoryMappedBatch(MemoryMappedDb db)
+            {
+                _db = db;
+
+                if (_db._isDisposed)
+                {
+                    throw new ObjectDisposedException($"Attempted to create a batch on a disposed database {_db.Name}");
+                }
+
+                _batch = db._store.StartBatch();
+            }
+
+            public void Dispose()
+            {
+                if (_db._isDisposed)
+                {
+                    throw new ObjectDisposedException($"Attempted to commit a batch on a disposed database {_db.Name}");
+                }
+
+                _batch.Commit();
+                _batch.Dispose();
+            }
+
+            public byte[]? this[byte[] key]
+            {
+                get => _db[key];
+                set
+                {
+                    if (value == null)
+                    {
+                        _batch.Delete(key);
+                    }
+                    else
+                    {
+                        _batch.Put(key, value);
+                    }
+                }
+            }
+        }
+
+        public void Flush() { }
+
+        public void Clear() { }
+
+        public Span<byte> GetSpan(byte[] key) => _store.TryGet(key, out MemoryMappedKeyValueStore.Slice slice) ? slice.Span : Span<byte>.Empty;
+
+        public void DangerousReleaseMemory(in Span<byte> span) { }
+    }
+}

--- a/src/Nethermind/Nethermind.Db/MemoryMappedKeyValueStore.cs
+++ b/src/Nethermind/Nethermind.Db/MemoryMappedKeyValueStore.cs
@@ -7,7 +7,6 @@ using System.IO.MemoryMappedFiles;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
-using System.Threading.Channels;
 
 namespace Nethermind.Db
 {
@@ -49,7 +48,7 @@ namespace Nethermind.Db
         private volatile bool _runFlusher;
 
         /// <summary>
-        /// Configures the key value store.
+        /// Configures the key value store to store data in a specific directory with a specific page size. The store will generate files big as 16MB * pageSize, which for 4k gives 64 GBs of a single file.
         /// </summary>
         /// <param name="directoryPath">The path where the database files will be located. Both jump table and the log files are included in there.</param>
         /// <param name="pageSize">The size of the page that stores values prefixed with the same </param>

--- a/src/Nethermind/Nethermind.Db/MemoryMappedKeyValueStore.cs
+++ b/src/Nethermind/Nethermind.Db/MemoryMappedKeyValueStore.cs
@@ -1,0 +1,580 @@
+using System;
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.MemoryMappedFiles;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace Nethermind.Db
+{
+    /// <summary>
+    /// A memory mapped map. It keeps the data in a concurrent dictionary, trying to flush them as soon as possible.
+    /// </summary>
+    /// <remarks>
+    /// A single log entry consists of:
+    /// - 8 bytes header (ulong)
+    ///  - 2 high bytes for the length of value
+    ///  - 6 low bytes for the jumps address
+    /// - 32 bytes of Keccak
+    /// - N bytes of the value (aligned to 8 byte boundary)
+    /// </remarks>
+    public class MemoryMappedKeyValueStore : IDisposable
+    {
+        public const string Prefix = "log_";
+        public const string JumpsFileName = "jumps";
+        public const int KeyLength = KeccakLength;
+        const int MaxValueLength = NullValueLength - 1;
+        const int NullValueLength = short.MaxValue;
+        const int MaxNumberOfFiles = 2048;
+        const byte EndMarker = 0; // a marker that when written as the first byte of the length in a file marks it as 0
+        const int AddressSize = sizeof(ulong);
+
+        private readonly int _prefixBits;
+        private readonly int _jumpsCount;
+        private readonly int _jumpsFileSize;
+        
+        const int ValueLengthShift = 6 * BitsInByte;
+        const int BitsInByte = 8;
+
+        const int ByteAlignment = 8;
+        const int HeaderLength = 8;
+        const int KeccakLength = 32;
+
+        readonly string _dir;
+        readonly int _logFileSize;
+        readonly int _maxBatchFlushSize;
+        readonly List<MemoryMappedFile> _files = new List<MemoryMappedFile>();
+        readonly Map[] _maps = new Map[MaxNumberOfFiles];
+
+        private readonly ConcurrentQueue<WriteBatch> _batches = new ConcurrentQueue<WriteBatch>();
+        private readonly Dictionary<int, long> _jumpCache = new Dictionary<int, long>(1024);
+
+        private long _flushFrom;
+        private Map _jumps;
+        private Thread _flusher;
+        private volatile bool _runFlusher;
+
+        /// <summary>
+        /// Configures the key value store.
+        /// </summary>
+        /// <param name="directoryPath">The path where the database files will be located. Both jump table and the log files are included in there.</param>
+        /// <param name="keyPrefixBits">This is an important settings as it heavily affects the size of the jump file and the lookup speed. The bigger it is, the bigger the jump file, the more buckets for colliding keys and the smaller linked lists for each bucket.</param>
+        /// <param name="logFileSize">The size of a single chunk of the log. Once the chunk is fully written, it won't be overwritten again.</param>
+        /// <param name="maxBatchFlushSize">The maximum number of bytes written down in one batch under one lock in <see cref="Commit"/>.</param>
+        public MemoryMappedKeyValueStore(string directoryPath, 
+            int keyPrefixBits = 24,
+            int logFileSize = 256 * 1024 * 1024, 
+            int maxBatchFlushSize = 10 * 1024 * 1024)
+        {
+            _dir = directoryPath;
+            _logFileSize = logFileSize;
+            _maxBatchFlushSize = maxBatchFlushSize;
+            _prefixBits = keyPrefixBits;
+            _jumpsCount = 1 << keyPrefixBits;
+            _jumpsFileSize = AddressSize * _jumpsCount;
+        }
+
+        public void Initialize()
+        {
+            if (!Directory.Exists(_dir))
+            {
+                Directory.CreateDirectory(_dir);
+            }
+
+            string jumpsPath = Path.Combine(_dir, JumpsFileName);
+            _jumps = InitializeMap(jumpsPath, _jumpsFileSize, cleanOnCreate: true);
+
+            string[] existingFiles = Directory.GetFiles(_dir, Prefix + "*.*");
+            if (existingFiles.Length > 0)
+            {
+                foreach (string file in existingFiles)
+                {
+                    Map map = InitializeMap(file, _logFileSize);
+                    _maps[map.Number] = map;
+                }
+            }
+            else
+            {
+                // first file
+                Map map = CreateLogFile(1);
+                _maps[map.Number] = map;
+            }
+
+            Map current = _maps.Last(m => m != null);
+            _flushFrom = current.Number * _logFileSize + current.Offset;
+
+            _runFlusher = true;
+            _flusher = new Thread(RunFlusher);
+            _flusher.Start();
+        }
+
+        private void RunFlusher()
+        {
+            void Flush()
+            {
+                lock (_batches)
+                {
+                    int fileNumber = GetFileAndPosition(out int position);
+                    if (position > 0)
+                    {
+                        Map map = _maps[fileNumber];
+                        map?.Flush(position);
+                    }
+
+                }
+            }
+
+            TimeSpan flushPeriod = TimeSpan.FromSeconds(5);
+
+            while (_runFlusher)
+            {
+                Thread.Sleep(flushPeriod);
+                Flush();
+            }
+
+            Flush();
+        }
+
+        public bool HasNoEntriesToFlush => _batches.IsEmpty;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static long BuildHeader(int valueLength, long jump) => ((long)valueLength << ValueLengthShift) | jump;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static (int valueLength, long jump) ParseHeader(long header)
+        {
+            const long jumpMask = (1L << ValueLengthShift) - 1;
+            const int lengthMask = 0xFFFF; // should be calculated.
+
+            return ((int)((header >> ValueLengthShift) & lengthMask), header & jumpMask);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        int ReadJumpIndex(ReadOnlySpan<byte> key)
+        {
+            int mask = (_prefixBits << 1) - 1;
+            int shift = 32 - _prefixBits;
+            uint value = BinaryPrimitives.ReadUInt32LittleEndian(key);
+            return (int)((value >> shift) & mask);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static int Align(int value) => (value + (ByteAlignment - 1)) & -ByteAlignment;
+
+        Map CreateLogFile(int fileNumber)
+        {
+            return InitializeMap(Path.Combine(_dir, GetFileName(fileNumber)), _logFileSize);
+        }
+
+        static string GetFileName(int number) => $"{Prefix}{number:D6}";
+
+        Map InitializeMap(string file, int size, bool cleanOnCreate = false)
+        {
+            bool created = false;
+            FileStream stream = File.Open(file, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read);
+            if (stream.Length == 0)
+            {
+                // new one needs to be initialized
+                stream.SetLength(size);
+                stream.WriteByte(0); // this is sufficient to create an empty file.
+                stream.Flush(true);
+                created = true;
+            }
+
+            MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(stream, null, 0, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
+            _files.Add(mmf);
+
+            string justNumber = new FileInfo(file).Name.Replace(Prefix, "");
+            int.TryParse(justNumber, out int number);
+            Map map = new Map(stream, mmf, file, number);
+            map.Initialize();
+
+            if (created && cleanOnCreate)
+            {
+                unsafe
+                {
+                    new Span<byte>(map.Pointer, size).Clear();
+
+                    map.Flush(0);
+                }
+            }
+
+            return map;
+        }
+
+        private unsafe void Commit(WriteBatch batch)
+        {
+            _batches.Enqueue(batch);
+
+            lock (_batches)
+            {
+                if (batch._isCommitted)
+                {
+                    return; // this batch is already committed
+                }
+
+                Span<long> jumpTable = new Span<long>(_jumps.Pointer, _jumpsCount);
+
+                int writtenSoFar = 0;
+
+                while (_batches.TryPeek(out WriteBatch commit) && writtenSoFar < _maxBatchFlushSize)
+                {
+                    int fileNumber = GetFileAndPosition(out int position);
+
+                    ref Map file = ref _maps[fileNumber];
+
+                    if (file == null)
+                    {
+                        Volatile.Write(ref file, CreateLogFile(fileNumber));
+                    }
+
+                    Span<byte> data = commit.Data;
+
+                    int leftover = _logFileSize - position;
+                    Span<byte> destination = new Span<byte>(file.Pointer + position, leftover);
+
+                    if (data.Length > destination.Length)
+                    {
+                        // Leave zeros, bump up the flushFrom and re-roll the loop
+                        _flushFrom += leftover;
+
+                        // Seal up the current, it written till the limit of the file.
+                        file.Flush(_logFileSize);
+
+                        // Flush jumps only when the log is being sealed. When recovery is introduced, this will require to scan only up to one log to recover when needed. 
+                        // For regular usage this should limit the flushes
+                        _jumps.Flush(_jumpsFileSize);
+
+                        // spin again to peek the commit again
+                        continue;
+                    }
+
+                    // revisit data, writing proper jumps
+                    Span<byte> toRewrite = data;
+                    while (!toRewrite.IsEmpty)
+                    {
+                        // parse existing header to obtain the length
+                        (int valueLength, _) = ParseHeader(BinaryPrimitives.ReadInt64LittleEndian(toRewrite));
+
+                        // retrieve the right jump
+                        int jumpIndex = ReadJumpIndex(toRewrite.Slice(HeaderLength));
+                        if (!_jumpCache.TryGetValue(jumpIndex, out long jump))
+                        {
+                            // this value was not overwritten by this flush, it needs to be read back from the table
+                            jump = jumpTable[jumpIndex];
+                        }
+
+                        // write down the header
+                        BinaryPrimitives.WriteInt64LittleEndian(toRewrite, BuildHeader(valueLength, jump));
+
+                        int length = HeaderLength + KeccakLength + (valueLength == NullValueLength ? 0 : Align(valueLength));
+
+                        // overwrite the jump to make it flushable AFTER the file is flushed
+                        _jumpCache[jumpIndex] = _flushFrom + writtenSoFar;
+
+                        writtenSoFar += length;
+
+                        toRewrite = toRewrite.Slice(length);
+                    }
+
+                    data.CopyTo(destination);   // copy data
+                    _flushFrom += data.Length;  // set proper cursor _flushFrom
+
+                    _batches.TryDequeue(out _); // dequeue the current that was Peeked at the beginning
+                    commit._isCommitted = true;// mark this as committed
+                }
+
+                // write down jumps with volatile to ensure that once the jump is visible the data are visible as well
+                foreach ((int key, long jump) in _jumpCache)
+                {
+                    Volatile.Write(ref jumpTable[key], jump);
+                }
+
+                _jumpCache.Clear(); // not needed anymore, clear as the same entries might not be reused
+            }
+        }
+
+        private int GetFileAndPosition(out int position)
+        {
+            int fileNumber = (int)Math.DivRem(_flushFrom, _logFileSize, out long pos);
+            position = (int)pos;
+            return fileNumber;
+        }
+
+        public void Delete(byte[] key)
+        {
+            using WriteBatch batch = new WriteBatch(this);
+            batch.Delete(key);
+            batch.Commit();
+        }
+
+        public void Set(byte[] key, byte[] value)
+        {
+            using WriteBatch batch = new WriteBatch(this);
+            batch.Put(key, value);
+            batch.Commit();
+        }
+
+        public unsafe bool TryGet(byte[] key, out Slice value)
+        {
+            int index = ReadJumpIndex(key);
+            Span<long> jumpTable = new Span<long>(_jumps.Pointer, _jumpsCount);
+
+            long jump = Volatile.Read(ref jumpTable[index]);
+
+            while (jump != 0)
+            {
+                int file = (int)Math.DivRem(jump, _logFileSize, out long position);
+
+                Map map = Volatile.Read(ref _maps[file]);
+                if (map == null)
+                {
+                    value = default;
+                    return false;
+                }
+
+                byte* pointer = map.Pointer + position;
+                long header = Unsafe.Read<long>(pointer);
+                (int valueLength, long nextJump) = ParseHeader(header);
+
+                Span<byte> actualKey = new Span<byte>(pointer + HeaderLength, KeccakLength);
+                if (actualKey.StartsWith(key))
+                {
+                    if (valueLength != NullValueLength)
+                    {
+                        value = new Slice(pointer + HeaderLength + KeccakLength, valueLength);
+                        return true;
+                    }
+
+                    value = default;
+                    return false;
+                }
+
+                jump = nextJump;
+            }
+
+            value = default;
+            return false;
+        }
+
+        public readonly unsafe struct Slice
+        {
+            private readonly byte[] _bytes;
+            private readonly byte* _pointer;
+            private readonly int _length;
+
+            public Slice(byte* pointer, int length)
+            {
+                _pointer = pointer;
+                _length = length;
+                _bytes = null;
+            }
+
+            public Slice(byte[] bytes)
+            {
+                _pointer = null;
+                _length = 0;
+                _bytes = bytes;
+            }
+
+            public Span<byte> Span => _bytes ?? new Span<byte>(_pointer, _length);
+
+            public byte[] ToArray() => _bytes ?? new Span<byte>(_pointer, _length).ToArray();
+        }
+
+        public void Dispose()
+        {
+            _runFlusher = false;
+            _flusher.Join();
+
+            foreach (Map map in _maps)
+            {
+                map?.Dispose();
+            }
+
+            foreach (MemoryMappedFile disposable in _files)
+            {
+                disposable.Dispose();
+            }
+        }
+
+        class Map : IDisposable
+        {
+            readonly FileStream _file;
+            readonly MemoryMappedFile _mmf;
+            readonly MemoryMappedViewAccessor _accessor;
+
+            public string Path { get; }
+            public int Number { get; }
+
+            volatile int _offset;
+            IntPtr _pointer;
+
+            public Map(FileStream file, MemoryMappedFile mmf, string path, int number)
+            {
+                _file = file;
+                _mmf = mmf;
+                _accessor = mmf.CreateViewAccessor();
+                Path = path;
+                Number = number;
+            }
+
+            public int Offset => _offset;
+
+            public void Dispose()
+            {
+                if (_pointer != IntPtr.Zero)
+                {
+                    _pointer = IntPtr.Zero;
+                    _accessor.SafeMemoryMappedViewHandle.ReleasePointer();
+                }
+
+                _accessor?.Dispose();
+                _mmf.Dispose();
+                _file.DisposeAsync();
+            }
+
+            /// <summary>
+            /// Initializes the accessor by scanning its content and setting the offset properly.
+            /// </summary>
+            public unsafe void Initialize()
+            {
+                // scan to find last written
+                byte* ptr = null;
+                _accessor.SafeMemoryMappedViewHandle.AcquirePointer(ref ptr);
+
+                _pointer = new IntPtr(ptr);
+
+                int length;
+
+                int cursor = 0;
+                while (cursor < _accessor.Capacity && (length = Unsafe.ReadUnaligned<byte>(ptr + cursor)) != EndMarker)
+                {
+                    cursor += 1;
+                    if (length == byte.MaxValue)
+                    {
+                        length += Unsafe.ReadUnaligned<byte>(ptr + cursor);
+                        cursor += 1;
+                    }
+
+                    cursor += length;
+                }
+
+                _offset = cursor;
+            }
+
+            public unsafe byte* Pointer => (byte*)_pointer.ToPointer();
+
+            public void Flush(int nextOffsetPosition)
+            {
+                // flush and update
+                _accessor.Flush();
+                _file.Flush(true);
+
+                _offset = nextOffsetPosition;
+            }
+        }
+
+        public IWriteBatch StartBatch() => new WriteBatch(this);
+
+        public interface IWriteBatch : IDisposable
+        {
+            void Put(byte[] key, byte[] value);
+            void Delete(byte[] key);
+            void Commit();
+        }
+
+        class WriteBatch : IWriteBatch
+        {
+            private readonly MemoryMappedKeyValueStore _store;
+            private int _written;
+            private byte[] _buffer;
+            private const int InitialLength = 256 * 1024;
+
+            private static readonly byte[] s_empty = new byte[0];
+
+            public bool _isCommitted;
+
+            public WriteBatch(MemoryMappedKeyValueStore store)
+            {
+                _store = store;
+                _buffer = ArrayPool<byte>.Shared.Rent(InitialLength);
+            }
+
+            public void Put(byte[] key, byte[] value)
+            {
+                // the jump to previous is not known now,
+                const int unknownJumpForNow = 0;
+
+                if (key.Length != KeyLength)
+                {
+                    throw new ArgumentException($"The key should be {KeyLength} long", nameof(key));
+                }
+
+                long header;
+
+                if (value != null)
+                {
+                    if (value.Length > MaxValueLength)
+                    {
+                        throw new ArgumentException($"The value breached {MaxValueLength}", nameof(value));
+                    }
+
+                    header = BuildHeader(value.Length, unknownJumpForNow);
+                }
+                else
+                {
+                    header = BuildHeader(NullValueLength, unknownJumpForNow); // set 0 for now as the jump is unknown
+                    value = s_empty;
+                }
+
+                int length = HeaderLength + KeccakLength + Align(value.Length);
+                Ensure(length);
+
+                Span<byte> span = new Span<byte>(_buffer, _written, _buffer.Length - _written);
+
+                BinaryPrimitives.WriteInt64LittleEndian(span, header);
+                key.CopyTo(span.Slice(HeaderLength));
+                value.CopyTo(span.Slice(HeaderLength + KeccakLength));
+
+                _written += length;
+            }
+
+            public void Commit()
+            {
+                if (_written > 0)
+                {
+                    _store.Commit(this);
+                }
+            }
+
+            public void Delete(byte[] key) => Put(key, null);
+
+            public void Dispose()
+            {
+                if (_buffer != null)
+                {
+                    ArrayPool<byte>.Shared.Return(_buffer);
+                    _buffer = null;
+                }
+            }
+
+            public Span<byte> Data => new Span<byte>(_buffer, 0, _written);
+
+            private void Ensure(int length)
+            {
+                if (_buffer.Length - _written < length)
+                {
+                    byte[] bytes = ArrayPool<byte>.Shared.Rent(_buffer.Length * 2);
+                    _buffer.CopyTo(bytes, 0);
+                    ArrayPool<byte>.Shared.Return(_buffer);
+                    _buffer = bytes;
+                }
+            }
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Db/Nethermind.Db.csproj
+++ b/src/Nethermind/Nethermind.Db/Nethermind.Db.csproj
@@ -5,6 +5,7 @@
     <Deterministic>true</Deterministic>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <Nullable>annotations</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Nethermind.Config\Nethermind.Config.csproj" />

--- a/src/Nethermind/Nethermind.Db/NullRocksDbFactory.cs
+++ b/src/Nethermind/Nethermind.Db/NullRocksDbFactory.cs
@@ -30,6 +30,11 @@ namespace Nethermind.Db
             throw new InvalidOperationException();
         }
 
+        public IDb CreateMemoryMappedDb(RocksDbSettings rocksDbSettings)
+        {
+            throw new InvalidOperationException();
+        }
+
         public IColumnsDb<T> CreateColumnsDb<T>(RocksDbSettings rocksDbSettings)
         {
             throw new InvalidOperationException();

--- a/src/Nethermind/Nethermind.Db/RocksDbInitializer.cs
+++ b/src/Nethermind/Nethermind.Db/RocksDbInitializer.cs
@@ -55,6 +55,11 @@ namespace Nethermind.Db
             AddRegisterAction(settings, () => _rocksDbFactory.CreateColumnsDb<T>(settings), () => _memDbFactory.CreateColumnsDb<T>(settings.DbName));
         }
 
+        protected void RegisterMemoryMappedDb(RocksDbSettings settings)
+        {
+            AddRegisterAction(settings, () => _rocksDbFactory.CreateMemoryMappedDb(settings), () => _memDbFactory.CreateDb(settings.DbName));
+        }
+
         private void AddRegisterAction(RocksDbSettings settings, Func<IDb> rocksDbCreation, Func<IDb> memDbCreation)
         {
             var action = new Action(() =>

--- a/src/Nethermind/Nethermind.Db/StandardDbInitializer.cs
+++ b/src/Nethermind/Nethermind.Db/StandardDbInitializer.cs
@@ -46,7 +46,7 @@ namespace Nethermind.Db
             RegisterDb(BuildRocksDbSettings(DbNames.Blocks, () => Metrics.BlocksDbReads++, () => Metrics.BlocksDbWrites++));
             RegisterDb(BuildRocksDbSettings(DbNames.Headers, () => Metrics.HeaderDbReads++, () => Metrics.HeaderDbWrites++));
             RegisterDb(BuildRocksDbSettings(DbNames.BlockInfos, () => Metrics.BlockInfosDbReads++, () => Metrics.BlockInfosDbWrites++));
-            RegisterDb(BuildRocksDbSettings(DbNames.State, () => Metrics.StateDbReads++, () => Metrics.StateDbWrites++));
+            RegisterMemoryMappedDb(BuildRocksDbSettings(DbNames.State, () => Metrics.StateDbReads++, () => Metrics.StateDbWrites++));
             RegisterDb(BuildRocksDbSettings(DbNames.Code, () => Metrics.CodeDbReads++, () => Metrics.CodeDbWrites++));
             RegisterDb(BuildRocksDbSettings(DbNames.PendingTxs, () => Metrics.PendingTxsDbReads++, () => Metrics.PendingTxsDbWrites++));
             RegisterDb(BuildRocksDbSettings(DbNames.Bloom, () => Metrics.BloomDbReads++, () => Metrics.BloomDbWrites++));


### PR DESCRIPTION
This is a follow up PR to the https://github.com/NethermindEth/nethermind/pull/2651

This PR introduces a paged memory-mapped database. The database uses a prefix of a key to select a page number `pageNo`. Then, uses this `pageNo` to scan through all the files in a search of a key or a place to insert a new value. The database is configured with two parameters

- a prefix length (in number of bytes)
- a page size (should be aligned, most likely 4kb)

which for 3 bytes long prefix and 4kb big page gives 64GB per one file.

### The page layout

The page is constructed as following:

- `8 bytes` - a `long` header
- `pageSize - 8` - space for entries

Each consists of:
- `32 - prefixLength` bytes of Keccak
- `2` bytes  of the value length
- `N` bytes of the value itself

### Concurrency

1. Only a single writer acts at the same time, combining multiple batches.
2. Flushing is done it a separate thread.
3. Key value writes are followed up by updating the `header` with `Volatile.Write` which means that once the header is observed, the value is there as well.
4. Reads are done in a lock-free manner.

**This is a really speculative work. It doesn't work yet and its performance is yet to be determined. Please, do not merge it.**

### Performance cosiderations

A direct jump based on the key itself and collocated values should provide better locality for values sharing the same prefix.

Potentially, pages could be written in two directions, meaning, that the keys would be written from the beginning and values from the end of a page. This could speed up scans for a specific key.

