### PR TITLE
Fix incorrect config valiation

### DIFF
--- a/src/Nethermind/Nethermind.Config.Test/ConfigProvider_FindIncorrectSettings_Tests.cs
+++ b/src/Nethermind/Nethermind.Config.Test/ConfigProvider_FindIncorrectSettings_Tests.cs
@@ -15,14 +15,7 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
-using Nethermind.Core.Extensions;
-using Nethermind.JsonRpc;
-using Nethermind.KeyStore.Config;
-using Nethermind.Network.Config;
-using Nethermind.Stats;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -41,7 +34,9 @@ namespace Nethermind.Config.Test
             env.GetEnvironmentVariables().Returns(new Dictionary<string, string>() { { "NETHERMIND_NETWORKCONFIG_MAXCANDIDATEPEERCOUNT", "500" } });
             var envSource = new EnvConfigSource(env);
 
-            var argsSource = new ArgsConfigSource(new Dictionary<string, string>() { { "DiscoveryConfig.BucketSize", "10" }, { "NetworkConfig.DiscoveryPort", "30301" } });
+            var argsSource = new ArgsConfigSource(new Dictionary<string, string>() { 
+                { "DiscoveryConfig.BucketSize", "10" }, 
+                { "NetworkConfig.DiscoveryPort", "30301" } });
 
             var configProvider = new ConfigProvider();
             configProvider.AddSource(jsonSource);
@@ -57,42 +52,33 @@ namespace Nethermind.Config.Test
         }
 
         [Test]
-        public void SettingWithTypos()
-        {
-            var jsonSource = new JsonConfigSource("SampleJson/ConfigWithTypos.cfg");
-
-            var env = Substitute.For<IEnvironment>();
-            env.GetEnvironmentVariables().Returns(new Dictionary<string, string>() { { "NETHERMIND_NETWORKCONFIG_MAXCANDIDATEPERCOUNT", "500" } });
-            var envSource = new EnvConfigSource(env);
-
-            var argsSource = new ArgsConfigSource(new Dictionary<string, string>() { { "DiscoveryConfig.BucketSize", "10" }, { "NetworkConfig.DiscoverPort", "30301" }, { "Network.P2PPort", "30301" } });
-
-            var configProvider = new ConfigProvider();
-            configProvider.AddSource(jsonSource);
-            configProvider.AddSource(envSource);
-            configProvider.AddSource(argsSource);
-
-            configProvider.Initialize();
-
-            var res = configProvider.FindIncorrectSettings();
-
-            Assert.AreEqual(5, res.Errors.Count);
-            Assert.AreEqual("Concurrenc", res.Errors[0].Name);
-            Assert.AreEqual("BlomConfig", res.Errors[1].Category);
-            Assert.AreEqual("MAXCANDIDATEPERCOUNT", res.Errors[2].Name);
-            Assert.AreEqual("DiscoverPort", res.Errors[3].Name);
-            Assert.AreEqual("Network", res.Errors[4].Category);
-            Assert.AreEqual($"Nethermind.Config.JsonConfigSource:DiscoveRyConfig:Concurrenc{Environment.NewLine}Nethermind.Config.JsonConfigSource:BlomConfig:IndexLevelBucketSizes{Environment.NewLine}Nethermind.Config.EnvConfigSource:NETWORKCONFIG:MAXCANDIDATEPERCOUNT{Environment.NewLine}Nethermind.Config.ArgsConfigSource:NetworkConfig:DiscoverPort{Environment.NewLine}Nethermind.Config.ArgsConfigSource:Network:P2PPort", res.ErrorMsg);
-        }
-
-        [Test]
-        public void IncorrectFormat()
+        public void NoCategorySettings()
         {
             var env = Substitute.For<IEnvironment>();
-            env.GetEnvironmentVariables().Returns(new Dictionary<string, string>() { { "NETHERMIND_NETWORKCONFIGMAXCANDIDATEPEERCOUNT", "500" } });
+            env.GetEnvironmentVariables().Returns(new Dictionary<string, string>() { 
+                { "NETHERMIND_CLI_SWITCH_LOCAL", "http://localhost:80" },
+                { "NETHERMIND_MONITORING_JOB", "nethermindJob" },
+                { "NETHERMIND_MONITORING_GROUP", "nethermindGroup" },
+                { "NETHERMIND_ENODE_IPADDRESS", "1.2.3.4" },
+                { "NETHERMIND_HIVE_ENABLED", "true" },
+                { "NETHERMIND_URL", "http://test:80" },
+                { "NETHERMIND_CORS_ORIGINS", "*" },
+                { "NETHERMIND_CONFIG", "test2.cfg" },
+                { "NETHERMIND_XYZ", "xyz" },    // not existing, should get error
+                { "QWER", "qwerty" }    // not Nethermind setting, no error
+            }); 
             var envSource = new EnvConfigSource(env);
 
-            var argsSource = new ArgsConfigSource(new Dictionary<string, string>() { { "DiscoveryConfig.BucketSize", "10" }, { "NetworkConfigP2PPort", "30301" } });
+            var argsSource = new ArgsConfigSource(new Dictionary<string, string>() {
+                { "config", "test.cfg" },
+                { "datadir", "Data" },
+                { "ConfigsDirectory", "ConfDir" },
+                { "baseDbPath", "DB" },
+                { "logLevel", "info" },
+                { "loggerConfigSource", "logSource" },
+                { "pluginsDirectory", "Plugins" },
+                { "Abc", "abc" }    // not existing, should get error
+            });
 
             var configProvider = new ConfigProvider();
             configProvider.AddSource(envSource);
@@ -103,9 +89,70 @@ namespace Nethermind.Config.Test
             var res = configProvider.FindIncorrectSettings();
 
             Assert.AreEqual(2, res.Errors.Count);
-            Assert.AreEqual("NETWORKCONFIGMAXCANDIDATEPEERCOUNT", res.Errors[0].Category);
-            Assert.AreEqual("NetworkConfigP2PPort", res.Errors[1].Category);
-            Assert.AreEqual($"Nethermind.Config.EnvConfigSource:NETWORKCONFIGMAXCANDIDATEPEERCOUNT:{Environment.NewLine}Nethermind.Config.ArgsConfigSource:NetworkConfigP2PPort:", res.ErrorMsg);
+            Assert.AreEqual("XYZ", res.Errors[0].Name);
+            Assert.AreEqual("Abc", res.Errors[1].Name);
+            Assert.AreEqual($"ConfigType:EnvironmentVariable(NETHERMIND_*)|Category:|Name:XYZ{Environment.NewLine}ConfigType:RuntimeOption|Category:|Name:Abc", res.ErrorMsg);
+
+        }
+
+        [Test]
+        public void SettingWithTypos()
+        {
+            var jsonSource = new JsonConfigSource("SampleJson/ConfigWithTypos.cfg");
+
+            var env = Substitute.For<IEnvironment>();
+            env.GetEnvironmentVariables().Returns(new Dictionary<string, string>() { 
+                { "NETHERMIND_NETWORKCONFIG_MAXCANDIDATEPERCOUNT", "500" }  // incorrect, should be NETHERMIND_NETWORKCONFIG_MAXCANDIDATEPEERCOUNT
+            });
+            var envSource = new EnvConfigSource(env);
+
+            var argsSource = new ArgsConfigSource(new Dictionary<string, string>() { 
+                { "DiscoveryConfig.BucketSize", "10" }, 
+                { "NetworkConfig.DiscoverPort", "30301" }, // incorrect, should be NetworkConfig.DiscoveryPort
+                { "Network.P2PPort", "30301" } });
+
+            var configProvider = new ConfigProvider();
+            configProvider.AddSource(jsonSource);
+            configProvider.AddSource(envSource);
+            configProvider.AddSource(argsSource);
+
+            configProvider.Initialize();
+
+            var res = configProvider.FindIncorrectSettings();
+
+            Assert.AreEqual(4, res.Errors.Count);
+            Assert.AreEqual("Concurrenc", res.Errors[0].Name);
+            Assert.AreEqual("BlomConfig", res.Errors[1].Category);
+            Assert.AreEqual("MAXCANDIDATEPERCOUNT", res.Errors[2].Name);
+            Assert.AreEqual("DiscoverPort", res.Errors[3].Name);
+            Assert.AreEqual($"ConfigType:JsonConfigFile|Category:DiscoveRyConfig|Name:Concurrenc{Environment.NewLine}ConfigType:JsonConfigFile|Category:BlomConfig|Name:IndexLevelBucketSizes{Environment.NewLine}ConfigType:EnvironmentVariable(NETHERMIND_*)|Category:NETWORKCONFIG|Name:MAXCANDIDATEPERCOUNT{Environment.NewLine}ConfigType:RuntimeOption|Category:NetworkConfig|Name:DiscoverPort", res.ErrorMsg);
+        }
+
+        [Test]
+        public void IncorrectFormat()
+        {
+            var env = Substitute.For<IEnvironment>();
+            env.GetEnvironmentVariables().Returns(new Dictionary<string, string>() { 
+                { "NETHERMIND_NETWORKCONFIGMAXCANDIDATEPEERCOUNT", "500" }  // incorrect, should be NETHERMIND_NETWORKCONFIG_MAXCANDIDATEPEERCOUNT
+            });
+            var envSource = new EnvConfigSource(env);
+
+            var argsSource = new ArgsConfigSource(new Dictionary<string, string>() { 
+                { "DiscoveryConfig.BucketSize", "10" }, 
+                { "NetworkConfigP2PPort", "30301" } }); // incorrect, should be Network.P2PPort
+
+            var configProvider = new ConfigProvider();
+            configProvider.AddSource(envSource);
+            configProvider.AddSource(argsSource);
+
+            configProvider.Initialize();
+
+            var res = configProvider.FindIncorrectSettings();
+
+            Assert.AreEqual(2, res.Errors.Count);
+            Assert.AreEqual("NETWORKCONFIGMAXCANDIDATEPEERCOUNT", res.Errors[0].Name);
+            Assert.AreEqual("NetworkConfigP2PPort", res.Errors[1].Name);
+            Assert.AreEqual($"ConfigType:EnvironmentVariable(NETHERMIND_*)|Category:|Name:NETWORKCONFIGMAXCANDIDATEPEERCOUNT{Environment.NewLine}ConfigType:RuntimeOption|Category:|Name:NetworkConfigP2PPort", res.ErrorMsg);
         }
 
     }

--- a/src/Nethermind/Nethermind.Config/ArgsConfigSource.cs
+++ b/src/Nethermind/Nethermind.Config/ArgsConfigSource.cs
@@ -37,14 +37,27 @@ namespace Nethermind.Config
 
         public (bool IsSet, string Value) GetRawValue(string category, string name)
         {
-            var variableName = $"{category}.{name}";
+            var variableName = string.IsNullOrEmpty(category) ? name : $"{category}.{name}";
             bool isSet = _args.ContainsKey(variableName);
             return (isSet, isSet ? _args[variableName] : null);
         }
 
         public IEnumerable<(string Category, string Name)> GetConfigKeys()
         {
-            var argsPairs = _args.Keys.Select(k => k.Split('.')).Select(a => (a.Length > 0 ? a[0] : "", a.Length > 1 ? a[1] : ""));
+            var argsPairs = _args.Keys.Select(k => k.Split('.')).Select(a =>
+            {
+                if (a.Length == 0)
+                {
+                    return (null, null);
+                }
+                if (a.Length == 1)
+                {
+                    return (null, a[0]);
+                }
+
+                return (a[0], a[1]);
+            });
+
             return argsPairs;
         }
     }

--- a/src/Nethermind/Nethermind.Config/ConfigProvider.cs
+++ b/src/Nethermind/Nethermind.Config/ConfigProvider.cs
@@ -98,7 +98,7 @@ namespace Nethermind.Config
                     {
                         for (int i = 0; i < _configSource.Count; i++)
                         {
-                            string category = @interface.Name == nameof(INoCategoryConfig) ? null : config.GetType().Name;
+                            string category = @interface.IsAssignableFrom(typeof(INoCategoryConfig)) ? null : config.GetType().Name;
                             string name = propertyInfo.Name;
                             (bool isSet, object value) = _configSource[i].GetValue(propertyInfo.PropertyType, category, name);
                             if (isSet)
@@ -127,7 +127,7 @@ namespace Nethermind.Config
                 Initialize();
             }
 
-            var propertySet = _instances.Values.SelectMany(i => i.GetType().GetProperties().Select(p => GetKey(i.GetType().Name , p.Name))).ToHashSet(StringComparer.OrdinalIgnoreCase);
+            HashSet<string> propertySet = _instances.Values.SelectMany(i => i.GetType().GetProperties().Select(p => GetKey(i.GetType().Name , p.Name))).ToHashSet(StringComparer.OrdinalIgnoreCase);
 
             List<(IConfigSource Source, string Category, string Name)> incorrectSettings = new();
 

--- a/src/Nethermind/Nethermind.Config/ConfigProvider.cs
+++ b/src/Nethermind/Nethermind.Config/ConfigProvider.cs
@@ -29,6 +29,11 @@ namespace Nethermind.Config
         private readonly ConcurrentDictionary<Type, object> _instances = new();
         
         private readonly List<IConfigSource> _configSource = new();
+        private Dictionary<string, object> Categories { get; set; } = new(StringComparer.InvariantCultureIgnoreCase);
+
+        private readonly Dictionary<Type, Type> _implementations = new();
+
+        private readonly TypeDiscovery _typeDiscovery = new();
 
         public T GetConfig<T>() where T : IConfig
         {
@@ -72,12 +77,6 @@ namespace Nethermind.Config
             _configSource.Add(configSource);
         }
         
-        private Dictionary<string, object> Categories { get; set; } = new(StringComparer.InvariantCultureIgnoreCase);
-        
-        private readonly Dictionary<Type, Type> _implementations = new();
-        
-        private readonly TypeDiscovery _typeDiscovery = new();
-        
         public void Initialize()
         {
             Type type = typeof(IConfig);
@@ -99,7 +98,7 @@ namespace Nethermind.Config
                     {
                         for (int i = 0; i < _configSource.Count; i++)
                         {
-                            string category = config.GetType().Name;
+                            string category = @interface.Name == nameof(INoCategoryConfig) ? null : config.GetType().Name;
                             string name = propertyInfo.Name;
                             (bool isSet, object value) = _configSource[i].GetValue(propertyInfo.PropertyType, category, name);
                             if (isSet)
@@ -145,12 +144,31 @@ namespace Nethermind.Config
                 }
             }
 
-            var msg = string.Join(Environment.NewLine, incorrectSettings.Select(s => s.Source.ToString() + ":" + s.Category + ":" + s.Name));
-
+            var msg = string.Join(Environment.NewLine, incorrectSettings.Select(s => $"ConfigType:{GetConfigSourceName(s.Source)}|Category:{s.Category}|Name:{s.Name}"));
 
             return (msg, incorrectSettings);
 
-            static string GetKey(string category, string name) => category + '.' + name;
+            static string GetConfigSourceName(IConfigSource source) => source switch
+            {
+                ArgsConfigSource => "RuntimeOption",
+                EnvConfigSource => "EnvironmentVariable(NETHERMIND_*)",
+                JsonConfigSource => "JsonConfigFile",
+                _ => source.ToString()
+            };
+
+            static string GetKey(string category, string name)
+            {
+                if(string.IsNullOrEmpty(category))
+                {
+                    category = nameof(NoCategoryConfig);
+                }
+                else if(!category.EndsWith("config", StringComparison.OrdinalIgnoreCase))
+                {
+                    category += "Config";
+                }
+
+                return category + '.' + name;
+            }
         }
     }
 }

--- a/src/Nethermind/Nethermind.Config/EnvConfigSource.cs
+++ b/src/Nethermind/Nethermind.Config/EnvConfigSource.cs
@@ -50,19 +50,25 @@ namespace Nethermind.Config
         {
             return _environmentWrapper.GetEnvironmentVariables().Keys.Cast<string>().Where(k => k.StartsWith("NETHERMIND_")).Select(v => v.Split('_')).Select(a =>
             {
+                // actually only possible value is "NETHERMIND_"
                 if (a.Length <= 1)
                 {
                     return (null, null);
                 }
+
+                // variables like "NETHERMIND_URL", "NETHERMIND_CONFIG" ...
                 if (a.Length == 2)
                 {
                     return (null, a[1]);
                 }
-                if(a.Length > 2 && !a[1].EndsWith("config", StringComparison.OrdinalIgnoreCase))
+
+                // VARIABLES like "NETHERMIND_CLI_SWITCH_LOCAL", "NETHERMIND_MONITORING_JOB" ...
+                if (a.Length > 2 && !a[1].EndsWith("config", StringComparison.OrdinalIgnoreCase))
                 {
                     return (null, string.Join(null, a[1..]));
                 }
 
+                // Variables like "NETHERMIND_JSONRPCCONFIG_ENABLED" ...
                 return (a[1], a[2]);
             });
         }

--- a/src/Nethermind/Nethermind.Config/INoCategoryConfig.cs
+++ b/src/Nethermind/Nethermind.Config/INoCategoryConfig.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Nethermind.Config
+{
+    public interface INoCategoryConfig : IConfig
+    {
+        public string DataDir { get; set; }
+
+        [ConfigItem(Description = "Path to the JSON configuration file.", DefaultValue = "null")]
+        public string Config { get; set; }
+        public string ConfigsDirectory { get; set; }
+        public string BaseDbPath { get; set; }
+        public string LogLevel { get; set; }       
+        public string LoggerConfigSource { get; set; }
+        public string PluginsDirectory { get; set; }
+        public string MonitoringJob { get; set; }
+        public string MonitoringGroup { get; set; }
+        public string EnodeIpAddress { get; set; }
+        public bool HiveEnabled { get; set; }
+        public string Url { get; set; }
+        public string CorsOrigins { get; set; }
+        public string CliSwitchLocal { get; set; }
+    }
+}

--- a/src/Nethermind/Nethermind.Config/JsonConfigSource.cs
+++ b/src/Nethermind/Nethermind.Config/JsonConfigSource.cs
@@ -1,4 +1,4 @@
-﻿//  Copyright (c) 2021 Demerzel Solutions Limited
+//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
 // 
 //  The Nethermind library is free software: you can redistribute it and/or modify
@@ -142,6 +142,11 @@ namespace Nethermind.Config
 
         public (bool IsSet, string Value) GetRawValue(string category, string name)
         {
+            if(string.IsNullOrEmpty(category) || string.IsNullOrEmpty(name))
+            {
+                return (false, null);
+            }
+
             bool isSet = _values.ContainsKey(category) && _values[category].ContainsKey(name);
             return (isSet, isSet ? _values[category][name] : null);
         }

--- a/src/Nethermind/Nethermind.Config/NoCategoryConfig.cs
+++ b/src/Nethermind/Nethermind.Config/NoCategoryConfig.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Nethermind.Config
+{
+    public class NoCategoryConfig : INoCategoryConfig
+    {
+        public string Config { get; set; } = null;
+        public string DataDir { get; set; }
+        public string ConfigsDirectory { get; set; }
+        public string BaseDbPath { get; set; }
+        public string LogLevel { get; set; }
+        public string LoggerConfigSource { get; set; }
+        public string PluginsDirectory { get; set; }
+        public string MonitoringJob { get; set; }
+        public string MonitoringGroup { get; set; }
+        public string EnodeIpAddress { get; set; }
+        public bool HiveEnabled { get; set; }
+        public string Url { get; set; }
+        public string CorsOrigins { get; set; }
+        public string CliSwitchLocal { get; set; }
+    }
+}


### PR DESCRIPTION
Fixes  #3248 

## Changes:
More configuration options is going to be handled including ones without a Category.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No

**Comments about testing , should you have some** (optional)

When running the Runner we should observe if there are any warnings related to incorrect configuration.
For example:
2021-07-26 19-55-35.4491|Incorrect config settings found:
ConfigType:EnvironmentVariable(NETHERMIND_*)|Category:|Name:QAZ
ConfigType:JsonConfigFile|Category:JsonRpcConfig|Name:TracerTimeout