### PR TITLE
Fix replacing 1559 transactions

### DIFF
--- a/src/Nethermind/Nethermind.TxPool/Comparison/CompareReplacedTxByFee.cs
+++ b/src/Nethermind/Nethermind.TxPool/Comparison/CompareReplacedTxByFee.cs
@@ -39,17 +39,12 @@ namespace Nethermind.TxPool.Comparison
             if (ReferenceEquals(x, y)) return 0;
             if (ReferenceEquals(null, y)) return 1;
             if (ReferenceEquals(null, x)) return -1;
-            
-            // if gas bottleneck was calculated, it's highest priority for sorting
-            // if not, different method of sorting by gas price is needed
-            if (x.GasBottleneck != 0 || y.GasBottleneck != 0)
-            {
-                y.GasBottleneck.Divide(PartOfFeeRequiredToIncrease, out UInt256 bumpGasBottleneck);
-                return (y.GasBottleneck + bumpGasBottleneck).CompareTo(x.GasBottleneck);
-            }
-            
-            y.GasPrice.Divide(10, out UInt256 bumpGasPrice);
-            return (y.GasPrice + bumpGasPrice).CompareTo(x.GasPrice);
+
+            y.MaxFeePerGas.Divide(PartOfFeeRequiredToIncrease, out UInt256 bumpMaxFeePerGas);
+            if (y.MaxFeePerGas + bumpMaxFeePerGas > x.MaxFeePerGas) return 1;
+
+            y.MaxPriorityFeePerGas.Divide(PartOfFeeRequiredToIncrease, out UInt256 bumpMaxPriorityFeePerGas);
+            return (y.MaxPriorityFeePerGas + bumpMaxPriorityFeePerGas).CompareTo(x.MaxPriorityFeePerGas);
         }
 
     }


### PR DESCRIPTION
## Changes:
- adjusting transaction replacement comparator to work with 1559 txs. Now both MaxFeePerGas and MaxPriorityFeePerGas of new tx need to be higher by at least 10% than old ones to successfully replace transaction with the same SenderAddress and nonce.
This solution is compatible with Legacy txs as well.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No