### PR TITLE
Changes mainnet pruning cache size to 2GB.

### DIFF
--- a/src/Nethermind/Nethermind.Runner/configs/mainnet_pruned.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/mainnet_pruned.cfg
@@ -29,7 +29,7 @@
   },
   "Pruning": {
     "Enabled": true,
-    "CacheMb": 2048,
+    "CacheMb": 1024,
     "PersistenceInterval": 16384
   },
   "Sync": {

--- a/src/Nethermind/Nethermind.Runner/configs/mainnet_pruned.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/mainnet_pruned.cfg
@@ -29,7 +29,7 @@
   },
   "Pruning": {
     "Enabled": true,
-    "CacheMb": 256,
+    "CacheMb": 2048,
     "PersistenceInterval": 16384
   },
   "Sync": {


### PR DESCRIPTION
2GB works for me, though I don't know if it is "optimal".  I'm open to setting it to some other default that is perhaps more reasonable if this one isn't, but I believe we can all agree that 256MB is *not* a reasonable default.  😄