### PR TITLE
Memory mapped db

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/RocksDbFactory.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/RocksDbFactory.cs
@@ -14,6 +14,7 @@
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
+using System.IO;
 using Nethermind.Db.Rocks.Config;
 using Nethermind.Logging;
 
@@ -32,11 +33,18 @@ namespace Nethermind.Db.Rocks
         }
 
         public IDb CreateDb(RocksDbSettings rocksDbSettings)
-        { 
-            return new SimpleRocksDb(_basePath, 
+        {
+            return new SimpleRocksDb(_basePath,
                 rocksDbSettings,
-                _dbConfig, 
+                _dbConfig,
                 _logManager);
+        }
+
+        public IDb CreateMemoryMappedDb(RocksDbSettings rocksDbSettings)
+        {
+            MemoryMappedKeyValueStore store = new(Path.Combine(_basePath, rocksDbSettings.DbName), 2, 16 * 1024); // 1GB + header per file
+            store.Initialize();
+            return new MemoryMappedDb(rocksDbSettings.DbPath, store);
         }
 
         public IColumnsDb<T> CreateColumnsDb<T>(RocksDbSettings rocksDbSettings) where T : notnull

--- a/src/Nethermind/Nethermind.Db.Rpc/RpcDbFactory.cs
+++ b/src/Nethermind/Nethermind.Db.Rpc/RpcDbFactory.cs
@@ -42,6 +42,11 @@ namespace Nethermind.Db.Rpc
             _logManager = logManager;
         }
 
+        public IDb CreateMemoryMappedDb(RocksDbSettings rocksDbSettings)
+        {
+            throw new System.NotImplementedException();
+        }
+
         public IColumnsDb<T> CreateColumnsDb<T>(RocksDbSettings rocksDbSettings)
         {
             var rocksDb = _wrappedRocksDbFactory.CreateColumnsDb<T>(rocksDbSettings);

--- a/src/Nethermind/Nethermind.Db.Test/MemoryMappedKeyValueStoreTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/MemoryMappedKeyValueStoreTests.cs
@@ -1,0 +1,166 @@
+//  Copyright (c) 2018 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
+
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using NUnit.Framework;
+
+namespace Nethermind.Db.Test
+{
+    [Explicit("Disk IO ")]
+    public class MemoryMappedKeyValueStoreTests
+    {
+        private static string TestWorkDirectory => Path.Combine(TestContext.CurrentContext.WorkDirectory,
+            TestContext.CurrentContext.Test.Name);
+
+        [SetUp]
+        public void SetUp()
+        {
+            // lazy IO makes these tests hard on shared file names. Let's sleep it through.
+            Thread.Sleep(TimeSpan.FromSeconds(5));
+
+            if (Directory.Exists(TestWorkDirectory))
+            {
+                Directory.Delete(TestWorkDirectory, true);
+            }
+
+            Console.WriteLine("Working directory {0}", TestWorkDirectory);
+        }
+
+        [Category("Benchmark")]
+        [Test]
+        public void HammeringOnePageAcrossManyFiles()
+        {
+            const int prefix = 1;
+            
+            using MemoryMappedKeyValueStore store = new(TestWorkDirectory, prefix, 4 * 1024);
+            store.Initialize();
+
+            byte[] key = new byte[MemoryMappedKeyValueStore.KeyLength];
+            Span<byte> tail = key.AsSpan(prefix);
+            byte[] value = new byte[1];
+
+            const int size = 4000;
+
+            for (int i = 0; i < size; i++)
+            {   
+                BinaryPrimitives.WriteInt32LittleEndian(tail, i);
+                store.Put(key, value);
+            }
+
+            for (int spin = 0; spin < 1000; spin++)
+            {
+                for (int i = 0; i < size; i++)
+                {
+                    BinaryPrimitives.WriteInt32LittleEndian(tail, i);
+                    if (!store.TryGet(key, out _))
+                    {
+                        Assert.Fail("The key is missing");
+                    }
+                }
+            }
+        }
+
+        [Test]
+        public void ReadAndWriteRandoms()
+        {
+            const int size = 1_000_000;
+            const int batchSize = 100;
+            const int minLength = 32;
+            const int maxLength = 50;
+
+            using MemoryMappedKeyValueStore store = new(TestWorkDirectory, 2, 2 * 1024);
+            store.Initialize();
+
+            Random random = new(size);
+
+            List<(byte[] key, byte[] value)> pairs = new();
+
+            MemoryMappedKeyValueStore.IWriteBatch batch = store.StartBatch();
+            int batchCount = 0;
+
+            for (int i = 0; i < size; i++)
+            {
+                int length = random.Next(minLength, maxLength);
+
+                byte[] value = new byte[length];
+                byte[] key = new byte[MemoryMappedKeyValueStore.KeyLength];
+
+                value.AsSpan().Fill((byte)i);
+
+                random.NextBytes(key);
+
+                pairs.Add((key, value));
+
+                batch.Put(key, value);
+                if (batchCount++ == batchSize)
+                {
+                    batch.Commit();
+                    batch.Dispose();
+                    batch = store.StartBatch();
+                    batchCount = 0;
+                }
+            }
+
+            batch.Commit();
+            batch.Dispose();
+
+            SpinWait.SpinUntil(() => store.HasNoEntriesToFlush);
+
+            int j = 0;
+            foreach ((byte[] key, byte[] expected) in pairs)
+            {
+                Assert.True(store.TryGet(key, out Span<byte> actual), "Key was not found");
+                Assert.AreEqual(expected.Length, actual.Length, "Value lengths are different for value index {0}", j);
+                Assert.True(expected.AsSpan().SequenceEqual(actual), "Value is different from the expected one for index {0}", j);
+                j++;
+            }
+
+            byte[] nonExistent = new byte[MemoryMappedKeyValueStore.KeyLength];
+            random.NextBytes(nonExistent);
+
+            Assert.IsFalse(store.TryGet(nonExistent, out _));
+        }
+
+        [Test]
+        public void Deletes()
+        {
+            using MemoryMappedKeyValueStore store = new(TestWorkDirectory, 2, 4 * 1024);
+            store.Initialize();
+
+            byte[] key = new byte[MemoryMappedKeyValueStore.KeyLength];
+            key.AsSpan().Fill(13);
+
+            byte[] value = { 47 };
+
+            store.Put(key, value);
+
+            SpinWait.SpinUntil(() => store.HasNoEntriesToFlush);
+
+            store.Delete(key);
+
+            Assert.False(store.TryGet(key, out _));
+
+            SpinWait.SpinUntil(() => store.HasNoEntriesToFlush);
+
+            Assert.False(store.TryGet(key, out _));
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Db/IRocksDbFactory.cs
+++ b/src/Nethermind/Nethermind.Db/IRocksDbFactory.cs
@@ -20,6 +20,8 @@ namespace Nethermind.Db
     {
         IDb CreateDb(RocksDbSettings rocksDbSettings);
         
+        IDb CreateMemoryMappedDb(RocksDbSettings rocksDbSettings);
+        
         IColumnsDb<T> CreateColumnsDb<T>(RocksDbSettings rocksDbSettings) where T : notnull;
     }
 }

--- a/src/Nethermind/Nethermind.Db/MemoryMappedDb.cs
+++ b/src/Nethermind/Nethermind.Db/MemoryMappedDb.cs
@@ -1,0 +1,142 @@
+//  Copyright (c) 2018 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
+
+using System;
+using System.Collections.Generic;
+using Nethermind.Core;
+
+namespace Nethermind.Db
+{
+    public class MemoryMappedDb : IDbWithSpan
+    {
+        private readonly MemoryMappedKeyValueStore _store;
+        private bool _isDisposed;
+
+        public MemoryMappedDb(string name, MemoryMappedKeyValueStore store)
+        {
+            _store = store;
+            Name = name;
+        }
+
+        public byte[] this[byte[] key]
+        {
+            get
+            {
+                if (_isDisposed)
+                {
+                    throw new ObjectDisposedException($"Attempted to read form a disposed database {Name}");
+                }
+
+                return Get(key);
+            }
+            set
+            {
+                if (_isDisposed)
+                {
+                    throw new ObjectDisposedException($"Attempted to write to a disposed database {Name}");
+                }
+
+                if (value == null)
+                {
+                    Remove(key);
+                }
+                else
+                {
+                    _store.Put(key, value);
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            _isDisposed = true;
+            _store.Dispose();
+        }
+
+        public string Name { get; }
+
+        public KeyValuePair<byte[], byte[]>[] this[byte[][] keys] => throw new NotImplementedException();
+
+        public IEnumerable<KeyValuePair<byte[], byte[]>> GetAll(bool ordered = false) => throw new NotImplementedException();
+
+        public IEnumerable<byte[]> GetAllValues(bool ordered = false) => throw new NotImplementedException("");
+
+        public void Remove(byte[] key) => _store.Delete(key);
+
+        private byte[] Get(byte[] key) => _store.TryGet(key, out Span<byte> value) ? value.ToArray() : null;
+
+        public bool KeyExists(byte[] key) => _store.KeyExists(key);
+
+        public IDb Innermost => this;
+
+        public IBatch StartBatch() => new MemoryMappedBatch(this);
+
+        internal class MemoryMappedBatch : IBatch
+        {
+            private readonly MemoryMappedDb _db;
+
+            internal readonly MemoryMappedKeyValueStore.IWriteBatch _batch;
+
+            public MemoryMappedBatch(MemoryMappedDb db)
+            {
+                _db = db;
+
+                if (_db._isDisposed)
+                {
+                    throw new ObjectDisposedException($"Attempted to create a batch on a disposed database {_db.Name}");
+                }
+
+                _batch = db._store.StartBatch();
+            }
+
+            public void Dispose()
+            {
+                if (_db._isDisposed)
+                {
+                    throw new ObjectDisposedException($"Attempted to commit a batch on a disposed database {_db.Name}");
+                }
+
+                _batch.Commit();
+                _batch.Dispose();
+            }
+
+            public byte[]? this[byte[] key]
+            {
+                get => _db[key];
+                set
+                {
+                    if (value == null)
+                    {
+                        _batch.Delete(key);
+                    }
+                    else
+                    {
+                        _batch.Put(key, value);
+                    }
+                }
+            }
+        }
+
+        public void Flush() { }
+
+        public void Clear() { }
+
+        public Span<byte> GetSpan(byte[] key) => _store.TryGet(key, out Span<byte> span) ? span: Span<byte>.Empty;
+
+        public void DangerousReleaseMemory(in Span<byte> span) { }
+    }
+}

--- a/src/Nethermind/Nethermind.Db/MemoryMappedKeyValueStore.cs
+++ b/src/Nethermind/Nethermind.Db/MemoryMappedKeyValueStore.cs
@@ -1,0 +1,579 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.MemoryMappedFiles;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace Nethermind.Db
+{
+    /// <summary>
+    /// A memory mapped map.
+    /// </summary>
+    public class MemoryMappedKeyValueStore : IDisposable
+    {
+        public const int KeyLength = KeccakLength;
+        const int MaxNumberOfFiles = 2048;
+
+        const int KeccakLength = 32;
+        const int BitsInByte = 8;
+
+        readonly string _dir;
+        readonly int _keyPrefixBytesCount;
+        readonly int _pageSize;
+        readonly List<MemoryMappedFile> _files = new();
+
+        readonly Map[] _maps = new Map[MaxNumberOfFiles];
+        private volatile int _mapCount;
+
+        private readonly ConcurrentQueue<WriteBatch> _batches = new();
+
+        private Thread _flusher;
+        private volatile bool _runFlusher;
+
+        /// <summary>
+        /// Configures the key value store to store data in a specific directory with a specific page size. The store will generate files big as 16MB * pageSize, which for 4k gives 64 GBs of a single file.
+        /// </summary>
+        /// <param name="directoryPath">The path where the database files will be located. Both jump table and the log files are included in there.</param>
+        public MemoryMappedKeyValueStore(string directoryPath, int keyPrefixBytesCount, int pageSize)
+        {
+            _dir = directoryPath;
+            _keyPrefixBytesCount = keyPrefixBytesCount;
+            _pageSize = pageSize;
+        }
+
+        public void Initialize()
+        {
+            if (!Directory.Exists(_dir))
+            {
+                Directory.CreateDirectory(_dir);
+            }
+
+            string[] existingFiles = Directory.GetFiles(_dir);
+            if (existingFiles.Length > 0)
+            {
+                foreach (string file in existingFiles)
+                {
+                    Map map = InitializeMap(file, _keyPrefixBytesCount, _pageSize);
+                    _maps[map.Number] = map;
+                }
+
+                _mapCount = _maps.Count(m => m != null);
+            }
+            else
+            {
+                // first file
+                Map map = CreateFile(0);
+                _maps[map.Number] = map;
+                _mapCount = 1;
+            }
+
+            _runFlusher = true;
+            _flusher = new Thread(RunFlusher);
+            _flusher.Start();
+        }
+
+        private void RunFlusher()
+        {
+            bool TryFlushDirtyMaps()
+            {
+                Queue<Map> toFlush = new(_maps.Where((map, index) => index < _mapCount && map.ShouldFlush));
+                if (toFlush.Count == 0)
+                {
+                    return false;
+                }
+
+                // spin till all files are flushed
+                while (toFlush.TryDequeue(out Map map))
+                {
+                    if (Monitor.TryEnter(map))
+                    {
+                        map.Flush();
+                        Monitor.Exit(map);
+                    }
+                    else
+                    {
+                        toFlush.Enqueue(map);
+                    }
+                }
+
+                return true;
+            }
+
+            while (_runFlusher)
+            {
+                if (!TryFlushDirtyMaps())
+                {
+                    Thread.Sleep(TimeSpan.FromMilliseconds(100));
+                }
+            }
+
+            TryFlushDirtyMaps();
+        }
+
+        public bool HasNoEntriesToFlush => _batches.IsEmpty;
+
+        Map CreateFile(int fileNumber)
+        {
+            return InitializeMap(Path.Combine(_dir, $"{fileNumber:D5}"), _keyPrefixBytesCount, _pageSize, true);
+        }
+
+        Map InitializeMap(string file, int keyPrefixBytesCount, int pageSize, bool clear = false)
+        {
+            FileStream stream = File.Open(file, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read);
+            if (stream.Length == 0)
+            {
+                // new one needs to be initialized
+                stream.SetLength(Map.GetTotalFileSize(keyPrefixBytesCount, pageSize));
+                stream.WriteByte(0); // this is sufficient to create an empty file.
+                stream.Flush(true);
+            }
+
+            MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(stream, null, 0, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false);
+            _files.Add(mmf);
+
+            string justNumber = new FileInfo(file).Name;
+            int.TryParse(justNumber, out int number);
+            Map map = new(stream, mmf, _keyPrefixBytesCount, _pageSize, number);
+            map.Initialize(clear);
+
+            return map;
+        }
+
+        private void Commit(WriteBatch batch)
+        {
+            _batches.Enqueue(batch);
+
+            lock (_batches)
+            {
+                if (batch._isCommitted)
+                {
+                    return; // this batch is already committed
+                }
+
+                HashSet<Map> locks = new();
+
+                while (_batches.TryPeek(out WriteBatch commit))
+                {
+                    foreach ((byte[] key, byte[] value) in commit.Pairs)
+                    {
+                        // from the oldest, to the newest, try write
+                        int i = 0;
+                        for (; i < _mapCount; i++)
+                        {
+                            Map map = _maps[i];
+                            
+                            if (!map.CanWrite(key, value))
+                            {
+                                // no place, spin again
+                                continue;
+                            }
+                            
+                            if (!locks.Contains(map))
+                            {
+                                // TODO: recovery and possibly skip map
+                                if (Monitor.TryEnter(map))
+                                {
+                                    locks.Add(map);
+                                }
+                                else
+                                {
+                                    // no lock taken, move to next
+                                    continue;
+                                }
+                            }
+                            
+                            // lock taken, try write and break on success
+                            if (map.TryWrite(key, value))
+                            {
+                                break;
+                            }
+                        }
+                        
+                        if (i == _mapCount)
+                        {
+                            Map map = _maps[_mapCount] = CreateFile(_mapCount);
+                            _mapCount = _mapCount + 1;
+
+                            Monitor.Enter(map);
+                            locks.Add(map);
+
+                            map.TryWrite(key, value);
+                        }
+                    }
+
+                    _batches.TryDequeue(out _); // dequeue the current that was Peeked at the beginning
+                    commit._isCommitted = true; // mark this as committed
+                }
+
+                // release the locks
+                foreach (Map @lock in locks)
+                {
+                    Monitor.Exit(@lock);
+                }
+            }
+        }
+
+      
+        public void Delete(byte[] key)
+        {
+            using WriteBatch batch = new(this);
+            batch.Delete(key);
+            batch.Commit();
+        }
+
+        public void Put(byte[] key, byte[] value)
+        {
+            using WriteBatch batch = new(this);
+            batch.Put(key, value);
+            batch.Commit();
+        }
+
+        public bool KeyExists(byte[] key)
+        {
+            for (int i = _mapCount - 1; i >= 0; i--)
+            {
+                if (_maps[i].KeyExists(key))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+        
+        public bool TryGet(byte[] key, out Span<byte> value)
+        {
+            for (int i = _mapCount - 1; i >= 0; i--)
+            {
+                if (_maps[i].TryGet(key, out value))
+                {
+                    return true;
+                }
+            }
+
+            value = default;
+            return false;
+        }
+
+        public void Dispose()
+        {
+            _runFlusher = false;
+            _flusher.Join();
+
+            foreach (Map map in _maps)
+            {
+                map?.Dispose();
+            }
+
+            foreach (MemoryMappedFile disposable in _files)
+            {
+                disposable.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// A single memory-mapped file.
+        /// </summary>
+        /// <remarks>
+        /// A single page grows in two directions:
+        /// - from the beginning in chunks of [keysuffix][short: value lenght]
+        /// - from the end with values
+        ///
+        /// This should allow faster scans for the specific key 
+        /// </remarks>
+        class Map : IDisposable
+        {
+            readonly FileStream _file;
+            readonly MemoryMappedFile _mmf;
+            readonly int _prefix;
+            readonly int _pageSize;
+            readonly int _headerSize;
+            readonly MemoryMappedViewAccessor _accessor;
+            volatile bool _shouldFlush;
+
+            public int Number { get; }
+            IntPtr _pointer;
+
+            /// <summary>
+            /// The number of bytes needed for each head entry.
+            /// </summary>
+            readonly int _headEntryLength;
+
+            /// <summary>
+            /// The actual number of bytes stored for each key.
+            /// </summary>
+            readonly int _keySuffixLength;
+
+            const int ValuePrefixCountBytesCount = sizeof(short);
+            
+            /// <summary>
+            /// The size of a single item of the header.
+            /// </summary>
+            const int HeaderItemSize = sizeof(int);
+
+            /// <summary>
+            /// Due to encoding of the header with <see cref="DecodeHeader"/> and <see cref="EncodeHeader"/>.
+            /// </summary>
+            private const int MaxPageSize = ushort.MaxValue;
+
+            public static long GetTotalFileSize(int keyPrefixBytesCount, int pageSize)
+            {
+                long prefixCount = GetPrefixesCount(keyPrefixBytesCount);
+
+                return prefixCount * HeaderItemSize + // header of the file, containing offset for each page
+                       prefixCount * pageSize;      // pages
+            }
+
+            private static int GetPrefixesCount(int keyPrefixBytesCount) => 1 << (keyPrefixBytesCount * BitsInByte);
+
+            public Map(FileStream file, MemoryMappedFile mmf, int prefix, int pageSize,  int number)
+            {
+                if (pageSize > MaxPageSize)
+                {
+                    throw new ArgumentException();
+                }
+                
+                _file = file;
+                _mmf = mmf;
+                _prefix = prefix;
+                _accessor = mmf.CreateViewAccessor();
+                _headerSize = GetPrefixesCount(prefix) * HeaderItemSize;
+                _pageSize = pageSize;
+                Number = number;
+                _keySuffixLength = KeyLength - _prefix;
+                _headEntryLength = _keySuffixLength + ValuePrefixCountBytesCount;
+            }
+
+            public void Dispose()
+            {
+                if (_pointer != IntPtr.Zero)
+                {
+                    _pointer = IntPtr.Zero;
+                    _accessor.SafeMemoryMappedViewHandle.ReleasePointer();
+                }
+
+                _accessor.Dispose();
+                _mmf.Dispose();
+                _file.DisposeAsync();
+            }
+
+            /// <summary>
+            /// Initializes the accessor by scanning its content and setting the offset properly.
+            /// </summary>
+            public unsafe void Initialize(bool clear)
+            {
+                byte* ptr = null;
+                _accessor.SafeMemoryMappedViewHandle.AcquirePointer(ref ptr);
+                _pointer = new IntPtr(ptr);
+
+                if (clear)
+                {
+                    // clear just headers, it's enough
+                    new Span<byte>(ptr, _headerSize).Clear();
+                    Flush(true);
+                }
+            }
+
+            public unsafe bool CanWrite(byte[] key, byte[] value)
+            {
+                ref uint header = ref GetPageInfo(key, out byte* _);
+
+                (ushort _, ushort written) = DecodeHeader(ref header);
+
+                int leftover = _pageSize - written;
+                uint neededBytes = CalculateNeededBytes(key, value);
+                
+                return leftover >= neededBytes;
+            }
+
+            public unsafe bool TryWrite(byte[] key, byte[] value)
+            {
+                ref uint header = ref GetPageInfo(key, out byte* pageStart);
+
+                (ushort entriesCount, ushort written) = DecodeHeader(ref header);
+
+                int leftover = _pageSize - written;
+                uint neededBytes = CalculateNeededBytes(key, value);
+                if (leftover >= neededBytes)
+                {
+                    ushort valueLength = (ushort)value.Length;
+
+                    // write head entry: keySuffix
+                    int existingHeadSpace = _headEntryLength * entriesCount;
+                    byte* headStart = pageStart + existingHeadSpace;
+                    Span<byte> head = new(headStart, _headEntryLength);
+                    key.AsSpan(_prefix).CopyTo(head);
+
+                    // write head entry: value length
+                    Unsafe.WriteUnaligned(headStart + _keySuffixLength, valueLength);
+
+                    // write tail entry: value content
+                    int offset = _pageSize - (written - existingHeadSpace) - valueLength;
+                    Span<byte> destination = new(pageStart + offset, valueLength);
+                    value.CopyTo(destination);
+
+                    // make the value visible by writing the header with the volatile.
+                    Volatile.Write(ref header, EncodeHeader((ushort)(entriesCount + 1), (ushort)(written + neededBytes)));
+
+                    _shouldFlush = true;
+                    
+                    return true;
+                }
+
+                return false;
+            }
+
+            // Probably no need for optimizations. TryGet is zero-copy and the only overhead is the creation of a Span.
+            public bool KeyExists(byte[] key) => TryGet(key, out _);
+
+            public unsafe bool TryGet(Span<byte> key, out Span<byte> value)
+            {
+                uint header = GetPageInfo(key, out byte* pageStart);
+
+                (ushort entriesCount, ushort _) = DecodeHeader(ref header);
+
+                if (entriesCount == 0)
+                {
+                    value = default;
+                    return false;
+                }
+
+                // optimization for searches, to compare 8 bytes of the key stored in the page, than, if matched, search for more
+                Span<byte> suffix = key.Slice(_prefix);
+                
+                ulong searched = Unsafe.ReadUnaligned<ulong>(ref suffix[0]);
+
+                uint valueLengthAccumulated = 0;
+                byte* search = pageStart;
+                for (int i = 0; i < entriesCount; i++)
+                {
+                    ulong current = Unsafe.ReadUnaligned<ulong>(search);
+                    ushort valueLength = Unsafe.ReadUnaligned<ushort>(search + _keySuffixLength);
+                    valueLengthAccumulated += valueLength;
+                    
+                    if (current == searched)
+                    {
+                        if (suffix.SequenceEqual(new ReadOnlySpan<byte>(search, _keySuffixLength)))
+                        {
+                            // found! jump to the value
+                            value = new Span<byte>(pageStart + _pageSize - valueLengthAccumulated, valueLength);
+                            return true;
+                        }
+                    }
+
+                    search += _headEntryLength;
+                }
+
+                value = default;
+                return false;
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private int GetPageNumber(Span<byte> key) => (int)(ReadMachineSpecificUnaligned(key) >> ((sizeof(uint) - _prefix) * BitsInByte));
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private static (ushort entriesCount, ushort written) DecodeHeader(ref uint header)
+            {
+                uint current = Volatile.Read(ref header);
+                return ((ushort)(current >> 16), (ushort)current);
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private static uint EncodeHeader(ushort entriesCount, ushort written) => (((uint)entriesCount) << 16) | written ;
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private static uint ReadMachineSpecificUnaligned(Span<byte> key) => Unsafe.ReadUnaligned<uint>(ref MemoryMarshal.GetReference(key));
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private uint CalculateNeededBytes(byte[] key, byte[] value) => (uint) (key.Length + value.Length - _prefix + ValuePrefixCountBytesCount);
+
+            private unsafe ref uint GetPageInfo(Span<byte> key, out byte* pageStart)
+            {
+                int pageNo = GetPageNumber(key);
+                byte* pointer = (byte*) _pointer.ToPointer();
+                ref uint start = ref Unsafe.AsRef<uint>(pointer);
+                ref uint header = ref Unsafe.Add(ref start, pageNo);
+                pageStart = pointer + _headerSize + (pageNo * _pageSize);
+                return ref header;
+            }
+
+            public void Flush(bool force = false)
+            {
+                if (_shouldFlush || force)
+                {
+                    // flush and update
+                    _accessor.Flush();
+
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                    {
+                        _file.Flush(true);
+                    }
+                    
+                    _shouldFlush = false;
+                }
+            }
+
+            public bool ShouldFlush => _shouldFlush;
+        }
+
+        public IWriteBatch StartBatch() => new WriteBatch(this);
+
+        public interface IWriteBatch : IDisposable
+        {
+            void Put(byte[] key, byte[] value);
+            void Delete(byte[] key);
+            void Commit();
+        }
+
+        class WriteBatch : IWriteBatch
+        {
+            private readonly MemoryMappedKeyValueStore _store;
+
+            private static readonly byte[] s_empty = new byte[0];
+            public bool _isCommitted;
+
+            private List<(byte[], byte[])> _pairs = new();
+
+            public WriteBatch(MemoryMappedKeyValueStore store)
+            {
+                _store = store;
+            }
+
+            public void Put(byte[] key, byte[] value)
+            {
+                if (key.Length != KeyLength)
+                {
+                    throw new ArgumentException($"The key should be {KeyLength} long", nameof(key));
+                }
+
+                if (value.Length > 1024)
+                {
+                    throw new ArgumentException($"The value length {value.Length} breaches the max size of {1024} bytes, which is over a half page long.", nameof(value));
+                }
+
+                _pairs.Add((key, value));
+            }
+
+            public IEnumerable<(byte[], byte[])> Pairs => _pairs;
+
+            public void Commit()
+            {
+                if (_pairs != null)
+                {
+                    _store.Commit(this);
+                    _pairs = null;
+                }
+            }
+
+            public void Delete(byte[] key) => Put(key, null);
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Db/Nethermind.Db.csproj
+++ b/src/Nethermind/Nethermind.Db/Nethermind.Db.csproj
@@ -5,6 +5,7 @@
     <Deterministic>true</Deterministic>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <Nullable>annotations</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Nethermind.Config\Nethermind.Config.csproj" />

--- a/src/Nethermind/Nethermind.Db/NullRocksDbFactory.cs
+++ b/src/Nethermind/Nethermind.Db/NullRocksDbFactory.cs
@@ -30,6 +30,11 @@ namespace Nethermind.Db
             throw new InvalidOperationException();
         }
 
+        public IDb CreateMemoryMappedDb(RocksDbSettings rocksDbSettings)
+        {
+            throw new InvalidOperationException();
+        }
+
         public IColumnsDb<T> CreateColumnsDb<T>(RocksDbSettings rocksDbSettings)
         {
             throw new InvalidOperationException();

--- a/src/Nethermind/Nethermind.Db/RocksDbInitializer.cs
+++ b/src/Nethermind/Nethermind.Db/RocksDbInitializer.cs
@@ -55,6 +55,11 @@ namespace Nethermind.Db
             AddRegisterAction(settings, () => _rocksDbFactory.CreateColumnsDb<T>(settings), () => _memDbFactory.CreateColumnsDb<T>(settings.DbName));
         }
 
+        protected void RegisterMemoryMappedDb(RocksDbSettings settings)
+        {
+            AddRegisterAction(settings, () => _rocksDbFactory.CreateMemoryMappedDb(settings), () => _memDbFactory.CreateDb(settings.DbName));
+        }
+
         private void AddRegisterAction(RocksDbSettings settings, Func<IDb> rocksDbCreation, Func<IDb> memDbCreation)
         {
             var action = new Action(() =>

--- a/src/Nethermind/Nethermind.Db/StandardDbInitializer.cs
+++ b/src/Nethermind/Nethermind.Db/StandardDbInitializer.cs
@@ -46,7 +46,7 @@ namespace Nethermind.Db
             RegisterDb(BuildRocksDbSettings(DbNames.Blocks, () => Metrics.BlocksDbReads++, () => Metrics.BlocksDbWrites++));
             RegisterDb(BuildRocksDbSettings(DbNames.Headers, () => Metrics.HeaderDbReads++, () => Metrics.HeaderDbWrites++));
             RegisterDb(BuildRocksDbSettings(DbNames.BlockInfos, () => Metrics.BlockInfosDbReads++, () => Metrics.BlockInfosDbWrites++));
-            RegisterDb(BuildRocksDbSettings(DbNames.State, () => Metrics.StateDbReads++, () => Metrics.StateDbWrites++));
+            RegisterMemoryMappedDb(BuildRocksDbSettings(DbNames.State, () => Metrics.StateDbReads++, () => Metrics.StateDbWrites++));
             RegisterDb(BuildRocksDbSettings(DbNames.Code, () => Metrics.CodeDbReads++, () => Metrics.CodeDbWrites++));
             RegisterDb(BuildRocksDbSettings(DbNames.PendingTxs, () => Metrics.PendingTxsDbReads++, () => Metrics.PendingTxsDbWrites++));
             RegisterDb(BuildRocksDbSettings(DbNames.Bloom, () => Metrics.BloomDbReads++, () => Metrics.BloomDbWrites++));

--- a/src/Nethermind/Nethermind.Runner/libman.json
+++ b/src/Nethermind/Nethermind.Runner/libman.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0",
+  "defaultProvider": "cdnjs",
+  "libraries": []
+}


### PR DESCRIPTION
This is a follow up work to #2729

This PR introduces a new implementation of `IDbWithSpan` based on memory mapped files.

### Configuration

The database is configured by 2 parameters:

1. keyPrefixBytesCount
2. pageSize

`keyPrefixBytesCount` defines the number of bytes from the `key` used for direct addressing. If the value is equal to `1`, then there'll be only `256` pages per file addressed with the first byte of the key. If the value is equal to `2`, then there's 256*256 pages per file. For `3`, there's over 16 million pages per file. It's highly unlikely that somobody wants to go with `4` and more.

`pageSize` determines the size of a page that stores key-value pairs with the same key prefix consisting of `keyPrefixBytesCount`   first bytes.

The overall size of the pages can be counted with the following forumula `pageCount * pageSize`, where `pageCount` is equal to `(1<< (keyPrefixBytesCount * 8))`. For example, for `keyPrefixBytesCount=1` and `pageSize=16kb` this is `1GB`.

### Files

The database consists of multiple files that are numbered with consecutive natural number from 0. For writes the files are accessed from 0 to the current one, to ensure that no data is written to an older file if there's a place in a younger one. For reads,  the files are accessed in the opposite order, assuming some kind of LRU behavior for reads.

All files are memory mapped and are occasionally flushed when they're marked as dirty. The flushing mechanism ensures that no writes are done when the file is flushed to the disk.

### File structure

Each file consists of a header area and pages. 

The header consists of `pageCount` uints. Having the header separated from the pages allows for fast checks whether a value can be written to a specific page and helps with flushing down the metadata (headers contain information about pages, hence, once they are zeroed at the beginning, the zeroing of the rest of the file is not needed).

The pages are continuous chunks of memory that are `pageSize` bytes long. They are written in a special way, placing the keys in the front of the page and values at the end of it. This allows for fast key scans (keys are located together at the beginning of the page) and retrieving the value only when the key is found. 

An example of the page:
```bash
+---------------------------------------------------------------------------------------------------+
|             |               |              |               |                   |        |         |
|key1  suffix | value1 length | key2  suffix | value2 length |       EMPTY       | value2 |  value1 |
|             |               |              |               |                   |        |         |
+---------------------------------------------------------------------------------------------------+
```

where

- `keyN suffix` - a suffix of a key after removing `keyPrefixBytesCount` first bytes from Keccak (32bytes)
- `valueN length` - a value length represented as `ushort` takes 2 bytes
- `valueN` - a binary payload representing a specific page

### Writing

The writing process goes from the file 0 to the latest one trying to find a place in a page specified by the first bytes of the key. If, for the specific file, there's no place in the page, the next file is considered. Once the last one fails a new file is created. 

This means that it can access multiple files trying to find it. Currently there's no optimization providing a "sealing" mechanism. This can be introduced adding a simple bit vector for each file marking whether the specific page is filled or not.

### Reading

The reading process is a zero-copy process. First, the page number is determined. Next files are scanned (the same page address in every file). Due to the nature of the page, that stores all the keys in the front and usage of a `ulong` match before spans are compared, the lookup should be fast. Once the key is found, a zero-copy slice using `Span<byte>(void*, int)` is returned to the caller.
