### PR TITLE
Fix ReportMemoryChange dataOffset overflow

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/ParityLikeTxTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/ParityLikeTxTracerTests.cs
@@ -304,8 +304,9 @@ namespace Nethermind.Evm.Test.Tracing
             Assert.AreEqual("delegatecall", trace.Action.Subtraces[0].CallType, "[0] type");
         }
 
-        [Test]
-        public void Can_trace_call_code_calls()
+        [TestCase(0ul)]
+        [TestCase(ulong.MaxValue)]
+        public void Can_trace_call_code_calls(ulong dataOffset)
         {
             byte[] deployedCode = new byte[3];
 
@@ -323,7 +324,7 @@ namespace Nethermind.Evm.Test.Tracing
             TestState.UpdateCodeHash(TestItem.AddressC, createCodeHash, Spec);
 
             byte[] code = Prepare.EvmCode
-                .CallCode(TestItem.AddressC, 50000)
+                .CallCode(TestItem.AddressC, 50000, dataOffset)
                 .Op(Instruction.STOP)
                 .Done;
 

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/ParityLikeTxTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/ParityLikeTxTracerTests.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Linq;
+using FluentAssertions;
 using Nethermind.Core;
 using Nethermind.Core.Attributes;
 using Nethermind.Core.Crypto;
@@ -304,9 +305,9 @@ namespace Nethermind.Evm.Test.Tracing
             Assert.AreEqual("delegatecall", trace.Action.Subtraces[0].CallType, "[0] type");
         }
 
-        [TestCase(0ul)]
-        [TestCase(ulong.MaxValue)]
-        public void Can_trace_call_code_calls(ulong dataOffset)
+
+        [Test]
+        public void Can_trace_call_code_calls()
         {
             byte[] deployedCode = new byte[3];
 
@@ -324,7 +325,7 @@ namespace Nethermind.Evm.Test.Tracing
             TestState.UpdateCodeHash(TestItem.AddressC, createCodeHash, Spec);
 
             byte[] code = Prepare.EvmCode
-                .CallCode(TestItem.AddressC, 50000, dataOffset)
+                .CallCode(TestItem.AddressC, 50000)
                 .Op(Instruction.STOP)
                 .Done;
 
@@ -339,6 +340,34 @@ namespace Nethermind.Evm.Test.Tracing
             };
 
             Assert.AreEqual("callcode", trace.Action.Subtraces[0].CallType, "[0] type");
+        }
+        
+        [Test]
+        public void Can_trace_call_code_calls_with_large_data_offset()
+        {
+            byte[] deployedCode = new byte[3];
+
+            byte[] initCode = Prepare.EvmCode
+                .ForInitOf(deployedCode)
+                .Done;
+
+            byte[] createCode = Prepare.EvmCode
+                .Create(initCode, 0)
+                .Op(Instruction.STOP)
+                .Done;
+
+            TestState.CreateAccount(TestItem.AddressC, 1.Ether());
+            Keccak createCodeHash = TestState.UpdateCode(createCode);
+            TestState.UpdateCodeHash(TestItem.AddressC, createCodeHash, Spec);
+
+            byte[] code = Prepare.EvmCode
+                .CallCode(TestItem.AddressC, 50000, UInt256.MaxValue, ulong.MaxValue)
+                .Op(Instruction.STOP)
+                .Done;
+
+            ParityLikeTxTrace trace = ExecuteAndTraceParityCall(code).trace;
+            trace.Action!.Error.Should().BeNullOrEmpty();
+
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Evm/ByteCodeBuilder.cs
+++ b/src/Nethermind/Nethermind.Evm/ByteCodeBuilder.cs
@@ -154,12 +154,12 @@ namespace Nethermind.Evm
             return this;
         }
 
-        public Prepare CallCode(Address address, long gasLimit)
+        public Prepare CallCode(Address address, long gasLimit, ulong dataOffset = 0)
         {
             PushData(0);
             PushData(0);
             PushData(0);
-            PushData(0);
+            PushData(dataOffset);
             PushData(0);
             PushData(address);
             PushData(gasLimit);

--- a/src/Nethermind/Nethermind.Evm/ByteCodeBuilder.cs
+++ b/src/Nethermind/Nethermind.Evm/ByteCodeBuilder.cs
@@ -154,13 +154,13 @@ namespace Nethermind.Evm
             return this;
         }
 
-        public Prepare CallCode(Address address, long gasLimit, ulong dataOffset = 0)
+        public Prepare CallCode(Address address, long gasLimit, UInt256? transferValue = null, UInt256? dataOffset = null)
         {
             PushData(0);
             PushData(0);
             PushData(0);
-            PushData(dataOffset);
-            PushData(0);
+            PushData(dataOffset ?? UInt256.Zero);
+            PushData(transferValue ?? UInt256.Zero);
             PushData(address);
             PushData(gasLimit);
             Op(Instruction.CALLCODE);

--- a/src/Nethermind/Nethermind.Evm/Tracing/ITxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/ITxTracer.cs
@@ -15,6 +15,7 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
@@ -99,6 +100,14 @@ namespace Nethermind.Evm.Tracing
         void SetOperationMemorySize(ulong newSize);
 
         void ReportMemoryChange(long offset, in ReadOnlySpan<byte> data);
+
+        void ReportMemoryChange(UInt256 offset, in ReadOnlySpan<byte> data)
+        {
+            if (offset.u1 <= 0 && offset.u2 <= 0 && offset.u3 <= 0 && offset.u0 <= long.MaxValue)
+            {
+                ReportMemoryChange((long) offset, data);
+            }
+        }
 
         void ReportMemoryChange(long offset, byte data)
         {

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -1753,7 +1753,7 @@ namespace Nethermind.Evm
                         stack.PopUInt256(out UInt256 memPosition);
                         UpdateMemoryCost(in memPosition, 32);
                         Span<byte> memData = vmState.Memory.LoadSpan(in memPosition);
-                        if (_txTracer.IsTracingInstructions) _txTracer.ReportMemoryChange((long) memPosition, memData);
+                        if (_txTracer.IsTracingInstructions) _txTracer.ReportMemoryChange(memPosition, memData);
 
                         stack.PushBytes(memData);
                         break;
@@ -2497,7 +2497,7 @@ namespace Nethermind.Evm
                             {
                                 // very specific for Parity trace, need to find generalization - very peculiar 32 length...
                                 ReadOnlyMemory<byte> memoryTrace = vmState.Memory.Load(in dataOffset, 32);
-                                _txTracer.ReportMemoryChange((long) dataOffset, memoryTrace.Span);
+                                _txTracer.ReportMemoryChange(dataOffset, memoryTrace.Span);
                             }
 
                             if (isTrace) _logger.Trace("FAIL - call depth");


### PR DESCRIPTION
## Changes:
Fixes potential overflow on ReportMemoryChange on wrong stack parameters -> reported from FuzzyVM tests.

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No

I've tested it on, test provided by @MariusVanDerWijden, it worked, but failed with GethTracer attached. Decided not to add this test to codebase after the fix as I don't find it relevant. Added a simple test instead.