### PR TITLE
IS and NOT Operators

### DIFF
--- a/src/Nethermind/Nethermind.Dsl/ANTLR/Interpreter.cs
+++ b/src/Nethermind/Nethermind.Dsl/ANTLR/Interpreter.cs
@@ -122,10 +122,10 @@ namespace Nethermind.Dsl.ANTLR
             _logger.Info($"Adding new pipeline element with OPERATION: {operation}");
             return operation switch
             {
-                "==" => new PipelineElement<Transaction, Transaction>(
+                "IS" => new PipelineElement<Transaction, Transaction>(
                             condition: (t => t.GetType().GetProperty(key).GetValue(t).ToString() == value),
                             transformData: (t => t), _logger),
-                "!=" => new PipelineElement<Transaction, Transaction>(
+                "NOT" => new PipelineElement<Transaction, Transaction>(
                             condition: (t => t.GetType().GetProperty(key).GetValue(t).ToString() != value),
                             transformData: (t => t), _logger),
                 ">" => new PipelineElement<Transaction, Transaction>(
@@ -151,10 +151,10 @@ namespace Nethermind.Dsl.ANTLR
         {
             return operation switch
             {
-                "==" => new PipelineElement<Block, Block>(
+                "IS" => new PipelineElement<Block, Block>(
                             condition: (b => b.GetType().GetProperty(key).GetValue(b).ToString() == value),
                             transformData: (b => b), _logger),
-                "!=" => new PipelineElement<Block, Block>(
+                "NOT" => new PipelineElement<Block, Block>(
                             condition: (b => b.GetType().GetProperty(key).GetValue(b).ToString() != value),
                             transformData: (b => b), _logger),
                 ">" => new PipelineElement<Block, Block>(

--- a/src/Nethermind/Nethermind.Dsl/ANTLR/Interpreter.cs
+++ b/src/Nethermind/Nethermind.Dsl/ANTLR/Interpreter.cs
@@ -125,7 +125,13 @@ namespace Nethermind.Dsl.ANTLR
                 "IS" => new PipelineElement<Transaction, Transaction>(
                             condition: (t => t.GetType().GetProperty(key).GetValue(t).ToString() == value),
                             transformData: (t => t), _logger),
+                "==" => new PipelineElement<Transaction, Transaction>(
+                            condition: (t => t.GetType().GetProperty(key).GetValue(t).ToString() == value),
+                            transformData: (t => t), _logger)
                 "NOT" => new PipelineElement<Transaction, Transaction>(
+                            condition: (t => t.GetType().GetProperty(key).GetValue(t).ToString() != value),
+                            transformData: (t => t), _logger),
+                "!=" => new PipelineElement<Transaction, Transaction>(
                             condition: (t => t.GetType().GetProperty(key).GetValue(t).ToString() != value),
                             transformData: (t => t), _logger),
                 ">" => new PipelineElement<Transaction, Transaction>(

--- a/src/Nethermind/Nethermind.Dsl/ANTLR/Interpreter.cs
+++ b/src/Nethermind/Nethermind.Dsl/ANTLR/Interpreter.cs
@@ -127,7 +127,7 @@ namespace Nethermind.Dsl.ANTLR
                             transformData: (t => t), _logger),
                 "==" => new PipelineElement<Transaction, Transaction>(
                             condition: (t => t.GetType().GetProperty(key).GetValue(t).ToString() == value),
-                            transformData: (t => t), _logger)
+                            transformData: (t => t), _logger),
                 "NOT" => new PipelineElement<Transaction, Transaction>(
                             condition: (t => t.GetType().GetProperty(key).GetValue(t).ToString() != value),
                             transformData: (t => t), _logger),
@@ -160,9 +160,15 @@ namespace Nethermind.Dsl.ANTLR
                 "IS" => new PipelineElement<Block, Block>(
                             condition: (b => b.GetType().GetProperty(key).GetValue(b).ToString() == value),
                             transformData: (b => b), _logger),
+                "==" => new PipelineElement<Transaction, Transaction>(
+                            condition: (t => t.GetType().GetProperty(key).GetValue(t).ToString() == value),
+                            transformData: (t => t), _logger),
                 "NOT" => new PipelineElement<Block, Block>(
                             condition: (b => b.GetType().GetProperty(key).GetValue(b).ToString() != value),
                             transformData: (b => b), _logger),
+                "!=" => new PipelineElement<Transaction, Transaction>(
+                            condition: (t => t.GetType().GetProperty(key).GetValue(t).ToString() != value),
+                            transformData: (t => t), _logger),
                 ">" => new PipelineElement<Block, Block>(
                             condition: (b => (UInt256)b.GetType().GetProperty(key).GetValue(b) > UInt256.Parse(value)),
                             transformData: (b => b), _logger),

--- a/src/Nethermind/Nethermind.Dsl/ANTLR/Token.cs
+++ b/src/Nethermind/Nethermind.Dsl/ANTLR/Token.cs
@@ -5,6 +5,8 @@ namespace Nethermind.Dsl.ANTLR
        SOURCE,
        WATCH,
        WHERE,
-       PUBLISH 
+       PUBLISH,
+       IS,
+       NOT
     }
 }

--- a/src/Nethermind/Nethermind.Dsl/Grammar/DslGrammar.g4
+++ b/src/Nethermind/Nethermind.Dsl/Grammar/DslGrammar.g4
@@ -11,7 +11,7 @@ andCondition : AND condition ;
 orCondition : OR condition ;
 
 BOOLEAN_OPERATOR : ARITHMETIC_SYMBOL | CONTAINS ;
-ARITHMETIC_SYMBOL : IS | NOT | '<' | '>' | '<=' | '>=' ;
+ARITHMETIC_SYMBOL : '==' | '!=' | '<' | '>' | '<=' | '>=' | IS | NOT ;
 
 SOURCE : 'SOURCE' ;
 WATCH : 'WATCH' ;

--- a/src/Nethermind/Nethermind.Dsl/Grammar/DslGrammar.g4
+++ b/src/Nethermind/Nethermind.Dsl/Grammar/DslGrammar.g4
@@ -11,7 +11,7 @@ andCondition : AND condition ;
 orCondition : OR condition ;
 
 BOOLEAN_OPERATOR : ARITHMETIC_SYMBOL | CONTAINS ;
-ARITHMETIC_SYMBOL : '==' | '!=' | '<' | '>' | '<=' | '>=' ;
+ARITHMETIC_SYMBOL : IS | NOT | '<' | '>' | '<=' | '>=' ;
 
 SOURCE : 'SOURCE' ;
 WATCH : 'WATCH' ;
@@ -20,6 +20,8 @@ PUBLISH : 'PUBLISH' ;
 AND : 'AND' ;
 OR : 'OR' ;
 CONTAINS : 'CONTAINS' ;
+IS: 'IS' ;
+NOT: 'NOT' ;
 
 PUBLISH_VALUE : WEBSOCKETS | LOG_PUBLISHER ;
 WEBSOCKETS : 'WebSockets' | 'webSockets' | 'websockets' ;


### PR DESCRIPTION
Implemented IS and NOT:
- Added IS and NOT alongside '==' and '!=" as Boolean Operators in the DslGrammar.g4 grammar file, as well as the necessary adjustments to GetNextBlockElement() and GetNextTransactionElement(), which define the two operations in the Interpreter class of Interpreter.cs