### PR TITLE
Make BlockRewardType values consistent with BenefactorKind

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Rewards/BlockRewardType.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Rewards/BlockRewardType.cs
@@ -22,8 +22,8 @@ namespace Nethermind.Blockchain.Rewards
     {
         Block = 0,
         Uncle = 1,
-        External = 2,
-        EmptyStep = 3
+        EmptyStep = 2,
+        External = 3
     }
 
     public static class BlockRewardTypeExtension


### PR DESCRIPTION
## Changes:
Make BlockRewardType labels have values same as BenefactorKind

## Types of changes

What types of changes does your code introduce?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [x] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [x] No

**Comments about testing , should you have some** (optional)

This is not a functional change, nothing is changing how the reward mechanism works. BlockRewardType enum types are only used by label and their int value isn't used anywhere. This can cause confusion though and is inconsistent with BenefactorKind.