### PR TITLE
Fix transactions pointing to wrong block

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Receipts/PersistentReceiptStorageTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Receipts/PersistentReceiptStorageTests.cs
@@ -123,6 +123,33 @@ namespace Nethermind.Blockchain.Test.Receipts
             receiptStructRef.Logs.Should().BeEquivalentTo(receipts.First().Logs);
             iterator.TryGetNext(out receiptStructRef).Should().BeFalse();
         }
+
+        [Test]
+        public void Should_not_overwrite_reference_from_tx_to_block_when_adding_rollbacked_receipts()
+        {
+            Transaction transaction = Build.A.Transaction.SignedAndResolved().TestObject;
+            
+            Block oldBlock = Build.A.Block
+                .WithTransactions(transaction)
+                .WithReceiptsRoot(TestItem.KeccakA).TestObject;
+
+            Block newBlock = Build.A.Block
+                .WithTransactions(transaction)
+                .WithReceiptsRoot(TestItem.KeccakB).TestObject;
+            
+            TxReceipt[] receipts = {Build.A.Receipt.TestObject};
+            
+            _storage.Insert(oldBlock, receipts);
+            
+            foreach (TxReceipt receipt in receipts)
+            {
+                receipt.Removed = true;
+            }
+            
+            _storage.Insert(newBlock, receipts);
+
+            _storage.FindBlockHash(transaction.Hash).Should().Be(oldBlock.Hash);
+        }
         
         [Test]
         public void Adds_and_retrieves_receipts_for_block_with_iterator()

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
@@ -227,8 +227,11 @@ namespace Nethermind.Blockchain.Receipts
             
             for (int i = 0; i < txReceipts.Length; i++)
             {
-                var txHash = block.Transactions[i].Hash;
-                _transactionDb.Set(txHash, block.Hash.Bytes);
+                if (txReceipts[i].Removed == false)
+                {
+                    var txHash = block.Transactions[i].Hash;
+                    _transactionDb.Set(txHash, block.Hash.Bytes);
+                }
             }
 
             if (blockNumber < MigratedBlockNumber)

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
@@ -210,8 +210,9 @@ namespace Nethermind.Blockchain.Receipts
         public void Insert(Block block, params TxReceipt[] txReceipts)
         {
             txReceipts ??= Array.Empty<TxReceipt>();
+            int txReceiptsLength = txReceipts.Length;
             
-            if (block.Transactions.Length != txReceipts.Length)
+            if (block.Transactions.Length != txReceiptsLength)
             {
                 throw new InvalidDataException(
                     $"Block {block.ToString(Block.Format.FullHashAndNumber)} has different numbers " +
@@ -224,10 +225,10 @@ namespace Nethermind.Blockchain.Receipts
             var spec = _specProvider.GetSpec(blockNumber);
             RlpBehaviors behaviors = spec.IsEip658Enabled ? RlpBehaviors.Eip658Receipts | RlpBehaviors.Storage : RlpBehaviors.Storage;
             _blocksDb.Set(block.Hash, StorageDecoder.Encode(txReceipts, behaviors).Bytes);
-            
-            for (int i = 0; i < txReceipts.Length; i++)
+
+            if (txReceiptsLength > 0 && !txReceipts[0].Removed)
             {
-                if (txReceipts[i].Removed == false)
+                for (int i = 0; i < txReceiptsLength; i++)
                 {
                     var txHash = block.Transactions[i].Hash;
                     _transactionDb.Set(txHash, block.Hash.Bytes);


### PR DESCRIPTION
Resolves #3052

## Changes:

While adding eth_subscribe I added class ReceiptCanonicalityMonitor, which is getting receipts of old blocks (after reorganization), is changing flag "Removed" to true and inserting these changed receipts (and these rollbacked receipts are sended to subscribers).

Inside PersistentReceiptStorage, in method Insert, we are setting in DB reference from tx to block and it was overwritten by removed txs.

I changed it to be overwritten only if flag "Removed" of TxReceipt is false.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No