### PR TITLE
feat: align sync peers reports columns

### DIFF
--- a/src/Nethermind/Nethermind.Network.Stats/INodeStats.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/INodeStats.cs
@@ -32,6 +32,7 @@ namespace Nethermind.Stats
 
         void AddTransferSpeedCaptureEvent(TransferSpeedType speedType, long bytesPerMillisecond);
         long? GetAverageTransferSpeed(TransferSpeedType speedType);
+        string GetPaddedAverageTransferSpeed(TransferSpeedType transferSpeedType, int padding = 5);
 
         (bool Result, NodeStatsEventType? DelayReason) IsConnectionDelayed();
         

--- a/src/Nethermind/Nethermind.Network.Stats/INodeStats.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/INodeStats.cs
@@ -32,7 +32,7 @@ namespace Nethermind.Stats
 
         void AddTransferSpeedCaptureEvent(TransferSpeedType speedType, long bytesPerMillisecond);
         long? GetAverageTransferSpeed(TransferSpeedType speedType);
-        string GetPaddedAverageTransferSpeed(TransferSpeedType transferSpeedType, int padding = 5);
+        string GetPaddedAverageTransferSpeed(TransferSpeedType transferSpeedType);
 
         (bool Result, NodeStatsEventType? DelayReason) IsConnectionDelayed();
         

--- a/src/Nethermind/Nethermind.Network.Stats/Model/Node.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/Model/Node.cs
@@ -1,4 +1,4 @@
-﻿//  Copyright (c) 2021 Demerzel Solutions Limited
+//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
 // 
 //  The Nethermind library is free software: you can redistribute it and/or modify
@@ -27,6 +27,8 @@ namespace Nethermind.Stats.Model
     public class Node : IFormattable
     {
         private string _clientId;
+        private string _paddedHost;
+        private string _paddedPort;
 
         /// <summary>
         /// Node public key - same as in enode. 
@@ -106,6 +108,10 @@ namespace Nethermind.Stats.Model
             Host = address.Address.MapToIPv4().ToString();
             Port = address.Port;
             Address = address;
+            // xxx.xxx.xxx.xxx = 15
+            _paddedHost = Host.PadLeft(15, ' ');
+            // Port are up to 65535 => 5 chars
+            _paddedPort = Port.ToString().PadLeft(5, ' ');
         }
 
         private void SetIPEndPoint(string host, int port)
@@ -138,12 +144,12 @@ namespace Nethermind.Stats.Model
         {
             return format switch
             {
-                "s" => $"{Host}:{Port}",
-                "c" => $"[Node|{Host}:{Port}|{ClientId}|{EthDetails}]",
-                "f" => $"enode://{Id.ToString(false)}@{Host}:{Port}|{ClientId}",
-                "e" => $"enode://{Id.ToString(false)}@{Host}:{Port}",
-                "p" => $"enode://{Id.ToString(false)}@{Host}:{Port}|{Id.Address}",
-                _ => $"enode://{Id.ToString(false)}@{Host}:{Port}"
+                "s" => $"{_paddedHost}:{_paddedPort}",
+                "c" => $"[Node|{_paddedHost}:{_paddedPort}|{EthDetails}|{ClientId}]",
+                "f" => $"enode://{Id.ToString(false)}@{_paddedHost}:{_paddedPort}|{ClientId}",
+                "e" => $"enode://{Id.ToString(false)}@{_paddedHost}:{_paddedPort}",
+                "p" => $"enode://{Id.ToString(false)}@{_paddedHost}:{_paddedPort}|{Id.Address}",
+                _ => $"enode://{Id.ToString(false)}@{_paddedHost}:{_paddedPort}"
             };
         }
 

--- a/src/Nethermind/Nethermind.Network.Stats/NodeStatsLight.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/NodeStatsLight.cs
@@ -182,6 +182,20 @@ namespace Nethermind.Stats
             });
         }
 
+        public string GetPaddedAverageTransferSpeed(TransferSpeedType transferSpeedType, int padding = 5)
+        {
+            string paddedEmpty = "0".PadLeft(padding, ' ');
+            return (transferSpeedType switch
+            {
+                TransferSpeedType.Latency => _averageLatency?.ToString("0").PadLeft(padding, ' ') ?? paddedEmpty,
+                TransferSpeedType.NodeData => _averageNodesTransferSpeed?.ToString("0").PadLeft(padding, ' ') ?? paddedEmpty,
+                TransferSpeedType.Headers => _averageHeadersTransferSpeed?.ToString("0").PadLeft(padding, ' ') ?? paddedEmpty,
+                TransferSpeedType.Bodies => _averageBodiesTransferSpeed?.ToString("0").PadLeft(padding, ' ') ?? paddedEmpty,
+                TransferSpeedType.Receipts => _averageReceiptsTransferSpeed?.ToString("0").PadLeft(padding, ' ') ?? paddedEmpty,
+                _ => throw new ArgumentOutOfRangeException()
+            });
+        }
+
         public (bool Result, NodeStatsEventType? DelayReason) IsConnectionDelayed()
         {
             if (IsDelayedDueToDisconnect())

--- a/src/Nethermind/Nethermind.Network.Test/NodeStatsTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/NodeStatsTests.cs
@@ -1,4 +1,4 @@
-﻿//  Copyright (c) 2021 Demerzel Solutions Limited
+//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
 // 
 //  The Nethermind library is free software: you can redistribute it and/or modify
@@ -60,6 +60,9 @@ namespace Nethermind.Network.Test
 
             var av = _nodeStats.GetAverageTransferSpeed(speedType);
             Assert.AreEqual(102, av);
+
+            var paddedAv = _nodeStats.GetPaddedAverageTransferSpeed(speedType);
+            Assert.AreEqual("  102", paddedAv);
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Network.Test/Stats/NodeTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/Stats/NodeTests.cs
@@ -41,12 +41,12 @@ namespace Nethermind.Network.Test.Stats
             node.Equals(1).Should().BeFalse();
         }
         
-        [TestCase("s", "127.0.0.1:30303")]
-        [TestCase("c", "[Node|127.0.0.1:30303|ClientId|Details]")]
-        [TestCase("f", "enode://a49ac7010c2e0a444dfeeabadbafa4856ba4a2d732acb86d20c577b3b365fdaeb0a70ce47f890cf2f9fca562a7ed784f76eb870a2c75c0f2ab476a70ccb67e92@127.0.0.1:30303|ClientId")]
-        [TestCase("e", "enode://a49ac7010c2e0a444dfeeabadbafa4856ba4a2d732acb86d20c577b3b365fdaeb0a70ce47f890cf2f9fca562a7ed784f76eb870a2c75c0f2ab476a70ccb67e92@127.0.0.1:30303")]
-        [TestCase("p", "enode://a49ac7010c2e0a444dfeeabadbafa4856ba4a2d732acb86d20c577b3b365fdaeb0a70ce47f890cf2f9fca562a7ed784f76eb870a2c75c0f2ab476a70ccb67e92@127.0.0.1:30303|0xb7705ae4c6f81b66cdb323c65f4e8133690fc099")]
-        [TestCase("zzz", "enode://a49ac7010c2e0a444dfeeabadbafa4856ba4a2d732acb86d20c577b3b365fdaeb0a70ce47f890cf2f9fca562a7ed784f76eb870a2c75c0f2ab476a70ccb67e92@127.0.0.1:30303")]
+        [TestCase("s", "      127.0.0.1:30303")]
+        [TestCase("c", "[Node|      127.0.0.1:30303|Details|ClientId]")]
+        [TestCase("f", "enode://a49ac7010c2e0a444dfeeabadbafa4856ba4a2d732acb86d20c577b3b365fdaeb0a70ce47f890cf2f9fca562a7ed784f76eb870a2c75c0f2ab476a70ccb67e92@      127.0.0.1:30303|ClientId")]
+        [TestCase("e", "enode://a49ac7010c2e0a444dfeeabadbafa4856ba4a2d732acb86d20c577b3b365fdaeb0a70ce47f890cf2f9fca562a7ed784f76eb870a2c75c0f2ab476a70ccb67e92@      127.0.0.1:30303")]
+        [TestCase("p", "enode://a49ac7010c2e0a444dfeeabadbafa4856ba4a2d732acb86d20c577b3b365fdaeb0a70ce47f890cf2f9fca562a7ed784f76eb870a2c75c0f2ab476a70ccb67e92@      127.0.0.1:30303|0xb7705ae4c6f81b66cdb323c65f4e8133690fc099")]
+        [TestCase("zzz", "enode://a49ac7010c2e0a444dfeeabadbafa4856ba4a2d732acb86d20c577b3b365fdaeb0a70ce47f890cf2f9fca562a7ed784f76eb870a2c75c0f2ab476a70ccb67e92@      127.0.0.1:30303")]
         public void To_string_formats(string format, string expectedFormat)
         {
             Node GetNode(string host) => 

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
@@ -59,7 +59,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
         // this means that we know what the number, hash, and total diff of the head block is
         public bool IsInitialized { get; set; }
 
-        public override string ToString() => $"[Peer|{Name}|{HeadNumber}|{ClientId}|{Node:s}]";
+        public override string ToString() => $"[Peer|{Name}|{HeadNumber,8}|{Node:s}]";
 
         protected Keccak _remoteHeadBlockHash;
         protected readonly ITimestamper _timestamper;

--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeersReport.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeersReport.cs
@@ -103,7 +103,15 @@ namespace Nethermind.Synchronization.Peers
 
         private void AddPeerInfo(PeerInfo peerInfo)
         {
-            _stringBuilder.Append($"   {peerInfo}[{_stats.GetOrAdd(peerInfo.SyncPeer.Node).GetAverageTransferSpeed(TransferSpeedType.Latency) ?? 0}|{_stats.GetOrAdd(peerInfo.SyncPeer.Node).GetAverageTransferSpeed(TransferSpeedType.Headers) ?? 0}|{_stats.GetOrAdd(peerInfo.SyncPeer.Node).GetAverageTransferSpeed(TransferSpeedType.Bodies) ?? 0}|{_stats.GetOrAdd(peerInfo.SyncPeer.Node).GetAverageTransferSpeed(TransferSpeedType.Receipts) ?? 0}|{_stats.GetOrAdd(peerInfo.SyncPeer.Node).GetAverageTransferSpeed(TransferSpeedType.NodeData) ?? 0}]");
+            INodeStats stats = _stats.GetOrAdd(peerInfo.SyncPeer.Node);
+            _stringBuilder.Append("   ").Append(peerInfo);
+            _stringBuilder.Append('[').Append(stats.GetPaddedAverageTransferSpeed(TransferSpeedType.Latency));
+            _stringBuilder.Append('|').Append(stats.GetPaddedAverageTransferSpeed(TransferSpeedType.Headers));
+            _stringBuilder.Append('|').Append(stats.GetPaddedAverageTransferSpeed(TransferSpeedType.Bodies));
+            _stringBuilder.Append('|').Append(stats.GetPaddedAverageTransferSpeed(TransferSpeedType.Receipts));
+            _stringBuilder.Append('|').Append(stats.GetPaddedAverageTransferSpeed(TransferSpeedType.NodeData));
+            _stringBuilder.Append(']');
+            _stringBuilder.Append('[').Append(peerInfo.SyncPeer.ClientId).Append(']');
         }
 
         private void RememberState(out bool initializedCountChanged)


### PR DESCRIPTION
Closes #1188 

## Changes:

* add method for padded string
* pad IP and port values
* remove `ClientId` from `SyncPeerProtocolHandlerBase.ToString()`
* split_Append()_ calls for better lisibility and performance
* update tests
* padded variables in `Node` class possible because private properties (and set only in one place)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [x] No

**Comments about testing , should you have some** (optional)

Tests were updated to reflect changes in padding display