### PR TITLE
Increase refresh timeout

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization/Timeouts.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Timeouts.cs
@@ -22,6 +22,6 @@ namespace Nethermind.Synchronization
     public class Timeouts
     {
         public static readonly TimeSpan Eth = TimeSpan.FromSeconds(10);
-        public static readonly TimeSpan RefreshDifficulty = TimeSpan.FromSeconds(3);
+        public static readonly TimeSpan RefreshDifficulty = TimeSpan.FromSeconds(8);
     }
 }


### PR DESCRIPTION
Fixes issue with peer disconnecting during state sync.

- It was observed that during state sync, FCU refresh tend to timeout when trying to fetch header. 
- At worst case, most of the peer timeout, causing a large drop in number of sync peer, which reduces sync dispatch for the state sync, the peers get reconnected immediately and the cycle repeats.
- Increasing the timeout seems to help partly.

## Changes:
-Increase timeout for FCU refresh.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [X] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [X] No

**Comments about testing , should you have some** (optional)

Issue persist but less often.

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...