### PR TITLE
Increase Eth timeout from 3 to 10 seconds

### DIFF
--- a/src/Nethermind/Nethermind.Network/Timeouts.cs
+++ b/src/Nethermind/Nethermind.Network/Timeouts.cs
@@ -22,7 +22,7 @@ namespace Nethermind.Network
     {
         public static readonly TimeSpan InitialConnection = TimeSpan.FromSeconds(2);
         public static readonly TimeSpan TcpClose = TimeSpan.FromSeconds(5);
-        public static readonly TimeSpan Eth = TimeSpan.FromSeconds(3);
+        public static readonly TimeSpan Eth = TimeSpan.FromSeconds(30);
         public static readonly TimeSpan P2PPing = TimeSpan.FromSeconds(3);
         public static readonly TimeSpan P2PHello = TimeSpan.FromSeconds(3);
         public static readonly TimeSpan Eth62Status = TimeSpan.FromSeconds(3);

--- a/src/Nethermind/Nethermind.Network/Timeouts.cs
+++ b/src/Nethermind/Nethermind.Network/Timeouts.cs
@@ -22,7 +22,7 @@ namespace Nethermind.Network
     {
         public static readonly TimeSpan InitialConnection = TimeSpan.FromSeconds(2);
         public static readonly TimeSpan TcpClose = TimeSpan.FromSeconds(5);
-        public static readonly TimeSpan Eth = TimeSpan.FromSeconds(30);
+        public static readonly TimeSpan Eth = TimeSpan.FromSeconds(10);
         public static readonly TimeSpan P2PPing = TimeSpan.FromSeconds(3);
         public static readonly TimeSpan P2PHello = TimeSpan.FromSeconds(3);
         public static readonly TimeSpan Eth62Status = TimeSpan.FromSeconds(3);


### PR DESCRIPTION
## Changes:
Increase timeout for GetHeaders/GetBlock/GetReceipts/GetState to 10s, this helps:
1. When the payload are big and throughput is small
2. When latency gets high

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Other (please describe): 

Increase network timeout

## Testing
**Requires testing**

- [ ] Yes
- [x] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [ ] No