### PR TITLE
Fix/arm64 binary

### DIFF
--- a/scripts/deployment/build-runner.sh
+++ b/scripts/deployment/build-runner.sh
@@ -2,6 +2,7 @@
 #exit when any command fails
 set -e
 RUNNER_PATH=$RELEASE_DIRECTORY/nethermind/src/Nethermind/Nethermind.Runner
+ARM_ROCKSDB_PATH=$RELEASE_DIRECTORY/nethermind/scripts/deployment/arm
 PUBLISH_PATH=bin/release/net5.0
 OUT=out
 
@@ -16,6 +17,8 @@ dotnet publish -c release -r $LINUX -p:PublishSingleFile=true -p:IncludeAllConte
 dotnet publish -c release -r $OSX -p:PublishSingleFile=true -p:IncludeAllContentForSelfExtract=true -o $OUT/$OSX_RELEASE
 dotnet publish -c release -r $WIN10 -p:PublishSingleFile=true -p:IncludeAllContentForSelfExtract=true -o $OUT/$WIN_RELEASE
 dotnet publish -c release -r $LINUX_ARM -p:PublishSingleFile=true -p:IncludeAllContentForSelfExtract=true -o $OUT/$LIN_ARM_RELEASE
+
+cp $ARM_ROCKSDB_PATH/librocksdb.so ../../rocksdb-sharp/RocksDbNative/runtimes/linux-arm64/native/librocksdb.so
 dotnet publish -c release -r $LINUX_ARM64 -p:PublishSingleFile=true -p:IncludeAllContentForSelfExtract=true -o $OUT/$LIN_ARM64_RELEASE
 
 rm -rf $OUT/$LIN_RELEASE/Data

--- a/scripts/deployment/build-runner.sh
+++ b/scripts/deployment/build-runner.sh
@@ -2,7 +2,7 @@
 #exit when any command fails
 set -e
 RUNNER_PATH=$RELEASE_DIRECTORY/nethermind/src/Nethermind/Nethermind.Runner
-ARM_ROCKSDB_PATH=$RELEASE_DIRECTORY/nethermind/scripts/deployment/arm
+ARM_ROCKSDB_PATH=$RELEASE_DIRECTORY/nethermind/scripts/deployment/arm64/runtimes
 PUBLISH_PATH=bin/release/net5.0
 OUT=out
 


### PR DESCRIPTION
* workaround using 5.17.2 rocksdb version for arm64 binaries to avoid `Core dump (Illegal instruction)`
* docker arm64 stays intact