### PR TITLE
Refactor persistent broadcast

### DIFF
--- a/src/Nethermind/Nethermind.TxPool.Test/TxBroadcasterTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxBroadcasterTests.cs
@@ -61,14 +61,12 @@ public class TxBroadcasterTests
         _headInfo = Substitute.For<IChainHeadInfoProvider>();
     }
     
-    [TestCase(0)]
     [TestCase(1)]
     [TestCase(2)]
     [TestCase(99)]
     [TestCase(100)]
     [TestCase(101)]
     [TestCase(1000)]
-    [TestCase(-10)]
     public void should_pick_best_persistent_txs_to_broadcast(int threshold)
     {
         _txPoolConfig = new TxPoolConfig() { PeerNotificationThreshold = threshold };
@@ -105,14 +103,12 @@ public class TxBroadcasterTests
         expectedTxs.Should().BeEquivalentTo(pickedTxs);
     }
     
-    [TestCase(0)]
     [TestCase(1)]
     [TestCase(2)]
     [TestCase(99)]
     [TestCase(100)]
     [TestCase(101)]
     [TestCase(1000)]
-    [TestCase(-10)]
     public void should_not_pick_txs_with_GasPrice_lower_than_CurrentBaseFee(int threshold)
     {
         _txPoolConfig = new TxPoolConfig() { PeerNotificationThreshold = threshold };
@@ -156,14 +152,12 @@ public class TxBroadcasterTests
         expectedTxs.Should().BeEquivalentTo(pickedTxs);
     }
     
-    [TestCase(0)]
     [TestCase(1)]
     [TestCase(2)]
     [TestCase(99)]
     [TestCase(100)]
     [TestCase(101)]
     [TestCase(1000)]
-    [TestCase(-10)]
     public void should_not_pick_1559_txs_with_MaxFeePerGas_lower_than_CurrentBaseFee(int threshold)
     {
         _txPoolConfig = new TxPoolConfig() { PeerNotificationThreshold = threshold };

--- a/src/Nethermind/Nethermind.TxPool.Test/TxBroadcasterTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxBroadcasterTests.cs
@@ -88,7 +88,7 @@ public class TxBroadcasterTests
         
         _broadcaster.GetSnapshot().Length.Should().Be(addedTxsCount);
 
-        _broadcaster.GetPersistentTxsToSend(out IList<Transaction> pickedTxs);
+        IList<Transaction> pickedTxs = _broadcaster.GetPersistentTxsToSend();
 
         int expectedCount = Math.Min(addedTxsCount * threshold / 100 + 1, addedTxsCount);
         pickedTxs.Count.Should().Be(expectedCount);
@@ -137,7 +137,7 @@ public class TxBroadcasterTests
         
         _broadcaster.GetSnapshot().Length.Should().Be(addedTxsCount);
 
-        _broadcaster.GetPersistentTxsToSend(out IList<Transaction> pickedTxs);
+        IList<Transaction> pickedTxs = _broadcaster.GetPersistentTxsToSend();
 
         int expectedCount = Math.Min(addedTxsCount * threshold / 100 + 1, addedTxsCount - currentBaseFeeInGwei);
         pickedTxs.Count.Should().Be(expectedCount);
@@ -187,7 +187,7 @@ public class TxBroadcasterTests
         
         _broadcaster.GetSnapshot().Length.Should().Be(addedTxsCount);
 
-        _broadcaster.GetPersistentTxsToSend(out IList<Transaction> pickedTxs);
+        IList<Transaction> pickedTxs = _broadcaster.GetPersistentTxsToSend();
 
         int expectedCount = Math.Min(addedTxsCount * threshold / 100 + 1, addedTxsCount - currentBaseFeeInGwei);
         pickedTxs.Count.Should().Be(expectedCount);

--- a/src/Nethermind/Nethermind.TxPool.Test/TxBroadcasterTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxBroadcasterTests.cs
@@ -90,7 +90,7 @@ public class TxBroadcasterTests
         
         _broadcaster.GetSnapshot().Length.Should().Be(addedTxsCount);
 
-        List<Transaction> pickedTxs = _broadcaster.GetPersistentTxsToSend().ToList();
+        _broadcaster.GetPersistentTxsToSend(out IList<Transaction> pickedTxs);
 
         int expectedCount = threshold <= 0 ? 0 : Math.Min(addedTxsCount * threshold / 100 + 1, addedTxsCount);
         pickedTxs.Count.Should().Be(expectedCount);
@@ -141,7 +141,7 @@ public class TxBroadcasterTests
         
         _broadcaster.GetSnapshot().Length.Should().Be(addedTxsCount);
 
-        List<Transaction> pickedTxs = _broadcaster.GetPersistentTxsToSend().ToList();
+        _broadcaster.GetPersistentTxsToSend(out IList<Transaction> pickedTxs);
 
         int expectedCount = threshold <= 0 ? 0 : Math.Min(addedTxsCount * threshold / 100 + 1, addedTxsCount - currentBaseFeeInGwei);
         pickedTxs.Count.Should().Be(expectedCount);
@@ -158,6 +158,10 @@ public class TxBroadcasterTests
     
     [TestCase(0)]
     [TestCase(1)]
+    [TestCase(2)]
+    [TestCase(99)]
+    [TestCase(100)]
+    [TestCase(101)]
     [TestCase(1000)]
     [TestCase(-10)]
     public void should_not_pick_1559_txs_with_MaxFeePerGas_lower_than_CurrentBaseFee(int threshold)
@@ -189,9 +193,9 @@ public class TxBroadcasterTests
         
         _broadcaster.GetSnapshot().Length.Should().Be(addedTxsCount);
 
-        List<Transaction> pickedTxs = _broadcaster.GetPersistentTxsToSend().ToList();
+        _broadcaster.GetPersistentTxsToSend(out IList<Transaction> pickedTxs);
 
-        int expectedCount = threshold <= 0 ? 0 : addedTxsCount - currentBaseFeeInGwei;
+        int expectedCount = threshold <= 0 ? 0 : Math.Min(addedTxsCount * threshold / 100 + 1, addedTxsCount - currentBaseFeeInGwei);
         pickedTxs.Count.Should().Be(expectedCount);
 
         List<Transaction> expectedTxs = new();

--- a/src/Nethermind/Nethermind.TxPool.Test/TxBroadcasterTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxBroadcasterTests.cs
@@ -63,6 +63,10 @@ public class TxBroadcasterTests
     
     [TestCase(0)]
     [TestCase(1)]
+    [TestCase(2)]
+    [TestCase(99)]
+    [TestCase(100)]
+    [TestCase(101)]
     [TestCase(1000)]
     [TestCase(-10)]
     public void should_pick_best_persistent_txs_to_broadcast(int threshold)
@@ -88,12 +92,25 @@ public class TxBroadcasterTests
 
         List<Transaction> pickedTxs = _broadcaster.GetPersistentTxsToSend().ToList();
 
-        int expectedCount = threshold <= 0 ? 0 : addedTxsCount;
+        int expectedCount = threshold <= 0 ? 0 : Math.Min(addedTxsCount * threshold / 100 + 1, addedTxsCount);
         pickedTxs.Count.Should().Be(expectedCount);
+        
+        List<Transaction> expectedTxs = new();
+
+        for (int i = 1; i <= expectedCount; i++)
+        {
+            expectedTxs.Add(transactions[addedTxsCount - i]);
+        }
+
+        expectedTxs.Should().BeEquivalentTo(pickedTxs);
     }
     
     [TestCase(0)]
     [TestCase(1)]
+    [TestCase(2)]
+    [TestCase(99)]
+    [TestCase(100)]
+    [TestCase(101)]
     [TestCase(1000)]
     [TestCase(-10)]
     public void should_not_pick_txs_with_GasPrice_lower_than_CurrentBaseFee(int threshold)
@@ -126,7 +143,7 @@ public class TxBroadcasterTests
 
         List<Transaction> pickedTxs = _broadcaster.GetPersistentTxsToSend().ToList();
 
-        int expectedCount = threshold <= 0 ? 0 : addedTxsCount - currentBaseFeeInGwei;
+        int expectedCount = threshold <= 0 ? 0 : Math.Min(addedTxsCount * threshold / 100 + 1, addedTxsCount - currentBaseFeeInGwei);
         pickedTxs.Count.Should().Be(expectedCount);
 
         List<Transaction> expectedTxs = new();

--- a/src/Nethermind/Nethermind.TxPool.Test/TxBroadcasterTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxBroadcasterTests.cs
@@ -90,7 +90,7 @@ public class TxBroadcasterTests
 
         _broadcaster.GetPersistentTxsToSend(out IList<Transaction> pickedTxs);
 
-        int expectedCount = threshold <= 0 ? 0 : Math.Min(addedTxsCount * threshold / 100 + 1, addedTxsCount);
+        int expectedCount = Math.Min(addedTxsCount * threshold / 100 + 1, addedTxsCount);
         pickedTxs.Count.Should().Be(expectedCount);
         
         List<Transaction> expectedTxs = new();
@@ -139,7 +139,7 @@ public class TxBroadcasterTests
 
         _broadcaster.GetPersistentTxsToSend(out IList<Transaction> pickedTxs);
 
-        int expectedCount = threshold <= 0 ? 0 : Math.Min(addedTxsCount * threshold / 100 + 1, addedTxsCount - currentBaseFeeInGwei);
+        int expectedCount = Math.Min(addedTxsCount * threshold / 100 + 1, addedTxsCount - currentBaseFeeInGwei);
         pickedTxs.Count.Should().Be(expectedCount);
 
         List<Transaction> expectedTxs = new();
@@ -189,7 +189,7 @@ public class TxBroadcasterTests
 
         _broadcaster.GetPersistentTxsToSend(out IList<Transaction> pickedTxs);
 
-        int expectedCount = threshold <= 0 ? 0 : Math.Min(addedTxsCount * threshold / 100 + 1, addedTxsCount - currentBaseFeeInGwei);
+        int expectedCount = Math.Min(addedTxsCount * threshold / 100 + 1, addedTxsCount - currentBaseFeeInGwei);
         pickedTxs.Count.Should().Be(expectedCount);
 
         List<Transaction> expectedTxs = new();

--- a/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
@@ -154,7 +154,7 @@ namespace Nethermind.TxPool.Collections
             SortedSet<TValue> sortedValues = new(_sortedComparer);
             foreach (KeyValuePair<TGroupKey, SortedSet<TValue>> bucket in _buckets)
             {
-                sortedValues.Add(bucket.Value.Max!);
+                sortedValues.Add(bucket.Value.Min!);
             }
 
             return sortedValues;

--- a/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
@@ -137,19 +137,14 @@ namespace Nethermind.TxPool.Collections
         [MethodImpl(MethodImplOptions.Synchronized)]
         public bool TryTakeFirst(out TValue first)
         {
-            SortedSet<TValue> sortedValues = new(_sortedComparer);
-            foreach (KeyValuePair<TGroupKey, SortedSet<TValue>> bucket in _buckets)
-            {
-                sortedValues.Add(bucket.Value.Min!);
-            }
-            return TryRemove(GetKey(sortedValues.Min), out first);
+            return TryRemove(GetKey(GetFirsts().Min), out first);
         }
         
         /// <summary>
         /// Returns best element of each bucket in supplied comparer order.
         /// </summary>
         [MethodImpl(MethodImplOptions.Synchronized)]
-        public IEnumerable<TValue> GetFirsts()
+        public SortedSet<TValue> GetFirsts()
         {
             SortedSet<TValue> sortedValues = new(_sortedComparer);
             foreach (KeyValuePair<TGroupKey, SortedSet<TValue>> bucket in _buckets)

--- a/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
@@ -146,6 +146,21 @@ namespace Nethermind.TxPool.Collections
         }
         
         /// <summary>
+        /// Returns best element of each bucket in supplied comparer order.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.Synchronized)]
+        public IEnumerable<TValue> GetFirsts()
+        {
+            SortedSet<TValue> sortedValues = new(_sortedComparer);
+            foreach (KeyValuePair<TGroupKey, SortedSet<TValue>> bucket in _buckets)
+            {
+                sortedValues.Add(bucket.Value.Max!);
+            }
+
+            return sortedValues;
+        }
+        
+        /// <summary>
         /// Gets last element in supplied comparer order.
         /// </summary>
         [MethodImpl(MethodImplOptions.Synchronized)]

--- a/src/Nethermind/Nethermind.TxPool/ITxPoolConfig.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxPoolConfig.cs
@@ -20,7 +20,7 @@ namespace Nethermind.TxPool
 {
     public interface ITxPoolConfig : IConfig
     {
-        [ConfigItem(DefaultValue = "1", Description = "Defines average percent of tx hashes from persistent broadcast send to peer together with hashes of last added txs.")]
+        [ConfigItem(DefaultValue = "5", Description = "Defines average percent of tx hashes from persistent broadcast send to peer together with hashes of last added txs.")]
         int PeerNotificationThreshold { get; set; }
         
         [ConfigItem(DefaultValue = "2048", Description = "Max number of transactions held in mempool (more transactions in mempool mean more memory used")]

--- a/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
@@ -156,8 +156,8 @@ namespace Nethermind.TxPool
         
         internal void GetPersistentTxsToSend(out IList<Transaction> persistentTxsToSend)
         {
-            // PeerNotificationThreshold is a declared in config percent of transactions in persistent broadcast,
-            // which will be sent when timer elapse. numberOfPersistentTxsToBroadcast is equal to
+            // PeerNotificationThreshold is a declared in config max percent of transactions in persistent broadcast,
+            // which will be sent after processing of every block. numberOfPersistentTxsToBroadcast is equal to
             // PeerNotificationThreshold multiplication by number of transactions in persistent broadcast, rounded up.
             int numberOfPersistentTxsToBroadcast =
                 Math.Min(_txPoolConfig.PeerNotificationThreshold * _persistentTxs.Count / 100 + 1,

--- a/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
@@ -132,7 +132,7 @@ namespace Nethermind.TxPool
         {
             if (_txPoolConfig.PeerNotificationThreshold > 0)
             {
-                GetPersistentTxsToSend(out IList<Transaction> persistentTxsToSend);
+                IList<Transaction> persistentTxsToSend = GetPersistentTxsToSend();
 
                 if (persistentTxsToSend.Count > 0)
                 {
@@ -154,7 +154,7 @@ namespace Nethermind.TxPool
             }
         }
         
-        internal void GetPersistentTxsToSend(out IList<Transaction> persistentTxsToSend)
+        internal IList<Transaction> GetPersistentTxsToSend()
         {
             // PeerNotificationThreshold is a declared in config max percent of transactions in persistent broadcast,
             // which will be sent after processing of every block. numberOfPersistentTxsToBroadcast is equal to
@@ -163,7 +163,7 @@ namespace Nethermind.TxPool
                 Math.Min(_txPoolConfig.PeerNotificationThreshold * _persistentTxs.Count / 100 + 1,
                     _persistentTxs.Count);
 
-            persistentTxsToSend = new List<Transaction>(numberOfPersistentTxsToBroadcast);
+            List<Transaction> persistentTxsToSend = new(numberOfPersistentTxsToBroadcast);
 
             foreach (Transaction tx in _persistentTxs.GetFirsts())
             {
@@ -180,6 +180,8 @@ namespace Nethermind.TxPool
                     break;
                 }
             }
+
+            return persistentTxsToSend;
         }
         
         public void StopBroadcast(Keccak txHash)

--- a/src/Nethermind/Nethermind.TxPool/TxPoolConfig.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPoolConfig.cs
@@ -18,7 +18,7 @@ namespace Nethermind.TxPool
 {
     public class TxPoolConfig : ITxPoolConfig
     {
-        public int PeerNotificationThreshold { get; set; } = 1;
+        public int PeerNotificationThreshold { get; set; } = 5;
         public int Size { get; set; } = 2048;
         public int HashCacheSize { get; set; } = 512 * 1024;
         public long? GasLimit { get; set; } = null;


### PR DESCRIPTION
## Changes:
- prepare `transactions to send` from persistent broadcast only once per block instead once per block per every peer
- broadcast only up to defined percent (`PeerNotificationThreshold`) of transactions from persistent broadcast instead of every transaction that meets the condition `tx.MaxFeePerGas >= CurrentBaseFee`
- increased `PeerNotificationThreshold` to 5%

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No