### PR TITLE
Reduce default max bucket size and warn on payload too large

### DIFF
--- a/src/Nethermind/Nethermind.Network.Discovery/DiscoveryConfig.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/DiscoveryConfig.cs
@@ -20,7 +20,7 @@ namespace Nethermind.Network.Discovery;
 
 public class DiscoveryConfig : IDiscoveryConfig
 {
-    public int BucketSize { get; set; } = 16;
+    public int BucketSize { get; set; } = 12;
 
     public int BucketsCount { get; set; } = 256;
 

--- a/src/Nethermind/Nethermind.Network.Discovery/NettyDiscoveryHandler.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/NettyDiscoveryHandler.cs
@@ -94,7 +94,7 @@ public class NettyDiscoveryHandler : SimpleChannelInboundHandler<DatagramPacket>
 
         if (msgBytes.Length > 1280)
         {
-            _logger.Warn($"Attempting to send message larger than 1280 bytes. This is out of spec and may not work for all client. Msg: ${discoveryMsg}");
+            if (_logger.IsWarn) _logger.Warn($"Attempting to send message larger than 1280 bytes. This is out of spec and may not work for all client. Msg: ${discoveryMsg}");
         }
 
         IByteBuffer copiedBuffer = Unpooled.CopiedBuffer(msgBytes);

--- a/src/Nethermind/Nethermind.Network.Discovery/NettyDiscoveryHandler.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/NettyDiscoveryHandler.cs
@@ -92,6 +92,11 @@ public class NettyDiscoveryHandler : SimpleChannelInboundHandler<DatagramPacket>
             return;
         }
 
+        if (msgBytes.Length > 1280)
+        {
+            _logger.Warn($"Attempting to send message larger than 1280 bytes. This is out of spec and may not work for all client. Msg: ${discoveryMsg}");
+        }
+
         IByteBuffer copiedBuffer = Unpooled.CopiedBuffer(msgBytes);
         IAddressedEnvelope<IByteBuffer> packet = new DatagramPacket(copiedBuffer, discoveryMsg.FarAddress);
         


### PR DESCRIPTION
Resolves #3974

## Changes:
- Change default max bucket size to 12 following geth default https://github.com/ethereum/go-ethereum/blob/master/p2p/discover/v4wire/v4wire.go#L113
- Added warning message when trying to send payload that is too large.

## Types of changes

- [X ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing

- Confirmed warning shows up if bucket size is 16.
- Did not found other warning so far when bucket size is set to 12.