### PR TITLE
+2 hive tests. Merge/latest block after payload

### DIFF
--- a/src/Nethermind/Nethermind.Facade.Test/BlockchainBridgeTests.cs
+++ b/src/Nethermind/Nethermind.Facade.Test/BlockchainBridgeTests.cs
@@ -194,5 +194,36 @@ namespace Nethermind.Facade.Test
 
             _blockchainBridge.HeadBlock.Should().Be(head);
         }
+
+        [TestCase(true, true)]
+        [TestCase(true, false)]
+        [TestCase(false, true)]
+        [TestCase(false, false)]
+        public void GetReceiptAndEffectiveGasPrice_returns_correct_results(bool isCanonical, bool isRemoved)
+        {
+            Keccak txHash = TestItem.KeccakA;
+            Keccak blockHash = TestItem.KeccakB;
+            UInt256 effectiveGasPrice = 123;
+            
+            Transaction tx = Build.A.Transaction
+                .WithGasPrice(effectiveGasPrice)
+                .TestObject;
+            Block block = Build.A.Block
+                .WithTransactions(tx)
+                .TestObject;
+            TxReceipt receipt = Build.A.Receipt
+                .WithBlockHash(blockHash)
+                .WithTransactionHash(txHash)
+                .WithRemoved(isRemoved)
+                .TestObject;
+
+            _blockTree.FindBlock(blockHash, Arg.Is(BlockTreeLookupOptions.RequireCanonical)).Returns(isCanonical ? block : null);
+            _blockTree.FindBlock(blockHash, Arg.Is(BlockTreeLookupOptions.TotalDifficultyNotNeeded)).Returns(block);
+            _receiptStorage.FindBlockHash(txHash).Returns(blockHash);
+            _receiptStorage.Get(block).Returns(new[] {receipt});
+
+            (TxReceipt Receipt, UInt256? EffectiveGasPrice) result = isCanonical || isRemoved ? (receipt, effectiveGasPrice) : (null, null);
+            _blockchainBridge.GetReceiptAndEffectiveGasPrice(txHash).Should().BeEquivalentTo(result);
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
@@ -101,7 +101,10 @@ namespace Nethermind.Facade
                 bool is1559Enabled = _specProvider.GetSpec(block.Number).IsEip1559Enabled;
                 UInt256 effectiveGasPrice = tx.CalculateEffectiveGasPrice(is1559Enabled, block.Header.BaseFeePerGas);
                 
-                return (txReceipt, effectiveGasPrice);
+                return txReceipt.Removed ||
+                       _processingEnv.BlockTree.FindBlock(blockHash, BlockTreeLookupOptions.RequireCanonical) is not null
+                    ? (txReceipt, effectiveGasPrice)
+                    : (null, null);
             }
 
             return (null, null);


### PR DESCRIPTION
## Changes:
- post merge we are processing blocks and adding receipts when processing NewPayload, but we shouldn't return those receipts until they are forkchoice updated.
For optimization we will firstly look for canonical block and we will look for any block only if canonical one will not be found

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

It's tested in engine hive tests