### PR TITLE
Makes docker-build workflow only run as part of tihs repository.

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   dockers-build:
+    if: github.repository_owner == 'NethermindEth'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
If you have a fork of this repository, this job tries to run on commit but fails because secrets aren't available.  This failure results in emails being sent to the author.

This conditional should make it so it only runs as part of this repository.