### PR TITLE
Add `Rpc` rpc modules

### DIFF
--- a/src/Nethermind/Nethermind.Init/Steps/RegisterRpcModules.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/RegisterRpcModules.cs
@@ -43,6 +43,7 @@ using Nethermind.JsonRpc.Modules.Witness;
 using Nethermind.Logging;
 using Nethermind.Network.Config;
 using Nethermind.JsonRpc.Modules.Eth.FeeHistory;
+using Nethermind.JsonRpc.Modules.Rpc;
 
 namespace Nethermind.Init.Steps
 {
@@ -231,6 +232,9 @@ namespace Nethermind.Init.Steps
                 await plugin.InitRpcModules();
             }
             
+            RpcRpcModule rpcRpcModule = new(rpcModuleProvider.Enabled.ToList());
+            rpcModuleProvider.RegisterSingle<IRpcRpcModule>(rpcRpcModule);
+
             if (logger.IsDebug) logger.Debug($"RPC modules  : {string.Join(", ", rpcModuleProvider.Enabled.OrderBy(x => x))}");
             ThisNodeInfo.AddInfo("RPC modules  :", $"{string.Join(", ", rpcModuleProvider.Enabled.OrderBy(x => x))}");
         }

--- a/src/Nethermind/Nethermind.Init/Steps/RegisterRpcModules.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/RegisterRpcModules.cs
@@ -232,7 +232,7 @@ namespace Nethermind.Init.Steps
                 await plugin.InitRpcModules();
             }
             
-            RpcRpcModule rpcRpcModule = new(rpcModuleProvider.Enabled.ToList());
+            RpcRpcModule rpcRpcModule = new(rpcModuleProvider.Enabled);
             rpcModuleProvider.RegisterSingle<IRpcRpcModule>(rpcRpcModule);
 
             if (logger.IsDebug) logger.Debug($"RPC modules  : {string.Join(", ", rpcModuleProvider.Enabled.OrderBy(x => x))}");

--- a/src/Nethermind/Nethermind.JsonRpc/IJsonRpcConfig.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/IJsonRpcConfig.cs
@@ -63,7 +63,7 @@ namespace Nethermind.JsonRpc
 
         [ConfigItem(
             Description = "Defines which RPC modules should be enabled. Built in modules are: Admin, Baseline, Clique, Consensus, Db, Debug, Deposit, Erc20, Eth, Evm, Health Mev, NdmConsumer, NdmProvider, Net, Nft, Parity, Personal, Proof, Subscribe, Trace, TxPool, Vault, Web3.",
-            DefaultValue = "[Eth, Subscribe, Trace, TxPool, Web3, Personal, Proof, Net, Parity, Health]")]
+            DefaultValue = "[Eth, Subscribe, Trace, TxPool, Web3, Personal, Proof, Net, Parity, Health, Rpc]")]
         string[] EnabledModules { get; set; }
 
         [ConfigItem(

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Module/IRpcRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Module/IRpcRpcModule.cs
@@ -1,0 +1,29 @@
+//  Copyright (c) 2021 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Nethermind.JsonRpc.Modules.Rpc;
+
+[RpcModule(ModuleType.Rpc)]
+public interface IRpcRpcModule: IRpcModule
+{
+    [JsonRpcMethod(Description = "Retrieves a list of modules.", IsImplemented = true, IsSharable = true)]
+    ResultWrapper<IDictionary<String, String>> rpc_modules();
+}

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Module/RpcRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Module/RpcRpcModule.cs
@@ -1,0 +1,42 @@
+//  Copyright (c) 2021 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Nethermind.JsonRpc.Modules.Rpc;
+
+/// Replicate https://github.com/ethereum/go-ethereum/blob/4860e50e057b0fb0fa7ff9672fcdd737ac137d1c/rpc/server.go#L139
+/// so that `geth attach` would work with nethermind. Redundant name, but consistent with other module.
+public class RpcRpcModule: IRpcRpcModule
+{
+    private readonly List<String> _enabledModules;
+
+    public RpcRpcModule(List<String> enabledModules)
+    {
+        _enabledModules = enabledModules;
+    }
+    
+    public ResultWrapper<IDictionary<string, string>> rpc_modules()
+    {
+        // Geth seems to fix version at 1.0t 
+        IDictionary<string, string> response = _enabledModules.ToDictionary((s => s), s => "1.0");
+        
+        return ResultWrapper<IDictionary<string, string>>.Success(response);
+    }
+}

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Module/RpcRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Module/RpcRpcModule.cs
@@ -29,8 +29,8 @@ public class RpcRpcModule: IRpcRpcModule
 
     public RpcRpcModule(IReadOnlyCollection<string> enabledModules)
     {
-        // Geth seems to fix version at 1.0t 
-        _enabledModules = enabledModules.ToDictionary((s => s), s => "1.0");;
+        // Geth seems to fix version at 1.0
+        _enabledModules = enabledModules.ToDictionary((s => s), s => "1.0");
     }
     
     public ResultWrapper<IDictionary<string, string>> rpc_modules()

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Module/RpcRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Module/RpcRpcModule.cs
@@ -25,18 +25,16 @@ namespace Nethermind.JsonRpc.Modules.Rpc;
 /// so that `geth attach` would work with nethermind. Redundant name, but consistent with other module.
 public class RpcRpcModule: IRpcRpcModule
 {
-    private readonly List<String> _enabledModules;
+    private readonly IDictionary<string, string> _enabledModules;
 
-    public RpcRpcModule(List<String> enabledModules)
+    public RpcRpcModule(IReadOnlyCollection<string> enabledModules)
     {
-        _enabledModules = enabledModules;
+        // Geth seems to fix version at 1.0t 
+        _enabledModules = enabledModules.ToDictionary((s => s), s => "1.0");;
     }
     
     public ResultWrapper<IDictionary<string, string>> rpc_modules()
     {
-        // Geth seems to fix version at 1.0t 
-        IDictionary<string, string> response = _enabledModules.ToDictionary((s => s), s => "1.0");
-        
-        return ResultWrapper<IDictionary<string, string>>.Success(response);
+        return ResultWrapper<IDictionary<string, string>>.Success(_enabledModules);
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/ModuleType.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/ModuleType.cs
@@ -47,6 +47,7 @@ namespace Nethermind.JsonRpc.Modules
         public const string Health= nameof(Health);
         public const string Witness = nameof(Witness);
         public const string AccountAbstraction = nameof(AccountAbstraction);
+        public const string Rpc = nameof(Rpc);
         
         public static IEnumerable<string> AllBuiltInModules { get; } = new List<string>()
         {
@@ -89,7 +90,8 @@ namespace Nethermind.JsonRpc.Modules
             Proof, 
             Net,
             Parity,
-            Health
+            Health,
+            Rpc
         };
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/ModuleType.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/ModuleType.cs
@@ -76,7 +76,8 @@ namespace Nethermind.JsonRpc.Modules
             Deposit,
             Health,
             Witness,
-            AccountAbstraction
+            AccountAbstraction,
+            Rpc,
         };
 
         public static IEnumerable<string> DefaultModules { get; } = new List<string>()
@@ -91,7 +92,7 @@ namespace Nethermind.JsonRpc.Modules
             Net,
             Parity,
             Health,
-            Rpc
+            Rpc,
         };
     }
 }


### PR DESCRIPTION
Closes #3972

Replicate geth's `rpc_modules` command. so that `geth attach` would work.

## Changes:
- Add `RpcRpcModule`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing

- Call method, got
```
{'jsonrpc': '2.0', 'result': {'eth': '1.0', 'proof': '1.0', 'debug': '1.0', 'trace': '1.0', 'personal': '1.0', 'txPool': '1.0', 'net': '1.0', 'parity': '1.0', 'subscribe': '1.0', 'web3': '1.0'}, 'id': 12}
```
- Specify ipc port to `~/.ethereum/geth.ipc`, run `get attach`, call `eth.getBlockByNumber(1)`, seems to return a block.

## Further comments (optional)

`Rpc` module is not turned on by default on most config.