### PR TITLE
Uses the first segment of the path instead of the last for web socket module name.

### DIFF
--- a/src/Nethermind/Nethermind.WebSockets/Extensions.cs
+++ b/src/Nethermind/Nethermind.WebSockets/Extensions.cs
@@ -49,7 +49,7 @@ namespace Nethermind.WebSockets
                     if (context.Request.Path.HasValue)
                     {
                         var path = context.Request.Path.Value;
-                        moduleName = path.Split("/").FirstOrDefault();
+                        moduleName = path.Split("/", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).FirstOrDefault();
                     }
 
                     module = webSocketsManager.GetModule(moduleName);

--- a/src/Nethermind/Nethermind.WebSockets/Extensions.cs
+++ b/src/Nethermind/Nethermind.WebSockets/Extensions.cs
@@ -49,7 +49,7 @@ namespace Nethermind.WebSockets
                     if (context.Request.Path.HasValue)
                     {
                         var path = context.Request.Path.Value;
-                        moduleName = path.Split("/").LastOrDefault();
+                        moduleName = path.Split("/").FirstOrDefault();
                     }
 
                     module = webSocketsManager.GetModule(moduleName);


### PR DESCRIPTION
This allows modules to utilize the rest of the path for module-specific things like `ws://nethermind:8545/my_module/watch/contract_address/`.