### PR TITLE
Fix overflow exception on decoding due to negative long field

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Encoding/HeaderDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/HeaderDecoderTests.cs
@@ -119,5 +119,22 @@ namespace Nethermind.Core.Test.Encoding
                 HeaderDecoder.Eip1559TransitionBlock = long.MaxValue;
             }
         }
+        
+        [TestCase(-1)]
+        [TestCase(long.MinValue)]
+        public void Can_encode_decode_with_negative_long_fields(long negativeLong)
+        {
+            BlockHeader header = Build.A.BlockHeader.
+                WithNumber(negativeLong).
+                WithGasUsed(negativeLong).
+                WithGasLimit(negativeLong).TestObject;
+            
+            Rlp rlp = Rlp.Encode(header);
+            BlockHeader blockHeader = Rlp.Decode<BlockHeader>(rlp);
+            
+            blockHeader.GasUsed.Should().Be(negativeLong);
+            blockHeader.Number.Should().Be(negativeLong);
+            blockHeader.GasLimit.Should().Be(negativeLong);
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/HeaderDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/HeaderDecoder.cs
@@ -116,9 +116,9 @@ namespace Nethermind.Serialization.Rlp
             Keccak? receiptsRoot = rlpStream.DecodeKeccak();
             Bloom? bloom = rlpStream.DecodeBloom();
             UInt256 difficulty = rlpStream.DecodeUInt256();
-            UInt256 number = rlpStream.DecodeUInt256();
-            UInt256 gasLimit = rlpStream.DecodeUInt256();
-            UInt256 gasUsed = rlpStream.DecodeUInt256();
+            long number = rlpStream.DecodeLong();
+            long gasLimit = rlpStream.DecodeLong();
+            long gasUsed = rlpStream.DecodeLong();
             UInt256 timestamp = rlpStream.DecodeUInt256();
             byte[]? extraData = rlpStream.DecodeByteArray();
 
@@ -127,8 +127,8 @@ namespace Nethermind.Serialization.Rlp
                 unclesHash,
                 beneficiary,
                 difficulty,
-                (long)number,
-                (long)gasLimit,
+                number,
+                gasLimit,
                 timestamp,
                 extraData)
             {
@@ -136,7 +136,7 @@ namespace Nethermind.Serialization.Rlp
                 TxRoot = transactionsRoot,
                 ReceiptsRoot = receiptsRoot,
                 Bloom = bloom,
-                GasUsed = (long)gasUsed,
+                GasUsed = gasUsed,
                 Hash = Keccak.Compute(headerRlp)
             };
 


### PR DESCRIPTION
- Fix overflow error when storing negative long field (like 0xffffffffffffffff which is -1 when interpreted as signed number)

## Changes:
- Decode to long directly

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing

- Added unit test, confirm exception.
- Fix, confirm no excepion.

## Further comments (optional)

- Ideally, the field itself should be changed to ulong, but that seems like a lot of potential issue.