### PR TITLE
Update AdditionalRpcUrls to meet naming convention

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcUrlCollectionTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcUrlCollectionTests.cs
@@ -124,7 +124,7 @@ namespace Nethermind.JsonRpc.Test
             {
                 Enabled = true,
                 EnabledModules = _enabledModules,
-                AdditionalRPCUrls = new [] { "https://localhost:1234|https;wss|admin;debug" }
+                AdditionalRpcUrls = new [] { "https://localhost:1234|https;wss|admin;debug" }
             };
 
             JsonRpcUrlCollection urlCollection = new JsonRpcUrlCollection(Substitute.For<ILogManager>(), jsonRpcConfig, true);
@@ -142,7 +142,7 @@ namespace Nethermind.JsonRpc.Test
             {
                 Enabled = true,
                 EnabledModules = _enabledModules,
-                AdditionalRPCUrls = new [] { "http://localhost:1234|ws|admin;debug" }
+                AdditionalRpcUrls = new [] { "http://localhost:1234|ws|admin;debug" }
             };
 
             JsonRpcUrlCollection urlCollection = new JsonRpcUrlCollection(Substitute.For<ILogManager>(), jsonRpcConfig, false);
@@ -159,7 +159,7 @@ namespace Nethermind.JsonRpc.Test
             {
                 Enabled = true,
                 EnabledModules = _enabledModules,
-                AdditionalRPCUrls = new [] { "http://localhost:1234|http;ws|admin;debug" }
+                AdditionalRpcUrls = new [] { "http://localhost:1234|http;ws|admin;debug" }
             };
 
             JsonRpcUrlCollection urlCollection = new JsonRpcUrlCollection(Substitute.For<ILogManager>(), jsonRpcConfig, false);
@@ -178,7 +178,7 @@ namespace Nethermind.JsonRpc.Test
                 Enabled = true,
                 EnabledModules = _enabledModules,
                 WebSocketsPort = 9876,
-                AdditionalRPCUrls = new []
+                AdditionalRpcUrls = new []
                 {
                     "http://localhost:8545|http;ws|admin;debug",
                     "https://127.0.0.1:1234|https;wss|eth;web3",
@@ -203,7 +203,7 @@ namespace Nethermind.JsonRpc.Test
             {
                 Enabled = true,
                 EnabledModules = _enabledModules,
-                AdditionalRPCUrls = new []
+                AdditionalRpcUrls = new []
                 {
                     string.Empty,
                     "test",

--- a/src/Nethermind/Nethermind.JsonRpc/IJsonRpcConfig.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/IJsonRpcConfig.cs
@@ -66,9 +66,9 @@ namespace Nethermind.JsonRpc
         string[] EnabledModules { get; set; }
 
         [ConfigItem(
-            Description = "Defines additional RPC urls to listen on. Example url format: http://localhost:8550|http,wss|engine,eth,net,subscribe",
+            Description = "Defines additional RPC urls to listen on. Example url format: http://localhost:8550|http;wss|engine;eth;net;subscribe",
             DefaultValue = "[]")]
-        string[] AdditionalRPCUrls { get; set; }
+        string[] AdditionalRpcUrls { get; set; }
 
         [ConfigItem(
             Description = "Gas limit for eth_call and eth_estimateGas",

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcConfig.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcConfig.cs
@@ -42,7 +42,7 @@ namespace Nethermind.JsonRpc
         public string? IpcUnixDomainSocketPath { get; set; } = null;
 
         public string[] EnabledModules { get; set; } = ModuleType.DefaultModules.ToArray();
-        public string[] AdditionalRPCUrls { get; set; } = Array.Empty<string>();
+        public string[] AdditionalRpcUrls { get; set; } = Array.Empty<string>();
         public long? GasCap { get; set; } = 100000000;
         public int ReportIntervalSeconds { get; set; } = 300;
         public bool BufferResponses { get; set; }

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcUrlCollection.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcUrlCollection.cs
@@ -71,7 +71,7 @@ namespace Nethermind.JsonRpc
                     defaultUrl.RpcEndpoint |= RpcEndpoint.Ws;
             }
 
-            foreach (string additionalRpcUrl in _jsonRpcConfig.AdditionalRPCUrls)
+            foreach (string additionalRpcUrl in _jsonRpcConfig.AdditionalRpcUrls)
             {
                 try
                 {


### PR DESCRIPTION
Fixes AdditionalRPCUrls name

## Changes:
- changed all instances of `AdditionalRPCUrls` to `AdditionalRpcUrls` to meet the naming convention
- fixed an example to accurately detail how to use `AdditionalRpcUrls` 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [x] No

**Comments about testing , should you have some**
I am not sure if it needs to be tested or not. I build it and tested if it worked with `AdditionalRpcUrls` in both the command line flags and the .cfg file.

Both worked fine.
So I don't think it needs to be tested anymore, but if someone does it won't hurt.

