### PR TITLE
Makes `INethermindPlugin` `IAsyncDisposable`.

### DIFF
--- a/src/Nethermind/Nethermind.Analytics/AnalyticsPlugin.cs
+++ b/src/Nethermind/Nethermind.Analytics/AnalyticsPlugin.cs
@@ -33,7 +33,7 @@ namespace Nethermind.Analytics
 
         private bool _isOn;
 
-        public void Dispose() { }
+        public ValueTask DisposeAsync() { return ValueTask.CompletedTask; }
 
         public string Name => "Analytics";
 

--- a/src/Nethermind/Nethermind.Api/Extensions/IPlugin.cs
+++ b/src/Nethermind/Nethermind.Api/Extensions/IPlugin.cs
@@ -20,7 +20,7 @@ using System.Threading.Tasks;
 
 namespace Nethermind.Api.Extensions
 {
-    public interface INethermindPlugin : IDisposable
+    public interface INethermindPlugin : IAsyncDisposable
     {
         string Name { get; }
         

--- a/src/Nethermind/Nethermind.Consensus.Clique/CliquePlugin.cs
+++ b/src/Nethermind/Nethermind.Consensus.Clique/CliquePlugin.cs
@@ -183,9 +183,7 @@ namespace Nethermind.Consensus.Clique
 
         public SealEngineType SealEngineType => SealEngineType.Clique;
 
-        public void Dispose()
-        {
-        }
+        public ValueTask DisposeAsync() { return ValueTask.CompletedTask; }
 
         private INethermindApi? _nethermindApi;
 

--- a/src/Nethermind/Nethermind.Consensus.Ethash/EthashPlugin.cs
+++ b/src/Nethermind/Nethermind.Consensus.Ethash/EthashPlugin.cs
@@ -27,9 +27,7 @@ namespace Nethermind.Consensus.Ethash
     {
         private INethermindApi _nethermindApi;
 
-        public void Dispose()
-        {
-        }
+        public ValueTask DisposeAsync() { return ValueTask.CompletedTask; }
 
         public string Name => "Ethash";
 

--- a/src/Nethermind/Nethermind.Consensus.Ethash/NethDevPlugin.cs
+++ b/src/Nethermind/Nethermind.Consensus.Ethash/NethDevPlugin.cs
@@ -36,7 +36,7 @@ namespace Nethermind.Consensus.Ethash
     {
         private INethermindApi? _nethermindApi;
 
-        public void Dispose() { }
+        public ValueTask DisposeAsync() { return ValueTask.CompletedTask; }
 
         public string Name => "NethDev";
 

--- a/src/Nethermind/Nethermind.HealthChecks/HealthChecksPlugin.cs
+++ b/src/Nethermind/Nethermind.HealthChecks/HealthChecksPlugin.cs
@@ -34,9 +34,7 @@ namespace Nethermind.HealthChecks
         private ILogger _logger;
         private IJsonRpcConfig _jsonRpcConfig;
 
-        public void Dispose()
-        {
-        }
+        public ValueTask DisposeAsync() { return ValueTask.CompletedTask; }
 
         public string Name => "HealthChecks";
 

--- a/src/Nethermind/Nethermind.PubSub.Kafka/KafkaPlugin.cs
+++ b/src/Nethermind/Nethermind.PubSub.Kafka/KafkaPlugin.cs
@@ -33,9 +33,10 @@ namespace Nethermind.PubSub.Kafka
         private ILogger _logger;
         private INethermindApi _api;
 
-        public void Dispose()
+        public ValueTask DisposeAsync()
         {
             _kafkaPublisher.Dispose();
+            return ValueTask.CompletedTask;
         }
 
         public string Name => "Kafka";

--- a/src/Nethermind/Nethermind.Runner/Ethereum/EthereumRunner.cs
+++ b/src/Nethermind/Nethermind.Runner/Ethereum/EthereumRunner.cs
@@ -67,13 +67,13 @@ namespace Nethermind.Runner.Ethereum
 
             foreach (INethermindPlugin plugin in _api.Plugins)
             {
-                Stop(() => plugin.Dispose(), $"Disposing plugin {plugin.Name}");
+                await Stop(async () => await plugin.DisposeAsync(), $"Disposing plugin {plugin.Name}");
             }
 
             while (_api.DisposeStack.Count != 0)
             {
                 IAsyncDisposable disposable = _api.DisposeStack.Pop();
-                await Stop(() => disposable.DisposeAsync(), $"Disposing {disposable}");
+                await Stop(async () => await disposable.DisposeAsync(), $"Disposing {disposable}");
             }
 
             Stop(() => _api.DbProvider?.Dispose(), "Closing DBs");


### PR DESCRIPTION
This will allow plugins to dispose async stuff, such as HTTP/WebSocket connections.

Also fixes a warning around async disposal of components (the missing async/await was being complained about, even though it wasn't required).