### PR TITLE
MEV  build only when bundle + consensus diagnose improvements

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/BlockTreeExtensions.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTreeExtensions.cs
@@ -15,13 +15,14 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 // 
 
+using Nethermind.Core;
+
 namespace Nethermind.Blockchain
 {
     public static class BlockTreeExtensions
     {
-        public static ReadOnlyBlockTree AsReadOnly(this IBlockTree blockTree)
-        {
-            return new(blockTree);
-        }
+        public static ReadOnlyBlockTree AsReadOnly(this IBlockTree blockTree) => new(blockTree);
+        
+        public static BlockHeader? GetProducedBlockParent(this IBlockTree blockTree, BlockHeader? parentHeader) => parentHeader ?? blockTree.Head?.Header;
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/LogTraceDumper.cs
+++ b/src/Nethermind/Nethermind.Blockchain/LogTraceDumper.cs
@@ -15,6 +15,7 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 // 
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Nethermind.Core;
@@ -86,6 +87,12 @@ namespace Nethermind.Blockchain
                 if (logger.IsError)
                     logger.Error($"Cannot save trace of block {blockHash} in file {fileName}", e);
             }
+        }
+
+        public static void LogTraceFailure(IBlockTracer blockTracer, Keccak blockHash, Exception exception, ILogger logger)
+        {
+            if (logger.IsError)
+                logger.Error($"Cannot create trace of blocks starting from {blockHash} of type {blockTracer.GetType().Name}", exception);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/LogTraceDumper.cs
+++ b/src/Nethermind/Nethermind.Blockchain/LogTraceDumper.cs
@@ -17,6 +17,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Evm.Tracing;
 using Nethermind.Evm.Tracing.GethStyle;
@@ -48,10 +49,22 @@ namespace Nethermind.Blockchain
             {
                 IJsonSerializer serializer = new EthereumJsonSerializer();
                 serializer.RegisterConverters(Converters);
+
+                if (blockTracer is BlockReceiptsTracer receiptsTracer)
+                {
+                    fileName = $"receipts_{blockHash}.txt";
+                    using FileStream diagnosticFile = GetFileStream(fileName);               
+                    IReadOnlyList<TxReceipt> receipts = receiptsTracer.TxReceipts;
+                    serializer.Serialize(diagnosticFile, receipts, true);
+                    if (logger.IsInfo)
+                        logger.Info($"Created a Receipts trace of block {blockHash} in file {diagnosticFile.Name}");
+
+                }
+                
                 if (blockTracer is GethLikeBlockTracer gethTracer)
                 {
                     fileName = $"gethStyle_{blockHash}.txt";
-                    using FileStream diagnosticFile = GetFileStream(fileName);                    
+                    using FileStream diagnosticFile = GetFileStream(fileName);
                     IReadOnlyCollection<GethLikeTxTrace> trace = gethTracer.BuildResult();
                     serializer.Serialize(diagnosticFile, trace, true);
                     if (logger.IsInfo)

--- a/src/Nethermind/Nethermind.Blockchain/Processing/BlockchainProcessor.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Processing/BlockchainProcessor.cs
@@ -373,11 +373,17 @@ namespace Nethermind.Blockchain.Processing
                 TraceFailingBranch(
                     processingBranch,
                     options,
-                    new GethLikeBlockTracer(GethTraceOptions.Default));
+                    new BlockReceiptsTracer());
+                
                 TraceFailingBranch(
                     processingBranch,
                     options,
                     new ParityLikeBlockTracer(ParityTraceTypes.StateDiff | ParityTraceTypes.Trace));
+                
+                TraceFailingBranch(
+                    processingBranch,
+                    options,
+                    new GethLikeBlockTracer(GethTraceOptions.Default));
 
                 Keccak invalidBlockHash = ex.InvalidBlockHash;
                 for (int i = 0; i < processingBranch.BlocksToProcess.Count; i++)

--- a/src/Nethermind/Nethermind.Blockchain/Producers/MultipleBlockProducer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Producers/MultipleBlockProducer.cs
@@ -122,7 +122,11 @@ namespace Nethermind.Blockchain.Producers
             Block? bestBlock = _bestBlockPicker.GetBestBlock(blocksWithProducers);
             if (bestBlock is not null)
             {
-                if (_logger.IsInfo) _logger.Info($"Picked block {bestBlock} to be included to the chain.");
+                if (produceTasks.Count(t => t.IsCompletedSuccessfully && t.Result is not null) > 1)
+                {
+                    if (_logger.IsInfo) _logger.Info($"Picked block {bestBlock} to be included to the chain.");
+                }
+
                 BlockProduced?.Invoke(this, new BlockEventArgs(bestBlock));
             }
 

--- a/src/Nethermind/Nethermind.Blockchain/Producers/TriggerWithCondition.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Producers/TriggerWithCondition.cs
@@ -21,17 +21,22 @@ namespace Nethermind.Blockchain.Producers
 {
     public class TriggerWithCondition : IBlockProductionTrigger
     {
-        private readonly Func<bool> _checkCondition;
+        private readonly Func<BlockProductionEventArgs, bool> _checkCondition;
 
-        public TriggerWithCondition(IBlockProductionTrigger trigger, Func<bool> checkCondition)
+        public TriggerWithCondition(IBlockProductionTrigger trigger, Func<bool> checkCondition) : this(trigger, _ => checkCondition())
+        {
+        }
+        
+        public TriggerWithCondition(IBlockProductionTrigger trigger, Func<BlockProductionEventArgs, bool> checkCondition)
         {
             _checkCondition = checkCondition;
             trigger.TriggerBlockProduction += TriggerOnTriggerBlockProduction;
         }
 
+
         private void TriggerOnTriggerBlockProduction(object? sender, BlockProductionEventArgs e)
         {
-            if (_checkCondition.Invoke())
+            if (_checkCondition.Invoke(e))
             {
                 TriggerBlockProduction?.Invoke(this, e);
             }

--- a/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockProducer.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockProducer.cs
@@ -61,7 +61,7 @@ namespace Nethermind.Core.Test.Blockchain
         
         private BlockHeader? _blockParent = null;
 
-        private BlockHeader? BlockParent
+        public BlockHeader? BlockParent
         {
             get
             {

--- a/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockProducer.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockProducer.cs
@@ -24,6 +24,7 @@ using Nethermind.Blockchain.Synchronization;
 using Nethermind.Consensus;
 using Nethermind.Consensus.Transactions;
 using Nethermind.Core.Specs;
+using Nethermind.Evm.Tracing;
 using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.Specs;
@@ -59,8 +60,8 @@ namespace Nethermind.Core.Test.Blockchain
         }
         
         private BlockHeader? _blockParent = null;
-        
-        public BlockHeader? BlockParent
+
+        private BlockHeader? BlockParent
         {
             get
             {
@@ -72,6 +73,10 @@ namespace Nethermind.Core.Test.Blockchain
             }
         }
 
-        protected override BlockHeader? GetProducedBlockParent(BlockHeader? parentHeader) => parentHeader ?? BlockParent;
+        protected override Task<Block?> TryProduceNewBlock(CancellationToken token, BlockHeader? parentHeader, IBlockTracer? blockTracer = null)
+        {
+            parentHeader ??= BlockParent;
+            return base.TryProduceNewBlock(token, parentHeader, blockTracer);
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
@@ -106,7 +106,7 @@ namespace Nethermind.Core.Test.Blockchain
 
         public IReadOnlyTrieStore ReadOnlyTrieStore { get; private set; }
 
-        public ManualTimestamper Timestamper { get; private set; }
+        public ManualTimestamper Timestamper { get; protected set; }
         
         public ProducedBlockSuggester Suggester { get; private set; }
 
@@ -336,7 +336,7 @@ namespace Nethermind.Core.Test.Blockchain
 
         public virtual void Dispose()
         {
-            TestContext.Out.WriteLine($"dispozing {this.GetHashCode()}");
+            TestContext.Out.WriteLine($"disposing {this.GetHashCode()}");
             BlockProducer?.StopAsync();
             CodeDb?.Dispose();
             StateDb?.Dispose();

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeBlockchain.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeBlockchain.cs
@@ -32,7 +32,9 @@ using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Db;
 using Nethermind.Evm;
+using Nethermind.Evm.Tracing;
 using Nethermind.Evm.TransactionProcessing;
+using Nethermind.JsonRpc.Converters;
 using Nethermind.JsonRpc.Modules.DebugModule;
 using Nethermind.JsonRpc.Modules.Trace;
 using Nethermind.Logging;
@@ -69,6 +71,7 @@ namespace Nethermind.Init.Steps
         {
             BlockTraceDumper.Converters.AddRange(DebugModuleFactory.Converters);
             BlockTraceDumper.Converters.AddRange(TraceModuleFactory.Converters);
+            BlockTraceDumper.Converters.Add(new TxReceiptConverter());
             
             var (getApi, setApi) = _api.ForBlockchain;
             

--- a/src/Nethermind/Nethermind.JsonRpc/Converters/TxReceiptConverter.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Converters/TxReceiptConverter.cs
@@ -1,0 +1,38 @@
+﻿//  Copyright (c) 2021 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
+
+using System;
+using Nethermind.Core;
+using Nethermind.Int256;
+using Nethermind.JsonRpc.Data;
+using Newtonsoft.Json;
+
+namespace Nethermind.JsonRpc.Converters
+{
+    public class TxReceiptConverter : JsonConverter<TxReceipt>
+    {
+        public override void WriteJson(JsonWriter writer, TxReceipt value, JsonSerializer serializer)
+        {
+            serializer.Serialize(writer, new ReceiptForRpc(value.TxHash!, value, UInt256.Zero));
+        }
+
+        public override TxReceipt ReadJson(JsonReader reader, Type objectType, TxReceipt existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            return serializer.Deserialize<ReceiptForRpc>(reader)?.ToReceipt() ?? existingValue;
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/ConsensusModuleTests.Setup.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/ConsensusModuleTests.Setup.cs
@@ -43,14 +43,12 @@ namespace Nethermind.Merge.Plugin.Test
 {
     public partial class ConsensusModuleTests
     {
-        private readonly ManualTimestamper _manualTimestamper = new();
-        
-        private async Task<MergeTestBlockchain> CreateBlockChain() => await new MergeTestBlockchain(_manualTimestamper).Build(new SingleReleaseSpecProvider(Berlin.Instance, 1));
+        private async Task<MergeTestBlockchain> CreateBlockChain() => await new MergeTestBlockchain(new ManualTimestamper()).Build(new SingleReleaseSpecProvider(Berlin.Instance, 1));
 
         private IConsensusRpcModule CreateConsensusModule(MergeTestBlockchain chain)
         {
             return new ConsensusRpcModule(
-                new AssembleBlockHandler(chain.BlockTree, chain.BlockProductionTrigger, _manualTimestamper, chain.LogManager),
+                new AssembleBlockHandler(chain.BlockTree, chain.BlockProductionTrigger, chain.Timestamper, chain.LogManager),
                 new NewBlockHandler(chain.BlockTree, chain.BlockPreprocessorStep, chain.BlockchainProcessor, chain.State, new InitConfig(), chain.LogManager),
                 new SetHeadBlockHandler(chain.BlockTree, chain.State, chain.LogManager),
                 new FinaliseBlockHandler(chain.BlockFinder, chain.BlockFinalizationManager, chain.LogManager),
@@ -59,11 +57,9 @@ namespace Nethermind.Merge.Plugin.Test
 
         private class MergeTestBlockchain : TestBlockchain
         {
-            private readonly ManualTimestamper _timestamper;
-
             public MergeTestBlockchain(ManualTimestamper timestamper)
             {
-                _timestamper = timestamper;
+                Timestamper = timestamper;
                 GenesisBlockBuilder = Core.Test.Builders.Build.A.Block.Genesis.Genesis
                     .WithTimestamp(UInt256.One);
                 Signer = new Eth2Signer(MinerAddress);
@@ -102,7 +98,7 @@ namespace Nethermind.Merge.Plugin.Test
                     BlockProductionTrigger,
                     SpecProvider,
                     Signer,
-                    _timestamper,
+                    Timestamper,
                     miningConfig,
                     LogManager);
             }

--- a/src/Nethermind/Nethermind.Mev.Test/BundlePoolTests.cs
+++ b/src/Nethermind/Nethermind.Mev.Test/BundlePoolTests.cs
@@ -282,13 +282,11 @@ namespace Nethermind.Mev.Test
             chain.BundlePool.AddBundle(normalBundle);
 
             CancellationTokenSource cts = new(TestBlockchain.DefaultTimeout);
-            await chain.BundlePool.WaitForSimulationToFinish(failingBundle, cts.Token);
-            await chain.BundlePool.WaitForSimulationToFinish(normalBundle, cts.Token);
+            (await chain.BundlePool.WaitForSimulationToFinish(failingBundle, cts.Token)).Should().BeFalse();
+            (await chain.BundlePool.WaitForSimulationToFinish(normalBundle, cts.Token)).Should().BeTrue();
 
             MevBundle[] bundlePoolBundles = chain.BundlePool.GetBundles(2, UInt256.Zero).ToArray();
-            bundlePoolBundles.Should().NotContain(failingBundle);
-            bundlePoolBundles.Should().Contain(normalBundle);
-            bundlePoolBundles.Length.Should().Be(1);
+            bundlePoolBundles.Should().BeEquivalentTo(normalBundle);
         }
         
         [TestCase(1u, 1)]

--- a/src/Nethermind/Nethermind.Mev.Test/BundlePoolTests.cs
+++ b/src/Nethermind/Nethermind.Mev.Test/BundlePoolTests.cs
@@ -285,6 +285,8 @@ namespace Nethermind.Mev.Test
             (await chain.BundlePool.WaitForSimulationToFinish(failingBundle, cts.Token)).Should().BeFalse();
             (await chain.BundlePool.WaitForSimulationToFinish(normalBundle, cts.Token)).Should().BeTrue();
 
+            await Task.Delay(10, cts.Token); //give time for background task to remove failed simulation
+            
             MevBundle[] bundlePoolBundles = chain.BundlePool.GetBundles(2, UInt256.Zero).ToArray();
             bundlePoolBundles.Should().BeEquivalentTo(normalBundle);
         }

--- a/src/Nethermind/Nethermind.Mev.Test/TestBundlePool.cs
+++ b/src/Nethermind/Nethermind.Mev.Test/TestBundlePool.cs
@@ -51,11 +51,11 @@ namespace Nethermind.Mev.Test
             return simulatedMevBundleContext;
         }
 
-        public Task WaitForSimulationToFinish(MevBundle bundle, CancellationToken token) => WaitForSimulation(true, bundle, token);
+        public Task<bool?> WaitForSimulationToFinish(MevBundle bundle, CancellationToken token) => WaitForSimulation(true, bundle, token);
 
         public Task WaitForSimulationToStart(MevBundle bundle, CancellationToken token) => WaitForSimulation(false, bundle, token);
 
-        private async Task WaitForSimulation(bool toFinish, MevBundle bundle, CancellationToken token)
+        private async Task<bool?> WaitForSimulation(bool toFinish, MevBundle bundle, CancellationToken token)
         {
             foreach ((MevBundle Bundle, SimulatedMevBundleContext? Context) simulatedBundle in _queue.GetConsumingEnumerable(token))
             {
@@ -68,7 +68,8 @@ namespace Nethermind.Mev.Test
                 {
                     if (toFinish && simulatedBundle.Context is not null)
                     {
-                        await simulatedBundle.Item2.Task;
+                        SimulatedMevBundle simulatedMevBundle = await simulatedBundle.Item2.Task;
+                        return simulatedMevBundle.Success;
                     }
 
                     break;
@@ -78,6 +79,8 @@ namespace Nethermind.Mev.Test
                     _queue.Add(simulatedBundle, token);
                 }
             }
+
+            return null;
         }
     }
 }

--- a/src/Nethermind/Nethermind.Mev/Data/BundleEventArgs.cs
+++ b/src/Nethermind/Nethermind.Mev/Data/BundleEventArgs.cs
@@ -1,0 +1,31 @@
+//  Copyright (c) 2021 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
+
+using System;
+
+namespace Nethermind.Mev.Data
+{
+    public class BundleEventArgs : EventArgs
+    {
+        public MevBundle MevBundle { get; }
+        
+        public BundleEventArgs(MevBundle mevBundle)
+        {
+            MevBundle = mevBundle;
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Mev/IMevConfig.cs
+++ b/src/Nethermind/Nethermind.Mev/IMevConfig.cs
@@ -37,7 +37,7 @@ namespace Nethermind.Mev
             DefaultValue = "200")]
         int BundlePoolSize { get; set; }
 
-        [ConfigItem(Description = "Defines the maximum number of MEV bundles to be included within a single block", DefaultValue = "0")]
+        [ConfigItem(Description = "Defines the maximum number of MEV bundles to be included within a single block", DefaultValue = "1")]
         int MaxMergedBundles { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.Mev/MevConfig.cs
+++ b/src/Nethermind/Nethermind.Mev/MevConfig.cs
@@ -28,6 +28,6 @@ namespace Nethermind.Mev
         public bool Enabled { get; set; }
         public UInt256 BundleHorizon { get; set; } = 60 * 60;
         public int BundlePoolSize { get; set; } = 200;
-        public int MaxMergedBundles { get; set; }
+        public int MaxMergedBundles { get; set; } = 1;
     }
 }

--- a/src/Nethermind/Nethermind.Mev/Source/BundlePool.cs
+++ b/src/Nethermind/Nethermind.Mev/Source/BundlePool.cs
@@ -118,7 +118,8 @@ namespace Nethermind.Mev.Source
         public bool AddBundle(MevBundle bundle)
         {
             Metrics.BundlesReceived++;
-            NewReceived?.Invoke(this, new BundleEventArgs(bundle));
+            BundleEventArgs bundleEventArgs = new(bundle);
+            NewReceived?.Invoke(this, bundleEventArgs);
             
             if (ValidateBundle(bundle))
             {
@@ -127,7 +128,7 @@ namespace Nethermind.Mev.Source
                 if (result)
                 {
                     Metrics.ValidBundlesReceived++;
-                    NewPending?.Invoke(this, new BundleEventArgs(bundle));
+                    NewPending?.Invoke(this, bundleEventArgs);
                     if (bundle.BlockNumber == HeadNumber + 1)
                     { 
                         TrySimulateBundle(bundle);

--- a/src/Nethermind/Nethermind.Mev/Source/IBundlePool.cs
+++ b/src/Nethermind/Nethermind.Mev/Source/IBundlePool.cs
@@ -15,6 +15,7 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 // 
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using Nethermind.Core;
@@ -25,6 +26,8 @@ namespace Nethermind.Mev.Source
 {
     public interface IBundlePool : IBundleSource
     {
+        event EventHandler<BundleEventArgs> NewReceived;
+        event EventHandler<BundleEventArgs> NewPending;
         bool AddBundle(MevBundle bundle);
         IEnumerable<MevBundle> GetBundles(long block, UInt256 timestamp, CancellationToken token = default);
     }

--- a/src/Nethermind/Nethermind.Mev/Source/IBundlePool.cs
+++ b/src/Nethermind/Nethermind.Mev/Source/IBundlePool.cs
@@ -28,4 +28,10 @@ namespace Nethermind.Mev.Source
         bool AddBundle(MevBundle bundle);
         IEnumerable<MevBundle> GetBundles(long block, UInt256 timestamp, CancellationToken token = default);
     }
+    
+    public static class BundlePoolExtensions
+    {
+        public static IEnumerable<MevBundle> GetBundles(this IBundlePool bundleSource, BlockHeader parent, ITimestamper timestamper, CancellationToken token = default) => 
+            bundleSource.GetBundles(parent.Number + 1, timestamper.UnixTime.Seconds, token);
+    }
 }

--- a/src/Nethermind/Nethermind.Mev/Source/IBundleTxSource.cs
+++ b/src/Nethermind/Nethermind.Mev/Source/IBundleTxSource.cs
@@ -47,7 +47,7 @@ namespace Nethermind.Mev.Source
             IEnumerable<MevBundle> bundles = bundlesTasks.Result; // Is it ok as it will timeout on cancellation token and not create a deadlock?
             foreach (MevBundle bundle in bundles)
             {
-                foreach (Transaction transaction in bundle.Transactions)
+                foreach (BundleTransaction transaction in bundle.Transactions)
                 {
                     yield return transaction;
                 }


### PR DESCRIPTION
## Changes:

1. Improve dumps on consensus issues:
- Delete invalid blocks before dump
- Add Receipt dump
- Make dumps from least resource intensive to most (Receipts, Parity, Geth)
- Handle exceptions when dump fails
- Improve json serialization of a dump

2. Build bundle blocks only when bundles are available. When bundles are not available for block, then blocks for those bundles will not be created.

3. Change default MevConfig.MaxMergedBundles to 1.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No

**Comments about testing , should you have some** (optional)

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...