### PR TITLE
Broadcast best persistent txs instead of random

### DIFF
--- a/src/Nethermind/Nethermind.TxPool.Test/TxBroadcasterTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxBroadcasterTests.cs
@@ -121,6 +121,11 @@ public class TxBroadcasterTests
 
         const int currentBaseFeeInGwei = 250;
         _headInfo.CurrentBaseFee.Returns(currentBaseFeeInGwei.GWei());
+        Block headBlock = Build.A.Block
+            .WithNumber(RopstenSpecProvider.LondonBlockNumber)
+            .WithBaseFeePerGas(currentBaseFeeInGwei.GWei())
+            .TestObject;
+        _blockTree.Head.Returns(headBlock);
 
         int addedTxsCount = TestItem.PrivateKeys.Length;
         Transaction[] transactions = new Transaction[addedTxsCount];

--- a/src/Nethermind/Nethermind.TxPool.Test/TxBroadcasterTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxBroadcasterTests.cs
@@ -75,7 +75,7 @@ public class TxBroadcasterTests
         int addedTxsCount = TestItem.PrivateKeys.Length;
         Transaction[] transactions = new Transaction[addedTxsCount];
 
-        for (int i = 0; i < TestItem.PrivateKeys.Length; i++)
+        for (int i = 0; i < addedTxsCount; i++)
         {
             transactions[i] = Build.A.Transaction
                 .WithSenderAddress(TestItem.PrivateKeys[i].Address)

--- a/src/Nethermind/Nethermind.TxPool.Test/TxBroadcasterTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxBroadcasterTests.cs
@@ -1,0 +1,106 @@
+//  Copyright (c) 2022 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using FluentAssertions;
+using Nethermind.Blockchain;
+using Nethermind.Blockchain.Comparers;
+using Nethermind.Core;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Specs;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Timers;
+using Nethermind.Crypto;
+using Nethermind.Logging;
+using Nethermind.Specs;
+using NSubstitute;
+using NUnit.Framework;
+
+[assembly: InternalsVisibleTo("Nethermind.Blockchain.Test")]
+
+namespace Nethermind.TxPool.Test;
+
+[TestFixture]
+public class TxBroadcasterTests
+{
+    private ILogManager _logManager;
+    private ISpecProvider _specProvider;
+    private IBlockTree _blockTree;
+    private IComparer<Transaction> _comparer;
+    private TxBroadcaster _broadcaster;
+    private EthereumEcdsa _ethereumEcdsa;
+    private TxPoolConfig _txPoolConfig;
+
+    [SetUp]
+    public void Setup()
+    {
+        _logManager = LimboLogs.Instance;
+        _specProvider = RopstenSpecProvider.Instance;
+        _ethereumEcdsa = new EthereumEcdsa(_specProvider.ChainId, _logManager);
+        _blockTree = Substitute.For<IBlockTree>();
+        _comparer = new TransactionComparerProvider(_specProvider, _blockTree).GetDefaultComparer();
+        _txPoolConfig = new TxPoolConfig();
+    }
+    
+    [TestCase(0)]
+    [TestCase(1)]
+    [TestCase(2)]
+    [TestCase(99)]
+    [TestCase(100)]
+    [TestCase(101)]
+    [TestCase(1000)]
+    [TestCase(-10)]
+    public void should_pick_best_persistent_txs_to_broadcast(int threshold)
+    {
+        _txPoolConfig = new TxPoolConfig() { PeerNotificationThreshold = threshold };
+        _broadcaster = new TxBroadcaster(_comparer, TimerFactory.Default, _txPoolConfig, _logManager);
+
+        int addedTxsCount = TestItem.PrivateKeys.Length;
+        Transaction[] transactions = new Transaction[addedTxsCount];
+
+        for (int i = 0; i < TestItem.PrivateKeys.Length; i++)
+        {
+            transactions[i] = Build.A.Transaction
+                .WithSenderAddress(TestItem.PrivateKeys[i].Address)
+                .WithGasPrice(i.GWei())
+                .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeys[i])
+                .TestObject;
+                
+            _broadcaster.StartBroadcast(transactions[i]);
+        }
+        
+        _broadcaster.GetSnapshot().Length.Should().Be(addedTxsCount);
+
+        ITxPoolPeer txPoolPeer = Substitute.For<ITxPoolPeer>();
+        List<Transaction> pickedTxs = _broadcaster.GetTxsToSend(txPoolPeer, ArraySegment<Transaction>.Empty).ToList();
+
+        int expectedCount = threshold <= 0 ? 0 : Math.Min(addedTxsCount * threshold / 100 + 1, addedTxsCount);
+        pickedTxs.Count.Should().Be(expectedCount);
+
+        List<Transaction> expectedTxs = new();
+
+        for (int i = 1; i <= expectedCount; i++)
+        {
+            expectedTxs.Add(transactions[addedTxsCount - i]);
+        }
+
+        expectedTxs.Should().BeEquivalentTo(pickedTxs);
+    }
+}

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -707,7 +707,8 @@ namespace Nethermind.TxPool.Test
             _txPool = CreatePool();
 
             Transaction[] transactions = new Transaction[10];
-            
+            EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
+
             for (int i = 0; i < 10; i++)
             {
                 transactions[i] = Build.A.Transaction
@@ -716,8 +717,6 @@ namespace Nethermind.TxPool.Test
                     .WithGasPrice(10.GWei())
                     .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA)
                     .TestObject;
-                
-                EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
                 _txPool.SubmitTx(transactions[i], TxHandlingOptions.PersistentBroadcast);
             }
             _txPool.GetOwnPendingTransactions().Length.Should().Be(10);

--- a/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
@@ -146,10 +146,10 @@ namespace Nethermind.TxPool.Collections
         }
         
         /// <summary>
-        /// Returns specified number of elements from the start of supplied comparer order.
+        /// Returns best element of each bucket in supplied comparer order.
         /// </summary>
         [MethodImpl(MethodImplOptions.Synchronized)]
-        public IEnumerable<TValue> GetFirsts(int numberOfValues)
+        public IEnumerable<TValue> GetFirsts()
         {
             SortedSet<TValue> sortedValues = new(_sortedComparer);
             foreach (KeyValuePair<TGroupKey, SortedSet<TValue>> bucket in _buckets)
@@ -157,7 +157,7 @@ namespace Nethermind.TxPool.Collections
                 sortedValues.Add(bucket.Value.Max!);
             }
 
-            return sortedValues.Take(numberOfValues);
+            return sortedValues;
         }
         
         /// <summary>

--- a/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
@@ -146,6 +146,21 @@ namespace Nethermind.TxPool.Collections
         }
         
         /// <summary>
+        /// Returns specified number of elements from the start of supplied comparer order.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.Synchronized)]
+        public IEnumerable<TValue> TryGetFirsts(int numberOfValues)
+        {
+            SortedSet<TValue> sortedValues = new(_sortedComparer);
+            foreach (KeyValuePair<TGroupKey, SortedSet<TValue>> bucket in _buckets)
+            {
+                sortedValues.AddRange(bucket.Value);
+            }
+
+            return sortedValues.Take(numberOfValues);
+        }
+        
+        /// <summary>
         /// Gets last element in supplied comparer order.
         /// </summary>
         [MethodImpl(MethodImplOptions.Synchronized)]

--- a/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
@@ -149,7 +149,7 @@ namespace Nethermind.TxPool.Collections
         /// Returns specified number of elements from the start of supplied comparer order.
         /// </summary>
         [MethodImpl(MethodImplOptions.Synchronized)]
-        public IEnumerable<TValue> TryGetFirsts(int numberOfValues)
+        public IEnumerable<TValue> GetFirsts(int numberOfValues)
         {
             SortedSet<TValue> sortedValues = new(_sortedComparer);
             foreach (KeyValuePair<TGroupKey, SortedSet<TValue>> bucket in _buckets)

--- a/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
@@ -232,7 +232,7 @@ namespace Nethermind.TxPool.Collections
         /// <param name="where">Predicated criteria.</param>
         /// <returns>Elements matching predicated criteria.</returns>
         [MethodImpl(MethodImplOptions.Synchronized)]
-        public IEnumerable<TValue> TryGetStaleValues(TGroupKey groupKey, Predicate<TValue?> where)
+        public IEnumerable<TValue> TryGetStaleValues(TGroupKey groupKey, Predicate<TValue> where)
         {
             if (_buckets.TryGetValue(groupKey, out SortedSet<TValue>? bucket))
             {

--- a/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
@@ -225,6 +225,24 @@ namespace Nethermind.TxPool.Collections
         [MethodImpl(MethodImplOptions.Synchronized)]
         public bool TryRemove(TKey key) => TryRemove(key, out _, out _);
 
+        public IEnumerable<TValue> TryGetStaleValues(TGroupKey groupKey, Predicate<TValue> where)
+        {
+            if (_buckets.TryGetValue(groupKey, out SortedSet<TValue>? bucket))
+            {
+                foreach (TValue value in bucket)
+                {
+                    if (where(value))
+                    {
+                        yield return value;
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+            }
+        }
+
         /// <summary>
         /// Tries to get element.
         /// </summary>

--- a/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
@@ -225,6 +225,12 @@ namespace Nethermind.TxPool.Collections
         [MethodImpl(MethodImplOptions.Synchronized)]
         public bool TryRemove(TKey key) => TryRemove(key, out _, out _);
 
+        /// <summary>
+        /// Tries to get elements matching predicated criteria, iterating through SortedSet with break on first mismatch.
+        /// </summary>
+        /// <param name="groupKey">Given GroupKey, which elements are checked.</param>
+        /// <param name="where">Predicated criteria.</param>
+        /// <returns>Elements matching predicated criteria.</returns>
         public IEnumerable<TValue> TryGetStaleValues(TGroupKey groupKey, Predicate<TValue> where)
         {
             if (_buckets.TryGetValue(groupKey, out SortedSet<TValue>? bucket))

--- a/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
@@ -154,7 +154,7 @@ namespace Nethermind.TxPool.Collections
             SortedSet<TValue> sortedValues = new(_sortedComparer);
             foreach (KeyValuePair<TGroupKey, SortedSet<TValue>> bucket in _buckets)
             {
-                sortedValues.AddRange(bucket.Value);
+                sortedValues.Add(bucket.Value.Max!);
             }
 
             return sortedValues.Take(numberOfValues);

--- a/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
@@ -236,26 +236,23 @@ namespace Nethermind.TxPool.Collections
         {
             if (_buckets.TryGetValue(groupKey, out SortedSet<TValue>? bucket))
             {
-                if (!where(bucket.First()))
+                using SortedSet<TValue>.Enumerator enumerator = bucket.GetEnumerator();
+                bool keepGoing = true;
+                List<TValue>? list = null;
+
+                while (keepGoing && enumerator.MoveNext())
                 {
-                    return ArraySegment<TValue>.Empty;
-                }
-                
-                List<TValue> staleValues = new() { bucket.First() };
-                foreach (TValue value in bucket.Skip(1))
-                {
-                    if (where(value))
+                    keepGoing = where(enumerator.Current);
+                    if (keepGoing)
                     {
-                        staleValues.Add(value);
+                        list ??= new List<TValue>();
+                        list.Add(enumerator.Current);
                     }
-                    else
-                    {
-                        return staleValues;
-                    }
+                    else return list ?? Enumerable.Empty<TValue>();
                 }
-                return staleValues;
+                return list!;
             }
-            return ArraySegment<TValue>.Empty;
+            return Enumerable.Empty<TValue>();
         }
 
         /// <summary>

--- a/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
@@ -232,25 +232,25 @@ namespace Nethermind.TxPool.Collections
         /// <param name="where">Predicated criteria.</param>
         /// <returns>Elements matching predicated criteria.</returns>
         [MethodImpl(MethodImplOptions.Synchronized)]
-        public IEnumerable<TValue> TryGetStaleValues(TGroupKey groupKey, Predicate<TValue> where)
+        public IEnumerable<TValue> TakeWhile(TGroupKey groupKey, Predicate<TValue> where)
         {
             if (_buckets.TryGetValue(groupKey, out SortedSet<TValue>? bucket))
             {
-                using SortedSet<TValue>.Enumerator enumerator = bucket.GetEnumerator();
-                bool keepGoing = true;
+                using SortedSet<TValue>.Enumerator enumerator = bucket!.GetEnumerator();
                 List<TValue>? list = null;
 
-                while (keepGoing && enumerator.MoveNext())
+                while (enumerator.MoveNext())
                 {
-                    keepGoing = where(enumerator.Current);
-                    if (keepGoing)
+                    if (!where(enumerator.Current))
                     {
-                        list ??= new List<TValue>();
-                        list.Add(enumerator.Current);
+                        break;
                     }
-                    else return list ?? Enumerable.Empty<TValue>();
+
+                    list ??= new List<TValue>();
+                    list.Add(enumerator.Current);
                 }
-                return list!;
+                
+                return list ?? Enumerable.Empty<TValue>();
             }
             return Enumerable.Empty<TValue>();
         }

--- a/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
@@ -158,7 +158,7 @@ namespace Nethermind.TxPool
             {
                 // PeerNotificationThreshold is a declared in config percent of transactions in persistent broadcast,
                 // which will be sent when timer elapse. numberOfPersistentTxsToBroadcast is equal to
-                // PeerNotificationThreshold multiplicated by number of transactions in persistent broadcast, rounded up.
+                // PeerNotificationThreshold multiplication by number of transactions in persistent broadcast, rounded up.
                 int numberOfPersistentTxsToBroadcast =
                     Math.Min(_txPoolConfig.PeerNotificationThreshold * _persistentTxs.Count / 100 + 1,
                         _persistentTxs.Count);

--- a/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
@@ -168,10 +168,17 @@ namespace Nethermind.TxPool
 
                 foreach (Transaction tx in _persistentTxs.GetFirsts())
                 {
-                    if (numberOfPersistentTxsToBroadcast > 0 && tx.MaxFeePerGas >= _headInfo.CurrentBaseFee)
+                    if (numberOfPersistentTxsToBroadcast > 0)
                     {
-                        numberOfPersistentTxsToBroadcast--;
-                        yield return tx;
+                        if (tx.MaxFeePerGas >= _headInfo.CurrentBaseFee)
+                        {
+                            numberOfPersistentTxsToBroadcast--;
+                            yield return tx;
+                        }
+                    }
+                    else
+                    {
+                        break;
                     }
                 }
             }

--- a/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
@@ -126,22 +126,9 @@ namespace Nethermind.TxPool
         {
             if (_persistentTxs.Count != 0)
             {
-                IEnumerable<Transaction> transactions =
-                    _persistentTxs.TryGetStaleValues(address, t => t.Nonce <= nonce);
-                
-                if (transactions.Any())
+                foreach (Transaction tx in _persistentTxs.TryGetStaleValues(address, t => t.Nonce <= nonce).ToList())
                 {
-                    List<Transaction> transactionsToRemoveFromPersistentTransactions = new List<Transaction>();
-                    
-                    foreach (Transaction tx in transactions)
-                    {
-                        transactionsToRemoveFromPersistentTransactions.Add(tx);
-                    }
-                    
-                    foreach (Transaction tx in transactionsToRemoveFromPersistentTransactions)
-                    {
-                        StopBroadcast(tx.Hash!);
-                    }
+                    StopBroadcast(tx.Hash!);
                 }
             }
         }

--- a/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
@@ -126,8 +126,7 @@ namespace Nethermind.TxPool
         {
             if (_persistentTxs.Count != 0)
             {
-                // it is needed to use .ToList() here to not remove tx from bucket during iterating through this bucket.
-                foreach (Transaction tx in _persistentTxs.TryGetStaleValues(address, t => t.Nonce <= nonce).ToList())
+                foreach (Transaction tx in _persistentTxs.TryGetStaleValues(address, t => t.Nonce <= nonce))
                 {
                     StopBroadcast(tx.Hash!);
                 }

--- a/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
@@ -126,6 +126,7 @@ namespace Nethermind.TxPool
         {
             if (_persistentTxs.Count != 0)
             {
+                // it is needed to use .ToList() here to not remove tx from bucket during iterating through this bucket.
                 foreach (Transaction tx in _persistentTxs.TryGetStaleValues(address, t => t.Nonce <= nonce).ToList())
                 {
                     StopBroadcast(tx.Hash!);

--- a/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
@@ -153,7 +153,7 @@ namespace Nethermind.TxPool
             _timer.Enabled = true;
         }
 
-        private IEnumerable<Transaction> GetTxsToSend(ITxPoolPeer peer, IEnumerable<Transaction> txsToSend)
+        internal IEnumerable<Transaction> GetTxsToSend(ITxPoolPeer peer, IEnumerable<Transaction> txsToSend)
         {
             if (_txPoolConfig.PeerNotificationThreshold > 0)
             {

--- a/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
@@ -174,7 +174,8 @@ namespace Nethermind.TxPool
                 // which will be sent when timer elapse. numberOfPersistentTxsToBroadcast is equal to
                 // PeerNotificationThreshold multiplicated by number of transactions in persistent broadcast, rounded up.
                 int numberOfPersistentTxsToBroadcast =
-                    _txPoolConfig.PeerNotificationThreshold * _persistentTxs.Count / 100 + 1;
+                    Math.Min(_txPoolConfig.PeerNotificationThreshold * _persistentTxs.Count / 100 + 1,
+                        _persistentTxs.Count);
 
                 foreach (Transaction tx in _persistentTxs.TryGetFirsts(numberOfPersistentTxsToBroadcast))
                 {

--- a/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
@@ -18,7 +18,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;

--- a/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
@@ -142,17 +142,20 @@ namespace Nethermind.TxPool
 
         private IEnumerable<Transaction> GetTxsToSend(ITxPoolPeer peer, IEnumerable<Transaction> txsToSend)
         {
-            // PeerNotificationThreshold is a declared in config percent of transactions in persistent broadcast, which
-            // will be sent when timer elapse. numberOfPersistentTxsToBroadcast is equal to PeerNotificationThreshold
-            // multiplicated by number of transactions in persistent broadcast, rounded down and increased by 1.
-            int numberOfPersistentTxsToBroadcast =
-                _txPoolConfig.PeerNotificationThreshold * _persistentTxs.Count / 100 + 1;
-
-            foreach (Transaction tx in _persistentTxs.TryGetFirsts(numberOfPersistentTxsToBroadcast))
+            if (_txPoolConfig.PeerNotificationThreshold > 0)
             {
-                yield return tx;
+                // PeerNotificationThreshold is a declared in config percent of transactions in persistent broadcast,
+                // which will be sent when timer elapse. numberOfPersistentTxsToBroadcast is equal to
+                // PeerNotificationThreshold multiplicated by number of transactions in persistent broadcast, rounded up.
+                int numberOfPersistentTxsToBroadcast =
+                    _txPoolConfig.PeerNotificationThreshold * _persistentTxs.Count / 100 + 1;
+
+                foreach (Transaction tx in _persistentTxs.TryGetFirsts(numberOfPersistentTxsToBroadcast))
+                {
+                    yield return tx;
+                }
             }
-            
+
             foreach (Transaction tx in txsToSend)
             {
                 if (tx.DeliveredBy is null || !tx.DeliveredBy.Equals(peer.Id))

--- a/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
@@ -125,7 +125,7 @@ namespace Nethermind.TxPool
         {
             if (_persistentTxs.Count != 0)
             {
-                foreach (Transaction tx in _persistentTxs.TryGetStaleValues(address, t => t.Nonce <= nonce))
+                foreach (Transaction tx in _persistentTxs.TakeWhile(address, t => t.Nonce <= nonce))
                 {
                     StopBroadcast(tx.Hash!);
                 }

--- a/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
@@ -122,7 +122,7 @@ namespace Nethermind.TxPool
             }
         }
 
-        public void EnsureStopBroadcast(Address address, UInt256 nonce)
+        public void EnsureStopBroadcastUpToNonce(Address address, UInt256 nonce)
         {
             if (_persistentTxs.Count != 0)
             {
@@ -165,7 +165,7 @@ namespace Nethermind.TxPool
                     Math.Min(_txPoolConfig.PeerNotificationThreshold * _persistentTxs.Count / 100 + 1,
                         _persistentTxs.Count);
 
-                foreach (Transaction tx in _persistentTxs.TryGetFirsts(numberOfPersistentTxsToBroadcast))
+                foreach (Transaction tx in _persistentTxs.GetFirsts(numberOfPersistentTxsToBroadcast))
                 {
                     yield return tx;
                 }

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -221,6 +221,8 @@ namespace Nethermind.TxPool
                 {
                     eip1559Txs++;
                 }
+
+                _broadcaster.EnsureStopBroadcast(blockTransactions[i].SenderAddress!, blockTransactions[i].Nonce);
             }
 
             if (transactionsInBlock != 0)

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -222,7 +222,7 @@ namespace Nethermind.TxPool
                     eip1559Txs++;
                 }
 
-                _broadcaster.EnsureStopBroadcast(blockTransactions[i].SenderAddress!, blockTransactions[i].Nonce);
+                _broadcaster.EnsureStopBroadcastUpToNonce(blockTransactions[i].SenderAddress!, blockTransactions[i].Nonce);
             }
 
             if (transactionsInBlock != 0)

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -212,7 +212,7 @@ namespace Nethermind.TxPool
                     discoveredForHashCache++;
                 }
 
-                if (!RemoveTransaction(txHash))
+                if (!RemoveIncludedTransaction(blockTransactions[i]))
                 {
                     discoveredForPendingTxs++;
                 }
@@ -221,8 +221,6 @@ namespace Nethermind.TxPool
                 {
                     eip1559Txs++;
                 }
-
-                _broadcaster.EnsureStopBroadcastUpToNonce(blockTransactions[i].SenderAddress!, blockTransactions[i].Nonce);
             }
 
             if (transactionsInBlock != 0)
@@ -231,6 +229,13 @@ namespace Nethermind.TxPool
                 Metrics.DarkPoolRatioLevel2 = (float)discoveredForPendingTxs / transactionsInBlock;
                 Metrics.Eip1559TransactionsRatio = (float)eip1559Txs / transactionsInBlock;
             }
+        }
+
+        private bool RemoveIncludedTransaction(Transaction tx)
+        {
+            bool removed = RemoveTransaction(tx.Hash);
+            _broadcaster.EnsureStopBroadcastUpToNonce(tx.SenderAddress!, tx.Nonce);
+            return removed;
         }
 
         public void AddPeer(ITxPoolPeer peer)

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -104,7 +104,7 @@ namespace Nethermind.TxPool
             AddNodeInfoEntryForTxPool();
 
             _transactions = new TxDistinctSortedPool(MemoryAllowance.MemPoolSize, comparer, logManager);
-            _broadcaster = new TxBroadcaster(comparer, TimerFactory.Default, txPoolConfig, logManager);
+            _broadcaster = new TxBroadcaster(comparer, TimerFactory.Default, txPoolConfig, chainHeadInfoProvider, logManager);
 
             _headInfo.HeadChanged += OnHeadChange;
 


### PR DESCRIPTION
## Changes:
- pick and broadcast declared percent (PeerNotificationThreshold) of best persistent transactions instead of random transactions
- broadcast persistent transactions only when their MaxFeePerGas >= CurrentBaseFee
- remove stale transactions from persistent transactions

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No