### PR TITLE
codeQlImpr

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,10 +21,6 @@ jobs:
         fetch-depth: 2
     - name: Updating submodules
       run: git submodule update --init src/int256 src/rocksdb-sharp src/Dirichlet src/tests
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1
       with:


### PR DESCRIPTION
Followed the guidance from the build message:


1 issue was detected with this workflow: git checkout HEAD^2 is no longer necessary. Please remove this step as Code Scanning recommends analyzing the merge commit for best results. | Analyze Nethermind code (csharp): .github#L1
-- | --


