### PR TITLE
Allow replacement of zero fee transactions

### DIFF
--- a/src/Nethermind/Nethermind.TxPool/Comparison/CompareReplacedTxByFee.cs
+++ b/src/Nethermind/Nethermind.TxPool/Comparison/CompareReplacedTxByFee.cs
@@ -41,7 +41,7 @@ namespace Nethermind.TxPool.Comparison
             if (ReferenceEquals(null, x)) return -1;
 
             // always allow replacement of zero fee txs (in legacy txs MaxFeePerGas equals GasPrice)
-            if (y.MaxFeePerGas == UInt256.Zero) return -1;
+            if (y.MaxFeePerGas.IsZero) return -1;
 
             if (!x.IsEip1559 && !y.IsEip1559)
             {

--- a/src/Nethermind/Nethermind.TxPool/Comparison/CompareReplacedTxByFee.cs
+++ b/src/Nethermind/Nethermind.TxPool/Comparison/CompareReplacedTxByFee.cs
@@ -40,6 +40,9 @@ namespace Nethermind.TxPool.Comparison
             if (ReferenceEquals(null, y)) return 1;
             if (ReferenceEquals(null, x)) return -1;
 
+            // always allow replacement of zero fee txs (in legacy txs MaxFeePerGas equals GasPrice)
+            if (y.MaxFeePerGas == UInt256.Zero) return -1;
+
             if (!x.IsEip1559 && !y.IsEip1559)
             {
                 y.GasPrice.Divide(PartOfFeeRequiredToIncrease, out UInt256 bumpGasPrice);


### PR DESCRIPTION
## Changes:
- always allow replacement of zero fee tx

More context: replacement of 0-fee transactions is needed for AuRa whitelisted accounts. Allowing general replacement of 0-fee transactions has much less complexity than loading whitelisted accounts from contract and allowing such replacement only for these accounts.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No