### PR TITLE
Add additional symlink for Fedora 35

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 [Linux x64/arm64](http://downloads.nethermind.io)<br/>
 [MacOS](http://downloads.nethermind.io)<br/>
 
-It syncs fully on: 
+It syncs fully on:
 * `Mainnet`
 * `Goerli`
 * `Rinkeby`
@@ -103,6 +103,8 @@ sudo yum install -y glibc-devel snappy libzstd
 # Link libraries
 sudo ln -s `find /usr/lib64/ -type f -name "libbz2.so.1*"` /usr/lib64/libbz2.so.1.0 && \
 sudo ln -s `find /usr/lib64/ -type f -name "libsnappy.so.1*"` /usr/lib64/libsnappy.so
+# also required for Fedora 35
+sudo ln -s `find /usr/lib64/ -type f -name "libdl.so.2*"` /usr/lib64/libdl.so
 ```
 *Tested on Fedora 32*
 
@@ -166,4 +168,3 @@ Nethermind client can be used in your projects, when setting up private Ethereum
 
 # License
 [![GitHub](https://img.shields.io/github/license/nethermindeth/nethermind.svg)](https://github.com/NethermindEth/nethermind/blob/master/LICENSE)
-


### PR DESCRIPTION
This fixes usage with Fedora 35. Same as Ubuntu 21.10 fix. Matched
"find" usage with existing Fedora symlinks. Tested on `registry.fedoraproject.org/fedora:35` docker image.

## Changes:
- Adds instructions to make a symlink for libdl in Fedora 35.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
