### PR TITLE
Fixes using blockhash for BlockParameter.

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Find/BlockParameter.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Find/BlockParameter.cs
@@ -76,7 +76,7 @@ namespace Nethermind.Blockchain.Find
                 case null:
                     return Latest;
                 case { } hash when hash.Length == 66 && hash.StartsWith("0x"):
-                    return Latest;
+                    return new BlockParameter(new Keccak(hash));
                 default:
                     return new BlockParameter(LongConverter.FromString(jsonValue.Trim('"')));
             }


### PR DESCRIPTION
## Changes:
- Adds support for specifying a block hash when doing operations requiring a BlockParameter (e.g., `eth_call`).

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [X] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [X] No

**Comments about testing , should you have some** (optional)

## Further comments (optional)

I believe this is non-standard behavior, but it is super useful and really should be standard behavior.  However, what Nethermind was doing prior to this PR *definitely* wrong because the user was providing a hash (or at least something that looked like a hash) and Nethermind was proceeding to completely ignore it.  More correct behavior would be to try to interpret it as a block number (which would fail), or just fail on unsupported/malformed input.

This change makes it so this super useful feature should actually work.