### PR TITLE
Add documentation to all parameters shown by --help

### DIFF
--- a/src/Nethermind/Nethermind.Config.Test/ConfigProvider_FindIncorrectSettings_Tests.cs
+++ b/src/Nethermind/Nethermind.Config.Test/ConfigProvider_FindIncorrectSettings_Tests.cs
@@ -74,7 +74,7 @@ namespace Nethermind.Config.Test
                 { "datadir", "Data" },
                 { "ConfigsDirectory", "ConfDir" },
                 { "baseDbPath", "DB" },
-                { "logLevel", "info" },
+                { "log", "info" },
                 { "loggerConfigSource", "logSource" },
                 { "pluginsDirectory", "Plugins" },
                 { "Abc", "abc" }    // not existing, should get error

--- a/src/Nethermind/Nethermind.Config/ConfigItemAttribute.cs
+++ b/src/Nethermind/Nethermind.Config/ConfigItemAttribute.cs
@@ -25,7 +25,9 @@ namespace Nethermind.Config
         public string DefaultValue { get; set; }
         
         public bool HiddenFromDocs { get; set; }
-        
+
         public bool DisabledForCli { get; set; }
+
+        public string EnvironmentVariable { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.Config/INoCategoryConfig.cs
+++ b/src/Nethermind/Nethermind.Config/INoCategoryConfig.cs
@@ -8,21 +8,46 @@ namespace Nethermind.Config
 {
     public interface INoCategoryConfig : IConfig
     {
+        [ConfigItem(Description = "Parent directory or path for BaseDbPath, KeyStoreDirectory, LogDirectory configurations.")]
         public string DataDir { get; set; }
 
-        [ConfigItem(Description = "Path to the JSON configuration file.", DefaultValue = "null")]
+        [ConfigItem(Description = "Path to the JSON configuration file.")]
         public string Config { get; set; }
+
+        [ConfigItem(Description = "Path or directory for configuration files.", DefaultValue = "configs")]
         public string ConfigsDirectory { get; set; }
+
+        [ConfigItem(Description = "Path or directory for database files.", DefaultValue = "db")]
         public string BaseDbPath { get; set; }
-        public string LogLevel { get; set; }       
+
+        [ConfigItem(Description = "Log level override. Possible values: OFF|TRACE|DEBUG|INFO|WARN|ERROR")]
+        public string Log { get; set; }
+
+        [ConfigItem(Description = "Path to the NLog config file")]
         public string LoggerConfigSource { get; set; }
+
+        [ConfigItem(Description = "Plugins directory")]
         public string PluginsDirectory { get; set; }
+
+        [ConfigItem(Description = "Sets the job name for metrics monitoring. Configurable via environment variable NETHERMIND_MONITORING_JOB", EnvironmentVariable = "NETHERMIND_MONITORING_JOB")]
         public string MonitoringJob { get; set; }
+
+        [ConfigItem(Description = "Sets the default group name for metrics monitoring. Configurable via environment variable NETHERMIND_MONITORING_GROUP", EnvironmentVariable = "NETHERMIND_MONITORING_GROUP")]
         public string MonitoringGroup { get; set; }
+
+        [ConfigItem(Description = "Sets the external IP for the node. Configurable via environment variable NETHERMIND_ENODE_IPADDRESS", EnvironmentVariable = "NETHERMIND_ENODE_IPADDRESS")]
         public string EnodeIpAddress { get; set; }
+
+        [ConfigItem(Description = "Enables Hive plugin used for executing Hive Ethereum Tests. Configurable via environment variable NETHERMIND_HIVE_ENABLED", EnvironmentVariable = "NETHERMIND_HIVE_ENABLED")]
         public bool HiveEnabled { get; set; }
+
+        [ConfigItem(Description = "Defines default URL for JSON RPC. Configurable via environment variable NETHERMIND_URL", EnvironmentVariable = "NETHERMIND_URL")]
         public string Url { get; set; }
+
+        [ConfigItem(Description = "Defines CORS origins for JSON RPC. Configurable via environment variable NETHERMIND_CORS_ORIGINS", DefaultValue = "*", EnvironmentVariable = "NETHERMIND_CORS_ORIGINS")]
         public string CorsOrigins { get; set; }
+
+        [ConfigItem(Description = "Defines host value for CLI function \"switchLocal\". Configurable via environment variable NETHERMIND_CLI_SWITCH_LOCAL", DefaultValue = "http://localhost", EnvironmentVariable = "NETHERMIND_CLI_SWITCH_LOCAL")]
         public string CliSwitchLocal { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.Config/INoCategoryConfig.cs
+++ b/src/Nethermind/Nethermind.Config/INoCategoryConfig.cs
@@ -29,25 +29,25 @@ namespace Nethermind.Config
         [ConfigItem(Description = "Plugins directory")]
         public string PluginsDirectory { get; set; }
 
-        [ConfigItem(Description = "Sets the job name for metrics monitoring. Configurable via environment variable NETHERMIND_MONITORING_JOB", EnvironmentVariable = "NETHERMIND_MONITORING_JOB")]
+        [ConfigItem(Description = "Sets the job name for metrics monitoring.", EnvironmentVariable = "NETHERMIND_MONITORING_JOB")]
         public string MonitoringJob { get; set; }
 
-        [ConfigItem(Description = "Sets the default group name for metrics monitoring. Configurable via environment variable NETHERMIND_MONITORING_GROUP", EnvironmentVariable = "NETHERMIND_MONITORING_GROUP")]
+        [ConfigItem(Description = "Sets the default group name for metrics monitoring.", EnvironmentVariable = "NETHERMIND_MONITORING_GROUP")]
         public string MonitoringGroup { get; set; }
 
-        [ConfigItem(Description = "Sets the external IP for the node. Configurable via environment variable NETHERMIND_ENODE_IPADDRESS", EnvironmentVariable = "NETHERMIND_ENODE_IPADDRESS")]
+        [ConfigItem(Description = "Sets the external IP for the node.", EnvironmentVariable = "NETHERMIND_ENODE_IPADDRESS")]
         public string EnodeIpAddress { get; set; }
 
-        [ConfigItem(Description = "Enables Hive plugin used for executing Hive Ethereum Tests. Configurable via environment variable NETHERMIND_HIVE_ENABLED", EnvironmentVariable = "NETHERMIND_HIVE_ENABLED")]
+        [ConfigItem(Description = "Enables Hive plugin used for executing Hive Ethereum Tests.", EnvironmentVariable = "NETHERMIND_HIVE_ENABLED")]
         public bool HiveEnabled { get; set; }
 
-        [ConfigItem(Description = "Defines default URL for JSON RPC. Configurable via environment variable NETHERMIND_URL", EnvironmentVariable = "NETHERMIND_URL")]
+        [ConfigItem(Description = "Defines default URL for JSON RPC.", EnvironmentVariable = "NETHERMIND_URL")]
         public string Url { get; set; }
 
-        [ConfigItem(Description = "Defines CORS origins for JSON RPC. Configurable via environment variable NETHERMIND_CORS_ORIGINS", DefaultValue = "*", EnvironmentVariable = "NETHERMIND_CORS_ORIGINS")]
+        [ConfigItem(Description = "Defines CORS origins for JSON RPC.", DefaultValue = "*", EnvironmentVariable = "NETHERMIND_CORS_ORIGINS")]
         public string CorsOrigins { get; set; }
 
-        [ConfigItem(Description = "Defines host value for CLI function \"switchLocal\". Configurable via environment variable NETHERMIND_CLI_SWITCH_LOCAL", DefaultValue = "http://localhost", EnvironmentVariable = "NETHERMIND_CLI_SWITCH_LOCAL")]
+        [ConfigItem(Description = "Defines host value for CLI function \"switchLocal\".", DefaultValue = "http://localhost", EnvironmentVariable = "NETHERMIND_CLI_SWITCH_LOCAL")]
         public string CliSwitchLocal { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.Config/INoCategoryConfig.cs
+++ b/src/Nethermind/Nethermind.Config/INoCategoryConfig.cs
@@ -38,7 +38,7 @@ namespace Nethermind.Config
         [ConfigItem(Description = "Sets the external IP for the node.", EnvironmentVariable = "NETHERMIND_ENODE_IPADDRESS")]
         public string EnodeIpAddress { get; set; }
 
-        [ConfigItem(Description = "Enables Hive plugin used for executing Hive Ethereum Tests.", EnvironmentVariable = "NETHERMIND_HIVE_ENABLED")]
+        [ConfigItem(Description = "Enables Hive plugin used for executing Hive Ethereum Tests.", EnvironmentVariable = "NETHERMIND_HIVE_ENABLED", DefaultValue = "false")]
         public bool HiveEnabled { get; set; }
 
         [ConfigItem(Description = "Defines default URL for JSON RPC.", EnvironmentVariable = "NETHERMIND_URL")]

--- a/src/Nethermind/Nethermind.Config/NoCategoryConfig.cs
+++ b/src/Nethermind/Nethermind.Config/NoCategoryConfig.cs
@@ -12,7 +12,7 @@ namespace Nethermind.Config
         public string DataDir { get; set; }
         public string ConfigsDirectory { get; set; }
         public string BaseDbPath { get; set; }
-        public string LogLevel { get; set; }
+        public string Log { get; set; }
         public string LoggerConfigSource { get; set; }
         public string PluginsDirectory { get; set; }
         public string MonitoringJob { get; set; }

--- a/src/Nethermind/Nethermind.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Runner/Program.cs
@@ -21,6 +21,7 @@ using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.CommandLineUtils;
@@ -106,12 +107,12 @@ namespace Nethermind.Runner
             _ = app.HelpOption("-?|-h|--help");
             _ = app.VersionOption("-v|--version", () => ClientVersion.Version, () => ClientVersion.Description);
 
-            CommandOption dataDir = app.Option("-dd|--datadir <dataDir>", "data directory", CommandOptionType.SingleValue);
-            CommandOption configFile = app.Option("-c|--config <configFile>", "config file path", CommandOptionType.SingleValue);
-            CommandOption dbBasePath = app.Option("-d|--baseDbPath <baseDbPath>", "base db path", CommandOptionType.SingleValue);
-            CommandOption logLevelOverride = app.Option("-l|--log <logLevel>", "log level", CommandOptionType.SingleValue);
-            CommandOption configsDirectory = app.Option("-cd|--configsDirectory <configsDirectory>", "configs directory", CommandOptionType.SingleValue);
-            CommandOption loggerConfigSource = app.Option("-lcs|--loggerConfigSource <loggerConfigSource>", "path to the NLog config file", CommandOptionType.SingleValue);
+            CommandOption dataDir = app.Option("-dd|--datadir <dataDir>", "Data directory", CommandOptionType.SingleValue);
+            CommandOption configFile = app.Option("-c|--config <configFile>", "Config file path", CommandOptionType.SingleValue);
+            CommandOption dbBasePath = app.Option("-d|--baseDbPath <baseDbPath>", "Base db path", CommandOptionType.SingleValue);
+            CommandOption logLevelOverride = app.Option("-l|--log <logLevel>", "Log level override. Possible values: OFF|TRACE|DEBUG|INFO|WARN|ERROR", CommandOptionType.SingleValue);
+            CommandOption configsDirectory = app.Option("-cd|--configsDirectory <configsDirectory>", "Configs directory", CommandOptionType.SingleValue);
+            CommandOption loggerConfigSource = app.Option("-lcs|--loggerConfigSource <loggerConfigSource>", "Path to the NLog config file", CommandOptionType.SingleValue);
             _ = app.Option("-pd|--pluginsDirectory <pluginsDirectory>", "plugins directory", CommandOptionType.SingleValue);
 
             IFileSystem fileSystem = new FileSystem();
@@ -129,7 +130,7 @@ namespace Nethermind.Runner
             IEnumerable<Type> configTypes = new TypeDiscovery().FindNethermindTypes(configurationType)
                 .Where(ct => ct.IsInterface);
 
-            foreach (Type configType in configTypes.OrderBy(c => c.Name))
+            foreach (Type configType in configTypes.Where(ct => !ct.IsAssignableTo(typeof(INoCategoryConfig))).OrderBy(c => c.Name))
             {
                 if (configType == null)
                 {
@@ -154,6 +155,25 @@ namespace Nethermind.Runner
                         
                     }
                 }
+            }
+
+            Type noCategoryConfig = configTypes.FirstOrDefault(ct => ct.IsAssignableTo(typeof(INoCategoryConfig)));
+
+            if (noCategoryConfig != null)
+            {
+                StringBuilder sb = new();
+                sb.AppendLine();
+                sb.AppendLine("Configurable Environment Variables:");
+                foreach (PropertyInfo propertyInfo in noCategoryConfig.GetProperties(BindingFlags.Public | BindingFlags.Instance).OrderBy(p => p.Name))
+                {
+                    ConfigItemAttribute? configItemAttribute = propertyInfo.GetCustomAttribute<ConfigItemAttribute>();
+                    if (configItemAttribute != null && !(string.IsNullOrEmpty(configItemAttribute?.EnvironmentVariable)))
+                    {
+                        sb.AppendLine($"{configItemAttribute.EnvironmentVariable} - {(string.IsNullOrEmpty(configItemAttribute.Description) ? "<missing documentation>" : configItemAttribute.Description)} (DEFAULT: {configItemAttribute.DefaultValue})");
+                    }
+                }
+
+                app.ExtendedHelpText = sb.ToString();
             }
 
             ManualResetEventSlim appClosed = new(true);


### PR DESCRIPTION
Resolves #3774

- Add description attribute to all parameters from the _NoCategory_ category.
- Don't add NoCategory configs dynamically as Command Line options, because some are already added explicitly in _Programs.cs_ and some are only Environment Variable configs
- Add additional information about available Environment Variables when `--help` is run
```
...
  --Wallet.DevAccounts                                         Number of auto-generted dev accounts to work with. Dev accounts will have private keys from 00...01 to 00..n (DEFAULT: 10)

Configurable Environment Variables:
NETHERMIND_CLI_SWITCH_LOCAL - Defines host value for CLI function "switchLocal". (DEFAULT: http://localhost)
NETHERMIND_CORS_ORIGINS - Defines CORS origins for JSON RPC. (DEFAULT: *)
NETHERMIND_ENODE_IPADDRESS - Sets the external IP for the node. (DEFAULT: )
NETHERMIND_HIVE_ENABLED - Enables Hive plugin used for executing Hive Ethereum Tests. (DEFAULT: false)
NETHERMIND_MONITORING_GROUP - Sets the default group name for metrics monitoring. (DEFAULT: )
NETHERMIND_MONITORING_JOB - Sets the job name for metrics monitoring. (DEFAULT: )
NETHERMIND_URL - Defines default URL for JSON RPC. (DEFAULT: )
```

## Types of changes

What types of changes does your code introduce?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [x] No
