### PR TITLE
Bugfix/add mt reads of lrpstream

### DIFF
--- a/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
@@ -505,8 +505,8 @@ namespace Nethermind.Trie.Test
         {
             TrieNode node = new(NodeType.Branch);
             TrieNode randomTrieNode = new(NodeType.Leaf);
-            randomTrieNode.Key = new HexPrefix(true, new byte[] {1, 2, 3});
-            randomTrieNode.Value = new byte[] {1, 2, 3};
+            randomTrieNode.Key = new HexPrefix(true, new byte[] { 1, 2, 3 });
+            randomTrieNode.Value = new byte[] { 1, 2, 3 };
             for (int i = 0; i < 16; i++)
             {
                 node.SetChild(i, randomTrieNode);
@@ -517,6 +517,25 @@ namespace Nethermind.Trie.Test
             TrieNode restoredNode = new(NodeType.Branch, rlp);
 
             restoredNode.RlpEncode(NullTrieNodeResolver.Instance);
+        }
+
+        [Test]
+        public void Can_parallel_read_unresolved_children()
+        {
+            TrieNode node = new(NodeType.Branch);
+            for (int i = 0; i < 16; i++)
+            {
+                TrieNode randomTrieNode = new(NodeType.Leaf);
+                randomTrieNode.Key = new HexPrefix(true, new byte[] { (byte)i, 2, 3 });
+                randomTrieNode.Value = new byte[] { 1, 2, 3 };
+                node.SetChild(i, randomTrieNode);
+            }
+
+            byte[] rlp = node.RlpEncode(NullTrieNodeResolver.Instance);
+
+            TrieNode restoredNode = new(NodeType.Branch, rlp);
+
+            Parallel.For(0, 32, (index,_) => restoredNode.GetChild(NullTrieNodeResolver.Instance, index % 3));
         }
 
         [Test]


### PR DESCRIPTION
Resolves #3958

## Changes:
- Add RlpStream parallel reader concept

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No

## Further comments (optional)

RlpStream.UnsafeReader has been introduced. It allows to read the same stream from multiple threads. No write protection is implemented. This is a partial implementation that covers just GetChild method.
