### PR TITLE
Fix `newHeads` subscription

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
@@ -83,7 +83,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             _blockTree.FindHeader(Arg.Any<BlockParameter>(), true).Returns(toBlock);
         }
 
-        private JsonRpcResult GetNewHeadBlockResult(BlockEventArgs blockEventArgs, out string subscriptionId)
+        private JsonRpcResult GetBlockAddedToMainResult(BlockReplacementEventArgs blockReplacementEventArgs, out string subscriptionId)
         {
             NewHeadSubscription newHeadSubscription = new NewHeadSubscription(_jsonRpcDuplexClient, _blockTree, _logManager);
             
@@ -96,7 +96,7 @@ namespace Nethermind.JsonRpc.Test.Modules
                 manualResetEvent.Set();
             }));
             
-            _blockTree.NewHeadBlock += Raise.EventWith(new object(), blockEventArgs);
+            _blockTree.BlockAddedToMain += Raise.EventWith(new object(), blockReplacementEventArgs);
             manualResetEvent.WaitOne(TimeSpan.FromMilliseconds(100));
 
             subscriptionId = newHeadSubscription.Id;
@@ -198,12 +198,12 @@ namespace Nethermind.JsonRpc.Test.Modules
         }
         
         [Test]
-        public void NewHeadSubscription_on_NewHeadBlock_event()
+        public void NewHeadSubscription_on_BlockAddedToMain_event()
         {
             Block block = Build.A.Block.WithDifficulty(1991).WithExtraData(new byte[] {3, 5, 8}).TestObject;
-            BlockEventArgs blockEventArgs = new BlockEventArgs(block);
+            BlockReplacementEventArgs blockReplacementEventArgs = new(block);
 
-            JsonRpcResult jsonRpcResult = GetNewHeadBlockResult(blockEventArgs, out var subscriptionId);
+            JsonRpcResult jsonRpcResult = GetBlockAddedToMainResult(blockReplacementEventArgs, out var subscriptionId);
 
             jsonRpcResult.Response.Should().NotBeNull();
             string serialized = _jsonSerializer.Serialize(jsonRpcResult.Response);
@@ -212,11 +212,11 @@ namespace Nethermind.JsonRpc.Test.Modules
         }
         
         [Test]
-        public void NewHeadSubscription_on_NewHeadBlock_event_with_null_block()
+        public void NewHeadSubscription_on_BlockAddedToMain_event_with_null_block()
         {
-            BlockEventArgs blockEventArgs = new BlockEventArgs(null);
+            BlockReplacementEventArgs blockReplacementEventArgs = new(null);
             
-            JsonRpcResult jsonRpcResult = GetNewHeadBlockResult(blockEventArgs, out _);
+            JsonRpcResult jsonRpcResult = GetBlockAddedToMainResult(blockReplacementEventArgs, out _);
 
             jsonRpcResult.Response.Should().BeNull();
         }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/NewHeadSubscription.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/NewHeadSubscription.cs
@@ -35,11 +35,11 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
             _blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
             _logger = logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
             
-            _blockTree.NewHeadBlock += OnNewHeadBlock;
+            _blockTree.BlockAddedToMain += OnBlockAddedToMain;
             if(_logger.IsTrace) _logger.Trace($"NewHeads subscription {Id} will track NewHeadBlocks");
         }
 
-        private void OnNewHeadBlock(object? sender, BlockEventArgs e)
+        private void OnBlockAddedToMain(object? sender, BlockReplacementEventArgs e)
         {
             Task.Run(() =>
             {
@@ -62,7 +62,7 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
         
         public override void Dispose()
         {
-            _blockTree.NewHeadBlock -= OnNewHeadBlock;
+            _blockTree.BlockAddedToMain -= OnBlockAddedToMain;
             if(_logger.IsTrace) _logger.Trace($"NewHeads subscription {Id} will no longer track NewHeadBlocks");
         }
     }


### PR DESCRIPTION
Resolves #3178

## Changes:
- fix 'newHeads' subscription
We were sending subscriptions with headers when NewHeadBlock event happens. It didn't send new headers after reorgs or when blocks comes quickly one after one. Now we will send subscriptions on every BlockAddedToMain event.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [x] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [ ] No

Tested manually with `newHeads` subscription working simultaneously on Nethermind and on Geth (on Goerli).