### PR TITLE
Fix issue in payload disposing and add unit test for asking multiple times by the same `payloadId`

### DIFF
--- a/src/Nethermind/Nethermind.Core/Extensions/CancellationTokenExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/CancellationTokenExtensions.cs
@@ -1,31 +1,59 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Nethermind.Core.Extensions
 {
     public static class CancellationTokenExtensions
     {
-        public static Task AsTask(this System.Threading.CancellationToken token)
+        /// <summary>
+        /// Converts <see cref="CancellationToken"/> to a awaitable <see cref="Task"/> when token is cancelled.
+        /// </summary>
+        /// <param name="token"></param>
+        /// <returns></returns>
+        public static Task AsTask(this CancellationToken token)
         {
             TaskCompletionSource taskCompletionSource = new();
             token.Register(() => taskCompletionSource.TrySetCanceled(), false);
             return taskCompletionSource.Task;
+        }
+
+        /// <summary>
+        /// <see cref="CancellationTokenSource.Cancel()"/>s and <see cref="CancellationTokenSource.Dispose"/>s the <see cref="CancellationTokenSource"/>
+        /// and also sets it to null so multiple calls to this method are safe and <see cref="CancellationTokenSource.Cancel()"/> will be called only once.
+        /// </summary>
+        /// <param name="cancellationTokenSource"></param>
+        /// <remarks>
+        /// This method is thread-sage and uses <see cref="Interlocked.CompareExchange{T}(ref T,T,T)"/> to safely manage reference.
+        /// </remarks>
+        public static void CancelDisposeAndClear(ref CancellationTokenSource? cancellationTokenSource)
+        {
+            CancellationTokenSource? source = cancellationTokenSource;
+            if (source is not null)
+            {
+                source = Interlocked.CompareExchange(ref cancellationTokenSource, null, source);
+                if (source is not null)
+                {
+                    source.Cancel();
+                    source.Dispose();
+                }
+            }
         }
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.DelayBlockImprovementContextFactory.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.DelayBlockImprovementContextFactory.cs
@@ -1,19 +1,19 @@
 ﻿//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using System;
 using System.Threading;
@@ -27,7 +27,7 @@ namespace Nethermind.Merge.Plugin.Test;
 
 public partial class EngineModuleTests
 {
-    private class DelayBlockImprovementContextFactory : IBlockImprovementContextFactory 
+    private class DelayBlockImprovementContextFactory : IBlockImprovementContextFactory
     {
         private readonly IManualBlockProductionTrigger _productionTrigger;
         private readonly TimeSpan _timeout;
@@ -40,13 +40,13 @@ public partial class EngineModuleTests
             _delay = delay;
         }
 
-        public IBlockImprovementContext StartBlockImprovementContext(Block currentBestBlock, BlockHeader parentHeader, PayloadAttributes payloadAttributes) => 
+        public IBlockImprovementContext StartBlockImprovementContext(Block currentBestBlock, BlockHeader parentHeader, PayloadAttributes payloadAttributes) =>
             new DelayBlockImprovementContext(currentBestBlock, _productionTrigger, _timeout, parentHeader, payloadAttributes, _delay);
     }
 
     private class DelayBlockImprovementContext : IBlockImprovementContext
     {
-        private readonly CancellationTokenSource _cancellationTokenSource;
+        private CancellationTokenSource? _cancellationTokenSource;
 
         public DelayBlockImprovementContext(
             Block currentBestBlock,
@@ -58,13 +58,18 @@ public partial class EngineModuleTests
         {
             _cancellationTokenSource = new CancellationTokenSource(timeout);
             CurrentBestBlock = currentBestBlock;
-            ImprovementTask = BuildBlock(blockProductionTrigger, parentHeader, payloadAttributes, delay);
+            ImprovementTask = BuildBlock(blockProductionTrigger, parentHeader, payloadAttributes, delay, _cancellationTokenSource.Token);
         }
 
-        private async Task<Block?> BuildBlock(IManualBlockProductionTrigger blockProductionTrigger, BlockHeader parentHeader, PayloadAttributes payloadAttributes, int delay)
+        private async Task<Block?> BuildBlock(
+            IManualBlockProductionTrigger blockProductionTrigger,
+            BlockHeader parentHeader,
+            PayloadAttributes payloadAttributes,
+            int delay,
+            CancellationToken cancellationToken)
         {
-            Block? block = await blockProductionTrigger.BuildBlock(parentHeader, _cancellationTokenSource.Token, NullBlockTracer.Instance, payloadAttributes);
-            await Task.Delay(delay);
+            Block? block = await blockProductionTrigger.BuildBlock(parentHeader, cancellationToken, NullBlockTracer.Instance, payloadAttributes);
+            await Task.Delay(delay, cancellationToken);
             if (block is not null)
             {
                 CurrentBestBlock = block;
@@ -79,8 +84,16 @@ public partial class EngineModuleTests
 
         public void Dispose()
         {
-            _cancellationTokenSource.Cancel();
-            _cancellationTokenSource.Dispose();
+            CancellationTokenSource? source = _cancellationTokenSource;
+            if (source is not null)
+            {
+                source = Interlocked.CompareExchange(ref _cancellationTokenSource, null, source);
+                if (source is not null)
+                {
+                    source.Cancel();
+                    source.Dispose();
+                }
+            }
         }
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.DelayBlockImprovementContextFactory.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.DelayBlockImprovementContextFactory.cs
@@ -20,6 +20,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Consensus.Producers;
 using Nethermind.Core;
+using Nethermind.Core.Extensions;
 using Nethermind.Evm.Tracing;
 using Nethermind.Merge.Plugin.BlockProduction;
 
@@ -84,16 +85,7 @@ public partial class EngineModuleTests
 
         public void Dispose()
         {
-            CancellationTokenSource? source = _cancellationTokenSource;
-            if (source is not null)
-            {
-                source = Interlocked.CompareExchange(ref _cancellationTokenSource, null, source);
-                if (source is not null)
-                {
-                    source.Cancel();
-                    source.Dispose();
-                }
-            }
+            CancellationTokenExtensions.CancelDisposeAndClear(ref _cancellationTokenSource);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
@@ -1,19 +1,19 @@
 ﻿//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using System;
 using System.Collections;
@@ -94,7 +94,7 @@ namespace Nethermind.Merge.Plugin.Test
             Address feeRecipient = TestItem.AddressC;
             UInt256 timestamp = Timestamper.UnixTime.Seconds;
 
-            
+
             var forkChoiceUpdatedParams = new
             {
                 headBlockHash = startingHead.ToString(),
@@ -240,23 +240,23 @@ namespace Nethermind.Merge.Plugin.Test
         [Test]
         public async Task getPayloadV1_should_allow_asking_multiple_times_by_same_payload_id()
         {
-            using var chain = await CreateBlockChain();
-            var rpc = CreateEngineModule(chain);
+            using MergeTestBlockchain chain = await CreateBlockChain();
+            IEngineRpcModule rpc = CreateEngineModule(chain);
 
-            var startingHead = chain.BlockTree.HeadHash;
-            var forkchoiceState = new ForkchoiceStateV1(startingHead, Keccak.Zero, startingHead);
-            var payload = new PayloadAttributes
+            Keccak startingHead = chain.BlockTree.HeadHash;
+            ForkchoiceStateV1 forkchoiceState = new(startingHead, Keccak.Zero, startingHead);
+            PayloadAttributes payload = new()
             {
                 Timestamp = Timestamper.UnixTime.Seconds,
                 SuggestedFeeRecipient = Address.Zero,
                 PrevRandao = Keccak.Zero
             };
-            var forkchoiceResponse = rpc.engine_forkchoiceUpdatedV1(forkchoiceState, payload);
-            var payloadId = Bytes.FromHexString(forkchoiceResponse.Result.Data.PayloadId!);
-            var responseFirst = await rpc.engine_getPayloadV1(payloadId);
+            Task<ResultWrapper<ForkchoiceUpdatedV1Result>> forkchoiceResponse = rpc.engine_forkchoiceUpdatedV1(forkchoiceState, payload);
+            byte[] payloadId = Bytes.FromHexString(forkchoiceResponse.Result.Data.PayloadId!);
+            ResultWrapper<ExecutionPayloadV1?> responseFirst = await rpc.engine_getPayloadV1(payloadId);
             responseFirst.Should().NotBeNull();
             responseFirst.Result.ResultType.Should().Be(ResultType.Success);
-            var responseSecond = await rpc.engine_getPayloadV1(payloadId);
+            ResultWrapper<ExecutionPayloadV1?> responseSecond = await rpc.engine_getPayloadV1(payloadId);
             responseSecond.Should().NotBeNull();
             responseSecond.Result.ResultType.Should().Be(ResultType.Success);
 
@@ -273,11 +273,11 @@ namespace Nethermind.Merge.Plugin.Test
             chain.PayloadPreparationService = new PayloadPreparationService(
                 chain.PostMergeBlockProducer!,
                 improvementContextFactory,
-                chain.SealEngine, 
-                TimerFactory.Default, 
-                chain.LogManager, 
+                chain.SealEngine,
+                TimerFactory.Default,
+                chain.LogManager,
                 timePerSlot);
-            
+
             IEngineRpcModule rpc = CreateEngineModule(chain);
             Keccak startingHead = chain.BlockTree.HeadHash;
             UInt256 timestamp = Timestamper.UnixTime.Seconds;
@@ -389,7 +389,7 @@ namespace Nethermind.Merge.Plugin.Test
         {
             using MergeTestBlockchain chain = await CreateBlockChain();
             IEngineRpcModule rpc = CreateEngineModule(chain);
-            
+
             ExecutionPayloadV1 getPayloadResult = await BuildAndGetPayloadResult(chain, rpc);
             Keccak newHead = getPayloadResult.BlockHash!;
 
@@ -401,7 +401,7 @@ namespace Nethermind.Merge.Plugin.Test
             chain.BlockTree.FindBlock(newHead, BlockTreeLookupOptions.RequireCanonical).Should().NotBeNull();
             chain.BlockTree.FindBlock(newHead, BlockTreeLookupOptions.None).Should().NotBeNull();
         }
-        
+
         [Test]
         public async Task block_should_not_be_canonical_after_reorg()
         {
@@ -413,15 +413,15 @@ namespace Nethermind.Merge.Plugin.Test
             Keccak random = Keccak.Zero;
             Address feeRecipientA = TestItem.AddressD;
             Address feeRecipientB = TestItem.AddressE;
-            
+
             ExecutionPayloadV1 getPayloadResultA = await BuildAndGetPayloadResult(rpc, chain, startingHead,
                 finalizedHash, startingHead, timestamp, random, feeRecipientA);
             Keccak blochHashA = getPayloadResultA.BlockHash!;
-            
+
             ExecutionPayloadV1 getPayloadResultB = await BuildAndGetPayloadResult(rpc, chain, startingHead,
                 finalizedHash, startingHead, timestamp, random, feeRecipientB);
             Keccak blochHashB = getPayloadResultB.BlockHash!;
-            
+
             await rpc.engine_newPayloadV1(getPayloadResultA);
             chain.BlockTree.FindBlock(blochHashA, BlockTreeLookupOptions.RequireCanonical).Should().BeNull();
             chain.BlockTree.FindBlock(blochHashB, BlockTreeLookupOptions.RequireCanonical).Should().BeNull();
@@ -433,19 +433,19 @@ namespace Nethermind.Merge.Plugin.Test
             chain.BlockTree.FindBlock(blochHashB, BlockTreeLookupOptions.RequireCanonical).Should().BeNull();
             chain.BlockTree.FindBlock(blochHashA, BlockTreeLookupOptions.None).Should().NotBeNull();
             chain.BlockTree.FindBlock(blochHashB, BlockTreeLookupOptions.None).Should().NotBeNull();
-            
+
             await rpc.engine_forkchoiceUpdatedV1(new ForkchoiceStateV1(blochHashA, finalizedHash, startingHead));
             chain.BlockTree.FindBlock(blochHashA, BlockTreeLookupOptions.RequireCanonical).Should().NotBeNull();
             chain.BlockTree.FindBlock(blochHashB, BlockTreeLookupOptions.RequireCanonical).Should().BeNull();
             chain.BlockTree.FindBlock(blochHashA, BlockTreeLookupOptions.None).Should().NotBeNull();
             chain.BlockTree.FindBlock(blochHashB, BlockTreeLookupOptions.None).Should().NotBeNull();
-            
+
             await rpc.engine_forkchoiceUpdatedV1(new ForkchoiceStateV1(blochHashB, finalizedHash, startingHead));
             chain.BlockTree.FindBlock(blochHashA, BlockTreeLookupOptions.RequireCanonical).Should().BeNull();
             chain.BlockTree.FindBlock(blochHashB, BlockTreeLookupOptions.RequireCanonical).Should().NotBeNull();
             chain.BlockTree.FindBlock(blochHashA, BlockTreeLookupOptions.None).Should().NotBeNull();
             chain.BlockTree.FindBlock(blochHashB, BlockTreeLookupOptions.None).Should().NotBeNull();
-            
+
             await rpc.engine_forkchoiceUpdatedV1(new ForkchoiceStateV1(blochHashA, finalizedHash, startingHead));
             chain.BlockTree.FindBlock(blochHashA, BlockTreeLookupOptions.RequireCanonical).Should().NotBeNull();
             chain.BlockTree.FindBlock(blochHashB, BlockTreeLookupOptions.RequireCanonical).Should().BeNull();
@@ -494,7 +494,7 @@ namespace Nethermind.Merge.Plugin.Test
                 yield return GetNewBlockRequestBadDataTestCase(r => r.GasUsed, 1);
             }
         }
-        
+
         [Test]
         public async Task executePayloadV1_unknown_parentHash_return_accepted()
         {
@@ -577,7 +577,7 @@ namespace Nethermind.Merge.Plugin.Test
             using MergeTestBlockchain chain = await CreateBaseBlockChain()
                 .ThrottleBlockProcessor(throttleBlockProcessor ? 100 : 0)
                 .Build(new SingleReleaseSpecProvider(London.Instance, 1));
-            
+
             IEngineRpcModule rpc = CreateEngineModule(chain);
             Block block = Build.A.Block.WithNumber(1).WithParent(chain.BlockTree.Head!).WithDifficulty(0).WithNonce(0)
                 .WithStateRoot(new Keccak("0x1ef7300d8961797263939a3d29bbba4ccf1702fabf02d8ad7a20b454edb6fd2f"))
@@ -609,7 +609,7 @@ namespace Nethermind.Merge.Plugin.Test
             actualHead.Should().Be(newHeadHash);
             AssertExecutionStatusChanged(rpc, newHeadHash!, Keccak.Zero, startingHead);
         }
-        
+
         [Test]
         public async Task forkchoiceUpdatedV1_should_update_finalized_block_hash()
         {
@@ -624,11 +624,11 @@ namespace Nethermind.Merge.Plugin.Test
             ResultWrapper<ForkchoiceUpdatedV1Result> forkchoiceUpdatedResult = await rpc.engine_forkchoiceUpdatedV1(forkchoiceStateV1);
             forkchoiceUpdatedResult.Data.PayloadStatus.Status.Should().Be(PayloadStatus.Valid);
             forkchoiceUpdatedResult.Data.PayloadId.Should().Be(null);
-            
+
             Keccak? actualFinalizedHash = chain.BlockTree.FinalizedHash;
             actualFinalizedHash.Should().NotBeNull();
             actualFinalizedHash.Should().Be(startingHead);
-            
+
             BlockForRpc blockForRpc = testRpc.EthRpcModule.eth_getBlockByNumber(BlockParameter.Finalized).Data;
             blockForRpc.Should().NotBeNull();
             actualFinalizedHash = blockForRpc.Hash;
@@ -638,7 +638,7 @@ namespace Nethermind.Merge.Plugin.Test
             Assert.AreEqual(actualFinalizedHash, chain.BlockFinalizationManager.LastFinalizedHash);
             AssertExecutionStatusChanged(rpc, newHeadHash!, startingHead, startingHead);
         }
-        
+
         [Test]
         public async Task forkchoiceUpdatedV1_should_update_safe_block_hash()
         {
@@ -653,21 +653,21 @@ namespace Nethermind.Merge.Plugin.Test
             ResultWrapper<ForkchoiceUpdatedV1Result> forkchoiceUpdatedResult = await rpc.engine_forkchoiceUpdatedV1(forkchoiceStateV1);
             forkchoiceUpdatedResult.Data.PayloadStatus.Status.Should().Be(PayloadStatus.Valid);
             forkchoiceUpdatedResult.Data.PayloadId.Should().Be(null);
-            
+
             Keccak? actualSafeHash = chain.BlockTree.SafeHash;
             actualSafeHash.Should().NotBeNull();
             actualSafeHash.Should().Be(startingHead);
-            
+
             BlockForRpc blockForRpc = testRpc.EthRpcModule.eth_getBlockByNumber(BlockParameter.Safe).Data;
             blockForRpc.Should().NotBeNull();
             actualSafeHash = blockForRpc.Hash;
             actualSafeHash.Should().NotBeNull();
             actualSafeHash.Should().Be(startingHead);
-            
+
             AssertExecutionStatusChanged(rpc, newHeadHash!, startingHead, startingHead);
         }
-        
-        
+
+
         [Test]
         public async Task forkchoiceUpdatedV1_should_work_with_zero_keccak_as_safe_block()
         {
@@ -744,19 +744,19 @@ namespace Nethermind.Merge.Plugin.Test
             Keccak? startingHead = chain.BlockTree.HeadHash;
             Block parent = Build.A.Block.WithNumber(2).WithParentHash(TestItem.KeccakA).WithNonce(0).WithDifficulty(0).TestObject;
             Block block = Build.A.Block.WithNumber(3).WithParent(parent).WithNonce(0).WithDifficulty(0).TestObject;
-            
+
             await rpc.engine_newPayloadV1(new ExecutionPayloadV1(parent));
-            
+
             ForkchoiceStateV1 forkchoiceStateV1 = new(parent.Hash!, startingHead, startingHead);
             ResultWrapper<ForkchoiceUpdatedV1Result> forkchoiceUpdatedResult = await rpc.engine_forkchoiceUpdatedV1(forkchoiceStateV1);
             forkchoiceUpdatedResult.Data.PayloadStatus.Status.Should().Be("SYNCING");
-            
+
             await rpc.engine_newPayloadV1(new ExecutionPayloadV1(block));
-            
+
             ForkchoiceStateV1 forkchoiceStateV11 = new(parent.Hash!, startingHead, startingHead);
             ResultWrapper<ForkchoiceUpdatedV1Result> forkchoiceUpdatedResult_1 = await rpc.engine_forkchoiceUpdatedV1(forkchoiceStateV11);
             forkchoiceUpdatedResult_1.Data.PayloadStatus.Status.Should().Be("SYNCING");
-            
+
             AssertExecutionStatusNotChangedV1(rpc, block.Hash!, startingHead, startingHead);
         }
 
@@ -920,7 +920,7 @@ namespace Nethermind.Merge.Plugin.Test
 
             await CanReorganizeToLastBlock(chain, branch1, branch2);
         }
-        
+
         [Test]
         public async Task forkchoiceUpdatedV1_head_block_after_reorg()
         {
@@ -989,7 +989,7 @@ namespace Nethermind.Merge.Plugin.Test
                 RootCheckVisitor rootCheckVisitor = new();
                 chain.StateReader.RunTreeVisitor(rootCheckVisitor, executePayloadRequest.StateRoot);
                 rootCheckVisitor.HasRoot.Should().BeTrue();
-                
+
                 chain.StateReader.GetBalance(executePayloadRequest.StateRoot, to).Should().Be(toBalanceAfter);
                 if (moveHead)
                 {
@@ -1031,7 +1031,7 @@ namespace Nethermind.Merge.Plugin.Test
                 chain.StateReader.RunTreeVisitor(rootCheckVisitor, executionPayload.StateRoot);
                 rootCheckVisitor.HasRoot.Should().BeTrue();
 
-                UInt256 fromBalanceAfter = chain.StateReader.GetBalance(executionPayload.StateRoot, from.Address); 
+                UInt256 fromBalanceAfter = chain.StateReader.GetBalance(executionPayload.StateRoot, from.Address);
                 Assert.True(fromBalanceAfter < fromBalance - toBalanceAfter);
                 chain.StateReader.GetBalance(executionPayload.StateRoot, to).Should().Be(toBalanceAfter);
                 Block findBlock = chain.BlockTree.FindBlock(executionPayload.BlockHash, BlockTreeLookupOptions.None)!;
@@ -1058,7 +1058,7 @@ namespace Nethermind.Merge.Plugin.Test
                 new ForkchoiceStateV1(startingHead, Keccak.Zero, startingHead),
                 new PayloadAttributes() { Timestamp = 100, PrevRandao = TestItem.KeccakA, SuggestedFeeRecipient = Address.Zero })
                 .Result.Data.PayloadId!;
-            
+
             await blockImprovementLock.WaitAsync(10000);
             ExecutionPayloadV1 getPayloadResult = (await rpc.engine_getPayloadV1(Bytes.FromHexString(payloadId))).Data!;
 
@@ -1207,7 +1207,7 @@ namespace Nethermind.Merge.Plugin.Test
             (await rpc.engine_getPayloadV1(Bytes.FromHexString(payloadId))).Data!.FeeRecipient.Should()
                 .Be(TestItem.AddressC);
         }
-        
+
         [TestCase(0, "0x0000000000000000000000000000000000000000000000000000000000000000")]
         [TestCase(1000001, "0x191dc9697d77129ee5b6f6d57074d2c854a38129913e3fdd3d9f0ebc930503a6")]
         public async Task exchangeTransitionConfiguration_return_expected_results(long clTtd, string terminalBlockHash)
@@ -1215,19 +1215,19 @@ namespace Nethermind.Merge.Plugin.Test
             using MergeTestBlockchain chain =
                 await CreateBlockChain(new MergeConfig() { Enabled = true, TerminalTotalDifficulty = "1000001", TerminalBlockHash = new Keccak("0x191dc9697d77129ee5b6f6d57074d2c854a38129913e3fdd3d9f0ebc930503a6").ToString(true), TerminalBlockNumber = 1 });
             IEngineRpcModule rpc = CreateEngineModule(chain);
-            
+
             TransitionConfigurationV1 result = rpc.engine_exchangeTransitionConfigurationV1(new TransitionConfigurationV1()
             {
                 TerminalBlockNumber = 0,
                 TerminalBlockHash = new Keccak(terminalBlockHash),
                 TerminalTotalDifficulty = (UInt256)clTtd
             }).Data;
-            
+
             Assert.AreEqual((UInt256)1000001, result.TerminalTotalDifficulty);
             Assert.AreEqual(1, result.TerminalBlockNumber);
             Assert.AreEqual("0x191dc9697d77129ee5b6f6d57074d2c854a38129913e3fdd3d9f0ebc930503a6", result.TerminalBlockHash.ToString());
         }
-        
+
         [TestCase(0, "0x0000000000000000000000000000000000000000000000000000000000000000")]
         [TestCase(1000001, "0x191dc9697d77129ee5b6f6d57074d2c854a38129913e3fdd3d9f0ebc930503a6")]
         public async Task exchangeTransitionConfiguration_return_with_empty_Nethermind_configuration(long clTtd, string terminalBlockHash)
@@ -1235,14 +1235,14 @@ namespace Nethermind.Merge.Plugin.Test
             using MergeTestBlockchain chain =
                 await CreateBlockChain(new MergeConfig() { Enabled = true });
             IEngineRpcModule rpc = CreateEngineModule(chain);
-            
+
             TransitionConfigurationV1 result = rpc.engine_exchangeTransitionConfigurationV1(new TransitionConfigurationV1()
             {
                 TerminalBlockNumber = 0,
                 TerminalBlockHash = new Keccak(terminalBlockHash),
                 TerminalTotalDifficulty = (UInt256)clTtd
             }).Data;
-            
+
             Assert.AreEqual((UInt256)0, result.TerminalTotalDifficulty);
             Assert.AreEqual(0, result.TerminalBlockNumber);
             Assert.AreEqual("0x0000000000000000000000000000000000000000000000000000000000000000", result.TerminalBlockHash.ToString());
@@ -1310,7 +1310,7 @@ namespace Nethermind.Merge.Plugin.Test
             ResultWrapper<ForkchoiceUpdatedV1Result> forkchoiceUpdatedResult1 =
                 await rpc.engine_forkchoiceUpdatedV1(forkChoiceState1);
             forkchoiceUpdatedResult1.Data.PayloadStatus.Status.Should().Be(PayloadStatus.Valid);
-            
+
             ResultWrapper<PayloadStatusV1> newPayloadResult2 = await rpc.engine_newPayloadV1(executionPayloadV11);
             newPayloadResult2.Data.Status.Should().Be(PayloadStatus.Valid);
             newPayloadResult2.Data.LatestValidHash.Should().Be(executionPayloadV11.BlockHash);
@@ -1361,7 +1361,7 @@ namespace Nethermind.Merge.Plugin.Test
                 executionPayloadV12B.BlockHash);
             ResultWrapper<ForkchoiceUpdatedV1Result> forkchoiceUpdatedResult2B = await rpc.engine_forkchoiceUpdatedV1(forkChoiceState2B);
             forkchoiceUpdatedResult2B.Data.PayloadStatus.Status.Should().Be(PayloadStatus.Valid);
-            
+
             // New payload unknown parent hash
             ExecutionPayloadV1 executionPayloadV13A = CreateBlockRequest(executionPayloadV12A, TestItem.AddressA);
             ResultWrapper<PayloadStatusV1> newPayloadResult3A = await rpc.engine_newPayloadV1(executionPayloadV13A);
@@ -1373,7 +1373,7 @@ namespace Nethermind.Merge.Plugin.Test
                 executionPayloadV13A.BlockHash);
             ResultWrapper<ForkchoiceUpdatedV1Result> forkchoiceUpdatedResult3A = await rpc.engine_forkchoiceUpdatedV1(forkChoiceState3A);
             forkchoiceUpdatedResult3A.Data.PayloadStatus.Status.Should().Be(PayloadStatus.Syncing);
-            
+
             ExecutionPayloadV1 executionPayloadV13B = CreateBlockRequest(executionPayloadV12B, TestItem.AddressA);
             ResultWrapper<PayloadStatusV1> newPayloadResult3B = await rpc.engine_newPayloadV1(executionPayloadV13B);
             newPayloadResult3B.Data.Status.Should().Be(PayloadStatus.Valid);
@@ -1391,36 +1391,36 @@ namespace Nethermind.Merge.Plugin.Test
             using MergeTestBlockchain chain =
                 await CreateBlockChain(new MergeConfig() { Enabled = true, TerminalTotalDifficulty = "0" });
             IEngineRpcModule rpc = CreateEngineModule(chain);
-            
+
             ExecutionPayloadV1 blockRequestResult1 = CreateBlockRequest(
                 CreateParentBlockRequestOnHead(chain.BlockTree),
                 TestItem.AddressA);
             ResultWrapper<PayloadStatusV1> newPayloadResult1 = await rpc.engine_newPayloadV1(blockRequestResult1);
             newPayloadResult1.Data.Status.Should().Be(PayloadStatus.Valid);
-            
+
             ForkchoiceStateV1 forkChoiceState1 = new ForkchoiceStateV1(blockRequestResult1.BlockHash, blockRequestResult1.BlockHash,
                 blockRequestResult1.BlockHash);
             ResultWrapper<ForkchoiceUpdatedV1Result> forkchoiceUpdatedResult1 = await rpc.engine_forkchoiceUpdatedV1(forkChoiceState1);
             forkchoiceUpdatedResult1.Data.PayloadStatus.Status.Should().Be(PayloadStatus.Valid);
-            
+
             ExecutionPayloadV1 blockRequestResult2A = CreateBlockRequest(blockRequestResult1, TestItem.AddressB);
             ResultWrapper<PayloadStatusV1> newPayloadResult2A = await rpc.engine_newPayloadV1(blockRequestResult2A);
             newPayloadResult2A.Data.Status.Should().Be(PayloadStatus.Valid);
-            
+
             ExecutionPayloadV1 blockRequestResult2B = CreateBlockRequest(blockRequestResult1, TestItem.AddressA);
             ResultWrapper<PayloadStatusV1> newPayloadResult2B = await rpc.engine_newPayloadV1(blockRequestResult2B);
             newPayloadResult2B.Data.Status.Should().Be(PayloadStatus.Valid);
-            
+
             ExecutionPayloadV1 blockRequestResult3B = CreateBlockRequest(blockRequestResult2B, TestItem.AddressA);
             ResultWrapper<PayloadStatusV1> newPayloadResult3B = await rpc.engine_newPayloadV1(blockRequestResult3B);
             newPayloadResult3B.Data.Status.Should().Be(PayloadStatus.Valid);
-            
+
             ForkchoiceStateV1 forkChoiceState3 = new ForkchoiceStateV1(blockRequestResult3B.BlockHash, blockRequestResult2A.BlockHash,
                 blockRequestResult3B.BlockHash); // finalized hash - inconsistent blockRequestResult2A
             ResultWrapper<ForkchoiceUpdatedV1Result> forkchoiceUpdatedResult3 = await rpc.engine_forkchoiceUpdatedV1(forkChoiceState3);
             forkchoiceUpdatedResult3.ErrorCode.Should().Be(MergeErrorCodes.InvalidForkchoiceState);
         }
-        
+
         [Test]
         public async Task inconsistent_safe_hash()
         {
@@ -1438,25 +1438,25 @@ namespace Nethermind.Merge.Plugin.Test
                 blockRequestResult1.BlockHash);
             ResultWrapper<ForkchoiceUpdatedV1Result> forkchoiceUpdatedResult1 = await rpc.engine_forkchoiceUpdatedV1(forkChoiceState1);
             forkchoiceUpdatedResult1.Data.PayloadStatus.Status.Should().Be(PayloadStatus.Valid);
-            
+
             ExecutionPayloadV1 blockRequestResult2A = CreateBlockRequest(blockRequestResult1, TestItem.AddressB);
             ResultWrapper<PayloadStatusV1> newPayloadResult2A = await rpc.engine_newPayloadV1(blockRequestResult2A);
             newPayloadResult2A.Data.Status.Should().Be(PayloadStatus.Valid);
-            
+
             ExecutionPayloadV1 blockRequestResult2B = CreateBlockRequest(blockRequestResult1, TestItem.AddressA);
             ResultWrapper<PayloadStatusV1> newPayloadResult2B = await rpc.engine_newPayloadV1(blockRequestResult2B);
             newPayloadResult2B.Data.Status.Should().Be(PayloadStatus.Valid);
-            
+
             ExecutionPayloadV1 blockRequestResult3B = CreateBlockRequest(blockRequestResult2B, TestItem.AddressA);
             ResultWrapper<PayloadStatusV1> newPayloadResult3B = await rpc.engine_newPayloadV1(blockRequestResult3B);
             newPayloadResult3B.Data.Status.Should().Be(PayloadStatus.Valid);
-            
+
             ForkchoiceStateV1 forkChoiceState3 = new ForkchoiceStateV1(blockRequestResult3B.BlockHash, blockRequestResult3B.BlockHash,
                 blockRequestResult2A.BlockHash); // safe block hash - inconsistent blockRequestResult2A
             ResultWrapper<ForkchoiceUpdatedV1Result> forkchoiceUpdatedResult3 = await rpc.engine_forkchoiceUpdatedV1(forkChoiceState3);
             forkchoiceUpdatedResult3.ErrorCode.Should().Be(MergeErrorCodes.InvalidForkchoiceState);
         }
-        
+
 
         [Test]
         public async Task payloadV1_latest_block_after_reorg()

--- a/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/BlockImprovementContext.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/BlockImprovementContext.cs
@@ -1,19 +1,19 @@
 ﻿//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using System;
 using System.Threading;
@@ -26,13 +26,13 @@ namespace Nethermind.Merge.Plugin.BlockProduction;
 
 public class BlockImprovementContext : IBlockImprovementContext
 {
-    private readonly CancellationTokenSource _cancellationTokenSource;
-    
+    private CancellationTokenSource? _cancellationTokenSource;
+
     public BlockImprovementContext(
-        Block currentBestBlock, 
-        IManualBlockProductionTrigger blockProductionTrigger, 
+        Block currentBestBlock,
+        IManualBlockProductionTrigger blockProductionTrigger,
         TimeSpan timeout,
-        BlockHeader parentHeader, 
+        BlockHeader parentHeader,
         PayloadAttributes payloadAttributes)
     {
         _cancellationTokenSource = new CancellationTokenSource(timeout);
@@ -55,13 +55,21 @@ public class BlockImprovementContext : IBlockImprovementContext
                 CurrentBestBlock = task.Result;
             }
         }
-                
+
         return task.Result;
     }
 
     public void Dispose()
     {
-        _cancellationTokenSource.Cancel();
-        _cancellationTokenSource.Dispose();
+        CancellationTokenSource? source = _cancellationTokenSource;
+        if (source is not null)
+        {
+            source = Interlocked.CompareExchange(ref _cancellationTokenSource, null, source);
+            if (source is not null)
+            {
+                source.Cancel();
+                source.Dispose();
+            }
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/BlockImprovementContext.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/BlockImprovementContext.cs
@@ -20,6 +20,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Consensus.Producers;
 using Nethermind.Core;
+using Nethermind.Core.Extensions;
 using Nethermind.Evm.Tracing;
 
 namespace Nethermind.Merge.Plugin.BlockProduction;
@@ -61,15 +62,6 @@ public class BlockImprovementContext : IBlockImprovementContext
 
     public void Dispose()
     {
-        CancellationTokenSource? source = _cancellationTokenSource;
-        if (source is not null)
-        {
-            source = Interlocked.CompareExchange(ref _cancellationTokenSource, null, source);
-            if (source is not null)
-            {
-                source.Cancel();
-                source.Dispose();
-            }
-        }
+        CancellationTokenExtensions.CancelDisposeAndClear(ref _cancellationTokenSource);
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/PayloadPreparationService.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/PayloadPreparationService.cs
@@ -1,19 +1,19 @@
 ﻿//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using System;
 using System.Collections.Concurrent;
@@ -45,14 +45,14 @@ namespace Nethermind.Merge.Plugin.BlockProduction
         private readonly ISealer _sealer;
         private readonly ILogger _logger;
         private readonly List<string> _payloadsToRemove = new();
-        
+
         // by default we will cleanup the old payload once per six slot. There is no need to fire it more often
         public const int SlotsPerOldPayloadCleanup = 6;
         private readonly TimeSpan _cleanupOldPayloadDelay;
 
         // first ExecutionPayloadV1 is empty (without txs), second one is the ideal one
         private readonly ConcurrentDictionary<string, IBlockImprovementContext> _payloadStorage = new();
-        
+
         public PayloadPreparationService(
             PostMergeBlockProducer blockProducer,
             IBlockImprovementContextFactory blockImprovementContextFactory,
@@ -108,7 +108,7 @@ namespace Nethermind.Merge.Plugin.BlockProduction
                 blockImprovementContext.Dispose();
             }
         }
-        
+
         private void CleanupOldPayloads(object? sender, EventArgs e)
         {
             if (_logger.IsTrace) _logger.Trace($"Started old payloads cleanup");
@@ -131,7 +131,7 @@ namespace Nethermind.Merge.Plugin.BlockProduction
                     if (_logger.IsInfo) _logger.Info($"Cleaned up payload with id={payloadToRemove} as it was not requested");
                 }
             }
-            
+
             _payloadsToRemove.Clear();
             if (_logger.IsTrace) _logger.Trace($"Finished old payloads cleanup");
         }
@@ -166,7 +166,10 @@ namespace Nethermind.Merge.Plugin.BlockProduction
         {
             if (_payloadStorage.TryGetValue(payloadId, out IBlockImprovementContext? blockContext))
             {
-                return blockContext.CurrentBestBlock;
+                using (blockContext)
+                {
+                    return blockContext.CurrentBestBlock;
+                }
             }
 
             return null;

--- a/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/PayloadPreparationService.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/PayloadPreparationService.cs
@@ -166,10 +166,7 @@ namespace Nethermind.Merge.Plugin.BlockProduction
         {
             if (_payloadStorage.TryGetValue(payloadId, out IBlockImprovementContext? blockContext))
             {
-                using (blockContext)
-                {
-                    return blockContext.CurrentBestBlock;
-                }
+                return blockContext.CurrentBestBlock;
             }
 
             return null;


### PR DESCRIPTION
## Changes:
- Fix an issue that caused the `BlockImprovementContext.CancellationTokenSource` to be disposed multiple times
- Add unit test to verify we can ask multiple times using the same `payloadId` without errors

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No