### PR TITLE
Set timeout in HiveRunner and update ethereum tests

### DIFF
--- a/.github/workflows/run-nethermind-tests-with-code-coverage.yml
+++ b/.github/workflows/run-nethermind-tests-with-code-coverage.yml
@@ -209,10 +209,10 @@ jobs:
         dotnet test -c Release $EXCLUDE_TEST_PROJECTS src/Nethermind/Ethereum.KeyAddress.Test
     - name: Ethereum.PoW.Test
       run: |
-        dotnet test -c Release $EXCLUDE_TEST_PROJECTS src/Nethermind/Ethereum.Rlp.Test
+        dotnet test -c Release $EXCLUDE_TEST_PROJECTS src/Nethermind/Ethereum.PoW.Test
     - name: Ethereum.Rlp.Test
       run: |
-        dotnet test -c Release $EXCLUDE_TEST_PROJECTS src/Nethermind/Ethereum.Basic.Test
+        dotnet test -c Release $EXCLUDE_TEST_PROJECTS src/Nethermind/Ethereum.Rlp.Test
     - name: Ethereum.Transaction.Test
       run: |
         dotnet test -c Release $EXCLUDE_TEST_PROJECTS src/Nethermind/Ethereum.Transaction.Test
@@ -222,6 +222,9 @@ jobs:
     - name: Ethereum.Trie.Test
       run: |
         dotnet test -c Release $EXCLUDE_TEST_PROJECTS src/Nethermind/Ethereum.Trie.Test
+    - name: Ethereum.VM.Test
+      run: |
+        dotnet test -c Release $EXCLUDE_TEST_PROJECTS src/Nethermind/Ethereum.VM.Test
     - name: Upload Codecov Report
       if: matrix.os == 'ubuntu-latest'
       uses: actions/upload-artifact@v2

--- a/src/Nethermind/Nethermind.Hive/HiveRunner.cs
+++ b/src/Nethermind/Nethermind.Hive/HiveRunner.cs
@@ -199,7 +199,7 @@ namespace Nethermind.Hive
 
         private async Task WaitForBlockProcessing(SemaphoreSlim semaphore)
         {
-            if (!await semaphore.WaitAsync(-1))
+            if (!await semaphore.WaitAsync(5000))
             {
                 throw new InvalidOperationException();
             }


### PR DESCRIPTION
## Changes:
- change timeout in HiveRunner from infinite to 5 seconds. Hive consensus tests connected with DAO transition will pass now.
- update ethereum tests
- fix run-nethermind-tests-with-code-coverage.yml similar to run-nethermind-tests.yml fixed in last PR with ethereum tests update

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [x] No

It's tested by hive tests