### PR TITLE
Accept underpaid local txs in FeeTooLowFilter

### DIFF
--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -441,7 +441,7 @@ namespace Nethermind.TxPool.Test
             foreach (Transaction transaction in transactions)
             {
                 transaction.GasPrice = 10;
-                _txPool.SubmitTx(transaction, TxHandlingOptions.PersistentBroadcast);
+                _txPool.SubmitTx(transaction, TxHandlingOptions.None);
             }
             
             Transaction tx = Build.A.Transaction
@@ -450,8 +450,10 @@ namespace Nethermind.TxPool.Test
                 .TestObject;
             EnsureSenderBalance(tx.SenderAddress, UInt256.MaxValue);
             _txPool.GetPendingTransactions().Length.Should().Be(30);
+            _txPool.GetOwnPendingTransactions().Length.Should().Be(0);
             AcceptTxResult result = _txPool.SubmitTx(tx, txHandlingOptions);
             _txPool.GetPendingTransactions().Length.Should().Be(30);
+            _txPool.GetOwnPendingTransactions().Length.Should().Be(isLocal ? 1 : 0);
             result.ToString().Should().Contain(isLocal ? nameof(AcceptTxResult.Accepted) : nameof(AcceptTxResult.FeeTooLow));
         }
 

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -446,8 +446,9 @@ namespace Nethermind.TxPool.Test
             
             Transaction tx = Build.A.Transaction
                 .WithGasPrice(UInt256.Zero)
-                .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA).TestObject;
-            EnsureSenderBalance(tx.SenderAddress, (UInt256)(15 * tx.GasLimit));
+                .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA)
+                .TestObject;
+            EnsureSenderBalance(tx.SenderAddress, UInt256.MaxValue);
             _txPool.GetPendingTransactions().Length.Should().Be(30);
             AcceptTxResult result = _txPool.SubmitTx(tx, txHandlingOptions);
             _txPool.GetPendingTransactions().Length.Should().Be(30);

--- a/src/Nethermind/Nethermind.TxPool/Filters/FeeTooLowFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/FeeTooLowFilter.cs
@@ -26,7 +26,7 @@ namespace Nethermind.TxPool.Filters
     /// <summary>
     /// Filters out transactions where gas fee properties were set too low or where the sender has not enough balance.
     /// </summary>
-    internal class FeeToLowFilter : IIncomingTxFilter
+    internal class FeeTooLowFilter : IIncomingTxFilter
     {
         private readonly IChainHeadSpecProvider _specProvider;
         private readonly IChainHeadInfoProvider _headInfo;
@@ -34,7 +34,7 @@ namespace Nethermind.TxPool.Filters
         private readonly TxDistinctSortedPool _txs;
         private readonly ILogger _logger;
 
-        public FeeToLowFilter(IChainHeadInfoProvider headInfo, IAccountStateProvider accountStateProvider, TxDistinctSortedPool txs, ILogger logger)
+        public FeeTooLowFilter(IChainHeadInfoProvider headInfo, IAccountStateProvider accountStateProvider, TxDistinctSortedPool txs, ILogger logger)
         {
             _specProvider = headInfo.SpecProvider;
             _headInfo = headInfo;

--- a/src/Nethermind/Nethermind.TxPool/Filters/FeeTooLowFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/FeeTooLowFilter.cs
@@ -49,10 +49,12 @@ namespace Nethermind.TxPool.Filters
             Account account = _accounts.GetAccount(tx.SenderAddress!);
             UInt256 balance = account.Balance;
             UInt256 affordableGasPrice = tx.CalculateAffordableGasPrice(spec.IsEip1559Enabled, _headInfo.CurrentBaseFee, balance);
+            bool isNotLocal = (handlingOptions & TxHandlingOptions.PersistentBroadcast) != TxHandlingOptions.PersistentBroadcast;
             
             if (_txs.IsFull()
                 && _txs.TryGetLast(out Transaction? lastTx)
-                && affordableGasPrice <= lastTx?.GasBottleneck)
+                && affordableGasPrice <= lastTx?.GasBottleneck
+                && isNotLocal)
             {
                 Metrics.PendingTransactionsTooLowFee++;
                 if (_logger.IsTrace)

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -117,7 +117,7 @@ namespace Nethermind.TxPool
             _filterPipeline.Add(new LowNonceFilter(_accounts, _logger));
             _filterPipeline.Add(new GapNonceFilter(_accounts, _transactions, _logger));
             _filterPipeline.Add(new TooExpensiveTxFilter(_headInfo, _accounts, _transactions, _logger));
-            _filterPipeline.Add(new FeeToLowFilter(_headInfo, _accounts, _transactions, _logger));
+            _filterPipeline.Add(new FeeTooLowFilter(_headInfo, _accounts, _transactions, _logger));
             _filterPipeline.Add(new ReusedOwnNonceTxFilter(_accounts, _nonces, _logger));
             if (incomingTxFilter is not null)
             {


### PR DESCRIPTION
## Changes:
- Don't filter out local transactions because of too low fee when adding to TxPool

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No