### PR TITLE
Print PoS banner when terminal block is reached

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin/PoSSwitcher.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/PoSSwitcher.cs
@@ -167,6 +167,30 @@ namespace Nethermind.Merge.Plugin
                 _finalizedBlockHash = finalizedHash;
             }
         }
+        
+        private void PrintPoSBanner(BlockHeader header)
+        {
+            if (!_logger.IsInfo) return;
+
+            _logger.Info("┌──────────────────────────────────────────────────────────────────────────────────────────┐");
+            _logger.Info("│ You have now reached...                                                                  │");
+            _logger.Info("│                   ,,,         ,,,                                                        │");
+            _logger.Info("│                 ;\"   ^;     ;'   \",                                                      │");
+            _logger.Info("│                 ;    s$$$$$$$s     ;   ████████╗             ████████╗                   │");
+            _logger.Info("│                 ,  ss$$$$$$$$$$s  ,'   ██╔════██╗            ██╔═════╝                   │");
+            _logger.Info("│                 ;s$$$$$$$$$$$$$$$      ██║    ██║            ██║                         │");
+            _logger.Info("│                 $$$$$$$$$$$$$$$$$$     ██║    ██║  ███████╗  ██║                         │");
+            _logger.Info("│                $$$$P\"\"Y$$$Y\"\"W$$$$$    ████████╔╝ ██╔════██╗ ████████╗                   │");
+            _logger.Info("│                $$$$  p\"$$$\"q  $$$$$    ██╔═════╝  ██║    ██║ ╚═════██║                   │");
+            _logger.Info("│                $$$$  .$$$$$.  $$$$     ██║        ██║    ██║       ██║                   │");
+            _logger.Info("│                 $$DcaU$$$$$$$$$$       ██║        ██║    ██║       ██║                   │");
+            _logger.Info("│                   \"Y$$$\"*\"$$$Y\"        ██║        ╚███████╔╝ ████████║                   │");
+            _logger.Info("│                       \"$b.$$\"          ╚═╝         ╚══════╝  ╚═══════╝                   │");
+            _logger.Info("│                                                                                          │");
+            _logger.Info($"│ Terminal block number: {header.Number,-33}                                 │");
+            _logger.Info($"│ Terminal block hash: {header.Hash,-65} │");
+            _logger.Info("└──────────────────────────────────────────────────────────────────────────────────────────┘");
+        }
 
         public bool TransitionFinished => FinalTotalDifficulty != null || _finalizedBlockHash != Keccak.Zero;
         


### PR DESCRIPTION
Print PoS banner when terminal block is reached.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing

Synched kiln. Printed the following:
```
2022-06-13 18:54:42.6129|Beacon Headers from block 50001 to block 641075 | 434112 / 591075 | queue 38592 | current     0.00bps | total  5999.93bps 
2022-06-13 18:54:43.6132|Beacon Headers from block 50001 to block 641075 | 434112 / 591075 | queue 38592 | current     0.00bps | total  5918.07bps 
2022-06-13 18:54:43.6729|┌──────────────────────────────────────────────────────────────────────────────────────────┐ 
2022-06-13 18:54:43.6729|│ You have now reached...                                                                  │ 
2022-06-13 18:54:43.6729|│                   ,,,         ,,,                                                        │ 
2022-06-13 18:54:43.6729|│                 ;"   ^;     ;'   ",                                                      │ 
2022-06-13 18:54:43.6729|│                 ;    s$$$$$$$s     ;   ████████╗             ████████╗                   │ 
2022-06-13 18:54:43.6729|│                 ,  ss$$$$$$$$$$s  ,'   ██╔════██╗            ██╔═════╝                   │ 
2022-06-13 18:54:43.6729|│                 ;s$$$$$$$$$$$$$$$      ██║    ██║            ██║                         │ 
2022-06-13 18:54:43.6729|│                 $$$$$$$$$$$$$$$$$$     ██║    ██║  ███████╗  ██║                         │ 
2022-06-13 18:54:43.6729|│                $$$$P""Y$$$Y""W$$$$$    ████████╔╝ ██╔════██╗ ████████╗                   │ 
2022-06-13 18:54:43.6729|│                $$$$  p"$$$"q  $$$$$    ██╔═════╝  ██║    ██║ ╚═════██║                   │ 
2022-06-13 18:54:43.6729|│                $$$$  .$$$$$.  $$$$     ██║        ██║    ██║       ██║                   │ 
2022-06-13 18:54:43.6729|│                 $$DcaU$$$$$$$$$$       ██║        ██║    ██║       ██║                   │ 
2022-06-13 18:54:43.6729|│                   "Y$$$"*"$$$Y"        ██║        ╚███████╔╝ ████████║                   │ 
2022-06-13 18:54:43.6729|│                       "$b.$$"          ╚═╝         ╚══════╝  ╚═══════╝                   │ 
2022-06-13 18:54:43.6729|│                                                                                          │ 
2022-06-13 18:54:43.6729|│ Terminal block number: 55127                                                             │ 
2022-06-13 18:54:43.6729|│ Terminal block hash: 0x0d8429901f32846ee3a6b5765603e38cbcb8507c72a05aaaa681fad1876eba9e  │ 
2022-06-13 18:54:43.6729|└──────────────────────────────────────────────────────────────────────────────────────────┘ 
2022-06-13 18:54:44.6130|Beacon Headers from block 50001 to block 641075 | 434112 / 591075 | queue 38592 | current     0.00bps | total  5838.45bps 
```

## Further comments (optional)

Can't make nethermind logo fit well.