### PR TITLE
trace_call is missed in the docs

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Trace/ITraceRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Trace/ITraceRpcModule.cs
@@ -25,7 +25,7 @@ namespace Nethermind.JsonRpc.Modules.Trace
     [RpcModule(ModuleType.Trace)]
     public interface ITraceRpcModule : IRpcModule
     {
-        [JsonRpcMethod(Description = "", IsImplemented = false, IsSharable = false)]
+        [JsonRpcMethod(Description = "", IsImplemented = true, IsSharable = false)]
         ResultWrapper<ParityTxTraceFromReplay> trace_call(TransactionForRpc message, string[] traceTypes, BlockParameter blockParameter);
         
         [JsonRpcMethod(Description = "", IsImplemented = false, IsSharable = false)]


### PR DESCRIPTION
## Changes:
trace_call is missed in the docs: https://docs.nethermind.io/nethermind/ethereum-client/json-rpc/trace
I think by accident.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [x] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [x] No