### PR TITLE
Tx pool improvements 2

### DIFF
--- a/src/Nethermind/Nethermind.AuRa.Test/Transactions/PermissionTxComparerTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/Transactions/PermissionTxComparerTests.cs
@@ -268,7 +268,7 @@ namespace Nethermind.AuRa.Test.Transactions
             transactions = transactionSelect?.Invoke(transactions) ?? transactions;
             expectation = transactionSelect?.Invoke(expectation) ?? expectation;
 
-            IComparer<Transaction> comparer = new CompareTxByPermissionOnSpecifiedBlock(sendersWhitelist, priorities, blockHeader)
+            IComparer<Transaction> comparer = new CompareTxByPriorityOnSpecifiedBlock(sendersWhitelist, priorities, blockHeader)
                 .ThenBy(TxPool.TxPool.DefaultComparer); 
             
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/TxPools/Collections/DistinctValueSortedPoolTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TxPools/Collections/DistinctValueSortedPoolTests.cs
@@ -149,6 +149,8 @@ namespace Nethermind.Blockchain.Test.TxPools.Collections
 
             protected override IComparer<WithFinalizer> GetUniqueComparer(IComparer<WithFinalizer> comparer) => comparer;
 
+            protected override IComparer<WithFinalizer> GetGroupComparer(IComparer<WithFinalizer> comparer) => comparer;
+
             protected override int MapToGroup(WithFinalizer value) => value.Index;
         }
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/TxPools/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TxPools/TxPoolTests.cs
@@ -187,6 +187,17 @@ namespace Nethermind.Blockchain.Test.TxPools
             _txPool.GetPendingTransactions().Length.Should().Be(0);
             result.Should().Be(AddTxResult.OldNonce);
         }
+        
+        [Test]
+        public void should_ignore_transactions_too_far_into_future()
+        {
+            _txPool = CreatePool(_noTxStorage);
+            Transaction tx = Build.A.Transaction.WithNonce(_txPool.FutureNonceRetention + 1).SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA).TestObject;
+            EnsureSenderBalance(tx);
+            AddTxResult result = _txPool.AddTransaction(tx, TxHandlingOptions.PersistentBroadcast);
+            _txPool.GetPendingTransactions().Length.Should().Be(0);
+            result.Should().Be(AddTxResult.FutureNonce);
+        }
 
         [Test]
         public void should_ignore_overflow_transactions()

--- a/src/Nethermind/Nethermind.Blockchain/Producers/TxPoolTxSource.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Producers/TxPoolTxSource.cs
@@ -151,7 +151,7 @@ namespace Nethermind.Blockchain.Producers
                         _transactionPool.RemoveTransaction(tx.Hash, 0, true);    
                     }
                     
-                    if (tx.Nonce > expectedNonce + 16)
+                    if (tx.Nonce > expectedNonce + _transactionPool.FutureNonceRetention)
                     {
                         _transactionPool.RemoveTransaction(tx.Hash, 0);
                     }

--- a/src/Nethermind/Nethermind.Consensus.AuRa/Transactions/CompareTxByPriorityBase.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/Transactions/CompareTxByPriorityBase.cs
@@ -28,14 +28,14 @@ using Nethermind.TxPool;
 
 namespace Nethermind.Consensus.AuRa.Transactions
 {
-    public abstract class CompareTxByPermissionBase : IComparer<Transaction>
+    public abstract class CompareTxByPriorityBase : IComparer<Transaction>
     {
         private readonly IContractDataStore<Address> _sendersWhitelist;
         private readonly IDictionaryContractDataStore<TxPriorityContract.Destination> _priorities;
         private Keccak _blockHash;
         private ISet<Address> _sendersWhiteListSet;
 
-        public CompareTxByPermissionBase(IContractDataStore<Address> sendersWhitelist, // expected HashSet based
+        public CompareTxByPriorityBase(IContractDataStore<Address> sendersWhitelist, // expected HashSet based
             IDictionaryContractDataStore<TxPriorityContract.Destination> priorities) // expected SortedList based)
         {
             _sendersWhitelist = sendersWhitelist ?? throw new ArgumentNullException(nameof(sendersWhitelist));

--- a/src/Nethermind/Nethermind.Consensus.AuRa/Transactions/CompareTxByPriorityOnHead.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/Transactions/CompareTxByPriorityOnHead.cs
@@ -16,24 +16,29 @@
 // 
 
 using System;
+using System.Linq;
+using System.Threading;
+using Nethermind.Blockchain;
 using Nethermind.Consensus.AuRa.Contracts;
 using Nethermind.Consensus.AuRa.Contracts.DataStore;
 using Nethermind.Core;
-using Nethermind.Core.Extensions;
 using Nethermind.Int256;
 
 namespace Nethermind.Consensus.AuRa.Transactions
 {
-    public class CompareTxByPermissionOnSpecifiedBlock : CompareTxByPermissionBase
+    public class CompareTxByPriorityOnHead : CompareTxByPriorityBase
     {
-        public CompareTxByPermissionOnSpecifiedBlock(
-            IContractDataStore<Address> sendersWhitelist, 
-            IDictionaryContractDataStore<TxPriorityContract.Destination> priorities, 
-            BlockHeader blockHeader) : base(sendersWhitelist, priorities)
+        private readonly IBlockTree _blockTree;
+
+        public CompareTxByPriorityOnHead(
+            IContractDataStore<Address> sendersWhitelist, // expected HashSet based
+            IDictionaryContractDataStore<TxPriorityContract.Destination> priorities, // expected SortedList based
+            IBlockTree blockTree) 
+            : base(sendersWhitelist, priorities)
         {
-            BlockHeader = blockHeader;
+            _blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
         }
 
-        protected override BlockHeader BlockHeader { get; }
+        protected override BlockHeader BlockHeader => _blockTree.Head.Header;
     }
 }

--- a/src/Nethermind/Nethermind.Consensus.AuRa/Transactions/CompareTxByPriorityOnSpecifiedBlock.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/Transactions/CompareTxByPriorityOnSpecifiedBlock.cs
@@ -16,28 +16,24 @@
 // 
 
 using System;
-using System.Linq;
-using Nethermind.Blockchain;
 using Nethermind.Consensus.AuRa.Contracts;
 using Nethermind.Consensus.AuRa.Contracts.DataStore;
 using Nethermind.Core;
+using Nethermind.Core.Extensions;
 using Nethermind.Int256;
 
 namespace Nethermind.Consensus.AuRa.Transactions
 {
-    public class CompareTxByPermissionOnHead : CompareTxByPermissionBase
+    public class CompareTxByPriorityOnSpecifiedBlock : CompareTxByPriorityBase
     {
-        private readonly IBlockTree _blockTree;
-
-        public CompareTxByPermissionOnHead(
-            IContractDataStore<Address> sendersWhitelist, // expected HashSet based
-            IDictionaryContractDataStore<TxPriorityContract.Destination> priorities, // expected SortedList based
-            IBlockTree blockTree) 
-            : base(sendersWhitelist, priorities)
+        public CompareTxByPriorityOnSpecifiedBlock(
+            IContractDataStore<Address> sendersWhitelist, 
+            IDictionaryContractDataStore<TxPriorityContract.Destination> priorities, 
+            BlockHeader blockHeader) : base(sendersWhitelist, priorities)
         {
-            _blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
+            BlockHeader = blockHeader;
         }
 
-        protected override BlockHeader BlockHeader => _blockTree.Head.Header;
+        protected override BlockHeader BlockHeader { get; }
     }
 }

--- a/src/Nethermind/Nethermind.Consensus.AuRa/Transactions/CompareTxSameSenderNonce.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/Transactions/CompareTxSameSenderNonce.cs
@@ -1,0 +1,53 @@
+//  Copyright (c) 2018 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
+
+using System.Collections.Generic;
+using Nethermind.Core;
+
+namespace Nethermind.Consensus.AuRa.Transactions
+{
+    public class CompareTxSameSenderNonce : IComparer<Transaction>
+    {
+        private readonly IComparer<Transaction> _sameSenderNoncePriorityComparer;
+        private readonly IComparer<Transaction> _differentSenderNoncePriorityComparer;
+
+        public CompareTxSameSenderNonce(
+            IComparer<Transaction> sameSenderNoncePriorityComparer, 
+            IComparer<Transaction> differentSenderNoncePriorityComparer)
+        {
+            _sameSenderNoncePriorityComparer = sameSenderNoncePriorityComparer;
+            _differentSenderNoncePriorityComparer = differentSenderNoncePriorityComparer;
+        }
+            
+        public int Compare(Transaction? x, Transaction? y)
+        {
+            IComparer<Transaction> firstComparer = _differentSenderNoncePriorityComparer;
+            IComparer<Transaction> secondComparer = _sameSenderNoncePriorityComparer;
+
+            bool sameNonceAndSender = Equals(x?.Nonce, y?.Nonce) && Equals(x?.SenderAddress, y?.SenderAddress);
+            if (sameNonceAndSender)
+            {
+                
+                firstComparer = _sameSenderNoncePriorityComparer;
+                secondComparer = _differentSenderNoncePriorityComparer;
+            }
+
+            int result = firstComparer.Compare(x, y);
+            return result != 0 ? result : secondComparer.Compare(x, y);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Consensus.AuRa/Transactions/TxPriorityTxSource.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/Transactions/TxPriorityTxSource.cs
@@ -35,7 +35,7 @@ namespace Nethermind.Consensus.AuRa.Transactions
     {
         private readonly IContractDataStore<Address> _sendersWhitelist;
         private readonly IDictionaryContractDataStore<TxPriorityContract.Destination> _priorities;
-        private CompareTxByPermissionOnSpecifiedBlock _comparer;
+        private CompareTxByPriorityOnSpecifiedBlock _comparer;
 
 
         public TxPriorityTxSource(
@@ -53,7 +53,7 @@ namespace Nethermind.Consensus.AuRa.Transactions
 
         protected override IComparer<Transaction> GetComparer(BlockHeader parent)
         {
-            _comparer = new CompareTxByPermissionOnSpecifiedBlock(_sendersWhitelist, _priorities, parent);
+            _comparer = new CompareTxByPriorityOnSpecifiedBlock(_sendersWhitelist, _priorities, parent);
             return _comparer.ThenBy(base.GetComparer(parent));
         }
 

--- a/src/Nethermind/Nethermind.Core/CompositeComparer.cs
+++ b/src/Nethermind/Nethermind.Core/CompositeComparer.cs
@@ -58,10 +58,8 @@ namespace Nethermind.Core
             }
         }
         
-#pragma warning disable 8767
-        // fixed C# 9
-        public int Compare(T x, T y)
-#pragma warning restore 8767
+
+        public int Compare(T? x, T? y)
         {
             int result = 0;
             for (int i = 0; i < _comparers.Count; i++)

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/ParityModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/ParityModuleTests.cs
@@ -74,9 +74,11 @@ namespace Nethermind.JsonRpc.Test.Modules
             peerManager.ActivePeers.Returns(new List<Peer> {peerA, peerB, peerC});
             peerManager.ConnectedPeers.Returns(new List<Peer> {peerA, peerB, peerA, peerC, peerB});
             peerManager.MaxActivePeers.Returns(15);
+
+            StateProvider stateProvider = new StateProvider(new TrieStore(new MemDb(), LimboLogs.Instance), new MemDb(), LimboLogs.Instance);
             
             var txPool = new TxPool.TxPool(txStorage, ethereumEcdsa, new FixedBlockChainHeadSpecProvider(specProvider), new TxPoolConfig(),
-                new StateProvider(new TrieStore(new MemDb(), LimboLogs.Instance), new MemDb(), LimboLogs.Instance), new TxValidator(specProvider.ChainId), LimboLogs.Instance);
+                stateProvider, new TxValidator(specProvider.ChainId), LimboLogs.Instance);
             
             IDb blockDb = new MemDb();
             IDb headerDb = new MemDb();
@@ -94,6 +96,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             var pendingTransaction = Build.A.Transaction.Signed(ethereumEcdsa, TestItem.PrivateKeyD, false)
                 .WithSenderAddress(Address.FromNumber((UInt256)blockNumber)).TestObject;
             pendingTransaction.Signature.V = 37;
+            stateProvider.CreateAccount(pendingTransaction.SenderAddress, UInt256.UInt128MaxValue);
             txPool.AddTransaction(pendingTransaction, TxHandlingOptions.None);
             
             blockNumber = 1;
@@ -101,6 +104,7 @@ namespace Nethermind.JsonRpc.Test.Modules
                 .WithSenderAddress(Address.FromNumber((UInt256)blockNumber))
                 .WithNonce(100).TestObject;
             transaction.Signature.V = 37;
+            stateProvider.CreateAccount(transaction.SenderAddress, UInt256.UInt128MaxValue);
             txPool.AddTransaction(transaction, TxHandlingOptions.None);
 
             

--- a/src/Nethermind/Nethermind.Runner/Ethereum/Steps/InitializeBlockchainAuRa.cs
+++ b/src/Nethermind/Nethermind.Runner/Ethereum/Steps/InitializeBlockchainAuRa.cs
@@ -241,10 +241,10 @@ namespace Nethermind.Runner.Ethereum.Steps
 
                 _api.DisposeStack.Push(whitelistContractDataStore);
                 _api.DisposeStack.Push(prioritiesContractDataStore);
-                IComparer<Transaction> txByPermissionComparer = new CompareTxByPermissionOnHead(whitelistContractDataStore, prioritiesContractDataStore, _api.BlockTree);
+                IComparer<Transaction> txByPriorityComparer = new CompareTxByPriorityOnHead(whitelistContractDataStore, prioritiesContractDataStore, _api.BlockTree);
+                IComparer<Transaction> sameSenderNonceComparer = new CompareTxSameSenderNonce(CompareTxByGasPrice.Instance, txByPriorityComparer);
                 
-                return CompareTxByGasPrice.Instance
-                    .ThenBy(txByPermissionComparer)
+                return sameSenderNonceComparer
                     .ThenBy(CompareTxByTimestamp.Instance)
                     .ThenBy(CompareTxByPoolIndex.Instance)
                     .ThenBy(CompareTxByGasLimit.Instance);

--- a/src/Nethermind/Nethermind.TxPool/AddTxResult.cs
+++ b/src/Nethermind/Nethermind.TxPool/AddTxResult.cs
@@ -19,12 +19,12 @@ namespace Nethermind.TxPool
     public enum AddTxResult
     {
         AlreadyKnown,
-        OldScheme,
         Invalid,
         OldNonce,
         PotentiallyUseless,
         Added,
         OwnNonceAlreadyUsed,
-        Filtered
+        Filtered,
+        InsufficientFunds
     }
 }

--- a/src/Nethermind/Nethermind.TxPool/AddTxResult.cs
+++ b/src/Nethermind/Nethermind.TxPool/AddTxResult.cs
@@ -25,6 +25,7 @@ namespace Nethermind.TxPool
         Added,
         OwnNonceAlreadyUsed,
         Filtered,
-        InsufficientFunds
+        InsufficientFunds,
+        FutureNonce
     }
 }

--- a/src/Nethermind/Nethermind.TxPool/Collections/TxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/TxDistinctSortedPool.cs
@@ -30,6 +30,9 @@ namespace Nethermind.TxPool.Collections
         }
 
         protected override IComparer<Transaction> GetUniqueComparer(IComparer<Transaction> comparer) =>
+            TxSortedPool.GetPoolUniqueTxComparer(comparer);
+
+        protected override IComparer<Transaction> GetGroupComparer(IComparer<Transaction> comparer) =>
             TxSortedPool.GetPoolUniqueTxComparerByNonce(comparer);
 
         protected override Address MapToGroup(Transaction value) => TxSortedPool.MapTxToGroup(value);

--- a/src/Nethermind/Nethermind.TxPool/Collections/TxSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/TxSortedPool.cs
@@ -31,14 +31,18 @@ namespace Nethermind.TxPool.Collections
         {
         }
 
-        protected override IComparer<Transaction> GetUniqueComparer(IComparer<Transaction> comparer) => GetPoolUniqueTxComparerByNonce(comparer);
+        protected override IComparer<Transaction> GetUniqueComparer(IComparer<Transaction> comparer) => GetPoolUniqueTxComparer(comparer);
+        protected override IComparer<Transaction> GetGroupComparer(IComparer<Transaction> comparer) => GetPoolUniqueTxComparerByNonce(comparer);
 
         protected override Address MapToGroup(Transaction value) => MapTxToGroup(value);
+        
+        internal static IComparer<Transaction> GetPoolUniqueTxComparer(IComparer<Transaction> comparer)
+            => comparer
+                .ThenBy(DistinctCompareTx.Instance); // in order to sort properly and not loose transactions we need to differentiate on their identity which provided comparer might not be doing
 
         internal static IComparer<Transaction> GetPoolUniqueTxComparerByNonce(IComparer<Transaction> comparer)
             => CompareTxByNonce.Instance // we need to ensure transactions are ordered by nonce, which might not be done in supplied comparer
-                .ThenBy(comparer)
-                .ThenBy(DistinctCompareTx.Instance); // in order to sort properly and not loose transactions we need to differentiate on their identity which provided comparer might not be doing
+                .ThenBy(GetPoolUniqueTxComparer(comparer));
 
         internal static Address MapTxToGroup(Transaction value) => value.SenderAddress;
     }

--- a/src/Nethermind/Nethermind.TxPool/ITxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxPool.cs
@@ -41,5 +41,7 @@ namespace Nethermind.TxPool
         event EventHandler<TxEventArgs> NewDiscovered;
         event EventHandler<TxEventArgs> NewPending;
         event EventHandler<TxEventArgs> RemovedPending;
+        
+        public uint FutureNonceRetention { get; }
     }
 }

--- a/src/Nethermind/Nethermind.TxPool/ITxPoolConfig.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxPoolConfig.cs
@@ -26,6 +26,9 @@ namespace Nethermind.TxPool
         [ConfigItem(DefaultValue = "2048", Description = "Max number of transactions held in mempool (more transactions in mempool mean more memory used")]
         int Size { get; set; }
         
+        [ConfigItem(DefaultValue = "16", Description = "Defines how much into the future transactions are kept.")]
+        uint FutureNonceRetention { get; set; }
+        
         [ConfigItem(DefaultValue = "524288",
             Description = "Max number of cached hashes of already known transactions." +
                           "It is set automatically by the memory hint.")]

--- a/src/Nethermind/Nethermind.TxPool/NullTxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/NullTxPool.cs
@@ -70,5 +70,7 @@ namespace Nethermind.TxPool
             add { }
             remove { }
         }
+
+        public uint FutureNonceRetention { get; } = 16;
     }
 }

--- a/src/Nethermind/Nethermind.TxPool/TxPoolConfig.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPoolConfig.cs
@@ -20,6 +20,7 @@ namespace Nethermind.TxPool
     {
         public int PeerNotificationThreshold { get; set; } = 5;
         public int Size { get; set; } = 2048;
+        public uint FutureNonceRetention { get; set; } = 16;
         public int HashCacheSize { get; set; } = 512 * 1024;
     }
 }


### PR DESCRIPTION
This PR tries to solve an issue on xdai that some prioritized transactions didn't get mined. Conclusions for investigations:
1. Sorting logic to remove transactions were wrong - nonce over priority. We need to sort for nonce only in per sender buckets.
2. A lot of garbage transactions were pushing out good transactions beyond TxPool capacity and they were getting dropped.

Changes:
1. Improvements to not accepting transactions into pool in the first place if:
a) Nonce is too old
b) Nonce is far into the future (configurable - maybe better naming needed for FutureNonceRetention)
c) Balance is too low
d) Tx cost is too high (overflow)

2. Better sorting for transaction removal (separate sorting criteria in buckets and for removal).
3. Some general refactorings