### PR TITLE
Accept "latest" and "finalized" as block number values for debug_traceBlockByNumber method

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Tracing/GethStyleTracer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Tracing/GethStyleTracer.cs
@@ -1,4 +1,4 @@
-﻿//  Copyright (c) 2021 Demerzel Solutions Limited
+//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
 // 
 //  The Nethermind library is free software: you can redistribute it and/or modify
@@ -122,16 +122,10 @@ namespace Nethermind.Consensus.Tracing
             _processor.Process(block, ProcessingOptions.Trace, blockTracer.WithCancellation(cancellationToken));
             return blockTracer.BuildResult().SingleOrDefault();
         }
-
-        public GethLikeTxTrace[] TraceBlock(Keccak blockHash, GethTraceOptions options, CancellationToken cancellationToken)
+        public GethLikeTxTrace[] TraceBlock(BlockParameter blockParameter, GethTraceOptions options, CancellationToken cancellationToken)
         {
-            Block block = _blockTree.FindBlock(blockHash, BlockTreeLookupOptions.None);
-            return TraceBlock(block, options, cancellationToken);
-        }
+            var block = _blockTree.FindBlock(blockParameter);
 
-        public GethLikeTxTrace[] TraceBlock(long blockNumber, GethTraceOptions options, CancellationToken cancellationToken)
-        {
-            Block? block = _blockTree.FindBlock(blockNumber, BlockTreeLookupOptions.RequireCanonical);
             return TraceBlock(block, options, cancellationToken);
         }
 

--- a/src/Nethermind/Nethermind.Consensus/Tracing/IGethStyleTracer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Tracing/IGethStyleTracer.cs
@@ -1,4 +1,4 @@
-﻿//  Copyright (c) 2021 Demerzel Solutions Limited
+//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
 // 
 //  The Nethermind library is free software: you can redistribute it and/or modify
@@ -31,8 +31,7 @@ namespace Nethermind.Consensus.Tracing
         GethLikeTxTrace Trace(Keccak blockHash, int txIndex, GethTraceOptions options, CancellationToken cancellationToken);
         GethLikeTxTrace Trace(Rlp blockRlp, Keccak txHash, GethTraceOptions options, CancellationToken cancellationToken);
         GethLikeTxTrace? Trace(BlockParameter blockParameter, Transaction tx, GethTraceOptions options, CancellationToken cancellationToken);
-        GethLikeTxTrace[] TraceBlock(Keccak blockHash, GethTraceOptions options, CancellationToken cancellationToken);
-        GethLikeTxTrace[] TraceBlock(long blockNumber, GethTraceOptions options, CancellationToken cancellationToken);
+        GethLikeTxTrace[] TraceBlock(BlockParameter blockParameter, GethTraceOptions options, CancellationToken cancellationToken);
         GethLikeTxTrace[] TraceBlock(Rlp blockRlp, GethTraceOptions options, CancellationToken cancellationToken);
     }
 }

--- a/src/Nethermind/Nethermind.Core.Test/Builders/TestItem.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Builders/TestItem.cs
@@ -15,7 +15,9 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
 using System;
+using System.IO;
 using System.Net;
+using System.Text.Json;
 using Nethermind.Core.Crypto;
 using Nethermind.Crypto;
 using Nethermind.Int256;
@@ -107,6 +109,17 @@ namespace Nethermind.Core.Test.Builders
         public static IPEndPoint IPEndPointF = IPEndPoint.Parse("10.0.0.6");
 
         public static Bloom NonZeroBloom;
+
+        public static T CloneObject<T>(T value)
+        {
+            using var stream = new MemoryStream();
+
+            JsonSerializer.Serialize(stream, value);
+
+            stream.Position = 0;
+
+            return JsonSerializer.Deserialize<T>(stream)!;
+        }
 
         public static Address GetRandomAddress(Random? random = null)
         {

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugModuleTests.cs
@@ -1,4 +1,4 @@
-﻿//  Copyright (c) 2021 Demerzel Solutions Limited
+//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
 // 
 //  The Nethermind library is free software: you can redistribute it and/or modify
@@ -15,6 +15,7 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using FluentAssertions;
 using Nethermind.Blockchain.Find;
@@ -28,7 +29,6 @@ using Nethermind.JsonRpc.Data;
 using Nethermind.JsonRpc.Modules.DebugModule;
 using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
-using Newtonsoft.Json;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -44,8 +44,8 @@ namespace Nethermind.JsonRpc.Test.Modules
         [Test]
         public void Get_from_db()
         {
-            byte[] key = new byte[] {1, 2, 3};
-            byte[] value = new byte[] {4, 5, 6};
+            byte[] key = new byte[] { 1, 2, 3 };
+            byte[] value = new byte[] { 4, 5, 6 };
             debugBridge.GetDbValue(Arg.Any<string>(), Arg.Any<byte[]>()).Returns(value);
 
             IConfigProvider configProvider = Substitute.For<IConfigProvider>();
@@ -58,8 +58,8 @@ namespace Nethermind.JsonRpc.Test.Modules
         [Test]
         public void Get_from_db_null_value()
         {
-            byte[] key = new byte[] {1, 2, 3};
-            debugBridge.GetDbValue(Arg.Any<string>(), Arg.Any<byte[]>()).Returns((byte[]) null);
+            byte[] key = new byte[] { 1, 2, 3 };
+            debugBridge.GetDbValue(Arg.Any<string>(), Arg.Any<byte[]>()).Returns((byte[])null);
 
             IConfigProvider configProvider = Substitute.For<IConfigProvider>();
             DebugRpcModule rpcModule = new(LimboLogs.Instance, debugBridge, jsonRpcConfig);
@@ -98,7 +98,7 @@ namespace Nethermind.JsonRpc.Test.Modules
 
             DebugRpcModule rpcModule = new(LimboLogs.Instance, debugBridge, jsonRpcConfig);
             JsonRpcSuccessResponse response = RpcTest.TestRequest<IDebugRpcModule>(rpcModule, "debug_getBlockRlpByHash", $"{Keccak.Zero.Bytes.ToHexString()}") as JsonRpcSuccessResponse;
-            Assert.AreEqual(rlp.Bytes, (byte[]) response?.Result);
+            Assert.AreEqual(rlp.Bytes, (byte[])response?.Result);
         }
 
         [Test]
@@ -112,13 +112,13 @@ namespace Nethermind.JsonRpc.Test.Modules
             DebugRpcModule rpcModule = new(LimboLogs.Instance, debugBridge, jsonRpcConfig);
             JsonRpcSuccessResponse response = RpcTest.TestRequest<IDebugRpcModule>(rpcModule, "debug_getBlockRlp", "1") as JsonRpcSuccessResponse;
 
-            Assert.AreEqual(rlp.Bytes, (byte[]) response?.Result);
+            Assert.AreEqual(rlp.Bytes, (byte[])response?.Result);
         }
 
         [Test]
         public void Get_block_rlp_when_missing()
         {
-            debugBridge.GetBlockRlp(1).Returns((byte[]) null);
+            debugBridge.GetBlockRlp(1).Returns((byte[])null);
 
             DebugRpcModule rpcModule = new(LimboLogs.Instance, debugBridge, jsonRpcConfig);
             JsonRpcErrorResponse response = RpcTest.TestRequest<IDebugRpcModule>(rpcModule, "debug_getBlockRlp", "1") as JsonRpcErrorResponse;
@@ -131,7 +131,7 @@ namespace Nethermind.JsonRpc.Test.Modules
         {
             BlockDecoder decoder = new();
             Rlp rlp = decoder.Encode(Build.A.Block.WithNumber(1).TestObject);
-            debugBridge.GetBlockRlp(Keccak.Zero).Returns((byte[]) null);
+            debugBridge.GetBlockRlp(Keccak.Zero).Returns((byte[])null);
 
             DebugRpcModule rpcModule = new(LimboLogs.Instance, debugBridge, jsonRpcConfig);
             JsonRpcErrorResponse response = RpcTest.TestRequest<IDebugRpcModule>(rpcModule, "debug_getBlockRlpByHash", $"{Keccak.Zero.Bytes.ToHexString()}") as JsonRpcErrorResponse;
@@ -219,7 +219,7 @@ namespace Nethermind.JsonRpc.Test.Modules
         public void Debug_traceCall_test()
         {
             GethTxTraceEntry entry = new();
-            
+
             entry.Storage = new Dictionary<string, string>
             {
                 {"1".PadLeft(64, '0'), "2".PadLeft(64, '0')},
@@ -307,6 +307,139 @@ namespace Nethermind.JsonRpc.Test.Modules
             IDebugRpcModule rpcModule = new DebugRpcModule(LimboLogs.Instance, debugBridge, jsonRpcConfig);
             RpcTest.TestSerializedRequest(rpcModule, "debug_resetHead", TestItem.KeccakA.ToString());
             debugBridge.Received().UpdateHeadBlock(TestItem.KeccakA);
+        }
+
+        [Test]
+        public void TraceBlock_Success()
+        {
+            var traces = Enumerable.Repeat(MockGethLikeTrace(), 2).ToArray();
+            var tracesClone = TestItem.CloneObject(traces);
+            var blockRlp = new Rlp(TestItem.RandomDataA);
+
+            debugBridge
+                .GetBlockTrace(blockRlp, Arg.Any<CancellationToken>(), Arg.Any<GethTraceOptions>())
+                .Returns(traces);
+
+            var rpcModule = new DebugRpcModule(LimboLogs.Instance, debugBridge, jsonRpcConfig);
+            var actual = rpcModule.debug_traceBlock(blockRlp.Bytes);
+            var expected = ResultWrapper<GethLikeTxTrace[]>.Success(tracesClone);
+
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Test]
+        public void TraceBlock_Fail()
+        {
+            var blockRlp = new Rlp(TestItem.RandomDataA);
+
+            debugBridge
+                .GetBlockTrace(blockRlp, Arg.Any<CancellationToken>(), Arg.Any<GethTraceOptions>())
+                .Returns(default(GethLikeTxTrace[]));
+
+            var rpcModule = new DebugRpcModule(LimboLogs.Instance, debugBridge, jsonRpcConfig);
+            var actual = rpcModule.debug_traceBlock(blockRlp.Bytes);
+            var expected = ResultWrapper<GethLikeTxTrace[]>.Fail($"Trace is null for RLP {blockRlp.Bytes.ToHexString()}", ErrorCodes.ResourceNotFound);
+
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Test]
+        public void TraceBlockByHash_Success()
+        {
+            var traces = Enumerable.Repeat(MockGethLikeTrace(), 2).ToArray();
+            var tracesClone = TestItem.CloneObject(traces);
+            var blockHash = TestItem.KeccakA;
+
+            debugBridge
+                .GetBlockTrace(new BlockParameter(blockHash), Arg.Any<CancellationToken>(), Arg.Any<GethTraceOptions>())
+                .Returns(traces);
+
+            var rpcModule = new DebugRpcModule(LimboLogs.Instance, debugBridge, jsonRpcConfig);
+            var actual = rpcModule.debug_traceBlockByHash(blockHash);
+            var expected = ResultWrapper<GethLikeTxTrace[]>.Success(tracesClone);
+
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Test]
+        public void TraceBlockByHash_Fail()
+        {
+            var blockHash = TestItem.KeccakA;
+
+            debugBridge
+                .GetBlockTrace(new BlockParameter(blockHash), Arg.Any<CancellationToken>(), Arg.Any<GethTraceOptions>())
+                .Returns(default(GethLikeTxTrace[]));
+
+            var rpcModule = new DebugRpcModule(LimboLogs.Instance, debugBridge, jsonRpcConfig);
+            var actual = rpcModule.debug_traceBlockByHash(blockHash);
+            var expected = ResultWrapper<GethLikeTxTrace[]>.Fail($"Trace is null for block {blockHash}", ErrorCodes.ResourceNotFound);
+
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Test]
+        public void TraceBlockByNumber_Success()
+        {
+            var traces = Enumerable.Repeat(MockGethLikeTrace(), 2).ToArray();
+            var tracesClone = TestItem.CloneObject(traces);
+            var blockNumber = BlockParameter.Latest;
+
+            debugBridge
+                .GetBlockTrace(blockNumber, Arg.Any<CancellationToken>(), Arg.Any<GethTraceOptions>())
+                .Returns(traces);
+
+            var rpcModule = new DebugRpcModule(LimboLogs.Instance, debugBridge, jsonRpcConfig);
+            var actual = rpcModule.debug_traceBlockByNumber(blockNumber);
+            var expected = ResultWrapper<GethLikeTxTrace[]>.Success(tracesClone);
+
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Test]
+        public void TraceBlockByNumber_Fail()
+        {
+            var blockNumber = BlockParameter.Latest;
+
+            debugBridge
+                .GetBlockTrace(blockNumber, Arg.Any<CancellationToken>(), Arg.Any<GethTraceOptions>())
+                .Returns(default(GethLikeTxTrace[]));
+
+            var rpcModule = new DebugRpcModule(LimboLogs.Instance, debugBridge, jsonRpcConfig);
+            var actual = rpcModule.debug_traceBlockByNumber(blockNumber);
+            var expected = ResultWrapper<GethLikeTxTrace[]>.Fail($"Trace is null for block {blockNumber}", ErrorCodes.ResourceNotFound);
+
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        private static GethLikeTxTrace MockGethLikeTrace()
+        {
+            var trace = new GethLikeTxTrace { ReturnValue = new byte[] { 0xA2 } };
+
+            trace.Entries.Add(new GethTxTraceEntry
+            {
+                Depth = 1,
+                Gas = 22000,
+                GasCost = 1,
+                Memory = new List<string>
+                {
+                    "5".PadLeft(64, '0'),
+                    "6".PadLeft(64, '0')
+                },
+                Operation = "STOP",
+                Pc = 32,
+                Stack = new List<string>
+                {
+                    "7".PadLeft(64, '0'),
+                    "8".PadLeft(64, '0')
+                },
+                Storage = new Dictionary<string, string>
+                {
+                    {"1".PadLeft(64, '0'), "2".PadLeft(64, '0')},
+                    {"3".PadLeft(64, '0'), "4".PadLeft(64, '0')},
+                }
+            });
+
+            return trace;
         }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugBridge.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugBridge.cs
@@ -1,4 +1,4 @@
-﻿//  Copyright (c) 2021 Demerzel Solutions Limited
+//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
 // 
 //  The Nethermind library is free software: you can redistribute it and/or modify
@@ -147,14 +147,9 @@ namespace Nethermind.JsonRpc.Modules.DebugModule
             return _tracer.Trace(blockParameter, transaction, gethTraceOptions ?? GethTraceOptions.Default, cancellationToken);
         }
 
-        public GethLikeTxTrace[] GetBlockTrace(Keccak blockHash,CancellationToken cancellationToken, GethTraceOptions gethTraceOptions = null)
+        public GethLikeTxTrace[] GetBlockTrace(BlockParameter blockParameter, CancellationToken cancellationToken, GethTraceOptions gethTraceOptions = null)
         {
-            return _tracer.TraceBlock(blockHash, gethTraceOptions ?? GethTraceOptions.Default, cancellationToken); 
-        }
-
-        public GethLikeTxTrace[] GetBlockTrace(long blockNumber, CancellationToken cancellationToken, GethTraceOptions gethTraceOptions = null)
-        {
-            return _tracer.TraceBlock(blockNumber, gethTraceOptions ?? GethTraceOptions.Default, cancellationToken); 
+            return _tracer.TraceBlock(blockParameter, gethTraceOptions ?? GethTraceOptions.Default, cancellationToken);
         }
 
         public GethLikeTxTrace[] GetBlockTrace(Rlp blockRlp, CancellationToken cancellationToken,GethTraceOptions gethTraceOptions = null)

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
@@ -1,4 +1,4 @@
-﻿//  Copyright (c) 2021 Demerzel Solutions Limited
+//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
 // 
 //  The Nethermind library is free software: you can redistribute it and/or modify
@@ -163,43 +163,44 @@ namespace Nethermind.JsonRpc.Modules.DebugModule
 
         public ResultWrapper<GethLikeTxTrace[]> debug_traceBlock(byte[] blockRlp, GethTraceOptions options = null)
         {
-            using CancellationTokenSource cancellationTokenSource = new(_traceTimeout);
-            CancellationToken cancellationToken = cancellationTokenSource.Token;
+            using var cancellationTokenSource = new CancellationTokenSource(_traceTimeout);
+            var cancellationToken = cancellationTokenSource.Token;
             var blockTrace = _debugBridge.GetBlockTrace(new Rlp(blockRlp), cancellationToken, options);
+
             if (blockTrace == null)
-            {
                 return ResultWrapper<GethLikeTxTrace[]>.Fail($"Trace is null for RLP {blockRlp.ToHexString()}", ErrorCodes.ResourceNotFound);
-            }
+
+            if (_logger.IsTrace) _logger.Trace($"{nameof(debug_traceBlock)} request {blockRlp.ToHexString()}, result: {blockTrace}");
 
             return ResultWrapper<GethLikeTxTrace[]>.Success(blockTrace);
         }
 
-        public ResultWrapper<GethLikeTxTrace[]> debug_traceBlockByNumber(UInt256 blockNumber, GethTraceOptions options = null)
+        public ResultWrapper<GethLikeTxTrace[]> debug_traceBlockByNumber(BlockParameter blockNumber, GethTraceOptions options = null)
         {
-            using CancellationTokenSource cancellationTokenSource = new(_traceTimeout);
-            CancellationToken cancellationToken = cancellationTokenSource.Token;
-            var blockTrace = _debugBridge.GetBlockTrace((long)blockNumber, cancellationToken, options);
-            if (blockTrace == null)
-            {
-                return ResultWrapper<GethLikeTxTrace[]>.Fail($"Trace is null for block {blockNumber}", ErrorCodes.ResourceNotFound);
-            }
+            using var cancellationTokenSource = new CancellationTokenSource(_traceTimeout);
+            var cancellationToken = cancellationTokenSource.Token;
+            var blockTrace = _debugBridge.GetBlockTrace(blockNumber, cancellationToken, options);
 
-            if (_logger.IsTrace) _logger.Trace($"{nameof(debug_traceBlockByNumber)} request {blockNumber}, result: blockTrace");
+            if (blockTrace == null)
+                return ResultWrapper<GethLikeTxTrace[]>.Fail($"Trace is null for block {blockNumber}", ErrorCodes.ResourceNotFound);
+
+            if (_logger.IsTrace) _logger.Trace($"{nameof(debug_traceBlockByNumber)} request {blockNumber}, result: {blockTrace}");
+
             return ResultWrapper<GethLikeTxTrace[]>.Success(blockTrace);
         }
 
         public ResultWrapper<GethLikeTxTrace[]> debug_traceBlockByHash(Keccak blockHash, GethTraceOptions options = null)
         {
-            using CancellationTokenSource cancellationTokenSource = new(_traceTimeout);
-            CancellationToken cancellationToken = cancellationTokenSource.Token;
-            GethLikeTxTrace[] gethLikeBlockTrace = _debugBridge.GetBlockTrace(blockHash, cancellationToken, options);
-            if (gethLikeBlockTrace == null)
-            {
-                return ResultWrapper<GethLikeTxTrace[]>.Fail($"Trace is null for block {blockHash}", ErrorCodes.ResourceNotFound);
-            }
+            using var cancellationTokenSource = new CancellationTokenSource(_traceTimeout);
+            var cancellationToken = cancellationTokenSource.Token;
+            var blockTrace = _debugBridge.GetBlockTrace(new BlockParameter(blockHash), cancellationToken, options);
 
-            if (_logger.IsTrace) _logger.Trace($"{nameof(debug_traceBlockByHash)} request {blockHash}, result: blockTrace");
-            return ResultWrapper<GethLikeTxTrace[]>.Success(gethLikeBlockTrace);
+            if (blockTrace == null)
+                return ResultWrapper<GethLikeTxTrace[]>.Fail($"Trace is null for block {blockHash}", ErrorCodes.ResourceNotFound);
+
+            if (_logger.IsTrace) _logger.Trace($"{nameof(debug_traceBlockByHash)} request {blockHash}, result: {blockTrace}");
+
+            return ResultWrapper<GethLikeTxTrace[]>.Success(blockTrace);
         }
 
         public ResultWrapper<GethLikeTxTrace[]> debug_traceBlockFromFile(string fileName, GethTraceOptions options = null)

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/IDebugBridge.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/IDebugBridge.cs
@@ -1,4 +1,4 @@
-﻿//  Copyright (c) 2021 Demerzel Solutions Limited
+//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
 // 
 //  The Nethermind library is free software: you can redistribute it and/or modify
@@ -31,8 +31,7 @@ namespace Nethermind.JsonRpc.Modules.DebugModule
         GethLikeTxTrace GetTransactionTrace(Keccak blockHash, int index, CancellationToken cancellationToken, GethTraceOptions? gethTraceOptions = null);
         GethLikeTxTrace GetTransactionTrace(Rlp blockRlp, Keccak transactionHash, CancellationToken cancellationToken, GethTraceOptions? gethTraceOptions = null);
         GethLikeTxTrace? GetTransactionTrace(Transaction transaction, BlockParameter blockParameter, CancellationToken cancellationToken, GethTraceOptions? gethTraceOptions = null);
-        GethLikeTxTrace[] GetBlockTrace(Keccak blockHash, CancellationToken cancellationToken, GethTraceOptions? gethTraceOptions = null);
-        GethLikeTxTrace[] GetBlockTrace(long blockNumber, CancellationToken cancellationToken, GethTraceOptions? gethTraceOptions = null);
+        GethLikeTxTrace[] GetBlockTrace(BlockParameter blockParameter, CancellationToken cancellationToken, GethTraceOptions gethTraceOptions = null);
         GethLikeTxTrace[] GetBlockTrace(Rlp blockRlp, CancellationToken cancellationToken, GethTraceOptions? gethTraceOptions = null);
         byte[] GetBlockRlp(Keccak blockHash);
         byte[] GetBlockRlp(long number);

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/IDebugRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/IDebugRpcModule.cs
@@ -51,7 +51,7 @@ namespace Nethermind.JsonRpc.Modules.DebugModule
         [JsonRpcMethod(Description = "Returns the full stack trace of all invoked opcodes of all transactions that were included in the block specified. The parent of the block must be present or it will fail.", IsImplemented = true, IsSharable = true)]
         ResultWrapper<GethLikeTxTrace[]> debug_traceBlock(byte[] blockRlp, GethTraceOptions options = null);
 
-        [JsonRpcMethod(Description = "Similar to debug_traceBlock, this method accepts a block number and replays the block that is already present in the database.", IsImplemented = true, IsSharable = true)]
+        [JsonRpcMethod(Description = "Similar to debug_traceBlock, this method accepts a block number as well as \"latest\" or \"finalized\" and replays the block that is already present in the database.", IsImplemented = true, IsSharable = true)]
         ResultWrapper<GethLikeTxTrace[]> debug_traceBlockByNumber(BlockParameter blockParameter, GethTraceOptions options = null);
 
         [JsonRpcMethod(Description = "Similar to debug_traceBlock, this method accepts a block hash and replays the block that is already present in the database.", IsImplemented = true, IsSharable = true)]

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/IDebugRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/IDebugRpcModule.cs
@@ -48,7 +48,7 @@ namespace Nethermind.JsonRpc.Modules.DebugModule
         [JsonRpcMethod(Description = "", IsSharable = true)]
         ResultWrapper<GethLikeTxTrace> debug_traceTransactionByBlockhashAndIndex(Keccak blockHash, int txIndex, GethTraceOptions options = null);
 
-        [JsonRpcMethod(Description = "Returns a full stack trace of all invoked opcodes of all transaction that were included included in this block. The parent of this block must be present or it will fail.", IsImplemented = true, IsSharable = true)]
+        [JsonRpcMethod(Description = "Returns the full stack trace of all invoked opcodes of all transactions that were included in the block specified. The parent of the block must be present or it will fail.", IsImplemented = true, IsSharable = true)]
         ResultWrapper<GethLikeTxTrace[]> debug_traceBlock(byte[] blockRlp, GethTraceOptions options = null);
 
         [JsonRpcMethod(Description = "Similar to debug_traceBlock, this method accepts a block number and replays the block that is already present in the database.", IsImplemented = true, IsSharable = true)]

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/IDebugRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/IDebugRpcModule.cs
@@ -1,4 +1,4 @@
-﻿//  Copyright (c) 2021 Demerzel Solutions Limited
+//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
 // 
 //  The Nethermind library is free software: you can redistribute it and/or modify
@@ -15,11 +15,8 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
 using System.Threading.Tasks;
-using Nethermind.Blockchain;
 using Nethermind.Blockchain.Find;
-using Nethermind.Core;
 using Nethermind.Core.Crypto;
-using Nethermind.Int256;
 using Nethermind.Evm.Tracing.GethStyle;
 using Nethermind.JsonRpc.Data;
 
@@ -54,10 +51,10 @@ namespace Nethermind.JsonRpc.Modules.DebugModule
         [JsonRpcMethod(Description = "Returns a full stack trace of all invoked opcodes of all transaction that were included included in this block. The parent of this block must be present or it will fail.", IsImplemented = true, IsSharable = true)]
         ResultWrapper<GethLikeTxTrace[]> debug_traceBlock(byte[] blockRlp, GethTraceOptions options = null);
 
-        [JsonRpcMethod(Description = "", IsImplemented = true, IsSharable = true)]
-        ResultWrapper<GethLikeTxTrace[]> debug_traceBlockByNumber(UInt256 number, GethTraceOptions options = null);
+        [JsonRpcMethod(Description = "Similar to debug_traceBlock, this method accepts a block number and replays the block that is already present in the database.", IsImplemented = true, IsSharable = true)]
+        ResultWrapper<GethLikeTxTrace[]> debug_traceBlockByNumber(BlockParameter blockParameter, GethTraceOptions options = null);
 
-        [JsonRpcMethod(Description = "", IsImplemented = true, IsSharable = true)]
+        [JsonRpcMethod(Description = "Similar to debug_traceBlock, this method accepts a block hash and replays the block that is already present in the database.", IsImplemented = true, IsSharable = true)]
         ResultWrapper<GethLikeTxTrace[]> debug_traceBlockByHash(Keccak blockHash, GethTraceOptions options = null);
 
         [JsonRpcMethod(Description = "", IsImplemented = false, IsSharable = false)]


### PR DESCRIPTION
Resolves #4133 

## Changes:
- `debug_traceBlockByNumber` now accepts `latest` and `finalized` as a block number value
- `debug_traceBlock`, `debug_traceBlockByNumber`, and `debug_traceBlockByHash` methods has been unified and refactored

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No

**Comments about testing , should you have some** (optional)
Test cases has been added for `debug_traceBlock`, `debug_traceBlockByNumber`, and `debug_traceBlockByHash` methods.

## Further comments (optional)

Further refactoring, unification, and new test cases on the Debug module will be done along with the other sub-tasks of #4210. 