### PR TITLE
Fix inconsistently failing test

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
@@ -300,8 +300,8 @@ namespace Nethermind.Core.Test.Blockchain
             await AddBlock(BuildSimpleTransaction.WithNonce(1).TestObject, BuildSimpleTransaction.WithNonce(2).TestObject);
         }
 
-        protected virtual BlockProcessor CreateBlockProcessor() =>
-            new(
+        protected virtual IBlockProcessor CreateBlockProcessor() =>
+            new BlockProcessor(
                 SpecProvider,
                 BlockValidator,
                 NoBlockRewards.Instance,

--- a/src/Nethermind/Nethermind.Merge.AuRa.Test/AuRaMergePluginTests.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa.Test/AuRaMergePluginTests.cs
@@ -28,9 +28,9 @@ namespace Nethermind.Merge.AuRa.Test;
 [TestFixture]
 public class AuRaMergeEngineModuleTests : EngineModuleTests
 {
-    protected override async Task<MergeTestBlockchain> CreateBlockChain(IMergeConfig? mergeConfig = null, IPayloadPreparationService? mockedPayloadService = null) =>
-        await new MergeAuRaTestBlockchain(mergeConfig, mockedPayloadService)
-            .Build(new SingleReleaseSpecProvider(London.Instance, 1));
+    protected override MergeTestBlockchain CreateBaseBlockChain(IMergeConfig mergeConfig = null,
+        IPayloadPreparationService? mockedPayloadService = null)
+        => new MergeAuRaTestBlockchain(mergeConfig, mockedPayloadService);
 
     protected override Keccak ExpectedBlockHash => new("0x0ec8f29f7438df15ac81d68da632ea8bca8914335ed48cee8d613317c781b447");
 
@@ -57,11 +57,11 @@ public class AuRaMergeEngineModuleTests : EngineModuleTests
         await Task.CompletedTask;
     }
 
-    [Test]
-    [Parallelizable(ParallelScope.None)]
-    public override Task executePayloadV1_accepts_already_known_block()
+    [TestCase(true)]
+    [TestCase(false)]
+    public virtual async Task executePayloadV1_accepts_already_known_block(bool throttleBlockProcessor)
     {
-        return base.executePayloadV1_accepts_already_known_block();
+        await base.executePayloadV1_accepts_already_known_block(throttleBlockProcessor);
     }
 
     class MergeAuRaTestBlockchain : EngineModuleTests.MergeTestBlockchain

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
@@ -44,6 +44,8 @@ using Nethermind.Merge.Plugin.Data;
 using Nethermind.Merge.Plugin.Data.V1;
 using Nethermind.Merge.Plugin.Handlers;
 using Nethermind.Merge.Plugin.Synchronization;
+using Nethermind.Specs;
+using Nethermind.Specs.Forks;
 using Nethermind.State;
 using Nethermind.Trie;
 using Newtonsoft.Json;
@@ -541,11 +543,14 @@ namespace Nethermind.Merge.Plugin.Test
         }
 
 
-        [Test]
-        [Parallelizable(ParallelScope.None)]
-        public virtual async Task executePayloadV1_accepts_already_known_block()
+        [TestCase(true)]
+        [TestCase(false)]
+        public virtual async Task executePayloadV1_accepts_already_known_block(bool throttleBlockProcessor)
         {
-            using MergeTestBlockchain chain = await CreateBlockChain();
+            using MergeTestBlockchain chain = await CreateBaseBlockChain()
+                .ThrottleBlockProcessor(throttleBlockProcessor ? 100 : 0)
+                .Build(new SingleReleaseSpecProvider(London.Instance, 1));
+            
             IEngineRpcModule rpc = CreateEngineModule(chain);
             Block block = Build.A.Block.WithNumber(1).WithParent(chain.BlockTree.Head!).WithDifficulty(0).WithNonce(0)
                 .WithStateRoot(new Keccak("0x1ef7300d8961797263939a3d29bbba4ccf1702fabf02d8ad7a20b454edb6fd2f"))

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/V1/NewPayloadV1Handler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/V1/NewPayloadV1Handler.cs
@@ -18,6 +18,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using FastEnumUtility;
 using Nethermind.Api;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Synchronization;
@@ -172,7 +173,7 @@ namespace Nethermind.Merge.Plugin.Handlers.V1
                     if (_logger.IsInfo) _logger.Info($"{resultStr}. Result of {requestStr}.");
                 }
 
-                if (!isValid)
+                if (result == ValidationResult.Invalid)
                 {
                     _invalidChainTracker.OnInvalidBlock(request.BlockHash, request.ParentHash);
                     return ResultWrapper<PayloadStatusV1>.Success(BuildInvalidPayloadStatusV1(request, message));


### PR DESCRIPTION
Fixes inconsistent test

- When processing is done quickly enough, NewPayload will exit here https://github.com/NethermindEth/nethermind/blob/master/src/Nethermind/Nethermind.Merge.Plugin/Handlers/V1/NewPayloadV1Handler.cs#L140.
- When processing is slow/throttled, NewPayload will get AlreadyKnown here https://github.com/NethermindEth/nethermind/blob/master/src/Nethermind/Nethermind.Merge.Plugin/Handlers/V1/NewPayloadV1Handler.cs#L264 as BlockTree.IsKnownBlock does not check if the block is not on main chain.

## Changes:
- Added throttle to block processor in test.
- Fix Accepted considered invalid.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [X] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [X] Yes
- [ ] No

**Comments about testing , should you have some** (optional)

## Further comments (optional)

NP probably should check if the block is on main tree.