### PR TITLE
Add witness for StateProvider only

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
@@ -101,59 +101,65 @@ namespace Nethermind.Consensus.Processing
             bool readOnly = (options & ProcessingOptions.ReadOnlyChain) != 0;
             int blocksCount = suggestedBlocks.Count;
             Block[] processedBlocks = new Block[blocksCount];
-            try
+            using (_witnessCollector.Track())
             {
-                for (int i = 0; i < blocksCount; i++)
+                try
                 {
-                    if (blocksCount > 64 && i % 8 == 0)
+                    for (int i = 0; i < blocksCount; i++)
                     {
-                        if(_logger.IsInfo) _logger.Info($"Processing part of a long blocks branch {i}/{blocksCount}. Block: {suggestedBlocks[i]}");
+                        if (blocksCount > 64 && i % 8 == 0)
+                        {
+                            if (_logger.IsInfo)
+                                _logger.Info(
+                                    $"Processing part of a long blocks branch {i}/{blocksCount}. Block: {suggestedBlocks[i]}");
+                        }
+
+                        _witnessCollector.Reset();
+                        (Block processedBlock, TxReceipt[] receipts) =
+                            ProcessOne(suggestedBlocks[i], options, blockTracer);
+                        processedBlocks[i] = processedBlock;
+
+                        // be cautious here as AuRa depends on processing
+                        PreCommitBlock(newBranchStateRoot, suggestedBlocks[i].Number);
+                        if (!readOnly)
+                        {
+                            _witnessCollector.Persist(processedBlock.Hash!);
+                            BlockProcessed?.Invoke(this, new BlockProcessedEventArgs(processedBlock, receipts));
+                        }
+
+                        // CommitBranch in parts if we have long running branch
+                        bool isFirstInBatch = i == 0;
+                        bool isLastInBatch = i == blocksCount - 1;
+                        bool isNotAtTheEdge = !isFirstInBatch && !isLastInBatch;
+                        bool isCommitPoint = i % MaxUncommittedBlocks == 0 && isNotAtTheEdge;
+                        if (isCommitPoint && readOnly == false)
+                        {
+                            if (_logger.IsInfo) _logger.Info($"Commit part of a long blocks branch {i}/{blocksCount}");
+                            CommitBranch();
+                            previousBranchStateRoot = CreateCheckpoint();
+                            Keccak? newStateRoot = suggestedBlocks[i].StateRoot;
+                            InitBranch(newStateRoot, false);
+                        }
                     }
 
-                    _witnessCollector.Reset();
-                    (Block processedBlock, TxReceipt[] receipts) = ProcessOne(suggestedBlocks[i], options, blockTracer);
-                    processedBlocks[i] = processedBlock;
-
-                    // be cautious here as AuRa depends on processing
-                    PreCommitBlock(newBranchStateRoot, suggestedBlocks[i].Number);
-                    if (!readOnly)
+                    if (readOnly)
                     {
-                        _witnessCollector.Persist(processedBlock.Hash!);
-                        BlockProcessed?.Invoke(this, new BlockProcessedEventArgs(processedBlock, receipts));
+                        RestoreBranch(previousBranchStateRoot);
                     }
-
-                    // CommitBranch in parts if we have long running branch
-                    bool isFirstInBatch = i == 0;
-                    bool isLastInBatch = i == blocksCount - 1;
-                    bool isNotAtTheEdge = !isFirstInBatch && !isLastInBatch;
-                    bool isCommitPoint = i % MaxUncommittedBlocks == 0 && isNotAtTheEdge;
-                    if (isCommitPoint && readOnly == false)
+                    else
                     {
-                        if (_logger.IsInfo) _logger.Info($"Commit part of a long blocks branch {i}/{blocksCount}");
+                        // TODO: move to branch processor
                         CommitBranch();
-                        previousBranchStateRoot = CreateCheckpoint();
-                        Keccak? newStateRoot = suggestedBlocks[i].StateRoot;
-                        InitBranch(newStateRoot, false);
                     }
-                }
 
-                if (readOnly)
+                    return processedBlocks;
+                }
+                catch (Exception ex) // try to restore for all cost
                 {
+                    _logger.Trace($"Encountered exception {ex} while processing blocks.");
                     RestoreBranch(previousBranchStateRoot);
+                    throw;
                 }
-                else
-                {
-                    // TODO: move to branch processor
-                    CommitBranch();
-                }
-
-                return processedBlocks;
-            }
-            catch (Exception ex) // try to restore for all cost
-            {
-                _logger.Trace($"Encountered exception {ex} while processing blocks.");
-                RestoreBranch(previousBranchStateRoot);
-                throw;
             }
         }
 

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/WitnessModuleRpcTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/WitnessModuleRpcTests.cs
@@ -63,14 +63,13 @@ namespace Nethermind.JsonRpc.Test.Modules
         {
             _blockFinder.FindHeader((BlockParameter)null).ReturnsForAnyArgs(_block.Header);
             _blockFinder.Head.Returns(_block);
-            using (_witnessRepository.Track())
+            using (_witnessRepository.TrackOnThisThread())
             {
                 _witnessRepository.Add(_block.Hash);
                 _witnessRepository.Persist(_block.Hash);
             }
 
-            string serialized =
-                RpcTest.TestSerializedRequest<IWitnessRpcModule>(_witnessRpcModule, "get_witnesses", _block.CalculateHash().ToString());
+            string serialized = RpcTest.TestSerializedRequest<IWitnessRpcModule>(_witnessRpcModule, "get_witnesses", _block.CalculateHash().ToString());
             serialized.Should().Be(GetOneWitnessHashResponse);
         }
 

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/WitnessModuleRpcTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/WitnessModuleRpcTests.cs
@@ -63,9 +63,11 @@ namespace Nethermind.JsonRpc.Test.Modules
         {
             _blockFinder.FindHeader((BlockParameter)null).ReturnsForAnyArgs(_block.Header);
             _blockFinder.Head.Returns(_block);
-
-            _witnessRepository.Add(_block.Hash);
-            _witnessRepository.Persist(_block.Hash);
+            using (_witnessRepository.Track())
+            {
+                _witnessRepository.Add(_block.Hash);
+                _witnessRepository.Persist(_block.Hash);
+            }
 
             string serialized =
                 RpcTest.TestSerializedRequest<IWitnessRpcModule>(_witnessRpcModule, "get_witnesses", _block.CalculateHash().ToString());

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/WitnessModuleRpcTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/WitnessModuleRpcTests.cs
@@ -15,6 +15,7 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 // 
 
+using System;
 using FluentAssertions;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Find;
@@ -63,11 +64,10 @@ namespace Nethermind.JsonRpc.Test.Modules
         {
             _blockFinder.FindHeader((BlockParameter)null).ReturnsForAnyArgs(_block.Header);
             _blockFinder.Head.Returns(_block);
-            using (_witnessRepository.TrackOnThisThread())
-            {
-                _witnessRepository.Add(_block.Hash);
-                _witnessRepository.Persist(_block.Hash);
-            }
+            
+            using IDisposable tracker = _witnessRepository.TrackOnThisThread();
+            _witnessRepository.Add(_block.Hash);
+            _witnessRepository.Persist(_block.Hash);
 
             string serialized = RpcTest.TestSerializedRequest<IWitnessRpcModule>(_witnessRpcModule, "get_witnesses", _block.CalculateHash().ToString());
             serialized.Should().Be(GetOneWitnessHashResponse);

--- a/src/Nethermind/Nethermind.State.Test/Witnesses/WitnessCollectorTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/Witnesses/WitnessCollectorTests.cs
@@ -35,7 +35,7 @@ namespace Nethermind.Store.Test.Witnesses
         {
             WitnessCollector witnessCollector = new(new MemDb(), LimboLogs.Instance);
             
-            using (witnessCollector.Track())
+            using (witnessCollector.TrackOnThisThread())
             {
                 witnessCollector.Add(Keccak.Zero);
                 witnessCollector.Add(Keccak.Zero);
@@ -48,7 +48,7 @@ namespace Nethermind.Store.Test.Witnesses
         public void Can_collect_many()
         {
             WitnessCollector witnessCollector = new(new MemDb(), LimboLogs.Instance);
-            using (witnessCollector.Track())
+            using (witnessCollector.TrackOnThisThread())
             {
                 witnessCollector.Add(TestItem.KeccakA);
                 witnessCollector.Add(TestItem.KeccakB);
@@ -62,7 +62,7 @@ namespace Nethermind.Store.Test.Witnesses
         {
             WitnessCollector witnessCollector = new(new MemDb(), LimboLogs.Instance);
             
-            using (witnessCollector.Track())
+            using (witnessCollector.TrackOnThisThread())
             {
                 witnessCollector.Add(TestItem.KeccakA);
                 witnessCollector.Add(TestItem.KeccakB);
@@ -77,7 +77,7 @@ namespace Nethermind.Store.Test.Witnesses
         {
             WitnessCollector witnessCollector = new(new MemDb(), LimboLogs.Instance);
 
-            using (witnessCollector.Track())
+            using (witnessCollector.TrackOnThisThread())
             {
                 witnessCollector.Add(TestItem.KeccakA);
                 witnessCollector.Add(TestItem.KeccakB);
@@ -92,7 +92,7 @@ namespace Nethermind.Store.Test.Witnesses
         public void Collects_what_it_should_collect()
         {
             WitnessCollector witnessCollector = new(new MemDb(), LimboLogs.Instance);
-            using (witnessCollector.Track())
+            using (witnessCollector.TrackOnThisThread())
             {
                 witnessCollector.Add(TestItem.KeccakA);
                 witnessCollector.Add(TestItem.KeccakB);
@@ -106,7 +106,7 @@ namespace Nethermind.Store.Test.Witnesses
         public void Can_reset_empty()
         {
             WitnessCollector witnessCollector = new(new MemDb(), LimboLogs.Instance);
-            using (witnessCollector.Track())
+            using (witnessCollector.TrackOnThisThread())
             {
                 witnessCollector.Reset();
             }
@@ -118,7 +118,7 @@ namespace Nethermind.Store.Test.Witnesses
         public void Can_reset_empty_many_times()
         {
             WitnessCollector witnessCollector = new(new MemDb(), LimboLogs.Instance);
-            using (witnessCollector.Track())
+            using (witnessCollector.TrackOnThisThread())
             {
                 witnessCollector.Reset();
                 witnessCollector.Reset();
@@ -132,7 +132,7 @@ namespace Nethermind.Store.Test.Witnesses
         public void Can_reset_non_empty_many_times()
         {
             WitnessCollector witnessCollector = new(new MemDb(), LimboLogs.Instance);
-            using (witnessCollector.Track())
+            using (witnessCollector.TrackOnThisThread())
             {
                 witnessCollector.Add(TestItem.KeccakA);
                 witnessCollector.Reset();
@@ -160,7 +160,7 @@ namespace Nethermind.Store.Test.Witnesses
         {
             IKeyValueStore keyValueStore = new MemDb();
             WitnessCollector witnessCollector = new(keyValueStore, LimboLogs.Instance);
-            using (witnessCollector.Track())
+            using (witnessCollector.TrackOnThisThread())
             {
                 witnessCollector.Add(TestItem.KeccakA);
                 witnessCollector.Add(TestItem.KeccakB);
@@ -177,7 +177,7 @@ namespace Nethermind.Store.Test.Witnesses
             IKeyValueStore keyValueStore = new MemDb();
             WitnessCollector witnessCollector = new(keyValueStore, LimboLogs.Instance);
             
-            using (witnessCollector.Track())
+            using (witnessCollector.TrackOnThisThread())
             {
                 witnessCollector.Add(TestItem.KeccakA);
                 witnessCollector.Add(TestItem.KeccakB);

--- a/src/Nethermind/Nethermind.State.Test/Witnesses/WitnessCollectorTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/Witnesses/WitnessCollectorTests.cs
@@ -34,8 +34,13 @@ namespace Nethermind.Store.Test.Witnesses
         public void Collects_each_cache_once()
         {
             WitnessCollector witnessCollector = new(new MemDb(), LimboLogs.Instance);
-            witnessCollector.Add(Keccak.Zero);
-            witnessCollector.Add(Keccak.Zero);
+            
+            using (witnessCollector.Track())
+            {
+                witnessCollector.Add(Keccak.Zero);
+                witnessCollector.Add(Keccak.Zero);
+            }
+
             witnessCollector.Collected.Should().HaveCount(1);
         }
         
@@ -43,8 +48,12 @@ namespace Nethermind.Store.Test.Witnesses
         public void Can_collect_many()
         {
             WitnessCollector witnessCollector = new(new MemDb(), LimboLogs.Instance);
-            witnessCollector.Add(TestItem.KeccakA);
-            witnessCollector.Add(TestItem.KeccakB);
+            using (witnessCollector.Track())
+            {
+                witnessCollector.Add(TestItem.KeccakA);
+                witnessCollector.Add(TestItem.KeccakB);
+            }
+
             witnessCollector.Collected.Should().HaveCount(2);
         }
         
@@ -52,9 +61,14 @@ namespace Nethermind.Store.Test.Witnesses
         public void Can_reset()
         {
             WitnessCollector witnessCollector = new(new MemDb(), LimboLogs.Instance);
-            witnessCollector.Add(TestItem.KeccakA);
-            witnessCollector.Add(TestItem.KeccakB);
-            witnessCollector.Reset();
+            
+            using (witnessCollector.Track())
+            {
+                witnessCollector.Add(TestItem.KeccakA);
+                witnessCollector.Add(TestItem.KeccakB);
+                witnessCollector.Reset();
+            }
+
             witnessCollector.Collected.Should().HaveCount(0);
         }
         
@@ -62,10 +76,15 @@ namespace Nethermind.Store.Test.Witnesses
         public void Can_collect_after_reset()
         {
             WitnessCollector witnessCollector = new(new MemDb(), LimboLogs.Instance);
-            witnessCollector.Add(TestItem.KeccakA);
-            witnessCollector.Add(TestItem.KeccakB);
-            witnessCollector.Reset();
-            witnessCollector.Add(TestItem.KeccakC);
+
+            using (witnessCollector.Track())
+            {
+                witnessCollector.Add(TestItem.KeccakA);
+                witnessCollector.Add(TestItem.KeccakB);
+                witnessCollector.Reset();
+                witnessCollector.Add(TestItem.KeccakC);
+            }
+
             witnessCollector.Collected.Should().HaveCount(1);
         }
         
@@ -73,8 +92,12 @@ namespace Nethermind.Store.Test.Witnesses
         public void Collects_what_it_should_collect()
         {
             WitnessCollector witnessCollector = new(new MemDb(), LimboLogs.Instance);
-            witnessCollector.Add(TestItem.KeccakA);
-            witnessCollector.Add(TestItem.KeccakB);
+            using (witnessCollector.Track())
+            {
+                witnessCollector.Add(TestItem.KeccakA);
+                witnessCollector.Add(TestItem.KeccakB);
+            }
+
             witnessCollector.Collected.Should().Contain(TestItem.KeccakA);
             witnessCollector.Collected.Should().Contain(TestItem.KeccakB);
         }
@@ -83,7 +106,11 @@ namespace Nethermind.Store.Test.Witnesses
         public void Can_reset_empty()
         {
             WitnessCollector witnessCollector = new(new MemDb(), LimboLogs.Instance);
-            witnessCollector.Reset();
+            using (witnessCollector.Track())
+            {
+                witnessCollector.Reset();
+            }
+
             witnessCollector.Collected.Should().HaveCount(0);
         }
         
@@ -91,9 +118,13 @@ namespace Nethermind.Store.Test.Witnesses
         public void Can_reset_empty_many_times()
         {
             WitnessCollector witnessCollector = new(new MemDb(), LimboLogs.Instance);
-            witnessCollector.Reset();
-            witnessCollector.Reset();
-            witnessCollector.Reset();
+            using (witnessCollector.Track())
+            {
+                witnessCollector.Reset();
+                witnessCollector.Reset();
+                witnessCollector.Reset();
+            }
+
             witnessCollector.Collected.Should().HaveCount(0);
         }
         
@@ -101,12 +132,16 @@ namespace Nethermind.Store.Test.Witnesses
         public void Can_reset_non_empty_many_times()
         {
             WitnessCollector witnessCollector = new(new MemDb(), LimboLogs.Instance);
-            witnessCollector.Add(TestItem.KeccakA);
-            witnessCollector.Reset();
-            witnessCollector.Add(TestItem.KeccakA);
-            witnessCollector.Reset();
-            witnessCollector.Add(TestItem.KeccakA);
-            witnessCollector.Reset();
+            using (witnessCollector.Track())
+            {
+                witnessCollector.Add(TestItem.KeccakA);
+                witnessCollector.Reset();
+                witnessCollector.Add(TestItem.KeccakA);
+                witnessCollector.Reset();
+                witnessCollector.Add(TestItem.KeccakA);
+                witnessCollector.Reset();
+            }
+
             witnessCollector.Collected.Should().HaveCount(0);
         }
         
@@ -125,9 +160,13 @@ namespace Nethermind.Store.Test.Witnesses
         {
             IKeyValueStore keyValueStore = new MemDb();
             WitnessCollector witnessCollector = new(keyValueStore, LimboLogs.Instance);
-            witnessCollector.Add(TestItem.KeccakA);
-            witnessCollector.Add(TestItem.KeccakB);
-            witnessCollector.Persist(Keccak.Zero);
+            using (witnessCollector.Track())
+            {
+                witnessCollector.Add(TestItem.KeccakA);
+                witnessCollector.Add(TestItem.KeccakB);
+                witnessCollector.Persist(Keccak.Zero);
+            }
+
             var witness = keyValueStore[Keccak.Zero.Bytes];
             witness.Length.Should().Be(64);
         }
@@ -137,9 +176,14 @@ namespace Nethermind.Store.Test.Witnesses
         {
             IKeyValueStore keyValueStore = new MemDb();
             WitnessCollector witnessCollector = new(keyValueStore, LimboLogs.Instance);
-            witnessCollector.Add(TestItem.KeccakA);
-            witnessCollector.Add(TestItem.KeccakB);
-            witnessCollector.Persist(Keccak.Zero);
+            
+            using (witnessCollector.Track())
+            {
+                witnessCollector.Add(TestItem.KeccakA);
+                witnessCollector.Add(TestItem.KeccakB);
+                witnessCollector.Persist(Keccak.Zero);
+            }
+
             var witness = witnessCollector.Load(Keccak.Zero);
             witness.Should().HaveCount(2);
         }

--- a/src/Nethermind/Nethermind.State.Test/Witnesses/WitnessingStoreTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/Witnesses/WitnessingStoreTests.cs
@@ -38,10 +38,22 @@ namespace Nethermind.Store.Test.Witnesses
         {
             Context context = new();
             context.Wrapped[Key1].Returns(Value1);
-            _ = context.Database[Key1];
+            using (context.WitnessCollector.Track())
+            {
+                _ = context.Database[Key1];
+            }
             context.WitnessCollector.Collected.Should().HaveCount(1);
         }
         
+        [Test]
+        public void Does_not_collect_if_no_tracking()
+        {
+            Context context = new();
+            context.Wrapped[Key1].Returns(Value1);
+            _ = context.Database[Key1];
+            context.WitnessCollector.Collected.Should().HaveCount(0);
+        }
+
         [Test]
         public void Collects_on_reads_when_cached_underneath()
         {
@@ -49,14 +61,24 @@ namespace Nethermind.Store.Test.Witnesses
             context.Wrapped[Key1].Returns(Value1);
             context.Wrapped[Key2].Returns(Value2);
             context.Wrapped[Key3].Returns(Value3);
-            _ = context.Database[Key1];
-            _ = context.Database[Key2];
-            _ = context.Database[Key3];
+            
+            using (context.WitnessCollector.Track())
+            {
+                _ = context.Database[Key1];
+                _ = context.Database[Key2];
+                _ = context.Database[Key3];
+            }
+
             context.WitnessCollector.Collected.Should().HaveCount(3);
-            context.WitnessCollector.Reset();
-            _ = context.Database[Key1];
-            _ = context.Database[Key2];
-            _ = context.Database[Key3];
+            
+            using (context.WitnessCollector.Track())
+            {
+                context.WitnessCollector.Reset();
+                _ = context.Database[Key1];
+                _ = context.Database[Key2];
+                _ = context.Database[Key3];
+            }
+
             context.WitnessCollector.Collected.Should().HaveCount(3);
         }
         
@@ -64,13 +86,17 @@ namespace Nethermind.Store.Test.Witnesses
         public void Collects_on_reads_when_cached_underneath_and_previously_populated()
         {
             Context context = new(3);
-            context.Database[Key1] = Value1;
-            context.Database[Key2] = Value1;
-            context.Database[Key3] = Value1;
-            context.WitnessCollector.Collected.Should().HaveCount(0);
-            _ = context.Database[Key1];
-            _ = context.Database[Key2];
-            _ = context.Database[Key3];
+            using (context.WitnessCollector.Track())
+            {
+                context.Database[Key1] = Value1;
+                context.Database[Key2] = Value1;
+                context.Database[Key3] = Value1;
+                context.WitnessCollector.Collected.Should().HaveCount(0);
+                _ = context.Database[Key1];
+                _ = context.Database[Key2];
+                _ = context.Database[Key3];
+            }
+
             context.WitnessCollector.Collected.Should().HaveCount(3);
         }
         

--- a/src/Nethermind/Nethermind.State.Test/Witnesses/WitnessingStoreTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/Witnesses/WitnessingStoreTests.cs
@@ -38,10 +38,10 @@ namespace Nethermind.Store.Test.Witnesses
         {
             Context context = new();
             context.Wrapped[Key1].Returns(Value1);
-            using (context.WitnessCollector.TrackOnThisThread())
-            {
-                _ = context.Database[Key1];
-            }
+            
+            using IDisposable tracker = context.WitnessCollector.TrackOnThisThread();
+            _ = context.Database[Key1];
+            
             context.WitnessCollector.Collected.Should().HaveCount(1);
         }
         
@@ -62,22 +62,17 @@ namespace Nethermind.Store.Test.Witnesses
             context.Wrapped[Key2].Returns(Value2);
             context.Wrapped[Key3].Returns(Value3);
             
-            using (context.WitnessCollector.TrackOnThisThread())
-            {
-                _ = context.Database[Key1];
-                _ = context.Database[Key2];
-                _ = context.Database[Key3];
-            }
+            using IDisposable tracker = context.WitnessCollector.TrackOnThisThread();
+            _ = context.Database[Key1];
+            _ = context.Database[Key2];
+            _ = context.Database[Key3];
 
             context.WitnessCollector.Collected.Should().HaveCount(3);
             
-            using (context.WitnessCollector.TrackOnThisThread())
-            {
-                context.WitnessCollector.Reset();
-                _ = context.Database[Key1];
-                _ = context.Database[Key2];
-                _ = context.Database[Key3];
-            }
+            context.WitnessCollector.Reset();
+            _ = context.Database[Key1];
+            _ = context.Database[Key2];
+            _ = context.Database[Key3];
 
             context.WitnessCollector.Collected.Should().HaveCount(3);
         }
@@ -86,16 +81,15 @@ namespace Nethermind.Store.Test.Witnesses
         public void Collects_on_reads_when_cached_underneath_and_previously_populated()
         {
             Context context = new(3);
-            using (context.WitnessCollector.TrackOnThisThread())
-            {
-                context.Database[Key1] = Value1;
-                context.Database[Key2] = Value1;
-                context.Database[Key3] = Value1;
-                context.WitnessCollector.Collected.Should().HaveCount(0);
-                _ = context.Database[Key1];
-                _ = context.Database[Key2];
-                _ = context.Database[Key3];
-            }
+            
+            using IDisposable tracker = context.WitnessCollector.TrackOnThisThread();
+            context.Database[Key1] = Value1;
+            context.Database[Key2] = Value1;
+            context.Database[Key3] = Value1;
+            context.WitnessCollector.Collected.Should().HaveCount(0);
+            _ = context.Database[Key1];
+            _ = context.Database[Key2];
+            _ = context.Database[Key3];
 
             context.WitnessCollector.Collected.Should().HaveCount(3);
         }

--- a/src/Nethermind/Nethermind.State.Test/Witnesses/WitnessingStoreTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/Witnesses/WitnessingStoreTests.cs
@@ -38,7 +38,7 @@ namespace Nethermind.Store.Test.Witnesses
         {
             Context context = new();
             context.Wrapped[Key1].Returns(Value1);
-            using (context.WitnessCollector.Track())
+            using (context.WitnessCollector.TrackOnThisThread())
             {
                 _ = context.Database[Key1];
             }
@@ -62,7 +62,7 @@ namespace Nethermind.Store.Test.Witnesses
             context.Wrapped[Key2].Returns(Value2);
             context.Wrapped[Key3].Returns(Value3);
             
-            using (context.WitnessCollector.Track())
+            using (context.WitnessCollector.TrackOnThisThread())
             {
                 _ = context.Database[Key1];
                 _ = context.Database[Key2];
@@ -71,7 +71,7 @@ namespace Nethermind.Store.Test.Witnesses
 
             context.WitnessCollector.Collected.Should().HaveCount(3);
             
-            using (context.WitnessCollector.Track())
+            using (context.WitnessCollector.TrackOnThisThread())
             {
                 context.WitnessCollector.Reset();
                 _ = context.Database[Key1];
@@ -86,7 +86,7 @@ namespace Nethermind.Store.Test.Witnesses
         public void Collects_on_reads_when_cached_underneath_and_previously_populated()
         {
             Context context = new(3);
-            using (context.WitnessCollector.Track())
+            using (context.WitnessCollector.TrackOnThisThread())
             {
                 context.Database[Key1] = Value1;
                 context.Database[Key2] = Value1;

--- a/src/Nethermind/Nethermind.State/IWitnessCollector.cs
+++ b/src/Nethermind/Nethermind.State/IWitnessCollector.cs
@@ -15,6 +15,7 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 // 
 
+using System;
 using System.Collections.Generic;
 using Nethermind.Core.Crypto;
 
@@ -32,5 +33,7 @@ namespace Nethermind.State
         void Reset();
         
         void Persist(Keccak blockHash);
+
+        IDisposable Track();
     }
 }

--- a/src/Nethermind/Nethermind.State/IWitnessCollector.cs
+++ b/src/Nethermind/Nethermind.State/IWitnessCollector.cs
@@ -34,6 +34,6 @@ namespace Nethermind.State
         
         void Persist(Keccak blockHash);
 
-        IDisposable Track();
+        IDisposable TrackOnThisThread();
     }
 }

--- a/src/Nethermind/Nethermind.State/NullWitnessCollector.cs
+++ b/src/Nethermind/Nethermind.State/NullWitnessCollector.cs
@@ -39,6 +39,15 @@ namespace Nethermind.State
         
         public void Persist(Keccak blockHash) { }
 
+        class EmptyDisposable: IDisposable
+        {
+            public void Dispose()
+            {
+            }
+        }
+        
+        public IDisposable Track() { return new EmptyDisposable(); }
+
         public Keccak[]? Load(Keccak blockHash)
         {
             throw new InvalidOperationException(

--- a/src/Nethermind/Nethermind.State/NullWitnessCollector.cs
+++ b/src/Nethermind/Nethermind.State/NullWitnessCollector.cs
@@ -46,7 +46,7 @@ namespace Nethermind.State
             }
         }
         
-        public IDisposable Track() { return new EmptyDisposable(); }
+        public IDisposable TrackOnThisThread() { return new EmptyDisposable(); }
 
         public Keccak[]? Load(Keccak blockHash)
         {

--- a/src/Nethermind/Nethermind.State/Witnesses/WitnessCollector.cs
+++ b/src/Nethermind/Nethermind.State/Witnesses/WitnessCollector.cs
@@ -36,8 +36,7 @@ namespace Nethermind.State.Witnesses
         [ThreadStatic]
         private static bool _collectWitness;
         
-        private readonly LruCache<Keccak, Keccak[]> _witnessCache
-            = new(256, "Witnesses");
+        private readonly LruCache<Keccak, Keccak[]> _witnessCache = new(256, "Witnesses");
         
         public IReadOnlyCollection<Keccak> Collected => _collected;
 
@@ -91,20 +90,11 @@ namespace Nethermind.State.Witnesses
 
         class WitnessCollectorTrackingScope: IDisposable
         {
-            public WitnessCollectorTrackingScope()
-            {
-                _collectWitness = true;
-            }
-            public void Dispose()
-            {
-                _collectWitness = false;
-            }
+            public WitnessCollectorTrackingScope() => _collectWitness = true;
+            public void Dispose() => _collectWitness = false;
         }
         
-        public IDisposable Track()
-        {
-            return new WitnessCollectorTrackingScope();
-        }
+        public IDisposable TrackOnThisThread() => new WitnessCollectorTrackingScope();
 
         public Keccak[]? Load(Keccak blockHash)
         {


### PR DESCRIPTION
Fixes | Closes | Resolves https://github.com/NethermindEth/nethermind/issues/4196

## Changes:
- Make witness collection work only with the state provider

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes (+ below)
- [ ] No

1. Sync with any network, shutdown the client, enable WitnessProtocol and specific DiagnosticMode as below, start it up, multi-threading errors appear

2. grep "witness" messages with DEBUG log enabled, confirm witness collected is the same as for master
```
{
   ...
  "Init": {
    "DiagnosticMode" : "VerifyTrie"
  },
  "Sync": {
    ...
    "WitnessProtocolEnabled": true
  },
}
```