### PR TITLE
Swaps in ConcurrentLru for LruCache.

### DIFF
--- a/src/Nethermind/Nethermind.AuRa.Test/Transactions/TxPermissionFilterTest.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/Transactions/TxPermissionFilterTest.cs
@@ -232,7 +232,7 @@ namespace Nethermind.AuRa.Test.Transactions
             var transactionPermissionContract = new VersionedTransactionPermissionContract(new AbiEncoder(), 
                 TestItem.AddressA,
                 5, 
-                Substitute.For<IReadOnlyTxProcessorSource>(), new LruCache<Keccak, UInt256>(100, "TestCache"),
+                Substitute.For<IReadOnlyTxProcessorSource>(), new LruCache<Keccak, UInt256>(100),
                 LimboLogs.Instance);
             
             var filter = new PermissionBasedTxFilter(transactionPermissionContract, new PermissionBasedTxFilter.Cache(), LimboLogs.Instance);
@@ -254,8 +254,7 @@ namespace Nethermind.AuRa.Test.Transactions
                     ValidatorType = AuRaParameters.ValidatorType.List
                 };
 
-                TransactionPermissionContractVersions =
-                    new LruCache<Keccak, UInt256>(PermissionBasedTxFilter.Cache.MaxCacheSize, nameof(TransactionPermissionContract));
+                TransactionPermissionContractVersions = new LruCache<Keccak, UInt256>(PermissionBasedTxFilter.Cache.MaxCacheSize);
 
                 var trieStore = new TrieStore(DbProvider.StateDb, LimboLogs.Instance).AsReadOnly();
                 IReadOnlyTxProcessorSource txProcessorSource = new ReadOnlyTxProcessingEnv(

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -48,8 +48,8 @@ namespace Nethermind.Blockchain
         internal static Keccak HeadAddressInDb = Keccak.Zero;
         
         private const int CacheSize = 64;
-        private readonly ICache<Keccak, Block> _blockCache = new LruCache<Keccak, Block>(CacheSize, CacheSize, "blocks");
-        private readonly ICache<Keccak, BlockHeader> _headerCache = new LruCache<Keccak, BlockHeader>(CacheSize, CacheSize, "headers");
+        private readonly ICache<Keccak, Block> _blockCache = new LruCache<Keccak, Block>(CacheSize);
+        private readonly ICache<Keccak, BlockHeader> _headerCache = new LruCache<Keccak, BlockHeader>(CacheSize);
 
         private const int BestKnownSearchLimit = 256_000_000;
 
@@ -59,7 +59,7 @@ namespace Nethermind.Blockchain
         private readonly IDb _headerDb;
         private readonly IDb _blockInfoDb;
 
-        private ICache<long, HashSet<Keccak>> _invalidBlocks = new LruCache<long, HashSet<Keccak>>(128, 128, "invalid blocks");
+        private ICache<long, HashSet<Keccak>> _invalidBlocks = new LruCache<long, HashSet<Keccak>>(128);
         private readonly BlockDecoder _blockDecoder = new();
         private readonly HeaderDecoder _headerDecoder = new();
         private readonly ILogger _logger;

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
@@ -40,7 +40,7 @@ namespace Nethermind.Blockchain.Receipts
         private static readonly ReceiptStorageDecoder StorageDecoder = ReceiptStorageDecoder.Instance;
         
         private const int CacheSize = 64;
-        private readonly ICache<Keccak, TxReceipt[]> _receiptsCache = new LruCache<Keccak, TxReceipt[]>(CacheSize, CacheSize, "receipts");
+        private readonly ICache<Keccak, TxReceipt[]> _receiptsCache = new LruCache<Keccak, TxReceipt[]>(CacheSize);
 
         public PersistentReceiptStorage(IColumnsDb<ReceiptsColumns> receiptsDb, ISpecProvider specProvider, IReceiptsRecovery receiptsRecovery)
         {

--- a/src/Nethermind/Nethermind.Consensus.AuRa/AuRaContractGasLimitOverride.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/AuRaContractGasLimitOverride.cs
@@ -112,7 +112,7 @@ namespace Nethermind.Consensus.AuRa
         {
             private const int MaxCacheSize = 10;
 
-            internal ICache<Keccak, long?> GasLimitCache { get; } = new LruCache<Keccak, long?>(MaxCacheSize, "BlockGasLimit");
+            internal ICache<Keccak, long?> GasLimitCache { get; } = new LruCache<Keccak, long?>(MaxCacheSize);
         }
 
         public bool IsGasLimitValid(BlockHeader parentHeader, in long gasLimit, out long? expectedGasLimit)

--- a/src/Nethermind/Nethermind.Consensus.AuRa/Transactions/TxPermissionFilter.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/Transactions/TxPermissionFilter.cs
@@ -119,7 +119,7 @@ namespace Nethermind.Consensus.AuRa.Transactions
             public const int MaxCacheSize = 4096;
             
             internal ICache<(Keccak ParentHash, Address Sender), (ITransactionPermissionContract.TxPermissions Permissions, bool ContractExists)> Permissions { get; } =
-                new LruCache<(Keccak ParentHash, Address Sender), (ITransactionPermissionContract.TxPermissions Permissions, bool ContractExists)>(MaxCacheSize, "TxPermissions");
+                new LruCache<(Keccak ParentHash, Address Sender), (ITransactionPermissionContract.TxPermissions Permissions, bool ContractExists)>(MaxCacheSize);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Consensus.AuRa/Validators/ReportingContractBasedValidator.Cache.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/Validators/ReportingContractBasedValidator.Cache.cs
@@ -29,8 +29,7 @@ namespace Nethermind.Consensus.AuRa.Validators
         {
             internal LinkedList<PersistentReport> PersistentReports { get; } = new LinkedList<PersistentReport>();
             
-            private readonly LruCache<(Address Validator, ReportType ReportType, long BlockNumber), bool> _lastBlockReports = 
-                new LruCache<(Address Validator, ReportType ReportType, long BlockNumber), bool>(MaxQueuedReports, "ReportCache"); 
+            private readonly LruCache<(Address Validator, ReportType ReportType, long BlockNumber), bool> _lastBlockReports = new(MaxQueuedReports);
         
             internal bool AlreadyReported(ReportType reportType, Address validator, in long blockNumber)
             {

--- a/src/Nethermind/Nethermind.Consensus.Clique/SnapshotManager.cs
+++ b/src/Nethermind/Nethermind.Consensus.Clique/SnapshotManager.cs
@@ -42,13 +42,13 @@ namespace Nethermind.Consensus.Clique
         private readonly IEthereumEcdsa _ecdsa;
         private IDb _blocksDb;
         private ulong _lastSignersCount = 0;
-        private ICache<Keccak, Snapshot> _snapshotCache = new LruCache<Keccak, Snapshot>(Clique.InMemorySnapshots, "clique snapshots");
+        private ICache<Keccak, Snapshot> _snapshotCache = new LruCache<Keccak, Snapshot>(Clique.InMemorySnapshots);
 
         public SnapshotManager(ICliqueConfig cliqueConfig, IDb blocksDb, IBlockTree blockTree, IEthereumEcdsa ecdsa, ILogManager logManager)
         {
             _logger = logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
             _cliqueConfig = cliqueConfig ?? throw new ArgumentNullException(nameof(cliqueConfig));
-            _signatures = new LruCache<Keccak, Address>(Clique.InMemorySignatures, Clique.InMemorySignatures, "signatures");
+            _signatures = new LruCache<Keccak, Address>(Clique.InMemorySignatures);
             _ecdsa = ecdsa ?? throw new ArgumentNullException(nameof(ecdsa));
             _blocksDb = blocksDb ?? throw new ArgumentNullException(nameof(blocksDb));
             _blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));

--- a/src/Nethermind/Nethermind.Consensus.Ethash/EthashSealValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus.Ethash/EthashSealValidator.cs
@@ -31,7 +31,7 @@ namespace Nethermind.Consensus.Ethash
         private IEthash _ethash;
         private ILogger _logger;
 
-        private ICache<Keccak, bool> _sealCache = new LruCache<Keccak, bool>(2048, 2048, "ethash seals");
+        private ICache<Keccak, bool> _sealCache = new LruCache<Keccak, bool>(2048);
         private const int SealValidationIntervalConstantComponent = 1024;
         private int sealValidationInterval = SealValidationIntervalConstantComponent;
 

--- a/src/Nethermind/Nethermind.Core.Test/Caching/LruCacheTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Caching/LruCacheTests.cs
@@ -143,15 +143,15 @@ namespace Nethermind.Core.Test.Caching
                 cache.Get(_addresses[i]).Should().Be(_accounts[MapForRefill(i)]);
             }
         }
-        
+
         [Test]
         public void Delete_keeps_internal_structure()
         {
             int maxCapacity = 32;
             int itemsToKeep = 10;
             int iterations = 40;
-                
-            LruCache<int, int> cache = new LruCache<int, int>(maxCapacity, "test");
+
+            LruCache<int, int> cache = new LruCache<int, int>(maxCapacity);
 
             for (int i = 0; i < iterations; i++)
             {
@@ -160,7 +160,7 @@ namespace Nethermind.Core.Test.Caching
             }
 
             int count = 0;
-            
+
             for (int i = 0; i < iterations; i++)
             {
                 if (cache.TryGet(i, out int val))

--- a/src/Nethermind/Nethermind.Core/Nethermind.Core.csproj
+++ b/src/Nethermind/Nethermind.Core/Nethermind.Core.csproj
@@ -22,4 +22,7 @@
     <ProjectReference Include="..\Nethermind.Logging\Nethermind.Logging.csproj" />
     <ProjectReference Include="..\Nethermind.Secp256k1\Nethermind.Secp256k1.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="BitFaster.Caching" Version="1.0.2" />
+  </ItemGroup>
 </Project>

--- a/src/Nethermind/Nethermind.Db/Blooms/BloomStorage.cs
+++ b/src/Nethermind/Nethermind.Db/Blooms/BloomStorage.cs
@@ -257,7 +257,7 @@ namespace Nethermind.Db.Blooms
                 LevelElementSize = levelElementSize;
                 LevelMultiplier = levelMultiplier;
                 _migrationStatistics = migrationStatistics;
-                _cache = new LruCache<long, Bloom>(levelMultiplier, levelMultiplier, "blooms");
+                _cache = new LruCache<long, Bloom>(levelMultiplier);
             }
 
             public void Store(long blockNumber, Bloom bloom)

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -69,7 +69,7 @@ namespace Nethermind.Evm
 
         private readonly IBlockhashProvider _blockhashProvider;
         private readonly ISpecProvider _specProvider;
-        private static readonly ICache<Keccak, CodeInfo> _codeCache = new LruCache<Keccak, CodeInfo>(MemoryAllowance.CodeCacheSize, MemoryAllowance.CodeCacheSize, "VM bytecodes");
+        private static readonly ICache<Keccak, CodeInfo> _codeCache = new LruCache<Keccak, CodeInfo>(MemoryAllowance.CodeCacheSize);
         private readonly ILogger _logger;
         private readonly IStateProvider _state;
         private readonly Stack<EvmState> _stateStack = new();

--- a/src/Nethermind/Nethermind.Runner/Ethereum/Api/AuRaNethermindApi.cs
+++ b/src/Nethermind/Nethermind.Runner/Ethereum/Api/AuRaNethermindApi.cs
@@ -41,10 +41,7 @@ namespace Nethermind.Runner.Ethereum.Api
 
         public IValidatorStore? ValidatorStore { get; set; }
 
-        public ICache<Keccak, UInt256> TransactionPermissionContractVersions { get; }
-            = new LruCache<Keccak, UInt256>(
-                PermissionBasedTxFilter.Cache.MaxCacheSize,
-                nameof(TransactionPermissionContract));
+        public ICache<Keccak, UInt256> TransactionPermissionContractVersions { get; } = new LruCache<Keccak, UInt256>(PermissionBasedTxFilter.Cache.MaxCacheSize);
 
         public AuRaContractGasLimitOverride.Cache? GasLimitCalculatorCache { get; set; }
 

--- a/src/Nethermind/Nethermind.State/Repositories/ChainLevelInfoRepository.cs
+++ b/src/Nethermind/Nethermind.State/Repositories/ChainLevelInfoRepository.cs
@@ -27,7 +27,7 @@ namespace Nethermind.State.Repositories
         private const int CacheSize = 64;
 
         private readonly object _writeLock = new();
-        private readonly ICache<long, ChainLevelInfo> _blockInfoCache = new LruCache<long, ChainLevelInfo>(CacheSize, CacheSize, "chain level infos");
+        private readonly ICache<long, ChainLevelInfo> _blockInfoCache = new LruCache<long, ChainLevelInfo>(CacheSize);
 
         private readonly IDb _blockInfoDb;
 

--- a/src/Nethermind/Nethermind.State/Witnesses/WitnessCollector.cs
+++ b/src/Nethermind/Nethermind.State/Witnesses/WitnessCollector.cs
@@ -33,7 +33,7 @@ namespace Nethermind.State.Witnesses
     public class WitnessCollector : IWitnessCollector
     {
         private readonly LruCache<Keccak, Keccak[]> _witnessCache
-            = new(256, "Witnesses");
+            = new(256);
         
         public IReadOnlyCollection<Keccak> Collected => _collected;
 

--- a/src/Nethermind/Nethermind.Synchronization/SyncServer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SyncServer.cs
@@ -60,7 +60,7 @@ namespace Nethermind.Synchronization
         private object _dummyValue = new();
 
         private ICache<Keccak, object> _recentlySuggested =
-            new LruCache<Keccak, object>(128, 128, "recently suggested blocks");
+            new LruCache<Keccak, object>(128);
 
         private long _pivotNumber;
         private Keccak _pivotHash;

--- a/src/Nethermind/Nethermind.Trie/CachingStore.cs
+++ b/src/Nethermind/Nethermind.Trie/CachingStore.cs
@@ -36,7 +36,7 @@ namespace Nethermind.Trie
         public CachingStore(IKeyValueStoreWithBatching wrappedStore, int maxCapacity)
         {
             _wrappedStore = wrappedStore ?? throw new ArgumentNullException(nameof(wrappedStore));
-            _cache = new LruCache<byte[], byte[]>(maxCapacity, "RLP Cache");
+            _cache = new LruCache<byte[], byte[]>(maxCapacity);
         }
 
         private readonly LruCache<byte[], byte[]> _cache;


### PR DESCRIPTION
The current LruCache uses locks for thread synchronization, which can be quite slow.  This change makes it so we use a concurrent LRU instead.

I chose to just wrap the existing LruCache to minimize the changes in this PR.  In a future PR, it would be reasonable to just use `ConcurrentLru` directly, though that would require adding it as a dependency to a lot of projects.

Note: I don't know Nethermind's view on third party libraries.  The referenced library is open source and MIT so we could just copy it over rather than referencing it via NuGet, but that is marginally more work and there is a good chance this change doesn't get accepted so I chose to do less work initially.

Note: The LruCache `name` constructor parameter was never used, so I have removed it as part of this PR since I was touching all of the constructor calls anyway due to removal of the `startCapacity`.