### PR TITLE
Sepolia - DifficultyBombDisabled

### DIFF
--- a/src/Nethermind/Chains/sepolia.json
+++ b/src/Nethermind/Chains/sepolia.json
@@ -12,9 +12,6 @@
         },
         "homesteadTransition": "0x0",
         "eip100bTransition": "0x0",
-        "difficultyBombDelays": {
-          "0xFFFFFFFF": "0x3D0900"
-        }
       }
     }
   },

--- a/src/Nethermind/Chains/sepolia.json
+++ b/src/Nethermind/Chains/sepolia.json
@@ -6,12 +6,13 @@
       "params": {
         "minimumDifficulty": "0x20000",
         "difficultyBoundDivisor": "0x800",
+        "difficultyBombDisabled": "true",
         "durationLimit": "0xd",
         "blockReward": {
           "0x0": "0x1bc16d674ec80000"
         },
         "homesteadTransition": "0x0",
-        "eip100bTransition": "0x0",
+        "eip100bTransition": "0x0"
       }
     }
   },

--- a/src/Nethermind/Nethermind.Consensus.Ethash/EthashDifficultyCalculator.cs
+++ b/src/Nethermind/Nethermind.Consensus.Ethash/EthashDifficultyCalculator.cs
@@ -91,6 +91,9 @@ namespace Nethermind.Consensus.Ethash
 
         private BigInteger TimeBomb(IReleaseSpec spec, long blockNumber)
         {
+            if (spec.DifficultyBombDisabled)
+                return BigInteger.Zero;
+
             blockNumber = blockNumber - spec.DifficultyBombDelay;
             
             return blockNumber < InitialDifficultyBombBlock ? BigInteger.Zero : BigInteger.Pow(2, (int)(BigInteger.Divide(blockNumber, 100000) - 2));

--- a/src/Nethermind/Nethermind.Core/ChainId.cs
+++ b/src/Nethermind/Nethermind.Core/ChainId.cs
@@ -59,6 +59,7 @@ namespace Nethermind.Core
         public const int xDai = 100;
         public const int PoaCore = 99;
         public const int Volta = 73799;
+        public const int Sepolia = 11155111;
 
         public static string GetChainName(ulong chainId)
         {
@@ -80,6 +81,7 @@ namespace Nethermind.Core
                 xDai => "xDai",
                 PoaCore => "PoaCore",
                 Volta => "Volta",
+                Sepolia => "Sepolia",
                 _ => chainId.ToString()
             };
         }

--- a/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
@@ -29,6 +29,7 @@ namespace Nethermind.Core.Specs
         long MinGasLimit { get; }
         long GasLimitBoundDivisor { get; }
         UInt256 BlockReward { get; }
+        bool DifficultyBombDisabled { get; }
         long DifficultyBombDelay { get; }
         long DifficultyBoundDivisor { get; }
         long? FixedDifficulty { get; }

--- a/src/Nethermind/Nethermind.Ethash.Test/DifficultyCalculatorTests.cs
+++ b/src/Nethermind/Nethermind.Ethash.Test/DifficultyCalculatorTests.cs
@@ -17,7 +17,9 @@
 using Nethermind.Consensus.Ethash;
 using Nethermind.Core.Specs;
 using Nethermind.Int256;
+using Nethermind.Specs;
 using Nethermind.Specs.Forks;
+using Nethermind.Specs.Test;
 using NUnit.Framework;
 using NSubstitute;
 
@@ -80,6 +82,28 @@ namespace Nethermind.Ethash.Test
         {
             Calculation_should_not_be_equal_on_different_difficulty_hard_forks(blocksAbove,
                 London.Instance, ArrowGlacier.Instance);
+        }
+        
+        [TestCase(9700000 + EthashDifficultyCalculator.InitialDifficultyBombBlock + 730000 + 1)]
+        public void Calculation_should_change_based_on_difficulty_bomb_disabled_flag(long blocksAbove)
+        {
+            UInt256 parentDifficulty = 0x55f78f7;
+            UInt256 parentTimestamp = 1613570258;
+            UInt256 currentTimestamp = 0x602d20d2;
+            OverridableReleaseSpec enabledBombReleaseSpec = new(London.Instance);
+            enabledBombReleaseSpec.DifficultyBombDisabled = false;
+            TestSpecProvider enabledBombSpecProvider = new(new OverridableReleaseSpec(enabledBombReleaseSpec));
+            
+            EthashDifficultyCalculator enabledDifficultyCalculator = new(enabledBombSpecProvider);
+            UInt256 enabledResult = enabledDifficultyCalculator.Calculate(parentDifficulty, parentTimestamp, currentTimestamp, blocksAbove, false);
+            
+            OverridableReleaseSpec disabledReleaseSpec = new(London.Instance);
+            disabledReleaseSpec.DifficultyBombDisabled = true;
+            TestSpecProvider disabledBombSpecProvider = new(new OverridableReleaseSpec(disabledReleaseSpec));
+            EthashDifficultyCalculator disabledDifficultyCalculator = new(disabledBombSpecProvider);
+            UInt256 disabledResult = disabledDifficultyCalculator.Calculate(parentDifficulty, parentTimestamp, currentTimestamp, blocksAbove, false);
+            
+            Assert.AreNotEqual(enabledResult, disabledResult);
         }
 
         private void Calculation_should_not_be_equal_on_different_difficulty_hard_forks(

--- a/src/Nethermind/Nethermind.Ethash.Test/Nethermind.Ethash.Test.csproj
+++ b/src/Nethermind/Nethermind.Ethash.Test/Nethermind.Ethash.Test.csproj
@@ -24,6 +24,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\Nethermind.Consensus.Ethash\Nethermind.Consensus.Ethash.csproj" />
+      <ProjectReference Include="..\Nethermind.Specs.Test\Nethermind.Specs.Test.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecBasedSpecProviderTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecBasedSpecProviderTests.cs
@@ -36,6 +36,26 @@ namespace Nethermind.Specs.Test.ChainSpecStyle
     public class ChainSpecBasedSpecProviderTests
     {
         [Test]
+        public void Sepolia_loads_properly()
+        {
+            ChainSpecLoader loader = new(new EthereumJsonSerializer());
+            string path = Path.Combine(TestContext.CurrentContext.WorkDirectory, "../../../../Chains/sepolia.json");
+            ChainSpec chainSpec = loader.Load(File.ReadAllText(path));
+            chainSpec.Parameters.Eip2537Transition.Should().BeNull();
+
+            ChainSpecBasedSpecProvider provider = new(chainSpec);
+            SepoliaSpecProvider sepolia = SepoliaSpecProvider.Instance;
+
+            List<long> blockNumbersToTest = new()
+            {
+                120_000_000, // far in the future
+            };
+            
+            CompareSpecProviders(sepolia, provider, blockNumbersToTest);
+            Assert.AreEqual(0, provider.GenesisSpec.Eip1559TransitionBlock);
+        }
+        
+        [Test]
         public void Rinkeby_loads_properly()
         {
             ChainSpecLoader loader = new(new EthereumJsonSerializer());

--- a/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecBasedSpecProviderTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecBasedSpecProviderTests.cs
@@ -467,7 +467,6 @@ namespace Nethermind.Specs.Test.ChainSpecStyle
                 r.Eip1559TransitionBlock = 15590L;
                 r.IsTimeAdjustmentPostOlympic = true;
                 r.MaximumUncleCount = 2;
-                r.DifficultyBombDisabled = true;
             });
 
             TestTransitions(1L, r =>

--- a/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecBasedSpecProviderTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecBasedSpecProviderTests.cs
@@ -53,6 +53,7 @@ namespace Nethermind.Specs.Test.ChainSpecStyle
             
             CompareSpecProviders(sepolia, provider, blockNumbersToTest);
             Assert.AreEqual(0, provider.GenesisSpec.Eip1559TransitionBlock);
+            Assert.AreEqual(true, provider.GenesisSpec.DifficultyBombDisabled);
         }
         
         [Test]
@@ -82,6 +83,7 @@ namespace Nethermind.Specs.Test.ChainSpecStyle
             
             CompareSpecProviders(rinkeby, provider, blockNumbersToTest);
             Assert.AreEqual(RinkebySpecProvider.LondonBlockNumber, provider.GenesisSpec.Eip1559TransitionBlock);
+            Assert.AreEqual(false, provider.GenesisSpec.DifficultyBombDisabled);
         }
 
         [Test]
@@ -166,6 +168,7 @@ namespace Nethermind.Specs.Test.ChainSpecStyle
             Assert.AreEqual(9_700_000, provider.GetSpec(13_772_999).DifficultyBombDelay);
             Assert.AreEqual(10_700_000, provider.GetSpec(13_773_000).DifficultyBombDelay);
             Assert.AreEqual(10_700_000, provider.GetSpec(99_414_000).DifficultyBombDelay);
+            Assert.AreEqual(false, provider.GenesisSpec.DifficultyBombDisabled);
         }
 
         private static void CompareSpecProviders(
@@ -196,6 +199,7 @@ namespace Nethermind.Specs.Test.ChainSpecStyle
                 .Where(p => isMainnet || p.Name != nameof(IReleaseSpec.BlockReward))
                 .Where(p => isMainnet || checkDifficultyBomb || p.Name != nameof(IReleaseSpec.DifficultyBombDelay))
                 .Where(p => isMainnet || checkDifficultyBomb || p.Name != nameof(IReleaseSpec.DifficultyBoundDivisor))
+                .Where(p => isMainnet || checkDifficultyBomb || p.Name != nameof(IReleaseSpec.DifficultyBombDisabled))
                 .Where(p => p.Name != nameof(IReleaseSpec.Eip1559TransitionBlock)))
             {
                 Assert.AreEqual(propertyInfo.GetValue(oldSpec), propertyInfo.GetValue(newSpec),
@@ -237,6 +241,7 @@ namespace Nethermind.Specs.Test.ChainSpecStyle
 
             CompareSpecProviders(ropsten, provider, blockNumbersToTest, true);
             Assert.AreEqual(RopstenSpecProvider.LondonBlockNumber, provider.GenesisSpec.Eip1559TransitionBlock);
+            Assert.AreEqual(false, provider.GenesisSpec.DifficultyBombDisabled);
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecBasedSpecProviderTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecBasedSpecProviderTests.cs
@@ -50,12 +50,12 @@ namespace Nethermind.Specs.Test.ChainSpecStyle
             {
                 120_000_000, // far in the future
             };
-            
+
             CompareSpecProviders(sepolia, provider, blockNumbersToTest);
             Assert.AreEqual(0, provider.GenesisSpec.Eip1559TransitionBlock);
             Assert.AreEqual(true, provider.GenesisSpec.DifficultyBombDisabled);
         }
-        
+
         [Test]
         public void Rinkeby_loads_properly()
         {
@@ -80,7 +80,7 @@ namespace Nethermind.Specs.Test.ChainSpecStyle
                 RinkebySpecProvider.LondonBlockNumber,
                 120_000_000, // far in the future
             };
-            
+
             CompareSpecProviders(rinkeby, provider, blockNumbersToTest);
             Assert.AreEqual(RinkebySpecProvider.LondonBlockNumber, provider.GenesisSpec.Eip1559TransitionBlock);
             Assert.AreEqual(false, provider.GenesisSpec.DifficultyBombDisabled);
@@ -194,13 +194,16 @@ namespace Nethermind.Specs.Test.ChainSpecStyle
             PropertyInfo[] propertyInfos =
                 typeof(IReleaseSpec).GetProperties(BindingFlags.Public | BindingFlags.Instance);
             foreach (PropertyInfo propertyInfo in propertyInfos
-                .Where(p => p.Name != nameof(IReleaseSpec.Name))
-                .Where(p => isMainnet || p.Name != nameof(IReleaseSpec.MaximumExtraDataSize))
-                .Where(p => isMainnet || p.Name != nameof(IReleaseSpec.BlockReward))
-                .Where(p => isMainnet || checkDifficultyBomb || p.Name != nameof(IReleaseSpec.DifficultyBombDelay))
-                .Where(p => isMainnet || checkDifficultyBomb || p.Name != nameof(IReleaseSpec.DifficultyBoundDivisor))
-                .Where(p => isMainnet || checkDifficultyBomb || p.Name != nameof(IReleaseSpec.DifficultyBombDisabled))
-                .Where(p => p.Name != nameof(IReleaseSpec.Eip1559TransitionBlock)))
+                         .Where(p => p.Name != nameof(IReleaseSpec.Name))
+                         .Where(p => isMainnet || p.Name != nameof(IReleaseSpec.MaximumExtraDataSize))
+                         .Where(p => isMainnet || p.Name != nameof(IReleaseSpec.BlockReward))
+                         .Where(p => isMainnet || checkDifficultyBomb ||
+                                     p.Name != nameof(IReleaseSpec.DifficultyBombDelay))
+                         .Where(p => isMainnet || checkDifficultyBomb ||
+                                     p.Name != nameof(IReleaseSpec.DifficultyBoundDivisor))
+                         .Where(p => isMainnet || checkDifficultyBomb ||
+                                     p.Name != nameof(IReleaseSpec.DifficultyBombDisabled))
+                         .Where(p => p.Name != nameof(IReleaseSpec.Eip1559TransitionBlock)))
             {
                 Assert.AreEqual(propertyInfo.GetValue(oldSpec), propertyInfo.GetValue(newSpec),
                     blockNumber + "." + propertyInfo.Name);
@@ -247,7 +250,7 @@ namespace Nethermind.Specs.Test.ChainSpecStyle
         [Test]
         public void Chain_id_is_set_correctly()
         {
-            ChainSpec chainSpec = new() {Parameters = new ChainParameters(), ChainId = 5};
+            ChainSpec chainSpec = new() { Parameters = new ChainParameters(), ChainId = 5 };
 
             ChainSpecBasedSpecProvider provider = new(chainSpec);
             Assert.AreEqual(5, provider.ChainId);
@@ -269,8 +272,8 @@ namespace Nethermind.Specs.Test.ChainSpecStyle
         {
             ChainSpec chainSpec = new()
             {
-                Parameters = new ChainParameters {GasLimitBoundDivisor = 17},
-                Ethash = new EthashParameters {DifficultyBoundDivisor = 19}
+                Parameters = new ChainParameters { GasLimitBoundDivisor = 17 },
+                Ethash = new EthashParameters { DifficultyBoundDivisor = 19 }
             };
 
             ChainSpecBasedSpecProvider provider = new(chainSpec);
@@ -288,11 +291,11 @@ namespace Nethermind.Specs.Test.ChainSpecStyle
                 {
                     DifficultyBombDelays = new Dictionary<long, long>
                     {
-                        {3, 100},
-                        {7, 200},
-                        {13, 300},
-                        {17, 400},
-                        {19, 500},
+                        { 3, 100 },
+                        { 7, 200 },
+                        { 13, 300 },
+                        { 17, 400 },
+                        { 19, 500 },
                     }
                 }
             };
@@ -328,7 +331,7 @@ namespace Nethermind.Specs.Test.ChainSpecStyle
         [Test]
         public void Eip2200_is_set_correctly_directly()
         {
-            ChainSpec chainSpec = new() {Parameters = new ChainParameters {Eip2200Transition = 5}};
+            ChainSpec chainSpec = new() { Parameters = new ChainParameters { Eip2200Transition = 5 } };
 
             ChainSpecBasedSpecProvider provider = new(chainSpec);
             provider.GetSpec(5).IsEip2200Enabled.Should().BeTrue();
@@ -338,7 +341,7 @@ namespace Nethermind.Specs.Test.ChainSpecStyle
         public void Eip2200_is_set_correctly_indirectly()
         {
             ChainSpec chainSpec =
-                new() {Parameters = new ChainParameters {Eip1706Transition = 5, Eip1283Transition = 5}};
+                new() { Parameters = new ChainParameters { Eip1706Transition = 5, Eip1283Transition = 5 } };
 
             ChainSpecBasedSpecProvider provider = new(chainSpec);
             provider.GetSpec(5).IsEip2200Enabled.Should().BeTrue();
@@ -385,7 +388,12 @@ namespace Nethermind.Specs.Test.ChainSpecStyle
 
             ChainSpec chainSpec = new()
             {
-                Ethash = new EthashParameters {HomesteadTransition = 70, Eip100bTransition = 1000},
+                Ethash =
+                    new EthashParameters
+                    {
+                        HomesteadTransition = 70,
+                        Eip100bTransition = 1000
+                    },
                 ByzantiumBlockNumber = 1960,
                 ConstantinopleBlockNumber = 6490,
                 Parameters = new ChainParameters
@@ -459,9 +467,14 @@ namespace Nethermind.Specs.Test.ChainSpecStyle
                 r.Eip1559TransitionBlock = 15590L;
                 r.IsTimeAdjustmentPostOlympic = true;
                 r.MaximumUncleCount = 2;
+                r.DifficultyBombDisabled = true;
             });
-            
-            TestTransitions(1L, r => { r.MaxCodeSize = maxCodeSize; r.IsEip170Enabled = true; });
+
+            TestTransitions(1L, r =>
+            {
+                r.MaxCodeSize = maxCodeSize;
+                r.IsEip170Enabled = true;
+            });
             TestTransitions(70L, r => { r.IsEip2Enabled = r.IsEip7Enabled = true; });
             TestTransitions(1000L, r => { r.IsEip100Enabled = true; });
             TestTransitions(1400L, r => { r.IsEip140Enabled = true; });
@@ -471,7 +484,8 @@ namespace Nethermind.Specs.Test.ChainSpecStyle
             TestTransitions(1550L, r => { r.IsEip155Enabled = true; });
             TestTransitions(1580L, r => { r.IsEip158Enabled = true; });
             TestTransitions(1600L, r => { r.IsEip160Enabled = true; });
-            TestTransitions(1960L, r => { r.IsEip196Enabled = r.IsEip197Enabled = r.IsEip198Enabled = r.IsEip649Enabled = true; });
+            TestTransitions(1960L,
+                r => { r.IsEip196Enabled = r.IsEip197Enabled = r.IsEip198Enabled = r.IsEip649Enabled = true; });
             TestTransitions(2110L, r => { r.IsEip211Enabled = true; });
             TestTransitions(2140L, r => { r.IsEip214Enabled = true; });
             TestTransitions(6580L, r => { r.IsEip658Enabled = r.IsEip1234Enabled = true; });

--- a/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
@@ -50,8 +50,6 @@ namespace Nethermind.Specs.Test
         public long DifficultyBombDelay => _spec.DifficultyBombDelay;
 
         public long DifficultyBoundDivisor => _spec.DifficultyBoundDivisor;
-
-        public bool DifficultyBombDisabled => _spec.DifficultyBombDisabled;
         
         public long? FixedDifficulty => _spec.FixedDifficulty;
 
@@ -146,6 +144,19 @@ namespace Nethermind.Specs.Test
             set
             {
                 _overridenEip1559TransitionBlock = value;
+            }
+        }
+        
+        private bool? _overridenDifficultyBombDisabled;
+        public bool DifficultyBombDisabled
+        {
+            get
+            {
+                return _overridenDifficultyBombDisabled ?? _spec.DifficultyBombDisabled;
+            }
+            set
+            {
+                _overridenDifficultyBombDisabled = value;
             }
         }
 

--- a/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
@@ -50,6 +50,8 @@ namespace Nethermind.Specs.Test
         public long DifficultyBombDelay => _spec.DifficultyBombDelay;
 
         public long DifficultyBoundDivisor => _spec.DifficultyBoundDivisor;
+
+        public bool DifficultyBombDisabled => _spec.DifficultyBombDisabled;
         
         public long? FixedDifficulty => _spec.FixedDifficulty;
 

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
@@ -155,7 +155,7 @@ namespace Nethermind.Specs.ChainSpecStyle
                         }
                     }
 
-                    releaseSpec.DifficultyBombDisabled = !(_chainSpec.Ethash.DifficultyBombDelays?.Any() ?? false);
+                    releaseSpec.DifficultyBombDisabled = _chainSpec.Ethash.DifficultyBombDisabled ?? false;
                     foreach (KeyValuePair<long,long> bombDelay in _chainSpec.Ethash.DifficultyBombDelays ?? Enumerable.Empty<KeyValuePair<long, long>>())
                     {
                         if (bombDelay.Key <= releaseStartBlock)

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
@@ -154,7 +154,8 @@ namespace Nethermind.Specs.ChainSpecStyle
                             releaseSpec.BlockReward = blockReward.Value;
                         }
                     }
-                        
+
+                    releaseSpec.DifficultyBombDisabled = !_chainSpec.Ethash.DifficultyBombDelays?.Any() ?? false;
                     foreach (KeyValuePair<long,long> bombDelay in _chainSpec.Ethash.DifficultyBombDelays ?? Enumerable.Empty<KeyValuePair<long, long>>())
                     {
                         if (bombDelay.Key <= releaseStartBlock)

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
@@ -155,7 +155,7 @@ namespace Nethermind.Specs.ChainSpecStyle
                         }
                     }
 
-                    releaseSpec.DifficultyBombDisabled = !_chainSpec.Ethash.DifficultyBombDelays?.Any() ?? false;
+                    releaseSpec.DifficultyBombDisabled = !(_chainSpec.Ethash.DifficultyBombDelays?.Any() ?? false);
                     foreach (KeyValuePair<long,long> bombDelay in _chainSpec.Ethash.DifficultyBombDelays ?? Enumerable.Empty<KeyValuePair<long, long>>())
                     {
                         if (bombDelay.Key <= releaseStartBlock)

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
@@ -293,7 +293,8 @@ namespace Nethermind.Specs.ChainSpecStyle
                     DaoHardforkAccounts = chainSpecJson.Engine.Ethash.DaoHardforkAccounts ?? Array.Empty<Address>(),
                     Eip100bTransition = chainSpecJson.Engine.Ethash.Eip100bTransition ?? 0L,
                     FixedDifficulty = chainSpecJson.Engine.Ethash.FixedDifficulty,
-                    BlockRewards = chainSpecJson.Engine.Ethash.BlockReward
+                    BlockRewards = chainSpecJson.Engine.Ethash.BlockReward,
+                    DifficultyBombDisabled = chainSpecJson.Engine.Ethash.DifficultyBombDisabled
                 };
 
                 chainSpec.Ethash.DifficultyBombDelays = new Dictionary<long, long>();

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/EthashParameters.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/EthashParameters.cs
@@ -50,5 +50,7 @@ namespace Nethermind.Specs.ChainSpecStyle
         public IDictionary<long, UInt256> BlockRewards { get; set; }
 
         public IDictionary<long, long> DifficultyBombDelays { get; set; }
+        
+        public bool? DifficultyBombDisabled { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecJson.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecJson.cs
@@ -50,6 +50,7 @@ namespace Nethermind.Specs.ChainSpecStyle.Json
             public UInt256? MinimumDifficulty => Params?.MinimumDifficulty;
             public IDictionary<long, UInt256> BlockReward => Params?.BlockReward;
             public IDictionary<string, long> DifficultyBombDelays => Params?.DifficultyBombDelays;
+            public bool? DifficultyBombDisabled => Params?.DifficultyBombDisabled;
             public EthashEngineParamsJson Params { get; set; }
         }
         
@@ -66,6 +67,8 @@ namespace Nethermind.Specs.ChainSpecStyle.Json
             public long? FixedDifficulty { get; set; }
             public BlockRewardJson BlockReward { get; set; }
             public Dictionary<string, long> DifficultyBombDelays { get; set; }
+            
+            public bool? DifficultyBombDisabled { get; set; }
         }
     
         internal class CliqueEngineJson

--- a/src/Nethermind/Nethermind.Specs/Forks/00_Olympic.cs
+++ b/src/Nethermind/Nethermind.Specs/Forks/00_Olympic.cs
@@ -37,6 +37,7 @@ namespace Nethermind.Specs.Forks
         public long MinGasLimit => 5000;
         public long GasLimitBoundDivisor => 0x0400;
         public UInt256 BlockReward { get; } = UInt256.Parse("5000000000000000000");
+        public bool DifficultyBombDisabled => false;
         public long DifficultyBombDelay => 0L;
         public long DifficultyBoundDivisor => 0x0800;
         public long? FixedDifficulty => null;

--- a/src/Nethermind/Nethermind.Specs/Forks/01_Frontier.cs
+++ b/src/Nethermind/Nethermind.Specs/Forks/01_Frontier.cs
@@ -39,6 +39,7 @@ namespace Nethermind.Specs.Forks
         public UInt256 BlockReward { get; } = UInt256.Parse("5000000000000000000");
         public long DifficultyBombDelay => 0L;
         public long DifficultyBoundDivisor => 0x0800;
+        public bool DifficultyBombDisabled => false;
         public long? FixedDifficulty => null;
         public int MaximumUncleCount => 2;
         public bool IsTimeAdjustmentPostOlympic => true;

--- a/src/Nethermind/Nethermind.Specs/Forks/02_Homestead.cs
+++ b/src/Nethermind/Nethermind.Specs/Forks/02_Homestead.cs
@@ -37,6 +37,7 @@ namespace Nethermind.Specs.Forks
         public UInt256 BlockReward { get; } = UInt256.Parse("5000000000000000000");
         public long DifficultyBombDelay => 0L;
         public long DifficultyBoundDivisor => 0x0800;
+        public bool DifficultyBombDisabled => false;
         public long? FixedDifficulty => null;
         public int MaximumUncleCount => 2;
         public bool IsTimeAdjustmentPostOlympic => true;

--- a/src/Nethermind/Nethermind.Specs/Forks/03_Dao.cs
+++ b/src/Nethermind/Nethermind.Specs/Forks/03_Dao.cs
@@ -39,6 +39,7 @@ namespace Nethermind.Specs.Forks
         public UInt256 BlockReward { get; } = UInt256.Parse("5000000000000000000");
         public long DifficultyBombDelay => 0L;
         public long DifficultyBoundDivisor => 0x0800;
+        public bool DifficultyBombDisabled => false;
         public long? FixedDifficulty => null;
         public int MaximumUncleCount => 2;
         public bool IsTimeAdjustmentPostOlympic => true;

--- a/src/Nethermind/Nethermind.Specs/Forks/04_TangerineWhistle.cs
+++ b/src/Nethermind/Nethermind.Specs/Forks/04_TangerineWhistle.cs
@@ -39,6 +39,7 @@ namespace Nethermind.Specs.Forks
         public UInt256 BlockReward { get; } = UInt256.Parse("5000000000000000000");
         public long DifficultyBombDelay => 0L;
         public long DifficultyBoundDivisor => 0x0800;
+        public bool DifficultyBombDisabled => false;
         public long? FixedDifficulty => null;
         public int MaximumUncleCount => 2;
         public bool IsTimeAdjustmentPostOlympic => true;

--- a/src/Nethermind/Nethermind.Specs/Forks/05_SpuriousDragon.cs
+++ b/src/Nethermind/Nethermind.Specs/Forks/05_SpuriousDragon.cs
@@ -39,6 +39,7 @@ namespace Nethermind.Specs.Forks
         public UInt256 BlockReward { get; } = UInt256.Parse("5000000000000000000");
         public long DifficultyBombDelay => 0L;
         public long DifficultyBoundDivisor => 0x0800;
+        public bool DifficultyBombDisabled => false;
         public long? FixedDifficulty => null;
         public int MaximumUncleCount => 2;
         public bool IsTimeAdjustmentPostOlympic => true;

--- a/src/Nethermind/Nethermind.Specs/Forks/06_Byzantium.cs
+++ b/src/Nethermind/Nethermind.Specs/Forks/06_Byzantium.cs
@@ -39,6 +39,7 @@ namespace Nethermind.Specs.Forks
         public UInt256 BlockReward { get; } = UInt256.Parse("3000000000000000000");
         public long DifficultyBombDelay => 3000000L;
         public long DifficultyBoundDivisor => 0x0800;
+        public bool DifficultyBombDisabled => false;
         public long? FixedDifficulty => null;
         public int MaximumUncleCount => 2;
         public bool IsTimeAdjustmentPostOlympic => true;

--- a/src/Nethermind/Nethermind.Specs/Forks/07_Constantinople.cs
+++ b/src/Nethermind/Nethermind.Specs/Forks/07_Constantinople.cs
@@ -39,6 +39,7 @@ namespace Nethermind.Specs.Forks
         public UInt256 BlockReward { get; } = UInt256.Parse("2000000000000000000");
         public long DifficultyBombDelay => 5000000L;
         public long DifficultyBoundDivisor => 0x0800;
+        public bool DifficultyBombDisabled => false;
         public long? FixedDifficulty => null;
         public int MaximumUncleCount => 2;
         public bool IsTimeAdjustmentPostOlympic => true;

--- a/src/Nethermind/Nethermind.Specs/Forks/08_ConstantinopleFix.cs
+++ b/src/Nethermind/Nethermind.Specs/Forks/08_ConstantinopleFix.cs
@@ -41,6 +41,7 @@ namespace Nethermind.Specs.Forks
         public UInt256 BlockReward { get; } = UInt256.Parse("2000000000000000000");
         public long DifficultyBombDelay => 5000000L;
         public long DifficultyBoundDivisor => 0x0800;
+        public bool DifficultyBombDisabled => false;
         public long? FixedDifficulty => null;
         public int MaximumUncleCount => 2;
         public bool IsTimeAdjustmentPostOlympic => true;

--- a/src/Nethermind/Nethermind.Specs/Forks/09_Istanbul.cs
+++ b/src/Nethermind/Nethermind.Specs/Forks/09_Istanbul.cs
@@ -39,6 +39,7 @@ namespace Nethermind.Specs.Forks
         public UInt256 BlockReward { get; } = UInt256.Parse("2000000000000000000");
         public long DifficultyBombDelay => 5000000L;
         public long DifficultyBoundDivisor => 0x0800;
+        public bool DifficultyBombDisabled => false;
         public long? FixedDifficulty => null;
         public int MaximumUncleCount => 2;
         public bool IsTimeAdjustmentPostOlympic => true;

--- a/src/Nethermind/Nethermind.Specs/Forks/10_MuirGlacier.cs
+++ b/src/Nethermind/Nethermind.Specs/Forks/10_MuirGlacier.cs
@@ -37,6 +37,7 @@ namespace Nethermind.Specs.Forks
         public UInt256 BlockReward { get; } = UInt256.Parse("2000000000000000000");
         public long DifficultyBombDelay => 9000000L;
         public long DifficultyBoundDivisor => 0x0800;
+        public bool DifficultyBombDisabled => false;
         public long? FixedDifficulty => null;
         public int MaximumUncleCount => 2;
         public bool IsTimeAdjustmentPostOlympic => true;

--- a/src/Nethermind/Nethermind.Specs/Forks/11_Berlin.cs
+++ b/src/Nethermind/Nethermind.Specs/Forks/11_Berlin.cs
@@ -39,6 +39,7 @@ namespace Nethermind.Specs.Forks
         public UInt256 BlockReward { get; } = UInt256.Parse("2000000000000000000");
         public long DifficultyBombDelay => 9000000L;
         public long DifficultyBoundDivisor => 0x0800;
+        public bool DifficultyBombDisabled => false;
         public long? FixedDifficulty => null;
         public int MaximumUncleCount => 2;
         public bool IsTimeAdjustmentPostOlympic => true;

--- a/src/Nethermind/Nethermind.Specs/Forks/12_London.cs
+++ b/src/Nethermind/Nethermind.Specs/Forks/12_London.cs
@@ -39,6 +39,7 @@ namespace Nethermind.Specs.Forks
         public long GasLimitBoundDivisor => 0x0400;
         public UInt256 BlockReward { get; } = UInt256.Parse("2000000000000000000");
         public long DifficultyBombDelay => 9700000L;
+        public bool DifficultyBombDisabled => false;
         public long DifficultyBoundDivisor => 0x0800;
         public long? FixedDifficulty => null;
         public int MaximumUncleCount => 2;

--- a/src/Nethermind/Nethermind.Specs/Forks/13_ArrowGlacier.cs
+++ b/src/Nethermind/Nethermind.Specs/Forks/13_ArrowGlacier.cs
@@ -40,6 +40,7 @@ namespace Nethermind.Specs.Forks
         public UInt256 BlockReward { get; } = UInt256.Parse("2000000000000000000");
         public long DifficultyBombDelay => 10700000L;
         public long DifficultyBoundDivisor => 0x0800;
+        public bool DifficultyBombDisabled => false;
         public long? FixedDifficulty => null;
         public int MaximumUncleCount => 2;
         public bool IsTimeAdjustmentPostOlympic => true;

--- a/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
@@ -28,6 +28,7 @@ namespace Nethermind.Specs
         public long MinGasLimit { get; set; }
         public long GasLimitBoundDivisor { get; set; }
         public UInt256 BlockReward { get; set; }
+        public bool DifficultyBombDisabled { get; set; }
         public long DifficultyBombDelay { get; set; }
         public long DifficultyBoundDivisor { get; set; }
         public long? FixedDifficulty { get; set; }

--- a/src/Nethermind/Nethermind.Specs/SepoliaSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Specs/SepoliaSpecProvider.cs
@@ -1,0 +1,44 @@
+﻿//  Copyright (c) 2021 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
+
+using Nethermind.Core.Specs;
+using Nethermind.Specs.Forks;
+
+namespace Nethermind.Specs;
+
+public class SepoliaSpecProvider : ISpecProvider
+{
+    public IReleaseSpec GenesisSpec => London.Instance;
+
+        public IReleaseSpec GetSpec(long blockNumber)
+        {
+            return London.Instance;
+        }
+
+        public long? DaoBlockNumber => null;
+        
+
+        public ulong ChainId => Core.ChainId.Rinkeby;
+
+        public long[] TransitionBlocks { get; } =
+        {
+        };
+
+        private SepoliaSpecProvider() { }
+
+        public static readonly SepoliaSpecProvider Instance = new();
+}

--- a/src/Nethermind/Nethermind.Specs/SystemTransactionReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs/SystemTransactionReleaseSpec.cs
@@ -42,6 +42,7 @@ namespace Nethermind.Specs
         public UInt256 BlockReward => _spec.BlockReward;
 
         public long DifficultyBombDelay => _spec.DifficultyBombDelay;
+        public bool DifficultyBombDisabled => _spec.DifficultyBombDisabled;
 
         public long DifficultyBoundDivisor => _spec.DifficultyBoundDivisor;
         


### PR DESCRIPTION
## Changes:
- Added DifficultyBombDisabled to ReleaseSpec based on DifficultyBombDelays. By default, new testnets don't have DifficultyBomb, so my goal was to turn off DiffcultyBomb for them without changing chainspecs for mainnet, rinkeby, ropsten.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No
