### PR TITLE
Move logged request param size to json rpc config

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcServiceTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcServiceTests.cs
@@ -61,7 +61,7 @@ namespace Nethermind.JsonRpc.Test
         {
             RpcModuleProvider moduleProvider = new(new FileSystem(), _configurationProvider.GetConfig<IJsonRpcConfig>(), LimboLogs.Instance);
             moduleProvider.Register(new SingletonModulePool<T>(new SingletonFactory<T>(module), true));
-            _jsonRpcService = new JsonRpcService(moduleProvider, _logManager);
+            _jsonRpcService = new JsonRpcService(moduleProvider, _logManager, new JsonRpcConfig());
             JsonRpcRequest request = RpcTest.GetJsonRequest(method, parameters);
             JsonRpcResponse response = _jsonRpcService.SendRequestAsync(request, _context).Result;
             Assert.AreEqual(request.Id, response.Id);

--- a/src/Nethermind/Nethermind.JsonRpc.Test/RpcTest.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/RpcTest.cs
@@ -83,7 +83,7 @@ namespace Nethermind.JsonRpc.Test
             var moduleProvider = new TestRpcModuleProvider<T>(module);
 
             moduleProvider.Register(new SingletonModulePool<T>(new TestSingletonFactory<T>(module, converters), true));
-            IJsonRpcService service = new JsonRpcService(moduleProvider, LimboLogs.Instance);
+            IJsonRpcService service = new JsonRpcService(moduleProvider, LimboLogs.Instance, new JsonRpcConfig());
             return service;
         }
 

--- a/src/Nethermind/Nethermind.JsonRpc/IJsonRpcConfig.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/IJsonRpcConfig.cs
@@ -108,5 +108,10 @@ namespace Nethermind.JsonRpc
                           "If this limit is exceeded on Http calls 503 Service Unavailable will be returned along with Json RPC error. " +
                           "Defaults to number of logical processes.")]
         int? EthModuleConcurrentInstances { get; set; }
+
+        [ConfigItem(
+            Description = "Max logged request size",
+            DefaultValue = "2000")]
+        int maxLoggedRequestSize { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/IJsonRpcConfig.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/IJsonRpcConfig.cs
@@ -111,7 +111,7 @@ namespace Nethermind.JsonRpc
 
         [ConfigItem(
             Description = "Max logged request size",
-            DefaultValue = "2000")]
-        int maxLoggedRequestSize { get; set; }
+            DefaultValue = "None")]
+        int? MaxLoggedRequestSize { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcConfig.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcConfig.cs
@@ -49,6 +49,6 @@ namespace Nethermind.JsonRpc
         public string CallsFilterFilePath { get; set; } = "Data/jsonrpc.filter";
         public long? MaxRequestBodySize { get; set; } = 30000000;
         public int? EthModuleConcurrentInstances { get; set; } = null;
-        public int maxLoggedRequestSize { get; set; } = 2000;
+        public int? MaxLoggedRequestSize { get; set; } = null;
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcConfig.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcConfig.cs
@@ -49,5 +49,6 @@ namespace Nethermind.JsonRpc
         public string CallsFilterFilePath { get; set; } = "Data/jsonrpc.filter";
         public long? MaxRequestBodySize { get; set; } = 30000000;
         public int? EthModuleConcurrentInstances { get; set; } = null;
+        public int maxLoggedRequestSize { get; set; } = 2000;
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
@@ -38,12 +38,14 @@ namespace Nethermind.JsonRpc
         private readonly ILogger _logger;
         private readonly IRpcModuleProvider _rpcModuleProvider;
         private readonly JsonSerializer _serializer;
+        private readonly IJsonRpcConfig _jsonRpcConfig;
 
-        public JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogManager logManager)
+        public JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogManager logManager, IJsonRpcConfig jsonRpcConfig)
         {
             _logger = logManager.GetClassLogger();
             _rpcModuleProvider = rpcModuleProvider;
             _serializer = new JsonSerializer();
+            _jsonRpcConfig = jsonRpcConfig ?? throw new ArgumentNullException(nameof(jsonRpcConfig));
 
             List<JsonConverter> converterList = new();
             foreach (JsonConverter converter in rpcModuleProvider.Converters)
@@ -122,8 +124,8 @@ namespace Nethermind.JsonRpc
             if (_logger.IsInfo)
             {
                 var paramStr = string.Join(',', providedParameters);
-                const int maxParamsLength = 2000; // ToDo move it to JSON RPC config as max logged request size?
-                var paramStrAdjusted = paramStr.Substring(0, Math.Min(paramStr.Length, maxParamsLength));
+                var paramStrAdjusted = paramStr.Substring(0, Math.Min(paramStr.Length, _jsonRpcConfig.maxLoggedRequestSize));
+                if (paramStrAdjusted.Length < paramStr.Length) paramStrAdjusted += "...";
                 _logger.Info($"Executing JSON RPC call {methodName} with params [{paramStrAdjusted}]");
             }
 

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
@@ -124,7 +124,7 @@ namespace Nethermind.JsonRpc
             if (_logger.IsInfo)
             {
                 var paramStr = string.Join(',', providedParameters);
-                var paramStrAdjusted = paramStr.Substring(0, Math.Min(paramStr.Length, _jsonRpcConfig.maxLoggedRequestSize));
+                var paramStrAdjusted = paramStr.Substring(0, Math.Min(paramStr.Length, _jsonRpcConfig.MaxLoggedRequestSize ?? paramStr.Length));
                 if (paramStrAdjusted.Length < paramStr.Length) paramStrAdjusted += "...";
                 _logger.Info($"Executing JSON RPC call {methodName} with params [{paramStrAdjusted}]");
             }

--- a/src/Nethermind/Nethermind.Runner/Ethereum/Steps/StartRpc.cs
+++ b/src/Nethermind/Nethermind.Runner/Ethereum/Steps/StartRpc.cs
@@ -53,7 +53,7 @@ namespace Nethermind.Runner.Ethereum.Steps
                     jsonRpcConfig,
                     _api.LogManager);
 
-                JsonRpcService jsonRpcService = new(_api.RpcModuleProvider, _api.LogManager);
+                JsonRpcService jsonRpcService = new(_api.RpcModuleProvider, _api.LogManager, new JsonRpcConfig());
                 IJsonSerializer jsonSerializer = CreateJsonSerializer(jsonRpcService);
 
                 JsonRpcProcessor jsonRpcProcessor = new(


### PR DESCRIPTION

## Changes:
Add max logged size parameter to JSON RPC config which sets the maximum length of logged JSON RPC service parameters

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [x] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [x] No
