### PR TITLE
IL Virtual Machine

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/IlVirtualMachineTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/IlVirtualMachineTests.cs
@@ -1,0 +1,237 @@
+//  Copyright (c) 2021 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
+
+using System;
+using System.Buffers.Binary;
+using System.Diagnostics;
+using Nethermind.Core.Test;
+using Nethermind.Logging;
+using NUnit.Framework;
+
+namespace Nethermind.Evm.Test;
+
+public class IlVirtualMachineTests : VirtualMachineTestsBase
+{
+    protected override ILogManager GetLogManager() => new NUnitLogManager();
+
+    [Test]
+    public void PC_POP()
+    {
+        Machine.BuildILForNext();
+
+        byte[] code = Prepare.EvmCode
+            .Op(Instruction.PC)
+            .Op(Instruction.POP)
+            .Done;
+
+        TestAllTracerWithOutput result = Execute(code);
+
+        Console.WriteLine(result.Error);
+    }
+
+    [Test]
+    public void Jump_Invalid()
+    {
+        Machine.BuildILForNext();
+
+        byte[] code = Prepare.EvmCode
+            .PushData(1)
+            .Op(Instruction.JUMP)
+            .Done;
+
+        TestAllTracerWithOutput result = Execute(code);
+
+        Assert.AreEqual(result.Error, EvmExceptionType.InvalidJumpDestination.ToString());
+    }
+
+    [Test]
+    public void Jump_Valid()
+    {
+        Machine.BuildILForNext();
+
+        byte[] code = Prepare.EvmCode
+            .PushData(3)
+            .Op(Instruction.JUMP)
+            .Op(Instruction.JUMPDEST)
+            .Done;
+
+        TestAllTracerWithOutput result = Execute(code);
+
+        Console.WriteLine(result.Error);
+    }
+
+    [Test]
+    public void Jumpi_InvalidCondition()
+    {
+        Machine.BuildILForNext();
+
+        byte[] code = Prepare.EvmCode
+            .PushData(0) // invalid condition
+            .PushData(1) // address
+            .Op(Instruction.JUMPI)
+            .Done;
+
+        TestAllTracerWithOutput result = Execute(code);
+
+        Console.WriteLine(result.Error);
+    }
+
+    [Test]
+    public void Jumpi_ValidCondition_InvalidAddress()
+    {
+        Machine.BuildILForNext();
+
+        byte[] code = Prepare.EvmCode
+            .PushData(1) // valid condition
+            .PushData(1) // address
+            .Op(Instruction.JUMPI)
+            .Done;
+
+        TestAllTracerWithOutput result = Execute(code);
+
+        Assert.AreEqual(result.Error, EvmExceptionType.InvalidJumpDestination.ToString());
+    }
+
+    [Test]
+    public void Jumpi_ValidCondition_ValidAddress()
+    {
+        Machine.BuildILForNext();
+
+        byte[] code = Prepare.EvmCode
+            .PushData(1) // valid condition
+            .PushData(5) // address
+            .Op(Instruction.JUMPI)
+            .Op(Instruction.JUMPDEST)
+            .Done;
+
+        TestAllTracerWithOutput result = Execute(code);
+
+        Console.WriteLine(result.Error);
+    }
+
+    [Test]
+    public void Sub()
+    {
+        Machine.BuildILForNext();
+
+        byte[] code = Prepare.EvmCode
+            .PushData(1)
+            .PushData(2)
+            .PushData(1)
+            .PushData(4)
+            .Op(Instruction.SUB)    // 4 - 1 = 3
+            .Op(Instruction.SUB)    // 3 - 2 = 1
+            .Op(Instruction.SUB)    // 1 - 1 = 0
+            .Done;
+
+        TestAllTracerWithOutput result = Execute(code);
+
+        Console.WriteLine(result.Error);
+    }
+
+    [Test]
+    public void Dup()
+    {
+        Machine.BuildILForNext();
+
+        byte[] code = Prepare.EvmCode
+            .PushData(1)
+            .Op(Instruction.DUP1)
+            .Op(Instruction.SUB)
+            .Op(Instruction.POP)
+            .Done;
+
+        TestAllTracerWithOutput result = Execute(code);
+
+        Console.WriteLine(result.Error);
+    }
+
+    [Test]
+    public void Swap()
+    {
+        Machine.BuildILForNext();
+
+        byte[] code = Prepare.EvmCode
+            .PushData(2)
+            .PushData(1)
+            .Op(Instruction.SWAP1)
+            .Op(Instruction.SUB)
+            .Done;
+
+        TestAllTracerWithOutput result = Execute(code);
+
+        Console.WriteLine(result.Error);
+    }
+
+    //[Test]
+    //public void OutOfGas()
+    //{
+    //    // an infinite loop
+    //    byte[] code = Prepare.EvmCode
+    //        .Op(Instruction.JUMPDEST)
+    //        .PushData(0)
+    //        .Op(Instruction.JUMP)
+    //        .Done;
+
+    //    TestAllTracerWithOutput result = Execute(BlockNumber, 10000, code);
+
+    //    Assert.AreEqual(result.Error, EvmExceptionType.OutOfGas.ToString());
+    //}
+
+    [TestCase(true, TestName = "IL")]
+    [TestCase(false, TestName = "Interpreter")]
+    [Explicit]
+    public void Long_Loop(bool isIL)
+    {
+        if (isIL)
+        {
+            Machine.BuildILForNext();
+        }
+
+        const int loopCount = 200_000;
+        byte[] repeat = new byte[4];
+        BinaryPrimitives.TryWriteInt32BigEndian(repeat, loopCount);
+
+        Prepare code = Prepare.EvmCode
+            .PushData(repeat)
+            .Op(Instruction.JUMPDEST) // counter
+            .PushData(1) // counter, 1
+            .Op(Instruction.SWAP1) // 1, counter
+            .Op(Instruction.SUB) // counter-1
+            .Op(Instruction.DUP1) // counter-1, counter-1
+            .PushData(1 + repeat.Length) // counter-1, counter-1, 2
+            .Op(Instruction.JUMPI);      // counter-1
+
+        if (isIL)
+        {
+            // differentiate by adding one point
+            code = code.Op(Instruction.POP);
+        }
+
+        // warmup
+        Execute(BlockNumber, 10_000, code.Done);
+
+        Stopwatch sw = Stopwatch.StartNew();
+
+        TestAllTracerWithOutput result = Execute(BlockNumber, 7_000_000, code.Done);
+
+        const int n = 1_000;
+
+        Console.WriteLine($"Execution of {loopCount} took {sw.Elapsed} taking {((double)sw.ElapsedMilliseconds * n) / loopCount}ms per {n} spins");
+        Console.WriteLine(result.Error);
+    }
+}

--- a/src/Nethermind/Nethermind.Evm/CodeAnalysis/CodeInfo.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeAnalysis/CodeInfo.cs
@@ -1,4 +1,4 @@
-﻿//  Copyright (c) 2021 Demerzel Solutions Limited
+//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
 // 
 //  The Nethermind library is free software: you can redistribute it and/or modify
@@ -15,9 +15,6 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
 using System;
-using System.Collections;
-using System.Reflection.PortableExecutable;
-using System.Threading;
 using Nethermind.Evm.Precompiles;
 
 namespace Nethermind.Evm.CodeAnalysis
@@ -27,22 +24,30 @@ namespace Nethermind.Evm.CodeAnalysis
         private const int SampledCodeLength = 10_001;
         private const int PercentageOfPush1 = 40;
         private const int NumberOfSamples = 100;
-        private static Random _rand = new();
         
-        public byte[] MachineCode { get; set; }
-        public IPrecompile? Precompile { get; set; }
+        public byte[] MachineCode { get; }
+        public IPrecompile? Precompile => _data as IPrecompile;
+
+        /// <summary>
+        /// Raw additional data stored for this.
+        /// </summary>
+        public object? Data => _data;
+
+        private readonly object? _data;
+
         private ICodeInfoAnalyzer? _analyzer;
 
-        public CodeInfo(byte[] code)
+        public CodeInfo(byte[] code, object? data = null)
         {
             MachineCode = code;
+            _data = data;
         }
 
-        public bool IsPrecompile => Precompile != null;
+        public bool IsPrecompile => _data is IPrecompile;
         
         public CodeInfo(IPrecompile precompile)
         {
-            Precompile = precompile;
+            _data = precompile;
             MachineCode = Array.Empty<byte>();
         }
 
@@ -69,7 +74,7 @@ namespace Nethermind.Evm.CodeAnalysis
                 // we check (by sampling randomly) how many PUSH1 instructions are in the code
                 for (int i = 0; i < NumberOfSamples; i++)
                 {
-                    byte instruction = MachineCode[_rand.Next(0, MachineCode.Length)];
+                    byte instruction = MachineCode[Random.Shared.Next(0, MachineCode.Length)];
 
                     // PUSH1
                     if (instruction == 0x60)

--- a/src/Nethermind/Nethermind.Evm/IL/EmitExtensions.cs
+++ b/src/Nethermind/Nethermind.Evm/IL/EmitExtensions.cs
@@ -1,0 +1,220 @@
+//  Copyright (c) 2021 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
+
+using System;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace Nethermind.Evm.IL;
+
+/// <summary>
+/// Extensions for <see cref="ILGenerator"/>.
+/// </summary>
+static class EmitExtensions
+{
+    public static void Load(this ILGenerator il, LocalBuilder local)
+    {
+        switch (local.LocalIndex)
+        {
+            case 0:
+                il.Emit(OpCodes.Ldloc_0);
+                break;
+            case 1:
+                il.Emit(OpCodes.Ldloc_1);
+                break;
+            case 2:
+                il.Emit(OpCodes.Ldloc_2);
+                break;
+            case 3:
+                il.Emit(OpCodes.Ldloc_3);
+                break;
+            default:
+                if (local.LocalIndex < 255)
+                {
+                    il.Emit(OpCodes.Ldloc_S, (byte)local.LocalIndex);
+                }
+                else
+                {
+                    il.Emit(OpCodes.Ldloc, local.LocalIndex);
+                }
+                break;
+        }
+    }
+
+    public static void LoadAddress(this ILGenerator il, LocalBuilder local)
+    {
+        if (local.LocalIndex <= 255)
+        {
+            il.Emit(OpCodes.Ldloca_S, (byte)local.LocalIndex);
+        }
+        else
+        {
+            il.Emit(OpCodes.Ldloca, local.LocalIndex);
+        }
+    }
+
+    public static void Load(this ILGenerator il, LocalBuilder local, FieldInfo wordField)
+    {
+        if (local.LocalType != typeof(Word*))
+        {
+            throw new ArgumentException($"Only Word* can be used. This variable is of type {local.LocalType}");
+        }
+
+        if (wordField.DeclaringType != typeof(Word))
+        {
+            throw new ArgumentException($"Only Word fields can be used. This field is declared for {wordField.DeclaringType}");
+        }
+
+        il.Load(local);
+        il.Emit(OpCodes.Ldfld, wordField);
+    }
+
+    public static void CleanWord(this ILGenerator il, LocalBuilder local)
+    {
+        if (local.LocalType != typeof(Word*))
+        {
+            throw new ArgumentException(
+                $"Only {nameof(Word)} pointers are supported. The passed local was type of {local.LocalType}.");
+        }
+
+        il.Load(local);
+        il.Emit(OpCodes.Initobj, typeof(Word));
+    }
+
+    /// <summary>
+    /// Advances the stack one word up.
+    /// </summary>
+    public static void StackPush(this ILGenerator il, LocalBuilder local)
+    {
+        il.Load(local);
+        il.LoadValue(Word.Size);
+        il.Emit(OpCodes.Conv_I);
+        il.Emit(OpCodes.Add);
+        il.Store(local);
+    }
+
+    /// <summary>
+    /// Moves the stack <paramref name="count"/> words down.
+    /// </summary>
+    public static void StackPop(this ILGenerator il, LocalBuilder local, int count = 1)
+    {
+        il.Load(local);
+        il.LoadValue(Word.Size * count);
+        il.Emit(OpCodes.Conv_I);
+        il.Emit(OpCodes.Sub);
+        il.Store(local);
+    }
+
+    /// <summary>
+    /// Moves the stack <paramref name="count"/> words down.
+    /// </summary>
+    public static void StackPop(this ILGenerator il, LocalBuilder local, LocalBuilder count)
+    {
+        il.Load(local);
+        il.LoadValue(Word.Size);
+        il.Load(count);
+        il.Emit(OpCodes.Mul);
+        il.Emit(OpCodes.Conv_I);
+        il.Emit(OpCodes.Sub);
+        il.Store(local);
+    }
+
+    /// <summary>
+    /// Loads the previous EVM stack value on top of .NET stack.
+    /// </summary>
+    public static void StackLoadPrevious(this ILGenerator il, LocalBuilder local, int count = 1)
+    {
+        il.Load(local);
+        il.LoadValue(Word.Size * count);
+        il.Emit(OpCodes.Conv_I);
+        il.Emit(OpCodes.Sub);
+    }
+
+    public static void Store(this ILGenerator il, LocalBuilder local)
+    {
+        switch (local.LocalIndex)
+        {
+            case 0:
+                il.Emit(OpCodes.Stloc_0);
+                break;
+            case 1:
+                il.Emit(OpCodes.Stloc_1);
+                break;
+            case 2:
+                il.Emit(OpCodes.Stloc_2);
+                break;
+            case 3:
+                il.Emit(OpCodes.Stloc_3);
+                break;
+            default:
+                if (local.LocalIndex < 255)
+                {
+                    il.Emit(OpCodes.Stloc_S, (byte)local.LocalIndex);
+                }
+                else
+                {
+                    il.Emit(OpCodes.Stloc, local.LocalIndex);
+                }
+                break;
+        }
+    }
+
+    public static void LoadValue(this ILGenerator il, long value)
+    {
+        il.Emit(OpCodes.Ldc_I8, value);
+    }
+
+    public static void LoadValue(this ILGenerator il, int value)
+    {
+        switch (value)
+        {
+            case 0:
+                il.Emit(OpCodes.Ldc_I4_0);
+                break;
+            case 1:
+                il.Emit(OpCodes.Ldc_I4_1);
+                break;
+            case 2:
+                il.Emit(OpCodes.Ldc_I4_2);
+                break;
+            case 3:
+                il.Emit(OpCodes.Ldc_I4_3);
+                break;
+            case 4:
+                il.Emit(OpCodes.Ldc_I4_4);
+                break;
+            case 5:
+                il.Emit(OpCodes.Ldc_I4_5);
+                break;
+            case 6:
+                il.Emit(OpCodes.Ldc_I4_6);
+                break;
+            case 7:
+                il.Emit(OpCodes.Ldc_I4_7);
+                break;
+            case 8:
+                il.Emit(OpCodes.Ldc_I4_8);
+                break;
+            default:
+                if (value <= 255)
+                    il.Emit(OpCodes.Ldc_I4_S, (byte)value);
+                else
+                    il.Emit(OpCodes.Ldc_I4, value);
+                break;
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Evm/IL/ILVirtualMachineBuilder.cs
+++ b/src/Nethermind/Nethermind.Evm/IL/ILVirtualMachineBuilder.cs
@@ -1,0 +1,426 @@
+//  Copyright (c) 2021 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
+
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using Iced.Intel;
+using Microsoft.Diagnostics.Runtime;
+using Microsoft.Diagnostics.Runtime.Implementation;
+using Nethermind.Core.Extensions;
+using Nethermind.Int256;
+using Label = System.Reflection.Emit.Label;
+
+namespace Nethermind.Evm.IL;
+
+class ILVirtualMachineBuilder
+{
+    public static Func<long, EvmExceptionType> Build(byte[] code)
+    {
+        Dictionary<int, long> gasCost = BuildCostLookup(code);
+
+        // TODO: stack invariants, gasCost application
+
+        string name = "ILVM_" + Guid.NewGuid();
+
+        DynamicMethod method = new(name, typeof(EvmExceptionType), new[] { typeof(long) }, typeof(ILVirtualMachineBuilder).Assembly.Modules.First(), true)
+        {
+            InitLocals = false
+        };
+
+        ILGenerator il = method.GetILGenerator();
+
+        LocalBuilder jmpDestination = il.DeclareLocal(Word.Int0Field.FieldType);
+        LocalBuilder consumeJumpCondition = il.DeclareLocal(typeof(int));
+        LocalBuilder uint256A = il.DeclareLocal(typeof(UInt256));
+        LocalBuilder uint256B = il.DeclareLocal(typeof(UInt256));
+        LocalBuilder uint256C = il.DeclareLocal(typeof(UInt256));
+
+        LocalBuilder gasAvailable = il.DeclareLocal(typeof(long));
+
+        // TODO: stack check for head
+        LocalBuilder stack = il.DeclareLocal(typeof(Word*));
+        LocalBuilder current = il.DeclareLocal(typeof(Word*));
+
+        const int wordToAlignTo = 32;
+
+        il.Emit(OpCodes.Ldc_I4, EvmStack.MaxStackSize * Word.Size + wordToAlignTo);
+        il.Emit(OpCodes.Localloc);
+
+        // align to the boundary, so that the Word can be written using the aligned longs.
+        il.LoadValue(wordToAlignTo);
+        il.Emit(OpCodes.Conv_I);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ldc_I4, ~(wordToAlignTo - 1));
+        il.Emit(OpCodes.Conv_I);
+        il.Emit(OpCodes.And);
+
+        il.Store(stack); // store as start
+
+        il.Load(stack);
+        il.Store(current); // copy to the current
+
+        // gas
+        il.Emit(OpCodes.Ldarg_0);
+        il.Store(gasAvailable);
+        Label outOfGas = il.DefineLabel();
+
+        Label ret = il.DefineLabel(); // the label just before return
+        Label invalidAddress = il.DefineLabel(); // invalid jump address
+        Label jumpTable = il.DefineLabel(); // jump table
+
+        Dictionary<int, Label> jumpDestinations = new();
+
+        for (int pc = 0; pc < code.Length; pc++)
+        {
+            Operation op = Operation.Operations[(Instruction)code[pc]];
+
+            if (gasCost.TryGetValue(pc, out long required))
+            {
+                // check required > available
+                il.LoadValue(required);
+                il.Load(gasAvailable);
+                il.Emit(OpCodes.Cgt);
+                il.Emit(OpCodes.Brtrue, outOfGas); // jump to out of gas
+
+                // gasAvailable = gasAvailable - required
+                il.Load(gasAvailable);
+                il.LoadValue(required);
+                il.Emit(OpCodes.Sub);
+                il.Store(gasAvailable);
+            }
+
+            switch (op.Instruction)
+            {
+                case Instruction.PC:
+                    il.CleanWord(current);
+                    il.Load(current);
+                    il.LoadValue(BinaryPrimitives.ReverseEndianness(pc)); // TODO: assumes little endian machine
+                    il.Emit(OpCodes.Stfld, Word.UInt0Field);
+                    il.StackPush(current);
+                    break;
+
+                // pushes work as follows
+                // 1. load the next top pointer of the stack
+                // 2. zero it
+                // 3. load the value
+                // 4. set the field
+                // 5. advance pointer
+                case Instruction.PUSH1:
+                    il.Load(current);
+                    il.Emit(OpCodes.Initobj, typeof(Word));
+                    il.Load(current);
+                    byte push1 = (byte)((pc + 1 >= code.Length) ? 0 : code[pc + 1]);
+                    il.Emit(OpCodes.Ldc_I4_S, push1);
+                    il.Emit(OpCodes.Stfld, Word.Byte0Field);
+                    il.StackPush(current);
+                    pc += 1;
+                    break;
+                case Instruction.PUSH2:
+                    il.Load(current);
+                    il.Emit(OpCodes.Initobj, typeof(Word));
+                    il.Load(current);
+
+                    if (pc + 2 >= code.Length)
+                        throw new NotImplementedException("Not handled yet!");
+
+                    if (!BitConverter.IsLittleEndian)
+                        throw new NotImplementedException("Currently only little endian!");
+
+                    il.Emit(OpCodes.Ldc_I4, BinaryPrimitives.ReadInt16LittleEndian(code.Slice(pc + 1)) << 16);
+                    il.Emit(OpCodes.Stfld, Word.Int0Field);
+                    il.StackPush(current);
+                    pc += 2;
+                    break;
+                case Instruction.PUSH4:
+                    il.Load(current);
+                    il.Emit(OpCodes.Initobj, typeof(Word));
+                    il.Load(current);
+
+                    if (pc + 4 >= code.Length)
+                        throw new NotImplementedException("Not handled yet!");
+
+                    if (!BitConverter.IsLittleEndian)
+                        throw new NotImplementedException("Currently only little endian!");
+
+                    il.Emit(OpCodes.Ldc_I4, BinaryPrimitives.ReadInt32LittleEndian(code.Slice(pc + 1)));
+                    il.Emit(OpCodes.Stfld, Word.Int0Field);
+                    il.StackPush(current);
+                    pc += 4;
+                    break;
+                case Instruction.DUP1:
+                    il.Load(current);
+                    il.StackLoadPrevious(current, 1 + op.Instruction - Instruction.DUP1);       // TODO: ready for other DUP_N with the substitution
+                    il.Emit(OpCodes.Ldobj, typeof(Word));
+                    il.Emit(OpCodes.Stobj, typeof(Word));
+                    il.StackPush(current);
+                    break;
+                case Instruction.SWAP1:
+                    // copy to a helper variable the top item
+                    il.LoadAddress(uint256C); // reuse uint as a swap placeholder
+                    il.StackLoadPrevious(current, 1);
+                    il.Emit(OpCodes.Ldobj, typeof(Word));
+                    il.Emit(OpCodes.Stobj, typeof(Word));
+
+                    byte swapWith = 2 + op.Instruction - Instruction.SWAP1; // TODO: ready for other SWAP_N with the substitution
+
+                    // write to the top item
+                    il.StackLoadPrevious(current, 1);
+                    il.StackLoadPrevious(current, swapWith);
+                    il.Emit(OpCodes.Ldobj, typeof(Word));
+                    il.Emit(OpCodes.Stobj, typeof(Word)); // top item overwritten
+
+                    // write to the more nested one from local variable
+                    il.StackLoadPrevious(current, swapWith);
+                    il.LoadAddress(uint256C);
+                    il.Emit(OpCodes.Ldobj, typeof(Word));
+                    il.Emit(OpCodes.Stobj, typeof(Word));
+                    break;
+                case Instruction.POP:
+                    il.StackPop(current);
+                    break;
+                case Instruction.JUMPDEST:
+                    Label dest = il.DefineLabel();
+                    jumpDestinations[pc] = dest;
+                    il.MarkLabel(dest);
+                    break;
+                case Instruction.JUMP:
+                    il.Emit(OpCodes.Br, jumpTable);
+                    break;
+                case Instruction.JUMPI:
+                    Label noJump = il.DefineLabel();
+
+                    il.StackLoadPrevious(current, 2); // load condition that is on the second
+                    il.EmitCall(OpCodes.Call, Word.GetIsZero, null);
+
+                    il.Emit(OpCodes.Brtrue_S, noJump); // if zero, just jump to removal two values and move on
+
+                    // condition is met, mark condition as to be removed
+                    il.LoadValue(1);
+                    il.Store(consumeJumpCondition);
+                    il.Emit(OpCodes.Br, jumpTable);
+
+                    // condition is not met, just consume
+                    il.MarkLabel(noJump);
+                    il.StackPop(current, 2);
+                    break;
+                case Instruction.SUB:
+                    // a
+                    il.StackLoadPrevious(current, 1);
+                    il.EmitCall(OpCodes.Call, Word.GetUInt256, null);
+                    il.Store(uint256A);
+
+                    // b
+                    il.StackLoadPrevious(current, 2);
+                    il.EmitCall(OpCodes.Call, Word.GetUInt256, null); // stack: uint256, uint256
+                    il.Store(uint256B);
+
+                    // a - b = c
+                    il.LoadAddress(uint256A);
+                    il.LoadAddress(uint256B);
+                    il.LoadAddress(uint256C);
+
+                    MethodInfo subtract = typeof(UInt256).GetMethod(nameof(UInt256.Subtract), BindingFlags.Public | BindingFlags.Static)!;
+                    il.EmitCall(OpCodes.Call, subtract, null); // stack: _
+
+                    il.StackPop(current, 2);
+                    il.Load(current);
+                    il.Load(uint256C); // stack: word*, uint256
+                    il.EmitCall(OpCodes.Call, Word.SetUInt256, null);
+                    il.StackPush(current);
+                    break;
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+
+        // jump to return
+        il.LoadValue((int)EvmExceptionType.None);
+        il.Emit(OpCodes.Br, ret);
+
+        // jump table
+        il.MarkLabel(jumpTable);
+
+        il.StackPop(current); // move the stack down to address
+
+        // if (jumpDest > uint.MaxValue)
+        // ULong3 | Ulong2 | Ulong1 | Uint1 | Ushort1
+        il.Load(current, Word.Ulong3Field);
+        il.Load(current, Word.Ulong2Field);
+        il.Emit(OpCodes.Or);
+        il.Load(current, Word.Ulong1Field);
+        il.Emit(OpCodes.Or);
+        il.Load(current, Word.UInt1Field);
+        il.Emit(OpCodes.Conv_U8);
+        il.Emit(OpCodes.Or);
+
+        il.Emit(OpCodes.Brtrue, invalidAddress);
+
+        // emit actual jump table with first switch statement covering fanout of values, then ifs in specific branches
+        const int jumpFanOutLog = 7; // 128
+        const int bitMask = (1 << jumpFanOutLog) - 1;
+
+        Label[] jumps = new Label[jumpFanOutLog];
+        for (int i = 0; i < jumpFanOutLog; i++)
+        {
+            jumps[i] = il.DefineLabel();
+        }
+
+        // save to helper
+        il.Load(current, Word.Int0Field);
+
+        // endianess!
+        il.EmitCall(OpCodes.Call, typeof(BinaryPrimitives).GetMethod(nameof(BinaryPrimitives.ReverseEndianness), BindingFlags.Public | BindingFlags.Static, new[] { typeof(uint) }), null);
+        il.Store(jmpDestination);
+
+        // consume if this was a conditional jump and zero it. Notice that this is a branch-free approach that uses 0 or 1 + multiplication to advance the word pointer or not
+        il.StackPop(current, consumeJumpCondition);
+        il.LoadValue(0);
+        il.Store(consumeJumpCondition);
+
+        // & with mask
+        il.Load(jmpDestination);
+        il.LoadValue(bitMask);
+        il.Emit(OpCodes.And);
+
+        il.Emit(OpCodes.Switch, jumps); // actual jump table to jump directly to the specific range of addresses
+
+        int[] destinations = jumpDestinations.Keys.ToArray();
+
+        for (int i = 0; i < jumpFanOutLog; i++)
+        {
+            il.MarkLabel(jumps[i]);
+
+            // for each destination matching the bit mask emit check for the equality
+            foreach (int dest in destinations.Where(dest => (dest & bitMask) == i))
+            {
+                il.Load(jmpDestination);
+                il.LoadValue(dest);
+                il.Emit(OpCodes.Beq, jumpDestinations[dest]);
+            }
+
+            // each bucket ends with a jump to invalid access to do not fall through to another one
+            il.Emit(OpCodes.Br, invalidAddress);
+        }
+
+        // out of gas
+        il.MarkLabel(outOfGas);
+        il.LoadValue((int)EvmExceptionType.OutOfGas);
+        il.Emit(OpCodes.Br, ret);
+
+        // invalid address return
+        il.MarkLabel(invalidAddress);
+        il.LoadValue((int)EvmExceptionType.InvalidJumpDestination);
+        il.Emit(OpCodes.Br, ret);
+
+        // return
+        il.MarkLabel(ret);
+        il.Emit(OpCodes.Ret);
+
+        Func<long, EvmExceptionType> del = method.CreateDelegate<Func<long, EvmExceptionType>>();
+
+        // TODO: extracting ASM requires to have this run at least once!
+        //using DataTarget dt = DataTarget.CreateSnapshotAndAttach(Process.GetCurrentProcess().Id);
+        //using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+        //ClrHeap heap = runtime.Heap;
+
+        //ClrmdMethod clrMethod = heap.GetProxies("System.Reflection.Emit.DynamicMethod")
+        //    .Select(proxy =>
+        //    {
+        //        ulong mdToken = (ulong)proxy.m_methodHandle.m_value.m_handle;
+        //        return runtime.GetMethodByHandle(mdToken);
+        //    }).Single(m => m.Name == name) as ClrmdMethod;
+
+        //TextWriter writer = Console.Out;
+
+        //ulong address = clrMethod.NativeCode;
+        //const int length = 2048;
+        
+        //writer.WriteLine($"ASM-------------");
+
+        //unsafe
+        //{
+        //    byte[] asm = new Span<byte>(new UIntPtr(address).ToPointer(), length).ToArray();
+
+        //    Decoder decoder = Decoder.Create(IntPtr.Size * 8, asm);
+
+        //    IntelFormatter formatter = new();
+        //    StringOutput? output = new();
+
+        //    decoder.IP = address;
+        //    while (decoder.IP < (address + length))
+        //    {
+        //        decoder.Decode(out Iced.Intel.Instruction instruction);
+
+        //        formatter.Format(instruction, output);
+
+        //        writer.Write((instruction.IP - address).ToString("x4"));
+        //        writer.Write(": ");
+        //        writer.WriteLine(output.ToStringAndReset());
+        //    }
+        //}
+
+        //writer.WriteLine("ASM END-------------");
+        //writer.WriteLine();
+
+        return del;
+    }
+    
+    private static Dictionary<int, long> BuildCostLookup(ReadOnlySpan<byte> code)
+    {
+        Dictionary<int, long> costs = new();
+        int costStart = 0;
+        long costCurrent = 0;
+
+        for (int pc = 0; pc < code.Length; pc++)
+        {
+            Operation op = Operation.Operations[(Instruction)code[pc]];
+            switch (op.Instruction)
+            {
+                case Instruction.JUMPDEST:
+                    costs[costStart] = costCurrent; // remember the current chain of opcodes
+                    costStart = pc;
+                    costCurrent = op.GasCost;
+                    break;
+                case Instruction.JUMPI:
+                case Instruction.JUMP:
+                    costCurrent += op.GasCost;
+                    costs[costStart] = costCurrent; // remember the current chain of opcodes
+                    costStart = pc + 1;             // start with the next again
+                    costCurrent = 0;
+                    break;
+                default:
+                    costCurrent += op.GasCost;
+                    break;
+            }
+
+            pc += op.AdditionalBytes;
+        }
+
+        if (costCurrent > 0)
+        {
+            costs[costStart] = costCurrent;
+        }
+
+        return costs;
+    }
+}

--- a/src/Nethermind/Nethermind.Evm/IL/Operation.cs
+++ b/src/Nethermind/Nethermind.Evm/IL/Operation.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Nethermind.Evm.IL;
+
+/// <summary>
+/// Represents an instruction <see cref="Instruction"/> with additional metadata required for a proper EVM construction.
+/// </summary>
+public readonly struct Operation
+{
+    /// <summary>
+    /// The actual instruction
+    /// </summary>
+    public Instruction Instruction { get; }
+
+    /// <summary>
+    /// The gas cost.
+    /// </summary>
+    public long GasCost { get; }
+
+    /// <summary>
+    /// How many following bytes does this instruction have.
+    /// </summary>
+    public byte AdditionalBytes { get; }
+
+    /// <summary>
+    /// How many bytes are popped by this instruction.
+    /// </summary>
+    public byte StackBehaviorPop { get; }
+
+    /// <summary>
+    /// How many bytes are pushed by this instruction.
+    /// </summary>
+    public byte StackBehaviorPush { get; }
+
+    /// <summary>
+    /// Creates the new operation.
+    /// </summary>
+    public Operation(Instruction instruction, long gasCost, byte additionalBytes, byte stackBehaviorPop, byte stackBehaviorPush)
+    {
+        Instruction = instruction;
+        GasCost = gasCost;
+        AdditionalBytes = additionalBytes;
+        StackBehaviorPop = stackBehaviorPop;
+        StackBehaviorPush = stackBehaviorPush;
+    }
+
+    public static readonly IReadOnlyDictionary<Instruction, Operation> Operations =
+        new Operation[]
+        {
+            new(Instruction.POP, GasCostOf.Base, 0, 1, 0),
+            new(Instruction.PC, GasCostOf.Base, 0, 0, 1),
+            new(Instruction.PUSH1, GasCostOf.VeryLow, 1, 0, 1),
+            new(Instruction.PUSH2, GasCostOf.VeryLow, 2, 0, 1),
+            new(Instruction.PUSH4, GasCostOf.VeryLow, 4, 0, 1),
+            new(Instruction.JUMPDEST, GasCostOf.JumpDest, 0, 0, 0),
+            new(Instruction.JUMP, GasCostOf.Mid, 0, 1, 0),
+            new(Instruction.JUMPI, GasCostOf.High, 0, 2, 0),
+            new(Instruction.SUB, GasCostOf.VeryLow, 0, 2, 1),
+            new(Instruction.DUP1, GasCostOf.VeryLow, 0, 1, 2),
+            new(Instruction.SWAP1, GasCostOf.VeryLow, 0, 2, 2)
+        }.ToDictionary(op => op.Instruction);
+}

--- a/src/Nethermind/Nethermind.Evm/IL/Word.cs
+++ b/src/Nethermind/Nethermind.Evm/IL/Word.cs
@@ -1,0 +1,113 @@
+//  Copyright (c) 2021 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
+
+using System;
+using System.Buffers.Binary;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using Nethermind.Int256;
+
+namespace Nethermind.Evm.IL;
+
+[StructLayout(LayoutKind.Explicit, Size = Size)]
+struct Word
+{
+    public const int Size = 32;
+
+    [FieldOffset(0)] public unsafe fixed byte _buffer[Size];
+
+    [FieldOffset(Size - sizeof(byte))]
+    public byte Byte0;
+
+    [FieldOffset(Size - sizeof(int))]
+    public int Int0;
+
+    [FieldOffset(Size - sizeof(int))]
+    public uint UInt0;
+
+    [FieldOffset(Size - 2 * sizeof(int))]
+    public uint UInt1;
+
+    [FieldOffset(Size - 1 * sizeof(ulong))]
+    public ulong Ulong0;
+
+    [FieldOffset(Size - 2 * sizeof(ulong))]
+    public ulong Ulong1;
+
+    [FieldOffset(Size - 3 * sizeof(ulong))]
+    public ulong Ulong2;
+
+    [FieldOffset(Size - 4 * sizeof(ulong))]
+    public ulong Ulong3;
+
+    public static readonly FieldInfo Byte0Field = typeof(Word).GetField(nameof(Byte0));
+
+    public static readonly FieldInfo Int0Field = typeof(Word).GetField(nameof(Int0));
+
+    public static readonly FieldInfo UInt0Field = typeof(Word).GetField(nameof(UInt0));
+    public static readonly FieldInfo UInt1Field = typeof(Word).GetField(nameof(UInt1));
+
+    public static readonly FieldInfo Ulong0Field = typeof(Word).GetField(nameof(Ulong0));
+    public static readonly FieldInfo Ulong1Field = typeof(Word).GetField(nameof(Ulong1));
+    public static readonly FieldInfo Ulong2Field = typeof(Word).GetField(nameof(Ulong2));
+    public static readonly FieldInfo Ulong3Field = typeof(Word).GetField(nameof(Ulong3));
+
+    public static readonly MethodInfo GetIsZero = typeof(Word).GetProperty(nameof(IsZero))!.GetMethod;
+
+    public static readonly MethodInfo GetUInt256 = typeof(Word).GetProperty(nameof(UInt256))!.GetMethod;
+    public static readonly MethodInfo SetUInt256 = typeof(Word).GetProperty(nameof(UInt256))!.SetMethod;
+
+    public bool IsZero => (Ulong0 | Ulong1 | Ulong2 | Ulong3) == 0;
+
+    public UInt256 UInt256
+    {
+        get
+        {
+            ulong u3 = Ulong3;
+            ulong u2 = Ulong2;
+            ulong u1 = Ulong1;
+            ulong u0 = Ulong0;
+
+            if (BitConverter.IsLittleEndian)
+            {
+                u3 = BinaryPrimitives.ReverseEndianness(u3);
+                u2 = BinaryPrimitives.ReverseEndianness(u2);
+                u1 = BinaryPrimitives.ReverseEndianness(u1);
+                u0 = BinaryPrimitives.ReverseEndianness(u0);
+            }
+
+            return new UInt256(u0, u1, u2, u3);
+        }
+        set
+        {
+            if (BitConverter.IsLittleEndian)
+            {
+                Ulong3 = BinaryPrimitives.ReverseEndianness(value.u3);
+                Ulong2 = BinaryPrimitives.ReverseEndianness(value.u2);
+                Ulong1 = BinaryPrimitives.ReverseEndianness(value.u1);
+                Ulong0 = BinaryPrimitives.ReverseEndianness(value.u0);
+            }
+            else
+            {
+                Ulong3 = value.u3;
+                Ulong2 = value.u2;
+                Ulong1 = value.u1;
+                Ulong0 = value.u0;
+            }
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Evm/Instruction.cs
+++ b/src/Nethermind/Nethermind.Evm/Instruction.cs
@@ -1,4 +1,4 @@
-﻿//  Copyright (c) 2021 Demerzel Solutions Limited
+//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
 // 
 //  The Nethermind library is free software: you can redistribute it and/or modify

--- a/src/Nethermind/Nethermind.Evm/Nethermind.Evm.csproj
+++ b/src/Nethermind/Nethermind.Evm/Nethermind.Evm.csproj
@@ -12,9 +12,17 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="DynaMD" Version="1.0.9.1" />
+    <PackageReference Include="Iced" Version="1.17.0" />
+    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="2.0.226801" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\..\Math.Gmp.Native\MathGmp.Native\MathGmp.Native.csproj" />
     <ProjectReference Include="..\Nethermind.Core\Nethermind.Core.csproj" />
     <ProjectReference Include="..\Nethermind.Serialization.Rlp\Nethermind.Serialization.Rlp.csproj" />
     <ProjectReference Include="..\Nethermind.State\Nethermind.State.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="IL\" />
   </ItemGroup>
 </Project>

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -32,6 +32,7 @@ using Nethermind.Evm.Precompiles.Snarks.Shamatar;
 using Nethermind.Evm.Tracing;
 using Nethermind.Logging;
 using Nethermind.State;
+using ILDelegate = System.Func<long, Nethermind.Evm.EvmExceptionType>;
 
 [assembly: InternalsVisibleTo("Nethermind.Evm.Test")]
 
@@ -42,34 +43,33 @@ namespace Nethermind.Evm
         public const int MaxCallDepth = 1024;
 
         private bool _simdOperationsEnabled = Vector<byte>.Count == 32;
-        private UInt256 P255Int = (UInt256) BigInteger.Pow(2, 255);
+        private UInt256 P255Int = (UInt256)BigInteger.Pow(2, 255);
         private UInt256 P255 => P255Int;
         private UInt256 BigInt256 = 256;
         public UInt256 BigInt32 = 32;
 
-        internal byte[] BytesZero = {0};
+        internal byte[] BytesZero = { 0 };
 
         internal byte[] BytesZero32 =
         {
-            0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
         };
 
         internal byte[] BytesMax32 =
         {
-            255, 255, 255, 255, 255, 255, 255, 255,
-            255, 255, 255, 255, 255, 255, 255, 255,
-            255, 255, 255, 255, 255, 255, 255, 255,
-            255, 255, 255, 255, 255, 255, 255, 255
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255
         };
 
         private readonly byte[] _chainId;
 
         private readonly IBlockhashProvider _blockhashProvider;
         private readonly ISpecProvider _specProvider;
-        private static readonly ICache<Keccak, CodeInfo> _codeCache = new LruCache<Keccak, CodeInfo>(MemoryAllowance.CodeCacheSize, MemoryAllowance.CodeCacheSize, "VM bytecodes");
+
+        private static readonly ICache<Keccak, CodeInfo> _codeCache =
+            new LruCache<Keccak, CodeInfo>(MemoryAllowance.CodeCacheSize, MemoryAllowance.CodeCacheSize,
+                "VM bytecodes");
+
         private readonly ILogger _logger;
         private IWorldState _worldState;
         private IStateProvider _state;
@@ -99,7 +99,7 @@ namespace Nethermind.Evm
             _state = worldState.StateProvider;
             _storage = worldState.StorageProvider;
             _worldState = worldState;
-            
+
             IReleaseSpec spec = _specProvider.GetSpec(state.Env.TxExecutionContext.Header.Number);
             EvmState currentState = state;
             byte[] previousCallResult = null;
@@ -119,7 +119,8 @@ namespace Nethermind.Evm
                     {
                         if (_txTracer.IsTracingActions)
                         {
-                            _txTracer.ReportAction(currentState.GasAvailable, currentState.Env.Value, currentState.From, currentState.To, currentState.Env.InputData, currentState.ExecutionType, true);
+                            _txTracer.ReportAction(currentState.GasAvailable, currentState.Env.Value, currentState.From,
+                                currentState.To, currentState.Env.InputData, currentState.ExecutionType, true);
                         }
 
                         callResult = ExecutePrecompile(currentState, spec);
@@ -141,16 +142,23 @@ namespace Nethermind.Evm
                     {
                         if (_txTracer.IsTracingActions && !currentState.IsContinuation)
                         {
-                            _txTracer.ReportAction(currentState.GasAvailable, currentState.Env.Value, currentState.From, currentState.To, currentState.ExecutionType.IsAnyCreate() ? currentState.Env.CodeInfo.MachineCode : currentState.Env.InputData, currentState.ExecutionType);
-                            if (_txTracer.IsTracingCode) _txTracer.ReportByteCode(currentState.Env.CodeInfo.MachineCode);
+                            _txTracer.ReportAction(currentState.GasAvailable, currentState.Env.Value, currentState.From,
+                                currentState.To,
+                                currentState.ExecutionType.IsAnyCreate()
+                                    ? currentState.Env.CodeInfo.MachineCode
+                                    : currentState.Env.InputData, currentState.ExecutionType);
+                            if (_txTracer.IsTracingCode)
+                                _txTracer.ReportByteCode(currentState.Env.CodeInfo.MachineCode);
                         }
 
-                        callResult = ExecuteCall(currentState, previousCallResult, previousCallOutput, previousCallOutputDestination, spec);
+                        callResult = ExecuteCall(currentState, previousCallResult, previousCallOutput,
+                            previousCallOutputDestination, spec);
                         if (!callResult.IsReturn)
                         {
                             _stateStack.Push(currentState);
                             currentState = callResult.StateToExecute;
-                            previousCallResult = null; // TODO: testing on ropsten sync, write VirtualMachineTest for this case as it was not covered by Ethereum tests (failing block 9411 on Ropsten https://ropsten.etherscan.io/vmtrace?txhash=0x666194d15c14c54fffafab1a04c08064af165870ef9a87f65711dcce7ed27fe1)
+                            previousCallResult =
+                                null; // TODO: testing on ropsten sync, write VirtualMachineTest for this case as it was not covered by Ethereum tests (failing block 9411 on Ropsten https://ropsten.etherscan.io/vmtrace?txhash=0x666194d15c14c54fffafab1a04c08064af165870ef9a87f65711dcce7ed27fe1)
                             _returnDataBuffer = Array.Empty<byte>();
                             previousCallOutput = ZeroPaddedSpan.Empty;
                             continue;
@@ -169,7 +177,8 @@ namespace Nethermind.Evm
 
                             if (currentState.IsTopLevel)
                             {
-                                return new TransactionSubstate(callResult.ExceptionType, _txTracer != NullTxTracer.Instance);
+                                return new TransactionSubstate(callResult.ExceptionType,
+                                    _txTracer != NullTxTracer.Instance);
                             }
 
                             previousCallResult = StatusCode.FailureBytes;
@@ -189,7 +198,7 @@ namespace Nethermind.Evm
                         if (_txTracer.IsTracingActions)
                         {
                             long codeDepositGasCost = CodeDepositHandler.CalculateCost(callResult.Output.Length, spec);
-                            
+
                             if (callResult.IsException)
                             {
                                 _txTracer.ReportActionError(callResult.ExceptionType);
@@ -198,7 +207,8 @@ namespace Nethermind.Evm
                             {
                                 if (currentState.ExecutionType.IsAnyCreate())
                                 {
-                                    _txTracer.ReportActionError(EvmExceptionType.Revert, currentState.GasAvailable - codeDepositGasCost);
+                                    _txTracer.ReportActionError(EvmExceptionType.Revert,
+                                        currentState.GasAvailable - codeDepositGasCost);
                                 }
                                 else
                                 {
@@ -207,12 +217,14 @@ namespace Nethermind.Evm
                             }
                             else
                             {
-                                if (currentState.ExecutionType.IsAnyCreate() && currentState.GasAvailable < codeDepositGasCost)
+                                if (currentState.ExecutionType.IsAnyCreate() &&
+                                    currentState.GasAvailable < codeDepositGasCost)
                                 {
                                     _txTracer.ReportActionError(EvmExceptionType.OutOfGas);
                                 }
                                 // Reject code starting with 0xEF if EIP-3541 is enabled.
-                                else if (currentState.ExecutionType.IsAnyCreate() && CodeDepositHandler.CodeIsInvalid(spec, callResult.Output))
+                                else if (currentState.ExecutionType.IsAnyCreate() &&
+                                         CodeDepositHandler.CodeIsInvalid(spec, callResult.Output))
                                 {
                                     _txTracer.ReportActionError(EvmExceptionType.InvalidCode);
                                 }
@@ -220,7 +232,8 @@ namespace Nethermind.Evm
                                 {
                                     if (currentState.ExecutionType.IsAnyCreate())
                                     {
-                                        _txTracer.ReportActionEnd(currentState.GasAvailable - codeDepositGasCost, currentState.To, callResult.Output);
+                                        _txTracer.ReportActionEnd(currentState.GasAvailable - codeDepositGasCost,
+                                            currentState.To, callResult.Output);
                                     }
                                     else
                                     {
@@ -231,11 +244,11 @@ namespace Nethermind.Evm
                         }
 
                         return new TransactionSubstate(
-                            callResult.Output, 
-                            currentState.Refund, 
-                            (IReadOnlyCollection<Address>)currentState.DestroyList, 
-                            (IReadOnlyCollection<LogEntry>)currentState.Logs, 
-                            callResult.ShouldRevert, 
+                            callResult.Output,
+                            currentState.Refund,
+                            (IReadOnlyCollection<Address>)currentState.DestroyList,
+                            (IReadOnlyCollection<LogEntry>)currentState.Logs,
+                            callResult.ShouldRevert,
                             _txTracer != NullTxTracer.Instance);
                     }
 
@@ -248,7 +261,8 @@ namespace Nethermind.Evm
 
                     if (!callResult.ShouldRevert)
                     {
-                        long gasAvailableForCodeDeposit = previousState.GasAvailable; // TODO: refactor, this is to fix 61363 Ropsten
+                        long gasAvailableForCodeDeposit =
+                            previousState.GasAvailable; // TODO: refactor, this is to fix 61363 Ropsten
                         if (previousState.ExecutionType.IsAnyCreate())
                         {
                             previousCallResult = callCodeOwner.Bytes;
@@ -266,7 +280,8 @@ namespace Nethermind.Evm
 
                                 if (_txTracer.IsTracingActions)
                                 {
-                                    _txTracer.ReportActionEnd(previousState.GasAvailable - codeDepositGasCost, callCodeOwner, callResult.Output);
+                                    _txTracer.ReportActionEnd(previousState.GasAvailable - codeDepositGasCost,
+                                        callCodeOwner, callResult.Output);
                                 }
                             }
                             else
@@ -296,15 +311,21 @@ namespace Nethermind.Evm
                         else
                         {
                             _returnDataBuffer = callResult.Output;
-                            previousCallResult = callResult.PrecompileSuccess.HasValue ? (callResult.PrecompileSuccess.Value ? StatusCode.SuccessBytes : StatusCode.FailureBytes) : StatusCode.SuccessBytes;
-                            previousCallOutput = callResult.Output.AsSpan().SliceWithZeroPadding(0, Math.Min(callResult.Output.Length, (int) previousState.OutputLength));
-                            previousCallOutputDestination = (ulong) previousState.OutputDestination;
+                            previousCallResult = callResult.PrecompileSuccess.HasValue
+                                ? (callResult.PrecompileSuccess.Value
+                                    ? StatusCode.SuccessBytes
+                                    : StatusCode.FailureBytes)
+                                : StatusCode.SuccessBytes;
+                            previousCallOutput = callResult.Output.AsSpan().SliceWithZeroPadding(0,
+                                Math.Min(callResult.Output.Length, (int)previousState.OutputLength));
+                            previousCallOutputDestination = (ulong)previousState.OutputDestination;
                             if (previousState.IsPrecompile)
                             {
                                 // parity induced if else for vmtrace
                                 if (_txTracer.IsTracingInstructions)
                                 {
-                                    _txTracer.ReportMemoryChange((long) previousCallOutputDestination, previousCallOutput);
+                                    _txTracer.ReportMemoryChange((long)previousCallOutputDestination,
+                                        previousCallOutput);
                                 }
                             }
 
@@ -324,8 +345,9 @@ namespace Nethermind.Evm
                         worldState.Restore(previousState.Snapshot);
                         _returnDataBuffer = callResult.Output;
                         previousCallResult = StatusCode.FailureBytes;
-                        previousCallOutput = callResult.Output.AsSpan().SliceWithZeroPadding(0, Math.Min(callResult.Output.Length, (int) previousState.OutputLength));
-                        previousCallOutputDestination = (ulong) previousState.OutputDestination;
+                        previousCallOutput = callResult.Output.AsSpan().SliceWithZeroPadding(0,
+                            Math.Min(callResult.Output.Length, (int)previousState.OutputLength));
+                        previousCallOutputDestination = (ulong)previousState.OutputDestination;
 
 
                         if (_txTracer.IsTracingActions)
@@ -338,7 +360,9 @@ namespace Nethermind.Evm
                 }
                 catch (Exception ex) when (ex is EvmException || ex is OverflowException)
                 {
-                    if (_logger.IsTrace) _logger.Trace($"exception ({ex.GetType().Name}) in {currentState.ExecutionType} at depth {currentState.Env.CallDepth} - restoring snapshot");
+                    if (_logger.IsTrace)
+                        _logger.Trace(
+                            $"exception ({ex.GetType().Name}) in {currentState.ExecutionType} at depth {currentState.Env.CallDepth} - restoring snapshot");
 
                     _worldState.Restore(currentState.Snapshot);
 
@@ -350,7 +374,9 @@ namespace Nethermind.Evm
 
                     if (txTracer.IsTracingInstructions)
                     {
-                        txTracer.ReportOperationError(ex is EvmException evmException ? evmException.ExceptionType : EvmExceptionType.Other);
+                        txTracer.ReportOperationError(ex is EvmException evmException
+                            ? evmException.ExceptionType
+                            : EvmExceptionType.Other);
                         txTracer.ReportOperationRemainingGas(0);
                     }
 
@@ -362,7 +388,9 @@ namespace Nethermind.Evm
 
                     if (currentState.IsTopLevel)
                     {
-                        return new TransactionSubstate(ex is OverflowException ? EvmExceptionType.Other : (ex as EvmException).ExceptionType, _txTracer != NullTxTracer.Instance);
+                        return new TransactionSubstate(
+                            ex is OverflowException ? EvmExceptionType.Other : (ex as EvmException).ExceptionType,
+                            _txTracer != NullTxTracer.Instance);
                     }
 
                     previousCallResult = StatusCode.FailureBytes;
@@ -377,6 +405,10 @@ namespace Nethermind.Evm
             }
         }
 
+        public void BuildILForNext() => _buildILForNext = true;
+
+        private bool _buildILForNext;
+
         public CodeInfo GetCachedCodeInfo(IWorldState worldState, Address codeSource, IReleaseSpec vmSpec)
         {
             IStateProvider state = worldState.StateProvider;
@@ -386,7 +418,7 @@ namespace Nethermind.Evm
                 {
                     throw new InvalidOperationException("EVM precompile have not been initialized properly.");
                 }
-                
+
                 return _precompiles[codeSource];
             }
 
@@ -395,13 +427,25 @@ namespace Nethermind.Evm
             if (cachedCodeInfo == null)
             {
                 byte[] code = state.GetCode(codeHash);
-                
+
                 if (code == null)
                 {
                     throw new NullReferenceException($"Code {codeHash} missing in the state for address {codeSource}");
                 }
 
-                cachedCodeInfo = new CodeInfo(code);
+                object? data = null;
+
+                // TODO: poor man's algo to select to build
+                if (_buildILForNext)
+                {
+                    _buildILForNext = false; // consume
+                    _logger.Info("Emitting a new IL VM");
+
+                    ILDelegate build = IL.ILVirtualMachineBuilder.Build(code);
+                    data = build;
+                }
+
+                cachedCodeInfo = new CodeInfo(code, data);
                 _codeCache.Set(codeHash, cachedCodeInfo);
             }
             else
@@ -462,11 +506,11 @@ namespace Nethermind.Evm
         {
             gasAvailable += refund;
         }
-        
+
         private bool ChargeAccountAccessGas(ref long gasAvailable, EvmState vmState, Address address, IReleaseSpec spec, bool chargeForWarm = true)
         {
             // Console.WriteLine($"Accessing {address}");
-            
+
             bool result = true;
             if (spec.UseHotAndColdStorage)
             {
@@ -474,7 +518,7 @@ namespace Nethermind.Evm
                 {
                     vmState.WarmUp(address);
                 }
-                
+
                 if (vmState.IsCold(address) && !address.IsPrecompile(spec))
                 {
                     result = UpdateGas(GasCostOf.ColdAccountAccess, ref gasAvailable);
@@ -494,7 +538,7 @@ namespace Nethermind.Evm
             SLOAD,
             SSTORE
         }
-        
+
         private bool ChargeStorageAccessGas(
             ref long gasAvailable,
             EvmState vmState,
@@ -503,7 +547,7 @@ namespace Nethermind.Evm
             IReleaseSpec spec)
         {
             // Console.WriteLine($"Accessing {storageCell} {storageAccessType}");
-            
+
             bool result = true;
             if (spec.UseHotAndColdStorage)
             {
@@ -547,7 +591,7 @@ namespace Nethermind.Evm
             {
                 _state.AddToBalance(state.Env.ExecutingAccount, transferValue, spec);
             }
-            
+
             // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-161.md
             // An additional issue was found in Parity,
             // where the Parity client incorrectly failed
@@ -594,13 +638,10 @@ namespace Nethermind.Evm
 
         private CallResult ExecuteCall(EvmState vmState, byte[]? previousCallResult, ZeroPaddedSpan previousCallOutput, in UInt256 previousCallOutputDestination, IReleaseSpec spec)
         {
-            bool isTrace = _logger.IsTrace;
-            bool traceOpcodes = _txTracer.IsTracingInstructions;
-            ExecutionEnvironment env = vmState.Env;
-            TxExecutionContext txCtx = env.TxExecutionContext;
-            
             if (!vmState.IsContinuation)
             {
+                ExecutionEnvironment env = vmState.Env;
+
                 if (!_state.AccountExists(env.ExecutingAccount))
                 {
                     _state.CreateAccount(env.ExecutingAccount, env.TransferValue);
@@ -621,12 +662,29 @@ namespace Nethermind.Evm
                 return CallResult.Empty;
             }
 
+            if (vmState.Env.CodeInfo.Data is ILDelegate @delegate)
+            {
+                _logger.Info("Executing as an IL delegate!");
+                EvmExceptionType evmExceptionType = @delegate(vmState.GasAvailable);
+                return new CallResult(Array.Empty<byte>(), null, false, evmExceptionType);
+            }
+
+            // fallback to regular evm, if no IL based
+            return ExecuteMachine(vmState, previousCallResult, previousCallOutput, previousCallOutputDestination, spec);
+        }
+
+        private CallResult ExecuteMachine(EvmState vmState, byte[]? previousCallResult, ZeroPaddedSpan previousCallOutput, UInt256 previousCallOutputDestination, IReleaseSpec spec)
+        {
+            bool isTrace = _logger.IsTrace;
+            bool traceOpcodes = _txTracer.IsTracingInstructions;
+            ExecutionEnvironment env = vmState.Env;
+            TxExecutionContext txCtx = env.TxExecutionContext;
+
             vmState.InitStacks();
             EvmStack stack = new(vmState.DataStack.AsSpan(), vmState.DataStackHead, _txTracer);
             long gasAvailable = vmState.GasAvailable;
             int programCounter = vmState.ProgramCounter;
             Span<byte> code = env.CodeInfo.MachineCode.AsSpan();
-            
 
             static void UpdateCurrentState(EvmState state, in int pc, in long gas, in int stackHead)
             {
@@ -679,17 +737,17 @@ namespace Nethermind.Evm
                     EndInstructionTraceError(EvmExceptionType.InvalidJumpDestination);
                     // https://github.com/NethermindEth/nethermind/issues/140
                     throw new InvalidJumpDestinationException();
-//                                return CallResult.InvalidJumpDestination; // TODO: add a test, validating inside the condition was not covered by existing tests and fails on 0xf435a354924097686ea88dab3aac1dd464e6a3b387c77aeee94145b0fa5a63d2 mainnet
+                    //                                return CallResult.InvalidJumpDestination; // TODO: add a test, validating inside the condition was not covered by existing tests and fails on 0xf435a354924097686ea88dab3aac1dd464e6a3b387c77aeee94145b0fa5a63d2 mainnet
                 }
 
-                int jumpDestInt = (int) jumpDest;
+                int jumpDestInt = (int)jumpDest;
 
                 if (!env.CodeInfo.ValidateJump(jumpDestInt, isSubroutine))
                 {
                     EndInstructionTraceError(EvmExceptionType.InvalidJumpDestination);
                     // https://github.com/NethermindEth/nethermind/issues/140
                     throw new InvalidJumpDestinationException();
-//                                return CallResult.InvalidJumpDestination; // TODO: add a test, validating inside the condition was not covered by existing tests and fails on 61363 Ropsten
+                    //                                return CallResult.InvalidJumpDestination; // TODO: add a test, validating inside the condition was not covered by existing tests and fails on 61363 Ropsten
                 }
 
                 programCounter = jumpDestInt;
@@ -701,7 +759,7 @@ namespace Nethermind.Evm
                 {
                     throw new InvalidOperationException("EVM memory has not been initialized properly.");
                 }
-                
+
                 long memoryCost = vmState.Memory.CalculateMemoryCost(in position, length);
                 if (memoryCost != 0L)
                 {
@@ -723,20 +781,20 @@ namespace Nethermind.Evm
             if (previousCallOutput.Length > 0)
             {
                 UInt256 localPreviousDest = previousCallOutputDestination;
-                UpdateMemoryCost(in localPreviousDest, (ulong) previousCallOutput.Length);
-                
+                UpdateMemoryCost(in localPreviousDest, (ulong)previousCallOutput.Length);
+
                 if (vmState.Memory is null)
                 {
                     throw new InvalidOperationException("EVM memory has not been initialized properly.");
                 }
-                
+
                 vmState.Memory.Save(in localPreviousDest, previousCallOutput);
-//                if(_txTracer.IsTracingInstructions) _txTracer.ReportMemoryChange((long)localPreviousDest, previousCallOutput);
+                //                if(_txTracer.IsTracingInstructions) _txTracer.ReportMemoryChange((long)localPreviousDest, previousCallOutput);
             }
-            
+
             while (programCounter < code.Length)
             {
-                Instruction instruction = (Instruction) code[programCounter];
+                Instruction instruction = (Instruction)code[programCounter];
                 // Console.WriteLine(instruction);
                 if (traceOpcodes)
                 {
@@ -747,1356 +805,1361 @@ namespace Nethermind.Evm
                 switch (instruction)
                 {
                     case Instruction.STOP:
-                    {
-                        UpdateCurrentState(vmState, programCounter, gasAvailable, stack.Head);
-                        EndInstructionTrace();
-                        return CallResult.Empty;
-                    }
+                        {
+                            UpdateCurrentState(vmState, programCounter, gasAvailable, stack.Head);
+                            EndInstructionTrace();
+                            return CallResult.Empty;
+                        }
                     case Instruction.ADD:
-                    {
-                        if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
                         {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        stack.PopUInt256(out UInt256 b);
-                        stack.PopUInt256(out UInt256 a);
-                        UInt256.Add(in a, in b, out UInt256 c);
-                        stack.PushUInt256(c);
-
-                        break;
-                    }
-                    case Instruction.MUL:
-                    {
-                        if (!UpdateGas(GasCostOf.Low, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        stack.PopUInt256(out UInt256 a);
-                        stack.PopUInt256(out UInt256 b);
-                        UInt256.Multiply(in a, in b, out UInt256 res);
-                        stack.PushUInt256(in res);
-                        break;
-                    }
-                    case Instruction.SUB:
-                    {
-                        if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        stack.PopUInt256(out UInt256 a);
-                        stack.PopUInt256(out UInt256 b);
-                        UInt256.Subtract(in a, in b, out UInt256 result);
-
-                        stack.PushUInt256(in result);
-                        break;
-                    }
-                    case Instruction.DIV:
-                    {
-                        if (!UpdateGas(GasCostOf.Low, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        stack.PopUInt256(out UInt256 a);
-                        stack.PopUInt256(out UInt256 b);
-                        if (b.IsZero)
-                        {
-                            stack.PushZero();
-                        }
-                        else
-                        {
-                            UInt256.Divide(in a, in b, out UInt256 res);
-                            stack.PushUInt256(in res);
-                        }
-
-                        break;
-                    }
-                    case Instruction.SDIV:
-                    {
-                        if (!UpdateGas(GasCostOf.Low, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        stack.PopUInt256(out UInt256 a);
-                        stack.PopSignedInt256(out Int256.Int256 b);
-                        if (b.IsZero)
-                        {
-                            stack.PushZero();
-                        }
-                        else if (b == Int256.Int256.MinusOne && a == P255)
-                        {
-                            UInt256 res = P255;
-                            stack.PushUInt256(in res);
-                        }
-                        else
-                        {
-                            Int256.Int256 signedA = new(a);
-                            Int256.Int256.Divide(in signedA, in b, out Int256.Int256 res);
-                            stack.PushSignedInt256(in res);
-                        }
-
-                        break;
-                    }
-                    case Instruction.MOD:
-                    {
-                        if (!UpdateGas(GasCostOf.Low, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        stack.PopUInt256(out UInt256 a);
-                        stack.PopUInt256(out UInt256 b);
-                        UInt256.Mod(in a, in b, out UInt256 result);
-                        stack.PushUInt256(in result);
-                        break;
-                    }
-                    case Instruction.SMOD:
-                    {
-                        if (!UpdateGas(GasCostOf.Low, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        stack.PopSignedInt256(out Int256.Int256 a);
-                        stack.PopSignedInt256(out Int256.Int256 b);
-                        if (b.IsZero || b.IsOne)
-                        {
-                            stack.PushZero();
-                        }
-                        else
-                        {
-                            a.Abs(out Int256.Int256 absA);
-                            b.Abs(out Int256.Int256 absB);
-                            absA.Mod(in absB, out Int256.Int256 mod);
-
-                            int sign = a.Sign;
-                            if (sign < 0)
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
                             {
-                                mod.Neg(out Int256.Int256 res);
-                                stack.PushSignedInt256(in res);
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            stack.PopUInt256(out UInt256 b);
+                            stack.PopUInt256(out UInt256 a);
+                            UInt256.Add(in a, in b, out UInt256 c);
+                            stack.PushUInt256(c);
+
+                            break;
+                        }
+                    case Instruction.MUL:
+                        {
+                            if (!UpdateGas(GasCostOf.Low, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            stack.PopUInt256(out UInt256 a);
+                            stack.PopUInt256(out UInt256 b);
+                            UInt256.Multiply(in a, in b, out UInt256 res);
+                            stack.PushUInt256(in res);
+                            break;
+                        }
+                    case Instruction.SUB:
+                        {
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            stack.PopUInt256(out UInt256 a);
+                            stack.PopUInt256(out UInt256 b);
+                            UInt256.Subtract(in a, in b, out UInt256 result);
+
+                            stack.PushUInt256(in result);
+                            break;
+                        }
+                    case Instruction.DIV:
+                        {
+                            if (!UpdateGas(GasCostOf.Low, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            stack.PopUInt256(out UInt256 a);
+                            stack.PopUInt256(out UInt256 b);
+                            if (b.IsZero)
+                            {
+                                stack.PushZero();
                             }
                             else
                             {
-                                stack.PushSignedInt256(in mod);
+                                UInt256.Divide(in a, in b, out UInt256 res);
+                                stack.PushUInt256(in res);
                             }
-                        }
 
-                        break;
-                    }
+                            break;
+                        }
+                    case Instruction.SDIV:
+                        {
+                            if (!UpdateGas(GasCostOf.Low, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            stack.PopUInt256(out UInt256 a);
+                            stack.PopSignedInt256(out Int256.Int256 b);
+                            if (b.IsZero)
+                            {
+                                stack.PushZero();
+                            }
+                            else if (b == Int256.Int256.MinusOne && a == P255)
+                            {
+                                UInt256 res = P255;
+                                stack.PushUInt256(in res);
+                            }
+                            else
+                            {
+                                Int256.Int256 signedA = new(a);
+                                Int256.Int256.Divide(in signedA, in b, out Int256.Int256 res);
+                                stack.PushSignedInt256(in res);
+                            }
+
+                            break;
+                        }
+                    case Instruction.MOD:
+                        {
+                            if (!UpdateGas(GasCostOf.Low, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            stack.PopUInt256(out UInt256 a);
+                            stack.PopUInt256(out UInt256 b);
+                            UInt256.Mod(in a, in b, out UInt256 result);
+                            stack.PushUInt256(in result);
+                            break;
+                        }
+                    case Instruction.SMOD:
+                        {
+                            if (!UpdateGas(GasCostOf.Low, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            stack.PopSignedInt256(out Int256.Int256 a);
+                            stack.PopSignedInt256(out Int256.Int256 b);
+                            if (b.IsZero || b.IsOne)
+                            {
+                                stack.PushZero();
+                            }
+                            else
+                            {
+                                a.Abs(out Int256.Int256 absA);
+                                b.Abs(out Int256.Int256 absB);
+                                absA.Mod(in absB, out Int256.Int256 mod);
+
+                                int sign = a.Sign;
+                                if (sign < 0)
+                                {
+                                    mod.Neg(out Int256.Int256 res);
+                                    stack.PushSignedInt256(in res);
+                                }
+                                else
+                                {
+                                    stack.PushSignedInt256(in mod);
+                                }
+                            }
+
+                            break;
+                        }
                     case Instruction.ADDMOD:
-                    {
-                        if (!UpdateGas(GasCostOf.Mid, ref gasAvailable))
                         {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
+                            if (!UpdateGas(GasCostOf.Mid, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
 
-                        stack.PopUInt256(out UInt256 a);
-                        stack.PopUInt256(out UInt256 b);
-                        stack.PopUInt256(out UInt256 mod);
+                            stack.PopUInt256(out UInt256 a);
+                            stack.PopUInt256(out UInt256 b);
+                            stack.PopUInt256(out UInt256 mod);
 
-                        if (mod.IsZero)
-                        {
-                            stack.PushZero();
-                        }
-                        else
-                        {
-                            UInt256.AddMod(a, b, mod, out UInt256 res);
-                            stack.PushUInt256(in res);
-                        }
+                            if (mod.IsZero)
+                            {
+                                stack.PushZero();
+                            }
+                            else
+                            {
+                                UInt256.AddMod(a, b, mod, out UInt256 res);
+                                stack.PushUInt256(in res);
+                            }
 
-                        break;
-                    }
+                            break;
+                        }
                     case Instruction.MULMOD:
-                    {
-                        if (!UpdateGas(GasCostOf.Mid, ref gasAvailable))
                         {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
+                            if (!UpdateGas(GasCostOf.Mid, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
 
-                        stack.PopUInt256(out UInt256 a);
-                        stack.PopUInt256(out UInt256 b);
-                        stack.PopUInt256(out UInt256 mod);
+                            stack.PopUInt256(out UInt256 a);
+                            stack.PopUInt256(out UInt256 b);
+                            stack.PopUInt256(out UInt256 mod);
 
-                        if (mod.IsZero)
-                        {
-                            stack.PushZero();
-                        }
-                        else
-                        {
-                            UInt256.MultiplyMod(in a, in b, in mod, out UInt256 res);
-                            stack.PushUInt256(in res);
-                        }
+                            if (mod.IsZero)
+                            {
+                                stack.PushZero();
+                            }
+                            else
+                            {
+                                UInt256.MultiplyMod(in a, in b, in mod, out UInt256 res);
+                                stack.PushUInt256(in res);
+                            }
 
-                        break;
-                    }
+                            break;
+                        }
                     case Instruction.EXP:
-                    {
-                        if (!UpdateGas(GasCostOf.Exp, ref gasAvailable))
                         {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        Metrics.ModExpOpcode++;
-
-                        stack.PopUInt256(out UInt256 baseInt);
-                        Span<byte> exp = stack.PopBytes();
-
-                        int leadingZeros = exp.LeadingZerosCount();
-                        if (leadingZeros != 32)
-                        {
-                            int expSize = 32 - leadingZeros;
-                            if (!UpdateGas(spec.GetExpByteCost() * expSize, ref gasAvailable))
+                            if (!UpdateGas(GasCostOf.Exp, ref gasAvailable))
                             {
                                 EndInstructionTraceError(EvmExceptionType.OutOfGas);
                                 return CallResult.OutOfGasException;
                             }
-                        }
-                        else
-                        {
-                            stack.PushOne();
+
+                            Metrics.ModExpOpcode++;
+
+                            stack.PopUInt256(out UInt256 baseInt);
+                            Span<byte> exp = stack.PopBytes();
+
+                            int leadingZeros = exp.LeadingZerosCount();
+                            if (leadingZeros != 32)
+                            {
+                                int expSize = 32 - leadingZeros;
+                                if (!UpdateGas(spec.GetExpByteCost() * expSize, ref gasAvailable))
+                                {
+                                    EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                    return CallResult.OutOfGasException;
+                                }
+                            }
+                            else
+                            {
+                                stack.PushOne();
+                                break;
+                            }
+
+                            if (baseInt.IsZero)
+                            {
+                                stack.PushZero();
+                            }
+                            else if (baseInt.IsOne)
+                            {
+                                stack.PushOne();
+                            }
+                            else
+                            {
+                                UInt256.Exp(baseInt, new UInt256(exp, true), out UInt256 res);
+                                stack.PushUInt256(in res);
+                            }
+
                             break;
                         }
-
-                        if (baseInt.IsZero)
-                        {
-                            stack.PushZero();
-                        }
-                        else if (baseInt.IsOne)
-                        {
-                            stack.PushOne();
-                        }
-                        else
-                        {
-                            UInt256.Exp(baseInt, new UInt256(exp, true), out UInt256 res);
-                            stack.PushUInt256(in res);
-                        }
-
-                        break;
-                    }
                     case Instruction.SIGNEXTEND:
-                    {
-                        if (!UpdateGas(GasCostOf.Low, ref gasAvailable))
                         {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        stack.PopUInt256(out UInt256 a);
-                        if (a >= BigInt32)
-                        {
-                            stack.EnsureDepth(1);
-                            break;
-                        }
-
-                        int position = 31 - (int) a;
-
-                        Span<byte> b = stack.PopBytes();
-                        sbyte sign = (sbyte) b[position];
-
-                        if (sign >= 0)
-                        {
-                            BytesZero32.AsSpan(0, position).CopyTo(b.Slice(0, position));
-                        }
-                        else
-                        {
-                            BytesMax32.AsSpan(0, position).CopyTo(b.Slice(0, position));
-                        }
-
-                        stack.PushBytes(b);
-                        break;
-                    }
-                    case Instruction.LT:
-                    {
-                        if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        stack.PopUInt256(out UInt256 a);
-                        stack.PopUInt256(out UInt256 b);
-                        if (a < b)
-                        {
-                            stack.PushOne();
-                        }
-                        else
-                        {
-                            stack.PushZero();
-                        }
-
-                        break;
-                    }
-                    case Instruction.GT:
-                    {
-                        if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        stack.PopUInt256(out UInt256 a);
-                        stack.PopUInt256(out UInt256 b);
-                        if (a > b)
-                        {
-                            stack.PushOne();
-                        }
-                        else
-                        {
-                            stack.PushZero();
-                        }
-
-                        break;
-                    }
-                    case Instruction.SLT:
-                    {
-                        if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        stack.PopSignedInt256(out Int256.Int256 a);
-                        stack.PopSignedInt256(out Int256.Int256 b);
-
-                        if (a.CompareTo(b) < 0)
-                        {
-                            stack.PushOne();
-                        }
-                        else
-                        {
-                            stack.PushZero();
-                        }
-
-                        break;
-                    }
-                    case Instruction.SGT:
-                    {
-                        if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        stack.PopSignedInt256(out Int256.Int256 a);
-                        stack.PopSignedInt256(out Int256.Int256 b);
-                        if (a.CompareTo(b) > 0)
-                        {
-                            stack.PushOne();
-                        }
-                        else
-                        {
-                            stack.PushZero();
-                        }
-
-                        break;
-                    }
-                    case Instruction.EQ:
-                    {
-                        if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        Span<byte> a = stack.PopBytes();
-                        Span<byte> b = stack.PopBytes();
-                        if (a.SequenceEqual(b))
-                        {
-                            stack.PushOne();
-                        }
-                        else
-                        {
-                            stack.PushZero();
-                        }
-
-                        break;
-                    }
-                    case Instruction.ISZERO:
-                    {
-                        if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        Span<byte> a = stack.PopBytes();
-                        if (a.SequenceEqual(BytesZero32))
-                        {
-                            stack.PushOne();
-                        }
-                        else
-                        {
-                            stack.PushZero();
-                        }
-
-                        break;
-                    }
-                    case Instruction.AND:
-                    {
-                        if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        Span<byte> a = stack.PopBytes();
-                        Span<byte> b = stack.PopBytes();
-
-                        if (_simdOperationsEnabled)
-                        {
-                            Vector<byte> aVec = new(a);
-                            Vector<byte> bVec = new(b);
-
-                            Vector.BitwiseAnd(aVec, bVec).CopyTo(stack.Register);
-                        }
-                        else
-                        {
-                            ref ulong refA = ref MemoryMarshal.AsRef<ulong>(a);
-                            ref ulong refB = ref MemoryMarshal.AsRef<ulong>(b);
-                            ref ulong refBuffer = ref MemoryMarshal.AsRef<ulong>(stack.Register);
-
-                            refBuffer = refA & refB;
-                            Unsafe.Add(ref refBuffer, 1) = Unsafe.Add(ref refA, 1) & Unsafe.Add(ref refB, 1);
-                            Unsafe.Add(ref refBuffer, 2) = Unsafe.Add(ref refA, 2) & Unsafe.Add(ref refB, 2);
-                            Unsafe.Add(ref refBuffer, 3) = Unsafe.Add(ref refA, 3) & Unsafe.Add(ref refB, 3);
-                        }
-
-                        stack.PushBytes(stack.Register);
-                        break;
-                    }
-                    case Instruction.OR:
-                    {
-                        if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        Span<byte> a = stack.PopBytes();
-                        Span<byte> b = stack.PopBytes();
-
-                        if (_simdOperationsEnabled)
-                        {
-                            Vector<byte> aVec = new(a);
-                            Vector<byte> bVec = new(b);
-
-                            Vector.BitwiseOr(aVec, bVec).CopyTo(stack.Register);
-                        }
-                        else
-                        {
-                            ref ulong refA = ref MemoryMarshal.AsRef<ulong>(a);
-                            ref ulong refB = ref MemoryMarshal.AsRef<ulong>(b);
-                            ref ulong refBuffer = ref MemoryMarshal.AsRef<ulong>(stack.Register);
-
-                            refBuffer = refA | refB;
-                            Unsafe.Add(ref refBuffer, 1) = Unsafe.Add(ref refA, 1) | Unsafe.Add(ref refB, 1);
-                            Unsafe.Add(ref refBuffer, 2) = Unsafe.Add(ref refA, 2) | Unsafe.Add(ref refB, 2);
-                            Unsafe.Add(ref refBuffer, 3) = Unsafe.Add(ref refA, 3) | Unsafe.Add(ref refB, 3);
-                        }
-
-                        stack.PushBytes(stack.Register);
-                        break;
-                    }
-                    case Instruction.XOR:
-                    {
-                        if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        Span<byte> a = stack.PopBytes();
-                        Span<byte> b = stack.PopBytes();
-
-                        if (_simdOperationsEnabled)
-                        {
-                            Vector<byte> aVec = new(a);
-                            Vector<byte> bVec = new(b);
-
-                            Vector.Xor(aVec, bVec).CopyTo(stack.Register);
-                        }
-                        else
-                        {
-                            ref ulong refA = ref MemoryMarshal.AsRef<ulong>(a);
-                            ref ulong refB = ref MemoryMarshal.AsRef<ulong>(b);
-                            ref ulong refBuffer = ref MemoryMarshal.AsRef<ulong>(stack.Register);
-
-                            refBuffer = refA ^ refB;
-                            Unsafe.Add(ref refBuffer, 1) = Unsafe.Add(ref refA, 1) ^ Unsafe.Add(ref refB, 1);
-                            Unsafe.Add(ref refBuffer, 2) = Unsafe.Add(ref refA, 2) ^ Unsafe.Add(ref refB, 2);
-                            Unsafe.Add(ref refBuffer, 3) = Unsafe.Add(ref refA, 3) ^ Unsafe.Add(ref refB, 3);
-                        }
-
-                        stack.PushBytes(stack.Register);
-                        break;
-                    }
-                    case Instruction.NOT:
-                    {
-                        if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        Span<byte> a = stack.PopBytes();
-
-                        if (_simdOperationsEnabled)
-                        {
-                            Vector<byte> aVec = new(a);
-                            Vector<byte> negVec = Vector.Xor(aVec, new Vector<byte>(BytesMax32));
-
-                            negVec.CopyTo(stack.Register);
-                        }
-                        else
-                        {
-                            ref var refA = ref MemoryMarshal.AsRef<ulong>(a);
-                            ref var refBuffer = ref MemoryMarshal.AsRef<ulong>(stack.Register);
-
-                            refBuffer = ~refA;
-                            Unsafe.Add(ref refBuffer, 1) = ~Unsafe.Add(ref refA, 1);
-                            Unsafe.Add(ref refBuffer, 2) = ~Unsafe.Add(ref refA, 2);
-                            Unsafe.Add(ref refBuffer, 3) = ~Unsafe.Add(ref refA, 3);
-                        }
-
-                        stack.PushBytes(stack.Register);
-                        break;
-                    }
-                    case Instruction.BYTE:
-                    {
-                        if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        stack.PopUInt256(out UInt256 position);
-                        Span<byte> bytes = stack.PopBytes();
-
-                        if (position >= BigInt32)
-                        {
-                            stack.PushZero();
-                            break;
-                        }
-
-                        int adjustedPosition = bytes.Length - 32 + (int) position;
-                        if (adjustedPosition < 0)
-                        {
-                            stack.PushZero();
-                        }
-                        else
-                        {
-                            stack.PushByte(bytes[adjustedPosition]);
-                        }
-
-                        break;
-                    }
-                    case Instruction.SHA3:
-                    {
-                        stack.PopUInt256(out UInt256 memSrc);
-                        stack.PopUInt256(out UInt256 memLength);
-                        if (!UpdateGas(GasCostOf.Sha3 + GasCostOf.Sha3Word * EvmPooledMemory.Div32Ceiling(memLength),
-                            ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        UpdateMemoryCost(in memSrc, memLength);
-
-                        Span<byte> memData = vmState.Memory.LoadSpan(in memSrc, memLength);
-                        stack.PushBytes(ValueKeccak.Compute(memData).BytesAsSpan);
-                        break;
-                    }
-                    case Instruction.ADDRESS:
-                    {
-                        if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        stack.PushBytes(env.ExecutingAccount.Bytes);
-                        break;
-                    }
-                    case Instruction.BALANCE:
-                    {
-                        long gasCost = spec.GetBalanceCost();
-                        if (gasCost != 0 && !UpdateGas(gasCost, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        Address address = stack.PopAddress();
-                        if (!ChargeAccountAccessGas(ref gasAvailable, vmState, address, spec))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-                        
-                        UInt256 balance = _state.GetBalance(address);
-                        stack.PushUInt256(in balance);
-                        break;
-                    }
-                    case Instruction.CALLER:
-                    {
-                        if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        stack.PushBytes(env.Caller.Bytes);
-                        break;
-                    }
-                    case Instruction.CALLVALUE:
-                    {
-                        if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        UInt256 callValue = env.Value;
-                        stack.PushUInt256(in callValue);
-                        break;
-                    }
-                    case Instruction.ORIGIN:
-                    {
-                        if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        stack.PushBytes(txCtx.Origin.Bytes);
-                        break;
-                    }
-                    case Instruction.CALLDATALOAD:
-                    {
-                        if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        stack.PopUInt256(out UInt256 src);
-                        stack.PushBytes(env.InputData.SliceWithZeroPadding(src, 32));
-                        break;
-                    }
-                    case Instruction.CALLDATASIZE:
-                    {
-                        if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        UInt256 callDataSize = (UInt256) env.InputData.Length;
-                        stack.PushUInt256(in callDataSize);
-                        break;
-                    }
-                    case Instruction.CALLDATACOPY:
-                    {
-                        stack.PopUInt256(out UInt256 dest);
-                        stack.PopUInt256(out UInt256 src);
-                        stack.PopUInt256(out UInt256 length);
-                        if (!UpdateGas(GasCostOf.VeryLow + GasCostOf.Memory * EvmPooledMemory.Div32Ceiling(length),
-                            ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        if(length > UInt256.Zero)
-                        {
-                            UpdateMemoryCost(in dest, length);
-                            
-                            ZeroPaddedMemory callDataSlice = env.InputData.SliceWithZeroPadding(src, (int) length);
-                            vmState.Memory.Save(in dest, callDataSlice);
-                            if (_txTracer.IsTracingInstructions)
-                            {
-                                _txTracer.ReportMemoryChange((long)dest, callDataSlice);
-                            }
-                        }
-                        
-                        break;
-                    }
-                    case Instruction.CODESIZE:
-                    {
-                        if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        UInt256 codeLength = (UInt256) code.Length;
-                        stack.PushUInt256(in codeLength);
-                        break;
-                    }
-                    case Instruction.CODECOPY:
-                    {
-                        stack.PopUInt256(out UInt256 dest);
-                        stack.PopUInt256(out UInt256 src);
-                        stack.PopUInt256(out UInt256 length);
-                        if (!UpdateGas(GasCostOf.VeryLow + GasCostOf.Memory * EvmPooledMemory.Div32Ceiling(length), ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-                        
-                        if (length > UInt256.Zero)
-                        {
-                            UpdateMemoryCost(in dest, length);
-                            
-                            ZeroPaddedSpan codeSlice = code.SliceWithZeroPadding(src, (int) length);
-                            vmState.Memory.Save(in dest, codeSlice);
-                            if (_txTracer.IsTracingInstructions) _txTracer.ReportMemoryChange((long) dest, codeSlice);
-                        }
-                        
-                        break;
-                    }
-                    case Instruction.GASPRICE:
-                    {
-                        if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        UInt256 gasPrice = txCtx.GasPrice;
-                        stack.PushUInt256(in gasPrice);
-                        break;
-                    }
-                    case Instruction.EXTCODESIZE:
-                    {
-                        long gasCost = spec.GetExtCodeCost();
-                        if (!UpdateGas(gasCost, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        Address address = stack.PopAddress();
-                        if (!ChargeAccountAccessGas(ref gasAvailable, vmState, address, spec))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        byte[] accountCode = GetCachedCodeInfo(_worldState, address, spec).MachineCode;
-                        UInt256 codeSize = (UInt256) accountCode.Length;
-                        stack.PushUInt256(in codeSize);
-                        break;
-                    }
-                    case Instruction.EXTCODECOPY:
-                    {
-                        Address address = stack.PopAddress();
-                        stack.PopUInt256(out UInt256 dest);
-                        stack.PopUInt256(out UInt256 src);
-                        stack.PopUInt256(out UInt256 length);
-
-                        long gasCost = spec.GetExtCodeCost();
-                        if (!UpdateGas(gasCost + GasCostOf.Memory * EvmPooledMemory.Div32Ceiling(length),
-                            ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-                        
-                        if (!ChargeAccountAccessGas(ref gasAvailable, vmState, address, spec))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        if (length > UInt256.Zero)
-                        {
-                            UpdateMemoryCost(in dest, length);
-                            
-                            byte[] externalCode = GetCachedCodeInfo(_worldState, address, spec).MachineCode;
-                            ZeroPaddedSpan callDataSlice = externalCode.SliceWithZeroPadding(src, (int) length);
-                            vmState.Memory.Save(in dest, callDataSlice);
-                            if (_txTracer.IsTracingInstructions)
-                            {
-                                _txTracer.ReportMemoryChange((long)dest, callDataSlice);
-                            }
-                        }
-
-                        break;
-                    }
-                    case Instruction.RETURNDATASIZE:
-                    {
-                        if (!spec.ReturnDataOpcodesEnabled)
-                        {
-                            EndInstructionTraceError(EvmExceptionType.BadInstruction);
-                            return CallResult.InvalidInstructionException;
-                        }
-
-                        if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        UInt256 res = (UInt256) _returnDataBuffer.Length;
-                        stack.PushUInt256(in res);
-                        break;
-                    }
-                    case Instruction.RETURNDATACOPY:
-                    {
-                        if (!spec.ReturnDataOpcodesEnabled)
-                        {
-                            EndInstructionTraceError(EvmExceptionType.BadInstruction);
-                            return CallResult.InvalidInstructionException;
-                        }
-
-                        stack.PopUInt256(out UInt256 dest);
-                        stack.PopUInt256(out UInt256 src);
-                        stack.PopUInt256(out UInt256 length);
-                        if (!UpdateGas(GasCostOf.VeryLow + GasCostOf.Memory * EvmPooledMemory.Div32Ceiling(length), ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        if (UInt256.AddOverflow(length, src, out UInt256 newLength) || newLength > _returnDataBuffer.Length)
-                        {
-                            return CallResult.AccessViolationException;
-                        }
-                        
-                        if (length > UInt256.Zero)
-                        {
-                            UpdateMemoryCost(in dest, length);
-
-                            ZeroPaddedSpan returnDataSlice = _returnDataBuffer.AsSpan().SliceWithZeroPadding(src, (int)length);
-                            vmState.Memory.Save(in dest, returnDataSlice);
-                            if (_txTracer.IsTracingInstructions)
-                            {
-                                _txTracer.ReportMemoryChange((long)dest, returnDataSlice);
-                            }
-                        }
-
-                        break;
-                    }
-                    case Instruction.BLOCKHASH:
-                    {
-                        Metrics.BlockhashOpcode++;
-
-                        if (!UpdateGas(GasCostOf.BlockHash, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        stack.PopUInt256(out UInt256 a);
-                        long number = a > long.MaxValue ? long.MaxValue : (long) a;
-                        Keccak blockHash = _blockhashProvider.GetBlockhash(txCtx.Header, number);
-                        stack.PushBytes(blockHash?.Bytes ?? BytesZero32);
-
-                        if (isTrace)
-                        {
-                            if (_txTracer.IsTracingBlockHash && blockHash != null)
-                            {
-                                _txTracer.ReportBlockHash(blockHash);
-                            }
-                        }
-
-                        break;
-                    }
-                    case Instruction.COINBASE:
-                    {
-                        if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        stack.PushBytes(txCtx.Header.GasBeneficiary.Bytes);
-                        break;
-                    }
-                    case Instruction.DIFFICULTY:
-                    {
-                        if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        UInt256 diff = txCtx.Header.Difficulty;
-                        stack.PushUInt256(in diff);
-                        break;
-                    }
-                    case Instruction.TIMESTAMP:
-                    {
-                        if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        UInt256 timestamp = txCtx.Header.Timestamp;
-                        stack.PushUInt256(in timestamp);
-                        break;
-                    }
-                    case Instruction.NUMBER:
-                    {
-                        if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        UInt256 blockNumber = (UInt256) txCtx.Header.Number;
-                        stack.PushUInt256(in blockNumber);
-                        break;
-                    }
-                    case Instruction.GASLIMIT:
-                    {
-                        if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        UInt256 gasLimit = (UInt256) txCtx.Header.GasLimit;
-                        stack.PushUInt256(in gasLimit);
-                        break;
-                    }
-                    case Instruction.CHAINID:
-                    {
-                        if (!spec.ChainIdOpcodeEnabled)
-                        {
-                            EndInstructionTraceError(EvmExceptionType.BadInstruction);
-                            return CallResult.InvalidInstructionException;
-                        }
-
-                        if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        stack.PushBytes(_chainId);
-                        break;
-                    }
-                    case Instruction.SELFBALANCE:
-                    {
-                        if (!spec.SelfBalanceOpcodeEnabled)
-                        {
-                            EndInstructionTraceError(EvmExceptionType.BadInstruction);
-                            return CallResult.InvalidInstructionException;
-                        }
-
-                        if (!UpdateGas(GasCostOf.SelfBalance, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        UInt256 balance = _state.GetBalance(env.ExecutingAccount);
-                        stack.PushUInt256(in balance);
-                        break;
-                    }
-                    case Instruction.BASEFEE:
-                    {
-                        if (!spec.BaseFeeEnabled)
-                        {
-                            EndInstructionTraceError(EvmExceptionType.BadInstruction);
-                            return CallResult.InvalidInstructionException;
-                        }
-
-                        if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        UInt256 baseFee = txCtx.Header.BaseFeePerGas;
-                        stack.PushUInt256(in baseFee);
-                        break;
-                    }
-                    case Instruction.POP:
-                    {
-                        if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        stack.PopLimbo();
-                        break;
-                    }
-                    case Instruction.MLOAD:
-                    {
-                        if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        stack.PopUInt256(out UInt256 memPosition);
-                        UpdateMemoryCost(in memPosition, 32);
-                        Span<byte> memData = vmState.Memory.LoadSpan(in memPosition);
-                        if (_txTracer.IsTracingInstructions) _txTracer.ReportMemoryChange(memPosition, memData);
-
-                        stack.PushBytes(memData);
-                        break;
-                    }
-                    case Instruction.MSTORE:
-                    {
-                        if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        stack.PopUInt256(out UInt256 memPosition);
-
-                        Span<byte> data = stack.PopBytes();
-                        UpdateMemoryCost(in memPosition, 32);
-                        vmState.Memory.SaveWord(in memPosition, data);
-                        if (_txTracer.IsTracingInstructions) _txTracer.ReportMemoryChange((long) memPosition, data.SliceWithZeroPadding(0, 32, PadDirection.Left));
-
-                        break;
-                    }
-                    case Instruction.MSTORE8:
-                    {
-                        if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        stack.PopUInt256(out UInt256 memPosition);
-                        byte data = stack.PopByte();
-                        UpdateMemoryCost(in memPosition, UInt256.One);
-                        vmState.Memory.SaveByte(in memPosition, data);
-                        if (_txTracer.IsTracingInstructions) _txTracer.ReportMemoryChange((long) memPosition, data);
-
-                        break;
-                    }
-                    case Instruction.SLOAD:
-                    {
-                        Metrics.SloadOpcode++;
-                        var gasCost = spec.GetSLoadCost();
-
-                        if (!UpdateGas(gasCost, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        stack.PopUInt256(out UInt256 storageIndex);
-                        StorageCell storageCell = new(env.ExecutingAccount, storageIndex);
-                        if (!ChargeStorageAccessGas(
-                            ref gasAvailable,
-                            vmState,
-                            storageCell,
-                            StorageAccessType.SLOAD,
-                            spec))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-                        
-                        byte[] value = _storage.Get(storageCell);
-                        stack.PushBytes(value);
-                        break;
-                    }
-                    case Instruction.SSTORE:
-                    {
-                        Metrics.SstoreOpcode++;
-
-                        if (vmState.IsStatic)
-                        {
-                            EndInstructionTraceError(EvmExceptionType.StaticCallViolation);
-                            return CallResult.StaticCallViolationException;
-                        }
-                        
-                        // fail fast before the first storage read if gas is not enough even for reset
-                        if (!spec.UseNetGasMetering && !UpdateGas(spec.GetSStoreResetCost(), ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-                        
-                        if (spec.UseNetGasMeteringWithAStipendFix)
-                        {
-                            if (_txTracer.IsTracingRefunds) _txTracer.ReportExtraGasPressure(GasCostOf.CallStipend - spec.GetNetMeteredSStoreCost() + 1);
-                            if (gasAvailable <= GasCostOf.CallStipend)
+                            if (!UpdateGas(GasCostOf.Low, ref gasAvailable))
                             {
                                 EndInstructionTraceError(EvmExceptionType.OutOfGas);
                                 return CallResult.OutOfGasException;
                             }
-                        }
 
-                        stack.PopUInt256(out UInt256 storageIndex);
-                        Span<byte> newValue = stack.PopBytes();
-                        bool newIsZero = newValue.IsZero();
-                        if (!newIsZero)
-                        {
-                            newValue = newValue.WithoutLeadingZeros().ToArray();
-                        }
-                        else
-                        {
-                            newValue = new byte[] {0};
-                        }
-
-                        StorageCell storageCell = new(env.ExecutingAccount, storageIndex);
-
-                        if (!ChargeStorageAccessGas(
-                            ref gasAvailable,
-                            vmState,
-                            storageCell,
-                            StorageAccessType.SSTORE,
-                            spec))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-                        
-                        Span<byte> currentValue = _storage.Get(storageCell);
-                        // Console.WriteLine($"current: {currentValue.ToHexString()} newValue {newValue.ToHexString()}");
-                        bool currentIsZero = currentValue.IsZero();
-
-                        bool newSameAsCurrent = (newIsZero && currentIsZero) || Bytes.AreEqual(currentValue, newValue);
-                        long sClearRefunds = RefundOf.SClear(spec.IsEip3529Enabled);
-
-                        if (!spec.UseNetGasMetering) // note that for this case we already deducted 5000
-                        {
-                            if (newIsZero)
+                            stack.PopUInt256(out UInt256 a);
+                            if (a >= BigInt32)
                             {
-                                if (!newSameAsCurrent)
+                                stack.EnsureDepth(1);
+                                break;
+                            }
+
+                            int position = 31 - (int)a;
+
+                            Span<byte> b = stack.PopBytes();
+                            sbyte sign = (sbyte)b[position];
+
+                            if (sign >= 0)
+                            {
+                                BytesZero32.AsSpan(0, position).CopyTo(b.Slice(0, position));
+                            }
+                            else
+                            {
+                                BytesMax32.AsSpan(0, position).CopyTo(b.Slice(0, position));
+                            }
+
+                            stack.PushBytes(b);
+                            break;
+                        }
+                    case Instruction.LT:
+                        {
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            stack.PopUInt256(out UInt256 a);
+                            stack.PopUInt256(out UInt256 b);
+                            if (a < b)
+                            {
+                                stack.PushOne();
+                            }
+                            else
+                            {
+                                stack.PushZero();
+                            }
+
+                            break;
+                        }
+                    case Instruction.GT:
+                        {
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            stack.PopUInt256(out UInt256 a);
+                            stack.PopUInt256(out UInt256 b);
+                            if (a > b)
+                            {
+                                stack.PushOne();
+                            }
+                            else
+                            {
+                                stack.PushZero();
+                            }
+
+                            break;
+                        }
+                    case Instruction.SLT:
+                        {
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            stack.PopSignedInt256(out Int256.Int256 a);
+                            stack.PopSignedInt256(out Int256.Int256 b);
+
+                            if (a.CompareTo(b) < 0)
+                            {
+                                stack.PushOne();
+                            }
+                            else
+                            {
+                                stack.PushZero();
+                            }
+
+                            break;
+                        }
+                    case Instruction.SGT:
+                        {
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            stack.PopSignedInt256(out Int256.Int256 a);
+                            stack.PopSignedInt256(out Int256.Int256 b);
+                            if (a.CompareTo(b) > 0)
+                            {
+                                stack.PushOne();
+                            }
+                            else
+                            {
+                                stack.PushZero();
+                            }
+
+                            break;
+                        }
+                    case Instruction.EQ:
+                        {
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            Span<byte> a = stack.PopBytes();
+                            Span<byte> b = stack.PopBytes();
+                            if (a.SequenceEqual(b))
+                            {
+                                stack.PushOne();
+                            }
+                            else
+                            {
+                                stack.PushZero();
+                            }
+
+                            break;
+                        }
+                    case Instruction.ISZERO:
+                        {
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            Span<byte> a = stack.PopBytes();
+                            if (a.SequenceEqual(BytesZero32))
+                            {
+                                stack.PushOne();
+                            }
+                            else
+                            {
+                                stack.PushZero();
+                            }
+
+                            break;
+                        }
+                    case Instruction.AND:
+                        {
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            Span<byte> a = stack.PopBytes();
+                            Span<byte> b = stack.PopBytes();
+
+                            if (_simdOperationsEnabled)
+                            {
+                                Vector<byte> aVec = new(a);
+                                Vector<byte> bVec = new(b);
+
+                                Vector.BitwiseAnd(aVec, bVec).CopyTo(stack.Register);
+                            }
+                            else
+                            {
+                                ref ulong refA = ref MemoryMarshal.AsRef<ulong>(a);
+                                ref ulong refB = ref MemoryMarshal.AsRef<ulong>(b);
+                                ref ulong refBuffer = ref MemoryMarshal.AsRef<ulong>(stack.Register);
+
+                                refBuffer = refA & refB;
+                                Unsafe.Add(ref refBuffer, 1) = Unsafe.Add(ref refA, 1) & Unsafe.Add(ref refB, 1);
+                                Unsafe.Add(ref refBuffer, 2) = Unsafe.Add(ref refA, 2) & Unsafe.Add(ref refB, 2);
+                                Unsafe.Add(ref refBuffer, 3) = Unsafe.Add(ref refA, 3) & Unsafe.Add(ref refB, 3);
+                            }
+
+                            stack.PushBytes(stack.Register);
+                            break;
+                        }
+                    case Instruction.OR:
+                        {
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            Span<byte> a = stack.PopBytes();
+                            Span<byte> b = stack.PopBytes();
+
+                            if (_simdOperationsEnabled)
+                            {
+                                Vector<byte> aVec = new(a);
+                                Vector<byte> bVec = new(b);
+
+                                Vector.BitwiseOr(aVec, bVec).CopyTo(stack.Register);
+                            }
+                            else
+                            {
+                                ref ulong refA = ref MemoryMarshal.AsRef<ulong>(a);
+                                ref ulong refB = ref MemoryMarshal.AsRef<ulong>(b);
+                                ref ulong refBuffer = ref MemoryMarshal.AsRef<ulong>(stack.Register);
+
+                                refBuffer = refA | refB;
+                                Unsafe.Add(ref refBuffer, 1) = Unsafe.Add(ref refA, 1) | Unsafe.Add(ref refB, 1);
+                                Unsafe.Add(ref refBuffer, 2) = Unsafe.Add(ref refA, 2) | Unsafe.Add(ref refB, 2);
+                                Unsafe.Add(ref refBuffer, 3) = Unsafe.Add(ref refA, 3) | Unsafe.Add(ref refB, 3);
+                            }
+
+                            stack.PushBytes(stack.Register);
+                            break;
+                        }
+                    case Instruction.XOR:
+                        {
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            Span<byte> a = stack.PopBytes();
+                            Span<byte> b = stack.PopBytes();
+
+                            if (_simdOperationsEnabled)
+                            {
+                                Vector<byte> aVec = new(a);
+                                Vector<byte> bVec = new(b);
+
+                                Vector.Xor(aVec, bVec).CopyTo(stack.Register);
+                            }
+                            else
+                            {
+                                ref ulong refA = ref MemoryMarshal.AsRef<ulong>(a);
+                                ref ulong refB = ref MemoryMarshal.AsRef<ulong>(b);
+                                ref ulong refBuffer = ref MemoryMarshal.AsRef<ulong>(stack.Register);
+
+                                refBuffer = refA ^ refB;
+                                Unsafe.Add(ref refBuffer, 1) = Unsafe.Add(ref refA, 1) ^ Unsafe.Add(ref refB, 1);
+                                Unsafe.Add(ref refBuffer, 2) = Unsafe.Add(ref refA, 2) ^ Unsafe.Add(ref refB, 2);
+                                Unsafe.Add(ref refBuffer, 3) = Unsafe.Add(ref refA, 3) ^ Unsafe.Add(ref refB, 3);
+                            }
+
+                            stack.PushBytes(stack.Register);
+                            break;
+                        }
+                    case Instruction.NOT:
+                        {
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            Span<byte> a = stack.PopBytes();
+
+                            if (_simdOperationsEnabled)
+                            {
+                                Vector<byte> aVec = new(a);
+                                Vector<byte> negVec = Vector.Xor(aVec, new Vector<byte>(BytesMax32));
+
+                                negVec.CopyTo(stack.Register);
+                            }
+                            else
+                            {
+                                ref var refA = ref MemoryMarshal.AsRef<ulong>(a);
+                                ref var refBuffer = ref MemoryMarshal.AsRef<ulong>(stack.Register);
+
+                                refBuffer = ~refA;
+                                Unsafe.Add(ref refBuffer, 1) = ~Unsafe.Add(ref refA, 1);
+                                Unsafe.Add(ref refBuffer, 2) = ~Unsafe.Add(ref refA, 2);
+                                Unsafe.Add(ref refBuffer, 3) = ~Unsafe.Add(ref refA, 3);
+                            }
+
+                            stack.PushBytes(stack.Register);
+                            break;
+                        }
+                    case Instruction.BYTE:
+                        {
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            stack.PopUInt256(out UInt256 position);
+                            Span<byte> bytes = stack.PopBytes();
+
+                            if (position >= BigInt32)
+                            {
+                                stack.PushZero();
+                                break;
+                            }
+
+                            int adjustedPosition = bytes.Length - 32 + (int)position;
+                            if (adjustedPosition < 0)
+                            {
+                                stack.PushZero();
+                            }
+                            else
+                            {
+                                stack.PushByte(bytes[adjustedPosition]);
+                            }
+
+                            break;
+                        }
+                    case Instruction.SHA3:
+                        {
+                            stack.PopUInt256(out UInt256 memSrc);
+                            stack.PopUInt256(out UInt256 memLength);
+                            if (!UpdateGas(GasCostOf.Sha3 + GasCostOf.Sha3Word * EvmPooledMemory.Div32Ceiling(memLength),
+                                    ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            UpdateMemoryCost(in memSrc, memLength);
+
+                            Span<byte> memData = vmState.Memory.LoadSpan(in memSrc, memLength);
+                            stack.PushBytes(ValueKeccak.Compute(memData).BytesAsSpan);
+                            break;
+                        }
+                    case Instruction.ADDRESS:
+                        {
+                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            stack.PushBytes(env.ExecutingAccount.Bytes);
+                            break;
+                        }
+                    case Instruction.BALANCE:
+                        {
+                            long gasCost = spec.GetBalanceCost();
+                            if (gasCost != 0 && !UpdateGas(gasCost, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            Address address = stack.PopAddress();
+                            if (!ChargeAccountAccessGas(ref gasAvailable, vmState, address, spec))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            UInt256 balance = _state.GetBalance(address);
+                            stack.PushUInt256(in balance);
+                            break;
+                        }
+                    case Instruction.CALLER:
+                        {
+                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            stack.PushBytes(env.Caller.Bytes);
+                            break;
+                        }
+                    case Instruction.CALLVALUE:
+                        {
+                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            UInt256 callValue = env.Value;
+                            stack.PushUInt256(in callValue);
+                            break;
+                        }
+                    case Instruction.ORIGIN:
+                        {
+                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            stack.PushBytes(txCtx.Origin.Bytes);
+                            break;
+                        }
+                    case Instruction.CALLDATALOAD:
+                        {
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            stack.PopUInt256(out UInt256 src);
+                            stack.PushBytes(env.InputData.SliceWithZeroPadding(src, 32));
+                            break;
+                        }
+                    case Instruction.CALLDATASIZE:
+                        {
+                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            UInt256 callDataSize = (UInt256)env.InputData.Length;
+                            stack.PushUInt256(in callDataSize);
+                            break;
+                        }
+                    case Instruction.CALLDATACOPY:
+                        {
+                            stack.PopUInt256(out UInt256 dest);
+                            stack.PopUInt256(out UInt256 src);
+                            stack.PopUInt256(out UInt256 length);
+                            if (!UpdateGas(GasCostOf.VeryLow + GasCostOf.Memory * EvmPooledMemory.Div32Ceiling(length),
+                                    ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            if (length > UInt256.Zero)
+                            {
+                                UpdateMemoryCost(in dest, length);
+
+                                ZeroPaddedMemory callDataSlice = env.InputData.SliceWithZeroPadding(src, (int)length);
+                                vmState.Memory.Save(in dest, callDataSlice);
+                                if (_txTracer.IsTracingInstructions)
                                 {
-                                    vmState.Refund += sClearRefunds;
-                                    if (_txTracer.IsTracingRefunds) _txTracer.ReportRefund(sClearRefunds);
+                                    _txTracer.ReportMemoryChange((long)dest, callDataSlice);
                                 }
                             }
-                            else if (currentIsZero)
+
+                            break;
+                        }
+                    case Instruction.CODESIZE:
+                        {
+                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
                             {
-                                if (!UpdateGas(GasCostOf.SSet - GasCostOf.SReset, ref gasAvailable))
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            UInt256 codeLength = (UInt256)code.Length;
+                            stack.PushUInt256(in codeLength);
+                            break;
+                        }
+                    case Instruction.CODECOPY:
+                        {
+                            stack.PopUInt256(out UInt256 dest);
+                            stack.PopUInt256(out UInt256 src);
+                            stack.PopUInt256(out UInt256 length);
+                            if (!UpdateGas(GasCostOf.VeryLow + GasCostOf.Memory * EvmPooledMemory.Div32Ceiling(length),
+                                    ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            if (length > UInt256.Zero)
+                            {
+                                UpdateMemoryCost(in dest, length);
+
+                                ZeroPaddedSpan codeSlice = code.SliceWithZeroPadding(src, (int)length);
+                                vmState.Memory.Save(in dest, codeSlice);
+                                if (_txTracer.IsTracingInstructions) _txTracer.ReportMemoryChange((long)dest, codeSlice);
+                            }
+
+                            break;
+                        }
+                    case Instruction.GASPRICE:
+                        {
+                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            UInt256 gasPrice = txCtx.GasPrice;
+                            stack.PushUInt256(in gasPrice);
+                            break;
+                        }
+                    case Instruction.EXTCODESIZE:
+                        {
+                            long gasCost = spec.GetExtCodeCost();
+                            if (!UpdateGas(gasCost, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            Address address = stack.PopAddress();
+                            if (!ChargeAccountAccessGas(ref gasAvailable, vmState, address, spec))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            byte[] accountCode = GetCachedCodeInfo(_worldState, address, spec).MachineCode;
+                            UInt256 codeSize = (UInt256)accountCode.Length;
+                            stack.PushUInt256(in codeSize);
+                            break;
+                        }
+                    case Instruction.EXTCODECOPY:
+                        {
+                            Address address = stack.PopAddress();
+                            stack.PopUInt256(out UInt256 dest);
+                            stack.PopUInt256(out UInt256 src);
+                            stack.PopUInt256(out UInt256 length);
+
+                            long gasCost = spec.GetExtCodeCost();
+                            if (!UpdateGas(gasCost + GasCostOf.Memory * EvmPooledMemory.Div32Ceiling(length),
+                                    ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            if (!ChargeAccountAccessGas(ref gasAvailable, vmState, address, spec))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            if (length > UInt256.Zero)
+                            {
+                                UpdateMemoryCost(in dest, length);
+
+                                byte[] externalCode = GetCachedCodeInfo(_worldState, address, spec).MachineCode;
+                                ZeroPaddedSpan callDataSlice = externalCode.SliceWithZeroPadding(src, (int)length);
+                                vmState.Memory.Save(in dest, callDataSlice);
+                                if (_txTracer.IsTracingInstructions)
+                                {
+                                    _txTracer.ReportMemoryChange((long)dest, callDataSlice);
+                                }
+                            }
+
+                            break;
+                        }
+                    case Instruction.RETURNDATASIZE:
+                        {
+                            if (!spec.ReturnDataOpcodesEnabled)
+                            {
+                                EndInstructionTraceError(EvmExceptionType.BadInstruction);
+                                return CallResult.InvalidInstructionException;
+                            }
+
+                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            UInt256 res = (UInt256)_returnDataBuffer.Length;
+                            stack.PushUInt256(in res);
+                            break;
+                        }
+                    case Instruction.RETURNDATACOPY:
+                        {
+                            if (!spec.ReturnDataOpcodesEnabled)
+                            {
+                                EndInstructionTraceError(EvmExceptionType.BadInstruction);
+                                return CallResult.InvalidInstructionException;
+                            }
+
+                            stack.PopUInt256(out UInt256 dest);
+                            stack.PopUInt256(out UInt256 src);
+                            stack.PopUInt256(out UInt256 length);
+                            if (!UpdateGas(GasCostOf.VeryLow + GasCostOf.Memory * EvmPooledMemory.Div32Ceiling(length),
+                                    ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            if (UInt256.AddOverflow(length, src, out UInt256 newLength) || newLength > _returnDataBuffer.Length)
+                            {
+                                return CallResult.AccessViolationException;
+                            }
+
+                            if (length > UInt256.Zero)
+                            {
+                                UpdateMemoryCost(in dest, length);
+
+                                ZeroPaddedSpan returnDataSlice = _returnDataBuffer.AsSpan().SliceWithZeroPadding(src, (int)length);
+                                vmState.Memory.Save(in dest, returnDataSlice);
+                                if (_txTracer.IsTracingInstructions)
+                                {
+                                    _txTracer.ReportMemoryChange((long)dest, returnDataSlice);
+                                }
+                            }
+
+                            break;
+                        }
+                    case Instruction.BLOCKHASH:
+                        {
+                            Metrics.BlockhashOpcode++;
+
+                            if (!UpdateGas(GasCostOf.BlockHash, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            stack.PopUInt256(out UInt256 a);
+                            long number = a > long.MaxValue ? long.MaxValue : (long)a;
+                            Keccak blockHash = _blockhashProvider.GetBlockhash(txCtx.Header, number);
+                            stack.PushBytes(blockHash?.Bytes ?? BytesZero32);
+
+                            if (isTrace)
+                            {
+                                if (_txTracer.IsTracingBlockHash && blockHash != null)
+                                {
+                                    _txTracer.ReportBlockHash(blockHash);
+                                }
+                            }
+
+                            break;
+                        }
+                    case Instruction.COINBASE:
+                        {
+                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            stack.PushBytes(txCtx.Header.GasBeneficiary.Bytes);
+                            break;
+                        }
+                    case Instruction.DIFFICULTY:
+                        {
+                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            UInt256 diff = txCtx.Header.Difficulty;
+                            stack.PushUInt256(in diff);
+                            break;
+                        }
+                    case Instruction.TIMESTAMP:
+                        {
+                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            UInt256 timestamp = txCtx.Header.Timestamp;
+                            stack.PushUInt256(in timestamp);
+                            break;
+                        }
+                    case Instruction.NUMBER:
+                        {
+                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            UInt256 blockNumber = (UInt256)txCtx.Header.Number;
+                            stack.PushUInt256(in blockNumber);
+                            break;
+                        }
+                    case Instruction.GASLIMIT:
+                        {
+                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            UInt256 gasLimit = (UInt256)txCtx.Header.GasLimit;
+                            stack.PushUInt256(in gasLimit);
+                            break;
+                        }
+                    case Instruction.CHAINID:
+                        {
+                            if (!spec.ChainIdOpcodeEnabled)
+                            {
+                                EndInstructionTraceError(EvmExceptionType.BadInstruction);
+                                return CallResult.InvalidInstructionException;
+                            }
+
+                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            stack.PushBytes(_chainId);
+                            break;
+                        }
+                    case Instruction.SELFBALANCE:
+                        {
+                            if (!spec.SelfBalanceOpcodeEnabled)
+                            {
+                                EndInstructionTraceError(EvmExceptionType.BadInstruction);
+                                return CallResult.InvalidInstructionException;
+                            }
+
+                            if (!UpdateGas(GasCostOf.SelfBalance, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            UInt256 balance = _state.GetBalance(env.ExecutingAccount);
+                            stack.PushUInt256(in balance);
+                            break;
+                        }
+                    case Instruction.BASEFEE:
+                        {
+                            if (!spec.BaseFeeEnabled)
+                            {
+                                EndInstructionTraceError(EvmExceptionType.BadInstruction);
+                                return CallResult.InvalidInstructionException;
+                            }
+
+                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            UInt256 baseFee = txCtx.Header.BaseFeePerGas;
+                            stack.PushUInt256(in baseFee);
+                            break;
+                        }
+                    case Instruction.POP:
+                        {
+                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            stack.PopLimbo();
+                            break;
+                        }
+                    case Instruction.MLOAD:
+                        {
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            stack.PopUInt256(out UInt256 memPosition);
+                            UpdateMemoryCost(in memPosition, 32);
+                            Span<byte> memData = vmState.Memory.LoadSpan(in memPosition);
+                            if (_txTracer.IsTracingInstructions) _txTracer.ReportMemoryChange(memPosition, memData);
+
+                            stack.PushBytes(memData);
+                            break;
+                        }
+                    case Instruction.MSTORE:
+                        {
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            stack.PopUInt256(out UInt256 memPosition);
+
+                            Span<byte> data = stack.PopBytes();
+                            UpdateMemoryCost(in memPosition, 32);
+                            vmState.Memory.SaveWord(in memPosition, data);
+                            if (_txTracer.IsTracingInstructions)
+                                _txTracer.ReportMemoryChange((long)memPosition,
+                                    data.SliceWithZeroPadding(0, 32, PadDirection.Left));
+
+                            break;
+                        }
+                    case Instruction.MSTORE8:
+                        {
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            stack.PopUInt256(out UInt256 memPosition);
+                            byte data = stack.PopByte();
+                            UpdateMemoryCost(in memPosition, UInt256.One);
+                            vmState.Memory.SaveByte(in memPosition, data);
+                            if (_txTracer.IsTracingInstructions) _txTracer.ReportMemoryChange((long)memPosition, data);
+
+                            break;
+                        }
+                    case Instruction.SLOAD:
+                        {
+                            Metrics.SloadOpcode++;
+                            var gasCost = spec.GetSLoadCost();
+
+                            if (!UpdateGas(gasCost, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            stack.PopUInt256(out UInt256 storageIndex);
+                            StorageCell storageCell = new(env.ExecutingAccount, storageIndex);
+                            if (!ChargeStorageAccessGas(
+                                    ref gasAvailable,
+                                    vmState,
+                                    storageCell,
+                                    StorageAccessType.SLOAD,
+                                    spec))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            byte[] value = _storage.Get(storageCell);
+                            stack.PushBytes(value);
+                            break;
+                        }
+                    case Instruction.SSTORE:
+                        {
+                            Metrics.SstoreOpcode++;
+
+                            if (vmState.IsStatic)
+                            {
+                                EndInstructionTraceError(EvmExceptionType.StaticCallViolation);
+                                return CallResult.StaticCallViolationException;
+                            }
+
+                            // fail fast before the first storage read if gas is not enough even for reset
+                            if (!spec.UseNetGasMetering && !UpdateGas(spec.GetSStoreResetCost(), ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            if (spec.UseNetGasMeteringWithAStipendFix)
+                            {
+                                if (_txTracer.IsTracingRefunds)
+                                    _txTracer.ReportExtraGasPressure(GasCostOf.CallStipend - spec.GetNetMeteredSStoreCost() + 1);
+                                if (gasAvailable <= GasCostOf.CallStipend)
                                 {
                                     EndInstructionTraceError(EvmExceptionType.OutOfGas);
                                     return CallResult.OutOfGasException;
                                 }
                             }
-                        }
-                        else // net metered
-                        {
-                            if (newSameAsCurrent)
+
+                            stack.PopUInt256(out UInt256 storageIndex);
+                            Span<byte> newValue = stack.PopBytes();
+                            bool newIsZero = newValue.IsZero();
+                            if (!newIsZero)
                             {
-                                if (!UpdateGas(spec.GetNetMeteredSStoreCost(), ref gasAvailable))
-                                {
-                                    EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                    return CallResult.OutOfGasException;
-                                }
+                                newValue = newValue.WithoutLeadingZeros().ToArray();
                             }
-                            else // net metered, C != N
+                            else
                             {
-                                Span<byte> originalValue = _storage.GetOriginal(storageCell);
-                                bool originalIsZero = originalValue.IsZero();
+                                newValue = new byte[] { 0 };
+                            }
 
-                                bool currentSameAsOriginal = Bytes.AreEqual(originalValue, currentValue);
-                                if (currentSameAsOriginal)
+                            StorageCell storageCell = new(env.ExecutingAccount, storageIndex);
+
+                            if (!ChargeStorageAccessGas(
+                                    ref gasAvailable,
+                                    vmState,
+                                    storageCell,
+                                    StorageAccessType.SSTORE,
+                                    spec))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            Span<byte> currentValue = _storage.Get(storageCell);
+                            // Console.WriteLine($"current: {currentValue.ToHexString()} newValue {newValue.ToHexString()}");
+                            bool currentIsZero = currentValue.IsZero();
+
+                            bool newSameAsCurrent = (newIsZero && currentIsZero) || Bytes.AreEqual(currentValue, newValue);
+                            long sClearRefunds = RefundOf.SClear(spec.IsEip3529Enabled);
+
+                            if (!spec.UseNetGasMetering) // note that for this case we already deducted 5000
+                            {
+                                if (newIsZero)
                                 {
-                                    if (currentIsZero)
+                                    if (!newSameAsCurrent)
                                     {
-                                        if (!UpdateGas(GasCostOf.SSet, ref gasAvailable))
-                                        {
-                                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                            return CallResult.OutOfGasException;
-                                        }
-                                    }
-                                    else // net metered, current == original != new, !currentIsZero
-                                    {
-                                        if (!UpdateGas(spec.GetSStoreResetCost(), ref gasAvailable))
-                                        {
-                                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                            return CallResult.OutOfGasException;
-                                        }
-
-                                        if (newIsZero)
-                                        {
-                                            vmState.Refund += sClearRefunds;
-                                            if (_txTracer.IsTracingRefunds) _txTracer.ReportRefund(sClearRefunds);
-                                        }
+                                        vmState.Refund += sClearRefunds;
+                                        if (_txTracer.IsTracingRefunds) _txTracer.ReportRefund(sClearRefunds);
                                     }
                                 }
-                                else // net metered, new != current != original
+                                else if (currentIsZero)
                                 {
-                                    long netMeteredStoreCost = spec.GetNetMeteredSStoreCost();
-                                    if (!UpdateGas(netMeteredStoreCost, ref gasAvailable))
+                                    if (!UpdateGas(GasCostOf.SSet - GasCostOf.SReset, ref gasAvailable))
                                     {
                                         EndInstructionTraceError(EvmExceptionType.OutOfGas);
                                         return CallResult.OutOfGasException;
                                     }
+                                }
+                            }
+                            else // net metered
+                            {
+                                if (newSameAsCurrent)
+                                {
+                                    if (!UpdateGas(spec.GetNetMeteredSStoreCost(), ref gasAvailable))
+                                    {
+                                        EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                        return CallResult.OutOfGasException;
+                                    }
+                                }
+                                else // net metered, C != N
+                                {
+                                    Span<byte> originalValue = _storage.GetOriginal(storageCell);
+                                    bool originalIsZero = originalValue.IsZero();
 
-                                    if (!originalIsZero) // net metered, new != current != original != 0
+                                    bool currentSameAsOriginal = Bytes.AreEqual(originalValue, currentValue);
+                                    if (currentSameAsOriginal)
                                     {
                                         if (currentIsZero)
                                         {
-                                            vmState.Refund -= sClearRefunds;
-                                            if (_txTracer.IsTracingRefunds) _txTracer.ReportRefund(-sClearRefunds);
+                                            if (!UpdateGas(GasCostOf.SSet, ref gasAvailable))
+                                            {
+                                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                                return CallResult.OutOfGasException;
+                                            }
                                         }
-
-                                        if (newIsZero)
+                                        else // net metered, current == original != new, !currentIsZero
                                         {
-                                            vmState.Refund += sClearRefunds;
-                                            if (_txTracer.IsTracingRefunds) _txTracer.ReportRefund(sClearRefunds);
+                                            if (!UpdateGas(spec.GetSStoreResetCost(), ref gasAvailable))
+                                            {
+                                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                                return CallResult.OutOfGasException;
+                                            }
+
+                                            if (newIsZero)
+                                            {
+                                                vmState.Refund += sClearRefunds;
+                                                if (_txTracer.IsTracingRefunds) _txTracer.ReportRefund(sClearRefunds);
+                                            }
                                         }
                                     }
-
-                                    bool newSameAsOriginal = Bytes.AreEqual(originalValue, newValue);
-                                    if (newSameAsOriginal)
+                                    else // net metered, new != current != original
                                     {
-                                        long refundFromReversal;
-                                        if (originalIsZero)
+                                        long netMeteredStoreCost = spec.GetNetMeteredSStoreCost();
+                                        if (!UpdateGas(netMeteredStoreCost, ref gasAvailable))
                                         {
-                                            refundFromReversal = spec.GetSetReversalRefund();
-                                        }
-                                        else
-                                        {
-                                            refundFromReversal = spec.GetClearReversalRefund();
+                                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                            return CallResult.OutOfGasException;
                                         }
 
-                                        vmState.Refund += refundFromReversal;
-                                        if (_txTracer.IsTracingRefunds) _txTracer.ReportRefund(refundFromReversal);
+                                        if (!originalIsZero) // net metered, new != current != original != 0
+                                        {
+                                            if (currentIsZero)
+                                            {
+                                                vmState.Refund -= sClearRefunds;
+                                                if (_txTracer.IsTracingRefunds) _txTracer.ReportRefund(-sClearRefunds);
+                                            }
+
+                                            if (newIsZero)
+                                            {
+                                                vmState.Refund += sClearRefunds;
+                                                if (_txTracer.IsTracingRefunds) _txTracer.ReportRefund(sClearRefunds);
+                                            }
+                                        }
+
+                                        bool newSameAsOriginal = Bytes.AreEqual(originalValue, newValue);
+                                        if (newSameAsOriginal)
+                                        {
+                                            long refundFromReversal;
+                                            if (originalIsZero)
+                                            {
+                                                refundFromReversal = spec.GetSetReversalRefund();
+                                            }
+                                            else
+                                            {
+                                                refundFromReversal = spec.GetClearReversalRefund();
+                                            }
+
+                                            vmState.Refund += refundFromReversal;
+                                            if (_txTracer.IsTracingRefunds) _txTracer.ReportRefund(refundFromReversal);
+                                        }
                                     }
                                 }
                             }
-                        }
 
-                        if (!newSameAsCurrent)
-                        {
-                            Span<byte> valueToStore = newIsZero ? BytesZero : newValue;
-                            _storage.Set(storageCell, valueToStore.ToArray());
-                        }
+                            if (!newSameAsCurrent)
+                            {
+                                Span<byte> valueToStore = newIsZero ? BytesZero : newValue;
+                                _storage.Set(storageCell, valueToStore.ToArray());
+                            }
 
-                        if (_txTracer.IsTracingInstructions)
-                        {
-                            Span<byte> valueToStore = newIsZero ? BytesZero : newValue;
-                            Span<byte> span = new byte[32]; // do not stackalloc here
-                            storageCell.Index.ToBigEndian(span);
-                            _txTracer.ReportStorageChange(span, valueToStore);
-                        }
+                            if (_txTracer.IsTracingInstructions)
+                            {
+                                Span<byte> valueToStore = newIsZero ? BytesZero : newValue;
+                                Span<byte> span = new byte[32]; // do not stackalloc here
+                                storageCell.Index.ToBigEndian(span);
+                                _txTracer.ReportStorageChange(span, valueToStore);
+                            }
 
-                        if (_txTracer.IsTracingOpLevelStorage)
-                        {
-                            _txTracer.SetOperationStorage(storageCell.Address, storageIndex, newValue, currentValue);
-                        }
+                            if (_txTracer.IsTracingOpLevelStorage)
+                            {
+                                _txTracer.SetOperationStorage(storageCell.Address, storageIndex, newValue, currentValue);
+                            }
 
-                        break;
-                    }
+                            break;
+                        }
                     case Instruction.JUMP:
-                    {
-                        if (!UpdateGas(GasCostOf.Mid, ref gasAvailable))
                         {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
+                            if (!UpdateGas(GasCostOf.Mid, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
 
-                        stack.PopUInt256(out UInt256 jumpDest);
-                        Jump(jumpDest);
-                        break;
-                    }
-                    case Instruction.JUMPI:
-                    {
-                        if (!UpdateGas(GasCostOf.High, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        stack.PopUInt256(out UInt256 jumpDest);
-                        Span<byte> condition = stack.PopBytes();
-                        if (!condition.SequenceEqual(BytesZero32))
-                        {
+                            stack.PopUInt256(out UInt256 jumpDest);
                             Jump(jumpDest);
+                            break;
                         }
+                    case Instruction.JUMPI:
+                        {
+                            if (!UpdateGas(GasCostOf.High, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
 
-                        break;
-                    }
+                            stack.PopUInt256(out UInt256 jumpDest);
+                            Span<byte> condition = stack.PopBytes();
+                            if (!condition.SequenceEqual(BytesZero32))
+                            {
+                                Jump(jumpDest);
+                            }
+
+                            break;
+                        }
                     case Instruction.PC:
-                    {
-                        if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
                         {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
+                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
 
-                        stack.PushUInt32(programCounter - 1);
-                        break;
-                    }
+                            stack.PushUInt32(programCounter - 1);
+                            break;
+                        }
                     case Instruction.MSIZE:
-                    {
-                        if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
                         {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
+                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
 
-                        UInt256 size = vmState.Memory.Size;
-                        stack.PushUInt256(in size);
-                        break;
-                    }
+                            UInt256 size = vmState.Memory.Size;
+                            stack.PushUInt256(in size);
+                            break;
+                        }
                     case Instruction.GAS:
-                    {
-                        if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
                         {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
+                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
 
-                        UInt256 gas = (UInt256) gasAvailable;
-                        stack.PushUInt256(in gas);
-                        break;
-                    }
+                            UInt256 gas = (UInt256)gasAvailable;
+                            stack.PushUInt256(in gas);
+                            break;
+                        }
                     case Instruction.JUMPDEST:
-                    {
-                        if (!UpdateGas(GasCostOf.JumpDest, ref gasAvailable))
                         {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
+                            if (!UpdateGas(GasCostOf.JumpDest, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
 
-                        break;
-                    }
+                            break;
+                        }
                     case Instruction.PUSH1:
-                    {
-                        if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
                         {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
 
-                        int programCounterInt = programCounter;
-                        if (programCounterInt >= code.Length)
-                        {
-                            stack.PushZero();
-                        }
-                        else
-                        {
-                            stack.PushByte(code[programCounterInt]);
-                        }
+                            int programCounterInt = programCounter;
+                            if (programCounterInt >= code.Length)
+                            {
+                                stack.PushZero();
+                            }
+                            else
+                            {
+                                stack.PushByte(code[programCounterInt]);
+                            }
 
-                        programCounter++;
-                        break;
-                    }
+                            programCounter++;
+                            break;
+                        }
                     case Instruction.PUSH2:
                     case Instruction.PUSH3:
                     case Instruction.PUSH4:
@@ -2128,22 +2191,22 @@ namespace Nethermind.Evm
                     case Instruction.PUSH30:
                     case Instruction.PUSH31:
                     case Instruction.PUSH32:
-                    {
-                        if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
                         {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            int length = instruction - Instruction.PUSH1 + 1;
+                            int programCounterInt = programCounter;
+                            int usedFromCode = Math.Min(code.Length - programCounterInt, length);
+
+                            stack.PushLeftPaddedBytes(code.Slice(programCounterInt, usedFromCode), length);
+
+                            programCounter += length;
+                            break;
                         }
-
-                        int length = instruction - Instruction.PUSH1 + 1;
-                        int programCounterInt = programCounter;
-                        int usedFromCode = Math.Min(code.Length - programCounterInt, length);
-
-                        stack.PushLeftPaddedBytes(code.Slice(programCounterInt, usedFromCode), length);
-
-                        programCounter += length;
-                        break;
-                    }
                     case Instruction.DUP1:
                     case Instruction.DUP2:
                     case Instruction.DUP3:
@@ -2160,16 +2223,16 @@ namespace Nethermind.Evm
                     case Instruction.DUP14:
                     case Instruction.DUP15:
                     case Instruction.DUP16:
-                    {
-                        if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
                         {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
 
-                        stack.Dup(instruction - Instruction.DUP1 + 1);
-                        break;
-                    }
+                            stack.Dup(instruction - Instruction.DUP1 + 1);
+                            break;
+                        }
                     case Instruction.SWAP1:
                     case Instruction.SWAP2:
                     case Instruction.SWAP3:
@@ -2186,668 +2249,677 @@ namespace Nethermind.Evm
                     case Instruction.SWAP14:
                     case Instruction.SWAP15:
                     case Instruction.SWAP16:
-                    {
-                        if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
                         {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
 
-                        stack.Swap(instruction - Instruction.SWAP1 + 2);
-                        break;
-                    }
+                            stack.Swap(instruction - Instruction.SWAP1 + 2);
+                            break;
+                        }
                     case Instruction.LOG0:
                     case Instruction.LOG1:
                     case Instruction.LOG2:
                     case Instruction.LOG3:
                     case Instruction.LOG4:
-                    {
-                        if (vmState.IsStatic)
                         {
-                            EndInstructionTraceError(EvmExceptionType.StaticCallViolation);
-                            return CallResult.StaticCallViolationException;
-                        }
+                            if (vmState.IsStatic)
+                            {
+                                EndInstructionTraceError(EvmExceptionType.StaticCallViolation);
+                                return CallResult.StaticCallViolationException;
+                            }
 
-                        stack.PopUInt256(out UInt256 memoryPos);
-                        stack.PopUInt256(out UInt256 length);
-                        long topicsCount = instruction - Instruction.LOG0;
-                        UpdateMemoryCost(in memoryPos, length);
-                        if (!UpdateGas(
-                            GasCostOf.Log + topicsCount * GasCostOf.LogTopic +
-                            (long) length * GasCostOf.LogData, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
+                            stack.PopUInt256(out UInt256 memoryPos);
+                            stack.PopUInt256(out UInt256 length);
+                            long topicsCount = instruction - Instruction.LOG0;
+                            UpdateMemoryCost(in memoryPos, length);
+                            if (!UpdateGas(
+                                    GasCostOf.Log + topicsCount * GasCostOf.LogTopic +
+                                    (long)length * GasCostOf.LogData, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
 
-                        ReadOnlyMemory<byte> data = vmState.Memory.Load(in memoryPos, length);
-                        Keccak[] topics = new Keccak[topicsCount];
-                        for (int i = 0; i < topicsCount; i++)
-                        {
-                            topics[i] = new Keccak(stack.PopBytes().ToArray());
-                        }
+                            ReadOnlyMemory<byte> data = vmState.Memory.Load(in memoryPos, length);
+                            Keccak[] topics = new Keccak[topicsCount];
+                            for (int i = 0; i < topicsCount; i++)
+                            {
+                                topics[i] = new Keccak(stack.PopBytes().ToArray());
+                            }
 
-                        LogEntry logEntry = new(
-                            env.ExecutingAccount,
-                            data.ToArray(),
-                            topics);
-                        vmState.Logs.Add(logEntry);
-                        break;
-                    }
+                            LogEntry logEntry = new(
+                                env.ExecutingAccount,
+                                data.ToArray(),
+                                topics);
+                            vmState.Logs.Add(logEntry);
+                            break;
+                        }
                     case Instruction.CREATE:
                     case Instruction.CREATE2:
-                    {
-                        if (!spec.Create2OpcodeEnabled && instruction == Instruction.CREATE2)
                         {
-                            EndInstructionTraceError(EvmExceptionType.BadInstruction);
-                            return CallResult.InvalidInstructionException;
+                            if (!spec.Create2OpcodeEnabled && instruction == Instruction.CREATE2)
+                            {
+                                EndInstructionTraceError(EvmExceptionType.BadInstruction);
+                                return CallResult.InvalidInstructionException;
+                            }
+
+                            if (vmState.IsStatic)
+                            {
+                                EndInstructionTraceError(EvmExceptionType.StaticCallViolation);
+                                return CallResult.StaticCallViolationException;
+                            }
+
+                            // TODO: happens in CREATE_empty000CreateInitCode_Transaction but probably has to be handled differently
+                            if (!_state.AccountExists(env.ExecutingAccount))
+                            {
+                                _state.CreateAccount(env.ExecutingAccount, UInt256.Zero);
+                            }
+
+                            stack.PopUInt256(out UInt256 value);
+                            stack.PopUInt256(out UInt256 memoryPositionOfInitCode);
+                            stack.PopUInt256(out UInt256 initCodeLength);
+                            Span<byte> salt = null;
+                            if (instruction == Instruction.CREATE2)
+                            {
+                                salt = stack.PopBytes();
+                            }
+
+                            long gasCost = GasCostOf.Create + (instruction == Instruction.CREATE2
+                                ? GasCostOf.Sha3Word * EvmPooledMemory.Div32Ceiling(initCodeLength)
+                                : 0);
+                            if (!UpdateGas(gasCost, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            UpdateMemoryCost(in memoryPositionOfInitCode, initCodeLength);
+
+                            // TODO: copy pasted from CALL / DELEGATECALL, need to move it outside?
+                            if (env.CallDepth >=
+                                MaxCallDepth) // TODO: fragile ordering / potential vulnerability for different clients
+                            {
+                                // TODO: need a test for this
+                                _returnDataBuffer = Array.Empty<byte>();
+                                stack.PushZero();
+                                break;
+                            }
+
+                            Span<byte> initCode = vmState.Memory.LoadSpan(in memoryPositionOfInitCode, initCodeLength);
+
+                            UInt256 balance = _state.GetBalance(env.ExecutingAccount);
+                            if (value > balance)
+                            {
+                                _returnDataBuffer = Array.Empty<byte>();
+                                stack.PushZero();
+                                break;
+                            }
+
+                            UInt256 accountNonce = _state.GetNonce(env.ExecutingAccount);
+                            UInt256 maxNonce = ulong.MaxValue;
+                            if (accountNonce >= maxNonce)
+                            {
+                                _returnDataBuffer = Array.Empty<byte>();
+                                stack.PushZero();
+                                break;
+                            }
+
+                            EndInstructionTrace();
+                            // todo: === below is a new call - refactor / move
+
+                            long callGas = spec.Use63Over64Rule ? gasAvailable - gasAvailable / 64L : gasAvailable;
+                            if (!UpdateGas(callGas, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            Address contractAddress = instruction == Instruction.CREATE
+                                ? ContractAddress.From(env.ExecutingAccount, _state.GetNonce(env.ExecutingAccount))
+                                : ContractAddress.From(env.ExecutingAccount, salt, initCode);
+
+                            if (spec.UseHotAndColdStorage)
+                            {
+                                // EIP-2929 assumes that warm-up cost is included in the costs of CREATE and CREATE2
+                                vmState.WarmUp(contractAddress);
+                            }
+
+                            _state.IncrementNonce(env.ExecutingAccount);
+
+                            Snapshot snapshot = _worldState.TakeSnapshot();
+
+                            bool accountExists = _state.AccountExists(contractAddress);
+                            if (accountExists && (GetCachedCodeInfo(_worldState, contractAddress, spec).MachineCode.Length != 0 ||
+                                                  _state.GetNonce(contractAddress) != 0))
+                            {
+                                /* we get the snapshot before this as there is a possibility with that we will touch an empty account and remove it even if the REVERT operation follows */
+                                if (isTrace) _logger.Trace($"Contract collision at {contractAddress}");
+                                _returnDataBuffer = Array.Empty<byte>();
+                                stack.PushZero();
+                                break;
+                            }
+
+                            if (accountExists)
+                            {
+                                _state.UpdateStorageRoot(contractAddress, Keccak.EmptyTreeHash);
+                            }
+                            else if (_state.IsDeadAccount(contractAddress))
+                            {
+                                _storage.ClearStorage(contractAddress);
+                            }
+
+                            _state.SubtractFromBalance(env.ExecutingAccount, value, spec);
+                            ExecutionEnvironment callEnv = new();
+                            callEnv.TxExecutionContext = env.TxExecutionContext;
+                            callEnv.CallDepth = env.CallDepth + 1;
+                            callEnv.Caller = env.ExecutingAccount;
+                            callEnv.ExecutingAccount = contractAddress;
+                            callEnv.CodeSource = null;
+                            callEnv.CodeInfo = new CodeInfo(initCode.ToArray());
+                            callEnv.InputData = ReadOnlyMemory<byte>.Empty;
+                            callEnv.TransferValue = value;
+                            callEnv.Value = value;
+
+                            EvmState callState = new(
+                                callGas,
+                                callEnv,
+                                instruction == Instruction.CREATE2 ? ExecutionType.Create2 : ExecutionType.Create,
+                                false,
+                                snapshot,
+                                0L,
+                                0L,
+                                vmState.IsStatic,
+                                vmState,
+                                false,
+                                accountExists);
+
+                            UpdateCurrentState(vmState, programCounter, gasAvailable, stack.Head);
+                            return new CallResult(callState);
                         }
-
-                        if (vmState.IsStatic)
-                        {
-                            EndInstructionTraceError(EvmExceptionType.StaticCallViolation);
-                            return CallResult.StaticCallViolationException;
-                        }
-
-                        // TODO: happens in CREATE_empty000CreateInitCode_Transaction but probably has to be handled differently
-                        if (!_state.AccountExists(env.ExecutingAccount))
-                        {
-                            _state.CreateAccount(env.ExecutingAccount, UInt256.Zero);
-                        }
-
-                        stack.PopUInt256(out UInt256 value);
-                        stack.PopUInt256(out UInt256 memoryPositionOfInitCode);
-                        stack.PopUInt256(out UInt256 initCodeLength);
-                        Span<byte> salt = null;
-                        if (instruction == Instruction.CREATE2)
-                        {
-                            salt = stack.PopBytes();
-                        }
-
-                        long gasCost = GasCostOf.Create + (instruction == Instruction.CREATE2 ? GasCostOf.Sha3Word * EvmPooledMemory.Div32Ceiling(initCodeLength) : 0);
-                        if (!UpdateGas(gasCost, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        UpdateMemoryCost(in memoryPositionOfInitCode, initCodeLength);
-
-                        // TODO: copy pasted from CALL / DELEGATECALL, need to move it outside?
-                        if (env.CallDepth >= MaxCallDepth) // TODO: fragile ordering / potential vulnerability for different clients
-                        {
-                            // TODO: need a test for this
-                            _returnDataBuffer = Array.Empty<byte>();
-                            stack.PushZero();
-                            break;
-                        }
-
-                        Span<byte> initCode = vmState.Memory.LoadSpan(in memoryPositionOfInitCode, initCodeLength);
-                        
-                        UInt256 balance = _state.GetBalance(env.ExecutingAccount);
-                        if (value > balance)
-                        {
-                            _returnDataBuffer = Array.Empty<byte>();
-                            stack.PushZero();
-                            break;
-                        }
-                        
-                        UInt256 accountNonce = _state.GetNonce(env.ExecutingAccount);
-                        UInt256 maxNonce = ulong.MaxValue;
-                        if (accountNonce >= maxNonce)
-                        {
-                            _returnDataBuffer = Array.Empty<byte>();
-                            stack.PushZero();
-                            break;
-                        }
-
-                        EndInstructionTrace();
-                        // todo: === below is a new call - refactor / move
-
-                        long callGas = spec.Use63Over64Rule ? gasAvailable - gasAvailable / 64L : gasAvailable;
-                        if (!UpdateGas(callGas, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        Address contractAddress = instruction == Instruction.CREATE
-                            ? ContractAddress.From(env.ExecutingAccount, _state.GetNonce(env.ExecutingAccount))
-                            : ContractAddress.From(env.ExecutingAccount, salt, initCode);
-
-                        if (spec.UseHotAndColdStorage)
-                        {
-                            // EIP-2929 assumes that warm-up cost is included in the costs of CREATE and CREATE2
-                            vmState.WarmUp(contractAddress);
-                        }
-
-                        _state.IncrementNonce(env.ExecutingAccount);
-
-                        Snapshot snapshot = _worldState.TakeSnapshot();
-
-                        bool accountExists = _state.AccountExists(contractAddress);
-                        if (accountExists && (GetCachedCodeInfo(_worldState, contractAddress, spec).MachineCode.Length != 0 || _state.GetNonce(contractAddress) != 0))
-                        {
-                            /* we get the snapshot before this as there is a possibility with that we will touch an empty account and remove it even if the REVERT operation follows */
-                            if (isTrace) _logger.Trace($"Contract collision at {contractAddress}");
-                            _returnDataBuffer = Array.Empty<byte>();
-                            stack.PushZero();
-                            break;
-                        }
-
-                        if (accountExists)
-                        {
-                            _state.UpdateStorageRoot(contractAddress, Keccak.EmptyTreeHash);
-                        }
-                        else if (_state.IsDeadAccount(contractAddress))
-                        {
-                            _storage.ClearStorage(contractAddress);
-                        }
-
-                        _state.SubtractFromBalance(env.ExecutingAccount, value, spec);
-                        ExecutionEnvironment callEnv = new();
-                        callEnv.TxExecutionContext = env.TxExecutionContext;
-                        callEnv.CallDepth = env.CallDepth + 1;
-                        callEnv.Caller = env.ExecutingAccount;
-                        callEnv.ExecutingAccount = contractAddress;
-                        callEnv.CodeSource = null;
-                        callEnv.CodeInfo = new CodeInfo(initCode.ToArray());
-                        callEnv.InputData = ReadOnlyMemory<byte>.Empty;
-                        callEnv.TransferValue = value;
-                        callEnv.Value = value;
-                        
-                        EvmState callState = new(
-                            callGas,
-                            callEnv,
-                            instruction == Instruction.CREATE2 ? ExecutionType.Create2 : ExecutionType.Create,
-                            false,
-                            snapshot,
-                            0L,
-                            0L,
-                            vmState.IsStatic,
-                            vmState,
-                            false,
-                            accountExists);
-
-                        UpdateCurrentState(vmState, programCounter, gasAvailable, stack.Head);
-                        return new CallResult(callState);
-                    }
                     case Instruction.RETURN:
-                    {
-                        stack.PopUInt256(out UInt256 memoryPos);
-                        stack.PopUInt256(out UInt256 length);
+                        {
+                            stack.PopUInt256(out UInt256 memoryPos);
+                            stack.PopUInt256(out UInt256 length);
 
-                        UpdateMemoryCost(in memoryPos, length);
-                        ReadOnlyMemory<byte> returnData = vmState.Memory.Load(in memoryPos, length);
+                            UpdateMemoryCost(in memoryPos, length);
+                            ReadOnlyMemory<byte> returnData = vmState.Memory.Load(in memoryPos, length);
 
-                        UpdateCurrentState(vmState, programCounter, gasAvailable, stack.Head);
-                        EndInstructionTrace();
-                        return new CallResult(returnData.ToArray(), null);
-                    }
+                            UpdateCurrentState(vmState, programCounter, gasAvailable, stack.Head);
+                            EndInstructionTrace();
+                            return new CallResult(returnData.ToArray(), null);
+                        }
                     case Instruction.CALL:
                     case Instruction.CALLCODE:
                     case Instruction.DELEGATECALL:
                     case Instruction.STATICCALL:
-                    {
-                        Metrics.Calls++;
-
-                        if (instruction == Instruction.DELEGATECALL && !spec.DelegateCallEnabled ||
-                            instruction == Instruction.STATICCALL && !spec.StaticCallEnabled)
                         {
+                            Metrics.Calls++;
+
+                            if (instruction == Instruction.DELEGATECALL && !spec.DelegateCallEnabled ||
+                                instruction == Instruction.STATICCALL && !spec.StaticCallEnabled)
+                            {
+                                EndInstructionTraceError(EvmExceptionType.BadInstruction);
+                                return CallResult.InvalidInstructionException;
+                            }
+
+                            stack.PopUInt256(out UInt256 gasLimit);
+                            Address codeSource = stack.PopAddress();
+
+                            // Console.WriteLine($"CALLIN {codeSource}");
+                            if (!ChargeAccountAccessGas(ref gasAvailable, vmState, codeSource, spec))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            UInt256 callValue;
+                            switch (instruction)
+                            {
+                                case Instruction.STATICCALL:
+                                    callValue = UInt256.Zero;
+                                    break;
+                                case Instruction.DELEGATECALL:
+                                    callValue = env.Value;
+                                    break;
+                                default:
+                                    stack.PopUInt256(out callValue);
+                                    break;
+                            }
+
+                            UInt256 transferValue = instruction == Instruction.DELEGATECALL ? UInt256.Zero : callValue;
+                            stack.PopUInt256(out UInt256 dataOffset);
+                            stack.PopUInt256(out UInt256 dataLength);
+                            stack.PopUInt256(out UInt256 outputOffset);
+                            stack.PopUInt256(out UInt256 outputLength);
+
+                            if (vmState.IsStatic && !transferValue.IsZero && instruction != Instruction.CALLCODE)
+                            {
+                                EndInstructionTraceError(EvmExceptionType.StaticCallViolation);
+                                return CallResult.StaticCallViolationException;
+                            }
+
+                            Address caller = instruction == Instruction.DELEGATECALL ? env.Caller : env.ExecutingAccount;
+                            Address target = instruction == Instruction.CALL || instruction == Instruction.STATICCALL
+                                ? codeSource
+                                : env.ExecutingAccount;
+
+                            if (isTrace)
+                            {
+                                _logger.Trace($"caller {caller}");
+                                _logger.Trace($"code source {codeSource}");
+                                _logger.Trace($"target {target}");
+                                _logger.Trace($"value {callValue}");
+                                _logger.Trace($"transfer value {transferValue}");
+                            }
+
+                            long gasExtra = 0L;
+
+                            if (!transferValue.IsZero)
+                            {
+                                gasExtra += GasCostOf.CallValue;
+                            }
+
+                            if (!spec.ClearEmptyAccountWhenTouched && !_state.AccountExists(target))
+                            {
+                                gasExtra += GasCostOf.NewAccount;
+                            }
+                            else if (spec.ClearEmptyAccountWhenTouched && transferValue != 0 && _state.IsDeadAccount(target))
+                            {
+                                gasExtra += GasCostOf.NewAccount;
+                            }
+
+                            if (!UpdateGas(spec.GetCallCost(), ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            UpdateMemoryCost(in dataOffset, dataLength);
+                            UpdateMemoryCost(in outputOffset, outputLength);
+                            if (!UpdateGas(gasExtra, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            if (spec.Use63Over64Rule)
+                            {
+                                gasLimit = UInt256.Min((UInt256)(gasAvailable - gasAvailable / 64), gasLimit);
+                            }
+
+                            long gasLimitUl = (long)gasLimit;
+                            if (!UpdateGas(gasLimitUl, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            if (!transferValue.IsZero)
+                            {
+                                if (_txTracer.IsTracingRefunds) _txTracer.ReportExtraGasPressure(GasCostOf.CallStipend);
+                                gasLimitUl += GasCostOf.CallStipend;
+                            }
+
+                            if (env.CallDepth >= MaxCallDepth ||
+                                !transferValue.IsZero && _state.GetBalance(env.ExecutingAccount) < transferValue)
+                            {
+                                _returnDataBuffer = Array.Empty<byte>();
+                                stack.PushZero();
+
+                                if (_txTracer.IsTracingInstructions)
+                                {
+                                    // very specific for Parity trace, need to find generalization - very peculiar 32 length...
+                                    ReadOnlyMemory<byte> memoryTrace = vmState.Memory.Inspect(in dataOffset, 32);
+                                    _txTracer.ReportMemoryChange(dataOffset, memoryTrace.Span);
+                                }
+
+                                if (isTrace) _logger.Trace("FAIL - call depth");
+                                if (_txTracer.IsTracingInstructions) _txTracer.ReportOperationRemainingGas(gasAvailable);
+                                if (_txTracer.IsTracingInstructions)
+                                    _txTracer.ReportOperationError(EvmExceptionType.NotEnoughBalance);
+
+                                UpdateGasUp(gasLimitUl, ref gasAvailable);
+                                if (_txTracer.IsTracingInstructions) _txTracer.ReportGasUpdateForVmTrace(gasLimitUl, gasAvailable);
+                                break;
+                            }
+
+                            ReadOnlyMemory<byte> callData = vmState.Memory.Load(in dataOffset, dataLength);
+
+                            Snapshot snapshot = _worldState.TakeSnapshot();
+                            _state.SubtractFromBalance(caller, transferValue, spec);
+
+                            ExecutionEnvironment callEnv = new();
+                            callEnv.TxExecutionContext = env.TxExecutionContext;
+                            callEnv.CallDepth = env.CallDepth + 1;
+                            callEnv.Caller = caller;
+                            callEnv.CodeSource = codeSource;
+                            callEnv.ExecutingAccount = target;
+                            callEnv.TransferValue = transferValue;
+                            callEnv.Value = callValue;
+                            callEnv.InputData = callData;
+                            callEnv.CodeInfo = GetCachedCodeInfo(_worldState, codeSource, spec);
+
+                            if (isTrace) _logger.Trace($"Tx call gas {gasLimitUl}");
+                            if (outputLength == 0)
+                            {
+                                // TODO: when output length is 0 outputOffset can have any value really
+                                // and the value does not matter and it can cause trouble when beyond long range
+                                outputOffset = 0;
+                            }
+
+                            ExecutionType executionType = GetCallExecutionType(instruction);
+                            EvmState callState = new(
+                                gasLimitUl,
+                                callEnv,
+                                executionType,
+                                false,
+                                snapshot,
+                                (long)outputOffset,
+                                (long)outputLength,
+                                instruction == Instruction.STATICCALL || vmState.IsStatic,
+                                vmState,
+                                false,
+                                false);
+
+                            UpdateCurrentState(vmState, programCounter, gasAvailable, stack.Head);
+                            EndInstructionTrace();
+                            return new CallResult(callState);
+                        }
+                    case Instruction.REVERT:
+                        {
+                            if (!spec.RevertOpcodeEnabled)
+                            {
+                                EndInstructionTraceError(EvmExceptionType.BadInstruction);
+                                return CallResult.InvalidInstructionException;
+                            }
+
+                            stack.PopUInt256(out UInt256 memoryPos);
+                            stack.PopUInt256(out UInt256 length);
+
+                            UpdateMemoryCost(in memoryPos, length);
+                            ReadOnlyMemory<byte> errorDetails = vmState.Memory.Load(in memoryPos, length);
+
+                            UpdateCurrentState(vmState, programCounter, gasAvailable, stack.Head);
+                            EndInstructionTrace();
+                            return new CallResult(errorDetails.ToArray(), null, true);
+                        }
+                    case Instruction.INVALID:
+                        {
+                            if (!UpdateGas(GasCostOf.High, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
                             EndInstructionTraceError(EvmExceptionType.BadInstruction);
                             return CallResult.InvalidInstructionException;
                         }
-
-                        stack.PopUInt256(out UInt256 gasLimit);
-                        Address codeSource = stack.PopAddress();
-                        
-                        // Console.WriteLine($"CALLIN {codeSource}");
-                        if (!ChargeAccountAccessGas(ref gasAvailable, vmState, codeSource, spec))
+                    case Instruction.SELFDESTRUCT:
                         {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-                        
-                        UInt256 callValue;
-                        switch (instruction)
-                        {
-                            case Instruction.STATICCALL:
-                                callValue = UInt256.Zero;
-                                break;
-                            case Instruction.DELEGATECALL:
-                                callValue = env.Value;
-                                break;
-                            default:
-                                stack.PopUInt256(out callValue);
-                                break;
-                        }
-
-                        UInt256 transferValue = instruction == Instruction.DELEGATECALL ? UInt256.Zero : callValue;
-                        stack.PopUInt256(out UInt256 dataOffset);
-                        stack.PopUInt256(out UInt256 dataLength);
-                        stack.PopUInt256(out UInt256 outputOffset);
-                        stack.PopUInt256(out UInt256 outputLength);
-
-                        if (vmState.IsStatic && !transferValue.IsZero && instruction != Instruction.CALLCODE)
-                        {
-                            EndInstructionTraceError(EvmExceptionType.StaticCallViolation);
-                            return CallResult.StaticCallViolationException;
-                        }
-
-                        Address caller = instruction == Instruction.DELEGATECALL ? env.Caller : env.ExecutingAccount;
-                        Address target = instruction == Instruction.CALL || instruction == Instruction.STATICCALL ? codeSource : env.ExecutingAccount;
-
-                        if (isTrace)
-                        {
-                            _logger.Trace($"caller {caller}");
-                            _logger.Trace($"code source {codeSource}");
-                            _logger.Trace($"target {target}");
-                            _logger.Trace($"value {callValue}");
-                            _logger.Trace($"transfer value {transferValue}");
-                        }
-
-                        long gasExtra = 0L;
-
-                        if (!transferValue.IsZero)
-                        {
-                            gasExtra += GasCostOf.CallValue;
-                        }
-
-                        if (!spec.ClearEmptyAccountWhenTouched && !_state.AccountExists(target))
-                        {
-                            gasExtra += GasCostOf.NewAccount;
-                        }
-                        else if (spec.ClearEmptyAccountWhenTouched && transferValue != 0 && _state.IsDeadAccount(target))
-                        {
-                            gasExtra += GasCostOf.NewAccount;
-                        }
-
-                        if (!UpdateGas(spec.GetCallCost(), ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        UpdateMemoryCost(in dataOffset, dataLength);
-                        UpdateMemoryCost(in outputOffset, outputLength);
-                        if (!UpdateGas(gasExtra, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        if (spec.Use63Over64Rule)
-                        {
-                            gasLimit = UInt256.Min((UInt256) (gasAvailable - gasAvailable / 64), gasLimit);
-                        }
-
-                        long gasLimitUl = (long) gasLimit;
-                        if (!UpdateGas(gasLimitUl, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        if (!transferValue.IsZero)
-                        {
-                            if (_txTracer.IsTracingRefunds) _txTracer.ReportExtraGasPressure(GasCostOf.CallStipend);
-                            gasLimitUl += GasCostOf.CallStipend;
-                        }
-
-                        if (env.CallDepth >= MaxCallDepth || !transferValue.IsZero && _state.GetBalance(env.ExecutingAccount) < transferValue)
-                        {
-                            _returnDataBuffer = Array.Empty<byte>();
-                            stack.PushZero();
-
-                            if (_txTracer.IsTracingInstructions)
+                            if (vmState.IsStatic)
                             {
-                                // very specific for Parity trace, need to find generalization - very peculiar 32 length...
-                                ReadOnlyMemory<byte> memoryTrace = vmState.Memory.Inspect(in dataOffset, 32);
-                                _txTracer.ReportMemoryChange(dataOffset, memoryTrace.Span);
+                                EndInstructionTraceError(EvmExceptionType.StaticCallViolation);
+                                return CallResult.StaticCallViolationException;
                             }
 
-                            if (isTrace) _logger.Trace("FAIL - call depth");
-                            if (_txTracer.IsTracingInstructions) _txTracer.ReportOperationRemainingGas(gasAvailable);
-                            if (_txTracer.IsTracingInstructions) _txTracer.ReportOperationError(EvmExceptionType.NotEnoughBalance);
+                            if (spec.UseShanghaiDDosProtection && !UpdateGas(GasCostOf.SelfDestructEip150, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
 
-                            UpdateGasUp(gasLimitUl, ref gasAvailable);
-                            if (_txTracer.IsTracingInstructions) _txTracer.ReportGasUpdateForVmTrace(gasLimitUl, gasAvailable);
+                            Metrics.SelfDestructs++;
+
+                            Address inheritor = stack.PopAddress();
+                            if (!ChargeAccountAccessGas(ref gasAvailable, vmState, inheritor, spec, false))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            vmState.DestroyList.Add(env.ExecutingAccount);
+
+                            UInt256 ownerBalance = _state.GetBalance(env.ExecutingAccount);
+                            if (_txTracer.IsTracingActions)
+                                _txTracer.ReportSelfDestruct(env.ExecutingAccount, ownerBalance, inheritor);
+                            if (spec.ClearEmptyAccountWhenTouched && ownerBalance != 0 && _state.IsDeadAccount(inheritor))
+                            {
+                                if (!UpdateGas(GasCostOf.NewAccount, ref gasAvailable))
+                                {
+                                    EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                    return CallResult.OutOfGasException;
+                                }
+                            }
+
+                            bool inheritorAccountExists = _state.AccountExists(inheritor);
+                            if (!spec.ClearEmptyAccountWhenTouched && !inheritorAccountExists && spec.UseShanghaiDDosProtection)
+                            {
+                                if (!UpdateGas(GasCostOf.NewAccount, ref gasAvailable))
+                                {
+                                    EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                    return CallResult.OutOfGasException;
+                                }
+                            }
+
+                            if (!inheritorAccountExists)
+                            {
+                                _state.CreateAccount(inheritor, ownerBalance);
+                            }
+                            else if (!inheritor.Equals(env.ExecutingAccount))
+                            {
+                                _state.AddToBalance(inheritor, ownerBalance, spec);
+                            }
+
+                            _state.SubtractFromBalance(env.ExecutingAccount, ownerBalance, spec);
+
+                            UpdateCurrentState(vmState, programCounter, gasAvailable, stack.Head);
+                            EndInstructionTrace();
+                            return CallResult.Empty;
+                        }
+                    case Instruction.SHL:
+                        {
+                            if (!spec.ShiftOpcodesEnabled)
+                            {
+                                EndInstructionTraceError(EvmExceptionType.BadInstruction);
+                                return CallResult.InvalidInstructionException;
+                            }
+
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            stack.PopUInt256(out UInt256 a);
+                            if (a >= 256UL)
+                            {
+                                stack.PopLimbo();
+                                stack.PushZero();
+                            }
+                            else
+                            {
+                                stack.PopUInt256(out UInt256 b);
+                                UInt256 res = b << (int)a.u0;
+                                stack.PushUInt256(in res);
+                            }
+
                             break;
                         }
-
-                        ReadOnlyMemory<byte> callData = vmState.Memory.Load(in dataOffset, dataLength);
-
-                        Snapshot snapshot = _worldState.TakeSnapshot();
-                        _state.SubtractFromBalance(caller, transferValue, spec);
-
-                        ExecutionEnvironment callEnv = new();
-                        callEnv.TxExecutionContext = env.TxExecutionContext;
-                        callEnv.CallDepth = env.CallDepth + 1;
-                        callEnv.Caller = caller;
-                        callEnv.CodeSource = codeSource;
-                        callEnv.ExecutingAccount = target;
-                        callEnv.TransferValue = transferValue;
-                        callEnv.Value = callValue;
-                        callEnv.InputData = callData;
-                        callEnv.CodeInfo = GetCachedCodeInfo(_worldState, codeSource, spec);
-
-                        if (isTrace) _logger.Trace($"Tx call gas {gasLimitUl}");
-                        if (outputLength == 0)
-                        {
-                            // TODO: when output length is 0 outputOffset can have any value really
-                            // and the value does not matter and it can cause trouble when beyond long range
-                            outputOffset = 0;
-                        }
-
-                        ExecutionType executionType = GetCallExecutionType(instruction);
-                        EvmState callState = new(
-                            gasLimitUl,
-                            callEnv,
-                            executionType,
-                            false,
-                            snapshot,
-                            (long) outputOffset,
-                            (long) outputLength,
-                            instruction == Instruction.STATICCALL || vmState.IsStatic,
-                            vmState,
-                            false,
-                            false);
-
-                        UpdateCurrentState(vmState, programCounter, gasAvailable, stack.Head);
-                        EndInstructionTrace();
-                        return new CallResult(callState);
-                    }
-                    case Instruction.REVERT:
-                    {
-                        if (!spec.RevertOpcodeEnabled)
-                        {
-                            EndInstructionTraceError(EvmExceptionType.BadInstruction);
-                            return CallResult.InvalidInstructionException;
-                        }
-
-                        stack.PopUInt256(out UInt256 memoryPos);
-                        stack.PopUInt256(out UInt256 length);
-
-                        UpdateMemoryCost(in memoryPos, length);
-                        ReadOnlyMemory<byte> errorDetails = vmState.Memory.Load(in memoryPos, length);
-
-                        UpdateCurrentState(vmState, programCounter, gasAvailable, stack.Head);
-                        EndInstructionTrace();
-                        return new CallResult(errorDetails.ToArray(), null, true);
-                    }
-                    case Instruction.INVALID:
-                    {
-                        if (!UpdateGas(GasCostOf.High, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        EndInstructionTraceError(EvmExceptionType.BadInstruction);
-                        return CallResult.InvalidInstructionException;
-                    }
-                    case Instruction.SELFDESTRUCT:
-                    {
-                        if (vmState.IsStatic)
-                        {
-                            EndInstructionTraceError(EvmExceptionType.StaticCallViolation);
-                            return CallResult.StaticCallViolationException;
-                        }
-
-                        if (spec.UseShanghaiDDosProtection && !UpdateGas(GasCostOf.SelfDestructEip150, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        Metrics.SelfDestructs++;
-
-                        Address inheritor = stack.PopAddress();
-                        if (!ChargeAccountAccessGas(ref gasAvailable, vmState, inheritor, spec, false))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-                        
-                        vmState.DestroyList.Add(env.ExecutingAccount);
-
-                        UInt256 ownerBalance = _state.GetBalance(env.ExecutingAccount);
-                        if (_txTracer.IsTracingActions) _txTracer.ReportSelfDestruct(env.ExecutingAccount, ownerBalance, inheritor);
-                        if (spec.ClearEmptyAccountWhenTouched && ownerBalance != 0 && _state.IsDeadAccount(inheritor))
-                        {
-                            if (!UpdateGas(GasCostOf.NewAccount, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
-                        }
-
-                        bool inheritorAccountExists = _state.AccountExists(inheritor);
-                        if (!spec.ClearEmptyAccountWhenTouched && !inheritorAccountExists && spec.UseShanghaiDDosProtection)
-                        {
-                            if (!UpdateGas(GasCostOf.NewAccount, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
-                        }
-
-                        if (!inheritorAccountExists)
-                        {
-                            _state.CreateAccount(inheritor, ownerBalance);
-                        }
-                        else if (!inheritor.Equals(env.ExecutingAccount))
-                        {
-                            _state.AddToBalance(inheritor, ownerBalance, spec);
-                        }
-
-                        _state.SubtractFromBalance(env.ExecutingAccount, ownerBalance, spec);
-
-                        UpdateCurrentState(vmState, programCounter, gasAvailable, stack.Head);
-                        EndInstructionTrace();
-                        return CallResult.Empty;
-                    }
-                    case Instruction.SHL:
-                    {
-                        if (!spec.ShiftOpcodesEnabled)
-                        {
-                            EndInstructionTraceError(EvmExceptionType.BadInstruction);
-                            return CallResult.InvalidInstructionException;
-                        }
-
-                        if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        stack.PopUInt256(out UInt256 a);
-                        if (a >= 256UL)
-                        {
-                            stack.PopLimbo();
-                            stack.PushZero();
-                        }
-                        else
-                        {
-                            stack.PopUInt256(out UInt256 b);
-                            UInt256 res = b << (int) a.u0;
-                            stack.PushUInt256(in res);
-                        }
-
-                        break;
-                    }
                     case Instruction.SHR:
-                    {
-                        if (!spec.ShiftOpcodesEnabled)
                         {
-                            EndInstructionTraceError(EvmExceptionType.BadInstruction);
-                            return CallResult.InvalidInstructionException;
-                        }
+                            if (!spec.ShiftOpcodesEnabled)
+                            {
+                                EndInstructionTraceError(EvmExceptionType.BadInstruction);
+                                return CallResult.InvalidInstructionException;
+                            }
 
-                        if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
 
-                        stack.PopUInt256(out UInt256 a);
-                        if (a >= 256)
-                        {
-                            stack.PopLimbo();
-                            stack.PushZero();
-                        }
-                        else
-                        {
-                            stack.PopUInt256(out UInt256 b);
-                            UInt256 res = b >> (int) a.u0;
-                            stack.PushUInt256(in res);
-                        }
+                            stack.PopUInt256(out UInt256 a);
+                            if (a >= 256)
+                            {
+                                stack.PopLimbo();
+                                stack.PushZero();
+                            }
+                            else
+                            {
+                                stack.PopUInt256(out UInt256 b);
+                                UInt256 res = b >> (int)a.u0;
+                                stack.PushUInt256(in res);
+                            }
 
-                        break;
-                    }
+                            break;
+                        }
                     case Instruction.SAR:
-                    {
-                        if (!spec.ShiftOpcodesEnabled)
                         {
-                            EndInstructionTraceError(EvmExceptionType.BadInstruction);
-                            return CallResult.InvalidInstructionException;
-                        }
+                            if (!spec.ShiftOpcodesEnabled)
+                            {
+                                EndInstructionTraceError(EvmExceptionType.BadInstruction);
+                                return CallResult.InvalidInstructionException;
+                            }
 
-                        if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
 
-                        stack.PopUInt256(out UInt256 a);
-                        stack.PopSignedInt256(out Int256.Int256 b);
-                        if (a >= BigInt256)
+                            stack.PopUInt256(out UInt256 a);
+                            stack.PopSignedInt256(out Int256.Int256 b);
+                            if (a >= BigInt256)
+                            {
+                                if (b.Sign >= 0)
+                                {
+                                    stack.PushZero();
+                                }
+                                else
+                                {
+                                    Int256.Int256 res = Int256.Int256.MinusOne;
+                                    stack.PushSignedInt256(in res);
+                                }
+                            }
+                            else
+                            {
+                                b.RightShift((int)a, out Int256.Int256 res);
+                                stack.PushSignedInt256(in res);
+                            }
+
+                            break;
+                        }
+                    case Instruction.EXTCODEHASH:
                         {
-                            if (b.Sign >= 0)
+                            if (!spec.ExtCodeHashOpcodeEnabled)
+                            {
+                                EndInstructionTraceError(EvmExceptionType.BadInstruction);
+                                return CallResult.InvalidInstructionException;
+                            }
+
+                            var gasCost = spec.GetExtCodeHashCost();
+                            if (!UpdateGas(gasCost, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            Address address = stack.PopAddress();
+                            if (!ChargeAccountAccessGas(ref gasAvailable, vmState, address, spec))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            if (!_state.AccountExists(address) || _state.IsDeadAccount(address))
                             {
                                 stack.PushZero();
                             }
                             else
                             {
-                                Int256.Int256 res = Int256.Int256.MinusOne;
-                                stack.PushSignedInt256(in res);
+                                stack.PushBytes(_state.GetCodeHash(address).Bytes);
                             }
-                        }
-                        else
-                        {
-                            b.RightShift((int) a, out Int256.Int256 res);
-                            stack.PushSignedInt256(in res);
-                        }
 
-                        break;
-                    }
-                    case Instruction.EXTCODEHASH:
-                    {
-                        if (!spec.ExtCodeHashOpcodeEnabled)
-                        {
-                            EndInstructionTraceError(EvmExceptionType.BadInstruction);
-                            return CallResult.InvalidInstructionException;
+                            break;
                         }
-
-                        var gasCost = spec.GetExtCodeHashCost();
-                        if (!UpdateGas(gasCost, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        Address address = stack.PopAddress();
-                        if (!ChargeAccountAccessGas(ref gasAvailable, vmState, address, spec))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-                        
-                        if (!_state.AccountExists(address) || _state.IsDeadAccount(address))
-                        {
-                            stack.PushZero();
-                        }
-                        else
-                        {
-                            stack.PushBytes(_state.GetCodeHash(address).Bytes);
-                        }
-
-                        break;
-                    }
                     case Instruction.BEGINSUB:
-                    {
-                        if (!spec.SubroutinesEnabled)
                         {
-                            EndInstructionTraceError(EvmExceptionType.BadInstruction);
-                            return CallResult.InvalidInstructionException;
-                        }
+                            if (!spec.SubroutinesEnabled)
+                            {
+                                EndInstructionTraceError(EvmExceptionType.BadInstruction);
+                                return CallResult.InvalidInstructionException;
+                            }
 
-                        // why do we even need the cost of it?
-                        if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
+                            // why do we even need the cost of it?
+                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
 
-                        EndInstructionTraceError(EvmExceptionType.InvalidSubroutineEntry);
-                        return CallResult.InvalidSubroutineEntry;
-                    }
+                            EndInstructionTraceError(EvmExceptionType.InvalidSubroutineEntry);
+                            return CallResult.InvalidSubroutineEntry;
+                        }
                     case Instruction.RETURNSUB:
-                    {
-                        if (!spec.SubroutinesEnabled)
                         {
-                            EndInstructionTraceError(EvmExceptionType.BadInstruction);
-                            return CallResult.InvalidInstructionException;
-                        }
+                            if (!spec.SubroutinesEnabled)
+                            {
+                                EndInstructionTraceError(EvmExceptionType.BadInstruction);
+                                return CallResult.InvalidInstructionException;
+                            }
 
-                        if (!UpdateGas(GasCostOf.Low, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
+                            if (!UpdateGas(GasCostOf.Low, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
 
-                        if (vmState.ReturnStackHead == 0)
-                        {
-                            EndInstructionTraceError(EvmExceptionType.InvalidSubroutineReturn);
-                            return CallResult.InvalidSubroutineReturn;
-                        }
+                            if (vmState.ReturnStackHead == 0)
+                            {
+                                EndInstructionTraceError(EvmExceptionType.InvalidSubroutineReturn);
+                                return CallResult.InvalidSubroutineReturn;
+                            }
 
-                        programCounter = vmState.ReturnStack[--vmState.ReturnStackHead];
-                        break;
-                    }
+                            programCounter = vmState.ReturnStack[--vmState.ReturnStackHead];
+                            break;
+                        }
                     case Instruction.JUMPSUB:
-                    {
-                        if (!spec.SubroutinesEnabled)
+                        {
+                            if (!spec.SubroutinesEnabled)
+                            {
+                                EndInstructionTraceError(EvmExceptionType.BadInstruction);
+                                return CallResult.InvalidInstructionException;
+                            }
+
+                            if (!UpdateGas(GasCostOf.High, ref gasAvailable))
+                            {
+                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                return CallResult.OutOfGasException;
+                            }
+
+                            if (vmState.ReturnStackHead == EvmStack.ReturnStackSize)
+                            {
+                                EndInstructionTraceError(EvmExceptionType.StackOverflow);
+                                return CallResult.StackOverflowException;
+                            }
+
+                            vmState.ReturnStack[vmState.ReturnStackHead++] = programCounter;
+
+                            stack.PopUInt256(out UInt256 jumpDest);
+                            Jump(jumpDest, true);
+                            programCounter++;
+
+                            break;
+                        }
+                    default:
                         {
                             EndInstructionTraceError(EvmExceptionType.BadInstruction);
                             return CallResult.InvalidInstructionException;
                         }
-
-                        if (!UpdateGas(GasCostOf.High, ref gasAvailable))
-                        {
-                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                            return CallResult.OutOfGasException;
-                        }
-
-                        if (vmState.ReturnStackHead == EvmStack.ReturnStackSize)
-                        {
-                            EndInstructionTraceError(EvmExceptionType.StackOverflow);
-                            return CallResult.StackOverflowException;
-                        }
-
-                        vmState.ReturnStack[vmState.ReturnStackHead++] = programCounter;
-
-                        stack.PopUInt256(out UInt256 jumpDest);
-                        Jump(jumpDest, true);
-                        programCounter++;
-
-                        break;
-                    }
-                    default:
-                    {
-                        EndInstructionTraceError(EvmExceptionType.BadInstruction);
-                        return CallResult.InvalidInstructionException;
-                    }
                 }
 
                 EndInstructionTrace();
@@ -2902,8 +2974,8 @@ namespace Nethermind.Evm
             public static CallResult StaticCallViolationException => new(EvmExceptionType.StaticCallViolation);
             public static CallResult StackOverflowException => new(EvmExceptionType.StackOverflow); // TODO: use these to avoid CALL POP attacks
             public static CallResult StackUnderflowException => new(EvmExceptionType.StackUnderflow); // TODO: use these to avoid CALL POP attacks
-            
-            public static CallResult InvalidCodeException => new(EvmExceptionType.InvalidCode); 
+
+            public static CallResult InvalidCodeException => new(EvmExceptionType.InvalidCode);
             public static CallResult Empty => new(Array.Empty<byte>(), null);
 
             public CallResult(EvmState stateToExecute)

--- a/src/Nethermind/Nethermind.sln.DotSettings
+++ b/src/Nethermind/Nethermind.sln.DotSettings
@@ -20,6 +20,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=CHT/@EntryIndexedValue">CHT</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=CTR/@EntryIndexedValue">CTR</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=EIP/@EntryIndexedValue">EIP</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IL/@EntryIndexedValue">IL</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IP/@EntryIndexedValue">IP</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IV/@EntryIndexedValue">IV</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ADDMOD/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
Implements #4672

This PR proposes an introduction of another `IVirtualMachine` implementation based on transpiling `EVM` bytecode to `IL`. `IL`, or `MSIL`, is an intermediate language that .NET (the runtime that Nethermind uses) languages compile to, to be later JITted to assembly by the runtime. In this PR, instead of having a loop and executing instructions on the pc basis it emits the whole contract as a single method. 

### Tentative Plan of Future Actions

The plan of action, that is frequently updated and reorganized:

- [x] initial implementation of a few opcodes
- [x] gas calculation of existing ones
- [x] `ClrMD` and ASM print for the method
- [ ] stack checks with potential change from `Word*` to offset based (start + int as the current)
- [ ] endianess of the executor

### Currently supported

- opcodes:
  - `POP` 
  - `PC`
  - `PUSH1`, `PUSH2`,  `PUSH4`
  - `DUP1`
  - `SWAP1`
  - `SUB`
  - `JUMPDEST` 
  - `JUMP` - this is a full blown two layer jump table, first based on the switch with fanout 128, second layer with simple ifs
  - `JUMPI` - uses the same jump table as above + branch-free condition pop from the stack
- gas management, calculations and returning `OutOfGas` when it happens

### Ahead of ILVM

- more gas cost calculation - for any sequence of instruction between flow control statements and instructions of variable cost (for example `SHA3`)
- no stack head checks - similar as above, every operation has a push and pop behavior added, so that it can be calculated upfront whether the stack wont be breached. Majority of the checks can be optimized away or moved at the beginning of the jump
- jumps - IL label for each `JUMPDEST`, a global jump table at the end of the function. If the destination for the jump is known at static time (`PUSHN` followed by `JUMP`), this can go directly to the label without any check
- endianess - compilining a method directly for the specific endianess
- tracing - compliling methods with various flavors, like no tracing at all and selecting the right one for the specific set of a tracer flags
- handling all the `CALL`s and discussing how to interop with other contracts

### Potential

Potential usages:

- precompile hot contracts like StarkNet, Uniswap, Sushi when Nethermind is built so that the client includes much faster VM
- provide TIERed execution, when hot contracts are IL emitted in the client whenever some statistics of usage shows that it should be done
- be the fastest EVM implementation (non-business case, pure ego-driven)

### Benchmarks

The following code was used for a terribly simple benchmark. It represents a simple loop that performs multiple spins

```csharp
byte[] code = Prepare.EvmCode
    .PushData(repeat)
    .Op(Instruction.JUMPDEST)
    .PushData(1)
    .Op(Instruction.SWAP1)
    .Op(Instruction.SUB)
    .Op(Instruction.DUP1)
    .PushData(1 + repeat.Length) // jump adress
    .Op(Instruction.JUMPI)
    .Op(Instruction.POP)
    .Done;
```

The comparison with a long enough run that should amortize all the const costs is as follows:

|  VM |  probe size | time per one million spins (less better) |
|---|---|---|
|  existing | 10_000_000  |  5,228 s |
|  IL VM |  1_000_000_000 |  0,048 s |

🔥  This means that in this terrible benchmark **ILVM is 100x faster than the existing one**!

#### Benchmarks ASM output

The bytecode JITted away, according to my knowledge of JIT, and ASM and addressing, results in the following code

<details>

```asm
0000: push rbp
0001: push rdi
0002: push rsi
0003: sub rsp,90h
000a: vzeroupper
000d: lea rbp,[rsp+20h]
0012: mov rax,59E479AB6165h
001c: mov [rbp+8],rax
0020: add rsp,20h
0024: mov eax,8040h
0029: neg rax
002c: add rax,rsp
002f: jb short 00007FFCD40918F3h
0031: xor eax,eax
0033: test [rsp],esp
0036: mov rdx,rsp
0039: sub rdx,1000h
0040: mov rsp,rdx
0043: cmp rsp,rax
0046: jae short 00007FFCD40918F3h
0048: mov rsp,rax
004b: test [rsp],esp
004e: sub rsp,20h
0052: lea rdx,[rsp+20h]
0057: add rdx,20h
005b: and rdx,0FFFFFFFFFFFFFFE0h
005f: mov rsi,rcx
0062: cmp rsi,3
0066: jl 00007FFCD4091A93h
006c: add rsi,0FFFFFFFFFFFFFFFDh
0070: vxorps xmm0,xmm0,xmm0
0074: vmovdqu [rdx],xmm0
0078: vmovdqu [rdx+10h],xmm0
007d: mov dword ptr [rdx+1Ch],0E1F505h
0084: add rdx,20h
0088: cmp rsi,1Ah
008c: jl 00007FFCD4091A93h
0092: add rsi,0FFFFFFFFFFFFFFE6h
0096: vxorps xmm0,xmm0,xmm0
009a: vmovdqu [rdx],xmm0
009e: vmovdqu [rdx+10h],xmm0
00a3: mov byte ptr [rdx+1Fh],1
00a7: add rdx,20h
00ab: lea rcx,[rdx-20h]
00af: vmovdqu xmm0,[rcx]
00b3: vmovdqu [rbp+10h],xmm0
00b8: vmovdqu xmm0,[rcx+10h]
00bd: vmovdqu [rbp+20h],xmm0
00c2: lea rdi,[rdx-40h]
00c6: vmovdqu xmm0,[rdi]
00ca: vmovdqu [rcx],xmm0
00ce: vmovdqu xmm0,[rdi+10h]
00d3: vmovdqu [rcx+10h],xmm0
00d8: vmovdqu xmm0,[rbp+10h]
00dd: vmovdqu [rdi],xmm0
00e1: vmovdqu xmm0,[rbp+20h]
00e6: vmovdqu [rdi+10h],xmm0
00eb: lea rdx,[rbp+50h]
00ef: call 00007FFCD46D35B8h
00f4: mov rcx,rdi
00f7: lea rdx,[rbp+30h]
00fb: call 00007FFCD46D35B8h
0100: lea rcx,[rbp+50h]
0104: lea rdx,[rbp+30h]
0108: lea r8,[rbp+10h]
010c: call 00007FFCD42A9DC0h
0111: mov rdx,rdi
0114: mov rax,[rbp+10h]
0118: mov rcx,[rbp+18h]
011c: mov r8,[rbp+20h]
0120: mov r9,[rbp+28h]
0124: bswap r9
0127: mov [rdx],r9
012a: bswap r8
012d: mov [rdx+8],r8
0131: bswap rcx
0134: mov [rdx+10h],rcx
0138: bswap rax
013b: mov [rdx+18h],rax
013f: add rdx,20h
0143: vmovdqu xmm0,[rdx-20h]
0148: vmovdqu [rdx],xmm0
014c: vmovdqu xmm0,[rdx-10h]
0151: vmovdqu [rdx+10h],xmm0
0156: add rdx,20h
015a: vxorps xmm0,xmm0,xmm0
015e: vmovdqu [rdx],xmm0
0162: vmovdqu [rdx+10h],xmm0
0167: mov byte ptr [rdx+1Fh],5
016b: add rdx,20h
016f: lea rax,[rdx-40h]
0173: mov rcx,[rax+18h]
0177: or rcx,[rax+10h]
017b: or rcx,[rax+8]
017f: or rcx,[rax]
0182: je short 00007FFCD4091A89h
0184: add rdx,0FFFFFFFFFFFFFFE0h
0188: mov rax,[rdx]
018b: or rax,[rdx+8]
018f: or rax,[rdx+10h]
0193: mov ecx,[rdx+18h]
0196: or rax,rcx
0199: jne short 00007FFCD4091A9Ah
019b: mov eax,[rdx+1Ch]
019e: mov ecx,eax
01a0: bswap ecx
01a2: sub rdx,20h
01a6: mov r8d,ecx
01a9: and r8d,7Fh
01ad: cmp r8d,6
01b1: ja short 00007FFCD4091A9Ah
01b3: mov eax,5Fh
01b8: bt eax,r8d
01bc: jb short 00007FFCD4091A9Ah
01be: cmp ecx,5
01c1: je 00007FFCD4091956h
01c7: jmp short 00007FFCD4091A9Ah
01c9: cmp rsi,2
01cd: jl short 00007FFCD4091A93h
01cf: xor eax,eax
01d1: jmp short 00007FFCD4091A9Fh
01d3: mov eax,4
01d8: jmp short 00007FFCD4091A9Fh
01da: mov eax,8
01df: mov rcx,59E479AB6165h
01e9: cmp [rbp+8],rcx
01ed: je short 00007FFCD4091AB4h
01ef: call 00007FFD336F0280h
01f4: nop
01f5: lea rsp,[rbp+70h]
01f9: pop rsi
01fa: pop rdi
01fb: pop rbp
01fc: ret
```

</details>