### PR TITLE
Fix eth_getlogs not returning error when receipt is unavailable

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Find/LogFinderTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Find/LogFinderTests.cs
@@ -155,7 +155,7 @@ namespace Nethermind.Blockchain.Test.Find
             var logFilter = AllBlockFilter().Build();
             var action = new Func<IEnumerable<FilterLog>>(() =>_logFinder.FindLogs(logFilter));
             action.Should().Throw<ResourceNotFoundException>();
-            blockFinder.Received().FindHeader(logFilter.ToBlock, true);
+            blockFinder.Received().FindHeader(logFilter.ToBlock, false);
             blockFinder.DidNotReceive().FindHeader(logFilter.FromBlock);
         }
         

--- a/src/Nethermind/Nethermind.Blockchain.Test/Receipts/PersistentReceiptStorageTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Receipts/PersistentReceiptStorageTests.cs
@@ -191,7 +191,7 @@ namespace Nethermind.Blockchain.Test.Receipts
         [Test]
         public void HasBlock_should_returnFalseForMissingHash()
         {
-            _storage.HasBlock(Keccak.Zero).Should().BeFalse();
+            _storage.HasBlock(Keccak.Compute("missing-value")).Should().BeFalse();
         }
         
         [Test]

--- a/src/Nethermind/Nethermind.Blockchain.Test/Receipts/PersistentReceiptStorageTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Receipts/PersistentReceiptStorageTests.cs
@@ -188,6 +188,18 @@ namespace Nethermind.Blockchain.Test.Receipts
             _storage.Insert(block, receipts);
         }
         
+        [Test]
+        public void HasBlock_should_returnFalseForMissingHash()
+        {
+            _storage.HasBlock(Keccak.Zero).Should().BeFalse();
+        }
+        
+        [Test]
+        public void HasBlock_should_returnTrueForKnownHash()
+        {
+            var (block, receipts) = InsertBlock();
+            _storage.HasBlock(block.Hash).Should().BeTrue();
+        }
 
         private (Block block, TxReceipt[] receipts) InsertBlock(Block block = null)
         {

--- a/src/Nethermind/Nethermind.Blockchain/Find/ResourceNotFoundException.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Find/ResourceNotFoundException.cs
@@ -13,19 +13,16 @@
 // 
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
 
 using System;
-using Nethermind.Core;
-using Nethermind.Core.Crypto;
+using System.Transactions;
 
-namespace Nethermind.Blockchain.Receipts
+namespace Nethermind.Blockchain.Find;
+
+public class ResourceNotFoundException: ArgumentException
 {
-    public interface IReceiptStorage : IReceiptFinder
+    public ResourceNotFoundException(string message) : base(message)
     {
-        void Insert(Block block, params TxReceipt[] txReceipts);
-        long? LowestInsertedReceiptBlockNumber { get; set; }
-        long MigratedBlockNumber { get; set; }
-        event EventHandler<ReceiptsEventArgs> ReceiptsInserted;
-        bool HasBlock(Keccak hash);
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/InMemoryReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/InMemoryReceiptStorage.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Linq;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Db;
@@ -78,6 +79,11 @@ namespace Nethermind.Blockchain.Receipts
 
             bool wasRemoved = txReceipts.Length > 0 && txReceipts[0].Removed;
             ReceiptsInserted?.Invoke(this, new ReceiptsEventArgs(block.Header, txReceipts, wasRemoved));
+        }
+        
+        public bool HasBlock(Keccak hash)
+        {
+            return _receipts.ContainsKey(hash);
         }
 
         public long? LowestInsertedReceiptBlockNumber { get; set; }

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/NullReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/NullReceiptStorage.cs
@@ -55,5 +55,10 @@ namespace Nethermind.Blockchain.Receipts
             add { }
             remove { }
         }
+
+        public bool HasBlock(Keccak hash)
+        {
+            return false;
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
@@ -234,6 +234,11 @@ namespace Nethermind.Blockchain.Receipts
             _receiptsCache.Clear();
         }
         
+        public bool HasBlock(Keccak hash)
+        {
+            return _receiptsCache.Contains(hash) || _blocksDb.KeyExists(hash);
+        }
+        
         public event EventHandler<ReceiptsEventArgs> ReceiptsInserted;
     }
 }

--- a/src/Nethermind/Nethermind.Facade/Filters/LogFinder.cs
+++ b/src/Nethermind/Nethermind.Facade/Filters/LogFinder.cs
@@ -63,7 +63,7 @@ namespace Nethermind.Blockchain.Find
         public IEnumerable<FilterLog> FindLogs(LogFilter filter, CancellationToken cancellationToken = default)
         {
             BlockHeader FindHeader(BlockParameter blockParameter, string name, bool headLimit) => 
-                _blockFinder.FindHeader(blockParameter, headLimit) ?? throw new ResourceNotFoundException($"Block not found: {name}");
+                _blockFinder.FindHeader(blockParameter, headLimit) ?? throw new ResourceNotFoundException($"Block not found: {name} {blockParameter}");
 
             cancellationToken.ThrowIfCancellationRequested();
             var toBlock = FindHeader(filter.ToBlock, nameof(filter.ToBlock), false);

--- a/src/Nethermind/Nethermind.Facade/Filters/LogFinder.cs
+++ b/src/Nethermind/Nethermind.Facade/Filters/LogFinder.cs
@@ -66,7 +66,7 @@ namespace Nethermind.Blockchain.Find
                 _blockFinder.FindHeader(blockParameter, headLimit) ?? throw new ResourceNotFoundException($"Block not found: {name}");
 
             cancellationToken.ThrowIfCancellationRequested();
-            var toBlock = FindHeader(filter.ToBlock, nameof(filter.ToBlock), true);
+            var toBlock = FindHeader(filter.ToBlock, nameof(filter.ToBlock), false);
             cancellationToken.ThrowIfCancellationRequested();
             var fromBlock = FindHeader(filter.FromBlock, nameof(filter.FromBlock), false);
 

--- a/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/Migrations/ReceiptMigrationTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/Migrations/ReceiptMigrationTests.cs
@@ -132,6 +132,11 @@ namespace Nethermind.Runner.Test.Ethereum.Steps.Migrations
                 get => _outStorage.MigratedBlockNumber;
                 set => _outStorage.MigratedBlockNumber = value;
             }
+            
+            public bool HasBlock(Keccak hash)
+            {
+                return _outStorage.HasBlock(hash);
+            }
 
             public event EventHandler<ReceiptsEventArgs> ReceiptsInserted { add { } remove { } }
         }


### PR DESCRIPTION
Fixes #3983

## Changes:
- Added `HasBlock` method to `IReceiptStorage`.
  - `ReceiptPersistentStorage` implemented it by checking its cache first, then the blocks column.
- `LogFinder` will check `HasBlock` on first and last block and will throw `ResourceNotFoundException` if receipt not found.
- `EthRpcModule` will return resource not found code when `ResourceNotFoundException` is encountered.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
- [ X] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [ X] Yes
- [ ] No

**Comments about testing , should you have some** (optional)

- Tested by running a clean DB. During fast sync after header was downloaded, query for block where the header already download. Confirmed error is returned.
- Queried again after full sync. Confirmed logs was returned.