### PR TITLE
Fix revert error

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/TransactionSubstateTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/TransactionSubstateTests.cs
@@ -1,0 +1,60 @@
+//  Copyright (c) 2021 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
+
+using System;
+using FluentAssertions;
+using Nethermind.Core;
+using NUnit.Framework;
+
+namespace Nethermind.Evm.Test
+{
+    public class TransactionSubstateTests
+    {
+        [Test]
+        public void should_return_proper_revert_error_when_there_is_no_exception()
+        {
+            byte[] data = {0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x20,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x5,
+                0x05, 0x06, 0x07, 0x08, 0x09};
+            ReadOnlyMemory<byte> readOnlyMemory = new(data);
+            TransactionSubstate transactionSubstate = new(readOnlyMemory,
+                0,
+                new ArraySegment<Address>(),
+                new LogEntry[] {},
+                true,
+                true);
+            transactionSubstate.Error.Should().Be("Reverted 0x0506070809");
+        }
+        
+        [Test]
+        public void should_return_proper_revert_error_when_there_is_exception()
+        {
+            byte[] data = {0x05, 0x06, 0x07, 0x08, 0x09};
+            ReadOnlyMemory<byte> readOnlyMemory = new(data);
+            TransactionSubstate transactionSubstate = new(readOnlyMemory,
+                0,
+                new ArraySegment<Address>(),
+                new LogEntry[] {},
+                true,
+                true);
+            transactionSubstate.Error.Should().Be("Reverted 0x0506070809");
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Evm/TransactionSubstate.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionSubstate.cs
@@ -17,7 +17,6 @@
 using System;
 using System.Collections.Generic;
 using System.Numerics;
-using System.Text;
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
 
@@ -65,13 +64,14 @@ namespace Nethermind.Evm
                         {
                             BigInteger start = Output.Span.Slice(4, 32).ToUnsignedBigInteger();
                             BigInteger length = Output.Slice((int) start + 4, 32).Span.ToUnsignedBigInteger();
-                            Error = "revert: " + Encoding.ASCII.GetString(Output.Slice((int) start + 32 + 4, (int) length).Span);
+                            Error = string.Concat("Reverted ",
+                                Output.Slice((int)start + 32 + 4, (int)length).ToArray().ToHexString(true));
                         }
                         catch (Exception)
                         {
                             try
                             {
-                                Error = "revert: " + Output.ToArray().ToHexString(true);
+                                Error = string.Concat("Reverted ", Output.ToArray().ToHexString(true));
                             }
                             catch
                             {


### PR DESCRIPTION
Resolves #3207

## Changes:
- converting from byte array to string
Encoding.ASCII.GetString were returning whitespaces instead of proper values. Changed it to simple .ToHexString.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No