### PR TITLE
Terminal block hash validation

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
@@ -216,8 +216,7 @@ namespace Nethermind.Merge.Plugin.Test
                 PoSSwitcher = new PoSSwitcher(MergeConfig, SyncConfig.Default, new MemDb(), BlockTree, SpecProvider, LogManager);
                 SealValidator = new MergeSealValidator(PoSSwitcher, Always.Valid);
                 HeaderValidator preMergeHeaderValidator = new HeaderValidator(BlockTree, SealValidator, SpecProvider, LogManager);
-                HeaderValidator = new MergeHeaderValidator(PoSSwitcher, preMergeHeaderValidator, BlockTree, SpecProvider, SealValidator, LogManager);
-
+                HeaderValidator = new MergeHeaderValidator(PoSSwitcher, preMergeHeaderValidator, BlockTree, SpecProvider, SealValidator, MergeConfig, LogManager);
                 return new BlockValidator(
                     new TxValidator(SpecProvider.ChainId),
                     HeaderValidator,

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/MergeHeaderValidatorTest.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/MergeHeaderValidatorTest.cs
@@ -1,0 +1,114 @@
+//  Copyright (c) 2021 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+//
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+//
+
+using DotNetty.Codecs;
+using FluentAssertions;
+using Nethermind.Blockchain;
+using Nethermind.Consensus;
+using Nethermind.Consensus.Validators;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Specs;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Logging;
+using Nethermind.Logging.NLog;
+using Nethermind.Specs;
+using NLog;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Merge.Plugin.Test;
+
+public class MergeHeaderValidatorTest
+{
+    private IPoSSwitcher _poSSwitcher;
+    private IHeaderValidator _baseValidator;
+    private IBlockTree _blockTree;
+    private ISealValidator _sealValidator;
+    private ISpecProvider _specProvider;
+    private IMergeConfig _mergeConfig;
+
+    [SetUp]
+    public void Setup()
+    {
+        _poSSwitcher = Substitute.For<IPoSSwitcher>();
+        _blockTree = Build.A.BlockTree().TestObject;
+        _sealValidator = NullSealEngine.Instance;
+        _mergeConfig = Substitute.For<IMergeConfig>();
+        _specProvider = MainnetSpecProvider.Instance;
+        _baseValidator = Substitute.For<IHeaderValidator>();
+    }
+
+    private MergeHeaderValidator CreateValidator()
+    {
+        return new MergeHeaderValidator(
+            _poSSwitcher,
+            _baseValidator,
+            _blockTree,
+            _specProvider,
+            _sealValidator,
+            _mergeConfig,
+            LimboLogs.Instance);
+    }
+
+    [Test]
+    public void TestTerminalBlockHash_mismatch()
+    {
+        BlockHeader blockHeader = Build.A.BlockHeader.TestObject;
+        MergeHeaderValidator mergeHeaderValidator = CreateValidator();
+
+        GivenNextBlockIsTerminal();
+        GivenConfiguredTerminalBlockHash(Keccak.Compute("something else"));
+        GivenBaseValidatorAlwaysPass();
+        mergeHeaderValidator.Validate(blockHeader)
+            .Should()
+            .BeFalse();
+    }
+
+    [Test]
+    public void TestTerminalBlockHash_match()
+    {
+        BlockHeader blockHeader = Build.A.BlockHeader.TestObject;
+
+        MergeHeaderValidator mergeHeaderValidator = CreateValidator();
+
+        GivenNextBlockIsTerminal();
+        GivenConfiguredTerminalBlockHash(blockHeader.Hash);
+        GivenBaseValidatorAlwaysPass();
+        mergeHeaderValidator.Validate(blockHeader)
+            .Should()
+            .BeTrue();
+    }
+
+    private void GivenNextBlockIsTerminal()
+    {
+        _poSSwitcher.IsPostMerge(Arg.Any<BlockHeader>())
+            .Returns(false);
+        _poSSwitcher.GetBlockConsensusInfo(Arg.Any<BlockHeader>())
+            .Returns((true, false));
+    }
+
+    private void GivenConfiguredTerminalBlockHash(Keccak hash)
+    {
+        _mergeConfig.TerminalBlockHashParsed.Returns(hash);
+    }
+
+    private void GivenBaseValidatorAlwaysPass()
+    {
+        _baseValidator.Validate(Arg.Any<BlockHeader>(), Arg.Any<BlockHeader>()).Returns(true);
+    }
+}

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
@@ -180,6 +180,7 @@ namespace Nethermind.Merge.Plugin
                         _api.BlockTree,
                         _api.SpecProvider,
                         _api.SealValidator,
+                        _mergeConfig,
                         _api.LogManager);
 
                 _api.HeaderValidator = new InvalidHeaderInterceptor(
@@ -329,6 +330,7 @@ namespace Nethermind.Merge.Plugin
                         _api.BlockTree,
                         _api.SpecProvider,
                         _api.SealValidator,
+                        _mergeConfig,
                         _api.LogManager);
 
                 _api.HeaderValidator = new InvalidHeaderInterceptor(

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncServerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncServerTests.cs
@@ -187,7 +187,7 @@ namespace Nethermind.Synchronization.Test
                 testSpecProvider,
                 LimboLogs.Instance);
 
-            MergeHeaderValidator mergeHeaderValidator = new(poSSwitcher, headerValidator, localBlockTree, testSpecProvider, Always.Valid, LimboLogs.Instance);
+            MergeHeaderValidator mergeHeaderValidator = new(poSSwitcher, headerValidator, localBlockTree, testSpecProvider, Always.Valid, new MergeConfig(), LimboLogs.Instance);
             BlockValidator blockValidator = new(
                 Always.Valid,
                 mergeHeaderValidator,
@@ -337,7 +337,7 @@ namespace Nethermind.Synchronization.Test
                 sealEngine,
                 testSpecProvider,
                 LimboLogs.Instance);
-            MergeHeaderValidator mergeHeaderValidator = new(poSSwitcher, headerValidator, localBlockTree, testSpecProvider, Always.Valid, LimboLogs.Instance);
+            MergeHeaderValidator mergeHeaderValidator = new(poSSwitcher, headerValidator, localBlockTree, testSpecProvider, Always.Valid, new MergeConfig(), LimboLogs.Instance);
 
             InvalidChainTracker invalidChainTracker = new(
                 poSSwitcher,


### PR DESCRIPTION
Validate terminal blockhash if explicitly specified.

## Changes:
- Added a validation in HeaderValidator to check if terminal block have the same hash as configured.
- Can't really set a global flag because then it can't suggest a different FcU head to change to a different branch meaning we can't verify it if we are syncing far behind because invalid chain tracker have limited tracking.
 
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

