### PR TITLE
Cache previous state sync results

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
@@ -506,6 +506,7 @@ namespace Nethermind.Synchronization.ParallelSync
         private bool CanBeInSnapRangesPhase(Snapshot best)
         {
             bool isCloseToHead = best.PeerBlock >= best.Header && (best.PeerBlock - best.Header) < Constants.MaxDistanceFromHead;
+            bool isFullStateAncientOrNotFound = best.PeerBlock - best.State > FastSyncCatchUpHeightDelta || best.State == 0;
             bool snapNotFinished = !_syncProgressResolver.IsSnapGetRangesFinished();
 
             if (_logger.IsTrace)
@@ -513,12 +514,14 @@ namespace Nethermind.Synchronization.ParallelSync
                 LogDetailedSyncModeChecks("SNAP_RANGES",
                     (nameof(SnapSyncEnabled), SnapSyncEnabled),
                     (nameof(isCloseToHead), isCloseToHead),
-                    (nameof(snapNotFinished), snapNotFinished));
+                    (nameof(snapNotFinished), snapNotFinished),
+                    (nameof(isFullStateAncientOrNotFound), isFullStateAncientOrNotFound));
             }
 
             return SnapSyncEnabled
                 && isCloseToHead
-                && snapNotFinished;
+                && snapNotFinished 
+                && isFullStateAncientOrNotFound;
         }
 
         private bool HasJustStartedFullSync(Snapshot best) =>

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
@@ -506,7 +506,7 @@ namespace Nethermind.Synchronization.ParallelSync
         private bool CanBeInSnapRangesPhase(Snapshot best)
         {
             bool isCloseToHead = best.PeerBlock >= best.Header && (best.PeerBlock - best.Header) < Constants.MaxDistanceFromHead;
-            bool isFullStateAncientOrNotFound = best.PeerBlock - best.State > FastSyncCatchUpHeightDelta || best.State == 0;
+            bool isFullStateAncientOrNotFound = best.PeerBlock - best.State >= FastSyncCatchUpHeightDelta || best.State == 0;
             bool snapNotFinished = !_syncProgressResolver.IsSnapGetRangesFinished();
 
             if (_logger.IsTrace)


### PR DESCRIPTION
Resolves #4108 

## Changes:
- Prevent SnapSync from running for an already synchronized state

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No

Manual tests

```
Feature: Depending on the synchronisation history and current settings, a specific sync mode should be used

Scenario Outline: A node has not been synchronized before and starts
    Given node with blank database
    And peer has <delta>th state synced
    And <current_sync> enabled
    When node is started
    Then <expected_sync> happens on state synchronization step

    Examples:
        | delta                        | current_sync  | expected_sync |
        | < FastSyncCatchUpHeightDelta | Just FastSync | StateSync     |
        | < FastSyncCatchUpHeightDelta | SnapSync      | StateSync     |
        | > FastSyncCatchUpHeightDelta | Just FastSync | StateSync     |
        | > FastSyncCatchUpHeightDelta | SnapSync      | SnapSync      |

Scenario Outline: A node was synchronized before and starts
    Given node with database of #N state synced
    And synchronization was done by <previous_sync>
    And <current_sync> enabled
    And peer has N+<delta>th state
    When node is started
    Then <expected_sync> happens on state synchronization step

    Examples:
        | previous_sync | current_sync  | delta                        | expected_sync |
        | Just FastSync | Just FastSync | < FastSyncCatchUpHeightDelta | FastSync      |
        | Just FastSync | SnapSync      | < FastSyncCatchUpHeightDelta | FastSync      |
        | SnapSync      | Just FastSync | < FastSyncCatchUpHeightDelta | FastSync      |
        | SnapSync      | SnapSync      | < FastSyncCatchUpHeightDelta | FastSync      |
        | Just FastSync | Just FastSync | > FastSyncCatchUpHeightDelta | StateSync     |
        | Just FastSync | SnapSync      | > FastSyncCatchUpHeightDelta | SnapSync      |
        | SnapSync      | Just FastSync | > FastSyncCatchUpHeightDelta | StateSync     |
        | SnapSync      | SnapSync      | > FastSyncCatchUpHeightDelta | SnapSync      |
```