### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,10 @@ RUN if [ "$TARGETARCH" = "amd64" ] ; \
 FROM --platform=$TARGETPLATFORM mcr.microsoft.com/dotnet/aspnet:6.0-jammy
 RUN apt-get update && apt-get -y install libsnappy-dev libc6-dev libc6
 # Fix rocksdb issue in ubuntu 22.04
-RUN ln -s /usr/lib/x86_64-linux-gnu/libdl.so.2 /usr/lib/x86_64-linux-gnu/libdl.so > /dev/null 2>&1
+RUN if [ "$TARGETARCH" = "amd64" ] ; \
+    then ln -s /usr/lib/x86_64-linux-gnu/libdl.so.2 /usr/lib/x86_64-linux-gnu/libdl.so > /dev/null 2>&1 ; \
+    else ln -s /usr/lib/aarch64-linux-gnu/libdl.so.2 /usr/lib/aarch64-linux-gnu/libdl.so > /dev/null 2>&1 ; \
+    fi
 
 WORKDIR /nethermind
 


### PR DESCRIPTION
Update the Dockerfile to use Ubuntu instead of Debian. Also adds the symlink fix for libdl that occurs on Ubuntu22 and add arm support on the symlink.

Fixes | 
## Changes:

Changes the Dockerfile to use Ubuntu instead of Debian as baseimage. 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [X] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [X] No