### PR TITLE
[Account Abstraction] Make default subscription give only RequestId

### DIFF
--- a/src/Nethermind/Nethermind.AccountAbstraction.Test/UserOperationSubscribeTests.cs
+++ b/src/Nethermind/Nethermind.AccountAbstraction.Test/UserOperationSubscribeTests.cs
@@ -88,7 +88,7 @@ namespace Nethermind.AccountAbstraction.Test
                 _specProvider,
                 jsonSerializer);
             
-            subscriptionFactory.RegisterSubscriptionType<EntryPointsParam?>(
+            subscriptionFactory.RegisterSubscriptionType<UserOperationSubscriptionParam?>(
                 "newPendingUserOperations",
                 (jsonRpcDuplexClient,entryPoints) => new NewPendingUserOpsSubscription(
                     jsonRpcDuplexClient,
@@ -96,7 +96,7 @@ namespace Nethermind.AccountAbstraction.Test
                     _logManager,
                     entryPoints)
             );
-            subscriptionFactory.RegisterSubscriptionType<EntryPointsParam?>(
+            subscriptionFactory.RegisterSubscriptionType<UserOperationSubscriptionParam?>(
                 "newReceivedUserOperations",
                 (jsonRpcDuplexClient,entryPoints) => new NewReceivedUserOpsSubscription(
                     jsonRpcDuplexClient,

--- a/src/Nethermind/Nethermind.AccountAbstraction.Test/UserOperationSubscribeTests.cs
+++ b/src/Nethermind/Nethermind.AccountAbstraction.Test/UserOperationSubscribeTests.cs
@@ -113,11 +113,15 @@ namespace Nethermind.AccountAbstraction.Test
             _subscribeRpcModule.Context = new JsonRpcContext(RpcEndpoint.Ws, _jsonRpcDuplexClient);
         }
 
-        private JsonRpcResult GetNewPendingUserOpsResult(UserOperationEventArgs userOperationEventArgs,
-            out string subscriptionId)
+        private JsonRpcResult GetNewPendingUserOpsResult(
+            UserOperationEventArgs userOperationEventArgs,
+            out string subscriptionId,
+            bool includeUserOperations = false)
         {
+            UserOperationSubscriptionParam param = new() {IncludeUserOperations = includeUserOperations};
+
             NewPendingUserOpsSubscription newPendingUserOpsSubscription =
-                new(_jsonRpcDuplexClient, _userOperationPools, _logManager);
+                new(_jsonRpcDuplexClient, _userOperationPools, _logManager, param);
             JsonRpcResult jsonRpcResult = new();
 
             ManualResetEvent manualResetEvent = new(false);
@@ -134,11 +138,15 @@ namespace Nethermind.AccountAbstraction.Test
             return jsonRpcResult;
         }
         
-        private JsonRpcResult GetNewReceivedUserOpsResult(UserOperationEventArgs userOperationEventArgs,
-            out string subscriptionId)
+        private JsonRpcResult GetNewReceivedUserOpsResult(
+            UserOperationEventArgs userOperationEventArgs,
+            out string subscriptionId, 
+            bool includeUserOperations = false)
         {
+            UserOperationSubscriptionParam param = new() {IncludeUserOperations = includeUserOperations};
+
             NewReceivedUserOpsSubscription newReceivedUserOpsSubscription =
-                new(_jsonRpcDuplexClient, _userOperationPools, _logManager);
+                new(_jsonRpcDuplexClient, _userOperationPools, _logManager, param);
             JsonRpcResult jsonRpcResult = new();
 
             ManualResetEvent manualResetEvent = new(false);
@@ -191,14 +199,30 @@ namespace Nethermind.AccountAbstraction.Test
         public void NewPendingUserOperationsSubscription_on_NewPending_event()
         {
             UserOperation userOperation = Build.A.UserOperation.TestObject;
+            userOperation.CalculateRequestId(_entryPointAddress, 1);
             UserOperationEventArgs userOperationEventArgs = new(userOperation, _entryPointAddress);
 
-            JsonRpcResult jsonRpcResult = GetNewPendingUserOpsResult(userOperationEventArgs, out var subscriptionId);
+            JsonRpcResult jsonRpcResult = GetNewPendingUserOpsResult(userOperationEventArgs, out var subscriptionId, true);
 
             jsonRpcResult.Response.Should().NotBeNull();
             string serialized = _jsonSerializer.Serialize(jsonRpcResult.Response);
-            string expectedResult = Expected_text_response_to_UserOperation_event(userOperation, subscriptionId);
-            expectedResult.Should().Be(serialized);
+            string expectedResult = Expected_text_response_to_UserOperation_event_with_full_ops(userOperation, subscriptionId);
+            serialized.Should().Be(expectedResult);
+        }
+        
+        [Test]
+        public void NewPendingUserOperationsSubscription_on_NewPending_event_without_full_user_operations()
+        {
+            UserOperation userOperation = Build.A.UserOperation.TestObject;
+            userOperation.CalculateRequestId(_entryPointAddress, 1);
+            UserOperationEventArgs userOperationEventArgs = new(userOperation, _entryPointAddress);
+
+            JsonRpcResult jsonRpcResult = GetNewPendingUserOpsResult(userOperationEventArgs, out var subscriptionId, false);
+
+            jsonRpcResult.Response.Should().NotBeNull();
+            string serialized = _jsonSerializer.Serialize(jsonRpcResult.Response);
+            string expectedResult = Expected_text_response_to_UserOperation_event_without_full_ops(userOperation, subscriptionId);
+            serialized.Should().Be(expectedResult);
         }
         
         [Test]
@@ -236,13 +260,29 @@ namespace Nethermind.AccountAbstraction.Test
         public void NewReceivedUserOperationsSubscription_on_NewPending_event()
         {
             UserOperation userOperation = Build.A.UserOperation.TestObject;
+            userOperation.CalculateRequestId(_entryPointAddress, 1);
             UserOperationEventArgs userOperationEventArgs = new(userOperation, _entryPointAddress);
 
-            JsonRpcResult jsonRpcResult = GetNewReceivedUserOpsResult(userOperationEventArgs, out var subscriptionId);
+            JsonRpcResult jsonRpcResult = GetNewReceivedUserOpsResult(userOperationEventArgs, out var subscriptionId, true);
 
             jsonRpcResult.Response.Should().NotBeNull();
             string serialized = _jsonSerializer.Serialize(jsonRpcResult.Response);
-            string expectedResult = Expected_text_response_to_UserOperation_event(userOperation, subscriptionId);
+            string expectedResult = Expected_text_response_to_UserOperation_event_with_full_ops(userOperation, subscriptionId);
+            expectedResult.Should().Be(serialized);
+        }
+        
+        [Test]
+        public void NewReceivedUserOperationsSubscription_on_NewPending_event_without_full_user_operations()
+        {
+            UserOperation userOperation = Build.A.UserOperation.TestObject;
+            userOperation.CalculateRequestId(_entryPointAddress, 1);
+            UserOperationEventArgs userOperationEventArgs = new(userOperation, _entryPointAddress);
+
+            JsonRpcResult jsonRpcResult = GetNewReceivedUserOpsResult(userOperationEventArgs, out var subscriptionId, false);
+
+            jsonRpcResult.Response.Should().NotBeNull();
+            string serialized = _jsonSerializer.Serialize(jsonRpcResult.Response);
+            string expectedResult = Expected_text_response_to_UserOperation_event_without_full_ops(userOperation, subscriptionId);
             expectedResult.Should().Be(serialized);
         }
 
@@ -277,7 +317,7 @@ namespace Nethermind.AccountAbstraction.Test
             expectedLogsUnsub.Should().Be(serializedLogsUnsub);
         }
 
-        private string Expected_text_response_to_UserOperation_event(UserOperation userOperation, string subscriptionId) => 
+        private string Expected_text_response_to_UserOperation_event_with_full_ops(UserOperation userOperation, string subscriptionId) => 
             "{\"jsonrpc\":\"2.0\",\"method\":\"eth_subscription\",\"params\":{\"subscription\":\""
                    + subscriptionId
                    + "\",\"result\":{\"userOperation\":{\"sender\":\""
@@ -305,5 +345,14 @@ namespace Nethermind.AccountAbstraction.Test
                    + "\"},\"entryPoint\":\""
                    + _entryPointAddress
                    + "\"}}}";
+        
+        private string Expected_text_response_to_UserOperation_event_without_full_ops(UserOperation userOperation, string subscriptionId) => 
+            "{\"jsonrpc\":\"2.0\",\"method\":\"eth_subscription\",\"params\":{\"subscription\":\""
+            + subscriptionId
+            + "\",\"result\":{\"userOperation\":\""
+            + userOperation.RequestId
+            + "\",\"entryPoint\":\""
+            + _entryPointAddress
+            + "\"}}}";
     }
 }

--- a/src/Nethermind/Nethermind.AccountAbstraction/AccountAbstractionPlugin.cs
+++ b/src/Nethermind/Nethermind.AccountAbstraction/AccountAbstractionPlugin.cs
@@ -311,7 +311,7 @@ namespace Nethermind.AccountAbstraction
                 
                 ISubscriptionFactory subscriptionFactory = _nethermindApi.SubscriptionFactory;
                 //Register custom UserOperation websocket subscription types in the SubscriptionFactory.
-                subscriptionFactory.RegisterSubscriptionType<EntryPointsParam?>(
+                subscriptionFactory.RegisterSubscriptionType<UserOperationSubscriptionParam?>(
                     "newPendingUserOperations",
                     (jsonRpcDuplexClient, param) => new NewPendingUserOpsSubscription(
                         jsonRpcDuplexClient,
@@ -319,7 +319,7 @@ namespace Nethermind.AccountAbstraction
                         logManager,
                         param)
                 );
-                subscriptionFactory.RegisterSubscriptionType<EntryPointsParam?>(
+                subscriptionFactory.RegisterSubscriptionType<UserOperationSubscriptionParam?>(
                     "newReceivedUserOperations",
                     (jsonRpcDuplexClient, param) => new NewReceivedUserOpsSubscription(
                         jsonRpcDuplexClient,

--- a/src/Nethermind/Nethermind.AccountAbstraction/Subscribe/NewPendingUserOpsSubscription.cs
+++ b/src/Nethermind/Nethermind.AccountAbstraction/Subscribe/NewPendingUserOpsSubscription.cs
@@ -32,21 +32,31 @@ namespace Nethermind.AccountAbstraction.Subscribe
     public class NewPendingUserOpsSubscription : Subscription
     {
         private readonly IUserOperationPool[] _userOperationPoolsToTrack;
+        private readonly bool _includeUserOperations;
     
         public NewPendingUserOpsSubscription(
             IJsonRpcDuplexClient jsonRpcDuplexClient, 
             IDictionary<Address, IUserOperationPool>? userOperationPools, 
             ILogManager? logManager, 
-            EntryPointsParam? entryPoints = null) 
+            UserOperationSubscriptionParam? userOperationSubscriptionParam = null) 
             : base(jsonRpcDuplexClient)
         {
             if (userOperationPools is null) throw new ArgumentNullException(nameof(userOperationPools));
-            if (entryPoints is not null)
+            if (userOperationSubscriptionParam is not null)
             {
-                _userOperationPoolsToTrack = userOperationPools
-                    .Where(kv => entryPoints.EntryPoints.Contains(kv.Key))
-                    .Select(kv => kv.Value)
-                    .ToArray();
+                if (userOperationSubscriptionParam.EntryPoints.Length == 0)
+                {
+                    _userOperationPoolsToTrack = userOperationPools.Values.ToArray();
+                }
+                else
+                {
+                    _userOperationPoolsToTrack = userOperationPools
+                        .Where(kv => userOperationSubscriptionParam.EntryPoints.Contains(kv.Key))
+                        .Select(kv => kv.Value)
+                        .ToArray();
+                }
+
+                _includeUserOperations = userOperationSubscriptionParam.IncludeUserOperations;
             }
             else
             {
@@ -68,7 +78,15 @@ namespace Nethermind.AccountAbstraction.Subscribe
         {
             ScheduleAction(() =>
             {
-                JsonRpcResult result = CreateSubscriptionMessage(new { UserOperation = new UserOperationRpc(e.UserOperation), EntryPoint = e.EntryPoint });
+                JsonRpcResult result;
+                if (_includeUserOperations)
+                {
+                    result = CreateSubscriptionMessage(new { UserOperation = new UserOperationRpc(e.UserOperation), EntryPoint = e.EntryPoint });
+                }
+                else
+                {
+                    result = CreateSubscriptionMessage(new { UserOperation = e.UserOperation.RequestId, EntryPoint = e.EntryPoint });
+                }
                 JsonRpcDuplexClient.SendJsonRpcResult(result);
                 if(_logger.IsTrace) _logger.Trace($"newPendingUserOperations subscription {Id} printed hash of newPendingUserOperations.");
             });

--- a/src/Nethermind/Nethermind.AccountAbstraction/Subscribe/UserOperationSubscriptionParam.cs
+++ b/src/Nethermind/Nethermind.AccountAbstraction/Subscribe/UserOperationSubscriptionParam.cs
@@ -24,7 +24,7 @@ namespace Nethermind.AccountAbstraction.Subscribe
 {
     public class UserOperationSubscriptionParam : IJsonRpcParam
     {
-        public Address[] EntryPoints { get; set; } = null!;
+        public Address[] EntryPoints { get; set; } = Array.Empty<Address>();
         public bool IncludeUserOperations { get; set; }
     
         public void FromJson(JsonSerializer serializer, string jsonValue)

--- a/src/Nethermind/Nethermind.AccountAbstraction/Subscribe/UserOperationSubscriptionParam.cs
+++ b/src/Nethermind/Nethermind.AccountAbstraction/Subscribe/UserOperationSubscriptionParam.cs
@@ -16,22 +16,24 @@
 // 
 
 using System;
-using System.Collections.Generic;
 using Nethermind.Core;
 using Nethermind.JsonRpc;
 using Newtonsoft.Json;
 
-namespace Nethermind.AccountAbstraction.Subscribe;
-
-public class EntryPointsParam : IJsonRpcParam
+namespace Nethermind.AccountAbstraction.Subscribe
 {
-    public Address[] EntryPoints { get; set; } = null!;
-    
-    public void FromJson(JsonSerializer serializer, string jsonValue)
+    public class UserOperationSubscriptionParam : IJsonRpcParam
     {
-        EntryPointsParam ep = serializer.Deserialize<EntryPointsParam>(jsonValue.ToJsonTextReader())
-                              ?? throw new ArgumentException($"Invalid 'entryPoints' filter: {jsonValue}");
-        EntryPoints = ep.EntryPoints;
+        public Address[] EntryPoints { get; set; } = null!;
+        public bool IncludeUserOperations { get; set; }
+    
+        public void FromJson(JsonSerializer serializer, string jsonValue)
+        {
+            UserOperationSubscriptionParam ep = serializer.Deserialize<UserOperationSubscriptionParam>(jsonValue.ToJsonTextReader())
+                                  ?? throw new ArgumentException($"Invalid 'entryPoints' filter: {jsonValue}");
+            EntryPoints = ep.EntryPoints;
+            IncludeUserOperations = ep.IncludeUserOperations;
 
+        }
     }
 }


### PR DESCRIPTION
## Changes:
- When making a newPendingUserOperations or newReceivedUserOperations sub, the user will receive only the hash unless they set the includeUserOperations field to true

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No
