### PR TITLE
Cache CodeInfo when executing CREATE

### DIFF
--- a/src/Nethermind/Nethermind.Core/Caching/LruCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/LruCache.cs
@@ -33,6 +33,8 @@ namespace Nethermind.Core.Caching
         private readonly Dictionary<TKey, LinkedListNode<LruCacheItem>> _cacheMap;
         private readonly LinkedList<LruCacheItem> _lruList;
 
+        public int MapSize => _cacheMap.Count;
+
         [MethodImpl(MethodImplOptions.Synchronized)]
         public void Clear()
         {

--- a/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
@@ -254,6 +254,16 @@ namespace Nethermind.Core.Extensions
             return result;
         }
 
+        public static byte[] PadRightWithoutTrailingZeros(this byte[] bytes, int length)
+        {
+            if (bytes.Length <= length)
+            {
+                return (byte[])bytes.Clone();
+            }
+
+            return bytes.Slice(0, length);
+        }
+
         public static byte[] Concat(params byte[][] parts)
         {
             int totalLength = 0;

--- a/src/Nethermind/Nethermind.Evm.Benchmark/Nethermind.Evm.Benchmark.csproj
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/Nethermind.Evm.Benchmark.csproj
@@ -5,10 +5,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+      <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
     </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\Nethermind.Evm.Test\Nethermind.Evm.Test.csproj" />
       <ProjectReference Include="..\Nethermind.Evm\Nethermind.Evm.csproj" />
       <ProjectReference Include="..\Nethermind.Logging\Nethermind.Logging.csproj" />
       <ProjectReference Include="..\Nethermind.State\Nethermind.State.csproj" />

--- a/src/Nethermind/Nethermind.Evm.Test/JumpdestAnalysisTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/JumpdestAnalysisTests.cs
@@ -1,0 +1,53 @@
+using System;
+using FluentAssertions;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Int256;
+using NUnit.Framework;
+
+namespace Nethermind.Evm.Test
+{
+    [TestFixture]
+    public class JumpdestAnalysisTests : VirtualMachineTestsBase
+    {
+
+        [Test]
+        public void CreateInLoop()
+        {
+            byte[] createCode = InitTest();
+            TestAllTracerWithOutput res = CreateInLoop( 10_000_000, createCode);
+
+            res.Error.Should().Contain("OutOfGas");
+        }
+
+        public TestAllTracerWithOutput CreateInLoop(int tranGasLimit, byte[] createCode)
+        {
+            var res = Execute(0, tranGasLimit, createCode, 50_000_000);
+
+            return res;
+        }
+
+        public byte[] InitTest()
+        {
+            long initCodeSize = 32;
+            
+            // 32 bytes of code: JUMP + 29 of JUMPDEST
+            byte[] longJumpCode = Prepare.EvmCode
+                .PushData(initCodeSize - 1) // location of the last JUMPDEST
+                .Op(Instruction.JUMP)
+                .Op(Instruction.JUMPDEST, 29)
+                .Done;
+            
+            var createCode = Prepare.EvmCode
+                .StoreDataInMemoryWithoutTrailingZeros(0, longJumpCode) // insert the long JUMP code at the beginning of the memory
+                .AddJumpDest(out int jumpDestLoc) // JUMPDEST for the infinite loop
+                .Create((UInt256)initCodeSize, 0, 0) // CREATE init code from the memory
+                .PushData(jumpDestLoc) // the infinite loop jump destination
+                .Op(Instruction.JUMP) // the infinite loop jump
+                .Done;
+
+            return createCode;
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Evm.Test/VirtualMachineTestsBase.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/VirtualMachineTestsBase.cs
@@ -122,10 +122,14 @@ namespace Nethermind.Evm.Test
             return tracer;
         }
 
-        protected TestAllTracerWithOutput Execute(long blockNumber, long gasLimit, byte[] code)
+        protected TestAllTracerWithOutput Execute(long blockNumber, long gasLimit, byte[] code, long? blockGasLimit = null)
         {
             (Block block, Transaction transaction) = PrepareTx(blockNumber, gasLimit, code);
             TestAllTracerWithOutput tracer = CreateTracer();
+            if (blockGasLimit.HasValue)
+            {
+                block.Header.GasLimit = blockGasLimit.Value;
+            }
             _processor.Execute(transaction, block.Header, tracer);
             return tracer;
         }


### PR DESCRIPTION
Resolves #3355

## Changes:
- CodeInfo will be cached whenever CREATE is executed

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No
