### PR TITLE
Reject pre-pivot payloads

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
@@ -74,6 +74,7 @@ namespace Nethermind.Merge.Plugin.Test
                     chain.BlockTree, 
                     chain.BlockchainProcessor,
                     new InitConfig(),
+                    new SyncConfig(),
                     chain.PoSSwitcher,
                     chain.BeaconSync,
                     chain.BeaconPivot,

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/V1/NewPayloadV1Handler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/V1/NewPayloadV1Handler.cs
@@ -116,11 +116,11 @@ namespace Nethermind.Merge.Plugin.Handlers.V1
 
             if (block.Header.Number <= _syncConfig.PivotNumberParsed)
             {
+                if (_logger.IsTrace) _logger.Trace($"Pre-pivot block, ignored and returned Syncing. Result of {requestStr}.");
                 return NewPayloadV1Result.Syncing;
             }
             
             block.Header.TotalDifficulty = _poSSwitcher.FinalTotalDifficulty;
-            // ToDo if block is below syncPivot, we can return SYNCING and ignore block
 
             BlockHeader? parentHeader = _blockTree.FindHeader(request.ParentHash, BlockTreeLookupOptions.None);
             if (parentHeader is null)

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
@@ -260,6 +260,7 @@ namespace Nethermind.Merge.Plugin
                         _api.BlockTree,
                         _api.BlockchainProcessor,
                         _api.Config<IInitConfig>(),
+                        _api.Config<ISyncConfig>(),
                         _poSSwitcher,
                         _beaconSync,
                         _beaconPivot,


### PR DESCRIPTION
## Changes:
- return `syncing` when received payload is pre-pivot
This PR is fixing issue with not downloading old blocks if pivot is post-merge

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [x] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [ ] No