### PR TITLE
Feature/3535 multiple jsonrpc urls

### DIFF
--- a/src/Nethermind/Nethermind.Analytics/AnalyticsWebSocketsModule.cs
+++ b/src/Nethermind/Nethermind.Analytics/AnalyticsWebSocketsModule.cs
@@ -42,9 +42,9 @@ namespace Nethermind.Analytics
             _logManager = logManager;
         }
 
-        public ISocketsClient CreateClient(WebSocket webSocket, string client, int port)
+        public ISocketsClient CreateClient(WebSocket webSocket, string clientName, int port)
         {
-            var socketsClient = new SocketClient(client, new WebSocketHandler(webSocket, _logManager), _jsonSerializer);
+            var socketsClient = new SocketClient(clientName, new WebSocketHandler(webSocket, _logManager), _jsonSerializer);
             _clients.TryAdd(socketsClient.Id, socketsClient);
 
             return socketsClient;

--- a/src/Nethermind/Nethermind.Analytics/AnalyticsWebSocketsModule.cs
+++ b/src/Nethermind/Nethermind.Analytics/AnalyticsWebSocketsModule.cs
@@ -42,9 +42,9 @@ namespace Nethermind.Analytics
             _logManager = logManager;
         }
 
-        public ISocketsClient CreateClient(WebSocket webSocket, string clientName)
+        public ISocketsClient CreateClient(WebSocket webSocket, string client, int port)
         {
-            var socketsClient = new SocketClient(clientName, new WebSocketHandler(webSocket, _logManager), _jsonSerializer);
+            var socketsClient = new SocketClient(client, new WebSocketHandler(webSocket, _logManager), _jsonSerializer);
             _clients.TryAdd(socketsClient.Id, socketsClient);
 
             return socketsClient;

--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcProcessorTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcProcessorTests.cs
@@ -24,6 +24,7 @@ using FluentAssertions;
 using Nethermind.Core.Extensions;
 using Nethermind.Logging;
 using Nethermind.Serialization.Json;
+using Nethermind.JsonRpc.Modules;
 using Newtonsoft.Json;
 using NSubstitute;
 using NUnit.Framework;
@@ -37,6 +38,7 @@ namespace Nethermind.JsonRpc.Test
     {
         private readonly bool _returnErrors;
         private IFileSystem _fileSystem;
+        private JsonRpcContext _context;
 
         private JsonRpcErrorResponse _errorResponse = new();
         
@@ -61,6 +63,7 @@ namespace Nethermind.JsonRpc.Test
             JsonRpcConfig configWithRecorder = new() {RpcRecorderState = RpcRecorderState.All};
 
             _jsonRpcProcessor = new JsonRpcProcessor(service, new EthereumJsonSerializer(), configWithRecorder, _fileSystem, LimboLogs.Instance);
+            _context = new JsonRpcContext(RpcEndpoint.Http);
         }
 
         private JsonRpcProcessor _jsonRpcProcessor;
@@ -73,7 +76,7 @@ namespace Nethermind.JsonRpc.Test
             Assert.AreEqual("840b55c4-18b0-431c-be1d-6d22198b53f2", result[0].Response.Id);
         }
 
-        private Task<List<JsonRpcResult>> ProcessAsync(string request) => _jsonRpcProcessor.ProcessAsync(request, JsonRpcContext.Http).ToListAsync();
+        private Task<List<JsonRpcResult>> ProcessAsync(string request) => _jsonRpcProcessor.ProcessAsync(request, _context).ToListAsync();
 
         [Test]
         public async Task Can_process_non_hex_ids()

--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcServiceTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcServiceTests.cs
@@ -49,11 +49,13 @@ namespace Nethermind.JsonRpc.Test
             Assembly jConfig = typeof(JsonRpcConfig).Assembly;
             _configurationProvider = new ConfigProvider();
             _logManager = LimboLogs.Instance;
+            _context = new JsonRpcContext(RpcEndpoint.Http);
         }
 
         private IJsonRpcService _jsonRpcService;
         private IConfigProvider _configurationProvider;
         private ILogManager _logManager;
+        private JsonRpcContext _context;
 
         private JsonRpcResponse TestRequest<T>(T module, string method, params string[] parameters) where T : IRpcModule
         {
@@ -61,7 +63,7 @@ namespace Nethermind.JsonRpc.Test
             moduleProvider.Register(new SingletonModulePool<T>(new SingletonFactory<T>(module), true));
             _jsonRpcService = new JsonRpcService(moduleProvider, _logManager);
             JsonRpcRequest request = RpcTest.GetJsonRequest(method, parameters);
-            JsonRpcResponse response = _jsonRpcService.SendRequestAsync(request, JsonRpcContext.Http).Result;
+            JsonRpcResponse response = _jsonRpcService.SendRequestAsync(request, _context).Result;
             Assert.AreEqual(request.Id, response.Id);
             return response;
         }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcUrlCollectionTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcUrlCollectionTests.cs
@@ -1,0 +1,221 @@
+//  Copyright (c) 2021 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using Nethermind.Logging;
+using Nethermind.JsonRpc.Modules;
+using NUnit.Framework;
+using NSubstitute;
+
+namespace Nethermind.JsonRpc.Test
+{
+    [TestFixture]
+    public class JsonRpcUrlCollectionTests
+    {
+        [SetUp]
+        public void Initialize()
+        {
+            _enabledModules = new string[] { ModuleType.Eth, ModuleType.Web3, ModuleType.Net };
+        }
+
+        private string[] _enabledModules;
+
+        [TearDown]
+        public void TearDown()
+        {
+            Environment.SetEnvironmentVariable("NETHERMIND_URL", null);
+        }
+
+        [Test]
+        public void Empty_when_disabled()
+        {
+            JsonRpcConfig jsonRpcConfig = new JsonRpcConfig() { Enabled = false };
+            JsonRpcUrlCollection urlCollection = new JsonRpcUrlCollection(Substitute.For<ILogManager>(), jsonRpcConfig, true);
+            CollectionAssert.IsEmpty(urlCollection);
+        }
+
+        [Test]
+        public void Contains_single_default_url()
+        {
+            JsonRpcConfig jsonRpcConfig = new JsonRpcConfig()
+            {
+                Enabled = true,
+                EnabledModules = _enabledModules
+            };
+
+            JsonRpcUrlCollection urlCollection = new JsonRpcUrlCollection(Substitute.For<ILogManager>(), jsonRpcConfig, true);
+            CollectionAssert.AreEquivalent(new JsonRpcUrl[]
+            {
+                new JsonRpcUrl("http", "127.0.0.1", 8545, RpcEndpoint.Http | RpcEndpoint.WebSocket, _enabledModules)
+            }, urlCollection);
+        }
+
+        [Test]
+        public void Contains_single_default_url_overridden_by_environment_variable()
+        {
+            Environment.SetEnvironmentVariable("NETHERMIND_URL", "http://localhost:1234", EnvironmentVariableTarget.Process);
+
+            JsonRpcConfig jsonRpcConfig = new JsonRpcConfig()
+            {
+                Enabled = true,
+                EnabledModules = _enabledModules
+            };
+
+            JsonRpcUrlCollection urlCollection = new JsonRpcUrlCollection(Substitute.For<ILogManager>(), jsonRpcConfig, true);
+            CollectionAssert.AreEquivalent(new JsonRpcUrl[]
+            {
+                new JsonRpcUrl("http", "localhost", 1234, RpcEndpoint.Http | RpcEndpoint.WebSocket, _enabledModules)
+            }, urlCollection);
+        }
+
+        [Test]
+        public void Contains_multiple_default_urls_with_different_ws_port()
+        {
+            JsonRpcConfig jsonRpcConfig = new JsonRpcConfig()
+            {
+                Enabled = true,
+                WebSocketsPort = 1234,
+                EnabledModules = _enabledModules
+            };
+
+            JsonRpcUrlCollection urlCollection = new JsonRpcUrlCollection(Substitute.For<ILogManager>(), jsonRpcConfig, true);
+            CollectionAssert.AreEquivalent(new JsonRpcUrl[]
+            {
+                new JsonRpcUrl("http", "127.0.0.1", 8545, RpcEndpoint.Http, _enabledModules),
+                new JsonRpcUrl("http", "127.0.0.1", 1234, RpcEndpoint.WebSocket, _enabledModules)
+            }, urlCollection);
+        }
+
+        [Test]
+        public void Contains_single_default_http_url_when_ws_disabled()
+        {
+            JsonRpcConfig jsonRpcConfig = new JsonRpcConfig()
+            {
+                Enabled = true,
+                WebSocketsPort = 1234,
+                EnabledModules = _enabledModules
+            };
+
+            JsonRpcUrlCollection urlCollection = new JsonRpcUrlCollection(Substitute.For<ILogManager>(), jsonRpcConfig, false);
+            CollectionAssert.AreEquivalent(new JsonRpcUrl[]
+            {
+                new JsonRpcUrl("http", "127.0.0.1", 8545, RpcEndpoint.Http, _enabledModules),
+            }, urlCollection);
+        }
+
+        [Test]
+        public void Contains_additional_urls()
+        {
+            JsonRpcConfig jsonRpcConfig = new JsonRpcConfig()
+            {
+                Enabled = true,
+                EnabledModules = _enabledModules,
+                AdditionalRPCUrls = new string[] { "http://localhost:1234|http,ws|admin,debug" }
+            };
+
+            JsonRpcUrlCollection urlCollection = new JsonRpcUrlCollection(Substitute.For<ILogManager>(), jsonRpcConfig, true);
+            CollectionAssert.AreEquivalent(new JsonRpcUrl[]
+            {
+                new JsonRpcUrl("http", "127.0.0.1", 8545, RpcEndpoint.Http | RpcEndpoint.WebSocket, _enabledModules),
+                new JsonRpcUrl("http", "localhost", 1234, RpcEndpoint.Http | RpcEndpoint.WebSocket, new string[] { "admin", "debug" })
+            }, urlCollection);
+        }
+
+        [Test]
+        public void Skips_additional_ws_only_urls_when_ws_disabled()
+        {
+            JsonRpcConfig jsonRpcConfig = new JsonRpcConfig()
+            {
+                Enabled = true,
+                EnabledModules = _enabledModules,
+                AdditionalRPCUrls = new string[] { "http://localhost:1234|ws|admin,debug" }
+            };
+
+            JsonRpcUrlCollection urlCollection = new JsonRpcUrlCollection(Substitute.For<ILogManager>(), jsonRpcConfig, false);
+            CollectionAssert.AreEquivalent(new JsonRpcUrl[]
+            {
+                new JsonRpcUrl("http", "127.0.0.1", 8545, RpcEndpoint.Http, _enabledModules)
+            }, urlCollection);
+        }
+
+        [Test]
+        public void Clears_flag_on_additional_ws_urls_when_ws_disabled()
+        {
+            JsonRpcConfig jsonRpcConfig = new JsonRpcConfig()
+            {
+                Enabled = true,
+                EnabledModules = _enabledModules,
+                AdditionalRPCUrls = new string[] { "http://localhost:1234|http,ws|admin,debug" }
+            };
+
+            JsonRpcUrlCollection urlCollection = new JsonRpcUrlCollection(Substitute.For<ILogManager>(), jsonRpcConfig, false);
+            CollectionAssert.AreEquivalent(new JsonRpcUrl[]
+            {
+                new JsonRpcUrl("http", "127.0.0.1", 8545, RpcEndpoint.Http, _enabledModules),
+                new JsonRpcUrl("http", "localhost", 1234, RpcEndpoint.Http, new string[] { "admin", "debug" })
+            }, urlCollection);
+        }
+
+        [Test]
+        public void Skips_additional_urls_with_port_conficts()
+        {
+            JsonRpcConfig jsonRpcConfig = new JsonRpcConfig()
+            {
+                Enabled = true,
+                EnabledModules = _enabledModules,
+                WebSocketsPort = 9876,
+                AdditionalRPCUrls = new string[]
+                {
+                    "http://localhost:8545|http,ws|admin,debug",
+                    "http://127.0.0.1:1234|http,ws|eth,web3",
+                    "http://127.0.0.1:9876|http,ws|net,proof",
+                    "http://localhost:1234|http,ws|db,erc20"
+                }
+            };
+
+            JsonRpcUrlCollection urlCollection = new JsonRpcUrlCollection(Substitute.For<ILogManager>(), jsonRpcConfig, true);
+            CollectionAssert.AreEquivalent(new JsonRpcUrl[]
+            {
+                new JsonRpcUrl("http", "127.0.0.1", 8545, RpcEndpoint.Http, _enabledModules),
+                new JsonRpcUrl("http", "127.0.0.1", 9876, RpcEndpoint.WebSocket, _enabledModules),
+                new JsonRpcUrl("http", "127.0.0.1", 1234, RpcEndpoint.Http | RpcEndpoint.WebSocket, new string[] { "eth", "web3" })
+            }, urlCollection);
+        }
+
+        [Test]
+        public void Skips_additional_urls_when_invalid()
+        {
+            JsonRpcConfig jsonRpcConfig = new JsonRpcConfig()
+            {
+                Enabled = true,
+                EnabledModules = _enabledModules,
+                AdditionalRPCUrls = new string[]
+                {
+                    string.Empty,
+                    "test",
+                    "http://localhost:1234|http|db,erc20,web3"
+                }
+            };
+
+            JsonRpcUrlCollection urlCollection = new JsonRpcUrlCollection(Substitute.For<ILogManager>(), jsonRpcConfig, true);
+            CollectionAssert.AreEquivalent(new JsonRpcUrl[]
+            {
+                new JsonRpcUrl("http", "127.0.0.1", 8545, RpcEndpoint.Http | RpcEndpoint.WebSocket, _enabledModules),
+                new JsonRpcUrl("http", "localhost", 1234, RpcEndpoint.Http, new string[] { "db", "erc20", "web3" })
+            }, urlCollection); ;
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcUrlCollectionTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcUrlCollectionTests.cs
@@ -15,6 +15,7 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
 using System;
+using System.Collections.Generic;
 using Nethermind.Logging;
 using Nethermind.JsonRpc.Modules;
 using NUnit.Framework;
@@ -28,7 +29,7 @@ namespace Nethermind.JsonRpc.Test
         [SetUp]
         public void Initialize()
         {
-            _enabledModules = new string[] { ModuleType.Eth, ModuleType.Web3, ModuleType.Net };
+            _enabledModules = new [] { ModuleType.Eth, ModuleType.Web3, ModuleType.Net };
         }
 
         private string[] _enabledModules;
@@ -57,9 +58,9 @@ namespace Nethermind.JsonRpc.Test
             };
 
             JsonRpcUrlCollection urlCollection = new JsonRpcUrlCollection(Substitute.For<ILogManager>(), jsonRpcConfig, true);
-            CollectionAssert.AreEquivalent(new JsonRpcUrl[]
+            CollectionAssert.AreEquivalent(new Dictionary<int, JsonRpcUrl>()
             {
-                new JsonRpcUrl("http", "127.0.0.1", 8545, RpcEndpoint.Http | RpcEndpoint.WebSocket, _enabledModules)
+                { 8545, new JsonRpcUrl("http", "127.0.0.1", 8545, RpcEndpoint.Http | RpcEndpoint.Ws, _enabledModules) }
             }, urlCollection);
         }
 
@@ -75,9 +76,9 @@ namespace Nethermind.JsonRpc.Test
             };
 
             JsonRpcUrlCollection urlCollection = new JsonRpcUrlCollection(Substitute.For<ILogManager>(), jsonRpcConfig, true);
-            CollectionAssert.AreEquivalent(new JsonRpcUrl[]
+            CollectionAssert.AreEquivalent(new Dictionary<int, JsonRpcUrl>()
             {
-                new JsonRpcUrl("http", "localhost", 1234, RpcEndpoint.Http | RpcEndpoint.WebSocket, _enabledModules)
+                { 1234, new JsonRpcUrl("http", "localhost", 1234, RpcEndpoint.Http | RpcEndpoint.Ws, _enabledModules) }
             }, urlCollection);
         }
 
@@ -92,10 +93,10 @@ namespace Nethermind.JsonRpc.Test
             };
 
             JsonRpcUrlCollection urlCollection = new JsonRpcUrlCollection(Substitute.For<ILogManager>(), jsonRpcConfig, true);
-            CollectionAssert.AreEquivalent(new JsonRpcUrl[]
+            CollectionAssert.AreEquivalent(new Dictionary<int, JsonRpcUrl>()
             {
-                new JsonRpcUrl("http", "127.0.0.1", 8545, RpcEndpoint.Http, _enabledModules),
-                new JsonRpcUrl("http", "127.0.0.1", 1234, RpcEndpoint.WebSocket, _enabledModules)
+                { 8545, new JsonRpcUrl("http", "127.0.0.1", 8545, RpcEndpoint.Http, _enabledModules) },
+                { 1234, new JsonRpcUrl("http", "127.0.0.1", 1234, RpcEndpoint.Ws, _enabledModules) }
             }, urlCollection);
         }
 
@@ -110,9 +111,9 @@ namespace Nethermind.JsonRpc.Test
             };
 
             JsonRpcUrlCollection urlCollection = new JsonRpcUrlCollection(Substitute.For<ILogManager>(), jsonRpcConfig, false);
-            CollectionAssert.AreEquivalent(new JsonRpcUrl[]
+            CollectionAssert.AreEquivalent(new Dictionary<int, JsonRpcUrl>()
             {
-                new JsonRpcUrl("http", "127.0.0.1", 8545, RpcEndpoint.Http, _enabledModules),
+                { 8545, new JsonRpcUrl("http", "127.0.0.1", 8545, RpcEndpoint.Http, _enabledModules) },
             }, urlCollection);
         }
 
@@ -123,14 +124,14 @@ namespace Nethermind.JsonRpc.Test
             {
                 Enabled = true,
                 EnabledModules = _enabledModules,
-                AdditionalRPCUrls = new string[] { "http://localhost:1234|http,ws|admin,debug" }
+                AdditionalRPCUrls = new [] { "https://localhost:1234|https,wss|admin,debug" }
             };
 
             JsonRpcUrlCollection urlCollection = new JsonRpcUrlCollection(Substitute.For<ILogManager>(), jsonRpcConfig, true);
-            CollectionAssert.AreEquivalent(new JsonRpcUrl[]
+            CollectionAssert.AreEquivalent(new Dictionary<int, JsonRpcUrl>()
             {
-                new JsonRpcUrl("http", "127.0.0.1", 8545, RpcEndpoint.Http | RpcEndpoint.WebSocket, _enabledModules),
-                new JsonRpcUrl("http", "localhost", 1234, RpcEndpoint.Http | RpcEndpoint.WebSocket, new string[] { "admin", "debug" })
+                { 8545, new JsonRpcUrl("http", "127.0.0.1", 8545, RpcEndpoint.Http | RpcEndpoint.Ws, _enabledModules) },
+                { 1234, new JsonRpcUrl("https", "localhost", 1234, RpcEndpoint.Https | RpcEndpoint.Wss, new[] { "admin", "debug" }) }
             }, urlCollection);
         }
 
@@ -141,13 +142,13 @@ namespace Nethermind.JsonRpc.Test
             {
                 Enabled = true,
                 EnabledModules = _enabledModules,
-                AdditionalRPCUrls = new string[] { "http://localhost:1234|ws|admin,debug" }
+                AdditionalRPCUrls = new [] { "http://localhost:1234|ws|admin,debug" }
             };
 
             JsonRpcUrlCollection urlCollection = new JsonRpcUrlCollection(Substitute.For<ILogManager>(), jsonRpcConfig, false);
-            CollectionAssert.AreEquivalent(new JsonRpcUrl[]
+            CollectionAssert.AreEquivalent(new Dictionary<int, JsonRpcUrl>()
             {
-                new JsonRpcUrl("http", "127.0.0.1", 8545, RpcEndpoint.Http, _enabledModules)
+                { 8545, new JsonRpcUrl("http", "127.0.0.1", 8545, RpcEndpoint.Http, _enabledModules) }
             }, urlCollection);
         }
 
@@ -158,14 +159,14 @@ namespace Nethermind.JsonRpc.Test
             {
                 Enabled = true,
                 EnabledModules = _enabledModules,
-                AdditionalRPCUrls = new string[] { "http://localhost:1234|http,ws|admin,debug" }
+                AdditionalRPCUrls = new [] { "http://localhost:1234|http,ws|admin,debug" }
             };
 
             JsonRpcUrlCollection urlCollection = new JsonRpcUrlCollection(Substitute.For<ILogManager>(), jsonRpcConfig, false);
-            CollectionAssert.AreEquivalent(new JsonRpcUrl[]
+            CollectionAssert.AreEquivalent(new Dictionary<int, JsonRpcUrl>()
             {
-                new JsonRpcUrl("http", "127.0.0.1", 8545, RpcEndpoint.Http, _enabledModules),
-                new JsonRpcUrl("http", "localhost", 1234, RpcEndpoint.Http, new string[] { "admin", "debug" })
+                { 8545, new JsonRpcUrl("http", "127.0.0.1", 8545, RpcEndpoint.Http, _enabledModules) },
+                { 1234, new JsonRpcUrl("http", "localhost", 1234, RpcEndpoint.Http, new [] { "admin", "debug" }) }
             }, urlCollection);
         }
 
@@ -177,21 +178,21 @@ namespace Nethermind.JsonRpc.Test
                 Enabled = true,
                 EnabledModules = _enabledModules,
                 WebSocketsPort = 9876,
-                AdditionalRPCUrls = new string[]
+                AdditionalRPCUrls = new []
                 {
                     "http://localhost:8545|http,ws|admin,debug",
-                    "http://127.0.0.1:1234|http,ws|eth,web3",
-                    "http://127.0.0.1:9876|http,ws|net,proof",
+                    "https://127.0.0.1:1234|https,wss|eth,web3",
+                    "https://127.0.0.1:9876|https,wss|net,proof",
                     "http://localhost:1234|http,ws|db,erc20"
                 }
             };
 
             JsonRpcUrlCollection urlCollection = new JsonRpcUrlCollection(Substitute.For<ILogManager>(), jsonRpcConfig, true);
-            CollectionAssert.AreEquivalent(new JsonRpcUrl[]
+            CollectionAssert.AreEquivalent(new Dictionary<int, JsonRpcUrl>()
             {
-                new JsonRpcUrl("http", "127.0.0.1", 8545, RpcEndpoint.Http, _enabledModules),
-                new JsonRpcUrl("http", "127.0.0.1", 9876, RpcEndpoint.WebSocket, _enabledModules),
-                new JsonRpcUrl("http", "127.0.0.1", 1234, RpcEndpoint.Http | RpcEndpoint.WebSocket, new string[] { "eth", "web3" })
+                { 8545, new JsonRpcUrl("http", "127.0.0.1", 8545, RpcEndpoint.Http, _enabledModules) },
+                { 9876, new JsonRpcUrl("http", "127.0.0.1", 9876, RpcEndpoint.Ws, _enabledModules) },
+                { 1234, new JsonRpcUrl("https", "127.0.0.1", 1234, RpcEndpoint.Https | RpcEndpoint.Wss, new [] { "eth", "web3" }) }
             }, urlCollection);
         }
 
@@ -202,7 +203,7 @@ namespace Nethermind.JsonRpc.Test
             {
                 Enabled = true,
                 EnabledModules = _enabledModules,
-                AdditionalRPCUrls = new string[]
+                AdditionalRPCUrls = new []
                 {
                     string.Empty,
                     "test",
@@ -211,10 +212,10 @@ namespace Nethermind.JsonRpc.Test
             };
 
             JsonRpcUrlCollection urlCollection = new JsonRpcUrlCollection(Substitute.For<ILogManager>(), jsonRpcConfig, true);
-            CollectionAssert.AreEquivalent(new JsonRpcUrl[]
+            CollectionAssert.AreEquivalent(new Dictionary<int, JsonRpcUrl>()
             {
-                new JsonRpcUrl("http", "127.0.0.1", 8545, RpcEndpoint.Http | RpcEndpoint.WebSocket, _enabledModules),
-                new JsonRpcUrl("http", "localhost", 1234, RpcEndpoint.Http, new string[] { "db", "erc20", "web3" })
+                { 8545, new JsonRpcUrl("http", "127.0.0.1", 8545, RpcEndpoint.Http | RpcEndpoint.Ws, _enabledModules) },
+                { 1234, new JsonRpcUrl("http", "localhost", 1234, RpcEndpoint.Http, new [] { "db", "erc20", "web3" }) }
             }, urlCollection); ;
         }
     }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcUrlCollectionTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcUrlCollectionTests.cs
@@ -36,7 +36,7 @@ namespace Nethermind.JsonRpc.Test
         [TearDown]
         public void TearDown()
         {
-            Environment.SetEnvironmentVariable("NETHERMIND_URL", null);
+            Environment.SetEnvironmentVariable("NETHERMIND_URL", null, EnvironmentVariableTarget.Process);
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcUrlCollectionTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcUrlCollectionTests.cs
@@ -124,7 +124,7 @@ namespace Nethermind.JsonRpc.Test
             {
                 Enabled = true,
                 EnabledModules = _enabledModules,
-                AdditionalRPCUrls = new [] { "https://localhost:1234|https,wss|admin,debug" }
+                AdditionalRPCUrls = new [] { "https://localhost:1234|https;wss|admin;debug" }
             };
 
             JsonRpcUrlCollection urlCollection = new JsonRpcUrlCollection(Substitute.For<ILogManager>(), jsonRpcConfig, true);
@@ -142,7 +142,7 @@ namespace Nethermind.JsonRpc.Test
             {
                 Enabled = true,
                 EnabledModules = _enabledModules,
-                AdditionalRPCUrls = new [] { "http://localhost:1234|ws|admin,debug" }
+                AdditionalRPCUrls = new [] { "http://localhost:1234|ws|admin;debug" }
             };
 
             JsonRpcUrlCollection urlCollection = new JsonRpcUrlCollection(Substitute.For<ILogManager>(), jsonRpcConfig, false);
@@ -159,7 +159,7 @@ namespace Nethermind.JsonRpc.Test
             {
                 Enabled = true,
                 EnabledModules = _enabledModules,
-                AdditionalRPCUrls = new [] { "http://localhost:1234|http,ws|admin,debug" }
+                AdditionalRPCUrls = new [] { "http://localhost:1234|http;ws|admin;debug" }
             };
 
             JsonRpcUrlCollection urlCollection = new JsonRpcUrlCollection(Substitute.For<ILogManager>(), jsonRpcConfig, false);
@@ -180,10 +180,10 @@ namespace Nethermind.JsonRpc.Test
                 WebSocketsPort = 9876,
                 AdditionalRPCUrls = new []
                 {
-                    "http://localhost:8545|http,ws|admin,debug",
-                    "https://127.0.0.1:1234|https,wss|eth,web3",
-                    "https://127.0.0.1:9876|https,wss|net,proof",
-                    "http://localhost:1234|http,ws|db,erc20"
+                    "http://localhost:8545|http;ws|admin;debug",
+                    "https://127.0.0.1:1234|https;wss|eth;web3",
+                    "https://127.0.0.1:9876|https;wss|net;proof",
+                    "http://localhost:1234|http;ws|db;erc20"
                 }
             };
 
@@ -207,7 +207,7 @@ namespace Nethermind.JsonRpc.Test
                 {
                     string.Empty,
                     "test",
-                    "http://localhost:1234|http|db,erc20,web3"
+                    "http://localhost:1234|http|db;erc20;web3"
                 }
             };
 

--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcUrlTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcUrlTests.cs
@@ -25,8 +25,8 @@ namespace Nethermind.JsonRpc.Test
     public class JsonRpcUrlTests
     {
         [TestCase("http://127.0.0.1:1234|http|eth,web3,net", "http", "127.0.0.1", 1234, RpcEndpoint.Http, new string[] { "eth", "web3", "net" })]
-        [TestCase("http://0.0.0.0|ws|eth,web3,net", "http", "0.0.0.0", 80, RpcEndpoint.WebSocket, new string[] { "eth", "web3", "net" })]
-        [TestCase("http://localhost:9876|HTTP,wS|eth,Web3,NET", "http", "localhost", 9876, RpcEndpoint.Http | RpcEndpoint.WebSocket, new string[] { "eth", "Web3", "NET" })]
+        [TestCase("http://0.0.0.0|ws|eth,web3,net", "http", "0.0.0.0", 80, RpcEndpoint.Ws, new string[] { "eth", "web3", "net" })]
+        [TestCase("https://localhost:9876|HTTpS,wSs|eth,Web3,NET", "https", "localhost", 9876, RpcEndpoint.Http | RpcEndpoint.Ws, new string[] { "eth", "Web3", "NET" })]
         public void Parse_success(string packedUrlValue, string expectedScheme, string expectedHost, int expectedPort, RpcEndpoint expectedRpcEndpoint, string[] expectedEnabledModules)
         {
             JsonRpcUrl url = JsonRpcUrl.Parse(packedUrlValue);
@@ -43,11 +43,9 @@ namespace Nethermind.JsonRpc.Test
         [TestCase("http://127.0.0.1:0|a|a", typeof(UriFormatException))]
         [TestCase("http://127.0.0.1:-1|a|a", typeof(UriFormatException))]
         [TestCase("http://127.0.0.1:1234/test|a|a", typeof(UriFormatException))]
-        [TestCase("https://127.0.0.1:1234|a|a", typeof(UriFormatException))]
         [TestCase("a://127.0.0.1:1234|a|a", typeof(UriFormatException))]
-        [TestCase("http://127.0.0.1:1234|a|a", typeof(FormatException))]
-        [TestCase("http://127.0.0.1:1234|http,a|a", typeof(FormatException))]
-        [TestCase("http://127.0.0.1:1234|http|NotAModule", typeof(FormatException))]
+        [TestCase("http://127.0.0.1:1234|a|a", typeof(ArgumentException))]
+        [TestCase("http://127.0.0.1:1234|ipc|a", typeof(FormatException))]
         public void Parse_fail(string packedUrlValue, Type expectedExceptionType) =>
             Assert.Throws(expectedExceptionType, () => JsonRpcUrl.Parse(packedUrlValue));
     }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcUrlTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcUrlTests.cs
@@ -24,9 +24,9 @@ namespace Nethermind.JsonRpc.Test
     [TestFixture]
     public class JsonRpcUrlTests
     {
-        [TestCase("http://127.0.0.1:1234|http|eth,web3,net", "http", "127.0.0.1", 1234, RpcEndpoint.Http, new string[] { "eth", "web3", "net" })]
-        [TestCase("http://0.0.0.0|ws|eth,web3,net", "http", "0.0.0.0", 80, RpcEndpoint.Ws, new string[] { "eth", "web3", "net" })]
-        [TestCase("https://localhost:9876|HTTpS,wSs|eth,Web3,NET", "https", "localhost", 9876, RpcEndpoint.Http | RpcEndpoint.Ws, new string[] { "eth", "Web3", "NET" })]
+        [TestCase("http://127.0.0.1:1234|http|eth;web3;net", "http", "127.0.0.1", 1234, RpcEndpoint.Http, new string[] { "eth", "web3", "net" })]
+        [TestCase("http://0.0.0.0|ws|eth ;web3; net", "http", "0.0.0.0", 80, RpcEndpoint.Ws, new string[] { "eth", "web3", "net" })]
+        [TestCase("https://localhost:9876|HTTpS; wSs|eth;Web3;NET", "https", "localhost", 9876, RpcEndpoint.Http | RpcEndpoint.Ws, new string[] { "eth", "Web3", "NET" })]
         public void Parse_success(string packedUrlValue, string expectedScheme, string expectedHost, int expectedPort, RpcEndpoint expectedRpcEndpoint, string[] expectedEnabledModules)
         {
             JsonRpcUrl url = JsonRpcUrl.Parse(packedUrlValue);
@@ -39,13 +39,15 @@ namespace Nethermind.JsonRpc.Test
 
         [TestCase(null, typeof(ArgumentNullException))]
         [TestCase("", typeof(FormatException))]
-        [TestCase("127.0.0.1:1234|a|a", typeof(UriFormatException))]
-        [TestCase("http://127.0.0.1:0|a|a", typeof(UriFormatException))]
-        [TestCase("http://127.0.0.1:-1|a|a", typeof(UriFormatException))]
-        [TestCase("http://127.0.0.1:1234/test|a|a", typeof(UriFormatException))]
-        [TestCase("a://127.0.0.1:1234|a|a", typeof(UriFormatException))]
-        [TestCase("http://127.0.0.1:1234|a|a", typeof(ArgumentException))]
+        [TestCase("127.0.0.1:1234|a|a", typeof(FormatException))]
+        [TestCase("http://127.0.0.1:0|a|a", typeof(FormatException))]
+        [TestCase("http://127.0.0.1:-1|a|a", typeof(FormatException))]
+        [TestCase("http://127.0.0.1:1234||", typeof(FormatException))]
+        [TestCase("http://127.0.0.1:1234/test|a|a", typeof(FormatException))]
+        [TestCase("a://127.0.0.1:1234|a|a", typeof(FormatException))]
+        [TestCase("http://127.0.0.1:1234|a|a", typeof(FormatException))]
         [TestCase("http://127.0.0.1:1234|ipc|a", typeof(FormatException))]
+        [TestCase("http://127.0.0.1:1234|http|", typeof(FormatException))]
         public void Parse_fail(string packedUrlValue, Type expectedExceptionType) =>
             Assert.Throws(expectedExceptionType, () => JsonRpcUrl.Parse(packedUrlValue));
     }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcUrlTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcUrlTests.cs
@@ -1,0 +1,54 @@
+//  Copyright (c) 2021 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using Nethermind.JsonRpc.Modules;
+using NUnit.Framework;
+
+namespace Nethermind.JsonRpc.Test
+{
+    [Parallelizable(ParallelScope.All)]
+    [TestFixture]
+    public class JsonRpcUrlTests
+    {
+        [TestCase("http://127.0.0.1:1234|http|eth,web3,net", "http", "127.0.0.1", 1234, RpcEndpoint.Http, new string[] { "eth", "web3", "net" })]
+        [TestCase("http://0.0.0.0|ws|eth,web3,net", "http", "0.0.0.0", 80, RpcEndpoint.WebSocket, new string[] { "eth", "web3", "net" })]
+        [TestCase("http://localhost:9876|HTTP,wS|eth,Web3,NET", "http", "localhost", 9876, RpcEndpoint.Http | RpcEndpoint.WebSocket, new string[] { "eth", "Web3", "NET" })]
+        public void Parse_success(string packedUrlValue, string expectedScheme, string expectedHost, int expectedPort, RpcEndpoint expectedRpcEndpoint, string[] expectedEnabledModules)
+        {
+            JsonRpcUrl url = JsonRpcUrl.Parse(packedUrlValue);
+            Assert.AreEqual(expectedScheme, url.Scheme);
+            Assert.AreEqual(expectedHost, url.Host);
+            Assert.AreEqual(expectedPort, url.Port);
+            Assert.AreEqual(expectedRpcEndpoint, url.RpcEndpoint);
+            CollectionAssert.AreEqual(expectedEnabledModules, url.EnabledModules);
+        }
+
+        [TestCase(null, typeof(ArgumentNullException))]
+        [TestCase("", typeof(FormatException))]
+        [TestCase("127.0.0.1:1234|a|a", typeof(UriFormatException))]
+        [TestCase("http://127.0.0.1:0|a|a", typeof(UriFormatException))]
+        [TestCase("http://127.0.0.1:-1|a|a", typeof(UriFormatException))]
+        [TestCase("http://127.0.0.1:1234/test|a|a", typeof(UriFormatException))]
+        [TestCase("https://127.0.0.1:1234|a|a", typeof(UriFormatException))]
+        [TestCase("a://127.0.0.1:1234|a|a", typeof(UriFormatException))]
+        [TestCase("http://127.0.0.1:1234|a|a", typeof(FormatException))]
+        [TestCase("http://127.0.0.1:1234|http,a|a", typeof(FormatException))]
+        [TestCase("http://127.0.0.1:1234|http|NotAModule", typeof(FormatException))]
+        public void Parse_fail(string packedUrlValue, Type expectedExceptionType) =>
+            Assert.Throws(expectedExceptionType, () => JsonRpcUrl.Parse(packedUrlValue));
+    }
+}

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/RpcModuleProviderTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/RpcModuleProviderTests.cs
@@ -102,7 +102,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             Assert.AreEqual(ModuleResolution.Enabled, inScopeResolution);
 
             ModuleResolution outOfScopeResolution = _moduleProvider.Check("proof_call", JsonRpcContext.Http(url));
-            Assert.AreEqual(ModuleResolution.EndpointDisabled, outOfScopeResolution);
+            Assert.AreEqual(ModuleResolution.Disabled, outOfScopeResolution);
 
             ModuleResolution fallbackResolution = _moduleProvider.Check("proof_call", new JsonRpcContext(RpcEndpoint.Http));
             Assert.AreEqual(ModuleResolution.Enabled, fallbackResolution);

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/RpcModuleProviderTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/RpcModuleProviderTests.cs
@@ -30,14 +30,15 @@ namespace Nethermind.JsonRpc.Test.Modules
     public class RpcModuleProviderTests
     {
         private RpcModuleProvider _moduleProvider;
-
         private IFileSystem _fileSystem;
+        private JsonRpcContext _context;
 
         [SetUp]
         public void Initialize()
         {
             _fileSystem = Substitute.For<IFileSystem>();
             _moduleProvider = new RpcModuleProvider(_fileSystem, new JsonRpcConfig(), LimboLogs.Instance);
+            _context = new JsonRpcContext(RpcEndpoint.Http);
         }
 
         [Test]
@@ -47,7 +48,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             jsonRpcConfig.EnabledModules = new string[0];
             _moduleProvider = new RpcModuleProvider(new FileSystem(), jsonRpcConfig, LimboLogs.Instance);
             _moduleProvider.Register(new SingletonModulePool<IProofRpcModule>(Substitute.For<IProofRpcModule>(), false));
-            ModuleResolution resolution = _moduleProvider.Check("proof_call", RpcEndpoint.Http);
+            ModuleResolution resolution = _moduleProvider.Check("proof_call", _context);
             Assert.AreEqual(ModuleResolution.Disabled, resolution);
         }
 
@@ -57,10 +58,10 @@ namespace Nethermind.JsonRpc.Test.Modules
             SingletonModulePool<INetRpcModule> pool = new(new NetRpcModule(LimboLogs.Instance, Substitute.For<INetBridge>()), true);
             _moduleProvider.Register(pool);
 
-            _moduleProvider.Check("net_VeRsIoN", RpcEndpoint.Http).Should().Be(ModuleResolution.Unknown);
-            _moduleProvider.Check("net_Version", RpcEndpoint.Http).Should().Be(ModuleResolution.Unknown);
-            _moduleProvider.Check("Net_Version", RpcEndpoint.Http).Should().Be(ModuleResolution.Unknown);
-            _moduleProvider.Check("net_version", RpcEndpoint.Http).Should().Be(ModuleResolution.Enabled);
+            _moduleProvider.Check("net_VeRsIoN", _context).Should().Be(ModuleResolution.Unknown);
+            _moduleProvider.Check("net_Version", _context).Should().Be(ModuleResolution.Unknown);
+            _moduleProvider.Check("Net_Version", _context).Should().Be(ModuleResolution.Unknown);
+            _moduleProvider.Check("net_version", _context).Should().Be(ModuleResolution.Enabled);
         }
 
         [TestCase("eth_.*", ModuleResolution.Unknown)]
@@ -75,7 +76,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             SingletonModulePool<INetRpcModule> pool = new(new NetRpcModule(LimboLogs.Instance, Substitute.For<INetBridge>()), true);
             _moduleProvider.Register(pool);
 
-            ModuleResolution resolution = _moduleProvider.Check("net_version", RpcEndpoint.Http);
+            ModuleResolution resolution = _moduleProvider.Check("net_version", _context);
             resolution.Should().Be(expectedResult);
         }
 
@@ -85,7 +86,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             SingletonModulePool<INetRpcModule> pool = new(Substitute.For<INetRpcModule>(), true);
             _moduleProvider.Register(pool);
 
-            ModuleResolution resolution = _moduleProvider.Check("unknown_method", RpcEndpoint.Http);
+            ModuleResolution resolution = _moduleProvider.Check("unknown_method", _context);
             Assert.AreEqual(ModuleResolution.Unknown, resolution);
         }
     }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/RpcModuleProviderTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/RpcModuleProviderTests.cs
@@ -102,7 +102,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             Assert.AreEqual(ModuleResolution.Enabled, inScopeResolution);
 
             ModuleResolution outOfScopeResolution = _moduleProvider.Check("proof_call", JsonRpcContext.Http(url));
-            Assert.AreEqual(ModuleResolution.Disabled, outOfScopeResolution);
+            Assert.AreEqual(ModuleResolution.EndpointDisabled, outOfScopeResolution);
 
             ModuleResolution fallbackResolution = _moduleProvider.Check("proof_call", new JsonRpcContext(RpcEndpoint.Http));
             Assert.AreEqual(ModuleResolution.Enabled, fallbackResolution);

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
@@ -82,7 +82,7 @@ namespace Nethermind.JsonRpc.Test.Modules
                 _logManager);
             
             _subscribeRpcModule = new SubscribeRpcModule(_subscriptionManager);
-            _subscribeRpcModule.Context = new JsonRpcContext(RpcEndpoint.WebSocket, _jsonRpcDuplexClient);
+            _subscribeRpcModule.Context = new JsonRpcContext(RpcEndpoint.Ws, _jsonRpcDuplexClient);
             
             // block numbers matching filters in LogsSubscriptions with null arguments will be 33333-77777
             BlockHeader fromBlock = Build.A.BlockHeader.WithNumber(33333).TestObject;

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TestRpcModuleProvider.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TestRpcModuleProvider.cs
@@ -72,9 +72,9 @@ namespace Nethermind.JsonRpc.Test.Modules
         public IReadOnlyCollection<JsonConverter> Converters => _provider.Converters;
         public IReadOnlyCollection<string> Enabled => _provider.All;
         public IReadOnlyCollection<string> All => _provider.All;
-        public ModuleResolution Check(string methodName, RpcEndpoint rpcEndpoint)
+        public ModuleResolution Check(string methodName, JsonRpcContext context)
         {
-            return _provider.Check(methodName, rpcEndpoint);
+            return _provider.Check(methodName, context);
         }
 
         public (MethodInfo, bool) Resolve(string methodName)

--- a/src/Nethermind/Nethermind.JsonRpc.Test/RpcTest.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/RpcTest.cs
@@ -33,15 +33,15 @@ namespace Nethermind.JsonRpc.Test
         {
             IJsonRpcService service = BuildRpcService(module);
             JsonRpcRequest request = GetJsonRequest(method, parameters);
-            return service.SendRequestAsync(request, JsonRpcContext.Http).Result;
+            return service.SendRequestAsync(request, new JsonRpcContext(RpcEndpoint.Http)).Result;
         }
         
         public static string TestSerializedRequest<T>(IReadOnlyCollection<JsonConverter> converters, T module, string method, params string[] parameters) where T : class, IRpcModule
         {
             IJsonRpcService service = BuildRpcService(module);
             JsonRpcRequest request = GetJsonRequest(method, parameters);
-            
-            JsonRpcContext context = JsonRpcContext.Http;
+
+            JsonRpcContext context = new JsonRpcContext(RpcEndpoint.Http);
             if (module is IContextAwareRpcModule contextAwareModule
                 && contextAwareModule.Context != null)
             {

--- a/src/Nethermind/Nethermind.JsonRpc/IJsonRpcConfig.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/IJsonRpcConfig.cs
@@ -66,6 +66,11 @@ namespace Nethermind.JsonRpc
         string[] EnabledModules { get; set; }
 
         [ConfigItem(
+            Description = "Defines additional RPC urls to listen on. Example url format: http://localhost:8550|http,wss|engine,eth,net,subscribe",
+            DefaultValue = "None")]
+        string[] AdditionalRPCUrls { get; set; }
+
+        [ConfigItem(
             Description = "Gas limit for eth_call and eth_estimateGas",
             DefaultValue = "100000000")]
         long? GasCap { get; set; }

--- a/src/Nethermind/Nethermind.JsonRpc/IJsonRpcConfig.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/IJsonRpcConfig.cs
@@ -67,7 +67,7 @@ namespace Nethermind.JsonRpc
 
         [ConfigItem(
             Description = "Defines additional RPC urls to listen on. Example url format: http://localhost:8550|http,wss|engine,eth,net,subscribe",
-            DefaultValue = "None")]
+            DefaultValue = "[]")]
         string[] AdditionalRPCUrls { get; set; }
 
         [ConfigItem(

--- a/src/Nethermind/Nethermind.JsonRpc/IJsonRpcUrlCollection.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/IJsonRpcUrlCollection.cs
@@ -20,9 +20,8 @@ using System.Collections.Generic;
 
 namespace Nethermind.JsonRpc
 {
-    public interface IJsonRpcUrlCollection : IReadOnlyCollection<JsonRpcUrl>
+    public interface IJsonRpcUrlCollection : IReadOnlyDictionary<int, JsonRpcUrl>
     {
-        IEnumerable<string> UrlValues { get; }
     }
 }
 

--- a/src/Nethermind/Nethermind.JsonRpc/IJsonRpcUrlCollection.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/IJsonRpcUrlCollection.cs
@@ -22,6 +22,7 @@ namespace Nethermind.JsonRpc
 {
     public interface IJsonRpcUrlCollection : IReadOnlyDictionary<int, JsonRpcUrl>
     {
+        string[] Urls { get; }
     }
 }
 

--- a/src/Nethermind/Nethermind.JsonRpc/IJsonRpcUrlCollection.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/IJsonRpcUrlCollection.cs
@@ -1,0 +1,28 @@
+//  Copyright (c) 2021 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+using System.Collections.Generic;
+
+namespace Nethermind.JsonRpc
+{
+    public interface IJsonRpcUrlCollection : IReadOnlyCollection<JsonRpcUrl>
+    {
+        IEnumerable<string> UrlValues { get; }
+    }
+}
+

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcConfig.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcConfig.cs
@@ -42,6 +42,7 @@ namespace Nethermind.JsonRpc
         public string? IpcUnixDomainSocketPath { get; set; } = null;
 
         public string[] EnabledModules { get; set; } = ModuleType.DefaultModules.ToArray();
+        public string[] AdditionalRPCUrls { get; set; } = new string[0];
         public long? GasCap { get; set; } = 100000000;
         public int ReportIntervalSeconds { get; set; } = 300;
         public bool BufferResponses { get; set; }

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcConfig.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcConfig.cs
@@ -42,7 +42,7 @@ namespace Nethermind.JsonRpc
         public string? IpcUnixDomainSocketPath { get; set; } = null;
 
         public string[] EnabledModules { get; set; } = ModuleType.DefaultModules.ToArray();
-        public string[] AdditionalRPCUrls { get; set; } = new string[0];
+        public string[] AdditionalRPCUrls { get; set; } = Array.Empty<string>();
         public long? GasCap { get; set; } = 100000000;
         public int ReportIntervalSeconds { get; set; } = 300;
         public bool BufferResponses { get; set; }

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcContext.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcContext.cs
@@ -21,15 +21,18 @@ namespace Nethermind.JsonRpc
 {
     public class JsonRpcContext
     {
-        public static readonly JsonRpcContext Http = new(RpcEndpoint.Http);
+        public static JsonRpcContext Http(JsonRpcUrl url) => new(RpcEndpoint.Http, url: url);
+        public static JsonRpcContext WebSocket(JsonRpcUrl url) => new(RpcEndpoint.WebSocket, url: url);
 
-        public RpcEndpoint RpcEndpoint { get; }
-        public IJsonRpcDuplexClient? DuplexClient { get; }
-
-        public JsonRpcContext(RpcEndpoint rpcEndpoint, IJsonRpcDuplexClient? duplexClient = null)
+        public JsonRpcContext(RpcEndpoint rpcEndpoint, IJsonRpcDuplexClient? duplexClient = null, JsonRpcUrl? url = null)
         {
             RpcEndpoint = rpcEndpoint;
             DuplexClient = duplexClient;
+            Url = url;
         }
+
+        public RpcEndpoint RpcEndpoint { get; }
+        public IJsonRpcDuplexClient? DuplexClient { get; }
+        public JsonRpcUrl? Url { get; }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcContext.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcContext.cs
@@ -22,7 +22,7 @@ namespace Nethermind.JsonRpc
     public class JsonRpcContext
     {
         public static JsonRpcContext Http(JsonRpcUrl url) => new(RpcEndpoint.Http, url: url);
-        public static JsonRpcContext WebSocket(JsonRpcUrl url) => new(RpcEndpoint.WebSocket, url: url);
+        public static JsonRpcContext WebSocket(JsonRpcUrl url) => new(RpcEndpoint.Ws, url: url);
 
         public JsonRpcContext(RpcEndpoint rpcEndpoint, IJsonRpcDuplexClient? duplexClient = null, JsonRpcUrl? url = null)
         {

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
@@ -338,7 +338,7 @@ namespace Nethermind.JsonRpc
             {
                 ModuleResolution.Unknown => ((int?) ErrorCodes.MethodNotFound, $"Method {methodName} is not supported"),
                 ModuleResolution.Disabled => (ErrorCodes.InvalidRequest, $"{methodName} found but the containing module is disabled for the url '{context.Url?.ToString() ?? string.Empty}', consider adding module in JsonRpcConfig.AdditionalRpcUrls for additional url, or to JsonRpcConfig.EnabledModules for default url"),
-                ModuleResolution.EndpointDisabled => (ErrorCodes.InvalidRequest, $"{methodName} found but disabled for {context.RpcEndpoint}"),
+                ModuleResolution.EndpointDisabled => (ErrorCodes.InvalidRequest, $"{methodName} found for the url '{context.Url?.ToString() ?? string.Empty}' but is disabled for {context.RpcEndpoint}"),
                 _ => (null, null)
             };
         }

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
@@ -337,7 +337,7 @@ namespace Nethermind.JsonRpc
             return result switch
             {
                 ModuleResolution.Unknown => ((int?) ErrorCodes.MethodNotFound, $"Method {methodName} is not supported"),
-                ModuleResolution.Disabled => (ErrorCodes.InvalidRequest, $"{methodName} found but the containing module is disabled for the url, consider adding module for additional url in JsonRpcConfig.AdditionalRpcUrls or to JsonRpcConfig.EnabledModules"),
+                ModuleResolution.Disabled => (ErrorCodes.InvalidRequest, $"{methodName} found but the containing module is disabled for the url '{context.Url?.ToString() ?? string.Empty}', consider adding module in JsonRpcConfig.AdditionalRpcUrls for additional url, or to JsonRpcConfig.EnabledModules for default url"),
                 ModuleResolution.EndpointDisabled => (ErrorCodes.InvalidRequest, $"{methodName} found but disabled for {context.RpcEndpoint}"),
                 _ => (null, null)
             };

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
@@ -70,7 +70,7 @@ namespace Nethermind.JsonRpc
         {
             try
             {
-                (int? errorCode, string errorMessage) = Validate(rpcRequest, context.RpcEndpoint);
+                (int? errorCode, string errorMessage) = Validate(rpcRequest, context);
                 if (errorCode.HasValue)
                 {
                     return GetErrorResponse(rpcRequest.Method, errorCode.Value, errorMessage, null, rpcRequest.Id);
@@ -318,7 +318,7 @@ namespace Nethermind.JsonRpc
             return response;
         }
 
-        private (int? ErrorType, string ErrorMessage) Validate(JsonRpcRequest? rpcRequest, RpcEndpoint rpcEndpoint)
+        private (int? ErrorType, string ErrorMessage) Validate(JsonRpcRequest? rpcRequest, JsonRpcContext context)
         {
             if (rpcRequest == null)
             {
@@ -333,12 +333,12 @@ namespace Nethermind.JsonRpc
 
             methodName = methodName.Trim();
 
-            ModuleResolution result = _rpcModuleProvider.Check(methodName, rpcEndpoint);
+            ModuleResolution result = _rpcModuleProvider.Check(methodName, context);
             return result switch
             {
                 ModuleResolution.Unknown => ((int?) ErrorCodes.MethodNotFound, $"Method {methodName} is not supported"),
-                ModuleResolution.Disabled => (ErrorCodes.InvalidRequest, $"{methodName} found but the containing module is disabled, consider adding module to JsonRpcConfig.EnabledModules"),
-                ModuleResolution.EndpointDisabled => (ErrorCodes.InvalidRequest, $"{methodName} found but disabled for {rpcEndpoint}"),
+                ModuleResolution.Disabled => (ErrorCodes.InvalidRequest, $"{methodName} found but the containing module is disabled, consider adding module to JsonRpcConfig.EnabledModule"),
+                ModuleResolution.EndpointDisabled => (ErrorCodes.InvalidRequest, $"{methodName} found but disabled for {context.RpcEndpoint}"),
                 _ => (null, null)
             };
         }

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
@@ -337,7 +337,7 @@ namespace Nethermind.JsonRpc
             return result switch
             {
                 ModuleResolution.Unknown => ((int?) ErrorCodes.MethodNotFound, $"Method {methodName} is not supported"),
-                ModuleResolution.Disabled => (ErrorCodes.InvalidRequest, $"{methodName} found but the containing module is disabled, consider adding module to JsonRpcConfig.EnabledModule"),
+                ModuleResolution.Disabled => (ErrorCodes.InvalidRequest, $"{methodName} found but the containing module is disabled for the url, consider adding module for additional url in JsonRpcConfig.AdditionalRpcUrls or to JsonRpcConfig.EnabledModules"),
                 ModuleResolution.EndpointDisabled => (ErrorCodes.InvalidRequest, $"{methodName} found but disabled for {context.RpcEndpoint}"),
                 _ => (null, null)
             };

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcUrl.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcUrl.cs
@@ -89,7 +89,7 @@ namespace Nethermind.JsonRpc
 
         public bool Equals(JsonRpcUrl other)
         {
-            if (ReferenceEquals(null, other))
+            if (other == null)
                 return false;
 
             if (ReferenceEquals(this, other))
@@ -99,18 +99,18 @@ namespace Nethermind.JsonRpc
                    string.Equals(Host, other.Host) &&
                    Port == other.Port &&
                    RpcEndpoint == other.RpcEndpoint &&
-                   Enumerable.SequenceEqual(EnabledModules, other.EnabledModules);
+                   EnabledModules.SequenceEqual(other.EnabledModules);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object other)
         {
-            if (ReferenceEquals(null, obj))
+            if (other == null)
                 return false;
 
-            if (ReferenceEquals(this, obj))
+            if (ReferenceEquals(this, other))
                 return true;
 
-            return obj.GetType() == GetType() && Equals((JsonRpcUrl)obj);
+            return other is JsonRpcUrl url && Equals(url);
         }
 
         public override int GetHashCode() => HashCode.Combine(Scheme, Host, Port, RpcEndpoint, EnabledModules as IStructuralEquatable);

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcUrl.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcUrl.cs
@@ -1,0 +1,105 @@
+//  Copyright (c) 2021 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+using System.Linq;
+
+using Nethermind.JsonRpc.Modules;
+
+namespace Nethermind.JsonRpc
+{
+    public class JsonRpcUrl : ICloneable
+    {
+        private const string HttpEndpointValue = "http";
+        private const string WebSocketEndpointValue = "ws";
+
+        public JsonRpcUrl(string scheme, string host, int port, RpcEndpoint rpcEndpoint, string[] enabledModules)
+        {
+            Scheme = scheme;
+            Host = host;
+            Port = port;
+            RpcEndpoint = rpcEndpoint;
+            EnabledModules = enabledModules;
+        }
+
+        public static JsonRpcUrl Parse(string packedUrlValue)
+        {
+            //Ensure packaged url value specified
+            if (packedUrlValue == null)
+                throw new ArgumentNullException(nameof(packedUrlValue));
+
+            //Unpack parts
+            string[] parts = packedUrlValue.Split('|');
+            if (parts.Length != 3)
+                throw new FormatException("Packed url value must contain 3 parts delimited by '|'");
+
+            //Parse url part
+            string url = parts[0];
+            if (!Uri.TryCreate(url, UriKind.Absolute, out Uri? uri))
+                throw new FormatException("First part must be a valid url");
+
+            //Parse endpoint part
+            string[] endpointValues = parts[1].Split(',');
+            if (endpointValues.Length == 0)
+                throw new FormatException("Second part must contain at least one valid endpoint value delimited by ','");
+
+            //Parse endpoint values
+            RpcEndpoint endpoint = RpcEndpoint.None;
+            foreach (string endpointValue in endpointValues)
+            {
+                switch(endpointValue)
+                {
+                    case HttpEndpointValue:
+                        endpoint |= RpcEndpoint.Http;
+                        break;
+                    case WebSocketEndpointValue:
+                        endpoint |= RpcEndpoint.WebSocket;
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            //Ensure at least one valid endpoint value was observed
+            if (endpoint == RpcEndpoint.None)
+                throw new FormatException($"Second part must contain at least one valid endpoint value: {HttpEndpointValue}, {WebSocketEndpointValue}");
+
+            //Parse enabled modules part
+            string[] enabledModules = parts[2].Split(',');
+            if (enabledModules.Length == 0)
+                throw new FormatException("Third part must contain at least one valid endpoint value delimited by ','");
+
+            //Ensure all enabled modules are valid
+            bool modulesValid = enabledModules.All(x => ModuleType.AllBuiltInModules.Contains(x));
+            if (!modulesValid)
+                throw new FormatException($"Fourth part must contain at least one valid module: {string.Join(',', ModuleType.AllBuiltInModules)}");
+
+            //Return new jspn rpc url
+            return new JsonRpcUrl(uri.Scheme, uri.Host, uri.Port, endpoint, enabledModules);
+        }
+
+        public string Scheme { get; set; }
+        public string Host { get; set; }
+        public int Port { get; set; }
+        public RpcEndpoint RpcEndpoint { get; set; }
+        public string[] EnabledModules { get; set; }
+
+        public override string ToString() => $"{Scheme}://{Host}:{Port}";
+        public object Clone() => new JsonRpcUrl(Scheme, Host, Port, RpcEndpoint, EnabledModules);
+    }
+}
+

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcUrl.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcUrl.cs
@@ -16,6 +16,7 @@
 //
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -23,7 +24,7 @@ using Nethermind.JsonRpc.Modules;
 
 namespace Nethermind.JsonRpc
 {
-    public class JsonRpcUrl : ICloneable
+    public class JsonRpcUrl : IEquatable<JsonRpcUrl>, ICloneable
     {
         private const string HttpEndpointValue = "http";
         private const string WebSocketEndpointValue = "ws";
@@ -39,57 +40,44 @@ namespace Nethermind.JsonRpc
 
         public static JsonRpcUrl Parse(string packedUrlValue)
         {
-            //Ensure packaged url value specified
             if (packedUrlValue == null)
                 throw new ArgumentNullException(nameof(packedUrlValue));
 
-            //Unpack parts
             string[] parts = packedUrlValue.Split('|');
             if (parts.Length != 3)
                 throw new FormatException("Packed url value must contain 3 parts delimited by '|'");
 
-            //Parse url part
             string url = parts[0];
-            if (!Uri.TryCreate(url, UriKind.Absolute, out Uri? uri))
-                throw new FormatException("First part must be a valid url");
+            if (!Uri.TryCreate(url, UriKind.Absolute, out Uri? uri) ||
+                uri.Scheme != "http" ||
+                uri.Segments.Count() > 1 ||
+                uri.Port <= 0)
+                throw new UriFormatException("First part must be a valid url with the format: http://host:port");
 
-            //Parse endpoint part
             string[] endpointValues = parts[1].Split(',');
             if (endpointValues.Length == 0)
                 throw new FormatException("Second part must contain at least one valid endpoint value delimited by ','");
 
-            //Parse endpoint values
             RpcEndpoint endpoint = RpcEndpoint.None;
             foreach (string endpointValue in endpointValues)
             {
-                switch(endpointValue)
-                {
-                    case HttpEndpointValue:
-                        endpoint |= RpcEndpoint.Http;
-                        break;
-                    case WebSocketEndpointValue:
-                        endpoint |= RpcEndpoint.WebSocket;
-                        break;
-                    default:
-                        break;
-                }
+                if (endpointValue.Equals(HttpEndpointValue, StringComparison.InvariantCultureIgnoreCase))
+                    endpoint |= RpcEndpoint.Http;
+                else if (endpointValue.Equals(WebSocketEndpointValue, StringComparison.InvariantCultureIgnoreCase))
+                    endpoint |= RpcEndpoint.WebSocket;
             }
 
-            //Ensure at least one valid endpoint value was observed
             if (endpoint == RpcEndpoint.None)
                 throw new FormatException($"Second part must contain at least one valid endpoint value: {HttpEndpointValue}, {WebSocketEndpointValue}");
 
-            //Parse enabled modules part
             string[] enabledModules = parts[2].Split(',');
             if (enabledModules.Length == 0)
                 throw new FormatException("Third part must contain at least one valid endpoint value delimited by ','");
 
-            //Ensure all enabled modules are valid
             bool modulesValid = enabledModules.All(x => ModuleType.AllBuiltInModules.Contains(x, StringComparer.InvariantCultureIgnoreCase));
             if (!modulesValid)
                 throw new FormatException($"Fourth part must contain at least one valid module: {string.Join(',', ModuleType.AllBuiltInModules)}");
 
-            //Return new json rpc url
             return new JsonRpcUrl(uri.Scheme, uri.Host, uri.Port, endpoint, enabledModules);
         }
 
@@ -99,8 +87,35 @@ namespace Nethermind.JsonRpc
         public RpcEndpoint RpcEndpoint { get; set; }
         public IReadOnlyCollection<string> EnabledModules { get; set; }
 
-        public override string ToString() => $"{Scheme}://{Host}:{Port}";
+        public bool Equals(JsonRpcUrl other)
+        {
+            if (ReferenceEquals(null, other))
+                return false;
+
+            if (ReferenceEquals(this, other))
+                return true;
+
+            return string.Equals(Scheme, other.Scheme) &&
+                   string.Equals(Host, other.Host) &&
+                   Port == other.Port &&
+                   RpcEndpoint == other.RpcEndpoint &&
+                   Enumerable.SequenceEqual(EnabledModules, other.EnabledModules);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+                return false;
+
+            if (ReferenceEquals(this, obj))
+                return true;
+
+            return obj.GetType() == GetType() && Equals((JsonRpcUrl)obj);
+        }
+
+        public override int GetHashCode() => HashCode.Combine(Scheme, Host, Port, RpcEndpoint, EnabledModules as IStructuralEquatable);
         public object Clone() => new JsonRpcUrl(Scheme, Host, Port, RpcEndpoint, EnabledModules as string[]);
+        public override string ToString() => $"{Scheme}://{Host}:{Port}";
     }
 }
 

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcUrl.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcUrl.cs
@@ -49,26 +49,26 @@ namespace Nethermind.JsonRpc
                 (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps) ||
                 uri.Segments.Count() > 1 ||
                 uri.Port == 0)
-                throw new UriFormatException("First part must be a valid url with the format: scheme://host:port");
+                throw new FormatException("First part must be a valid url with the format: scheme://host:port");
 
-            string[] endpointValues = parts[1].Split(',');
+            string[] endpointValues = parts[1].Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
             if (endpointValues.Length == 0)
-                throw new FormatException("Second part must contain at least one valid endpoint value delimited by ','");
+                throw new FormatException("Second part must contain at least one valid endpoint value delimited by ';'");
 
             RpcEndpoint endpoint = RpcEndpoint.None;
             foreach (string endpointValue in endpointValues)
             {
-                RpcEndpoint parsedEndpoint = Enum.Parse<RpcEndpoint>(endpointValue, ignoreCase: true);
-                if (parsedEndpoint == RpcEndpoint.Http || parsedEndpoint == RpcEndpoint.Ws)
+                if (Enum.TryParse(endpointValue, ignoreCase: true, out RpcEndpoint parsedEndpoint) &&
+                    (parsedEndpoint == RpcEndpoint.Http || parsedEndpoint == RpcEndpoint.Ws))
                     endpoint |= parsedEndpoint;
             }
 
             if (endpoint == RpcEndpoint.None)
                 throw new FormatException($"Second part must contain at least one valid endpoint value (http, https, ws, wss)");
 
-            string[] enabledModules = parts[2].Split(',');
+            string[] enabledModules = parts[2].Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
             if (enabledModules.Length == 0)
-                throw new FormatException("Third part must contain at least one valid endpoint value delimited by ','");
+                throw new FormatException("Third part must contain at least one module delimited by ';'");
 
             return new JsonRpcUrl(uri.Scheme, uri.Host, uri.Port, endpoint, enabledModules);
         }

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcUrl.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcUrl.cs
@@ -16,6 +16,7 @@
 //
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 using Nethermind.JsonRpc.Modules;
@@ -84,11 +85,11 @@ namespace Nethermind.JsonRpc
                 throw new FormatException("Third part must contain at least one valid endpoint value delimited by ','");
 
             //Ensure all enabled modules are valid
-            bool modulesValid = enabledModules.All(x => ModuleType.AllBuiltInModules.Contains(x));
+            bool modulesValid = enabledModules.All(x => ModuleType.AllBuiltInModules.Contains(x, StringComparer.InvariantCultureIgnoreCase));
             if (!modulesValid)
                 throw new FormatException($"Fourth part must contain at least one valid module: {string.Join(',', ModuleType.AllBuiltInModules)}");
 
-            //Return new jspn rpc url
+            //Return new json rpc url
             return new JsonRpcUrl(uri.Scheme, uri.Host, uri.Port, endpoint, enabledModules);
         }
 
@@ -96,10 +97,10 @@ namespace Nethermind.JsonRpc
         public string Host { get; set; }
         public int Port { get; set; }
         public RpcEndpoint RpcEndpoint { get; set; }
-        public string[] EnabledModules { get; set; }
+        public IReadOnlyCollection<string> EnabledModules { get; set; }
 
         public override string ToString() => $"{Scheme}://{Host}:{Port}";
-        public object Clone() => new JsonRpcUrl(Scheme, Host, Port, RpcEndpoint, EnabledModules);
+        public object Clone() => new JsonRpcUrl(Scheme, Host, Port, RpcEndpoint, EnabledModules as string[]);
     }
 }
 

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcUrlCollection.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcUrlCollection.cs
@@ -102,12 +102,6 @@ namespace Nethermind.JsonRpc
                         _logger.Info($"Additional JSON RPC URL packed value '{additionalRpcUrl}' format error: {fe.Message}; skipping...");
                     continue;
                 }
-                catch (Exception e)
-                {
-                    if (_logger.IsWarn)
-                        _logger.Warn($"Additional JSON RPC URL packed value '{additionalRpcUrl}' failed to parse: {e.Message}; skipping...");
-                    continue;
-                }
             }
         }
     }

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcUrlCollection.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcUrlCollection.cs
@@ -1,0 +1,102 @@
+//  Copyright (c) 2021 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Nethermind.Logging;
+using Nethermind.Config;
+using Nethermind.JsonRpc.Modules;
+
+namespace Nethermind.JsonRpc
+{
+    public class JsonRpcUrlCollection : IJsonRpcUrlCollection
+    {
+        private const string NethermindUrlVariable = "NETHERMIND_URL";
+
+        private readonly ILogger _logger;
+        private readonly IJsonRpcConfig _jsonRpcConfig;
+        private readonly List<JsonRpcUrl> _urls;
+
+        public JsonRpcUrlCollection(ILogManager logManager, IJsonRpcConfig jsonRpcConfig, bool includeWebSockets)
+        {
+            _logger = logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
+            _jsonRpcConfig = jsonRpcConfig ?? throw new ArgumentNullException(nameof(jsonRpcConfig));
+            _urls = new List<JsonRpcUrl>();
+
+            BuildUrls(includeWebSockets);
+        }
+
+        public JsonRpcUrl this[int index] => _urls[index];
+        public int Count => _urls.Count;
+        public IEnumerator<JsonRpcUrl> GetEnumerator() => _urls.GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public IEnumerable<string> UrlValues => this.Select(x => x.ToString());
+
+        private void BuildUrls(bool includeWebSockets)
+        {
+            JsonRpcUrl defaultUrl = new JsonRpcUrl("http", _jsonRpcConfig.Host, _jsonRpcConfig.Port, RpcEndpoint.Http, _jsonRpcConfig.EnabledModules);
+            string environmentVariableUrl = Environment.GetEnvironmentVariable(NethermindUrlVariable);
+            if (!string.IsNullOrWhiteSpace(environmentVariableUrl))
+            {
+                if (Uri.TryCreate(environmentVariableUrl, UriKind.Absolute, out Uri? uri))
+                {
+                    defaultUrl.Scheme = uri.Scheme;
+                    defaultUrl.Host = uri.Host;
+                    defaultUrl.Port = !uri.IsDefaultPort ? uri.Port : defaultUrl.Port;
+                }
+                else if (_logger.IsWarn)
+                    _logger.Warn($"Environment variable '{NethermindUrlVariable}' value '{environmentVariableUrl}' is not valid JSON RPC URL, using default url : '{defaultUrl}'");
+            }
+            _urls.Add(defaultUrl);
+
+            if (includeWebSockets)
+            {
+                if (_jsonRpcConfig.WebSocketsPort != _jsonRpcConfig.Port)
+                {
+                    JsonRpcUrl defaultWebSocketUrl = defaultUrl.Clone() as JsonRpcUrl;
+                    defaultWebSocketUrl.Port = _jsonRpcConfig.Port;
+                    defaultWebSocketUrl.RpcEndpoint = RpcEndpoint.WebSocket;
+                    _urls.Add(defaultWebSocketUrl);
+                }
+                else
+                    defaultUrl.RpcEndpoint |= RpcEndpoint.WebSocket;
+            }
+
+            foreach (string additionalRpcUrl in _jsonRpcConfig.AdditionalRPCUrls)
+            {
+                try
+                {
+                    JsonRpcUrl url = JsonRpcUrl.Parse(additionalRpcUrl);
+                    if (!includeWebSockets && url.RpcEndpoint.HasFlag(RpcEndpoint.WebSocket))
+                        continue;
+
+                    _urls.Add(url);
+                }
+                catch (Exception)
+                {
+                    if (_logger.IsWarn)
+                        _logger.Warn($"Additional JSON RPC URL packed value '{additionalRpcUrl}' is not formatted correctly, skipping...");
+                    continue;
+                }
+            }
+        }
+    }
+}
+

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcUrlCollection.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcUrlCollection.cs
@@ -89,8 +89,8 @@ namespace Nethermind.JsonRpc
                         url.RpcEndpoint &= ~RpcEndpoint.WebSocket;
                         if (url.RpcEndpoint == RpcEndpoint.None)
                         {
-                            if (_logger.IsWarn)
-                                _logger.Warn($"Additional JSON RPC URL '{url}' has web socket endpoint type and web sockets are not enabled; skipping...");
+                            if (_logger.IsInfo)
+                                _logger.Info($"Additional JSON RPC URL '{url}' has web socket endpoint type and web sockets are not enabled; skipping...");
                             continue;
                         }
                     }

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcUrlCollection.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcUrlCollection.cs
@@ -89,17 +89,23 @@ namespace Nethermind.JsonRpc
 
                     if (ContainsKey(url.Port))
                     {
-                        if (_logger.IsWarn)
-                        { _logger.Warn($"Additional JSON RPC URL '{url}' wants port {url.Port}, but port already in use; skipping..."); }
+                        if (_logger.IsInfo)
+                            _logger.Info($"Additional JSON RPC URL '{url}' wants port {url.Port}, but port already in use; skipping...");
                         continue;
                     }
 
                     Add(url.Port, url);
                 }
-                catch (Exception)
+                catch (FormatException fe)
+                {
+                    if (_logger.IsInfo)
+                        _logger.Info($"Additional JSON RPC URL packed value '{additionalRpcUrl}' format error: {fe.Message}; skipping...");
+                    continue;
+                }
+                catch (Exception e)
                 {
                     if (_logger.IsWarn)
-                        _logger.Warn($"Additional JSON RPC URL packed value '{additionalRpcUrl}' is not formatted correctly, skipping...");
+                        _logger.Warn($"Additional JSON RPC URL packed value '{additionalRpcUrl}' failed to parse: {e.Message}; skipping...");
                     continue;
                 }
             }

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcUrlCollection.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcUrlCollection.cs
@@ -17,6 +17,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Nethermind.Logging;
 using Nethermind.JsonRpc.Modules;
 
@@ -37,6 +38,8 @@ namespace Nethermind.JsonRpc
             if (_jsonRpcConfig.Enabled)
                 BuildUrls(includeWebSockets);
         }
+
+        public string[] Urls => Values.Select(x => x.ToString()).ToArray();
 
         private void BuildUrls(bool includeWebSockets)
         {

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/IRpcModuleProvider.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/IRpcModuleProvider.cs
@@ -30,10 +30,10 @@ namespace Nethermind.JsonRpc.Modules
         IReadOnlyCollection<JsonConverter> Converters { get; }
 
         IReadOnlyCollection<string> Enabled { get; }
-        
+
         IReadOnlyCollection<string> All { get; }
 
-        ModuleResolution Check(string methodName, RpcEndpoint rpcEndpoint);
+        ModuleResolution Check(string methodName, JsonRpcContext context);
         
         (MethodInfo MethodInfo, bool ReadOnly) Resolve(string methodName);
         

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/NullModuleProvider.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/NullModuleProvider.cs
@@ -41,7 +41,7 @@ namespace Nethermind.JsonRpc.Modules
         
         public IReadOnlyCollection<string> All => Array.Empty<string>();
         
-        public ModuleResolution Check(string methodName, RpcEndpoint rpcEndpoint)
+        public ModuleResolution Check(string methodName, JsonRpcContext context)
         {
             return ModuleResolution.Unknown;
         }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/RpcEndpoint.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/RpcEndpoint.cs
@@ -24,8 +24,10 @@ namespace Nethermind.JsonRpc.Modules
     {
         None = 0,
         Http = 1,
-        WebSocket = 2,
+        Ws = 2,
         IPC = 4,
-        All = Http | WebSocket | IPC
+        Https = Http,
+        Wss = Ws,
+        All = Http | Ws | IPC
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/RpcModuleProvider.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/RpcModuleProvider.cs
@@ -97,9 +97,9 @@ namespace Nethermind.JsonRpc.Modules
 
             if ((result.Availability & context.RpcEndpoint) == RpcEndpoint.None) return ModuleResolution.EndpointDisabled;
 
-            if (context.Url != null) return context.Url.EnabledModules.Contains(result.ModuleType, StringComparer.InvariantCultureIgnoreCase) ? ModuleResolution.Enabled : ModuleResolution.Disabled;
+            if (context.Url != null) return context.Url.EnabledModules.Contains(result.ModuleType, StringComparer.InvariantCultureIgnoreCase) ? ModuleResolution.Enabled : ModuleResolution.EndpointDisabled;
 
-            return _enabledModules.Contains(result.ModuleType) == true ? ModuleResolution.Enabled : ModuleResolution.Disabled;
+            return _enabledModules.Contains(result.ModuleType) ? ModuleResolution.Enabled : ModuleResolution.Disabled;
         }
 
         public (MethodInfo, bool) Resolve(string methodName)

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/RpcModuleProvider.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/RpcModuleProvider.cs
@@ -93,11 +93,14 @@ namespace Nethermind.JsonRpc.Modules
 
         public ModuleResolution Check(string methodName, JsonRpcContext context)
         {
-            if (!_methods.TryGetValue(methodName, out ResolvedMethodInfo result)) return ModuleResolution.Unknown;
+            if (!_methods.TryGetValue(methodName, out ResolvedMethodInfo result))
+                return ModuleResolution.Unknown;
 
-            if ((result.Availability & context.RpcEndpoint) == RpcEndpoint.None) return ModuleResolution.EndpointDisabled;
+            if ((result.Availability & context.RpcEndpoint) == RpcEndpoint.None)
+                return ModuleResolution.EndpointDisabled;
 
-            if (context.Url != null) return context.Url.EnabledModules.Contains(result.ModuleType, StringComparer.InvariantCultureIgnoreCase) ? ModuleResolution.Enabled : ModuleResolution.EndpointDisabled;
+            if (context.Url != null)
+                return context.Url.EnabledModules.Contains(result.ModuleType, StringComparer.InvariantCultureIgnoreCase) ? ModuleResolution.Enabled : ModuleResolution.Disabled;
 
             return _enabledModules.Contains(result.ModuleType) ? ModuleResolution.Enabled : ModuleResolution.Disabled;
         }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/RpcModuleProvider.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/RpcModuleProvider.cs
@@ -33,7 +33,7 @@ namespace Nethermind.JsonRpc.Modules
         
         private List<string> _modules = new();
         private List<string> _enabledModules = new();
-        
+
         private Dictionary<string, ResolvedMethodInfo> _methods
             = new(StringComparer.InvariantCulture);
         
@@ -91,13 +91,15 @@ namespace Nethermind.JsonRpc.Modules
             }
         }
 
-        public ModuleResolution Check(string methodName, RpcEndpoint rpcEndpoint)
+        public ModuleResolution Check(string methodName, JsonRpcContext context)
         {
             if (!_methods.TryGetValue(methodName, out ResolvedMethodInfo result)) return ModuleResolution.Unknown;
 
-            if ((result.Availability & rpcEndpoint) == RpcEndpoint.None) return ModuleResolution.EndpointDisabled;
-            
-            return _enabledModules.Contains(result.ModuleType) ? ModuleResolution.Enabled : ModuleResolution.Disabled;
+            if ((result.Availability & context.RpcEndpoint) == RpcEndpoint.None) return ModuleResolution.EndpointDisabled;
+
+            if (context.Url != null) return context.Url.EnabledModules.Contains(result.ModuleType, StringComparer.InvariantCultureIgnoreCase) ? ModuleResolution.Enabled : ModuleResolution.Disabled;
+
+            return _enabledModules.Contains(result.ModuleType) == true ? ModuleResolution.Enabled : ModuleResolution.Disabled;
         }
 
         public (MethodInfo, bool) Resolve(string methodName)

--- a/src/Nethermind/Nethermind.JsonRpc/WebSockets/JsonRpcSocketsClient.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/WebSockets/JsonRpcSocketsClient.cs
@@ -46,6 +46,7 @@ namespace Nethermind.JsonRpc.WebSockets
             string clientName,
             ISocketHandler handler,
             RpcEndpoint endpointType,
+            JsonRpcUrl? url,
             IJsonRpcProcessor jsonRpcProcessor,
             IJsonRpcService jsonRpcService,
             IJsonRpcLocalStats jsonRpcLocalStats,
@@ -55,7 +56,7 @@ namespace Nethermind.JsonRpc.WebSockets
             _jsonRpcProcessor = jsonRpcProcessor;
             _jsonRpcService = jsonRpcService;
             _jsonRpcLocalStats = jsonRpcLocalStats;
-            _jsonRpcContext = new JsonRpcContext(endpointType, this);
+            _jsonRpcContext = new JsonRpcContext(endpointType, this, url);
         }
 
         public override void Dispose()

--- a/src/Nethermind/Nethermind.JsonRpc/WebSockets/JsonRpcSocketsClient.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/WebSockets/JsonRpcSocketsClient.cs
@@ -46,11 +46,11 @@ namespace Nethermind.JsonRpc.WebSockets
             string clientName,
             ISocketHandler handler,
             RpcEndpoint endpointType,
-            JsonRpcUrl? url,
             IJsonRpcProcessor jsonRpcProcessor,
             IJsonRpcService jsonRpcService,
             IJsonRpcLocalStats jsonRpcLocalStats,
-            IJsonSerializer jsonSerializer)
+            IJsonSerializer jsonSerializer,
+            JsonRpcUrl? url = null)
             : base(clientName, handler, jsonSerializer)
         {
             _jsonRpcProcessor = jsonRpcProcessor;
@@ -99,7 +99,7 @@ namespace Nethermind.JsonRpc.WebSockets
 
         private void IncrementBytesReceivedMetric(int size)
         {
-            if (_jsonRpcContext.RpcEndpoint == RpcEndpoint.WebSocket)
+            if (_jsonRpcContext.RpcEndpoint == RpcEndpoint.Ws)
             {
                 Interlocked.Add(ref Metrics.JsonRpcBytesReceivedWebSockets, size);
             }
@@ -112,7 +112,7 @@ namespace Nethermind.JsonRpc.WebSockets
         
         private void IncrementBytesSentMetric(int size)
         {
-            if (_jsonRpcContext.RpcEndpoint == RpcEndpoint.WebSocket)
+            if (_jsonRpcContext.RpcEndpoint == RpcEndpoint.Ws)
             {
                 Interlocked.Add(ref Metrics.JsonRpcBytesSentWebSockets, size);
             }

--- a/src/Nethermind/Nethermind.JsonRpc/WebSockets/JsonRpcWebSocketsModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/WebSockets/JsonRpcWebSocketsModule.cs
@@ -58,17 +58,19 @@ namespace Nethermind.JsonRpc.WebSockets
 
         public ISocketsClient CreateClient(WebSocket webSocket, string clientName, int port)
         {
-            JsonRpcUrl jsonRpcUrl = _jsonRpcUrlCollection.FirstOrDefault(x => x.Port == port && x.RpcEndpoint.HasFlag(RpcEndpoint.WebSocket));
+            if (!_jsonRpcUrlCollection.TryGetValue(port, out JsonRpcUrl jsonRpcUrl) ||
+                !jsonRpcUrl.RpcEndpoint.HasFlag(RpcEndpoint.Ws))
+                throw new InvalidOperationException($"WebSocket-enabled url not defined for port {port}");
 
             var socketsClient = new JsonRpcSocketsClient(
                 clientName, 
                 new WebSocketHandler(webSocket, _logManager), 
-                RpcEndpoint.WebSocket,
-                jsonRpcUrl,
+                RpcEndpoint.Ws,
                 _jsonRpcProcessor, 
                 _jsonRpcService,  
                 _jsonRpcLocalStats, 
-                _jsonSerializer);
+                _jsonSerializer,
+                jsonRpcUrl);
 
             _clients.TryAdd(socketsClient.Id, socketsClient);
 

--- a/src/Nethermind/Nethermind.JsonRpc/WebSockets/JsonRpcWebSocketsModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/WebSockets/JsonRpcWebSocketsModule.cs
@@ -56,12 +56,12 @@ namespace Nethermind.JsonRpc.WebSockets
             _jsonRpcUrlCollection = jsonRpcUrlCollection;
         }
 
-        public ISocketsClient CreateClient(WebSocket webSocket, string client, int port)
+        public ISocketsClient CreateClient(WebSocket webSocket, string clientName, int port)
         {
             JsonRpcUrl jsonRpcUrl = _jsonRpcUrlCollection.FirstOrDefault(x => x.Port == port && x.RpcEndpoint.HasFlag(RpcEndpoint.WebSocket));
 
             var socketsClient = new JsonRpcSocketsClient(
-                client, 
+                clientName, 
                 new WebSocketHandler(webSocket, _logManager), 
                 RpcEndpoint.WebSocket,
                 jsonRpcUrl,

--- a/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/RegisterRpcModulesTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/RegisterRpcModulesTests.cs
@@ -45,7 +45,7 @@ namespace Nethermind.Runner.Test.Ethereum.Steps
             RegisterRpcModules registerRpcModules = new(context);
             await registerRpcModules.Execute(CancellationToken.None);
 
-            context.RpcModuleProvider.Check("proof_call", RpcEndpoint.Http).Should().Be(ModuleResolution.Enabled);
+            context.RpcModuleProvider.Check("proof_call", new JsonRpcContext(RpcEndpoint.Http)).Should().Be(ModuleResolution.Enabled);
         }
         
         [Test]

--- a/src/Nethermind/Nethermind.Runner/Ethereum/JsonRpcRunner.cs
+++ b/src/Nethermind/Nethermind.Runner/Ethereum/JsonRpcRunner.cs
@@ -72,7 +72,7 @@ namespace Nethermind.Runner.Ethereum
         public Task Start(CancellationToken cancellationToken)
         {
             if (_logger.IsDebug) _logger.Debug("Initializing JSON RPC");
-            string[] urls = _jsonRpcUrlCollection.Select(x => x.ToString()).ToArray();
+            string[] urls = _jsonRpcUrlCollection.Urls;
             var webHost = WebHost.CreateDefaultBuilder()
                 .ConfigureServices(s =>
                 {

--- a/src/Nethermind/Nethermind.Runner/Ethereum/JsonRpcRunner.cs
+++ b/src/Nethermind/Nethermind.Runner/Ethereum/JsonRpcRunner.cs
@@ -72,7 +72,7 @@ namespace Nethermind.Runner.Ethereum
         public Task Start(CancellationToken cancellationToken)
         {
             if (_logger.IsDebug) _logger.Debug("Initializing JSON RPC");
-            string[] urls = _jsonRpcUrlCollection.UrlValues.ToArray();
+            string[] urls = _jsonRpcUrlCollection.Select(x => x.ToString()).ToArray();
             var webHost = WebHost.CreateDefaultBuilder()
                 .ConfigureServices(s =>
                 {

--- a/src/Nethermind/Nethermind.Runner/Ethereum/Steps/StartRpc.cs
+++ b/src/Nethermind/Nethermind.Runner/Ethereum/Steps/StartRpc.cs
@@ -46,6 +46,8 @@ namespace Nethermind.Runner.Ethereum.Steps
             if (jsonRpcConfig.Enabled)
             {
                 IInitConfig initConfig = _api.Config<IInitConfig>();
+                IJsonRpcUrlCollection jsonRpcUrlCollection = new JsonRpcUrlCollection(_api.LogManager, jsonRpcConfig, initConfig.WebSocketsEnabled);
+
                 JsonRpcLocalStats jsonRpcLocalStats = new(
                     _api.Timestamper,
                     jsonRpcConfig,
@@ -73,6 +75,7 @@ namespace Nethermind.Runner.Ethereum.Steps
                 Bootstrap.Instance.JsonRpcLocalStats = jsonRpcLocalStats;
                 JsonRpcRunner? jsonRpcRunner = new(
                     jsonRpcProcessor,
+                    jsonRpcUrlCollection,
                     _api.WebSocketsManager!,
                     _api.ConfigProvider,
                     _api.LogManager,

--- a/src/Nethermind/Nethermind.Runner/Ethereum/Steps/StartRpc.cs
+++ b/src/Nethermind/Nethermind.Runner/Ethereum/Steps/StartRpc.cs
@@ -65,7 +65,7 @@ namespace Nethermind.Runner.Ethereum.Steps
 
                 if (initConfig.WebSocketsEnabled)
                 {
-                    JsonRpcWebSocketsModule webSocketsModule = new (jsonRpcProcessor, jsonRpcService, jsonRpcLocalStats, _api.LogManager, jsonSerializer);
+                    JsonRpcWebSocketsModule webSocketsModule = new (jsonRpcProcessor, jsonRpcService, jsonRpcLocalStats, _api.LogManager, jsonSerializer, jsonRpcUrlCollection);
                     _api.WebSocketsManager!.AddModule(webSocketsModule, true);
                 }
 

--- a/src/Nethermind/Nethermind.Runner/JsonRpc/JsonRpcIpcRunner.cs
+++ b/src/Nethermind/Nethermind.Runner/JsonRpc/JsonRpcIpcRunner.cs
@@ -124,6 +124,7 @@ namespace Nethermind.Runner.JsonRpc
                     string.Empty,
                     new IpcSocketsHandler(socket),
                     RpcEndpoint.IPC,
+                    null,
                     _jsonRpcProcessor,
                     _jsonRpcService,
                     _jsonRpcLocalStats,

--- a/src/Nethermind/Nethermind.Runner/JsonRpc/JsonRpcIpcRunner.cs
+++ b/src/Nethermind/Nethermind.Runner/JsonRpc/JsonRpcIpcRunner.cs
@@ -124,7 +124,6 @@ namespace Nethermind.Runner.JsonRpc
                     string.Empty,
                     new IpcSocketsHandler(socket),
                     RpcEndpoint.IPC,
-                    null,
                     _jsonRpcProcessor,
                     _jsonRpcService,
                     _jsonRpcLocalStats,

--- a/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
+++ b/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
@@ -154,7 +154,7 @@ namespace Nethermind.Runner.JsonRpc
                     using CountingTextReader request = new(new StreamReader(ctx.Request.Body, Encoding.UTF8));
                     try
                     {
-                        await foreach (JsonRpcResult result in jsonRpcProcessor.ProcessAsync(request, JsonRpcContext.Http))
+                        await foreach (JsonRpcResult result in jsonRpcProcessor.ProcessAsync(request, JsonRpcContext.Http(jsonRpcUrl)))
                         {
                             using (result)
                             {

--- a/src/Nethermind/Nethermind.Sockets.Test/WebSocketExtensionsTests.cs
+++ b/src/Nethermind/Nethermind.Sockets.Test/WebSocketExtensionsTests.cs
@@ -129,11 +129,11 @@ namespace Nethermind.Sockets.Test
                 "TestClient",
                 new WebSocketHandler(mock, Substitute.For<ILogManager>()),
                 RpcEndpoint.Ws,
-                null,
                 processor,
                 service,
                 localStats,
-                Substitute.For<IJsonSerializer>());
+                Substitute.For<IJsonSerializer>(),
+                null);
 
             webSocketsClient.Configure().SendJsonRpcResult(default).ReturnsForAnyArgs((x) =>
             {

--- a/src/Nethermind/Nethermind.Sockets.Test/WebSocketExtensionsTests.cs
+++ b/src/Nethermind/Nethermind.Sockets.Test/WebSocketExtensionsTests.cs
@@ -128,7 +128,7 @@ namespace Nethermind.Sockets.Test
             var webSocketsClient = Substitute.ForPartsOf< JsonRpcSocketsClient>(
                 "TestClient",
                 new WebSocketHandler(mock, Substitute.For<ILogManager>()),
-                RpcEndpoint.WebSocket,
+                RpcEndpoint.Ws,
                 null,
                 processor,
                 service,

--- a/src/Nethermind/Nethermind.Sockets.Test/WebSocketExtensionsTests.cs
+++ b/src/Nethermind/Nethermind.Sockets.Test/WebSocketExtensionsTests.cs
@@ -129,6 +129,7 @@ namespace Nethermind.Sockets.Test
                 "TestClient",
                 new WebSocketHandler(mock, Substitute.For<ILogManager>()),
                 RpcEndpoint.WebSocket,
+                null,
                 processor,
                 service,
                 localStats,

--- a/src/Nethermind/Nethermind.Sockets/Extensions.cs
+++ b/src/Nethermind/Nethermind.Sockets/Extensions.cs
@@ -63,7 +63,7 @@ namespace Nethermind.Sockets
 
                     if (logger?.IsDebug == true) logger.Info($"Initializing WebSockets for client: '{clientName}'.");
                     var webSocket = await context.WebSockets.AcceptWebSocketAsync();
-                    var socketsClient = module.CreateClient(webSocket, clientName);
+                    var socketsClient = module.CreateClient(webSocket, clientName, context.Connection.LocalPort);
                     id = socketsClient.Id;
                     await socketsClient.ReceiveAsync();
                 }

--- a/src/Nethermind/Nethermind.Sockets/IWebSocketsModule.cs
+++ b/src/Nethermind/Nethermind.Sockets/IWebSocketsModule.cs
@@ -22,7 +22,7 @@ namespace Nethermind.Sockets
     public interface IWebSocketsModule
     {
         string Name { get; }
-        ISocketsClient CreateClient(WebSocket webSocket, string client);
+        ISocketsClient CreateClient(WebSocket webSocket, string client, int port);
         void RemoveClient(string clientId);
         Task SendAsync(SocketsMessage message);
     }


### PR DESCRIPTION
Resolves #3535

## Changes:
- Added AdditionalRPCUrls option to IJsonRPCConfig
- Added new class JsonRpcUrl to represent the data parsed from the config format
- Added new interface IJsonRpcUrlCollection and implementation for managing all of the parsed JsonRpcUrls
- Refactored JsonRpcContext to include optional JsonRpcUrl
- Refactored JsonRpcRunner to use urls defined in JsonRpcUrlCollection
- Refactored JsonRpc Startup to match connection ports to JsonRpcUrls which are passed along through to the service/processor via JsonRpcContext
- Added port (int) parameter to the CreateClient() method of IWebSocketsModule. Needed to match the connection port to a JsonRpcUrl
- Refactored IRpcModuleProvider/RpcModuleProvider Check() method to use JsonRpcContext instead of RpcEndpoint. If context.Url is not null: use JsonRpcUrl's enables modules list for check; Else: fallback on default EnabledModules check logic.
- Updated unit tests to work with refactors

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No

**Comments about testing , should you have some** (optional)
* Adding testing to ensure RpcModuleProvider.Check() uses enabled modules scoped to a url when provided
* Added tests for JsonRpcUrl
* Added tests for JsonRpcUrlCollection

## Further comments (optional)
First PR to this project (hopefully first of many) so please enlighten me if I missed a step in the process. I tried to follow the existing coding styles in use.

Config file format should be backwards compatible and continue to work without presence of AdditionalRPCUrls config option.

I'm sure there will need to be some iteration to get this right, but figured it was a good starting point to get the conversation going.

Thanks!