### PR TITLE
BlockchainProcessor: skip DeleteInvalidBlocks in ReadOnly mode

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Processing/BlockchainProcessor.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Processing/BlockchainProcessor.cs
@@ -411,7 +411,7 @@ namespace Nethermind.Blockchain.Processing
             }
             finally
             {
-                if (invalidBlockHash is not null)
+                if (invalidBlockHash is not null && (options & ProcessingOptions.ReadOnlyChain) == 0)
                 {
                     DeleteInvalidBlocks(invalidBlockHash);
                 }


### PR DESCRIPTION
## Changes:
- skip deleting blocks in read only mode.
In hive tests we have exceptions because of trying to delete blocks in read only mode. This PR is fixing it.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [x] No