### PR TITLE
Remove pendingHashes from PooledTxsRequestor

### DIFF
--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V65/PooledTxsRequestorTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V65/PooledTxsRequestorTests.cs
@@ -38,31 +38,6 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V65
         
         
         [Test]
-        public void filter_properly_newPooledTxHashes()
-        {
-            _response = new List<Keccak>();
-            _requestor = new PooledTxsRequestor(_txPool);
-            _requestor.RequestTransactions(_doNothing, new List<Keccak>{TestItem.KeccakA, TestItem.KeccakD});
-
-            _request = new List<Keccak>{TestItem.KeccakA, TestItem.KeccakB, TestItem.KeccakC};
-            _expected = new List<Keccak>{TestItem.KeccakB, TestItem.KeccakC};
-            _requestor.RequestTransactions(Send, _request);
-            _response.Should().BeEquivalentTo(_expected);
-        }
-
-        [Test]
-        public void filter_properly_already_pending_hashes()
-        {
-            _response = new List<Keccak>();
-            _requestor = new PooledTxsRequestor(_txPool);
-            _requestor.RequestTransactions(_doNothing, new List<Keccak>{TestItem.KeccakA, TestItem.KeccakB, TestItem.KeccakC});
-            
-            _request = new List<Keccak>{TestItem.KeccakA, TestItem.KeccakB, TestItem.KeccakC};
-            _requestor.RequestTransactions(Send, _request);
-            _response.Should().BeEmpty();
-        }
-        
-        [Test]
         public void filter_properly_discovered_hashes()
         {
             _response = new List<Keccak>();

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/PooledTxsRequestor.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/PooledTxsRequestor.cs
@@ -27,8 +27,6 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V65
     public class PooledTxsRequestor : IPooledTxsRequestor
     {
         private readonly ITxPool _txPool;
-        private readonly LruKeyCache<Keccak> _pendingHashes = new(MemoryAllowance.TxHashCacheSize,
-            Math.Min(1024 * 16, MemoryAllowance.TxHashCacheSize), "pending tx hashes");
 
         public PooledTxsRequestor(ITxPool txPool)
         {
@@ -55,11 +53,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V65
                 Keccak hash = hashes[i];
                 if (!_txPool.IsKnown(hash))
                 {
-                    if (!_pendingHashes.Get(hash))
-                    {
-                        discoveredTxHashes.Add(hash);
-                        _pendingHashes.Set(hash);
-                    }
+                    discoveredTxHashes.Add(hash);
                 }
             }
 


### PR DESCRIPTION
## Changes:
- removes pendingHashes from PooledTxsRequestor
It was added due to eth65 txs policy. In eth65 we are receiving only txs hashes and if we want to receive whole tx, we need to request it. PendingHashes were added to not request multiple times for the same tx. Now, after last changes in TxPool, we have _currentBlockCache (cleared with every block), which is enough and we don't need pendingHashes anymore.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [x] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [x] No