### PR TITLE
Evm stack word fixup

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/VirtualMachineTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/VirtualMachineTests.cs
@@ -1,4 +1,4 @@
-﻿//  Copyright (c) 2021 Demerzel Solutions Limited
+//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
 // 
 //  The Nethermind library is free software: you can redistribute it and/or modify
@@ -265,11 +265,23 @@ namespace Nethermind.Evm.Test
         [Test]
         public void Dup1()
         {
-            var receipt = Execute(
-                (byte)Instruction.PUSH1,
-                0,
-                (byte)Instruction.DUP1);
-            Assert.AreEqual(GasCostOf.Transaction + GasCostOf.VeryLow * 2, receipt.GasSpent, "gas");
+            string data = "DE92C51EC07847B49840537ED96EAB2696AAE0B0A5AA4598AAA6CD1CAC0CC4ED".ToLowerInvariant();
+            byte[] code = Prepare.EvmCode
+                .PushData(data)
+                .Op(Instruction.DUP1)
+                .Op(Instruction.POP)
+                .Done;
+            
+            var trace = ExecuteAndTrace(code);
+
+            GethTxTraceEntry entry = trace.Entries[1];
+            Assert.AreEqual("DUP1", entry.Operation, nameof(entry.Operation));
+            Assert.AreEqual(GasCostOf.VeryLow, entry.GasCost, nameof(entry.GasCost));
+
+            var pop = trace.Entries[2];
+            Assert.AreEqual(2, pop.Stack.Count);
+            Assert.AreEqual(data, pop.Stack[0]);
+            Assert.AreEqual(data, pop.Stack[1]);
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Evm/EvmStack.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmStack.cs
@@ -381,13 +381,13 @@ namespace Nethermind.Evm
             [FieldOffset(0)]
             public ulong u0;
 
-            [FieldOffset(1)]
+            [FieldOffset(8)]
             public ulong u1;
 
-            [FieldOffset(2)]
+            [FieldOffset(16)]
             public ulong u2;
 
-            [FieldOffset(3)]
+            [FieldOffset(24)]
             public ulong u3;
         }
     }


### PR DESCRIPTION
This PR fixes up wrong offsets assigned to fields of the `EvmStack`.

### Updates 

I can't make it JIT to wrong ASM. For both cases the following

```csharp
WriteUnaligned(ref destination, ReadUnaligned<Word>(ref source));
```

issues a vectorized copy 

```asm
vmovdqu xmm0, [rax]
vmovdqu [rbp+0x10], xmm0
vmovdqu xmm0, [rax+0x10]
vmovdqu [rbp+0x20], xmm0
vmovdqu xmm0, [rbp+0x10]
vmovdqu [rax], xmm0
vmovdqu xmm0, [rbp+0x20]
vmovdqu [rax+0x10], xmm0
```

which I fail to find as invalid.