### PR TITLE
Enable compression for https

### DIFF
--- a/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
+++ b/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
@@ -78,6 +78,7 @@ namespace Nethermind.Runner.JsonRpc
                 options.Providers.Add<BrotliCompressionProvider>();
                 options.Providers.Add<GzipCompressionProvider>();
                 options.MimeTypes = ResponseCompressionDefaults.MimeTypes;
+                options.EnableForHttps = true;
             });
         }
 


### PR DESCRIPTION
Rationale:
https compression is off by default to prevent [BREACH ](https://en.wikipedia.org/wiki/BREACH) and [CRIME ](https://en.wikipedia.org/wiki/CRIME) attacks. Those attacks are based on coockies. We don't use coockies in JSON RPC, though we are not vulnerable. Some more details here: https://github.com/h5bp/server-configs-nginx/issues/72#issuecomment-472808075