### PR TITLE
Fix Distinct when loading assemblies

### DIFF
--- a/src/Nethermind/Nethermind.Core/TypeDiscovery.cs
+++ b/src/Nethermind/Nethermind.Core/TypeDiscovery.cs
@@ -55,7 +55,8 @@ namespace Nethermind.Core
 
             var missingRefs = loadedAssemblies
                 .SelectMany(x => x.GetReferencedAssemblies())
-                .Distinct()
+                .GroupBy(a => a.FullName)
+                .Select(g => g.First())
                 .Where(a => a.Name?.Contains("Nethermind") ?? false);
 
             foreach (AssemblyName missingRef in missingRefs)


### PR DESCRIPTION
We should only load the same assembly once. 

## Changes:
The distinct logic that enumerates referenced assemblies has been fixed.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [x] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [x] No

