### PR TITLE
first attempt to get rid of queues on pushes

### DIFF
--- a/.github/workflows/run-nethermind-tests-with-code-coverage.yml
+++ b/.github/workflows/run-nethermind-tests-with-code-coverage.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     env:
-      EXCLUDE_TEST_PROJECTS: fromJSON('['', '/p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="[Nethermind.HashLib]*%2c[*Test*]*"']')[matrix.os == 'ubuntu-latest']
+      EXCLUDE_TEST_PROJECTS: "${{ matrix.os == 'ubuntu-latest' && '/p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="/[Nethermind.HashLib]*%2c[*Test*]*"' || '' }}"
     steps:
     - uses: actions/checkout@v2
       with: 
@@ -169,7 +169,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     env:
-      EXCLUDE_TEST_PROJECTS: fromJSON('['', '/p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="[Nethermind.HashLib]*%2c[*Test*]*"']')[matrix.os == 'ubuntu-latest']
+      EXCLUDE_TEST_PROJECTS: "${{ matrix.os == 'ubuntu-latest' && '/p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="/[Nethermind.HashLib]*%2c[*Test*]*"' || '' }}"
     steps:
     - uses: actions/checkout@v2
     - name: Unshallow fetching

--- a/.github/workflows/run-nethermind-tests-with-code-coverage.yml
+++ b/.github/workflows/run-nethermind-tests-with-code-coverage.yml
@@ -177,7 +177,7 @@ jobs:
       run: git -c submodule."src/eth2.0-spec-tests".update=none submodule update --init
     - name: Set environment variable to exclude specific test projects
       if: matrix.os == 'ubuntu-latest'
-      run: echo 'EXCLUDE_TEST_PROJECTS=/p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="[Nethermind.HashLib]*%2c[*Test*]*"' >> "$GITHUB_ENV"
+      run: echo 'EXCLUDE_TEST_PROJECTS=/p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="[Nethermind.HashLib]*%2c[Nethermind.Core.Test]*%2c[Nethermind.Blockchain.Test]*%2c[Nethermind.DataMarketplace.Test]*%2c[Ethereum.Test.Base]*"' >> "$GITHUB_ENV"
     - name: Ethereum.Abi.Test
       run: |
         dotnet test -c Release $EXCLUDE_TEST_PROJECTS src/Nethermind/Ethereum.Abi.Test

--- a/.github/workflows/run-nethermind-tests-with-code-coverage.yml
+++ b/.github/workflows/run-nethermind-tests-with-code-coverage.yml
@@ -14,15 +14,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        code-coverage: ['', '/p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="[Nethermind.HashLib]*%2c[*Test*]*"'] 
-        exclude:
-          # excludes code-coverage reports for macos and windows
-          - os: [macOS-latest, windows-latest]
-            code-coverage: ['/p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="[Nethermind.HashLib]*%2c[*Test*]*"']
-          - os: [ubuntu-latest]
-            code-coverage: ['']
     env:
-      EXCLUDE_TEST_PROJECTS: ${{ matrix.code-coverage }}
+      EXCLUDE_TEST_PROJECTS: fromJSON('['', '/p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="[Nethermind.HashLib]*%2c[*Test*]*"']')[matrix.os == 'ubuntu-latest']
     steps:
     - uses: actions/checkout@v2
       with: 
@@ -163,7 +156,7 @@ jobs:
       run: |
         dotnet test -c Release $EXCLUDE_TEST_PROJECTS src/Math.Gmp.Native/MathGmp.Native.UnitTests                
     - name: Upload Codecov Report
-      if: matrix.code-coverage != ''
+      if: matrix.os == ubuntu-latest
       uses: actions/upload-artifact@v2
       with:
         name: codecov-report
@@ -175,15 +168,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        code-coverage: ['', '/p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="[Nethermind.HashLib]*%2c[*Test*]*"'] 
-        exclude:
-          # excludes code-coverage reports for macos and windows
-          - os: [macOS-latest, windows-latest]
-            code-coverage: ['/p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="[Nethermind.HashLib]*%2c[*Test*]*"']
-          - os: [ubuntu-latest]
-            code-coverage: ['']
     env:
-      EXCLUDE_TEST_PROJECTS: ${{ matrix.code-coverage }}
+      EXCLUDE_TEST_PROJECTS: fromJSON('['', '/p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="[Nethermind.HashLib]*%2c[*Test*]*"']')[matrix.os == 'ubuntu-latest']
     steps:
     - uses: actions/checkout@v2
     - name: Unshallow fetching
@@ -227,7 +213,7 @@ jobs:
       run: |
         dotnet test -c Release $EXCLUDE_TEST_PROJECTS src/Nethermind/Ethereum.Trie.Test
     - name: Upload Codecov Report
-      if: matrix.code-coverage != ''
+      if: matrix.os == ubuntu-latest
       uses: actions/upload-artifact@v2
       with:
         name: codecov-report

--- a/.github/workflows/run-nethermind-tests-with-code-coverage.yml
+++ b/.github/workflows/run-nethermind-tests-with-code-coverage.yml
@@ -156,7 +156,7 @@ jobs:
       run: |
         dotnet test -c Release $EXCLUDE_TEST_PROJECTS src/Math.Gmp.Native/MathGmp.Native.UnitTests                
     - name: Upload Codecov Report
-      if: matrix.os == ubuntu-latest
+      if: matrix.os == 'ubuntu-latest'
       uses: actions/upload-artifact@v2
       with:
         name: codecov-report
@@ -213,7 +213,7 @@ jobs:
       run: |
         dotnet test -c Release $EXCLUDE_TEST_PROJECTS src/Nethermind/Ethereum.Trie.Test
     - name: Upload Codecov Report
-      if: matrix.os == ubuntu-latest
+      if: matrix.os == 'ubuntu-latest'
       uses: actions/upload-artifact@v2
       with:
         name: codecov-report

--- a/.github/workflows/run-nethermind-tests-with-code-coverage.yml
+++ b/.github/workflows/run-nethermind-tests-with-code-coverage.yml
@@ -163,7 +163,7 @@ jobs:
       run: |
         dotnet test -c Release $EXCLUDE_TEST_PROJECTS src/Math.Gmp.Native/MathGmp.Native.UnitTests                
     - name: Upload Codecov Report
-      if: matrix.code-coverage !== ''
+      if: matrix.code-coverage != ''
       uses: actions/upload-artifact@v2
       with:
         name: codecov-report
@@ -227,7 +227,7 @@ jobs:
       run: |
         dotnet test -c Release $EXCLUDE_TEST_PROJECTS src/Nethermind/Ethereum.Trie.Test
     - name: Upload Codecov Report
-      if: matrix.code-coverage !== ''
+      if: matrix.code-coverage != ''
       uses: actions/upload-artifact@v2
       with:
         name: codecov-report

--- a/.github/workflows/run-nethermind-tests-with-code-coverage.yml
+++ b/.github/workflows/run-nethermind-tests-with-code-coverage.yml
@@ -10,19 +10,32 @@ jobs:
   neth-tests-cc:
     if: github.repository_owner == 'NethermindEth'
     name: Running Nethermind Tests with Code Coverage
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        code-coverage: ['', '/p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="[Nethermind.HashLib]*%2c[*Test*]*"'] 
+        exclude:
+          # excludes code-coverage reports for macos and windows
+          - os: [macOS-latest, windows-latest]
+            code-coverage: ['/p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="[Nethermind.HashLib]*%2c[*Test*]*"']
+          - os: [ubuntu-latest]
+            code-coverage: ['']
     env:
-      EXCLUDE_TEST_PROJECTS: '/p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="[Nethermind.HashLib]*%2c[*Test*]*"'
-    runs-on: ubuntu-latest
+      EXCLUDE_TEST_PROJECTS: ${{ matrix.code-coverage }}
     steps:
     - uses: actions/checkout@v2
-    - name: Unshallow fetching
-      run: git fetch --unshallow --progress --prune origin +refs/heads/*:refs/remotes/origin/*
-    - name: Updating submodules
-      run: git submodule update --init src/int256 src/rocksdb-sharp src/Dirichlet src/Math.Gmp.Native
+      with: 
+        submodules: true
+        fetch-depth: 0
     - name: Installing Linux packages
+      if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt-get update
         sudo apt-get install libsnappy-dev libc6-dev libc6
+    - name: Installing macOS packages
+      if: matrix.os == 'macOS-latest'
+      run: brew install gmp && brew install snappy && brew install lz4 && brew install zstd
     - name: Nethermind.Abi.Test
       run: |
         dotnet test -c Release $EXCLUDE_TEST_PROJECTS src/Nethermind/Nethermind.Abi.Test
@@ -150,15 +163,27 @@ jobs:
       run: |
         dotnet test -c Release $EXCLUDE_TEST_PROJECTS src/Math.Gmp.Native/MathGmp.Native.UnitTests                
     - name: Upload Codecov Report
+      if: matrix.code-coverage !== ''
       uses: actions/upload-artifact@v2
       with:
         name: codecov-report
         path: src/Nethermind/Nethermind.*/coverage.opencover.xml
+
   eth-tests-cc:
     name: Running Ethereum Tests with Code Coverage
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        code-coverage: ['', '/p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="[Nethermind.HashLib]*%2c[*Test*]*"'] 
+        exclude:
+          # excludes code-coverage reports for macos and windows
+          - os: [macOS-latest, windows-latest]
+            code-coverage: ['/p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="[Nethermind.HashLib]*%2c[*Test*]*"']
+          - os: [ubuntu-latest]
+            code-coverage: ['']
     env:
-      EXCLUDE_TEST_PROJECTS: '/p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="[Nethermind.HashLib]*%2c[Nethermind.Core.Test]*%2c[Nethermind.Blockchain.Test]*%2c[Nethermind.DataMarketplace.Test]*%2c[Ethereum.Test.Base]*"'
-    runs-on: ubuntu-latest
+      EXCLUDE_TEST_PROJECTS: ${{ matrix.code-coverage }}
     steps:
     - uses: actions/checkout@v2
     - name: Unshallow fetching
@@ -202,10 +227,13 @@ jobs:
       run: |
         dotnet test -c Release $EXCLUDE_TEST_PROJECTS src/Nethermind/Ethereum.Trie.Test
     - name: Upload Codecov Report
+      if: matrix.code-coverage !== ''
       uses: actions/upload-artifact@v2
       with:
         name: codecov-report
         path: src/Nethermind/Ethereum.*/coverage.opencover.xml
+
+  # uploads codecov reports to the codecov.io cloud
   codecov-upload:
     name: Uploading Codecov Reports
     needs: [neth-tests-cc, eth-tests-cc]

--- a/.github/workflows/run-nethermind-tests-with-code-coverage.yml
+++ b/.github/workflows/run-nethermind-tests-with-code-coverage.yml
@@ -14,8 +14,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-    env:
-      EXCLUDE_TEST_PROJECTS: "${{ matrix.os == 'ubuntu-latest' && '/p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="/[Nethermind.HashLib]*%2c[*Test*]*"' || '' }}"
     steps:
     - uses: actions/checkout@v2
       with: 
@@ -29,6 +27,9 @@ jobs:
     - name: Installing macOS packages
       if: matrix.os == 'macOS-latest'
       run: brew install gmp && brew install snappy && brew install lz4 && brew install zstd
+    - name: Set environment variable to exclude specific test projects
+      if: matrix.os == 'ubuntu-latest'
+      run: echo 'EXCLUDE_TEST_PROJECTS=/p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="[Nethermind.HashLib]*%2c[*Test*]*"' >> "$GITHUB_ENV"
     - name: Nethermind.Abi.Test
       run: |
         dotnet test -c Release $EXCLUDE_TEST_PROJECTS src/Nethermind/Nethermind.Abi.Test
@@ -168,14 +169,15 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-    env:
-      EXCLUDE_TEST_PROJECTS: "${{ matrix.os == 'ubuntu-latest' && '/p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="/[Nethermind.HashLib]*%2c[*Test*]*"' || '' }}"
     steps:
     - uses: actions/checkout@v2
     - name: Unshallow fetching
       run: git fetch --unshallow
     - name: Updating submodules
       run: git -c submodule."src/eth2.0-spec-tests".update=none submodule update --init
+    - name: Set environment variable to exclude specific test projects
+      if: matrix.os == 'ubuntu-latest'
+      run: echo 'EXCLUDE_TEST_PROJECTS=/p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="[Nethermind.HashLib]*%2c[*Test*]*"' >> "$GITHUB_ENV"
     - name: Ethereum.Abi.Test
       run: |
         dotnet test -c Release $EXCLUDE_TEST_PROJECTS src/Nethermind/Ethereum.Abi.Test

--- a/.github/workflows/run-nethermind-tests.yml
+++ b/.github/workflows/run-nethermind-tests.yml
@@ -1,5 +1,9 @@
 name: '[RUN] Nethermind/Ethereum Tests'
 
+concurrency: 
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 on: 
   push:
   workflow_dispatch:
@@ -7,9 +11,6 @@ on:
 jobs:
   neth-tests:
     name: Running Nethermind Tests 1
-    concurrency: 
-      group: ${{ github.ref }}
-      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -48,9 +49,6 @@ jobs:
         dotnet test -c Release src/Nethermind/Nethermind.Cli.Test
   neth-tests2:
     name: Running Nethermind Tests 2
-    concurrency: 
-      group: ${{ github.ref }}
-      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -92,9 +90,6 @@ jobs:
         dotnet test -c Release src/Math.Gmp.Native/MathGmp.Native.UnitTests                
   neth-tests3:
     name: Running Nethermind Tests 3
-    concurrency: 
-      group: ${{ github.ref }}
-      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -133,9 +128,6 @@ jobs:
         dotnet test -c Release src/Nethermind/Nethermind.Specs.Test
   neth-tests4:
     name: Running Nethermind Tests 4
-    concurrency: 
-      group: ${{ github.ref }}
-      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -162,9 +154,6 @@ jobs:
         dotnet test -c Release src/Nethermind/Nethermind.Synchronization.Test
   neth-tests5:
     name: Running Nethermind Tests 5
-    concurrency: 
-      group: ${{ github.ref }}
-      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -209,9 +198,6 @@ jobs:
         dotnet test -c Release src/Nethermind/Nethermind.DataMarketplace.WebSockets.Test
   neth-runner:
     name: Nethermind Runner Tests
-    concurrency: 
-      group: ${{ github.ref }}
-      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -229,9 +215,6 @@ jobs:
         dotnet test -c Release src/Nethermind/Nethermind.State.Test.Runner.Test
   eth-tests:
     name: Running Ethereum Tests
-    concurrency: 
-      group: ${{ github.ref }}
-      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/run-nethermind-tests.yml
+++ b/.github/workflows/run-nethermind-tests.yml
@@ -7,22 +7,15 @@ on:
 jobs:
   neth-tests:
     name: Running Nethermind Tests 1
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Updating submodules
-      run: git submodule update --init src/rocksdb-sharp src/int256 src/Dirichlet src/Math.Gmp.Native
+      with:
+        submodules: true
     - name: Installing Linux packages
-      if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt-get update
         sudo apt-get install libsnappy-dev libc6-dev libc6
-    - name: Installing macOS packages
-      if: matrix.os == 'macOS-latest'
-      run: brew install snappy lz4 zstd
     - name: Nethermind.Abi.Test
       run: |
         dotnet test -c Release src/Nethermind/Nethermind.Abi.Test;
@@ -52,22 +45,15 @@ jobs:
         dotnet test -c Release src/Nethermind/Nethermind.Cli.Test
   neth-tests2:
     name: Running Nethermind Tests 2
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Updating submodules
-      run: git submodule update --init src/rocksdb-sharp src/int256 src/Dirichlet src/Math.Gmp.Native
+      with:
+        submodules: true
     - name: Installing Linux packages
-      if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt-get update
         sudo apt-get install libsnappy-dev libc6-dev libc6
-    - name: Installing macOS packages
-      if: matrix.os == 'macOS-latest'
-      run: brew install snappy lz4 zstd
     - name: Nethermind.Clique.Test
       run: |
         dotnet test -c Release src/Nethermind/Nethermind.Clique.Test
@@ -100,22 +86,15 @@ jobs:
         dotnet test -c Release src/Math.Gmp.Native/MathGmp.Native.UnitTests                
   neth-tests3:
     name: Running Nethermind Tests 3
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Updating submodules
-      run: git submodule update --init src/rocksdb-sharp src/int256 src/Dirichlet src/Math.Gmp.Native
+      with:
+        submodules: true
     - name: Installing Linux packages
-      if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt-get update
         sudo apt-get install libsnappy-dev libc6-dev libc6
-    - name: Installing macOS packages
-      if: matrix.os == 'macOS-latest'
-      run: brew install snappy lz4 zstd
     - name: Nethermind.HealthChecks.Test
       run: |
         dotnet test -c Release src/Nethermind/Nethermind.HealthChecks.Test
@@ -145,22 +124,15 @@ jobs:
         dotnet test -c Release src/Nethermind/Nethermind.Specs.Test
   neth-tests4:
     name: Running Nethermind Tests 4
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Updating submodules
-      run: git submodule update --init src/rocksdb-sharp src/int256 src/Math.Gmp.Native
+      with:
+        submodules: true
     - name: Installing Linux packages
-      if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt-get update
         sudo apt-get install libsnappy-dev libc6-dev libc6
-    - name: Installing macOS packages
-      if: matrix.os == 'macOS-latest'
-      run: brew install snappy lz4 zstd
     - name: Nethermind.Secp256k1.Test.Linux
       run: |
         dotnet test -c Release src/Nethermind/Nethermind.Secp256k1.Test
@@ -178,22 +150,15 @@ jobs:
         dotnet test -c Release src/Nethermind/Nethermind.Synchronization.Test
   neth-tests5:
     name: Running Nethermind Tests 5
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Updating submodules
-      run: git submodule update --init src/rocksdb-sharp src/int256 src/Dirichlet src/Math.Gmp.Native
+      with:
+        submodules: true
     - name: Installing Linux packages
-      if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt-get update
         sudo apt-get install libsnappy-dev libc6-dev libc6
-    - name: Installing macOS packages
-      if: matrix.os == 'macOS-latest'
-      run: brew install snappy lz4 zstd
     - name: Nethermind.Ssz.Test
       run: |
         dotnet test -c Release src/Nethermind/Nethermind.Ssz.Test
@@ -229,22 +194,15 @@ jobs:
         dotnet test -c Release src/Nethermind/Nethermind.DataMarketplace.WebSockets.Test
   neth-runner:
     name: Nethermind Runner Tests
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Updating submodules
-      run: git submodule update --init src/rocksdb-sharp src/int256 src/Dirichlet src/Math.Gmp.Native
+      with:
+        submodules: true
     - name: Installing Linux packages
-      if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt-get update
         sudo apt-get install libsnappy-dev libc6-dev libc6
-    - name: Installing macOS packages
-      if: matrix.os == 'macOS-latest'
-      run: brew install gmp && brew install snappy && brew install lz4 && brew install zstd
     - name: Nethermind.Runner.Test
       run: |
         dotnet test -c Release src/Nethermind/Nethermind.Runner.Test
@@ -253,10 +211,7 @@ jobs:
         dotnet test -c Release src/Nethermind/Nethermind.State.Test.Runner.Test
   eth-tests:
     name: Running Ethereum Tests
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Unshallow fetching

--- a/.github/workflows/run-nethermind-tests.yml
+++ b/.github/workflows/run-nethermind-tests.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   neth-tests:
     name: Running Nethermind Tests 1
+    concurrency: 
+      group: ${{ github.head_ref }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -45,6 +48,9 @@ jobs:
         dotnet test -c Release src/Nethermind/Nethermind.Cli.Test
   neth-tests2:
     name: Running Nethermind Tests 2
+    concurrency: 
+      group: ${{ github.head_ref }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -86,6 +92,9 @@ jobs:
         dotnet test -c Release src/Math.Gmp.Native/MathGmp.Native.UnitTests                
   neth-tests3:
     name: Running Nethermind Tests 3
+    concurrency: 
+      group: ${{ github.head_ref }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -124,6 +133,9 @@ jobs:
         dotnet test -c Release src/Nethermind/Nethermind.Specs.Test
   neth-tests4:
     name: Running Nethermind Tests 4
+    concurrency: 
+      group: ${{ github.head_ref }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -150,6 +162,9 @@ jobs:
         dotnet test -c Release src/Nethermind/Nethermind.Synchronization.Test
   neth-tests5:
     name: Running Nethermind Tests 5
+    concurrency: 
+      group: ${{ github.head_ref }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -194,6 +209,9 @@ jobs:
         dotnet test -c Release src/Nethermind/Nethermind.DataMarketplace.WebSockets.Test
   neth-runner:
     name: Nethermind Runner Tests
+    concurrency: 
+      group: ${{ github.head_ref }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -211,6 +229,9 @@ jobs:
         dotnet test -c Release src/Nethermind/Nethermind.State.Test.Runner.Test
   eth-tests:
     name: Running Ethereum Tests
+    concurrency: 
+      group: ${{ github.head_ref }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/run-nethermind-tests.yml
+++ b/.github/workflows/run-nethermind-tests.yml
@@ -8,7 +8,7 @@ jobs:
   neth-tests:
     name: Running Nethermind Tests 1
     concurrency: 
-      group: ${{ github.head_ref }}
+      group: ${{ github.ref }}
       cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
@@ -49,7 +49,7 @@ jobs:
   neth-tests2:
     name: Running Nethermind Tests 2
     concurrency: 
-      group: ${{ github.head_ref }}
+      group: ${{ github.ref }}
       cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
@@ -93,7 +93,7 @@ jobs:
   neth-tests3:
     name: Running Nethermind Tests 3
     concurrency: 
-      group: ${{ github.head_ref }}
+      group: ${{ github.ref }}
       cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
@@ -134,7 +134,7 @@ jobs:
   neth-tests4:
     name: Running Nethermind Tests 4
     concurrency: 
-      group: ${{ github.head_ref }}
+      group: ${{ github.ref }}
       cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
@@ -163,7 +163,7 @@ jobs:
   neth-tests5:
     name: Running Nethermind Tests 5
     concurrency: 
-      group: ${{ github.head_ref }}
+      group: ${{ github.ref }}
       cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
@@ -210,7 +210,7 @@ jobs:
   neth-runner:
     name: Nethermind Runner Tests
     concurrency: 
-      group: ${{ github.head_ref }}
+      group: ${{ github.ref }}
       cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
@@ -230,7 +230,7 @@ jobs:
   eth-tests:
     name: Running Ethereum Tests
     concurrency: 
-      group: ${{ github.head_ref }}
+      group: ${{ github.ref }}
       cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/run-vault-integration-tests.yml
+++ b/.github/workflows/run-vault-integration-tests.yml
@@ -1,7 +1,10 @@
 name: '[RUN] Vault Integration Tests'
 
-on: push
-
+on:
+  push:
+    branches:
+      - master
+      
 jobs:
   run-vault-tests:
     name: Running Vault Integration Tests

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 COPY . .
 RUN git submodule update --init src/Dirichlet src/int256 src/rocksdb-sharp src/Math.Gmp.Native
 RUN dotnet publish src/Nethermind/Nethermind.DataMarketplace.Consumers.Test.EndToEnd -c release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1
+FROM mcr.microsoft.com/dotnet/aspnet:5.0
 RUN apt-get update && apt-get -y install libsnappy-dev libc6-dev libc6 unzip
 WORKDIR /e2e
 COPY --from=build /out .


### PR DESCRIPTION
- introducing concurrency group for standard tests which run after each commit (previous, not finished runs will be canceled upon new commit)
- standard tests to run on ubuntu machine only to reduce the total time of each run under 10 minutes
- standard tests with code coverage are to be run on each OS system, the coverage report however will be produced only on Linux