### PR TITLE
Berlin HF on POA Core and Sokol

### DIFF
--- a/src/Nethermind/Chains/poacore.json
+++ b/src/Nethermind/Chains/poacore.json
@@ -46,7 +46,10 @@
     "eip1344Transition": 12598600,
     "eip1706Transition": 12598600,
     "eip1884Transition": 12598600,
-    "eip2028Transition": 12598600
+    "eip2028Transition": 12598600,
+    "eip2565Transition": 21364900,
+    "eip2929Transition": 21364900,
+    "eip2930Transition": 21364900
   },
   "genesis": {
     "seal": {

--- a/src/Nethermind/Chains/sokol.json
+++ b/src/Nethermind/Chains/sokol.json
@@ -51,7 +51,10 @@
     "eip1344Transition": 12095200,
     "eip1706Transition": 12095200,
     "eip1884Transition": 12095200,
-    "eip2028Transition": 12095200
+    "eip2028Transition": 12095200,
+    "eip2565Transition": 21050600,
+    "eip2929Transition": 21050600,
+    "eip2930Transition": 21050600
   },
   "genesis": {
     "seal": {


### PR DESCRIPTION
We are going to activate Berlin HF on POA Core and Sokol at `~10:00 am UTC, May 24`. Block number for `POA Core` is  `21364900`. Block number for `POA Sokol` is `21050600`. Relates to https://github.com/openethereum/openethereum/pull/398.