### PR TITLE
Merge/mev boost

### DIFF
--- a/src/Nethermind/Nethermind.AccountAbstraction.Test/AccountAbstractionRpcModuleTests.TestAccountAbstractionRpcBlockchain.cs
+++ b/src/Nethermind/Nethermind.AccountAbstraction.Test/AccountAbstractionRpcModuleTests.TestAccountAbstractionRpcBlockchain.cs
@@ -46,6 +46,7 @@ using Nethermind.Int256;
 using Nethermind.JsonRpc;
 using Nethermind.JsonRpc.Test.Modules;
 using Nethermind.Logging;
+using Nethermind.Merge.Plugin.BlockProduction;
 using Nethermind.Merge.Plugin.Data;
 using Nethermind.Merge.Plugin.Handlers;
 using Nethermind.Specs;

--- a/src/Nethermind/Nethermind.Consensus.Clique/CliqueBlockProducer.cs
+++ b/src/Nethermind/Nethermind.Consensus.Clique/CliqueBlockProducer.cs
@@ -329,7 +329,6 @@ namespace Nethermind.Consensus.Clique
                 return true;
         }
 
-        public ITimestamper Timestamper => _timestamper;
         public event EventHandler<BlockEventArgs>? BlockProduced;
 
         private Keccak? _recentNotAllowedParent;

--- a/src/Nethermind/Nethermind.Consensus/IBlockProducer.cs
+++ b/src/Nethermind/Nethermind.Consensus/IBlockProducer.cs
@@ -18,11 +18,12 @@ using System;
 using System.Threading.Tasks;
 using Nethermind.Core;
 
+namespace Nethermind.Consensus;
+
 public interface IBlockProducer
 {
     Task Start();
     Task StopAsync();
     bool IsProducingBlocks(ulong? maxProducingInterval);
-    ITimestamper Timestamper { get; }
     event EventHandler<BlockEventArgs> BlockProduced;
 }

--- a/src/Nethermind/Nethermind.Consensus/Producers/BlockProducerBase.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/BlockProducerBase.cs
@@ -282,8 +282,7 @@ namespace Nethermind.Consensus.Producers
         protected virtual BlockHeader PrepareBlockHeader(BlockHeader parent,
             PayloadAttributes? payloadAttributes = null)
         {
-            UInt256 timestamp = payloadAttributes?.Timestamp ??
-                                UInt256.Max(parent.Timestamp + 1, Timestamper.UnixTime.Seconds);
+            UInt256 timestamp = payloadAttributes?.Timestamp ?? UInt256.Max(parent.Timestamp + 1, Timestamper.UnixTime.Seconds);
             Address blockAuthor = payloadAttributes?.SuggestedFeeRecipient ?? Sealer.Address;
             BlockHeader header = new(
                 parent.Hash!,
@@ -291,7 +290,7 @@ namespace Nethermind.Consensus.Producers
                 blockAuthor,
                 UInt256.Zero, 
                 parent.Number + 1,
-                _gasLimitCalculator.GetGasLimit(parent),
+                payloadAttributes?.GasLimit ?? _gasLimitCalculator.GetGasLimit(parent),
                 timestamp,
                 GetExtraData())
             {

--- a/src/Nethermind/Nethermind.Consensus/Producers/BlockProducerBase.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/BlockProducerBase.cs
@@ -49,7 +49,7 @@ namespace Nethermind.Consensus.Producers
     {
         private IBlockchainProcessor Processor { get; }
         protected IBlockTree BlockTree { get; }
-        public ITimestamper Timestamper { get; }
+        private ITimestamper Timestamper { get; }
         public event EventHandler<BlockEventArgs>? BlockProduced;
 
         private ISealer Sealer { get; }

--- a/src/Nethermind/Nethermind.Consensus/Producers/MultipleBlockProducer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/MultipleBlockProducer.cs
@@ -85,8 +85,6 @@ namespace Nethermind.Consensus.Producers
             return false;
         }
         
-        public ITimestamper Timestamper => _blockProducers[0].BlockProducer.Timestamper;
-        
         public event EventHandler<BlockEventArgs>? BlockProduced;
         
         private void OnBlockProduction(object? sender, BlockProductionEventArgs e)

--- a/src/Nethermind/Nethermind.Core/Timers/ITimer.cs
+++ b/src/Nethermind/Nethermind.Core/Timers/ITimer.cs
@@ -21,12 +21,39 @@ namespace Nethermind.Core.Timers
 {
     public interface ITimer : IDisposable
     {
+        /// <summary>
+        /// Gets or sets a Boolean indicating whether the <see cref="ITimer"/> should raise the <see cref="Elapsed"/> event only once (false) or repeatedly (true).
+        /// </summary>
         bool AutoReset { get; set; }
+        
+        /// <summary>
+        /// Gets or sets a value indicating whether the <see cref="ITimer"/> should raise the <see cref="Elapsed"/> event.
+        /// </summary>
         bool Enabled { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the interval, at which to raise the <see cref="Elapsed"/> event.
+        /// </summary>
         TimeSpan Interval { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the interval, expressed in milliseconds, at which to raise the <see cref="Elapsed"/> event.
+        /// </summary>
         double IntervalMilliseconds { get; set; }
+        
+        /// <summary>
+        /// Starts raising the <see cref="Elapsed"/> event by setting <see cref="Enabled"/> to true.
+        /// </summary>
         void Start();
+        
+        /// <summary>
+        /// Stops raising the <see cref="Elapsed"/> event by setting <see cref="Enabled"/> to false.
+        /// </summary>
         void Stop();
+        
+        /// <summary>
+        /// Occurs when the interval elapses.
+        /// </summary>
         event EventHandler Elapsed;
     }
 }

--- a/src/Nethermind/Nethermind.Facade/Proxy/DefaultHttpClient.cs
+++ b/src/Nethermind/Nethermind.Facade/Proxy/DefaultHttpClient.cs
@@ -18,6 +18,7 @@ using System;
 using System.Diagnostics;
 using System.Net.Http;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Logging;
 using Nethermind.Serialization.Json;
@@ -32,8 +33,12 @@ namespace Nethermind.Facade.Proxy
         private readonly int _retries;
         private readonly int _retryDelayMilliseconds;
 
-        public DefaultHttpClient(HttpClient client, IJsonSerializer jsonSerializer, ILogManager logManager,
-            int retries = 3, int retryDelayMilliseconds = 1000)
+        public DefaultHttpClient(
+            HttpClient client, 
+            IJsonSerializer jsonSerializer, 
+            ILogManager logManager,
+            int retries = 3,
+            int retryDelayMilliseconds = 1000)
         {
             _client = client ?? throw new ArgumentNullException(nameof(client));
             _jsonSerializer = jsonSerializer ?? throw new ArgumentNullException(nameof(jsonSerializer));
@@ -42,17 +47,17 @@ namespace Nethermind.Facade.Proxy
             _retryDelayMilliseconds = retryDelayMilliseconds;
         }
 
-        public Task<T> GetAsync<T>(string endpoint)
-            => ExecuteAsync<T>(Method.Get, endpoint);
+        public Task<T> GetAsync<T>(string endpoint, CancellationToken cancellationToken = default)
+            => ExecuteAsync<T>(Method.Get, endpoint, cancellationToken);
 
-        public  Task<T> PostJsonAsync<T>(string endpoint, object payload = null)
-            => ExecuteAsync<T>(Method.Post, endpoint, payload);
+        public Task<T> PostJsonAsync<T>(string endpoint, object? payload = null, CancellationToken cancellationToken = default)
+            => ExecuteAsync<T>(Method.Post, endpoint, payload, cancellationToken);
 
-        private async Task<T> ExecuteAsync<T>(Method method, string endpoint, object payload = null)
+        private async Task<T> ExecuteAsync<T>(Method method, string endpoint, object? payload = null, CancellationToken cancellationToken = default)
         {
-            var requestId = Guid.NewGuid().ToString("N");
-            var methodType = method.ToString();
-            var currentRetry = 0;
+            string requestId = Guid.NewGuid().ToString("N");
+            string methodType = method.ToString();
+            int currentRetry = 0;
             do
             {
                 try
@@ -64,7 +69,7 @@ namespace Nethermind.Facade.Proxy
                     
                     currentRetry++;
 
-                    return await ProcessRequestAsync<T>(method, endpoint, requestId, payload);
+                    return await ProcessRequestAsync<T>(method, endpoint, requestId, payload, cancellationToken);
                 }
                 catch (Exception ex)
                 {
@@ -82,22 +87,20 @@ namespace Nethermind.Facade.Proxy
             return default;
         }
 
-        private async Task<T> ProcessRequestAsync<T>(Method method, string endpoint, string requestId,
-            object payload = null)
+        private async Task<T> ProcessRequestAsync<T>(Method method, string endpoint, string requestId, object? payload = null, CancellationToken cancellationToken = default)
         {
-            var methodType = method.ToString();
-            var json = payload is null ? "{}" : _jsonSerializer.Serialize(payload);
+            string methodType = method.ToString();
+            string json = payload is null ? "{}" : _jsonSerializer.Serialize(payload);
             if (_logger.IsTrace) _logger.Trace($"Sending HTTP {methodType} request to: {endpoint} [id: {requestId}]{(method == Method.Get ? "." : $": {json}")}");
-            var stopWatch = new Stopwatch();
-            stopWatch.Start();
+            Stopwatch stopWatch = Stopwatch.StartNew();
             HttpResponseMessage response;
             switch (method)
             {
-                case Method.Get: response = await _client.GetAsync(endpoint);
+                case Method.Get: response = await _client.GetAsync(endpoint, cancellationToken);
                     break;
                 case Method.Post: 
-                    var payloadContent = new StringContent(json, Encoding.UTF8, "application/json");
-                    response = await _client.PostAsync(endpoint, payloadContent);
+                    StringContent payloadContent = new(json, Encoding.UTF8, "application/json");
+                    response = await _client.PostAsync(endpoint, payloadContent, cancellationToken);
                     break;
                 default:
                     if (_logger.IsError) _logger.Error($"Unsupported HTTP method: {methodType}.");
@@ -111,7 +114,7 @@ namespace Nethermind.Facade.Proxy
                 return default;
             }
             
-            var content = await response.Content.ReadAsStringAsync();
+            string content = await response.Content.ReadAsStringAsync(cancellationToken);
             
             return _jsonSerializer.Deserialize<T>(content);
         }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.HelperFunctions.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.HelperFunctions.cs
@@ -56,7 +56,7 @@ namespace Nethermind.Merge.Plugin.Test
              Assert.AreEqual(safeBlockHash, result.SafeBlockHash);
         }
         
-        private (UInt256, UInt256) AddTransactions(MergeTestBlockchain chain, BlockRequestResult executePayloadRequest,
+        private (UInt256, UInt256) AddTransactions(MergeTestBlockchain chain, ExecutionPayloadV1 executePayloadRequest,
             PrivateKey from, Address to, uint count, int value, out BlockHeader parentHeader)
         {
             Transaction[] transactions = BuildTransactions(chain, executePayloadRequest.ParentHash, from, to, count, value,
@@ -89,19 +89,19 @@ namespace Nethermind.Merge.Plugin.Test
                 .Select(i => BuildTransaction((uint)i, account)).ToArray();
         }
 
-        private BlockRequestResult CreateParentBlockRequestOnHead(IBlockTree blockTree)
+        private ExecutionPayloadV1 CreateParentBlockRequestOnHead(IBlockTree blockTree)
         {
             Block? head = blockTree.Head;
             if (head == null) throw new NotSupportedException();
-            return new BlockRequestResult()
+            return new ExecutionPayloadV1()
             {
                 BlockNumber = head.Number, BlockHash = head.Hash!, StateRoot = head.StateRoot!, ReceiptsRoot = head.ReceiptsRoot!, GasLimit = head.GasLimit, Timestamp = (ulong)head.Timestamp
             };
         }
 
-        private static BlockRequestResult CreateBlockRequest(BlockRequestResult parent, Address miner)
+        private static ExecutionPayloadV1 CreateBlockRequest(ExecutionPayloadV1 parent, Address miner)
         {
-            BlockRequestResult blockRequest = new()
+            ExecutionPayloadV1 blockRequest = new()
             {
                 ParentHash = parent.BlockHash,
                 FeeRecipient = miner,
@@ -120,10 +120,10 @@ namespace Nethermind.Merge.Plugin.Test
             return blockRequest;
         }
 
-        private static BlockRequestResult[] CreateBlockRequestBranch(BlockRequestResult parent, Address miner, int count)
+        private static ExecutionPayloadV1[] CreateBlockRequestBranch(ExecutionPayloadV1 parent, Address miner, int count)
         {
-            BlockRequestResult currentBlock = parent;
-            BlockRequestResult[] blockRequests = new BlockRequestResult[count];
+            ExecutionPayloadV1 currentBlock = parent;
+            ExecutionPayloadV1[] blockRequests = new ExecutionPayloadV1[count];
             for (int i = 0; i < count; i++)
             {
                 currentBlock = CreateBlockRequest(currentBlock, miner);
@@ -148,11 +148,11 @@ namespace Nethermind.Merge.Plugin.Test
         }
 
         private static TestCaseData GetNewBlockRequestBadDataTestCase<T>(
-            Expression<Func<BlockRequestResult, T>> propertyAccess, T wrongValue)
+            Expression<Func<ExecutionPayloadV1, T>> propertyAccess, T wrongValue)
         {
-            Action<BlockRequestResult, T> setter = propertyAccess.GetSetter();
+            Action<ExecutionPayloadV1, T> setter = propertyAccess.GetSetter();
             // ReSharper disable once ConvertToLocalFunction
-            Action<BlockRequestResult> wrongValueSetter = r => setter(r, wrongValue);
+            Action<ExecutionPayloadV1> wrongValueSetter = r => setter(r, wrongValue);
             return new TestCaseData(wrongValueSetter)
             {
                 TestName =
@@ -160,7 +160,7 @@ namespace Nethermind.Merge.Plugin.Test
             };
         }
 
-        private static bool TryCalculateHash(BlockRequestResult request, out Keccak hash)
+        private static bool TryCalculateHash(ExecutionPayloadV1 request, out Keccak hash)
         {
             if (request.TryGetBlock(out Block? block) && block != null)
             {

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
@@ -36,6 +36,7 @@ using Nethermind.Db;
 using Nethermind.Facade.Eth;
 using Nethermind.Int256;
 using Nethermind.Logging;
+using Nethermind.Merge.Plugin.BlockProduction;
 using Nethermind.Merge.Plugin.Data;
 using Nethermind.Merge.Plugin.Handlers;
 using Nethermind.Merge.Plugin.Handlers.V1;

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
@@ -15,6 +15,7 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 // 
 
+using System;
 using System.Threading.Tasks;
 using Nethermind.Api;
 using Nethermind.Blockchain;
@@ -142,8 +143,13 @@ namespace Nethermind.Merge.Plugin.Test
                 PostMergeBlockProducer? postMergeBlockProducer = blockProducerFactory.Create(
                     blockProducerEnv, BlockProductionTrigger);
                 PostMergeBlockProducer = postMergeBlockProducer;
-                PayloadPreparationService ??= new PayloadPreparationService(postMergeBlockProducer, BlockProductionTrigger, SealEngine,
-                    MergeConfig, TimerFactory.Default, LogManager);
+                PayloadPreparationService ??= new PayloadPreparationService(
+                    postMergeBlockProducer, 
+                    new BlockImprovementContextFactory(BlockProductionTrigger, TimeSpan.FromSeconds(MergeConfig.SecondsPerSlot)),
+                    SealEngine,
+                    TimerFactory.Default, 
+                    LogManager,
+                    MergeConfig.SecondsPerSlot);
                 return new MergeBlockProducer(preMergeBlockProducer, postMergeBlockProducer, PoSSwitcher);
             }
             

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Synchronization.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Synchronization.cs
@@ -54,7 +54,7 @@ public partial class EngineModuleTests
             .WithAuthor(Address.Zero)
             .WithPostMergeFlag(true)
             .TestObject;
-        await rpc.engine_newPayloadV1(new BlockRequestResult(block));
+        await rpc.engine_newPayloadV1(new ExecutionPayloadV1(block));
         // sync has not started yet
         chain.BeaconSync.IsBeaconSyncHeadersFinished().Should().BeTrue();
         chain.BeaconSync.IsBeaconSyncFinished(block.Header).Should().BeTrue();
@@ -93,10 +93,10 @@ public partial class EngineModuleTests
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak startingHead = chain.BlockTree.HeadHash;
         
-        BlockRequestResult parentBlockRequest = new (Build.A.Block.WithNumber(2).TestObject);
-        BlockRequestResult[] requests = CreateBlockRequestBranch(parentBlockRequest, Address.Zero, 7);
+        ExecutionPayloadV1 parentBlockRequest = new (Build.A.Block.WithNumber(2).TestObject);
+        ExecutionPayloadV1[] requests = CreateBlockRequestBranch(parentBlockRequest, Address.Zero, 7);
         ResultWrapper<PayloadStatusV1> payloadStatus;
-        foreach (BlockRequestResult r in requests)
+        foreach (ExecutionPayloadV1 r in requests)
         {
             payloadStatus = await rpc.engine_newPayloadV1(r);
             payloadStatus.Data.Status.Should().Be(nameof(PayloadStatusV1.Accepted).ToUpper());
@@ -136,7 +136,7 @@ public partial class EngineModuleTests
         using MergeTestBlockchain chain = await CreateBlockChain();
         Keccak startingHead = chain.BlockTree.HeadHash;
         IEngineRpcModule rpc = CreateEngineModule(chain);
-        BlockRequestResult[] requests = CreateBlockRequestBranch(new(chain.BlockTree.Head!), Address.Zero, 7);
+        ExecutionPayloadV1[] requests = CreateBlockRequestBranch(new(chain.BlockTree.Head!), Address.Zero, 7);
 
         ResultWrapper<PayloadStatusV1> payloadStatus;
         for (int i = 4; i < requests.Length - 1; i++)
@@ -183,7 +183,7 @@ public partial class EngineModuleTests
         Keccak startingHead = chain.BlockTree.HeadHash;
         // create 7 block gap
         int gap = 7;
-        BlockRequestResult headBlockRequest = new(chain.BlockTree.Head!);
+        ExecutionPayloadV1 headBlockRequest = new(chain.BlockTree.Head!);
         Block[] missingBlocks = new Block[gap];
         for (int i = 0; i < gap; i++)
         {
@@ -192,7 +192,7 @@ public partial class EngineModuleTests
             missingBlocks[i] = block!;
         }
         // setting up beacon pivot
-        BlockRequestResult pivotRequest = CreateBlockRequest(headBlockRequest, Address.Zero);
+        ExecutionPayloadV1 pivotRequest = CreateBlockRequest(headBlockRequest, Address.Zero);
         ResultWrapper<PayloadStatusV1> payloadStatus = await rpc.engine_newPayloadV1(pivotRequest);
         payloadStatus.Data.Status.Should().Be(nameof(PayloadStatusV1.Accepted).ToUpper());
         pivotRequest.TryGetBlock(out Block? pivotBlock);
@@ -214,7 +214,7 @@ public partial class EngineModuleTests
         forkchoiceUpdatedResult.Data.PayloadStatus.Status.Should()
             .Be(nameof(PayloadStatusV1.Syncing).ToUpper());
         // trigger insertion of blocks in cache into block tree by adding new block
-        BlockRequestResult bestBeaconBlockRequest = CreateBlockRequest(pivotRequest, Address.Zero);
+        ExecutionPayloadV1 bestBeaconBlockRequest = CreateBlockRequest(pivotRequest, Address.Zero);
         payloadStatus = await rpc.engine_newPayloadV1(bestBeaconBlockRequest);
         payloadStatus.Data.Status.Should().Be(nameof(PayloadStatusV1.Syncing).ToUpper());
         // simulate headers sync by inserting 3 headers from pivot backwards
@@ -290,10 +290,10 @@ public partial class EngineModuleTests
         IEngineRpcModule rpc = CreateEngineModule(chain, syncConfig);
         // create block gap from fast sync pivot
         int gap = 7;
-        BlockRequestResult[] requests =
-            CreateBlockRequestBranch(new BlockRequestResult(syncedBlockTree.Head!), Address.Zero, gap);
+        ExecutionPayloadV1[] requests =
+            CreateBlockRequestBranch(new ExecutionPayloadV1(syncedBlockTree.Head!), Address.Zero, gap);
         // setting up beacon pivot
-        BlockRequestResult pivotRequest = CreateBlockRequest(requests[^1], Address.Zero);
+        ExecutionPayloadV1 pivotRequest = CreateBlockRequest(requests[^1], Address.Zero);
         ResultWrapper<PayloadStatusV1> payloadStatus = await rpc.engine_newPayloadV1(pivotRequest);
         payloadStatus.Data.Status.Should().Be(nameof(PayloadStatusV1.Accepted).ToUpper());
         pivotRequest.TryGetBlock(out Block? pivotBlock);
@@ -316,7 +316,7 @@ public partial class EngineModuleTests
         forkchoiceUpdatedResult.Data.PayloadStatus.Status.Should()
             .Be(nameof(PayloadStatusV1.Syncing).ToUpper());
         // trigger insertion of blocks in cache into block tree by adding new block
-        BlockRequestResult bestBeaconBlockRequest = CreateBlockRequest(pivotRequest, Address.Zero);
+        ExecutionPayloadV1 bestBeaconBlockRequest = CreateBlockRequest(pivotRequest, Address.Zero);
         payloadStatus = await rpc.engine_newPayloadV1(bestBeaconBlockRequest);
         payloadStatus.Data.Status.Should().Be(nameof(PayloadStatusV1.Syncing).ToUpper());
         // fill in beacon headers until fast headers pivot

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
@@ -38,6 +38,7 @@ using Nethermind.JsonRpc;
 using Nethermind.JsonRpc.Modules.Eth;
 using Nethermind.JsonRpc.Test;
 using Nethermind.JsonRpc.Test.Modules;
+using Nethermind.Merge.Plugin.BlockProduction;
 using Nethermind.Merge.Plugin.Data;
 using Nethermind.Merge.Plugin.Data.V1;
 using Nethermind.Merge.Plugin.Handlers;

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/MergePluginTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/MergePluginTests.cs
@@ -25,6 +25,7 @@ using Nethermind.Core;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
 using Nethermind.JsonRpc.Modules;
+using Nethermind.Merge.Plugin.BlockProduction;
 using Nethermind.Merge.Plugin.Handlers;
 using Nethermind.Specs.ChainSpecStyle;
 using NUnit.Framework;

--- a/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/BlockImprovementContextFactory.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/BlockImprovementContextFactory.cs
@@ -15,31 +15,27 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 // 
 
+using System;
+using Nethermind.Consensus.Producers;
 using Nethermind.Core;
-using Nethermind.Core.Crypto;
-using Nethermind.Int256;
+using Org.BouncyCastle.Asn1.Cms;
 
-namespace Nethermind.Consensus.Producers
+namespace Nethermind.Merge.Plugin.BlockProduction;
+
+public class BlockImprovementContextFactory : IBlockImprovementContextFactory
 {
-    public class PayloadAttributes
+    private readonly IManualBlockProductionTrigger _blockProductionTrigger;
+    private readonly TimeSpan _timeout;
+
+    public BlockImprovementContextFactory(IManualBlockProductionTrigger blockProductionTrigger, TimeSpan timeout)
     {
-        public UInt256 Timestamp { get; set; }
-        
-        public Keccak PrevRandao { get; set; }
-        
-        public Address SuggestedFeeRecipient { get; set; }
-        
-        /// <summary>
-        /// GasLimit
-        /// </summary>
-        /// <remarks>
-        /// Only used for MEV-Boost
-        /// </remarks>
-        public long? GasLimit { get; set; }
-        
-        public override string ToString()
-        {
-            return $"PayloadAttributes: ({nameof(Timestamp)}: {Timestamp}, {nameof(PrevRandao)}: {PrevRandao}, {nameof(SuggestedFeeRecipient)}: {SuggestedFeeRecipient})";
-        }
+        _blockProductionTrigger = blockProductionTrigger;
+        _timeout = timeout;
     }
+    
+    public IBlockImprovementContext StartBlockImprovementContext(
+        Block currentBestBlock, 
+        BlockHeader parentHeader, 
+        PayloadAttributes payloadAttributes) =>
+        new BlockImprovementContext(currentBestBlock, _blockProductionTrigger, _timeout, parentHeader, payloadAttributes);
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/Boost/BoostBlockImprovementContext.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/Boost/BoostBlockImprovementContext.cs
@@ -1,0 +1,79 @@
+﻿//  Copyright (c) 2021 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
+
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Nethermind.Consensus.Producers;
+using Nethermind.Core;
+using Nethermind.Evm.Tracing;
+using Nethermind.Facade.Proxy;
+using Nethermind.Int256;
+using Nethermind.Merge.Plugin.Data.V1;
+using Nethermind.State;
+
+namespace Nethermind.Merge.Plugin.BlockProduction.Boost;
+
+public class BoostBlockImprovementContext : IBlockImprovementContext
+{
+    private readonly IBoostRelay _boostRelay;
+    private readonly IStateReader _stateReader;
+    private readonly CancellationTokenSource _cancellationTokenSource;
+
+    public BoostBlockImprovementContext(
+        Block currentBestBlock,
+        IManualBlockProductionTrigger blockProductionTrigger,
+        TimeSpan timeout,
+        BlockHeader parentHeader,
+        PayloadAttributes payloadAttributes,
+        IBoostRelay boostRelay,
+        IStateReader stateReader)
+    {
+        _boostRelay = boostRelay;
+        _stateReader = stateReader;
+        _cancellationTokenSource = new CancellationTokenSource(timeout);
+        CurrentBestBlock = currentBestBlock;
+        ImprovementTask = StartImprovingBlock(blockProductionTrigger, parentHeader, payloadAttributes);
+    }
+
+    private async Task<Block?> StartImprovingBlock(IManualBlockProductionTrigger blockProductionTrigger, BlockHeader parentHeader, PayloadAttributes payloadAttributes)
+    {
+        CancellationToken cancellationToken = _cancellationTokenSource.Token;
+        payloadAttributes = await _boostRelay.GetPayloadAttributes(payloadAttributes, cancellationToken);
+        UInt256 balanceBefore = _stateReader.GetAccount(parentHeader.StateRoot!, payloadAttributes.SuggestedFeeRecipient)?.Balance ?? UInt256.Zero;
+        Block? block = await blockProductionTrigger.BuildBlock(parentHeader, cancellationToken, NullBlockTracer.Instance, payloadAttributes);
+        if (block is not null)
+        {
+            CurrentBestBlock = block;
+            UInt256 balanceAfter = _stateReader.GetAccount(block.StateRoot!, payloadAttributes.SuggestedFeeRecipient)?.Balance ?? UInt256.Zero;
+            await _boostRelay.SendPayload(new BoostExecutionPayloadV1 { Block = new ExecutionPayloadV1(block), Profit = balanceAfter - balanceBefore }, cancellationToken);
+        }
+
+        return CurrentBestBlock;
+    }
+
+    public Task<Block?> ImprovementTask { get; }
+
+    public Block? CurrentBestBlock { get; private set; }
+
+    public void Dispose()
+    {
+        _cancellationTokenSource.Cancel();
+        _cancellationTokenSource.Dispose();
+    }
+}

--- a/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/Boost/BoostBlockImprovementContextFactory.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/Boost/BoostBlockImprovementContextFactory.cs
@@ -1,0 +1,47 @@
+﻿//  Copyright (c) 2021 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
+
+using System;
+using System.Net.Http;
+using Nethermind.Consensus.Producers;
+using Nethermind.Core;
+using Nethermind.Facade.Proxy;
+using Nethermind.State;
+
+namespace Nethermind.Merge.Plugin.BlockProduction.Boost;
+
+public class BoostBlockImprovementContextFactory : IBlockImprovementContextFactory
+{
+    private readonly IManualBlockProductionTrigger _blockProductionTrigger;
+    private readonly TimeSpan _timeout;
+    private readonly IBoostRelay _boostRelay;
+    private readonly IStateReader _stateReader;
+
+    public BoostBlockImprovementContextFactory(IManualBlockProductionTrigger blockProductionTrigger, TimeSpan timeout, IBoostRelay boostRelay, IStateReader stateReader)
+    {
+        _blockProductionTrigger = blockProductionTrigger;
+        _timeout = timeout;
+        _boostRelay = boostRelay;
+        _stateReader = stateReader;
+    }
+    
+    public IBlockImprovementContext StartBlockImprovementContext(
+        Block currentBestBlock, 
+        BlockHeader parentHeader, 
+        PayloadAttributes payloadAttributes) =>
+        new BoostBlockImprovementContext(currentBestBlock, _blockProductionTrigger, _timeout, parentHeader, payloadAttributes, _boostRelay, _stateReader);
+}

--- a/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/Boost/BoostExecutionPayloadV1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/Boost/BoostExecutionPayloadV1.cs
@@ -1,4 +1,4 @@
-//  Copyright (c) 2021 Demerzel Solutions Limited
+﻿//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
 // 
 //  The Nethermind library is free software: you can redistribute it and/or modify
@@ -13,15 +13,15 @@
 // 
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
 
-using System.Threading;
-using System.Threading.Tasks;
+using Nethermind.Int256;
+using Nethermind.Merge.Plugin.Data.V1;
 
-namespace Nethermind.Facade.Proxy
+namespace Nethermind.Merge.Plugin.BlockProduction.Boost;
+
+public class BoostExecutionPayloadV1
 {
-    public interface IHttpClient
-    {
-        Task<T> GetAsync<T>(string endpoint, CancellationToken cancellationToken = default);
-        Task<T> PostJsonAsync<T>(string endpoint, object? payload = null, CancellationToken cancellationToken = default);
-    }
+    public ExecutionPayloadV1 Block { get; set; }
+    public UInt256 Profit { get; set; }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/Boost/BoostRelay.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/Boost/BoostRelay.cs
@@ -1,0 +1,46 @@
+﻿//  Copyright (c) 2021 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Nethermind.Consensus.Producers;
+using Nethermind.Facade.Proxy;
+
+namespace Nethermind.Merge.Plugin.BlockProduction.Boost;
+
+public class BoostRelay : IBoostRelay
+{
+    private readonly IHttpClient _httpClient;
+    private readonly string _relayUrl;
+    private const string getPayloadAttributes = "/eth/v1/relay/payload_attributes";
+    private const string submitBlock = "/eth/v1/relay/submit_block";
+
+    public BoostRelay(IHttpClient httpClient, string relayUrl)
+    {
+        _httpClient = httpClient;
+        _relayUrl = relayUrl;
+    }
+    
+    public Task<PayloadAttributes> GetPayloadAttributes(PayloadAttributes payloadAttributes, CancellationToken cancellationToken) => 
+        _httpClient.PostJsonAsync<PayloadAttributes>(GetUri(_relayUrl, getPayloadAttributes), payloadAttributes, cancellationToken);
+
+    public Task SendPayload(BoostExecutionPayloadV1 executionPayloadV1, CancellationToken cancellationToken) => 
+        _httpClient.PostJsonAsync<object>(GetUri(_relayUrl, submitBlock), executionPayloadV1, cancellationToken);
+    
+    private string GetUri(string relayUrl, string relativeUrl) => relayUrl + relativeUrl;
+}

--- a/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/Boost/IBoostRelay.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/Boost/IBoostRelay.cs
@@ -1,4 +1,4 @@
-//  Copyright (c) 2021 Demerzel Solutions Limited
+﻿//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
 // 
 //  The Nethermind library is free software: you can redistribute it and/or modify
@@ -13,15 +13,16 @@
 // 
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
 
 using System.Threading;
 using System.Threading.Tasks;
+using Nethermind.Consensus.Producers;
 
-namespace Nethermind.Facade.Proxy
+namespace Nethermind.Merge.Plugin.BlockProduction.Boost;
+
+public interface IBoostRelay
 {
-    public interface IHttpClient
-    {
-        Task<T> GetAsync<T>(string endpoint, CancellationToken cancellationToken = default);
-        Task<T> PostJsonAsync<T>(string endpoint, object? payload = null, CancellationToken cancellationToken = default);
-    }
+    Task<PayloadAttributes> GetPayloadAttributes(PayloadAttributes payloadAttributes, CancellationToken cancellationToken);
+    Task SendPayload(BoostExecutionPayloadV1 executionPayloadV1, CancellationToken cancellationToken);
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/IBlockImprovementContext.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/IBlockImprovementContext.cs
@@ -1,4 +1,4 @@
-//  Copyright (c) 2021 Demerzel Solutions Limited
+﻿//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
 // 
 //  The Nethermind library is free software: you can redistribute it and/or modify
@@ -13,15 +13,16 @@
 // 
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
 
-using System.Threading;
+using System;
 using System.Threading.Tasks;
+using Nethermind.Core;
 
-namespace Nethermind.Facade.Proxy
+namespace Nethermind.Merge.Plugin.BlockProduction;
+
+public interface IBlockImprovementContext : IDisposable
 {
-    public interface IHttpClient
-    {
-        Task<T> GetAsync<T>(string endpoint, CancellationToken cancellationToken = default);
-        Task<T> PostJsonAsync<T>(string endpoint, object? payload = null, CancellationToken cancellationToken = default);
-    }
+    Task<Block?> ImprovementTask { get; }
+    Block? CurrentBestBlock { get; }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/IBlockImprovementContextFactory.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/IBlockImprovementContextFactory.cs
@@ -1,4 +1,4 @@
-//  Copyright (c) 2021 Demerzel Solutions Limited
+﻿//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
 // 
 //  The Nethermind library is free software: you can redistribute it and/or modify
@@ -13,15 +13,17 @@
 // 
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
 
-using System.Threading;
-using System.Threading.Tasks;
+using Nethermind.Consensus.Producers;
+using Nethermind.Core;
 
-namespace Nethermind.Facade.Proxy
+namespace Nethermind.Merge.Plugin.BlockProduction;
+
+public interface IBlockImprovementContextFactory
 {
-    public interface IHttpClient
-    {
-        Task<T> GetAsync<T>(string endpoint, CancellationToken cancellationToken = default);
-        Task<T> PostJsonAsync<T>(string endpoint, object? payload = null, CancellationToken cancellationToken = default);
-    }
+    IBlockImprovementContext StartBlockImprovementContext(
+        Block currentBestBlock, 
+        BlockHeader parentHeader, 
+        PayloadAttributes payloadAttributes);
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/IPayloadPreparationService.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/IPayloadPreparationService.cs
@@ -20,13 +20,13 @@ using System.Threading.Tasks;
 using Nethermind.Consensus.Producers;
 using Nethermind.Core;
 
-namespace Nethermind.Merge.Plugin.Handlers
+namespace Nethermind.Merge.Plugin.BlockProduction
 {
     public interface IPayloadPreparationService
     {
         string? StartPreparingPayload(BlockHeader parentHeader, PayloadAttributes payloadAttributes);
 
-        Block? GetPayload(byte[] payloadId);
+        ValueTask<Block?> GetPayload(byte[] payloadId);
 
         event EventHandler<BlockEventArgs>? BlockImproved;
     }

--- a/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/MergeBlockProducer.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/MergeBlockProducer.cs
@@ -1,0 +1,78 @@
+﻿//  Copyright (c) 2021 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
+
+using System;
+using System.Threading.Tasks;
+using Nethermind.Consensus;
+using Nethermind.Core;
+
+namespace Nethermind.Merge.Plugin.BlockProduction;
+
+public class MergeBlockProducer : IBlockProducer
+{
+    private readonly IBlockProducer? _preMergeProducer;
+    private readonly IBlockProducer _eth2BlockProducer;
+    private readonly IPoSSwitcher _poSSwitcher;
+    private bool HasPreMergeProducer => _preMergeProducer != null;
+
+    public MergeBlockProducer(IBlockProducer? preMergeProducer, IBlockProducer? postMergeBlockProducer, IPoSSwitcher? poSSwitcher)
+    {
+        _preMergeProducer = preMergeProducer;
+        _eth2BlockProducer = postMergeBlockProducer ?? throw new ArgumentNullException(nameof(postMergeBlockProducer));
+        _poSSwitcher = poSSwitcher ?? throw new ArgumentNullException(nameof(poSSwitcher));
+        _poSSwitcher.TerminalBlockReached += OnSwitchHappened;
+        if (HasPreMergeProducer)
+            _preMergeProducer!.BlockProduced += OnBlockProduced;
+            
+        postMergeBlockProducer.BlockProduced += OnBlockProduced;
+    }
+
+    private void OnBlockProduced(object? sender, BlockEventArgs e)
+    {
+        BlockProduced?.Invoke(this, e);
+    }
+
+    private void OnSwitchHappened(object? sender, EventArgs e)
+    {
+        _preMergeProducer?.StopAsync();
+    }
+
+    public async Task Start()
+    {
+        await _eth2BlockProducer.Start();
+        if (_poSSwitcher.HasEverReachedTerminalBlock() == false && HasPreMergeProducer)
+        {
+            await _preMergeProducer!.Start();
+        }
+    }
+
+    public async Task StopAsync()
+    {
+        await _eth2BlockProducer.StopAsync();
+        if (_poSSwitcher.HasEverReachedTerminalBlock() && HasPreMergeProducer)
+            await _preMergeProducer!.StopAsync();
+    }
+
+    public bool IsProducingBlocks(ulong? maxProducingInterval)
+    {
+        return _poSSwitcher.HasEverReachedTerminalBlock() || HasPreMergeProducer == false
+            ? _eth2BlockProducer.IsProducingBlocks(maxProducingInterval)
+            : _preMergeProducer!.IsProducingBlocks(maxProducingInterval);
+    }
+
+    public event EventHandler<BlockEventArgs>? BlockProduced;
+}

--- a/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/PostMergeBlockProducer.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/PostMergeBlockProducer.cs
@@ -16,7 +16,6 @@
 // 
 
 using System;
-using System.Threading.Tasks;
 using Nethermind.Blockchain;
 using Nethermind.Consensus;
 using Nethermind.Consensus.Processing;
@@ -29,66 +28,8 @@ using Nethermind.Crypto;
 using Nethermind.Logging;
 using Nethermind.State;
 
-namespace Nethermind.Merge.Plugin.Handlers
+namespace Nethermind.Merge.Plugin.BlockProduction
 {
-    public class MergeBlockProducer : IBlockProducer
-    {
-        private readonly IBlockProducer? _preMergeProducer;
-        private readonly IBlockProducer _eth2BlockProducer;
-        private readonly IPoSSwitcher _poSSwitcher;
-        private bool HasPreMergeProducer => _preMergeProducer != null;
-
-        // TODO: remove this
-        public ITimestamper Timestamper => _preMergeProducer?.Timestamper;
-
-        public MergeBlockProducer(IBlockProducer? preMergeProducer, IBlockProducer? postMergeBlockProducer, IPoSSwitcher? poSSwitcher)
-        {
-            _preMergeProducer = preMergeProducer;
-            _eth2BlockProducer = postMergeBlockProducer ?? throw new ArgumentNullException(nameof(postMergeBlockProducer));
-            _poSSwitcher = poSSwitcher ?? throw new ArgumentNullException(nameof(poSSwitcher));
-            _poSSwitcher.TerminalBlockReached += OnSwitchHappened;
-            if (HasPreMergeProducer)
-                _preMergeProducer!.BlockProduced += OnBlockProduced;
-            
-            postMergeBlockProducer.BlockProduced += OnBlockProduced;
-        }
-
-        private void OnBlockProduced(object? sender, BlockEventArgs e)
-        {
-            BlockProduced?.Invoke(this, e);
-        }
-
-        private void OnSwitchHappened(object? sender, EventArgs e)
-        {
-            _preMergeProducer?.StopAsync();
-        }
-
-        public async Task Start()
-        {
-            await _eth2BlockProducer.Start();
-            if (_poSSwitcher.HasEverReachedTerminalBlock() == false && HasPreMergeProducer)
-            {
-                await _preMergeProducer!.Start();
-            }
-        }
-
-        public async Task StopAsync()
-        {
-            await _eth2BlockProducer.StopAsync();
-            if (_poSSwitcher.HasEverReachedTerminalBlock() && HasPreMergeProducer)
-                await _preMergeProducer!.StopAsync();
-        }
-
-        public bool IsProducingBlocks(ulong? maxProducingInterval)
-        {
-            return _poSSwitcher.HasEverReachedTerminalBlock() || HasPreMergeProducer == false
-                ? _eth2BlockProducer.IsProducingBlocks(maxProducingInterval)
-                : _preMergeProducer!.IsProducingBlocks(maxProducingInterval);
-        }
-
-        public event EventHandler<BlockEventArgs>? BlockProduced;
-    }
-    
     public class PostMergeBlockProducer : BlockProducerBase
     {
         public PostMergeBlockProducer(

--- a/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/PostMergeBlockProducerFactory.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/PostMergeBlockProducerFactory.cs
@@ -15,16 +15,14 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 // 
 
-using Nethermind.Blockchain;
 using Nethermind.Consensus;
 using Nethermind.Consensus.Producers;
 using Nethermind.Consensus.Transactions;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
 using Nethermind.Logging;
-using Nethermind.Merge.Plugin.Data;
 
-namespace Nethermind.Merge.Plugin.Handlers
+namespace Nethermind.Merge.Plugin.BlockProduction
 {
     public class PostMergeBlockProducerFactory
     {

--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/V1/ExecutionPayloadV1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/V1/ExecutionPayloadV1.cs
@@ -16,9 +16,6 @@
 // 
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using Nethermind.Blockchain;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Int256;
@@ -26,18 +23,18 @@ using Nethermind.Serialization.Rlp;
 using Nethermind.State.Proofs;
 using Newtonsoft.Json;
 
-namespace Nethermind.Merge.Plugin.Data
+namespace Nethermind.Merge.Plugin.Data.V1
 {
     /// <summary>
     /// A data object representing a block as being sent from the execution layer to the consensus layer.
     /// </summary>
-    public class BlockRequestResult
+    public class ExecutionPayloadV1
     {
-        public BlockRequestResult()
+        public ExecutionPayloadV1()
         {
         }
 
-        public BlockRequestResult(Block block)
+        public ExecutionPayloadV1(Block block)
         {
             BlockHash = block.Hash!;
             ParentHash = block.ParentHash!;

--- a/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.cs
@@ -30,8 +30,8 @@ namespace Nethermind.Merge.Plugin
 {
     public class EngineRpcModule : IEngineRpcModule
     {
-        private readonly IAsyncHandler<byte[], BlockRequestResult?> _getPayloadHandlerV1;
-        private readonly IAsyncHandler<BlockRequestResult, PayloadStatusV1> _newPayloadV1Handler;
+        private readonly IAsyncHandler<byte[], ExecutionPayloadV1?> _getPayloadHandlerV1;
+        private readonly IAsyncHandler<ExecutionPayloadV1, PayloadStatusV1> _newPayloadV1Handler;
         private readonly IForkchoiceUpdatedV1Handler _forkchoiceUpdatedV1Handler;
         private readonly IHandler<ExecutionStatusResult> _executionStatusHandler;
         private readonly IAsyncHandler<Keccak[], ExecutionPayloadBodyV1Result[]> _executionPayloadBodiesHandler;
@@ -41,8 +41,8 @@ namespace Nethermind.Merge.Plugin
         private readonly ILogger _logger;
 
         public EngineRpcModule(
-            IAsyncHandler<byte[], BlockRequestResult?> getPayloadHandlerV1,
-            IAsyncHandler<BlockRequestResult, PayloadStatusV1> newPayloadV1Handler,
+            IAsyncHandler<byte[], ExecutionPayloadV1?> getPayloadHandlerV1,
+            IAsyncHandler<ExecutionPayloadV1, PayloadStatusV1> newPayloadV1Handler,
             IForkchoiceUpdatedV1Handler forkchoiceUpdatedV1Handler,
             IHandler<ExecutionStatusResult> executionStatusHandler,
             IAsyncHandler<Keccak[], ExecutionPayloadBodyV1Result[]> executionPayloadBodiesHandler,
@@ -63,14 +63,13 @@ namespace Nethermind.Merge.Plugin
             return _executionStatusHandler.Handle();
         }
 
-        public async Task<ResultWrapper<BlockRequestResult?>> engine_getPayloadV1(byte[] payloadId)
+        public async Task<ResultWrapper<ExecutionPayloadV1?>> engine_getPayloadV1(byte[] payloadId)
         {
             return await (_getPayloadHandlerV1.HandleAsync(payloadId));
         }
 
 
-        public async Task<ResultWrapper<PayloadStatusV1>> engine_newPayloadV1(
-            BlockRequestResult executionPayload)
+        public async Task<ResultWrapper<PayloadStatusV1>> engine_newPayloadV1(ExecutionPayloadV1 executionPayload)
         {
             if (await _locker.WaitAsync(Timeout))
             {

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/V1/ForkchoiceUpdatedV1Handler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/V1/ForkchoiceUpdatedV1Handler.cs
@@ -29,6 +29,7 @@ using Nethermind.Crypto;
 using Nethermind.Facade.Eth;
 using Nethermind.JsonRpc;
 using Nethermind.Logging;
+using Nethermind.Merge.Plugin.BlockProduction;
 using Nethermind.Merge.Plugin.Data.V1;
 using Nethermind.Merge.Plugin.Synchronization;
 using Nethermind.Synchronization;

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/V1/GetPayloadV1Handler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/V1/GetPayloadV1Handler.cs
@@ -20,6 +20,7 @@ using Nethermind.Core;
 using Nethermind.Core.Extensions;
 using Nethermind.JsonRpc;
 using Nethermind.Logging;
+using Nethermind.Merge.Plugin.BlockProduction;
 using Nethermind.Merge.Plugin.Data;
 
 namespace Nethermind.Merge.Plugin.Handlers.V1
@@ -48,7 +49,7 @@ namespace Nethermind.Merge.Plugin.Handlers.V1
 
         public async Task<ResultWrapper<BlockRequestResult?>> HandleAsync(byte[] payloadId)
         {
-            Block? block = _payloadPreparationService.GetPayload(payloadId);
+            Block? block = await _payloadPreparationService.GetPayload(payloadId);
 
             if (block == null)
             {

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/V1/GetPayloadV1Handler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/V1/GetPayloadV1Handler.cs
@@ -22,6 +22,7 @@ using Nethermind.JsonRpc;
 using Nethermind.Logging;
 using Nethermind.Merge.Plugin.BlockProduction;
 using Nethermind.Merge.Plugin.Data;
+using Nethermind.Merge.Plugin.Data.V1;
 
 namespace Nethermind.Merge.Plugin.Handlers.V1
 {
@@ -36,7 +37,7 @@ namespace Nethermind.Merge.Plugin.Handlers.V1
     /// a payload has been cancelled due to the timeout then execution client must respond with error message.
     /// Execution client may stop the building process with the corresponding payload_id value after serving this call.
     /// </summary>
-    public class GetPayloadV1Handler: IAsyncHandler<byte[], BlockRequestResult?>
+    public class GetPayloadV1Handler: IAsyncHandler<byte[], ExecutionPayloadV1?>
     {
         private readonly IPayloadPreparationService _payloadPreparationService;
         private readonly ILogger _logger;
@@ -47,14 +48,14 @@ namespace Nethermind.Merge.Plugin.Handlers.V1
             _logger = logManager.GetClassLogger();
         }
 
-        public async Task<ResultWrapper<BlockRequestResult?>> HandleAsync(byte[] payloadId)
+        public async Task<ResultWrapper<ExecutionPayloadV1?>> HandleAsync(byte[] payloadId)
         {
             Block? block = await _payloadPreparationService.GetPayload(payloadId);
 
             if (block == null)
             {
                 if (_logger.IsWarn) _logger.Warn($"Block production for payload with id={payloadId.ToHexString()} failed");
-                return ResultWrapper<BlockRequestResult?>.Fail(
+                return ResultWrapper<ExecutionPayloadV1?>.Fail(
                     "unknown payload",
                     MergeErrorCodes.UnavailablePayloadV1);
             }
@@ -64,8 +65,8 @@ namespace Nethermind.Merge.Plugin.Handlers.V1
                 _logger.Info($"GetPayloadV1 result: {block.Header.ToString(BlockHeader.Format.Full)}");
             }
 
-            BlockRequestResult result = new(block);
-            return ResultWrapper<BlockRequestResult?>.Success(result);
+            ExecutionPayloadV1 result = new(block);
+            return ResultWrapper<ExecutionPayloadV1?>.Success(result);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/V1/NewPayloadV1Handler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/V1/NewPayloadV1Handler.cs
@@ -46,7 +46,7 @@ namespace Nethermind.Merge.Plugin.Handlers.V1
     /// Verifies the payload according to the execution environment rule set (EIP-3675)
     /// and returns the status of the verification and the hash of the last valid block
     /// </summary>
-    public class NewPayloadV1Handler : IAsyncHandler<BlockRequestResult, PayloadStatusV1>
+    public class NewPayloadV1Handler : IAsyncHandler<ExecutionPayloadV1, PayloadStatusV1>
     {
         private readonly IBlockValidator _blockValidator;
         private readonly IBlockTree _blockTree;
@@ -88,7 +88,7 @@ namespace Nethermind.Merge.Plugin.Handlers.V1
             _logger = logManager.GetClassLogger();
         }
 
-        public async Task<ResultWrapper<PayloadStatusV1>> HandleAsync(BlockRequestResult request)
+        public async Task<ResultWrapper<PayloadStatusV1>> HandleAsync(ExecutionPayloadV1 request)
         {
             string requestStr = $"a new payload: {request}";
             if (_logger.IsInfo) { _logger.Info($"Received {requestStr}"); }
@@ -290,7 +290,7 @@ namespace Nethermind.Merge.Plugin.Handlers.V1
             return options;
         }
 
-        private PayloadStatusV1 BuildExecutePayloadResult(BlockRequestResult request, bool isValid, BlockHeader? parent,
+        private PayloadStatusV1 BuildExecutePayloadResult(ExecutionPayloadV1 request, bool isValid, BlockHeader? parent,
             string? validationMessage)
         {
             PayloadStatusV1 payloadStatus = new();

--- a/src/Nethermind/Nethermind.Merge.Plugin/IEngineRpcModule.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/IEngineRpcModule.cs
@@ -42,14 +42,14 @@ namespace Nethermind.Merge.Plugin
                 "Returns the most recent version of an execution payload with respect to the transaction set contained by the mempool.",
             IsSharable = true,
             IsImplemented = true)]
-        Task<ResultWrapper<BlockRequestResult?>> engine_getPayloadV1(byte[] payloadId);
+        Task<ResultWrapper<ExecutionPayloadV1?>> engine_getPayloadV1(byte[] payloadId);
         
         [JsonRpcMethod(
             Description =
                 "Verifies the payload according to the execution environment rules and returns the verification status and hash of the last valid block.",
             IsSharable = true,
             IsImplemented = true)]
-        Task<ResultWrapper<PayloadStatusV1>> engine_newPayloadV1(BlockRequestResult executionPayload);
+        Task<ResultWrapper<PayloadStatusV1>> engine_newPayloadV1(ExecutionPayloadV1 executionPayload);
         
         [JsonRpcMethod(
             Description =

--- a/src/Nethermind/Nethermind.Merge.Plugin/IMergeConfig.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/IMergeConfig.cs
@@ -55,5 +55,8 @@ namespace Nethermind.Merge.Plugin
         
         [ConfigItem(DisabledForCli = true, HiddenFromDocs = true)]
         Keccak TerminalBlockHashParsed => string.IsNullOrWhiteSpace(TerminalBlockHash) ? Keccak.Zero : new Keccak(Bytes.FromHexString(TerminalBlockHash));
+        
+        [ConfigItem(Description = "URL to Boost Relay.", DefaultValue = "null")]
+        string? BoostRelayUrl { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergeConfig.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergeConfig.cs
@@ -35,5 +35,7 @@ namespace Nethermind.Merge.Plugin
         public long? TerminalBlockNumber { get; set; }
         
         public ulong SecondsPerSlot { get; set; } = 12;
+        
+        public string? BoostRelayUrl { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.BlockProducer.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.BlockProducer.cs
@@ -23,6 +23,7 @@ using Nethermind.Consensus.Producers;
 using Nethermind.Consensus.Transactions;
 using Nethermind.Core;
 using Nethermind.Logging;
+using Nethermind.Merge.Plugin.BlockProduction;
 using Nethermind.Merge.Plugin.Data;
 using Nethermind.Merge.Plugin.Handlers;
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
@@ -15,6 +15,7 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
 using System;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Api;
@@ -29,11 +30,13 @@ using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Timers;
 using Nethermind.Db;
+using Nethermind.Facade.Proxy;
 using Nethermind.JsonRpc;
 using Nethermind.Int256;
 using Nethermind.JsonRpc.Modules;
 using Nethermind.Logging;
 using Nethermind.Merge.Plugin.BlockProduction;
+using Nethermind.Merge.Plugin.BlockProduction.Boost;
 using Nethermind.Merge.Plugin.Handlers;
 using Nethermind.Merge.Plugin.Handlers.V1;
 using Nethermind.Merge.Plugin.Synchronization;
@@ -131,11 +134,10 @@ namespace Nethermind.Merge.Plugin
                 if (_api.EthSyncingInfo is null) throw new ArgumentNullException(nameof(_api.EthSyncingInfo));
                 if (_api.Sealer is null) throw new ArgumentNullException(nameof(_api.Sealer));
                 if (_api.BlockValidator is null) throw new ArgumentNullException(nameof(_api.BlockValidator));
-                if (_api.BlockProcessingQueue is null)
-                    throw new ArgumentNullException(nameof(_api.BlockProcessingQueue));
-                if (_api.SyncProgressResolver is null)
-                    throw new ArgumentNullException(nameof(_api.SyncProgressResolver));
+                if (_api.BlockProcessingQueue is null) throw new ArgumentNullException(nameof(_api.BlockProcessingQueue));
+                if (_api.SyncProgressResolver is null) throw new ArgumentNullException(nameof(_api.SyncProgressResolver));
                 if (_api.SpecProvider is null) throw new ArgumentNullException(nameof(_api.SpecProvider));
+                if (_api.StateReader is null) throw new ArgumentNullException(nameof(_api.StateReader));
                 if (_beaconPivot is null) throw new ArgumentNullException(nameof(_beaconPivot));
                 if (_beaconSync is null) throw new ArgumentNullException(nameof(_beaconSync));
                 if (_blockProductionTrigger is null) throw new ArgumentNullException(nameof(_blockProductionTrigger));
@@ -152,7 +154,20 @@ namespace Nethermind.Merge.Plugin
                 }
                 Thread.Sleep(5000);
 
-                PayloadPreparationService payloadPreparationService = new (_postMergeBlockProducer, _blockProductionTrigger, _api.Sealer, _mergeConfig, TimerFactory.Default, _api.LogManager);
+                IBlockImprovementContextFactory improvementContextFactory;
+                if (string.IsNullOrEmpty(_mergeConfig.BoostRelayUrl))
+                {
+                    improvementContextFactory = new BlockImprovementContextFactory(_blockProductionTrigger, TimeSpan.FromSeconds(_mergeConfig.SecondsPerSlot));
+                }
+                else
+                {
+                    DefaultHttpClient httpClient = new(new HttpClient(), _api.EthereumJsonSerializer, _api.LogManager, retryDelayMilliseconds: 100);
+                    IBoostRelay boostRelay = new BoostRelay(httpClient, _mergeConfig.BoostRelayUrl);
+                    BoostBlockImprovementContextFactory boostBlockImprovementContextFactory = new(_blockProductionTrigger, TimeSpan.FromSeconds(_mergeConfig.SecondsPerSlot), boostRelay, _api.StateReader);
+                    improvementContextFactory = boostBlockImprovementContextFactory;
+                }
+
+                PayloadPreparationService payloadPreparationService = new(_postMergeBlockProducer, improvementContextFactory, _api.Sealer, TimerFactory.Default, _api.LogManager, _mergeConfig.SecondsPerSlot);
 
                 IEngineRpcModule engineRpcModule = new EngineRpcModule(
                     new GetPayloadV1Handler(payloadPreparationService, _api.LogManager),

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
@@ -33,6 +33,7 @@ using Nethermind.JsonRpc;
 using Nethermind.Int256;
 using Nethermind.JsonRpc.Modules;
 using Nethermind.Logging;
+using Nethermind.Merge.Plugin.BlockProduction;
 using Nethermind.Merge.Plugin.Handlers;
 using Nethermind.Merge.Plugin.Handlers.V1;
 using Nethermind.Merge.Plugin.Synchronization;

--- a/src/Nethermind/Nethermind.Mev.Test/MevRpcModuleTests.TestMevRpcBlockchain.cs
+++ b/src/Nethermind/Nethermind.Mev.Test/MevRpcModuleTests.TestMevRpcBlockchain.cs
@@ -40,6 +40,7 @@ using Nethermind.Int256;
 using Nethermind.JsonRpc;
 using Nethermind.JsonRpc.Test.Modules;
 using Nethermind.Logging;
+using Nethermind.Merge.Plugin.BlockProduction;
 using Nethermind.Merge.Plugin.Data;
 using Nethermind.Merge.Plugin.Handlers;
 using Nethermind.Mev.Data;

--- a/src/Nethermind/Nethermind.Network/IP/WebIPSource.cs
+++ b/src/Nethermind/Nethermind.Network/IP/WebIPSource.cs
@@ -37,7 +37,7 @@ namespace Nethermind.Network.IP
         {
             try
             {
-                HttpClient httpClient = new() {Timeout = TimeSpan.FromSeconds(3)};
+                using HttpClient httpClient = new() {Timeout = TimeSpan.FromSeconds(3)};
                 if(_logger.IsInfo) _logger.Info($"Using {_url} to get external ip");
                 string ip = httpClient.GetStringAsync(_url).Result.Trim();
                 if(_logger.IsDebug) _logger.Debug($"External ip: {ip}");


### PR DESCRIPTION
## Changes:
1. Add `GasLimit` to `PayloadAttributes` for Mev-boost only.
2. Add `IBlockImprovementContext` and `BlockImprovementContextFactory` to `PayloadPreparationService`
3. Add `BoostBlockImprovementContext`, this calls to `BoostRelay` in order to get proper `PayloadAttributes` from it, and after creating a block sends it to the relay with `BoostExecutionPayloadV1`.
4. Add `BoostRelayUrl` to `MegeConfig` and setup proper `BlockImprovementContextFactory` based on it.

Refactors:
1. Remove `Timestamper` from `BlockProducer`.
2. Extend `DefaultHttpClient` with `CancellationToken`
3. Rename `BlockRequestResult` to `ExcecutionPayloadV1` (based on engine api spec)
6. Removed `TaskQueue` as it didn't do anything

Potential questions?
If PayloadAttributes from relay should also affect empty block. Should we also send empty block to the relay?

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [ ] No

**Comments about testing , should you have some** (optional)

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...