### PR TITLE
Fix low initialized peer

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
@@ -625,7 +625,6 @@ namespace Nethermind.Synchronization.Peers
 
                             UpdateSyncPeerHeadIfHeaderIsBetter(syncPeer, header);
 
-                            syncPeer.IsInitialized = true;
                             SignalPeersChanged();
                         }
                     }
@@ -691,6 +690,7 @@ namespace Nethermind.Synchronization.Peers
                 syncPeer.HeadNumber = header.Number;
                 syncPeer.HeadHash = header.Hash!;
             }
+            syncPeer.IsInitialized = true;
         }
 
         public void ReportRefreshFailed(ISyncPeer syncPeer, string reason, Exception? exception = null)

--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
@@ -282,6 +282,7 @@ namespace Nethermind.Synchronization.Peers
             if (header is not null)
             {
                 syncPeer.HeadNumber = header.Number;
+                UpdateSyncPeerHeadIfHeaderIsBetter(syncPeer, header);
             }
             else
             {


### PR DESCRIPTION
Fix low initlaized peer after fcu update.
 
## Changes:
- Set IsInitialized if header is known ahead of time when added (likely happen after a reconnection).
- Set IsIniitlalized even on FCU head refresh.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [ ] No

**Comments about testing , should you have some** (optional)

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...