### PR TITLE
Disable snap sync if state has ever been sycned

### DIFF
--- a/src/Nethermind/Nethermind.Runner/configs/goerli.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/goerli.cfg
@@ -14,6 +14,7 @@
   },
   "Sync": {
     "FastSync": true,
+    "SnapSync": true,
     "PivotNumber": 7020000,
     "PivotHash": "0x6a9c8d32cb58fb0966b358896ed73f2ee2d80ea10bc08d3af669349b6e15d10d",
     "PivotTotalDifficulty": "10292996",

--- a/src/Nethermind/Nethermind.Runner/configs/mainnet.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/mainnet.cfg
@@ -11,6 +11,7 @@
   },
   "Sync": {
     "FastSync": true,
+    "SnapSync": true,
     "PivotNumber": 14957000,
     "PivotHash": "0x7ce2c9cb601721e33ee6313e91b30c9f035b74ee282402b5bdfb1095c572acd7",
     "PivotTotalDifficulty": "51613742220579521774353",

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorSnapSyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorSnapSyncTests.cs
@@ -67,5 +67,25 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                 .AndGoodPeersAreKnown()
                 .TheSyncModeShouldBe(GetExpectationsIfNeedToWaitForHeaders(SyncMode.SnapSync | SyncMode.FastHeaders));
         }
+
+        [Test]
+        public void Finished_any_sync_before()
+        {
+            Scenario.GoesLikeThis(_needToWaitForHeaders)
+                .IfThisNodeJustFinishedStateSyncButNeedsToCatchUpToHeaders()
+                .WhenSnapSyncWithFastBlocksIsConfigured()
+                .AndGoodPeersAreKnown()
+                .TheSyncModeShouldBe(SyncMode.StateNodes);
+        }
+
+        [Test]
+        public void Finished_any_sync_far_time_ago()
+        {
+            Scenario.GoesLikeThis(_needToWaitForHeaders)
+                .IfThisNodeJustCameBackFromBeingOfflineForLongTimeAndFinishedFastSyncCatchUp()
+                .WhenSnapSyncWithFastBlocksIsConfigured()
+                .AndGoodPeersAreKnown()
+                .TheSyncModeShouldBe(SyncMode.StateNodes);
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
@@ -64,10 +64,11 @@ namespace Nethermind.Synchronization.ParallelSync
         private readonly IBetterPeerStrategy _betterPeerStrategy;
         private readonly bool _needToWaitForHeaders;
         private readonly ILogger _logger;
+        private readonly bool _isSnapSyncDisabledAfterAnyStateSync;
 
         private readonly long _pivotNumber;
         private bool FastSyncEnabled => _syncConfig.FastSync;
-        private bool SnapSyncEnabled => _syncConfig.SnapSync;
+        private bool SnapSyncEnabled => _syncConfig.SnapSync && !_isSnapSyncDisabledAfterAnyStateSync;
         private bool FastBlocksEnabled => _syncConfig.FastSync && _syncConfig.FastBlocks;
         private bool FastBodiesEnabled => FastBlocksEnabled && _syncConfig.DownloadBodiesInFastSync;
         private bool FastReceiptsEnabled => FastBlocksEnabled && _syncConfig.DownloadReceiptsInFastSync;
@@ -110,8 +111,9 @@ namespace Nethermind.Synchronization.ParallelSync
             }
 
             _pivotNumber = _syncConfig.PivotNumberParsed;
+            _isSnapSyncDisabledAfterAnyStateSync = _syncProgressResolver.FindBestFullState() != 0;
 
-            _timer = StartUpdateTimer();
+            _timer = StartUpdateTimer();           
         }
 
         private Timer StartUpdateTimer()


### PR DESCRIPTION
Resolves #4108


## Changes:
- Enable SnapSync for mainnet and goerly by default
- Disable snap sync if the node has been already fully synced before

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No

Manual testing should cover:

- [ ] Load the state without snapsync, turn off the node, enable SnapSync, run again. SnapSync should not run

