### PR TITLE
Gitbook docs generating update after renaming RPC classes

### DIFF
--- a/src/Nethermind/Nethermind.GitBook/MetricsGenerator.cs
+++ b/src/Nethermind/Nethermind.GitBook/MetricsGenerator.cs
@@ -44,20 +44,20 @@ namespace Nethermind.GitBook
                 Assembly assembly = Assembly.LoadFile(dll);
                 Type[] modules  = assembly.GetExportedTypes().Where(t => t.Name == "Metrics").ToArray();
                 
-                
                 foreach (Type module in modules)
                 {
-                    string name = module.FullName.Replace("Nethermind.", "").Replace(".Metrics", "");
-                    GenerateDocFileContent(module, name, docsDir);
+                    GenerateDocFileContent(module, docsDir);
                 }
             }
         }
 
-        private void GenerateDocFileContent(Type metricsType, string moduleName, string docsDir)
+        private void GenerateDocFileContent(Type metricsType, string docsDir)
         {
             StringBuilder docBuilder = new StringBuilder();
 
             PropertyInfo[] moduleProperties = metricsType.GetProperties().OrderBy(x => x.Name).ToArray();
+            
+            string moduleName = metricsType.FullName.Replace("Nethermind.", "").Replace(".Metrics", "");
 
             docBuilder.AppendLine(@$"# {moduleName}");
             docBuilder.AppendLine();

--- a/src/Nethermind/Nethermind.GitBook/MetricsGenerator.cs
+++ b/src/Nethermind/Nethermind.GitBook/MetricsGenerator.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.ComponentModel;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -35,46 +36,21 @@ namespace Nethermind.GitBook
         {
             string docsDir = DocsDirFinder.FindDocsDir();
             
-            //ToFix: Create MetricsCategoryAttribute and add MetricsCategory attribute to every "Metrics" class and load Metrics automatically instead of manually
-            Type metricsType = Assembly.Load("Nethermind.Blockchain").GetTypes()
-                                        .First(t => typeof(Blockchain.Metrics).IsAssignableFrom(t));
-            GenerateDocFileContent(metricsType, "Blockchain", docsDir);
-            
-            metricsType = Assembly.Load("Nethermind.Evm").GetTypes()
-                .First(t => typeof(Evm.Metrics).IsAssignableFrom(t));
-            GenerateDocFileContent(metricsType, "Evm", docsDir);
-            
-            metricsType = Assembly.Load("Nethermind.JsonRpc").GetTypes()
-                .First(t => typeof(JsonRpc.Metrics).IsAssignableFrom(t));
-            GenerateDocFileContent(metricsType, "JsonRpc", docsDir);
-            
-            metricsType = Assembly.Load("Nethermind.Network").GetTypes()
-                .First(t => typeof(Network.Metrics).IsAssignableFrom(t));
-            GenerateDocFileContent(metricsType, "Network", docsDir);
-            
-            metricsType = Assembly.Load("Nethermind.Db").GetTypes()
-                .First(t => typeof(Db.Metrics).IsAssignableFrom(t));
-            GenerateDocFileContent(metricsType, "Store", docsDir);
-            
-            metricsType = Assembly.Load("Nethermind.Consensus.AuRa").GetTypes()
-                .First(t => typeof(Consensus.AuRa.Metrics).IsAssignableFrom(t));
-            GenerateDocFileContent(metricsType, "Consensus.Aura", docsDir);
-            
-            metricsType = Assembly.Load("Nethermind.Runner").GetTypes()
-                .First(t => typeof(Runner.Metrics).IsAssignableFrom(t));
-            GenerateDocFileContent(metricsType, "Runner", docsDir);
-            
-            metricsType = Assembly.Load("Nethermind.Synchronization").GetTypes()
-                .First(t => typeof(Synchronization.Metrics).IsAssignableFrom(t));
-            GenerateDocFileContent(metricsType, "Synchronization", docsDir);
-            
-            metricsType = Assembly.Load("Nethermind.Trie").GetTypes()
-                .First(t => typeof(Trie.Metrics).IsAssignableFrom(t));
-            GenerateDocFileContent(metricsType, "Trie", docsDir);
-            
-            metricsType = Assembly.Load("Nethermind.TxPool").GetTypes()
-                .First(t => typeof(TxPool.Metrics).IsAssignableFrom(t));
-            GenerateDocFileContent(metricsType, "TxPool", docsDir);
+            string[] dlls = Directory.GetFiles(AppDomain.CurrentDomain.BaseDirectory, "Nethermind.*.dll")
+                .OrderBy(n => n).ToArray();
+
+            foreach (string dll in dlls)
+            {
+                Assembly assembly = Assembly.LoadFile(dll);
+                Type[] modules  = assembly.GetExportedTypes().Where(t => t.Name == "Metrics").ToArray();
+                
+                
+                foreach (Type module in modules)
+                {
+                    string name = module.FullName.Replace("Nethermind.", "").Replace(".Metrics", "");
+                    GenerateDocFileContent(module, name, docsDir);
+                }
+            }
         }
 
         private void GenerateDocFileContent(Type metricsType, string moduleName, string docsDir)
@@ -94,9 +70,29 @@ namespace Nethermind.GitBook
             foreach (PropertyInfo property in moduleProperties)
             {
                 Attribute attr = property.GetCustomAttribute(typeof(DescriptionAttribute));
-                docBuilder.AppendLine($"| {property.Name} | {((DescriptionAttribute)attr)?.Description ?? ""} |");
+                docBuilder.AppendLine($"| {GetMetricName(property.Name)} | {((DescriptionAttribute)attr)?.Description ?? ""} |");
             }
             _sharedContent.Save(moduleName, docsDir + "/ethereum-client/metrics", docBuilder);
+        }
+
+        private string GetMetricName(string propertyName)
+        {
+            StringBuilder nameBuilder = new StringBuilder("nethermind");
+            
+            foreach (char ch in propertyName)
+            {
+                if (char.IsUpper(ch))
+                {
+                    nameBuilder.Append("_");
+                    nameBuilder.Append(ch.ToString().ToLower());
+                }
+                else
+                {
+                    nameBuilder.Append(ch);
+                }
+            }
+
+            return nameBuilder.ToString();
         }
     }
 }

--- a/src/Nethermind/Nethermind.GitBook/RpcAndCliDataProvider.cs
+++ b/src/Nethermind/Nethermind.GitBook/RpcAndCliDataProvider.cs
@@ -46,16 +46,16 @@ namespace Nethermind.GitBook
             List<Type> jsonRpcModules = new List<Type>();
         
             foreach (Type type in assembly.GetTypes()
-                .Where(t => typeof(IModule).IsAssignableFrom(t))
-                .Where(t => !typeof(IContextAwareModule).IsAssignableFrom(t))
-                .Where(t => t.IsInterface && t != typeof(IModule)))
+                .Where(t => typeof(IRpcModule).IsAssignableFrom(t))
+                .Where(t => !typeof(IContextAwareRpcModule).IsAssignableFrom(t))
+                .Where(t => t.IsInterface && t != typeof(IRpcModule)))
             {
                 jsonRpcModules.Add(type);
             }
             
             jsonRpcModules.Add( Assembly.Load("Nethermind.Consensus.Clique").GetTypes()
-                .Where(t => typeof(IModule).IsAssignableFrom(t))
-                .First(t => t.IsInterface && t != typeof(IModule)));
+                .Where(t => typeof(IRpcModule).IsAssignableFrom(t))
+                .First(t => t.IsInterface && t != typeof(IRpcModule)));
             
             return jsonRpcModules;
         }
@@ -78,7 +78,7 @@ namespace Nethermind.GitBook
         {
             foreach (Type rpcType in rpcTypes)
             {
-                string rpcModuleName = rpcType.Name.Substring(1).Replace("Module", "").ToLower();
+                string rpcModuleName = rpcType.Name.Substring(1).Replace("RpcModule", "").ToLower();
                 
                 MethodInfo[] moduleMethods = rpcType.GetMethods();
                 Dictionary<string, MethodData> methods =

--- a/src/Nethermind/Nethermind.GitBook/SharedContent.cs
+++ b/src/Nethermind/Nethermind.GitBook/SharedContent.cs
@@ -21,6 +21,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using Nethermind.Blockchain.Find;
+using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.GitBook.Extensions;
 
@@ -69,6 +70,13 @@ namespace Nethermind.GitBook
                 if(type == typeof(BlockParameterType))
                 {
                     moduleBuilder.AppendLine("- `Quantity` or `String` (latest, earliest, pending)");
+                    moduleBuilder.AppendLine();
+                    continue;
+                }
+                
+                if(type == typeof(TxType))
+                {
+                    moduleBuilder.AppendLine("- [EIP2718](https://eips.ethereum.org/EIPS/eip-2718) transaction type");
                     moduleBuilder.AppendLine();
                     continue;
                 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/IEthRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/IEthRpcModule.cs
@@ -98,8 +98,17 @@ namespace Nethermind.JsonRpc.Modules.Eth
         [JsonRpcMethod(IsImplemented = true, Description = "Executes a tx call and returns gas used (does not create a transaction)", IsSharable = false)]
         ResultWrapper<UInt256?> eth_estimateGas(TransactionForRpc transactionCall, BlockParameter? blockParameter = null);
         
-        [JsonRpcMethod(IsImplemented = true, Description = "CreateAccessList creates a EIP-2930 type AccessList for the given transaction", IsSharable = false)]
-        ResultWrapper<AccessListForRpc> eth_createAccessList(TransactionForRpc transactionCall, BlockParameter? blockParameter = null, bool optimize = true);
+        [JsonRpcMethod(IsImplemented = true,
+            Description = "Creates an [EIP2930](https://eips.ethereum.org/EIPS/eip-2930) type AccessList for the given transaction",
+            EdgeCaseHint = "If your transaction has code executed, then you can generate transaction access list with eth_createAccessList. If you send it with your transaction then it will lower your gas cost on Ethereum",
+            IsSharable = false)]
+        ResultWrapper<AccessListForRpc> eth_createAccessList(
+            [JsonRpcParameter(Description = "Transaction's details")]
+            TransactionForRpc transactionCall,
+            [JsonRpcParameter(Description = "(optional)")]
+            BlockParameter? blockParameter = null,
+            [JsonRpcParameter(Description = "(optional)")]
+            bool optimize = true);
         
         [JsonRpcMethod(IsImplemented = true, Description = "Retrieves a block by hash", IsSharable = true)]
         ResultWrapper<BlockForRpc> eth_getBlockByHash(Keccak blockHash, bool returnFullTransactionObjects = false);


### PR DESCRIPTION
After recent changes in naming (IModule => IRpcModule etc) automated docs generating still had old names and stopped working.

This quick fix:
* changing names for new ones
* changing metrics names from CamelCase to prometheus_convention_ones
* fixing way of searching configs and metrics files
* adding some content to the new RPC eth_createAccessList  description