### PR TITLE
Added support for extra 1559 parameters in the genesis 

### DIFF
--- a/src/Nethermind/Chains/hive.json
+++ b/src/Nethermind/Chains/hive.json
@@ -149,7 +149,6 @@
     "eip160Transition": "0x7fffffffffffffff",
     "eip161abcTransition": "0x7fffffffffffffff",
     "eip161dTransition": "0x7fffffffffffffff"
-
   },
   "nodes": [],
   "accounts": {

--- a/src/Nethermind/Ethereum.Test.Base/GeneralTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/GeneralTestBase.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using Nethermind.Blockchain;
 using Nethermind.Blockchain.Validators;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;

--- a/src/Nethermind/Nethermind.Core/BaseFeeCalculator.cs
+++ b/src/Nethermind/Nethermind.Core/BaseFeeCalculator.cs
@@ -25,7 +25,7 @@ namespace Nethermind.Core
     {
         public static UInt256 Calculate(BlockHeader parent, IReleaseSpec spec)
         {
-            UInt256 expectedBaseFee = UInt256.Zero;
+            UInt256 expectedBaseFee = parent.BaseFeePerGas;
             if (spec.IsEip1559Enabled)
             {
                 UInt256 parentBaseFee = parent.BaseFeePerGas;

--- a/src/Nethermind/Nethermind.Core/Eip1559Constants.cs
+++ b/src/Nethermind/Nethermind.Core/Eip1559Constants.cs
@@ -29,7 +29,7 @@ namespace Nethermind.Core
         
         public static readonly int DefaultElasticityMultiplier = 2;
         
-        // The default fork base fee is 1 Gwei. However, we can override it in genesis
+        // The above values are the default ones. However, we're allowing to override it from genesis
         public static UInt256 ForkBaseFee { get; set; } = DefaultForkBaseFee;
         public static UInt256 BaseFeeMaxChangeDenominator { get; set; } = DefaultBaseFeeMaxChangeDenominator;
         public static long ElasticityMultiplier { get; set;  } = DefaultElasticityMultiplier;

--- a/src/Nethermind/Nethermind.Core/Eip1559Constants.cs
+++ b/src/Nethermind/Nethermind.Core/Eip1559Constants.cs
@@ -32,6 +32,6 @@ namespace Nethermind.Core
         // The default fork base fee is 1 Gwei. However, we can override it in genesis
         public static UInt256 ForkBaseFee { get; set; } = DefaultForkBaseFee;
         public static UInt256 BaseFeeMaxChangeDenominator { get; set; } = DefaultBaseFeeMaxChangeDenominator;
-        public static int ElasticityMultiplier { get; set;  }= DefaultElasticityMultiplier;
+        public static long ElasticityMultiplier { get; set;  } = DefaultElasticityMultiplier;
     }
 }

--- a/src/Nethermind/Nethermind.Core/Eip1559Constants.cs
+++ b/src/Nethermind/Nethermind.Core/Eip1559Constants.cs
@@ -22,13 +22,16 @@ namespace Nethermind.Core
 {
     public class Eip1559Constants
     {
-        public static readonly UInt256 BaseFeeMaxChangeDenominator = 8;
-        
+                
         public static readonly UInt256 DefaultForkBaseFee = 1.GWei();
+        
+        public static readonly UInt256 DefaultBaseFeeMaxChangeDenominator = 8;
+        
+        public static readonly int DefaultElasticityMultiplier = 2;
         
         // The default fork base fee is 1 Gwei. However, we can override it in genesis
         public static UInt256 ForkBaseFee { get; set; } = DefaultForkBaseFee;
-
-        public const int ElasticityMultiplier = 2;
+        public static UInt256 BaseFeeMaxChangeDenominator { get; set; } = DefaultBaseFeeMaxChangeDenominator;
+        public static int ElasticityMultiplier { get; set;  }= DefaultElasticityMultiplier;
     }
 }

--- a/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecLoaderTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecLoaderTests.cs
@@ -62,7 +62,7 @@ namespace Nethermind.Specs.Test.ChainSpecStyle
             Assert.AreEqual(1, chainSpec.ChainId, $"{nameof(chainSpec.ChainId)}");
             Assert.NotNull(chainSpec.Genesis, $"{nameof(ChainSpec.Genesis)}");
             
-            Assert.AreEqual((UInt256)11, chainSpec.Parameters.Eip1559BaseFeeInitialValue, $"fork base fee");
+            Assert.AreEqual((UInt256)11, chainSpec.Genesis.BaseFeePerGas, $"genesis base fee");
             Assert.AreEqual(0xdeadbeefdeadbeef, chainSpec.Genesis.Header.Nonce, $"genesis {nameof(BlockHeader.Nonce)}");
             Assert.AreEqual(Keccak.Zero, chainSpec.Genesis.Header.MixHash, $"genesis {nameof(BlockHeader.MixHash)}");
             Assert.AreEqual(0x10, (long)chainSpec.Genesis.Header.Difficulty, $"genesis {nameof(BlockHeader.Difficulty)}");

--- a/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecLoaderTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecLoaderTests.cs
@@ -62,7 +62,7 @@ namespace Nethermind.Specs.Test.ChainSpecStyle
             Assert.AreEqual(1, chainSpec.ChainId, $"{nameof(chainSpec.ChainId)}");
             Assert.NotNull(chainSpec.Genesis, $"{nameof(ChainSpec.Genesis)}");
             
-            Assert.AreEqual((UInt256)11, chainSpec.ForkBaseFee, $"fork base fee");
+            Assert.AreEqual((UInt256)11, chainSpec.Parameters.Eip1559BaseFeeInitialValue, $"fork base fee");
             Assert.AreEqual(0xdeadbeefdeadbeef, chainSpec.Genesis.Header.Nonce, $"genesis {nameof(BlockHeader.Nonce)}");
             Assert.AreEqual(Keccak.Zero, chainSpec.Genesis.Header.MixHash, $"genesis {nameof(BlockHeader.MixHash)}");
             Assert.AreEqual(0x10, (long)chainSpec.Genesis.Header.Difficulty, $"genesis {nameof(BlockHeader.Difficulty)}");
@@ -141,7 +141,7 @@ namespace Nethermind.Specs.Test.ChainSpecStyle
             Assert.AreEqual("Ropsten Testnet", chainSpec.Name, $"{nameof(chainSpec.Name)}");
             Assert.NotNull(chainSpec.Genesis, $"{nameof(ChainSpec.Genesis)}");
             
-            Assert.AreEqual(1.GWei(), chainSpec.ForkBaseFee, $"fork base fee");
+            Assert.AreEqual(1.GWei(), chainSpec.Parameters.Eip1559BaseFeeInitialValue, $"fork base fee");
             Assert.AreEqual(0x0000000000000042UL, chainSpec.Genesis.Header.Nonce, $"genesis {nameof(BlockHeader.Nonce)}");
             Assert.AreEqual(Keccak.Zero, chainSpec.Genesis.Header.MixHash, $"genesis {nameof(BlockHeader.MixHash)}");
             Assert.AreEqual(0x100000L, (long)chainSpec.Genesis.Header.Difficulty, $"genesis {nameof(BlockHeader.Difficulty)}");
@@ -199,7 +199,7 @@ namespace Nethermind.Specs.Test.ChainSpecStyle
             string path = Path.Combine(TestContext.CurrentContext.WorkDirectory, "../../../../", "Chains/goerli.json");
             ChainSpec chainSpec = LoadChainSpec(path);
             
-            Assert.AreEqual(1.GWei(), chainSpec.ForkBaseFee, $"fork base fee");
+            Assert.AreEqual(1.GWei(), chainSpec.Parameters.Eip1559BaseFeeInitialValue, $"fork base fee");
             Assert.AreEqual(5, chainSpec.ChainId, $"{nameof(chainSpec.ChainId)}");
             Assert.AreEqual("Görli Testnet", chainSpec.Name, $"{nameof(chainSpec.Name)}");
             Assert.AreEqual("goerli", chainSpec.DataDir, $"{nameof(chainSpec.DataDir)}");
@@ -227,7 +227,7 @@ namespace Nethermind.Specs.Test.ChainSpecStyle
             string path = Path.Combine(TestContext.CurrentContext.WorkDirectory, "../../../../", "Chains/xdai.json");
             ChainSpec chainSpec = LoadChainSpec(path);
             
-            Assert.AreEqual(1.GWei(), chainSpec.ForkBaseFee, $"fork base fee");
+            Assert.AreEqual(1.GWei(), chainSpec.Parameters.Eip1559BaseFeeInitialValue, $"fork base fee");
             Assert.AreEqual(100, chainSpec.ChainId, $"{nameof(chainSpec.ChainId)}");
             Assert.AreEqual("DaiChain", chainSpec.Name, $"{nameof(chainSpec.Name)}");
             Assert.AreEqual(SealEngineType.AuRa, chainSpec.SealEngineType, "engine");
@@ -244,7 +244,7 @@ namespace Nethermind.Specs.Test.ChainSpecStyle
             string path = Path.Combine(TestContext.CurrentContext.WorkDirectory, "../../../../", "Chains/rinkeby.json");
             ChainSpec chainSpec = LoadChainSpec(path);
             
-            Assert.AreEqual(1.GWei(), chainSpec.ForkBaseFee, $"fork base fee");
+            Assert.AreEqual(1.GWei(), chainSpec.Parameters.Eip1559BaseFeeInitialValue, $"fork base fee");
             Assert.AreEqual(4, chainSpec.ChainId, $"{nameof(chainSpec.ChainId)}");
             Assert.AreEqual("Rinkeby", chainSpec.Name, $"{nameof(chainSpec.Name)}");
             Assert.AreEqual(SealEngineType.Clique, chainSpec.SealEngineType, "engine");
@@ -267,7 +267,7 @@ namespace Nethermind.Specs.Test.ChainSpecStyle
             string path = Path.Combine(TestContext.CurrentContext.WorkDirectory, "../../../../", "Chains/foundation.json");
             ChainSpec chainSpec = LoadChainSpec(path);
             
-            Assert.AreEqual(1.GWei(), chainSpec.ForkBaseFee, $"fork base fee");
+            Assert.AreEqual(1.GWei(), chainSpec.Parameters.Eip1559BaseFeeInitialValue, $"fork base fee");
             Assert.AreEqual(1, chainSpec.ChainId, $"{nameof(chainSpec.ChainId)}");
             Assert.AreEqual("Ethereum", chainSpec.Name, $"{nameof(chainSpec.Name)}");
             Assert.AreEqual("ethereum", chainSpec.DataDir, $"{nameof(chainSpec.Name)}");
@@ -291,7 +291,7 @@ namespace Nethermind.Specs.Test.ChainSpecStyle
             string path = Path.Combine(TestContext.CurrentContext.WorkDirectory, "../../../../", "Chains/sokol.json");
             ChainSpec chainSpec = LoadChainSpec(path);
             
-            Assert.AreEqual(1.GWei(), chainSpec.ForkBaseFee, $"fork base fee");
+            Assert.AreEqual(1.GWei(), chainSpec.Parameters.Eip1559BaseFeeInitialValue, $"fork base fee");
             Assert.AreEqual(0x4d, chainSpec.ChainId, $"{nameof(chainSpec.ChainId)}");
             Assert.AreEqual("Sokol", chainSpec.Name, $"{nameof(chainSpec.Name)}");
             Assert.AreEqual(SealEngineType.AuRa, chainSpec.SealEngineType, "engine");

--- a/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecLoaderTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecLoaderTests.cs
@@ -62,7 +62,7 @@ namespace Nethermind.Specs.Test.ChainSpecStyle
             Assert.AreEqual(1, chainSpec.ChainId, $"{nameof(chainSpec.ChainId)}");
             Assert.NotNull(chainSpec.Genesis, $"{nameof(ChainSpec.Genesis)}");
 
-            Assert.AreEqual((UInt256)10, chainSpec.Parameters.Eip1559BaseFeeInitialValue, $"initial base fee value");
+            Assert.AreEqual(1.GWei(), chainSpec.Parameters.Eip1559BaseFeeInitialValue, $"initial base fee value");
             Assert.AreEqual((long)1, chainSpec.Parameters.Eip1559ElasticityMultiplier, $"elasticity multiplier");
             Assert.AreEqual((UInt256)7, chainSpec.Parameters.Eip1559BaseFeeMaxChangeDenominator, $"base fee max change denominator");
             Assert.AreEqual((UInt256)11, chainSpec.Genesis.BaseFeePerGas, $"genesis base fee");

--- a/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecLoaderTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecLoaderTests.cs
@@ -61,8 +61,12 @@ namespace Nethermind.Specs.Test.ChainSpecStyle
 
             Assert.AreEqual(1, chainSpec.ChainId, $"{nameof(chainSpec.ChainId)}");
             Assert.NotNull(chainSpec.Genesis, $"{nameof(ChainSpec.Genesis)}");
-            
+
+            Assert.AreEqual((UInt256)10, chainSpec.Parameters.Eip1559BaseFeeInitialValue, $"initial base fee value");
+            Assert.AreEqual((long)1, chainSpec.Parameters.Eip1559ElasticityMultiplier, $"elasticity multiplier");
+            Assert.AreEqual((UInt256)7, chainSpec.Parameters.Eip1559BaseFeeMaxChangeDenominator, $"base fee max change denominator");
             Assert.AreEqual((UInt256)11, chainSpec.Genesis.BaseFeePerGas, $"genesis base fee");
+            
             Assert.AreEqual(0xdeadbeefdeadbeef, chainSpec.Genesis.Header.Nonce, $"genesis {nameof(BlockHeader.Nonce)}");
             Assert.AreEqual(Keccak.Zero, chainSpec.Genesis.Header.MixHash, $"genesis {nameof(BlockHeader.MixHash)}");
             Assert.AreEqual(0x10, (long)chainSpec.Genesis.Header.Difficulty, $"genesis {nameof(BlockHeader.Difficulty)}");

--- a/src/Nethermind/Nethermind.Specs.Test/Specs/hive.json
+++ b/src/Nethermind/Nethermind.Specs.Test/Specs/hive.json
@@ -47,7 +47,10 @@
     "eip145Transition": 7080000,
     "eip1014Transition": 7080000,
     "eip1052Transition": 7080000,
-    "eip1283Transition": 7080000
+    "eip1283Transition": 7080000,
+    "eip1559BaseFeeMaxChangeDenominator": "0x7",
+    "eip1559ElasticityMultiplier": "0x1",
+    "eip1559BaseFeeInitialValue": "0xa"
   },
   "genesis": {
     "seal": {

--- a/src/Nethermind/Nethermind.Specs.Test/Specs/hive.json
+++ b/src/Nethermind/Nethermind.Specs.Test/Specs/hive.json
@@ -50,7 +50,7 @@
     "eip1283Transition": 7080000,
     "eip1559BaseFeeMaxChangeDenominator": "0x7",
     "eip1559ElasticityMultiplier": "0x1",
-    "eip1559BaseFeeInitialValue": "0xa"
+    "eip1559BaseFeeInitialValue": "0x3b9aca00"
   },
   "genesis": {
     "seal": {

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
@@ -65,6 +65,12 @@ namespace Nethermind.Specs.ChainSpecStyle
         
         public long? Eip3541Transition { get; set; }
         
+        public UInt256? Eip1559BaseFeeInitialValue { get; set; }
+
+        public UInt256? Eip1559BaseFeeMaxChangeDenominator { get; set; }    
+            
+        public int? Eip1559ElasticityMultiplier { get; set; }
+        
         /// <summary>
         ///  Transaction permission managing contract address.
         /// </summary>

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
@@ -65,11 +65,11 @@ namespace Nethermind.Specs.ChainSpecStyle
         
         public long? Eip3541Transition { get; set; }
         
-        public UInt256? Eip1559BaseFeeInitialValue { get; set; }
+        public UInt256 Eip1559BaseFeeInitialValue { get; set; }
 
-        public UInt256? Eip1559BaseFeeMaxChangeDenominator { get; set; }    
+        public UInt256 Eip1559BaseFeeMaxChangeDenominator { get; set; }    
             
-        public int? Eip1559ElasticityMultiplier { get; set; }
+        public int Eip1559ElasticityMultiplier { get; set; }
         
         /// <summary>
         ///  Transaction permission managing contract address.

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
@@ -69,7 +69,7 @@ namespace Nethermind.Specs.ChainSpecStyle
 
         public UInt256 Eip1559BaseFeeMaxChangeDenominator { get; set; }    
             
-        public int Eip1559ElasticityMultiplier { get; set; }
+        public long Eip1559ElasticityMultiplier { get; set; }
         
         /// <summary>
         ///  Transaction permission managing contract address.

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpec.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpec.cs
@@ -56,8 +56,6 @@ namespace Nethermind.Specs.ChainSpecStyle
         
         public long? FixedDifficulty { get; set; }
         
-        public UInt256 ForkBaseFee { get; set; }
-        
         public long? DaoForkBlockNumber { get; set; }
 
         public long? HomesteadBlockNumber { get; set; }

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
@@ -156,6 +156,13 @@ namespace Nethermind.Specs.ChainSpecStyle
                                                        ?? GetTransitionForExpectedPricing("alt_bn128_mul", "price.alt_bn128_const_operations.price", 6000)
                                                        ?? GetTransitionForExpectedPricing("alt_bn128_pairing", "price.alt_bn128_pairing.base", 45000);
             chainSpec.Parameters.Eip2565Transition ??= GetTransitionIfInnerPathExists("modexp", "price.modexp2565");
+
+            Eip1559Constants.ElasticityMultiplier = 
+                chainSpecJson.Params.Eip1559ElasticityMultiplier ?? Eip1559Constants.ElasticityMultiplier;
+            Eip1559Constants.ForkBaseFee =
+                chainSpecJson.Params.Eip1559BaseFeeInitialValue ?? Eip1559Constants.ForkBaseFee;
+            Eip1559Constants.BaseFeeMaxChangeDenominator = chainSpecJson.Params.Eip1559BaseFeeMaxChangeDenominator ??
+                                                           Eip1559Constants.BaseFeeMaxChangeDenominator;
         }
 
         private static void ValidateParams(ChainSpecParamsJson parameters)
@@ -326,11 +333,11 @@ namespace Nethermind.Specs.ChainSpecStyle
             byte[] extraData = chainSpecJson.Genesis.ExtraData ?? Array.Empty<byte>();
             UInt256 gasLimit = chainSpecJson.Genesis.GasLimit;
             Address beneficiary = chainSpecJson.Genesis.Author ?? Address.Zero;
-            UInt256 baseFee = UInt256.Zero;
-            chainSpec.ForkBaseFee = chainSpecJson.Genesis.BaseFeePerGas ?? Eip1559Constants.DefaultForkBaseFee;
-            Eip1559Constants.ForkBaseFee = chainSpec.ForkBaseFee;
+            UInt256 baseFee = chainSpecJson.Genesis.BaseFeePerGas ?? UInt256.Zero;
             if (chainSpecJson.Params.Eip1559Transition != null)
-                baseFee = chainSpecJson.Params.Eip1559Transition == 0 ? chainSpec.ForkBaseFee : UInt256.Zero;
+                baseFee = chainSpecJson.Params.Eip1559Transition == 0
+                    ? (chainSpecJson.Genesis.BaseFeePerGas ?? Eip1559Constants.DefaultForkBaseFee)
+                    : UInt256.Zero;
 
             
             BlockHeader genesisHeader = new(

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
@@ -149,6 +149,10 @@ namespace Nethermind.Specs.ChainSpecStyle
                 TransactionPermissionContractTransition = chainSpecJson.Params.TransactionPermissionContractTransition,
                 ValidateChainIdTransition = chainSpecJson.Params.ValidateChainIdTransition,
                 ValidateReceiptsTransition = chainSpecJson.Params.ValidateReceiptsTransition,
+                Eip1559ElasticityMultiplier = chainSpecJson.Params.Eip1559ElasticityMultiplier ?? Eip1559Constants.ElasticityMultiplier,
+                Eip1559BaseFeeInitialValue = chainSpecJson.Params.Eip1559BaseFeeInitialValue ?? Eip1559Constants.ForkBaseFee,
+                Eip1559BaseFeeMaxChangeDenominator = chainSpecJson.Params.Eip1559BaseFeeMaxChangeDenominator ??
+                                                     Eip1559Constants.BaseFeeMaxChangeDenominator
             };
 
             chainSpec.Parameters.Eip152Transition ??= GetTransitionForExpectedPricing("blake2_f", "price.blake2_f.gas_per_round", 1);
@@ -157,12 +161,9 @@ namespace Nethermind.Specs.ChainSpecStyle
                                                        ?? GetTransitionForExpectedPricing("alt_bn128_pairing", "price.alt_bn128_pairing.base", 45000);
             chainSpec.Parameters.Eip2565Transition ??= GetTransitionIfInnerPathExists("modexp", "price.modexp2565");
 
-            Eip1559Constants.ElasticityMultiplier = 
-                chainSpecJson.Params.Eip1559ElasticityMultiplier ?? Eip1559Constants.ElasticityMultiplier;
-            Eip1559Constants.ForkBaseFee =
-                chainSpecJson.Params.Eip1559BaseFeeInitialValue ?? Eip1559Constants.ForkBaseFee;
-            Eip1559Constants.BaseFeeMaxChangeDenominator = chainSpecJson.Params.Eip1559BaseFeeMaxChangeDenominator ??
-                                                           Eip1559Constants.BaseFeeMaxChangeDenominator;
+            Eip1559Constants.ElasticityMultiplier = chainSpec.Parameters.Eip1559ElasticityMultiplier;
+            Eip1559Constants.ForkBaseFee = chainSpec.Parameters.Eip1559BaseFeeInitialValue;
+            Eip1559Constants.BaseFeeMaxChangeDenominator = chainSpec.Parameters.Eip1559BaseFeeMaxChangeDenominator;
         }
 
         private static void ValidateParams(ChainSpecParamsJson parameters)

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
@@ -110,6 +110,12 @@ namespace Nethermind.Specs.ChainSpecStyle.Json
         public long? Eip3529Transition { get; set; }
 
         public long? Eip3541Transition { get; set; }
+
+        public UInt256? Eip1559BaseFeeInitialValue { get; set; }
+
+        public UInt256? Eip1559BaseFeeMaxChangeDenominator { get; set; }    
+            
+        public int? Eip1559ElasticityMultiplier { get; set; }
         
         public Address TransactionPermissionContract { get; set; }
 

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
@@ -115,7 +115,7 @@ namespace Nethermind.Specs.ChainSpecStyle.Json
 
         public UInt256? Eip1559BaseFeeMaxChangeDenominator { get; set; }    
             
-        public int? Eip1559ElasticityMultiplier { get; set; }
+        public long? Eip1559ElasticityMultiplier { get; set; }
         
         public Address TransactionPermissionContract { get; set; }
 


### PR DESCRIPTION
## Changes:
Add parameters to the gensis:
- eip1559BaseFeeMaxChangeDenominator
- eip1559ElasticityMultiplier
- eip1559BaseFeeInitialValue

Thanks to that, we have the same genesis as OpenEthereum, which is expected by xdai.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No
