### PR TITLE
disable 3607 for eth call

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
@@ -117,7 +117,7 @@ namespace Nethermind.Core.Test.Blockchain
         {
             Timestamper = new ManualTimestamper(new DateTime(2020, 2, 15, 12, 50, 30, DateTimeKind.Utc));
             JsonSerializer = new EthereumJsonSerializer();
-            SpecProvider = new OverridableSpecProvider(specProvider ?? MainnetSpecProvider.Instance, s => new OverridableReleaseSpec(s));
+            SpecProvider = CreateSpecProvider(specProvider ?? MainnetSpecProvider.Instance);
             EthereumEcdsa = new EthereumEcdsa(ChainId.Mainnet, LogManager);
             DbProvider = await TestMemDbProvider.InitAsync();
             TrieStore = new TrieStore(StateDb.Innermost, LogManager);
@@ -191,6 +191,13 @@ namespace Nethermind.Core.Test.Blockchain
             await WaitAsync(_resetEvent, "Failed to process genesis in time.");
             await AddBlocksOnStart();
             return this;
+        }
+
+        private static ISpecProvider CreateSpecProvider(ISpecProvider specProvider)
+        {
+            return specProvider is TestSpecProvider { AllowTestChainOverride: false } 
+                ? specProvider 
+                : new OverridableSpecProvider(specProvider, s => new OverridableReleaseSpec(s) { IsEip3607Enabled = false });
         }
 
         private async Task WaitAsync(SemaphoreSlim semaphore, string error, int timeout = DefaultTimeout)

--- a/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
@@ -117,7 +117,7 @@ namespace Nethermind.Core.Test.Blockchain
         {
             Timestamper = new ManualTimestamper(new DateTime(2020, 2, 15, 12, 50, 30, DateTimeKind.Utc));
             JsonSerializer = new EthereumJsonSerializer();
-            SpecProvider = new OverridableSpecProvider(specProvider ?? MainnetSpecProvider.Instance, s => new OverridableReleaseSpec(s) { IsEip3607Enabled = false });
+            SpecProvider = new OverridableSpecProvider(specProvider ?? MainnetSpecProvider.Instance, s => new OverridableReleaseSpec(s));
             EthereumEcdsa = new EthereumEcdsa(ChainId.Mainnet, LogManager);
             DbProvider = await TestMemDbProvider.InitAsync();
             TrieStore = new TrieStore(StateDb.Innermost, LogManager);

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -174,7 +174,7 @@ namespace Nethermind.Evm.TransactionProcessing
                 return;
             }
 
-            if (_stateProvider.IsInvalidContractSender(spec, caller))
+            if (_stateProvider.IsInvalidContractSender(spec, caller) && !restore)
             {
                 TraceLogInvalidTx(transaction, "SENDER_IS_CONTRACT");
                 QuickFail(transaction, block, txTracer, eip658NotEnabled, "sender has deployed code");

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -174,7 +174,7 @@ namespace Nethermind.Evm.TransactionProcessing
                 return;
             }
 
-            if (_stateProvider.IsInvalidContractSender(spec, caller) && !restore)
+            if (!restore && _stateProvider.IsInvalidContractSender(spec, caller))
             {
                 TraceLogInvalidTx(transaction, "SENDER_IS_CONTRACT");
                 QuickFail(transaction, block, txTracer, eip658NotEnabled, "sender has deployed code");

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
@@ -19,12 +19,15 @@ using System;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Nethermind.Core;
+using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
+using Nethermind.Core.Test.Builders;
 using Nethermind.Evm;
 using Nethermind.Evm.Tracing;
 using Nethermind.JsonRpc.Data;
 using Nethermind.Specs;
 using Nethermind.Specs.Forks;
+using Nethermind.Specs.Test;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
@@ -255,6 +258,23 @@ namespace Nethermind.JsonRpc.Test.Modules.Eth
             Assert.AreEqual(
                 "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32015,\"message\":\"revert\"},\"id\":67}",
                 serialized);
+        }
+        
+        [Test]
+        public async Task should_estimate_transaction_with_deployed_code_when_eip3607_enabled()
+        {
+            OverridableReleaseSpec releaseSpec = new(London.Instance) { Eip1559TransitionBlock = 1, IsEip3607Enabled = true };
+            TestSpecProvider specProvider = new(releaseSpec) { ChainId = ChainId.Mainnet, AllowTestChainOverride = false };
+            using Context ctx = await Context.Create(specProvider);
+            
+            Transaction tx = Build.A.Transaction.SignedAndResolved(TestItem.PrivateKeyA).TestObject;
+            TransactionForRpc transaction = new(Keccak.Zero, 1L, 1, tx);
+            ctx._test.State.UpdateCodeHash(TestItem.AddressA, TestItem.KeccakH, London.Instance);
+            transaction.To = TestItem.AddressB;
+
+            string serialized =
+                ctx._test.TestEthRpc("eth_estimateGas", ctx._test.JsonSerializer.Serialize(transaction), "latest");
+            Assert.AreEqual("{\"jsonrpc\":\"2.0\",\"result\":\"0x5208\",\"id\":67}", serialized);
         }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EthCall.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EthCall.cs
@@ -110,6 +110,21 @@ namespace Nethermind.JsonRpc.Test.Modules.Eth
                 "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32015,\"message\":\"VM execution error.\",\"data\":\"StackUnderflow\"},\"id\":67}",
                 serialized);
         }
+        
+        
+        [Test]
+        public async Task should_not_reject_transactions_with_deployed_code_when_eip3607_enabled()
+        {
+            using Context ctx = await Context.CreateWithLondonEnabled();
+            Transaction tx = Build.A.Transaction.SignedAndResolved(TestItem.PrivateKeyA).TestObject;
+            TransactionForRpc transaction = new(Keccak.Zero, 1L, 1, tx);
+            ctx._test.State.UpdateCodeHash(TestItem.AddressA, TestItem.KeccakH, London.Instance);
+            transaction.To = TestItem.AddressB;
+
+            string serialized =
+                ctx._test.TestEthRpc("eth_call", ctx._test.JsonSerializer.Serialize(transaction), "latest");
+            Assert.AreEqual("{\"jsonrpc\":\"2.0\",\"result\":\"0x\",\"id\":67}", serialized);
+        }
 
         [Test]
         public async Task Eth_call_ethereum_recipient()

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EthCall.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EthCall.cs
@@ -25,6 +25,7 @@ using Nethermind.Evm;
 using Nethermind.JsonRpc.Data;
 using Nethermind.Specs;
 using Nethermind.Specs.Forks;
+using Nethermind.Specs.Test;
 using NUnit.Framework;
 
 namespace Nethermind.JsonRpc.Test.Modules.Eth
@@ -115,7 +116,10 @@ namespace Nethermind.JsonRpc.Test.Modules.Eth
         [Test]
         public async Task should_not_reject_transactions_with_deployed_code_when_eip3607_enabled()
         {
-            using Context ctx = await Context.CreateWithLondonEnabled();
+            OverridableReleaseSpec releaseSpec = new(London.Instance) { Eip1559TransitionBlock = 1, IsEip3607Enabled = true };
+            TestSpecProvider specProvider = new(releaseSpec) { ChainId = ChainId.Mainnet, AllowTestChainOverride = false };
+            using Context ctx = await Context.Create(specProvider);
+            
             Transaction tx = Build.A.Transaction.SignedAndResolved(TestItem.PrivateKeyA).TestObject;
             TransactionForRpc transaction = new(Keccak.Zero, 1L, 1, tx);
             ctx._test.State.UpdateCodeHash(TestItem.AddressA, TestItem.KeccakH, London.Instance);

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
@@ -892,9 +892,7 @@ namespace Nethermind.JsonRpc.Test.Modules.Eth
             
             public static async Task<Context> CreateWithLondonEnabled()
             {
-                OverridableReleaseSpec releaseSpec = new(London.Instance);
-                releaseSpec.Eip1559TransitionBlock = 1;
-                releaseSpec.IsEip3607Enabled = true;
+                OverridableReleaseSpec releaseSpec = new(London.Instance) { Eip1559TransitionBlock = 1 };
                 TestSpecProvider specProvider = new(releaseSpec) {ChainId = ChainId.Mainnet};
                 return await Create(specProvider);
             }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
@@ -894,6 +894,7 @@ namespace Nethermind.JsonRpc.Test.Modules.Eth
             {
                 OverridableReleaseSpec releaseSpec = new(London.Instance);
                 releaseSpec.Eip1559TransitionBlock = 1;
+                releaseSpec.IsEip3607Enabled = true;
                 TestSpecProvider specProvider = new(releaseSpec) {ChainId = ChainId.Mainnet};
                 return await Create(specProvider);
             }

--- a/src/Nethermind/Nethermind.Specs/TestSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Specs/TestSpecProvider.cs
@@ -38,5 +38,6 @@ namespace Nethermind.Specs
         public long? DaoBlockNumber { get; set; }
         public ulong ChainId { get; set; }
         public long[] TransitionBlocks { get; set; } = new long[] {0};
+        public bool AllowTestChainOverride { get; set; } = true;
     }
 }


### PR DESCRIPTION
Fixes | Closes | Resolves #3574

## Changes:
Disable 3607 for RPC calls

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No