### PR TITLE
Fix CREATE/CREATE2 when account has max nonce

### DIFF
--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -2295,6 +2295,15 @@ namespace Nethermind.Evm
                             stack.PushZero();
                             break;
                         }
+                        
+                        UInt256 accountNonce = _state.GetNonce(env.ExecutingAccount);
+                        UInt256 maxNonce = ulong.MaxValue;
+                        if (accountNonce >= maxNonce)
+                        {
+                            _returnDataBuffer = Array.Empty<byte>();
+                            stack.PushZero();
+                            break;
+                        }
 
                         EndInstructionTrace();
                         // todo: === below is a new call - refactor / move


### PR DESCRIPTION
## Changes:
- Break execution of CREATE/CREATE2 when account already has max nonce.
This change is fixing 86 hive consensus tests (out of 99 failing because of CREATE/CREATE2). Constantinople is still failing. I will investigate it next week. Other test (sstoreGas_d0g0v0_Constantinople) is failing only on Constantinople too, so probably problem is in other place than related with this PR.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [x] No

It's covered in hive consensus tests