### PR TITLE
Add Discord announcement workflow on new release

### DIFF
--- a/.github/workflows/run-discord-announcement.yml
+++ b/.github/workflows/run-discord-announcement.yml
@@ -1,9 +1,8 @@
 name: '[RUN] Discord new release announcement'
    
 on:
-  workflow_dispatch:
-  #release:
-    #types: [published]
+  release:
+    types: [released]
 
 jobs:
   push-announcement:
@@ -12,7 +11,7 @@ jobs:
     env:      
       WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
     steps:
-    - name: REST API with curl
+    - name: CURL Discord API with announcement
       shell: bash
       run: |
         CHANGELOG=$(curl -s https://api.github.com/repos/nethermindeth/nethermind/releases | jq '.[0].body' | grep -Po '(?<=\\n\\r\\n)(.*?)(?=\##)')

--- a/.github/workflows/run-discord-announcement.yml
+++ b/.github/workflows/run-discord-announcement.yml
@@ -16,5 +16,5 @@ jobs:
       run: |
         CHANGELOG=$(curl -s https://api.github.com/repos/nethermindeth/nethermind/releases | jq '.[0].body' | grep -Po '(?<=\\n\\r\\n)(.*?)(?=\##)')
         read VERSION LINK < <(echo $(curl -s 'https://api.github.com/repos/nethermindeth/nethermind/releases' | jq -r '.[0].name, .[0].html_url'))
-        MESSAGE="**${VERSION} RELEASE CHANGELOG**\n\n${CHANGELOG}<${LINK}>"
+        MESSAGE="**New Nethermind release version: ${VERSION}**\n\n${CHANGELOG}<${LINK}>"
         curl -s -H "Content-Type: application/json" -d '{"username": "Nethermind", "content": "'"$MESSAGE"'"}' $WEBHOOK_URL > /dev/null 2>&1

--- a/.github/workflows/run-discord-announcement.yml
+++ b/.github/workflows/run-discord-announcement.yml
@@ -17,4 +17,4 @@ jobs:
         CHANGELOG=$(curl -s https://api.github.com/repos/nethermindeth/nethermind/releases | jq '.[0].body' | grep -Po '(?<=\\n\\r\\n)(.*?)(?=\##)')
         read VERSION LINK < <(echo $(curl -s 'https://api.github.com/repos/nethermindeth/nethermind/releases' | jq -r '.[0].name, .[0].html_url'))
         MESSAGE="**${VERSION} RELEASE CHANGELOG**\n\n${CHANGELOG}<${LINK}>"
-        curl -H "Content-Type: application/json" -d '{"username": "Nethermind", "content": "'"$MESSAGE"'"}' $WEBHOOK_URL > /dev/null 2>&1
+        curl -s -H "Content-Type: application/json" -d '{"username": "Nethermind", "content": "'"$MESSAGE"'"}' $WEBHOOK_URL > /dev/null 2>&1

--- a/.github/workflows/run-discord-announcement.yml
+++ b/.github/workflows/run-discord-announcement.yml
@@ -1,0 +1,21 @@
+name: '[RUN] Discord new release announcement'
+   
+on:
+  workflow_dispatch:
+  #release:
+    #types: [published]
+
+jobs:
+  push-announcement:
+    name: Pushing release announcement to Discord
+    runs-on: ubuntu-latest
+    env:      
+      WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+    steps:
+    - name: REST API with curl
+      shell: bash
+      run: |
+        CHANGELOG=$(curl -s https://api.github.com/repos/nethermindeth/nethermind/releases | jq '.[0].body' | grep -Po '(?<=\\n\\r\\n)(.*?)(?=\##)')
+        read VERSION LINK < <(echo $(curl -s 'https://api.github.com/repos/nethermindeth/nethermind/releases' | jq -r '.[0].name, .[0].html_url'))
+        MESSAGE="**${VERSION} RELEASE CHANGELOG**\n\n${CHANGELOG}<${LINK}>"
+        curl -H "Content-Type: application/json" -d '{"username": "Nethermind", "content": "'"$MESSAGE"'"}' $WEBHOOK_URL > /dev/null 2>&1


### PR DESCRIPTION
Adds a new Github action that will trigger on a new Github release. This action will post an announcement to the Discord channel with the latest changelog. 

I've added an example announcement below, we could change the "design" in the future. 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [X] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [X] No

![image](https://user-images.githubusercontent.com/1364936/178011835-8f8194f7-f278-4bca-b1dc-fdb770089678.png)