### PR TITLE
Simplify SliceWithZeroPaddingEmptyOnError method

### DIFF
--- a/src/Nethermind/Nethermind.Core/Extensions/ByteArrayExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/ByteArrayExtensions.cs
@@ -56,25 +56,17 @@ namespace Nethermind.Core.Extensions
             return slice;
         }
 
-        public static byte[] SliceWithZeroPaddingEmptyOnError(this byte[] bytes, BigInteger startIndex, int length)
+        public static byte[] SliceWithZeroPaddingEmptyOnError(this byte[] bytes, int startIndex, int length)
         {
-            if (startIndex >= bytes.Length || length == 0)
+            int copiedFragmentLength = Math.Min(bytes.Length - startIndex, length);
+            if (copiedFragmentLength <= 0)
             {
                 return Array.Empty<byte>();
             }
 
-            if (length == 1)
-            {
-                return bytes.Length == 0 ? Array.Empty<byte>() : new[] {bytes[(int)startIndex]};
-            }
-
             byte[] slice = new byte[length];
-            if (startIndex > bytes.Length - 1)
-            {
-                return slice;
-            }
 
-            Buffer.BlockCopy(bytes, (int)startIndex, slice, 0, Math.Min(bytes.Length - (int)startIndex, length));
+            Buffer.BlockCopy(bytes, startIndex, slice, 0, copiedFragmentLength);
             return slice;
         }
     }

--- a/src/Nethermind/Nethermind.Evm/Precompiles/ModExpPrecompile.cs
+++ b/src/Nethermind/Nethermind.Evm/Precompiles/ModExpPrecompile.cs
@@ -75,7 +75,7 @@ namespace Nethermind.Evm.Precompiles
                 UInt256 expLengthUpTo32 = UInt256.Min(32, expLength);
                 UInt256 startIndex = 96 + baseLength; //+ expLength - expLengthUpTo32; // Geth takes head here, why?
                 UInt256 exp = new(
-                    inputData.SliceWithZeroPaddingEmptyOnError((BigInteger)startIndex, (int)expLengthUpTo32), true);
+                    inputData.SliceWithZeroPaddingEmptyOnError((int)startIndex, (int)expLengthUpTo32), true);
                 UInt256 iterationCount = CalculateIterationCount(expLength, exp);
 
                 return Math.Max(200L, (long)(complexity * iterationCount / 3));


### PR DESCRIPTION
I've noticed that the SliceWithZeroPaddingEmptyOnError method is overly complicated with lots of redundant code, so I fixed it