### PR TITLE
Start metrics for endpoint if configured

### DIFF
--- a/src/Nethermind/Nethermind.Init/Steps/StartMonitoring.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/StartMonitoring.cs
@@ -47,7 +47,7 @@ namespace Nethermind.Init.Steps
                 _api.LogManager.SetGlobalVariable("nodeName", metricsConfig.NodeName);
             }
             
-            if (metricsConfig.Enabled)
+            if (metricsConfig.Enabled || metricsConfig.ExposePort != null)
             {
                 Metrics.Version = VersionToMetrics.ConvertToNumber(ClientVersion.Version);
                 MetricsUpdater metricsUpdater = new MetricsUpdater(metricsConfig);


### PR DESCRIPTION
Fixes #3475 

## Changes:
- Starts the metrics subsystem if a metrics endpoint port is configured.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [x] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [x] No