### PR TITLE
London hard fork on POA Core

### DIFF
--- a/src/Nethermind/Chains/poacore.json
+++ b/src/Nethermind/Chains/poacore.json
@@ -49,7 +49,16 @@
     "eip2028Transition": 12598600,
     "eip2565Transition": 21364900,
     "eip2929Transition": 21364900,
-    "eip2930Transition": 21364900
+    "eip2930Transition": 21364900,
+    "eip3198Transition": 24090200,
+    "eip3529Transition": 24090200,
+    "eip3541Transition": 24090200,
+    "eip1559Transition": 24090200,
+    "eip1559BaseFeeMaxChangeDenominator": "0x8",
+    "eip1559ElasticityMultiplier": "0x2",
+    "eip1559BaseFeeInitialValue": "0x3b9aca00",
+    "eip1559FeeCollector": "0x517F3AcfF3aFC2fb45e574718bca6F919b798e10",
+    "eip1559FeeCollectorTransition": 24090200
   },
   "genesis": {
     "seal": {


### PR DESCRIPTION
We are going to activate London on POA Core at block 24090200 (November 2). Please, make a new release ASAP.