### PR TITLE
Add alphabetical ordering of capabilities in Hello handler

### DIFF
--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandler.cs
@@ -109,7 +109,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
                     HandleHello(Deserialize<HelloMessage>(msg.Data));
                     
                     foreach (Capability capability in
-                        _agreedCapabilities.GroupBy(c => c.ProtocolCode).Select(c => c.OrderBy(v => v.Version).Last()))
+                        _agreedCapabilities.OrderBy(c => c.ProtocolCode).GroupBy(c => c.ProtocolCode).Select(c => c.OrderBy(v => v.Version).Last()))
                     {
                         if (Logger.IsTrace) Logger.Trace($"{Session} Starting protocolHandler for {capability.ProtocolCode} v{capability.Version} on {Session.RemotePort}");
                         SubprotocolRequested?.Invoke(this, new ProtocolEventArgs(capability.ProtocolCode, capability.Version));

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandler.cs
@@ -108,6 +108,10 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
                     Metrics.HellosReceived++;
                     HandleHello(Deserialize<HelloMessage>(msg.Data));
                     
+                    // We need to initialize subprotocols in alphabetical order. Protocols are using AdaptiveId,
+                    // which should be constant for the whole session. Some protocols (like Eth) are sending messages
+                    // on initialization and we need to avoid changing theirs AdaptiveId by initializing protocols,
+                    // which are alphabetically before already initialized ones.
                     foreach (Capability capability in
                         _agreedCapabilities.GroupBy(c => c.ProtocolCode).Select(c => c.OrderBy(v => v.Version).Last()).OrderBy(c => c.ProtocolCode))
                     {

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandler.cs
@@ -109,7 +109,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
                     HandleHello(Deserialize<HelloMessage>(msg.Data));
                     
                     foreach (Capability capability in
-                        _agreedCapabilities.OrderBy(c => c.ProtocolCode).GroupBy(c => c.ProtocolCode).Select(c => c.OrderBy(v => v.Version).Last()))
+                        _agreedCapabilities.GroupBy(c => c.ProtocolCode).Select(c => c.OrderBy(v => v.Version).Last()).OrderBy(c => c.ProtocolCode))
                     {
                         if (Logger.IsTrace) Logger.Trace($"{Session} Starting protocolHandler for {capability.ProtocolCode} v{capability.Version} on {Session.RemotePort}");
                         SubprotocolRequested?.Invoke(this, new ProtocolEventArgs(capability.ProtocolCode, capability.Version));


### PR DESCRIPTION
Fixes #3659

## Changes:
- adding alphabetical ordering of capabilities in Hello handler

Bug description:
1. We initialize P2P.
2. We handle P2P Hello:
https://github.com/NethermindEth/nethermind/blob/93cde2024a82b17f2e6c82e86a2410366ad8aebd/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandler.cs#L106-L119
3. In Hello handler, in foreach loop, we can have not alphabetical order, i.e. Eth before Aa
4. Eth protocol requested.
5. Eth is initializing. We have only P2P and Eth. Status message is sent (it is in eth62 Init())
6. Aa protocol requested.
7. Aa protocol is initializing, order in AdaptiveCodeResolver changed

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [x] No