### PR TITLE
Fix flaky hive tests

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
@@ -1575,6 +1575,18 @@ namespace Nethermind.Blockchain.Test
             await acceptTask;
         }
 
+        [Test]
+        public async Task SuggestBlockAsync_should_wait_for_blockTree_unlock()
+        {
+            BlockTree blockTree = Build.A.BlockTree().OfChainLength(3).TestObject;
+            blockTree.BlockAcceptingNewBlocks();
+            Task suggest = blockTree.SuggestBlockAsync(Build.A.Block.WithNumber(3).TestObject);
+            suggest.Status.Should().Be(TaskStatus.WaitingForActivation);
+            blockTree.ReleaseAcceptingNewBlocks();
+            await suggest;
+            suggest.Status.Should().Be(TaskStatus.RanToCompletion);
+        }
+
         private class TestBlockTreeVisitor : IBlockTreeVisitor
         {
             private readonly ManualResetEvent _manualResetEvent;

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
@@ -1586,6 +1586,39 @@ namespace Nethermind.Blockchain.Test
             await suggest;
             suggest.Status.Should().Be(TaskStatus.RanToCompletion);
         }
+        
+        [Test]
+        public async Task SuggestBlockAsync_works_well_with_multiple_locks_and_unlocks()
+        {
+            BlockTree blockTree = Build.A.BlockTree().OfChainLength(3).TestObject;
+            blockTree.BlockAcceptingNewBlocks();        // 1st blockade
+            blockTree.ReleaseAcceptingNewBlocks();      // release - access unlocked
+            blockTree.BlockAcceptingNewBlocks();        // 1st blockade
+            blockTree.BlockAcceptingNewBlocks();        // 2nd blockade
+            blockTree.BlockAcceptingNewBlocks();        // 3rd blockade
+            Task suggest = blockTree.SuggestBlockAsync(Build.A.Block.WithNumber(3).TestObject);
+            suggest.Status.Should().Be(TaskStatus.WaitingForActivation);
+            blockTree.ReleaseAcceptingNewBlocks();      // 1st release - 2 blockades left
+            suggest.Status.Should().Be(TaskStatus.WaitingForActivation);
+            blockTree.ReleaseAcceptingNewBlocks();      // 2nd release - 1 blockade left
+            suggest.Status.Should().Be(TaskStatus.WaitingForActivation);
+            blockTree.BlockAcceptingNewBlocks();        // 1 more blockade - 2 blockades left
+            suggest.Status.Should().Be(TaskStatus.WaitingForActivation);
+            blockTree.ReleaseAcceptingNewBlocks();      // release - 1 blockade left
+            suggest.Status.Should().Be(TaskStatus.WaitingForActivation);
+            blockTree.ReleaseAcceptingNewBlocks();      // 3rd release - access unlocked
+            await suggest;
+            suggest.Status.Should().Be(TaskStatus.RanToCompletion);
+        }
+        
+        [Test]
+        public async Task SuggestBlockAsync_works_well_when_there_are_no_blockades()
+        {
+            BlockTree blockTree = Build.A.BlockTree().OfChainLength(3).TestObject;
+            Task suggest = blockTree.SuggestBlockAsync(Build.A.Block.WithNumber(3).TestObject);
+            await suggest;
+            suggest.Status.Should().Be(TaskStatus.RanToCompletion);
+        }
 
         private class TestBlockTreeVisitor : IBlockTreeVisitor
         {

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -20,6 +20,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Nethermind.Blockchain.Find;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core;
@@ -95,6 +96,8 @@ namespace Nethermind.Blockchain
 
         private int _canAcceptNewBlocksCounter;
         public bool CanAcceptNewBlocks => _canAcceptNewBlocksCounter == 0;
+
+        public TaskCompletionSource<bool>? _taskCompletionSource;
 
         public BlockTree(
             IDbProvider? dbProvider,
@@ -582,6 +585,12 @@ namespace Nethermind.Blockchain
         public AddBlockResult SuggestHeader(BlockHeader header)
         {
             return Suggest(null, header);
+        }
+        
+        public async Task<AddBlockResult> SuggestBlockAsync(Block block, bool shouldProcess = true, bool? setAsMain = null)
+        {
+            await WaitForReadinessToAcceptNewBlock;
+            return SuggestBlock(block, shouldProcess, setAsMain);
         }
 
         public AddBlockResult SuggestBlock(Block block, bool shouldProcess = true, bool? setAsMain = null)
@@ -1546,13 +1555,24 @@ namespace Nethermind.Blockchain
 
         internal void BlockAcceptingNewBlocks()
         {
+            if (_canAcceptNewBlocksCounter == 0)
+            {
+                _taskCompletionSource = new TaskCompletionSource<bool>();
+            }
             Interlocked.Increment(ref _canAcceptNewBlocksCounter);
         }
 
         internal void ReleaseAcceptingNewBlocks()
         {
             Interlocked.Decrement(ref _canAcceptNewBlocksCounter);
+            if (_canAcceptNewBlocksCounter == 0)
+            {
+                _taskCompletionSource.SetResult(true);
+                _taskCompletionSource = null;
+            }
         }
+
+        private Task WaitForReadinessToAcceptNewBlock => _taskCompletionSource?.Task ?? Task.CompletedTask;
 
         public void SavePruningReorganizationBoundary(long blockNumber)
         {

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -97,7 +97,7 @@ namespace Nethermind.Blockchain
         private int _canAcceptNewBlocksCounter;
         public bool CanAcceptNewBlocks => _canAcceptNewBlocksCounter == 0;
 
-        public TaskCompletionSource<bool>? _taskCompletionSource;
+        private TaskCompletionSource<bool>? _taskCompletionSource;
 
         public BlockTree(
             IDbProvider? dbProvider,
@@ -1555,7 +1555,7 @@ namespace Nethermind.Blockchain
 
         internal void BlockAcceptingNewBlocks()
         {
-            if (_canAcceptNewBlocksCounter == 0)
+            if (CanAcceptNewBlocks)
             {
                 _taskCompletionSource = new TaskCompletionSource<bool>();
             }
@@ -1565,7 +1565,7 @@ namespace Nethermind.Blockchain
         internal void ReleaseAcceptingNewBlocks()
         {
             Interlocked.Decrement(ref _canAcceptNewBlocksCounter);
-            if (_canAcceptNewBlocksCounter == 0)
+            if (CanAcceptNewBlocks)
             {
                 _taskCompletionSource.SetResult(true);
                 _taskCompletionSource = null;

--- a/src/Nethermind/Nethermind.Blockchain/IBlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/IBlockTree.cs
@@ -87,6 +87,14 @@ namespace Nethermind.Blockchain
         /// <param name="shouldProcess">Whether a block should be processed or just added to the store</param>
         /// <returns>Result of the operation, eg. Added, AlreadyKnown, etc.</returns>
         AddBlockResult SuggestBlock(Block block, bool shouldProcess = true, bool? setAsMain = null);
+        
+        /// <summary>
+        /// Suggests block for inclusion in the block tree. Wait for DB unlock if needed.
+        /// </summary>
+        /// <param name="block">Block to be included</param>
+        /// <param name="shouldProcess">Whether a block should be processed or just added to the store</param>
+        /// <returns>Result of the operation, eg. Added, AlreadyKnown, etc.</returns>
+        Task<AddBlockResult> SuggestBlockAsync(Block block, bool shouldProcess = true, bool? setAsMain = null);
 
         /// <summary>
         /// Suggests a block header (without body)

--- a/src/Nethermind/Nethermind.Blockchain/ReadOnlyBlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/ReadOnlyBlockTree.cs
@@ -71,6 +71,8 @@ namespace Nethermind.Blockchain
         }
 
         public AddBlockResult SuggestBlock(Block block, bool shouldProcess = true, bool? setAsMain = null) => throw new InvalidOperationException($"{nameof(ReadOnlyBlockTree)} does not expect {nameof(SuggestBlock)} calls");
+        
+        public Task<AddBlockResult> SuggestBlockAsync(Block block, bool shouldProcess = true, bool? setAsMain = null) => throw new InvalidOperationException($"{nameof(ReadOnlyBlockTree)} does not expect {nameof(SuggestBlockAsync)} calls");
 
         public AddBlockResult Insert(BlockHeader header) => throw new InvalidOperationException($"{nameof(ReadOnlyBlockTree)} does not expect {nameof(Insert)} calls");
 

--- a/src/Nethermind/Nethermind.Hive/HiveRunner.cs
+++ b/src/Nethermind/Nethermind.Hive/HiveRunner.cs
@@ -210,7 +210,7 @@ namespace Nethermind.Hive
                     return;
                 }
 
-                AddBlockResult result = _blockTree.SuggestBlock(block);
+                AddBlockResult result = await _blockTree.SuggestBlockAsync(block);
                 if (result != AddBlockResult.Added && result != AddBlockResult.AlreadyKnown)
                 {
                     if (_logger.IsError)

--- a/src/Nethermind/Nethermind.Hive/HiveRunner.cs
+++ b/src/Nethermind/Nethermind.Hive/HiveRunner.cs
@@ -211,6 +211,17 @@ namespace Nethermind.Hive
                 }
 
                 AddBlockResult result = _blockTree.SuggestBlock(block);
+                int i = 1;
+
+                while (result.Equals(AddBlockResult.CannotAccept) && i < 10)
+                {
+                    i++;
+                    if (_logger.IsWarn)
+                        _logger.Warn($"Cannot accept block {block} - block tree already in use, trying again (try {i} out of 10)");
+                    Thread.Sleep(50);
+                    result = _blockTree.SuggestBlock(block);
+                }
+                
                 if (result != AddBlockResult.Added && result != AddBlockResult.AlreadyKnown)
                 {
                     if (_logger.IsError)

--- a/src/Nethermind/Nethermind.Hive/HiveRunner.cs
+++ b/src/Nethermind/Nethermind.Hive/HiveRunner.cs
@@ -211,17 +211,6 @@ namespace Nethermind.Hive
                 }
 
                 AddBlockResult result = _blockTree.SuggestBlock(block);
-                int i = 1;
-
-                while (result.Equals(AddBlockResult.CannotAccept) && i < 10)
-                {
-                    i++;
-                    if (_logger.IsWarn)
-                        _logger.Warn($"Cannot accept block {block} - block tree already in use, trying again (try {i} out of 10)");
-                    Thread.Sleep(50);
-                    result = _blockTree.SuggestBlock(block);
-                }
-                
                 if (result != AddBlockResult.Added && result != AddBlockResult.AlreadyKnown)
                 {
                     if (_logger.IsError)

--- a/src/Nethermind/Nethermind.Init/Steps/RegisterRpcModules.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/RegisterRpcModules.cs
@@ -45,7 +45,7 @@ using Nethermind.JsonRpc.Modules.Eth.FeeHistory;
 
 namespace Nethermind.Init.Steps
 {
-    [RunnerStepDependencies(typeof(InitializeNetwork), typeof(SetupKeyStore), typeof(InitializeBlockchain), typeof(InitializePlugins), typeof(ReviewBlockTree))]
+    [RunnerStepDependencies(typeof(InitializeNetwork), typeof(SetupKeyStore), typeof(InitializeBlockchain), typeof(InitializePlugins))]
     public class RegisterRpcModules : IStep
     {
         private readonly INethermindApi _api;

--- a/src/Nethermind/Nethermind.Init/Steps/RegisterRpcModules.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/RegisterRpcModules.cs
@@ -45,7 +45,7 @@ using Nethermind.JsonRpc.Modules.Eth.FeeHistory;
 
 namespace Nethermind.Init.Steps
 {
-    [RunnerStepDependencies(typeof(InitializeNetwork), typeof(SetupKeyStore), typeof(InitializeBlockchain), typeof(InitializePlugins))]
+    [RunnerStepDependencies(typeof(InitializeNetwork), typeof(SetupKeyStore), typeof(InitializeBlockchain), typeof(InitializePlugins), typeof(ReviewBlockTree))]
     public class RegisterRpcModules : IStep
     {
         private readonly INethermindApi _api;


### PR DESCRIPTION
## Changes:
- ~~retry up to 10 times if result of suggesting block is CannotAccept (because of BlockTree lock)~~
We are irregularly failing about 50-75 hive consensus tests because of suggesting blocks when BlockTree is already in use. ~~This PR is adding retries if SuggestBlock is failing because of temporarily locked BlockTree.~~
Hive consensus tests run from this branch on VM no longer fail because of this.
- add SuggestBlockAsync, which is waiting for BlockTree to be able to add new block.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [x] No

It is covered by hive consensus tests