### PR TITLE
newHeads subscription gets incorrect blocks when re-org

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/ReorgTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/ReorgTests.cs
@@ -120,7 +120,8 @@ namespace Nethermind.Blockchain.Test
             Block block1 = Build.A.Block.WithParent(block0).WithDifficulty(1).WithTotalDifficulty(1L).TestObject;
             Block block2 = Build.A.Block.WithParent(block1).WithDifficulty(2).WithTotalDifficulty(3L).TestObject;
             Block block3 = Build.A.Block.WithParent(block2).WithDifficulty(3).WithTotalDifficulty(6L).TestObject;
-            Block block1B = Build.A.Block.WithParent(block0).WithDifficulty(10).WithTotalDifficulty(10L).TestObject;
+            Block block1B = Build.A.Block.WithParent(block0).WithDifficulty(5).WithTotalDifficulty(5L).TestObject;
+            Block block2B = Build.A.Block.WithParent(block1B).WithDifficulty(6).WithTotalDifficulty(11L).TestObject;
 
             _blockchainProcessor.Start();
             
@@ -129,9 +130,10 @@ namespace Nethermind.Blockchain.Test
             _blockTree.SuggestBlock(block2);
             _blockTree.SuggestBlock(block3);
             _blockTree.SuggestBlock(block1B);
+            _blockTree.SuggestBlock(block2B);
 
             Thread.Sleep(200);
-            _blockTree.Head.Should().Be(block1B);
+            _blockTree.Head.Should().Be(block2B);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Processing/BlockchainProcessor.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Processing/BlockchainProcessor.cs
@@ -437,8 +437,6 @@ namespace Nethermind.Blockchain.Processing
 
                     blocksToProcess.Add(block);
                 }
-
-                blocksToProcess.Reverse();
             }
 
             if (_logger.IsTrace) _logger.Trace($"Processing {blocksToProcess.Count} blocks from state root {processingBranch.Root}");
@@ -516,6 +514,7 @@ namespace Nethermind.Blockchain.Processing
 
             Keccak stateRoot = branchingPoint?.StateRoot;
             if (_logger.IsTrace) _logger.Trace($"State root lookup: {stateRoot}");
+            blocksToBeAddedToMain.Reverse();
             return new ProcessingBranch(stateRoot, blocksToBeAddedToMain);
         }
 


### PR DESCRIPTION
Fixes #3444 

## Changes:
The branch will be reversed earlier to process blocks in the correct order.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No
