### PR TITLE
Synchronize LruKeyCache.Clear

### DIFF
--- a/src/Nethermind/Nethermind.Core/Caching/LruCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/LruCache.cs
@@ -33,13 +33,6 @@ namespace Nethermind.Core.Caching
         private readonly Dictionary<TKey, LinkedListNode<LruCacheItem>> _cacheMap;
         private readonly LinkedList<LruCacheItem> _lruList;
 
-        [MethodImpl(MethodImplOptions.Synchronized)]
-        public void Clear()
-        {
-            _cacheMap?.Clear();
-            _lruList?.Clear();
-        }
-
         public LruCache(int maxCapacity, int startCapacity, string name)
         {
             if (maxCapacity < 1) 
@@ -57,6 +50,13 @@ namespace Nethermind.Core.Caching
         public LruCache(int maxCapacity, string name)
             : this(maxCapacity, 0, name)
         {
+        }
+        
+        [MethodImpl(MethodImplOptions.Synchronized)]
+        public void Clear()
+        {
+            _cacheMap.Clear();
+            _lruList.Clear();
         }
 
         [MethodImpl(MethodImplOptions.Synchronized)]

--- a/src/Nethermind/Nethermind.Core/Caching/LruKeyCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/LruKeyCache.cs
@@ -31,12 +31,6 @@ namespace Nethermind.Core.Caching
         private readonly Dictionary<TKey, LinkedListNode<TKey>> _cacheMap;
         private readonly LinkedList<TKey> _lruList;
 
-        public void Clear()
-        {
-            _cacheMap.Clear();
-            _lruList.Clear();
-        }
-
         public LruKeyCache(int maxCapacity, int startCapacity, string name)
         {
             _maxCapacity = maxCapacity;
@@ -51,6 +45,13 @@ namespace Nethermind.Core.Caching
             : this(maxCapacity, 0, name)
         {
         }
+        
+        [MethodImpl(MethodImplOptions.Synchronized)]
+        public void Clear()
+        {
+            _cacheMap.Clear();
+            _lruList.Clear();
+        }        
 
         [MethodImpl(MethodImplOptions.Synchronized)]
         public bool Get(TKey key)


### PR DESCRIPTION
Fixes 

ERROR|52|Couldn't correctly add or remove transactions from txpool after processing block 12991869 (0x39416672b6a326f403743d3895e50cacff56b2d4e59f1e9b9a6c0182ce44529e). System.NullReferenceException: Object reference not set to an instance of an object.
ERROR|40|Couldn't correctly add or remove transactions from txpool after processing block 13009572 (0x9b674d60ff2d0a4016594f7c2169e1ba02de0fc68f0b9447e9cedf8035caaa2a). System.NullReferenceException: Object reference not set to an instance of an object.
ERROR|46|Couldn't correctly add or remove transactions from txpool after processing block 13070711 (0x56d832257fb398d28013abe33038a47cc0c23943d392d3c0bda45e4d8cc1ccc0). System.InvalidOperationException: Operations that change non-concurrent collections must have exclusive access. A concurrent update was performed on this collection and corrupted its state. The collection's state is no longer correct.


## Changes:
LruKeyCache public methods need to be thread safe

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [x] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [x] No