### PR TITLE
Increase BlockchainProcessor exception log level to warn

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -68,11 +68,11 @@ namespace Nethermind.Consensus.Processing
         private int _currentRecoveryQueueSize;
         private readonly CompositeBlockTracer _compositeBlockTracer = new();
         private readonly Stopwatch _stopwatch = new();
-        
+
         public event EventHandler<IBlockchainProcessor.InvalidBlockEventArgs> InvalidBlock;
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="blockTree"></param>
         /// <param name="blockProcessor"></param>
@@ -129,7 +129,7 @@ namespace Nethermind.Consensus.Processing
             BlockRef blockRef = currentRecoveryQueueSize >= SoftMaxRecoveryQueueSizeInTx
                 ? new BlockRef(blockHash, processingOptions)
                 : new BlockRef(block, processingOptions);
-            
+
             if (!_recoveryQueue.IsAddingCompleted)
             {
                 Interlocked.Increment(ref _queueCount);
@@ -302,7 +302,7 @@ namespace Nethermind.Consensus.Processing
                 }
                 catch (Exception exception)
                 {
-                    if (_logger.IsDebug) _logger.Debug($"Processing loop threw an exception. Block: {blockRef}, Exception: {exception}");
+                    if (_logger.IsWarn) _logger.Warn($"Processing loop threw an exception. Block: {blockRef}, Exception: {exception}");
                     BlockRemoved?.Invoke(this, new BlockHashEventArgs(blockRef.BlockHash, ProcessingResult.Exception));
                 }
                 finally
@@ -467,7 +467,7 @@ namespace Nethermind.Consensus.Processing
                 {
                     InvalidBlockHash = ex.InvalidBlockHash,
                 });
-                
+
                 invalidBlockHash = ex.InvalidBlockHash;
                 TraceFailingBranch(
                     processingBranch,


### PR DESCRIPTION
## Changes:
- Increase BlockchainProcessor exception log level to warn
- Rider seems to auto remove the space.

## Types of changes


- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] Other (please describe): log adjustment

## Testing
**Requires testing**

- [X] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [X] No

**Comments about testing , should you have some** (optional)
 
Can compile and run.

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...