### PR TITLE
#2988 Exception when memory hint is too big

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Caching/LruCacheTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Caching/LruCacheTests.cs
@@ -172,5 +172,17 @@ namespace Nethermind.Core.Test.Caching
 
             count.Should().Be(itemsToKeep);
         }
+
+        [Test]
+        public void Wrong_capacity_number_at_constructor()
+        {
+            int maxCapacity = 0;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => 
+                {
+                    LruCache<int, int> cache = new LruCache<int, int>(maxCapacity, "test");
+                });
+
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Core/Caching/LruCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/LruCache.cs
@@ -29,7 +29,7 @@ namespace Nethermind.Core.Caching
     /// </summary>
     public class LruCache<TKey, TValue> : ICache<TKey, TValue> where TKey : notnull
     {
-        private readonly int _maxCapacity;
+        private readonly long _maxCapacity;
         private readonly Dictionary<TKey, LinkedListNode<LruCacheItem>> _cacheMap;
         private readonly LinkedList<LruCacheItem> _lruList;
 
@@ -40,7 +40,7 @@ namespace Nethermind.Core.Caching
             _lruList?.Clear();
         }
 
-        public LruCache(int maxCapacity, int startCapacity, string name)
+        public LruCache(long maxCapacity, int startCapacity, string name)
         {
             _maxCapacity = maxCapacity;
             _cacheMap = typeof(TKey) == typeof(byte[])
@@ -49,7 +49,7 @@ namespace Nethermind.Core.Caching
             _lruList = new LinkedList<LruCacheItem>();
         }
 
-        public LruCache(int maxCapacity, string name)
+        public LruCache(long maxCapacity, string name)
             : this(maxCapacity, 0, name)
         {
         }

--- a/src/Nethermind/Nethermind.Core/Caching/LruCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/LruCache.cs
@@ -29,7 +29,7 @@ namespace Nethermind.Core.Caching
     /// </summary>
     public class LruCache<TKey, TValue> : ICache<TKey, TValue> where TKey : notnull
     {
-        private readonly long _maxCapacity;
+        private readonly int _maxCapacity;
         private readonly Dictionary<TKey, LinkedListNode<LruCacheItem>> _cacheMap;
         private readonly LinkedList<LruCacheItem> _lruList;
 
@@ -40,7 +40,7 @@ namespace Nethermind.Core.Caching
             _lruList?.Clear();
         }
 
-        public LruCache(long maxCapacity, int startCapacity, string name)
+        public LruCache(int maxCapacity, int startCapacity, string name)
         {
             if (maxCapacity < 1) 
             {
@@ -54,7 +54,7 @@ namespace Nethermind.Core.Caching
             _lruList = new LinkedList<LruCacheItem>();
         }
 
-        public LruCache(long maxCapacity, string name)
+        public LruCache(int maxCapacity, string name)
             : this(maxCapacity, 0, name)
         {
         }

--- a/src/Nethermind/Nethermind.Core/Caching/LruCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/LruCache.cs
@@ -42,6 +42,11 @@ namespace Nethermind.Core.Caching
 
         public LruCache(long maxCapacity, int startCapacity, string name)
         {
+            if (maxCapacity < 1) 
+            {
+                throw new ArgumentOutOfRangeException();
+            }
+
             _maxCapacity = maxCapacity;
             _cacheMap = typeof(TKey) == typeof(byte[])
                 ? new Dictionary<TKey, LinkedListNode<LruCacheItem>>((IEqualityComparer<TKey>)Bytes.EqualityComparer)

--- a/src/Nethermind/Nethermind.Runner.Test/MemoryHintManTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/MemoryHintManTests.cs
@@ -164,5 +164,13 @@ namespace Nethermind.Runner.Test
             Assert.Throws<ArgumentOutOfRangeException>(
                 () => SetMemoryAllowances(cpuCount));
         }
+
+        [TestCase(500 * GB)]
+        public void Big_value_at_memory_hint(long memoryHint)
+        {
+            _initConfig.MemoryHint = memoryHint;
+            SetMemoryAllowances(1);
+            Trie.MemoryAllowance.TrieNodeCacheCount.Should().BeGreaterThan(0);
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Trie/CachingStore.cs
+++ b/src/Nethermind/Nethermind.Trie/CachingStore.cs
@@ -23,7 +23,7 @@ namespace Nethermind.Trie
 {
     public static class KeyValueStoreWithBatchingExtensions
     {
-        public static IKeyValueStoreWithBatching Cached(this IKeyValueStoreWithBatching @this, int maxCapacity)
+        public static IKeyValueStoreWithBatching Cached(this IKeyValueStoreWithBatching @this, long maxCapacity)
         {
             return new CachingStore(@this, maxCapacity);
         }
@@ -33,7 +33,7 @@ namespace Nethermind.Trie
     {
         private readonly IKeyValueStoreWithBatching _wrappedStore;
 
-        public CachingStore(IKeyValueStoreWithBatching wrappedStore, int maxCapacity)
+        public CachingStore(IKeyValueStoreWithBatching wrappedStore, long maxCapacity)
         {
             _wrappedStore = wrappedStore ?? throw new ArgumentNullException(nameof(wrappedStore));
             _cache = new LruCache<byte[], byte[]>(maxCapacity, "RLP Cache");

--- a/src/Nethermind/Nethermind.Trie/CachingStore.cs
+++ b/src/Nethermind/Nethermind.Trie/CachingStore.cs
@@ -23,7 +23,7 @@ namespace Nethermind.Trie
 {
     public static class KeyValueStoreWithBatchingExtensions
     {
-        public static IKeyValueStoreWithBatching Cached(this IKeyValueStoreWithBatching @this, long maxCapacity)
+        public static IKeyValueStoreWithBatching Cached(this IKeyValueStoreWithBatching @this, int maxCapacity)
         {
             return new CachingStore(@this, maxCapacity);
         }
@@ -33,7 +33,7 @@ namespace Nethermind.Trie
     {
         private readonly IKeyValueStoreWithBatching _wrappedStore;
 
-        public CachingStore(IKeyValueStoreWithBatching wrappedStore, long maxCapacity)
+        public CachingStore(IKeyValueStoreWithBatching wrappedStore, int maxCapacity)
         {
             _wrappedStore = wrappedStore ?? throw new ArgumentNullException(nameof(wrappedStore));
             _cache = new LruCache<byte[], byte[]>(maxCapacity, "RLP Cache");

--- a/src/Nethermind/Nethermind.Trie/MemoryAllowance.cs
+++ b/src/Nethermind/Nethermind.Trie/MemoryAllowance.cs
@@ -22,6 +22,6 @@ namespace Nethermind.Trie
     {
         public static long TrieNodeCacheMemory { get; set; } = 128.MB();
 
-        public static int TrieNodeCacheCount => (int)TrieNodeCacheMemory / PatriciaTree.OneNodeAvgMemoryEstimate;
+        public static int TrieNodeCacheCount => (int)(TrieNodeCacheMemory / PatriciaTree.OneNodeAvgMemoryEstimate);
     }
 }

--- a/src/Nethermind/Nethermind.Trie/MemoryAllowance.cs
+++ b/src/Nethermind/Nethermind.Trie/MemoryAllowance.cs
@@ -22,6 +22,6 @@ namespace Nethermind.Trie
     {
         public static long TrieNodeCacheMemory { get; set; } = 128.MB();
 
-        public static int TrieNodeCacheCount => (int)TrieNodeCacheMemory / PatriciaTree.OneNodeAvgMemoryEstimate;
+        public static long TrieNodeCacheCount => TrieNodeCacheMemory / PatriciaTree.OneNodeAvgMemoryEstimate;
     }
 }

--- a/src/Nethermind/Nethermind.Trie/MemoryAllowance.cs
+++ b/src/Nethermind/Nethermind.Trie/MemoryAllowance.cs
@@ -22,6 +22,6 @@ namespace Nethermind.Trie
     {
         public static long TrieNodeCacheMemory { get; set; } = 128.MB();
 
-        public static long TrieNodeCacheCount => TrieNodeCacheMemory / PatriciaTree.OneNodeAvgMemoryEstimate;
+        public static int TrieNodeCacheCount => (int)TrieNodeCacheMemory / PatriciaTree.OneNodeAvgMemoryEstimate;
     }
 }


### PR DESCRIPTION
#2988 
When a big value as the used in the issue description is set as ```MemoryHint```, the ```Nethermind.Trie.MemmoryAllowance.TrieNodeCacheCount``` value will overflow because it is casted to ```int```, causing that the ```maxCapacity``` of the ```LruCache``` could be negative therefore the first time ```LruCache.Set``` is called it will try to remove the first element that doesn't exist.


This PR add the following changes: 

- Cast to ```int``` after divison when computing ```Nethermind.Trie.MemmoryAllowance.TrieNodeCacheCount```
- Thow ```ArgumentoOutOfRangeException``` when LruCache constructor is called with a ```maxCapacity``` lower than 1.
- Add test to check  ```maxCapacity``` argument validation.
- Add test to check big values as HintMemory.