### PR TITLE
Fixes outdated NLog.config.

### DIFF
--- a/src/Nethermind/Nethermind.Runner/NLog.config
+++ b/src/Nethermind/Nethermind.Runner/NLog.config
@@ -62,18 +62,18 @@
         <!-- <logger name="JsonRpc.*" final="true"/> -->
 
         <!-- big chance that you do not like the peers report - you can disable it here -->
-        <!-- <logger name="Synchronization.BeamSync.BeamSyncDb" minlevel="Error" writeTo="file-async"/> -->
-        <!-- <logger name="Synchronization.BeamSync.BeamSyncDb" minlevel="Error" writeTo="auto-colored-console-async"/> -->
-        <!-- <logger name="Synchronization.BeamSync.BeamSyncDb" final="true"/> -->
+        <!-- <logger name="Synchronization.Peers.SyncPeersReport" minlevel="Error" writeTo="file-async"/> -->
+        <!-- <logger name="Synchronization.Peers.SyncPeersReport" minlevel="Error" writeTo="auto-colored-console-async"/> -->
+        <!-- <logger name="Synchronization.Peers.SyncPeersReport" final="true"/> -->
         
         <!-- if sync get stuck this is the best thing to enable the Trace on -->
         <!-- <logger name="Synchronization.ParallelSync.MultiSyncModeSelector" minlevel="Trace" writeTo="file-async"/> -->
         <!-- <logger name="Synchronization.ParallelSync.MultiSyncModeSelector" minlevel="Trace" writeTo="auto-colored-console-async"/> -->
         <!-- <logger name="Synchronization.ParallelSync.MultiSyncModeSelector" final="true"/> -->
 
-      <!-- <logger name="Network.*" minlevel="Trace" writeTo="file-async"/> -->
-      <!-- <logger name="Network.*" minlevel="Trace" writeTo="auto-colored-console-async"/> -->
-      <!-- <logger name="Network.*" final="true"/> -->
+        <!-- <logger name="Network.*" minlevel="Trace" writeTo="file-async"/> -->
+        <!-- <logger name="Network.*" minlevel="Trace" writeTo="auto-colored-console-async"/> -->
+        <!-- <logger name="Network.*" final="true"/> -->
 
         <!-- for a detailed pruning analysis -->
         <!-- <logger name="Trie.*" minlevel="Trace" writeTo="file-async"/> -->


### PR DESCRIPTION
I'm guessing the sync report moved at some point, and the NLog.config was just never updated.

## Changes:
- Corrects sync peer report  in sample NLog.config.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [X] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [X] No

**Comments about testing , should you have some** (optional)
I did run with this change locally and it allowed me to block the sync report, without this change I wasn't able to.