### PR TITLE
block production triggers

### DIFF
--- a/src/Nethermind/Nethermind.Api/IApiWithBlockchain.cs
+++ b/src/Nethermind/Nethermind.Api/IApiWithBlockchain.cs
@@ -19,6 +19,7 @@
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Filters;
 using Nethermind.Blockchain.Processing;
+using Nethermind.Blockchain.Producers;
 using Nethermind.Blockchain.Rewards;
 using Nethermind.Blockchain.Validators;
 using Nethermind.Config;
@@ -48,6 +49,7 @@ namespace Nethermind.Api
         IFilterStore? FilterStore { get; set; }
         IFilterManager? FilterManager { get; set; }
         IHeaderValidator? HeaderValidator { get; set; }
+        IManualBlockProductionTrigger ManualBlockProductionTrigger { get; set; }
         ReadOnlyTrieStore? ReadOnlyTrieStore { get; set; }
         IRewardCalculatorSource? RewardCalculatorSource { get; set; }
         ISealer? Sealer { get; set; }

--- a/src/Nethermind/Nethermind.Api/IApiWithNetwork.cs
+++ b/src/Nethermind/Nethermind.Api/IApiWithNetwork.cs
@@ -48,7 +48,7 @@ namespace Nethermind.Api
         IProtocolValidator? ProtocolValidator { get; set; }
         IList<IPublisher> Publishers { get; }
         IRlpxPeer? RlpxPeer { get; set; }
-        IRpcModuleProvider RpcModuleProvider { get; set; }
+        IRpcModuleProvider? RpcModuleProvider { get; set; }
         ISessionMonitor? SessionMonitor { get; set; }
         IStaticNodesManager? StaticNodesManager { get; set; }
         ISynchronizer? Synchronizer { get; set; }

--- a/src/Nethermind/Nethermind.Blockchain.Test/Consensus/OneByOneTxSourceTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Consensus/OneByOneTxSourceTests.cs
@@ -1,0 +1,41 @@
+//  Copyright (c) 2021 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
+
+using System.Linq;
+using FluentAssertions;
+using Nethermind.Consensus.Transactions;
+using Nethermind.Core;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Blockchain.Test.Consensus
+{
+    [TestFixture]
+    public class OneByOneTxSourceTests
+    {
+        [Test]
+        public void Can_serve_one_by_one()
+        {
+            ITxSource source = Substitute.For<ITxSource>();
+            source.GetTransactions(null, 0).Returns(new Transaction[5]);
+            
+            ITxSource oneByOne = source.ServeTxsOneByOne();
+            oneByOne.GetTransactions(null, 0).Count().Should().Be(1);
+
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Blockchain.Test/Producers/BlockProducerTests_IsProducingBlocks.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Producers/BlockProducerTests_IsProducingBlocks.cs
@@ -15,6 +15,7 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 // 
 
+using System;
 using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
@@ -56,7 +57,7 @@ namespace Nethermind.Blockchain.Test.Producers
                 testRpc.State,
                 testRpc.BlockTree,
                 Substitute.For<IBlockProcessingQueue>(),
-                testRpc.TxPool,
+                new BuildBlocksRegularly(TimeSpan.FromMilliseconds(200)).IfPoolIsNotEmpty(testRpc.TxPool),
                 testRpc.Timestamper, 
                 testRpc.SpecProvider,
                 new MiningConfig(),

--- a/src/Nethermind/Nethermind.Blockchain.Test/Producers/BuildBlockOnEachPendingTxTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Producers/BuildBlockOnEachPendingTxTests.cs
@@ -1,0 +1,45 @@
+//  Copyright (c) 2018 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
+
+using FluentAssertions;
+using Nethermind.Blockchain.Producers;
+using Nethermind.Core.Test.Builders;
+using Nethermind.TxPool;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Blockchain.Test.Producers
+{
+    [TestFixture]
+    public class BuildBlockOnEachPendingTxTests
+    {
+        [Test]
+        public void On_pending_trigger_works()
+        {
+            int triggered = 0;
+            ITxPool txPool = Substitute.For<ITxPool>();
+            BuildBlockOnEachPendingTx trigger = new BuildBlockOnEachPendingTx(txPool);
+            trigger.TriggerBlockProduction += (s, e) => triggered++;
+            for (int i = 0; i < 2; i++)
+            {
+                txPool.NewPending += Raise.EventWith(new TxEventArgs(Build.A.Transaction.TestObject));    
+            }
+            
+            triggered.Should().Be(2);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Blockchain.Test/Producers/BuildBlockRegularlyTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Producers/BuildBlockRegularlyTests.cs
@@ -34,7 +34,7 @@ namespace Nethermind.Blockchain.Test.Producers
             trigger.TriggerBlockProduction += (s, e) => triggered++;
             Thread.Sleep(50);
 
-            triggered.Should().BeInRange(5, 15);
+            triggered.Should().BeInRange(1, 11);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain.Test/Producers/BuildBlockRegularlyTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Producers/BuildBlockRegularlyTests.cs
@@ -1,0 +1,40 @@
+//  Copyright (c) 2018 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
+
+using System;
+using System.Threading;
+using FluentAssertions;
+using Nethermind.Blockchain.Producers;
+using NUnit.Framework;
+
+namespace Nethermind.Blockchain.Test.Producers
+{
+    [TestFixture]
+    public class BuildBlockRegularlyTests
+    {
+        [Test]
+        public void Regular_trigger_works()
+        {
+            int triggered = 0;
+            BuildBlocksRegularly trigger = new BuildBlocksRegularly(TimeSpan.FromMilliseconds(5));
+            trigger.TriggerBlockProduction += (s, e) => triggered++;
+            Thread.Sleep(50);
+
+            triggered.Should().BeInRange(5, 15);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Blockchain.Test/Producers/BuildBlocksWhenRequestedTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Producers/BuildBlocksWhenRequestedTests.cs
@@ -1,0 +1,38 @@
+//  Copyright (c) 2018 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
+
+using FluentAssertions;
+using Nethermind.Blockchain.Producers;
+using Nethermind.Core.Test.Builders;
+using NUnit.Framework;
+
+namespace Nethermind.Blockchain.Test.Producers
+{
+    [TestFixture]
+    public class BuildBlocksWhenRequestedTests
+    {
+        [Test]
+        public void Manual_trigger_works()
+        {
+            bool triggered = false;
+            BuildBlocksWhenRequested trigger = new BuildBlocksWhenRequested();
+            trigger.TriggerBlockProduction += (s, e) => triggered = true;
+            trigger.BuildBlock();
+            triggered.Should().BeTrue();
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Blockchain.Test/Producers/CompositeBlockProductionTriggerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Producers/CompositeBlockProductionTriggerTests.cs
@@ -1,0 +1,45 @@
+//  Copyright (c) 2018 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
+
+using System;
+using System.Threading;
+using FluentAssertions;
+using Nethermind.Blockchain.Producers;
+using NUnit.Framework;
+
+namespace Nethermind.Blockchain.Test.Producers
+{
+    [TestFixture]
+    public class CompositeBlockProductionTriggerTests
+    {
+        [Test]
+        public void On_pending_trigger_works()
+        {
+            int triggered = 0;
+            BuildBlocksWhenRequested trigger1 = new BuildBlocksWhenRequested();
+            BuildBlocksWhenRequested trigger2 = new BuildBlocksWhenRequested();
+            IBlockProductionTrigger composite = trigger1.Or(trigger2);
+            composite.TriggerBlockProduction += (s, e) => triggered++;
+            trigger1.BuildBlock();
+            trigger2.BuildBlock();
+            trigger1.BuildBlock();
+            trigger2.BuildBlock();
+
+            triggered.Should().Be(4);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Blockchain.Test/Producers/IfPoolIsNotEmptyTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Producers/IfPoolIsNotEmptyTests.cs
@@ -1,0 +1,43 @@
+//  Copyright (c) 2018 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
+
+using FluentAssertions;
+using Nethermind.Blockchain.Producers;
+using Nethermind.Core;
+using Nethermind.TxPool;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Blockchain.Test.Producers
+{
+    public class IfPoolIsNotEmptyTests
+    {
+        [TestCase(0, false)]
+        [TestCase(1, true)]
+        public void Does_not_trigger_when_empty(int txCount, bool shouldTrigger)
+        {
+            var pool = Substitute.For<ITxPool>();
+            pool.GetPendingTransactions().Returns(new Transaction[txCount]);
+            bool triggered = false;
+            BuildBlocksWhenRequested trigger = new BuildBlocksWhenRequested();
+            IBlockProductionTrigger withCondition = trigger.IfPoolIsNotEmpty(pool);
+            withCondition.TriggerBlockProduction += (s, e) => triggered = true;
+            trigger.BuildBlock();
+            triggered.Should().Be(shouldTrigger);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Blockchain/BlockEventArgs.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockEventArgs.cs
@@ -21,9 +21,9 @@ namespace Nethermind.Blockchain
 {
     public class BlockEventArgs : EventArgs
     {
-        public Block Block { get; }
+        public Block? Block { get; }
 
-        public BlockEventArgs(Block block)
+        public BlockEventArgs(Block? block)
         {
             Block = block;
         }

--- a/src/Nethermind/Nethermind.Blockchain/BlockhashProvider.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockhashProvider.cs
@@ -28,9 +28,9 @@ namespace Nethermind.Blockchain
     {
         private static int _maxDepth = 256;
         private readonly IBlockTree _blockTree;
-        private ILogger _logger;
+        private readonly ILogger _logger;
 
-        public BlockhashProvider(IBlockTree blockTree, ILogManager logManager)
+        public BlockhashProvider(IBlockTree blockTree, ILogManager? logManager)
         {
             _blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
             _logger = logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));

--- a/src/Nethermind/Nethermind.Blockchain/Find/BlockParameter.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Find/BlockParameter.cs
@@ -21,25 +21,20 @@ using Nethermind.Serialization.Json;
 
 namespace Nethermind.Blockchain.Find
 {
-    [Todo(Improve.Refactor, "Can make it struct?")]
     public class BlockParameter : IEquatable<BlockParameter>
     {
-        public static BlockParameter Earliest = new BlockParameter(BlockParameterType.Earliest);
+        public static BlockParameter Earliest = new(BlockParameterType.Earliest);
 
-        public static BlockParameter Pending = new BlockParameter(BlockParameterType.Pending);
+        public static BlockParameter Pending = new(BlockParameterType.Pending);
 
-        public static BlockParameter Latest = new BlockParameter(BlockParameterType.Latest);
+        public static BlockParameter Latest = new(BlockParameterType.Latest);
 
         public BlockParameterType Type { get; set; }
         public long? BlockNumber { get; }
         
-        public Keccak BlockHash { get; }
+        public Keccak? BlockHash { get; }
 
         public bool RequireCanonical { get; }
-
-        public BlockParameter()
-        {
-        }
 
         public BlockParameter(BlockParameterType type)
         {
@@ -91,14 +86,14 @@ namespace Nethermind.Blockchain.Find
         {
             return $"{Type}, {BlockNumber?.ToString() ?? BlockHash?.ToString()}";
         }
-        public bool Equals(BlockParameter other)
+        public bool Equals(BlockParameter? other)
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
             return Type == other.Type && BlockNumber == other.BlockNumber && BlockHash == other.BlockHash && other.RequireCanonical == RequireCanonical;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;

--- a/src/Nethermind/Nethermind.Blockchain/Find/IBlockFinder.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Find/IBlockFinder.cs
@@ -23,101 +23,118 @@ namespace Nethermind.Blockchain.Find
     public interface IBlockFinder
     {
         Keccak HeadHash { get; }
-        
+
         Keccak GenesisHash { get; }
-        
+
         Keccak? PendingHash { get; }
-        
+
         Block? Head { get; }
-        
+
         Block? FindBlock(Keccak blockHash, BlockTreeLookupOptions options);
-        
+
         Block? FindBlock(long blockNumber, BlockTreeLookupOptions options);
-        
+
         BlockHeader? FindHeader(Keccak blockHash, BlockTreeLookupOptions options);
-        
+
         BlockHeader? FindHeader(long blockNumber, BlockTreeLookupOptions options);
-        
+
         Keccak? FindBlockHash(long blockNumber);
-        
+
         /// <summary>
         /// Checks if the block is currently in the canonical chain
         /// </summary>
         /// <param name="blockHeader">Block header to check</param>
         /// <returns><value>True</value> if part of the canonical chain, otherwise <value>False</value></returns>
         bool IsMainChain(BlockHeader blockHeader);
-        
+
         /// <summary>
         /// Checks if the block is currently in the canonical chain
         /// </summary>
         /// <param name="blockHash">Hash of the block to check</param>
         /// <returns><value>True</value> if part of the canonical chain, otherwise <value>False</value></returns>
         bool IsMainChain(Keccak blockHash);
-        
-        public Block FindBlock(Keccak blockHash) => FindBlock(blockHash, BlockTreeLookupOptions.None);
-        
-        public Block FindBlock(long blockNumber) => FindBlock(blockNumber, BlockTreeLookupOptions.RequireCanonical);
-        
-        public Block FindGenesisBlock() => FindBlock(GenesisHash, BlockTreeLookupOptions.RequireCanonical);
-        
-        public Block FindHeadBlock() => Head;
-        
-        public Block FindEarliestBlock() => FindGenesisBlock();
-        
-        public Block FindLatestBlock() => FindHeadBlock();
-        
-        public Block FindPendingBlock() => FindBlock(PendingHash, BlockTreeLookupOptions.None);
-        
-        public BlockHeader FindHeader(Keccak blockHash) => FindHeader(blockHash, BlockTreeLookupOptions.None);
-        
-        public BlockHeader FindHeader(long blockNumber) => FindHeader(blockNumber, BlockTreeLookupOptions.RequireCanonical);
-        
-        public BlockHeader FindGenesisHeader() => FindHeader(GenesisHash, BlockTreeLookupOptions.RequireCanonical);
+
+        public Block? FindBlock(Keccak blockHash) => FindBlock(blockHash, BlockTreeLookupOptions.None);
+
+        public Block? FindBlock(long blockNumber) => FindBlock(blockNumber, BlockTreeLookupOptions.RequireCanonical);
+
+        public Block? FindGenesisBlock() => FindBlock(GenesisHash, BlockTreeLookupOptions.RequireCanonical);
+
+        public Block? FindHeadBlock() => Head;
+
+        public Block? FindEarliestBlock() => FindGenesisBlock();
+
+        public Block? FindLatestBlock() => FindHeadBlock();
+
+        public Block? FindPendingBlock() =>
+            PendingHash == null ? null : FindBlock(PendingHash, BlockTreeLookupOptions.None);
+
+        public BlockHeader? FindHeader(Keccak blockHash) => FindHeader(blockHash, BlockTreeLookupOptions.None);
+
+        public BlockHeader? FindHeader(long blockNumber) =>
+            FindHeader(blockNumber, BlockTreeLookupOptions.RequireCanonical);
+
+        public BlockHeader FindGenesisHeader() =>
+            FindHeader(GenesisHash, BlockTreeLookupOptions.RequireCanonical)
+            ?? throw new Exception("Genesis header could not be found");
 
         public BlockHeader FindEarliestHeader() => FindGenesisHeader();
-        
-        public BlockHeader FindLatestHeader() => Head?.Header;
 
-        public BlockHeader FindPendingHeader() => FindHeader(PendingHash, BlockTreeLookupOptions.None);
-        
+        public BlockHeader? FindLatestHeader() => Head?.Header;
+
+        public BlockHeader? FindPendingHeader() =>
+            PendingHash == null ? null : FindHeader(PendingHash, BlockTreeLookupOptions.None);
+
         BlockHeader FindBestSuggestedHeader();
 
-        public Block FindBlock(BlockParameter blockParameter, bool headLimit = false)
+        public Block? FindBlock(BlockParameter? blockParameter, bool headLimit = false)
         {
             if (blockParameter == null)
             {
                 return FindLatestBlock();
             }
-            
+
             return blockParameter.Type switch
             {
                 BlockParameterType.Pending => FindPendingBlock(),
                 BlockParameterType.Latest => FindLatestBlock(),
                 BlockParameterType.Earliest => FindEarliestBlock(),
-                BlockParameterType.BlockNumber => headLimit && blockParameter.BlockNumber.Value >= Head.Number 
+                BlockParameterType.BlockNumber => headLimit && blockParameter.BlockNumber!.Value >= Head.Number
                     ? FindLatestBlock()
-                    : FindBlock(blockParameter.BlockNumber.Value, blockParameter.RequireCanonical ? BlockTreeLookupOptions.RequireCanonical : BlockTreeLookupOptions.None),
-                BlockParameterType.BlockHash => FindBlock(blockParameter.BlockHash, blockParameter.RequireCanonical ? BlockTreeLookupOptions.RequireCanonical : BlockTreeLookupOptions.None),
+                    : FindBlock(blockParameter.BlockNumber!.Value,
+                        blockParameter.RequireCanonical
+                            ? BlockTreeLookupOptions.RequireCanonical
+                            : BlockTreeLookupOptions.None),
+                BlockParameterType.BlockHash => FindBlock(blockParameter.BlockHash!,
+                    blockParameter.RequireCanonical
+                        ? BlockTreeLookupOptions.RequireCanonical
+                        : BlockTreeLookupOptions.None),
                 _ => throw new ArgumentException($"{nameof(BlockParameterType)} not supported: {blockParameter.Type}")
             };
         }
-        
-        public BlockHeader FindHeader(BlockParameter blockParameter, bool headLimit = false)
+
+        public BlockHeader? FindHeader(BlockParameter? blockParameter, bool headLimit = false)
         {
             if (blockParameter == null)
             {
                 return FindLatestHeader();
             }
-            
+
             return blockParameter.Type switch
             {
                 BlockParameterType.Pending => FindPendingHeader(),
                 BlockParameterType.Latest => FindLatestHeader(),
                 BlockParameterType.Earliest => FindEarliestHeader(),
-                BlockParameterType.BlockNumber => headLimit && blockParameter.BlockNumber.Value >= Head.Number 
-                    ? FindLatestHeader() 
-                    : FindHeader(blockParameter.BlockNumber.Value, blockParameter.RequireCanonical ? BlockTreeLookupOptions.RequireCanonical : BlockTreeLookupOptions.None),
-                BlockParameterType.BlockHash => FindHeader(blockParameter.BlockHash, blockParameter.RequireCanonical ? BlockTreeLookupOptions.RequireCanonical : BlockTreeLookupOptions.None),
+                BlockParameterType.BlockNumber => headLimit && blockParameter.BlockNumber!.Value >= Head.Number
+                    ? FindLatestHeader()
+                    : FindHeader(blockParameter.BlockNumber!.Value,
+                        blockParameter.RequireCanonical
+                            ? BlockTreeLookupOptions.RequireCanonical
+                            : BlockTreeLookupOptions.None),
+                BlockParameterType.BlockHash => FindHeader(blockParameter.BlockHash!,
+                    blockParameter.RequireCanonical
+                        ? BlockTreeLookupOptions.RequireCanonical
+                        : BlockTreeLookupOptions.None),
                 _ => throw new ArgumentException($"{nameof(BlockParameterType)} not supported: {blockParameter.Type}")
             };
         }

--- a/src/Nethermind/Nethermind.Blockchain/IBlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/IBlockTree.cs
@@ -40,7 +40,7 @@ namespace Nethermind.Blockchain
         /// <summary>
         /// Best header that has been suggested for processing
         /// </summary>
-        BlockHeader BestSuggestedHeader { get; }
+        BlockHeader? BestSuggestedHeader { get; }
 
         /// <summary>
         /// Best block that has been suggested for processing

--- a/src/Nethermind/Nethermind.Blockchain/Processing/BlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Processing/BlockProcessor.cs
@@ -54,19 +54,19 @@ namespace Nethermind.Blockchain.Processing
         /// We use a single receipt tracer for all blocks. Internally receipt tracer forwards most of the calls
         /// to any block-specific tracers.
         /// </summary>
-        private BlockReceiptsTracer _receiptsTracer;
+        private readonly BlockReceiptsTracer _receiptsTracer;
 
         public BlockProcessor(
-            ISpecProvider specProvider,
-            IBlockValidator blockValidator,
-            IRewardCalculator rewardCalculator,
-            ITransactionProcessor transactionProcessor,
-            IStateProvider stateProvider,
-            IStorageProvider storageProvider,
-            ITxPool txPool,
-            IReceiptStorage receiptStorage,
-            IWitnessCollector witnessCollector,
-            ILogManager logManager)
+            ISpecProvider? specProvider,
+            IBlockValidator? blockValidator,
+            IRewardCalculator? rewardCalculator,
+            ITransactionProcessor? transactionProcessor,
+            IStateProvider? stateProvider,
+            IStorageProvider? storageProvider,
+            ITxPool? txPool,
+            IReceiptStorage? receiptStorage,
+            IWitnessCollector? witnessCollector,
+            ILogManager? logManager)
         {
             _logger = logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
             _specProvider = specProvider ?? throw new ArgumentNullException(nameof(specProvider));

--- a/src/Nethermind/Nethermind.Blockchain/Processing/ReadOnlyTxProcessingEnv.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Processing/ReadOnlyTxProcessingEnv.cs
@@ -14,6 +14,7 @@
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
+using System;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.Db;
@@ -47,20 +48,20 @@ namespace Nethermind.Blockchain.Processing
         }
 
         public ReadOnlyTxProcessingEnv(
-            IReadOnlyDbProvider readOnlyDbProvider,
-            ReadOnlyTrieStore readOnlyTrieStore,
-            ReadOnlyBlockTree readOnlyBlockTree,
-            ISpecProvider specProvider,
-            ILogManager logManager)
+            IReadOnlyDbProvider? readOnlyDbProvider,
+            ReadOnlyTrieStore? readOnlyTrieStore,
+            ReadOnlyBlockTree? readOnlyBlockTree,
+            ISpecProvider? specProvider,
+            ILogManager? logManager)
         {
-            DbProvider = readOnlyDbProvider;
+            DbProvider = readOnlyDbProvider ?? throw new ArgumentNullException(nameof(readOnlyDbProvider));
             _codeDb = readOnlyDbProvider.CodeDb.AsReadOnly(true);
             
             StateReader = new StateReader(readOnlyTrieStore, _codeDb, logManager);
             StateProvider = new StateProvider(readOnlyTrieStore, _codeDb, logManager);
             StorageProvider = new StorageProvider(readOnlyTrieStore, StateProvider, logManager);
 
-            BlockTree = readOnlyBlockTree;
+            BlockTree = readOnlyBlockTree ?? throw new ArgumentNullException(nameof(readOnlyBlockTree));
             BlockhashProvider = new BlockhashProvider(BlockTree, logManager);
 
             Machine = new VirtualMachine(StateProvider, StorageProvider, BlockhashProvider, specProvider, logManager);

--- a/src/Nethermind/Nethermind.Blockchain/Producers/BuildBlockOnEachPendingTx.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Producers/BuildBlockOnEachPendingTx.cs
@@ -1,0 +1,45 @@
+//  Copyright (c) 2018 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
+
+using System;
+using Nethermind.TxPool;
+
+namespace Nethermind.Blockchain.Producers
+{
+    public class BuildBlockOnEachPendingTx : IBlockProductionTrigger, IDisposable
+    {
+        private readonly ITxPool _txPool;
+
+        public BuildBlockOnEachPendingTx(ITxPool txPool)
+        {
+            _txPool = txPool ?? throw new ArgumentNullException(nameof(txPool));
+            _txPool.NewPending += TxPoolOnNewPending;
+        }
+
+        private void TxPoolOnNewPending(object? sender, TxEventArgs e)
+        {
+            TriggerBlockProduction?.Invoke(this, EventArgs.Empty);
+        }
+
+        public event EventHandler? TriggerBlockProduction;
+
+        public void Dispose()
+        {
+            _txPool.NewPending -= TxPoolOnNewPending;
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Blockchain/Producers/BuildBlocksRegularly.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Producers/BuildBlocksRegularly.cs
@@ -1,0 +1,48 @@
+//  Copyright (c) 2018 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
+
+using System;
+using System.Timers;
+
+namespace Nethermind.Blockchain.Producers
+{
+    public class BuildBlocksRegularly : IBlockProductionTrigger, IDisposable
+    {
+        private readonly Timer _timer;
+        
+        public BuildBlocksRegularly(TimeSpan interval)
+        {
+            _timer = new Timer(interval.TotalMilliseconds);
+            _timer.Elapsed += TimerOnElapsed;
+            _timer.AutoReset = false;
+            _timer.Start();
+        }
+        
+        private void TimerOnElapsed(object sender, ElapsedEventArgs e)
+        {
+            TriggerBlockProduction?.Invoke(this, EventArgs.Empty);
+            _timer.Enabled = true;
+        }
+
+        public event EventHandler? TriggerBlockProduction;
+
+        public void Dispose()
+        {
+            _timer.Dispose();
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Blockchain/Producers/BuildBlocksWhenRequested.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Producers/BuildBlocksWhenRequested.cs
@@ -1,0 +1,31 @@
+//  Copyright (c) 2018 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
+
+using System;
+
+namespace Nethermind.Blockchain.Producers
+{
+    public class BuildBlocksWhenRequested : IManualBlockProductionTrigger
+    {
+        public void BuildBlock()
+        {
+            TriggerBlockProduction?.Invoke(this, EventArgs.Empty);
+        }
+
+        public event EventHandler? TriggerBlockProduction;
+    }
+}

--- a/src/Nethermind/Nethermind.Blockchain/Producers/CompositeBlockProductionTrigger.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Producers/CompositeBlockProductionTrigger.cs
@@ -1,0 +1,50 @@
+//  Copyright (c) 2018 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
+
+using System;
+
+namespace Nethermind.Blockchain.Producers
+{
+    public class CompositeBlockProductionTrigger : IBlockProductionTrigger, IDisposable
+    {
+        private readonly IBlockProductionTrigger[] _triggers;
+
+        public CompositeBlockProductionTrigger(params IBlockProductionTrigger[] triggers)
+        {
+            _triggers = triggers;
+            foreach (IBlockProductionTrigger trigger in _triggers)
+            {
+                trigger.TriggerBlockProduction += BlockProductionTriggerOnTriggerBlockProduction;
+            }
+        }
+
+        private void BlockProductionTriggerOnTriggerBlockProduction(object? sender, EventArgs e)
+        {
+            TriggerBlockProduction?.Invoke(sender, e);
+        }
+
+        public event EventHandler? TriggerBlockProduction;
+
+        public void Dispose()
+        {
+            foreach (IBlockProductionTrigger trigger in _triggers)
+            {
+                trigger.TriggerBlockProduction -= BlockProductionTriggerOnTriggerBlockProduction;
+            }
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Blockchain/Producers/IBlockProductionTrigger.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Producers/IBlockProductionTrigger.cs
@@ -1,0 +1,26 @@
+//  Copyright (c) 2018 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
+
+using System;
+
+namespace Nethermind.Blockchain.Producers
+{
+    public interface IBlockProductionTrigger
+    {
+        event EventHandler TriggerBlockProduction;
+    }
+}

--- a/src/Nethermind/Nethermind.Blockchain/Producers/IBlockProductionTriggerExtensions.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Producers/IBlockProductionTriggerExtensions.cs
@@ -1,0 +1,41 @@
+//  Copyright (c) 2018 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
+
+using System;
+using System.Linq;
+using Nethermind.TxPool;
+
+namespace Nethermind.Blockchain.Producers
+{
+    // ReSharper disable once InconsistentNaming
+    public static class IBlockProductionTriggerExtensions
+    {
+        public static IBlockProductionTrigger IfPoolIsNotEmpty(this IBlockProductionTrigger? trigger, ITxPool? txPool)
+        {
+            if (trigger == null) throw new ArgumentNullException(nameof(trigger));
+            if (txPool == null) throw new ArgumentNullException(nameof(txPool));
+            return new TriggerWithCondition(trigger, () => txPool.GetPendingTransactions().Any());
+        }
+        
+        public static IBlockProductionTrigger Or(this IBlockProductionTrigger? trigger, IBlockProductionTrigger? alternative)
+        {
+            if (trigger == null) throw new ArgumentNullException(nameof(trigger));
+            if (alternative == null) throw new ArgumentNullException(nameof(alternative));
+            return new CompositeBlockProductionTrigger(trigger, alternative);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Blockchain/Producers/IManualBlockProductionTrigger.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Producers/IManualBlockProductionTrigger.cs
@@ -1,0 +1,24 @@
+//  Copyright (c) 2018 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
+
+namespace Nethermind.Blockchain.Producers
+{
+    public interface IManualBlockProductionTrigger : IBlockProductionTrigger
+    {
+        public void BuildBlock();
+    }
+}

--- a/src/Nethermind/Nethermind.Blockchain/Producers/LoopBlockProducerBase.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Producers/LoopBlockProducerBase.cs
@@ -32,11 +32,11 @@ namespace Nethermind.Blockchain.Producers
     {
         private const int ChainNotYetProcessedMillisecondsDelay = 100;
         private readonly string _name;
-        private Task _producerTask;
-        private bool _isRunning = false;
+        private Task? _producerTask;
+        private bool _isRunning;
         
-        protected CancellationTokenSource LoopCancellationTokenSource { get; } = new CancellationTokenSource();
-        protected int _canProduce = 0;
+        protected CancellationTokenSource LoopCancellationTokenSource { get; } = new();
+        protected int _canProduce;
 
         protected LoopBlockProducerBase(
             ITxSource txSource,
@@ -94,7 +94,7 @@ namespace Nethermind.Blockchain.Producers
             BlockTree.NewBestSuggestedBlock -= BlockTreeOnNewBestSuggestedBlock;
             _isRunning = false;
             
-            LoopCancellationTokenSource?.Cancel();
+            LoopCancellationTokenSource.Cancel();
             await (_producerTask ?? Task.CompletedTask);
         }
 

--- a/src/Nethermind/Nethermind.Blockchain/Producers/TriggerWithCondition.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Producers/TriggerWithCondition.cs
@@ -1,0 +1,42 @@
+//  Copyright (c) 2018 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
+
+using System;
+
+namespace Nethermind.Blockchain.Producers
+{
+    public class TriggerWithCondition : IBlockProductionTrigger
+    {
+        private readonly Func<bool> _checkCondition;
+
+        public TriggerWithCondition(IBlockProductionTrigger trigger, Func<bool> checkCondition)
+        {
+            _checkCondition = checkCondition;
+            trigger.TriggerBlockProduction += TriggerOnTriggerBlockProduction;
+        }
+
+        private void TriggerOnTriggerBlockProduction(object? sender, EventArgs e)
+        {
+            if (_checkCondition.Invoke())
+            {
+                TriggerBlockProduction?.Invoke(this, EventArgs.Empty);
+            }
+        }
+
+        public event EventHandler? TriggerBlockProduction;
+    }
+}

--- a/src/Nethermind/Nethermind.Blockchain/Producers/TxPoolTxSource.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Producers/TxPoolTxSource.cs
@@ -40,7 +40,7 @@ namespace Nethermind.Blockchain.Producers
         private readonly ITxFilter _txFilter;
         protected readonly ILogger _logger;
 
-        public TxPoolTxSource(ITxPool transactionPool, IStateReader stateReader, ILogManager logManager, ITxFilter txFilter = null)
+        public TxPoolTxSource(ITxPool? transactionPool, IStateReader? stateReader, ILogManager? logManager, ITxFilter? txFilter = null)
         {
             _transactionPool = transactionPool ?? throw new ArgumentNullException(nameof(transactionPool));
             _stateReader = stateReader ?? throw new ArgumentNullException(nameof(stateReader));

--- a/src/Nethermind/Nethermind.Consensus/Transactions/ITxSource.cs
+++ b/src/Nethermind/Nethermind.Consensus/Transactions/ITxSource.cs
@@ -23,4 +23,6 @@ namespace Nethermind.Consensus.Transactions
     {
         IEnumerable<Transaction> GetTransactions(BlockHeader parent, long gasLimit);
     }
+    
+    
 }

--- a/src/Nethermind/Nethermind.Consensus/Transactions/ITxSourceExtensions.cs
+++ b/src/Nethermind/Nethermind.Consensus/Transactions/ITxSourceExtensions.cs
@@ -1,0 +1,28 @@
+//  Copyright (c) 2018 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
+
+namespace Nethermind.Consensus.Transactions
+{
+    // ReSharper disable once InconsistentNaming
+    public static class ITxSourceExtensions
+    {
+        public static ITxSource ServeTxsOneByOne(this ITxSource source)
+        {
+            return new OneByOneTxSource(source);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Consensus/Transactions/OneByOneTxSource.cs
+++ b/src/Nethermind/Nethermind.Consensus/Transactions/OneByOneTxSource.cs
@@ -1,0 +1,41 @@
+//  Copyright (c) 2018 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
+
+using System.Collections.Generic;
+using Nethermind.Core;
+
+namespace Nethermind.Consensus.Transactions
+{
+    public class OneByOneTxSource : ITxSource
+    {
+        private readonly ITxSource _txSource;
+
+        public OneByOneTxSource(ITxSource txSource)
+        {
+            _txSource = txSource;
+        }
+
+        public IEnumerable<Transaction> GetTransactions(BlockHeader parent, long gasLimit)
+        {
+            foreach (Transaction transaction in _txSource.GetTransactions(parent, gasLimit))
+            {
+                yield return transaction;
+                break;
+            }
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.DataMarketplace.Infrastructure/NdmApi.cs
+++ b/src/Nethermind/Nethermind.DataMarketplace.Infrastructure/NdmApi.cs
@@ -23,6 +23,7 @@ using Nethermind.Blockchain;
 using Nethermind.Blockchain.Filters;
 using Nethermind.Blockchain.Find;
 using Nethermind.Blockchain.Processing;
+using Nethermind.Blockchain.Producers;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Blockchain.Rewards;
 using Nethermind.Blockchain.Validators;
@@ -240,6 +241,12 @@ namespace Nethermind.DataMarketplace.Infrastructure
         {
             get => _nethermindApi.HeaderValidator;
             set => _nethermindApi.HeaderValidator = value;
+        }
+
+        public IManualBlockProductionTrigger ManualBlockProductionTrigger
+        {
+            get => _nethermindApi.ManualBlockProductionTrigger;
+            set => _nethermindApi.ManualBlockProductionTrigger = value;
         }
 
         public IIPResolver? IpResolver

--- a/src/Nethermind/Nethermind.Evm/Tracing/EstimateGasTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/EstimateGasTracer.cs
@@ -56,14 +56,14 @@ namespace Nethermind.Evm.Tracing
 
         public byte StatusCode { get; set; }
 
-        public void MarkAsSuccess(Address recipient, long gasSpent, byte[] output, LogEntry[] logs, Keccak stateRoot = null)
+        public void MarkAsSuccess(Address recipient, long gasSpent, byte[] output, LogEntry[] logs, Keccak? stateRoot = null)
         {
             GasSpent = gasSpent;
             ReturnValue = output;
             StatusCode = Evm.StatusCode.Success;
         }
 
-        public void MarkAsFailed(Address recipient, long gasSpent, byte[] output, string error, Keccak stateRoot = null)
+        public void MarkAsFailed(Address recipient, long gasSpent, byte[]? output, string error, Keccak? stateRoot = null)
         {
             GasSpent = gasSpent;
             Error = error;
@@ -200,7 +200,7 @@ namespace Nethermind.Evm.Tracing
 
         private int _currentNestingLevel = -1;
 
-        private bool _isInPrecompile = false;
+        private bool _isInPrecompile;
 
         private Stack<GasAndNesting> _currentGasAndNesting = new Stack<GasAndNesting>();
 

--- a/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
@@ -159,7 +159,7 @@ namespace Nethermind.Facade
 
         public CallOutput Call(BlockHeader blockHeader, Transaction transaction, CancellationToken cancellationToken)
         {
-            CallOutputTracer callOutputTracer = new CallOutputTracer();
+            CallOutputTracer callOutputTracer = new();
             CallAndRestore(blockHeader, blockHeader.Number, blockHeader.Timestamp, transaction,
                 new CancellationTxTracer(callOutputTracer, cancellationToken)
                 {
@@ -178,7 +178,7 @@ namespace Nethermind.Facade
 
         public CallOutput EstimateGas(BlockHeader header, Transaction tx, CancellationToken cancellationToken)
         {
-            EstimateGasTracer estimateGasTracer = new EstimateGasTracer();
+            EstimateGasTracer estimateGasTracer = new();
             CallAndRestore(
                 header,
                 header.Number + 1,
@@ -210,7 +210,7 @@ namespace Nethermind.Facade
                     transaction.Nonce = GetNonce(_stateProvider.StateRoot, transaction.SenderAddress);
                 }
 
-                BlockHeader callHeader = new BlockHeader(
+                BlockHeader callHeader = new(
                     blockHeader.Hash,
                     Keccak.OfAnEmptySequenceRlp,
                     Address.Zero,

--- a/src/Nethermind/Nethermind.Facade/Proxy/Models/BlockModel.cs
+++ b/src/Nethermind/Nethermind.Facade/Proxy/Models/BlockModel.cs
@@ -44,7 +44,7 @@ namespace Nethermind.Facade.Proxy.Models
 
         public Block ToBlock()
         {
-            Block block = new Block(new BlockHeader(ParentHash, Sha3Uncles, Miner, Difficulty, (long) Number,
+            Block block = new(new BlockHeader(ParentHash, Sha3Uncles, Miner, Difficulty, (long) Number,
                 (long) GasLimit, Timestamp, ExtraData));
 
             block.Header.StateRoot = StateRoot;

--- a/src/Nethermind/Nethermind.Facade/Proxy/Models/BlockParameterModel.cs
+++ b/src/Nethermind/Nethermind.Facade/Proxy/Models/BlockParameterModel.cs
@@ -23,28 +23,28 @@ namespace Nethermind.Facade.Proxy.Models
         public string Type { get; set; }
         public UInt256? Number { get; set; }
 
-        public static BlockParameterModel FromNumber(long number) => new BlockParameterModel
+        public static BlockParameterModel FromNumber(long number) => new()
         {
             Number = (UInt256?) number
         };
 
-        public static BlockParameterModel FromNumber(UInt256 number) => new BlockParameterModel
+        public static BlockParameterModel FromNumber(UInt256 number) => new()
         {
             Number = number
         };
 
-        public static BlockParameterModel Earliest => new BlockParameterModel
+        public static BlockParameterModel Earliest => new()
         {
             Type = "earliest"
         };
 
-        public static BlockParameterModel Latest => new BlockParameterModel
+        public static BlockParameterModel Latest => new()
         {
             Type = "latest"
         };
 
 
-        public static BlockParameterModel Pending => new BlockParameterModel
+        public static BlockParameterModel Pending => new()
         {
             Type = "pending"
         };

--- a/src/Nethermind/Nethermind.Facade/Proxy/Models/CallTransactionModel.cs
+++ b/src/Nethermind/Nethermind.Facade/Proxy/Models/CallTransactionModel.cs
@@ -29,7 +29,7 @@ namespace Nethermind.Facade.Proxy.Models
         public byte[] Data { get; set; }
 
         public static CallTransactionModel FromTransaction(Transaction transaction)
-            => new CallTransactionModel
+            => new()
             {
                 From = transaction.SenderAddress,
                 To = transaction.To,

--- a/src/Nethermind/Nethermind.Facade/Proxy/Models/ReceiptModel.cs
+++ b/src/Nethermind/Nethermind.Facade/Proxy/Models/ReceiptModel.cs
@@ -29,7 +29,7 @@ namespace Nethermind.Facade.Proxy.Models
         public Address From { get; set; }
         public UInt256 GasUsed { get; set; }
         public LogModel[] Logs { get; set; }
-        public byte[] LogsBloom { get; set; }
+        public byte[]? LogsBloom { get; set; }
         public UInt256 Status { get; set; }
         public Address To { get; set; }
         public Keccak TransactionHash { get; set; }

--- a/src/Nethermind/Nethermind.Facade/Proxy/Models/TransactionModel.cs
+++ b/src/Nethermind/Nethermind.Facade/Proxy/Models/TransactionModel.cs
@@ -34,7 +34,7 @@ namespace Nethermind.Facade.Proxy.Models
         public UInt256 Value { get; set; }
 
         public Transaction ToTransaction()
-            => new Transaction
+            => new()
             {
                 Hash = Hash,
                 Nonce = Nonce,

--- a/src/Nethermind/Nethermind.Facade/Proxy/RpcResult.cs
+++ b/src/Nethermind/Nethermind.Facade/Proxy/RpcResult.cs
@@ -23,13 +23,13 @@ namespace Nethermind.Facade.Proxy
         public RpcError Error { get; set; }
         public bool IsValid => Error is null;
 
-        public static RpcResult<T> Ok(T result, int id = 0) => new RpcResult<T>
+        public static RpcResult<T> Ok(T result, int id = 0) => new()
         {
             Result = result,
             Id = id
         };
 
-        public static RpcResult<T> Fail(string message) => new RpcResult<T>
+        public static RpcResult<T> Fail(string message) => new()
         {
             Error = new RpcError
             {

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/EvmModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/EvmModuleTests.cs
@@ -1,0 +1,38 @@
+﻿//  Copyright (c) 2021 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+
+using Nethermind.Blockchain.Producers;
+using Nethermind.JsonRpc.Modules.Evm;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.JsonRpc.Test.Modules
+{
+    [Parallelizable(ParallelScope.Self)]
+    [TestFixture]
+    public class EvmModuleTests
+    {
+        [Test]
+        public void Evm_mine()
+        {
+            IManualBlockProductionTrigger trigger = Substitute.For<IManualBlockProductionTrigger>();
+            EvmModule module = new EvmModule(trigger);
+            string response = RpcTest.TestSerializedRequest<IEvmModule>(module, "evm_mine");
+            Assert.AreEqual("{\"jsonrpc\":\"2.0\",\"result\":true,\"id\":67}", response);
+            trigger.Received().BuildBlock();
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/NetModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/NetModuleTests.cs
@@ -31,14 +31,6 @@ namespace Nethermind.JsonRpc.Test.Modules
     [TestFixture]
     public class NetModuleTests
     {
-        private INetModule _netModule;
-
-        [SetUp]
-        public void Initialize()
-        {
-            _netModule = new NetModule(LimboLogs.Instance, Substitute.For<INetBridge>());
-        }
-
         [Test]
         public void NetPeerCountSuccessTest()
         {

--- a/src/Nethermind/Nethermind.JsonRpc/Data/BlockParameterConverter.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Data/BlockParameterConverter.cs
@@ -26,9 +26,9 @@ namespace Nethermind.JsonRpc.Data
 {
     public class BlockParameterConverter : JsonConverter<BlockParameter>
     {
-        private NullableLongConverter _longConverter = new NullableLongConverter();
+        private NullableLongConverter _longConverter = new();
 
-        private KeccakConverter _keccakConverter = new KeccakConverter();
+        private KeccakConverter _keccakConverter = new();
 
         public override void WriteJson(JsonWriter writer, BlockParameter value, JsonSerializer serializer)
         {
@@ -113,7 +113,7 @@ namespace Nethermind.JsonRpc.Data
                     }
                 }
 
-                BlockParameter parameter = new BlockParameter(blockHash, requireCanonical);
+                BlockParameter parameter = new(blockHash, requireCanonical);
                 return parameter;
             }
 

--- a/src/Nethermind/Nethermind.JsonRpc/Data/LogEntryForRpc.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Data/LogEntryForRpc.cs
@@ -50,7 +50,7 @@ namespace Nethermind.JsonRpc.Data
 
         public LogEntry ToLogEntry()
         {
-            return new LogEntry(Address, Data, Topics);
+            return new(Address, Data, Topics);
         }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Data/ReceiptForRpc.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Data/ReceiptForRpc.cs
@@ -60,14 +60,14 @@ namespace Nethermind.JsonRpc.Data
         [JsonProperty(NullValueHandling = NullValueHandling.Include)]
         public Address ContractAddress { get; set; }
         public LogEntryForRpc[] Logs { get; set; }
-        public Bloom LogsBloom { get; set; }
+        public Bloom? LogsBloom { get; set; }
         public Keccak Root { get; set; }
         public long Status { get; set; }
         public string Error { get; set; }
 
         public TxReceipt ToReceipt()
         {
-            TxReceipt receipt = new TxReceipt();
+            TxReceipt receipt = new();
             receipt.Bloom = LogsBloom;
             receipt.Error = Error;
             receipt.Index = (int)TransactionIndex;

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcContext.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcContext.cs
@@ -21,7 +21,7 @@ namespace Nethermind.JsonRpc
 {
     public class JsonRpcContext
     {
-        public static readonly JsonRpcContext Http = new JsonRpcContext(RpcEndpoint.Http);
+        public static readonly JsonRpcContext Http = new(RpcEndpoint.Http);
         public RpcEndpoint RpcEndpoint { get; }
         public IJsonRpcDuplexClient DuplexClient { get; }
 

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcLocalStats.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcLocalStats.cs
@@ -32,8 +32,8 @@ namespace Nethermind.JsonRpc
         private readonly IJsonRpcConfig _jsonRpcConfig;
         private readonly TimeSpan _reportingInterval;
 
-        private ConcurrentDictionary<string, MethodStats> _currentStats = new ConcurrentDictionary<string, MethodStats>();
-        private ConcurrentDictionary<string, MethodStats> _previousStats = new ConcurrentDictionary<string, MethodStats>();
+        private ConcurrentDictionary<string, MethodStats> _currentStats = new();
+        private ConcurrentDictionary<string, MethodStats> _previousStats = new();
         private DateTime _lastReport = DateTime.MinValue;
         private readonly ILogger _logger;
 
@@ -114,13 +114,13 @@ namespace Nethermind.JsonRpc
                                         " avg time | " +
                                         " max time |";
 
-            StringBuilder stringBuilder = new StringBuilder();
+            StringBuilder stringBuilder = new();
             stringBuilder.AppendLine("***** JSON RPC report *****");
-            string divider = new string(Enumerable.Repeat('-', reportHeader.Length).ToArray());
+            string divider = new(Enumerable.Repeat('-', reportHeader.Length).ToArray());
             stringBuilder.AppendLine(divider);
             stringBuilder.AppendLine(reportHeader);
             stringBuilder.AppendLine(divider);
-            MethodStats total = new MethodStats();
+            MethodStats total = new();
             foreach (KeyValuePair<string, MethodStats> methodStats in _previousStats.OrderBy(kv => kv.Key))
             {
                 total.AvgTimeOfSuccesses = total.Successes + methodStats.Value.Successes == 0

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
@@ -66,7 +66,7 @@ namespace Nethermind.JsonRpc
         /// </summary>
         private void BuildTraceJsonSerializer()
         {
-            JsonSerializerSettings jsonSettings = new JsonSerializerSettings
+            JsonSerializerSettings jsonSettings = new()
             {
                 ContractResolver = new CamelCasePropertyNamesContractResolver()
             };
@@ -79,7 +79,7 @@ namespace Nethermind.JsonRpc
             _traceSerializer = JsonSerializer.Create(jsonSettings);
         }
 
-        private JsonSerializer _obsoleteBasicJsonSerializer = new JsonSerializer();
+        private JsonSerializer _obsoleteBasicJsonSerializer = new();
 
         private (JsonRpcRequest Model, List<JsonRpcRequest> Collection) DeserializeObjectOrArray(string json)
         {
@@ -180,7 +180,7 @@ namespace Nethermind.JsonRpc
                 var responses = new List<JsonRpcResponse>(rpcRequest.Collection.Count);
                 var reports = new List<RpcReport>(rpcRequest.Collection.Count);
                 int requestIndex = 0;
-                Stopwatch singleRequestWatch = new Stopwatch();
+                Stopwatch singleRequestWatch = new();
                 for (var index = 0; index < rpcRequest.Collection.Count; index++)
                 {
                     JsonRpcRequest jsonRpcRequest = rpcRequest.Collection[index];
@@ -225,9 +225,9 @@ namespace Nethermind.JsonRpc
         {
             if (_logger.IsTrace)
             {
-                StringBuilder builder = new StringBuilder();
-                using StringWriter stringWriter = new StringWriter(builder);
-                using JsonTextWriter jsonWriter = new JsonTextWriter(stringWriter);
+                StringBuilder builder = new();
+                using StringWriter stringWriter = new(builder);
+                using JsonTextWriter jsonWriter = new(stringWriter);
                 _traceSerializer.Serialize(jsonWriter, response);
 
                 _logger.Trace($"Sending JSON RPC response: {builder}");
@@ -238,9 +238,9 @@ namespace Nethermind.JsonRpc
         {
             if (_logger.IsTrace)
             {
-                StringBuilder builder = new StringBuilder();
-                using StringWriter stringWriter = new StringWriter(builder);
-                using JsonTextWriter jsonWriter = new JsonTextWriter(stringWriter);
+                StringBuilder builder = new();
+                using StringWriter stringWriter = new(builder);
+                using JsonTextWriter jsonWriter = new(stringWriter);
                 _traceSerializer.Serialize(jsonWriter, responses);
 
                 _logger.Trace($"Sending JSON RPC response: {builder}");

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcResult.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcResult.cs
@@ -46,10 +46,10 @@ namespace Nethermind.JsonRpc
         }
 
         public static JsonRpcResult Single(JsonRpcResponse response, RpcReport report)
-            => new JsonRpcResult(response, report);
+            => new(response, report);
 
         public static JsonRpcResult Collection(IReadOnlyList<JsonRpcResponse> responses, IReadOnlyList<RpcReport> reports)
-            => new JsonRpcResult(responses, reports);
+            => new(responses, reports);
 
         public void Dispose()
         {

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/BlockFinderExtensions.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/BlockFinderExtensions.cs
@@ -22,7 +22,7 @@ namespace Nethermind.JsonRpc.Modules
 {
     public static class BlockFinderExtensions
     {
-        public static SearchResult<BlockHeader> SearchForHeader(this IBlockFinder blockFinder, BlockParameter blockParameter, bool allowNulls = false)
+        public static SearchResult<BlockHeader> SearchForHeader(this IBlockFinder blockFinder, BlockParameter? blockParameter, bool allowNulls = false)
         {
             if (blockFinder.Head == null)
             {

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/BoundedModulePool.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/BoundedModulePool.cs
@@ -26,7 +26,7 @@ namespace Nethermind.JsonRpc.Modules
         private readonly int _timeout;
         private readonly T _shared;
         private readonly Task<T> _sharedAsTask;
-        private readonly ConcurrentQueue<T> _pool = new ConcurrentQueue<T>();
+        private readonly ConcurrentQueue<T> _pool = new();
         private readonly SemaphoreSlim _semaphore;
 
         public BoundedModulePool(IRpcModuleFactory<T> factory, int exclusiveCapacity, int timeout)

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugBridge.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugBridge.cs
@@ -112,7 +112,7 @@ namespace Nethermind.JsonRpc.Modules.DebugModule
             }
 
             Block block = searchResult.Object;
-            ReceiptTrie receiptTrie = new ReceiptTrie(_specProvider.GetSpec(block.Number), txReceipts);
+            ReceiptTrie receiptTrie = new(_specProvider.GetSpec(block.Number), txReceipts);
             receiptTrie.UpdateRootHash();
             if (block.ReceiptsRoot != receiptTrie.RootHash)
             {

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugModule.cs
@@ -61,7 +61,7 @@ namespace Nethermind.JsonRpc.Modules.DebugModule
 
         public ResultWrapper<GethLikeTxTrace> debug_traceTransaction(Keccak transactionHash, GethTraceOptions options = null)
         {
-            using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(_traceTimeout);
+            using CancellationTokenSource cancellationTokenSource = new(_traceTimeout);
             CancellationToken cancellationToken = cancellationTokenSource.Token;
             GethLikeTxTrace transactionTrace = _debugBridge.GetTransactionTrace(transactionHash, cancellationToken, options);
             if (transactionTrace == null)
@@ -75,7 +75,7 @@ namespace Nethermind.JsonRpc.Modules.DebugModule
 
         public ResultWrapper<GethLikeTxTrace> debug_traceTransactionByBlockhashAndIndex(Keccak blockhash, int index, GethTraceOptions options = null)
         {
-            using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(_traceTimeout);
+            using CancellationTokenSource cancellationTokenSource = new(_traceTimeout);
             CancellationToken cancellationToken = cancellationTokenSource.Token;
             var transactionTrace = _debugBridge.GetTransactionTrace(blockhash, index, cancellationToken, options);
             if (transactionTrace == null)
@@ -89,7 +89,7 @@ namespace Nethermind.JsonRpc.Modules.DebugModule
 
         public ResultWrapper<GethLikeTxTrace> debug_traceTransactionByBlockAndIndex(BlockParameter blockParameter, int index, GethTraceOptions options = null)
         {
-            using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(_traceTimeout);
+            using CancellationTokenSource cancellationTokenSource = new(_traceTimeout);
             CancellationToken cancellationToken = cancellationTokenSource.Token;
             long? blockNo = blockParameter.BlockNumber;
             if (!blockNo.HasValue)
@@ -109,7 +109,7 @@ namespace Nethermind.JsonRpc.Modules.DebugModule
 
         public ResultWrapper<GethLikeTxTrace> debug_traceTransactionInBlockByHash(byte[] blockRlp, Keccak transactionHash, GethTraceOptions options = null)
         {
-            using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(_traceTimeout);
+            using CancellationTokenSource cancellationTokenSource = new(_traceTimeout);
             CancellationToken cancellationToken = cancellationTokenSource.Token;
             var transactionTrace = _debugBridge.GetTransactionTrace(new Rlp(blockRlp), transactionHash, cancellationToken, options);
             if (transactionTrace == null)
@@ -122,7 +122,7 @@ namespace Nethermind.JsonRpc.Modules.DebugModule
         
         public ResultWrapper<GethLikeTxTrace> debug_traceTransactionInBlockByIndex(byte[] blockRlp, int txIndex, GethTraceOptions options = null)
         {
-            using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(_traceTimeout);
+            using CancellationTokenSource cancellationTokenSource = new(_traceTimeout);
             CancellationToken cancellationToken = cancellationTokenSource.Token;
             var blockTrace = _debugBridge.GetBlockTrace(new Rlp(blockRlp), cancellationToken, options);
             var transactionTrace = blockTrace?.ElementAtOrDefault(txIndex);
@@ -145,7 +145,7 @@ namespace Nethermind.JsonRpc.Modules.DebugModule
 
         public ResultWrapper<GethLikeTxTrace[]> debug_traceBlock(byte[] blockRlp, GethTraceOptions options = null)
         {
-            using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(_traceTimeout);
+            using CancellationTokenSource cancellationTokenSource = new(_traceTimeout);
             CancellationToken cancellationToken = cancellationTokenSource.Token;
             var blockTrace = _debugBridge.GetBlockTrace(new Rlp(blockRlp), cancellationToken, options);
             if (blockTrace == null)
@@ -158,7 +158,7 @@ namespace Nethermind.JsonRpc.Modules.DebugModule
 
         public ResultWrapper<GethLikeTxTrace[]> debug_traceBlockByNumber(UInt256 blockNumber, GethTraceOptions options = null)
         {
-            using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(_traceTimeout);
+            using CancellationTokenSource cancellationTokenSource = new(_traceTimeout);
             CancellationToken cancellationToken = cancellationTokenSource.Token;
             var blockTrace = _debugBridge.GetBlockTrace((long)blockNumber, cancellationToken, options);
             if (blockTrace == null)
@@ -172,7 +172,7 @@ namespace Nethermind.JsonRpc.Modules.DebugModule
 
         public ResultWrapper<GethLikeTxTrace[]> debug_traceBlockByHash(Keccak blockHash, GethTraceOptions options = null)
         {
-            using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(_traceTimeout);
+            using CancellationTokenSource cancellationTokenSource = new(_traceTimeout);
             CancellationToken cancellationToken = cancellationTokenSource.Token;
             GethLikeTxTrace[] gethLikeBlockTrace = _debugBridge.GetBlockTrace(blockHash, cancellationToken, options);
             if (gethLikeBlockTrace == null)

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/BlockForRpc.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/BlockForRpc.cs
@@ -29,7 +29,7 @@ namespace Nethermind.JsonRpc.Modules.Eth
 {
     public class BlockForRpc
     {
-        private readonly BlockDecoder _blockDecoder = new BlockDecoder();
+        private readonly BlockDecoder _blockDecoder = new();
         private readonly bool _isAuRaBlock;
 
         public BlockForRpc(Block block, bool includeFullTransactionData)

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthModule.cs
@@ -46,7 +46,7 @@ namespace Nethermind.JsonRpc.Modules.Eth
 {
     public class EthModule : IEthModule
     {
-        private Encoding _messageEncoding = Encoding.UTF8;
+        private readonly Encoding _messageEncoding = Encoding.UTF8;
 
         private readonly IJsonRpcConfig _rpcConfig;
         private readonly IBlockchainBridge _blockchainBridge;
@@ -57,11 +57,11 @@ namespace Nethermind.JsonRpc.Modules.Eth
         private readonly IWallet _wallet;
 
         private readonly ILogger _logger;
-        private TimeSpan _cancellationTokenTimeout;
+        private readonly TimeSpan _cancellationTokenTimeout;
 
         private bool HasStateForBlock(BlockHeader header)
         {
-            RootCheckVisitor rootCheckVisitor = new RootCheckVisitor();
+            RootCheckVisitor rootCheckVisitor = new();
             _blockchainBridge.RunTreeVisitor(rootCheckVisitor, header.StateRoot);
             return rootCheckVisitor.HasRoot;
         }
@@ -71,7 +71,7 @@ namespace Nethermind.JsonRpc.Modules.Eth
             IBlockchainBridge blockchainBridge,
             IBlockFinder blockFinder,
             IStateReader stateReader,
-            ITxPool _txPool,
+            ITxPool txPool,
             ITxSender txSender,
             IWallet wallet,
             ILogManager logManager)
@@ -81,7 +81,7 @@ namespace Nethermind.JsonRpc.Modules.Eth
             _blockchainBridge = blockchainBridge ?? throw new ArgumentNullException(nameof(blockchainBridge));
             _blockFinder = blockFinder ?? throw new ArgumentNullException(nameof(blockFinder));
             _stateReader = stateReader ?? throw new ArgumentNullException(nameof(stateReader));
-            _txPoolBridge = _txPool ?? throw new ArgumentNullException(nameof(_txPool));
+            _txPoolBridge = txPool ?? throw new ArgumentNullException(nameof(txPool));
             _txSender = txSender ?? throw new ArgumentNullException(nameof(txSender));
             _wallet = wallet ?? throw new ArgumentNullException(nameof(wallet));
             _cancellationTokenTimeout = TimeSpan.FromMilliseconds(rpcConfig.Timeout);
@@ -96,13 +96,15 @@ namespace Nethermind.JsonRpc.Modules.Eth
         {
             SyncingResult result;
             long bestSuggestedNumber = _blockFinder.FindBestSuggestedHeader().Number;
-            bool isSyncing = bestSuggestedNumber > _blockFinder.Head.Number + 8;
-            
+
+            long headNumberOrZero = _blockFinder.Head?.Number ?? 0;
+            bool isSyncing = bestSuggestedNumber > headNumberOrZero + 8;
+
             if (isSyncing)
             {
                 result = new SyncingResult
                 {
-                    CurrentBlock = _blockFinder.Head.Number,
+                    CurrentBlock = headNumberOrZero,
                     HighestBlock = bestSuggestedNumber,
                     StartingBlock = 0L,
                     IsSyncing = true
@@ -162,7 +164,7 @@ namespace Nethermind.JsonRpc.Modules.Eth
             return Task.FromResult(ResultWrapper<long?>.Success(number));
         }
 
-        public Task<ResultWrapper<UInt256?>> eth_getBalance(Address address, BlockParameter blockParameter = null)
+        public Task<ResultWrapper<UInt256?>> eth_getBalance(Address address, BlockParameter? blockParameter = null)
         {
             SearchResult<BlockHeader> searchResult = _blockFinder.SearchForHeader(blockParameter);
             if (searchResult.IsError)
@@ -173,14 +175,16 @@ namespace Nethermind.JsonRpc.Modules.Eth
             BlockHeader header = searchResult.Object;
             if (!HasStateForBlock(header))
             {
-                return Task.FromResult(ResultWrapper<UInt256?>.Fail($"No state available for block {header.Hash}", ErrorCodes.ResourceUnavailable));
+                return Task.FromResult(ResultWrapper<UInt256?>.Fail($"No state available for block {header.Hash}",
+                    ErrorCodes.ResourceUnavailable));
             }
 
             Account account = _stateReader.GetAccount(header.StateRoot, address);
             return Task.FromResult(ResultWrapper<UInt256?>.Success(account?.Balance ?? UInt256.Zero));
         }
 
-        public ResultWrapper<byte[]> eth_getStorageAt(Address address, UInt256 positionIndex, BlockParameter blockParameter = null)
+        public ResultWrapper<byte[]> eth_getStorageAt(Address address, UInt256 positionIndex,
+            BlockParameter? blockParameter = null)
         {
             SearchResult<BlockHeader> searchResult = _blockFinder.SearchForHeader(blockParameter);
             if (searchResult.IsError)
@@ -188,14 +192,14 @@ namespace Nethermind.JsonRpc.Modules.Eth
                 return ResultWrapper<byte[]>.Fail(searchResult);
             }
 
-            BlockHeader header = searchResult.Object;
+            BlockHeader? header = searchResult.Object;
             Account account = _stateReader.GetAccount(header.StateRoot, address);
             if (account == null)
             {
                 return ResultWrapper<byte[]>.Success(Array.Empty<byte>());
             }
 
-            var storage = _stateReader.GetStorage(account.StorageRoot, positionIndex);
+            byte[] storage = _stateReader.GetStorage(account.StorageRoot, positionIndex);
             return ResultWrapper<byte[]>.Success(storage.PadLeft(32));
         }
 
@@ -210,7 +214,8 @@ namespace Nethermind.JsonRpc.Modules.Eth
             BlockHeader header = searchResult.Object;
             if (!HasStateForBlock(header))
             {
-                return Task.FromResult(ResultWrapper<UInt256?>.Fail($"No state available for block {header.Hash}", ErrorCodes.ResourceUnavailable));
+                return Task.FromResult(ResultWrapper<UInt256?>.Fail($"No state available for block {header.Hash}",
+                    ErrorCodes.ResourceUnavailable));
             }
 
             Account account = _stateReader.GetAccount(header.StateRoot, address);
@@ -227,7 +232,7 @@ namespace Nethermind.JsonRpc.Modules.Eth
                 return ResultWrapper<UInt256?>.Fail(searchResult);
             }
 
-            return ResultWrapper<UInt256?>.Success((UInt256) searchResult.Object.Transactions.Length);
+            return ResultWrapper<UInt256?>.Success((UInt256)searchResult.Object.Transactions.Length);
         }
 
         public ResultWrapper<UInt256?> eth_getBlockTransactionCountByNumber(BlockParameter blockParameter)
@@ -238,7 +243,7 @@ namespace Nethermind.JsonRpc.Modules.Eth
                 return ResultWrapper<UInt256?>.Fail(searchResult);
             }
 
-            return ResultWrapper<UInt256?>.Success((UInt256) searchResult.Object.Transactions.Length);
+            return ResultWrapper<UInt256?>.Success((UInt256)searchResult.Object.Transactions.Length);
         }
 
         public ResultWrapper<UInt256?> eth_getUncleCountByBlockHash(Keccak blockHash)
@@ -249,10 +254,10 @@ namespace Nethermind.JsonRpc.Modules.Eth
                 return ResultWrapper<UInt256?>.Fail(searchResult);
             }
 
-            return ResultWrapper<UInt256?>.Success((UInt256) searchResult.Object.Ommers.Length);
+            return ResultWrapper<UInt256?>.Success((UInt256)searchResult.Object.Ommers.Length);
         }
 
-        public ResultWrapper<UInt256?> eth_getUncleCountByBlockNumber(BlockParameter blockParameter)
+        public ResultWrapper<UInt256?> eth_getUncleCountByBlockNumber(BlockParameter? blockParameter)
         {
             SearchResult<Block> searchResult = _blockFinder.SearchForBlock(blockParameter);
             if (searchResult.IsError)
@@ -260,10 +265,10 @@ namespace Nethermind.JsonRpc.Modules.Eth
                 return ResultWrapper<UInt256?>.Fail(searchResult);
             }
 
-            return ResultWrapper<UInt256?>.Success((UInt256) searchResult.Object.Ommers.Length);
+            return ResultWrapper<UInt256?>.Success((UInt256)searchResult.Object.Ommers.Length);
         }
 
-        public ResultWrapper<byte[]> eth_getCode(Address address, BlockParameter blockParameter = null)
+        public ResultWrapper<byte[]> eth_getCode(Address address, BlockParameter? blockParameter = null)
         {
             SearchResult<BlockHeader> searchResult = _blockFinder.SearchForHeader(blockParameter);
             if (searchResult.IsError)
@@ -274,7 +279,8 @@ namespace Nethermind.JsonRpc.Modules.Eth
             BlockHeader header = searchResult.Object;
             if (!HasStateForBlock(header))
             {
-                return ResultWrapper<byte[]>.Fail($"No state available for block {header.Hash}", ErrorCodes.ResourceUnavailable);
+                return ResultWrapper<byte[]>.Fail($"No state available for block {header.Hash}",
+                    ErrorCodes.ResourceUnavailable);
             }
 
             Account account = _stateReader.GetAccount(header.StateRoot, address);
@@ -331,11 +337,13 @@ namespace Nethermind.JsonRpc.Modules.Eth
             }
         }
 
-        private async Task<ResultWrapper<Keccak>> SendTx(Transaction tx, TxHandlingOptions txHandlingOptions = TxHandlingOptions.None)
+        private async Task<ResultWrapper<Keccak>> SendTx(Transaction tx,
+            TxHandlingOptions txHandlingOptions = TxHandlingOptions.None)
         {
             try
             {
-                Keccak txHash = await _txSender.SendTransaction(tx, txHandlingOptions | TxHandlingOptions.PersistentBroadcast);
+                Keccak txHash =
+                    await _txSender.SendTransaction(tx, txHandlingOptions | TxHandlingOptions.PersistentBroadcast);
                 return ResultWrapper<Keccak>.Success(txHash);
             }
             catch (SecurityException e)
@@ -360,20 +368,23 @@ namespace Nethermind.JsonRpc.Modules.Eth
             BlockHeader header = searchResult.Object;
             if (!HasStateForBlock(header))
             {
-                return ResultWrapper<string>.Fail($"No state available for block {header.Hash}", ErrorCodes.ResourceUnavailable);
+                return ResultWrapper<string>.Fail($"No state available for block {header.Hash}",
+                    ErrorCodes.ResourceUnavailable);
             }
 
-            FixCallTx(transactionCall, header);
+            FixCallTx(transactionCall);
 
-            using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(_cancellationTokenTimeout);
+            using CancellationTokenSource cancellationTokenSource = new(_cancellationTokenTimeout);
             CancellationToken cancellationToken = cancellationTokenSource.Token;
             Transaction tx = transactionCall.ToTransaction();
             BlockchainBridge.CallOutput result = _blockchainBridge.Call(header, tx, cancellationToken);
 
-            return result.Error != null ? ResultWrapper<string>.Fail("VM execution error.", ErrorCodes.ExecutionError, result.Error) : ResultWrapper<string>.Success(result.OutputData.ToHexString(true));
+            return result.Error != null
+                ? ResultWrapper<string>.Fail("VM execution error.", ErrorCodes.ExecutionError, result.Error)
+                : ResultWrapper<string>.Success(result.OutputData.ToHexString(true));
         }
 
-        private void FixCallTx(TransactionForRpc transactionCall, BlockHeader header)
+        private void FixCallTx(TransactionForRpc transactionCall)
         {
             if (transactionCall.Gas == null || transactionCall.Gas == 0)
             {
@@ -399,7 +410,8 @@ namespace Nethermind.JsonRpc.Modules.Eth
 
             if (!HasStateForBlock(header))
             {
-                return ResultWrapper<UInt256?>.Fail($"No state available for block {header.Hash}", ErrorCodes.ResourceUnavailable);
+                return ResultWrapper<UInt256?>.Fail($"No state available for block {header.Hash}",
+                    ErrorCodes.ResourceUnavailable);
             }
 
             return EstimateGas(transactionCall, header);
@@ -407,15 +419,31 @@ namespace Nethermind.JsonRpc.Modules.Eth
 
         private ResultWrapper<UInt256?> EstimateGas(TransactionForRpc transactionCall, BlockHeader head)
         {
-            FixCallTx(transactionCall, head);
+            // 2021-03-04 08:54:18.6489|DEBUG|101|Responded to ID 40, eth_estimateGas({
+            //     "from": "0x2b5ad5c4795c026514f8317c7a215e218dccd6cf",
+            //     "to": "0xa28afda14be5789564ae5fa03665c4180e3c680b",
+            //     "data": "0x25936984"
+            // }) 
+            
+            // 2021-03-04 08:54:18.6533|DEBUG|13|Responded to ID 41, eth_sendTransaction({
+            //     "gas": "0x1f815f1",
+            //     "from": "0x2b5ad5c4795c026514f8317c7a215e218dccd6cf",
+            //     "to": "0xa28afda14be5789564ae5fa03665c4180e3c680b",
+            //     "data": "0x25936984",
+            //     "gasPrice": "0x4a817c800"
+            // }) 
+            
+            FixCallTx(transactionCall);
 
-            using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(_cancellationTokenTimeout);
-            CancellationToken cancellationToken = cancellationTokenSource.Token;
-            BlockchainBridge.CallOutput result = _blockchainBridge.EstimateGas(head, transactionCall.ToTransaction(), cancellationToken);
+            // using CancellationTokenSource cancellationTokenSource = new(_cancellationTokenTimeout);
+            CancellationToken cancellationToken = CancellationToken.None;
+            BlockchainBridge.CallOutput result =
+                _blockchainBridge.EstimateGas(head, transactionCall.ToTransaction(), cancellationToken);
 
             if (result.Error == null)
             {
-                return ResultWrapper<UInt256?>.Success((UInt256) result.GasSpent);
+                _logger.Error($"Estimating gas {transactionCall.From} {transactionCall.To} {transactionCall.Data} {transactionCall.Gas}");
+                return ResultWrapper<UInt256?>.Success((UInt256)result.GasSpent);
             }
 
             return ResultWrapper<UInt256?>.Fail(result.Error);
@@ -426,7 +454,8 @@ namespace Nethermind.JsonRpc.Modules.Eth
             return GetBlock(new BlockParameter(blockHash), returnFullTransactionObjects);
         }
 
-        public ResultWrapper<BlockForRpc> eth_getBlockByNumber(BlockParameter blockParameter, bool returnFullTransactionObjects)
+        public ResultWrapper<BlockForRpc> eth_getBlockByNumber(BlockParameter blockParameter,
+            bool returnFullTransactionObjects)
         {
             return GetBlock(blockParameter, returnFullTransactionObjects);
         }
@@ -439,13 +468,15 @@ namespace Nethermind.JsonRpc.Modules.Eth
                 return ResultWrapper<BlockForRpc>.Fail(searchResult);
             }
 
-            Block block = searchResult.Object;
+            Block? block = searchResult.Object;
             if (block != null)
             {
                 _blockchainBridge.RecoverTxSenders(block);
             }
 
-            return ResultWrapper<BlockForRpc>.Success(block == null ? null : new BlockForRpc(block, returnFullTransactionObjects));
+            return ResultWrapper<BlockForRpc>.Success(block == null
+                ? null
+                : new BlockForRpc(block, returnFullTransactionObjects));
         }
 
         public Task<ResultWrapper<TransactionForRpc>> eth_getTransactionByHash(Keccak transactionHash)
@@ -462,8 +493,10 @@ namespace Nethermind.JsonRpc.Modules.Eth
             }
 
             RecoverTxSenderIfNeeded(transaction);
-            TransactionForRpc transactionModel = new TransactionForRpc(receipt?.BlockHash, receipt?.BlockNumber, receipt?.Index, transaction);
-            if (_logger.IsTrace) _logger.Trace($"eth_getTransactionByHash request {transactionHash}, result: {transactionModel.Hash}");
+            TransactionForRpc transactionModel =
+                new(receipt?.BlockHash, receipt?.BlockNumber, receipt?.Index, transaction);
+            if (_logger.IsTrace)
+                _logger.Trace($"eth_getTransactionByHash request {transactionHash}, result: {transactionModel.Hash}");
             return Task.FromResult(ResultWrapper<TransactionForRpc>.Success(transactionModel));
         }
 
@@ -483,7 +516,8 @@ namespace Nethermind.JsonRpc.Modules.Eth
             return ResultWrapper<TransactionForRpc[]>.Success(transactionsModels);
         }
 
-        public ResultWrapper<TransactionForRpc> eth_getTransactionByBlockHashAndIndex(Keccak blockHash, UInt256 positionIndex)
+        public ResultWrapper<TransactionForRpc> eth_getTransactionByBlockHashAndIndex(Keccak blockHash,
+            UInt256 positionIndex)
         {
             SearchResult<Block> searchResult = _blockFinder.SearchForBlock(new BlockParameter(blockHash));
             if (searchResult.IsError)
@@ -497,15 +531,16 @@ namespace Nethermind.JsonRpc.Modules.Eth
                 return ResultWrapper<TransactionForRpc>.Fail("Position Index is incorrect", ErrorCodes.InvalidParams);
             }
 
-            Transaction transaction = block.Transactions[(int) positionIndex];
+            Transaction transaction = block.Transactions[(int)positionIndex];
             RecoverTxSenderIfNeeded(transaction);
 
-            TransactionForRpc transactionModel = new TransactionForRpc(block.Hash, block.Number, (int) positionIndex, transaction);
+            TransactionForRpc transactionModel = new(block.Hash, block.Number, (int)positionIndex, transaction);
 
             return ResultWrapper<TransactionForRpc>.Success(transactionModel);
         }
 
-        public ResultWrapper<TransactionForRpc> eth_getTransactionByBlockNumberAndIndex(BlockParameter blockParameter, UInt256 positionIndex)
+        public ResultWrapper<TransactionForRpc> eth_getTransactionByBlockNumberAndIndex(BlockParameter blockParameter,
+            UInt256 positionIndex)
         {
             SearchResult<Block> searchResult = _blockFinder.SearchForBlock(blockParameter);
             if (searchResult.IsError)
@@ -513,18 +548,20 @@ namespace Nethermind.JsonRpc.Modules.Eth
                 return ResultWrapper<TransactionForRpc>.Fail(searchResult);
             }
 
-            Block block = searchResult.Object;
+            Block? block = searchResult.Object;
             if (positionIndex < 0 || positionIndex > block.Transactions.Length - 1)
             {
                 return ResultWrapper<TransactionForRpc>.Fail("Position Index is incorrect", ErrorCodes.InvalidParams);
             }
 
-            Transaction transaction = block.Transactions[(int) positionIndex];
+            Transaction transaction = block.Transactions[(int)positionIndex];
             RecoverTxSenderIfNeeded(transaction);
 
-            TransactionForRpc transactionModel = new TransactionForRpc(block.Hash, block.Number, (int) positionIndex, transaction);
+            TransactionForRpc transactionModel = new(block.Hash, block.Number, (int)positionIndex, transaction);
 
-            if (_logger.IsDebug) _logger.Debug($"eth_getTransactionByBlockNumberAndIndex request {blockParameter}, index: {positionIndex}, result: {transactionModel.Hash}");
+            if (_logger.IsDebug)
+                _logger.Debug(
+                    $"eth_getTransactionByBlockNumberAndIndex request {blockParameter}, index: {positionIndex}, result: {transactionModel.Hash}");
             return ResultWrapper<TransactionForRpc>.Success(transactionModel);
         }
 
@@ -536,7 +573,7 @@ namespace Nethermind.JsonRpc.Modules.Eth
                 return Task.FromResult(ResultWrapper<ReceiptForRpc>.Success(null));
             }
 
-            ReceiptForRpc receiptModel = new ReceiptForRpc(txHash, receipt);
+            ReceiptForRpc receiptModel = new(txHash, receipt);
             if (_logger.IsTrace) _logger.Trace($"eth_getTransactionReceipt request {txHash}, result: {txHash}");
             return Task.FromResult(ResultWrapper<ReceiptForRpc>.Success(receiptModel));
         }
@@ -546,7 +583,8 @@ namespace Nethermind.JsonRpc.Modules.Eth
             return GetUncle(new BlockParameter(blockHash), positionIndex);
         }
 
-        public ResultWrapper<BlockForRpc> eth_getUncleByBlockNumberAndIndex(BlockParameter blockParameter, UInt256 positionIndex)
+        public ResultWrapper<BlockForRpc> eth_getUncleByBlockNumberAndIndex(BlockParameter blockParameter,
+            UInt256 positionIndex)
         {
             return GetUncle(blockParameter, positionIndex);
         }
@@ -565,7 +603,7 @@ namespace Nethermind.JsonRpc.Modules.Eth
                 return ResultWrapper<BlockForRpc>.Fail("Position Index is incorrect", ErrorCodes.InvalidParams);
             }
 
-            BlockHeader ommerHeader = block.Ommers[(int) positionIndex];
+            BlockHeader ommerHeader = block.Ommers[(int)positionIndex];
             return ResultWrapper<BlockForRpc>.Success(new BlockForRpc(new Block(ommerHeader, BlockBody.Empty), false));
         }
 
@@ -574,30 +612,30 @@ namespace Nethermind.JsonRpc.Modules.Eth
             BlockParameter fromBlock = filter.FromBlock;
             BlockParameter toBlock = filter.ToBlock;
             int filterId = _blockchainBridge.NewFilter(fromBlock, toBlock, filter.Address, filter.Topics);
-            return ResultWrapper<UInt256?>.Success((UInt256) filterId);
+            return ResultWrapper<UInt256?>.Success((UInt256)filterId);
         }
 
         public ResultWrapper<UInt256?> eth_newBlockFilter()
         {
             int filterId = _blockchainBridge.NewBlockFilter();
-            return ResultWrapper<UInt256?>.Success((UInt256) filterId);
+            return ResultWrapper<UInt256?>.Success((UInt256)filterId);
         }
 
         public ResultWrapper<UInt256?> eth_newPendingTransactionFilter()
         {
             int filterId = _blockchainBridge.NewPendingTransactionFilter();
-            return ResultWrapper<UInt256?>.Success((UInt256) filterId);
+            return ResultWrapper<UInt256?>.Success((UInt256)filterId);
         }
 
         public ResultWrapper<bool?> eth_uninstallFilter(UInt256 filterId)
         {
-            _blockchainBridge.UninstallFilter((int) filterId);
+            _blockchainBridge.UninstallFilter((int)filterId);
             return ResultWrapper<bool?>.Success(true);
         }
 
         public ResultWrapper<IEnumerable<object>> eth_getFilterChanges(UInt256 filterId)
         {
-            int id = (int) filterId;
+            int id = (int)filterId;
             FilterType filterType = _blockchainBridge.GetFilterType(id);
             switch (filterType)
             {
@@ -611,7 +649,8 @@ namespace Nethermind.JsonRpc.Modules.Eth
                 case FilterType.PendingTransactionFilter:
                 {
                     return _blockchainBridge.FilterExists(id)
-                        ? ResultWrapper<IEnumerable<object>>.Success(_blockchainBridge.GetPendingTransactionFilterChanges(id))
+                        ? ResultWrapper<IEnumerable<object>>.Success(_blockchainBridge
+                            .GetPendingTransactionFilterChanges(id))
                         : ResultWrapper<IEnumerable<object>>.Fail($"Filter with id: '{filterId}' does not exist.");
                 }
 
@@ -632,7 +671,7 @@ namespace Nethermind.JsonRpc.Modules.Eth
 
         public ResultWrapper<IEnumerable<FilterLog>> eth_getFilterLogs(UInt256 filterId)
         {
-            int id = (int) filterId;
+            int id = (int)filterId;
 
             return _blockchainBridge.FilterExists(id)
                 ? ResultWrapper<IEnumerable<FilterLog>>.Success(_blockchainBridge.GetFilterLogs(id))
@@ -641,11 +680,13 @@ namespace Nethermind.JsonRpc.Modules.Eth
 
         public ResultWrapper<IEnumerable<FilterLog>> eth_getLogs(Filter filter)
         {
-            IEnumerable<FilterLog> GetLogs(BlockParameter blockParameter, BlockParameter toBlockParameter, CancellationTokenSource cancellationTokenSource, CancellationToken token)
+            IEnumerable<FilterLog> GetLogs(BlockParameter blockParameter, BlockParameter toBlockParameter,
+                CancellationTokenSource cancellationTokenSource, CancellationToken token)
             {
                 using (cancellationTokenSource)
                 {
-                    foreach (FilterLog log in _blockchainBridge.GetLogs(blockParameter, toBlockParameter, filter.Address, filter.Topics, token))
+                    foreach (FilterLog log in _blockchainBridge.GetLogs(blockParameter, toBlockParameter,
+                        filter.Address, filter.Topics, token))
                     {
                         yield return log;
                     }
@@ -657,14 +698,16 @@ namespace Nethermind.JsonRpc.Modules.Eth
 
             try
             {
-                CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(_cancellationTokenTimeout);
-                return ResultWrapper<IEnumerable<FilterLog>>.Success(GetLogs(fromBlock, toBlock, cancellationTokenSource, cancellationTokenSource.Token));
+                CancellationTokenSource cancellationTokenSource = new(_cancellationTokenTimeout);
+                return ResultWrapper<IEnumerable<FilterLog>>.Success(GetLogs(fromBlock, toBlock,
+                    cancellationTokenSource, cancellationTokenSource.Token));
             }
             catch (ArgumentException e)
             {
                 switch (e.Message)
                 {
-                    case ILogFinder.NotFoundError: return ResultWrapper<IEnumerable<FilterLog>>.Fail(e.Message, ErrorCodes.ResourceNotFound);
+                    case ILogFinder.NotFoundError:
+                        return ResultWrapper<IEnumerable<FilterLog>>.Fail(e.Message, ErrorCodes.ResourceNotFound);
                     default:
                         return ResultWrapper<IEnumerable<FilterLog>>.Fail(e.Message, ErrorCodes.InvalidParams);
                 }
@@ -687,7 +730,8 @@ namespace Nethermind.JsonRpc.Modules.Eth
         }
 
         // https://github.com/ethereum/EIPs/issues/1186	
-        public ResultWrapper<AccountProof> eth_getProof(Address accountAddress, byte[][] storageKeys, BlockParameter blockParameter)
+        public ResultWrapper<AccountProof> eth_getProof(Address accountAddress, byte[][] storageKeys,
+            BlockParameter blockParameter)
         {
             BlockHeader header;
             try
@@ -695,12 +739,14 @@ namespace Nethermind.JsonRpc.Modules.Eth
                 header = _blockFinder.FindHeader(blockParameter);
                 if (header == null)
                 {
-                    return ResultWrapper<AccountProof>.Fail($"{blockParameter} block not found", ErrorCodes.ResourceNotFound, null);
+                    return ResultWrapper<AccountProof>.Fail($"{blockParameter} block not found",
+                        ErrorCodes.ResourceNotFound, null);
                 }
 
                 if (!HasStateForBlock(header))
                 {
-                    return ResultWrapper<AccountProof>.Fail($"No state available for block {header.Hash}", ErrorCodes.ResourceUnavailable);
+                    return ResultWrapper<AccountProof>.Fail($"No state available for block {header.Hash}",
+                        ErrorCodes.ResourceUnavailable);
                 }
             }
             catch (Exception ex)
@@ -708,7 +754,7 @@ namespace Nethermind.JsonRpc.Modules.Eth
                 return ResultWrapper<AccountProof>.Fail(ex.Message, ErrorCodes.InternalError, null);
             }
 
-            AccountProofCollector accountProofCollector = new AccountProofCollector(accountAddress, storageKeys);
+            AccountProofCollector accountProofCollector = new(accountAddress, storageKeys);
             _blockchainBridge.RunTreeVisitor(accountProofCollector, header.StateRoot);
 
             return ResultWrapper<AccountProof>.Success(accountProofCollector.BuildResult());

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/SyncingResult.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/SyncingResult.cs
@@ -18,7 +18,7 @@ namespace Nethermind.JsonRpc.Modules.Eth
 {
     public class SyncingResult
     {
-        public static SyncingResult NotSyncing = new SyncingResult();
+        public static SyncingResult NotSyncing = new();
         
         public bool IsSyncing { get; set; }
         public long StartingBlock { get; set; }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Evm/EvmModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Evm/EvmModule.cs
@@ -1,0 +1,37 @@
+﻿//  Copyright (c) 2021 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using Nethermind.Blockchain.Producers;
+
+namespace Nethermind.JsonRpc.Modules.Evm
+{
+    public class EvmModule : IEvmModule
+    {
+        private readonly IManualBlockProductionTrigger _trigger;
+
+        public EvmModule(IManualBlockProductionTrigger? trigger)
+        {
+            _trigger = trigger ?? throw new ArgumentNullException(nameof(trigger));
+        }
+
+        public ResultWrapper<bool> evm_mine()
+        {
+            _trigger.BuildBlock();
+            return ResultWrapper<bool>.Success(true);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Evm/IEvmModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Evm/IEvmModule.cs
@@ -1,0 +1,25 @@
+﻿//  Copyright (c) 2021 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+
+namespace Nethermind.JsonRpc.Modules.Evm
+{
+    [RpcModule(ModuleType.Evm)]
+    public interface IEvmModule : IModule
+    {
+        [JsonRpcMethod(Description = "Triggers block production.", IsImplemented = true, IsSharable = false)]
+        ResultWrapper<bool> evm_mine();
+    }
+}

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/IRpcModuleProvider.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/IRpcModuleProvider.cs
@@ -21,6 +21,8 @@ using Newtonsoft.Json;
 
 namespace Nethermind.JsonRpc.Modules
 {
+    // ReSharper disable once InconsistentNaming
+
     public interface IRpcModuleProvider
     {
         void Register<T>(IRpcModulePool<T> pool) where T : IModule;

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/IRpcModuleProviderExtensions.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/IRpcModuleProviderExtensions.cs
@@ -1,0 +1,54 @@
+//  Copyright (c) 2018 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
+
+using System;
+
+namespace Nethermind.JsonRpc.Modules
+{
+    public static class IRpcModuleProviderExtensions
+    {
+        private static readonly int _cpuCount = Environment.ProcessorCount;
+
+        public static void RegisterBounded<T>(
+            this IRpcModuleProvider rpcModuleProvider,
+            ModuleFactoryBase<T> factory,
+            int maxCount,
+            int timeout)
+            where T : IModule
+        {
+            rpcModuleProvider.Register(new BoundedModulePool<T>(factory, maxCount, timeout));
+        }
+        
+        public static void RegisterBoundedByCpuCount<T>(
+            this IRpcModuleProvider rpcModuleProvider,
+            ModuleFactoryBase<T> factory,
+            int timeout)
+            where T : IModule
+        {
+            RegisterBounded(rpcModuleProvider, factory, _cpuCount, timeout);
+        }
+        
+        public static void RegisterSingle<T>(
+            this IRpcModuleProvider rpcModuleProvider,
+            T module,
+            bool allowExclusive = true)
+            where T : IModule
+        {
+            rpcModuleProvider.Register(new SingletonModulePool<T>(module, allowExclusive));
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/ModuleType.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/ModuleType.cs
@@ -27,6 +27,7 @@ namespace Nethermind.JsonRpc.Modules
         Db,
         Debug,
         Eth,
+        Evm,
         NdmProvider,
         NdmConsumer,
         Net,

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/NullModuleProvider.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/NullModuleProvider.cs
@@ -24,7 +24,7 @@ namespace Nethermind.JsonRpc.Modules
 {
     public class NullModuleProvider : IRpcModuleProvider
     {
-        public static NullModuleProvider Instance = new NullModuleProvider();
+        public static NullModuleProvider Instance = new();
         private static Task<IModule> Null = Task.FromResult(default(IModule));
 
         private NullModuleProvider()

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/NullRpcMethodFilter.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/NullRpcMethodFilter.cs
@@ -23,7 +23,7 @@ namespace Nethermind.JsonRpc.Modules
         {
         }
 
-        public static NullRpcMethodFilter Instance { get; } = new NullRpcMethodFilter();
+        public static NullRpcMethodFilter Instance { get; } = new();
 
         public bool AcceptMethod(string methodName)
         {

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Parity/ParityModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Parity/ParityModule.cs
@@ -114,7 +114,7 @@ namespace Nethermind.JsonRpc.Modules.Parity
 
         public ResultWrapper<ParityNetPeers> parity_netPeers()
         {
-            ParityNetPeers parityNetPeers = new ParityNetPeers();
+            ParityNetPeers parityNetPeers = new();
             parityNetPeers.Active = _peerManager.ActivePeers.Count;
             parityNetPeers.Connected = _peerManager.ConnectedPeers.Count;
             parityNetPeers.Max = _peerManager.MaxActivePeers;

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Parity/PeerInfo.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Parity/PeerInfo.cs
@@ -44,8 +44,8 @@ namespace Nethermind.JsonRpc.Modules.Parity
         public PeerInfo(Peer peer)
         {
             ISession session = peer.InSession ?? peer.OutSession;
-            PeerNetworkInfo peerNetworkInfo = new PeerNetworkInfo();
-            EthProtocolInfo ethProtocolInfo = new EthProtocolInfo();
+            PeerNetworkInfo peerNetworkInfo = new();
+            EthProtocolInfo ethProtocolInfo = new();
             Caps = new List<string>();
 
             if (peer.Node != null)

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Personal/PersonalModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Personal/PersonalModule.cs
@@ -46,7 +46,7 @@ namespace Nethermind.JsonRpc.Modules.Personal
          [RequiresSecurityReview("Consider removing any operations that allow to provide passphrase in JSON RPC")]
          public ResultWrapper<Address> personal_importRawKey(byte[] keyData, string passphrase)
          {
-             PrivateKey privateKey = new PrivateKey(keyData);
+             PrivateKey privateKey = new(keyData);
              _keyStore.StoreKey(privateKey, passphrase.Secure());
              return ResultWrapper<Address>.Success(privateKey.Address);
          }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Proof/ProofModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Proof/ProofModule.cs
@@ -45,7 +45,7 @@ namespace Nethermind.JsonRpc.Modules.Proof
         private readonly IBlockFinder _blockFinder;
         private readonly IReceiptFinder _receiptFinder;
         private readonly ISpecProvider _specProvider;
-        private readonly HeaderDecoder _headerDecoder = new HeaderDecoder();
+        private readonly HeaderDecoder _headerDecoder = new();
 
         public ProofModule(
             ITracer tracer,
@@ -94,12 +94,12 @@ namespace Nethermind.JsonRpc.Modules.Proof
                 transaction.GasLimit = callHeader.GasLimit;
             }
 
-            Block block = new Block(callHeader, new[] {transaction}, Enumerable.Empty<BlockHeader>());
+            Block block = new(callHeader, new[] {transaction}, Enumerable.Empty<BlockHeader>());
 
-            ProofBlockTracer proofBlockTracer = new ProofBlockTracer(null, transaction.SenderAddress == Address.SystemUser);
+            ProofBlockTracer proofBlockTracer = new(null, transaction.SenderAddress == Address.SystemUser);
             _tracer.Trace(block, proofBlockTracer);
 
-            CallResultWithProof callResultWithProof = new CallResultWithProof();
+            CallResultWithProof callResultWithProof = new();
             ProofTxTracer proofTxTracer = proofBlockTracer.BuildResult().Single();
 
             callResultWithProof.BlockHeaders = CollectHeaderBytes(proofTxTracer, sourceHeader);
@@ -131,7 +131,7 @@ namespace Nethermind.JsonRpc.Modules.Proof
             Transaction[] txs = block.Transactions;
             Transaction transaction = txs[receipt.Index];
 
-            TransactionWithProof txWithProof = new TransactionWithProof();
+            TransactionWithProof txWithProof = new();
             txWithProof.Transaction = new TransactionForRpc(block.Hash, block.Number, receipt.Index, transaction);
             txWithProof.TxProof = BuildTxProofs(txs, _specProvider.GetSpec(block.Number), receipt.Index);
             if (includeHeader)
@@ -159,14 +159,14 @@ namespace Nethermind.JsonRpc.Modules.Proof
             Block block = searchResult.Object;
             TxReceipt receipt = _receiptFinder.Get(block).ForTransaction(txHash);
             
-            BlockReceiptsTracer receiptsTracer = new BlockReceiptsTracer();
+            BlockReceiptsTracer receiptsTracer = new();
             receiptsTracer.SetOtherTracer(NullBlockTracer.Instance);
             _tracer.Trace(block, receiptsTracer);
 
             TxReceipt[] receipts = receiptsTracer.TxReceipts;
             Transaction[] txs = block.Transactions;
 
-            ReceiptWithProof receiptWithProof = new ReceiptWithProof();
+            ReceiptWithProof receiptWithProof = new();
             receiptWithProof.Receipt = new ReceiptForRpc(txHash, receipt);
             receiptWithProof.ReceiptProof = BuildReceiptProofs(block.Number, receipts, receipt.Index);
             receiptWithProof.TxProof = BuildTxProofs(txs, _specProvider.GetSpec(block.Number), receipt.Index);
@@ -180,10 +180,10 @@ namespace Nethermind.JsonRpc.Modules.Proof
 
         private AccountProof[] CollectAccountProofs(Keccak stateRoot, ProofTxTracer proofTxTracer)
         {
-            List<AccountProof> accountProofs = new List<AccountProof>();
+            List<AccountProof> accountProofs = new();
             foreach (Address address in proofTxTracer.Accounts)
             {
-                AccountProofCollector collector = new AccountProofCollector(address, proofTxTracer.Storages
+                AccountProofCollector collector = new(address, proofTxTracer.Storages
                     .Where(s => s.Address == address)
                     .Select(s => s.Index).ToArray());
 
@@ -196,7 +196,7 @@ namespace Nethermind.JsonRpc.Modules.Proof
 
         private byte[][] CollectHeaderBytes(ProofTxTracer proofTxTracer, BlockHeader tracedBlockHeader)
         {
-            List<BlockHeader> relevantHeaders = new List<BlockHeader> {tracedBlockHeader};
+            List<BlockHeader> relevantHeaders = new() {tracedBlockHeader};
             foreach (Keccak blockHash in proofTxTracer.BlockHashes)
             {
                 relevantHeaders.Add(_blockFinder.FindHeader(blockHash));

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/RpcMethodFilter.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/RpcMethodFilter.cs
@@ -31,10 +31,10 @@ namespace Nethermind.JsonRpc.Modules
     internal class RpcMethodFilter : IRpcMethodFilter
     {
         private readonly ILogger _logger;
-        private readonly HashSet<string> _filters = new HashSet<string>();
+        private readonly HashSet<string> _filters = new();
         
         private readonly ConcurrentDictionary<string, bool> _methodsCache
-            = new ConcurrentDictionary<string, bool>();
+            = new();
 
         public RpcMethodFilter(string filePath, IFileSystem fileSystem, ILogger logger)
         {

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/RpcModuleProvider.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/RpcModuleProvider.cs
@@ -31,14 +31,14 @@ namespace Nethermind.JsonRpc.Modules
         private ILogger _logger;
         private IJsonRpcConfig _jsonRpcConfig;
         
-        private List<ModuleType> _modules = new List<ModuleType>();
-        private List<ModuleType> _enabledModules = new List<ModuleType>();
+        private List<ModuleType> _modules = new();
+        private List<ModuleType> _enabledModules = new();
         
         private Dictionary<string, ResolvedMethodInfo> _methods
-            = new Dictionary<string, ResolvedMethodInfo>(StringComparer.InvariantCulture);
+            = new(StringComparer.InvariantCulture);
         
         private Dictionary<ModuleType, (Func<bool, Task<IModule>> RentModule, Action<IModule> ReturnModule)> _pools
-            = new Dictionary<ModuleType, (Func<bool, Task<IModule>> RentModule, Action<IModule> ReturnModule)>();
+            = new();
         
         private IRpcMethodFilter _filter = NullRpcMethodFilter.Instance;
 
@@ -78,7 +78,7 @@ namespace Nethermind.JsonRpc.Modules
 
             foreach ((string name, (MethodInfo info, bool readOnly, RpcEndpoint availability)) in GetMethodDict(typeof(T)))
             {
-                ResolvedMethodInfo resolvedMethodInfo = new ResolvedMethodInfo(moduleType, info, readOnly, availability);
+                ResolvedMethodInfo resolvedMethodInfo = new(moduleType, info, readOnly, availability);
                 if (_filter.AcceptMethod(resolvedMethodInfo.ToString()))
                 {
                     _methods[name] = resolvedMethodInfo;

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/SearchResult.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/SearchResult.cs
@@ -32,9 +32,9 @@ namespace Nethermind.JsonRpc.Modules
             ErrorCode = 0;
         }
             
-        public T Object { get; set; }
+        public T? Object { get; set; }
 
-        public string Error { get; set; }
+        public string? Error { get; set; }
 
         public int ErrorCode { get; set; }
 

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/LogsSubscription.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/LogsSubscription.cs
@@ -101,7 +101,7 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
 
         private List<FilterLog> GetFilterLogs(ReceiptsEventArgs e)
         {
-            List<FilterLog> filterLogs = new List<FilterLog>();
+            List<FilterLog> filterLogs = new();
 
             if (_filter.Matches(e.BlockHeader.Bloom))
             {
@@ -117,7 +117,7 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
                             var receiptLog = receipt.Logs[j];
                             if (_filter.Accepts(receiptLog))
                             {
-                                FilterLog filterLog = new FilterLog(
+                                FilterLog filterLog = new(
                                     logIndex++,
                                     transactionLogIndex++,
                                     receipt,

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/SubscriptionManger.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/SubscriptionManger.cs
@@ -29,9 +29,9 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
         private readonly ILogger _logger;
         
         private readonly ConcurrentDictionary<string, Subscription> _subscriptions =
-            new ConcurrentDictionary<string, Subscription>();
+            new();
         private readonly ConcurrentDictionary<string, HashSet<Subscription>> _subscriptionsByJsonRpcClient =
-            new ConcurrentDictionary<string, HashSet<Subscription>>();
+            new();
         
         public SubscriptionManger(ISubscriptionFactory? subscriptionFactory, ILogManager? logManager)
         {

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Trace/ParityAccountStateChangeConverter.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Trace/ParityAccountStateChangeConverter.cs
@@ -27,9 +27,9 @@ namespace Nethermind.JsonRpc.Modules.Trace
 {
     public class ParityAccountStateChangeConverter : JsonConverter<ParityAccountStateChange>
     {
-        private ByteArrayConverter _bytesConverter = new ByteArrayConverter();
-        private NullableUInt256Converter _intConverter = new NullableUInt256Converter();
-        private Bytes32Converter _32BytesConverter = new Bytes32Converter();
+        private ByteArrayConverter _bytesConverter = new();
+        private NullableUInt256Converter _intConverter = new();
+        private Bytes32Converter _32BytesConverter = new();
 
         private void WriteChange(JsonWriter writer, ParityStateChange<byte[]> change, JsonSerializer serializer)
         {

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Trace/ParityTraceAddressConverter.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Trace/ParityTraceAddressConverter.cs
@@ -43,7 +43,7 @@ namespace Nethermind.JsonRpc.Modules.Trace
 
         public override int[] ReadJson(JsonReader reader, Type objectType, int[] existingValue, bool hasExistingValue, JsonSerializer serializer)
         {
-            List<int> result = new List<int>();
+            List<int> result = new();
             int? pathPart;
 
             do

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Trace/ParityTxTraceFromReplayConverter.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Trace/ParityTxTraceFromReplayConverter.cs
@@ -24,7 +24,7 @@ namespace Nethermind.JsonRpc.Modules.Trace
 {
     public class ParityTxTraceFromReplayConverter : JsonConverter<ParityTxTraceFromReplay>
     {
-        private ParityTraceAddressConverter _traceAddressConverter = new ParityTraceAddressConverter();
+        private ParityTraceAddressConverter _traceAddressConverter = new();
 
         public override void WriteJson(JsonWriter writer, ParityTxTraceFromReplay value, JsonSerializer serializer)
         {

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Trace/ParityTxTraceFromStore.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Trace/ParityTxTraceFromStore.cs
@@ -26,14 +26,14 @@ namespace Nethermind.JsonRpc.Modules.Trace
     {
         public static ParityTxTraceFromStore[] FromTxTrace(ParityLikeTxTrace txTrace)
         {
-            List<ParityTxTraceFromStore> results = new List<ParityTxTraceFromStore>();
+            List<ParityTxTraceFromStore> results = new();
             AddActionsRecursively(results, txTrace, txTrace.Action);
             return results.ToArray();
         }
 
         private static void AddActionsRecursively(List<ParityTxTraceFromStore> results, ParityLikeTxTrace txTrace, ParityTraceAction txTraceAction)
         {
-            ParityTxTraceFromStore result = new ParityTxTraceFromStore
+            ParityTxTraceFromStore result = new()
             {
                 Action = txTraceAction,
                 Result = txTraceAction.Result,

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Trace/TraceModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Trace/TraceModule.cs
@@ -37,7 +37,7 @@ namespace Nethermind.JsonRpc.Modules.Trace
         private readonly IReceiptFinder _receiptFinder;
         private readonly ITracer _tracer;
         private readonly IBlockFinder _blockFinder;
-        private readonly TxDecoder _txDecoder = new TxDecoder();
+        private readonly TxDecoder _txDecoder = new();
         private readonly IJsonRpcConfig _jsonRpcConfig;
         private readonly TimeSpan _cancellationTokenTimeout;
 
@@ -97,7 +97,7 @@ namespace Nethermind.JsonRpc.Modules.Trace
                 header.TotalDifficulty = 2 * header.Difficulty;
             }
 
-            Block block = new Block(header, new[] {tx}, Enumerable.Empty<BlockHeader>());
+            Block block = new(header, new[] {tx}, Enumerable.Empty<BlockHeader>());
 
             IReadOnlyCollection<ParityLikeTxTrace> result = TraceBlock(block, GetParityTypes(traceTypes));
             return ResultWrapper<ParityTxTraceFromReplay>.Success(new ParityTxTraceFromReplay(result.SingleOrDefault()));
@@ -185,10 +185,10 @@ namespace Nethermind.JsonRpc.Modules.Trace
 
         private IReadOnlyCollection<ParityLikeTxTrace> TraceBlock(Block block, ParityTraceTypes traceTypes)
         {
-            using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(_cancellationTokenTimeout);
+            using CancellationTokenSource cancellationTokenSource = new(_cancellationTokenTimeout);
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            ParityLikeBlockTracer listener = new ParityLikeBlockTracer(traceTypes);
+            ParityLikeBlockTracer listener = new(traceTypes);
             _tracer.Trace(block, listener.WithCancellation(cancellationToken));
 
             return listener.BuildResult();
@@ -196,10 +196,10 @@ namespace Nethermind.JsonRpc.Modules.Trace
 
         private ParityLikeTxTrace TraceTx(Block block, Keccak txHash, ParityTraceTypes traceTypes)
         {
-            using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(_cancellationTokenTimeout);
+            using CancellationTokenSource cancellationTokenSource = new(_cancellationTokenTimeout);
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            ParityLikeBlockTracer listener = new ParityLikeBlockTracer(txHash, traceTypes);
+            ParityLikeBlockTracer listener = new(txHash, traceTypes);
             _tracer.Trace(block, listener.WithCancellation(cancellationToken));
 
             return listener.BuildResult().SingleOrDefault();

--- a/src/Nethermind/Nethermind.JsonRpc/Recorder.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Recorder.cs
@@ -29,7 +29,7 @@ namespace Nethermind.JsonRpc
         private string _currentRecorderFilePath;
         private int _currentRecorderFileLength;
         private bool _isEnabled = true;
-        private object _recorderSync = new object();
+        private object _recorderSync = new();
 
         public Recorder(string basePath, IFileSystem fileSystem, ILogger logger)
         {

--- a/src/Nethermind/Nethermind.JsonRpc/ResultWrapper.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/ResultWrapper.cs
@@ -33,37 +33,37 @@ namespace Nethermind.JsonRpc
         
         public static ResultWrapper<T> Fail<TSearch>(SearchResult<TSearch> searchResult) where TSearch : class
         {
-            return new ResultWrapper<T> { Result = Result.Fail(searchResult.Error), ErrorCode = searchResult.ErrorCode};
+            return new() { Result = Result.Fail(searchResult.Error), ErrorCode = searchResult.ErrorCode};
         }
         
         public static ResultWrapper<T> Fail(string error)
         {
-            return new ResultWrapper<T> { Result = Result.Fail(error), ErrorCode = ErrorCodes.InternalError};
+            return new() { Result = Result.Fail(error), ErrorCode = ErrorCodes.InternalError};
         }
         
         public static ResultWrapper<T> Fail(Exception e)
         {
-            return new ResultWrapper<T> { Result = Result.Fail(e.ToString()), ErrorCode = ErrorCodes.InternalError};
+            return new() { Result = Result.Fail(e.ToString()), ErrorCode = ErrorCodes.InternalError};
         }
 
         public static ResultWrapper<T> Fail(string error, int errorCode, T outputData)
         {
-            return new ResultWrapper<T> { Result = Result.Fail(error), ErrorCode = errorCode, Data = outputData};
+            return new() { Result = Result.Fail(error), ErrorCode = errorCode, Data = outputData};
         }
         
         public static ResultWrapper<T> Fail(string error, int errorCode)
         {
-            return new ResultWrapper<T> { Result = Result.Fail(error), ErrorCode = errorCode};
+            return new() { Result = Result.Fail(error), ErrorCode = errorCode};
         }
         
         public static ResultWrapper<T> Fail(string error, T data)
         {
-            return new ResultWrapper<T> { Data = data, Result = Result.Fail(error) };
+            return new() { Data = data, Result = Result.Fail(error) };
         }
 
         public static ResultWrapper<T> Success(T data)
         {
-            return new ResultWrapper<T> { Data = data, Result = Result.Success };
+            return new() { Data = data, Result = Result.Success };
         }
 
         public Result GetResult()

--- a/src/Nethermind/Nethermind.JsonRpc/WebSockets/JsonRpcWebSocketsModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/WebSockets/JsonRpcWebSocketsModule.cs
@@ -27,7 +27,7 @@ namespace Nethermind.JsonRpc.WebSockets
     public class JsonRpcWebSocketsModule : IWebSocketsModule
     {
         private readonly ConcurrentDictionary<string, IWebSocketsClient> _clients =
-            new ConcurrentDictionary<string, IWebSocketsClient>();
+            new();
 
         private readonly JsonRpcProcessor _jsonRpcProcessor;
         private readonly JsonRpcService _jsonRpcService;

--- a/src/Nethermind/Nethermind.Runner/Ethereum/Api/NethermindApi.cs
+++ b/src/Nethermind/Nethermind.Runner/Ethereum/Api/NethermindApi.cs
@@ -24,6 +24,7 @@ using Nethermind.Blockchain;
 using Nethermind.Blockchain.Filters;
 using Nethermind.Blockchain.Find;
 using Nethermind.Blockchain.Processing;
+using Nethermind.Blockchain.Producers;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Blockchain.Rewards;
 using Nethermind.Blockchain.Synchronization;
@@ -137,6 +138,8 @@ namespace Nethermind.Runner.Ethereum.Api
         public IFilterManager? FilterManager { get; set; }
         public IGrpcServer? GrpcServer { get; set; }
         public IHeaderValidator? HeaderValidator { get; set; }
+        public IManualBlockProductionTrigger ManualBlockProductionTrigger { get; set; } =
+            new BuildBlocksWhenRequested();
         public IIPResolver? IpResolver { get; set; }
         public IJsonSerializer EthereumJsonSerializer { get; set; }
         public IKeyStore? KeyStore { get; set; }

--- a/src/Nethermind/Nethermind.Runner/Ethereum/Steps/RegisterRpcModules.cs
+++ b/src/Nethermind/Nethermind.Runner/Ethereum/Steps/RegisterRpcModules.cs
@@ -35,6 +35,7 @@ using Nethermind.JsonRpc.Modules.TxPool;
 using Nethermind.Logging;
 using Nethermind.Network.Config;
 using Nethermind.Core;
+using Nethermind.JsonRpc.Modules.Evm;
 using Nethermind.JsonRpc.Modules.Subscribe;
 using Nethermind.JsonRpc.Modules.Web3;
 using Nethermind.Runner.Ethereum.Steps.Migrations;
@@ -46,8 +47,6 @@ namespace Nethermind.Runner.Ethereum.Steps
     {
         private readonly INethermindApi _api;
 
-        private int _cpuCount = Environment.ProcessorCount;
-        
         public RegisterRpcModules(INethermindApi api)
         {
             _api = api;
@@ -95,7 +94,7 @@ namespace Nethermind.Runner.Ethereum.Steps
             ThreadPool.GetMinThreads(out int workerThreads, out int completionPortThreads);
             ThreadPool.SetMinThreads(workerThreads + Environment.ProcessorCount, completionPortThreads + Environment.ProcessorCount);
             
-            EthModuleFactory ethModuleFactory = new EthModuleFactory(
+            EthModuleFactory ethModuleFactory = new(
                 _api.TxPool,
                 _api.TxSender,
                 _api.Wallet,
@@ -104,17 +103,17 @@ namespace Nethermind.Runner.Ethereum.Steps
                 _api.LogManager,
                 _api.StateReader,
                 _api);
-            _api.RpcModuleProvider.Register(new BoundedModulePool<IEthModule>(ethModuleFactory, _cpuCount, rpcConfig.Timeout));
+            _api.RpcModuleProvider.RegisterBoundedByCpuCount(ethModuleFactory, rpcConfig.Timeout);
             
             if (_api.DbProvider == null) throw new StepDependencyException(nameof(_api.DbProvider));
             if (_api.BlockPreprocessor == null) throw new StepDependencyException(nameof(_api.BlockPreprocessor));
             if (_api.BlockValidator == null) throw new StepDependencyException(nameof(_api.BlockValidator));
             if (_api.RewardCalculatorSource == null) throw new StepDependencyException(nameof(_api.RewardCalculatorSource));
             
-            ProofModuleFactory proofModuleFactory = new ProofModuleFactory(_api.DbProvider, _api.BlockTree, _api.TrieStore, _api.BlockPreprocessor, _api.ReceiptFinder, _api.SpecProvider, _api.LogManager);
-            _api.RpcModuleProvider.Register(new BoundedModulePool<IProofModule>(proofModuleFactory, 2, rpcConfig.Timeout));
+            ProofModuleFactory proofModuleFactory = new(_api.DbProvider, _api.BlockTree, _api.TrieStore, _api.BlockPreprocessor, _api.ReceiptFinder, _api.SpecProvider, _api.LogManager);
+            _api.RpcModuleProvider.RegisterBounded(proofModuleFactory, 2, rpcConfig.Timeout);
 
-            DebugModuleFactory debugModuleFactory = new DebugModuleFactory(
+            DebugModuleFactory debugModuleFactory = new(
                 _api.DbProvider, 
                 _api.BlockTree,
 				rpcConfig, 
@@ -127,9 +126,9 @@ namespace Nethermind.Runner.Ethereum.Steps
                 _api.ConfigProvider, 
                 _api.SpecProvider, 
                 _api.LogManager);
-            _api.RpcModuleProvider.Register(new BoundedModulePool<IDebugModule>(debugModuleFactory, _cpuCount, rpcConfig.Timeout));
+            _api.RpcModuleProvider.RegisterBoundedByCpuCount(debugModuleFactory, rpcConfig.Timeout);
 
-            TraceModuleFactory traceModuleFactory = new TraceModuleFactory(
+            TraceModuleFactory traceModuleFactory = new(
                 _api.DbProvider,
                 _api.BlockTree,
                 _api.ReadOnlyTrieStore,
@@ -140,42 +139,42 @@ namespace Nethermind.Runner.Ethereum.Steps
                 _api.SpecProvider,
                 _api.LogManager);
 
-            _api.RpcModuleProvider.Register(new BoundedModulePool<ITraceModule>(traceModuleFactory, _cpuCount, rpcConfig.Timeout));
+            _api.RpcModuleProvider.RegisterBoundedByCpuCount(traceModuleFactory, rpcConfig.Timeout);
             
             if (_api.EthereumEcdsa == null) throw new StepDependencyException(nameof(_api.EthereumEcdsa));
             if (_api.Wallet == null) throw new StepDependencyException(nameof(_api.Wallet));
             
-            PersonalModule personalModule = new PersonalModule(
+            PersonalModule personalModule = new(
                 _api.EthereumEcdsa,
                 _api.Wallet,
                 _api.KeyStore);
-            _api.RpcModuleProvider.Register(new SingletonModulePool<IPersonalModule>(personalModule, true));
+            _api.RpcModuleProvider.RegisterSingle<IPersonalModule>(personalModule);
             
             if (_api.PeerManager == null) throw new StepDependencyException(nameof(_api.PeerManager));
             if (_api.StaticNodesManager == null) throw new StepDependencyException(nameof(_api.StaticNodesManager));
             if (_api.Enode == null) throw new StepDependencyException(nameof(_api.Enode));
 
-            AdminModule adminModule = new AdminModule(
+            AdminModule adminModule = new(
                 _api.BlockTree,
                 networkConfig,
                 _api.PeerManager,
                 _api.StaticNodesManager,
                 _api.Enode,
                 initConfig.BaseDbPath);
-            _api.RpcModuleProvider.Register(new SingletonModulePool<IAdminModule>(adminModule, true));
+            _api.RpcModuleProvider.RegisterSingle<IAdminModule>(adminModule);
             
             if (_api.TxPoolInfoProvider == null) throw new StepDependencyException(nameof(_api.TxPoolInfoProvider));
 
-            TxPoolModule txPoolModule = new TxPoolModule(_api.BlockTree, _api.TxPoolInfoProvider, _api.LogManager);
-            _api.RpcModuleProvider.Register(new SingletonModulePool<ITxPoolModule>(txPoolModule, true));
+            TxPoolModule txPoolModule = new(_api.BlockTree, _api.TxPoolInfoProvider, _api.LogManager);
+            _api.RpcModuleProvider.RegisterSingle<ITxPoolModule>(txPoolModule);
             
             if (_api.SyncServer == null) throw new StepDependencyException(nameof(_api.SyncServer));
             if (_api.EngineSignerStore == null) throw new StepDependencyException(nameof(_api.EngineSignerStore));
 
-            NetModule netModule = new NetModule(_api.LogManager, new NetBridge(_api.Enode, _api.SyncServer));
-            _api.RpcModuleProvider.Register(new SingletonModulePool<INetModule>(netModule, true));
+            NetModule netModule = new(_api.LogManager, new NetBridge(_api.Enode, _api.SyncServer));
+            _api.RpcModuleProvider.RegisterSingle<INetModule>(netModule);
 
-            ParityModule parityModule = new ParityModule(
+            ParityModule parityModule = new(
                 _api.EthereumEcdsa,
                 _api.TxPool,
                 _api.BlockTree,
@@ -185,22 +184,25 @@ namespace Nethermind.Runner.Ethereum.Steps
                 _api.KeyStore,
                 _api.LogManager,
                 _api.PeerManager);
-            _api.RpcModuleProvider.Register(new SingletonModulePool<IParityModule>(parityModule, true));
+            _api.RpcModuleProvider.RegisterSingle<IParityModule>(parityModule);
 
-            SubscriptionFactory subscriptionFactory = new SubscriptionFactory(
+            SubscriptionFactory subscriptionFactory = new(
                 _api.LogManager,
                 _api.BlockTree,
                 _api.TxPool,
                 _api.ReceiptStorage,
                 _api.FilterStore);
             
-            SubscriptionManger subscriptionManger = new SubscriptionManger(subscriptionFactory, _api.LogManager);
+            SubscriptionManger subscriptionManger = new(subscriptionFactory, _api.LogManager);
             
-            SubscribeModule subscribeModule = new SubscribeModule(subscriptionManger);
-            _api.RpcModuleProvider.Register(new SingletonModulePool<ISubscribeModule>(subscribeModule, true));
+            SubscribeModule subscribeModule = new(subscriptionManger);
+            _api.RpcModuleProvider.RegisterSingle<ISubscribeModule>(subscribeModule);
 
-            Web3Module web3Module = new Web3Module(_api.LogManager);
-            _api.RpcModuleProvider.Register(new SingletonModulePool<IWeb3Module>(web3Module, true));
+            Web3Module web3Module = new(_api.LogManager);
+            _api.RpcModuleProvider.RegisterSingle<IWeb3Module>(web3Module);
+
+            EvmModule evmModule = new(_api.ManualBlockProductionTrigger);
+            _api.RpcModuleProvider.RegisterSingle<IEvmModule>(evmModule);
 
             foreach (INethermindPlugin plugin in _api.Plugins)
             {

--- a/src/Nethermind/Nethermind.State/Proofs/TxTrie.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/TxTrie.cs
@@ -15,6 +15,7 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
 using System;
+using System.Collections.Generic;
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
@@ -36,11 +37,11 @@ namespace Nethermind.State.Proofs
         /// <param name="txs">Transactions to build a trie from.</param>
         /// <param name="allowMerkleProofConstructions">Some tries do not need to be used for proof constructions.
         /// In such cases we can avoid maintaining any in-memory databases.</param>
-        public TxTrie(Transaction[] txs, bool allowMerkleProofConstructions = false)
+        public TxTrie(IReadOnlyList<Transaction>? txs, bool allowMerkleProofConstructions = false)
             : base(allowMerkleProofConstructions ? (IDb) new MemDb() : NullDb.Instance, EmptyTreeHash, false, false, NullLogManager.Instance)
         {
             _allowMerkleProofConstructions = allowMerkleProofConstructions;
-            if (txs.Length == 0)
+            if ((txs?.Count ?? 0) == 0)
             {
                 return;
             }
@@ -48,7 +49,7 @@ namespace Nethermind.State.Proofs
             // 3% allocations (2GB) on a Goerli 3M blocks fast sync due to calling transaction encoder here
             // Avoiding it would require pooling byte arrays and passing them as Spans to temporary trees
             // a temporary trie would be a trie that exists to create a state root only and then be disposed of
-            for (int i = 0; i < txs.Length; i++)
+            for (int i = 0; i < txs.Count; i++)
             {
                 Rlp transactionRlp = _txDecoder.Encode(txs[i], RlpBehaviors.ForTxRoot);
                 Set(Rlp.Encode(i).Bytes, transactionRlp.Bytes);

--- a/src/Nethermind/Nethermind.State/StateProvider.cs
+++ b/src/Nethermind/Nethermind.State/StateProvider.cs
@@ -49,7 +49,7 @@ namespace Nethermind.State
         private Change?[] _changes = new Change?[StartCapacity];
         private int _currentPosition = -1;
         
-        public StateProvider(ITrieStore trieStore, IKeyValueStore codeDb, ILogManager? logManager)
+        public StateProvider(ITrieStore? trieStore, IKeyValueStore? codeDb, ILogManager? logManager)
         {
             _logger = logManager?.GetClassLogger<StateProvider>() ?? throw new ArgumentNullException(nameof(logManager));
             _codeDb = codeDb ?? throw new ArgumentNullException(nameof(codeDb));

--- a/src/Nethermind/Nethermind.State/StateReader.cs
+++ b/src/Nethermind/Nethermind.State/StateReader.cs
@@ -33,7 +33,7 @@ namespace Nethermind.State
         private readonly StateTree _state;
         private readonly StorageTree _storage;
 
-        public StateReader(ITrieStore trieStore, IDb codeDb, ILogManager logManager)
+        public StateReader(ITrieStore? trieStore, IDb? codeDb, ILogManager? logManager)
         {
             _logger = logManager?.GetClassLogger<StateReader>() ?? throw new ArgumentNullException(nameof(logManager));
             _codeDb = codeDb ?? throw new ArgumentNullException(nameof(codeDb));

--- a/src/Nethermind/Nethermind.State/StateTree.cs
+++ b/src/Nethermind/Nethermind.State/StateTree.cs
@@ -37,7 +37,7 @@ namespace Nethermind.State
         }
 
         [DebuggerStepThrough]
-        public StateTree(ITrieStore store, ILogManager logManager)
+        public StateTree(ITrieStore? store, ILogManager? logManager)
             : base(store, Keccak.EmptyTreeHash, true, true, logManager)
         {
             TrieType = TrieType.State;

--- a/src/Nethermind/Nethermind.State/StorageTree.cs
+++ b/src/Nethermind/Nethermind.State/StorageTree.cs
@@ -46,7 +46,7 @@ namespace Nethermind.State
             }
         }
         
-        public StorageTree(ITrieStore trieStore, Keccak rootHash, ILogManager logManager)
+        public StorageTree(ITrieStore? trieStore, Keccak rootHash, ILogManager? logManager)
             : base(trieStore, rootHash, false, true, logManager)
         {
             TrieType = TrieType.Storage;

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncThreadTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncThreadTests.cs
@@ -119,7 +119,7 @@ namespace Nethermind.Synchronization.Test
             }
         }
 
-        private const int _waitTime = 1000;
+        private const int WaitTime = 1000;
 
         [Test, Ignore("travis failures")]
         public void Can_sync_when_connected()
@@ -131,7 +131,7 @@ namespace Nethermind.Synchronization.Test
             SemaphoreSlim waitEvent = new(0);
             foreach (SyncTestContext peer in _peers)
             {
-                peer.Tree.NewHeadBlock += (s, e) =>
+                peer.Tree.NewHeadBlock += (_, e) =>
                 {
                     if (e.Block.Number == _chainLength) waitEvent.Release();
                 };
@@ -139,7 +139,7 @@ namespace Nethermind.Synchronization.Test
 
             for (int i = 0; i < _peers.Count; i++)
             {
-                waitEvent.Wait(_waitTime);
+                waitEvent.Wait(WaitTime);
             }
 
             for (int i = 0; i < _peers.Count; i++)
@@ -156,7 +156,7 @@ namespace Nethermind.Synchronization.Test
         {
             Block headBlock = _genesis;
             AutoResetEvent resetEvent = new(false);
-            _originPeer.Tree.NewHeadBlock += (s, e) =>
+            _originPeer.Tree.NewHeadBlock += (_, e) =>
             {
                 resetEvent.Set();
                 headBlock = e.Block;
@@ -200,7 +200,7 @@ namespace Nethermind.Synchronization.Test
             SemaphoreSlim waitEvent = new(0);
             foreach (SyncTestContext peer in _peers)
             {
-                peer.Tree.NewHeadBlock += (s, e) =>
+                peer.Tree.NewHeadBlock += (_, e) =>
                 {
                     if (e.Block.Number == _chainLength) waitEvent.Release();
                 };
@@ -210,7 +210,7 @@ namespace Nethermind.Synchronization.Test
 
             for (int i = 0; i < _peers.Count; i++)
             {
-                waitEvent.Wait(_waitTime);
+                waitEvent.Wait(WaitTime);
             }
 
             for (int i = 0; i < _peers.Count; i++)
@@ -341,7 +341,7 @@ namespace Nethermind.Synchronization.Test
                 devChainProcessor,
                 stateProvider, tree,
                 processor,
-                txPool,
+                new BuildBlocksRegularly(TimeSpan.FromMilliseconds(50)).IfPoolIsNotEmpty(txPool),
                 Timestamper.Default,
                 specProvider,
                 new MiningConfig(),
@@ -376,7 +376,7 @@ namespace Nethermind.Synchronization.Test
                 logManager);
 
             ManualResetEventSlim waitEvent = new();
-            tree.NewHeadBlock += (s, e) => waitEvent.Set();
+            tree.NewHeadBlock += (_, _) => waitEvent.Set();
 
             if (index == 0)
             {

--- a/src/Nethermind/Nethermind.Trie.Test/CacheTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/CacheTests.cs
@@ -12,14 +12,14 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Cache_initial_memory_calculated_correctly()
         {
-            MemCountingCache cache = new MemCountingCache(1024, string.Empty);
+            MemCountingCache cache = new(1024, string.Empty);
             cache.MemorySize.Should().Be(160);
         }
         
         [Test]
         public void Cache_post_init_memory_calculated_correctly()
         {
-            MemCountingCache cache = new MemCountingCache(1024, string.Empty);
+            MemCountingCache cache = new(1024, string.Empty);
             cache.Set(Keccak.Zero, new byte[0]); 
             cache.MemorySize.Should().Be(400);
         }
@@ -27,7 +27,7 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Cache_post_capacity_growth_memory_calculated_correctly()
         {
-            MemCountingCache cache = new MemCountingCache(1024, string.Empty);
+            MemCountingCache cache = new(1024, string.Empty);
             cache.Set(TestItem.KeccakA, new byte[0]);
             cache.Set(TestItem.KeccakB, new byte[0]);
             cache.Set(TestItem.KeccakC, new byte[0]);
@@ -38,7 +38,7 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Limit_by_memory_works_fine()
         {
-            MemCountingCache cache = new MemCountingCache(800, string.Empty);
+            MemCountingCache cache = new(800, string.Empty);
             cache.Set(TestItem.KeccakA, new byte[0]);
             cache.Set(TestItem.KeccakB, new byte[0]);
             cache.Set(TestItem.KeccakC, new byte[0]);
@@ -61,7 +61,7 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Limit_by_memory_works_fine_wth_deletes()
         {
-            MemCountingCache cache = new MemCountingCache(800, string.Empty);
+            MemCountingCache cache = new(800, string.Empty);
             cache.Set(TestItem.KeccakA, new byte[0]);
             cache.Set(TestItem.KeccakB, new byte[0]);
             cache.Set(TestItem.KeccakC, new byte[0]);

--- a/src/Nethermind/Nethermind.Trie.Test/HexPrefixTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/HexPrefixTests.cs
@@ -25,7 +25,7 @@ namespace Nethermind.Trie.Test
         [TestCase(true, (byte)3, (byte)51)]
         public void Encode_gives_correct_output_when_one(bool flag, byte nibble1, byte byte1)
         {
-            HexPrefix hexPrefix = new HexPrefix(flag, nibble1);
+            HexPrefix hexPrefix = new(flag, nibble1);
             byte[] output = hexPrefix.ToBytes();
             Assert.AreEqual(1, output.Length);
             Assert.AreEqual(byte1, output[0]);
@@ -35,7 +35,7 @@ namespace Nethermind.Trie.Test
         [TestCase(true, (byte)3, (byte)7, (byte)13, (byte)51, (byte)125)]
         public void Encode_gives_correct_output_when_odd(bool flag, byte nibble1, byte nibble2, byte nibble3, byte byte1, byte byte2)
         {
-            HexPrefix hexPrefix = new HexPrefix(flag, nibble1, nibble2, nibble3);
+            HexPrefix hexPrefix = new(flag, nibble1, nibble2, nibble3);
             byte[] output = hexPrefix.ToBytes();
             Assert.AreEqual(2, output.Length);
             Assert.AreEqual(byte1, output[0]);
@@ -46,7 +46,7 @@ namespace Nethermind.Trie.Test
         [TestCase(true, (byte)3, (byte)7, (byte)32, (byte)55)]
         public void Encode_gives_correct_output_when_even(bool flag, byte nibble1, byte nibble2, byte byte1, byte byte2)
         {
-            HexPrefix hexPrefix = new HexPrefix(flag, nibble1, nibble2);
+            HexPrefix hexPrefix = new(flag, nibble1, nibble2);
             byte[] output = hexPrefix.ToBytes();
             Assert.AreEqual(2, output.Length);
             Assert.AreEqual(byte1, output[0]);

--- a/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
@@ -66,10 +66,13 @@ namespace Nethermind.Trie.Test.Pruning
             TrieStore trieStore = new(new MemDb(), No.Pruning, Archive.Instance, _logManager);
             trieStore.ReorgBoundaryReached += (_, e) => reorgBoundaryCount += e.BlockNumber;
             trieStore.FinishBlockCommit(TrieType.State, 1, trieNode);
+            reorgBoundaryCount.Should().Be(0);
             trieStore.FinishBlockCommit(TrieType.State, 2, trieNode);
+            reorgBoundaryCount.Should().Be(1);
             trieStore.FinishBlockCommit(TrieType.State, 3, trieNode);
+            reorgBoundaryCount.Should().Be(3);
             trieStore.FinishBlockCommit(TrieType.State, 4, trieNode);
-            reorgBoundaryCount.Should().Be(10L);
+            reorgBoundaryCount.Should().Be(6);
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
@@ -26,16 +26,16 @@ namespace Nethermind.Trie.Test.Pruning
         [Test]
         public void Initial_memory_is_0()
         {
-            TrieStore trieStore = new TrieStore(new MemDb(), new TestPruningStrategy(true), No.Persistence, _logManager);
+            TrieStore trieStore = new(new MemDb(), new TestPruningStrategy(true), No.Persistence, _logManager);
             trieStore.MemoryUsedByDirtyCache.Should().Be(0);
         }
         
         [Test]
         public void Memory_with_one_node_is_288()
         {
-            TrieNode trieNode = new TrieNode(NodeType.Leaf, Keccak.Zero); // 56B
+            TrieNode trieNode = new(NodeType.Leaf, Keccak.Zero); // 56B
         
-            TrieStore trieStore = new TrieStore(new MemDb(), new TestPruningStrategy(true), No.Persistence, _logManager);
+            TrieStore trieStore = new(new MemDb(), new TestPruningStrategy(true), No.Persistence, _logManager);
             trieStore.CommitNode(1234, new NodeCommitInfo(trieNode));
             trieStore.MemoryUsedByDirtyCache.Should().Be(
                 trieNode.GetMemorySize(false));
@@ -46,22 +46,52 @@ namespace Nethermind.Trie.Test.Pruning
         [Test]
         public void Prunning_off_cache_should_not_change_commit_node()
         {
-            TrieNode trieNode = new TrieNode(NodeType.Leaf, Keccak.Zero);
-            TrieNode trieNode2 = new TrieNode(NodeType.Branch, TestItem.KeccakA);
-            TrieNode trieNode3 = new TrieNode(NodeType.Branch, TestItem.KeccakB);
+            TrieNode trieNode = new(NodeType.Leaf, Keccak.Zero);
+            TrieNode trieNode2 = new(NodeType.Branch, TestItem.KeccakA);
+            TrieNode trieNode3 = new(NodeType.Branch, TestItem.KeccakB);
 
-            TrieStore trieStore = new TrieStore(new MemDb(), No.Pruning, No.Persistence, _logManager);
+            TrieStore trieStore = new(new MemDb(), No.Pruning, No.Persistence, _logManager);
             trieStore.CommitNode(1234, new NodeCommitInfo(trieNode));
             trieStore.FinishBlockCommit(TrieType.State, 1234, trieNode);
             trieStore.CommitNode(124, new NodeCommitInfo(trieNode2));
             trieStore.CommitNode(11234, new NodeCommitInfo(trieNode3));
             trieStore.MemoryUsedByDirtyCache.Should().Be(0);
         }
+        
+        [Test]
+        public void Should_always_announce_reorg_boundary_when_pruning_disabled_and_persisting()
+        {
+            TrieNode trieNode = new(NodeType.Leaf, Keccak.Zero);
+
+            int reorgBoundaryCount = 0;
+            TrieStore trieStore = new(new MemDb(), No.Pruning, Archive.Instance, _logManager);
+            trieStore.ReorgBoundaryReached += (_, _) => reorgBoundaryCount++;
+            trieStore.FinishBlockCommit(TrieType.State, 1, trieNode);
+            trieStore.FinishBlockCommit(TrieType.State, 2, trieNode);
+            trieStore.FinishBlockCommit(TrieType.State, 3, trieNode);
+            trieStore.FinishBlockCommit(TrieType.State, 4, trieNode);
+            reorgBoundaryCount.Should().Be(4);
+        }
+        
+        [Test]
+        public void Should_never_announce_reorg_boundary_when_pruning_disabled_and_not_persisting()
+        {
+            TrieNode trieNode = new(NodeType.Leaf, Keccak.Zero);
+
+            int reorgBoundaryCount = 0;
+            TrieStore trieStore = new(new MemDb(), No.Pruning, No.Persistence, _logManager);
+            trieStore.ReorgBoundaryReached += (_, _) => reorgBoundaryCount++;
+            trieStore.FinishBlockCommit(TrieType.State, 1, trieNode);
+            trieStore.FinishBlockCommit(TrieType.State, 2, trieNode);
+            trieStore.FinishBlockCommit(TrieType.State, 3, trieNode);
+            trieStore.FinishBlockCommit(TrieType.State, 4, trieNode);
+            reorgBoundaryCount.Should().Be(0);
+        }
 
         [Test]
         public void Prunning_off_cache_should_not_find_cached_or_unknown()
         {
-            TrieStore trieStore = new TrieStore(new MemDb(), No.Pruning, No.Persistence, _logManager);
+            TrieStore trieStore = new(new MemDb(), No.Pruning, No.Persistence, _logManager);
             var returnedNode = trieStore.FindCachedOrUnknown(TestItem.KeccakA, true);
             var returnedNode2 = trieStore.FindCachedOrUnknown(TestItem.KeccakB, true);
             var returnedNode3 = trieStore.FindCachedOrUnknown(TestItem.KeccakC, true);
@@ -74,10 +104,10 @@ namespace Nethermind.Trie.Test.Pruning
         [Test]
         public void FindCachedOrUnknown_CorrectlyCalculatedMemoryUsedByDirtyCache()
         {
-            TrieStore trieStore = new TrieStore(new MemDb(), new TestPruningStrategy(true), No.Persistence, _logManager);
+            TrieStore trieStore = new(new MemDb(), new TestPruningStrategy(true), No.Persistence, _logManager);
             var startSize = trieStore.MemoryUsedByDirtyCache;
             trieStore.FindCachedOrUnknown(TestItem.KeccakA);
-            TrieNode trieNode = new TrieNode(NodeType.Leaf, Keccak.Zero);
+            TrieNode trieNode = new(NodeType.Leaf, Keccak.Zero);
             var oneKeccakSize = trieNode.GetMemorySize(false);
             Assert.AreEqual(startSize + oneKeccakSize, trieStore.MemoryUsedByDirtyCache);
             trieStore.FindCachedOrUnknown(TestItem.KeccakB);
@@ -93,10 +123,10 @@ namespace Nethermind.Trie.Test.Pruning
         [Test]
         public void Memory_with_two_nodes_is_correct()
         {
-            TrieNode trieNode1 = new TrieNode(NodeType.Leaf, TestItem.KeccakA);
-            TrieNode trieNode2 = new TrieNode(NodeType.Leaf, TestItem.KeccakB);
+            TrieNode trieNode1 = new(NodeType.Leaf, TestItem.KeccakA);
+            TrieNode trieNode2 = new(NodeType.Leaf, TestItem.KeccakB);
         
-            TrieStore trieStore = new TrieStore(new MemDb(), new TestPruningStrategy(true), No.Persistence, _logManager);
+            TrieStore trieStore = new(new MemDb(), new TestPruningStrategy(true), No.Persistence, _logManager);
             trieStore.CommitNode(1234, new NodeCommitInfo(trieNode1));
             trieStore.CommitNode(1234, new NodeCommitInfo(trieNode2));
             trieStore.MemoryUsedByDirtyCache.Should().Be(
@@ -107,12 +137,12 @@ namespace Nethermind.Trie.Test.Pruning
         [Test]
         public void Memory_with_two_times_two_nodes_is_correct()
         {
-            TrieNode trieNode1 = new TrieNode(NodeType.Leaf, TestItem.KeccakA);
-            TrieNode trieNode2 = new TrieNode(NodeType.Leaf, TestItem.KeccakB);
-            TrieNode trieNode3 = new TrieNode(NodeType.Leaf, TestItem.KeccakA);
-            TrieNode trieNode4 = new TrieNode(NodeType.Leaf, TestItem.KeccakB);
+            TrieNode trieNode1 = new(NodeType.Leaf, TestItem.KeccakA);
+            TrieNode trieNode2 = new(NodeType.Leaf, TestItem.KeccakB);
+            TrieNode trieNode3 = new(NodeType.Leaf, TestItem.KeccakA);
+            TrieNode trieNode4 = new(NodeType.Leaf, TestItem.KeccakB);
         
-            TrieStore trieStore = new TrieStore(new MemDb(), new TestPruningStrategy(true), No.Persistence, _logManager);
+            TrieStore trieStore = new(new MemDb(), new TestPruningStrategy(true), No.Persistence, _logManager);
             trieStore.CommitNode(1234, new NodeCommitInfo(trieNode1));
             trieStore.CommitNode(1234, new NodeCommitInfo(trieNode2));
             trieStore.FinishBlockCommit(TrieType.State, 1234, trieNode2);
@@ -129,18 +159,18 @@ namespace Nethermind.Trie.Test.Pruning
         [Test]
         public void Dispatcher_will_try_to_clear_memory()
         {
-            TrieNode trieNode1 = new TrieNode(NodeType.Leaf, new byte[0]);
+            TrieNode trieNode1 = new(NodeType.Leaf, new byte[0]);
             trieNode1.ResolveKey(null!, true);
-            TrieNode trieNode2 = new TrieNode(NodeType.Leaf, new byte[1]);
+            TrieNode trieNode2 = new(NodeType.Leaf, new byte[1]);
             trieNode2.ResolveKey(null!, true);
         
-            TrieNode trieNode3 = new TrieNode(NodeType.Leaf, new byte[2]);
+            TrieNode trieNode3 = new(NodeType.Leaf, new byte[2]);
             trieNode3.ResolveKey(null!, true);
         
-            TrieNode trieNode4 = new TrieNode(NodeType.Leaf, new byte[3]);
+            TrieNode trieNode4 = new(NodeType.Leaf, new byte[3]);
             trieNode4.ResolveKey(null!, true);
         
-            TrieStore trieStore = new TrieStore(new MemDb(), new MemoryLimit(640), No.Persistence, _logManager);
+            TrieStore trieStore = new(new MemDb(), new MemoryLimit(640), No.Persistence, _logManager);
             trieStore.CommitNode(1234, new NodeCommitInfo(trieNode1));
             trieStore.CommitNode(1234, new NodeCommitInfo(trieNode2));
             trieStore.FinishBlockCommit(TrieType.State, 1234, trieNode2);
@@ -158,18 +188,18 @@ namespace Nethermind.Trie.Test.Pruning
         [Test]
         public void Dispatcher_will_try_to_clear_memory_the_soonest_possible()
         {
-            TrieNode trieNode1 = new TrieNode(NodeType.Leaf, new byte[0]);
+            TrieNode trieNode1 = new(NodeType.Leaf, new byte[0]);
             trieNode1.ResolveKey(null!, true);
-            TrieNode trieNode2 = new TrieNode(NodeType.Leaf, new byte[1]);
+            TrieNode trieNode2 = new(NodeType.Leaf, new byte[1]);
             trieNode2.ResolveKey(null!, true);
         
-            TrieNode trieNode3 = new TrieNode(NodeType.Leaf, new byte[2]);
+            TrieNode trieNode3 = new(NodeType.Leaf, new byte[2]);
             trieNode3.ResolveKey(null!, true);
         
-            TrieNode trieNode4 = new TrieNode(NodeType.Leaf, new byte[3]);
+            TrieNode trieNode4 = new(NodeType.Leaf, new byte[3]);
             trieNode4.ResolveKey(null!, true);
         
-            TrieStore trieStore = new TrieStore(new MemDb(), new MemoryLimit(512), No.Persistence, _logManager);
+            TrieStore trieStore = new(new MemDb(), new MemoryLimit(512), No.Persistence, _logManager);
             trieStore.CommitNode(1234, new NodeCommitInfo(trieNode1));
             trieStore.CommitNode(1234, new NodeCommitInfo(trieNode2));
             trieStore.FinishBlockCommit(TrieType.State, 1234, trieNode2);
@@ -186,17 +216,17 @@ namespace Nethermind.Trie.Test.Pruning
         public void Dispatcher_will_always_try_to_clear_memory()
         {
 
-            TrieStore trieStore = new TrieStore(new MemDb(), new MemoryLimit(512), No.Persistence, _logManager);
+            TrieStore trieStore = new(new MemDb(), new MemoryLimit(512), No.Persistence, _logManager);
             for (int i = 0; i < 1024; i++)
             {
                 for (int j = 0; j < 1 + i % 3; j++)
                 {
-                    TrieNode trieNode = new TrieNode(NodeType.Leaf, new byte[0]); // 192B
+                    TrieNode trieNode = new(NodeType.Leaf, new byte[0]); // 192B
                     trieNode.ResolveKey(NullTrieNodeResolver.Instance, true);
                     trieStore.CommitNode(i, new NodeCommitInfo(trieNode));
                 }
         
-                TrieNode fakeRoot = new TrieNode(NodeType.Leaf, new byte[0]); // 192B
+                TrieNode fakeRoot = new(NodeType.Leaf, new byte[0]); // 192B
                 fakeRoot.ResolveKey(NullTrieNodeResolver.Instance, true);
                 trieStore.FinishBlockCommit(TrieType.State, i, fakeRoot);
             }
@@ -207,12 +237,12 @@ namespace Nethermind.Trie.Test.Pruning
         [Test]
         public void Dispatcher_will_save_to_db_everything_from_snapshot_blocks()
         {
-            TrieNode a = new TrieNode(NodeType.Leaf, new byte[0]); // 192B
+            TrieNode a = new(NodeType.Leaf, new byte[0]); // 192B
             a.ResolveKey(NullTrieNodeResolver.Instance, true);
 
-            MemDb memDb = new MemDb();
+            MemDb memDb = new();
 
-            TrieStore trieStore = new TrieStore(memDb, new MemoryLimit(16.MB()), new ConstantInterval(4), _logManager);
+            TrieStore trieStore = new(memDb, new MemoryLimit(16.MB()), new ConstantInterval(4), _logManager);
 
             trieStore.CommitNode(0, new NodeCommitInfo(a));
             trieStore.FinishBlockCommit(TrieType.State, 0, a);
@@ -228,12 +258,12 @@ namespace Nethermind.Trie.Test.Pruning
         [Test]
         public void Stays_in_memory_until_persisted()
         {
-            TrieNode a = new TrieNode(NodeType.Leaf, new byte[0]); // 192B
+            TrieNode a = new(NodeType.Leaf, new byte[0]); // 192B
             a.ResolveKey(NullTrieNodeResolver.Instance, true);
 
-            MemDb memDb = new MemDb();
+            MemDb memDb = new();
 
-            TrieStore trieStore = new TrieStore(memDb, new MemoryLimit(16.MB()), No.Persistence, _logManager);
+            TrieStore trieStore = new(memDb, new MemoryLimit(16.MB()), No.Persistence, _logManager);
 
             trieStore.CommitNode(0, new NodeCommitInfo(a));
             trieStore.FinishBlockCommit(TrieType.State, 0, a);
@@ -249,22 +279,22 @@ namespace Nethermind.Trie.Test.Pruning
         [Test]
         public void Can_load_from_rlp()
         {
-            MemDb memDb = new MemDb();
+            MemDb memDb = new();
             memDb[Keccak.Zero.Bytes] = new byte[] {1, 2, 3};
 
-            TrieStore trieStore = new TrieStore(memDb, _logManager);
+            TrieStore trieStore = new(memDb, _logManager);
             trieStore.LoadRlp(Keccak.Zero).Should().NotBeNull();
         }
 
         [Test]
         public void Will_get_persisted_on_snapshot_if_referenced()
         {
-            TrieNode a = new TrieNode(NodeType.Leaf, new byte[0]); // 192B
+            TrieNode a = new(NodeType.Leaf, new byte[0]); // 192B
             a.ResolveKey(NullTrieNodeResolver.Instance, true);
 
-            MemDb memDb = new MemDb();
+            MemDb memDb = new();
 
-            TrieStore trieStore = new TrieStore(memDb, new MemoryLimit(16.MB()), new ConstantInterval(4), _logManager);
+            TrieStore trieStore = new(memDb, new MemoryLimit(16.MB()), new ConstantInterval(4), _logManager);
 
             trieStore.FinishBlockCommit(TrieType.State, 0, null);
             trieStore.CommitNode(1, new NodeCommitInfo(a));
@@ -284,15 +314,15 @@ namespace Nethermind.Trie.Test.Pruning
         [Test]
         public void Will_not_get_dropped_on_snapshot_if_unreferenced_in_later_blocks()
         {
-            TrieNode a = new TrieNode(NodeType.Leaf, new byte[0]);
+            TrieNode a = new(NodeType.Leaf, new byte[0]);
             a.ResolveKey(NullTrieNodeResolver.Instance, true);
 
-            TrieNode b = new TrieNode(NodeType.Leaf, new byte[1]);
+            TrieNode b = new(NodeType.Leaf, new byte[1]);
             b.ResolveKey(NullTrieNodeResolver.Instance, true);
 
-            MemDb memDb = new MemDb();
+            MemDb memDb = new();
 
-            TrieStore trieStore = new TrieStore(memDb, new MemoryLimit(16.MB()), new ConstantInterval(4), _logManager);
+            TrieStore trieStore = new(memDb, new MemoryLimit(16.MB()), new ConstantInterval(4), _logManager);
 
             trieStore.FinishBlockCommit(TrieType.State, 0, null);
             trieStore.CommitNode(1, new NodeCommitInfo(a));
@@ -313,15 +343,15 @@ namespace Nethermind.Trie.Test.Pruning
         [Test]
         public void Will_get_dropped_on_snapshot_if_it_was_a_transient_node()
         {
-            TrieNode a = new TrieNode(NodeType.Leaf, new byte[] {1});
+            TrieNode a = new(NodeType.Leaf, new byte[] {1});
             a.ResolveKey(NullTrieNodeResolver.Instance, true);
 
-            TrieNode b = new TrieNode(NodeType.Leaf, new byte[] {2});
+            TrieNode b = new(NodeType.Leaf, new byte[] {2});
             b.ResolveKey(NullTrieNodeResolver.Instance, true);
 
-            MemDb memDb = new MemDb();
+            MemDb memDb = new();
 
-            TrieStore trieStore = new TrieStore(memDb, new MemoryLimit(16.MB()), new ConstantInterval(4), _logManager);
+            TrieStore trieStore = new(memDb, new MemoryLimit(16.MB()), new ConstantInterval(4), _logManager);
 
             trieStore.FinishBlockCommit(TrieType.State, 0, null);
             trieStore.CommitNode(1, new NodeCommitInfo(a));
@@ -339,23 +369,23 @@ namespace Nethermind.Trie.Test.Pruning
             trieStore.IsNodeCached(a.Keccak).Should().BeTrue();
         }
 
-        private AccountDecoder _accountDecoder = new AccountDecoder();
+        private AccountDecoder _accountDecoder = new();
 
         [Test]
         public void Will_store_storage_on_snapshot()
         {
-            TrieNode storage1 = new TrieNode(NodeType.Leaf, new byte[2]);
+            TrieNode storage1 = new(NodeType.Leaf, new byte[2]);
             storage1.ResolveKey(NullTrieNodeResolver.Instance, true);
 
-            TrieNode a = new TrieNode(NodeType.Leaf);
-            Account account = new Account(1, 1, storage1.Keccak, Keccak.OfAnEmptyString);
+            TrieNode a = new(NodeType.Leaf);
+            Account account = new(1, 1, storage1.Keccak, Keccak.OfAnEmptyString);
             a.Value = _accountDecoder.Encode(account).Bytes;
             a.Key = HexPrefix.Leaf("abc");
             a.ResolveKey(NullTrieNodeResolver.Instance, true);
 
-            MemDb memDb = new MemDb();
+            MemDb memDb = new();
 
-            TrieStore trieStore = new TrieStore(memDb, new MemoryLimit(16.MB()), new ConstantInterval(4), _logManager);
+            TrieStore trieStore = new(memDb, new MemoryLimit(16.MB()), new ConstantInterval(4), _logManager);
             trieStore.FinishBlockCommit(TrieType.State, 0, null);
             trieStore.CommitNode(1, new NodeCommitInfo(a));
             trieStore.CommitNode(1, new NodeCommitInfo(storage1));
@@ -378,21 +408,21 @@ namespace Nethermind.Trie.Test.Pruning
         [Test]
         public void Will_drop_transient_storage()
         {
-            TrieNode storage1 = new TrieNode(NodeType.Leaf, new byte[2]);
+            TrieNode storage1 = new(NodeType.Leaf, new byte[2]);
             storage1.ResolveKey(NullTrieNodeResolver.Instance, true);
 
-            TrieNode a = new TrieNode(NodeType.Leaf);
-            Account account = new Account(1, 1, storage1.Keccak, Keccak.OfAnEmptyString);
+            TrieNode a = new(NodeType.Leaf);
+            Account account = new(1, 1, storage1.Keccak, Keccak.OfAnEmptyString);
             a.Value = _accountDecoder.Encode(account).Bytes;
             a.Key = HexPrefix.Leaf("abc");
             a.ResolveKey(NullTrieNodeResolver.Instance, true);
 
-            TrieNode b = new TrieNode(NodeType.Leaf, new byte[1]);
+            TrieNode b = new(NodeType.Leaf, new byte[1]);
             b.ResolveKey(NullTrieNodeResolver.Instance, true);
 
-            MemDb memDb = new MemDb();
+            MemDb memDb = new();
 
-            TrieStore trieStore = new TrieStore(memDb, new MemoryLimit(16.MB()), new ConstantInterval(4), _logManager);
+            TrieStore trieStore = new(memDb, new MemoryLimit(16.MB()), new ConstantInterval(4), _logManager);
 
             trieStore.FinishBlockCommit(TrieType.State, 0, null);
             trieStore.CommitNode(1, new NodeCommitInfo(a));
@@ -417,32 +447,32 @@ namespace Nethermind.Trie.Test.Pruning
         [Test]
         public void Will_combine_same_storage()
         {
-            TrieNode storage1 = new TrieNode(NodeType.Leaf, new byte[32]);
+            TrieNode storage1 = new(NodeType.Leaf, new byte[32]);
             storage1.ResolveKey(NullTrieNodeResolver.Instance, true);
 
-            TrieNode a = new TrieNode(NodeType.Leaf);
-            Account account = new Account(1, 1, storage1.Keccak, Keccak.OfAnEmptyString);
+            TrieNode a = new(NodeType.Leaf);
+            Account account = new(1, 1, storage1.Keccak, Keccak.OfAnEmptyString);
             a.Value = _accountDecoder.Encode(account).Bytes;
             a.Key = HexPrefix.Leaf("abc");
             a.ResolveKey(NullTrieNodeResolver.Instance, true);
 
-            TrieNode storage2 = new TrieNode(NodeType.Leaf, new byte[32]);
+            TrieNode storage2 = new(NodeType.Leaf, new byte[32]);
             storage2.ResolveKey(NullTrieNodeResolver.Instance, true);
 
-            TrieNode b = new TrieNode(NodeType.Leaf);
-            Account accountB = new Account(2, 1, storage2.Keccak, Keccak.OfAnEmptyString);
+            TrieNode b = new(NodeType.Leaf);
+            Account accountB = new(2, 1, storage2.Keccak, Keccak.OfAnEmptyString);
             b.Value = _accountDecoder.Encode(accountB).Bytes;
             b.Key = HexPrefix.Leaf("abcd");
             b.ResolveKey(NullTrieNodeResolver.Instance, true);
 
-            TrieNode branch = new TrieNode(NodeType.Branch);
+            TrieNode branch = new(NodeType.Branch);
             branch.SetChild(0, a);
             branch.SetChild(1, b);
             branch.ResolveKey(NullTrieStore.Instance, true);
 
-            MemDb memDb = new MemDb();
+            MemDb memDb = new();
 
-            TrieStore trieStore = new TrieStore(memDb, new MemoryLimit(16.MB()), new ConstantInterval(4), _logManager);
+            TrieStore trieStore = new(memDb, new MemoryLimit(16.MB()), new ConstantInterval(4), _logManager);
 
             trieStore.FinishBlockCommit(TrieType.State, 0, null);
             trieStore.CommitNode(1, new NodeCommitInfo(storage1));

--- a/src/Nethermind/Nethermind.Trie.Test/PruningScenariosTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/PruningScenariosTests.cs
@@ -68,22 +68,22 @@ namespace Nethermind.Trie.Test
 
             public static PruningContext ArchiveWithManualPruning
             {
-                [DebuggerStepThrough] get => new PruningContext(new TestPruningStrategy(true), Persist.EveryBlock);
+                [DebuggerStepThrough] get => new(new TestPruningStrategy(true), Persist.EveryBlock);
             }
 
             public static PruningContext SnapshotEveryOtherBlockWithManualPruning
             {
-                [DebuggerStepThrough] get => new PruningContext(new TestPruningStrategy(true), new ConstantInterval(2));
+                [DebuggerStepThrough] get => new(new TestPruningStrategy(true), new ConstantInterval(2));
             }
 
             public static PruningContext InMemory
             {
-                [DebuggerStepThrough] get => new PruningContext(new TestPruningStrategy(true), No.Persistence);
+                [DebuggerStepThrough] get => new(new TestPruningStrategy(true), No.Persistence);
             }
 
             public static PruningContext SetupWithPersistenceEveryEightBlocks
             {
-                [DebuggerStepThrough] get => new PruningContext(new TestPruningStrategy(true), new ConstantInterval(8));
+                [DebuggerStepThrough] get => new(new TestPruningStrategy(true), new ConstantInterval(8));
             }
 
             public PruningContext CreateAccount(int accountIndex)
@@ -116,7 +116,7 @@ namespace Nethermind.Trie.Test
             {
                 _logger.Info($"READ   STORAGE {accountIndex}.{storageKey}");
                 StorageCell storageCell =
-                    new StorageCell(Address.FromNumber((UInt256) accountIndex), (UInt256) storageKey);
+                    new(Address.FromNumber((UInt256) accountIndex), (UInt256) storageKey);
                 _storageProvider.Get(storageCell);
                 return this;
             }

--- a/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
@@ -58,42 +58,42 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Throws_trie_exception_when_setting_value_on_branch()
         {
-            TrieNode trieNode = new TrieNode(NodeType.Branch);
+            TrieNode trieNode = new(NodeType.Branch);
             Assert.Throws<TrieException>(() => trieNode.Value = new byte[] {1, 2, 3});
         }
 
         [Test]
         public void Throws_trie_exception_on_missing_node()
         {
-            TrieNode trieNode = new TrieNode(NodeType.Unknown);
+            TrieNode trieNode = new(NodeType.Unknown);
             Assert.Throws<TrieException>(() => trieNode.ResolveNode(NullTrieNodeResolver.Instance));
         }
 
         [Test]
         public void Throws_trie_exception_on_unexpected_format()
         {
-            TrieNode trieNode = new TrieNode(NodeType.Unknown, new byte[42]);
+            TrieNode trieNode = new(NodeType.Unknown, new byte[42]);
             Assert.Throws<TrieException>(() => trieNode.ResolveNode(NullTrieNodeResolver.Instance));
         }
 
         [Test]
         public void When_resolving_an_unknown_node_without_keccak_and_rlp_trie_exception_should_be_thrown()
         {
-            TrieNode trieNode = new TrieNode(NodeType.Unknown);
+            TrieNode trieNode = new(NodeType.Unknown);
             Assert.Throws<TrieException>(() => trieNode.ResolveNode(NullTrieNodeResolver.Instance));
         }
 
         [Test]
         public void When_resolving_an_unknown_node_without_rlp_trie_exception_should_be_thrown()
         {
-            TrieNode trieNode = new TrieNode(NodeType.Unknown, Keccak.Zero);
+            TrieNode trieNode = new(NodeType.Unknown, Keccak.Zero);
             Assert.Throws<TrieException>(() => trieNode.ResolveNode(NullTrieNodeResolver.Instance));
         }
 
         [Test]
         public void Encoding_leaf_without_key_throws_trie_exception()
         {
-            TrieNode trieNode = new TrieNode(NodeType.Leaf);
+            TrieNode trieNode = new(NodeType.Leaf);
             trieNode.Value = new byte[] {1, 2, 3};
             Assert.Throws<TrieException>(() => trieNode.RlpEncode(NullTrieNodeResolver.Instance));
         }
@@ -101,24 +101,24 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Throws_trie_exception_when_resolving_key_on_missing_rlp()
         {
-            TrieNode trieNode = new TrieNode(NodeType.Unknown);
+            TrieNode trieNode = new(NodeType.Unknown);
             Assert.Throws<TrieException>(() => trieNode.ResolveKey(NullTrieNodeResolver.Instance, false));
         }
 
         [Test(Description = "This is controversial and only used in visitors. Can consider an exception instead.")]
         public void Get_child_hash_is_null_when_rlp_is_null()
         {
-            TrieNode trieNode = new TrieNode(NodeType.Branch);
+            TrieNode trieNode = new(NodeType.Branch);
             Assert.Null(trieNode.GetChildHash(0));
         }
 
         [Test]
         public void Can_check_if_branch_is_valid_with_one_child_less()
         {
-            Context ctx = new Context();
+            Context ctx = new();
             for (int i = 0; i < 16; i++)
             {
-                TrieNode trieNode = new TrieNode(NodeType.Branch);
+                TrieNode trieNode = new(NodeType.Branch);
                 for (int j = 0; j < i; j++)
                 {
                     trieNode.SetChild(j, ctx.TiniestLeaf);
@@ -138,17 +138,17 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Can_check_if_child_is_null_on_a_branch()
         {
-            Context ctx = new Context();
+            Context ctx = new();
             for (int nonNullChildrenCount = 0; nonNullChildrenCount < 16; nonNullChildrenCount++)
             {
-                TrieNode trieNode = new TrieNode(NodeType.Branch);
+                TrieNode trieNode = new(NodeType.Branch);
                 for (int j = 0; j < nonNullChildrenCount; j++)
                 {
                     trieNode.SetChild(j, ctx.TiniestLeaf);
                 }
 
                 byte[] rlp = trieNode.RlpEncode(NullTrieNodeResolver.Instance);
-                TrieNode restoredNode = new TrieNode(NodeType.Branch, rlp);
+                TrieNode restoredNode = new(NodeType.Branch, rlp);
 
                 for (int childIndex = 0; childIndex < 16; childIndex++)
                 {
@@ -169,13 +169,13 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Can_encode_decode_tiny_branch()
         {
-            Context ctx = new Context();
-            TrieNode trieNode = new TrieNode(NodeType.Branch);
+            Context ctx = new();
+            TrieNode trieNode = new(NodeType.Branch);
             trieNode.SetChild(11, ctx.TiniestLeaf);
 
             byte[] rlp = trieNode.RlpEncode(NullTrieNodeResolver.Instance);
 
-            TrieNode decoded = new TrieNode(NodeType.Unknown, rlp);
+            TrieNode decoded = new(NodeType.Unknown, rlp);
             decoded.ResolveNode(NullTrieNodeResolver.Instance);
             TrieNode decodedTiniest = decoded.GetChild(NullTrieNodeResolver.Instance, 11);
             decodedTiniest.ResolveNode(NullTrieNodeResolver.Instance);
@@ -187,13 +187,13 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Can_encode_decode_heavy_branch()
         {
-            Context ctx = new Context();
-            TrieNode trieNode = new TrieNode(NodeType.Branch);
+            Context ctx = new();
+            TrieNode trieNode = new(NodeType.Branch);
             trieNode.SetChild(11, ctx.HeavyLeaf);
 
             byte[] rlp = trieNode.RlpEncode(NullTrieNodeResolver.Instance);
 
-            TrieNode decoded = new TrieNode(NodeType.Unknown, rlp);
+            TrieNode decoded = new(NodeType.Unknown, rlp);
             decoded.ResolveNode(NullTrieNodeResolver.Instance);
             TrieNode decodedTiniest = decoded.GetChild(NullTrieNodeResolver.Instance, 11);
 
@@ -203,14 +203,14 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Can_encode_decode_tiny_extension()
         {
-            Context ctx = new Context();
-            TrieNode trieNode = new TrieNode(NodeType.Extension);
+            Context ctx = new();
+            TrieNode trieNode = new(NodeType.Extension);
             trieNode.Key = new HexPrefix(false, 5);
             trieNode.SetChild(0, ctx.TiniestLeaf);
 
             byte[] rlp = trieNode.RlpEncode(NullTrieNodeResolver.Instance);
 
-            TrieNode decoded = new TrieNode(NodeType.Unknown, rlp);
+            TrieNode decoded = new(NodeType.Unknown, rlp);
             decoded.ResolveNode(NullTrieNodeResolver.Instance);
             TrieNode? decodedTiniest = decoded.GetChild(NullTrieNodeResolver.Instance, 0);
             decodedTiniest?.ResolveNode(NullTrieNodeResolver.Instance);
@@ -222,14 +222,14 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Can_encode_decode_heavy_extension()
         {
-            Context ctx = new Context();
-            TrieNode trieNode = new TrieNode(NodeType.Extension);
+            Context ctx = new();
+            TrieNode trieNode = new(NodeType.Extension);
             trieNode.Key = new HexPrefix(false, 5);
             trieNode.SetChild(0, ctx.HeavyLeaf);
 
             byte[] rlp = trieNode.RlpEncode(NullTrieNodeResolver.Instance);
 
-            TrieNode decoded = new TrieNode(NodeType.Unknown, rlp);
+            TrieNode decoded = new(NodeType.Unknown, rlp);
             decoded.ResolveNode(NullTrieNodeResolver.Instance);
             TrieNode decodedTiniest = decoded.GetChild(NullTrieNodeResolver.Instance, 0);
 
@@ -239,11 +239,11 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Can_set_and_get_children_using_indexer()
         {
-            TrieNode tiniest = new TrieNode(NodeType.Leaf);
+            TrieNode tiniest = new(NodeType.Leaf);
             tiniest.Key = new HexPrefix(true, 5);
             tiniest.Value = new byte[] {10};
 
-            TrieNode trieNode = new TrieNode(NodeType.Branch);
+            TrieNode trieNode = new(NodeType.Branch);
             trieNode[11] = tiniest;
             TrieNode getResult = trieNode.GetChild(NullTrieNodeResolver.Instance, 11);
             Assert.AreSame(tiniest, getResult);
@@ -252,11 +252,11 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Get_child_hash_works_on_hashed_child_of_a_branch()
         {
-            Context ctx = new Context();
-            TrieNode trieNode = new TrieNode(NodeType.Branch);
+            Context ctx = new();
+            TrieNode trieNode = new(NodeType.Branch);
             trieNode[11] = ctx.HeavyLeaf;
             byte[] rlp = trieNode.RlpEncode(NullTrieNodeResolver.Instance);
-            TrieNode decoded = new TrieNode(NodeType.Branch, rlp);
+            TrieNode decoded = new(NodeType.Branch, rlp);
 
             Keccak getResult = decoded.GetChildHash(11);
             Assert.NotNull(getResult);
@@ -265,12 +265,12 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Get_child_hash_works_on_inlined_child_of_a_branch()
         {
-            Context ctx = new Context();
-            TrieNode trieNode = new TrieNode(NodeType.Branch);
+            Context ctx = new();
+            TrieNode trieNode = new(NodeType.Branch);
 
             trieNode[11] = ctx.TiniestLeaf;
             byte[] rlp = trieNode.RlpEncode(NullTrieNodeResolver.Instance);
-            TrieNode decoded = new TrieNode(NodeType.Branch, rlp);
+            TrieNode decoded = new(NodeType.Branch, rlp);
 
             Keccak getResult = decoded.GetChildHash(11);
             Assert.Null(getResult);
@@ -279,12 +279,12 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Get_child_hash_works_on_hashed_child_of_an_extension()
         {
-            Context ctx = new Context();
-            TrieNode trieNode = new TrieNode(NodeType.Extension);
+            Context ctx = new();
+            TrieNode trieNode = new(NodeType.Extension);
             trieNode[0] = ctx.HeavyLeaf;
             trieNode.Key = new HexPrefix(false, 5);
             byte[] rlp = trieNode.RlpEncode(NullTrieNodeResolver.Instance);
-            TrieNode decoded = new TrieNode(NodeType.Extension, rlp);
+            TrieNode decoded = new(NodeType.Extension, rlp);
 
             Keccak getResult = decoded.GetChildHash(0);
             Assert.NotNull(getResult);
@@ -293,12 +293,12 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Get_child_hash_works_on_inlined_child_of_an_extension()
         {
-            Context ctx = new Context();
-            TrieNode trieNode = new TrieNode(NodeType.Extension);
+            Context ctx = new();
+            TrieNode trieNode = new(NodeType.Extension);
             trieNode[0] = ctx.TiniestLeaf;
             trieNode.Key = new HexPrefix(false, 5);
             byte[] rlp = trieNode.RlpEncode(NullTrieNodeResolver.Instance);
-            TrieNode decoded = new TrieNode(NodeType.Extension, rlp);
+            TrieNode decoded = new(NodeType.Extension, rlp);
 
             Keccak getResult = decoded.GetChildHash(0);
             Assert.Null(getResult);
@@ -308,7 +308,7 @@ namespace Nethermind.Trie.Test
         public void Extension_can_accept_visitors()
         {
             ITreeVisitor visitor = Substitute.For<ITreeVisitor>();
-            TrieVisitContext context = new TrieVisitContext();
+            TrieVisitContext context = new();
             TrieNode ignore = TrieNodeFactory.CreateLeaf(HexPrefix.Leaf("ccc"), Array.Empty<byte>());
             TrieNode node = TrieNodeFactory.CreateExtension(HexPrefix.Extension("aa"), ignore);
 
@@ -321,8 +321,8 @@ namespace Nethermind.Trie.Test
         public void Unknown_node_with_missing_data_can_accept_visitor()
         {
             ITreeVisitor visitor = Substitute.For<ITreeVisitor>();
-            TrieVisitContext context = new TrieVisitContext();
-            TrieNode node = new TrieNode(NodeType.Unknown);
+            TrieVisitContext context = new();
+            TrieNode node = new(NodeType.Unknown);
 
             node.Accept(visitor, NullTrieNodeResolver.Instance, context);
 
@@ -333,9 +333,9 @@ namespace Nethermind.Trie.Test
         public void Leaf_with_simple_account_can_accept_visitors()
         {
             ITreeVisitor visitor = Substitute.For<ITreeVisitor>();
-            TrieVisitContext context = new TrieVisitContext();
-            Account account = new Account(100);
-            AccountDecoder decoder = new AccountDecoder();
+            TrieVisitContext context = new();
+            Account account = new(100);
+            AccountDecoder decoder = new();
             TrieNode node = TrieNodeFactory.CreateLeaf(HexPrefix.Leaf("aa"), decoder.Encode(account).Bytes);
 
             node.Accept(visitor, NullTrieNodeResolver.Instance, context);
@@ -347,9 +347,9 @@ namespace Nethermind.Trie.Test
         public void Leaf_with_contract_without_storage_and_empty_code_can_accept_visitors()
         {
             ITreeVisitor visitor = Substitute.For<ITreeVisitor>();
-            TrieVisitContext context = new TrieVisitContext();
-            Account account = new Account(1, 100, Keccak.EmptyTreeHash, Keccak.OfAnEmptyString);
-            AccountDecoder decoder = new AccountDecoder();
+            TrieVisitContext context = new();
+            Account account = new(1, 100, Keccak.EmptyTreeHash, Keccak.OfAnEmptyString);
+            AccountDecoder decoder = new();
             TrieNode node = TrieNodeFactory.CreateLeaf(HexPrefix.Leaf("aa"), decoder.Encode(account).Bytes);
 
             node.Accept(visitor, NullTrieNodeResolver.Instance, context);
@@ -363,9 +363,9 @@ namespace Nethermind.Trie.Test
             ITreeVisitor visitor = Substitute.For<ITreeVisitor>();
             visitor.ShouldVisit(Arg.Any<Keccak>()).Returns(true);
 
-            TrieVisitContext context = new TrieVisitContext();
-            Account account = new Account(1, 100, Keccak.EmptyTreeHash, Keccak.Zero);
-            AccountDecoder decoder = new AccountDecoder();
+            TrieVisitContext context = new();
+            Account account = new(1, 100, Keccak.EmptyTreeHash, Keccak.Zero);
+            AccountDecoder decoder = new();
             TrieNode node = TrieNodeFactory.CreateLeaf(HexPrefix.Leaf("aa"), decoder.Encode(account).Bytes);
 
             node.Accept(visitor, NullTrieNodeResolver.Instance, context);
@@ -379,9 +379,9 @@ namespace Nethermind.Trie.Test
             ITreeVisitor visitor = Substitute.For<ITreeVisitor>();
             visitor.ShouldVisit(Arg.Any<Keccak>()).Returns(true);
 
-            TrieVisitContext context = new TrieVisitContext();
-            Account account = new Account(1, 100, Keccak.Zero, Keccak.OfAnEmptyString);
-            AccountDecoder decoder = new AccountDecoder();
+            TrieVisitContext context = new();
+            Account account = new(1, 100, Keccak.Zero, Keccak.OfAnEmptyString);
+            AccountDecoder decoder = new();
             TrieNode node = TrieNodeFactory.CreateLeaf(HexPrefix.Leaf("aa"), decoder.Encode(account).Bytes);
 
             node.Accept(visitor, NullTrieNodeResolver.Instance, context);
@@ -392,7 +392,7 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Extension_with_leaf_can_be_visited()
         {
-            Context ctx = new Context();
+            Context ctx = new();
             ITreeVisitor visitor = Substitute.For<ITreeVisitor>();
             visitor.ShouldVisit(Arg.Any<Keccak>()).Returns(true);
 
@@ -408,12 +408,12 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Branch_with_children_can_be_visited()
         {
-            Context ctx = new Context();
+            Context ctx = new();
             ITreeVisitor visitor = Substitute.For<ITreeVisitor>();
             visitor.ShouldVisit(Arg.Any<Keccak>()).Returns(true);
 
-            TrieVisitContext context = new TrieVisitContext();
-            TrieNode node = new TrieNode(NodeType.Branch);
+            TrieVisitContext context = new();
+            TrieNode node = new(NodeType.Branch);
             for (int i = 0; i < 16; i++)
             {
                 node.SetChild(i, ctx.AccountLeaf);
@@ -429,8 +429,8 @@ namespace Nethermind.Trie.Test
         public void Branch_can_accept_visitors()
         {
             ITreeVisitor visitor = Substitute.For<ITreeVisitor>();
-            TrieVisitContext context = new TrieVisitContext();
-            TrieNode node = new TrieNode(NodeType.Branch);
+            TrieVisitContext context = new();
+            TrieNode node = new(NodeType.Branch);
             for (int i = 0; i < 16; i++)
             {
                 node.SetChild(i, null);
@@ -444,21 +444,21 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Can_encode_branch_with_nulls()
         {
-            TrieNode node = new TrieNode(NodeType.Branch);
+            TrieNode node = new(NodeType.Branch);
             node.RlpEncode(NullTrieNodeResolver.Instance);
         }
 
         [Test]
         public void Is_child_dirty_on_extension_when_child_is_null_returns_false()
         {
-            TrieNode node = new TrieNode(NodeType.Extension);
+            TrieNode node = new(NodeType.Extension);
             Assert.False(node.IsChildDirty(0));
         }
 
         [Test]
         public void Is_child_dirty_on_extension_when_child_is_null_node_returns_false()
         {
-            TrieNode node = new TrieNode(NodeType.Extension);
+            TrieNode node = new(NodeType.Extension);
             node.SetChild(0, null);
             Assert.False(node.IsChildDirty(0));
         }
@@ -466,8 +466,8 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Is_child_dirty_on_extension_when_child_is_not_dirty_returns_false()
         {
-            TrieNode node = new TrieNode(NodeType.Extension);
-            TrieNode cleanChild = new TrieNode(NodeType.Leaf, Keccak.Zero);
+            TrieNode node = new(NodeType.Extension);
+            TrieNode cleanChild = new(NodeType.Leaf, Keccak.Zero);
             node.SetChild(0, cleanChild);
             Assert.False(node.IsChildDirty(0));
         }
@@ -475,8 +475,8 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Is_child_dirty_on_extension_when_child_is_dirty_returns_true()
         {
-            TrieNode node = new TrieNode(NodeType.Extension);
-            TrieNode dirtyChild = new TrieNode(NodeType.Leaf);
+            TrieNode node = new(NodeType.Extension);
+            TrieNode dirtyChild = new(NodeType.Leaf);
             node.SetChild(0, dirtyChild);
             Assert.True(node.IsChildDirty(0));
         }
@@ -484,15 +484,15 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Empty_branch_will_not_be_valid_with_one_child_less()
         {
-            TrieNode node = new TrieNode(NodeType.Branch);
+            TrieNode node = new(NodeType.Branch);
             Assert.False(node.IsValidWithOneNodeLess);
         }
 
         [Test]
         public void Cannot_ask_about_validity_on_non_branch_nodes()
         {
-            TrieNode leaf = new TrieNode(NodeType.Leaf);
-            TrieNode extension = new TrieNode(NodeType.Leaf);
+            TrieNode leaf = new(NodeType.Leaf);
+            TrieNode extension = new(NodeType.Leaf);
             Assert.Throws<TrieException>(() => _ = leaf.IsValidWithOneNodeLess, "leaf");
             Assert.Throws<TrieException>(() => _ = extension.IsValidWithOneNodeLess, "extension");
         }
@@ -500,8 +500,8 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Can_encode_branch_with_unresolved_children()
         {
-            TrieNode node = new TrieNode(NodeType.Branch);
-            TrieNode randomTrieNode = new TrieNode(NodeType.Leaf);
+            TrieNode node = new(NodeType.Branch);
+            TrieNode randomTrieNode = new(NodeType.Leaf);
             randomTrieNode.Key = new HexPrefix(true, new byte[] {1, 2, 3});
             randomTrieNode.Value = new byte[] {1, 2, 3};
             for (int i = 0; i < 16; i++)
@@ -511,7 +511,7 @@ namespace Nethermind.Trie.Test
 
             byte[] rlp = node.RlpEncode(NullTrieNodeResolver.Instance);
 
-            TrieNode restoredNode = new TrieNode(NodeType.Branch, rlp);
+            TrieNode restoredNode = new(NodeType.Branch, rlp);
 
             restoredNode.RlpEncode(NullTrieNodeResolver.Instance);
         }
@@ -519,22 +519,22 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Size_of_a_heavy_leaf_is_correct()
         {
-            Context ctx = new Context();
+            Context ctx = new();
             Assert.AreEqual(184, ctx.HeavyLeaf.GetMemorySize(false));
         }
         
         [Test]
         public void Size_of_a_tiny_leaf_is_correct()
         {
-            Context ctx = new Context();
+            Context ctx = new();
             Assert.AreEqual(120, ctx.TiniestLeaf.GetMemorySize(false));
         }
 
         [Test]
         public void Size_of_a_branch_is_correct()
         {
-            Context ctx = new Context();
-            TrieNode node = new TrieNode(NodeType.Branch);
+            Context ctx = new();
+            TrieNode node = new(NodeType.Branch);
             node.Key = new HexPrefix(false, 1);
             for (int i = 0; i < 16; i++)
             {
@@ -548,8 +548,8 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Size_of_an_extension_is_correct()
         {
-            Context ctx = new Context();
-            TrieNode trieNode = new TrieNode(NodeType.Extension);
+            Context ctx = new();
+            TrieNode trieNode = new(NodeType.Extension);
             trieNode.Key = new HexPrefix(false, 1);
             trieNode.SetChild(0, ctx.TiniestLeaf);
             
@@ -559,8 +559,8 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Size_of_unknown_node_is_correct()
         {
-            Context ctx = new Context();
-            TrieNode trieNode = new TrieNode(NodeType.Extension);
+            Context ctx = new();
+            TrieNode trieNode = new(NodeType.Extension);
             trieNode.Key = new HexPrefix(false, 1);
             trieNode.SetChild(0, ctx.TiniestLeaf);
 
@@ -571,21 +571,21 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Size_of_an_unknown_empty_node_is_correct()
         {
-            TrieNode trieNode = new TrieNode(NodeType.Unknown);
+            TrieNode trieNode = new(NodeType.Unknown);
             trieNode.GetMemorySize(false).Should().Be(56);
         }
 
         [Test]
         public void Size_of_an_unknown_node_with_keccak_is_correct()
         {
-            TrieNode trieNode = new TrieNode(NodeType.Unknown, Keccak.Zero);
+            TrieNode trieNode = new(NodeType.Unknown, Keccak.Zero);
             trieNode.GetMemorySize(false).Should().Be(136);
         }
 
         [Test]
         public void Size_of_extension_with_child()
         {
-            TrieNode trieNode = new TrieNode(NodeType.Extension);
+            TrieNode trieNode = new(NodeType.Extension);
             trieNode.SetChild(0, null);
             trieNode.GetMemorySize(false).Should().Be(96);
         }
@@ -593,7 +593,7 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Size_of_branch_with_data()
         {
-            TrieNode trieNode = new TrieNode(NodeType.Branch);
+            TrieNode trieNode = new(NodeType.Branch);
             trieNode.SetChild(0, null);
             trieNode.GetMemorySize(false).Should().Be(208);
         }
@@ -601,7 +601,7 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Size_of_leaf_with_value()
         {
-            TrieNode trieNode = new TrieNode(NodeType.Leaf);
+            TrieNode trieNode = new(NodeType.Leaf);
             trieNode.Value = new byte[7];
             trieNode.GetMemorySize(false).Should().Be(128);
         }
@@ -609,7 +609,7 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Size_of_an_unknown_node_with_full_rlp_is_correct()
         {
-            TrieNode trieNode = new TrieNode(NodeType.Unknown, new byte[7]);
+            TrieNode trieNode = new(NodeType.Unknown, new byte[7]);
             trieNode.GetMemorySize(false).Should().Be(120);
         }
 
@@ -622,56 +622,56 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Size_of_rlp_stream_is_correct()
         {
-            RlpStream rlpStream = new RlpStream(100);
+            RlpStream rlpStream = new(100);
             rlpStream.MemorySize.Should().Be(160);
         }
 
         [Test]
         public void Size_of_rlp_stream_7_is_correct()
         {
-            RlpStream rlpStream = new RlpStream(7);
+            RlpStream rlpStream = new(7);
             rlpStream.MemorySize.Should().Be(64);
         }
 
         [Test]
         public void Size_of_rlp_unaligned_is_correct()
         {
-            Rlp rlp = new Rlp(new byte[1]);
+            Rlp rlp = new(new byte[1]);
             rlp.MemorySize.Should().Be(56);
         }
 
         [Test]
         public void Size_of_rlp_aligned_is_correct()
         {
-            Rlp rlp = new Rlp(new byte[8]);
+            Rlp rlp = new(new byte[8]);
             rlp.MemorySize.Should().Be(56);
         }
 
         [Test]
         public void Size_of_hex_prefix_is_correct()
         {
-            HexPrefix hexPrefix = new HexPrefix(true, new byte[5]);
+            HexPrefix hexPrefix = new(true, new byte[5]);
             hexPrefix.MemorySize.Should().Be(64);
         }
 
         [Test]
         public void Cannot_seal_already_sealed()
         {
-            TrieNode trieNode = new TrieNode(NodeType.Leaf, Keccak.Zero);
+            TrieNode trieNode = new(NodeType.Leaf, Keccak.Zero);
             Assert.Throws<InvalidOperationException>(() => trieNode.Seal());
         }
 
         [Test]
         public void Cannot_change_value_on_sealed()
         {
-            TrieNode trieNode = new TrieNode(NodeType.Leaf, Keccak.Zero);
+            TrieNode trieNode = new(NodeType.Leaf, Keccak.Zero);
             Assert.Throws<InvalidOperationException>(() => trieNode.Value = new byte[5]);
         }
 
         [Test]
         public void Cannot_change_key_on_sealed()
         {
-            TrieNode trieNode = new TrieNode(NodeType.Leaf, Keccak.Zero);
+            TrieNode trieNode = new(NodeType.Leaf, Keccak.Zero);
             Assert.Throws<InvalidOperationException>(
                 () => trieNode.Key = HexPrefix.FromBytes(Bytes.FromHexString("aaa")));
         }
@@ -679,16 +679,16 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Cannot_set_child_on_sealed()
         {
-            TrieNode child = new TrieNode(NodeType.Leaf, Keccak.Zero);
-            TrieNode trieNode = new TrieNode(NodeType.Extension, Keccak.Zero);
+            TrieNode child = new(NodeType.Leaf, Keccak.Zero);
+            TrieNode trieNode = new(NodeType.Extension, Keccak.Zero);
             Assert.Throws<InvalidOperationException>(() => trieNode.SetChild(0, child));
         }
 
         [Test]
         public void Pruning_regression()
         {
-            TrieNode child = new TrieNode(NodeType.Unknown, Keccak.Zero);
-            TrieNode trieNode = new TrieNode(NodeType.Extension);
+            TrieNode child = new(NodeType.Unknown, Keccak.Zero);
+            TrieNode trieNode = new(NodeType.Extension);
             trieNode.SetChild(0, child);
 
             trieNode.PrunePersistedRecursively(1);
@@ -699,8 +699,8 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Extension_child_as_keccak()
         {
-            TrieNode child = new TrieNode(NodeType.Unknown, Keccak.Zero);
-            TrieNode trieNode = new TrieNode(NodeType.Extension);
+            TrieNode child = new(NodeType.Unknown, Keccak.Zero);
+            TrieNode trieNode = new(NodeType.Extension);
             trieNode.SetChild(0, child);
 
             trieNode.PrunePersistedRecursively(1);
@@ -710,8 +710,8 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Extension_child_as_keccak_memory_size()
         {
-            TrieNode child = new TrieNode(NodeType.Unknown, Keccak.Zero);
-            TrieNode trieNode = new TrieNode(NodeType.Extension);
+            TrieNode child = new(NodeType.Unknown, Keccak.Zero);
+            TrieNode trieNode = new(NodeType.Extension);
             trieNode.SetChild(0, child);
 
             trieNode.PrunePersistedRecursively(1);
@@ -721,8 +721,8 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Extension_child_as_keccak_clone()
         {
-            TrieNode child = new TrieNode(NodeType.Unknown, Keccak.Zero);
-            TrieNode trieNode = new TrieNode(NodeType.Extension);
+            TrieNode child = new(NodeType.Unknown, Keccak.Zero);
+            TrieNode trieNode = new(NodeType.Extension);
             trieNode.SetChild(0, child);
 
             trieNode.PrunePersistedRecursively(1);
@@ -734,8 +734,8 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Unresolve_of_persisted()
         {
-            TrieNode child = new TrieNode(NodeType.Unknown, Keccak.Zero);
-            TrieNode trieNode = new TrieNode(NodeType.Extension);
+            TrieNode child = new(NodeType.Unknown, Keccak.Zero);
+            TrieNode trieNode = new(NodeType.Extension);
             trieNode.SetChild(0, child);
             trieNode.Key = HexPrefix.Extension("abcd");
             trieNode.ResolveKey(NullTrieStore.Instance, false);
@@ -747,13 +747,13 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Small_child_unresolve()
         {
-            TrieNode child = new TrieNode(NodeType.Leaf);
+            TrieNode child = new(NodeType.Leaf);
             child.Value = Bytes.FromHexString("a");
             child.Key = HexPrefix.Leaf("b");
             child.ResolveKey(NullTrieStore.Instance, false);
             child.IsPersisted = true;
 
-            TrieNode trieNode = new TrieNode(NodeType.Extension);
+            TrieNode trieNode = new(NodeType.Extension);
             trieNode.SetChild(0, child);
             trieNode.Key = HexPrefix.Extension("abcd");
             trieNode.ResolveKey(NullTrieStore.Instance, false);
@@ -765,8 +765,8 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Extension_child_as_keccak_not_dirty()
         {
-            TrieNode child = new TrieNode(NodeType.Unknown, Keccak.Zero);
-            TrieNode trieNode = new TrieNode(NodeType.Extension);
+            TrieNode child = new(NodeType.Unknown, Keccak.Zero);
+            TrieNode trieNode = new(NodeType.Extension);
             trieNode.SetChild(0, child);
 
             trieNode.PrunePersistedRecursively(1);
@@ -777,8 +777,8 @@ namespace Nethermind.Trie.Test
         [TestCase(false)]
         public void Extension_child_as_keccak_call_recursively(bool skipPersisted)
         {
-            TrieNode child = new TrieNode(NodeType.Unknown, Keccak.Zero);
-            TrieNode trieNode = new TrieNode(NodeType.Extension);
+            TrieNode child = new(NodeType.Unknown, Keccak.Zero);
+            TrieNode trieNode = new(NodeType.Extension);
             trieNode.SetChild(0, child);
 
             trieNode.PrunePersistedRecursively(1);
@@ -790,8 +790,8 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Branch_child_as_keccak_encode()
         {
-            TrieNode child = new TrieNode(NodeType.Unknown, Keccak.Zero);
-            TrieNode trieNode = new TrieNode(NodeType.Branch);
+            TrieNode child = new(NodeType.Unknown, Keccak.Zero);
+            TrieNode trieNode = new(NodeType.Branch);
             trieNode.SetChild(0, child);
             trieNode.SetChild(4, child);
 
@@ -802,8 +802,8 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Branch_child_as_keccak_resolved()
         {
-            TrieNode child = new TrieNode(NodeType.Unknown, Keccak.Zero);
-            TrieNode trieNode = new TrieNode(NodeType.Branch);
+            TrieNode child = new(NodeType.Unknown, Keccak.Zero);
+            TrieNode trieNode = new(NodeType.Branch);
             trieNode.SetChild(0, child);
             trieNode.SetChild(4, child);
 
@@ -818,8 +818,8 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Child_as_keccak_cached()
         {
-            TrieNode child = new TrieNode(NodeType.Unknown, Keccak.Zero);
-            TrieNode trieNode = new TrieNode(NodeType.Extension);
+            TrieNode child = new(NodeType.Unknown, Keccak.Zero);
+            TrieNode trieNode = new(NodeType.Extension);
             trieNode.SetChild(0, child);
 
             trieNode.PrunePersistedRecursively(1);
@@ -831,29 +831,29 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Rlp_is_cloned_when_cloning()
         {
-            TrieStore trieStore = new TrieStore(new MemDb(), NullLogManager.Instance);
+            TrieStore trieStore = new(new MemDb(), NullLogManager.Instance);
 
-            TrieNode leaf1 = new TrieNode(NodeType.Leaf);
+            TrieNode leaf1 = new(NodeType.Leaf);
             leaf1.Key = new HexPrefix(true, Bytes.FromHexString("abc"));
             leaf1.Value = new byte[111];
             leaf1.ResolveKey(trieStore, false);
             leaf1.Seal();
             trieStore.CommitNode(0, new NodeCommitInfo(leaf1));
 
-            TrieNode leaf2 = new TrieNode(NodeType.Leaf);
+            TrieNode leaf2 = new(NodeType.Leaf);
             leaf2.Key = new HexPrefix(true, Bytes.FromHexString("abd"));
             leaf2.Value = new byte[222];
             leaf2.ResolveKey(trieStore, false);
             leaf2.Seal();
             trieStore.CommitNode(0, new NodeCommitInfo(leaf2));
 
-            TrieNode trieNode = new TrieNode(NodeType.Branch);
+            TrieNode trieNode = new(NodeType.Branch);
             trieNode.SetChild(1, leaf1);
             trieNode.SetChild(2, leaf2);
             trieNode.ResolveKey(trieStore, true);
             byte[] rlp = trieNode.FullRlp;
 
-            TrieNode restoredBranch = new TrieNode(NodeType.Branch, rlp);
+            TrieNode restoredBranch = new(NodeType.Branch, rlp);
 
             TrieNode clone = restoredBranch.Clone();
             var restoredLeaf1 = clone.GetChild(trieStore, 1);
@@ -878,8 +878,8 @@ namespace Nethermind.Trie.Test
                 HeavyLeaf.Key = new HexPrefix(true, new byte[20]);
                 HeavyLeaf.Value = Keccak.EmptyTreeHash.Bytes.Concat(Keccak.EmptyTreeHash.Bytes).ToArray();
                 
-                Account account = new Account(100);
-                AccountDecoder decoder = new AccountDecoder();
+                Account account = new(100);
+                AccountDecoder decoder = new();
                 AccountLeaf = TrieNodeFactory.CreateLeaf(
                     HexPrefix.Leaf("bbb"),
                     decoder.Encode(account).Bytes);

--- a/src/Nethermind/Nethermind.Trie.Test/TrieTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieTests.cs
@@ -54,9 +54,9 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Single_leaf()
         {
-            MemDb memDb = new MemDb();
-            TrieStore trieStore = new TrieStore(memDb, Prune.WhenCacheReaches(1.MB()), Persist.EveryBlock, _logManager);
-            PatriciaTree patriciaTree = new PatriciaTree(trieStore, _logManager);
+            MemDb memDb = new();
+            TrieStore trieStore = new(memDb, Prune.WhenCacheReaches(1.MB()), Persist.EveryBlock, _logManager);
+            PatriciaTree patriciaTree = new(trieStore, _logManager);
             patriciaTree.Set(_keyA, _longLeaf1);
             patriciaTree.Commit(0);
 
@@ -67,9 +67,9 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Single_leaf_update_same_block()
         {
-            MemDb memDb = new MemDb();
-            TrieStore trieStore = new TrieStore(memDb, Prune.WhenCacheReaches(1.MB()), Persist.EveryBlock, _logManager);
-            PatriciaTree patriciaTree = new PatriciaTree(trieStore, _logManager);
+            MemDb memDb = new();
+            TrieStore trieStore = new(memDb, Prune.WhenCacheReaches(1.MB()), Persist.EveryBlock, _logManager);
+            PatriciaTree patriciaTree = new(trieStore, _logManager);
             patriciaTree.Set(_keyA, _longLeaf1);
             patriciaTree.Set(_keyA, _longLeaf2);
             patriciaTree.Commit(0);
@@ -85,9 +85,9 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Single_leaf_update_next_blocks()
         {
-            MemDb memDb = new MemDb();
-            TrieStore trieStore = new TrieStore(memDb, Prune.WhenCacheReaches(1.MB()), Persist.EveryBlock, _logManager);
-            PatriciaTree patriciaTree = new PatriciaTree(trieStore, _logManager);
+            MemDb memDb = new();
+            TrieStore trieStore = new(memDb, Prune.WhenCacheReaches(1.MB()), Persist.EveryBlock, _logManager);
+            PatriciaTree patriciaTree = new(trieStore, _logManager);
             patriciaTree.Set(_keyA, _longLeaf1);
             patriciaTree.Commit(0);
             patriciaTree.Set(_keyA, _longLeaf2);
@@ -105,9 +105,9 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Single_leaf_delete_same_block()
         {
-            MemDb memDb = new MemDb();
-            TrieStore trieStore = new TrieStore(memDb, Prune.WhenCacheReaches(1.MB()), No.Persistence, _logManager);
-            PatriciaTree patriciaTree = new PatriciaTree(trieStore, _logManager);
+            MemDb memDb = new();
+            TrieStore trieStore = new(memDb, Prune.WhenCacheReaches(1.MB()), No.Persistence, _logManager);
+            PatriciaTree patriciaTree = new(trieStore, _logManager);
             patriciaTree.Set(_keyA, _longLeaf1);
             patriciaTree.Set(_keyA, Array.Empty<byte>());
             patriciaTree.Commit(0);
@@ -122,9 +122,9 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Single_leaf_delete_next_block()
         {
-            MemDb memDb = new MemDb();
-            TrieStore trieStore = new TrieStore(memDb, Prune.WhenCacheReaches(1.MB()), Persist.EveryBlock, _logManager);
-            PatriciaTree patriciaTree = new PatriciaTree(trieStore, _logManager);
+            MemDb memDb = new();
+            TrieStore trieStore = new(memDb, Prune.WhenCacheReaches(1.MB()), Persist.EveryBlock, _logManager);
+            PatriciaTree patriciaTree = new(trieStore, _logManager);
             patriciaTree.Set(_keyA, _longLeaf1);
             patriciaTree.Commit(0);
             patriciaTree.Set(_keyA, Array.Empty<byte>());
@@ -141,9 +141,9 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Single_leaf_and_keep_for_multiple_dispatches_then_delete()
         {
-            MemDb memDb = new MemDb();
-            TrieStore trieStore = new TrieStore(memDb, Prune.WhenCacheReaches(1.MB()), new ConstantInterval(4), LimboLogs.Instance);
-            PatriciaTree patriciaTree = new PatriciaTree(trieStore, _logManager);
+            MemDb memDb = new();
+            TrieStore trieStore = new(memDb, Prune.WhenCacheReaches(1.MB()), new ConstantInterval(4), LimboLogs.Instance);
+            PatriciaTree patriciaTree = new(trieStore, _logManager);
             patriciaTree.Commit(0);
             patriciaTree.Commit(1);
             patriciaTree.Commit(2);
@@ -175,9 +175,9 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Branch_with_branch_and_leaf()
         {
-            MemDb memDb = new MemDb();
-            TrieStore trieStore = new TrieStore(memDb, Prune.WhenCacheReaches(1.MB()), Persist.EveryBlock, _logManager);
-            PatriciaTree patriciaTree = new PatriciaTree(trieStore, _logManager);
+            MemDb memDb = new();
+            TrieStore trieStore = new(memDb, Prune.WhenCacheReaches(1.MB()), Persist.EveryBlock, _logManager);
+            PatriciaTree patriciaTree = new(trieStore, _logManager);
             patriciaTree.Set(_keyA, _longLeaf1);
             patriciaTree.Set(_keyB, _longLeaf1);
             patriciaTree.Set(_keyC, _longLeaf1);
@@ -206,9 +206,9 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Branch_with_branch_and_leaf_then_deleted()
         {
-            MemDb memDb = new MemDb();
-            TrieStore trieStore = new TrieStore(memDb, Prune.WhenCacheReaches(1.MB()), Persist.EveryBlock, _logManager);
-            PatriciaTree patriciaTree = new PatriciaTree(trieStore, _logManager);
+            MemDb memDb = new();
+            TrieStore trieStore = new(memDb, Prune.WhenCacheReaches(1.MB()), Persist.EveryBlock, _logManager);
+            PatriciaTree patriciaTree = new(trieStore, _logManager);
             patriciaTree.Set(_keyA, _longLeaf1);
             patriciaTree.Set(_keyB, _longLeaf1);
             patriciaTree.Set(_keyC, _longLeaf1);
@@ -229,9 +229,9 @@ namespace Nethermind.Trie.Test
 
         public void Test_add_many(int i)
         {
-            MemDb memDb = new MemDb();
-            TrieStore trieStore = new TrieStore(memDb, new MemoryLimit(128.MB()), Persist.EveryBlock, _logManager);
-            PatriciaTree patriciaTree = new PatriciaTree(trieStore, Keccak.EmptyTreeHash, true, true, _logManager);
+            MemDb memDb = new();
+            TrieStore trieStore = new(memDb, new MemoryLimit(128.MB()), Persist.EveryBlock, _logManager);
+            PatriciaTree patriciaTree = new(trieStore, Keccak.EmptyTreeHash, true, true, _logManager);
 
             for (int j = 0; j < i; j++)
             {
@@ -254,9 +254,9 @@ namespace Nethermind.Trie.Test
 
         public void Test_try_delete_and_read_missing_nodes(int i)
         {
-            MemDb memDb = new MemDb();
-            TrieStore trieStore = new TrieStore(memDb, new MemoryLimit(128.MB()), Persist.EveryBlock, _logManager);
-            PatriciaTree patriciaTree = new PatriciaTree(trieStore, Keccak.EmptyTreeHash, true, true, _logManager);
+            MemDb memDb = new();
+            TrieStore trieStore = new(memDb, new MemoryLimit(128.MB()), Persist.EveryBlock, _logManager);
+            PatriciaTree patriciaTree = new(trieStore, Keccak.EmptyTreeHash, true, true, _logManager);
 
             for (int j = 0; j < i; j++)
             {
@@ -295,9 +295,9 @@ namespace Nethermind.Trie.Test
 
         public void Test_update_many(int i)
         {
-            MemDb memDb = new MemDb();
-            TrieStore trieStore = new TrieStore(memDb, new MemoryLimit(128.MB()), Persist.EveryBlock, _logManager);
-            PatriciaTree patriciaTree = new PatriciaTree(trieStore, _logManager);
+            MemDb memDb = new();
+            TrieStore trieStore = new(memDb, new MemoryLimit(128.MB()), Persist.EveryBlock, _logManager);
+            PatriciaTree patriciaTree = new(trieStore, _logManager);
 
             for (int j = 0; j < i; j++)
             {
@@ -327,9 +327,9 @@ namespace Nethermind.Trie.Test
 
         public void Test_update_many_next_block(int i)
         {
-            MemDb memDb = new MemDb();
-            TrieStore trieStore = new TrieStore(memDb, new MemoryLimit(128.MB()), Persist.EveryBlock, _logManager);
-            PatriciaTree patriciaTree = new PatriciaTree(trieStore, _logManager);
+            MemDb memDb = new();
+            TrieStore trieStore = new(memDb, new MemoryLimit(128.MB()), Persist.EveryBlock, _logManager);
+            PatriciaTree patriciaTree = new(trieStore, _logManager);
 
             for (int j = 0; j < i; j++)
             {
@@ -364,9 +364,9 @@ namespace Nethermind.Trie.Test
 
         public void Test_add_and_delete_many_same_block(int i)
         {
-            MemDb memDb = new MemDb();
-            TrieStore trieStore = new TrieStore(memDb, new MemoryLimit(128.MB()), Persist.EveryBlock, _logManager);
-            PatriciaTree patriciaTree = new PatriciaTree(trieStore, _logManager);
+            MemDb memDb = new();
+            TrieStore trieStore = new(memDb, new MemoryLimit(128.MB()), Persist.EveryBlock, _logManager);
+            PatriciaTree patriciaTree = new(trieStore, _logManager);
 
             for (int j = 0; j < i; j++)
             {
@@ -396,9 +396,9 @@ namespace Nethermind.Trie.Test
 
         public void Test_add_and_delete_many_next_block(int i)
         {
-            MemDb memDb = new MemDb();
-            TrieStore trieStore = new TrieStore(memDb, new MemoryLimit(128.MB()), Persist.EveryBlock, _logManager);
-            PatriciaTree patriciaTree = new PatriciaTree(trieStore, _logManager);
+            MemDb memDb = new();
+            TrieStore trieStore = new(memDb, new MemoryLimit(128.MB()), Persist.EveryBlock, _logManager);
+            PatriciaTree patriciaTree = new(trieStore, _logManager);
 
             for (int j = 0; j < i; j++)
             {
@@ -446,9 +446,9 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Two_branches_exactly_same_leaf()
         {
-            MemDb memDb = new MemDb();
-            TrieStore trieStore = new TrieStore(memDb, Prune.WhenCacheReaches(1.MB()), Persist.EveryBlock, _logManager);
-            PatriciaTree patriciaTree = new PatriciaTree(trieStore, _logManager);
+            MemDb memDb = new();
+            TrieStore trieStore = new(memDb, Prune.WhenCacheReaches(1.MB()), Persist.EveryBlock, _logManager);
+            PatriciaTree patriciaTree = new(trieStore, _logManager);
             patriciaTree.Set(_keyA, _longLeaf1);
             patriciaTree.Set(_keyB, _longLeaf1);
             patriciaTree.Set(_keyC, _longLeaf1);
@@ -467,13 +467,13 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Two_branches_exactly_same_leaf_then_one_removed()
         {
-            MemDb memDb = new MemDb();
-            TrieStore trieStore = new TrieStore(
+            MemDb memDb = new();
+            TrieStore trieStore = new(
                 memDb,
                 Prune.WhenCacheReaches(1.MB()),
                 Persist.EveryBlock,
                 LimboLogs.Instance);
-            PatriciaTree patriciaTree = new PatriciaTree(trieStore, _logManager);
+            PatriciaTree patriciaTree = new(trieStore, _logManager);
             patriciaTree.Set(_keyA, _longLeaf1);
             patriciaTree.Set(_keyB, _longLeaf1);
             patriciaTree.Set(_keyC, _longLeaf1);
@@ -492,7 +492,7 @@ namespace Nethermind.Trie.Test
 
         private static PatriciaTree CreateCheckTree(MemDb memDb, PatriciaTree patriciaTree)
         {
-            PatriciaTree checkTree = new PatriciaTree(memDb);
+            PatriciaTree checkTree = new(memDb);
             checkTree.RootHash = patriciaTree.RootHash;
             return checkTree;
         }
@@ -500,9 +500,9 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Extension_with_branch_with_two_different_children()
         {
-            MemDb memDb = new MemDb();
-            TrieStore trieStore = new TrieStore(memDb, Prune.WhenCacheReaches(1.MB()), Persist.EveryBlock, _logManager);
-            PatriciaTree patriciaTree = new PatriciaTree(trieStore, _logManager);
+            MemDb memDb = new();
+            TrieStore trieStore = new(memDb, Prune.WhenCacheReaches(1.MB()), Persist.EveryBlock, _logManager);
+            PatriciaTree patriciaTree = new(trieStore, _logManager);
             patriciaTree.Set(_keyA, _longLeaf1);
             patriciaTree.Set(_keyB, _longLeaf2);
             patriciaTree.Commit(0);
@@ -515,9 +515,9 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Extension_with_branch_with_two_same_children()
         {
-            MemDb memDb = new MemDb();
-            TrieStore trieStore = new TrieStore(memDb, Prune.WhenCacheReaches(1.MB()), Persist.EveryBlock, _logManager);
-            PatriciaTree patriciaTree = new PatriciaTree(trieStore, _logManager);
+            MemDb memDb = new();
+            TrieStore trieStore = new(memDb, Prune.WhenCacheReaches(1.MB()), Persist.EveryBlock, _logManager);
+            PatriciaTree patriciaTree = new(trieStore, _logManager);
             patriciaTree.Set(_keyA, _longLeaf1);
             patriciaTree.Set(_keyB, _longLeaf1);
             patriciaTree.Commit(0);
@@ -530,9 +530,9 @@ namespace Nethermind.Trie.Test
         [Test]
         public void When_branch_with_two_different_children_change_one_and_change_back_next_block()
         {
-            MemDb memDb = new MemDb();
-            TrieStore trieStore = new TrieStore(memDb, Prune.WhenCacheReaches(1.MB()), Persist.EveryBlock, _logManager);
-            PatriciaTree patriciaTree = new PatriciaTree(trieStore, _logManager);
+            MemDb memDb = new();
+            TrieStore trieStore = new(memDb, Prune.WhenCacheReaches(1.MB()), Persist.EveryBlock, _logManager);
+            PatriciaTree patriciaTree = new(trieStore, _logManager);
             patriciaTree.Set(_keyA, _longLeaf1);
             patriciaTree.Set(_keyB, _longLeaf2);
             patriciaTree.UpdateRootHash();
@@ -551,9 +551,9 @@ namespace Nethermind.Trie.Test
         [Test]
         public void When_branch_with_two_same_children_change_one_and_change_back_next_block()
         {
-            MemDb memDb = new MemDb();
-            TrieStore trieStore = new TrieStore(memDb, Prune.WhenCacheReaches(1.MB()), Persist.EveryBlock, _logManager);
-            PatriciaTree patriciaTree = new PatriciaTree(trieStore, _logManager);
+            MemDb memDb = new();
+            TrieStore trieStore = new(memDb, Prune.WhenCacheReaches(1.MB()), Persist.EveryBlock, _logManager);
+            PatriciaTree patriciaTree = new(trieStore, _logManager);
             patriciaTree.Set(_keyA, _longLeaf1);
             patriciaTree.Set(_keyB, _longLeaf1);
             patriciaTree.UpdateRootHash();
@@ -584,9 +584,9 @@ namespace Nethermind.Trie.Test
             byte[] key2 = Bytes.FromHexString("000000100000000bb");
             byte[] key3 = Bytes.FromHexString("000000200000000cc");
 
-            MemDb memDb = new MemDb();
-            TrieStore trieStore = new TrieStore(memDb, Prune.WhenCacheReaches(1.MB()), Persist.EveryBlock, _logManager);
-            PatriciaTree patriciaTree = new PatriciaTree(trieStore, _logManager);
+            MemDb memDb = new();
+            TrieStore trieStore = new(memDb, Prune.WhenCacheReaches(1.MB()), Persist.EveryBlock, _logManager);
+            PatriciaTree patriciaTree = new(trieStore, _logManager);
             patriciaTree.Set(key1, _longLeaf1);
             patriciaTree.Set(key2, _longLeaf1);
             patriciaTree.Set(key3, _longLeaf1);
@@ -632,9 +632,9 @@ namespace Nethermind.Trie.Test
             byte[] key2 = Bytes.FromHexString("000000100000000bb");
             byte[] key3 = Bytes.FromHexString("000000200000000cc");
 
-            MemDb memDb = new MemDb();
-            TrieStore trieStore = new TrieStore(memDb, Prune.WhenCacheReaches(1.MB()), Persist.EveryBlock, _logManager);
-            PatriciaTree patriciaTree = new PatriciaTree(trieStore, _logManager);
+            MemDb memDb = new();
+            TrieStore trieStore = new(memDb, Prune.WhenCacheReaches(1.MB()), Persist.EveryBlock, _logManager);
+            PatriciaTree patriciaTree = new(trieStore, _logManager);
             patriciaTree.Set(key1, _longLeaf1);
             patriciaTree.Set(key2, _longLeaf1);
             patriciaTree.Set(key3, _longLeaf1);
@@ -654,9 +654,9 @@ namespace Nethermind.Trie.Test
         [Test]
         public void When_two_branches_with_two_same_children_change_one_and_change_back_next_block()
         {
-            MemDb memDb = new MemDb();
-            TrieStore trieStore = new TrieStore(memDb, Prune.WhenCacheReaches(1.MB()), Persist.EveryBlock, _logManager);
-            PatriciaTree patriciaTree = new PatriciaTree(trieStore, _logManager);
+            MemDb memDb = new();
+            TrieStore trieStore = new(memDb, Prune.WhenCacheReaches(1.MB()), Persist.EveryBlock, _logManager);
+            PatriciaTree patriciaTree = new(trieStore, _logManager);
             patriciaTree.Set(_keyA, _longLeaf1);
             patriciaTree.Set(_keyB, _longLeaf1);
             patriciaTree.Set(_keyC, _longLeaf1);
@@ -676,8 +676,8 @@ namespace Nethermind.Trie.Test
             checkTree.Get(_keyD).Should().BeEquivalentTo(_longLeaf1);
         }
 
-        private AccountDecoder _accountDecoder = new AccountDecoder();
-        private Random _random = new Random();
+        private AccountDecoder _accountDecoder = new();
+        private Random _random = new();
 
         // [TestCase(256, 128, 128, 32)]
         [TestCase(128, 128, 8, 8)]
@@ -696,15 +696,15 @@ namespace Nethermind.Trie.Test
                 $"values: {uniqueValuesCount}, " +
                 $"lookup: {lookupLimit} into file {fileName}");
 
-            using FileStream fileStream = new FileStream(fileName, FileMode.Create);
-            using StreamWriter streamWriter = new StreamWriter(fileStream);
+            using FileStream fileStream = new(fileName, FileMode.Create);
+            using StreamWriter streamWriter = new(fileStream);
 
-            Queue<Keccak> rootQueue = new Queue<Keccak>();
+            Queue<Keccak> rootQueue = new();
 
-            MemDb memDb = new MemDb();
+            MemDb memDb = new();
 
-            TrieStore trieStore = new TrieStore(memDb, Prune.WhenCacheReaches(1.MB()), Persist.IfBlockOlderThan(lookupLimit), _logManager);
-            StateTree patriciaTree = new StateTree(trieStore, _logManager);
+            TrieStore trieStore = new(memDb, Prune.WhenCacheReaches(1.MB()), Persist.IfBlockOlderThan(lookupLimit), _logManager);
+            StateTree patriciaTree = new(trieStore, _logManager);
 
             byte[][] accounts = new byte[accountsCount][];
             byte[][] randomValues = new byte[uniqueValuesCount][];
@@ -800,7 +800,7 @@ namespace Nethermind.Trie.Test
 
         private Account GenerateRandomAccount()
         {
-            Account account = new Account(
+            Account account = new(
                 (UInt256) _random.Next(1000),
                 (UInt256) _random.Next(1000),
                 Keccak.EmptyTreeHash,
@@ -811,7 +811,7 @@ namespace Nethermind.Trie.Test
 
         private Account GenerateIndexedAccount(int index)
         {
-            Account account = new Account(
+            Account account = new(
                 (UInt256) index,
                 (UInt256) index,
                 Keccak.EmptyTreeHash,
@@ -849,16 +849,16 @@ namespace Nethermind.Trie.Test
                 $"values: {uniqueValuesCount}, " +
                 $"lookup: {lookupLimit} into file {fileName}");
 
-            using FileStream fileStream = new FileStream(fileName, FileMode.Create);
-            using StreamWriter streamWriter = new StreamWriter(fileStream);
+            using FileStream fileStream = new(fileName, FileMode.Create);
+            using StreamWriter streamWriter = new(fileStream);
 
-            Queue<Keccak> rootQueue = new Queue<Keccak>();
-            Stack<Keccak> rootStack = new Stack<Keccak>();
+            Queue<Keccak> rootQueue = new();
+            Stack<Keccak> rootStack = new();
 
-            MemDb memDb = new MemDb();
+            MemDb memDb = new();
 
-            TrieStore trieStore = new TrieStore(memDb, Prune.WhenCacheReaches(1.MB()), Persist.IfBlockOlderThan(lookupLimit), _logManager);
-            PatriciaTree patriciaTree = new PatriciaTree(trieStore, _logManager);
+            TrieStore trieStore = new(memDb, Prune.WhenCacheReaches(1.MB()), Persist.IfBlockOlderThan(lookupLimit), _logManager);
+            PatriciaTree patriciaTree = new(trieStore, _logManager);
 
             byte[][] accounts = new byte[accountsCount][];
             byte[][] randomValues = new byte[uniqueValuesCount][];
@@ -945,7 +945,7 @@ namespace Nethermind.Trie.Test
             int verifiedBlocks = 0;
 
             rootQueue.Clear();
-            Stack<Keccak> stackCopy = new Stack<Keccak>();
+            Stack<Keccak> stackCopy = new();
             while (rootStack.Any())
             {
                 stackCopy.Push(rootStack.Pop());
@@ -1004,16 +1004,16 @@ namespace Nethermind.Trie.Test
                 $"blocks {blocksCount}, " +
                 $"lookup: {lookupLimit} into file {fileName}");
 
-            using FileStream fileStream = new FileStream(fileName, FileMode.Create);
-            using StreamWriter streamWriter = new StreamWriter(fileStream);
+            using FileStream fileStream = new(fileName, FileMode.Create);
+            using StreamWriter streamWriter = new(fileStream);
 
-            Queue<Keccak> rootQueue = new Queue<Keccak>();
+            Queue<Keccak> rootQueue = new();
 
-            MemDb memDb = new MemDb();
+            MemDb memDb = new();
 
-            TrieStore trieStore = new TrieStore(memDb, Prune.WhenCacheReaches(1.MB()), Persist.IfBlockOlderThan(lookupLimit), _logManager);
-            StateProvider stateProvider = new StateProvider(trieStore, new MemDb(), _logManager);
-            StorageProvider storageProvider = new StorageProvider(trieStore, stateProvider, _logManager);
+            TrieStore trieStore = new(memDb, Prune.WhenCacheReaches(1.MB()), Persist.IfBlockOlderThan(lookupLimit), _logManager);
+            StateProvider stateProvider = new(trieStore, new MemDb(), _logManager);
+            StorageProvider storageProvider = new(trieStore, stateProvider, _logManager);
 
             Account[] accounts = new Account[accountsCount];
             Address[] addresses = new Address[accountsCount];

--- a/src/Nethermind/Nethermind.Trie/HexPrefix.cs
+++ b/src/Nethermind/Nethermind.Trie/HexPrefix.cs
@@ -34,23 +34,23 @@ namespace Nethermind.Trie
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static HexPrefix Leaf(params byte[] path)
         {
-            return new HexPrefix(true, path);
+            return new(true, path);
         }
 
         public static HexPrefix Leaf(string path)
         {
-            return new HexPrefix(true, Bytes.FromHexString(path));
+            return new(true, Bytes.FromHexString(path));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static HexPrefix Extension(params byte[] path)
         {
-            return new HexPrefix(false, path);
+            return new(false, path);
         }
 
         public static HexPrefix Extension(string path)
         {
-            return new HexPrefix(false, Bytes.FromHexString(path));
+            return new(false, Bytes.FromHexString(path));
         }
 
         public byte[] Path { get; private set; }
@@ -90,7 +90,7 @@ namespace Nethermind.Trie
 
         public static HexPrefix FromBytes(ReadOnlySpan<byte> bytes)
         {
-            HexPrefix hexPrefix = new HexPrefix(bytes[0] >= 32);
+            HexPrefix hexPrefix = new(bytes[0] >= 32);
             bool isEven = (bytes[0] & 16) == 0;
             int nibblesCount = bytes.Length * 2 - (isEven ? 2 : 1);
             hexPrefix.Path = new byte[nibblesCount];

--- a/src/Nethermind/Nethermind.Trie/Nibbles.cs
+++ b/src/Nethermind/Nethermind.Trie/Nibbles.cs
@@ -43,12 +43,12 @@ namespace Nethermind.Trie
 
         public static implicit operator Nibble(byte nibbleValue)
         {
-            return new Nibble(nibbleValue);
+            return new(nibbleValue);
         }
 
         public static implicit operator Nibble(char hexChar)
         {
-            return new Nibble(hexChar);
+            return new(hexChar);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -50,7 +50,7 @@ namespace Nethermind.Trie
         /// To save allocations this used to be static but this caused one of the hardest to reproduce issues
         /// when we decided to run some of the tree operations in parallel.
         /// </summary>
-        private readonly Stack<StackedNode> _nodeStack = new Stack<StackedNode>();
+        private readonly Stack<StackedNode> _nodeStack = new();
         
         private readonly ConcurrentQueue<Exception>? _commitExceptions;
 
@@ -97,13 +97,13 @@ namespace Nethermind.Trie
         }
 
         public PatriciaTree(
-            ITrieStore trieStore,
+            ITrieStore? trieStore,
             Keccak rootHash,
             bool parallelBranches,
             bool allowCommits,
-            ILogManager logManager)
+            ILogManager? logManager)
         {
-            _logger = logManager.GetClassLogger<PatriciaTree>() ?? throw new ArgumentNullException(nameof(logManager));
+            _logger = logManager?.GetClassLogger<PatriciaTree>() ?? throw new ArgumentNullException(nameof(logManager));
             TrieStore = trieStore ?? throw new ArgumentNullException(nameof(trieStore));
             _parallelBranches = parallelBranches;
             _allowCommits = allowCommits;
@@ -209,7 +209,7 @@ namespace Nethermind.Trie
                 }
                 else
                 {
-                    List<NodeCommitInfo> nodesToCommit = new List<NodeCommitInfo>();
+                    List<NodeCommitInfo> nodesToCommit = new();
                     for (int i = 0; i < 16; i++)
                     {
                         if (node.IsChildDirty(i))
@@ -365,7 +365,7 @@ namespace Nethermind.Trie
 #endif
             
             TraverseContext traverseContext =
-                new TraverseContext(updatePath.Slice(0, nibblesCount), updateValue, isUpdate, ignoreMissingDelete);
+                new(updatePath.Slice(0, nibblesCount), updateValue, isUpdate, ignoreMissingDelete);
 
             // lazy stack cleaning after the previous update
             if (traverseContext.IsUpdate)
@@ -990,7 +990,7 @@ namespace Nethermind.Trie
             if (visitor is null) throw new ArgumentNullException(nameof(visitor));
             if (rootHash is null) throw new ArgumentNullException(nameof(rootHash));
 
-            TrieVisitContext trieVisitContext = new TrieVisitContext();
+            TrieVisitContext trieVisitContext = new();
 
             // hacky but other solutions are not much better, something nicer would require a bit of thinking
             // we introduced a notion of an account on the visit context level which should have no knowledge of account really

--- a/src/Nethermind/Nethermind.Trie/Pruning/Archive.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/Archive.cs
@@ -21,7 +21,7 @@ namespace Nethermind.Trie.Pruning
     {
         private Archive() { }
 
-        public static Archive Instance { get; } = new Archive();
+        public static Archive Instance { get; } = new();
 
         public bool ShouldPersist(long blockNumber)
         {

--- a/src/Nethermind/Nethermind.Trie/Pruning/NoPersistence.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/NoPersistence.cs
@@ -20,7 +20,7 @@ namespace Nethermind.Trie.Pruning
     {
         private NoPersistence() { }
 
-        public static NoPersistence Instance { get; } = new NoPersistence();
+        public static NoPersistence Instance { get; } = new();
 
         public bool ShouldPersist(long blockNumber)
         {

--- a/src/Nethermind/Nethermind.Trie/Pruning/NoPruning.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/NoPruning.cs
@@ -20,7 +20,7 @@ namespace Nethermind.Trie.Pruning
     {
         private NoPruning() { }
 
-        public static NoPruning Instance { get; } = new NoPruning();
+        public static NoPruning Instance { get; } = new();
 
         public bool PruningEnabled => false;
 

--- a/src/Nethermind/Nethermind.Trie/TreeDumper.cs
+++ b/src/Nethermind/Nethermind.Trie/TreeDumper.cs
@@ -24,7 +24,7 @@ namespace Nethermind.Trie
 {
     public class TreeDumper : ITreeVisitor
     {
-        private StringBuilder _builder = new StringBuilder();
+        private StringBuilder _builder = new();
 
         public void Reset()
         {
@@ -50,7 +50,7 @@ namespace Nethermind.Trie
         
         private string GetPrefix(TrieVisitContext context) => string.Concat($"{GetIndent(context.Level)}", context.IsStorage ? "STORAGE " : "", $"{GetChildIndex(context)}");
         
-        private string GetIndent(int level) => new string('+', level * 2);
+        private string GetIndent(int level) => new('+', level * 2);
         private string GetChildIndex(TrieVisitContext context) => context.BranchChildIndex == null ? string.Empty : $"{context.BranchChildIndex:x2} ";
         
         public void VisitMissingNode(Keccak nodeHash, TrieVisitContext trieVisitContext)
@@ -68,7 +68,7 @@ namespace Nethermind.Trie
             _builder.AppendLine($"{GetPrefix(trieVisitContext)}EXTENSION {Nibbles.FromBytes(node.Path).ToPackedByteArray().ToHexString(false)} -> {(node.Keccak?.Bytes ?? node.FullRlp)?.ToHexString()}");
         }
 
-        private AccountDecoder decoder = new AccountDecoder();
+        private AccountDecoder decoder = new();
         
         public void VisitLeaf(TrieNode node, TrieVisitContext trieVisitContext, byte[] value = null)
         {

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
@@ -66,7 +66,7 @@ namespace Nethermind.Trie
 
                 int contentLength = Rlp.LengthOf(keyBytes) + (nodeRef.Keccak is null ? nodeRef.FullRlp.Length : Rlp.LengthOfKeccakRlp);
                 int totalLength = Rlp.LengthOfSequence(contentLength);
-                RlpStream rlpStream = new RlpStream(totalLength);
+                RlpStream rlpStream = new(totalLength);
                 rlpStream.StartSequence(contentLength);
                 rlpStream.Encode(keyBytes);
                 if (nodeRef.Keccak is null)
@@ -97,7 +97,7 @@ namespace Nethermind.Trie
                 byte[] keyBytes = node.Key.ToBytes();
                 int contentLength = Rlp.LengthOf(keyBytes) + Rlp.LengthOf(node.Value);
                 int totalLength = Rlp.LengthOfSequence(contentLength);
-                RlpStream rlpStream = new RlpStream(totalLength);
+                RlpStream rlpStream = new(totalLength);
                 rlpStream.StartSequence(contentLength);
                 rlpStream.Encode(keyBytes);
                 rlpStream.Encode(node.Value);

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Visitor.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Visitor.cs
@@ -111,7 +111,7 @@ namespace Nethermind.Trie
                         if (account.HasStorage && visitor.ShouldVisit(account.StorageRoot))
                         {
                             trieVisitContext.IsStorage = true;
-                            TrieNode storageRoot = new TrieNode(NodeType.Unknown, account.StorageRoot);
+                            TrieNode storageRoot = new(NodeType.Unknown, account.StorageRoot);
                             trieVisitContext.Level++;
                             trieVisitContext.BranchChildIndex = null;
                             storageRoot.Accept(visitor, nodeResolver, trieVisitContext);

--- a/src/Nethermind/Nethermind.Trie/TrieNode.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.cs
@@ -554,7 +554,7 @@ namespace Nethermind.Trie
 
         public TrieNode Clone()
         {
-            TrieNode trieNode = new TrieNode(NodeType);
+            TrieNode trieNode = new(NodeType);
             if (_data is not null)
             {
                 trieNode.InitData();
@@ -715,11 +715,11 @@ namespace Nethermind.Trie
             return hasStorage;
         }
 
-        private static object _nullNode = new object();
+        private static object _nullNode = new();
 
-        private static TrieNodeDecoder _nodeDecoder = new TrieNodeDecoder();
+        private static TrieNodeDecoder _nodeDecoder = new();
 
-        private static AccountDecoder _accountDecoder = new AccountDecoder();
+        private static AccountDecoder _accountDecoder = new();
 
         private static Action<TrieNode> _markPersisted => tn => tn.IsPersisted = true;
 
@@ -809,7 +809,7 @@ namespace Nethermind.Trie
                         {
                             _rlpStream.Position--;
                             Span<byte> fullRlp = _rlpStream.PeekNextItem();
-                            TrieNode child = new TrieNode(NodeType.Unknown, fullRlp.ToArray());
+                            TrieNode child = new(NodeType.Unknown, fullRlp.ToArray());
                             _data![i] = childOrRef = child;
                             break;
                         }

--- a/src/Nethermind/Nethermind.Trie/TrieNodeFactory.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNodeFactory.cs
@@ -23,7 +23,7 @@ namespace Nethermind.Trie
     {
         public static TrieNode CreateBranch()
         {
-            TrieNode node = new TrieNode(NodeType.Branch);
+            TrieNode node = new(NodeType.Branch);
             return node;
         }
 
@@ -33,7 +33,7 @@ namespace Nethermind.Trie
                 key.IsLeaf,
                 $"{nameof(NodeType.Leaf)} should always be created with a leaf {nameof(HexPrefix)}");
 
-            TrieNode node = new TrieNode(NodeType.Leaf);
+            TrieNode node = new(NodeType.Leaf);
             node.Key = key;
             node.Value = value;
             return node;
@@ -41,7 +41,7 @@ namespace Nethermind.Trie
 
         public static TrieNode CreateExtension(HexPrefix key)
         {
-            TrieNode node = new TrieNode(NodeType.Extension);
+            TrieNode node = new(NodeType.Extension);
             node.Key = key;
             return node;
         }
@@ -52,7 +52,7 @@ namespace Nethermind.Trie
                 key.IsExtension,
                 $"{nameof(NodeType.Extension)} should always be created with an extension {nameof(HexPrefix)}");
 
-            TrieNode node = new TrieNode(NodeType.Extension);
+            TrieNode node = new(NodeType.Extension);
             node.SetChild(0, child);
             node.Key = key;
             return node;

--- a/src/Nethermind/Nethermind.Trie/TrieStats.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieStats.cs
@@ -60,7 +60,7 @@ namespace Nethermind.Trie
 
         public override string ToString()
         {
-            StringBuilder builder = new StringBuilder();
+            StringBuilder builder = new();
             builder.AppendLine("TRIE STATS");
             builder.AppendLine($"  SIZE {Size} (STATE {StateSize}, CODE {CodeSize}, STORAGE {StorageSize})");
             builder.AppendLine($"  ALL NODES {NodesCount} ({StateBranchCount + StorageBranchCount}|{StateExtensionCount + StorageExtensionCount}|{AccountCount + StorageLeafCount})");

--- a/src/Nethermind/Nethermind.Trie/TrieStatsCollector.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieStatsCollector.cs
@@ -34,7 +34,7 @@ namespace Nethermind.Trie
             _logger = logManager.GetClassLogger();
         }
 
-        public TrieStats Stats { get; } = new TrieStats();
+        public TrieStats Stats { get; } = new();
 
         public bool ShouldVisit(Keccak nextNode)
         {

--- a/src/Nethermind/Nethermind.TxPool/ITxStorage.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxStorage.cs
@@ -21,7 +21,7 @@ namespace Nethermind.TxPool
 {
     public interface ITxStorage
     {
-        Transaction Get(Keccak hash);
+        Transaction? Get(Keccak hash);
         Transaction[] GetAll();
         void Add(Transaction transaction);
         void Delete(Keccak hash);


### PR DESCRIPTION
Adds:

evm_mine support

IBlockProductionTrigger
ManualBlockProductionTrigger
IntervalBlockproductionTrigger (Regularly)
OnPendingTxTriggerT introduce 

introduced a wrapper for TxSource that serves txs one by one

introduces nullability checks in many tocuehd classes
introduces new() syntax in any tocuehd classes

fixed checkpoints when running a full archive node (specifically important for persistent spaceneth that has less than 64 blocks)

DOES NOT implement ProcessingQueueEmpty triggers (which would be nice to have now with trigger producer)
DOES NOT refactor LoopBlockProducer