### PR TITLE
Enable HealthChecks by default in ndm_consumer_xdai.cfg

### DIFF
--- a/src/Nethermind/Nethermind.Runner/configs/ndm_consumer_xdai.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/ndm_consumer_xdai.cfg
@@ -84,8 +84,8 @@
       16
     ]
   },
-    "HealthChecks": {
-        "Enabled": true,
-        "UIEnabled": true
-    }
+  "HealthChecks": {
+    "Enabled": true,
+    "UIEnabled": true
+  }
 }

--- a/src/Nethermind/Nethermind.Runner/configs/ndm_consumer_xdai.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/ndm_consumer_xdai.cfg
@@ -83,5 +83,9 @@
       16,
       16
     ]
-  }
+  },
+    "HealthChecks": {
+        "Enabled": true,
+        "UIEnabled": true
+    }
 }


### PR DESCRIPTION
Would be great to enable HealthChecks plugin by default to check node status when having node connection issues in NDM. Telling whether the node is synced or not won't be easy to most users.