### PR TITLE
Fix receipt not found on block reorg

### DIFF
--- a/src/Nethermind/Nethermind.AccountAbstraction.Test/UserOperationPoolTests.cs
+++ b/src/Nethermind/Nethermind.AccountAbstraction.Test/UserOperationPoolTests.cs
@@ -344,7 +344,7 @@ namespace Nethermind.AccountAbstraction.Test
                 new FilterLog(0, 0, receipt,
                     new LogEntry(new Address(_entryPointContractAddress), 
                         Bytes.Zero32,
-                        new[] {_userOperationEventTopic, uops[0].RequestId!, Keccak.Zero, Keccak.Zero}))
+                        new[] {_userOperationEventTopic, uops[0].RequestId!, Keccak.Zero, Keccak.Zero}), false)
             });
             //_receiptFinder.Get(block).Returns(new[]{receipt});
             BlockEventArgs blockEventArgs = new(block);

--- a/src/Nethermind/Nethermind.AccountAbstraction.Test/UserOperationPoolTests.cs
+++ b/src/Nethermind/Nethermind.AccountAbstraction.Test/UserOperationPoolTests.cs
@@ -26,6 +26,7 @@ using NSubstitute;
 using NUnit.Framework;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Crypto;
+using Nethermind.Facade.Filters;
 using Nethermind.Int256;
 using Nethermind.JsonRpc;
 using Org.BouncyCastle.Asn1.Cms;
@@ -342,9 +343,9 @@ namespace Nethermind.AccountAbstraction.Test
             _logFinder.FindLogs(Arg.Any<LogFilter>()).Returns(new[]
             {
                 new FilterLog(0, 0, receipt,
-                    new LogEntry(new Address(_entryPointContractAddress), 
+                    new LogEntry(new Address(_entryPointContractAddress),
                         Bytes.Zero32,
-                        new[] {_userOperationEventTopic, uops[0].RequestId!, Keccak.Zero, Keccak.Zero}), false)
+                        new[] {_userOperationEventTopic, uops[0].RequestId!, Keccak.Zero, Keccak.Zero}))
             });
             //_receiptFinder.Get(block).Returns(new[]{receipt});
             BlockEventArgs blockEventArgs = new(block);

--- a/src/Nethermind/Nethermind.AccountAbstraction.Test/UserOperationSubscribeTests.cs
+++ b/src/Nethermind/Nethermind.AccountAbstraction.Test/UserOperationSubscribeTests.cs
@@ -51,8 +51,8 @@ namespace Nethermind.AccountAbstraction.Test
         private ILogManager _logManager = null!;
         private IBlockTree _blockTree = null!;
         private ITxPool _txPool = null!;
+        private ReceiptCanonicalityMonitor _receiptCanonicalityMonitor = null!;
         private IReceiptStorage _receiptStorage = null!;
-        private IReceiptFinder _receiptFinder = null!;
         private IFilterStore _filterStore = null!;
         private ISubscriptionManager _subscriptionManager = null!;
         private IJsonRpcDuplexClient _jsonRpcDuplexClient = null!;
@@ -70,7 +70,7 @@ namespace Nethermind.AccountAbstraction.Test
             _blockTree = Substitute.For<IBlockTree>();
             _txPool = Substitute.For<ITxPool>();
             _receiptStorage = Substitute.For<IReceiptStorage>();
-            _receiptFinder = Substitute.For<IReceiptFinder>();
+            _receiptCanonicalityMonitor = new ReceiptCanonicalityMonitor(_blockTree, _receiptStorage, _logManager);
             _specProvider = Substitute.For<ISpecProvider>();
             _userOperationPools[_testPoolAddress] = Substitute.For<IUserOperationPool>();
             _filterStore = new FilterStore();
@@ -84,8 +84,7 @@ namespace Nethermind.AccountAbstraction.Test
                 _logManager,
                 _blockTree,
                 _txPool,
-                _receiptStorage,
-                _receiptFinder,
+                _receiptCanonicalityMonitor,
                 _filterStore,
                 new EthSyncingInfo(_blockTree),
                 _specProvider,

--- a/src/Nethermind/Nethermind.AccountAbstraction.Test/UserOperationSubscribeTests.cs
+++ b/src/Nethermind/Nethermind.AccountAbstraction.Test/UserOperationSubscribeTests.cs
@@ -51,7 +51,7 @@ namespace Nethermind.AccountAbstraction.Test
         private ILogManager _logManager = null!;
         private IBlockTree _blockTree = null!;
         private ITxPool _txPool = null!;
-        private ReceiptCanonicalityMonitor _receiptCanonicalityMonitor = null!;
+        private IReceiptCanonicalityMonitor _receiptCanonicalityMonitor = null!;
         private IReceiptStorage _receiptStorage = null!;
         private IFilterStore _filterStore = null!;
         private ISubscriptionManager _subscriptionManager = null!;

--- a/src/Nethermind/Nethermind.AccountAbstraction.Test/UserOperationSubscribeTests.cs
+++ b/src/Nethermind/Nethermind.AccountAbstraction.Test/UserOperationSubscribeTests.cs
@@ -51,7 +51,7 @@ namespace Nethermind.AccountAbstraction.Test
         private ILogManager _logManager = null!;
         private IBlockTree _blockTree = null!;
         private ITxPool _txPool = null!;
-        private IReceiptCanonicalityMonitor _receiptCanonicalityMonitor = null!;
+        private IReceiptMonitor _receiptCanonicalityMonitor = null!;
         private IReceiptStorage _receiptStorage = null!;
         private IFilterStore _filterStore = null!;
         private ISubscriptionManager _subscriptionManager = null!;

--- a/src/Nethermind/Nethermind.AccountAbstraction/Source/UserOperationPool.cs
+++ b/src/Nethermind/Nethermind.AccountAbstraction/Source/UserOperationPool.cs
@@ -35,6 +35,7 @@ using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
+using Nethermind.Facade.Filters;
 using Nethermind.Int256;
 using Nethermind.JsonRpc;
 using Nethermind.Logging;

--- a/src/Nethermind/Nethermind.Api/IApiWithStores.cs
+++ b/src/Nethermind/Nethermind.Api/IApiWithStores.cs
@@ -37,7 +37,7 @@ namespace Nethermind.Api
         ProtectedPrivateKey? NodeKey { get; set; }
         IReceiptStorage? ReceiptStorage { get; set; }
         IReceiptFinder? ReceiptFinder { get; set; }
-        IReceiptCanonicalityMonitor? ReceiptMonitor { get; set; }
+        IReceiptMonitor? ReceiptMonitor { get; set; }
         IWallet? Wallet { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.Api/IApiWithStores.cs
+++ b/src/Nethermind/Nethermind.Api/IApiWithStores.cs
@@ -37,6 +37,7 @@ namespace Nethermind.Api
         ProtectedPrivateKey? NodeKey { get; set; }
         IReceiptStorage? ReceiptStorage { get; set; }
         IReceiptFinder? ReceiptFinder { get; set; }
+        IReceiptCanonicalityMonitor? ReceiptMonitor { get; set; }
         IWallet? Wallet { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.Api/INethermindApi.cs
+++ b/src/Nethermind/Nethermind.Api/INethermindApi.cs
@@ -16,6 +16,7 @@
 // 
 
 #nullable enable
+using Nethermind.Blockchain;
 using Nethermind.Config;
 
 namespace Nethermind.Api

--- a/src/Nethermind/Nethermind.Api/NethermindApi.cs
+++ b/src/Nethermind/Nethermind.Api/NethermindApi.cs
@@ -161,6 +161,7 @@ namespace Nethermind.Api
         public IWitnessCollector? WitnessCollector { get; set; }
         public IWitnessRepository? WitnessRepository { get; set; }
         public IReceiptFinder? ReceiptFinder { get; set; }
+        public IReceiptCanonicalityMonitor? ReceiptMonitor { get; set; }
         public IRewardCalculatorSource? RewardCalculatorSource { get; set; } = NoBlockRewards.Instance;
         public IRlpxHost? RlpxPeer { get; set; }
         public IRpcModuleProvider RpcModuleProvider { get; set; } = NullModuleProvider.Instance;

--- a/src/Nethermind/Nethermind.Api/NethermindApi.cs
+++ b/src/Nethermind/Nethermind.Api/NethermindApi.cs
@@ -161,7 +161,7 @@ namespace Nethermind.Api
         public IWitnessCollector? WitnessCollector { get; set; }
         public IWitnessRepository? WitnessRepository { get; set; }
         public IReceiptFinder? ReceiptFinder { get; set; }
-        public IReceiptCanonicalityMonitor? ReceiptMonitor { get; set; }
+        public IReceiptMonitor? ReceiptMonitor { get; set; }
         public IRewardCalculatorSource? RewardCalculatorSource { get; set; } = NoBlockRewards.Instance;
         public IRlpxHost? RlpxPeer { get; set; }
         public IRpcModuleProvider RpcModuleProvider { get; set; } = NullModuleProvider.Instance;

--- a/src/Nethermind/Nethermind.Baseline/Tree/BaselineTreeHelper.cs
+++ b/src/Nethermind/Nethermind.Baseline/Tree/BaselineTreeHelper.cs
@@ -23,6 +23,7 @@ using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Db;
+using Nethermind.Facade.Filters;
 using Nethermind.Logging;
 using Nethermind.Trie;
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/Filters/FilterManagerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Filters/FilterManagerTests.cs
@@ -23,6 +23,7 @@ using Nethermind.Blockchain.Test.Builders;
 using Nethermind.Consensus.Processing;
 using Nethermind.Core;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Facade.Filters;
 using Nethermind.Logging;
 using Nethermind.TxPool;
 using NSubstitute;

--- a/src/Nethermind/Nethermind.Blockchain.Test/Find/LogFinderTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Find/LogFinderTests.cs
@@ -33,6 +33,7 @@ using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
 using Nethermind.Logging;
 using Nethermind.Db.Blooms;
+using Nethermind.Facade.Filters;
 using NSubstitute;
 using NUnit.Framework;
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/Receipts/PersistentReceiptStorageTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Receipts/PersistentReceiptStorageTests.cs
@@ -53,7 +53,7 @@ namespace Nethermind.Blockchain.Test.Receipts
             var ethereumEcdsa = new EthereumEcdsa(specProvider.ChainId, LimboLogs.Instance);
             ReceiptsRecovery receiptsRecovery = new(ethereumEcdsa, specProvider);
             _receiptsDb = new MemColumnsDb<ReceiptsColumns>();
-            _storage = new PersistentReceiptStorage(_receiptsDb, MainnetSpecProvider.Instance, receiptsRecovery, new TestLogManager()) {MigratedBlockNumber = 0};
+            _storage = new PersistentReceiptStorage(_receiptsDb, MainnetSpecProvider.Instance, receiptsRecovery) {MigratedBlockNumber = 0};
             _receiptsDb.GetColumnDb(ReceiptsColumns.Blocks).Set(Keccak.Zero, Array.Empty<byte>());
         }
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/Receipts/PersistentReceiptStorageTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Receipts/PersistentReceiptStorageTests.cs
@@ -152,33 +152,6 @@ namespace Nethermind.Blockchain.Test.Receipts
         }
         
         [Test]
-        public void Should_not_overwrite_reference_from_tx_to_block_when_adding_rollbacked_receipts()
-        {
-            Transaction transaction = Build.A.Transaction.SignedAndResolved().TestObject;
-            
-            Block oldBlock = Build.A.Block
-                .WithTransactions(transaction)
-                .WithReceiptsRoot(TestItem.KeccakA).TestObject;
-
-            Block newBlock = Build.A.Block
-                .WithTransactions(transaction)
-                .WithReceiptsRoot(TestItem.KeccakB).TestObject;
-            
-            TxReceipt[] receipts = {Build.A.Receipt.TestObject};
-            
-            _storage.Insert(oldBlock, receipts);
-            
-            foreach (TxReceipt receipt in receipts)
-            {
-                receipt.Removed = true;
-            }
-            
-            _storage.Insert(newBlock, receipts);
-
-            _storage.FindBlockHash(transaction.Hash).Should().Be(oldBlock.Hash);
-        }
-
-        [Test]
         public void Should_handle_inserting_null_receipts()
         {
             Block block = Build.A.Block.WithReceiptsRoot(TestItem.KeccakA).TestObject;

--- a/src/Nethermind/Nethermind.Blockchain/ReceiptCanonicalityMonitor.cs
+++ b/src/Nethermind/Nethermind.Blockchain/ReceiptCanonicalityMonitor.cs
@@ -34,7 +34,7 @@ namespace Nethermind.Blockchain
         private readonly IReceiptStorage _receiptStorage;
         private readonly ILogger _logger;
         
-        public event EventHandler<ReceiptsEventArgs> ReceiptsInserted;
+        public event EventHandler<ReceiptsEventArgs>? ReceiptsInserted;
 
         public ReceiptCanonicalityMonitor(IBlockTree? blockTree, IReceiptStorage? receiptStorage, ILogManager? logManager)
         {
@@ -52,18 +52,18 @@ namespace Nethermind.Blockchain
             Task.Run(() => TriggerReceiptInsertedEvent(e.Block, e.PreviousBlock));
         }
 
-        private void TriggerReceiptInsertedEvent(Block newBlock, Block previousBlock)
+        private void TriggerReceiptInsertedEvent(Block newBlock, Block? previousBlock)
         {
             try
             {
-                if (previousBlock != null)
+                if (previousBlock is not null)
                 {
                     TxReceipt[] removedReceipts = _receiptStorage.Get(previousBlock);
                     ReceiptsInserted?.Invoke(this, new ReceiptsEventArgs(previousBlock.Header, removedReceipts, true));
                 }
                 
                 TxReceipt[] insertedReceipts = _receiptStorage.Get(newBlock);
-                ReceiptsInserted?.Invoke(this, new ReceiptsEventArgs(newBlock.Header, insertedReceipts, false));
+                ReceiptsInserted?.Invoke(this, new ReceiptsEventArgs(newBlock.Header, insertedReceipts));
             }
             catch (Exception exception)
             {

--- a/src/Nethermind/Nethermind.Blockchain/ReceiptCanonicalityMonitor.cs
+++ b/src/Nethermind/Nethermind.Blockchain/ReceiptCanonicalityMonitor.cs
@@ -23,7 +23,12 @@ using Nethermind.Logging;
 
 namespace Nethermind.Blockchain
 {
-    public class ReceiptCanonicalityMonitor : IDisposable
+    public interface IReceiptCanonicalityMonitor : IDisposable
+    {
+        event EventHandler<ReceiptsEventArgs> ReceiptsInserted;
+    }
+
+    public class ReceiptCanonicalityMonitor : IReceiptCanonicalityMonitor
     {
         private readonly IBlockTree _blockTree;
         private readonly IReceiptStorage _receiptStorage;

--- a/src/Nethermind/Nethermind.Blockchain/ReceiptCanonicalityMonitor.cs
+++ b/src/Nethermind/Nethermind.Blockchain/ReceiptCanonicalityMonitor.cs
@@ -23,12 +23,12 @@ using Nethermind.Logging;
 
 namespace Nethermind.Blockchain
 {
-    public interface IReceiptCanonicalityMonitor : IDisposable
+    public interface IReceiptMonitor : IDisposable
     {
         event EventHandler<ReceiptsEventArgs> ReceiptsInserted;
     }
 
-    public class ReceiptCanonicalityMonitor : IReceiptCanonicalityMonitor
+    public class ReceiptCanonicalityMonitor : IReceiptMonitor
     {
         private readonly IBlockTree _blockTree;
         private readonly IReceiptStorage _receiptStorage;

--- a/src/Nethermind/Nethermind.Blockchain/ReceiptCanonicalityMonitor.cs
+++ b/src/Nethermind/Nethermind.Blockchain/ReceiptCanonicalityMonitor.cs
@@ -40,7 +40,7 @@ namespace Nethermind.Blockchain
         private void OnBlockAddedToMain(object sender, BlockReplacementEventArgs e)
         {
             // we don't want this to be on main processing thread
-            Task.Run(() => RollbackReceipts(e.PreviousBlock))
+            Task.Run(() => SwitchCanonicalBlock(e.Block, e.PreviousBlock))
                 .ContinueWith(t =>
                 {
                     if (t.IsFaulted)
@@ -50,7 +50,7 @@ namespace Nethermind.Blockchain
                 });
         }
 
-        private void RollbackReceipts(Block? previousBlock)
+        private void SwitchCanonicalBlock(Block block, Block? previousBlock)
         {
             if (previousBlock != null)
             {
@@ -61,6 +61,8 @@ namespace Nethermind.Blockchain
                 }
                 _receiptStorage.Insert(previousBlock, txReceipts);
             }
+
+            _receiptStorage.EnsureCanonical(block);
         }
 
         public void Dispose()

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/IReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/IReceiptStorage.cs
@@ -22,10 +22,9 @@ namespace Nethermind.Blockchain.Receipts
 {
     public interface IReceiptStorage : IReceiptFinder
     {
-        void Insert(Block block, params TxReceipt[] txReceipts);
+        void Insert(Block block, TxReceipt[] txReceipts, bool ensureCanonical = true);
         long? LowestInsertedReceiptBlockNumber { get; set; }
         long MigratedBlockNumber { get; set; }
-        event EventHandler<ReceiptsEventArgs> ReceiptsInserted;
         bool HasBlock(Keccak hash);
         void EnsureCanonical(Block block);
     }

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/IReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/IReceiptStorage.cs
@@ -22,7 +22,8 @@ namespace Nethermind.Blockchain.Receipts
 {
     public interface IReceiptStorage : IReceiptFinder
     {
-        void Insert(Block block, TxReceipt[] txReceipts, bool ensureCanonical = true);
+        void Insert(Block block, params TxReceipt[]? txReceipts) => Insert(block, txReceipts, true);
+        void Insert(Block block, TxReceipt[]? txReceipts, bool ensureCanonical);
         long? LowestInsertedReceiptBlockNumber { get; set; }
         long MigratedBlockNumber { get; set; }
         bool HasBlock(Keccak hash);

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/IReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/IReceiptStorage.cs
@@ -27,5 +27,6 @@ namespace Nethermind.Blockchain.Receipts
         long MigratedBlockNumber { get; set; }
         event EventHandler<ReceiptsEventArgs> ReceiptsInserted;
         bool HasBlock(Keccak hash);
+        void EnsureCanonical(Block block);
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/InMemoryReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/InMemoryReceiptStorage.cs
@@ -70,11 +70,9 @@ namespace Nethermind.Blockchain.Receipts
         public void Insert(Block block, TxReceipt[] txReceipts, bool ensureCanonical = true)
         {
             _receipts[block.Hash] = txReceipts;
-            for (int i = 0; i < txReceipts.Length; i++)
+            if (ensureCanonical)
             {
-                var txReceipt = txReceipts[i];
-                txReceipt.BlockHash = block.Hash;
-                _transactions[txReceipt.TxHash] = txReceipt;
+                EnsureCanonical(block);
             }
         }
         
@@ -85,8 +83,13 @@ namespace Nethermind.Blockchain.Receipts
 
         public void EnsureCanonical(Block block)
         {
-            // InMemory does not seems to store mapping of tx hash to block
-            return;
+            TxReceipt[] txReceipts = Get(block);
+            for (int i = 0; i < txReceipts.Length; i++)
+            {
+                var txReceipt = txReceipts[i];
+                txReceipt.BlockHash = block.Hash;
+                _transactions[txReceipt.TxHash] = txReceipt;
+            }
         }
 
         public long? LowestInsertedReceiptBlockNumber { get; set; }

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/InMemoryReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/InMemoryReceiptStorage.cs
@@ -46,8 +46,12 @@ namespace Nethermind.Blockchain.Receipts
 
         public TxReceipt[] Get(Keccak blockHash)
         {
-            _receipts.TryGetValue(blockHash, out var receipts);
-            return receipts;
+            if (_receipts.TryGetValue(blockHash, out var receipts))
+            {
+                return receipts;
+            }
+
+            return new TxReceipt[] { };
         }
 
         public bool CanGetReceiptsByHash(long blockNumber) => true;

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/InMemoryReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/InMemoryReceiptStorage.cs
@@ -67,7 +67,7 @@ namespace Nethermind.Blockchain.Receipts
             }
         }
 
-        public void Insert(Block block, params TxReceipt[] txReceipts)
+        public void Insert(Block block, TxReceipt[] txReceipts, bool ensureCanonical = true)
         {
             _receipts[block.Hash] = txReceipts;
             for (int i = 0; i < txReceipts.Length; i++)
@@ -76,9 +76,6 @@ namespace Nethermind.Blockchain.Receipts
                 txReceipt.BlockHash = block.Hash;
                 _transactions[txReceipt.TxHash] = txReceipt;
             }
-
-            bool wasRemoved = txReceipts.Length > 0 && txReceipts[0].Removed;
-            ReceiptsInserted?.Invoke(this, new ReceiptsEventArgs(block.Header, txReceipts, wasRemoved));
         }
         
         public bool HasBlock(Keccak hash)
@@ -97,7 +94,5 @@ namespace Nethermind.Blockchain.Receipts
         public long MigratedBlockNumber { get; set; }
 
         public int Count => _transactions.Count;
-        
-        public event EventHandler<ReceiptsEventArgs> ReceiptsInserted;
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/InMemoryReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/InMemoryReceiptStorage.cs
@@ -86,6 +86,12 @@ namespace Nethermind.Blockchain.Receipts
             return _receipts.ContainsKey(hash);
         }
 
+        public void EnsureCanonical(Block block)
+        {
+            // InMemory does not seems to store mapping of tx hash to block
+            return;
+        }
+
         public long? LowestInsertedReceiptBlockNumber { get; set; }
 
         public long MigratedBlockNumber { get; set; }

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/NullReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/NullReceiptStorage.cs
@@ -30,7 +30,7 @@ namespace Nethermind.Blockchain.Receipts
         {
         }
 
-        public void Insert(Block block, params TxReceipt[] txReceipts) { }
+        public void Insert(Block block, TxReceipt[] txReceipts, bool ensureCanonical) { }
 
         public TxReceipt[] Get(Block block) => Array.Empty<TxReceipt>();
         public TxReceipt[] Get(Keccak blockHash) => Array.Empty<TxReceipt>();

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/NullReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/NullReceiptStorage.cs
@@ -60,5 +60,9 @@ namespace Nethermind.Blockchain.Receipts
         {
             return false;
         }
+
+        public void EnsureCanonical(Block block)
+        {
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
@@ -42,9 +42,8 @@ namespace Nethermind.Blockchain.Receipts
         
         private const int CacheSize = 64;
         private readonly ICache<Keccak, TxReceipt[]> _receiptsCache = new LruCache<Keccak, TxReceipt[]>(CacheSize, CacheSize, "receipts");
-        private ILogger _logger;
 
-        public PersistentReceiptStorage(IColumnsDb<ReceiptsColumns> receiptsDb, ISpecProvider specProvider, IReceiptsRecovery receiptsRecovery, ILogManager logManager)
+        public PersistentReceiptStorage(IColumnsDb<ReceiptsColumns> receiptsDb, ISpecProvider specProvider, IReceiptsRecovery receiptsRecovery)
         {
             long Get(Keccak key, long defaultValue) => _database.Get(key)?.ToLongFromBigEndianByteArrayWithoutLeadingZeros() ?? defaultValue;
             
@@ -53,7 +52,6 @@ namespace Nethermind.Blockchain.Receipts
             _receiptsRecovery = receiptsRecovery ?? throw new ArgumentNullException(nameof(receiptsRecovery));
             _blocksDb = _database.GetColumnDb(ReceiptsColumns.Blocks);
             _transactionDb = _database.GetColumnDb(ReceiptsColumns.Transactions);
-            _logger = logManager.GetClassLogger(GetType());
 
             byte[] lowestBytes = _database.Get(Keccak.Zero);
             _lowestInsertedReceiptBlock = lowestBytes == null ? (long?) null : new RlpStream(lowestBytes).DecodeLong();

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
@@ -168,7 +168,7 @@ namespace Nethermind.Blockchain.Receipts
             return result;
         }
 
-        public void Insert(Block block, TxReceipt[] txReceipts, bool ensureCanonical = true)
+        public void Insert(Block block, TxReceipt[]? txReceipts, bool ensureCanonical = true)
         {
             txReceipts ??= Array.Empty<TxReceipt>();
             int txReceiptsLength = txReceipts.Length;
@@ -185,7 +185,7 @@ namespace Nethermind.Blockchain.Receipts
             var blockNumber = block.Number;
             var spec = _specProvider.GetSpec(blockNumber);
             RlpBehaviors behaviors = spec.IsEip658Enabled ? RlpBehaviors.Eip658Receipts | RlpBehaviors.Storage : RlpBehaviors.Storage;
-            _blocksDb.Set(block.Hash, StorageDecoder.Encode(txReceipts, behaviors).Bytes);
+            _blocksDb.Set(block.Hash!, StorageDecoder.Encode(txReceipts, behaviors).Bytes);
 
             if (blockNumber < MigratedBlockNumber)
             {

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/ReceiptsEventArgs.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/ReceiptsEventArgs.cs
@@ -26,7 +26,7 @@ namespace Nethermind.Blockchain.Receipts
         public BlockHeader BlockHeader { get; }
         public bool WasRemoved { get; }
 
-        public ReceiptsEventArgs(BlockHeader blockHeader, TxReceipt[] txReceipts, bool wasRemoved)
+        public ReceiptsEventArgs(BlockHeader blockHeader, TxReceipt[] txReceipts, bool wasRemoved = false)
         {
             BlockHeader = blockHeader;
             TxReceipts = txReceipts;

--- a/src/Nethermind/Nethermind.Blockchain/Visitors/ReceiptsVerificationVisitor.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Visitors/ReceiptsVerificationVisitor.cs
@@ -62,7 +62,7 @@ namespace Nethermind.Blockchain.Visitors
         public Task<HeaderVisitOutcome> VisitHeader(BlockHeader header, CancellationToken cancellationToken) =>
             Task.FromResult(HeaderVisitOutcome.None);
 
-        public async Task<BlockVisitOutcome> VisitBlock(Block block, CancellationToken cancellationToken)
+        public virtual async Task<BlockVisitOutcome> VisitBlock(Block block, CancellationToken cancellationToken)
         {
             int txReceiptsLength = GetTxReceiptsLength(block, true);
             int transactionsLength = block.Transactions.Length;

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
@@ -252,7 +252,7 @@ namespace Nethermind.Consensus.Processing
         // TODO: block processor pipeline
         private void StoreTxReceipts(Block block, TxReceipt[] txReceipts)
         {
-            _receiptStorage.Insert(block, txReceipts);
+            _receiptStorage.Insert(block, txReceipts, false);
         }
 
         // TODO: block processor pipeline

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
@@ -252,6 +252,7 @@ namespace Nethermind.Consensus.Processing
         // TODO: block processor pipeline
         private void StoreTxReceipts(Block block, TxReceipt[] txReceipts)
         {
+            // Setting canonical is done by ReceiptCanonicalityMonitor on block move to main
             _receiptStorage.Insert(block, txReceipts, false);
         }
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
@@ -300,8 +300,9 @@ namespace Nethermind.Consensus.Processing
                         BlockRemoved?.Invoke(this, new BlockHashEventArgs(blockRef.BlockHash, ProcessingResult.Success));
                     }
                 }
-                catch
+                catch (Exception exception)
                 {
+                    if (_logger.IsDebug) _logger.Debug($"Processing loop threw an exception. Block: {blockRef}, Exception: {exception}");
                     BlockRemoved?.Invoke(this, new BlockHashEventArgs(blockRef.BlockHash, ProcessingResult.Exception));
                 }
                 finally

--- a/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
@@ -157,13 +157,14 @@ namespace Nethermind.Core.Test.Blockchain
             TxPool = CreateTxPool();
 
             _trieStoreWatcher = new TrieStoreBoundaryWatcher(TrieStore, BlockTree, LogManager);
-            
 
             ReceiptStorage = new InMemoryReceiptStorage();
             VirtualMachine virtualMachine = new(new BlockhashProvider(BlockTree, LogManager), SpecProvider, LogManager);
             TxProcessor = new TransactionProcessor(SpecProvider, State, Storage, virtualMachine, LogManager);
             BlockPreprocessorStep = new RecoverSignatures(EthereumEcdsa, TxPool, SpecProvider, LogManager);
             HeaderValidator = new HeaderValidator(BlockTree, Always.Valid, SpecProvider, LogManager);
+            
+            new ReceiptCanonicalityMonitor(BlockTree, ReceiptStorage, LogManager);
                 
             BlockValidator = new BlockValidator(
                 new TxValidator(SpecProvider.ChainId),

--- a/src/Nethermind/Nethermind.Core.Test/Builders/BlockTreeBuilder.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Builders/BlockTreeBuilder.cs
@@ -168,10 +168,10 @@ namespace Nethermind.Core.Test.Builders
                 }
 
                 currentBlock.Header.TxRoot = new TxTrie(currentBlock.Transactions).RootHash;
-                var txReceipts = receipts.ToArray();
+                TxReceipt[] txReceipts = receipts.ToArray();
                 currentBlock.Header.ReceiptsRoot = new ReceiptTrie(_specProvider.GetSpec(currentBlock.Number), txReceipts).RootHash;
                 currentBlock.Header.Hash = currentBlock.CalculateHash();
-                foreach (var txReceipt in txReceipts)
+                foreach (TxReceipt txReceipt in txReceipts)
                 {
                     txReceipt.BlockHash = currentBlock.Hash;
                 }

--- a/src/Nethermind/Nethermind.Core.Test/Builders/ReceiptBuilder.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Builders/ReceiptBuilder.cs
@@ -133,11 +133,5 @@ namespace Nethermind.Core.Test.Builders
             TestObjectInternal.StatusCode = statusCode;
             return this;
         }
-        
-        public ReceiptBuilder WithRemoved(bool removed)
-        {
-            TestObjectInternal.Removed = removed;
-            return this;
-        }
     }
 }

--- a/src/Nethermind/Nethermind.Core/TransactionReceipt.cs
+++ b/src/Nethermind/Nethermind.Core/TransactionReceipt.cs
@@ -51,7 +51,6 @@ namespace Nethermind.Core
         public Bloom? Bloom { get; set; }
         public LogEntry[]? Logs { get; set; }
         public string? Error { get; set; }
-        public bool Removed { get; set; }
 
         /// <summary>
         /// Ignores receipt output on RLP serialization.

--- a/src/Nethermind/Nethermind.Facade.Test/BlockchainBridgeTests.cs
+++ b/src/Nethermind/Nethermind.Facade.Test/BlockchainBridgeTests.cs
@@ -195,11 +195,9 @@ namespace Nethermind.Facade.Test
             _blockchainBridge.HeadBlock.Should().Be(head);
         }
 
-        [TestCase(true, true)]
-        [TestCase(true, false)]
-        [TestCase(false, true)]
-        [TestCase(false, false)]
-        public void GetReceiptAndEffectiveGasPrice_returns_correct_results(bool isCanonical, bool isRemoved)
+        [TestCase(true)]
+        [TestCase(false)]
+        public void GetReceiptAndEffectiveGasPrice_returns_correct_results(bool isCanonical)
         {
             Keccak txHash = TestItem.KeccakA;
             Keccak blockHash = TestItem.KeccakB;
@@ -214,7 +212,6 @@ namespace Nethermind.Facade.Test
             TxReceipt receipt = Build.A.Receipt
                 .WithBlockHash(blockHash)
                 .WithTransactionHash(txHash)
-                .WithRemoved(isRemoved)
                 .TestObject;
 
             _blockTree.FindBlock(blockHash, Arg.Is(BlockTreeLookupOptions.RequireCanonical)).Returns(isCanonical ? block : null);

--- a/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
@@ -35,6 +35,7 @@ using Nethermind.Consensus.Processing;
 using Nethermind.Core.Eip2930;
 using Nethermind.Core.Specs;
 using Nethermind.Evm.TransactionProcessing;
+using Nethermind.Facade.Filters;
 using Nethermind.State;
 
 namespace Nethermind.Facade

--- a/src/Nethermind/Nethermind.Facade/Filters/FilterLog.cs
+++ b/src/Nethermind/Nethermind.Facade/Filters/FilterLog.cs
@@ -17,7 +17,7 @@
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 
-namespace Nethermind.Blockchain.Filters
+namespace Nethermind.Facade.Filters
 {
     public class FilterLog
     {
@@ -32,7 +32,7 @@ namespace Nethermind.Blockchain.Filters
         public long TransactionIndex { get; }
         public long TransactionLogIndex { get; }
         
-        public FilterLog(long logIndex, long transactionLogIndex, TxReceipt txReceipt, LogEntry logEntry, bool removed)
+        public FilterLog(long logIndex, long transactionLogIndex, TxReceipt txReceipt, LogEntry logEntry, bool removed = false)
             : this(
                 logIndex,
                 transactionLogIndex,

--- a/src/Nethermind/Nethermind.Facade/Filters/FilterLog.cs
+++ b/src/Nethermind/Nethermind.Facade/Filters/FilterLog.cs
@@ -32,7 +32,7 @@ namespace Nethermind.Blockchain.Filters
         public long TransactionIndex { get; }
         public long TransactionLogIndex { get; }
         
-        public FilterLog(long logIndex, long transactionLogIndex, TxReceipt txReceipt, LogEntry logEntry)
+        public FilterLog(long logIndex, long transactionLogIndex, TxReceipt txReceipt, LogEntry logEntry, bool removed)
             : this(
                 logIndex,
                 transactionLogIndex,
@@ -42,8 +42,8 @@ namespace Nethermind.Blockchain.Filters
                 txReceipt.TxHash,
                 logEntry.LoggersAddress,
                 logEntry.Data,
-                logEntry.Topics,
-                txReceipt.Removed) { }
+                logEntry.Topics, 
+                removed) { }
 
         public FilterLog(long logIndex, long transactionLogIndex, long blockNumber, Keccak blockHash, int transactionIndex, Keccak transactionHash, Address address, byte[] data, Keccak[] topics, bool removed = false)
         {

--- a/src/Nethermind/Nethermind.Facade/Filters/FilterManager.cs
+++ b/src/Nethermind/Nethermind.Facade/Filters/FilterManager.cs
@@ -22,6 +22,7 @@ using Nethermind.Consensus.Processing;
 using Nethermind.Core;
 using Nethermind.Core.Attributes;
 using Nethermind.Core.Crypto;
+using Nethermind.Facade.Filters;
 using Nethermind.Logging;
 using Nethermind.TxPool;
 
@@ -266,16 +267,16 @@ namespace Nethermind.Blockchain.Filters
                 || logFilter.ToBlock.Type == BlockParameterType.Earliest
                 || logFilter.ToBlock.Type == BlockParameterType.Pending)
             {
-                return new FilterLog(index, transactionLogIndex, txReceipt, logEntry, false);
+                return new FilterLog(index, transactionLogIndex, txReceipt, logEntry);
             }
 
             if (logFilter.FromBlock.Type == BlockParameterType.Latest || logFilter.ToBlock.Type == BlockParameterType.Latest)
             {
                 //TODO: check if is last mined block
-                return new FilterLog(index, transactionLogIndex, txReceipt, logEntry, false);
+                return new FilterLog(index, transactionLogIndex, txReceipt, logEntry);
             }
 
-            return new FilterLog(index, transactionLogIndex, txReceipt, logEntry, false);
+            return new FilterLog(index, transactionLogIndex, txReceipt, logEntry);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Facade/Filters/FilterManager.cs
+++ b/src/Nethermind/Nethermind.Facade/Filters/FilterManager.cs
@@ -228,9 +228,9 @@ namespace Nethermind.Blockchain.Filters
             List<FilterLog> logs = _logs.GetOrAdd(filter.Id, i => new List<FilterLog>());
             for (int i = 0; i < txReceipt.Logs.Length; i++)
             {
-                var logEntry = txReceipt.Logs[i];
-                var filterLog = CreateLog(filter, txReceipt, logEntry, logIndex++, i);
-                if (!(filterLog is null))
+                LogEntry? logEntry = txReceipt.Logs[i];
+                FilterLog? filterLog = CreateLog(filter, txReceipt, logEntry, logIndex++, i);
+                if (filterLog is not null)
                 {
                     logs.Add(filterLog);
                 }
@@ -244,7 +244,7 @@ namespace Nethermind.Blockchain.Filters
             if (_logger.IsDebug) _logger.Debug($"Filter with id: '{filter.Id}' contains {logs.Count} logs.");
         }
 
-        private FilterLog CreateLog(LogFilter logFilter, TxReceipt txReceipt, LogEntry logEntry, long index, int transactionLogIndex)
+        private FilterLog? CreateLog(LogFilter logFilter, TxReceipt txReceipt, LogEntry logEntry, long index, int transactionLogIndex)
         {
             if (logFilter.FromBlock.Type == BlockParameterType.BlockNumber &&
                 logFilter.FromBlock.BlockNumber > txReceipt.BlockNumber)

--- a/src/Nethermind/Nethermind.Facade/Filters/FilterManager.cs
+++ b/src/Nethermind/Nethermind.Facade/Filters/FilterManager.cs
@@ -266,16 +266,16 @@ namespace Nethermind.Blockchain.Filters
                 || logFilter.ToBlock.Type == BlockParameterType.Earliest
                 || logFilter.ToBlock.Type == BlockParameterType.Pending)
             {
-                return new FilterLog(index, transactionLogIndex, txReceipt, logEntry);
+                return new FilterLog(index, transactionLogIndex, txReceipt, logEntry, false);
             }
 
             if (logFilter.FromBlock.Type == BlockParameterType.Latest || logFilter.ToBlock.Type == BlockParameterType.Latest)
             {
                 //TODO: check if is last mined block
-                return new FilterLog(index, transactionLogIndex, txReceipt, logEntry);
+                return new FilterLog(index, transactionLogIndex, txReceipt, logEntry, false);
             }
 
-            return new FilterLog(index, transactionLogIndex, txReceipt, logEntry);
+            return new FilterLog(index, transactionLogIndex, txReceipt, logEntry, false);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Facade/Filters/IFilterManager.cs
+++ b/src/Nethermind/Nethermind.Facade/Filters/IFilterManager.cs
@@ -15,6 +15,7 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
 using Nethermind.Core.Crypto;
+using Nethermind.Facade.Filters;
 
 namespace Nethermind.Blockchain.Filters
 {

--- a/src/Nethermind/Nethermind.Facade/Filters/ILogFinder.cs
+++ b/src/Nethermind/Nethermind.Facade/Filters/ILogFinder.cs
@@ -17,6 +17,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using Nethermind.Blockchain.Filters;
+using Nethermind.Facade.Filters;
 
 namespace Nethermind.Blockchain.Find
 {

--- a/src/Nethermind/Nethermind.Facade/Filters/LogFinder.cs
+++ b/src/Nethermind/Nethermind.Facade/Filters/LogFinder.cs
@@ -334,7 +334,7 @@ namespace Nethermind.Blockchain.Find
                             if (filter.Accepts(log))
                             {
                                 RecoverReceiptsData(blockHash, receipts);
-                                yield return new FilterLog(logIndexInBlock, j, receipt, log);
+                                yield return new FilterLog(logIndexInBlock, j, receipt, log, false);
                             }
 
                             logIndexInBlock++;

--- a/src/Nethermind/Nethermind.Facade/Filters/LogFinder.cs
+++ b/src/Nethermind/Nethermind.Facade/Filters/LogFinder.cs
@@ -25,6 +25,7 @@ using Nethermind.Core.Crypto;
 using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
 using Nethermind.Db.Blooms;
+using Nethermind.Facade.Filters;
 
 namespace Nethermind.Blockchain.Find
 {
@@ -283,7 +284,7 @@ namespace Nethermind.Blockchain.Find
 
         private IEnumerable<FilterLog> FilterLogsInBlockHighMemoryAllocation(LogFilter filter, Keccak blockHash, long blockNumber, CancellationToken cancellationToken)
         {
-            TxReceipt[] GetReceipts(Keccak hash, long number)
+            TxReceipt[]? GetReceipts(Keccak hash, long number)
             {
                 var canUseHash = _receiptFinder.CanGetReceiptsByHash(number);
                 if (canUseHash)
@@ -334,7 +335,7 @@ namespace Nethermind.Blockchain.Find
                             if (filter.Accepts(log))
                             {
                                 RecoverReceiptsData(blockHash, receipts);
-                                yield return new FilterLog(logIndexInBlock, j, receipt, log, false);
+                                yield return new FilterLog(logIndexInBlock, j, receipt, log);
                             }
 
                             logIndexInBlock++;

--- a/src/Nethermind/Nethermind.Facade/Filters/NullFilterManager.cs
+++ b/src/Nethermind/Nethermind.Facade/Filters/NullFilterManager.cs
@@ -16,6 +16,7 @@
 
 using System;
 using Nethermind.Core.Crypto;
+using Nethermind.Facade.Filters;
 
 namespace Nethermind.Blockchain.Filters
 {

--- a/src/Nethermind/Nethermind.Facade/IBlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/IBlockchainBridge.cs
@@ -20,6 +20,7 @@ using Nethermind.Blockchain.Filters;
 using Nethermind.Blockchain.Find;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
+using Nethermind.Facade.Filters;
 using Nethermind.Int256;
 using Nethermind.Trie;
 using Block = Nethermind.Core.Block;

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeBlockTree.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeBlockTree.cs
@@ -84,7 +84,7 @@ namespace Nethermind.Init.Steps
 
             ReceiptsRecovery receiptsRecovery = new(_get.EthereumEcdsa, _get.SpecProvider);
             IReceiptStorage? receiptStorage = _set.ReceiptStorage
-                = initConfig.StoreReceipts ? (IReceiptStorage?) new PersistentReceiptStorage(_get.DbProvider.ReceiptsDb, _get.SpecProvider, receiptsRecovery) : NullReceiptStorage.Instance;
+                = initConfig.StoreReceipts ? (IReceiptStorage?) new PersistentReceiptStorage(_get.DbProvider.ReceiptsDb, _get.SpecProvider, receiptsRecovery, _get.LogManager) : NullReceiptStorage.Instance;
             IReceiptFinder? receiptFinder = _set.ReceiptFinder = new FullInfoReceiptFinder(receiptStorage, receiptsRecovery, blockTree);
             
             LogFinder logFinder = new(

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeBlockTree.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeBlockTree.cs
@@ -84,7 +84,7 @@ namespace Nethermind.Init.Steps
 
             ReceiptsRecovery receiptsRecovery = new(_get.EthereumEcdsa, _get.SpecProvider);
             IReceiptStorage? receiptStorage = _set.ReceiptStorage
-                = initConfig.StoreReceipts ? (IReceiptStorage?) new PersistentReceiptStorage(_get.DbProvider.ReceiptsDb, _get.SpecProvider, receiptsRecovery, _get.LogManager) : NullReceiptStorage.Instance;
+                = initConfig.StoreReceipts ? (IReceiptStorage?) new PersistentReceiptStorage(_get.DbProvider.ReceiptsDb, _get.SpecProvider, receiptsRecovery) : NullReceiptStorage.Instance;
             IReceiptFinder? receiptFinder = _set.ReceiptFinder = new FullInfoReceiptFinder(receiptStorage, receiptsRecovery, blockTree);
             
             LogFinder logFinder = new(

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeBlockchain.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeBlockchain.cs
@@ -200,9 +200,6 @@ namespace Nethermind.Init.Steps
             
             ITxPool txPool = _api.TxPool = CreateTxPool();
 
-            ReceiptCanonicalityMonitor receiptCanonicalityMonitor = new(getApi.BlockTree, getApi.ReceiptStorage, _api.LogManager);
-            getApi.DisposeStack.Push(receiptCanonicalityMonitor);
-
             _api.BlockPreprocessor.AddFirst(
                 new RecoverSignatures(getApi.EthereumEcdsa, txPool, getApi.SpecProvider, getApi.LogManager));
             

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeBlockchain.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeBlockchain.cs
@@ -200,6 +200,10 @@ namespace Nethermind.Init.Steps
             
             ITxPool txPool = _api.TxPool = CreateTxPool();
 
+            ReceiptCanonicalityMonitor receiptCanonicalityMonitor = new(getApi.BlockTree, getApi.ReceiptStorage, _api.LogManager);
+            getApi.DisposeStack.Push(receiptCanonicalityMonitor);
+            _api.ReceiptMonitor = receiptCanonicalityMonitor;
+
             _api.BlockPreprocessor.AddFirst(
                 new RecoverSignatures(getApi.EthereumEcdsa, txPool, getApi.SpecProvider, getApi.LogManager));
             

--- a/src/Nethermind/Nethermind.Init/Steps/RegisterRpcModules.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/RegisterRpcModules.cs
@@ -20,6 +20,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Api;
 using Nethermind.Api.Extensions;
+using Nethermind.Blockchain;
 using Nethermind.Blockchain.FullPruning;
 using Nethermind.Consensus;
 using Nethermind.Core;
@@ -203,12 +204,14 @@ namespace Nethermind.Init.Steps
             WitnessRpcModule witnessRpcModule = new(_api.WitnessRepository, _api.BlockTree);
             rpcModuleProvider.RegisterSingle<IWitnessRpcModule>(witnessRpcModule);
             
+            ReceiptCanonicalityMonitor receiptCanonicalityMonitor = new(_api.BlockTree, _api.ReceiptStorage, _api.LogManager);
+            _api.DisposeStack.Push(receiptCanonicalityMonitor);
+            
             SubscriptionFactory subscriptionFactory = new(
                 _api.LogManager,
                 _api.BlockTree,
                 _api.TxPool,
-                _api.ReceiptStorage,
-                _api.ReceiptFinder,
+                receiptCanonicalityMonitor,
                 _api.FilterStore,
                 _api.EthSyncingInfo!,
                 _api.SpecProvider,

--- a/src/Nethermind/Nethermind.Init/Steps/RegisterRpcModules.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/RegisterRpcModules.cs
@@ -78,7 +78,7 @@ namespace Nethermind.Init.Steps
             if (_api.TxSender == null) throw new StepDependencyException(nameof(_api.TxSender));
             if (_api.StateReader == null) throw new StepDependencyException(nameof(_api.StateReader));
             if (_api.PeerManager == null) throw new StepDependencyException(nameof(_api.PeerManager));
-            
+
             if (jsonRpcConfig.Enabled)
             {
                 _api.RpcModuleProvider = new RpcModuleProvider(_api.FileSystem, jsonRpcConfig, _api.LogManager);
@@ -204,14 +204,13 @@ namespace Nethermind.Init.Steps
             WitnessRpcModule witnessRpcModule = new(_api.WitnessRepository, _api.BlockTree);
             rpcModuleProvider.RegisterSingle<IWitnessRpcModule>(witnessRpcModule);
             
-            ReceiptCanonicalityMonitor receiptCanonicalityMonitor = new(_api.BlockTree, _api.ReceiptStorage, _api.LogManager);
-            _api.DisposeStack.Push(receiptCanonicalityMonitor);
-            
+            if (_api.ReceiptMonitor == null) throw new StepDependencyException(nameof(_api.ReceiptMonitor));
+
             SubscriptionFactory subscriptionFactory = new(
                 _api.LogManager,
                 _api.BlockTree,
                 _api.TxPool,
-                receiptCanonicalityMonitor,
+                _api.ReceiptMonitor,
                 _api.FilterStore,
                 _api.EthSyncingInfo!,
                 _api.SpecProvider,

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
@@ -37,6 +37,7 @@ using Nethermind.Evm;
 using Nethermind.Evm.Tracing;
 using Nethermind.Evm.Tracing;
 using Nethermind.Facade;
+using Nethermind.Facade.Filters;
 using Nethermind.Int256;
 using Nethermind.JsonRpc.Data;
 using Nethermind.JsonRpc.Modules.Eth.FeeHistory;

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/ParityRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/ParityRpcModuleTests.cs
@@ -182,7 +182,7 @@ namespace Nethermind.JsonRpc.Test.Modules
                 Logs = logEntries
             };
             
-            receiptStorage.Insert(block, receipt1, receipt2, receipt3);
+            receiptStorage.Insert(block, new []{receipt1, receipt2, receipt3});
         }
         
         private static Peer SetUpPeerA()

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/ParityRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/ParityRpcModuleTests.cs
@@ -182,7 +182,7 @@ namespace Nethermind.JsonRpc.Test.Modules
                 Logs = logEntries
             };
             
-            receiptStorage.Insert(block, new []{receipt1, receipt2, receipt3});
+            receiptStorage.Insert(block, receipt1, receipt2, receipt3);
         }
         
         private static Peer SetUpPeerA()

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
@@ -61,7 +61,7 @@ namespace Nethermind.JsonRpc.Test.Modules
         private IJsonRpcDuplexClient _jsonRpcDuplexClient;
         private IJsonSerializer _jsonSerializer;
         private ISpecProvider _specProvider;
-        private ReceiptCanonicalityMonitor _receiptCanonicalityMonitor;
+        private IReceiptCanonicalityMonitor _receiptCanonicalityMonitor;
             
 
         [SetUp]
@@ -75,7 +75,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             _filterStore = new FilterStore();
             _jsonRpcDuplexClient = Substitute.For<IJsonRpcDuplexClient>();
             _jsonSerializer = new EthereumJsonSerializer();
-            _receiptCanonicalityMonitor = new(_blockTree, _receiptStorage, _logManager);
+            _receiptCanonicalityMonitor = new ReceiptCanonicalityMonitor(_blockTree, _receiptStorage, _logManager);
             
             JsonSerializer jsonSerializer = new();
             jsonSerializer.Converters.AddRange(EthereumJsonSerializer.CommonConverters);

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
@@ -56,12 +56,13 @@ namespace Nethermind.JsonRpc.Test.Modules
         private IBlockTree _blockTree;
         private ITxPool _txPool;
         private IReceiptStorage _receiptStorage;
-        private IReceiptFinder _receiptFinder;
         private IFilterStore _filterStore;
         private ISubscriptionManager _subscriptionManager;
         private IJsonRpcDuplexClient _jsonRpcDuplexClient;
         private IJsonSerializer _jsonSerializer;
         private ISpecProvider _specProvider;
+        private ReceiptCanonicalityMonitor _receiptCanonicalityMonitor;
+            
 
         [SetUp]
         public void Setup()
@@ -70,11 +71,11 @@ namespace Nethermind.JsonRpc.Test.Modules
             _blockTree = Substitute.For<IBlockTree>();
             _txPool = Substitute.For<ITxPool>();
             _receiptStorage = Substitute.For<IReceiptStorage>();
-            _receiptFinder = Substitute.For<IReceiptFinder>();
             _specProvider = Substitute.For<ISpecProvider>();
             _filterStore = new FilterStore();
             _jsonRpcDuplexClient = Substitute.For<IJsonRpcDuplexClient>();
             _jsonSerializer = new EthereumJsonSerializer();
+            _receiptCanonicalityMonitor = new(_blockTree, _receiptStorage, _logManager);
             
             JsonSerializer jsonSerializer = new();
             jsonSerializer.Converters.AddRange(EthereumJsonSerializer.CommonConverters);
@@ -83,8 +84,7 @@ namespace Nethermind.JsonRpc.Test.Modules
                 _logManager,
                 _blockTree,
                 _txPool,
-                _receiptStorage,
-                _receiptFinder,
+                _receiptCanonicalityMonitor,
                 _filterStore,
                 new EthSyncingInfo(_blockTree),
                 _specProvider,
@@ -124,9 +124,9 @@ namespace Nethermind.JsonRpc.Test.Modules
             return jsonRpcResult;
         }
         
-        private List<JsonRpcResult> GetLogsSubscriptionResult(Filter filter, BlockEventArgs blockEventArgs, out string subscriptionId)
+        private List<JsonRpcResult> GetLogsSubscriptionResult(Filter filter, BlockReplacementEventArgs blockEventArgs, out string subscriptionId)
         {
-            LogsSubscription logsSubscription = new(_jsonRpcDuplexClient, _receiptStorage, _receiptFinder, _filterStore, _blockTree, _logManager, filter);
+            LogsSubscription logsSubscription = new(_jsonRpcDuplexClient, _receiptCanonicalityMonitor, _filterStore, _blockTree, _logManager, filter);
             
             List<JsonRpcResult> jsonRpcResults = new();
 
@@ -136,7 +136,7 @@ namespace Nethermind.JsonRpc.Test.Modules
                 jsonRpcResults.Add(j);
             }));
             
-            _blockTree.NewHeadBlock += Raise.EventWith(new object(), blockEventArgs);
+            _blockTree.BlockAddedToMain += Raise.EventWith(new object(), blockEventArgs);
             semaphoreSlim.Wait(TimeSpan.FromMilliseconds(100));
 
             subscriptionId = logsSubscription.Id;
@@ -440,10 +440,10 @@ namespace Nethermind.JsonRpc.Test.Modules
             
             LogEntry logEntry = Build.A.LogEntry.WithAddress(TestItem.AddressA).WithTopics(TestItem.KeccakA).WithData(TestItem.RandomDataA).TestObject;
             TxReceipt[] txReceipts = {Build.A.Receipt.WithBlockNumber(blockNumber).WithLogs(logEntry).TestObject};
-            _receiptFinder.Get(Arg.Any<Block>()).Returns(txReceipts);
+            _receiptStorage.Get(Arg.Any<Block>()).Returns(txReceipts);
             
             Block block = Build.A.Block.WithNumber(blockNumber).TestObject;
-            BlockEventArgs blockEventArgs = new(block);
+            BlockReplacementEventArgs blockEventArgs = new(block);
         
             List<JsonRpcResult> jsonRpcResults = GetLogsSubscriptionResult(filter, blockEventArgs, out var subscriptionId);
 
@@ -464,7 +464,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             _receiptStorage.Get(Arg.Any<Block>()).Returns(txReceipts);
             
             Block block = Build.A.Block.WithNumber(blockNumber).TestObject;
-            BlockEventArgs blockEventArgs = new(block);
+            BlockReplacementEventArgs blockEventArgs = new(block);
         
             List<JsonRpcResult> jsonRpcResults = GetLogsSubscriptionResult(filter, blockEventArgs, out var subscriptionId);
 
@@ -482,10 +482,10 @@ namespace Nethermind.JsonRpc.Test.Modules
             LogEntry logEntryC = Build.A.LogEntry.WithData(TestItem.RandomDataC).TestObject;
 
             TxReceipt[] txReceipts = {Build.A.Receipt.WithBlockNumber(blockNumber).WithLogs(logEntryA, logEntryB, logEntryC).TestObject};
-            _receiptFinder.Get(Arg.Any<Block>()).Returns(txReceipts);
+            _receiptStorage.Get(Arg.Any<Block>()).Returns(txReceipts);
             
             Block block = Build.A.Block.WithNumber(blockNumber).TestObject;
-            BlockEventArgs blockEventArgs = new(block);
+            BlockReplacementEventArgs blockEventArgs = new(block);
         
             List<JsonRpcResult> jsonRpcResults = GetLogsSubscriptionResult(filter, blockEventArgs, out var subscriptionId);
 
@@ -520,10 +520,10 @@ namespace Nethermind.JsonRpc.Test.Modules
                 Build.A.Receipt.WithBlockNumber(blockNumber).WithIndex(33).WithLogs(logEntryB, logEntryC).TestObject
             };
             
-            _receiptFinder.Get(Arg.Any<Block>()).Returns(txReceipts);
+            _receiptStorage.Get(Arg.Any<Block>()).Returns(txReceipts);
             
             Block block = Build.A.Block.WithNumber(blockNumber).TestObject;
-            BlockEventArgs blockEventArgs = new(block);
+            BlockReplacementEventArgs blockEventArgs = new(block);
         
             List<JsonRpcResult> jsonRpcResults = GetLogsSubscriptionResult(filter, blockEventArgs, out var subscriptionId);
 
@@ -574,10 +574,10 @@ namespace Nethermind.JsonRpc.Test.Modules
                 Build.A.Receipt.WithBlockNumber(blockNumber).WithLogs(logEntryA, logEntryC, logEntryB, logEntryA, logEntryC).TestObject,
             };
             
-            _receiptFinder.Get(Arg.Any<Block>()).Returns(txReceipts);
+            _receiptStorage.Get(Arg.Any<Block>()).Returns(txReceipts);
             
             Block block = Build.A.Block.WithNumber(blockNumber).WithBloom(new Bloom(txReceipts.Select(r => r.Bloom).ToArray())).TestObject;
-            BlockEventArgs blockEventArgs = new(block);
+            BlockReplacementEventArgs blockEventArgs = new(block);
         
             List<JsonRpcResult> jsonRpcResults = GetLogsSubscriptionResult(filter, blockEventArgs, out var subscriptionId);
 
@@ -621,10 +621,10 @@ namespace Nethermind.JsonRpc.Test.Modules
                 Build.A.Receipt.WithBlockNumber(blockNumber).WithLogs(logEntryA, logEntryC, logEntryB, logEntryA, logEntryC).TestObject,
             };
 
-            _receiptFinder.Get(Arg.Any<Block>()).Returns(txReceipts);
+            _receiptStorage.Get(Arg.Any<Block>()).Returns(txReceipts);
             
             Block block = Build.A.Block.WithNumber(blockNumber).WithBloom(new Bloom(txReceipts.Select(r => r.Bloom).ToArray())).TestObject;
-            BlockEventArgs blockEventArgs = new(block);
+            BlockReplacementEventArgs blockEventArgs = new(block);
         
             List<JsonRpcResult> jsonRpcResults = GetLogsSubscriptionResult(filter, blockEventArgs, out var subscriptionId);
 
@@ -671,10 +671,10 @@ namespace Nethermind.JsonRpc.Test.Modules
                 Build.A.Receipt.WithBlockNumber(blockNumber).WithLogs(logEntryC, logEntryB, logEntryE, logEntryA, logEntryB).TestObject,
             };
             
-            _receiptFinder.Get(Arg.Any<Block>()).Returns(txReceipts);
+            _receiptStorage.Get(Arg.Any<Block>()).Returns(txReceipts);
             
             Block block = Build.A.Block.WithNumber(blockNumber).WithBloom(new Bloom(txReceipts.Select(r => r.Bloom).ToArray())).TestObject;
-            BlockEventArgs blockEventArgs = new(block);
+            BlockReplacementEventArgs blockEventArgs = new(block);
         
             List<JsonRpcResult> jsonRpcResults = GetLogsSubscriptionResult(filter, blockEventArgs, out var subscriptionId);
 
@@ -698,30 +698,30 @@ namespace Nethermind.JsonRpc.Test.Modules
             int blockNumber = 55555;
             Filter filter = null;
             
-            LogsSubscription logsSubscription = new(_jsonRpcDuplexClient, _receiptStorage, _receiptFinder, _filterStore, _blockTree, _logManager, filter);
+            LogsSubscription logsSubscription = new(_jsonRpcDuplexClient, _receiptCanonicalityMonitor, _filterStore, _blockTree, _logManager, filter);
 
             LogEntry logEntry = Build.A.LogEntry.WithAddress(TestItem.AddressA).WithTopics(TestItem.KeccakA).WithData(TestItem.RandomDataA).TestObject;
             TxReceipt[] txReceipts = {Build.A.Receipt.WithBlockNumber(blockNumber).WithLogs(logEntry).TestObject};
             BlockHeader blockHeader = Build.A.BlockHeader.WithNumber(blockNumber).TestObject;
             Block block = Build.A.Block.WithHeader(blockHeader).TestObject;
-            _receiptFinder.Get(Arg.Any<Block>()).Returns(txReceipts);
+            _receiptStorage.Get(Arg.Any<Block>()).Returns(txReceipts);
 
             List<JsonRpcResult> jsonRpcResults = new();
             
             ManualResetEvent manualResetEvent = new(false);
-            ReceiptsEventArgs receiptsEventArgs = new(blockHeader, txReceipts, txReceipts[0].Removed);
+            ReceiptsEventArgs receiptsEventArgs = new(blockHeader, txReceipts, false);
             logsSubscription.JsonRpcDuplexClient.SendJsonRpcResult(Arg.Do<JsonRpcResult>(j =>
             {
                 jsonRpcResults.Add(j);
                 manualResetEvent.Set();
             }));
-            _receiptStorage.ReceiptsInserted += Raise.EventWith(new object(), receiptsEventArgs);
+            _receiptCanonicalityMonitor.ReceiptsInserted += Raise.EventWith(new object(), receiptsEventArgs);
             manualResetEvent.WaitOne(TimeSpan.FromMilliseconds(200));
             
             jsonRpcResults.Count.Should().Be(0);
             
-            BlockEventArgs blockEventArgs = new(block);
-            _blockTree.NewHeadBlock += Raise.EventWith(new object(), blockEventArgs);
+            BlockReplacementEventArgs blockEventArgs = new(block);
+            _blockTree.BlockAddedToMain += Raise.EventWith(new object(), blockEventArgs);
             manualResetEvent.WaitOne(TimeSpan.FromMilliseconds(200));
             
             jsonRpcResults.Count.Should().Be(1);
@@ -1021,56 +1021,12 @@ namespace Nethermind.JsonRpc.Test.Modules
         }
 
         [Test]
-        public void ReceiptCanonicalityMonitor_can_change_removed_flag_of_receipt()
-        {
-            TxReceipt[] GetTxReceipts(LogEntry logEntry, LogEntry logEntryB1, LogEntry logEntryC1, bool removed = false) =>
-                new[]
-                {
-                    Build.A.Receipt.WithIndex(11).WithLogs(logEntry).WithRemoved(removed).TestObject,
-                    Build.A.Receipt.WithIndex(22).WithLogs(logEntry, logEntryB1).WithRemoved(removed).TestObject,
-                    Build.A.Receipt.WithIndex(33).WithLogs(logEntryB1, logEntryC1).WithRemoved(removed).TestObject
-                };
-
-            ReceiptCanonicalityMonitor receiptCanonicalityMonitor =
-                new(_blockTree, _receiptStorage, _logManager);
-            
-            LogEntry logEntryA = Build.A.LogEntry.WithAddress(TestItem.AddressA).WithTopics(TestItem.KeccakA).WithData(TestItem.RandomDataA).TestObject;
-            LogEntry logEntryB = Build.A.LogEntry.WithAddress(TestItem.AddressB).WithTopics(TestItem.KeccakB).TestObject;
-            LogEntry logEntryC = Build.A.LogEntry.WithData(TestItem.RandomDataC).TestObject;
-
-            TxReceipt[] txReceipts = GetTxReceipts(logEntryA, logEntryB, logEntryC);
-            
-            _receiptStorage.Get(Arg.Any<Block>()).Returns(txReceipts);
-
-            Block block = Build.A.Block.TestObject;
-            Block previousBlock = Build.A.Block.WithBloom(new Bloom(txReceipts.Select(r => r.Bloom).ToArray())).TestObject;
-            BlockReplacementEventArgs blockEventArgs = new(block, previousBlock);
-
-            TxReceipt[] receiptsRemoved = GetTxReceipts(logEntryA, logEntryB, logEntryC, true);
-            TxReceipt[] changedReceipts = Array.Empty<TxReceipt>();
-            ManualResetEvent manualResetEvent = new(false);
-            _receiptStorage.Insert(Arg.Any<Block>(), Arg.Do<TxReceipt[]>(r =>
-            {
-                changedReceipts = r;
-                manualResetEvent.Set();
-            }));
-            _blockTree.BlockAddedToMain += Raise.EventWith(new object(), blockEventArgs);
-            manualResetEvent.WaitOne(TimeSpan.FromMilliseconds(200));
-
-            txReceipts.Should().BeEquivalentTo(txReceipts);
-            changedReceipts.Should().BeEquivalentTo(receiptsRemoved);
-        }
-
-        [Test]
         public void LogsSubscription_can_send_logs_with_removed_txs_when_inserted()
         {
-            ReceiptCanonicalityMonitor receiptCanonicalityMonitor =
-                new(_blockTree, _receiptStorage, _logManager);
-            
             int blockNumber = 55555;
             Filter filter = null;
             
-            LogsSubscription logsSubscription = new(_jsonRpcDuplexClient, _receiptStorage, _receiptFinder, _filterStore, _blockTree, _logManager, filter);
+            LogsSubscription logsSubscription = new(_jsonRpcDuplexClient, _receiptCanonicalityMonitor, _filterStore, _blockTree, _logManager, filter);
 
             LogEntry logEntry = Build.A.LogEntry.WithAddress(TestItem.AddressA).WithTopics(TestItem.KeccakA).WithData(TestItem.RandomDataA).TestObject;
             TxReceipt[] txReceipts = {Build.A.Receipt.WithLogs(logEntry).WithBlockNumber(blockNumber).TestObject};
@@ -1086,12 +1042,6 @@ namespace Nethermind.JsonRpc.Test.Modules
             {
                 jsonRpcResults.Add(j);
                 manualResetEvent.Set();
-            }));
-            
-            _receiptStorage.Insert(Arg.Any<Block>(), Arg.Do<TxReceipt[]>(r =>
-            {
-                ReceiptsEventArgs receiptsEventArgs = new(blockHeader, r, r[0].Removed);
-                _receiptStorage.ReceiptsInserted += Raise.EventWith(new object(), receiptsEventArgs);
             }));
             
             _blockTree.BlockAddedToMain += Raise.EventWith(new object(), blockEventArgs);

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
@@ -61,7 +61,7 @@ namespace Nethermind.JsonRpc.Test.Modules
         private IJsonRpcDuplexClient _jsonRpcDuplexClient;
         private IJsonSerializer _jsonSerializer;
         private ISpecProvider _specProvider;
-        private IReceiptCanonicalityMonitor _receiptCanonicalityMonitor;
+        private IReceiptMonitor _receiptCanonicalityMonitor;
             
 
         [SetUp]

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
@@ -31,6 +31,7 @@ using Nethermind.Core.Specs;
 using Nethermind.Int256;
 using Nethermind.Facade;
 using Nethermind.Facade.Eth;
+using Nethermind.Facade.Filters;
 using Nethermind.JsonRpc.Data;
 using Nethermind.JsonRpc.Modules.Eth.FeeHistory;
 using Nethermind.JsonRpc.Modules.Eth.GasPrice;

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModuleProxy.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModuleProxy.cs
@@ -23,6 +23,7 @@ using Nethermind.Blockchain.Find;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Facade.Eth;
+using Nethermind.Facade.Filters;
 using Nethermind.Int256;
 using Nethermind.Facade.Proxy;
 using Nethermind.Facade.Proxy.Models;

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/IEthRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/IEthRpcModule.cs
@@ -21,6 +21,7 @@ using Nethermind.Blockchain.Find;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Facade.Eth;
+using Nethermind.Facade.Filters;
 using Nethermind.Int256;
 using Nethermind.JsonRpc.Data;
 using Nethermind.State.Proofs;

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/LogsSubscription.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/LogsSubscription.cs
@@ -24,6 +24,7 @@ using Nethermind.Blockchain.Filters;
 using Nethermind.Blockchain.Find;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Core;
+using Nethermind.Facade.Filters;
 using Nethermind.JsonRpc.Modules.Eth;
 using Nethermind.Logging;
 
@@ -107,16 +108,16 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
 
         private IEnumerable<FilterLog> GetFilterLogs(BlockHeader blockHeader, TxReceipt[] receipts, bool removed)
         {
-            if (_filter.Matches(blockHeader.Bloom))
+            if (_filter.Matches(blockHeader.Bloom!))
             {
                 int logIndex = 0;
                 for (int i = 0; i < receipts.Length; i++)
                 {
                     TxReceipt receipt = receipts[i];
-                    if (_filter.Matches(receipt.Bloom))
+                    if (_filter.Matches(receipt.Bloom!))
                     {
                         int transactionLogIndex = 0;
-                        for (int j = 0; j < receipt.Logs.Length; j++)
+                        for (int j = 0; j < receipt.Logs!.Length; j++)
                         {
                             var receiptLog = receipt.Logs[j];
                             if (_filter.Accepts(receiptLog))

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/LogsSubscription.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/LogsSubscription.cs
@@ -31,13 +31,13 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
 {
     public class LogsSubscription : Subscription
     {
-        private readonly ReceiptCanonicalityMonitor _receiptCanonicalityMonitor;
+        private readonly IReceiptCanonicalityMonitor _receiptCanonicalityMonitor;
         private readonly IBlockTree _blockTree;
         private readonly LogFilter _filter;
 
         public LogsSubscription(
             IJsonRpcDuplexClient jsonRpcDuplexClient,
-            ReceiptCanonicalityMonitor receiptCanonicalityMonitor,
+            IReceiptCanonicalityMonitor receiptCanonicalityMonitor,
             IFilterStore? store,
             IBlockTree? blockTree,
             ILogManager? logManager,

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/LogsSubscription.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/LogsSubscription.cs
@@ -32,13 +32,13 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
 {
     public class LogsSubscription : Subscription
     {
-        private readonly IReceiptCanonicalityMonitor _receiptCanonicalityMonitor;
+        private readonly IReceiptMonitor _receiptCanonicalityMonitor;
         private readonly IBlockTree _blockTree;
         private readonly LogFilter _filter;
 
         public LogsSubscription(
             IJsonRpcDuplexClient jsonRpcDuplexClient,
-            IReceiptCanonicalityMonitor receiptCanonicalityMonitor,
+            IReceiptMonitor receiptCanonicalityMonitor,
             IFilterStore? store,
             IBlockTree? blockTree,
             ILogManager? logManager,

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/SubscriptionFactory.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/SubscriptionFactory.cs
@@ -45,11 +45,10 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
         private readonly JsonSerializer _jsonSerializer;
         private readonly ConcurrentDictionary<string, CustomSubscriptionType> _subscriptionConstructors;
 
-
         public SubscriptionFactory(ILogManager? logManager,
             IBlockTree? blockTree,
             ITxPool? txPool,
-            ReceiptCanonicalityMonitor receiptCanonicalityMonitor,
+            IReceiptCanonicalityMonitor receiptCanonicalityMonitor,
             IFilterStore? filterStore,
             IEthSyncingInfo ethSyncingInfo,
             ISpecProvider specProvider, 

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/SubscriptionFactory.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/SubscriptionFactory.cs
@@ -48,7 +48,7 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
         public SubscriptionFactory(ILogManager? logManager,
             IBlockTree? blockTree,
             ITxPool? txPool,
-            IReceiptCanonicalityMonitor receiptCanonicalityMonitor,
+            IReceiptMonitor receiptCanonicalityMonitor,
             IFilterStore? filterStore,
             IEthSyncingInfo ethSyncingInfo,
             ISpecProvider specProvider, 

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/SubscriptionFactory.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/SubscriptionFactory.cs
@@ -49,8 +49,7 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
         public SubscriptionFactory(ILogManager? logManager,
             IBlockTree? blockTree,
             ITxPool? txPool,
-            IReceiptStorage? receiptStorage,
-            IReceiptFinder? receiptFinder,
+            ReceiptCanonicalityMonitor receiptCanonicalityMonitor,
             IFilterStore? filterStore,
             IEthSyncingInfo ethSyncingInfo,
             ISpecProvider specProvider, 
@@ -60,8 +59,7 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
             logManager = logManager ?? throw new ArgumentNullException(nameof(logManager));
             blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
             txPool = txPool ?? throw new ArgumentNullException(nameof(txPool));
-            receiptStorage = receiptStorage ?? throw new ArgumentNullException(nameof(receiptStorage));
-            receiptFinder = receiptFinder ?? throw new ArgumentNullException(nameof(receiptFinder));
+            receiptCanonicalityMonitor = receiptCanonicalityMonitor ?? throw new ArgumentNullException(nameof(receiptCanonicalityMonitor));
             filterStore = filterStore ?? throw new ArgumentNullException(nameof(filterStore));
             ethSyncingInfo = ethSyncingInfo ?? throw new ArgumentNullException(nameof(ethSyncingInfo));
             specProvider = specProvider ?? throw new ArgumentNullException(nameof(specProvider));
@@ -73,7 +71,7 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
                     new NewHeadSubscription(jsonRpcDuplexClient, blockTree, logManager, specProvider, args)),
                 
                 [SubscriptionType.Logs] = CreateSubscriptionType<Filter?>((jsonRpcDuplexClient, filter) => 
-                    new LogsSubscription(jsonRpcDuplexClient, receiptStorage, receiptFinder, filterStore, blockTree, logManager, filter)),
+                    new LogsSubscription(jsonRpcDuplexClient, receiptCanonicalityMonitor, filterStore, blockTree, logManager, filter)),
                 
                 [SubscriptionType.NewPendingTransactions] = CreateSubscriptionType<TransactionsOption?>((jsonRpcDuplexClient, args) => 
                     new NewPendingTransactionsSubscription(jsonRpcDuplexClient, txPool, logManager, args)),

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V66/ReceiptsMessageSerializerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V66/ReceiptsMessageSerializerTests.cs
@@ -56,7 +56,6 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V66
             txReceipt.BlockNumber.Should().Be(0x0);
             txReceipt.TxHash.Should().BeNull();
             txReceipt.BlockHash.Should().BeNull();
-            txReceipt.Removed.Should().BeFalse();
             txReceipt.Index.Should().Be(0x0);
             
             ReceiptsMessage message = new(1111, ethMessage);

--- a/src/Nethermind/Nethermind.Runner.Test/Ethereum/ContextWithMocks.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Ethereum/ContextWithMocks.cs
@@ -135,7 +135,8 @@ namespace Nethermind.Runner.Test.Ethereum
                 UnclesValidator = Substitute.For<IUnclesValidator>(),
                 BlockProductionPolicy = Substitute.For<IBlockProductionPolicy>(),
                 SyncProgressResolver = Substitute.For<ISyncProgressResolver>(),
-                BetterPeerStrategy = Substitute.For<IBetterPeerStrategy>()
+                BetterPeerStrategy = Substitute.For<IBetterPeerStrategy>(),
+                ReceiptMonitor = Substitute.For<IReceiptMonitor>()
             };
     }
 }

--- a/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/Migrations/ReceiptMigrationTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/Migrations/ReceiptMigrationTests.cs
@@ -118,10 +118,7 @@ namespace Nethermind.Runner.Test.Ethereum.Steps.Migrations
             public bool CanGetReceiptsByHash(long blockNumber) => _inStorage.CanGetReceiptsByHash(blockNumber);
             public bool TryGetReceiptsIterator(long blockNumber, Keccak blockHash, out ReceiptsIterator iterator) => _outStorage.TryGetReceiptsIterator(blockNumber, blockHash, out iterator);
 
-            public void Insert(Block block, TxReceipt[] txReceipts, bool ensureCanonical)
-            {
-                _outStorage.Insert(block, txReceipts);
-            }
+            public void Insert(Block block, TxReceipt[] txReceipts, bool ensureCanonical) => _outStorage.Insert(block, txReceipts);
 
             public long? LowestInsertedReceiptBlockNumber
             {

--- a/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/Migrations/ReceiptMigrationTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/Migrations/ReceiptMigrationTests.cs
@@ -72,9 +72,10 @@ namespace Nethermind.Runner.Test.Ethereum.Steps.Migrations
             for (int i = 1; i < chainLength; i++)
             {
                 Block block = context.BlockTree.FindBlock(i);
-                inMemoryReceiptStorage.Insert(block,
-                    Core.Test.Builders.Build.A.Receipt.WithTransactionHash(TestItem.Keccaks[txIndex++]).TestObject,
-                    Core.Test.Builders.Build.A.Receipt.WithTransactionHash(TestItem.Keccaks[txIndex++]).TestObject);
+                inMemoryReceiptStorage.Insert(block, new[] {
+                        Core.Test.Builders.Build.A.Receipt.WithTransactionHash(TestItem.Keccaks[txIndex++]).TestObject,
+                        Core.Test.Builders.Build.A.Receipt.WithTransactionHash(TestItem.Keccaks[txIndex++]).TestObject
+                    });
             }
             
             ManualResetEvent guard = new(false);
@@ -117,7 +118,7 @@ namespace Nethermind.Runner.Test.Ethereum.Steps.Migrations
             public bool CanGetReceiptsByHash(long blockNumber) => _inStorage.CanGetReceiptsByHash(blockNumber);
             public bool TryGetReceiptsIterator(long blockNumber, Keccak blockHash, out ReceiptsIterator iterator) => _outStorage.TryGetReceiptsIterator(blockNumber, blockHash, out iterator);
 
-            public void Insert(Block block, params TxReceipt[] txReceipts)
+            public void Insert(Block block, TxReceipt[] txReceipts, bool ensureCanonical)
             {
                 _outStorage.Insert(block, txReceipts);
             }

--- a/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/Migrations/ReceiptMigrationTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/Migrations/ReceiptMigrationTests.cs
@@ -138,6 +138,10 @@ namespace Nethermind.Runner.Test.Ethereum.Steps.Migrations
                 return _outStorage.HasBlock(hash);
             }
 
+            public void EnsureCanonical(Block block)
+            {
+            }
+
             public event EventHandler<ReceiptsEventArgs> ReceiptsInserted { add { } remove { } }
         }
     }

--- a/src/Nethermind/Nethermind.TxPool.Test/ReceiptStorageTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/ReceiptStorageTests.cs
@@ -105,7 +105,7 @@ namespace Nethermind.TxPool.Test
             var transaction = GetSignedTransaction();
             var block = GetBlock(transaction);
             var receipt = GetReceipt(transaction, block);
-            storage.Insert(block, receipt);
+            storage.Insert(block, new []{receipt});
             if (updateLowest)
             {
                 storage.LowestInsertedReceiptBlockNumber = block.Number;
@@ -123,7 +123,7 @@ namespace Nethermind.TxPool.Test
             transaction.SenderAddress = null;
             var block = GetBlock(transaction);
             var receipt = GetReceipt(transaction, block);
-            storage.Insert(block, receipt);
+            storage.Insert(block, new []{receipt});
             var blockHash = storage.FindBlockHash(transaction.Hash);
             blockHash.Should().Be(block.Hash);
             var fetchedReceipt = receiptFinder.Get(block).ForTransaction(transaction.Hash);
@@ -141,7 +141,7 @@ namespace Nethermind.TxPool.Test
             var transaction = GetSignedTransaction();
             var block = GetBlock(transaction);
             var receipt = GetReceipt(transaction, block);
-            storage.Insert(block, receipt);
+            storage.Insert(block, new [] {receipt});
             var blockHash = storage.FindBlockHash(transaction.Hash);
             blockHash.Should().Be(block.Hash);
             var fetchedReceipt = storage.Get(block).ForTransaction(transaction.Hash);

--- a/src/Nethermind/Nethermind.TxPool.Test/ReceiptStorageTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/ReceiptStorageTests.cs
@@ -51,7 +51,7 @@ namespace Nethermind.TxPool.Test
             _specProvider = RopstenSpecProvider.Instance;
             _ethereumEcdsa = new EthereumEcdsa(_specProvider.ChainId, LimboLogs.Instance);
             ReceiptsRecovery receiptsRecovery = new(_ethereumEcdsa, _specProvider);
-            _persistentStorage = new PersistentReceiptStorage(new MemColumnsDb<ReceiptsColumns>(), _specProvider, receiptsRecovery, new TestLogManager());
+            _persistentStorage = new PersistentReceiptStorage(new MemColumnsDb<ReceiptsColumns>(), _specProvider, receiptsRecovery);
             _receiptFinder = new FullInfoReceiptFinder(_persistentStorage, receiptsRecovery, Substitute.For<IBlockFinder>());
             _inMemoryStorage = new InMemoryReceiptStorage();
         }

--- a/src/Nethermind/Nethermind.TxPool.Test/ReceiptStorageTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/ReceiptStorageTests.cs
@@ -102,16 +102,16 @@ namespace Nethermind.TxPool.Test
 
         private void TestAddAndCheckLowest(IReceiptStorage storage, bool updateLowest)
         {
-            var transaction = GetSignedTransaction();
-            var block = GetBlock(transaction);
-            var receipt = GetReceipt(transaction, block);
-            storage.Insert(block, new []{receipt});
+            Transaction transaction = GetSignedTransaction();
+            Block block = GetBlock(transaction);
+            TxReceipt receipt = GetReceipt(transaction, block);
+            storage.Insert(block, receipt);
             if (updateLowest)
             {
                 storage.LowestInsertedReceiptBlockNumber = block.Number;
             }
 
-            storage.LowestInsertedReceiptBlockNumber.Should().Be(updateLowest ? (long?)0 : null);
+            storage.LowestInsertedReceiptBlockNumber.Should().Be(updateLowest ? 0 : null);
         }
         
         private void TestAddAndGetReceipt(IReceiptStorage storage, IReceiptFinder receiptFinder = null)
@@ -123,7 +123,7 @@ namespace Nethermind.TxPool.Test
             transaction.SenderAddress = null;
             var block = GetBlock(transaction);
             var receipt = GetReceipt(transaction, block);
-            storage.Insert(block, new []{receipt});
+            storage.Insert(block, receipt);
             var blockHash = storage.FindBlockHash(transaction.Hash);
             blockHash.Should().Be(block.Hash);
             var fetchedReceipt = receiptFinder.Get(block).ForTransaction(transaction.Hash);
@@ -141,7 +141,7 @@ namespace Nethermind.TxPool.Test
             var transaction = GetSignedTransaction();
             var block = GetBlock(transaction);
             var receipt = GetReceipt(transaction, block);
-            storage.Insert(block, new [] {receipt});
+            storage.Insert(block, receipt);
             var blockHash = storage.FindBlockHash(transaction.Hash);
             blockHash.Should().Be(block.Hash);
             var fetchedReceipt = storage.Get(block).ForTransaction(transaction.Hash);

--- a/src/Nethermind/Nethermind.TxPool.Test/ReceiptStorageTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/ReceiptStorageTests.cs
@@ -51,7 +51,7 @@ namespace Nethermind.TxPool.Test
             _specProvider = RopstenSpecProvider.Instance;
             _ethereumEcdsa = new EthereumEcdsa(_specProvider.ChainId, LimboLogs.Instance);
             ReceiptsRecovery receiptsRecovery = new(_ethereumEcdsa, _specProvider);
-            _persistentStorage = new PersistentReceiptStorage(new MemColumnsDb<ReceiptsColumns>(), _specProvider, receiptsRecovery);
+            _persistentStorage = new PersistentReceiptStorage(new MemColumnsDb<ReceiptsColumns>(), _specProvider, receiptsRecovery, new TestLogManager());
             _receiptFinder = new FullInfoReceiptFinder(_persistentStorage, receiptsRecovery, Substitute.For<IBlockFinder>());
             _inMemoryStorage = new InMemoryReceiptStorage();
         }


### PR DESCRIPTION
Fixes #4179

Fix receipt not found issue when the tx hash pointed to a non-main block. Reorg can cause this issue, confirmed with a custom hive test.

https://github.com/ethereum/hive/pull/580/commits/d4108f55303ea3ecf647cef188a58bb93e4bfbb2

## Changes:
- On `BlockAddedToMain` event, call `EnsureCanonical` which will re-set the tx hash to block hash mapping to the canonical block.
- Also addded a repair routine on the receipt repair so that client don't have to re-sync.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing

- Confirmed test now pass. For reference, besu and geth was passing.
- Confirmed hive rpc module passed.
- Subscribed manually, confirmed log show up.

## Further comments (optional)

- The `removed` flag is not unset when switching to main block. I'd like to remove the field entirely, but it seems to be used on some gas calculation test and log subscription test. Not gonna mess arount that at the moment.