### PR TITLE
Fcu peer refresher

### DIFF
--- a/src/Nethermind/Nethermind.Api/IApiWithNetwork.cs
+++ b/src/Nethermind/Nethermind.Api/IApiWithNetwork.cs
@@ -59,6 +59,7 @@ namespace Nethermind.Api
         IBlockDownloaderFactory? BlockDownloaderFactory { get; set; }
         IPivot? Pivot { get; set; }
         ISyncPeerPool? SyncPeerPool { get; set; }
+        IPeerDifficultyRefreshPool? PeerDifficultyRefreshPool { get; set; }
         ISyncServer? SyncServer { get; set; }
         IWebSocketsManager WebSocketsManager { get; set; }
         ISubscriptionFactory SubscriptionFactory { get; set; }

--- a/src/Nethermind/Nethermind.Api/NethermindApi.cs
+++ b/src/Nethermind/Nethermind.Api/NethermindApi.cs
@@ -191,6 +191,7 @@ namespace Nethermind.Api
         public IBlockDownloaderFactory? BlockDownloaderFactory { get; set; }
         public IPivot? Pivot { get; set; }
         public ISyncPeerPool? SyncPeerPool { get; set; }
+        public IPeerDifficultyRefreshPool? PeerDifficultyRefreshPool { get; set; }
         public ISynchronizer? Synchronizer { get; set; }
         public ISyncServer? SyncServer { get; set; }
         public IStateProvider? StateProvider { get; set; }

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncPeer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncPeer.cs
@@ -44,6 +44,7 @@ namespace Nethermind.Blockchain.Synchronization
         void Disconnect(DisconnectReason reason, string details);
         Task<BlockBody[]> GetBlockBodies(IReadOnlyList<Keccak> blockHashes, CancellationToken token);
         Task<BlockHeader[]> GetBlockHeaders(long number, int maxBlocks, int skip, CancellationToken token);
+        Task<BlockHeader[]> GetBlockHeaders(Keccak startHash, int maxBlocks, int skip, CancellationToken token);
         Task<BlockHeader?> GetHeadBlockHeader(Keccak hash, CancellationToken token);
         void NotifyOfNewBlock(Block block, SendBlockPriority priority);
         Task<TxReceipt[][]> GetReceipts(IReadOnlyList<Keccak> blockHash, CancellationToken token);

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -132,7 +132,9 @@ namespace Nethermind.Init.Steps
             
             int maxPeersCount = _networkConfig.ActivePeersMaxCount;
             int maxPriorityPeersCount = _networkConfig.PriorityPeersMaxCount;
-            _api.SyncPeerPool = new SyncPeerPool(_api.BlockTree!, _api.NodeStatsManager!, _api.BetterPeerStrategy, maxPeersCount, maxPriorityPeersCount, SyncPeerPool.DefaultUpgradeIntervalInMs, _api.LogManager);
+            SyncPeerPool apiSyncPeerPool = new(_api.BlockTree!, _api.NodeStatsManager!, _api.BetterPeerStrategy, maxPeersCount, maxPriorityPeersCount, SyncPeerPool.DefaultUpgradeIntervalInMs, _api.LogManager);
+            _api.SyncPeerPool = apiSyncPeerPool;
+            _api.PeerDifficultyRefreshPool = apiSyncPeerPool;
             _api.DisposeStack.Push(_api.SyncPeerPool);
             
             IEnumerable<ISynchronizationPlugin> synchronizationPlugins = _api.GetSynchronizationPlugins();

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/PeerRefresherTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/PeerRefresherTests.cs
@@ -39,7 +39,7 @@ public class PeerRefresherTests
     private BlockHeader _headParentBlockHeader = null!;
     private BlockHeader _finalizedBlockHeader = null!;
     private PeerRefresher _peerRefresher = null!;
-    private IRefreshablePeerDifficultyPool _syncPeerPool = null!;
+    private IPeerDifficultyRefreshPool _syncPeerPool = null!;
     private ISyncPeer _syncPeer = null!;
 
     [SetUp]
@@ -49,7 +49,7 @@ public class PeerRefresherTests
         _headBlockHeader = Build.A.BlockHeader.WithParent(_headParentBlockHeader).TestObject;
         _finalizedBlockHeader = Build.A.BlockHeader.WithExtraData(new byte []{ 1 }).TestObject;
 
-        _syncPeerPool = Substitute.For<IRefreshablePeerDifficultyPool>();
+        _syncPeerPool = Substitute.For<IPeerDifficultyRefreshPool>();
         _syncPeer = Substitute.For<ISyncPeer>();
         _peerRefresher = new PeerRefresher(_syncPeerPool, new TimerFactory(), new TestLogManager());
     }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/PeerRefresherTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/PeerRefresherTests.cs
@@ -1,0 +1,118 @@
+//  Copyright (c) 2021 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+// 
+
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Google.Protobuf.WellKnownTypes;
+using Nethermind.Blockchain.Synchronization;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Timers;
+using Nethermind.Logging;
+using Nethermind.Merge.Plugin.Synchronization;
+using Nethermind.Stats.Model;
+using Nethermind.Synchronization.Peers;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Merge.Plugin.Test.Synchronization;
+
+public class PeerRefresherTests
+{
+    private BlockHeader headBlockHeader;
+    private BlockHeader headParentBlockHeader;
+    private BlockHeader finalizedBlockHeader;
+    private PeerRefresher _peerRefresher;
+    private ISyncPeerPool _syncPeerPool;
+    private ISyncPeer _syncPeer;
+
+    [SetUp]
+    public void Setup()
+    {
+        headParentBlockHeader = Build.A.BlockHeader.WithExtraData(new byte []{ 0 }).TestObject;
+        headBlockHeader = Build.A.BlockHeader.WithParent(headParentBlockHeader).TestObject;
+        finalizedBlockHeader = Build.A.BlockHeader.WithExtraData(new byte []{ 1 }).TestObject;
+
+        _syncPeerPool = Substitute.For<ISyncPeerPool>();
+        _syncPeer = Substitute.For<ISyncPeer>();
+        _peerRefresher = new PeerRefresher(_syncPeerPool, new TimerFactory(), new TestLogManager());
+    }
+
+    [Test]
+    public async Task Given_allHeaderAvailable_thenShouldCallUpdateHeader_3Times()
+    {
+        GivenAllHeaderAvailable();
+
+        WhenCalledWithCorrectHash();
+        
+        _syncPeerPool.Received().UpdateSyncPeerHeadIfHeaderIsBetter(_syncPeer, headBlockHeader);
+        _syncPeerPool.Received().UpdateSyncPeerHeadIfHeaderIsBetter(_syncPeer, headParentBlockHeader);
+        _syncPeerPool.Received().UpdateSyncPeerHeadIfHeaderIsBetter(_syncPeer, finalizedBlockHeader);
+        _syncPeerPool.DidNotReceive().ReportRefreshFailed(_syncPeer, Arg.Any<string>());
+    }
+
+    [Test]
+    public async Task Given_headBlockNotAvailable_thenShouldCallUpdateHeader_forFinalizedBlockOnly()
+    {
+        GivenFinalizedHeaderAvailable();
+
+        WhenCalledWithCorrectHash();
+        
+        _syncPeerPool.DidNotReceive().UpdateSyncPeerHeadIfHeaderIsBetter(_syncPeer, headBlockHeader);
+        _syncPeerPool.DidNotReceive().UpdateSyncPeerHeadIfHeaderIsBetter(_syncPeer, headParentBlockHeader);
+        _syncPeerPool.Received().UpdateSyncPeerHeadIfHeaderIsBetter(_syncPeer, finalizedBlockHeader);
+        _syncPeerPool.DidNotReceive().ReportRefreshFailed(_syncPeer, Arg.Any<string>());
+    }
+    
+    [Test]
+    public async Task Given_finalizedBlockNotAvailable_thenShouldCallRefreshFailed()
+    {
+        WhenCalledWithCorrectHash();
+        
+        _syncPeerPool.DidNotReceive().UpdateSyncPeerHeadIfHeaderIsBetter(_syncPeer, headBlockHeader);
+        _syncPeerPool.DidNotReceive().UpdateSyncPeerHeadIfHeaderIsBetter(_syncPeer, headParentBlockHeader);
+        _syncPeerPool.DidNotReceive().UpdateSyncPeerHeadIfHeaderIsBetter(_syncPeer, finalizedBlockHeader);
+        _syncPeerPool.Received().ReportRefreshFailed(_syncPeer, Arg.Any<string>());
+    }
+
+    private Task WhenCalledWithCorrectHash()
+    {
+        return _peerRefresher.RefreshPeerForFcu(
+            _syncPeer,
+            headBlockHeader.Hash,
+            headParentBlockHeader.Hash,
+            finalizedBlockHeader.Hash, 
+            Task.Delay(1000),
+            new CancellationToken());
+    }
+    
+    private void GivenAllHeaderAvailable()
+    {
+        _syncPeer.GetBlockHeaders(headParentBlockHeader.Hash, 2, 0, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new[] { headParentBlockHeader, headBlockHeader }));
+        GivenFinalizedHeaderAvailable();
+    }
+    
+    private void GivenFinalizedHeaderAvailable()
+    {
+        _syncPeer.GetHeadBlockHeader(finalizedBlockHeader.Hash, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(finalizedBlockHeader));
+    }
+    
+}

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/V1/ForkchoiceUpdatedV1Handler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/V1/ForkchoiceUpdatedV1Handler.cs
@@ -89,7 +89,7 @@ namespace Nethermind.Merge.Plugin.Handlers.V1
                 if (_blockCacheService.BlockCache.TryGetValue(forkchoiceState.HeadBlockHash, out Block? block))
                 {
                     _mergeSyncController.InitBeaconHeaderSync(block.Header);
-                    _peerRefresher.RefreshPeers(block.ParentHash);
+                    _peerRefresher.RefreshPeers(block.Hash, block.ParentHash, forkchoiceState.FinalizedBlockHash);
                     _blockCacheService.SyncingHead = forkchoiceState.HeadBlockHash;
                     _blockCacheService.FinalizedHash = forkchoiceState.FinalizedBlockHash;
 
@@ -108,7 +108,7 @@ namespace Nethermind.Merge.Plugin.Handlers.V1
 
             if (!_blockTree.WasProcessed(newHeadBlock.Number, newHeadBlock.GetOrCalculateHash()))
             {
-                _peerRefresher.RefreshPeers(newHeadBlock.ParentHash);
+                _peerRefresher.RefreshPeers(newHeadBlock.Hash, newHeadBlock.ParentHash, forkchoiceState.FinalizedBlockHash);
                 _blockCacheService.SyncingHead = forkchoiceState.HeadBlockHash;
                 _blockCacheService.FinalizedHash = forkchoiceState.FinalizedBlockHash;
                 _mergeSyncController.StopBeaconModeControl();

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
@@ -300,19 +300,18 @@ namespace Nethermind.Merge.Plugin
                 if (_api.SyncPeerPool is null) throw new ArgumentNullException(nameof(_api.SyncPeerPool));
                 if (_api.BlockTree is null) throw new ArgumentNullException(nameof(_api.BlockTree));
                 if (_api.DbProvider is null) throw new ArgumentNullException(nameof(_api.DbProvider));
-                if (_api.SyncProgressResolver is null)
-                    throw new ArgumentNullException(nameof(_api.SyncProgressResolver));
-                if (_api.BlockProcessingQueue is null)
-                    throw new ArgumentNullException(nameof(_api.BlockProcessingQueue));
+                if (_api.SyncProgressResolver is null) throw new ArgumentNullException(nameof(_api.SyncProgressResolver));
+                if (_api.BlockProcessingQueue is null) throw new ArgumentNullException(nameof(_api.BlockProcessingQueue));
                 if (_blockCacheService is null) throw new ArgumentNullException(nameof(_blockCacheService));
                 if (_api.BetterPeerStrategy is null) throw new ArgumentNullException(nameof(_api.BetterPeerStrategy));
                 if (_api.SealValidator is null) throw new ArgumentNullException(nameof(_api.SealValidator));
                 if (_api.UnclesValidator is null) throw new ArgumentNullException(nameof(_api.UnclesValidator));
                 if (_api.NodeStatsManager is null) throw new ArgumentNullException(nameof(_api.NodeStatsManager));
                 if (_api.HeaderValidator is null) throw new ArgumentNullException(nameof(_api.HeaderValidator));
+                if (_api.PeerDifficultyRefreshPool is null) throw new ArgumentNullException(nameof(_api.PeerDifficultyRefreshPool));
 
                 // ToDo strange place for validators initialization
-                PeerRefresher peerRefresher = new((IRefreshablePeerDifficultyPool)_api.SyncPeerPool, _api.TimerFactory, _api.LogManager);
+                PeerRefresher peerRefresher = new(_api.PeerDifficultyRefreshPool, _api.TimerFactory, _api.LogManager);
                 _peerRefresher = peerRefresher;
                 _api.DisposeStack.Push(peerRefresher);
                 _beaconPivot = new BeaconPivot(_syncConfig, _api.DbProvider.MetadataDb, _api.BlockTree, _api.LogManager);

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
@@ -310,7 +310,7 @@ namespace Nethermind.Merge.Plugin
                 if (_api.HeaderValidator is null) throw new ArgumentNullException(nameof(_api.HeaderValidator));
 
                 // ToDo strange place for validators initialization
-                PeerRefresher peerRefresher = new(_api.SyncPeerPool, _api.TimerFactory);
+                PeerRefresher peerRefresher = new(_api.SyncPeerPool, _api.TimerFactory, _api.LogManager);
                 _peerRefresher = peerRefresher;
                 _api.DisposeStack.Push(peerRefresher);
                 _beaconPivot = new BeaconPivot(_syncConfig, _api.DbProvider.MetadataDb, _api.BlockTree, _api.LogManager);

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/PeerRefresher.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/PeerRefresher.cs
@@ -17,27 +17,39 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
+using Nethermind.Blockchain;
+using Nethermind.Blockchain.Synchronization;
+using Nethermind.Consensus.Validators;
+using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Timers;
+using Nethermind.Int256;
+using Nethermind.Logging;
+using Nethermind.Stats.Model;
 using Nethermind.Synchronization.Peers;
 
 namespace Nethermind.Merge.Plugin.Synchronization;
 
 public class PeerRefresher : IPeerRefresher, IAsyncDisposable
 {
+    private const int RefreshTimeout = 3000; // the Eth.Timeout hits us at 5000 (or whatever it is configured to)
     private readonly ISyncPeerPool _syncPeerPool;
     private static readonly TimeSpan _minRefreshDelay = TimeSpan.FromSeconds(10);
     private DateTime _lastRefresh = DateTime.MinValue;
     private (Keccak, Keccak, Keccak) _lastBlockhashes = (Keccak.Zero, Keccak.Zero, Keccak.Zero);
     private readonly ITimer _refreshTimer;
+    private ILogger _logger;
 
-    public PeerRefresher(ISyncPeerPool syncPeerPool, ITimerFactory timerFactory)
+    public PeerRefresher(ISyncPeerPool syncPeerPool, ITimerFactory timerFactory, ILogManager logManager)
     {
         _refreshTimer = timerFactory.CreateTimer(_minRefreshDelay);
         _refreshTimer.Elapsed += TimerOnElapsed;
         _refreshTimer.AutoReset = false;
         _syncPeerPool = syncPeerPool;
+        _logger = logManager.GetClassLogger(GetType());
     }
 
     public void RefreshPeers(Keccak headBlockhash, Keccak headParentBlockhash, Keccak finalizedBlockhash)
@@ -65,10 +77,146 @@ public class PeerRefresher : IPeerRefresher, IAsyncDisposable
         _lastRefresh = DateTime.Now;
         foreach (PeerInfo peer in _syncPeerPool.AllPeers)
         {
-            _syncPeerPool.RefreshTotalDifficultyForFcu(peer.SyncPeer, headBlockhash, headParentBlockhash, finalizedBlockhash);
+            StartPeerRefreshTask(peer.SyncPeer, headBlockhash, headParentBlockhash, finalizedBlockhash);
         }
     }
 
+    private async Task StartPeerRefreshTask(
+        ISyncPeer syncPeer,
+        Keccak headBlockhash,
+        Keccak headParentBlockhash,
+        Keccak finalizedBlockhash
+    )
+    {
+        Task.Run(() =>
+        {
+            CancellationTokenSource delaySource = new();
+            Task delayTask = Task.Delay(RefreshTimeout, delaySource.Token);
+            try
+            {
+                ExecuteRefreshTaskForFcu(syncPeer, headBlockhash, headParentBlockhash, finalizedBlockhash,
+                    delayTask, delaySource.Token);
+            }
+            catch (Exception exception)
+            {
+                if (_logger.IsError) _logger.Error($"Exception in peer refresh. This is unexpected. {syncPeer}", exception);
+            }
+            finally
+            {
+                delaySource.Cancel();
+            }
+        });
+    }
+
+    private async Task ExecuteRefreshTaskForFcu(
+        ISyncPeer syncPeer,
+        Keccak headBlockhash,
+        Keccak headParentBlockhash,
+        Keccak finalizedBlockhash,
+        Task? delayTask,
+        CancellationToken token
+    ) {
+        
+        // headBlockhash is obtained together with headParentBlockhash
+        Task<BlockHeader[]> getHeadParentHeaderTask = syncPeer.GetBlockHeaders(headParentBlockhash, 2, 0, token);
+        Task<BlockHeader?> getFinalizedHeaderTask = finalizedBlockhash == Keccak.Zero 
+            ? Task.FromResult<BlockHeader?>(null)
+            : syncPeer.GetHeadBlockHeader(finalizedBlockhash, token);
+
+        Task getHeaderTask = Task.WhenAll(getFinalizedHeaderTask, getFinalizedHeaderTask);
+        Task firstToComplete = await Task.WhenAny(getHeaderTask, delayTask);
+
+        if (firstToComplete == delayTask)
+        {
+            _syncPeerPool.ReportRefreshFailed(syncPeer, "timeout");
+            return;
+        }
+
+        BlockHeader? headBlockHeader = null;
+        BlockHeader? headParentBlockHeader = null;
+        BlockHeader? finalizedBlockHeader = null;
+        try
+        {
+            BlockHeader[] headAndParentHeaders = await getHeadParentHeaderTask;
+            if (headAndParentHeaders.Length == 1)
+            {
+                headParentBlockHeader = headAndParentHeaders[0];
+            }
+            else if (headAndParentHeaders.Length == 2)
+            {
+                // Maybe the head is not the same as we expected. In that case, leave it as null
+                if (headBlockhash == headAndParentHeaders[1].Hash)
+                {
+                    headBlockHeader = headAndParentHeaders[1];
+                }
+                headParentBlockHeader = headAndParentHeaders[0];
+            }
+            else if (headAndParentHeaders.Length > 0)
+            {
+                if (_logger.IsTrace) _logger.Trace($"PeerRefreshForFCU unexpected response length when fetching header: {headAndParentHeaders.Length}");
+            }
+
+            finalizedBlockHeader = await getFinalizedHeaderTask;
+        }
+        catch (TaskCanceledException exception)
+        {
+            if (_logger.IsTrace)
+                _logger.Trace(
+                    $"PeerRefreshForFCU canceled for node: {syncPeer.Node:c}{Environment.NewLine}{exception}");
+            _syncPeerPool.ReportRefreshCancelled(syncPeer);
+            throw;
+        }
+        catch (Exception exception)
+        {
+            if (_logger.IsTrace)
+                _logger.Trace($"PeerRefreshForFCU failed for node: {syncPeer.Node:c}{Environment.NewLine}{exception}");
+            _syncPeerPool.ReportRefreshFailed(syncPeer, "faulted");
+            // TODO: how to know if exception is transient
+            syncPeer.Disconnect(DisconnectReason.DisconnectRequested, "refresh peer info fault - faulted");
+            return;
+        }
+
+        if (_logger.IsTrace)
+        {
+            _logger.Trace($"PeerRefreshForFCU received block info from {syncPeer.Node:c}");
+            _logger.Trace($"PeerRefreshForFCU headHeader: {headBlockHeader}");
+            _logger.Trace($"PeerRefreshForFCU headParentHeader: {headParentBlockHeader}");
+            _logger.Trace($"PeerRefreshForFCU finalizedBlockHeader: {finalizedBlockHeader}");
+        }
+
+        if (finalizedBlockhash != Keccak.Zero && finalizedBlockHeader == null)
+        {
+            if (_logger.IsTrace)
+                _logger.Trace($"PeerRefreshForFCU failed for node: {syncPeer.Node:c}{Environment.NewLine} - Finalized block header not found");
+            _syncPeerPool.ReportRefreshFailed(syncPeer, "no finalized block header");
+            return;
+        }
+
+        List<BlockHeader> headersToCheck = new [] {
+            headBlockHeader,
+            headParentBlockHeader,
+            finalizedBlockHeader
+        }.Where((header) => header != null).ToList();
+        
+        foreach (BlockHeader header in headersToCheck)
+        {
+            if (!HeaderValidator.ValidateHash(header))
+            {
+                if (_logger.IsTrace)
+                    _logger.Trace($"PeerRefreshForFCU failed for node: {syncPeer.Node:c}{Environment.NewLine} Invalid block hash. Header: {header}");
+                _syncPeerPool.ReportRefreshFailed(syncPeer, "invalid header hash");
+                return;
+            }
+        }
+
+        foreach (BlockHeader header in headersToCheck)
+        {
+            _syncPeerPool.UpdateSyncPeerHeadIfHeaderIsBetter(syncPeer, header);
+        }
+
+        _syncPeerPool.SignalPeersChanged();
+    }
+        
     public ValueTask DisposeAsync()
     {
         _refreshTimer.Dispose();

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/PeerRefresher.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/PeerRefresher.cs
@@ -40,13 +40,13 @@ public class PeerRefresher : IPeerRefresher, IAsyncDisposable
         _syncPeerPool = syncPeerPool;
     }
 
-    public void RefreshPeers(Keccak headBlockhash, Keccak parentHeadBlockhash, Keccak finalizedBlockhash)
+    public void RefreshPeers(Keccak headBlockhash, Keccak headParentBlockhash, Keccak finalizedBlockhash)
     {
-        _lastBlockhashes = (headBlockhash, parentHeadBlockhash, finalizedBlockhash);
+        _lastBlockhashes = (headBlockhash, headParentBlockhash, finalizedBlockhash);
         TimeSpan timePassed = DateTime.Now - _lastRefresh;
         if (timePassed > _minRefreshDelay)
         {
-            Refresh(headBlockhash, parentHeadBlockhash, finalizedBlockhash);
+            Refresh(headBlockhash, headParentBlockhash, finalizedBlockhash);
         }
         else if (!_refreshTimer.Enabled)
         {
@@ -60,12 +60,12 @@ public class PeerRefresher : IPeerRefresher, IAsyncDisposable
         Refresh(_lastBlockhashes.Item1, _lastBlockhashes.Item2, _lastBlockhashes.Item3);
     }
     
-    private void Refresh(Keccak headBlockhash, Keccak parentHeadBlockhash, Keccak finalizedBlockhash)
+    private void Refresh(Keccak headBlockhash, Keccak headParentBlockhash, Keccak finalizedBlockhash)
     {
         _lastRefresh = DateTime.Now;
         foreach (PeerInfo peer in _syncPeerPool.AllPeers)
         {
-            _syncPeerPool.RefreshTotalDifficultyForFcu(peer.SyncPeer, headBlockhash, parentHeadBlockhash, finalizedBlockhash);
+            _syncPeerPool.RefreshTotalDifficultyForFcu(peer.SyncPeer, headBlockhash, headParentBlockhash, finalizedBlockhash);
         }
     }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/PeerRefresher.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/PeerRefresher.cs
@@ -37,14 +37,14 @@ namespace Nethermind.Merge.Plugin.Synchronization;
 
 public class PeerRefresher : IPeerRefresher, IAsyncDisposable
 {
-    private readonly IRefreshablePeerDifficultyPool _syncPeerPool;
+    private readonly IPeerDifficultyRefreshPool _syncPeerPool;
     private static readonly TimeSpan _minRefreshDelay = TimeSpan.FromSeconds(10);
     private DateTime _lastRefresh = DateTime.MinValue;
     private (Keccak headBlockhash, Keccak headParentBlockhash, Keccak finalizedBlockhash) _lastBlockhashes = (Keccak.Zero, Keccak.Zero, Keccak.Zero);
     private readonly ITimer _refreshTimer;
     private readonly ILogger _logger;
 
-    public PeerRefresher(IRefreshablePeerDifficultyPool syncPeerPool, ITimerFactory timerFactory, ILogManager logManager)
+    public PeerRefresher(IPeerDifficultyRefreshPool syncPeerPool, ITimerFactory timerFactory, ILogManager logManager)
     {
         _refreshTimer = timerFactory.CreateTimer(_minRefreshDelay);
         _refreshTimer.Elapsed += TimerOnElapsed;

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/PeerRefresher.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/PeerRefresher.cs
@@ -88,23 +88,20 @@ public class PeerRefresher : IPeerRefresher, IAsyncDisposable
         Keccak finalizedBlockhash
     )
     {
-        Task.Run(async () =>
+        CancellationTokenSource delaySource = new();
+        Task delayTask = Task.Delay(RefreshTimeout, delaySource.Token);
+        try
         {
-            CancellationTokenSource delaySource = new();
-            Task delayTask = Task.Delay(RefreshTimeout, delaySource.Token);
-            try
-            {
-                await RefreshPeerForFcu(syncPeer, headBlockhash, headParentBlockhash, finalizedBlockhash, delayTask, delaySource.Token);
-            }
-            catch (Exception exception)
-            {
-                if (_logger.IsError) _logger.Error($"Exception in peer refresh. This is unexpected. {syncPeer}", exception);
-            }
-            finally
-            {
-                delaySource.Cancel();
-            }
-        });
+            await RefreshPeerForFcu(syncPeer, headBlockhash, headParentBlockhash, finalizedBlockhash, delayTask, delaySource.Token);
+        }
+        catch (Exception exception)
+        {
+            if (_logger.IsError) _logger.Error($"Exception in peer refresh. This is unexpected. {syncPeer}", exception);
+        }
+        finally
+        {
+            delaySource.Cancel();
+        }
     }
 
     internal async Task RefreshPeerForFcu(

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
@@ -203,6 +203,23 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
             BlockHeader[] headers = await SendRequest(msg, token);
             return headers.Length > 0 ? headers[0] : null;
         }
+        
+        async Task<BlockHeader[]> ISyncPeer.GetBlockHeaders(Keccak startHash, int maxBlocks, int skip, CancellationToken token)
+        {
+            if (maxBlocks == 0)
+            {
+                return Array.Empty<BlockHeader>();
+            }
+
+            GetBlockHeadersMessage msg = new();
+            msg.StartBlockHash = startHash;
+            msg.MaxHeaders = maxBlocks;
+            msg.Reverse = 0;
+            msg.Skip = skip;
+
+            BlockHeader[] headers = await SendRequest(msg, token);
+            return headers;
+        }
 
         public virtual Task<TxReceipt[][]> GetReceipts(IReadOnlyList<Keccak> blockHash, CancellationToken token)
         {

--- a/src/Nethermind/Nethermind.Runner.Test/Ethereum/ContextWithMocks.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Ethereum/ContextWithMocks.cs
@@ -120,6 +120,7 @@ namespace Nethermind.Runner.Test.Ethereum
                 RpcModuleProvider = Substitute.For<IRpcModuleProvider>(),
                 SyncModeSelector = Substitute.For<ISyncModeSelector>(),
                 SyncPeerPool = Substitute.For<ISyncPeerPool>(),
+                PeerDifficultyRefreshPool = Substitute.For<IPeerDifficultyRefreshPool>(),
                 WebSocketsManager = Substitute.For<IWebSocketsManager>(),
                 ChainLevelInfoRepository = Substitute.For<IChainLevelInfoRepository>(),
                 TrieStore = Substitute.For<ITrieStore>(),

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
@@ -118,22 +118,6 @@ namespace Nethermind.Synchronization.Test.ParallelSync
 
             public event EventHandler<PeerBlockNotificationEventArgs> NotifyPeerBlock;
             public event EventHandler<PeerHeadRefreshedEventArgs> PeerRefreshed;
-            
-            public void SignalPeersChanged()
-            {
-            }
-
-            public void UpdateSyncPeerHeadIfHeaderIsBetter(ISyncPeer syncPeer, BlockHeader header)
-            {
-            }
-
-            public void ReportRefreshFailed(ISyncPeer syncPeer, string reason, Exception? exception)
-            {
-            }
-
-            public void ReportRefreshCancelled(ISyncPeer syncPeer)
-            {
-            }
         }
 
         private class TestBatch

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
@@ -22,6 +22,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Synchronization;
+using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Int256;
 using Nethermind.Logging;
@@ -122,6 +123,22 @@ namespace Nethermind.Synchronization.Test.ParallelSync
 
             public event EventHandler<PeerBlockNotificationEventArgs> NotifyPeerBlock;
             public event EventHandler<PeerHeadRefreshedEventArgs> PeerRefreshed;
+            
+            public void SignalPeersChanged()
+            {
+            }
+
+            public void UpdateSyncPeerHeadIfHeaderIsBetter(ISyncPeer syncPeer, BlockHeader header)
+            {
+            }
+
+            public void ReportRefreshFailed(ISyncPeer syncPeer, string reason)
+            {
+            }
+
+            public void ReportRefreshCancelled(ISyncPeer syncPeer)
+            {
+            }
         }
 
         private class TestBatch

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
@@ -102,11 +102,6 @@ namespace Nethermind.Synchronization.Test.ParallelSync
             {
             }
 
-            public void RefreshTotalDifficultyForFcu(ISyncPeer peerSyncPeer, Keccak headBlockhash, Keccak headParentBlockhash,
-                Keccak finalizedBlockhash)
-            {
-            }
-
             public void Start()
             {
             }
@@ -132,7 +127,7 @@ namespace Nethermind.Synchronization.Test.ParallelSync
             {
             }
 
-            public void ReportRefreshFailed(ISyncPeer syncPeer, string reason)
+            public void ReportRefreshFailed(ISyncPeer syncPeer, string reason, Exception? exception)
             {
             }
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
@@ -101,6 +101,11 @@ namespace Nethermind.Synchronization.Test.ParallelSync
             {
             }
 
+            public void RefreshTotalDifficultyForFcu(ISyncPeer peerSyncPeer, Keccak headBlockhash, Keccak headParentBlockhash,
+                Keccak finalizedBlockhash)
+            {
+            }
+
             public void Start()
             {
             }

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerPoolTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerPoolTests.cs
@@ -727,7 +727,6 @@ namespace Nethermind.Synchronization.Test
             ctx.Pool.Start();
             var syncPeer = Substitute.For<ISyncPeer>();
             syncPeer.Node.Returns(new Node(TestItem.PublicKeyA, "127.0.0.1", 30303));
-            ctx.Pool.AddPeer(syncPeer);
 
             // On add, it will refresh for init first
             syncPeer.GetHeadBlockHeader(null, Arg.Any<CancellationToken>()).Returns(Task.FromResult(initHeader));
@@ -736,6 +735,7 @@ namespace Nethermind.Synchronization.Test
                 .Returns(Task.FromResult(new []{parentBlockHeader, headHeader}));
             syncPeer.GetHeadBlockHeader(finalizedBlockHeader.Hash, Arg.Any<CancellationToken>()).Returns(Task.FromResult(finalizedBlockHeader));
             
+            ctx.Pool.AddPeer(syncPeer);
             ctx.Pool.RefreshTotalDifficultyForFcu(syncPeer, headHeader.Hash, parentBlockHeader.Hash, finalizedBlockHeader.Hash);
             await Task.Delay(100);
 
@@ -756,13 +756,13 @@ namespace Nethermind.Synchronization.Test
             ctx.Pool.Start();
             var syncPeer = Substitute.For<ISyncPeer>();
             syncPeer.Node.Returns(new Node(TestItem.PublicKeyA, "127.0.0.1", 30303));
-            ctx.Pool.AddPeer(syncPeer);
 
             // On add, it will refresh for init first
             syncPeer.GetHeadBlockHeader(null, Arg.Any<CancellationToken>()).Returns(Task.FromResult(headHeader));
             
             syncPeer.GetHeadBlockHeader(finalizedBlockHeader.Hash, Arg.Any<CancellationToken>()).Returns(Task.FromResult<BlockHeader?>(null));
             
+            ctx.Pool.AddPeer(syncPeer);
             ctx.Pool.RefreshTotalDifficultyForFcu(syncPeer, headHeader.Hash, parentBlockHeader.Hash, finalizedBlockHeader.Hash);
             await Task.Delay(100);
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerPoolTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerPoolTests.cs
@@ -714,62 +714,6 @@ namespace Nethermind.Synchronization.Test
                 Assert.Null(allocation.Current, "null A");
             }
         }
-        
-        [Test, Retry(3)]
-        public async Task Can_refresh_with_fcu()
-        {
-            BlockHeader initHeader = Build.A.BlockHeader.WithNumber(50).TestObject;
-            BlockHeader parentBlockHeader = Build.A.BlockHeader.WithNumber(101).TestObject;
-            BlockHeader headHeader = Build.A.BlockHeader.WithParent(parentBlockHeader).WithNumber(102).TestObject;
-            BlockHeader finalizedBlockHeader = Build.A.BlockHeader.WithNumber(100).TestObject;
-            
-            await using Context ctx = new();
-            ctx.Pool.Start();
-            var syncPeer = Substitute.For<ISyncPeer>();
-            syncPeer.Node.Returns(new Node(TestItem.PublicKeyA, "127.0.0.1", 30303));
-
-            // On add, it will refresh for init first
-            syncPeer.GetHeadBlockHeader(null, Arg.Any<CancellationToken>()).Returns(Task.FromResult(initHeader));
-            
-            syncPeer.GetBlockHeaders(parentBlockHeader.Hash, 2, 0, Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult(new []{parentBlockHeader, headHeader}));
-            syncPeer.GetHeadBlockHeader(finalizedBlockHeader.Hash, Arg.Any<CancellationToken>()).Returns(Task.FromResult(finalizedBlockHeader));
-            
-            ctx.Pool.AddPeer(syncPeer);
-            ctx.Pool.RefreshTotalDifficultyForFcu(syncPeer, headHeader.Hash, parentBlockHeader.Hash, finalizedBlockHeader.Hash);
-            await Task.Delay(100);
-
-            await syncPeer.Received(2).GetHeadBlockHeader(Arg.Any<Keccak>(), Arg.Any<CancellationToken>());
-            await syncPeer.Received(1).GetBlockHeaders(parentBlockHeader.Hash, 2, 0, Arg.Any<CancellationToken>());
-            syncPeer.DidNotReceive().Disconnect(Arg.Any<DisconnectReason>(), Arg.Any<string>());
-            syncPeer.HeadNumber.Should().Be(102);
-        }
-        
-        [Test, Retry(3)]
-        public async Task When_finalized_header_not_found_then_disconnect()
-        {
-            BlockHeader parentBlockHeader = Build.A.BlockHeader.TestObject;
-            BlockHeader headHeader = Build.A.BlockHeader.WithParent(parentBlockHeader).TestObject;
-            BlockHeader finalizedBlockHeader = Build.A.BlockHeader.WithNumber(99).TestObject;
-            
-            await using Context ctx = new();
-            ctx.Pool.Start();
-            var syncPeer = Substitute.For<ISyncPeer>();
-            syncPeer.Node.Returns(new Node(TestItem.PublicKeyA, "127.0.0.1", 30303));
-
-            // On add, it will refresh for init first
-            syncPeer.GetHeadBlockHeader(null, Arg.Any<CancellationToken>()).Returns(Task.FromResult(headHeader));
-            
-            syncPeer.GetHeadBlockHeader(finalizedBlockHeader.Hash, Arg.Any<CancellationToken>()).Returns(Task.FromResult<BlockHeader?>(null));
-            
-            ctx.Pool.AddPeer(syncPeer);
-            ctx.Pool.RefreshTotalDifficultyForFcu(syncPeer, headHeader.Hash, parentBlockHeader.Hash, finalizedBlockHeader.Hash);
-            await Task.Delay(100);
-
-            await syncPeer.Received(2).GetHeadBlockHeader(Arg.Any<Keccak>(), Arg.Any<CancellationToken>());
-            await syncPeer.Received(1).GetBlockHeaders(parentBlockHeader.Hash, 2, 0, Arg.Any<CancellationToken>());
-            syncPeer.Received().Disconnect(Arg.Any<DisconnectReason>(), Arg.Any<string>());
-        }
 
         private int _pendingRequests;
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerPoolTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerPoolTests.cs
@@ -94,6 +94,11 @@ namespace Nethermind.Synchronization.Test
                 return Task.FromResult(Array.Empty<BlockHeader>());
             }
 
+            public Task<BlockHeader[]> GetBlockHeaders(Keccak startHash, int maxBlocks, int skip, CancellationToken token)
+            {
+                return Task.FromResult(Array.Empty<BlockHeader>());
+            }
+
             public async Task<BlockHeader> GetHeadBlockHeader(Keccak hash, CancellationToken token)
             {
                 if (_shouldFail)

--- a/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
@@ -173,6 +173,11 @@ namespace Nethermind.Synchronization.Test
                 return Task.FromResult(result);
             }
 
+            public Task<BlockHeader[]> GetBlockHeaders(Keccak startHash, int maxBlocks, int skip, CancellationToken token)
+            {
+                throw new NotImplementedException();
+            }
+
             public async Task<BlockHeader> GetHeadBlockHeader(Keccak hash, CancellationToken token)
             {
                 if (_causeTimeoutOnInit)

--- a/src/Nethermind/Nethermind.Synchronization/Peers/IPeerDifficultyRefreshPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/IPeerDifficultyRefreshPool.cs
@@ -22,7 +22,7 @@ using Nethermind.Core;
 
 namespace Nethermind.Synchronization.Peers;
 
-public interface IRefreshablePeerDifficultyPool
+public interface IPeerDifficultyRefreshPool
 {
     /// <summary>
     /// All peers maintained by the pool

--- a/src/Nethermind/Nethermind.Synchronization/Peers/IRefreshablePeerDifficultyPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/IRefreshablePeerDifficultyPool.cs
@@ -1,27 +1,37 @@
-//  Copyright (c) 2021 Demerzel Solutions Limited
+﻿//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using System;
+using System.Collections.Generic;
+using Nethermind.Blockchain.Synchronization;
+using Nethermind.Core;
 
-namespace Nethermind.Synchronization
+namespace Nethermind.Synchronization.Peers;
+
+public interface IRefreshablePeerDifficultyPool
 {
-    public class Timeouts
-    {
-        public static readonly TimeSpan Eth = TimeSpan.FromSeconds(10);
-        public static readonly TimeSpan RefreshDifficulty = TimeSpan.FromSeconds(3);
-    }
+    /// <summary>
+    /// All peers maintained by the pool
+    /// </summary>
+    IEnumerable<PeerInfo> AllPeers { get; }
+
+    void SignalPeersChanged();
+
+    void UpdateSyncPeerHeadIfHeaderIsBetter(ISyncPeer syncPeer, BlockHeader header);
+
+    void ReportRefreshFailed(ISyncPeer syncPeer, string reason, Exception? exception = null);
 }

--- a/src/Nethermind/Nethermind.Synchronization/Peers/ISyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/ISyncPeerPool.cs
@@ -91,6 +91,16 @@ namespace Nethermind.Synchronization.Peers
         /// <param name="syncPeer"></param>
         /// <param name="hash">Hash of a block that we know might be the head block of the peer</param>
         void RefreshTotalDifficulty(ISyncPeer syncPeer, Keccak hash);
+        
+        /// <summary>
+        /// FCU have a slightly different handling in determining if the node should get disconnected. In particular,
+        /// if the node does not have a finalizedBlockhash, then we disconnect the node
+        /// </summary>
+        /// <param name="peerSyncPeer"></param>
+        /// <param name="headBlockhash"></param>
+        /// <param name="headParentBlockhash"></param>
+        /// <param name="finalizedBlockhash"></param>
+        void RefreshTotalDifficultyForFcu(ISyncPeer peerSyncPeer, Keccak headBlockhash, Keccak headParentBlockhash, Keccak finalizedBlockhash);
 
         /// <summary>
         /// Starts the pool loops.

--- a/src/Nethermind/Nethermind.Synchronization/Peers/ISyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/ISyncPeerPool.cs
@@ -114,7 +114,7 @@ namespace Nethermind.Synchronization.Peers
         
         void UpdateSyncPeerHeadIfHeaderIsBetter(ISyncPeer syncPeer, BlockHeader header);
         
-        void ReportRefreshFailed(ISyncPeer syncPeer, string reason);
+        void ReportRefreshFailed(ISyncPeer syncPeer, string reason, Exception? exception = null);
         
         void ReportRefreshCancelled(ISyncPeer syncPeer);
     }

--- a/src/Nethermind/Nethermind.Synchronization/Peers/ISyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/ISyncPeerPool.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Nethermind.Blockchain.Synchronization;
+using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Stats.Model;
 using Nethermind.Synchronization.Peers.AllocationStrategies;
@@ -93,16 +94,6 @@ namespace Nethermind.Synchronization.Peers
         void RefreshTotalDifficulty(ISyncPeer syncPeer, Keccak hash);
         
         /// <summary>
-        /// FCU have a slightly different handling in determining if the node should get disconnected. In particular,
-        /// if the node does not have a finalizedBlockhash, then we disconnect the node
-        /// </summary>
-        /// <param name="peerSyncPeer"></param>
-        /// <param name="headBlockhash"></param>
-        /// <param name="headParentBlockhash"></param>
-        /// <param name="finalizedBlockhash"></param>
-        void RefreshTotalDifficultyForFcu(ISyncPeer peerSyncPeer, Keccak headBlockhash, Keccak headParentBlockhash, Keccak finalizedBlockhash);
-
-        /// <summary>
         /// Starts the pool loops.
         /// </summary>
         void Start();
@@ -118,5 +109,13 @@ namespace Nethermind.Synchronization.Peers
         event EventHandler<PeerBlockNotificationEventArgs> NotifyPeerBlock;
         
         event EventHandler<PeerHeadRefreshedEventArgs> PeerRefreshed;
+        
+        void SignalPeersChanged();
+        
+        void UpdateSyncPeerHeadIfHeaderIsBetter(ISyncPeer syncPeer, BlockHeader header);
+        
+        void ReportRefreshFailed(ISyncPeer syncPeer, string reason);
+        
+        void ReportRefreshCancelled(ISyncPeer syncPeer);
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization/Peers/ISyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/ISyncPeerPool.cs
@@ -18,7 +18,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Nethermind.Blockchain.Synchronization;
-using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Stats.Model;
 using Nethermind.Synchronization.Peers.AllocationStrategies;
@@ -109,13 +108,5 @@ namespace Nethermind.Synchronization.Peers
         event EventHandler<PeerBlockNotificationEventArgs> NotifyPeerBlock;
         
         event EventHandler<PeerHeadRefreshedEventArgs> PeerRefreshed;
-        
-        void SignalPeersChanged();
-        
-        void UpdateSyncPeerHeadIfHeaderIsBetter(ISyncPeer syncPeer, BlockHeader header);
-        
-        void ReportRefreshFailed(ISyncPeer syncPeer, string reason, Exception? exception = null);
-        
-        void ReportRefreshCancelled(ISyncPeer syncPeer);
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
@@ -21,6 +21,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Find;
 using Nethermind.Blockchain.Synchronization;
@@ -35,6 +36,8 @@ using Nethermind.Specs;
 using Nethermind.Stats;
 using Nethermind.Stats.Model;
 using Nethermind.Synchronization.Peers.AllocationStrategies;
+using Prometheus;
+using ILogger = Nethermind.Logging.ILogger;
 using Timer = System.Timers.Timer;
 
 [assembly: InternalsVisibleTo("Nethermind.Blockchain.Test")]
@@ -256,6 +259,12 @@ namespace Nethermind.Synchronization.Peers
             RefreshTotalDiffTask task = new(blockHash, syncPeer);
             _peerRefreshQueue.Add(task);
         }
+        
+        public void RefreshTotalDifficultyForFcu(ISyncPeer syncPeer, Keccak headBlockHash, Keccak headParentBlockhash, Keccak finalizedBlockhash)
+        {
+            RefreshTotalDiffTask task = new(headBlockHash, headParentBlockhash, finalizedBlockhash, syncPeer);
+            _peerRefreshQueue.Add(task);
+        }
 
         public void AddPeer(ISyncPeer syncPeer)
         {
@@ -407,19 +416,27 @@ namespace Nethermind.Synchronization.Peers
             SignalPeersChanged();
         }
 
+        private static Gauge peerRefreshQueueSize = Prometheus.Metrics.CreateGauge("peer_refresh_queue_size", "Size of peer refresh queue");
+        private static Gauge pendingRefreshTaskSize = Prometheus.Metrics.CreateGauge("pending_refresh_task_size", "Pending peer refresh size");
+
         private async Task RunRefreshPeerLoop()
         {
+            // TODO: Why use a queue when it's not going to block
             foreach (RefreshTotalDiffTask refreshTask in _peerRefreshQueue.GetConsumingEnumerable(_refreshLoopCancellation.Token))
             {
                 ISyncPeer syncPeer = refreshTask.SyncPeer;
                 if (_logger.IsTrace) _logger.Trace($"Refreshing info for {syncPeer}.");
                 CancellationTokenSource initCancelSource = _refreshCancelTokens[syncPeer.Node.Id] = new CancellationTokenSource();
                 CancellationTokenSource linkedSource = CancellationTokenSource.CreateLinkedTokenSource(initCancelSource.Token, _refreshLoopCancellation.Token);
+                
+                pendingRefreshTaskSize.Inc();
+                peerRefreshQueueSize.Set(_peerRefreshQueue.Count);
 
 #pragma warning disable 4014
                 ExecuteRefreshTask(refreshTask, linkedSource.Token).ContinueWith(t =>
 #pragma warning restore 4014
                 {
+                    pendingRefreshTaskSize.Dec();
                     _refreshCancelTokens.TryRemove(syncPeer.Node.Id, out _);
                     if (t.IsFaulted)
                     {
@@ -584,93 +601,256 @@ namespace Nethermind.Synchronization.Peers
             ISyncPeer syncPeer = refreshTotalDiffTask.SyncPeer;
             if (_logger.IsTrace) _logger.Trace($"Requesting head block info from {syncPeer.Node:s}");
 
-            Task<BlockHeader?> getHeadHeaderTask = syncPeer.GetHeadBlockHeader(refreshTotalDiffTask.BlockHash ?? syncPeer.HeadHash, token);
             CancellationTokenSource delaySource = new();
             CancellationTokenSource linkedSource = CancellationTokenSource.CreateLinkedTokenSource(delaySource.Token, token);
             Task delayTask = Task.Delay(InitTimeout, linkedSource.Token);
-            Task firstToComplete = await Task.WhenAny(getHeadHeaderTask, delayTask);
-            await firstToComplete.ContinueWith(
-                t =>
+
+            try
+            {
+                if (refreshTotalDiffTask.FromFcu)
                 {
-                    try
+                    await ExecuteRefreshTaskForFcu(syncPeer, refreshTotalDiffTask.HeadBlockhash, refreshTotalDiffTask.HeadParentBlockhash, refreshTotalDiffTask.FinalizedBlockhash, delayTask, token);
+                }
+                else
+                {
+                    await ExecuteRefreshTaskForHead(syncPeer, refreshTotalDiffTask.BlockHash, delayTask, token);
+                }
+            }
+            finally
+            {
+                delaySource.Cancel();
+                linkedSource.Cancel();
+            }
+        }
+
+        private async Task ExecuteRefreshTaskForFcu(
+            ISyncPeer syncPeer,
+            Keccak headBlockhash,
+            Keccak headParentBlockhash,
+            Keccak finalizedBlockhash,
+            Task? delayTask,
+            CancellationToken token
+        ) {
+            
+            // headBlockhash is obtained together with headParentBlockhash
+            Task<BlockHeader[]> getHeadParentHeaderTask = syncPeer.GetBlockHeaders(headParentBlockhash, 2, 0, token);
+            Task<BlockHeader?> getFinalizedHeaderTask = finalizedBlockhash == Keccak.Zero 
+                ? Task.FromResult<BlockHeader?>(null)
+                : syncPeer.GetHeadBlockHeader(finalizedBlockhash, token);
+
+            Task getHeaderTask = Task.WhenAll(getFinalizedHeaderTask, getFinalizedHeaderTask);
+            Task firstToComplete = await Task.WhenAny(getHeaderTask, delayTask);
+
+            if (firstToComplete == delayTask)
+            {
+                if (_logger.IsTrace) _logger.Trace($"PeerRefreshForFCU timed out for node: {syncPeer.Node:c}");
+                _stats.ReportSyncEvent(syncPeer.Node,
+                    syncPeer.IsInitialized ? NodeStatsEventType.SyncFailed : NodeStatsEventType.SyncInitFailed);
+                syncPeer.Disconnect(DisconnectReason.DisconnectRequested, "refresh peer info fault - timeout");
+                return;
+            }
+
+            BlockHeader? headBlockHeader = null;
+            BlockHeader? headParentBlockHeader = null;
+            BlockHeader? finalizedBlockHeader = null;
+            try
+            {
+                BlockHeader[] headAndParentHeaders = await getHeadParentHeaderTask;
+                if (headAndParentHeaders.Length == 1)
+                {
+                    headBlockHeader = headAndParentHeaders[0];
+                }
+                else if (headAndParentHeaders.Length == 2)
+                {
+                    // Maybe the head is not the same as we expected. In that case, leave it as null
+                    if (headBlockhash == headAndParentHeaders[1].Hash)
                     {
-                        if (firstToComplete == delayTask)
-                        {
-                            if (_logger.IsTrace) _logger.Trace($"InitPeerInfo timed out for node: {syncPeer.Node:c}");
-                            _stats.ReportSyncEvent(syncPeer.Node, syncPeer.IsInitialized ? NodeStatsEventType.SyncFailed : NodeStatsEventType.SyncInitFailed);
-                            syncPeer.Disconnect(DisconnectReason.DisconnectRequested, "refresh peer info fault - timeout");
-                        }
-                        else if (firstToComplete.IsFaulted)
-                        {
-                            if (_logger.IsTrace) _logger.Trace($"InitPeerInfo failed for node: {syncPeer.Node:c}{Environment.NewLine}{t.Exception}");
-                            _stats.ReportSyncEvent(syncPeer.Node, syncPeer.IsInitialized ? NodeStatsEventType.SyncFailed : NodeStatsEventType.SyncInitFailed);
-                            syncPeer.Disconnect(DisconnectReason.DisconnectRequested, "refresh peer info fault - faulted");
-                        }
-                        else if (firstToComplete.IsCanceled)
-                        {
-                            if (_logger.IsTrace) _logger.Trace($"InitPeerInfo canceled for node: {syncPeer.Node:c}{Environment.NewLine}{t.Exception}");
-                            _stats.ReportSyncEvent(syncPeer.Node, syncPeer.IsInitialized ? NodeStatsEventType.SyncCancelled : NodeStatsEventType.SyncInitCancelled);
-                            token.ThrowIfCancellationRequested();
-                        }
-                        else
-                        {
-                            delaySource.Cancel();
-                            BlockHeader? header = getHeadHeaderTask.Result;
-                            if (header == null)
-                            {
-                                if (_logger.IsTrace) _logger.Trace($"InitPeerInfo failed for node: {syncPeer.Node:c}{Environment.NewLine}{t.Exception}");
-                                _stats.ReportSyncEvent(syncPeer.Node, syncPeer.IsInitialized ? NodeStatsEventType.SyncFailed : NodeStatsEventType.SyncInitFailed);
-                                syncPeer.Disconnect(DisconnectReason.DisconnectRequested, "refresh peer info fault - null response");
-                                return;
-                            }
-
-                            if (!HeaderValidator.ValidateHash(header))
-                            {
-                                if (_logger.IsTrace) _logger.Trace($"InitPeerInfo failed for node: {syncPeer.Node:c}{Environment.NewLine}Invalid block hash.");
-                                _stats.ReportSyncEvent(syncPeer.Node, syncPeer.IsInitialized ? NodeStatsEventType.SyncFailed : NodeStatsEventType.SyncInitFailed);
-                                syncPeer.Disconnect(DisconnectReason.DisconnectRequested, "refresh peer info fault - invalid header hash");
-                                return;
-                            }
-
-                            if (_logger.IsTrace) _logger.Trace($"Received head block info from {syncPeer.Node:c} with head block {header.ToString(BlockHeader.Format.Short)}, total difficulty {header.TotalDifficulty}");
-                            if (!syncPeer.IsInitialized) _stats.ReportSyncEvent(syncPeer.Node, NodeStatsEventType.SyncInitCompleted);
-
-                            if (_logger.IsTrace) _logger.Trace($"REFRESH Updating header of {syncPeer} from {syncPeer.HeadNumber} to {header.Number}");
-
-                            BlockHeader? parent = _blockTree.FindParentHeader(header, BlockTreeLookupOptions.None);
-                            if (parent != null && parent.TotalDifficulty != 0)
-                            {
-                                UInt256 newTotalDifficulty = (parent.TotalDifficulty ?? UInt256.Zero) + header.Difficulty;
-                                bool newValueIsNotWorseThanPeer =
-                                    _betterPeerStrategy.Compare((newTotalDifficulty, header.Number),
-                                        syncPeer) >=0;
-                                if (_logger.IsTrace) _logger.Trace($"REFRESH Updating header of {syncPeer} from {syncPeer.HeadNumber} to {header.Number} based on totalDifficulty, newValueIsNotWorseThanPeer {newValueIsNotWorseThanPeer}");
-                                if (newValueIsNotWorseThanPeer)
-                                {
-                                    syncPeer.TotalDifficulty = newTotalDifficulty;
-                                    syncPeer.HeadNumber = header.Number;
-                                    syncPeer.HeadHash = header.Hash!;
-                                    
-                                    PeerRefreshed?.Invoke(this, new PeerHeadRefreshedEventArgs(syncPeer, header));
-                                }
-                            }
-                            else if (header.Number > syncPeer.HeadNumber)
-                            {
-                                if (_logger.IsTrace) _logger.Trace($"REFRESH Updating header of {syncPeer} from {syncPeer.HeadNumber} to {header.Number} based on headNumber");
-                                syncPeer.HeadNumber = header.Number;
-                                syncPeer.HeadHash = header.Hash!;
-                            }
-
-                            syncPeer.IsInitialized = true;
-                            SignalPeersChanged();
-                        }
+                        headBlockHeader = headAndParentHeaders[1];
                     }
-                    finally
-                    {
-                        linkedSource.Dispose();
-                        delaySource.Dispose();
-                    }
-                }, token);
+                    headParentBlockHeader = headAndParentHeaders[0];
+                }
+                else if (headAndParentHeaders.Length > 0)
+                {
+                    if (_logger.IsTrace) _logger.Trace($"PeerRefreshForFCU unexpected response length when fetching header: {headAndParentHeaders.Length}");
+                }
+
+                finalizedBlockHeader = await getFinalizedHeaderTask;
+            }
+            catch (TaskCanceledException exception)
+            {
+                if (_logger.IsTrace)
+                    _logger.Trace(
+                        $"PeerRefreshForFCU canceled for node: {syncPeer.Node:c}{Environment.NewLine}{exception}");
+                _stats.ReportSyncEvent(syncPeer.Node,
+                    syncPeer.IsInitialized
+                        ? NodeStatsEventType.SyncCancelled
+                        : NodeStatsEventType.SyncInitCancelled);
+                token.ThrowIfCancellationRequested();
+                return;
+            }
+            catch (Exception exception)
+            {
+                if (_logger.IsTrace)
+                    _logger.Trace($"PeerRefreshForFCU failed for node: {syncPeer.Node:c}{Environment.NewLine}{exception}");
+                _stats.ReportSyncEvent(syncPeer.Node,
+                    syncPeer.IsInitialized ? NodeStatsEventType.SyncFailed : NodeStatsEventType.SyncInitFailed);
+                // TODO: how to know if exception is transient
+                syncPeer.Disconnect(DisconnectReason.DisconnectRequested, "refresh peer info fault - faulted");
+                return;
+            }
+
+            if (_logger.IsTrace)
+            {
+                _logger.Trace($"PeerRefreshForFCU received block info from {syncPeer.Node:c}");
+                _logger.Trace($"PeerRefreshForFCU headHeader: {headBlockHeader}");
+                _logger.Trace($"PeerRefreshForFCU headParentHeader: {headParentBlockHeader}");
+                _logger.Trace($"PeerRefreshForFCU finalizedBlockHeader: {finalizedBlockHeader}");
+            }
+
+            if (finalizedBlockhash != Keccak.Zero && finalizedBlockHeader == null)
+            {
+                if (_logger.IsTrace)
+                    _logger.Trace($"PeerRefreshForFCU failed for node: {syncPeer.Node:c}{Environment.NewLine} - Finalized block header not found");
+                _stats.ReportSyncEvent(syncPeer.Node,
+                    syncPeer.IsInitialized ? NodeStatsEventType.SyncFailed : NodeStatsEventType.SyncInitFailed);
+                syncPeer.Disconnect(DisconnectReason.DisconnectRequested, "refresh peer info fault - null response");
+                return;
+            }
+
+            List<BlockHeader> headersToCheck = new [] {
+                headBlockHeader,
+                headParentBlockHeader,
+                finalizedBlockHeader
+            }.Where((header) => header != null).ToList();
+            
+            foreach (BlockHeader header in headersToCheck)
+            {
+                if (!HeaderValidator.ValidateHash(header))
+                {
+                    if (_logger.IsTrace)
+                        _logger.Trace($"PeerRefreshForFCU failed for node: {syncPeer.Node:c}{Environment.NewLine} Invalid block hash. Header: {header}");
+                    _stats.ReportSyncEvent(syncPeer.Node,
+                        syncPeer.IsInitialized ? NodeStatsEventType.SyncFailed : NodeStatsEventType.SyncInitFailed);
+                    syncPeer.Disconnect(DisconnectReason.DisconnectRequested, "refresh peer info fault - invalid header hash");
+                    return;
+                }
+            }
+
+            foreach (BlockHeader header in headersToCheck)
+            {
+                UpdateSyncPeerHeadIfHeaderIsBetter(syncPeer, header);
+            }
+
+            if (!syncPeer.IsInitialized) _stats.ReportSyncEvent(syncPeer.Node, NodeStatsEventType.SyncInitCompleted);
+            syncPeer.IsInitialized = true;
+
+            SignalPeersChanged();
+        }
+        
+        private async Task ExecuteRefreshTaskForHead(ISyncPeer syncPeer, Keccak? hash, Task? delayTask, CancellationToken token)
+        {
+            Task<BlockHeader?> getHeadHeaderTask = syncPeer.GetHeadBlockHeader(hash ?? syncPeer.HeadHash, token);
+            Task firstToComplete = await Task.WhenAny(getHeadHeaderTask, delayTask);
+
+            if (firstToComplete == delayTask)
+            {
+                if (_logger.IsTrace) _logger.Trace($"InitPeerInfo timed out for node: {syncPeer.Node:c}");
+                _stats.ReportSyncEvent(syncPeer.Node,
+                    syncPeer.IsInitialized ? NodeStatsEventType.SyncFailed : NodeStatsEventType.SyncInitFailed);
+                syncPeer.Disconnect(DisconnectReason.DisconnectRequested, "refresh peer info fault - timeout");
+                return;
+            }
+
+            BlockHeader? header;
+            try
+            {
+                header = await getHeadHeaderTask;
+            }
+            catch (TaskCanceledException exception)
+            {
+                if (_logger.IsTrace)
+                    _logger.Trace(
+                        $"InitPeerInfo canceled for node: {syncPeer.Node:c}{Environment.NewLine}{exception}");
+                _stats.ReportSyncEvent(syncPeer.Node,
+                    syncPeer.IsInitialized
+                        ? NodeStatsEventType.SyncCancelled
+                        : NodeStatsEventType.SyncInitCancelled);
+                token.ThrowIfCancellationRequested();
+                return;
+            }
+            catch (Exception exception)
+            {
+                if (_logger.IsTrace)
+                    _logger.Trace($"InitPeerInfo failed for node: {syncPeer.Node:c}{Environment.NewLine}{exception}");
+                _stats.ReportSyncEvent(syncPeer.Node,
+                    syncPeer.IsInitialized ? NodeStatsEventType.SyncFailed : NodeStatsEventType.SyncInitFailed);
+                // TODO: how to know if exception is transient
+                syncPeer.Disconnect(DisconnectReason.DisconnectRequested, "refresh peer info fault - faulted");
+                return;
+            }
+
+            if (header == null)
+            {
+                if (_logger.IsTrace)
+                    _logger.Trace($"InitPeerInfo failed for node: {syncPeer.Node:c}{Environment.NewLine}");
+                _stats.ReportSyncEvent(syncPeer.Node,
+                    syncPeer.IsInitialized ? NodeStatsEventType.SyncFailed : NodeStatsEventType.SyncInitFailed);
+                syncPeer.Disconnect(DisconnectReason.DisconnectRequested, "refresh peer info fault - null response");
+                return;
+            }
+
+            if (!HeaderValidator.ValidateHash(header))
+            {
+                if (_logger.IsTrace)
+                    _logger.Trace($"InitPeerInfo failed for node: {syncPeer.Node:c}{Environment.NewLine}Invalid block hash.");
+                _stats.ReportSyncEvent(syncPeer.Node,
+                    syncPeer.IsInitialized ? NodeStatsEventType.SyncFailed : NodeStatsEventType.SyncInitFailed);
+                syncPeer.Disconnect(DisconnectReason.DisconnectRequested, "refresh peer info fault - invalid header hash");
+                return;
+            }
+
+            UpdateSyncPeerHeadIfHeaderIsBetter(syncPeer, header);
+
+            if (_logger.IsTrace)
+                _logger.Trace(
+                    $"Received head block info from {syncPeer.Node:c} with head block {header.ToString(BlockHeader.Format.Short)}, total difficulty {header.TotalDifficulty}");
+            if (!syncPeer.IsInitialized) _stats.ReportSyncEvent(syncPeer.Node, NodeStatsEventType.SyncInitCompleted);
+            syncPeer.IsInitialized = true;
+
+            SignalPeersChanged();
+        }
+
+        private void UpdateSyncPeerHeadIfHeaderIsBetter(ISyncPeer syncPeer, BlockHeader? header)
+        {
+            if (_logger.IsTrace)
+                _logger.Trace($"REFRESH Updating header of {syncPeer} from {syncPeer.HeadNumber} to {header.Number}");
+            BlockHeader? parent = _blockTree.FindParentHeader(header, BlockTreeLookupOptions.None);
+            if (parent != null && parent.TotalDifficulty != 0)
+            {
+                UInt256 newTotalDifficulty = (parent.TotalDifficulty ?? UInt256.Zero) + header.Difficulty;
+                bool newValueIsNotWorseThanPeer =
+                    _betterPeerStrategy.Compare((newTotalDifficulty, header.Number),
+                        syncPeer) >= 0;
+                if (_logger.IsTrace)
+                    _logger.Trace(
+                        $"REFRESH Updating header of {syncPeer} from {syncPeer.HeadNumber} to {header.Number} based on totalDifficulty, newValueIsNotWorseThanPeer {newValueIsNotWorseThanPeer}");
+                if (newValueIsNotWorseThanPeer)
+                {
+                    syncPeer.TotalDifficulty = newTotalDifficulty;
+                    syncPeer.HeadNumber = header.Number;
+                    syncPeer.HeadHash = header.Hash!;
+
+                    PeerRefreshed?.Invoke(this, new PeerHeadRefreshedEventArgs(syncPeer, header));
+                }
+            }
+            else if (header.Number > syncPeer.HeadNumber)
+            {
+                if (_logger.IsTrace)
+                    _logger.Trace(
+                        $"REFRESH Updating header of {syncPeer} from {syncPeer.HeadNumber} to {header.Number} based on headNumber");
+                syncPeer.HeadNumber = header.Number;
+                syncPeer.HeadHash = header.Hash!;
+            }
         }
 
         /// <summary>
@@ -717,9 +897,31 @@ namespace Nethermind.Synchronization.Peers
                 SyncPeer = syncPeer;
             }
             
+            public RefreshTotalDiffTask(
+                Keccak headBlockhash,
+                Keccak headParentBlockhash,
+                Keccak finalizedBlockhash,
+                ISyncPeer syncPeer
+            )
+            {
+                FromFcu = true;
+                HeadBlockhash = headBlockhash;
+                HeadParentBlockhash = headParentBlockhash;
+                FinalizedBlockhash = finalizedBlockhash;
+                SyncPeer = syncPeer;
+            }
+            
             public Keccak? BlockHash { get; }
 
             public ISyncPeer SyncPeer { get; }
+            
+            public bool FromFcu { get; }
+            
+            public Keccak HeadBlockhash { get; }
+            
+            public Keccak HeadParentBlockhash { get; }
+            
+            public Keccak FinalizedBlockhash { get; }
         }
 
         public void Dispose()

--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
@@ -600,12 +600,10 @@ namespace Nethermind.Synchronization.Peers
                         }
                         else if (firstToComplete.IsFaulted)
                         {
-                            if (_logger.IsTrace) _logger.Trace($"InitPeerInfo failed for node: {syncPeer.Node:c}{Environment.NewLine}{t.Exception}");
-                            ReportRefreshFailed(syncPeer, "faulted");
+                            ReportRefreshFailed(syncPeer, "faulted", t.Exception);
                         }
                         else if (firstToComplete.IsCanceled)
                         {
-                            if (_logger.IsTrace) _logger.Trace($"InitPeerInfo canceled for node: {syncPeer.Node:c}{Environment.NewLine}{t.Exception}");
                             ReportRefreshCancelled(syncPeer);
                             token.ThrowIfCancellationRequested();
                         }
@@ -726,9 +724,9 @@ namespace Nethermind.Synchronization.Peers
             }
         }
 
-        public void ReportRefreshFailed(ISyncPeer syncPeer, string reason)
+        public void ReportRefreshFailed(ISyncPeer syncPeer, string reason, Exception? exception = null)
         {
-            if (_logger.IsTrace) _logger.Trace($"Refresh failed reported: {syncPeer.Node:c}, {reason}");
+            if (_logger.IsTrace) _logger.Trace($"Refresh failed reported: {syncPeer.Node:c}, {reason}, {exception}");
             _stats.ReportSyncEvent(syncPeer.Node, syncPeer.IsInitialized ? NodeStatsEventType.SyncFailed : NodeStatsEventType.SyncInitFailed);
             syncPeer.Disconnect(DisconnectReason.DisconnectRequested, "refresh peer info fault - {reason}");
         }

--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
@@ -740,7 +740,8 @@ namespace Nethermind.Synchronization.Peers
         
         private async Task ExecuteRefreshTaskForHead(ISyncPeer syncPeer, Keccak? hash, Task? delayTask, CancellationToken token)
         {
-            Task<BlockHeader?> getHeadHeaderTask = syncPeer.GetHeadBlockHeader(hash ?? syncPeer.HeadHash, token);
+            Keccak effectiveHash = hash ?? syncPeer.HeadHash;
+            Task<BlockHeader?> getHeadHeaderTask = syncPeer.GetHeadBlockHeader(effectiveHash, token);
             Task firstToComplete = await Task.WhenAny(getHeadHeaderTask, delayTask);
 
             if (firstToComplete == delayTask)

--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
@@ -45,22 +45,18 @@ namespace Nethermind.Synchronization.Peers
     ///     Eth sync peer pool is capable of returning a sync peer allocation that is best suited for the requesting
     ///     sync process. It also manages all allocations allowing to replace peers with better peers whenever they connect.
     /// </summary>
-    public class SyncPeerPool : ISyncPeerPool, IRefreshablePeerDifficultyPool
+    public class SyncPeerPool : ISyncPeerPool, IPeerDifficultyRefreshPool
     {
         public const int DefaultUpgradeIntervalInMs = 1000;
 
         private readonly IBlockTree _blockTree;
         private readonly ILogger _logger;
-        private readonly BlockingCollection<RefreshTotalDiffTask> _peerRefreshQueue
-            = new();
+        private readonly BlockingCollection<RefreshTotalDiffTask> _peerRefreshQueue = new();
 
-        private readonly ConcurrentDictionary<PublicKey, PeerInfo> _peers
-            = new();
+        private readonly ConcurrentDictionary<PublicKey, PeerInfo> _peers = new();
 
-        private readonly ConcurrentDictionary<PublicKey, CancellationTokenSource> _refreshCancelTokens
-            = new();
-        private readonly ConcurrentDictionary<SyncPeerAllocation, object?> _replaceableAllocations
-            = new();
+        private readonly ConcurrentDictionary<PublicKey, CancellationTokenSource> _refreshCancelTokens = new();
+        private readonly ConcurrentDictionary<SyncPeerAllocation, object?> _replaceableAllocations = new();
         
         private readonly INodeStatsManager _stats;
         private readonly IBetterPeerStrategy _betterPeerStrategy;

--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
@@ -417,7 +417,6 @@ namespace Nethermind.Synchronization.Peers
 
         private async Task RunRefreshPeerLoop()
         {
-            // TODO: Why use a queue when it's not going to block
             foreach (RefreshTotalDiffTask refreshTask in _peerRefreshQueue.GetConsumingEnumerable(_refreshLoopCancellation.Token))
             {
                 ISyncPeer syncPeer = refreshTask.SyncPeer;
@@ -650,7 +649,7 @@ namespace Nethermind.Synchronization.Peers
                 BlockHeader[] headAndParentHeaders = await getHeadParentHeaderTask;
                 if (headAndParentHeaders.Length == 1)
                 {
-                    headBlockHeader = headAndParentHeaders[0];
+                    headParentBlockHeader = headAndParentHeaders[0];
                 }
                 else if (headAndParentHeaders.Length == 2)
                 {


### PR DESCRIPTION
- Update peer refreshing to use FCU's hashes.

## Changes:
- Update peer refreshing to use FCU's hashes. It will now only disconnect if the finalized block is not available from the peer.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing

- [X] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [X] Yes
- [ ] No

**Comments about testing , should you have some** (optional)

- Ropsten can sync to head.
