### PR TITLE
Add dynamic metrics and extract RocksDb stats

### DIFF
--- a/src/Nethermind/Nethermind.Config/ConfigProvider.cs
+++ b/src/Nethermind/Nethermind.Config/ConfigProvider.cs
@@ -128,7 +128,6 @@ namespace Nethermind.Config
                 Initialize();
             }
 
-            //var set = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             var propertySet = _instances.Values.SelectMany(i => i.GetType().GetProperties().Select(p => GetKey(i.GetType().Name , p.Name))).ToHashSet(StringComparer.OrdinalIgnoreCase);
 
             List<(IConfigSource Source, string Category, string Name)> incorrectSettings = new();

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
@@ -1,4 +1,4 @@
-﻿//  Copyright (c) 2021 Demerzel Solutions Limited
+//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
 // 
 //  The Nethermind library is free software: you can redistribute it and/or modify
@@ -77,5 +77,9 @@ namespace Nethermind.Db.Rocks.Config
         
         public uint RecycleLogFileNum { get; set; } = 0;
         public bool WriteAheadLogSync { get; set; } = false;
+
+        public bool EnableDbStatistics { get; set; } = false;
+        public bool EnableMetricsUpdater { get; set; } = false;
+        public uint StatsDumpPeriodSec { get; set; } = 600;
     }
 }

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/IDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/IDbConfig.cs
@@ -1,4 +1,4 @@
-﻿//  Copyright (c) 2021 Demerzel Solutions Limited
+//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
 // 
 //  The Nethermind library is free software: you can redistribute it and/or modify
@@ -72,5 +72,17 @@ namespace Nethermind.Db.Rocks.Config
         uint CanonicalHashTrieDbWriteBufferNumber { get; set; }
         ulong CanonicalHashTrieDbBlockCacheSize { get; set; }
         bool CanonicalHashTrieDbCacheIndexAndFilterBlocks { get; set; }
+
+        /// <summary>
+        /// Enables DB Statistics - https://github.com/facebook/rocksdb/wiki/Statistics
+        /// It can has a RocksDB perfomance hit between 5 and 10%.
+        /// </summary>
+        bool EnableDbStatistics { get; set; }
+        bool EnableMetricsUpdater { get; set; }
+        /// <summary>
+        /// If not zero, dump rocksdb.stats to LOG every stats_dump_period_sec
+        /// Default: 600 (10 min)
+        /// </summary>
+        uint StatsDumpPeriodSec { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.Db.Rocks/Statistics/DbMetricsUpdater.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Statistics/DbMetricsUpdater.cs
@@ -80,7 +80,7 @@ namespace Nethermind.Db.Rocks.Statistics
             {
                 foreach (var stat in levelStats)
                 {
-                    Metrics.MetricsDict[$"Db{_dbName}{stat.Name}"] = stat.Value;
+                    Metrics.DbStats[$"{_dbName}Db{stat.Name}"] = stat.Value;
                 }
             }
         }

--- a/src/Nethermind/Nethermind.Db.Rocks/Statistics/DbMetricsUpdater.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Statistics/DbMetricsUpdater.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Nethermind.Db.Rocks.Config;
+using Nethermind.Logging;
+using RocksDbSharp;
+
+namespace Nethermind.Db.Rocks.Statistics
+{
+    public class DbMetricsUpdater
+    {
+        private readonly string _dbName;
+        private readonly DbOptions _dbOptions;
+        private readonly RocksDb _db;
+        private readonly IDbConfig _dbConfig;
+        private readonly ILogger _logger;
+        private Timer? _timer;
+
+        public DbMetricsUpdater(string dbName, DbOptions dbOptions, RocksDb db, IDbConfig dbConfig, ILogger logger)
+        {
+            _dbName = dbName;
+            _dbOptions = dbOptions;
+            _db = db;
+            _dbConfig = dbConfig;
+            _logger = logger;
+        }
+
+        public void StartUpdating()
+        {
+            var offsetInSec = _dbConfig.StatsDumpPeriodSec * 1.1;
+
+            _timer = new Timer(UpdateMetrics, null, TimeSpan.FromSeconds(offsetInSec), TimeSpan.FromSeconds(offsetInSec));
+        }
+
+        private void UpdateMetrics(object? state)
+        {
+            try
+            {
+                var compactionStatsString = _db.GetProperty("rocksdb.stats");
+
+                ProcessCompactionStats(compactionStatsString);
+
+                if (_dbConfig.EnableDbStatistics)
+                {
+                    var dbStatsString = _dbOptions.GetStatisticsString();
+                    // TODO: extract required stats
+                }
+            }
+            catch (Exception exc)
+            {
+                _logger.Error($"Error when updating metrics for {_dbName} database.", exc);
+                // TODO: Maybe we would like to stop the _timer here?
+            }
+        }
+
+        public void ProcessCompactionStats(string compactionStatsString)
+        {
+            if (!string.IsNullOrEmpty(compactionStatsString))
+            {
+                var stats = ExctractStatsPerLevel(compactionStatsString);
+                UpdateMetricsFromList(stats);
+
+                stats = ExctractIntervalCompaction(compactionStatsString);
+                UpdateMetricsFromList(stats);
+            }
+            else
+            {
+                _logger.Warn($"No RocksDB compaction stats available for {_dbName} databse.");
+            }
+        }
+
+        private void UpdateMetricsFromList(List<(string Name, long Value)> levelStats)
+        {
+            if(levelStats != null)
+            {
+                foreach (var stat in levelStats)
+                {
+                    Metrics.MetricsDict[$"Db{_dbName}{stat.Name}"] = stat.Value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Example line:
+        ///   L0      2/0    1.77 MB   0.5      0.0     0.0      0.0       0.4      0.4       0.0   1.0      0.0     44.6      9.83              0.00       386    0.025       0      0
+        /// </summary>
+        private List<(string Name, long Value)> ExctractStatsPerLevel(string compactionStatsDump)
+        {
+            var stats = new List<(string Name, long Value)>(5);
+
+            if (!string.IsNullOrEmpty(compactionStatsDump))
+            {
+                var rgx = new Regex(@"^\s+L(\d+)\s+(\d+)\/(\d+).*$", RegexOptions.Multiline);
+                var matches = rgx.Matches(compactionStatsDump);
+
+                foreach (Match m in matches)
+                {
+                    var level = int.Parse(m.Groups[1].Value);
+                    stats.Add(($"Level{level}Files", int.Parse(m.Groups[2].Value)));
+                    stats.Add(($"Level{level}FilesCompacted", int.Parse(m.Groups[3].Value)));
+                }
+            }
+
+            return stats;
+        }
+
+        /// <summary>
+        /// Example line:
+        /// Interval compaction: 0.00 GB write, 0.00 MB/s write, 0.00 GB read, 0.00 MB/s read, 0.0 seconds
+        /// </summary>
+        private List<(string Name, long Value)> ExctractIntervalCompaction(string compactionStatsDump)
+        {
+            var stats = new List<(string Name, long Value)>(5);
+
+            if (!string.IsNullOrEmpty(compactionStatsDump))
+            {
+                var rgx = new Regex(@"^Interval compaction: (\d+)\.\d+.*GB write.*\s+(\d+)\.\d+.*MB\/s write.*\s+(\d+)\.\d+.*GB read.*\s+(\d+)\.\d+.*MB\/s read.*\s+(\d+)\.\d+.*seconds.*$", RegexOptions.Multiline);
+                var match = rgx.Match(compactionStatsDump);
+
+                if(match != null && match.Success)
+                {
+                    stats.Add(("IntervalCompactionGBWrite", long.Parse(match.Groups[1].Value)));
+                    stats.Add(("IntervalCompactionMBPerSecWrite", long.Parse(match.Groups[2].Value)));
+                    stats.Add(("IntervalCompactionGBRead", long.Parse(match.Groups[3].Value)));
+                    stats.Add(("IntervalCompactionMBPerSecRead", long.Parse(match.Groups[4].Value)));
+                    stats.Add(("IntervalCompactionSeconds", long.Parse(match.Groups[5].Value)));
+                }
+                else
+                {
+                    _logger.Warn($"Cannot find 'Interval compaction' stats for {_dbName} database in the compation stats dump:{Environment.NewLine}{compactionStatsDump}");
+                }
+            }
+
+            return stats;
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Db.Rocks/Statistics/DbMetricsUpdater.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Statistics/DbMetricsUpdater.cs
@@ -41,20 +41,20 @@ namespace Nethermind.Db.Rocks.Statistics
         {
             try
             {
+                // It seems that currently there is no other option with .NET api to extract the compaction statistics than through the dumped string
                 var compactionStatsString = _db.GetProperty("rocksdb.stats");
-
                 ProcessCompactionStats(compactionStatsString);
 
                 if (_dbConfig.EnableDbStatistics)
                 {
                     var dbStatsString = _dbOptions.GetStatisticsString();
-                    // TODO: extract required stats
+                    // Currently we don't extract any DB statistics but we can do it here
                 }
             }
             catch (Exception exc)
             {
                 _logger.Error($"Error when updating metrics for {_dbName} database.", exc);
-                // TODO: Maybe we would like to stop the _timer here?
+                // Maybe we would like to stop the _timer here to avoid logging the same error all over again?
             }
         }
 

--- a/src/Nethermind/Nethermind.Db.Test/DbMetricsUpdaterTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/DbMetricsUpdaterTests.cs
@@ -1,0 +1,117 @@
+//  Copyright (c) 2021 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.IO;
+using Nethermind.Db.Rocks.Statistics;
+using NUnit.Framework;
+using NSubstitute;
+using Nethermind.Logging;
+
+namespace Nethermind.Db.Test
+{
+    public class DbMetricsUpdaterTests
+    {
+        [TearDown]
+        public void TearDow()
+        {
+            Metrics.MetricsDict.Clear();
+        }
+
+        [Test]
+        public void ProcessCompactionStats_AllDataExist()
+        {
+            var logger = Substitute.For<ILogger>();
+
+            var testDump = File.ReadAllText(@"InputFiles/CompactionStatsExample_AllData.txt");
+            new DbMetricsUpdater("Test", null, null, null, logger).ProcessCompactionStats(testDump);
+
+            Assert.AreEqual(11, Metrics.MetricsDict.Count);
+            Assert.AreEqual(2, Metrics.MetricsDict["DbTestLevel0Files"]);
+            Assert.AreEqual(0, Metrics.MetricsDict["DbTestLevel0FilesCompacted"]);
+            Assert.AreEqual(4, Metrics.MetricsDict["DbTestLevel1Files"]);
+            Assert.AreEqual(2, Metrics.MetricsDict["DbTestLevel1FilesCompacted"]);
+            Assert.AreEqual(3, Metrics.MetricsDict["DbTestLevel2Files"]);
+            Assert.AreEqual(1, Metrics.MetricsDict["DbTestLevel2FilesCompacted"]);
+            Assert.AreEqual(10, Metrics.MetricsDict["DbTestIntervalCompactionGBWrite"]);
+            Assert.AreEqual(2, Metrics.MetricsDict["DbTestIntervalCompactionMBPerSecWrite"]);
+            Assert.AreEqual(123, Metrics.MetricsDict["DbTestIntervalCompactionGBRead"]);
+            Assert.AreEqual(0, Metrics.MetricsDict["DbTestIntervalCompactionMBPerSecRead"]);
+            Assert.AreEqual(111, Metrics.MetricsDict["DbTestIntervalCompactionSeconds"]);
+        }
+
+        [Test]
+        public void ProcessCompactionStats_MissingLevels()
+        {
+            var logger = Substitute.For<ILogger>();
+
+            var testDump = File.ReadAllText(@"InputFiles/CompactionStatsExample_MissingLevels.txt");
+            new DbMetricsUpdater("Test", null, null, null, logger).ProcessCompactionStats(testDump);
+
+            Assert.AreEqual(5, Metrics.MetricsDict.Count);
+            Assert.AreEqual(10, Metrics.MetricsDict["DbTestIntervalCompactionGBWrite"]);
+            Assert.AreEqual(2, Metrics.MetricsDict["DbTestIntervalCompactionMBPerSecWrite"]);
+            Assert.AreEqual(123, Metrics.MetricsDict["DbTestIntervalCompactionGBRead"]);
+            Assert.AreEqual(0, Metrics.MetricsDict["DbTestIntervalCompactionMBPerSecRead"]);
+            Assert.AreEqual(111, Metrics.MetricsDict["DbTestIntervalCompactionSeconds"]);
+        }
+
+        [Test]
+        public void ProcessCompactionStats_MissingIntervalCompaction_Warning()
+        {
+            var logger = Substitute.For<ILogger>();
+
+            var testDump = File.ReadAllText(@"InputFiles/CompactionStatsExample_MissingIntervalCompaction.txt");
+            new DbMetricsUpdater("Test", null, null, null, logger).ProcessCompactionStats(testDump);
+
+            Assert.AreEqual(6, Metrics.MetricsDict.Count);
+            Assert.AreEqual(2, Metrics.MetricsDict["DbTestLevel0Files"]);
+            Assert.AreEqual(0, Metrics.MetricsDict["DbTestLevel0FilesCompacted"]);
+            Assert.AreEqual(4, Metrics.MetricsDict["DbTestLevel1Files"]);
+            Assert.AreEqual(2, Metrics.MetricsDict["DbTestLevel1FilesCompacted"]);
+            Assert.AreEqual(3, Metrics.MetricsDict["DbTestLevel2Files"]);
+            Assert.AreEqual(1, Metrics.MetricsDict["DbTestLevel2FilesCompacted"]);
+
+            logger.Received().Warn(Arg.Is<string>(s => s.StartsWith("Cannot find 'Interval compaction' stats for Test database")));
+        }
+
+        [Test]
+        public void ProcessCompactionStats_EmptyDump()
+        {
+            var logger = Substitute.For<ILogger>();
+
+            var testDump = string.Empty;
+            new DbMetricsUpdater("Test", null, null, null, logger).ProcessCompactionStats(testDump);
+
+            Assert.AreEqual(0, Metrics.MetricsDict.Count);
+
+            logger.Received().Warn("No RocksDB compaction stats available for Test databse.");
+        }
+
+        [Test]
+        public void ProcessCompactionStats_NullDump()
+        {
+            var logger = Substitute.For<ILogger>();
+
+            string testDump = null;
+            new DbMetricsUpdater("Test", null, null, null, logger).ProcessCompactionStats(testDump);
+
+            Assert.AreEqual(0, Metrics.MetricsDict.Count);
+
+            logger.Received().Warn("No RocksDB compaction stats available for Test databse.");
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Db.Test/DbMetricsUpdaterTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/DbMetricsUpdaterTests.cs
@@ -28,7 +28,7 @@ namespace Nethermind.Db.Test
         [TearDown]
         public void TearDow()
         {
-            Metrics.MetricsDict.Clear();
+            Metrics.DbStats.Clear();
         }
 
         [Test]
@@ -39,18 +39,18 @@ namespace Nethermind.Db.Test
             var testDump = File.ReadAllText(@"InputFiles/CompactionStatsExample_AllData.txt");
             new DbMetricsUpdater("Test", null, null, null, logger).ProcessCompactionStats(testDump);
 
-            Assert.AreEqual(11, Metrics.MetricsDict.Count);
-            Assert.AreEqual(2, Metrics.MetricsDict["DbTestLevel0Files"]);
-            Assert.AreEqual(0, Metrics.MetricsDict["DbTestLevel0FilesCompacted"]);
-            Assert.AreEqual(4, Metrics.MetricsDict["DbTestLevel1Files"]);
-            Assert.AreEqual(2, Metrics.MetricsDict["DbTestLevel1FilesCompacted"]);
-            Assert.AreEqual(3, Metrics.MetricsDict["DbTestLevel2Files"]);
-            Assert.AreEqual(1, Metrics.MetricsDict["DbTestLevel2FilesCompacted"]);
-            Assert.AreEqual(10, Metrics.MetricsDict["DbTestIntervalCompactionGBWrite"]);
-            Assert.AreEqual(2, Metrics.MetricsDict["DbTestIntervalCompactionMBPerSecWrite"]);
-            Assert.AreEqual(123, Metrics.MetricsDict["DbTestIntervalCompactionGBRead"]);
-            Assert.AreEqual(0, Metrics.MetricsDict["DbTestIntervalCompactionMBPerSecRead"]);
-            Assert.AreEqual(111, Metrics.MetricsDict["DbTestIntervalCompactionSeconds"]);
+            Assert.AreEqual(11, Metrics.DbStats.Count);
+            Assert.AreEqual(2, Metrics.DbStats["DbTestLevel0Files"]);
+            Assert.AreEqual(0, Metrics.DbStats["DbTestLevel0FilesCompacted"]);
+            Assert.AreEqual(4, Metrics.DbStats["DbTestLevel1Files"]);
+            Assert.AreEqual(2, Metrics.DbStats["DbTestLevel1FilesCompacted"]);
+            Assert.AreEqual(3, Metrics.DbStats["DbTestLevel2Files"]);
+            Assert.AreEqual(1, Metrics.DbStats["DbTestLevel2FilesCompacted"]);
+            Assert.AreEqual(10, Metrics.DbStats["DbTestIntervalCompactionGBWrite"]);
+            Assert.AreEqual(2, Metrics.DbStats["DbTestIntervalCompactionMBPerSecWrite"]);
+            Assert.AreEqual(123, Metrics.DbStats["DbTestIntervalCompactionGBRead"]);
+            Assert.AreEqual(0, Metrics.DbStats["DbTestIntervalCompactionMBPerSecRead"]);
+            Assert.AreEqual(111, Metrics.DbStats["DbTestIntervalCompactionSeconds"]);
         }
 
         [Test]
@@ -61,12 +61,12 @@ namespace Nethermind.Db.Test
             var testDump = File.ReadAllText(@"InputFiles/CompactionStatsExample_MissingLevels.txt");
             new DbMetricsUpdater("Test", null, null, null, logger).ProcessCompactionStats(testDump);
 
-            Assert.AreEqual(5, Metrics.MetricsDict.Count);
-            Assert.AreEqual(10, Metrics.MetricsDict["DbTestIntervalCompactionGBWrite"]);
-            Assert.AreEqual(2, Metrics.MetricsDict["DbTestIntervalCompactionMBPerSecWrite"]);
-            Assert.AreEqual(123, Metrics.MetricsDict["DbTestIntervalCompactionGBRead"]);
-            Assert.AreEqual(0, Metrics.MetricsDict["DbTestIntervalCompactionMBPerSecRead"]);
-            Assert.AreEqual(111, Metrics.MetricsDict["DbTestIntervalCompactionSeconds"]);
+            Assert.AreEqual(5, Metrics.DbStats.Count);
+            Assert.AreEqual(10, Metrics.DbStats["DbTestIntervalCompactionGBWrite"]);
+            Assert.AreEqual(2, Metrics.DbStats["DbTestIntervalCompactionMBPerSecWrite"]);
+            Assert.AreEqual(123, Metrics.DbStats["DbTestIntervalCompactionGBRead"]);
+            Assert.AreEqual(0, Metrics.DbStats["DbTestIntervalCompactionMBPerSecRead"]);
+            Assert.AreEqual(111, Metrics.DbStats["DbTestIntervalCompactionSeconds"]);
         }
 
         [Test]
@@ -77,13 +77,13 @@ namespace Nethermind.Db.Test
             var testDump = File.ReadAllText(@"InputFiles/CompactionStatsExample_MissingIntervalCompaction.txt");
             new DbMetricsUpdater("Test", null, null, null, logger).ProcessCompactionStats(testDump);
 
-            Assert.AreEqual(6, Metrics.MetricsDict.Count);
-            Assert.AreEqual(2, Metrics.MetricsDict["DbTestLevel0Files"]);
-            Assert.AreEqual(0, Metrics.MetricsDict["DbTestLevel0FilesCompacted"]);
-            Assert.AreEqual(4, Metrics.MetricsDict["DbTestLevel1Files"]);
-            Assert.AreEqual(2, Metrics.MetricsDict["DbTestLevel1FilesCompacted"]);
-            Assert.AreEqual(3, Metrics.MetricsDict["DbTestLevel2Files"]);
-            Assert.AreEqual(1, Metrics.MetricsDict["DbTestLevel2FilesCompacted"]);
+            Assert.AreEqual(6, Metrics.DbStats.Count);
+            Assert.AreEqual(2, Metrics.DbStats["DbTestLevel0Files"]);
+            Assert.AreEqual(0, Metrics.DbStats["DbTestLevel0FilesCompacted"]);
+            Assert.AreEqual(4, Metrics.DbStats["DbTestLevel1Files"]);
+            Assert.AreEqual(2, Metrics.DbStats["DbTestLevel1FilesCompacted"]);
+            Assert.AreEqual(3, Metrics.DbStats["DbTestLevel2Files"]);
+            Assert.AreEqual(1, Metrics.DbStats["DbTestLevel2FilesCompacted"]);
 
             logger.Received().Warn(Arg.Is<string>(s => s.StartsWith("Cannot find 'Interval compaction' stats for Test database")));
         }
@@ -96,7 +96,7 @@ namespace Nethermind.Db.Test
             var testDump = string.Empty;
             new DbMetricsUpdater("Test", null, null, null, logger).ProcessCompactionStats(testDump);
 
-            Assert.AreEqual(0, Metrics.MetricsDict.Count);
+            Assert.AreEqual(0, Metrics.DbStats.Count);
 
             logger.Received().Warn("No RocksDB compaction stats available for Test databse.");
         }
@@ -109,7 +109,7 @@ namespace Nethermind.Db.Test
             string testDump = null;
             new DbMetricsUpdater("Test", null, null, null, logger).ProcessCompactionStats(testDump);
 
-            Assert.AreEqual(0, Metrics.MetricsDict.Count);
+            Assert.AreEqual(0, Metrics.DbStats.Count);
 
             logger.Received().Warn("No RocksDB compaction stats available for Test databse.");
         }

--- a/src/Nethermind/Nethermind.Db.Test/InputFiles/CompactionStatsExample_AllData.txt
+++ b/src/Nethermind/Nethermind.Db.Test/InputFiles/CompactionStatsExample_AllData.txt
@@ -1,0 +1,89 @@
+﻿
+** Compaction Stats [default] **
+Level    Files   Size     Score Read(GB)  Rn(GB) Rnp1(GB) Write(GB) Wnew(GB) Moved(GB) W-Amp Rd(MB/s) Wr(MB/s) Comp(sec) CompMergeCPU(sec) Comp(cnt) Avg(sec) KeyIn KeyDrop
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  L0      2/0    1.77 MB   0.5      0.0     0.0      0.0       0.4      0.4       0.0   1.0      0.0     44.6      9.83              0.00       386    0.025       0      0
+  L1      4/2   246.86 MB   1.0     16.6     0.4     16.2      16.6      0.4       0.0  38.9     69.7     69.7    243.72              0.00        96    2.539     39M      0
+  L2      3/1   193.22 MB   0.1      0.0     0.0      0.0       0.0      0.0       0.2   0.0      0.0      0.0      0.00              0.00         0    0.000       0      0
+ Sum      9/0   441.84 MB   0.0     16.6     0.4     16.2      17.0      0.9       0.2  39.8     67.0     68.7    253.55              0.00       482    0.526     39M      0
+ Int      0/0    0.00 KB   0.0      0.0     0.0      0.0       0.0      0.0       0.0   0.0      0.0      0.0      0.00              0.00         0    0.000       0      0
+
+** Compaction Stats [default] **
+Priority    Files   Size     Score Read(GB)  Rn(GB) Rnp1(GB) Write(GB) Wnew(GB) Moved(GB) W-Amp Rd(MB/s) Wr(MB/s) Comp(sec) CompMergeCPU(sec) Comp(cnt) Avg(sec) KeyIn KeyDrop
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Low      0/0    0.00 KB   0.0     16.6     0.4     16.2      16.6      0.4       0.0   0.0     69.7     69.7    243.72              0.00        96    2.539     39M      0
+High      0/0    0.00 KB   0.0      0.0     0.0      0.0       0.4      0.4       0.0   0.0      0.0     44.6      9.83              0.00       386    0.025       0      0
+Uptime(secs): 1854.6 total, 3.4 interval
+Flush(GB): cumulative 0.428, interval 0.000
+AddFile(GB): cumulative 0.000, interval 0.000
+AddFile(Total Files): cumulative 0, interval 0
+AddFile(L0 Files): cumulative 0, interval 0
+AddFile(Keys): cumulative 0, interval 0
+Cumulative compaction: 17.01 GB write, 9.39 MB/s write, 16.58 GB read, 9.16 MB/s read, 253.5 seconds
+Interval compaction: 10.77 GB write, 2.22 MB/s write, 123.66 GB read, 0.80 MB/s read, 111.45 seconds
+Stalls(count): 0 level0_slowdown, 0 level0_slowdown_with_compaction, 0 level0_numfiles, 0 level0_numfiles_with_compaction, 0 stop for pending_compaction_bytes, 0 slowdown for pending_compaction_bytes, 0 memtable_compaction, 0 memtable_slowdown, interval 0 total count
+
+** File Read Latency Histogram By Level [default] **
+** Level 0 read latency histogram (micros):
+Count: 46765 Average: 11.2629  StdDev: 26.78
+Min: 3  Median: 8.5501  Max: 1780
+Percentiles: P50: 8.55 P75: 10.82 P99: 33.93 P99.9: 342.35 P99.99: 1263.64
+------------------------------------------------------
+(       2,       3 ]       68   0.145%   0.145% 
+(       3,       4 ]      386   0.825%   0.971% 
+(       4,       6 ]     4813  10.292%  11.263% ##
+(       6,      10 ]    28415  60.761%  72.024% ############
+(      10,      15 ]     8457  18.084%  90.108% ####
+(      15,      22 ]     3186   6.813%  96.921% #
+(      22,      34 ]      978   2.091%  99.012% 
+(      34,      51 ]      192   0.411%  99.423% 
+(      51,      76 ]       73   0.156%  99.579% 
+(      76,     110 ]       48   0.103%  99.681% 
+(     110,     170 ]       64   0.137%  99.818% 
+(     170,     250 ]       29   0.062%  99.880% 
+(     250,     380 ]       13   0.028%  99.908% 
+(     380,     580 ]       12   0.026%  99.934% 
+(     580,     870 ]       19   0.041%  99.974% 
+(     870,    1300 ]        8   0.017%  99.991% 
+(    1300,    1900 ]        4   0.009% 100.000% 
+
+** Level 1 read latency histogram (micros):
+Count: 1556804 Average: 9.8775  StdDev: 74.86
+Min: 3  Median: 7.3886  Max: 58648
+Percentiles: P50: 7.39 P75: 9.50 P99: 61.79 P99.9: 186.55 P99.99: 1079.27
+------------------------------------------------------
+(       2,       3 ]       49   0.003%   0.003% 
+(       3,       4 ]     1784   0.115%   0.118% 
+(       4,       6 ]   520031  33.404%  33.521% #######
+(       6,      10 ]   739007  47.469%  80.991% #########
+(      10,      15 ]   200493  12.878%  93.869% ###
+(      15,      22 ]    55855   3.588%  97.457% #
+(      22,      34 ]    14505   0.932%  98.389% 
+(      34,      51 ]     4582   0.294%  98.683% 
+(      51,      76 ]    11419   0.733%  99.417% 
+(      76,     110 ]     4050   0.260%  99.677% 
+(     110,     170 ]     3311   0.213%  99.890% 
+(     170,     250 ]      779   0.050%  99.940% 
+(     250,     380 ]      276   0.018%  99.957% 
+(     380,     580 ]      229   0.015%  99.972% 
+(     580,     870 ]      217   0.014%  99.986% 
+(     870,    1300 ]      126   0.008%  99.994% 
+(    1300,    1900 ]       56   0.004%  99.998% 
+(    1900,    2900 ]       17   0.001%  99.999% 
+(    2900,    4400 ]        5   0.000%  99.999% 
+(    4400,    6600 ]        1   0.000%  99.999% 
+(    6600,    9900 ]        5   0.000% 100.000% 
+(    9900,   14000 ]        3   0.000% 100.000% 
+(   14000,   22000 ]        1   0.000% 100.000% 
+(   22000,   33000 ]        1   0.000% 100.000% 
+(   50000,   75000 ]        2   0.000% 100.000% 
+
+
+** DB Stats **
+Uptime(secs): 1854.6 total, 3.4 interval
+Cumulative writes: 1106K writes, 1106K keys, 1101K commit groups, 1.0 writes per commit group, ingest: 0.67 GB, 0.37 MB/s
+Cumulative WAL: 1106K writes, 0 syncs, 1106495.00 writes per sync, written: 0.67 GB, 0.37 MB/s
+Cumulative stall: 00:00:0.000 H:M:S, 0.0 percent
+Interval writes: 1 writes, 1 keys, 1 commit groups, 0.5 writes per commit group, ingest: 0.00 MB, 0.00 MB/s
+Interval WAL: 1 writes, 0 syncs, 1.00 writes per sync, written: 0.00 MB, 0.00 MB/s
+Interval stall: 00:00:0.000 H:M:S, 0.0 percent

--- a/src/Nethermind/Nethermind.Db.Test/InputFiles/CompactionStatsExample_MissingIntervalCompaction.txt
+++ b/src/Nethermind/Nethermind.Db.Test/InputFiles/CompactionStatsExample_MissingIntervalCompaction.txt
@@ -1,0 +1,88 @@
+﻿
+** Compaction Stats [default] **
+Level    Files   Size     Score Read(GB)  Rn(GB) Rnp1(GB) Write(GB) Wnew(GB) Moved(GB) W-Amp Rd(MB/s) Wr(MB/s) Comp(sec) CompMergeCPU(sec) Comp(cnt) Avg(sec) KeyIn KeyDrop
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  L0      2/0    1.77 MB   0.5      0.0     0.0      0.0       0.4      0.4       0.0   1.0      0.0     44.6      9.83              0.00       386    0.025       0      0
+  L1      4/2   246.86 MB   1.0     16.6     0.4     16.2      16.6      0.4       0.0  38.9     69.7     69.7    243.72              0.00        96    2.539     39M      0
+  L2      3/1   193.22 MB   0.1      0.0     0.0      0.0       0.0      0.0       0.2   0.0      0.0      0.0      0.00              0.00         0    0.000       0      0
+ Sum      9/0   441.84 MB   0.0     16.6     0.4     16.2      17.0      0.9       0.2  39.8     67.0     68.7    253.55              0.00       482    0.526     39M      0
+ Int      0/0    0.00 KB   0.0      0.0     0.0      0.0       0.0      0.0       0.0   0.0      0.0      0.0      0.00              0.00         0    0.000       0      0
+
+** Compaction Stats [default] **
+Priority    Files   Size     Score Read(GB)  Rn(GB) Rnp1(GB) Write(GB) Wnew(GB) Moved(GB) W-Amp Rd(MB/s) Wr(MB/s) Comp(sec) CompMergeCPU(sec) Comp(cnt) Avg(sec) KeyIn KeyDrop
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Low      0/0    0.00 KB   0.0     16.6     0.4     16.2      16.6      0.4       0.0   0.0     69.7     69.7    243.72              0.00        96    2.539     39M      0
+High      0/0    0.00 KB   0.0      0.0     0.0      0.0       0.4      0.4       0.0   0.0      0.0     44.6      9.83              0.00       386    0.025       0      0
+Uptime(secs): 1854.6 total, 3.4 interval
+Flush(GB): cumulative 0.428, interval 0.000
+AddFile(GB): cumulative 0.000, interval 0.000
+AddFile(Total Files): cumulative 0, interval 0
+AddFile(L0 Files): cumulative 0, interval 0
+AddFile(Keys): cumulative 0, interval 0
+Cumulative compaction: 17.01 GB write, 9.39 MB/s write, 16.58 GB read, 9.16 MB/s read, 253.5 seconds
+Stalls(count): 0 level0_slowdown, 0 level0_slowdown_with_compaction, 0 level0_numfiles, 0 level0_numfiles_with_compaction, 0 stop for pending_compaction_bytes, 0 slowdown for pending_compaction_bytes, 0 memtable_compaction, 0 memtable_slowdown, interval 0 total count
+
+** File Read Latency Histogram By Level [default] **
+** Level 0 read latency histogram (micros):
+Count: 46765 Average: 11.2629  StdDev: 26.78
+Min: 3  Median: 8.5501  Max: 1780
+Percentiles: P50: 8.55 P75: 10.82 P99: 33.93 P99.9: 342.35 P99.99: 1263.64
+------------------------------------------------------
+(       2,       3 ]       68   0.145%   0.145% 
+(       3,       4 ]      386   0.825%   0.971% 
+(       4,       6 ]     4813  10.292%  11.263% ##
+(       6,      10 ]    28415  60.761%  72.024% ############
+(      10,      15 ]     8457  18.084%  90.108% ####
+(      15,      22 ]     3186   6.813%  96.921% #
+(      22,      34 ]      978   2.091%  99.012% 
+(      34,      51 ]      192   0.411%  99.423% 
+(      51,      76 ]       73   0.156%  99.579% 
+(      76,     110 ]       48   0.103%  99.681% 
+(     110,     170 ]       64   0.137%  99.818% 
+(     170,     250 ]       29   0.062%  99.880% 
+(     250,     380 ]       13   0.028%  99.908% 
+(     380,     580 ]       12   0.026%  99.934% 
+(     580,     870 ]       19   0.041%  99.974% 
+(     870,    1300 ]        8   0.017%  99.991% 
+(    1300,    1900 ]        4   0.009% 100.000% 
+
+** Level 1 read latency histogram (micros):
+Count: 1556804 Average: 9.8775  StdDev: 74.86
+Min: 3  Median: 7.3886  Max: 58648
+Percentiles: P50: 7.39 P75: 9.50 P99: 61.79 P99.9: 186.55 P99.99: 1079.27
+------------------------------------------------------
+(       2,       3 ]       49   0.003%   0.003% 
+(       3,       4 ]     1784   0.115%   0.118% 
+(       4,       6 ]   520031  33.404%  33.521% #######
+(       6,      10 ]   739007  47.469%  80.991% #########
+(      10,      15 ]   200493  12.878%  93.869% ###
+(      15,      22 ]    55855   3.588%  97.457% #
+(      22,      34 ]    14505   0.932%  98.389% 
+(      34,      51 ]     4582   0.294%  98.683% 
+(      51,      76 ]    11419   0.733%  99.417% 
+(      76,     110 ]     4050   0.260%  99.677% 
+(     110,     170 ]     3311   0.213%  99.890% 
+(     170,     250 ]      779   0.050%  99.940% 
+(     250,     380 ]      276   0.018%  99.957% 
+(     380,     580 ]      229   0.015%  99.972% 
+(     580,     870 ]      217   0.014%  99.986% 
+(     870,    1300 ]      126   0.008%  99.994% 
+(    1300,    1900 ]       56   0.004%  99.998% 
+(    1900,    2900 ]       17   0.001%  99.999% 
+(    2900,    4400 ]        5   0.000%  99.999% 
+(    4400,    6600 ]        1   0.000%  99.999% 
+(    6600,    9900 ]        5   0.000% 100.000% 
+(    9900,   14000 ]        3   0.000% 100.000% 
+(   14000,   22000 ]        1   0.000% 100.000% 
+(   22000,   33000 ]        1   0.000% 100.000% 
+(   50000,   75000 ]        2   0.000% 100.000% 
+
+
+** DB Stats **
+Uptime(secs): 1854.6 total, 3.4 interval
+Cumulative writes: 1106K writes, 1106K keys, 1101K commit groups, 1.0 writes per commit group, ingest: 0.67 GB, 0.37 MB/s
+Cumulative WAL: 1106K writes, 0 syncs, 1106495.00 writes per sync, written: 0.67 GB, 0.37 MB/s
+Cumulative stall: 00:00:0.000 H:M:S, 0.0 percent
+Interval writes: 1 writes, 1 keys, 1 commit groups, 0.5 writes per commit group, ingest: 0.00 MB, 0.00 MB/s
+Interval WAL: 1 writes, 0 syncs, 1.00 writes per sync, written: 0.00 MB, 0.00 MB/s
+Interval stall: 00:00:0.000 H:M:S, 0.0 percent

--- a/src/Nethermind/Nethermind.Db.Test/InputFiles/CompactionStatsExample_MissingLevels.txt
+++ b/src/Nethermind/Nethermind.Db.Test/InputFiles/CompactionStatsExample_MissingLevels.txt
@@ -1,0 +1,86 @@
+﻿
+** Compaction Stats [default] **
+Level    Files   Size     Score Read(GB)  Rn(GB) Rnp1(GB) Write(GB) Wnew(GB) Moved(GB) W-Amp Rd(MB/s) Wr(MB/s) Comp(sec) CompMergeCPU(sec) Comp(cnt) Avg(sec) KeyIn KeyDrop
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sum      0/0    0.00 KB   0.0      0.0     0.0      0.0       0.0      0.0       0.0   0.0      0.0      0.0      0.00              0.00         0    0.000       0      0
+ Int      0/0    0.00 KB   0.0      0.0     0.0      0.0       0.0      0.0       0.0   0.0      0.0      0.0      0.00              0.00         0    0.000       0      0
+
+** Compaction Stats [default] **
+Priority    Files   Size     Score Read(GB)  Rn(GB) Rnp1(GB) Write(GB) Wnew(GB) Moved(GB) W-Amp Rd(MB/s) Wr(MB/s) Comp(sec) CompMergeCPU(sec) Comp(cnt) Avg(sec) KeyIn KeyDrop
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Low      0/0    0.00 KB   0.0     16.6     0.4     16.2      16.6      0.4       0.0   0.0     69.7     69.7    243.72              0.00        96    2.539     39M      0
+High      0/0    0.00 KB   0.0      0.0     0.0      0.0       0.4      0.4       0.0   0.0      0.0     44.6      9.83              0.00       386    0.025       0      0
+Uptime(secs): 1854.6 total, 3.4 interval
+Flush(GB): cumulative 0.428, interval 0.000
+AddFile(GB): cumulative 0.000, interval 0.000
+AddFile(Total Files): cumulative 0, interval 0
+AddFile(L0 Files): cumulative 0, interval 0
+AddFile(Keys): cumulative 0, interval 0
+Cumulative compaction: 17.01 GB write, 9.39 MB/s write, 16.58 GB read, 9.16 MB/s read, 253.5 seconds
+Interval compaction: 10.77 GB write, 2.22 MB/s write, 123.66 GB read, 0.80 MB/s read, 111.45 seconds
+Stalls(count): 0 level0_slowdown, 0 level0_slowdown_with_compaction, 0 level0_numfiles, 0 level0_numfiles_with_compaction, 0 stop for pending_compaction_bytes, 0 slowdown for pending_compaction_bytes, 0 memtable_compaction, 0 memtable_slowdown, interval 0 total count
+
+** File Read Latency Histogram By Level [default] **
+** Level 0 read latency histogram (micros):
+Count: 46765 Average: 11.2629  StdDev: 26.78
+Min: 3  Median: 8.5501  Max: 1780
+Percentiles: P50: 8.55 P75: 10.82 P99: 33.93 P99.9: 342.35 P99.99: 1263.64
+------------------------------------------------------
+(       2,       3 ]       68   0.145%   0.145% 
+(       3,       4 ]      386   0.825%   0.971% 
+(       4,       6 ]     4813  10.292%  11.263% ##
+(       6,      10 ]    28415  60.761%  72.024% ############
+(      10,      15 ]     8457  18.084%  90.108% ####
+(      15,      22 ]     3186   6.813%  96.921% #
+(      22,      34 ]      978   2.091%  99.012% 
+(      34,      51 ]      192   0.411%  99.423% 
+(      51,      76 ]       73   0.156%  99.579% 
+(      76,     110 ]       48   0.103%  99.681% 
+(     110,     170 ]       64   0.137%  99.818% 
+(     170,     250 ]       29   0.062%  99.880% 
+(     250,     380 ]       13   0.028%  99.908% 
+(     380,     580 ]       12   0.026%  99.934% 
+(     580,     870 ]       19   0.041%  99.974% 
+(     870,    1300 ]        8   0.017%  99.991% 
+(    1300,    1900 ]        4   0.009% 100.000% 
+
+** Level 1 read latency histogram (micros):
+Count: 1556804 Average: 9.8775  StdDev: 74.86
+Min: 3  Median: 7.3886  Max: 58648
+Percentiles: P50: 7.39 P75: 9.50 P99: 61.79 P99.9: 186.55 P99.99: 1079.27
+------------------------------------------------------
+(       2,       3 ]       49   0.003%   0.003% 
+(       3,       4 ]     1784   0.115%   0.118% 
+(       4,       6 ]   520031  33.404%  33.521% #######
+(       6,      10 ]   739007  47.469%  80.991% #########
+(      10,      15 ]   200493  12.878%  93.869% ###
+(      15,      22 ]    55855   3.588%  97.457% #
+(      22,      34 ]    14505   0.932%  98.389% 
+(      34,      51 ]     4582   0.294%  98.683% 
+(      51,      76 ]    11419   0.733%  99.417% 
+(      76,     110 ]     4050   0.260%  99.677% 
+(     110,     170 ]     3311   0.213%  99.890% 
+(     170,     250 ]      779   0.050%  99.940% 
+(     250,     380 ]      276   0.018%  99.957% 
+(     380,     580 ]      229   0.015%  99.972% 
+(     580,     870 ]      217   0.014%  99.986% 
+(     870,    1300 ]      126   0.008%  99.994% 
+(    1300,    1900 ]       56   0.004%  99.998% 
+(    1900,    2900 ]       17   0.001%  99.999% 
+(    2900,    4400 ]        5   0.000%  99.999% 
+(    4400,    6600 ]        1   0.000%  99.999% 
+(    6600,    9900 ]        5   0.000% 100.000% 
+(    9900,   14000 ]        3   0.000% 100.000% 
+(   14000,   22000 ]        1   0.000% 100.000% 
+(   22000,   33000 ]        1   0.000% 100.000% 
+(   50000,   75000 ]        2   0.000% 100.000% 
+
+
+** DB Stats **
+Uptime(secs): 1854.6 total, 3.4 interval
+Cumulative writes: 1106K writes, 1106K keys, 1101K commit groups, 1.0 writes per commit group, ingest: 0.67 GB, 0.37 MB/s
+Cumulative WAL: 1106K writes, 0 syncs, 1106495.00 writes per sync, written: 0.67 GB, 0.37 MB/s
+Cumulative stall: 00:00:0.000 H:M:S, 0.0 percent
+Interval writes: 1 writes, 1 keys, 1 commit groups, 0.5 writes per commit group, ingest: 0.00 MB, 0.00 MB/s
+Interval WAL: 1 writes, 0 syncs, 1.00 writes per sync, written: 0.00 MB, 0.00 MB/s
+Interval stall: 00:00:0.000 H:M:S, 0.0 percent

--- a/src/Nethermind/Nethermind.Db.Test/Nethermind.Db.Test.csproj
+++ b/src/Nethermind/Nethermind.Db.Test/Nethermind.Db.Test.csproj
@@ -23,4 +23,15 @@
     <ProjectReference Include="..\Nethermind.Db.Rpc\Nethermind.Db.Rpc.csproj" />
     <ProjectReference Include="..\Nethermind.Db\Nethermind.Db.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <None Update="InputFiles\CompactionStatsExample_MissingIntervalCompaction.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="InputFiles\CompactionStatsExample_MissingLevels.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="InputFiles\CompactionStatsExample_AllData.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/src/Nethermind/Nethermind.Db/Metrics.cs
+++ b/src/Nethermind/Nethermind.Db/Metrics.cs
@@ -14,6 +14,8 @@
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.ComponentModel;
 
 namespace Nethermind.Db
@@ -91,5 +93,8 @@ namespace Nethermind.Db
         
         [Description("Number of Witness DB writes.")]
         public static long WitnessDbWrites { get; set; }
+
+        [Description("test.")]
+        public static ConcurrentDictionary<string, long> MetricsDict { get; set; } = new ConcurrentDictionary<string, long>();
     }
 } 

--- a/src/Nethermind/Nethermind.Db/Metrics.cs
+++ b/src/Nethermind/Nethermind.Db/Metrics.cs
@@ -94,7 +94,7 @@ namespace Nethermind.Db
         [Description("Number of Witness DB writes.")]
         public static long WitnessDbWrites { get; set; }
 
-        [Description("test.")]
-        public static ConcurrentDictionary<string, long> MetricsDict { get; set; } = new ConcurrentDictionary<string, long>();
+        [Description("Metrics extracted from RocksDB Compacion Stats and DB Statistics")]
+        public static IDictionary<string, long> DbStats { get; set; } = new ConcurrentDictionary<string, long>();
     }
 } 

--- a/src/Nethermind/Nethermind.Runner/configs/goerli.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/goerli.cfg
@@ -25,7 +25,9 @@
     "Size": 1024
   },
   "Db": {
-    "CacheIndexAndFilterBlocks": false
+    "CacheIndexAndFilterBlocks": false,
+    "EnableMetricsUpdater": true,
+    "EnableDbStatistics": false
   },
   "Sync": {
     "FastSync": true,


### PR DESCRIPTION
## Changes:
- Nethermind.Db.Metrics has been extended with a dictionary that stores dynamic metrics that can be added online
- Multiple DB Config settings has been added to configure stats processing
- We can now extract Compaction stats and Database Stats from RocksDb

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No
