### PR TITLE
Add validation for wrong field range

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/HeaderValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/HeaderValidatorTests.cs
@@ -258,5 +258,35 @@ namespace Nethermind.Blockchain.Test.Validators
             
             Assert.True(result);
         }
+        
+        [Test]
+        public void When_block_number_is_negative()
+        {
+            _block.Header.Number = -1;
+            _block.Header.Hash = _block.CalculateHash();
+            
+            bool result = _validator.Validate(_block.Header);
+            Assert.False(result);
+        }
+        
+        [Test]
+        public void When_gas_used_is_negative()
+        {
+            _block.Header.GasUsed = -1;
+            _block.Header.Hash = _block.CalculateHash();
+            
+            bool result = _validator.Validate(_block.Header);
+            Assert.False(result);
+        }
+        
+        [Test]
+        public void When_gas_limit_is_negative()
+        {
+            _block.Header.GasLimit = -1;
+            _block.Header.Hash = _block.CalculateHash();
+            
+            bool result = _validator.Validate(_block.Header);
+            Assert.False(result);
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Consensus/Validators/HeaderValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/HeaderValidator.cs
@@ -63,6 +63,11 @@ namespace Nethermind.Consensus.Validators
         /// <returns></returns>
         public virtual bool Validate(BlockHeader header, BlockHeader? parent, bool isUncle = false)
         {
+            if (!ValidateFieldLimit(header))
+            {
+                return false;
+            }
+            
             bool hashAsExpected = ValidateHash(header);
             
             if (!hashAsExpected)
@@ -148,6 +153,30 @@ namespace Nethermind.Consensus.Validators
                 extraDataValid &&
                 eip1559Valid;
         }
+
+        private bool ValidateFieldLimit(BlockHeader blockHeader)
+        {
+            if (blockHeader.Number < 0)
+            {
+                if (_logger.IsWarn) _logger.Warn($"Invalid block header ({blockHeader.Hash}) - Block number is negative {blockHeader.Number}");
+                return false;
+            }
+            
+            if (blockHeader.GasLimit < 0)
+            {
+                if (_logger.IsWarn) _logger.Warn($"Invalid block header ({blockHeader.Hash}) - Block GasLimit is negative {blockHeader.GasLimit}");
+                return false;
+            }
+            
+            if (blockHeader.GasUsed < 0)
+            {
+                if (_logger.IsWarn) _logger.Warn($"Invalid block header ({blockHeader.Hash}) - Block GasUsed is negative {blockHeader.GasUsed}");
+                return false;
+            }
+
+            return true;
+        }
+        
         protected virtual bool ValidateExtraData(BlockHeader header, BlockHeader? parent, IReleaseSpec spec, bool isUncle = false)
         {
             bool extraDataValid =  header.ExtraData.Length <= spec.MaximumExtraDataSize

--- a/src/Nethermind/Nethermind.Consensus/Validators/HeaderValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/HeaderValidator.cs
@@ -156,6 +156,9 @@ namespace Nethermind.Consensus.Validators
 
         private bool ValidateFieldLimit(BlockHeader blockHeader)
         {
+            // Note, these are out of spec. Technically, there could be a block with field with very high value that is
+            // valid when using ulong, but wrapped to negative value when using long. However, switching to ulong
+            // at this point can cause other unexpected error. So we just won't support it for now.
             if (blockHeader.Number < 0)
             {
                 if (_logger.IsWarn) _logger.Warn($"Invalid block header ({blockHeader.Hash}) - Block number is negative {blockHeader.Number}");


### PR DESCRIPTION
Fixes  #4050

## Changes:
- Added validation for when long field in header that is not expected to be negative is set to negative. Not 

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing

- Kiln can sync.