### PR TITLE
Berlin guards

### DIFF
--- a/src/Nethermind/Chains/baseline.json
+++ b/src/Nethermind/Chains/baseline.json
@@ -36,7 +36,6 @@
         "eip2315Transition": "0x0",
         "eip2537Transition": "0x0",
         "eip2565Transition": "0x0",
-        "eip2718Transition": "0x0",
         "eip2929Transition": "0x0",
         "eip2930Transition": "0x0"
     },

--- a/src/Nethermind/Chains/foundation.json
+++ b/src/Nethermind/Chains/foundation.json
@@ -172,7 +172,6 @@
     "eip2028Transition": "0x8a61c8",
     "eip2200Transition": "0x8a61c8",
     "eip2565Transition": "0xBAD420",
-    "eip2718Transition": "0xBAD420",
     "eip2929Transition": "0xBAD420",
     "eip2930Transition": "0xBAD420"
   },

--- a/src/Nethermind/Chains/goerli.json
+++ b/src/Nethermind/Chains/goerli.json
@@ -33,7 +33,6 @@
 		"eip2028Transition": "0x17D433",
 		"eip2200Transition": "0x17D433",
         "eip2565Transition": "0x441064",
-        "eip2718Transition": "0x441064",
         "eip2929Transition": "0x441064",
         "eip2930Transition": "0x441064",
 		"gasLimitBoundDivisor": "0x400",

--- a/src/Nethermind/Chains/rinkeby.json
+++ b/src/Nethermind/Chains/rinkeby.json
@@ -33,7 +33,6 @@
     "eip2028Transition": "0x52efd1",
     "eip2200Transition": "0x52efd1",
     "eip2565Transition": "0x7E8270",
-    "eip2718Transition": "0x7E8270",
     "eip2929Transition": "0x7E8270",
     "eip2930Transition": "0x7E8270",
     "gasLimitBoundDivisor": "0x400",

--- a/src/Nethermind/Chains/ropsten.json
+++ b/src/Nethermind/Chains/ropsten.json
@@ -54,7 +54,6 @@
 		"eip2028Transition": "0x62F756",
 		"eip2200Transition": "0x62F756",
         "eip2565Transition": "0x95B8DD",
-        "eip2718Transition": "0x95B8DD",
         "eip2929Transition": "0x95B8DD",
         "eip2930Transition": "0x95B8DD"
     },

--- a/src/Nethermind/Chains/spaceneth.json
+++ b/src/Nethermind/Chains/spaceneth.json
@@ -36,7 +36,6 @@
         "eip2315Transition": "0x0",
         "eip2537Transition": "0x0",
         "eip2565Transition": "0x0",
-        "eip2718Transition": "0x0",
         "eip2929Transition": "0x0",
         "eip2930Transition": "0x0"
 	},

--- a/src/Nethermind/Chains/yolo_v3x.json
+++ b/src/Nethermind/Chains/yolo_v3x.json
@@ -31,7 +31,6 @@
     "eip2315Transition": "0x0",
     "eip2537Transition": "0x0",
     "eip2565Transition": "0x0",
-    "eip2718Transition": "0x0",
     "eip2929Transition": "0x0",
     "eip2930Transition": "0x0",
     "eip658Transition": "0x0",

--- a/src/Nethermind/Nethermind.Blockchain/Validators/TxValidator.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Validators/TxValidator.cs
@@ -48,9 +48,16 @@ namespace Nethermind.Blockchain.Validators
                    transaction.GasLimit >= IntrinsicGasCalculator.Calculate(transaction, releaseSpec) &&
                    /* if it is a call or a transfer then we require the 'To' field to have a value
                       while for an init it will be empty */
-                   ValidateSignature(transaction.Signature, releaseSpec);
+                   ValidateSignature(transaction.Signature, releaseSpec) &&
+                   ValidateTxType(transaction, releaseSpec);
         }
-        
+
+        private bool ValidateTxType(Transaction transaction, IReleaseSpec releaseSpec)
+        {
+            return transaction.Type == TxType.Legacy || 
+                   (transaction.Type == TxType.AccessList && releaseSpec.IsEip2930Enabled);
+        }
+
         private bool ValidateSignature(Signature signature, IReleaseSpec spec)
         {
             BigInteger sValue = signature.SAsSpan.ToUnsignedBigInteger();

--- a/src/Nethermind/Nethermind.Core.Test/TransactionTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/TransactionTests.cs
@@ -40,21 +40,5 @@ namespace Nethermind.Core.Test
             Assert.False(transaction.IsMessageCall, nameof(Transaction.IsMessageCall));
             Assert.True(transaction.IsContractCreation, nameof(Transaction.IsContractCreation));
         }
-        
-        [TestCase(TxType.Legacy)]
-        [TestCase(TxType.AccessList)]
-        [TestCase((TxType)100, true)]
-        public void Only_correct_types_allowed(TxType txType, bool shouldThrow = false)
-        {
-            Func<Transaction> transactionFactory = () => new Transaction() {Type = txType};
-            if (shouldThrow)
-            {
-                transactionFactory.Should().Throw<InvalidOperationException>();
-            }
-            else
-            {
-                transactionFactory.Should().NotThrow();
-            }
-        }
     }
 }

--- a/src/Nethermind/Nethermind.Core.Test/TransactionTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/TransactionTests.cs
@@ -14,6 +14,8 @@
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
+using System;
+using FluentAssertions;
 using NUnit.Framework;
 
 namespace Nethermind.Core.Test
@@ -37,6 +39,22 @@ namespace Nethermind.Core.Test
             transaction.To = null;
             Assert.False(transaction.IsMessageCall, nameof(Transaction.IsMessageCall));
             Assert.True(transaction.IsContractCreation, nameof(Transaction.IsContractCreation));
+        }
+        
+        [TestCase(TxType.Legacy)]
+        [TestCase(TxType.AccessList)]
+        [TestCase((TxType)100, true)]
+        public void Only_correct_types_allowed(TxType txType, bool shouldThrow = false)
+        {
+            Func<Transaction> transactionFactory = () => new Transaction() {Type = txType};
+            if (shouldThrow)
+            {
+                transactionFactory.Should().Throw<InvalidOperationException>();
+            }
+            else
+            {
+                transactionFactory.Should().NotThrow();
+            }
         }
     }
 }

--- a/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
@@ -206,12 +206,7 @@ namespace Nethermind.Core.Specs
         /// Berlin MODEXP precompiles
         /// </summary>
         bool IsEip2565Enabled { get; }
-        
-        /// <summary>
-        /// Berlin transaction type
-        /// </summary>
-        bool IsEip2718Enabled { get; }
-        
+
         /// <summary>
         /// Berlin gas cost increases for state reading opcodes
         /// </summary>
@@ -306,7 +301,5 @@ namespace Nethermind.Core.Specs
         public bool UseNetGasMeteringWithAStipendFix => UseIstanbulNetGasMetering;
         
         public bool Use63Over64Rule => UseShanghaiDDosProtection;
-        
-        public bool UseTransactionTypes => IsEip2718Enabled;
     }
 }

--- a/src/Nethermind/Nethermind.Core/Transaction.cs
+++ b/src/Nethermind/Nethermind.Core/Transaction.cs
@@ -14,6 +14,7 @@
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
@@ -27,14 +28,28 @@ namespace Nethermind.Core
     [DebuggerDisplay("{Hash}, Value: {Value}, To: {To}, Gas: {GasLimit}")]
     public class Transaction
     {
+        private TxType _type;
         public const int BaseTxGasCost = 21000;
         
         public ulong? ChainId { get; set; }
-        
+
         /// <summary>
         /// EIP-2718 transaction type
         /// </summary>
-        public TxType Type { get; set; }
+        public TxType Type
+        {
+            get => _type;
+            set
+            {
+                if (value > TxType.AccessList)
+                {
+                    throw new InvalidOperationException($"Invalid transaction type: {value}.");
+                }
+                
+                _type = value;
+            }
+        }
+
         public UInt256 Nonce { get; set; }
         public UInt256 GasPrice { get; set; }
         public UInt256 GasPremium => GasPrice; 

--- a/src/Nethermind/Nethermind.Core/Transaction.cs
+++ b/src/Nethermind/Nethermind.Core/Transaction.cs
@@ -28,7 +28,6 @@ namespace Nethermind.Core
     [DebuggerDisplay("{Hash}, Value: {Value}, To: {To}, Gas: {GasLimit}")]
     public class Transaction
     {
-        private TxType _type;
         public const int BaseTxGasCost = 21000;
         
         public ulong? ChainId { get; set; }
@@ -36,19 +35,7 @@ namespace Nethermind.Core
         /// <summary>
         /// EIP-2718 transaction type
         /// </summary>
-        public TxType Type
-        {
-            get => _type;
-            set
-            {
-                if (value > TxType.AccessList)
-                {
-                    throw new InvalidOperationException($"Invalid transaction type: {value}.");
-                }
-                
-                _type = value;
-            }
-        }
+        public TxType Type { get; set; }
 
         public UInt256 Nonce { get; set; }
         public UInt256 GasPrice { get; set; }

--- a/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecBasedSpecProviderTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecBasedSpecProviderTests.cs
@@ -373,7 +373,6 @@ namespace Nethermind.Specs.Test.ChainSpecStyle
                     Eip2315Transition = 23150L,
                     Eip2537Transition = 25370L,
                     Eip2565Transition = 25650L,
-                    Eip2718Transition = 27180L,
                     Eip2929Transition = 29290L,
                     Eip2930Transition = 29300L,
                     Eip1283ReenableTransition = 23000L,

--- a/src/Nethermind/Nethermind.Specs.Test/GoerliSpecProviderTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/GoerliSpecProviderTests.cs
@@ -33,7 +33,6 @@ namespace Nethermind.Specs.Test
             _specProvider.GetSpec(blockNumber).IsEip2315Enabled.Should().Be(false);
             _specProvider.GetSpec(blockNumber).IsEip2537Enabled.Should().Be(false);
             _specProvider.GetSpec(blockNumber).IsEip2565Enabled.Should().Be(isEnabled);
-            _specProvider.GetSpec(blockNumber).IsEip2718Enabled.Should().Be(isEnabled);
             _specProvider.GetSpec(blockNumber).IsEip2929Enabled.Should().Be(isEnabled);
             _specProvider.GetSpec(blockNumber).IsEip2930Enabled.Should().Be(isEnabled);
         }

--- a/src/Nethermind/Nethermind.Specs.Test/MainnetSpecProviderTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/MainnetSpecProviderTests.cs
@@ -33,7 +33,6 @@ namespace Nethermind.Specs.Test
             _specProvider.GetSpec(blockNumber).IsEip2315Enabled.Should().Be(false);
             _specProvider.GetSpec(blockNumber).IsEip2537Enabled.Should().Be(false);
             _specProvider.GetSpec(blockNumber).IsEip2565Enabled.Should().Be(isEnabled);
-            _specProvider.GetSpec(blockNumber).IsEip2718Enabled.Should().Be(isEnabled);
             _specProvider.GetSpec(blockNumber).IsEip2929Enabled.Should().Be(isEnabled);
             _specProvider.GetSpec(blockNumber).IsEip2930Enabled.Should().Be(isEnabled);
         }

--- a/src/Nethermind/Nethermind.Specs.Test/RinkebySpecProviderTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/RinkebySpecProviderTests.cs
@@ -33,7 +33,6 @@ namespace Nethermind.Specs.Test
             _specProvider.GetSpec(blockNumber).IsEip2315Enabled.Should().Be(false);
             _specProvider.GetSpec(blockNumber).IsEip2537Enabled.Should().Be(false);
             _specProvider.GetSpec(blockNumber).IsEip2565Enabled.Should().Be(isEnabled);
-            _specProvider.GetSpec(blockNumber).IsEip2718Enabled.Should().Be(isEnabled);
             _specProvider.GetSpec(blockNumber).IsEip2929Enabled.Should().Be(isEnabled);
             _specProvider.GetSpec(blockNumber).IsEip2930Enabled.Should().Be(isEnabled);
         }

--- a/src/Nethermind/Nethermind.Specs.Test/RopstenSpecProviderTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/RopstenSpecProviderTests.cs
@@ -33,7 +33,6 @@ namespace Nethermind.Specs.Test
             _specProvider.GetSpec(blockNumber).IsEip2315Enabled.Should().Be(false);
             _specProvider.GetSpec(blockNumber).IsEip2537Enabled.Should().Be(false);
             _specProvider.GetSpec(blockNumber).IsEip2565Enabled.Should().Be(isEnabled);
-            _specProvider.GetSpec(blockNumber).IsEip2718Enabled.Should().Be(isEnabled);
             _specProvider.GetSpec(blockNumber).IsEip2929Enabled.Should().Be(isEnabled);
             _specProvider.GetSpec(blockNumber).IsEip2930Enabled.Should().Be(isEnabled);
         }

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
@@ -58,7 +58,6 @@ namespace Nethermind.Specs.ChainSpecStyle
         public long? Eip2315Transition { get; set; }
         public long? Eip2537Transition { get; set; }
         public long? Eip2565Transition { get; set; }
-        public long? Eip2718Transition { get; set; }
         public long? Eip2929Transition { get; set; }
         public long? Eip2930Transition { get; set; }
         

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
@@ -132,7 +132,6 @@ namespace Nethermind.Specs.ChainSpecStyle
                 releaseSpec.IsEip2315Enabled = (_chainSpec.Parameters.Eip2315Transition ?? long.MaxValue) <= releaseStartBlock;
                 releaseSpec.IsEip2537Enabled = (_chainSpec.Parameters.Eip2537Transition ?? long.MaxValue) <= releaseStartBlock;
                 releaseSpec.IsEip2565Enabled = (_chainSpec.Parameters.Eip2565Transition ?? long.MaxValue) <= releaseStartBlock;
-                releaseSpec.IsEip2718Enabled = (_chainSpec.Parameters.Eip2718Transition ?? long.MaxValue) <= releaseStartBlock;
                 releaseSpec.IsEip2929Enabled = (_chainSpec.Parameters.Eip2929Transition ?? long.MaxValue) <= releaseStartBlock;
                 releaseSpec.IsEip2930Enabled = (_chainSpec.Parameters.Eip2930Transition ?? long.MaxValue) <= releaseStartBlock;
                 releaseSpec.ValidateChainId = (_chainSpec.Parameters.ValidateChainIdTransition ?? 0) <= releaseStartBlock; 

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
@@ -128,7 +128,6 @@ namespace Nethermind.Specs.ChainSpecStyle
                 Eip2315Transition = chainSpecJson.Params.Eip2315Transition,
                 Eip2537Transition = chainSpecJson.Params.Eip2537Transition,
                 Eip2565Transition = chainSpecJson.Params.Eip2565Transition,
-                Eip2718Transition = chainSpecJson.Params.Eip2718Transition,
                 Eip2929Transition = chainSpecJson.Params.Eip2929Transition,
                 Eip2930Transition = chainSpecJson.Params.Eip2930Transition,
                 TransactionPermissionContract = chainSpecJson.Params.TransactionPermissionContract,
@@ -183,7 +182,7 @@ namespace Nethermind.Specs.ChainSpecStyle
             chainSpec.MuirGlacierNumber = chainSpec.Ethash?.DifficultyBombDelays.Count > 2 ?
                 chainSpec.Ethash?.DifficultyBombDelays.Keys.ToArray()[2]
                 : null;
-            chainSpec.BerlinBlockNumber = chainSpec.Parameters.Eip2718Transition ?? (long.MaxValue - 1);
+            chainSpec.BerlinBlockNumber = chainSpec.Parameters.Eip2565Transition ?? (long.MaxValue - 1);
         }
 
         private static void LoadEngine(ChainSpecJson chainSpecJson, ChainSpec chainSpec)

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
@@ -182,7 +182,7 @@ namespace Nethermind.Specs.ChainSpecStyle
             chainSpec.MuirGlacierNumber = chainSpec.Ethash?.DifficultyBombDelays.Count > 2 ?
                 chainSpec.Ethash?.DifficultyBombDelays.Keys.ToArray()[2]
                 : null;
-            chainSpec.BerlinBlockNumber = chainSpec.Parameters.Eip2565Transition ?? (long.MaxValue - 1);
+            chainSpec.BerlinBlockNumber = chainSpec.Parameters.Eip2929Transition ?? (long.MaxValue - 1);
         }
 
         private static void LoadEngine(ChainSpecJson chainSpecJson, ChainSpec chainSpec)

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
@@ -100,9 +100,7 @@ namespace Nethermind.Specs.ChainSpecStyle.Json
         public long? Eip2537Transition { get; set; }
         
         public long? Eip2565Transition { get; set; }
-        
-        public long? Eip2718Transition { get; set; }
-        
+
         public long? Eip2929Transition { get; set; }
         
         public long? Eip2930Transition { get; set; }

--- a/src/Nethermind/Nethermind.Specs/Forks/00_Olympic.cs
+++ b/src/Nethermind/Nethermind.Specs/Forks/00_Olympic.cs
@@ -76,7 +76,6 @@ namespace Nethermind.Specs.Forks
         public bool IsEip2565Enabled => false;
         public bool IsEip2929Enabled => false;
         public bool IsEip2930Enabled => false;
-        public bool IsEip2718Enabled => false;
         public bool IsEip158IgnoredAccount(Address address) => false;
         public bool IsEip1559Enabled => false;
         public long Eip1559TransitionBlock => long.MaxValue;

--- a/src/Nethermind/Nethermind.Specs/Forks/01_Frontier.cs
+++ b/src/Nethermind/Nethermind.Specs/Forks/01_Frontier.cs
@@ -76,7 +76,6 @@ namespace Nethermind.Specs.Forks
         public long Eip1559TransitionBlock => long.MaxValue;
         public bool IsEip2929Enabled => false;
         public bool IsEip2930Enabled => false;
-        public bool IsEip2718Enabled => false;
         public bool IsEip158IgnoredAccount(Address address) => false;
     }
 }

--- a/src/Nethermind/Nethermind.Specs/Forks/02_Homestead.cs
+++ b/src/Nethermind/Nethermind.Specs/Forks/02_Homestead.cs
@@ -74,7 +74,6 @@ namespace Nethermind.Specs.Forks
         public long Eip1559TransitionBlock => long.MaxValue;
         public bool IsEip2929Enabled => false;
         public bool IsEip2930Enabled => false;
-        public bool IsEip2718Enabled => false;
         public bool IsEip158IgnoredAccount(Address address) => false;
     }
 }

--- a/src/Nethermind/Nethermind.Specs/Forks/03_Dao.cs
+++ b/src/Nethermind/Nethermind.Specs/Forks/03_Dao.cs
@@ -76,7 +76,6 @@ namespace Nethermind.Specs.Forks
         public long Eip1559TransitionBlock => long.MaxValue;
         public bool IsEip2929Enabled => false;
         public bool IsEip2930Enabled => false;
-        public bool IsEip2718Enabled => false;
         public bool IsEip158IgnoredAccount(Address address) => false;
     }
 }

--- a/src/Nethermind/Nethermind.Specs/Forks/04_TangerineWhistle.cs
+++ b/src/Nethermind/Nethermind.Specs/Forks/04_TangerineWhistle.cs
@@ -74,7 +74,6 @@ namespace Nethermind.Specs.Forks
         public bool IsEip2565Enabled => false;
         public bool IsEip2929Enabled => false;
         public bool IsEip2930Enabled => false;
-        public bool IsEip2718Enabled => false;
         public bool IsEip158IgnoredAccount(Address address) => false;
         public bool IsEip1559Enabled => false;
         public long Eip1559TransitionBlock => long.MaxValue;

--- a/src/Nethermind/Nethermind.Specs/Forks/05_SpuriousDragon.cs
+++ b/src/Nethermind/Nethermind.Specs/Forks/05_SpuriousDragon.cs
@@ -76,7 +76,6 @@ namespace Nethermind.Specs.Forks
         public long Eip1559TransitionBlock => long.MaxValue;
         public bool IsEip2929Enabled => false;
         public bool IsEip2930Enabled => false;
-        public bool IsEip2718Enabled => false;
         public bool IsEip158IgnoredAccount(Address address) => false;
     }
 }

--- a/src/Nethermind/Nethermind.Specs/Forks/06_Byzantium.cs
+++ b/src/Nethermind/Nethermind.Specs/Forks/06_Byzantium.cs
@@ -76,7 +76,6 @@ namespace Nethermind.Specs.Forks
         public long Eip1559TransitionBlock => long.MaxValue;
         public bool IsEip2929Enabled => false;
         public bool IsEip2930Enabled => false;
-        public bool IsEip2718Enabled => false;
         public bool IsEip158IgnoredAccount(Address address) => false;
     }
 }

--- a/src/Nethermind/Nethermind.Specs/Forks/07_Constantinople.cs
+++ b/src/Nethermind/Nethermind.Specs/Forks/07_Constantinople.cs
@@ -74,7 +74,6 @@ namespace Nethermind.Specs.Forks
         public bool IsEip2565Enabled => false;
         public bool IsEip2929Enabled => false;
         public bool IsEip2930Enabled => false;
-        public bool IsEip2718Enabled => false;
         public bool IsEip158IgnoredAccount(Address address) => false;
         public bool IsEip1559Enabled => false;
         public long Eip1559TransitionBlock => long.MaxValue;

--- a/src/Nethermind/Nethermind.Specs/Forks/08_ConstantinopleFix.cs
+++ b/src/Nethermind/Nethermind.Specs/Forks/08_ConstantinopleFix.cs
@@ -76,7 +76,6 @@ namespace Nethermind.Specs.Forks
         public bool IsEip2565Enabled => false;
         public bool IsEip2929Enabled => false;
         public bool IsEip2930Enabled => false;
-        public bool IsEip2718Enabled => false;
         public bool IsEip158IgnoredAccount(Address address) => false;
         public bool IsEip1559Enabled => false;
         public long Eip1559TransitionBlock => long.MaxValue;

--- a/src/Nethermind/Nethermind.Specs/Forks/09_Istanbul.cs
+++ b/src/Nethermind/Nethermind.Specs/Forks/09_Istanbul.cs
@@ -74,7 +74,6 @@ namespace Nethermind.Specs.Forks
         public bool IsEip2565Enabled => false;
         public bool IsEip2929Enabled => false;
         public bool IsEip2930Enabled => false;
-        public bool IsEip2718Enabled => false;
         public bool IsEip158IgnoredAccount(Address address) => false;
         public bool IsEip1559Enabled => false;
         public long Eip1559TransitionBlock => long.MaxValue;

--- a/src/Nethermind/Nethermind.Specs/Forks/10_MuirGlacier.cs
+++ b/src/Nethermind/Nethermind.Specs/Forks/10_MuirGlacier.cs
@@ -72,7 +72,6 @@ namespace Nethermind.Specs.Forks
         public bool IsEip2565Enabled => false;
         public bool IsEip2929Enabled => false;
         public bool IsEip2930Enabled => false;
-        public bool IsEip2718Enabled => false;
         public bool IsEip158IgnoredAccount(Address address) => false;
         public bool IsEip1559Enabled => false;
         public long Eip1559TransitionBlock => long.MaxValue;

--- a/src/Nethermind/Nethermind.Specs/Forks/11_Berlin.cs
+++ b/src/Nethermind/Nethermind.Specs/Forks/11_Berlin.cs
@@ -74,7 +74,6 @@ namespace Nethermind.Specs.Forks
         public bool IsEip2565Enabled => true;
         public bool IsEip2929Enabled => true;
         public bool IsEip2930Enabled => true;
-        public bool IsEip2718Enabled => true;
         public bool IsEip158IgnoredAccount(Address address) => false;
         public bool IsEip1559Enabled => false;
         public long Eip1559TransitionBlock => long.MaxValue;

--- a/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
@@ -65,7 +65,6 @@ namespace Nethermind.Specs
         public bool IsEip2565Enabled { get; set; }
         public bool IsEip2929Enabled { get; set; }
         public bool IsEip2930Enabled { get; set; }
-        public bool IsEip2718Enabled { get; set; }
         public bool IsEip158IgnoredAccount(Address address) => address == Address.SystemUser;
         public bool IsEip1559Enabled { get; set; }
         public bool ValidateChainId { get; set; }

--- a/src/Nethermind/Nethermind.Specs/SystemTransactionReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs/SystemTransactionReleaseSpec.cs
@@ -110,8 +110,6 @@ namespace Nethermind.Specs
         public bool IsEip2537Enabled => _spec.IsEip2315Enabled;
         
         public bool IsEip2565Enabled => _spec.IsEip2565Enabled;
-        
-        public bool IsEip2718Enabled => _spec.IsEip2718Enabled;
 
         public bool IsEip2929Enabled => _spec.IsEip2929Enabled;
         

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -261,15 +261,7 @@ namespace Nethermind.TxPool
 
             Metrics.PendingTransactionsReceived++;
             
-            IReleaseSpec releaseSpec = _specProvider.GetSpec();
-            if (tx.Type == TxType.AccessList && !releaseSpec.IsEip2930Enabled)
-            {
-                Metrics.PendingTransactionsDiscarded++;
-                if (_logger.IsTrace) _logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, wrong transaction type {tx.Type}.");
-                return AddTxResult.Invalid;
-            }
-            
-            if (!_validator.IsWellFormed(tx, releaseSpec))
+            if (!_validator.IsWellFormed(tx, _specProvider.GetSpec()))
             {
                 // It may happen that other nodes send us transactions that were signed for another chain or don't have enough gas.
                 Metrics.PendingTransactionsDiscarded++;


### PR DESCRIPTION
1. Add guard against wrong TxTypes
2. Add TxPool Eip2930 guard
3. Remove eip2718Transition as it makes no sense for it to be configurable. Use eip2930Transition instead.
