### PR TITLE
Disables config updating for forks.

### DIFF
--- a/.github/workflows/configs-update.yml
+++ b/.github/workflows/configs-update.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   configs-updating:
+    if: github.repository_owner == 'NethermindEth'
     name: Updating Fast Sync Settings
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Necessary because the scripts reference etherscan secrets that aren't available to forks.