### PR TITLE
Changed to ETH66 in EthStats and eth_protocolVersion

### DIFF
--- a/src/Nethermind/Nethermind.Core/Extensions/IntExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/IntExtensions.cs
@@ -85,6 +85,11 @@ namespace Nethermind.Core.Extensions
     
     public static class IntExtensions
     {
+        public static string ToHexString(this int @this)
+        {
+            return $"0x{@this:X}";
+        }
+        
         public static UInt256 Ether(this int @this)
         {
             return (uint)@this * Unit.Ether;

--- a/src/Nethermind/Nethermind.Init/Steps/StartEthStatsClient.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/StartEthStatsClient.cs
@@ -25,6 +25,7 @@ using Nethermind.EthStats.Integrations;
 using Nethermind.EthStats.Senders;
 using Nethermind.Logging;
 using Nethermind.Network.Config;
+using Nethermind.Network.P2P;
 
 namespace Nethermind.Init.Steps
 {
@@ -57,7 +58,7 @@ namespace Nethermind.Init.Steps
 
             string instanceId = $"{ethStatsConfig.Name}-{Keccak.Compute(_get.Enode.Info)}";
             if (_logger.IsInfo) _logger.Info($"Initializing ETH Stats for the instance: {instanceId}, server: {ethStatsConfig.Server}");
-            MessageSender sender = new MessageSender(instanceId, _get.LogManager);
+            MessageSender sender = new(instanceId, _get.LogManager);
             const int reconnectionInterval = 5000;
             const string api = "no";
             const string client = "0.1.1";
@@ -65,7 +66,7 @@ namespace Nethermind.Init.Steps
             string node = ClientVersion.Description;
             int port = networkConfig.P2PPort;
             string network = _get.SpecProvider.ChainId.ToString();
-            string protocol = "eth/65";
+            string protocol = $"{P2PProtocolInfoProvider.DefaultCapabilitiesToString()}";
             
             EthStatsClient ethStatsClient = new(
                 ethStatsConfig.Server,

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
@@ -448,7 +448,7 @@ namespace Nethermind.JsonRpc.Test.Modules.Eth
         {
             using Context ctx = await Context.Create();
             string serialized = ctx._test.TestEthRpc("eth_protocolVersion");
-            Assert.AreEqual("{\"jsonrpc\":\"2.0\",\"result\":\"0x41\",\"id\":67}", serialized);
+            Assert.AreEqual("{\"jsonrpc\":\"2.0\",\"result\":\"0x42\",\"id\":67}", serialized);
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
@@ -32,9 +32,11 @@ using Nethermind.Facade;
 using Nethermind.JsonRpc.Data;
 using Nethermind.JsonRpc.Modules.Eth.GasPrice;
 using Nethermind.Logging;
+using Nethermind.Network.P2P;
 using Nethermind.Serialization.Rlp;
 using Nethermind.State;
 using Nethermind.State.Proofs;
+using Nethermind.Stats.Model;
 using Nethermind.Trie;
 using Nethermind.TxPool;
 using Nethermind.Wallet;
@@ -93,7 +95,8 @@ namespace Nethermind.JsonRpc.Modules.Eth
 
         public ResultWrapper<string> eth_protocolVersion()
         {
-            return ResultWrapper<string>.Success("0x41");
+            int highestVersion =  P2PProtocolInfoProvider.GetHighestVersionOfEthProtocol();
+            return ResultWrapper<string>.Success(highestVersion.ToHexString());
         }
 
         public ResultWrapper<SyncingResult> eth_syncing()
@@ -151,7 +154,7 @@ namespace Nethermind.JsonRpc.Modules.Eth
         {
             try
             {
-                var result = _wallet.GetAccounts();
+                Address[] result = _wallet.GetAccounts();
                 Address[] data = result.ToArray();
                 return ResultWrapper<IEnumerable<Address>>.Success(data.ToArray());
             }
@@ -292,7 +295,7 @@ namespace Nethermind.JsonRpc.Modules.Eth
                 return ResultWrapper<byte[]>.Success(Array.Empty<byte>());
             }
 
-            var code = _stateReader.GetCode(account.CodeHash);
+            byte[]? code = _stateReader.GetCode(account.CodeHash);
             return ResultWrapper<byte[]>.Success(code);
         }
 
@@ -429,11 +432,11 @@ namespace Nethermind.JsonRpc.Modules.Eth
 
         public ResultWrapper<TransactionForRpc[]> eth_pendingTransactions()
         {
-            var transactions = _txPoolBridge.GetPendingTransactions();
-            var transactionsModels = new TransactionForRpc[transactions.Length];
+            Transaction[] transactions = _txPoolBridge.GetPendingTransactions();
+            TransactionForRpc[] transactionsModels = new TransactionForRpc[transactions.Length];
             for (int i = 0; i < transactions.Length; i++)
             {
-                var transaction = transactions[i];
+                Transaction transaction = transactions[i];
                 RecoverTxSenderIfNeeded(transaction);
                 transactionsModels[i] = new TransactionForRpc(transaction);
                 transactionsModels[i].BlockHash = Keccak.Zero;
@@ -494,7 +497,7 @@ namespace Nethermind.JsonRpc.Modules.Eth
 
         public Task<ResultWrapper<ReceiptForRpc>> eth_getTransactionReceipt(Keccak txHash)
         {
-            var result = _blockchainBridge.GetReceiptAndEffectiveGasPrice(txHash);
+            (TxReceipt Receipt, UInt256? EffectiveGasPrice) result = _blockchainBridge.GetReceiptAndEffectiveGasPrice(txHash);
             if (result.Receipt == null)
             {
                 return Task.FromResult(ResultWrapper<ReceiptForRpc>.Success(null));

--- a/src/Nethermind/Nethermind.Network.Test/P2P/P2PProtocolInfoProviderTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/P2PProtocolInfoProviderTests.cs
@@ -1,0 +1,41 @@
+﻿//  Copyright (c) 2021 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
+
+using Nethermind.Network.P2P;
+using NUnit.Framework;
+
+namespace Nethermind.Network.Test.P2P
+{
+    [Parallelizable(ParallelScope.All)]
+    [TestFixture]
+    public class P2PProtocolInfoProviderTests
+    {
+        [Test]
+        public void GetHighestVersionOfEthProtocol_ReturnExpectedResult()
+        {
+            int result = P2PProtocolInfoProvider.GetHighestVersionOfEthProtocol();
+            Assert.AreEqual(66, result);
+        }
+        
+        [Test]
+        public void DefaultCapabilitiesToString_ReturnExpectedResult()
+        {
+            string result = P2PProtocolInfoProvider.DefaultCapabilitiesToString();
+            Assert.AreEqual("eth/66,eth/65,eth/64,eth/63,eth/62", result);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Network/P2P/P2PProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/P2PProtocolHandler.cs
@@ -290,7 +290,7 @@ namespace Nethermind.Network.P2P
 
         protected override TimeSpan InitTimeout => Timeouts.P2PHello;
 
-        private static readonly IEnumerable<Capability> DefaultCapabilities = new Capability[]
+        public static readonly IEnumerable<Capability> DefaultCapabilities = new Capability[]
         {
             new Capability(Protocol.Eth, 62),
             new Capability(Protocol.Eth, 63),

--- a/src/Nethermind/Nethermind.Network/P2P/P2PProtocolInfoProvider.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/P2PProtocolInfoProvider.cs
@@ -1,0 +1,46 @@
+﻿//  Copyright (c) 2021 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
+
+using System.Collections.Generic;
+using System.Linq;
+using Nethermind.Stats.Model;
+
+namespace Nethermind.Network.P2P
+{
+    public static class P2PProtocolInfoProvider
+    {
+        public static int GetHighestVersionOfEthProtocol()
+        {
+            int highestVersion = 0;
+            foreach (Capability ethProtocol in P2PProtocolHandler.DefaultCapabilities)
+            {
+                if (ethProtocol.ProtocolCode == Protocol.Eth && highestVersion < ethProtocol.Version)
+                    highestVersion = ethProtocol.Version;
+            }
+
+            return highestVersion;
+        }
+
+        public static string DefaultCapabilitiesToString()
+        {
+            IEnumerable<string> capabilities = P2PProtocolHandler.DefaultCapabilities
+                .OrderBy(x => x.ProtocolCode).ThenByDescending(x => x.Version)
+                .Select(x => $"{x.ProtocolCode}/{x.Version}");
+            return string.Join(",", capabilities);
+        }
+    }
+}


### PR DESCRIPTION
## Changes:
- eth_protocolVersion -> ETH66
- ethStats changed like below (I observed that geth is working like that)
![image](https://user-images.githubusercontent.com/9356351/131251575-c2b95b8d-2771-4c11-b01b-d0bc2a982a32.png)


## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No