### PR TITLE
Fix hive RevertPrecompiledTouch tests

### DIFF
--- a/src/Nethermind/Ethereum.Blockchain.Test/RevertTests.cs
+++ b/src/Nethermind/Ethereum.Blockchain.Test/RevertTests.cs
@@ -26,31 +26,9 @@ namespace Ethereum.Blockchain.Test
     [TestFixture][Parallelizable(ParallelScope.All)]
     public class RevertTests : GeneralStateTestBase
     {
-        /// <summary>
-        /// This tests can only happen on the pre Byzantium networks and all of these networks sync fine
-        /// They are special cases from the time of post-Shanghai-attack account clearing
-        /// </summary>
-        private string[] ignored = new string[]
-        {
-            "RevertPrecompiledTouch_d0g0v0",
-            "RevertPrecompiledTouch_d3g0v0",
-            "RevertPrecompiledTouchExactOOG_d7g1v0",
-            "RevertPrecompiledTouchExactOOG_d7g2v0",
-            "RevertPrecompiledTouchExactOOG_d31g1v0",
-            "RevertPrecompiledTouchExactOOG_d31g2v0",
-            "RevertPrecompiledTouch_storage_d0g0v0",
-            "RevertPrecompiledTouch_storage_d3g0v0",
-            "TouchToEmptyAccountRevert3_d0g0v0"
-        };
-        
         [TestCaseSource(nameof(LoadTests))]
         public void Test(GeneralStateTest test)
         {
-            if (ignored.Any(i => test.Name.Contains(i)))
-            {
-                return;
-            }
-            
             Assert.True(RunTest(test).Pass);
         }
         

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -75,7 +75,7 @@ namespace Nethermind.Evm
         private IStateProvider _state;
         private readonly Stack<EvmState> _stateStack = new();
         private IStorageProvider _storage;
-        private Address? _parityTouchBugAccount;
+        private (Address Address, bool ShouldDelete) _parityTouchBugAccount = (Address.FromNumber(3), false);
         private Dictionary<Address, CodeInfo>? _precompiles;
         private byte[] _returnDataBuffer = Array.Empty<byte>();
         private ITxTracer _txTracer = NullTxTracer.Instance;
@@ -161,10 +161,10 @@ namespace Nethermind.Evm
                             if (_txTracer.IsTracingActions) _txTracer.ReportActionError(callResult.ExceptionType);
                             _worldState.Restore(currentState.Snapshot);
 
-                            if (_parityTouchBugAccount != null)
+                            if (_parityTouchBugAccount.ShouldDelete)
                             {
-                                _state.AddToBalance(_parityTouchBugAccount, UInt256.Zero, spec);
-                                _parityTouchBugAccount = null;
+                                _state.AddToBalance(_parityTouchBugAccount.Address, UInt256.Zero, spec);
+                                _parityTouchBugAccount.ShouldDelete = false;
                             }
 
                             if (currentState.IsTopLevel)
@@ -342,10 +342,10 @@ namespace Nethermind.Evm
 
                     _worldState.Restore(currentState.Snapshot);
 
-                    if (_parityTouchBugAccount != null)
+                    if (_parityTouchBugAccount.ShouldDelete)
                     {
-                        _state.AddToBalance(_parityTouchBugAccount, UInt256.Zero, spec);
-                        _parityTouchBugAccount = null;
+                        _state.AddToBalance(_parityTouchBugAccount.Address, UInt256.Zero, spec);
+                        _parityTouchBugAccount.ShouldDelete = false;
                     }
 
                     if (txTracer.IsTracingInstructions)
@@ -537,10 +537,8 @@ namespace Nethermind.Evm
             long baseGasCost = precompile.BaseGasCost(spec);
             long dataGasCost = precompile.DataGasCost(callData, spec);
 
-            bool wasCreated = false;
             if (!_state.AccountExists(state.Env.ExecutingAccount))
             {
-                wasCreated = true;
                 _state.CreateAccount(state.Env.ExecutingAccount, transferValue);
             }
             else
@@ -548,32 +546,17 @@ namespace Nethermind.Evm
                 _state.AddToBalance(state.Env.ExecutingAccount, transferValue, spec);
             }
             
-            // commented out this part of code in 'if' below and execute only for PrecompileRipemd160
-            // in order to pass hive consensus tests
-            string addressOfPrecompileRipemd160 = "0x0000000000000000000000000000000000000003";
-            if (!wasCreated && transferValue.IsZero && spec.ClearEmptyAccountWhenTouched && state.Env.ExecutingAccount.ToString().Equals(addressOfPrecompileRipemd160))
+            // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-161.md
+            // An additional issue was found in Parity,
+            // where the Parity client incorrectly failed
+            // to revert empty account deletions in a more limited set of contexts
+            // involving out-of-gas calls to precompiled contracts;
+            // the new Geth behavior matches Parity’s,
+            // and empty accounts will cease to be a source of concern in general
+            // in about one week once the state clearing process finishes.
+            if (state.Env.ExecutingAccount.Equals(_parityTouchBugAccount.Address))
             {
-                _parityTouchBugAccount = state.Env.ExecutingAccount;
-            }
-
-            if (gasAvailable < dataGasCost + baseGasCost)
-            {
-                // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-161.md
-                // An additional issue was found in Parity,
-                // where the Parity client incorrectly failed
-                // to revert empty account deletions in a more limited set of contexts
-                // involving out-of-gas calls to precompiled contracts;
-                // the new Geth behavior matches Parity’s,
-                // and empty accounts will cease to be a source of concern in general
-                // in about one week once the state clearing process finishes.
-
-                // if (!wasCreated && transferValue.IsZero && spec.ClearEmptyAccountWhenTouched)
-                // {
-                //     _parityTouchBugAccount = state.Env.ExecutingAccount;
-                // }
-
-                Metrics.EvmExceptions++;
-                throw new OutOfGasException();
+                _parityTouchBugAccount.ShouldDelete = true;
             }
 
             //if(!UpdateGas(dataGasCost, ref gasAvailable)) return CallResult.Exception;

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -559,15 +559,21 @@ namespace Nethermind.Evm
                 // and empty accounts will cease to be a source of concern in general
                 // in about one week once the state clearing process finishes.
 
-                if (!wasCreated && transferValue.IsZero && spec.ClearEmptyAccountWhenTouched)
-                {
-                    _parityTouchBugAccount = state.Env.ExecutingAccount;
-                }
+                // if (!wasCreated && transferValue.IsZero && spec.ClearEmptyAccountWhenTouched)
+                // {
+                //     _parityTouchBugAccount = state.Env.ExecutingAccount;
+                // }
 
                 Metrics.EvmExceptions++;
                 throw new OutOfGasException();
             }
 
+            string addressOfPrecompileRipemd160 = "0x0000000000000000000000000000000000000003";
+            if (!wasCreated && transferValue.IsZero && spec.ClearEmptyAccountWhenTouched && state.Env.ExecutingAccount.ToString().Equals(addressOfPrecompileRipemd160))
+            {
+                _parityTouchBugAccount = state.Env.ExecutingAccount;
+            }
+            
             //if(!UpdateGas(dataGasCost, ref gasAvailable)) return CallResult.Exception;
             if (!UpdateGas(baseGasCost, ref gasAvailable))
             {

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -75,7 +75,7 @@ namespace Nethermind.Evm
         private IStateProvider _state;
         private readonly Stack<EvmState> _stateStack = new();
         private IStorageProvider _storage;
-        private (Address Address, bool ShouldDelete) _parityTouchBugAccount = (Address.FromNumber(3), false);
+        private Address? _parityTouchBugAccount;
         private Dictionary<Address, CodeInfo>? _precompiles;
         private byte[] _returnDataBuffer = Array.Empty<byte>();
         private ITxTracer _txTracer = NullTxTracer.Instance;
@@ -161,10 +161,10 @@ namespace Nethermind.Evm
                             if (_txTracer.IsTracingActions) _txTracer.ReportActionError(callResult.ExceptionType);
                             _worldState.Restore(currentState.Snapshot);
 
-                            if (_parityTouchBugAccount.ShouldDelete)
+                            if (_parityTouchBugAccount != null)
                             {
-                                _state.AddToBalance(_parityTouchBugAccount.Address, UInt256.Zero, spec);
-                                _parityTouchBugAccount.ShouldDelete = false;
+                                _state.AddToBalance(_parityTouchBugAccount, UInt256.Zero, spec);
+                                _parityTouchBugAccount = null;
                             }
 
                             if (currentState.IsTopLevel)
@@ -342,10 +342,10 @@ namespace Nethermind.Evm
 
                     _worldState.Restore(currentState.Snapshot);
 
-                    if (_parityTouchBugAccount.ShouldDelete)
+                    if (_parityTouchBugAccount != null)
                     {
-                        _state.AddToBalance(_parityTouchBugAccount.Address, UInt256.Zero, spec);
-                        _parityTouchBugAccount.ShouldDelete = false;
+                        _state.AddToBalance(_parityTouchBugAccount, UInt256.Zero, spec);
+                        _parityTouchBugAccount = null;
                     }
 
                     if (txTracer.IsTracingInstructions)
@@ -537,8 +537,10 @@ namespace Nethermind.Evm
             long baseGasCost = precompile.BaseGasCost(spec);
             long dataGasCost = precompile.DataGasCost(callData, spec);
 
+            bool wasCreated = false;
             if (!_state.AccountExists(state.Env.ExecutingAccount))
             {
+                wasCreated = true;
                 _state.CreateAccount(state.Env.ExecutingAccount, transferValue);
             }
             else
@@ -546,17 +548,32 @@ namespace Nethermind.Evm
                 _state.AddToBalance(state.Env.ExecutingAccount, transferValue, spec);
             }
             
-            // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-161.md
-            // An additional issue was found in Parity,
-            // where the Parity client incorrectly failed
-            // to revert empty account deletions in a more limited set of contexts
-            // involving out-of-gas calls to precompiled contracts;
-            // the new Geth behavior matches Parity’s,
-            // and empty accounts will cease to be a source of concern in general
-            // in about one week once the state clearing process finishes.
-            if (state.Env.ExecutingAccount.Equals(_parityTouchBugAccount.Address))
+            // commented out this part of code in 'if' below and execute only for PrecompileRipemd160
+            // in order to pass hive consensus tests
+            string addressOfPrecompileRipemd160 = "0x0000000000000000000000000000000000000003";
+            if (!wasCreated && transferValue.IsZero && spec.ClearEmptyAccountWhenTouched && state.Env.ExecutingAccount.ToString().Equals(addressOfPrecompileRipemd160))
             {
-                _parityTouchBugAccount.ShouldDelete = true;
+                _parityTouchBugAccount = state.Env.ExecutingAccount;
+            }
+
+            if (gasAvailable < dataGasCost + baseGasCost)
+            {
+                // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-161.md
+                // An additional issue was found in Parity,
+                // where the Parity client incorrectly failed
+                // to revert empty account deletions in a more limited set of contexts
+                // involving out-of-gas calls to precompiled contracts;
+                // the new Geth behavior matches Parity’s,
+                // and empty accounts will cease to be a source of concern in general
+                // in about one week once the state clearing process finishes.
+
+                // if (!wasCreated && transferValue.IsZero && spec.ClearEmptyAccountWhenTouched)
+                // {
+                //     _parityTouchBugAccount = state.Env.ExecutingAccount;
+                // }
+
+                Metrics.EvmExceptions++;
+                throw new OutOfGasException();
             }
 
             //if(!UpdateGas(dataGasCost, ref gasAvailable)) return CallResult.Exception;

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -547,6 +547,14 @@ namespace Nethermind.Evm
             {
                 _state.AddToBalance(state.Env.ExecutingAccount, transferValue, spec);
             }
+            
+            // commented out this part of code in 'if' below and execute only for PrecompileRipemd160
+            // in order to pass hive consensus tests
+            string addressOfPrecompileRipemd160 = "0x0000000000000000000000000000000000000003";
+            if (!wasCreated && transferValue.IsZero && spec.ClearEmptyAccountWhenTouched && state.Env.ExecutingAccount.ToString().Equals(addressOfPrecompileRipemd160))
+            {
+                _parityTouchBugAccount = state.Env.ExecutingAccount;
+            }
 
             if (gasAvailable < dataGasCost + baseGasCost)
             {
@@ -568,12 +576,6 @@ namespace Nethermind.Evm
                 throw new OutOfGasException();
             }
 
-            string addressOfPrecompileRipemd160 = "0x0000000000000000000000000000000000000003";
-            if (!wasCreated && transferValue.IsZero && spec.ClearEmptyAccountWhenTouched && state.Env.ExecutingAccount.ToString().Equals(addressOfPrecompileRipemd160))
-            {
-                _parityTouchBugAccount = state.Env.ExecutingAccount;
-            }
-            
             //if(!UpdateGas(dataGasCost, ref gasAvailable)) return CallResult.Exception;
             if (!UpdateGas(baseGasCost, ref gasAvailable))
             {


### PR DESCRIPTION
## Changes:
- delete only PrecompileRipemd160 and do nothing with other precompiles in order to pass hive consensus tests.

There are special cases from the time of post-Shanghai-attack account clearing which were ignored in our ethereum tests, but we need to deal with them to pass hive tests - we are failing 18 of them because of this issue.

After change from this PR we are passing all of them, all RevertTests.

We were failing 12 tests because of not deleting PrecompileRipemd160 (0x0000000000000000000000000000000000000003) and 6 tests because of unexpected deleting of other precompiles. As only deleting of this exact precompile is expected by hive tests, I refactored our VirtualMachine to meet this expectations.

I don't like this kind of hacky fixes (and I'm not 100% sure if it will not break something), but don't have idea how to do it better - I will be grateful for feedback.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

It's covered by ethereum tests.