### PR TITLE
Refactor receipt recovery

### DIFF
--- a/src/Nethermind/Nethermind.AccountAbstraction.Test/UserOperationSubscribeTests.cs
+++ b/src/Nethermind/Nethermind.AccountAbstraction.Test/UserOperationSubscribeTests.cs
@@ -52,6 +52,7 @@ namespace Nethermind.AccountAbstraction.Test
         private IBlockTree _blockTree = null!;
         private ITxPool _txPool = null!;
         private IReceiptStorage _receiptStorage = null!;
+        private IReceiptFinder _receiptFinder = null!;
         private IFilterStore _filterStore = null!;
         private ISubscriptionManager _subscriptionManager = null!;
         private IJsonRpcDuplexClient _jsonRpcDuplexClient = null!;
@@ -69,6 +70,7 @@ namespace Nethermind.AccountAbstraction.Test
             _blockTree = Substitute.For<IBlockTree>();
             _txPool = Substitute.For<ITxPool>();
             _receiptStorage = Substitute.For<IReceiptStorage>();
+            _receiptFinder = Substitute.For<IReceiptFinder>();
             _specProvider = Substitute.For<ISpecProvider>();
             _userOperationPools[_testPoolAddress] = Substitute.For<IUserOperationPool>();
             _filterStore = new FilterStore();
@@ -83,6 +85,7 @@ namespace Nethermind.AccountAbstraction.Test
                 _blockTree,
                 _txPool,
                 _receiptStorage,
+                _receiptFinder,
                 _filterStore,
                 new EthSyncingInfo(_blockTree),
                 _specProvider,

--- a/src/Nethermind/Nethermind.Blockchain.Test/Find/LogFinderTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Find/LogFinderTests.cs
@@ -59,7 +59,7 @@ namespace Nethermind.Blockchain.Test.Find
             _blockTree = Build.A.BlockTree().WithTransactions(_receiptStorage, specProvider, LogsForBlockBuilder).OfChainLength(5).TestObject;
             _bloomStorage = new BloomStorage(new BloomConfig(), new MemDb(), new InMemoryDictionaryFileStoreFactory());
             _receiptsRecovery = Substitute.For<IReceiptsRecovery>();
-            _logFinder = new LogFinder(_blockTree, _receiptStorage, _bloomStorage, LimboLogs.Instance, _receiptsRecovery);
+            _logFinder = new LogFinder(_blockTree, _receiptStorage, _receiptStorage, _bloomStorage, LimboLogs.Instance, _receiptsRecovery);
         }
 
         private IEnumerable<LogEntry> LogsForBlockBuilder(Block block, Transaction transaction)
@@ -137,7 +137,7 @@ namespace Nethermind.Blockchain.Test.Find
         {
             StoreTreeBlooms(withBloomDb);
             _receiptStorage = NullReceiptStorage.Instance;
-            _logFinder = new LogFinder(_blockTree, _receiptStorage, _bloomStorage, LimboLogs.Instance, _receiptsRecovery);
+            _logFinder = new LogFinder(_blockTree, _receiptStorage, _receiptStorage, _bloomStorage, LimboLogs.Instance, _receiptsRecovery);
             
             var logFilter = AllBlockFilter().Build();
             var logs = _logFinder.FindLogs(logFilter);
@@ -149,7 +149,7 @@ namespace Nethermind.Blockchain.Test.Find
         {
             StoreTreeBlooms(withBloomDb);
             var blockFinder = Substitute.For<IBlockFinder>();
-            _logFinder = new LogFinder(blockFinder, _receiptStorage, _bloomStorage, LimboLogs.Instance, _receiptsRecovery);
+            _logFinder = new LogFinder(blockFinder, _receiptStorage, _receiptStorage, _bloomStorage, LimboLogs.Instance, _receiptsRecovery);
             var logFilter = AllBlockFilter().Build();
             var action = new Func<IEnumerable<FilterLog>>(() =>_logFinder.FindLogs(logFilter));
             action.Should().Throw<ArgumentException>();
@@ -251,7 +251,7 @@ namespace Nethermind.Blockchain.Test.Find
         public void filter_by_blocks_with_limit([ValueSource(nameof(WithBloomValues))]bool withBloomDb)
         {
             StoreTreeBlooms(withBloomDb);
-            _logFinder = new LogFinder(_blockTree,  _receiptStorage, _bloomStorage, LimboLogs.Instance, _receiptsRecovery, 2);
+            _logFinder = new LogFinder(_blockTree,  _receiptStorage, _receiptStorage, _bloomStorage, LimboLogs.Instance, _receiptsRecovery, 2);
             var filter = FilterBuilder.New().FromLatestBlock().ToLatestBlock().Build();
             var logs = _logFinder.FindLogs(filter).ToArray();
 
@@ -298,7 +298,7 @@ namespace Nethermind.Blockchain.Test.Find
 
             StoreTreeBlooms(true);
             _receiptStorage = NullReceiptStorage.Instance;
-            _logFinder = new LogFinder(_blockTree, _receiptStorage, _bloomStorage, LimboLogs.Instance, _receiptsRecovery);
+            _logFinder = new LogFinder(_blockTree, _receiptStorage, _receiptStorage, _bloomStorage, LimboLogs.Instance, _receiptsRecovery);
             var logFilter = AllBlockFilter().Build();
             var logs = _logFinder.FindLogs(logFilter, cancellationToken);
             

--- a/src/Nethermind/Nethermind.Blockchain.Test/Find/LogFinderTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Find/LogFinderTests.cs
@@ -59,7 +59,7 @@ namespace Nethermind.Blockchain.Test.Find
             _blockTree = Build.A.BlockTree().WithTransactions(_receiptStorage, specProvider, LogsForBlockBuilder).OfChainLength(5).TestObject;
             _bloomStorage = new BloomStorage(new BloomConfig(), new MemDb(), new InMemoryDictionaryFileStoreFactory());
             _receiptsRecovery = Substitute.For<IReceiptsRecovery>();
-            _logFinder = new LogFinder(_blockTree, _receiptStorage, _receiptStorage, _bloomStorage, LimboLogs.Instance, _receiptsRecovery);
+            _logFinder = new LogFinder(_blockTree, _receiptStorage, _bloomStorage, LimboLogs.Instance, _receiptsRecovery);
         }
 
         private IEnumerable<LogEntry> LogsForBlockBuilder(Block block, Transaction transaction)
@@ -137,7 +137,7 @@ namespace Nethermind.Blockchain.Test.Find
         {
             StoreTreeBlooms(withBloomDb);
             _receiptStorage = NullReceiptStorage.Instance;
-            _logFinder = new LogFinder(_blockTree, _receiptStorage, _receiptStorage, _bloomStorage, LimboLogs.Instance, _receiptsRecovery);
+            _logFinder = new LogFinder(_blockTree, _receiptStorage, _bloomStorage, LimboLogs.Instance, _receiptsRecovery);
             
             var logFilter = AllBlockFilter().Build();
             var logs = _logFinder.FindLogs(logFilter);
@@ -149,7 +149,7 @@ namespace Nethermind.Blockchain.Test.Find
         {
             StoreTreeBlooms(withBloomDb);
             var blockFinder = Substitute.For<IBlockFinder>();
-            _logFinder = new LogFinder(blockFinder, _receiptStorage, _receiptStorage, _bloomStorage, LimboLogs.Instance, _receiptsRecovery);
+            _logFinder = new LogFinder(blockFinder, _receiptStorage, _bloomStorage, LimboLogs.Instance, _receiptsRecovery);
             var logFilter = AllBlockFilter().Build();
             var action = new Func<IEnumerable<FilterLog>>(() =>_logFinder.FindLogs(logFilter));
             action.Should().Throw<ArgumentException>();
@@ -251,7 +251,7 @@ namespace Nethermind.Blockchain.Test.Find
         public void filter_by_blocks_with_limit([ValueSource(nameof(WithBloomValues))]bool withBloomDb)
         {
             StoreTreeBlooms(withBloomDb);
-            _logFinder = new LogFinder(_blockTree,  _receiptStorage, _receiptStorage, _bloomStorage, LimboLogs.Instance, _receiptsRecovery, 2);
+            _logFinder = new LogFinder(_blockTree,  _receiptStorage, _bloomStorage, LimboLogs.Instance, _receiptsRecovery, 2);
             var filter = FilterBuilder.New().FromLatestBlock().ToLatestBlock().Build();
             var logs = _logFinder.FindLogs(filter).ToArray();
 
@@ -298,7 +298,7 @@ namespace Nethermind.Blockchain.Test.Find
 
             StoreTreeBlooms(true);
             _receiptStorage = NullReceiptStorage.Instance;
-            _logFinder = new LogFinder(_blockTree, _receiptStorage, _receiptStorage, _bloomStorage, LimboLogs.Instance, _receiptsRecovery);
+            _logFinder = new LogFinder(_blockTree, _receiptStorage, _bloomStorage, LimboLogs.Instance, _receiptsRecovery);
             var logFilter = AllBlockFilter().Build();
             var logs = _logFinder.FindLogs(logFilter, cancellationToken);
             

--- a/src/Nethermind/Nethermind.Blockchain.Test/Receipts/PersistentReceiptStorageTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Receipts/PersistentReceiptStorageTests.cs
@@ -103,7 +103,7 @@ namespace Nethermind.Blockchain.Test.Receipts
                 .WithReceiptsRoot(TestItem.KeccakA)
                 .TestObject;
 
-            var emptyReceipts = new TxReceipt[] {null};
+            var emptyReceipts = Array.Empty<TxReceipt>();
             _storage.Get(block).Should().BeEquivalentTo(emptyReceipts);
             // can be from cache:
             _storage.Get(block).Should().BeEquivalentTo(emptyReceipts);

--- a/src/Nethermind/Nethermind.Blockchain/Find/LogFinder.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Find/LogFinder.cs
@@ -33,7 +33,6 @@ namespace Nethermind.Blockchain.Find
         private static int ParallelExecutions = 0;
         private static int ParallelLock = 0;
         
-        private readonly IReceiptFinder _receiptFinder;
         private readonly IReceiptStorage _receiptStorage;
         private readonly IBloomStorage _bloomStorage;
         private readonly IReceiptsRecovery _receiptsRecovery;
@@ -51,7 +50,6 @@ namespace Nethermind.Blockchain.Find
         {
             _blockFinder = blockFinder ?? throw new ArgumentNullException(nameof(blockFinder));
             _receiptStorage = receiptStorage ?? throw new ArgumentNullException(nameof(receiptStorage));
-            _receiptFinder = receiptStorage;
             _bloomStorage = bloomStorage ?? throw new ArgumentNullException(nameof(bloomStorage));
             _receiptsRecovery = receiptsRecovery ?? throw new ArgumentNullException(nameof(receiptsRecovery));
             _logger = logManager?.GetClassLogger<LogFinder>() ?? throw new ArgumentNullException(nameof(logManager));
@@ -205,7 +203,7 @@ namespace Nethermind.Blockchain.Find
         {
             if (blockHash != null)
             {
-                return _receiptFinder.TryGetReceiptsIterator(blockNumber, blockHash, out var iterator)
+                return _receiptStorage.TryGetReceiptsIterator(blockNumber, blockHash, out var iterator)
                     ? FilterLogsInBlockLowMemoryAllocation(filter, ref iterator, cancellationToken)
                     : FilterLogsInBlockHighMemoryAllocation(filter, blockHash, blockNumber, cancellationToken);
             }
@@ -273,15 +271,15 @@ namespace Nethermind.Blockchain.Find
         {
             TxReceipt[] GetReceipts(Keccak hash, long number)
             {
-                var canUseHash = _receiptFinder.CanGetReceiptsByHash(number);
+                var canUseHash = _receiptStorage.CanGetReceiptsByHash(number);
                 if (canUseHash)
                 {
-                    return _receiptFinder.Get(hash);
+                    return _receiptStorage.Get(hash);
                 }
                 else
                 {
                     var block = _blockFinder.FindBlock(blockHash, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
-                    return block == null ? null : _receiptFinder.Get(block);
+                    return block == null ? null : _receiptStorage.Get(block);
                 }
             }
 

--- a/src/Nethermind/Nethermind.Blockchain/Find/LogFinder.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Find/LogFinder.cs
@@ -43,7 +43,6 @@ namespace Nethermind.Blockchain.Find
         private readonly ILogger _logger;
         
         public LogFinder(IBlockFinder? blockFinder,
-            IReceiptFinder? receiptFinder,
             IReceiptStorage? receiptStorage,
             IBloomStorage? bloomStorage,
             ILogManager? logManager,
@@ -51,8 +50,8 @@ namespace Nethermind.Blockchain.Find
             int maxBlockDepth = 1000)
         {
             _blockFinder = blockFinder ?? throw new ArgumentNullException(nameof(blockFinder));
-            _receiptFinder = receiptFinder ?? throw new ArgumentNullException(nameof(receiptFinder));
-            _receiptStorage = receiptStorage ?? throw new ArgumentNullException(nameof(receiptStorage));;
+            _receiptStorage = receiptStorage ?? throw new ArgumentNullException(nameof(receiptStorage));
+            _receiptFinder = receiptStorage;
             _bloomStorage = bloomStorage ?? throw new ArgumentNullException(nameof(bloomStorage));
             _receiptsRecovery = receiptsRecovery ?? throw new ArgumentNullException(nameof(receiptsRecovery));
             _logger = logManager?.GetClassLogger<LogFinder>() ?? throw new ArgumentNullException(nameof(logManager));

--- a/src/Nethermind/Nethermind.Blockchain/Find/LogFinder.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Find/LogFinder.cs
@@ -43,6 +43,7 @@ namespace Nethermind.Blockchain.Find
         private readonly ILogger _logger;
         
         public LogFinder(IBlockFinder? blockFinder,
+            IReceiptFinder? receiptFinder,
             IReceiptStorage? receiptStorage,
             IBloomStorage? bloomStorage,
             ILogManager? logManager,
@@ -50,8 +51,8 @@ namespace Nethermind.Blockchain.Find
             int maxBlockDepth = 1000)
         {
             _blockFinder = blockFinder ?? throw new ArgumentNullException(nameof(blockFinder));
-            _receiptStorage = receiptStorage ?? throw new ArgumentNullException(nameof(receiptStorage));
-            _receiptFinder = receiptStorage;
+            _receiptFinder = receiptFinder ?? throw new ArgumentNullException(nameof(receiptFinder));
+            _receiptStorage = receiptStorage ?? throw new ArgumentNullException(nameof(receiptStorage));;
             _bloomStorage = bloomStorage ?? throw new ArgumentNullException(nameof(bloomStorage));
             _receiptsRecovery = receiptsRecovery ?? throw new ArgumentNullException(nameof(receiptsRecovery));
             _logger = logManager?.GetClassLogger<LogFinder>() ?? throw new ArgumentNullException(nameof(logManager));

--- a/src/Nethermind/Nethermind.Blockchain/Find/LogFinder.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Find/LogFinder.cs
@@ -34,6 +34,7 @@ namespace Nethermind.Blockchain.Find
         private static int ParallelLock = 0;
         
         private readonly IReceiptFinder _receiptFinder;
+        private readonly IReceiptStorage _receiptStorage;
         private readonly IBloomStorage _bloomStorage;
         private readonly IReceiptsRecovery _receiptsRecovery;
         private readonly int _maxBlockDepth;
@@ -41,16 +42,17 @@ namespace Nethermind.Blockchain.Find
         private readonly IBlockFinder _blockFinder;
         private readonly ILogger _logger;
         
-        public LogFinder(
-            IBlockFinder? blockFinder, 
-            IReceiptFinder? receiptFinder, 
-            IBloomStorage? bloomStorage, 
-            ILogManager? logManager, 
-            IReceiptsRecovery? receiptsRecovery, 
+        public LogFinder(IBlockFinder? blockFinder,
+            IReceiptFinder? receiptFinder,
+            IReceiptStorage? receiptStorage,
+            IBloomStorage? bloomStorage,
+            ILogManager? logManager,
+            IReceiptsRecovery? receiptsRecovery,
             int maxBlockDepth = 1000)
         {
             _blockFinder = blockFinder ?? throw new ArgumentNullException(nameof(blockFinder));
             _receiptFinder = receiptFinder ?? throw new ArgumentNullException(nameof(receiptFinder));
+            _receiptStorage = receiptStorage ?? throw new ArgumentNullException(nameof(receiptStorage));;
             _bloomStorage = bloomStorage ?? throw new ArgumentNullException(nameof(bloomStorage));
             _receiptsRecovery = receiptsRecovery ?? throw new ArgumentNullException(nameof(receiptsRecovery));
             _logger = logManager?.GetClassLogger<LogFinder>() ?? throw new ArgumentNullException(nameof(logManager));
@@ -291,7 +293,10 @@ namespace Nethermind.Blockchain.Find
                     var block = _blockFinder.FindBlock(hash, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
                     if (block != null)
                     {
-                        _receiptsRecovery.TryRecover(block, receipts);
+                        if (_receiptsRecovery.TryRecover(block, receipts))
+                        {
+                            _receiptStorage.Insert(block, receipts);
+                        }
                     }
                 }
             }

--- a/src/Nethermind/Nethermind.Blockchain/Processing/ProcessingStats.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Processing/ProcessingStats.cs
@@ -76,17 +76,11 @@ namespace Nethermind.Blockchain.Processing
 
             if (chunkMicroseconds > 1 * 1000 * 1000)
             {
-                long currentGen0 = GC.CollectionCount(0);
-                long currentGen1 = GC.CollectionCount(1);
-                long currentGen2 = GC.CollectionCount(2);
-                long currentMemory = GC.GetTotalMemory(false);
-                _maxMemory = Math.Max(_maxMemory, currentMemory);
                 long currentStateDbReads = Db.Metrics.StateDbReads;
                 long currentStateDbWrites = Db.Metrics.StateDbWrites;
                 long currentTreeNodeRlp = Trie.Metrics.TreeNodeRlpEncodings + Trie.Metrics.TreeNodeRlpDecodings;
                 long evmExceptions = Evm.Metrics.EvmExceptions;
                 long currentSelfDestructs = Evm.Metrics.SelfDestructs;
-
                 long chunkTx = Metrics.Transactions - _lastTotalTx;
                 long chunkBlocks = Metrics.Blocks - _lastBlockNumber;
                 decimal chunkMGas = Metrics.Mgas - _lastTotalMGas;
@@ -101,15 +95,23 @@ namespace Nethermind.Blockchain.Processing
                 decimal bps = chunkMicroseconds == 0 ? -1 : chunkBlocks / chunkMicroseconds * 1000m * 1000m;
 
                 if (_logger.IsInfo) _logger.Info($"Processed  {block.Number,9} |  {(chunkMicroseconds == 0 ? -1 : chunkMicroseconds / 1000),7:N0}ms, mgasps {mgasPerSecond,7:F2} total {totalMgasPerSecond,7:F2}, tps {txps,7:F2} total {totalTxPerSecond,7:F2}, bps {bps,7:F2} total {totalBlocksPerSecond,7:F2}, recv queue {recoveryQueueSize}, proc queue {blockQueueSize}");
-                if (_logger.IsDebug) _logger.Trace($"Gen0 {currentGen0 - _lastGen0,6}, Gen1 {currentGen1 - _lastGen1,6}, Gen2 {currentGen2 - _lastGen2,6}, maxmem {_maxMemory / 1000000,5}, mem {currentMemory / 1000000,5}, reads {currentStateDbReads - _lastStateDbReads,9}, writes {currentStateDbWrites - _lastStateDbWrites,9}, rlp {currentTreeNodeRlp - _lastTreeNodeRlp,9}, exceptions {evmExceptions - _lastEvmExceptions}, selfdstrcs {currentSelfDestructs - _lastSelfDestructs}");
+                if (_logger.IsDebug)
+                {
+                    long currentGen0 = GC.CollectionCount(0);
+                    long currentGen1 = GC.CollectionCount(1);
+                    long currentGen2 = GC.CollectionCount(2);
+                    long currentMemory = GC.GetTotalMemory(false);
+                    _maxMemory = Math.Max(_maxMemory, currentMemory);
+                    _logger.Trace($"Gen0 {currentGen0 - _lastGen0,6}, Gen1 {currentGen1 - _lastGen1,6}, Gen2 {currentGen2 - _lastGen2,6}, maxmem {_maxMemory / 1000000,5}, mem {currentMemory / 1000000,5}, reads {currentStateDbReads - _lastStateDbReads,9}, writes {currentStateDbWrites - _lastStateDbWrites,9}, rlp {currentTreeNodeRlp - _lastTreeNodeRlp,9}, exceptions {evmExceptions - _lastEvmExceptions}, selfdstrcs {currentSelfDestructs - _lastSelfDestructs}");
+                    _lastGen0 = currentGen0;
+                    _lastGen1 = currentGen1;
+                    _lastGen2 = currentGen2;
+                }
 
                 _lastBlockNumber = Metrics.Blocks;
                 _lastTotalMGas = Metrics.Mgas;
                 _lastElapsedTicks = currentTicks;
                 _lastTotalTx = Metrics.Transactions;
-                _lastGen0 = currentGen0;
-                _lastGen1 = currentGen1;
-                _lastGen2 = currentGen2;
                 _lastStateDbReads = currentStateDbReads;
                 _lastStateDbWrites = currentStateDbWrites;
                 _lastTreeNodeRlp = currentTreeNodeRlp;

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/FullInfoReceiptFinder.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/FullInfoReceiptFinder.cs
@@ -41,7 +41,7 @@ namespace Nethermind.Blockchain.Receipts
             var receipts = _receiptStorage.Get(block);
             if (_receiptsRecovery.TryRecover(block, receipts))
             {
-                _receiptStorage.Insert(block, true, receipts);
+                _receiptStorage.Insert(block, receipts);
             }
             
             return receipts;
@@ -56,7 +56,7 @@ namespace Nethermind.Blockchain.Receipts
                 var block = _blockFinder.FindBlock(blockHash, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
                 if (_receiptsRecovery.TryRecover(block, receipts))
                 {
-                    _receiptStorage.Insert(block, true, receipts);
+                    _receiptStorage.Insert(block, receipts);
                 }
             }
 

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/FullInfoReceiptFinder.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/FullInfoReceiptFinder.cs
@@ -49,7 +49,7 @@ namespace Nethermind.Blockchain.Receipts
 
         public TxReceipt[] Get(Keccak blockHash)
         {
-            TxReceipt[]? receipts = _receiptStorage.Get(blockHash);
+            var receipts = _receiptStorage.Get(blockHash);
             
             if (_receiptsRecovery.NeedRecover(receipts))
             {

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/FullInfoReceiptFinder.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/FullInfoReceiptFinder.cs
@@ -23,40 +23,47 @@ namespace Nethermind.Blockchain.Receipts
 {
     public class FullInfoReceiptFinder : IReceiptFinder
     {
-        private readonly IReceiptFinder _innerFinder;
+        private readonly IReceiptStorage _receiptStorage;
         private readonly IReceiptsRecovery _receiptsRecovery;
         private readonly IBlockFinder _blockFinder;
 
-        public FullInfoReceiptFinder(IReceiptFinder innerFinder, IReceiptsRecovery receiptsRecovery, IBlockFinder blockFinder)
+        public FullInfoReceiptFinder(IReceiptStorage receiptStorage, IReceiptsRecovery receiptsRecovery, IBlockFinder blockFinder)
         {
-            _innerFinder = innerFinder ?? throw new ArgumentNullException(nameof(innerFinder));
+            _receiptStorage = receiptStorage ?? throw new ArgumentNullException(nameof(receiptStorage));
             _receiptsRecovery = receiptsRecovery ?? throw new ArgumentNullException(nameof(receiptsRecovery));
             _blockFinder = blockFinder ?? throw new ArgumentNullException(nameof(blockFinder));
         }
         
-        public Keccak FindBlockHash(Keccak txHash) => _innerFinder.FindBlockHash(txHash);
+        public Keccak FindBlockHash(Keccak txHash) => _receiptStorage.FindBlockHash(txHash);
 
         public TxReceipt[] Get(Block block)
         {
-            var receipts = _innerFinder.Get(block);
-            _receiptsRecovery.TryRecover(block, receipts);
+            var receipts = _receiptStorage.Get(block);
+            if (_receiptsRecovery.TryRecover(block, receipts))
+            {
+                _receiptStorage.Insert(block, receipts);
+            }
+            
             return receipts;
         }
 
         public TxReceipt[] Get(Keccak blockHash)
         {
-            var receipts = _innerFinder.Get(blockHash);
+            TxReceipt[]? receipts = _receiptStorage.Get(blockHash);
             
             if (_receiptsRecovery.NeedRecover(receipts))
             {
                 var block = _blockFinder.FindBlock(blockHash, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
-                _receiptsRecovery.TryRecover(block, receipts);
+                if (_receiptsRecovery.TryRecover(block, receipts))
+                {
+                    _receiptStorage.Insert(block, receipts);
+                }
             }
 
             return receipts;
         }
 
-        public bool CanGetReceiptsByHash(long blockNumber) => _innerFinder.CanGetReceiptsByHash(blockNumber);
-        public bool TryGetReceiptsIterator(long blockNumber, Keccak blockHash, out ReceiptsIterator iterator) => _innerFinder.TryGetReceiptsIterator(blockNumber, blockHash, out iterator);
+        public bool CanGetReceiptsByHash(long blockNumber) => _receiptStorage.CanGetReceiptsByHash(blockNumber);
+        public bool TryGetReceiptsIterator(long blockNumber, Keccak blockHash, out ReceiptsIterator iterator) => _receiptStorage.TryGetReceiptsIterator(blockNumber, blockHash, out iterator);
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/FullInfoReceiptFinder.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/FullInfoReceiptFinder.cs
@@ -41,7 +41,7 @@ namespace Nethermind.Blockchain.Receipts
             var receipts = _receiptStorage.Get(block);
             if (_receiptsRecovery.TryRecover(block, receipts))
             {
-                _receiptStorage.Insert(block, receipts);
+                _receiptStorage.Insert(block, true, receipts);
             }
             
             return receipts;
@@ -56,7 +56,7 @@ namespace Nethermind.Blockchain.Receipts
                 var block = _blockFinder.FindBlock(blockHash, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
                 if (_receiptsRecovery.TryRecover(block, receipts))
                 {
-                    _receiptStorage.Insert(block, receipts);
+                    _receiptStorage.Insert(block, true, receipts);
                 }
             }
 

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/IReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/IReceiptStorage.cs
@@ -21,7 +21,6 @@ namespace Nethermind.Blockchain.Receipts
 {
     public interface IReceiptStorage : IReceiptFinder
     {
-        void Insert(Block block, bool wasRecovered, params TxReceipt[] txReceipts) => Insert(block, txReceipts);
         void Insert(Block block, params TxReceipt[] txReceipts);
         long? LowestInsertedReceiptBlockNumber { get; set; }
         long MigratedBlockNumber { get; set; }

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/IReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/IReceiptStorage.cs
@@ -21,6 +21,7 @@ namespace Nethermind.Blockchain.Receipts
 {
     public interface IReceiptStorage : IReceiptFinder
     {
+        void Insert(Block block, bool wasRecovered, params TxReceipt[] txReceipts) => Insert(block, txReceipts);
         void Insert(Block block, params TxReceipt[] txReceipts);
         long? LowestInsertedReceiptBlockNumber { get; set; }
         long MigratedBlockNumber { get; set; }

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/IReceiptsRecovery.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/IReceiptsRecovery.cs
@@ -20,7 +20,7 @@ namespace Nethermind.Blockchain.Receipts
 {
     public interface IReceiptsRecovery
     {
-        bool TryRecover(Block block, TxReceipt[] receipts, bool force = true);
-        bool NeedRecover(TxReceipt[] receipts, bool force = true);
+        bool TryRecover(Block block, TxReceipt[] receipts, bool forceRecoverSender = true);
+        bool NeedRecover(TxReceipt[] receipts, bool forceRecoverSender = true);
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/IReceiptsRecovery.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/IReceiptsRecovery.cs
@@ -20,7 +20,7 @@ namespace Nethermind.Blockchain.Receipts
 {
     public interface IReceiptsRecovery
     {
-        bool TryRecover(Block block, TxReceipt[] receipts);
-        bool NeedRecover(TxReceipt[] receipts);
+        bool TryRecover(Block block, TxReceipt[] receipts, bool force = true);
+        bool NeedRecover(TxReceipt[] receipts, bool force = true);
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/InMemoryReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/InMemoryReceiptStorage.cs
@@ -75,7 +75,9 @@ namespace Nethermind.Blockchain.Receipts
                 txReceipt.BlockHash = block.Hash;
                 _transactions[txReceipt.TxHash] = txReceipt;
             }
-            ReceiptsInserted?.Invoke(this, new ReceiptsEventArgs(block.Header, txReceipts));
+
+            bool wasRemoved = txReceipts.Length > 0 && txReceipts[0].Removed;
+            ReceiptsInserted?.Invoke(this, new ReceiptsEventArgs(block.Header, txReceipts, wasRemoved));
         }
 
         public long? LowestInsertedReceiptBlockNumber { get; set; }

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
@@ -203,12 +203,7 @@ namespace Nethermind.Blockchain.Receipts
             
             _receiptsCache.Set(block.Hash, txReceipts);
 
-            // Subscription with new receipts is invoked by NewHeadBlock event.
-            // Here we want to invoke ReceiptsInserted event only to send removed receipts (after reorg).
-            if (wasRemoved)
-            {
-                ReceiptsInserted?.Invoke(this, new ReceiptsEventArgs(block.Header, txReceipts));
-            }
+            ReceiptsInserted?.Invoke(this, new ReceiptsEventArgs(block.Header, txReceipts));
         }
 
         public long? LowestInsertedReceiptBlockNumber

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
@@ -207,7 +207,9 @@ namespace Nethermind.Blockchain.Receipts
             return result;
         }
 
-        public void Insert(Block block, params TxReceipt[] txReceipts)
+        public void Insert(Block block, params TxReceipt[] txReceipts) => Insert(block, false, txReceipts);
+
+        public void Insert(Block block, bool wasRecovered = false, params TxReceipt[] txReceipts)
         {
             txReceipts ??= Array.Empty<TxReceipt>();
             int txReceiptsLength = txReceipts.Length;
@@ -219,8 +221,8 @@ namespace Nethermind.Blockchain.Receipts
                     $"of transactions {block.Transactions.Length} and receipts {txReceipts.Length}.");
             }
 
-            bool wasRecovered = _receiptsRecovery.TryRecover(block, txReceipts, false);
-            
+            _receiptsRecovery.TryRecover(block, txReceipts, false);
+
             var blockNumber = block.Number;
             var spec = _specProvider.GetSpec(blockNumber);
             RlpBehaviors behaviors = spec.IsEip658Enabled ? RlpBehaviors.Eip658Receipts | RlpBehaviors.Storage : RlpBehaviors.Storage;

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
@@ -207,9 +207,7 @@ namespace Nethermind.Blockchain.Receipts
             return result;
         }
 
-        public void Insert(Block block, params TxReceipt[] txReceipts) => Insert(block, false, txReceipts);
-
-        public void Insert(Block block, bool wasRecovered = false, params TxReceipt[] txReceipts)
+        public void Insert(Block block, params TxReceipt[] txReceipts)
         {
             txReceipts ??= Array.Empty<TxReceipt>();
             int txReceiptsLength = txReceipts.Length;
@@ -221,8 +219,8 @@ namespace Nethermind.Blockchain.Receipts
                     $"of transactions {block.Transactions.Length} and receipts {txReceipts.Length}.");
             }
 
-            _receiptsRecovery.TryRecover(block, txReceipts, false);
-
+            bool wasRecovered = _receiptsRecovery.TryRecover(block, txReceipts, false);
+            
             var blockNumber = block.Number;
             var spec = _specProvider.GetSpec(blockNumber);
             RlpBehaviors behaviors = spec.IsEip658Enabled ? RlpBehaviors.Eip658Receipts | RlpBehaviors.Storage : RlpBehaviors.Storage;

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
@@ -209,7 +209,7 @@ namespace Nethermind.Blockchain.Receipts
 
         public void Insert(Block block, params TxReceipt[] txReceipts) => Insert(block, false, txReceipts);
 
-        public void Insert(Block block, bool wasRecovered, params TxReceipt[] txReceipts)
+        public void Insert(Block block, bool wasRecovered = false, params TxReceipt[] txReceipts)
         {
             txReceipts ??= Array.Empty<TxReceipt>();
             int txReceiptsLength = txReceipts.Length;

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
@@ -209,7 +209,7 @@ namespace Nethermind.Blockchain.Receipts
 
         public void Insert(Block block, params TxReceipt[] txReceipts) => Insert(block, false, txReceipts);
 
-        public void Insert(Block block, bool wasRecovered = false, params TxReceipt[] txReceipts)
+        public void Insert(Block block, bool wasRecovered, params TxReceipt[] txReceipts)
         {
             txReceipts ??= Array.Empty<TxReceipt>();
             int txReceiptsLength = txReceipts.Length;

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
@@ -203,7 +203,7 @@ namespace Nethermind.Blockchain.Receipts
             
             _receiptsCache.Set(block.Hash, txReceipts);
 
-            ReceiptsInserted?.Invoke(this, new ReceiptsEventArgs(block.Header, txReceipts));
+            ReceiptsInserted?.Invoke(this, new ReceiptsEventArgs(block.Header, txReceipts, wasRemoved));
         }
 
         public long? LowestInsertedReceiptBlockNumber

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
@@ -109,10 +109,16 @@ namespace Nethermind.Blockchain.Receipts
 
             if (_receiptsCache.TryGet(block.Hash, out var receipts))
             {
-                return receipts;
+                return receipts ?? Array.Empty<TxReceipt>();
             }
             
             var receiptsData = _blocksDb.GetSpan(block.Hash);
+
+            if (receiptsData.IsEmpty)
+            {
+                return Array.Empty<TxReceipt>();
+            }
+            
             try
             {
                 bool shouldCache = true;

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
@@ -219,7 +219,7 @@ namespace Nethermind.Blockchain.Receipts
                     $"of transactions {block.Transactions.Length} and receipts {txReceipts.Length}.");
             }
 
-            bool wasRecovered = _receiptsRecovery.TryRecover(block, txReceipts, false);
+            _receiptsRecovery.TryRecover(block, txReceipts, false);
             
             var blockNumber = block.Number;
             var spec = _specProvider.GetSpec(blockNumber);
@@ -243,7 +243,9 @@ namespace Nethermind.Blockchain.Receipts
             
             _receiptsCache.Set(block.Hash, txReceipts);
 
-            if (!wasRecovered || wasRemoved)
+            // Subscription with new receipts is invoked by NewHeadBlock event.
+            // Here we want to invoke ReceiptsInserted event only to send removed receipts (after reorg).
+            if (wasRemoved)
             {
                 ReceiptsInserted?.Invoke(this, new ReceiptsEventArgs(block.Header, txReceipts));
             }

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/ReceiptsEventArgs.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/ReceiptsEventArgs.cs
@@ -24,11 +24,13 @@ namespace Nethermind.Blockchain.Receipts
     {
         public TxReceipt[] TxReceipts { get; }
         public BlockHeader BlockHeader { get; }
+        public bool WasRemoved { get; }
 
-        public ReceiptsEventArgs(BlockHeader blockHeader, TxReceipt[] txReceipts)
+        public ReceiptsEventArgs(BlockHeader blockHeader, TxReceipt[] txReceipts, bool wasRemoved)
         {
             BlockHeader = blockHeader;
             TxReceipts = txReceipts;
+            WasRemoved = wasRemoved;
         }
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/ReceiptsRecovery.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/ReceiptsRecovery.cs
@@ -33,12 +33,12 @@ namespace Nethermind.Blockchain.Receipts
             _specProvider = specProvider ?? throw new ArgumentNullException(nameof(specProvider));
         }
         
-        public bool TryRecover(Block block, TxReceipt[] receipts, bool force = true)
+        public bool TryRecover(Block block, TxReceipt[] receipts, bool forceRecoverSender = true)
         {
             var canRecover = block.Transactions.Length == receipts?.Length;
             if (canRecover)
             {
-                var needRecover = NeedRecover(receipts, force);
+                var needRecover = NeedRecover(receipts, forceRecoverSender);
                 if (needRecover)
                 {
                     var releaseSpec = _specProvider.GetSpec(block.Number);
@@ -49,7 +49,7 @@ namespace Nethermind.Blockchain.Receipts
                         if (receipts.Length > receiptIndex)
                         {
                             TxReceipt receipt = receipts[receiptIndex];
-                            RecoverReceiptData(releaseSpec, receipt, block, transaction, receiptIndex, gasUsedBefore, force);
+                            RecoverReceiptData(releaseSpec, receipt, block, transaction, receiptIndex, gasUsedBefore, forceRecoverSender);
                             gasUsedBefore = receipt.GasUsedTotal;
                         }
                     }
@@ -61,7 +61,7 @@ namespace Nethermind.Blockchain.Receipts
             return false;
         }
         
-        public bool NeedRecover(TxReceipt[] receipts, bool force = true) => receipts?.Length > 0 && (receipts[0].BlockHash == null || (force && receipts[0].Sender == null));
+        public bool NeedRecover(TxReceipt[] receipts, bool forceRecoverSender = true) => receipts?.Length > 0 && (receipts[0].BlockHash == null || (forceRecoverSender && receipts[0].Sender == null));
 
         private void RecoverReceiptData(IReleaseSpec releaseSpec, TxReceipt receipt, Block block, Transaction transaction, int transactionIndex, long gasUsedBefore, bool force)
         {

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeBlockTree.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeBlockTree.cs
@@ -88,6 +88,7 @@ namespace Nethermind.Init.Steps
             
             LogFinder logFinder = new(
                 blockTree,
+                receiptFinder,
                 receiptStorage,
                 bloomStorage,
                 _get.LogManager,

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeBlockTree.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeBlockTree.cs
@@ -89,6 +89,7 @@ namespace Nethermind.Init.Steps
             LogFinder logFinder = new(
                 blockTree,
                 receiptFinder,
+                receiptStorage,
                 bloomStorage,
                 _get.LogManager,
                 new ReceiptsRecovery(_get.EthereumEcdsa, _get.SpecProvider), 

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeBlockTree.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeBlockTree.cs
@@ -88,7 +88,6 @@ namespace Nethermind.Init.Steps
             
             LogFinder logFinder = new(
                 blockTree,
-                receiptFinder,
                 receiptStorage,
                 bloomStorage,
                 _get.LogManager,

--- a/src/Nethermind/Nethermind.Init/Steps/RegisterRpcModules.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/RegisterRpcModules.cs
@@ -207,6 +207,7 @@ namespace Nethermind.Init.Steps
                 _api.BlockTree,
                 _api.TxPool,
                 _api.ReceiptStorage,
+                _api.ReceiptFinder,
                 _api.FilterStore,
                 _api.EthSyncingInfo!,
                 _api.SpecProvider,

--- a/src/Nethermind/Nethermind.JsonRpc.Benchmark/EthModuleBenchmarks.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Benchmark/EthModuleBenchmarks.cs
@@ -112,6 +112,7 @@ namespace Nethermind.JsonRpc.Benchmark
             LogFinder logFinder = new(
                 blockTree,
                 new InMemoryReceiptStorage(),
+                new InMemoryReceiptStorage(),
                 bloomStorage,
                 LimboLogs.Instance,
                 new ReceiptsRecovery(ecdsa, specProvider));

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
@@ -56,6 +56,7 @@ namespace Nethermind.JsonRpc.Test.Modules
         private IBlockTree _blockTree;
         private ITxPool _txPool;
         private IReceiptStorage _receiptStorage;
+        private IReceiptFinder _receiptFinder;
         private IFilterStore _filterStore;
         private ISubscriptionManager _subscriptionManager;
         private IJsonRpcDuplexClient _jsonRpcDuplexClient;
@@ -69,6 +70,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             _blockTree = Substitute.For<IBlockTree>();
             _txPool = Substitute.For<ITxPool>();
             _receiptStorage = Substitute.For<IReceiptStorage>();
+            _receiptFinder = Substitute.For<IReceiptFinder>();
             _specProvider = Substitute.For<ISpecProvider>();
             _filterStore = new FilterStore();
             _jsonRpcDuplexClient = Substitute.For<IJsonRpcDuplexClient>();
@@ -82,6 +84,7 @@ namespace Nethermind.JsonRpc.Test.Modules
                 _blockTree,
                 _txPool,
                 _receiptStorage,
+                _receiptFinder,
                 _filterStore,
                 new EthSyncingInfo(_blockTree),
                 _specProvider,
@@ -123,7 +126,7 @@ namespace Nethermind.JsonRpc.Test.Modules
         
         private List<JsonRpcResult> GetLogsSubscriptionResult(Filter filter, BlockEventArgs blockEventArgs, out string subscriptionId)
         {
-            LogsSubscription logsSubscription = new(_jsonRpcDuplexClient, _receiptStorage, _filterStore, _blockTree, _logManager, filter);
+            LogsSubscription logsSubscription = new(_jsonRpcDuplexClient, _receiptStorage, _receiptFinder, _filterStore, _blockTree, _logManager, filter);
             
             List<JsonRpcResult> jsonRpcResults = new();
 
@@ -695,7 +698,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             int blockNumber = 55555;
             Filter filter = null;
             
-            LogsSubscription logsSubscription = new(_jsonRpcDuplexClient, _receiptStorage, _filterStore, _blockTree, _logManager, filter);
+            LogsSubscription logsSubscription = new(_jsonRpcDuplexClient, _receiptStorage, _receiptFinder, _filterStore, _blockTree, _logManager, filter);
 
             LogEntry logEntry = Build.A.LogEntry.WithAddress(TestItem.AddressA).WithTopics(TestItem.KeccakA).WithData(TestItem.RandomDataA).TestObject;
             TxReceipt[] txReceipts = {Build.A.Receipt.WithBlockNumber(blockNumber).WithLogs(logEntry).TestObject};
@@ -1067,7 +1070,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             int blockNumber = 55555;
             Filter filter = null;
             
-            LogsSubscription logsSubscription = new(_jsonRpcDuplexClient, _receiptStorage, _filterStore, _blockTree, _logManager, filter);
+            LogsSubscription logsSubscription = new(_jsonRpcDuplexClient, _receiptStorage, _receiptFinder, _filterStore, _blockTree, _logManager, filter);
 
             LogEntry logEntry = Build.A.LogEntry.WithAddress(TestItem.AddressA).WithTopics(TestItem.KeccakA).WithData(TestItem.RandomDataA).TestObject;
             TxReceipt[] txReceipts = {Build.A.Receipt.WithLogs(logEntry).WithBlockNumber(blockNumber).TestObject};

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
@@ -440,7 +440,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             
             LogEntry logEntry = Build.A.LogEntry.WithAddress(TestItem.AddressA).WithTopics(TestItem.KeccakA).WithData(TestItem.RandomDataA).TestObject;
             TxReceipt[] txReceipts = {Build.A.Receipt.WithBlockNumber(blockNumber).WithLogs(logEntry).TestObject};
-            _receiptStorage.Get(Arg.Any<Block>()).Returns(txReceipts);
+            _receiptFinder.Get(Arg.Any<Block>()).Returns(txReceipts);
             
             Block block = Build.A.Block.WithNumber(blockNumber).TestObject;
             BlockEventArgs blockEventArgs = new(block);
@@ -482,7 +482,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             LogEntry logEntryC = Build.A.LogEntry.WithData(TestItem.RandomDataC).TestObject;
 
             TxReceipt[] txReceipts = {Build.A.Receipt.WithBlockNumber(blockNumber).WithLogs(logEntryA, logEntryB, logEntryC).TestObject};
-            _receiptStorage.Get(Arg.Any<Block>()).Returns(txReceipts);
+            _receiptFinder.Get(Arg.Any<Block>()).Returns(txReceipts);
             
             Block block = Build.A.Block.WithNumber(blockNumber).TestObject;
             BlockEventArgs blockEventArgs = new(block);
@@ -520,7 +520,7 @@ namespace Nethermind.JsonRpc.Test.Modules
                 Build.A.Receipt.WithBlockNumber(blockNumber).WithIndex(33).WithLogs(logEntryB, logEntryC).TestObject
             };
             
-            _receiptStorage.Get(Arg.Any<Block>()).Returns(txReceipts);
+            _receiptFinder.Get(Arg.Any<Block>()).Returns(txReceipts);
             
             Block block = Build.A.Block.WithNumber(blockNumber).TestObject;
             BlockEventArgs blockEventArgs = new(block);
@@ -574,7 +574,7 @@ namespace Nethermind.JsonRpc.Test.Modules
                 Build.A.Receipt.WithBlockNumber(blockNumber).WithLogs(logEntryA, logEntryC, logEntryB, logEntryA, logEntryC).TestObject,
             };
             
-            _receiptStorage.Get(Arg.Any<Block>()).Returns(txReceipts);
+            _receiptFinder.Get(Arg.Any<Block>()).Returns(txReceipts);
             
             Block block = Build.A.Block.WithNumber(blockNumber).WithBloom(new Bloom(txReceipts.Select(r => r.Bloom).ToArray())).TestObject;
             BlockEventArgs blockEventArgs = new(block);
@@ -621,7 +621,7 @@ namespace Nethermind.JsonRpc.Test.Modules
                 Build.A.Receipt.WithBlockNumber(blockNumber).WithLogs(logEntryA, logEntryC, logEntryB, logEntryA, logEntryC).TestObject,
             };
 
-            _receiptStorage.Get(Arg.Any<Block>()).Returns(txReceipts);
+            _receiptFinder.Get(Arg.Any<Block>()).Returns(txReceipts);
             
             Block block = Build.A.Block.WithNumber(blockNumber).WithBloom(new Bloom(txReceipts.Select(r => r.Bloom).ToArray())).TestObject;
             BlockEventArgs blockEventArgs = new(block);
@@ -671,7 +671,7 @@ namespace Nethermind.JsonRpc.Test.Modules
                 Build.A.Receipt.WithBlockNumber(blockNumber).WithLogs(logEntryC, logEntryB, logEntryE, logEntryA, logEntryB).TestObject,
             };
             
-            _receiptStorage.Get(Arg.Any<Block>()).Returns(txReceipts);
+            _receiptFinder.Get(Arg.Any<Block>()).Returns(txReceipts);
             
             Block block = Build.A.Block.WithNumber(blockNumber).WithBloom(new Bloom(txReceipts.Select(r => r.Bloom).ToArray())).TestObject;
             BlockEventArgs blockEventArgs = new(block);
@@ -704,7 +704,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             TxReceipt[] txReceipts = {Build.A.Receipt.WithBlockNumber(blockNumber).WithLogs(logEntry).TestObject};
             BlockHeader blockHeader = Build.A.BlockHeader.WithNumber(blockNumber).TestObject;
             Block block = Build.A.Block.WithHeader(blockHeader).TestObject;
-            _receiptStorage.Get(Arg.Any<Block>()).Returns(txReceipts);
+            _receiptFinder.Get(Arg.Any<Block>()).Returns(txReceipts);
 
             List<JsonRpcResult> jsonRpcResults = new();
             

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
@@ -709,7 +709,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             List<JsonRpcResult> jsonRpcResults = new();
             
             ManualResetEvent manualResetEvent = new(false);
-            ReceiptsEventArgs receiptsEventArgs = new(blockHeader, txReceipts);
+            ReceiptsEventArgs receiptsEventArgs = new(blockHeader, txReceipts, txReceipts[0].Removed);
             logsSubscription.JsonRpcDuplexClient.SendJsonRpcResult(Arg.Do<JsonRpcResult>(j =>
             {
                 jsonRpcResults.Add(j);
@@ -1090,7 +1090,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             
             _receiptStorage.Insert(Arg.Any<Block>(), Arg.Do<TxReceipt[]>(r =>
             {
-                ReceiptsEventArgs receiptsEventArgs = new(blockHeader, r);
+                ReceiptsEventArgs receiptsEventArgs = new(blockHeader, r, r[0].Removed);
                 _receiptStorage.ReceiptsInserted += Raise.EventWith(new object(), receiptsEventArgs);
             }));
             

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TestRpcBlockchain.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TestRpcBlockchain.cs
@@ -125,7 +125,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             IFilterManager filterManager = new FilterManager(filterStore, BlockProcessor, TxPool, LimboLogs.Instance);
 
             ReceiptsRecovery receiptsRecovery = new(new EthereumEcdsa(specProvider.ChainId, LimboLogs.Instance), specProvider);
-            LogFinder = new LogFinder(BlockTree, ReceiptStorage, ReceiptStorage, bloomStorage, LimboLogs.Instance, receiptsRecovery);
+            LogFinder = new LogFinder(BlockTree, ReceiptStorage, bloomStorage, LimboLogs.Instance, receiptsRecovery);
             
             ReadOnlyTxProcessingEnv processingEnv = new(
                 new ReadOnlyDbProvider(DbProvider, false),

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TestRpcBlockchain.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TestRpcBlockchain.cs
@@ -125,7 +125,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             IFilterManager filterManager = new FilterManager(filterStore, BlockProcessor, TxPool, LimboLogs.Instance);
 
             ReceiptsRecovery receiptsRecovery = new(new EthereumEcdsa(specProvider.ChainId, LimboLogs.Instance), specProvider);
-            LogFinder = new LogFinder(BlockTree, ReceiptStorage, bloomStorage, LimboLogs.Instance, receiptsRecovery);
+            LogFinder = new LogFinder(BlockTree, ReceiptStorage, ReceiptStorage, bloomStorage, LimboLogs.Instance, receiptsRecovery);
             
             ReadOnlyTxProcessingEnv processingEnv = new(
                 new ReadOnlyDbProvider(DbProvider, false),

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/LogsSubscription.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/LogsSubscription.cs
@@ -32,19 +32,22 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
     public class LogsSubscription : Subscription
     {
         private readonly IReceiptStorage _receiptStorage;
+        private readonly IReceiptFinder _receiptFinder;
         private readonly IBlockTree _blockTree;
         private readonly LogFilter _filter;
 
         public LogsSubscription(
             IJsonRpcDuplexClient jsonRpcDuplexClient,
-            IReceiptStorage? receiptStorage, 
-            IFilterStore? store, 
-            IBlockTree? blockTree, 
-            ILogManager? logManager, 
-            Filter? filter = null) 
+            IReceiptStorage? receiptStorage,
+            IReceiptFinder? receiptFinder,
+            IFilterStore? store,
+            IBlockTree? blockTree,
+            ILogManager? logManager,
+            Filter? filter = null)
             : base(jsonRpcDuplexClient)
         {
             _receiptStorage = receiptStorage ?? throw new ArgumentNullException(nameof(receiptStorage));
+            _receiptFinder = receiptFinder ?? throw new ArgumentNullException(nameof(receiptFinder));
             _blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
             _logger = logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
             IFilterStore filterStore = store ?? throw new ArgumentNullException(nameof(store));
@@ -75,7 +78,7 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
         {
             if (e.Block is not null)
             {
-                TryPublishReceiptsInBackground(e.Block.Header, () =>  _receiptStorage.Get(e.Block), nameof(_blockTree.NewHeadBlock));
+                TryPublishReceiptsInBackground(e.Block.Header, () =>  _receiptFinder.Get(e.Block), nameof(_blockTree.NewHeadBlock));
             }
         }
 

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/LogsSubscription.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/LogsSubscription.cs
@@ -84,7 +84,7 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
 
         private void OnReceiptsInserted(object? sender, ReceiptsEventArgs e)
         {
-            bool isReceiptRemoved = e.TxReceipts.FirstOrDefault()?.Removed == true;
+            bool isReceiptRemoved = e.WasRemoved;
             if (isReceiptRemoved)
             {
                 TryPublishReceiptsInBackground(e.BlockHeader, () => e.TxReceipts, nameof(_receiptStorage.ReceiptsInserted));

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/SubscriptionFactory.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/SubscriptionFactory.cs
@@ -50,6 +50,7 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
             IBlockTree? blockTree,
             ITxPool? txPool,
             IReceiptStorage? receiptStorage,
+            IReceiptFinder? receiptFinder,
             IFilterStore? filterStore,
             IEthSyncingInfo ethSyncingInfo,
             ISpecProvider specProvider, 
@@ -60,6 +61,7 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
             blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
             txPool = txPool ?? throw new ArgumentNullException(nameof(txPool));
             receiptStorage = receiptStorage ?? throw new ArgumentNullException(nameof(receiptStorage));
+            receiptFinder = receiptFinder ?? throw new ArgumentNullException(nameof(receiptFinder));
             filterStore = filterStore ?? throw new ArgumentNullException(nameof(filterStore));
             ethSyncingInfo = ethSyncingInfo ?? throw new ArgumentNullException(nameof(ethSyncingInfo));
             specProvider = specProvider ?? throw new ArgumentNullException(nameof(specProvider));
@@ -71,7 +73,7 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
                     new NewHeadSubscription(jsonRpcDuplexClient, blockTree, logManager, specProvider, args)),
                 
                 [SubscriptionType.Logs] = CreateSubscriptionType<Filter?>((jsonRpcDuplexClient, filter) => 
-                    new LogsSubscription(jsonRpcDuplexClient, receiptStorage, filterStore, blockTree, logManager, filter)),
+                    new LogsSubscription(jsonRpcDuplexClient, receiptStorage, receiptFinder, filterStore, blockTree, logManager, filter)),
                 
                 [SubscriptionType.NewPendingTransactions] = CreateSubscriptionType<TransactionsOption?>((jsonRpcDuplexClient, args) => 
                     new NewPendingTransactionsSubscription(jsonRpcDuplexClient, txPool, logManager, args)),

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloadContext.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloadContext.cs
@@ -119,7 +119,7 @@ namespace Nethermind.Synchronization.Blocks
             block = Blocks[_indexMapping[index]];
             receipts ??= Array.Empty<TxReceipt>();
 
-            bool result = _receiptsRecovery.TryRecover(block, receipts); 
+            bool result = _receiptsRecovery.TryRecover(block, receipts, false); 
             if (result)
             {
                 ValidateReceipts(block, receipts);

--- a/src/Nethermind/Nethermind.TxPool.Test/ReceiptStorageTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/ReceiptStorageTests.cs
@@ -14,7 +14,6 @@
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
-#nullable enable
 using FluentAssertions;
 using Nethermind.Blockchain.Find;
 using Nethermind.Blockchain.Receipts;
@@ -115,7 +114,7 @@ namespace Nethermind.TxPool.Test
             storage.LowestInsertedReceiptBlockNumber.Should().Be(updateLowest ? (long?)0 : null);
         }
         
-        private void TestAddAndGetReceipt(IReceiptStorage storage, IReceiptFinder? receiptFinder = null)
+        private void TestAddAndGetReceipt(IReceiptStorage storage, IReceiptFinder receiptFinder = null)
         {
             bool recoverSender = receiptFinder is not null;
             receiptFinder ??= storage;

--- a/src/Nethermind/Nethermind.TxPool.Test/ReceiptStorageTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/ReceiptStorageTests.cs
@@ -117,7 +117,7 @@ namespace Nethermind.TxPool.Test
         
         private void TestAddAndGetReceipt(IReceiptStorage storage, IReceiptFinder? receiptFinder = null)
         {
-            bool shouldRecoverSender = receiptFinder is not null;
+            bool recoverSender = receiptFinder is not null;
             receiptFinder ??= storage;
 
             var transaction = GetSignedTransaction();
@@ -131,7 +131,7 @@ namespace Nethermind.TxPool.Test
             receipt.StatusCode.Should().Be(fetchedReceipt.StatusCode);
             receipt.PostTransactionState.Should().Be(fetchedReceipt.PostTransactionState);
             receipt.TxHash.Should().Be(transaction.Hash);
-            if (shouldRecoverSender)
+            if (recoverSender)
             {
                 receipt.Sender.Should().BeEquivalentTo(TestItem.AddressA);
             }

--- a/src/Nethermind/Nethermind.TxPool.Test/ReceiptStorageTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/ReceiptStorageTests.cs
@@ -85,6 +85,22 @@ namespace Nethermind.TxPool.Test
         public void should_add_and_fetch_receipt_from_persistent_storage_with_eip_658()
             => TestAddAndGetReceiptEip658(_persistentStorage);
 
+        [Test]
+        public void should_not_throw_if_receiptFinder_asked_for_not_existing_receipts_by_block()
+        {
+            Block block = Build.A.Block.WithNumber(0).WithTransactions(5, _specProvider).TestObject;
+            TxReceipt[] receipts = _receiptFinder.Get(block);
+            receipts.Should().BeEmpty();
+        }
+        
+        [Test]
+        public void should_not_throw_if_receiptFinder_asked_for_not_existing_receipts_by_hash()
+        {
+            Block block = Build.A.Block.WithNumber(0).WithTransactions(5, _specProvider).TestObject;
+            TxReceipt[] receipts = _receiptFinder.Get(block.Hash);
+            receipts.Should().BeEmpty();
+        }
+
         private void TestAddAndCheckLowest(IReceiptStorage storage, bool updateLowest)
         {
             var transaction = GetSignedTransaction();


### PR DESCRIPTION
Fixes | Closes | Resolves #3839

## Changes:
- make fast receipt sync ~2x faster by not recovering sender during fast sync - after changes most of the time disc i/o is a bottleneck instead of CPU
- recover data only when we need to serve it
- update recovered data in db and cache to avoid recovering it again in future
- ~~invoke `ReceiptsInserted` event only for removed receipts (subscription with new receipts is invoked by `NewHeadBlock` event)~~
- in `LogsSubscription` use `Get()` from `ReceiptFinder` instead of `ReceiptStorage` in order to go through recovery process before sending logs
- simplify `Get(block)` in `PersistentReceiptStorage` - reuse `Get(blockHash)`. Drop old-style db search in `Get(block)`. It unify returned data for both methods (before we were returning `TxReceipt[]{null}` in `Get(block)` and `Array.Empty<TxReceipt>` in `Get(blockHash)`. Now it's always `Array.Empty<TxReceipt>`)

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No

Additionally, manually tested via `eth_subscribe` logs subscription and RPC requests, and of course by syncing nodes and monitoring receipts fast sync performance