### PR TITLE
create plugins folder after build + copy HealthChecks plugin do outdir

### DIFF
--- a/src/Nethermind/Nethermind.Runner/Nethermind.Runner.csproj
+++ b/src/Nethermind/Nethermind.Runner/Nethermind.Runner.csproj
@@ -113,7 +113,7 @@
     <None Remove="out\**" />
     <None Remove="keystore\**" />
   </ItemGroup>
-  <Target Name="CreatePluginsFolder" AfterTargets="AfterPublish">
+  <Target Name="CreatePluginsFolder" AfterTargets="AfterBuild;AfterPublish">
     <MakeDir Directories="$(PublishDir)plugins" Condition="!Exists('$(PublishDir)plugins')" /> 
   </Target>
   <Target Name="CreateNdmPluginsFolder" AfterTargets="AfterPublish">
@@ -128,7 +128,10 @@
           DestinationFolder="$(OutDir)plugins" 
           Condition="Exists('$(SolutionDir)Nethermind.Merge.Plugin\bin\$(Configuration)\$(TargetFramework)\Nethermind.Merge.Plugin.pdb')" 
           SkipUnchangedFiles="true"/>
-	  
+    <Copy SourceFiles="$(SolutionDir)Nethermind.HealthChecks\bin\$(Configuration)\$(TargetFramework)\Nethermind.HealthChecks.dll" 
+          DestinationFolder="$(OutDir)plugins" 
+          Condition="Exists('$(SolutionDir)Nethermind.HealthChecks\bin\$(Configuration)\$(TargetFramework)\Nethermind.HealthChecks.dll')" 
+          SkipUnchangedFiles="true" />
     <Copy SourceFiles="$(SolutionDir)Nethermind.Mev\bin\$(Configuration)\$(TargetFramework)\Nethermind.Mev.dll" 
           DestinationFolder="$(OutDir)plugins" 
           Condition="Exists('$(SolutionDir)Nethermind.Mev\bin\$(Configuration)\$(TargetFramework)\Nethermind.Mev.dll')" 
@@ -137,14 +140,14 @@
           DestinationFolder="$(OutDir)plugins" 
           Condition="Exists('$(SolutionDir)Nethermind.Mev\bin\$(Configuration)\$(TargetFramework)\Nethermind.Mev.pdb')" 
           SkipUnchangedFiles="true"/>	  
-	  
-   <Copy SourceFiles="$(SolutionDir)Nethermind.Dsl\bin\$(Configuration)\$(TargetFramework)\Nethermind.Dsl.dll" 
-   	 DestinationFolder="$(OutDir)plugins" Condition="Exists('$(SolutionDir)Nethermind.Dsl\bin\$(Configuration)\$(TargetFramework)\Nethermind.Dsl.dll')" 
-	 SkipUnchangedFiles="true" />
-   <Copy SourceFiles="$(SolutionDir)Nethermind.Dsl\bin\$(Configuration)\$(TargetFramework)\Nethermind.Dsl.pdb" 
-   	 DestinationFolder="$(OutDir)plugins" Condition="Exists('$(SolutionDir)Nethermind.Dsl\bin\$(Configuration)\$(TargetFramework)\Nethermind.Dsl.pdb')" 
-	 SkipUnchangedFiles="true" />	  
-	 
+    <Copy SourceFiles="$(SolutionDir)Nethermind.Dsl\bin\$(Configuration)\$(TargetFramework)\Nethermind.Dsl.dll" 
+   	      DestinationFolder="$(OutDir)plugins" 
+          Condition="Exists('$(SolutionDir)Nethermind.Dsl\bin\$(Configuration)\$(TargetFramework)\Nethermind.Dsl.dll')" 
+	        SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(SolutionDir)Nethermind.Dsl\bin\$(Configuration)\$(TargetFramework)\Nethermind.Dsl.pdb" 
+   	      DestinationFolder="$(OutDir)plugins" 
+          Condition="Exists('$(SolutionDir)Nethermind.Dsl\bin\$(Configuration)\$(TargetFramework)\Nethermind.Dsl.pdb')" 
+	        SkipUnchangedFiles="true" />
   </Target>
   <Target Name="CopyPluginsOnPublish" AfterTargets="AfterPublish">
     <Copy SourceFiles="$(OutputPath)Nethermind.HealthChecks.dll" DestinationFolder="$(PublishDir)plugins" />


### PR DESCRIPTION
## Changes:
Changes to `Nethermind.Runner.csproj`. Creates plugin folder after building Nethermind and copies the HealthChecks.dll to the outdir post build.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [x] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [ ] No