### PR TITLE
use value task consistently

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Consensus/NullSignerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Consensus/NullSignerTests.cs
@@ -15,11 +15,13 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 // 
 
+using System.Threading.Tasks;
 using FluentAssertions;
 using Nethermind.Consensus;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using NUnit.Framework;
+// ReSharper disable AssignNullToNotNullAttribute
 
 namespace Nethermind.Blockchain.Test.Consensus
 {
@@ -35,10 +37,10 @@ namespace Nethermind.Blockchain.Test.Consensus
         }
         
         [Test]
-        public void Test_signing()
+        public async Task Test_signing()
         {
             NullSigner signer = NullSigner.Instance;
-            signer.Sign((Transaction)null);
+            await signer.Sign((Transaction)null);
             signer.Sign((Keccak) null).Bytes.Should().HaveCount(64);
         }
     }

--- a/src/Nethermind/Nethermind.Blockchain.Test/Consensus/SignerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Consensus/SignerTests.cs
@@ -16,6 +16,7 @@
 // 
 
 using System;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Nethermind.Consensus;
 using Nethermind.Core;
@@ -24,6 +25,7 @@ using Nethermind.Core.Test.Builders;
 using Nethermind.Crypto;
 using Nethermind.Logging;
 using NUnit.Framework;
+// ReSharper disable AssignNullToNotNullAttribute
 
 namespace Nethermind.Blockchain.Test.Consensus
 {
@@ -79,10 +81,10 @@ namespace Nethermind.Blockchain.Test.Consensus
         }
         
         [Test]
-        public void Test_signing()
+        public async Task Test_signing()
         {
             Signer signer = new Signer(1, TestItem.PrivateKeyA, LimboLogs.Instance);
-            signer.Sign(Build.A.Transaction.TestObject);
+            await signer.Sign(Build.A.Transaction.TestObject);
             signer.Sign(Keccak.Zero).Bytes.Should().HaveCount(64);
         }
     }

--- a/src/Nethermind/Nethermind.TxPool/ITxSealer.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxSealer.cs
@@ -15,6 +15,7 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 // 
 
+using System.Threading.Tasks;
 using Nethermind.Core;
 
 namespace Nethermind.TxPool
@@ -24,6 +25,6 @@ namespace Nethermind.TxPool
     /// </summary>
     public interface ITxSealer
     {
-        void Seal(Transaction tx, TxHandlingOptions txHandlingOptions);
+        ValueTask Seal(Transaction tx, TxHandlingOptions txHandlingOptions);
     }
 }

--- a/src/Nethermind/Nethermind.TxPool/ITxSigner.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxSigner.cs
@@ -24,9 +24,6 @@ namespace Nethermind.TxPool
     {
         ValueTask Sign(Transaction tx);
 
-        void ITxSealer.Seal(Transaction tx, TxHandlingOptions txHandlingOptions)
-        {
-            Sign(tx);
-        }
+        ValueTask ITxSealer.Seal(Transaction tx, TxHandlingOptions txHandlingOptions) => Sign(tx);
     }
 }

--- a/src/Nethermind/Nethermind.TxPool/TxNonceTxPoolReserveSealer.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxNonceTxPoolReserveSealer.cs
@@ -16,6 +16,7 @@
 // 
 
 using System;
+using System.Threading.Tasks;
 using Nethermind.Core;
 
 namespace Nethermind.TxPool
@@ -31,7 +32,7 @@ namespace Nethermind.TxPool
             _txPool = txPool ?? throw new ArgumentNullException(nameof(txPool));
         }
 
-        public override void Seal(Transaction tx, TxHandlingOptions txHandlingOptions)
+        public override ValueTask Seal(Transaction tx, TxHandlingOptions txHandlingOptions)
         {
             bool manageNonce = (txHandlingOptions & TxHandlingOptions.ManagedNonce) == TxHandlingOptions.ManagedNonce;
             if (manageNonce)
@@ -40,7 +41,7 @@ namespace Nethermind.TxPool
                 txHandlingOptions |= TxHandlingOptions.AllowReplacingSignature;
             }
 
-            base.Seal(tx, txHandlingOptions);
+            return base.Seal(tx, txHandlingOptions);
         }
     }
 }

--- a/src/Nethermind/Nethermind.TxPool/TxSealer.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxSealer.cs
@@ -16,6 +16,7 @@
 // 
 
 using System;
+using System.Threading.Tasks;
 using Nethermind.Core;
 using Nethermind.Crypto;
 
@@ -32,7 +33,7 @@ namespace Nethermind.TxPool
             _timestamper = timestamper ?? throw new ArgumentNullException(nameof(timestamper));
         }
 
-        public virtual void Seal(Transaction tx, TxHandlingOptions txHandlingOptions)
+        public virtual ValueTask Seal(Transaction tx, TxHandlingOptions txHandlingOptions)
         {
             bool allowChangeExistingSignature = (txHandlingOptions & TxHandlingOptions.AllowReplacingSignature) == TxHandlingOptions.AllowReplacingSignature;
             if (tx.Signature == null || allowChangeExistingSignature)
@@ -42,6 +43,8 @@ namespace Nethermind.TxPool
 
             tx.Hash = tx.CalculateHash();
             tx.Timestamp = _timestamper.UnixTime.Seconds;
+            
+            return ValueTask.CompletedTask;
         }
     }
 }


### PR DESCRIPTION
Minor changes to use ValueTask in sealers as well as signers.