### PR TITLE
Refactor persistent broadcast

### DIFF
--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandlerTests.cs
@@ -108,7 +108,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V65
                 txs[i] = Build.A.Transaction.SignedAndResolved().TestObject;
             }
 
-            _handler.SendNewTransactions(txs);
+            _handler.SendNewTransactions(txs, false);
             
             _session.Received(1).DeliverMessage(Arg.Is<NewPooledTransactionHashesMessage>(m => m.Hashes.Count == txCount));
         }
@@ -127,7 +127,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V65
                 txs[i] = Build.A.Transaction.SignedAndResolved().TestObject;
             }
 
-            _handler.SendNewTransactions(txs);
+            _handler.SendNewTransactions(txs, false);
             
             _session.Received(messagesCount).DeliverMessage(Arg.Is<NewPooledTransactionHashesMessage>(m => m.Hashes.Count == NewPooledTransactionHashesMessage.MaxCount || m.Hashes.Count == nonFullMsgTxsCount));
         }

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
@@ -17,7 +17,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using DotNetty.Common.Utilities;
@@ -223,9 +222,6 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
         {
             SendMessage(new[]{tx});
         }
-
-        public void SendNewTransactions(IEnumerable<(Transaction Tx, bool IsPersistent)> txs) =>
-            SendNewTransactions(txs.Select(t => t.Tx));
 
         public virtual void SendNewTransactions(IEnumerable<Transaction> txs)
         {

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
@@ -223,7 +223,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
             SendMessage(new[]{tx});
         }
 
-        public virtual void SendNewTransactions(IEnumerable<Transaction> txs, bool isPersistent = false)
+        public virtual void SendNewTransactions(IEnumerable<Transaction> txs, bool sendFullTx = false)
         {
             const int maxCapacity = 256;
             using ArrayPoolList<Transaction> txsToSend = new(maxCapacity);

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
@@ -223,7 +223,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
             SendMessage(new[]{tx});
         }
 
-        public virtual void SendNewTransactions(IEnumerable<Transaction> txs)
+        public virtual void SendNewTransactions(IEnumerable<Transaction> txs, bool isPersistent = false)
         {
             const int maxCapacity = 256;
             using ArrayPoolList<Transaction> txsToSend = new(maxCapacity);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandler.cs
@@ -124,8 +124,14 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V65
             return new PooledTransactionsMessage(txs);
         }
         
-        public override void SendNewTransactions(IEnumerable<Transaction> txs)
+        public override void SendNewTransactions(IEnumerable<Transaction> txs, bool sendFullTx)
         {
+            if (sendFullTx)
+            {
+                base.SendNewTransactions(txs);
+                return;
+            }
+            
             using ArrayPoolList<Keccak> hashes = new(NewPooledTransactionHashesMessage.MaxCount);
 
             foreach (Transaction tx in txs)

--- a/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
@@ -567,7 +567,7 @@ namespace Nethermind.Synchronization.Test
 
             public PublicKey Id => Node.Id;
 
-            public void SendNewTransactions(IEnumerable<Transaction> txs, bool isPersistent)
+            public void SendNewTransactions(IEnumerable<Transaction> txs, bool sendFullTx)
             {
                 throw new NotImplementedException();
             }
@@ -1001,7 +1001,7 @@ namespace Nethermind.Synchronization.Test
 
             public PublicKey Id => Node.Id;
 
-            public void SendNewTransactions(IEnumerable<Transaction> txs, bool isPersistent)
+            public void SendNewTransactions(IEnumerable<Transaction> txs, bool sendFullTx)
             {
                 throw new NotImplementedException();
             }

--- a/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
@@ -567,7 +567,7 @@ namespace Nethermind.Synchronization.Test
 
             public PublicKey Id => Node.Id;
 
-            public void SendNewTransactions(IEnumerable<Transaction> txs)
+            public void SendNewTransactions(IEnumerable<Transaction> txs, bool isPersistent)
             {
                 throw new NotImplementedException();
             }
@@ -1001,7 +1001,7 @@ namespace Nethermind.Synchronization.Test
 
             public PublicKey Id => Node.Id;
 
-            public void SendNewTransactions(IEnumerable<Transaction> txs)
+            public void SendNewTransactions(IEnumerable<Transaction> txs, bool isPersistent)
             {
                 throw new NotImplementedException();
             }

--- a/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
@@ -567,7 +567,7 @@ namespace Nethermind.Synchronization.Test
 
             public PublicKey Id => Node.Id;
 
-            public void SendNewTransactions(IEnumerable<(Transaction Tx, bool IsPersistent)> txs)
+            public void SendNewTransactions(IEnumerable<Transaction> txs)
             {
                 throw new NotImplementedException();
             }
@@ -1001,7 +1001,7 @@ namespace Nethermind.Synchronization.Test
 
             public PublicKey Id => Node.Id;
 
-            public void SendNewTransactions(IEnumerable<(Transaction Tx, bool IsPersistent)> txs)
+            public void SendNewTransactions(IEnumerable<Transaction> txs)
             {
                 throw new NotImplementedException();
             }

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
@@ -240,7 +240,7 @@ namespace Nethermind.Synchronization.Test.FastSync
 
             public PublicKey Id => Node.Id;
 
-            public void SendNewTransactions(IEnumerable<Transaction> txs)
+            public void SendNewTransactions(IEnumerable<Transaction> txs, bool isPersistent)
             {
                 throw new NotImplementedException();
             }

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
@@ -240,7 +240,7 @@ namespace Nethermind.Synchronization.Test.FastSync
 
             public PublicKey Id => Node.Id;
 
-            public void SendNewTransactions(IEnumerable<Transaction> txs, bool isPersistent)
+            public void SendNewTransactions(IEnumerable<Transaction> txs, bool sendFullTx)
             {
                 throw new NotImplementedException();
             }

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
@@ -240,7 +240,7 @@ namespace Nethermind.Synchronization.Test.FastSync
 
             public PublicKey Id => Node.Id;
 
-            public void SendNewTransactions(IEnumerable<(Transaction Tx, bool IsPersistent)> txs)
+            public void SendNewTransactions(IEnumerable<Transaction> txs)
             {
                 throw new NotImplementedException();
             }

--- a/src/Nethermind/Nethermind.Synchronization.Test/LatencySyncPeerMock.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/LatencySyncPeerMock.cs
@@ -99,7 +99,7 @@ namespace Nethermind.Synchronization.Test
 
         public PublicKey Id => Node.Id;
 
-        public void SendNewTransactions(IEnumerable<(Transaction Tx, bool IsPersistent)> txs)
+        public void SendNewTransactions(IEnumerable<Transaction> txs)
         {
             throw new NotImplementedException();
         }

--- a/src/Nethermind/Nethermind.Synchronization.Test/LatencySyncPeerMock.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/LatencySyncPeerMock.cs
@@ -99,7 +99,7 @@ namespace Nethermind.Synchronization.Test
 
         public PublicKey Id => Node.Id;
 
-        public void SendNewTransactions(IEnumerable<Transaction> txs, bool isPersistent)
+        public void SendNewTransactions(IEnumerable<Transaction> txs, bool sendFullTx)
         {
             throw new NotImplementedException();
         }

--- a/src/Nethermind/Nethermind.Synchronization.Test/LatencySyncPeerMock.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/LatencySyncPeerMock.cs
@@ -99,7 +99,7 @@ namespace Nethermind.Synchronization.Test
 
         public PublicKey Id => Node.Id;
 
-        public void SendNewTransactions(IEnumerable<Transaction> txs)
+        public void SendNewTransactions(IEnumerable<Transaction> txs, bool isPersistent)
         {
             throw new NotImplementedException();
         }

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerMock.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerMock.cs
@@ -166,7 +166,7 @@ namespace Nethermind.Synchronization.Test
 
         public PublicKey Id => Node.Id;
         
-        public void SendNewTransactions(IEnumerable<Transaction> txs, bool isPersistent) { }
+        public void SendNewTransactions(IEnumerable<Transaction> txs, bool sendFullTx) { }
 
         public Task<TxReceipt[][]> GetReceipts(IReadOnlyList<Keccak> blockHash, CancellationToken token)
         {

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerMock.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerMock.cs
@@ -166,7 +166,7 @@ namespace Nethermind.Synchronization.Test
 
         public PublicKey Id => Node.Id;
         
-        public void SendNewTransactions(IEnumerable<(Transaction Tx, bool IsPersistent)> txs) { }
+        public void SendNewTransactions(IEnumerable<Transaction> txs) { }
 
         public Task<TxReceipt[][]> GetReceipts(IReadOnlyList<Keccak> blockHash, CancellationToken token)
         {

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerMock.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerMock.cs
@@ -166,7 +166,7 @@ namespace Nethermind.Synchronization.Test
 
         public PublicKey Id => Node.Id;
         
-        public void SendNewTransactions(IEnumerable<Transaction> txs) { }
+        public void SendNewTransactions(IEnumerable<Transaction> txs, bool isPersistent) { }
 
         public Task<TxReceipt[][]> GetReceipts(IReadOnlyList<Keccak> blockHash, CancellationToken token)
         {

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerPoolTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerPoolTests.cs
@@ -117,7 +117,7 @@ namespace Nethermind.Synchronization.Test
 
             public PublicKey Id => Node.Id;
             
-            public void SendNewTransactions(IEnumerable<Transaction> txs, bool isPersistent) { }
+            public void SendNewTransactions(IEnumerable<Transaction> txs, bool sendFullTx) { }
 
             public Task<TxReceipt[][]> GetReceipts(IReadOnlyList<Keccak> blockHash, CancellationToken token)
             {

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerPoolTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerPoolTests.cs
@@ -117,7 +117,7 @@ namespace Nethermind.Synchronization.Test
 
             public PublicKey Id => Node.Id;
             
-            public void SendNewTransactions(IEnumerable<Transaction> txs) { }
+            public void SendNewTransactions(IEnumerable<Transaction> txs, bool isPersistent) { }
 
             public Task<TxReceipt[][]> GetReceipts(IReadOnlyList<Keccak> blockHash, CancellationToken token)
             {

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerPoolTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerPoolTests.cs
@@ -117,7 +117,7 @@ namespace Nethermind.Synchronization.Test
 
             public PublicKey Id => Node.Id;
             
-            public void SendNewTransactions(IEnumerable<(Transaction Tx, bool IsPersistent)> txs) { }
+            public void SendNewTransactions(IEnumerable<Transaction> txs) { }
 
             public Task<TxReceipt[][]> GetReceipts(IReadOnlyList<Keccak> blockHash, CancellationToken token)
             {

--- a/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
@@ -193,7 +193,7 @@ namespace Nethermind.Synchronization.Test
 
             public PublicKey Id => Node.Id;
             
-            public void SendNewTransactions(IEnumerable<Transaction> txs, bool isPersistent) { }
+            public void SendNewTransactions(IEnumerable<Transaction> txs, bool sendFullTx) { }
 
             public Task<TxReceipt[][]> GetReceipts(IReadOnlyList<Keccak> blockHash, CancellationToken token)
             {

--- a/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
@@ -193,7 +193,7 @@ namespace Nethermind.Synchronization.Test
 
             public PublicKey Id => Node.Id;
             
-            public void SendNewTransactions(IEnumerable<Transaction> txs) { }
+            public void SendNewTransactions(IEnumerable<Transaction> txs, bool isPersistent) { }
 
             public Task<TxReceipt[][]> GetReceipts(IReadOnlyList<Keccak> blockHash, CancellationToken token)
             {

--- a/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
@@ -193,7 +193,7 @@ namespace Nethermind.Synchronization.Test
 
             public PublicKey Id => Node.Id;
             
-            public void SendNewTransactions(IEnumerable<(Transaction Tx, bool IsPersistent)> txs) { }
+            public void SendNewTransactions(IEnumerable<Transaction> txs) { }
 
             public Task<TxReceipt[][]> GetReceipts(IReadOnlyList<Keccak> blockHash, CancellationToken token)
             {

--- a/src/Nethermind/Nethermind.TxPool.Test/TxBroadcasterTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxBroadcasterTests.cs
@@ -85,13 +85,13 @@ public class TxBroadcasterTests
                 .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeys[i])
                 .TestObject;
                 
-            _broadcaster.StartBroadcast(transactions[i]);
+            _broadcaster.Broadcast(transactions[i], true);
         }
         
         _broadcaster.GetSnapshot().Length.Should().Be(addedTxsCount);
 
         ITxPoolPeer txPoolPeer = Substitute.For<ITxPoolPeer>();
-        List<Transaction> pickedTxs = _broadcaster.GetTxsToSend(txPoolPeer, ArraySegment<Transaction>.Empty).ToList();
+        List<Transaction> pickedTxs = _broadcaster.GetTxsToSend(txPoolPeer, Array.Empty<Transaction>()).ToList();
 
         int expectedCount = threshold <= 0 ? 0 : Math.Min(addedTxsCount * threshold / 100 + 1, addedTxsCount);
         pickedTxs.Count.Should().Be(expectedCount);
@@ -137,13 +137,13 @@ public class TxBroadcasterTests
                 .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeys[i])
                 .TestObject;
                 
-            _broadcaster.StartBroadcast(transactions[i]);
+            _broadcaster.Broadcast(transactions[i], true);
         }
         
         _broadcaster.GetSnapshot().Length.Should().Be(addedTxsCount);
 
         ITxPoolPeer txPoolPeer = Substitute.For<ITxPoolPeer>();
-        List<Transaction> pickedTxs = _broadcaster.GetTxsToSend(txPoolPeer, ArraySegment<Transaction>.Empty).ToList();
+        List<Transaction> pickedTxs = _broadcaster.GetTxsToSend(txPoolPeer, Array.Empty<Transaction>()).ToList();
 
         int expectedCount = threshold <= 0 ? 0 : Math.Min(addedTxsCount * threshold / 100 + 1, addedTxsCount - currentBaseFeeInGwei);
         pickedTxs.Count.Should().Be(expectedCount);
@@ -190,13 +190,13 @@ public class TxBroadcasterTests
                 .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeys[i])
                 .TestObject;
                 
-            _broadcaster.StartBroadcast(transactions[i]);
+            _broadcaster.Broadcast(transactions[i], true);
         }
         
         _broadcaster.GetSnapshot().Length.Should().Be(addedTxsCount);
 
         ITxPoolPeer txPoolPeer = Substitute.For<ITxPoolPeer>();
-        List<Transaction> pickedTxs = _broadcaster.GetTxsToSend(txPoolPeer, ArraySegment<Transaction>.Empty).ToList();
+        List<Transaction> pickedTxs = _broadcaster.GetTxsToSend(txPoolPeer, Array.Empty<Transaction>()).ToList();
 
         int expectedCount = threshold <= 0 ? 0 : Math.Min(addedTxsCount * threshold / 100 + 1, addedTxsCount - currentBaseFeeInGwei);
         pickedTxs.Count.Should().Be(expectedCount);

--- a/src/Nethermind/Nethermind.TxPool.Test/TxBroadcasterTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxBroadcasterTests.cs
@@ -63,10 +63,6 @@ public class TxBroadcasterTests
     
     [TestCase(0)]
     [TestCase(1)]
-    [TestCase(2)]
-    [TestCase(99)]
-    [TestCase(100)]
-    [TestCase(101)]
     [TestCase(1000)]
     [TestCase(-10)]
     public void should_pick_best_persistent_txs_to_broadcast(int threshold)
@@ -90,28 +86,14 @@ public class TxBroadcasterTests
         
         _broadcaster.GetSnapshot().Length.Should().Be(addedTxsCount);
 
-        ITxPoolPeer txPoolPeer = Substitute.For<ITxPoolPeer>();
-        List<Transaction> pickedTxs = _broadcaster.GetTxsToSend(txPoolPeer, Array.Empty<Transaction>()).ToList();
+        List<Transaction> pickedTxs = _broadcaster.GetPersistentTxsToSend().ToList();
 
-        int expectedCount = threshold <= 0 ? 0 : Math.Min(addedTxsCount * threshold / 100 + 1, addedTxsCount);
+        int expectedCount = threshold <= 0 ? 0 : addedTxsCount;
         pickedTxs.Count.Should().Be(expectedCount);
-
-        List<Transaction> expectedTxs = new();
-
-        for (int i = 1; i <= expectedCount; i++)
-        {
-            expectedTxs.Add(transactions[addedTxsCount - i]);
-        }
-
-        expectedTxs.Should().BeEquivalentTo(pickedTxs);
     }
     
     [TestCase(0)]
     [TestCase(1)]
-    [TestCase(2)]
-    [TestCase(99)]
-    [TestCase(100)]
-    [TestCase(101)]
     [TestCase(1000)]
     [TestCase(-10)]
     public void should_not_pick_txs_with_GasPrice_lower_than_CurrentBaseFee(int threshold)
@@ -142,10 +124,9 @@ public class TxBroadcasterTests
         
         _broadcaster.GetSnapshot().Length.Should().Be(addedTxsCount);
 
-        ITxPoolPeer txPoolPeer = Substitute.For<ITxPoolPeer>();
-        List<Transaction> pickedTxs = _broadcaster.GetTxsToSend(txPoolPeer, Array.Empty<Transaction>()).ToList();
+        List<Transaction> pickedTxs = _broadcaster.GetPersistentTxsToSend().ToList();
 
-        int expectedCount = threshold <= 0 ? 0 : Math.Min(addedTxsCount * threshold / 100 + 1, addedTxsCount - currentBaseFeeInGwei);
+        int expectedCount = threshold <= 0 ? 0 : addedTxsCount - currentBaseFeeInGwei;
         pickedTxs.Count.Should().Be(expectedCount);
 
         List<Transaction> expectedTxs = new();
@@ -160,10 +141,6 @@ public class TxBroadcasterTests
     
     [TestCase(0)]
     [TestCase(1)]
-    [TestCase(2)]
-    [TestCase(99)]
-    [TestCase(100)]
-    [TestCase(101)]
     [TestCase(1000)]
     [TestCase(-10)]
     public void should_not_pick_1559_txs_with_MaxFeePerGas_lower_than_CurrentBaseFee(int threshold)
@@ -195,10 +172,9 @@ public class TxBroadcasterTests
         
         _broadcaster.GetSnapshot().Length.Should().Be(addedTxsCount);
 
-        ITxPoolPeer txPoolPeer = Substitute.For<ITxPoolPeer>();
-        List<Transaction> pickedTxs = _broadcaster.GetTxsToSend(txPoolPeer, Array.Empty<Transaction>()).ToList();
+        List<Transaction> pickedTxs = _broadcaster.GetPersistentTxsToSend().ToList();
 
-        int expectedCount = threshold <= 0 ? 0 : Math.Min(addedTxsCount * threshold / 100 + 1, addedTxsCount - currentBaseFeeInGwei);
+        int expectedCount = threshold <= 0 ? 0 : addedTxsCount - currentBaseFeeInGwei;
         pickedTxs.Count.Should().Be(expectedCount);
 
         List<Transaction> expectedTxs = new();

--- a/src/Nethermind/Nethermind.TxPool.Test/TxBroadcasterTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxBroadcasterTests.cs
@@ -85,13 +85,13 @@ public class TxBroadcasterTests
                 .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeys[i])
                 .TestObject;
                 
-            _broadcaster.Broadcast(transactions[i], true);
+            _broadcaster.StartBroadcast(transactions[i]);
         }
         
         _broadcaster.GetSnapshot().Length.Should().Be(addedTxsCount);
 
         ITxPoolPeer txPoolPeer = Substitute.For<ITxPoolPeer>();
-        List<Transaction> pickedTxs = _broadcaster.GetTxsToSend(txPoolPeer, Array.Empty<Transaction>()).Select(t => t.Tx).ToList();
+        List<Transaction> pickedTxs = _broadcaster.GetTxsToSend(txPoolPeer, ArraySegment<Transaction>.Empty).ToList();
 
         int expectedCount = threshold <= 0 ? 0 : Math.Min(addedTxsCount * threshold / 100 + 1, addedTxsCount);
         pickedTxs.Count.Should().Be(expectedCount);
@@ -137,13 +137,13 @@ public class TxBroadcasterTests
                 .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeys[i])
                 .TestObject;
                 
-            _broadcaster.Broadcast(transactions[i], true);
+            _broadcaster.StartBroadcast(transactions[i]);
         }
         
         _broadcaster.GetSnapshot().Length.Should().Be(addedTxsCount);
 
         ITxPoolPeer txPoolPeer = Substitute.For<ITxPoolPeer>();
-        List<Transaction> pickedTxs = _broadcaster.GetTxsToSend(txPoolPeer, Array.Empty<Transaction>()).Select(t => t.Tx).ToList();
+        List<Transaction> pickedTxs = _broadcaster.GetTxsToSend(txPoolPeer, ArraySegment<Transaction>.Empty).ToList();
 
         int expectedCount = threshold <= 0 ? 0 : Math.Min(addedTxsCount * threshold / 100 + 1, addedTxsCount - currentBaseFeeInGwei);
         pickedTxs.Count.Should().Be(expectedCount);
@@ -190,13 +190,13 @@ public class TxBroadcasterTests
                 .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeys[i])
                 .TestObject;
                 
-            _broadcaster.Broadcast(transactions[i], true);
+            _broadcaster.StartBroadcast(transactions[i]);
         }
         
         _broadcaster.GetSnapshot().Length.Should().Be(addedTxsCount);
 
         ITxPoolPeer txPoolPeer = Substitute.For<ITxPoolPeer>();
-        List<Transaction> pickedTxs = _broadcaster.GetTxsToSend(txPoolPeer, Array.Empty<Transaction>()).Select(t => t.Tx).ToList();
+        List<Transaction> pickedTxs = _broadcaster.GetTxsToSend(txPoolPeer, ArraySegment<Transaction>.Empty).ToList();
 
         int expectedCount = threshold <= 0 ? 0 : Math.Min(addedTxsCount * threshold / 100 + 1, addedTxsCount - currentBaseFeeInGwei);
         pickedTxs.Count.Should().Be(expectedCount);

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -1018,7 +1018,7 @@ namespace Nethermind.TxPool.Test
             ITxPoolPeer txPoolPeer = Substitute.For<ITxPoolPeer>();
             txPoolPeer.Id.Returns(TestItem.PublicKeyA);
             _txPool.AddPeer(txPoolPeer);
-            txPoolPeer.Received().SendNewTransactions(Arg.Any<IEnumerable<Transaction>>());
+            txPoolPeer.Received().SendNewTransactions(Arg.Any<IEnumerable<Transaction>>(), false);
         }
         
         [Test]
@@ -1030,7 +1030,7 @@ namespace Nethermind.TxPool.Test
             _txPool.AddPeer(txPoolPeer);
             Transaction tx = AddTransactionToPool();
             await Task.Delay(500);
-            txPoolPeer.Received(1).SendNewTransactions(Arg.Any<IEnumerable<Transaction>>());
+            txPoolPeer.Received(1).SendNewTransactions(Arg.Any<IEnumerable<Transaction>>(), false);
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
@@ -146,21 +146,6 @@ namespace Nethermind.TxPool.Collections
         }
         
         /// <summary>
-        /// Returns best element of each bucket in supplied comparer order.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.Synchronized)]
-        public IEnumerable<TValue> GetFirsts()
-        {
-            SortedSet<TValue> sortedValues = new(_sortedComparer);
-            foreach (KeyValuePair<TGroupKey, SortedSet<TValue>> bucket in _buckets)
-            {
-                sortedValues.Add(bucket.Value.Max!);
-            }
-
-            return sortedValues;
-        }
-        
-        /// <summary>
         /// Gets last element in supplied comparer order.
         /// </summary>
         [MethodImpl(MethodImplOptions.Synchronized)]

--- a/src/Nethermind/Nethermind.TxPool/ITxPoolPeer.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxPoolPeer.cs
@@ -16,7 +16,6 @@
 // 
 
 using System.Collections.Generic;
-using System.Linq;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 
@@ -27,7 +26,6 @@ namespace Nethermind.TxPool
         public PublicKey Id { get; }
         public string Enode => string.Empty;
         void SendNewTransaction(Transaction tx) => SendNewTransactions(new[]{tx});
-        void SendNewTransactions(IEnumerable<(Transaction Tx, bool IsPersistent)> txs);
-        void SendNewTransactions(IEnumerable<Transaction> txs)  => SendNewTransactions(txs.Select(t => (t, false)));
+        void SendNewTransactions(IEnumerable<Transaction> txs);
     }
 }

--- a/src/Nethermind/Nethermind.TxPool/ITxPoolPeer.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxPoolPeer.cs
@@ -25,7 +25,7 @@ namespace Nethermind.TxPool
     {
         public PublicKey Id { get; }
         public string Enode => string.Empty;
-        void SendNewTransaction(Transaction tx) => SendNewTransactions(new[]{tx});
-        void SendNewTransactions(IEnumerable<Transaction> txs);
+        void SendNewTransaction(Transaction tx) => SendNewTransactions(new[]{tx}, true);
+        void SendNewTransactions(IEnumerable<Transaction> txs, bool sendFullTx);
     }
 }

--- a/src/Nethermind/Nethermind.TxPool/PeerInfo.cs
+++ b/src/Nethermind/Nethermind.TxPool/PeerInfo.cs
@@ -26,7 +26,7 @@ namespace Nethermind.TxPool
     {
         private ITxPoolPeer Peer { get; }
 
-        private LruKeyCache<Keccak> NotifiedTransactions { get; } = new(2 * MemoryAllowance.MemPoolSize, "notifiedTransactions");
+        private LruKeyCache<Keccak> NotifiedTransactions { get; } = new(MemoryAllowance.MemPoolSize, "notifiedTransactions");
 
         public PeerInfo(ITxPoolPeer peer)
         {
@@ -37,10 +37,7 @@ namespace Nethermind.TxPool
 
         public void SendNewTransaction(Transaction tx)
         {
-            if (NotifiedTransactions.Set(tx.Hash))
-            {
-                Peer.SendNewTransaction(tx);
-            }
+            Peer.SendNewTransaction(tx);
         }
 
         public void SendNewTransactions(IEnumerable<Transaction> txs, bool sendFullTx)

--- a/src/Nethermind/Nethermind.TxPool/PeerInfo.cs
+++ b/src/Nethermind/Nethermind.TxPool/PeerInfo.cs
@@ -43,16 +43,16 @@ namespace Nethermind.TxPool
             }
         }
 
-        public void SendNewTransactions(IEnumerable<Transaction> txs)
+        public void SendNewTransactions(IEnumerable<Transaction> txs, bool sendFullTx)
         {
-            Peer.SendNewTransactions(GetTxsToSendAndMarkAsNotified(txs));
+            Peer.SendNewTransactions(GetTxsToSendAndMarkAsNotified(txs, sendFullTx), sendFullTx);
         }
 
-        private IEnumerable<Transaction> GetTxsToSendAndMarkAsNotified(IEnumerable<Transaction> txs)
+        private IEnumerable<Transaction> GetTxsToSendAndMarkAsNotified(IEnumerable<Transaction> txs, bool sendFullTx)
         {
             foreach (Transaction tx in txs)
             {
-                if (NotifiedTransactions.Set(tx.Hash))
+                if (sendFullTx || NotifiedTransactions.Set(tx.Hash))
                 {
                     yield return tx;
                 }

--- a/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
@@ -193,7 +193,7 @@ namespace Nethermind.TxPool
             _timer.Enabled = true;
         }
 
-        internal IEnumerable<Transaction> GetTxsToSend(ITxPoolPeer peer, IEnumerable<Transaction> txsToSend)
+        private IEnumerable<Transaction> GetTxsToSend(ITxPoolPeer peer, IEnumerable<Transaction> txsToSend)
         {
             foreach (Transaction tx in txsToSend)
             {

--- a/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
@@ -106,7 +106,7 @@ namespace Nethermind.TxPool
                 BroadcastOnce(tx);
             }
         }
-        
+
         private void StartBroadcast(Transaction tx)
         {
             NotifyPeersAboutLocalTx(tx);

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -165,6 +165,7 @@ namespace Nethermind.TxPool
                             ReAddReorganisedTransactions(args.PreviousBlock);
                             RemoveProcessedTransactions(args.Block.Transactions);
                             UpdateBuckets();
+                            _broadcaster.BroadcastPersistentTxs();
                             Metrics.TransactionCount = _transactions.Count;
                         }
                         catch (Exception e)
@@ -320,14 +321,7 @@ namespace Nethermind.TxPool
                 }
             }
 
-            if (isPersistentBroadcast)
-            {
-                _broadcaster.StartBroadcast(tx);
-            }
-            else
-            {
-                _broadcaster.BroadcastOnce(tx);
-            }
+            _broadcaster.Broadcast(tx, isPersistentBroadcast);
 
             _hashCache.SetLongTerm(tx.Hash!);
             NewPending?.Invoke(this, new TxEventArgs(tx));

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -320,7 +320,14 @@ namespace Nethermind.TxPool
                 }
             }
 
-            _broadcaster.Broadcast(tx, isPersistentBroadcast);
+            if (isPersistentBroadcast)
+            {
+                _broadcaster.StartBroadcast(tx);
+            }
+            else
+            {
+                _broadcaster.BroadcastOnce(tx);
+            }
 
             _hashCache.SetLongTerm(tx.Hash!);
             NewPending?.Invoke(this, new TxEventArgs(tx));


### PR DESCRIPTION
## Changes:
- we are broadcasting hashes of recently incoming txs every 1s. We were including small amount of hashes of persistent txs to every message. Now we will not include it.
- we will send txs from persistent broadcast as full transactions after processing of every block. Every tx with `MaxFeePerGas > BaseFee` will be rebroadcasted.
- this change is fixing a bug reported by POA - transaction with currently too low fee should be rebroadcasted and mined right after base fee drop (we were sending only hashes and `_pendingHashes` in `PooledTxsRequestor` were blocking every hash after first ask)

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [x] No

I refactored already existing tests