### PR TITLE
Fix rocksdb error when shutting down and processing at the same time.

### DIFF
--- a/src/Nethermind/Nethermind.Runner/Ethereum/EthereumRunner.cs
+++ b/src/Nethermind/Nethermind.Runner/Ethereum/EthereumRunner.cs
@@ -69,9 +69,6 @@ namespace Nethermind.Runner.Ethereum
 
         public async Task StopAsync()
         {
-            if (_logger.IsInfo) _logger.Info("Persisting trie...");
-            _api.TrieStore?.HackPersistOnShutdown();
-            
             Stop(() => _api.SessionMonitor?.Stop(), "Stopping session monitor");
             Task discoveryStopTask = Stop(() => _api.DiscoveryApp?.StopAsync(), "Stopping discovery app");
             Task blockProducerTask = Stop(() => _api.BlockProducer?.StopAsync(), "Stopping block producer");

--- a/src/Nethermind/Nethermind.Trie/Pruning/ITrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ITrieStore.cs
@@ -27,8 +27,6 @@ namespace Nethermind.Trie.Pruning
         void FinishBlockCommit(TrieType trieType, long blockNumber, TrieNode? root);
 
         bool IsPersisted(Keccak keccak);
-
-        void HackPersistOnShutdown();
         
         IReadOnlyTrieStore AsReadOnly(IKeyValueStore? keyValueStore);
         

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -321,11 +321,6 @@ namespace Nethermind.Trie.Pruning
             }
         }
 
-        public void HackPersistOnShutdown()
-        {
-            PersistOnShutdown();
-        }
-
         public event EventHandler<ReorgBoundaryReached>? ReorgBoundaryReached;
 
         internal byte[] LoadRlp(Keccak keccak, IKeyValueStore? keyValueStore)


### PR DESCRIPTION
Fixes #4233

Fix exception on shutting down when TrieStore attempt to dispose batch while another thread is updating it. 

## Changes:
- Dont shotdown first on start. TrieStore already in dispose stack.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [X] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [X] No

**Comments about testing , should you have some** (optional)

- Run ropsten with full sync only. Start and stop 10 consecutive time during sync, no more exception. Previously it would take less than 5 tries.
