### PR TITLE
Fix EVM benchmarks

### DIFF
--- a/src/Nethermind/Nethermind.Benchmark.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Benchmark.Runner/Program.cs
@@ -14,11 +14,9 @@
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
-using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Jobs;
@@ -70,7 +68,7 @@ namespace Nethermind.Benchmark.Runner
             {
                 foreach (Assembly assembly in additionalJobAssemblies)
                 {
-                    BenchmarkRunner.Run(assembly, new DashboardConfig(Job.MediumRun.WithRuntime(CoreRuntime.Core50)));    
+                    BenchmarkRunner.Run(assembly, new DashboardConfig(Job.MediumRun.WithRuntime(CoreRuntime.Core60)));    
                 }    
                 
                 foreach (Assembly assembly in simpleJobAssemblies)

--- a/src/Nethermind/Nethermind.Evm.Benchmark/EvmBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/EvmBenchmarks.cs
@@ -21,64 +21,71 @@ using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Db;
+using Nethermind.Evm.CodeAnalysis;
 using Nethermind.Specs;
 using Nethermind.Evm.Tracing;
 using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.State;
+using Nethermind.Trie.Pruning;
 
 namespace Nethermind.Evm.Benchmark
 {
-    //[MemoryDiagnoser]
-    //public class EvmBenchmarks
-    //{
-    //    public static byte[] ByteCode { get; set; }
+    [MemoryDiagnoser]
+    public class EvmBenchmarks
+    {
+        public static byte[] ByteCode { get; set; }
 
-    //    private IReleaseSpec _spec = MainnetSpecProvider.Instance.GetSpec(MainnetSpecProvider.IstanbulBlockNumber);
-    //    private ITxTracer _txTracer = NullTxTracer.Instance;
-    //    private ExecutionEnvironment _environment;
-    //    private IVirtualMachine _virtualMachine;
-    //    private BlockHeader _header = new BlockHeader(Keccak.Zero, Keccak.Zero, Address.Zero, UInt256.One, MainnetSpecProvider.IstanbulBlockNumber, Int64.MaxValue, UInt256.One, Bytes.Empty);
-    //    private IBlockhashProvider _blockhashProvider = new TestBlockhashProvider();
-    //    private EvmState _evmState;
-    //    private StateProvider _stateProvider;
-    //    private StorageProvider _storageProvider;
+        private IReleaseSpec _spec = MainnetSpecProvider.Instance.GetSpec(MainnetSpecProvider.IstanbulBlockNumber);
+        private ITxTracer _txTracer = NullTxTracer.Instance;
+        private ExecutionEnvironment _environment;
+        private IVirtualMachine _virtualMachine;
+        private BlockHeader _header = new BlockHeader(Keccak.Zero, Keccak.Zero, Address.Zero, UInt256.One, MainnetSpecProvider.IstanbulBlockNumber, Int64.MaxValue, UInt256.One, Bytes.Empty);
+        private IBlockhashProvider _blockhashProvider = new TestBlockhashProvider();
+        private EvmState _evmState;
+        private StateProvider _stateProvider;
+        private StorageProvider _storageProvider;
+        private WorldState _worldState;
 
-    //    [GlobalSetup]
-    //    public void GlobalSetup()
-    //    {
-    //        ByteCode = Bytes.FromHexString(Environment.GetEnvironmentVariable("NETH.BENCHMARK.BYTECODE"));
-    //        Console.WriteLine($"Running benchmark for bytecode {ByteCode?.ToHexString()}");
-    //        IDb codeDb = new StateDb();
-    //        ISnapshotableDb stateDb = new StateDb();
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            ByteCode = Bytes.FromHexString(Environment.GetEnvironmentVariable("NETH.BENCHMARK.BYTECODE"));
+            Console.WriteLine($"Running benchmark for bytecode {ByteCode?.ToHexString()}");
 
-    //        _stateProvider = new StateProvider(stateDb, codeDb, LimboLogs.Instance);
-    //        _stateProvider.CreateAccount(Address.Zero, 1000.Ether());
-    //        _stateProvider.Commit(_spec);
-
-    //        _storageProvider = new StorageProvider(stateDb, _stateProvider, LimboLogs.Instance);
-    //        _virtualMachine = new VirtualMachine(_stateProvider, _storageProvider, _blockhashProvider, MainnetSpecProvider.Instance, LimboLogs.Instance);
+            TrieStore trieStore = new(new MemDb(), new OneLoggerLogManager(NullLogger.Instance));
+            IKeyValueStore codeDb = new MemDb();
             
-    //        _environment = new ExecutionEnvironment();
-    //        _environment.ExecutingAccount = Address.Zero;
-    //        _environment.CodeSource = Address.Zero;
-    //        _environment.Originator = Address.Zero;
-    //        _environment.Sender = Address.Zero;
-    //        _environment.CodeInfo = new CodeInfo(ByteCode);
-    //        _environment.GasPrice = 0;
-    //        _environment.Value = 0;
-    //        _environment.TransferValue = 0;
-    //        _environment.CurrentBlock = _header;
+            _stateProvider = new StateProvider(trieStore, codeDb, new OneLoggerLogManager(NullLogger.Instance));
+            _stateProvider.CreateAccount(Address.Zero, 1000.Ether());
+            _stateProvider.Commit(_spec);
             
-    //        _evmState = new EvmState(long.MaxValue, _environment, ExecutionType.Transaction, true, false);
-    //    }
+            _storageProvider = new StorageProvider(trieStore, _stateProvider, new OneLoggerLogManager(NullLogger.Instance));
+            
+            _worldState = new WorldState(_stateProvider, _storageProvider);
 
-    //    [Benchmark]
-    //    public void ExecuteCode()
-    //    {
-    //        _virtualMachine.Run(_evmState, _txTracer);
-    //        _stateProvider.Reset();
-    //        _storageProvider.Reset();
-    //    }
-    //}
+            _virtualMachine = new VirtualMachine(_blockhashProvider, MainnetSpecProvider.Instance, LimboLogs.Instance);
+            
+            _environment = new ExecutionEnvironment
+            {
+                ExecutingAccount = Address.Zero,
+                CodeSource = Address.Zero,
+                Caller = Address.Zero,
+                CodeInfo = new CodeInfo(ByteCode),
+                Value = 0,
+                TransferValue = 0,
+                TxExecutionContext = new TxExecutionContext(_header, Address.Zero, 0)
+            };
+
+            _evmState = new EvmState(long.MaxValue, _environment, ExecutionType.Transaction, true, _worldState.TakeSnapshot(), false);
+        }
+
+        [Benchmark]
+        public void ExecuteCode()
+        {
+            _virtualMachine.Run(_evmState, _worldState, _txTracer);
+            _stateProvider.Reset();
+            _storageProvider.Reset();
+        }
+    }
 }

--- a/src/Nethermind/Nethermind.Evm.Benchmark/EvmBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/EvmBenchmarks.cs
@@ -50,7 +50,7 @@ namespace Nethermind.Evm.Benchmark
         [GlobalSetup]
         public void GlobalSetup()
         {
-            ByteCode = Bytes.FromHexString(Environment.GetEnvironmentVariable("NETH.BENCHMARK.BYTECODE"));
+            ByteCode = Bytes.FromHexString(Environment.GetEnvironmentVariable("NETH.BENCHMARK.BYTECODE") ?? string.Empty);
             Console.WriteLine($"Running benchmark for bytecode {ByteCode?.ToHexString()}");
 
             TrieStore trieStore = new(new MemDb(), new OneLoggerLogManager(NullLogger.Instance));

--- a/src/Nethermind/Nethermind.Evm.Benchmark/StaticCallBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/StaticCallBenchmarks.cs
@@ -106,32 +106,7 @@ namespace Nethermind.Evm.Benchmark
             _worldState = new WorldState(_stateProvider, _storageProvider);
             Console.WriteLine(MuirGlacier.Instance);
             _virtualMachine = new VirtualMachine(_blockhashProvider, MainnetSpecProvider.Instance, new OneLoggerLogManager(NullLogger.Instance));
-        }
-
-        [Benchmark]
-        public void ExecuteCode()
-        {
-            _environment = new ExecutionEnvironment
-                {
-                    ExecutingAccount = Address.Zero,
-                    CodeSource = Address.Zero,
-                    Caller = Address.Zero,
-                    CodeInfo = new CodeInfo(Bytecode),
-                    Value = 0,
-                    TransferValue = 0,
-                    TxExecutionContext = new TxExecutionContext(_header, Address.Zero, 0)
-                };
-
-            _evmState = new EvmState(100_000_000L, _environment, ExecutionType.Transaction, true, _worldState.TakeSnapshot(), false);
             
-            _virtualMachine.Run(_evmState, _worldState, _txTracer);
-            _stateProvider.Reset();
-            _storageProvider.Reset();
-        }
-        
-        [Benchmark(Baseline = true)]
-        public void No_machine_running()
-        {
             _environment = new ExecutionEnvironment
             {
                 ExecutingAccount = Address.Zero,
@@ -144,7 +119,19 @@ namespace Nethermind.Evm.Benchmark
             };
         
             _evmState = new EvmState(100_000_000L, _environment, ExecutionType.Transaction, true, _worldState.TakeSnapshot(), false);
-            
+        }
+
+        [Benchmark]
+        public void ExecuteCode()
+        {
+            _virtualMachine.Run(_evmState, _worldState, _txTracer);
+            _stateProvider.Reset();
+            _storageProvider.Reset();
+        }
+        
+        [Benchmark(Baseline = true)]
+        public void No_machine_running()
+        {
             _stateProvider.Reset();
             _storageProvider.Reset();
         }

--- a/src/Nethermind/Nethermind.Evm.Benchmark/StaticCallBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/StaticCallBenchmarks.cs
@@ -22,131 +22,131 @@ using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Db;
+using Nethermind.Evm.CodeAnalysis;
 using Nethermind.Specs;
 using Nethermind.Evm.Tracing;
 using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.Specs.Forks;
 using Nethermind.State;
+using Nethermind.Trie.Pruning;
 
 namespace Nethermind.Evm.Benchmark
 {
-    //[MemoryDiagnoser]
-    //public class StaticCallBenchmarks
-    //{
-    //    private IReleaseSpec _spec = MainnetSpecProvider.Instance.GetSpec(MainnetSpecProvider.IstanbulBlockNumber);
-    //    private ITxTracer _txTracer = NullTxTracer.Instance;
-    //    private ExecutionEnvironment _environment;
-    //    private IVirtualMachine _virtualMachine;
-    //    private BlockHeader _header = new BlockHeader(Keccak.Zero, Keccak.Zero, Address.Zero, UInt256.One, MainnetSpecProvider.MuirGlacierBlockNumber, Int64.MaxValue, UInt256.One, Bytes.Empty);
-    //    private IBlockhashProvider _blockhashProvider = new TestBlockhashProvider();
-    //    private EvmState _evmState;
-    //    private StateProvider _stateProvider;
-    //    private StorageProvider _storageProvider;
+    [MemoryDiagnoser]
+    public class StaticCallBenchmarks
+    {
+        private IReleaseSpec _spec = MainnetSpecProvider.Instance.GetSpec(MainnetSpecProvider.IstanbulBlockNumber);
+        private ITxTracer _txTracer = NullTxTracer.Instance;
+        private ExecutionEnvironment _environment;
+        private IVirtualMachine _virtualMachine;
+        private BlockHeader _header = new BlockHeader(Keccak.Zero, Keccak.Zero, Address.Zero, UInt256.One, MainnetSpecProvider.MuirGlacierBlockNumber, Int64.MaxValue, UInt256.One, Bytes.Empty);
+        private IBlockhashProvider _blockhashProvider = new TestBlockhashProvider();
+        private EvmState _evmState;
+        private StateProvider _stateProvider;
+        private StorageProvider _storageProvider;
+        private WorldState _worldState;
 
-    //    public IEnumerable<byte[]> Bytecodes 
-    //    {
-    //        get
-    //        {
-    //            yield return bytecode1;
-    //            yield return bytecode2;
-    //        }
-    //    }
+        public IEnumerable<byte[]> Bytecodes 
+        {
+            get
+            {
+                yield return bytecode1;
+                yield return bytecode2;
+            }
+        }
 
-    //    byte[] bytecode1 = Prepare.EvmCode
-    //        .Op(Instruction.JUMPDEST)
-    //        .PushData(0)
-    //        .Op(Instruction.DUP1)
-    //        .Op(Instruction.DUP1)
-    //        .Op(Instruction.DUP1)
-    //        .PushData(4)
-    //        .Op(Instruction.GAS)
-    //        .Op(Instruction.STATICCALL)
-    //        .Op(Instruction.POP)
-    //        .PushData(0)
-    //        .Op(Instruction.JUMP)
-    //        .Done;
+        byte[] bytecode1 = Prepare.EvmCode
+            .Op(Instruction.JUMPDEST)
+            .PushData(0)
+            .Op(Instruction.DUP1)
+            .Op(Instruction.DUP1)
+            .Op(Instruction.DUP1)
+            .PushData(4)
+            .Op(Instruction.GAS)
+            .Op(Instruction.STATICCALL)
+            .Op(Instruction.POP)
+            .PushData(0)
+            .Op(Instruction.JUMP)
+            .Done;
         
-    //    byte[] bytecode2 = Prepare.EvmCode
-    //        .Op(Instruction.JUMPDEST)
-    //        .PushData(0)
-    //        .Op(Instruction.DUP1)
-    //        .Op(Instruction.DUP1)
-    //        .Op(Instruction.DUP1)
-    //        .PushData(4)
-    //        .Op(Instruction.GAS)
-    //        .Op(Instruction.POP)
-    //        .Op(Instruction.POP)
-    //        .Op(Instruction.POP)
-    //        .Op(Instruction.POP)
-    //        .Op(Instruction.POP)
-    //        .Op(Instruction.POP)
-    //        .PushData(0)
-    //        .Op(Instruction.JUMP)
-    //        .Done;
+        byte[] bytecode2 = Prepare.EvmCode
+            .Op(Instruction.JUMPDEST)
+            .PushData(0)
+            .Op(Instruction.DUP1)
+            .Op(Instruction.DUP1)
+            .Op(Instruction.DUP1)
+            .PushData(4)
+            .Op(Instruction.GAS)
+            .Op(Instruction.POP)
+            .Op(Instruction.POP)
+            .Op(Instruction.POP)
+            .Op(Instruction.POP)
+            .Op(Instruction.POP)
+            .Op(Instruction.POP)
+            .PushData(0)
+            .Op(Instruction.JUMP)
+            .Done;
         
-    //    [ParamsSource(nameof(Bytecodes))]
-    //    public byte[] Bytecode { get; set; }
+        [ParamsSource(nameof(Bytecodes))]
+        public byte[] Bytecode { get; set; }
 
-    //    [GlobalSetup]
-    //    public void GlobalSetup()
-    //    {
-    //        IDb codeDb = new StateDb();
-    //        ISnapshotableDb stateDb = new StateDb();
-
-    //        _stateProvider = new StateProvider(stateDb, codeDb, new OneLoggerLogManager(NullLogger.Instance));
-    //        _stateProvider.CreateAccount(Address.Zero, 1000.Ether());
-    //        _stateProvider.Commit(_spec);
-
-    //        EvmState evmState = new EvmState(1, default, default, true, true);
-    //        evmState.InitStacks();
-    //        evmState.Dispose();
-
-    //        Console.WriteLine(MuirGlacier.Instance);
+        [GlobalSetup]
+        public void GlobalSetup()
+        { 
+            TrieStore trieStore = new(new MemDb(), new OneLoggerLogManager(NullLogger.Instance));
+            IKeyValueStore codeDb = new MemDb();
             
-    //        _storageProvider = new StorageProvider(stateDb, _stateProvider, new OneLoggerLogManager(NullLogger.Instance));
-    //        _virtualMachine = new VirtualMachine(_stateProvider, _storageProvider, _blockhashProvider, MainnetSpecProvider.Instance, new OneLoggerLogManager(NullLogger.Instance));
-    //    }
-
-    //    [Benchmark]
-    //    public void ExecuteCode()
-    //    {
-    //        _environment = new ExecutionEnvironment();
-    //        _environment.ExecutingAccount = Address.Zero;
-    //        _environment.CodeSource = Address.Zero;
-    //        _environment.Originator = Address.Zero;
-    //        _environment.Sender = Address.Zero;
-    //        _environment.CodeInfo = new CodeInfo(Bytecode);
-    //        _environment.GasPrice = 0;
-    //        _environment.Value = 0;
-    //        _environment.TransferValue = 0;
-    //        _environment.CurrentBlock = _header;
-
-    //        _evmState = new EvmState(100_000_000L, _environment, ExecutionType.Transaction, true, false);
+            _stateProvider = new StateProvider(trieStore, codeDb, new OneLoggerLogManager(NullLogger.Instance));
+            _stateProvider.CreateAccount(Address.Zero, 1000.Ether());
+            _stateProvider.Commit(_spec);
             
-    //        _virtualMachine.Run(_evmState, _txTracer);
-    //        _stateProvider.Reset();
-    //        _storageProvider.Reset();
-    //    }
+            _storageProvider = new StorageProvider(trieStore, _stateProvider, new OneLoggerLogManager(NullLogger.Instance));
+            
+            _worldState = new WorldState(_stateProvider, _storageProvider);
+            Console.WriteLine(MuirGlacier.Instance);
+            _virtualMachine = new VirtualMachine(_blockhashProvider, MainnetSpecProvider.Instance, new OneLoggerLogManager(NullLogger.Instance));
+        }
+
+        [Benchmark]
+        public void ExecuteCode()
+        {
+            _environment = new ExecutionEnvironment
+                {
+                    ExecutingAccount = Address.Zero,
+                    CodeSource = Address.Zero,
+                    Caller = Address.Zero,
+                    CodeInfo = new CodeInfo(Bytecode),
+                    Value = 0,
+                    TransferValue = 0,
+                    TxExecutionContext = new TxExecutionContext(_header, Address.Zero, 0)
+                };
+
+            _evmState = new EvmState(100_000_000L, _environment, ExecutionType.Transaction, true, _worldState.TakeSnapshot(), false);
+            
+            _virtualMachine.Run(_evmState, _worldState, _txTracer);
+            _stateProvider.Reset();
+            _storageProvider.Reset();
+        }
         
-    //    // [Benchmark(Baseline = true)]
-    //    // public void No_machine_running()
-    //    // {
-    //    //     _environment = new ExecutionEnvironment();
-    //    //     _environment.ExecutingAccount = Address.Zero;
-    //    //     _environment.CodeSource = Address.Zero;
-    //    //     _environment.Originator = Address.Zero;
-    //    //     _environment.Sender = Address.Zero;
-    //    //     _environment.CodeInfo = new CodeInfo(Bytecode);
-    //    //     _environment.GasPrice = 0;
-    //    //     _environment.Value = 0;
-    //    //     _environment.TransferValue = 0;
-    //    //     _environment.CurrentBlock = _header;
-    //    //
-    //    //     _evmState = new EvmState(100_000_000l, _environment, ExecutionType.Transaction, false, true, false);
-    //    //     
-    //    //     _stateProvider.Reset();
-    //    //     _storageProvider.Reset();
-    //    // }
-    //}
+        [Benchmark(Baseline = true)]
+        public void No_machine_running()
+        {
+            _environment = new ExecutionEnvironment
+            {
+                ExecutingAccount = Address.Zero,
+                CodeSource = Address.Zero,
+                Caller = Address.Zero,
+                CodeInfo = new CodeInfo(Bytecode),
+                Value = 0,
+                TransferValue = 0,
+                TxExecutionContext = new TxExecutionContext(_header, Address.Zero, 0)
+            };
+        
+            _evmState = new EvmState(100_000_000L, _environment, ExecutionType.Transaction, true, _worldState.TakeSnapshot(), false);
+            
+            _stateProvider.Reset();
+            _storageProvider.Reset();
+        }
+    }
 }

--- a/src/Nethermind/Nethermind.Precompiles.Benchmark/Nethermind.Precompiles.Benchmark.csproj
+++ b/src/Nethermind/Nethermind.Precompiles.Benchmark/Nethermind.Precompiles.Benchmark.csproj
@@ -7,7 +7,7 @@
 
     <ItemGroup>
       <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
-      <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.12.1" />
+      <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.1" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Changes:
- fix setup of EVM benchmarks, broken after VM refactoring
- update Benchmark.Runner to run in dotnet 6.0
- update BenchmarkDotNet.Diagnostics.Windows nuget to 0.13.1

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [x] No