### PR TITLE
Increase default MemoryHint in Goerli config

### DIFF
--- a/src/Nethermind/Nethermind.Runner.Test/ConfigFilesTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/ConfigFilesTests.cs
@@ -203,7 +203,7 @@ namespace Nethermind.Runner.Test
         [TestCase("volta archive", 256000000)]
         [TestCase("volta ^archive", 256000000)]
         [TestCase("goerli archive", 768000000)]
-        [TestCase("goerli ^archive", 384000000)]
+        [TestCase("goerli ^archive", 768000000)]
         [TestCase("rinkeby archive", 1536000000)]
         [TestCase("rinkeby ^archive", 1024000000)]
         [TestCase("ropsten archive", 1536000000)]

--- a/src/Nethermind/Nethermind.Runner/configs/goerli.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/goerli.cfg
@@ -8,7 +8,7 @@
     "GenesisHash": "0xbf7e331f7f7c1dd2e05159666b3bf8bc7a8a3a9eb1d518969eab529dd9b88c1a",
     "BaseDbPath": "nethermind_db/goerli",
     "LogFileName": "goerli.logs.txt",
-    "MemoryHint": 384000000
+    "MemoryHint": 768000000
   },
   "Network": {
     "DiscoveryPort": 30303,

--- a/src/Nethermind/Nethermind.Runner/configs/goerli_beam.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/goerli_beam.cfg
@@ -8,7 +8,7 @@
     "GenesisHash": "0xbf7e331f7f7c1dd2e05159666b3bf8bc7a8a3a9eb1d518969eab529dd9b88c1a",
     "BaseDbPath": "nethermind_db/goerli",
     "LogFileName": "goerli_beam.logs.txt",
-    "MemoryHint": 384000000
+    "MemoryHint": 768000000
   },
   "Network": {
     "DiscoveryPort": 30303,


### PR DESCRIPTION
## Changes:
This PR increases default MemoryHint in Goerli config from 384MB to 768MB.

On other testnets it's like:
Ropsten: 1024MB
Rinkeby: 1024MB

I decided to use the 768MB value (same as in Goerli archive config) to not be too radical in increasing, but considered even 1024MB as on other testnets. Do you think 768MB will be the proper value for now? Open for discussion.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Other (please describe): 
changing default config

## Testing
**Requires testing**

- [ ] Yes
- [x] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [x] No