### PR TITLE
Fix/syncmode

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
@@ -31,11 +31,11 @@ namespace Nethermind.Blockchain.Synchronization
         [ConfigItem(Description = "If 'false' then the node does not download/process new blocks.", DefaultValue = "true")]
         bool SynchronizationEnabled { get; set; }
 
-        [ConfigItem(Description = "Sync mode for client to use", DefaultValue = "StateSyncMode.NotConfigured")]
+        [ConfigItem(Description = "Sync mode for client to use", DefaultValue = "StateSyncMode.FullSync")]
         StateSyncMode SyncMode { get; set; }
 
         [ConfigItem(
-            Description = "If set to 'true' then the Fast Sync (eth/63) synchronization algorithm will be used.",
+            Description = "[OBSOLETE] If set to 'true' then the Fast Sync (eth/63) synchronization algorithm will be used.",
             DefaultValue = "false")]
         bool FastSync { set; }
 
@@ -91,7 +91,7 @@ namespace Nethermind.Blockchain.Synchronization
         [ConfigItem(Description = "Enables witness protocol.", DefaultValue = "false")]
         public bool WitnessProtocolEnabled { get; set; }
 
-        [ConfigItem(Description = "Enables SNAP sync protocol", DefaultValue = "false")]
+        [ConfigItem(Description = "[OBSOLETE] Enables SNAP sync protocol", DefaultValue = "false")]
         public bool SnapSync { set; }
 
         [ConfigItem(Description = "[ONLY FOR MISSING RECEIPTS ISSUE] Turns on receipts validation that checks for ones that might be missing due to previous bug. It downloads them from network if needed." +

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
@@ -37,7 +37,7 @@ namespace Nethermind.Blockchain.Synchronization
         [ConfigItem(
             Description = "If set to 'true' then the Fast Sync (eth/63) synchronization algorithm will be used.",
             DefaultValue = "false")]
-        bool FastSync { get; set; }
+        bool FastSync { set; }
 
         // Minimum is taken from MultiSyncModeSelector.StickyStateNodesDelta
         [ConfigItem(Description = "Relevant only if 'FastSync' is 'true'. If set to a value, then it will set a minimum height threshold limit up to which FullSync, if already on, will stay on when chain will be behind network. If this limit will be exceeded, it will switch back to FastSync. In normal usage we do not recommend setting this to less than 32 as this can cause issues with chain reorgs. Please note that last 2 blocks will always be processed in FullSync, so setting it to less than 2 will have no effect.", DefaultValue = "8192")]
@@ -91,8 +91,8 @@ namespace Nethermind.Blockchain.Synchronization
         [ConfigItem(Description = "Enables witness protocol.", DefaultValue = "false")]
         public bool WitnessProtocolEnabled { get; set; }
 
-        [ConfigItem(Description = "Enables SNAP sync protocol.", DefaultValue = "false")]
-        public bool SnapSync { get; set; }
+        [ConfigItem(Description = "Enables SNAP sync protocol", DefaultValue = "false")]
+        public bool SnapSync { set; }
 
         [ConfigItem(Description = "[ONLY FOR MISSING RECEIPTS ISSUE] Turns on receipts validation that checks for ones that might be missing due to previous bug. It downloads them from network if needed." +
                                   "If used please check that PivotNumber is same as original used when syncing the node as its used as a cut-off point.", DefaultValue = "false")]

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -27,70 +27,73 @@ namespace Nethermind.Blockchain.Synchronization
     {
         [ConfigItem(Description = "If 'false' then the node does not connect to peers.", DefaultValue = "true")]
         bool NetworkingEnabled { get; set; }
-        
+
         [ConfigItem(Description = "If 'false' then the node does not download/process new blocks.", DefaultValue = "true")]
         bool SynchronizationEnabled { get; set; }
-        
+
+        [ConfigItem(Description = "Sync mode for client to use", DefaultValue = "StateSyncMode.NotConfigured")]
+        StateSyncMode SyncMode { get; set; }
+
         [ConfigItem(
             Description = "If set to 'true' then the Fast Sync (eth/63) synchronization algorithm will be used.",
             DefaultValue = "false")]
         bool FastSync { get; set; }
-        
+
         // Minimum is taken from MultiSyncModeSelector.StickyStateNodesDelta
         [ConfigItem(Description = "Relevant only if 'FastSync' is 'true'. If set to a value, then it will set a minimum height threshold limit up to which FullSync, if already on, will stay on when chain will be behind network. If this limit will be exceeded, it will switch back to FastSync. In normal usage we do not recommend setting this to less than 32 as this can cause issues with chain reorgs. Please note that last 2 blocks will always be processed in FullSync, so setting it to less than 2 will have no effect.", DefaultValue = "8192")]
         long? FastSyncCatchUpHeightDelta { get; set; }
 
         [ConfigItem(Description = "If set to 'true' then in the Fast Sync mode blocks will be first downloaded from the provided PivotNumber downwards. This allows for parallelization of requests with many sync peers and with no need to worry about syncing a valid branch (syncing downwards to 0). You need to enter the pivot block number, hash and total difficulty from a trusted source (you can use etherscan and confirm with other sources if you wan to change it).", DefaultValue = "false")]
         bool FastBlocks { get; set; }
-        
+
         [ConfigItem(Description = "If set to 'true' then in the Fast Blocks mode Nethermind generates smaller requests to avoid Geth from disconnecting. On the Geth heavy networks (mainnet) it is desired while on Parity or Nethermind heavy networks (Goerli, AuRa) it slows down the sync by a factor of ~4", DefaultValue = "true")]
         public bool UseGethLimitsInFastBlocks { get; set; }
-        
+
         [ConfigItem(Description = "If set to 'false' then fast sync will only download recent blocks.", DefaultValue = "true")]
         bool DownloadHeadersInFastSync { get; set; }
-        
+
         [ConfigItem(Description = "If set to 'true' then the block bodies will be downloaded in the Fast Sync mode.", DefaultValue = "true")]
         bool DownloadBodiesInFastSync { get; set; }
-        
+
         [ConfigItem(Description = "If set to 'true' then the receipts will be downloaded in the Fast Sync mode. This will slow down the process by a few hours but will allow you to interact with dApps that execute extensive historical logs searches (like Maker CDPs).", DefaultValue = "true")]
         bool DownloadReceiptsInFastSync { get; set; }
-        
+
         [ConfigItem(Description = "Total Difficulty of the pivot block for the Fast Blocks sync (not - this is total difficulty and not difficulty).", DefaultValue = "null")]
         string PivotTotalDifficulty { get; }
-        
+
         [ConfigItem(Description = "Number of the pivot block for the Fast Blocks sync.", DefaultValue = "null")]
         string PivotNumber { get; set; }
-        
+
         [ConfigItem(Description = "Hash of the pivot block for the Fast Blocks sync.", DefaultValue = "null")]
         string PivotHash { get; set; }
 
         [ConfigItem(DisabledForCli = true, HiddenFromDocs = true, DefaultValue = "0")]
         long PivotNumberParsed => LongConverter.FromString(PivotNumber ?? "0");
-        
+
         [ConfigItem(DisabledForCli = true, HiddenFromDocs = true, DefaultValue = "0")]
         UInt256 PivotTotalDifficultyParsed => UInt256.Parse(PivotTotalDifficulty ?? "0");
 
         [ConfigItem(DisabledForCli = true, HiddenFromDocs = true)]
         Keccak PivotHashParsed => PivotHash == null ? null : new Keccak(Bytes.FromHexString(PivotHash));
-        
+
         [ConfigItem(Description = "[EXPERIMENTAL] Defines the earliest body downloaded in fast sync when DownloadBodiesInFastSync is enabled. Actual values used will be Math.Max(1, Math.Min(PivotNumber, AncientBodiesBarrier))", DefaultValue = "0")]
         public long AncientBodiesBarrier { get; set; }
 
         [ConfigItem(DisabledForCli = true, HiddenFromDocs = true, DefaultValue = "1")]
         public long AncientBodiesBarrierCalc => Math.Max(1, Math.Min(PivotNumberParsed, AncientBodiesBarrier));
-        
+
         [ConfigItem(Description = "[EXPERIMENTAL] Defines the earliest receipts downloaded in fast sync when DownloadReceiptsInFastSync is enabled. Actual value used will be Math.Max(1, Math.Min(PivotNumber, Math.Max(AncientBodiesBarrier, AncientReceiptsBarrier)))", DefaultValue = "0")]
         public long AncientReceiptsBarrier { get; set; }
 
         [ConfigItem(DisabledForCli = true, HiddenFromDocs = true, DefaultValue = "1")]
         public long AncientReceiptsBarrierCalc => Math.Max(1, Math.Min(PivotNumberParsed, Math.Max(AncientBodiesBarrier, AncientReceiptsBarrier)));
-        
+
         [ConfigItem(Description = "Enables witness protocol.", DefaultValue = "false")]
         public bool WitnessProtocolEnabled { get; set; }
-        
+
         [ConfigItem(Description = "Enables SNAP sync protocol.", DefaultValue = "false")]
         public bool SnapSync { get; set; }
-        
+
         [ConfigItem(Description = "[ONLY FOR MISSING RECEIPTS ISSUE] Turns on receipts validation that checks for ones that might be missing due to previous bug. It downloads them from network if needed." +
                                   "If used please check that PivotNumber is same as original used when syncing the node as its used as a cut-off point.", DefaultValue = "false")]
         public bool FixReceipts { get; set; }

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/StateSyncMode.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/StateSyncMode.cs
@@ -15,12 +15,12 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 //
 
-namespace Nethermind.Blockchain.Synchronization;
-
-public enum StateSyncMode
+namespace Nethermind.Blockchain.Synchronization
 {
-    NotConfigured,
-    FullSync,
-    FastSync,
-    SnapSync
+    public enum StateSyncMode
+    {
+        FullSync = 1,
+        FastSync = 2,
+        SnapSync = FastSync | 4,
+    }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/StateSyncMode.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/StateSyncMode.cs
@@ -1,0 +1,26 @@
+//  Copyright (c) 2021 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+//
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+//
+
+namespace Nethermind.Blockchain.Synchronization;
+
+public enum StateSyncMode
+{
+    NotConfigured,
+    FullSync,
+    FastSync,
+    SnapSync
+}

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/StateSyncMode.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/StateSyncMode.cs
@@ -15,8 +15,11 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 //
 
+using System;
+
 namespace Nethermind.Blockchain.Synchronization
 {
+    [Flags]
     public enum StateSyncMode
     {
         FullSync = 1,

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
@@ -23,29 +23,30 @@ namespace Nethermind.Blockchain.Synchronization
     public class SyncConfig : ISyncConfig
     {
         private bool _synchronizationEnabled = true;
-        private bool _fastSync;
-        private StateSyncMode _syncMode = StateSyncMode.NotConfigured;
+        private bool? _fastSync;
+        private bool? _snapSync;
+        private StateSyncMode? _syncMode;
 
         public StateSyncMode SyncMode
         {
             get
             {
-                if (_syncMode != StateSyncMode.NotConfigured)
+                if (_syncMode.HasValue)
                 {
-                    return _syncMode;
+                    return _syncMode.Value;
                 }
-                else if (FastSync)
-                {
-                    return StateSyncMode.FastSync;
-                }
-                else if (SnapSync)
+
+                if (_snapSync.HasValue && _snapSync.Value)
                 {
                     return StateSyncMode.SnapSync;
                 }
-                else
+
+                if (_fastSync.HasValue && _fastSync.Value)
                 {
-                    return StateSyncMode.FullSync;
+                    return StateSyncMode.FastSync;
                 }
+
+                return StateSyncMode.FullSync;
             }
             set => _syncMode = value;
         }
@@ -68,12 +69,12 @@ namespace Nethermind.Blockchain.Synchronization
         public bool FastBlocks { get; set; }
         public bool UseGethLimitsInFastBlocks { get; set; } = true;
 
-        [Obsolete("This boolean will be deprecated in future release.")]
+        [Obsolete("FastSync flag will be deprecated in the future, consider using SyncMode.", false)]
         public bool FastSync
         {
-            get => _fastSync || SnapSync;
             set => _fastSync = value;
         }
+
         public bool DownloadHeadersInFastSync { get; set; } = true;
         public bool DownloadBodiesInFastSync { get; set; } = true;
         public bool DownloadReceiptsInFastSync { get; set; } = true;
@@ -84,8 +85,11 @@ namespace Nethermind.Blockchain.Synchronization
         public string PivotHash { get; set; }
         public bool WitnessProtocolEnabled { get; set; } = false;
 
-        [Obsolete("This boolean will be deprecated in future release.")]
-        public bool SnapSync { get; set; } = false;
+        [Obsolete("SnapSync flag will be deprecated in the future, consider using SyncMode.", false)]
+        public bool SnapSync
+        {
+            set => _snapSync = value;
+        }
 
         public bool FixReceipts { get; set; } = false;
         public bool BlockGossipEnabled { get; set; } = true;

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
@@ -31,31 +31,33 @@ namespace Nethermind.Blockchain.Synchronization
         {
             get
             {
-                if (_syncMode.HasValue)
-                {
-                    return _syncMode.Value;
-                }
-
                 if (_snapSync.HasValue && _snapSync.Value)
                 {
                     return StateSyncMode.SnapSync;
                 }
 
-                if (_fastSync.HasValue && _fastSync.Value)
+                if (_fastSync.HasValue)
                 {
-                    return StateSyncMode.FastSync;
+                    return _fastSync.Value ? StateSyncMode.FastSync : StateSyncMode.FullSync;
                 }
 
-                return StateSyncMode.FullSync;
+                return _syncMode ?? StateSyncMode.FullSync;
             }
             set => _syncMode = value;
         }
 
         public static ISyncConfig Default { get; } = new SyncConfig();
-        public static ISyncConfig WithFullSyncOnly { get; } = new SyncConfig {FastBlocks = false, SyncMode = StateSyncMode.FullSync};
-        public static ISyncConfig WithFastSync { get; } = new SyncConfig {SyncMode = StateSyncMode.FastSync};
-        public static ISyncConfig WithFastBlocks { get; } = new SyncConfig {FastBlocks = true, SyncMode = StateSyncMode.FastSync};
-        public static ISyncConfig WithEth2Merge { get; } = new SyncConfig {FastBlocks = false, BlockGossipEnabled = false};
+
+        public static ISyncConfig WithFullSyncOnly { get; } =
+            new SyncConfig { FastBlocks = false, SyncMode = StateSyncMode.FullSync };
+
+        public static ISyncConfig WithFastSync { get; } = new SyncConfig { SyncMode = StateSyncMode.FastSync };
+
+        public static ISyncConfig WithFastBlocks { get; } =
+            new SyncConfig { FastBlocks = true, SyncMode = StateSyncMode.FastSync };
+
+        public static ISyncConfig WithEth2Merge { get; } =
+            new SyncConfig { FastBlocks = false, BlockGossipEnabled = false };
 
         public bool NetworkingEnabled { get; set; } = true;
 
@@ -70,10 +72,7 @@ namespace Nethermind.Blockchain.Synchronization
         public bool UseGethLimitsInFastBlocks { get; set; } = true;
 
         [Obsolete("FastSync flag will be deprecated in the future, consider using SyncMode.", false)]
-        public bool FastSync
-        {
-            set => _fastSync = value;
-        }
+        public bool FastSync { set => _fastSync = value; }
 
         public bool DownloadHeadersInFastSync { get; set; } = true;
         public bool DownloadBodiesInFastSync { get; set; } = true;
@@ -86,11 +85,7 @@ namespace Nethermind.Blockchain.Synchronization
         public bool WitnessProtocolEnabled { get; set; } = false;
 
         [Obsolete("SnapSync flag will be deprecated in the future, consider using SyncMode.", false)]
-        public bool SnapSync
-        {
-            set => _snapSync = value;
-        }
-
+        public bool SnapSync { set => _snapSync = value; }
         public bool FixReceipts { get; set; } = false;
         public bool BlockGossipEnabled { get; set; } = true;
     }

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
@@ -1,19 +1,20 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
+using System;
 using Nethermind.Config;
 
 namespace Nethermind.Blockchain.Synchronization
@@ -23,12 +24,37 @@ namespace Nethermind.Blockchain.Synchronization
     {
         private bool _synchronizationEnabled = true;
         private bool _fastSync;
+        private StateSyncMode _syncMode = StateSyncMode.NotConfigured;
+
+        public StateSyncMode SyncMode
+        {
+            get
+            {
+                if (_syncMode != StateSyncMode.NotConfigured)
+                {
+                    return _syncMode;
+                }
+                else if (FastSync)
+                {
+                    return StateSyncMode.FastSync;
+                }
+                else if (SnapSync)
+                {
+                    return StateSyncMode.SnapSync;
+                }
+                else
+                {
+                    return StateSyncMode.FullSync;
+                }
+            }
+            set => _syncMode = value;
+        }
 
         public static ISyncConfig Default { get; } = new SyncConfig();
-        public static ISyncConfig WithFullSyncOnly { get; } = new SyncConfig {FastSync = false, FastBlocks = false};
-        public static ISyncConfig WithFastSync { get; } = new SyncConfig {FastSync = true};
-        public static ISyncConfig WithFastBlocks { get; } = new SyncConfig {FastSync = true, FastBlocks = true};
-        public static ISyncConfig WithEth2Merge { get; } = new SyncConfig {FastSync = false, FastBlocks = false, BlockGossipEnabled = false};
+        public static ISyncConfig WithFullSyncOnly { get; } = new SyncConfig {FastBlocks = false, SyncMode = StateSyncMode.FullSync};
+        public static ISyncConfig WithFastSync { get; } = new SyncConfig {SyncMode = StateSyncMode.FastSync};
+        public static ISyncConfig WithFastBlocks { get; } = new SyncConfig {FastBlocks = true, SyncMode = StateSyncMode.FastSync};
+        public static ISyncConfig WithEth2Merge { get; } = new SyncConfig {FastBlocks = false, BlockGossipEnabled = false};
 
         public bool NetworkingEnabled { get; set; } = true;
 
@@ -41,7 +67,13 @@ namespace Nethermind.Blockchain.Synchronization
         public long? FastSyncCatchUpHeightDelta { get; set; } = 8192;
         public bool FastBlocks { get; set; }
         public bool UseGethLimitsInFastBlocks { get; set; } = true;
-        public bool FastSync { get => _fastSync || SnapSync; set => _fastSync = value; }
+
+        [Obsolete("This boolean will be deprecated in future release.")]
+        public bool FastSync
+        {
+            get => _fastSync || SnapSync;
+            set => _fastSync = value;
+        }
         public bool DownloadHeadersInFastSync { get; set; } = true;
         public bool DownloadBodiesInFastSync { get; set; } = true;
         public bool DownloadReceiptsInFastSync { get; set; } = true;
@@ -51,7 +83,10 @@ namespace Nethermind.Blockchain.Synchronization
         public string PivotNumber { get; set; }
         public string PivotHash { get; set; }
         public bool WitnessProtocolEnabled { get; set; } = false;
+
+        [Obsolete("This boolean will be deprecated in future release.")]
         public bool SnapSync { get; set; } = false;
+
         public bool FixReceipts { get; set; } = false;
         public bool BlockGossipEnabled { get; set; } = true;
     }

--- a/src/Nethermind/Nethermind.Config/ConfigProvider.cs
+++ b/src/Nethermind/Nethermind.Config/ConfigProvider.cs
@@ -27,6 +27,11 @@ namespace Nethermind.Config
 {
     public class ConfigProvider : IConfigProvider
     {
+        public ConfigProvider(ILogger logger = null)
+        {
+            _logger = logger;
+        }
+
         private static ILogger _logger;
 
         private readonly ConcurrentDictionary<Type, object> _instances = new();
@@ -37,11 +42,6 @@ namespace Nethermind.Config
         private readonly Dictionary<Type, Type> _implementations = new();
 
         private readonly TypeDiscovery _typeDiscovery = new();
-
-        public void SetLogger(ILogger logger)
-        {
-            _logger = logger;
-        }
 
         public T GetConfig<T>() where T : IConfig
         {
@@ -114,11 +114,11 @@ namespace Nethermind.Config
                             {
                                 try
                                 {
-                                    foreach (CustomAttributeData ad in propertyInfo.CustomAttributes)
+                                    foreach (CustomAttributeData customAttributeData in propertyInfo.CustomAttributes)
                                     {
-                                        if (ad.AttributeType == typeof(ObsoleteAttribute))
+                                        if (customAttributeData.AttributeType == typeof(ObsoleteAttribute))
                                         {
-                                            _logger.Warn($"Boolean attribute {name} is going to be deprecated. Please use SyncMode={name} in your config instead.");
+                                            _logger?.Warn(customAttributeData.ConstructorArguments[0].Value as string);
                                         }
                                     }
                                     propertyInfo.SetValue(config, value);

--- a/src/Nethermind/Nethermind.Config/ConfigProvider.cs
+++ b/src/Nethermind/Nethermind.Config/ConfigProvider.cs
@@ -118,7 +118,7 @@ namespace Nethermind.Config
                                     {
                                         if (customAttributeData.AttributeType == typeof(ObsoleteAttribute))
                                         {
-                                            _logger?.Warn(customAttributeData.ConstructorArguments[0].Value as string);
+                                            _logger?.Warn($"{category}.{name} is obsolete: {customAttributeData.ConstructorArguments[0].Value}");
                                         }
                                     }
                                     propertyInfo.SetValue(config, value);

--- a/src/Nethermind/Nethermind.Config/JsonConfigProvider.cs
+++ b/src/Nethermind/Nethermind.Config/JsonConfigProvider.cs
@@ -1,32 +1,34 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
 using System;
+using Nethermind.Logging;
 
 namespace Nethermind.Config
 {
     public class JsonConfigProvider : IConfigProvider
     {
-        private ConfigProvider _provider = new();
+        private readonly ConfigProvider _provider;
 
-        public JsonConfigProvider(string jsonConfigFile)
+        public JsonConfigProvider(string jsonConfigFile, ILogger logger = null)
         {
+            _provider = new (logger);
             _provider.AddSource(new JsonConfigSource(jsonConfigFile));
         }
-        
+
         public T GetConfig<T>() where T : IConfig
         {
             return _provider.GetConfig<T>();

--- a/src/Nethermind/Nethermind.Init/MemoryHintMan.cs
+++ b/src/Nethermind/Nethermind.Init/MemoryHintMan.cs
@@ -1,19 +1,19 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using System;
 using System.Diagnostics;
@@ -30,7 +30,7 @@ using Nethermind.TxPool;
 namespace Nethermind.Init
 {
     /// <summary>
-    /// Applies changes to the NetworkConfig and the DbConfig so to adhere to the max memory limit hint. 
+    /// Applies changes to the NetworkConfig and the DbConfig so to adhere to the max memory limit hint.
     /// </summary>
     public class MemoryHintMan
     {
@@ -279,7 +279,7 @@ namespace Nethermind.Init
 
         private DbNeeds GetStateNeeds(uint cpuCount, ISyncConfig syncConfig)
         {
-            uint preferredBuffers = Math.Min(cpuCount, syncConfig.FastSync ? 8u : 4u);
+            uint preferredBuffers = Math.Min(cpuCount, (syncConfig.SyncMode == StateSyncMode.FastSync) ? 8u : 4u);
             // remove optimize for point lookup here?
             return new DbNeeds(
                 preferredBuffers,
@@ -352,7 +352,7 @@ namespace Nethermind.Init
 
         private DbNeeds GetCodeNeeds(uint cpuCount, ISyncConfig syncConfig)
         {
-            uint preferredBuffers = Math.Min(cpuCount, syncConfig.FastSync ? 4u : 2u);
+            uint preferredBuffers = Math.Min(cpuCount, (syncConfig.SyncMode == StateSyncMode.FastSync) ? 4u : 2u);
             return new DbNeeds(
                 preferredBuffers,
                 1.MB(), // min buffer size

--- a/src/Nethermind/Nethermind.Init/MemoryHintMan.cs
+++ b/src/Nethermind/Nethermind.Init/MemoryHintMan.cs
@@ -279,7 +279,7 @@ namespace Nethermind.Init
 
         private DbNeeds GetStateNeeds(uint cpuCount, ISyncConfig syncConfig)
         {
-            uint preferredBuffers = Math.Min(cpuCount, (syncConfig.SyncMode == StateSyncMode.FastSync) ? 8u : 4u);
+            uint preferredBuffers = Math.Min(cpuCount, (syncConfig.SyncMode.HasFlag(StateSyncMode.FastSync)) ? 8u : 4u);
             // remove optimize for point lookup here?
             return new DbNeeds(
                 preferredBuffers,
@@ -352,7 +352,7 @@ namespace Nethermind.Init
 
         private DbNeeds GetCodeNeeds(uint cpuCount, ISyncConfig syncConfig)
         {
-            uint preferredBuffers = Math.Min(cpuCount, (syncConfig.SyncMode == StateSyncMode.FastSync) ? 4u : 2u);
+            uint preferredBuffers = Math.Min(cpuCount, (syncConfig.SyncMode.HasFlag(StateSyncMode.FastSync)) ? 4u : 2u);
             return new DbNeeds(
                 preferredBuffers,
                 1.MB(), // min buffer size

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -213,7 +213,7 @@ namespace Nethermind.Init.Steps
                 }
             });
 
-            if (_syncConfig.SnapSync)
+            if (_syncConfig.SyncMode == StateSyncMode.SnapSync)
             {
                 SnapCapabilitySwitcher snapCapabilitySwitcher = new(_api.ProtocolsManager, progressTracker);
                 snapCapabilitySwitcher.EnableSnapCapabilityUntilSynced();

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -213,7 +213,7 @@ namespace Nethermind.Init.Steps
                 }
             });
 
-            if (_syncConfig.SyncMode == StateSyncMode.SnapSync)
+            if (_syncConfig.SyncMode.HasFlag(StateSyncMode.SnapSync))
             {
                 SnapCapabilitySwitcher snapCapabilitySwitcher = new(_api.ProtocolsManager, progressTracker);
                 snapCapabilitySwitcher.EnableSnapCapabilityUntilSynced();

--- a/src/Nethermind/Nethermind.Init/Steps/ReviewBlockTree.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/ReviewBlockTree.cs
@@ -59,7 +59,7 @@ namespace Nethermind.Init.Steps
             
             if (_api.BlockTree == null) throw new StepDependencyException(nameof(_api.BlockTree));
 
-            if (!syncConfig.FastSync)
+            if (!(syncConfig.SyncMode == StateSyncMode.FastSync))
             {
                 DbBlocksLoader loader = new(_api.BlockTree, _logger);
                 await _api.BlockTree.Accept(loader, cancellationToken).ContinueWith(t =>

--- a/src/Nethermind/Nethermind.Init/Steps/ReviewBlockTree.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/ReviewBlockTree.cs
@@ -59,7 +59,7 @@ namespace Nethermind.Init.Steps
 
             if (_api.BlockTree == null) throw new StepDependencyException(nameof(_api.BlockTree));
 
-            if (!(syncConfig.SyncMode.HasFlag(StateSyncMode.FastSync)))
+            if (!syncConfig.SyncMode.HasFlag(StateSyncMode.FastSync))
             {
                 DbBlocksLoader loader = new(_api.BlockTree, _logger);
                 await _api.BlockTree.Accept(loader, cancellationToken).ContinueWith(t =>

--- a/src/Nethermind/Nethermind.Init/Steps/ReviewBlockTree.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/ReviewBlockTree.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -38,7 +38,7 @@ namespace Nethermind.Init.Steps
         public Task Execute(CancellationToken cancellationToken)
         {
             if (_api.BlockTree == null) throw new StepDependencyException(nameof(_api.DbProvider));
-            
+
             if (_api.Config<IInitConfig>().ProcessingEnabled)
             {
                 return RunBlockTreeInitTasks(cancellationToken);
@@ -56,10 +56,10 @@ namespace Nethermind.Init.Steps
             {
                 return;
             }
-            
+
             if (_api.BlockTree == null) throw new StepDependencyException(nameof(_api.BlockTree));
 
-            if (!(syncConfig.SyncMode == StateSyncMode.FastSync))
+            if (!(syncConfig.SyncMode.HasFlag(StateSyncMode.FastSync)))
             {
                 DbBlocksLoader loader = new(_api.BlockTree, _logger);
                 await _api.BlockTree.Accept(loader, cancellationToken).ContinueWith(t =>

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Synchronization.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Synchronization.cs
@@ -542,7 +542,7 @@ public partial class EngineModuleTests
         BlockTree syncedBlockTree = Build.A.BlockTree(chain.BlockTree.Head!).OfChainLength(5).TestObject;
         ISyncConfig syncConfig = new SyncConfig
         {
-            FastSync = true,
+            SyncMode = StateSyncMode.FastSync,
             FastBlocks = true,
             PivotNumber = syncedBlockTree.Head?.Number.ToString() ?? "",
             PivotHash = syncedBlockTree.HeadHash?.ToString() ?? "",

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/MergePluginTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/MergePluginTests.cs
@@ -173,7 +173,7 @@ namespace Nethermind.Merge.Plugin.Test
         {
             _context.ConfigProvider.GetConfig<ISyncConfig>().Returns(new SyncConfig()
             {
-                FastSync = true,
+                SyncMode = StateSyncMode.FastSync,
                 DownloadBodiesInFastSync = downloadBody,
                 DownloadReceiptsInFastSync = downloadReceipt
             });

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/BeaconHeadersSyncTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/BeaconHeadersSyncTests.cs
@@ -116,7 +116,7 @@ public class BeaconHeadersSyncTests
             MainnetSpecProvider.Instance, NullBloomStorage.Instance, LimboLogs.Instance);
         ISyncConfig syncConfig = new SyncConfig
         {
-            FastSync = true,
+            SyncMode = StateSyncMode.FastSync,
             FastBlocks = true,
             PivotNumber = "1000",
             PivotHash = Keccak.Zero.ToString(),
@@ -149,7 +149,7 @@ public class BeaconHeadersSyncTests
         report.BeaconHeaders.Returns(measuredProgress);
         ISyncConfig syncConfig = new SyncConfig
         {
-            FastSync = true,
+            SyncMode = StateSyncMode.FastSync,
             FastBlocks = true,
             PivotNumber = "1000",
             PivotHash = Keccak.Zero.ToString(),
@@ -182,7 +182,7 @@ public class BeaconHeadersSyncTests
         blockTree.SuggestBlock(genesisBlock);
         ISyncConfig syncConfig = new SyncConfig
         {
-            FastSync = true,
+            SyncMode = StateSyncMode.FastSync,
             FastBlocks = true,
             PivotNumber = "500",
             PivotHash = Keccak.Zero.ToString(),

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/BeaconPivotTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/BeaconPivotTests.cs
@@ -1,19 +1,19 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using FluentAssertions;
 using Nethermind.Blockchain;
@@ -37,7 +37,7 @@ public class BeaconPivotTests
     {
         _syncConfig = new SyncConfig
         {
-            FastSync = true,
+            SyncMode = StateSyncMode.FastSync,
             FastBlocks = true,
             PivotNumber = "1000",
             PivotHash = Keccak.Zero.ToString(),

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
@@ -121,7 +121,7 @@ namespace Nethermind.Merge.Plugin
         private void EnsureReceiptAvailable()
         {
             ISyncConfig syncConfig = _api.Config<ISyncConfig>();
-            if (syncConfig.FastSync)
+            if (syncConfig.SyncMode == StateSyncMode.FastSync)
             {
                 if (!syncConfig.DownloadReceiptsInFastSync || !syncConfig.DownloadBodiesInFastSync)
                 {

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
@@ -121,7 +121,7 @@ namespace Nethermind.Merge.Plugin
         private void EnsureReceiptAvailable()
         {
             ISyncConfig syncConfig = _api.Config<ISyncConfig>();
-            if (syncConfig.SyncMode == StateSyncMode.FastSync)
+            if (syncConfig.SyncMode.HasFlag(StateSyncMode.FastSync))
             {
                 if (!syncConfig.DownloadReceiptsInFastSync || !syncConfig.DownloadBodiesInFastSync)
                 {

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconHeadersSyncFeed.cs
@@ -30,6 +30,7 @@ using Nethermind.Synchronization.FastBlocks;
 using Nethermind.Synchronization.ParallelSync;
 using Nethermind.Synchronization.Peers;
 using Nethermind.Synchronization.Reporting;
+using SyncMode = Nethermind.Synchronization.ParallelSync.SyncMode;
 
 namespace Nethermind.Merge.Plugin.Synchronization;
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconHeadersSyncFeed.cs
@@ -30,7 +30,6 @@ using Nethermind.Synchronization.FastBlocks;
 using Nethermind.Synchronization.ParallelSync;
 using Nethermind.Synchronization.Peers;
 using Nethermind.Synchronization.Reporting;
-using SyncMode = Nethermind.Synchronization.ParallelSync.SyncMode;
 
 namespace Nethermind.Merge.Plugin.Synchronization;
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/ChainLevelHelper.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/ChainLevelHelper.cs
@@ -171,7 +171,7 @@ public class ChainLevelHelper : IChainLevelHelper
                     $"Searching for starting point on level {startingPoint}. Header: {header.ToString(BlockHeader.Format.FullHashAndNumber)}, BlockInfo: {blockInfo?.ToString()}");
             --startingPoint;
             currentHash = header.ParentHash!;
-            if (_syncConfig.FastSync && startingPoint <= _syncConfig.PivotNumberParsed)
+            if ((_syncConfig.SyncMode == StateSyncMode.FastSync) && startingPoint <= _syncConfig.PivotNumberParsed)
             {
                 if (_logger.IsTrace) _logger.Trace($"Reached syncConfig pivot. Starting point: {startingPoint}");
                 break;

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/ChainLevelHelper.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/ChainLevelHelper.cs
@@ -171,7 +171,7 @@ public class ChainLevelHelper : IChainLevelHelper
                     $"Searching for starting point on level {startingPoint}. Header: {header.ToString(BlockHeader.Format.FullHashAndNumber)}, BlockInfo: {blockInfo?.ToString()}");
             --startingPoint;
             currentHash = header.ParentHash!;
-            if ((_syncConfig.SyncMode == StateSyncMode.FastSync) && startingPoint <= _syncConfig.PivotNumberParsed)
+            if ((_syncConfig.SyncMode.HasFlag(StateSyncMode.FastSync)) && startingPoint <= _syncConfig.PivotNumberParsed)
             {
                 if (_logger.IsTrace) _logger.Trace($"Reached syncConfig pivot. Starting point: {startingPoint}");
                 break;

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/ChainLevelHelper.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/ChainLevelHelper.cs
@@ -171,7 +171,7 @@ public class ChainLevelHelper : IChainLevelHelper
                     $"Searching for starting point on level {startingPoint}. Header: {header.ToString(BlockHeader.Format.FullHashAndNumber)}, BlockInfo: {blockInfo?.ToString()}");
             --startingPoint;
             currentHash = header.ParentHash!;
-            if ((_syncConfig.SyncMode.HasFlag(StateSyncMode.FastSync)) && startingPoint <= _syncConfig.PivotNumberParsed)
+            if (_syncConfig.SyncMode.HasFlag(StateSyncMode.FastSync) && startingPoint <= _syncConfig.PivotNumberParsed)
             {
                 if (_logger.IsTrace) _logger.Trace($"Reached syncConfig pivot. Starting point: {startingPoint}");
                 break;

--- a/src/Nethermind/Nethermind.Network.Test/NetworkStorageTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/NetworkStorageTests.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -37,13 +37,12 @@ namespace Nethermind.Network.Test
         {
             NetworkNodeDecoder.Init();
             ILogManager logManager = LimboLogs.Instance;
-            ConfigProvider configSource = new();
             _tempDir = TempPath.GetTempDirectory();
 
             var db = new SimpleFilePublicKeyDb("Test",_tempDir.Path, logManager);
             _storage = new NetworkStorage(db, logManager);
         }
-        
+
         [TearDown]
         public void TearDown()
         {

--- a/src/Nethermind/Nethermind.Runner.Test/ConfigFilesTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/ConfigFilesTests.cs
@@ -15,19 +15,15 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Threading.Tasks;
 using FluentAssertions;
 using Nethermind.Analytics;
 using Nethermind.Api;
 using Nethermind.Blockchain.Synchronization;
-using Nethermind.Config;
 using Nethermind.Config.Test;
-using Nethermind.Core;
 using Nethermind.EthStats;
 using Nethermind.Grpc;
 using Nethermind.JsonRpc;
@@ -56,16 +52,17 @@ namespace Nethermind.Runner.Test
             }
         }
 
-        [TestCase("validators", true, true)]
-        [TestCase("poacore_validator.cfg", true, true)]
-        [TestCase("xdai_validator.cfg", true, true)]
-        [TestCase("spaceneth", false, false)]
-        [TestCase("archive", false, false)]
-        [TestCase("baseline", false, false)]
-        [TestCase("fast", true, true)]
-        public void Sync_defaults_are_correct(string configWildcard, bool fastSyncEnabled, bool fastBlocksEnabled)
+        [TestCase("validators", StateSyncMode.FastSync, true)]
+        [TestCase("poacore_validator.cfg", StateSyncMode.FastSync, true)]
+        [TestCase("xdai_validator.cfg", StateSyncMode.FastSync, true)]
+        [TestCase("spaceneth", StateSyncMode.FullSync, false)]
+        [TestCase("archive", StateSyncMode.FullSync, false)]
+        [TestCase("baseline", StateSyncMode.FullSync, false)]
+        [TestCase("fast ^mainnet ^goerli ^ropsten", StateSyncMode.FastSync, true)]
+        [TestCase("mainnet goerli ropsten", StateSyncMode.SnapSync, true)]
+        public void Sync_defaults_are_correct(string configWildcard, StateSyncMode syncMode, bool fastBlocksEnabled)
         {
-            Test<ISyncConfig, bool>(configWildcard, c => c.FastSync, fastSyncEnabled);
+            Test<ISyncConfig, StateSyncMode>(configWildcard, c => c.SyncMode, syncMode);
             Test<ISyncConfig, bool>(configWildcard, c => c.FastBlocks, fastBlocksEnabled);
         }
 
@@ -286,18 +283,18 @@ namespace Nethermind.Runner.Test
             Test<ISyncConfig, bool>(configWildcard, c => c.DownloadHeadersInFastSync, downloadHeaders);
         }
 
-        [TestCase("archive", false)]
-        [TestCase("mainnet.cfg", true)]
-        [TestCase("goerli.cfg", true)]
-        [TestCase("ropsten.cfg", true)]
-        [TestCase("rinkeby.cfg", false)]
-        [TestCase("sepolia.cfg", false)]
-        [TestCase("xdai.cfg", false)]
-        [TestCase("sokol.cfg", false)]
-        [TestCase("kiln.cfg", false)]
-        public void Snap_sync_settings_as_expected(string configWildcard, bool enabled)
+        [TestCase("archive", StateSyncMode.FullSync)]
+        [TestCase("mainnet.cfg", StateSyncMode.SnapSync)]
+        [TestCase("goerli.cfg", StateSyncMode.SnapSync)]
+        [TestCase("ropsten.cfg", StateSyncMode.SnapSync)]
+        [TestCase("rinkeby.cfg", StateSyncMode.FastSync)]
+        [TestCase("sepolia.cfg", StateSyncMode.FastSync)]
+        [TestCase("xdai.cfg", StateSyncMode.FastSync)]
+        [TestCase("sokol.cfg", StateSyncMode.FastSync)]
+        [TestCase("kiln.cfg", StateSyncMode.FullSync)]
+        public void Snap_sync_settings_as_expected(string configWildcard, StateSyncMode syncNode)
         {
-            Test<ISyncConfig, bool>(configWildcard, c => c.SnapSync, enabled);
+            Test<ISyncConfig, StateSyncMode>(configWildcard, c => c.SyncMode, syncNode);
         }
 
         [TestCase("^aura ^ropsten ^sepolia ^goerli", false)]

--- a/src/Nethermind/Nethermind.Runner.Test/MemoryHintManTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/MemoryHintManTests.cs
@@ -1,19 +1,19 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using System;
 using FluentAssertions;
@@ -101,7 +101,10 @@ namespace Nethermind.Runner.Test
             SetMemoryAllowances(cpuCount);
 
             SyncConfig syncConfig = new SyncConfig();
-            syncConfig.FastSync = fastSync;
+            if (fastSync)
+            {
+                syncConfig.SyncMode = StateSyncMode.FastSync;
+            }
             syncConfig.FastBlocks = fastBlocks;
 
             IDbConfig dbConfig = _dbConfig;

--- a/src/Nethermind/Nethermind.Runner.Test/SyncModeCompatibilityTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/SyncModeCompatibilityTests.cs
@@ -1,0 +1,67 @@
+//  Copyright (c) 2021 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+//
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+
+
+using FluentAssertions;
+using Nethermind.Blockchain.Synchronization;
+using NUnit.Framework;
+
+namespace Nethermind.Runner.Test
+{
+    #pragma warning disable 0618
+    [Parallelizable(ParallelScope.All)]
+    [TestFixture]
+    public class SyncModeCompatibilityTests
+    {
+        [Test]
+        public void FullSync_ByDefault()
+        {
+            SyncConfig config = new();
+            config.SyncMode.Should().Be(StateSyncMode.FullSync);
+        }
+
+        [Test]
+        public void FastSync_SetInOldWay()
+        {
+            SyncConfig config = new();
+            config.FastSync = true;
+            config.SyncMode.Should().Be(StateSyncMode.FastSync);
+        }
+
+        [Test]
+        public void SnapSync_SetInOldWay()
+        {
+            SyncConfig config = new();
+            config.SnapSync = true;
+            config.SyncMode.Should().Be(StateSyncMode.SnapSync);
+        }
+
+
+        [Test]
+        public void OldSettings_AreNotConsidered()
+        {
+            SyncConfig config = new();
+            config.FastSync = true;
+            config.SyncMode = StateSyncMode.FullSync;
+            config.SyncMode.Should().Be(StateSyncMode.FullSync);
+
+            config = new();
+            config.FastSync = true;
+            config.SyncMode = StateSyncMode.SnapSync;
+            config.SyncMode.Should().Be(StateSyncMode.SnapSync);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Runner.Test/SyncModeCompatibilityTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/SyncModeCompatibilityTests.cs
@@ -34,43 +34,25 @@ namespace Nethermind.Runner.Test
             config.SyncMode.Should().Be(StateSyncMode.FullSync);
         }
 
-        [Test]
-        public void FastSync_SetInOldWay()
+        [TestCase(false, false, StateSyncMode.SnapSync, StateSyncMode.FullSync)]
+        [TestCase(false, null, StateSyncMode.SnapSync, StateSyncMode.FullSync)]
+        [TestCase(null, null, StateSyncMode.SnapSync, StateSyncMode.SnapSync)]
+        [TestCase(true, false, StateSyncMode.FullSync, StateSyncMode.FastSync)]
+        [TestCase(null, true, StateSyncMode.FullSync, StateSyncMode.SnapSync)]
+        public void NewSettings_AreIgnored_IfSyncModeSetInOldWay(bool? fastSync, bool? snapSync, StateSyncMode syncMode, StateSyncMode expectedSyncMode)
         {
             SyncConfig config = new();
-            config.FastSync = true;
-            config.SyncMode.Should().Be(StateSyncMode.FastSync);
-        }
-
-        [Test]
-        public void SnapSync_SetInOldWay()
-        {
-            SyncConfig config = new();
-            config.SnapSync = true;
-            config.SyncMode.Should().Be(StateSyncMode.SnapSync);
-            config.SyncMode.HasFlag(StateSyncMode.FastSync).Should().Be(true);
-        }
-
-        [Test]
-        public void OldSettings_AreIgnored_IfSyncModeSet()
-        {
-            foreach(bool? fastSync in new bool?[]{ false, true, null })
-            foreach(bool? snapSync in new bool?[]{ false, true, null })
-            foreach (StateSyncMode syncMode in Enum.GetValues(typeof(StateSyncMode)))
+            config.SyncMode = syncMode;
+            if (fastSync.HasValue)
             {
-                SyncConfig config = new();
-                config.SyncMode = syncMode;
-                if (fastSync.HasValue)
-                {
-                    config.FastSync = fastSync.Value;
-                }
-                if (snapSync.HasValue)
-                {
-                    config.FastSync = snapSync.Value;
-                }
-
-                config.SyncMode.Should().Be(syncMode);
+                config.FastSync = fastSync.Value;
             }
+            if (snapSync.HasValue)
+            {
+                config.SnapSync = snapSync.Value;
+            }
+
+            config.SyncMode.Should().Be(expectedSyncMode);
         }
     }
     #pragma warning restore 0618

--- a/src/Nethermind/Nethermind.Runner.Test/SyncModeCompatibilityTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/SyncModeCompatibilityTests.cs
@@ -15,6 +15,7 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
 
+using System;
 using FluentAssertions;
 using Nethermind.Blockchain.Synchronization;
 using NUnit.Framework;
@@ -47,21 +48,30 @@ namespace Nethermind.Runner.Test
             SyncConfig config = new();
             config.SnapSync = true;
             config.SyncMode.Should().Be(StateSyncMode.SnapSync);
+            config.SyncMode.HasFlag(StateSyncMode.FastSync).Should().Be(true);
         }
-
 
         [Test]
-        public void OldSettings_AreNotConsidered()
+        public void OldSettings_AreIgnored_IfSyncModeSet()
         {
-            SyncConfig config = new();
-            config.FastSync = true;
-            config.SyncMode = StateSyncMode.FullSync;
-            config.SyncMode.Should().Be(StateSyncMode.FullSync);
+            foreach(bool? fastSync in new bool?[]{ false, true, null })
+            foreach(bool? snapSync in new bool?[]{ false, true, null })
+            foreach (StateSyncMode syncMode in Enum.GetValues(typeof(StateSyncMode)))
+            {
+                SyncConfig config = new();
+                config.SyncMode = syncMode;
+                if (fastSync.HasValue)
+                {
+                    config.FastSync = fastSync.Value;
+                }
+                if (snapSync.HasValue)
+                {
+                    config.FastSync = snapSync.Value;
+                }
 
-            config = new();
-            config.FastSync = true;
-            config.SyncMode = StateSyncMode.SnapSync;
-            config.SyncMode.Should().Be(StateSyncMode.SnapSync);
+                config.SyncMode.Should().Be(syncMode);
+            }
         }
     }
+    #pragma warning restore 0618
 }

--- a/src/Nethermind/Nethermind.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Runner/Program.cs
@@ -368,7 +368,7 @@ namespace Nethermind.Runner
                 NLogConfigurator.ConfigureLogLevels(logLevelOverride);
             }
 
-            ConfigProvider configProvider = new();
+            ConfigProvider configProvider = new(logger);
             Dictionary<string, string> configArgs = new();
             foreach (CommandOption commandOption in app.Options)
             {
@@ -426,7 +426,6 @@ namespace Nethermind.Runner
             }
 
             logger.Info($"Reading config file from {configFilePath}");
-            configProvider.SetLogger(_logger);
             configProvider.AddSource(new JsonConfigSource(configFilePath));
             configProvider.Initialize();
             var incorrectSettings = configProvider.FindIncorrectSettings();

--- a/src/Nethermind/Nethermind.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Runner/Program.cs
@@ -426,6 +426,7 @@ namespace Nethermind.Runner
             }
 
             logger.Info($"Reading config file from {configFilePath}");
+            configProvider.SetLogger(_logger);
             configProvider.AddSource(new JsonConfigSource(configFilePath));
             configProvider.Initialize();
             var incorrectSettings = configProvider.FindIncorrectSettings();

--- a/src/Nethermind/Nethermind.Runner/configs/baseline_ropsten.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/baseline_ropsten.cfg
@@ -13,7 +13,7 @@
     "Enabled": true
   },
   "Sync": {
-    "FastSync": true,
+    "SyncMode": "FastSync",
     "FastBlocks": true,
     "DownloadHeadersInFastSync": false,
     "DownloadBodiesInFastSync": false,

--- a/src/Nethermind/Nethermind.Runner/configs/energyweb.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/energyweb.cfg
@@ -7,7 +7,7 @@
     "MemoryHint": 768000000
   },
   "Sync": {
-    "FastSync": true,
+    "SyncMode": "FastSync",
     "PivotNumber": 19320000,
     "PivotHash": "0xdc654561e52b0aee131f8ce4f1718a3c9ca59fa36f996d29dc4097c8a4503c50",
     "PivotTotalDifficulty": "6574255328912531114112397415581761844978775409",

--- a/src/Nethermind/Nethermind.Runner/configs/goerli.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/goerli.cfg
@@ -13,8 +13,7 @@
     "EnableMetricsUpdater": true
   },
   "Sync": {
-    "FastSync": true,
-    "SnapSync": true,
+    "SyncMode": "SnapSync",
     "PivotNumber": 7350000,
     "PivotHash": "0xfe9f45db9290a65374953b5a930a694b6f166a3745f579e6b239ea949a95aefa",
     "PivotTotalDifficulty": "10743071",

--- a/src/Nethermind/Nethermind.Runner/configs/goerli_aa.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/goerli_aa.cfg
@@ -31,8 +31,7 @@
     "EnableMetricsUpdater": true
   },
   "Sync": {
-    "FastSync": true,
-    "SnapSync": true,
+    "SyncMode": "SnapSync",
     "PivotNumber": 7350000,
     "PivotHash": "0xfe9f45db9290a65374953b5a930a694b6f166a3745f579e6b239ea949a95aefa",
     "PivotTotalDifficulty": "10743071",

--- a/src/Nethermind/Nethermind.Runner/configs/goerli_mev.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/goerli_mev.cfg
@@ -13,8 +13,7 @@
     "EnableMetricsUpdater": true
   },
   "Sync": {
-    "FastSync": true,
-    "SnapSync": true,
+    "SyncMode": "SnapSync",
     "PivotNumber": 7350000,
     "PivotHash": "0xfe9f45db9290a65374953b5a930a694b6f166a3745f579e6b239ea949a95aefa",
     "PivotTotalDifficulty": "10743071",

--- a/src/Nethermind/Nethermind.Runner/configs/goerli_mev_aa.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/goerli_mev_aa.cfg
@@ -37,8 +37,7 @@
     "EnableDbStatistics": false
   },
   "Sync": {
-    "FastSync": true,
-    "SnapSync": true,
+    "SyncMode": "SnapSync",
     "PivotNumber": 5730000,
     "PivotHash": "0xecedb7c3ba11fd8b7a2f1be4a84e1dbf2150efe509061f4e3c975f9b89d1a32b",
     "PivotTotalDifficulty": "8410193",

--- a/src/Nethermind/Nethermind.Runner/configs/goerli_nchain.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/goerli_nchain.cfg
@@ -14,7 +14,7 @@
     "CacheIndexAndFilterBlocks": false
   },
   "Sync": {
-    "FastSync": true,
+    "SyncMode": "FastSync",
     "PivotNumber": 3690000,
     "PivotHash": "0x9cfd6c23e4cca32ff677f99b51f87e4e06563a95417a2dbd7792423413e45222",
     "PivotTotalDifficulty": "5376604",

--- a/src/Nethermind/Nethermind.Runner/configs/goerli_shadowfork.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/goerli_shadowfork.cfg
@@ -32,7 +32,7 @@
     "EnableDbStatistics": false
   },
   "Sync": {
-    "FastSync": true,
+    "SyncMode": "FastSync",
     "PivotNumber": 7320000,
     "PivotHash": "0xc35b6dde5e22457634ce40fc4149cac93a3e514fd689e7367e98040c3a608d1a",
     "PivotTotalDifficulty": "10699279",

--- a/src/Nethermind/Nethermind.Runner/configs/kiln.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/kiln.cfg
@@ -2,8 +2,8 @@
   "Init": {
     "IsMining": true,
     "WebSocketsEnabled": true,
-    "StoreReceipts": true,    
-    "ChainSpecPath": "chainspec/kiln.json",    
+    "StoreReceipts": true,
+    "ChainSpecPath": "chainspec/kiln.json",
     "BaseDbPath": "nethermind_db/kiln",
     "LogFileName": "kiln.logs.txt",
     "MemoryHint": 768000000,
@@ -28,7 +28,7 @@
     "CacheIndexAndFilterBlocks": false
   },
   "Sync": {
-    "FastSync": false,
+    "SyncMode": "FullSync",
     "FastBlocks": false,
     "UseGethLimitsInFastBlocks": true,
     "DownloadBodiesInFastSync": true,

--- a/src/Nethermind/Nethermind.Runner/configs/kiln_devnet.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/kiln_devnet.cfg
@@ -2,8 +2,8 @@
   "Init": {
     "IsMining": true,
     "WebSocketsEnabled": true,
-    "StoreReceipts": true,    
-    "ChainSpecPath": "chainspec/kiln_devnet.json",    
+    "StoreReceipts": true,
+    "ChainSpecPath": "chainspec/kiln_devnet.json",
     "BaseDbPath": "nethermind_db/kiln_devnet",
     "LogFileName": "kiln_devnet.logs.txt",
     "MemoryHint": 768000000,
@@ -28,7 +28,7 @@
     "CacheIndexAndFilterBlocks": false
   },
   "Sync": {
-    "FastSync": false
+    "SyncMode": "FullSync",
   },
   "EthStats": {
     "Enabled": false,

--- a/src/Nethermind/Nethermind.Runner/configs/kiln_fastsync.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/kiln_fastsync.cfg
@@ -2,8 +2,8 @@
   "Init": {
     "IsMining": true,
     "WebSocketsEnabled": true,
-    "StoreReceipts": true,    
-    "ChainSpecPath": "chainspec/kiln.json",    
+    "StoreReceipts": true,
+    "ChainSpecPath": "chainspec/kiln.json",
     "BaseDbPath": "nethermind_db/kiln",
     "LogFileName": "kiln.logs.txt",
     "MemoryHint": 768000000,
@@ -28,7 +28,7 @@
     "CacheIndexAndFilterBlocks": false
   },
   "Sync": {
-    "FastSync": true,
+    "SyncMode": "FastSync",
     "FastBlocks": true,
     "UseGethLimitsInFastBlocks": true,
     "DownloadBodiesInFastSync": true,

--- a/src/Nethermind/Nethermind.Runner/configs/kiln_pre_ttd_pivot.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/kiln_pre_ttd_pivot.cfg
@@ -2,8 +2,8 @@
   "Init": {
     "IsMining": true,
     "WebSocketsEnabled": true,
-    "StoreReceipts": true,    
-    "ChainSpecPath": "chainspec/kiln.json",    
+    "StoreReceipts": true,
+    "ChainSpecPath": "chainspec/kiln.json",
     "BaseDbPath": "nethermind_db/kiln",
     "LogFileName": "kiln.logs.txt",
     "MemoryHint": 768000000,
@@ -28,7 +28,7 @@
     "CacheIndexAndFilterBlocks": false
   },
   "Sync": {
-    "FastSync": true,
+    "SyncMode": "FastSync",
     "FastBlocks": true,
     "UseGethLimitsInFastBlocks": true,
     "DownloadBodiesInFastSync": true,

--- a/src/Nethermind/Nethermind.Runner/configs/kiln_relay.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/kiln_relay.cfg
@@ -2,8 +2,8 @@
   "Init": {
     "IsMining": true,
     "WebSocketsEnabled": true,
-    "StoreReceipts": true,    
-    "ChainSpecPath": "chainspec/kiln.json",    
+    "StoreReceipts": true,
+    "ChainSpecPath": "chainspec/kiln.json",
     "BaseDbPath": "nethermind_db/kiln_relay",
     "LogFileName": "kiln_relay.logs.txt",
     "MemoryHint": 768000000,
@@ -28,7 +28,7 @@
     "CacheIndexAndFilterBlocks": false
   },
   "Sync": {
-    "FastSync": false,
+    "SyncMode": "FullSync",
     "FastBlocks": false,
     "UseGethLimitsInFastBlocks": true,
     "DownloadBodiesInFastSync": true,

--- a/src/Nethermind/Nethermind.Runner/configs/kovan.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/kovan.cfg
@@ -10,7 +10,7 @@
     "Size": 1024
   },
   "Sync": {
-    "FastSync": true,
+    "SyncMode": "FastSync",
     "PivotNumber": 33140000,
     "PivotHash": "0xdb8bc4d5f74cea9822115610c4c3934e21ad9a2baecbdb115d73a54d05c9e4e7",
     "PivotTotalDifficulty": "11226514521969907682290887301857720659108539361",

--- a/src/Nethermind/Nethermind.Runner/configs/mainnet.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/mainnet.cfg
@@ -10,8 +10,7 @@
     "ActivePeersMaxCount": 100
   },
   "Sync": {
-    "FastSync": true,
-    "SnapSync": true,
+    "SyncMode": "SnapSync",
     "PivotNumber": 15290000,
     "PivotHash": "0x5a44a71229b254198ce4b3b20dd6cd856941569b3d146cf3f0fd1bc2728d71cb",
     "PivotTotalDifficulty": "55748882672167094810743",

--- a/src/Nethermind/Nethermind.Runner/configs/mainnet_aa.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/mainnet_aa.cfg
@@ -24,7 +24,7 @@
     "ActivePeersMaxCount": 100
   },
   "Sync": {
-    "FastSync": true,
+    "SyncMode": "FastSync",
     "PivotNumber": 15290000,
     "PivotHash": "0x5a44a71229b254198ce4b3b20dd6cd856941569b3d146cf3f0fd1bc2728d71cb",
     "PivotTotalDifficulty": "55748882672167094810743",

--- a/src/Nethermind/Nethermind.Runner/configs/mainnet_mev.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/mainnet_mev.cfg
@@ -7,7 +7,7 @@
     "MemoryHint": 2048000000
   },
   "Sync": {
-    "FastSync": true,
+    "SyncMode": "FastSync",
     "PivotNumber": 15290000,
     "PivotHash": "0x5a44a71229b254198ce4b3b20dd6cd856941569b3d146cf3f0fd1bc2728d71cb",
     "PivotTotalDifficulty": "55748882672167094810743",

--- a/src/Nethermind/Nethermind.Runner/configs/mainnet_shadowfork.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/mainnet_shadowfork.cfg
@@ -10,8 +10,7 @@
     "ActivePeersMaxCount": 100
   },
   "Sync": {
-    "FastSync": true,
-    "SnapSync": true,
+    "SyncMode": "SnapSync",
     "PivotNumber": 15044000,
     "PivotHash": "0xa0c40b03487739df62b6224f97f37a68f0617711a7867d4567162d7135311528",
     "PivotTotalDifficulty": "52839809889322583936482",

--- a/src/Nethermind/Nethermind.Runner/configs/ndm_consumer_goerli.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/ndm_consumer_goerli.cfg
@@ -36,7 +36,7 @@
     "JsonRpcUrlProxies": ""
   },
   "Sync": {
-    "FastSync": true,
+    "SyncMode": "FastSync",
     "PivotNumber": 5610000,
     "PivotHash": "0x8f2934760ef5e17c87b0937d569b7243e20908020a9ed5fc01501d2b7d68415d",
     "PivotTotalDifficulty": "8242509",

--- a/src/Nethermind/Nethermind.Runner/configs/ndm_consumer_goerli_proxy.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/ndm_consumer_goerli_proxy.cfg
@@ -18,7 +18,7 @@
     "Enabled": true,
     "Timeout": 20000,
     "Host": "127.0.0.1",
-    "Port": 8545      
+    "Port": 8545
   },
   "Ndm": {
     "Enabled": true,
@@ -38,7 +38,7 @@
     "JsonRpcUrlProxies": ""
   },
   "Sync": {
-    "FastSync": true,
+    "SyncMode": "FastSync",
     "PivotNumber": 4200000,
     "PivotHash": "0x0e55036a74a2598a2e0456114a92edd609b9c257186e8b09675064c68bd4e6c3",
     "PivotTotalDifficulty": "6174171",

--- a/src/Nethermind/Nethermind.Runner/configs/ndm_consumer_mainnet.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/ndm_consumer_mainnet.cfg
@@ -41,7 +41,7 @@
     "JsonRpcUrlProxies": ""
   },
   "Sync": {
-    "FastSync": true,
+    "SyncMode": "FastSync",
     "PivotNumber": 13372000,
     "PivotHash": "0x6b2716f5f26c0a047c84243b3ea9a540d919dc3498c3c50fac501c26f4b85772",
     "PivotTotalDifficulty": "31973707849252147830269",

--- a/src/Nethermind/Nethermind.Runner/configs/ndm_consumer_ropsten.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/ndm_consumer_ropsten.cfg
@@ -40,7 +40,7 @@
     "JsonRpcUrlProxies": ""
   },
   "Sync": {
-    "FastSync": true,
+    "SyncMode": "FastSync",
     "FastBlocks": true,
     "UseGethLimitsInFastBlocks": true,
     "PivotNumber": 11170000,

--- a/src/Nethermind/Nethermind.Runner/configs/ndm_consumer_xdai.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/ndm_consumer_xdai.cfg
@@ -47,7 +47,7 @@
     "CacheIndexAndFilterBlocks": false
   },
   "Sync": {
-    "FastSync": true,
+    "SyncMode": "FastSync",
     "PivotNumber": 18450000,
     "PivotHash": "0x918b03acbf048bed8b5506c25f9fdda98f85c090b9e634a137d2963e4eaf59e0",
     "PivotTotalDifficulty": "6278209669691314650899261507116123501018164812",

--- a/src/Nethermind/Nethermind.Runner/configs/poacore.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/poacore.cfg
@@ -7,7 +7,7 @@
     "MemoryHint": 768000000
   },
   "Sync": {
-    "FastSync": true,
+    "SyncMode": "FastSync",
     "PivotNumber": 28710000,
     "PivotHash": "0x3bd19086df09109145506865b590e45597bcad88bfb3276902c59515cbde16fa",
     "PivotTotalDifficulty": "9769506754300143286033484979366065350541233351",

--- a/src/Nethermind/Nethermind.Runner/configs/poacore_validator.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/poacore_validator.cfg
@@ -1,7 +1,7 @@
 {
   "Init": {
     "StoreReceipts" : false,
-    "IsMining": true,      
+    "IsMining": true,
     "ChainSpecPath": "chainspec/poacore.json",
     "GenesisHash": "0x39f02c003dde5b073b3f6e1700fc0b84b4877f6839bb23edadd3d2d82a488634",
     "BaseDbPath": "nethermind_db/poacore",
@@ -9,7 +9,7 @@
     "MemoryHint": 768000000
   },
   "Sync": {
-    "FastSync": true,
+    "SyncMode": "FastSync",
     "DownloadReceiptsInFastSync": false,
     "PivotNumber" : 13200000,
     "PivotHash" : "0xa7a12fb5ec74204dbeed8630a5c762fa5875ea1e492d8199a15807316d4a8347",
@@ -26,5 +26,5 @@
   },
   "Bloom": {
     "Index" : false
-  }     
+  }
 }

--- a/src/Nethermind/Nethermind.Runner/configs/rinkeby.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/rinkeby.cfg
@@ -10,7 +10,7 @@
     "Size": 1024
   },
   "Sync": {
-    "FastSync": true,
+    "SyncMode": "FastSync",
     "PivotNumber": 11130000,
     "PivotHash": "0xa319ad8094cbf97a1a6aa9a6596b3644ac9f2bd8de54c7441adde7486c713147",
     "PivotTotalDifficulty": "18195895",

--- a/src/Nethermind/Nethermind.Runner/configs/ropsten.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/ropsten.cfg
@@ -10,8 +10,7 @@
     "Size": 1024
   },
   "Sync": {
-    "FastSync": true,
-    "SnapSync": true,
+    "SyncMode": "SnapSync",
     "FastBlocks": true,
     "UseGethLimitsInFastBlocks": true,
     "PivotNumber": 12720000,

--- a/src/Nethermind/Nethermind.Runner/configs/sepolia.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/sepolia.cfg
@@ -14,7 +14,7 @@
     "NodeName": "Sepolia"
   },
   "Sync": {
-    "FastSync": true,
+    "SyncMode": "FastSync",
     "FastBlocks": true,
     "UseGethLimitsInFastBlocks": true,
     "PivotNumber": 1648000,

--- a/src/Nethermind/Nethermind.Runner/configs/sokol.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/sokol.cfg
@@ -10,7 +10,7 @@
     "Size": 512
   },
   "Sync": {
-    "FastSync": true,
+    "SyncMode": "FastSync",
     "PivotNumber": 27140000,
     "PivotHash": "0x715eb319379a4c2119ff9144919e165d6ea5fd60f510e9b56150a17f10d5cbeb",
     "PivotTotalDifficulty": "9235263438234269898395986845698189258556918489",

--- a/src/Nethermind/Nethermind.Runner/configs/sokol_validator.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/sokol_validator.cfg
@@ -9,9 +9,9 @@
     "MemoryHint": 512000000
   },
   "Sync": {
-    "FastSync": true,
+    "SyncMode": "FastSync",
     "DownloadBodiesInFastSync": true,
-    "DownloadReceiptsInFastSync": false,    
+    "DownloadReceiptsInFastSync": false,
     "PivotNumber": 12900000,
     "PivotHash": "0xfb289bb3da92d8b30646fbab70d23f915bd487214e298958e0bd6827cedb5db7",
     "PivotTotalDifficulty": "4389642533280106178677532436000000000000000000",
@@ -28,5 +28,5 @@
   "Bloom":
   {
     "Index" : false
-  }     
+  }
 }

--- a/src/Nethermind/Nethermind.Runner/configs/themerge_hivetests.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/themerge_hivetests.cfg
@@ -2,8 +2,8 @@
   "Init": {
     "IsMining": true,
     "WebSocketsEnabled": true,
-    "StoreReceipts": true,    
-    "ChainSpecPath": "chainspec/themerge_hivetests.json",    
+    "StoreReceipts": true,
+    "ChainSpecPath": "chainspec/themerge_hivetests.json",
     "BaseDbPath": "nethermind_db/themerge_hivetests",
     "LogFileName": "themerge_hivetests.logs.txt",
     "MemoryHint": 768000000,
@@ -29,7 +29,7 @@
     "CacheIndexAndFilterBlocks": false
   },
   "Sync": {
-    "FastSync": false,
+    "SyncMode": "FastSync",
     "FastBlocks": false,
     "BeamSync": false,
     "UseGethLimitsInFastBlocks": true,

--- a/src/Nethermind/Nethermind.Runner/configs/themerge_kiln_m2.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/themerge_kiln_m2.cfg
@@ -2,8 +2,8 @@
   "Init": {
     "IsMining": true,
     "WebSocketsEnabled": true,
-    "StoreReceipts": true,    
-    "ChainSpecPath": "chainspec/themerge_kiln_m2.json",    
+    "StoreReceipts": true,
+    "ChainSpecPath": "chainspec/themerge_kiln_m2.json",
     "BaseDbPath": "nethermind_db/themerge_kiln_testvectors",
     "LogFileName": "themerge_kiln_testvectors.logs.txt",
     "MemoryHint": 768000000,
@@ -28,7 +28,7 @@
     "CacheIndexAndFilterBlocks": false
   },
   "Sync": {
-    "FastSync": false,
+    "SyncMode": "FullSync",
     "FastBlocks": false,
     "BeamSync": false,
     "UseGethLimitsInFastBlocks": true,

--- a/src/Nethermind/Nethermind.Runner/configs/themerge_kiln_mev.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/themerge_kiln_mev.cfg
@@ -2,8 +2,8 @@
   "Init": {
     "IsMining": true,
     "WebSocketsEnabled": true,
-    "StoreReceipts": true,    
-    "ChainSpecPath": "chainspec/themerge_kiln_testvectors.json",    
+    "StoreReceipts": true,
+    "ChainSpecPath": "chainspec/themerge_kiln_testvectors.json",
     "BaseDbPath": "nethermind_db/themerge_kiln_testvectors",
     "LogFileName": "themerge_kiln_testvectors.logs.txt",
     "MemoryHint": 768000000,
@@ -28,7 +28,7 @@
     "CacheIndexAndFilterBlocks": false
   },
   "Sync": {
-    "FastSync": false,
+    "SyncMode": "FullSync",
     "FastBlocks": false,
     "BeamSync": false,
     "UseGethLimitsInFastBlocks": true,

--- a/src/Nethermind/Nethermind.Runner/configs/themerge_kiln_testvectors.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/themerge_kiln_testvectors.cfg
@@ -2,8 +2,8 @@
   "Init": {
     "IsMining": true,
     "WebSocketsEnabled": true,
-    "StoreReceipts": true,    
-    "ChainSpecPath": "chainspec/themerge_kiln_testvectors.json",    
+    "StoreReceipts": true,
+    "ChainSpecPath": "chainspec/themerge_kiln_testvectors.json",
     "BaseDbPath": "nethermind_db/themerge_kiln_testvectors",
     "LogFileName": "themerge_kiln_testvectors.logs.txt",
     "MemoryHint": 768000000,
@@ -28,7 +28,7 @@
     "CacheIndexAndFilterBlocks": false
   },
   "Sync": {
-    "FastSync": false,
+    "SyncMode": "FullSync",
     "FastBlocks": false,
     "BeamSync": false,
     "UseGethLimitsInFastBlocks": true,

--- a/src/Nethermind/Nethermind.Runner/configs/volta.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/volta.cfg
@@ -11,7 +11,7 @@
     "ActivePeersMaxCount": 25
   },
   "Sync": {
-    "FastSync": true,
+    "SyncMode": "FastSync",
     "PivotNumber": 18740000,
     "PivotHash": "0x45c711dc567834da3e1e2d3731fba437d9a7ffe058230f34a4867dc91cb627cb",
     "PivotTotalDifficulty": "6376891556098386805303640143271336282334876718",

--- a/src/Nethermind/Nethermind.Runner/configs/xdai.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/xdai.cfg
@@ -7,7 +7,7 @@
     "MemoryHint": 768000000
   },
   "Sync": {
-    "FastSync": true,
+    "SyncMode": "FastSync",
     "PivotNumber": 23550000,
     "PivotHash": "0xdabad5d61e1f2de83a514b84c9c011a1dd55e43e53ef8d3b2c88e746d91f53a4",
     "PivotTotalDifficulty": "8013649740988100814562472005018141379433430148",

--- a/src/Nethermind/Nethermind.Runner/configs/xdai_aa.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/xdai_aa.cfg
@@ -21,7 +21,7 @@
     "EntryPointContractAddresses": "0xD3ebD80aFf10B54795708Ece1d6D3253e3258A05"
   },
   "Sync": {
-    "FastSync": true,
+    "SyncMode": "FastSync",
     "PivotNumber": 23550000,
     "PivotHash": "0xdabad5d61e1f2de83a514b84c9c011a1dd55e43e53ef8d3b2c88e746d91f53a4",
     "PivotTotalDifficulty": "8013649740988100814562472005018141379433430148",

--- a/src/Nethermind/Nethermind.Runner/configs/xdai_mev.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/xdai_mev.cfg
@@ -7,7 +7,7 @@
     "MemoryHint": 768000000
   },
   "Sync": {
-    "FastSync": true,
+    "SyncMode": "FastSync",
     "PivotNumber": 23550000,
     "PivotHash": "0xdabad5d61e1f2de83a514b84c9c011a1dd55e43e53ef8d3b2c88e746d91f53a4",
     "PivotTotalDifficulty": "8013649740988100814562472005018141379433430148",

--- a/src/Nethermind/Nethermind.Runner/configs/xdai_nethermind_testnet.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/xdai_nethermind_testnet.cfg
@@ -1,5 +1,5 @@
 {
-  "Init": { 
+  "Init": {
     "IsMining": true,
     "ChainSpecPath": "chainspec/xdai_nethermind_testnet.json",
     "GenesisHash": "0x0ae5a04b393944ed5c796c8a8c7bf49e163b4073c52e53d7aed7390842d0077c",
@@ -25,7 +25,7 @@
     "WebSocketsPort": 8547
   },
   "Sync": {
-    "FastSync": false,
+    "SyncMode": "FullSync",
     "PivotNumber": 17530000,
     "PivotHash": "0xa7219cb1f5aa614455d0e42018b45f56f6e28daa948504b55b5d7da112e42fbf",
     "PivotTotalDifficulty": "5965149892124051264512956868278896746480547121",

--- a/src/Nethermind/Nethermind.Runner/configs/xdai_testnet.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/xdai_testnet.cfg
@@ -1,5 +1,5 @@
 {
-  "Init": { 
+  "Init": {
     "ChainSpecPath": "chainspec/xdai_testnet.json",
     "GenesisHash": "0xe3a527b7597f94a4c5ffd7808d2542b011c6c21c7e8df6f7564deb7614e89fe7",
     "BaseDbPath": "nethermind_db/xdai_testnet",
@@ -26,7 +26,7 @@
     "CacheIndexAndFilterBlocks": false
   },
   "Sync": {
-    "FastSync": true,
+    "SyncMode": "FastSync",
     "PivotNumber": 1305267,
     "PivotHash": "0xae76ba32033a8444b7f40729db02af0dd302c3d72983b1c30b05795cd107b662",
     "PivotTotalDifficulty": "444159344223792585389448583718641797732966738",
@@ -47,7 +47,7 @@
     "PushGatewayUrl": "https://metrics.nethermind.io/metrics/validators-Ifa0eigee0deigah8doo5aisaeNa8huichahk5baip2daitholaeh4xiey0iec1vai6Nahxae1aeregul5Diehae7aeThengei7X",
     "IntervalSeconds": 30
   },
-  "Aura": {   
+  "Aura": {
     "TxPriorityContractAddress": "0x4100000000000000000000000000000000000000"
   },
   "Mining": {

--- a/src/Nethermind/Nethermind.Runner/configs/xdai_themerge.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/xdai_themerge.cfg
@@ -1,5 +1,5 @@
 {
-  "Init": {      
+  "Init": {
     "WebSocketsEnabled": false,
     "StoreReceipts" : true,
     "IsMining": true,
@@ -28,7 +28,7 @@
     "CacheIndexAndFilterBlocks": false
   },
   "Sync": {
-    "FastSync": false,
+    "SyncMode": "FullSync",
     "UseGethLimitsInFastBlocks" : false
   },
   "Mining": {

--- a/src/Nethermind/Nethermind.Runner/configs/xdai_validator.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/xdai_validator.cfg
@@ -1,5 +1,5 @@
 {
-  "Init": {      
+  "Init": {
     "StoreReceipts" : false,
     "IsMining": true,
     "ChainSpecPath": "chainspec/xdai.json",
@@ -9,8 +9,8 @@
     "MemoryHint": 768000000
   },
   "Sync": {
-    "FastSync": true,
-    "DownloadReceiptsInFastSync": false,    
+    "SyncMode": "FastSync",
+    "DownloadReceiptsInFastSync": false,
     "PivotNumber" : 8000000,
     "PivotHash" : "0xb27a82d1cd3cdbfd5cdb276bfb46bc4fd71776b47045081f83c732e78e3e1089",
     "PivotTotalDifficulty" : "2722258935367507707706996859000000000000000000",
@@ -29,5 +29,5 @@
   },
   "Bloom": {
     "Index" : false
-  }  
+  }
 }

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/FastHeadersSyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/FastHeadersSyncTests.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -48,24 +48,24 @@ namespace Nethermind.Synchronization.Test.FastBlocks
             BlockTree blockTree = new(memDbProvider.BlocksDb, memDbProvider.HeadersDb, memDbProvider.BlockInfosDb, new ChainLevelInfoRepository(memDbProvider.BlockInfosDb), MainnetSpecProvider.Instance, NullBloomStorage.Instance, LimboLogs.Instance);
             Assert.Throws<InvalidOperationException>(() => new HeadersSyncFeed(Substitute.For<ISyncModeSelector>(), blockTree, Substitute.For<ISyncPeerPool>(), new SyncConfig(), Substitute.For<ISyncReport>(), LimboLogs.Instance));
         }
-        
+
         [Test]
         public async Task Can_prepare_3_requests_in_a_row()
         {
             IDbProvider memDbProvider = await TestMemDbProvider.InitAsync();
             BlockTree blockTree = new(memDbProvider.BlocksDb, memDbProvider.HeadersDb, memDbProvider.BlockInfosDb, new ChainLevelInfoRepository(memDbProvider.BlockInfosDb), MainnetSpecProvider.Instance, NullBloomStorage.Instance, LimboLogs.Instance);
-            HeadersSyncFeed feed = new( Substitute.For<ISyncModeSelector>(), blockTree, Substitute.For<ISyncPeerPool>(), new SyncConfig{FastSync = true, FastBlocks = true, PivotNumber = "1000", PivotHash = Keccak.Zero.ToString(), PivotTotalDifficulty = "1000"}, Substitute.For<ISyncReport>(), LimboLogs.Instance);
+            HeadersSyncFeed feed = new( Substitute.For<ISyncModeSelector>(), blockTree, Substitute.For<ISyncPeerPool>(), new SyncConfig{SyncMode = StateSyncMode.FastSync, FastBlocks = true, PivotNumber = "1000", PivotHash = Keccak.Zero.ToString(), PivotTotalDifficulty = "1000"}, Substitute.For<ISyncReport>(), LimboLogs.Instance);
             HeadersSyncBatch? batch1 = await feed.PrepareRequest();
             HeadersSyncBatch? batch2 = await feed.PrepareRequest();
             HeadersSyncBatch? batch3 = await feed.PrepareRequest();
         }
-        
+
         [Test]
         public async Task Can_keep_returning_nulls_after_all_batches_were_prepared()
         {
             IDbProvider memDbProvider = await TestMemDbProvider.InitAsync();
             BlockTree blockTree = new(memDbProvider.BlocksDb, memDbProvider.HeadersDb, memDbProvider.BlockInfosDb, new ChainLevelInfoRepository(memDbProvider.BlockInfosDb), MainnetSpecProvider.Instance, NullBloomStorage.Instance, LimboLogs.Instance);
-            HeadersSyncFeed feed = new(Substitute.For<ISyncModeSelector>(), blockTree, Substitute.For<ISyncPeerPool>(), new SyncConfig{FastSync = true, FastBlocks = true, PivotNumber = "1000", PivotHash = Keccak.Zero.ToString(), PivotTotalDifficulty = "1000"}, Substitute.For<ISyncReport>(), LimboLogs.Instance);
+            HeadersSyncFeed feed = new(Substitute.For<ISyncModeSelector>(), blockTree, Substitute.For<ISyncPeerPool>(), new SyncConfig{SyncMode = StateSyncMode.FastSync, FastBlocks = true, PivotNumber = "1000", PivotHash = Keccak.Zero.ToString(), PivotTotalDifficulty = "1000"}, Substitute.For<ISyncReport>(), LimboLogs.Instance);
             for (int i = 0; i < 10; i++)
             {
                 await feed.PrepareRequest();
@@ -84,7 +84,7 @@ namespace Nethermind.Synchronization.Test.FastBlocks
             report.HeadersInQueue.Returns(new MeasuredProgress());
             MeasuredProgress measuredProgress = new();
             report.FastBlocksHeaders.Returns(measuredProgress);
-            HeadersSyncFeed feed = new(Substitute.For<ISyncModeSelector>(), blockTree, Substitute.For<ISyncPeerPool>(), new SyncConfig{FastSync = true, FastBlocks = true, PivotNumber = "1000", PivotHash = Keccak.Zero.ToString(), PivotTotalDifficulty = "1000"}, report, LimboLogs.Instance);
+            HeadersSyncFeed feed = new(Substitute.For<ISyncModeSelector>(), blockTree, Substitute.For<ISyncPeerPool>(), new SyncConfig{SyncMode = StateSyncMode.FastSync, FastBlocks = true, PivotNumber = "1000", PivotHash = Keccak.Zero.ToString(), PivotTotalDifficulty = "1000"}, report, LimboLogs.Instance);
             await feed.PrepareRequest();
             blockTree.LowestInsertedHeader.Returns(Build.A.BlockHeader.WithNumber(1).TestObject);
             var result = await feed.PrepareRequest();

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTestsBase.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTestsBase.cs
@@ -45,6 +45,7 @@ using Nethermind.Trie.Pruning;
 using NSubstitute;
 using NUnit.Framework;
 using BlockTree = Nethermind.Blockchain.BlockTree;
+using SyncMode = Nethermind.Synchronization.ParallelSync.SyncMode;
 
 namespace Nethermind.Synchronization.Test.FastSync
 {
@@ -94,7 +95,8 @@ namespace Nethermind.Synchronization.Test.FastSync
             ctx.Pool.AddPeer(syncPeer);
 
             SyncConfig syncConfig = new SyncConfig();
-            syncConfig.FastSync = true;
+            syncConfig.SyncMode = StateSyncMode.FastSync;
+            // syncConfig.FastSync = true;
             ctx.SyncModeSelector = StaticSelector.StateNodesWithFastBlocks;
             ctx.TreeFeed = new(SyncMode.StateNodes, dbContext.LocalCodeDb, dbContext.LocalStateDb, blockTree, _logManager);
             ctx.Feed = new StateSyncFeed(ctx.SyncModeSelector, ctx.TreeFeed, _logManager);

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTestsBase.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTestsBase.cs
@@ -45,7 +45,6 @@ using Nethermind.Trie.Pruning;
 using NSubstitute;
 using NUnit.Framework;
 using BlockTree = Nethermind.Blockchain.BlockTree;
-using SyncMode = Nethermind.Synchronization.ParallelSync.SyncMode;
 
 namespace Nethermind.Synchronization.Test.FastSync
 {

--- a/src/Nethermind/Nethermind.Synchronization.Test/OldStyleFullSynchronizerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/OldStyleFullSynchronizerTests.cs
@@ -61,7 +61,7 @@ namespace Nethermind.Synchronization.Test
             _codeDb = dbProvider.CodeDb;
             _receiptStorage = Substitute.For<IReceiptStorage>();
             SyncConfig quickConfig = new();
-            quickConfig.FastSync = false;
+            quickConfig.SyncMode = StateSyncMode.FullSync;
 
             ITimerFactory timerFactory = Substitute.For<ITimerFactory>();
             NodeStatsManager stats = new(timerFactory, LimboLogs.Instance);

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorBeaconTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorBeaconTests.cs
@@ -17,6 +17,7 @@
 
 using Nethermind.Synchronization.ParallelSync;
 using NUnit.Framework;
+//using SyncMode = Nethermind.Synchronization.ParallelSync.SyncMode;
 
 namespace Nethermind.Synchronization.Test.ParallelSync;
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorBeaconTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorBeaconTests.cs
@@ -17,7 +17,6 @@
 
 using Nethermind.Synchronization.ParallelSync;
 using NUnit.Framework;
-//using SyncMode = Nethermind.Synchronization.ParallelSync.SyncMode;
 
 namespace Nethermind.Synchronization.Test.ParallelSync;
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorFastSyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorFastSyncTests.cs
@@ -502,7 +502,8 @@ namespace Nethermind.Synchronization.Test.ParallelSync
             syncPeerPool.AllPeers.Returns(peerInfos);
 
             ISyncConfig syncConfig = new SyncConfig() { FastSyncCatchUpHeightDelta = 2 };
-            syncConfig.FastSync = true;
+            syncConfig.SyncMode = StateSyncMode.FastSync;
+            // syncConfig.FastSync = true;
             
             TotalDifficultyBetterPeerStrategy bestPeerStrategy = new(LimboLogs.Instance);
             MultiSyncModeSelector selector = new(syncProgressResolver, syncPeerPool, syncConfig, No.BeaconSync, bestPeerStrategy, LimboLogs.Instance);

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorTests.Scenario.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorTests.Scenario.cs
@@ -652,7 +652,7 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                 {
                     _configActions.Add(() =>
                     {
-                        SyncConfig.FastSync = true;
+                        SyncConfig.SyncMode = StateSyncMode.FastSync;
                         SyncConfig.FastBlocks = true;
                         return "fast sync with fast blocks";
                     });
@@ -664,7 +664,7 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                 {
                     _configActions.Add(() =>
                     {
-                        SyncConfig.FastSync = true;
+                        SyncConfig.SyncMode = StateSyncMode.FastSync;
                         SyncConfig.FastBlocks = false;
                         return "fast sync without fast blocks";
                     });
@@ -702,6 +702,7 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                 {
                     _configActions.Add(() =>
                     {
+                        SyncConfig.SyncMode = StateSyncMode.FullSync;
                         SyncConfig.FastSync = false;
                         SyncConfig.FastBlocks = false;
                         return "full archive";

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorTests.Scenario.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorTests.Scenario.cs
@@ -121,7 +121,7 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                     SyncProgressResolver.IsLoadingBlocksFromDb().Returns(false);
                     SyncProgressResolver.IsFastBlocksFinished().Returns(FastBlocksState.None);
 
-                    SyncConfig.FastSync = false;
+                    SyncConfig.SyncMode = StateSyncMode.FullSync;
                     SyncConfig.FastBlocks = false;
                     SyncConfig.PivotNumber = Pivot.Number.ToString();
                     SyncConfig.PivotHash = Keccak.Zero.ToString();
@@ -676,8 +676,7 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                 {
                     _configActions.Add(() =>
                     {
-                        SyncConfig.FastSync = true;
-                        SyncConfig.SnapSync = true;
+                        SyncConfig.SyncMode = StateSyncMode.FullSync;
                         SyncConfig.FastBlocks = true;
                         return "snap sync with fast blocks";
                     });
@@ -689,8 +688,7 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                 {
                     _configActions.Add(() =>
                     {
-                        SyncConfig.FastSync = true;
-                        SyncConfig.SnapSync = true;
+                        SyncConfig.SyncMode = StateSyncMode.FullSync;
                         SyncConfig.FastBlocks = false;
                         return "snap sync without fast blocks";
                     });
@@ -703,7 +701,6 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                     _configActions.Add(() =>
                     {
                         SyncConfig.SyncMode = StateSyncMode.FullSync;
-                        SyncConfig.FastSync = false;
                         SyncConfig.FastBlocks = false;
                         return "full archive";
                     });

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncReportTest.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncReportTest.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -25,6 +25,7 @@ using Nethermind.Synchronization.Peers;
 using Nethermind.Synchronization.Reporting;
 using NSubstitute;
 using NUnit.Framework;
+using SyncMode = Nethermind.Synchronization.ParallelSync.SyncMode;
 
 namespace Nethermind.Synchronization.Test
 {
@@ -39,7 +40,7 @@ namespace Nethermind.Synchronization.Test
             ISyncModeSelector selector = Substitute.For<ISyncModeSelector>();
             ISyncPeerPool pool = Substitute.For<ISyncPeerPool>();
             pool.InitializedPeersCount.Returns(1);
-            
+
             Queue<SyncMode> _syncModes = new();
             _syncModes.Enqueue(SyncMode.WaitingForBlock);
             _syncModes.Enqueue(SyncMode.FastSync);
@@ -50,8 +51,12 @@ namespace Nethermind.Synchronization.Test
 
             SyncConfig syncConfig = new();
             syncConfig.FastBlocks = fastBlocks;
-            syncConfig.FastSync = fastSync;
-            
+            if (fastSync) 
+            {
+                syncConfig.SyncMode = StateSyncMode.FastSync;
+            }
+            // syncConfig.FastSync = fastSync;
+
             SyncReport syncReport = new (pool, Substitute.For<INodeStatsManager>(), selector,  syncConfig, Substitute.For<IPivot>(), LimboLogs.Instance, 10);
             selector.Current.Returns((ci) => _syncModes.Count > 0 ? _syncModes.Dequeue() : SyncMode.Full);
             await Task.Delay(200);

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncReportTest.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncReportTest.cs
@@ -25,7 +25,6 @@ using Nethermind.Synchronization.Peers;
 using Nethermind.Synchronization.Reporting;
 using NSubstitute;
 using NUnit.Framework;
-using SyncMode = Nethermind.Synchronization.ParallelSync.SyncMode;
 
 namespace Nethermind.Synchronization.Test
 {
@@ -51,7 +50,7 @@ namespace Nethermind.Synchronization.Test
 
             SyncConfig syncConfig = new();
             syncConfig.FastBlocks = fastBlocks;
-            if (fastSync) 
+            if (fastSync)
             {
                 syncConfig.SyncMode = StateSyncMode.FastSync;
             }

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -70,14 +70,14 @@ namespace Nethermind.Synchronization.FastBlocks
             _pivotNumber = _syncConfig.PivotNumberParsed;
             _barrier = _barrier = _syncConfig.AncientBodiesBarrierCalc;
             if(_logger.IsInfo) _logger.Info($"Using pivot {_pivotNumber} and barrier {_barrier} in bodies sync");
-            
+
             _syncStatusList = new SyncStatusList(
                 _blockTree,
                 _pivotNumber,
                 _blockTree.LowestInsertedBodyNumber);
         }
 
-        protected override SyncMode ActivationSyncModes { get; } = SyncMode.FastBodies & ~SyncMode.FastBlocks;
+        protected override ParallelSync.SyncMode ActivationSyncModes { get; } = ParallelSync.SyncMode.FastBodies & ~ParallelSync.SyncMode.FastBlocks;
 
         public override bool IsMultiFeed => true;
 
@@ -137,7 +137,7 @@ namespace Nethermind.Synchronization.FastBlocks
                     if(_logger.IsDebug) _logger.Debug("Received a NULL batch as a response");
                     return SyncResponseHandlingResult.InternalError;
                 }
-                
+
                 int added = InsertBodies(batch);
                 return added == 0
                     ? SyncResponseHandlingResult.NoProgress
@@ -218,7 +218,7 @@ namespace Nethermind.Synchronization.FastBlocks
 
             return validResponsesCount;
         }
-        
+
         private void InsertOneBlock(Block block)
         {
             _blockTree.Insert(block);

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
@@ -77,7 +77,7 @@ namespace Nethermind.Synchronization.FastBlocks
                 _blockTree.LowestInsertedBodyNumber);
         }
 
-        protected override ParallelSync.SyncMode ActivationSyncModes { get; } = ParallelSync.SyncMode.FastBodies & ~ParallelSync.SyncMode.FastBlocks;
+        protected override SyncMode ActivationSyncModes { get; } = SyncMode.FastBodies & ~SyncMode.FastBlocks;
 
         public override bool IsMultiFeed => true;
 

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
@@ -133,8 +133,8 @@ namespace Nethermind.Synchronization.FastBlocks
 
         protected virtual bool StartingFeedCondition() => _syncConfig.FastBlocks;
 
-        protected override ParallelSync.SyncMode ActivationSyncModes { get; }
-            = ParallelSync.SyncMode.FastHeaders & ~ParallelSync.SyncMode.FastBlocks;
+        protected override SyncMode ActivationSyncModes { get; }
+            = SyncMode.FastHeaders & ~SyncMode.FastBlocks;
 
         public override bool IsMultiFeed => true;
         public override AllocationContexts Contexts => AllocationContexts.Headers;

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
@@ -133,8 +133,8 @@ namespace Nethermind.Synchronization.FastBlocks
 
         protected virtual bool StartingFeedCondition() => _syncConfig.FastBlocks;
 
-        protected override SyncMode ActivationSyncModes { get; }
-            = SyncMode.FastHeaders & ~SyncMode.FastBlocks;
+        protected override ParallelSync.SyncMode ActivationSyncModes { get; }
+            = ParallelSync.SyncMode.FastHeaders & ~ParallelSync.SyncMode.FastBlocks;
 
         public override bool IsMultiFeed => true;
         public override AllocationContexts Contexts => AllocationContexts.Headers;

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/ReceiptsSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/ReceiptsSyncFeed.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -47,7 +47,7 @@ namespace Nethermind.Synchronization.FastBlocks
         private SyncStatusList _syncStatusList;
         private readonly long _pivotNumber;
         private readonly long _barrier;
-        
+
         private bool ShouldFinish => !_syncConfig.DownloadReceiptsInFastSync || AllReceiptsDownloaded;
         private bool AllReceiptsDownloaded => _receiptStorage.LowestInsertedReceiptBlockNumber <= _barrier;
 
@@ -77,17 +77,17 @@ namespace Nethermind.Synchronization.FastBlocks
 
             _pivotNumber = _syncConfig.PivotNumberParsed;
             _barrier = _syncConfig.AncientReceiptsBarrierCalc;
-            
+
             if(_logger.IsInfo) _logger.Info($"Using pivot {_pivotNumber} and barrier {_barrier} in receipts sync");
-            
+
             _syncStatusList = new SyncStatusList(
                 _blockTree,
                 _pivotNumber,
                 _receiptStorage.LowestInsertedReceiptBlockNumber);
         }
 
-        protected override SyncMode ActivationSyncModes { get; }
-            = SyncMode.FastReceipts & ~SyncMode.FastBlocks;
+        protected override ParallelSync.SyncMode ActivationSyncModes { get; }
+            = ParallelSync.SyncMode.FastReceipts & ~ParallelSync.SyncMode.FastBlocks;
 
         public override bool IsMultiFeed => true;
 
@@ -183,8 +183,8 @@ namespace Nethermind.Synchronization.FastBlocks
                 else
                 {
                     IReleaseSpec releaseSpec = _specProvider.GetSpec(blockInfo.BlockNumber);
-                    preparedReceipts = receipts.GetReceiptsRoot(releaseSpec, header.ReceiptsRoot) != header.ReceiptsRoot 
-                        ? null 
+                    preparedReceipts = receipts.GetReceiptsRoot(releaseSpec, header.ReceiptsRoot) != header.ReceiptsRoot
+                        ? null
                         : receipts;
                 }
             }
@@ -223,7 +223,7 @@ namespace Nethermind.Synchronization.FastBlocks
                             {
                                 if (_logger.IsWarn) _logger.Warn($"Could not find block {blockInfo.BlockHash}");
                             }
-                            
+
                             _syncStatusList.MarkUnknown(blockInfo.BlockNumber);
                         }
                         else

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/ReceiptsSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/ReceiptsSyncFeed.cs
@@ -86,8 +86,8 @@ namespace Nethermind.Synchronization.FastBlocks
                 _receiptStorage.LowestInsertedReceiptBlockNumber);
         }
 
-        protected override ParallelSync.SyncMode ActivationSyncModes { get; }
-            = ParallelSync.SyncMode.FastReceipts & ~ParallelSync.SyncMode.FastBlocks;
+        protected override SyncMode ActivationSyncModes { get; }
+            = SyncMode.FastReceipts & ~SyncMode.FastBlocks;
 
         public override bool IsMultiFeed => true;
 

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
@@ -68,9 +68,9 @@ namespace Nethermind.Synchronization.ParallelSync
         private readonly bool _isSnapSyncDisabledAfterAnyStateSync;
 
         private readonly long _pivotNumber;
-        private bool FastSyncEnabled => (_syncConfig.SyncMode.HasFlag(StateSyncMode.FastSync));
-        private bool SnapSyncEnabled => (_syncConfig.SyncMode.HasFlag(StateSyncMode.SnapSync)) && !_isSnapSyncDisabledAfterAnyStateSync;
-        private bool FastBlocksEnabled => (_syncConfig.SyncMode.HasFlag(StateSyncMode.FastSync)) && _syncConfig.FastBlocks;
+        private bool FastSyncEnabled => _syncConfig.SyncMode.HasFlag(StateSyncMode.FastSync);
+        private bool SnapSyncEnabled => _syncConfig.SyncMode.HasFlag(StateSyncMode.SnapSync) && !_isSnapSyncDisabledAfterAnyStateSync;
+        private bool FastBlocksEnabled => _syncConfig.SyncMode.HasFlag(StateSyncMode.FastSync) && _syncConfig.FastBlocks;
         private bool FastBodiesEnabled => FastBlocksEnabled && _syncConfig.DownloadBodiesInFastSync;
         private bool FastReceiptsEnabled => FastBlocksEnabled && _syncConfig.DownloadReceiptsInFastSync;
         private bool FastBlocksHeadersFinished => !FastBlocksEnabled || _syncProgressResolver.IsFastBlocksHeadersFinished();

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
@@ -39,10 +39,10 @@ namespace Nethermind.Synchronization.ParallelSync
     /// * <see cref="SyncMode.BeaconHeaders"/> and Beacon Mode (<see cref="SyncMode.WaitingForBlock"/> from beacon node) are exclusive:
     ///     - Beacon modes have higher priority than conflicting modes.
     ///     - Their are enabled based on <see cref="IBeaconSyncStrategy.ShouldBeInBeaconHeaders"/> and <see cref="IBeaconSyncStrategy.ShouldBeInBeaconModeControl"/>.
-    /// * When <see cref="ISyncConfig.FastSync"/> is enabled:
+    /// * When <see cref="ISyncConfig.SyncMode"/> is set to FastSync:
     ///     - Beacon modes are exclusive with <see cref="SyncMode.FastSync"/>, <see cref="SyncMode.Full"/>, <see cref="SyncMode.StateNodes"/> and <see cref="SyncMode.SnapSync"/>.
     ///     - Beacon modes can run parallel with syncing old state (<see cref="SyncMode.FastHeaders"/>, <see cref="SyncMode.FastBlocks"/> and <see cref="SyncMode.FastReceipts"/>).
-    /// * When <see cref="ISyncConfig.FastSync"/> is disabled:
+    /// * When <see cref="ISyncConfig.SyncMode"/> is not set to FastSync:
     ///     - Beacon modes are allied directly.
     ///     - If no Beacon mode is applied and we have good peers on the network we apply <see cref="SyncMode.Full"/>,.
     /// </remarks>
@@ -68,9 +68,9 @@ namespace Nethermind.Synchronization.ParallelSync
         private readonly bool _isSnapSyncDisabledAfterAnyStateSync;
 
         private readonly long _pivotNumber;
-        private bool FastSyncEnabled => _syncConfig.FastSync;
-        private bool SnapSyncEnabled => _syncConfig.SnapSync && !_isSnapSyncDisabledAfterAnyStateSync;
-        private bool FastBlocksEnabled => _syncConfig.FastSync && _syncConfig.FastBlocks;
+        private bool FastSyncEnabled => (_syncConfig.SyncMode == StateSyncMode.FastSync);
+        private bool SnapSyncEnabled => (_syncConfig.SyncMode == StateSyncMode.SnapSync) && !_isSnapSyncDisabledAfterAnyStateSync;
+        private bool FastBlocksEnabled => (_syncConfig.SyncMode == StateSyncMode.FastSync) && _syncConfig.FastBlocks;
         private bool FastBodiesEnabled => FastBlocksEnabled && _syncConfig.DownloadBodiesInFastSync;
         private bool FastReceiptsEnabled => FastBlocksEnabled && _syncConfig.DownloadReceiptsInFastSync;
         private bool FastBlocksHeadersFinished => !FastBlocksEnabled || _syncProgressResolver.IsFastBlocksHeadersFinished();

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
@@ -68,9 +68,9 @@ namespace Nethermind.Synchronization.ParallelSync
         private readonly bool _isSnapSyncDisabledAfterAnyStateSync;
 
         private readonly long _pivotNumber;
-        private bool FastSyncEnabled => (_syncConfig.SyncMode == StateSyncMode.FastSync);
-        private bool SnapSyncEnabled => (_syncConfig.SyncMode == StateSyncMode.SnapSync) && !_isSnapSyncDisabledAfterAnyStateSync;
-        private bool FastBlocksEnabled => (_syncConfig.SyncMode == StateSyncMode.FastSync) && _syncConfig.FastBlocks;
+        private bool FastSyncEnabled => (_syncConfig.SyncMode.HasFlag(StateSyncMode.FastSync));
+        private bool SnapSyncEnabled => (_syncConfig.SyncMode.HasFlag(StateSyncMode.SnapSync)) && !_isSnapSyncDisabledAfterAnyStateSync;
+        private bool FastBlocksEnabled => (_syncConfig.SyncMode.HasFlag(StateSyncMode.FastSync)) && _syncConfig.FastBlocks;
         private bool FastBodiesEnabled => FastBlocksEnabled && _syncConfig.DownloadBodiesInFastSync;
         private bool FastReceiptsEnabled => FastBlocksEnabled && _syncConfig.DownloadReceiptsInFastSync;
         private bool FastBlocksHeadersFinished => !FastBlocksEnabled || _syncProgressResolver.IsFastBlocksHeadersFinished();

--- a/src/Nethermind/Nethermind.Synchronization/Reporting/SyncReport.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Reporting/SyncReport.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -29,7 +29,7 @@ namespace Nethermind.Synchronization.Reporting
     public class SyncReport : ISyncReport
     {
         private const int SpeedPaddingLength = 5;
-        
+
         private readonly ISyncPeerPool _syncPeerPool;
         private readonly ISyncConfig _syncConfig;
         private readonly ISyncModeSelector _syncModeSelector;
@@ -62,7 +62,7 @@ namespace Nethermind.Synchronization.Reporting
             _fastBlocksPivotNumber = _syncConfig.PivotNumberParsed;
             _blockPaddingLength = _fastBlocksPivotNumber.ToString().Length;
             _paddedPivot = $"{Pad(_fastBlocksPivotNumber, _blockPaddingLength)}";
-            
+
             StartTime = DateTime.UtcNow;
 
             TickTime = tickTime;
@@ -80,12 +80,12 @@ namespace Nethermind.Synchronization.Reporting
 
         private void SyncModeSelectorOnChanged(object? sender, SyncModeChangedEventArgs e)
         {
-            if (e.Previous.NotSyncing() && e.Current == SyncMode.Full ||
-                e.Previous == SyncMode.Full && e.Current.NotSyncing())
+            if (e.Previous.NotSyncing() && e.Current == ParallelSync.SyncMode.Full ||
+                e.Previous == ParallelSync.SyncMode.Full && e.Current.NotSyncing())
             {
                 return;
             }
-            
+
             if (e.Previous != e.Current)
             {
                 if (_logger.IsInfo) _logger.Info($"Sync mode changed from {e.Previous} to {e.Current}");
@@ -156,13 +156,13 @@ namespace Nethermind.Synchronization.Reporting
         private void WriteSyncReport()
         {
             UpdateMetrics();
-            
+
             if (!_logger.IsInfo)
             {
                 return;
             }
 
-            SyncMode currentSyncMode = _syncModeSelector.Current;
+            ParallelSync.SyncMode currentSyncMode = _syncModeSelector.Current;
             if (_logger.IsDebug) WriteSyncConfigReport();
 
             if (!_reportedFastBlocksSummary && FastBlocksHeaders.HasEnded && FastBlocksBodies.HasEnded && FastBlocksReceipts.HasEnded)
@@ -171,7 +171,7 @@ namespace Nethermind.Synchronization.Reporting
                 WriteFastBlocksReport(currentSyncMode);
             }
 
-            if ((currentSyncMode | SyncMode.Full) != SyncMode.Full)
+            if ((currentSyncMode | ParallelSync.SyncMode.Full) != ParallelSync.SyncMode.Full)
             {
                 if (_reportId % PeerCountFrequency == 0)
                 {
@@ -179,40 +179,40 @@ namespace Nethermind.Synchronization.Reporting
                 }
             }
 
-            if (currentSyncMode == SyncMode.Disconnected && _syncConfig.SynchronizationEnabled)
+            if (currentSyncMode == ParallelSync.SyncMode.Disconnected && _syncConfig.SynchronizationEnabled)
             {
                 WriteNotStartedReport();
             }
 
-            if (currentSyncMode == SyncMode.DbLoad)
+            if (currentSyncMode == ParallelSync.SyncMode.DbLoad)
             {
                 WriteDbSyncReport();
             }
 
-            if ((currentSyncMode & SyncMode.StateNodes) == SyncMode.StateNodes)
+            if ((currentSyncMode & ParallelSync.SyncMode.StateNodes) == ParallelSync.SyncMode.StateNodes)
             {
                 if (_reportId % NoProgressStateSyncReportFrequency == 0)
                 {
                     WriteStateNodesReport();
                 }
             }
-            
-            if ((currentSyncMode & SyncMode.FastBlocks) == SyncMode.FastBlocks)
+
+            if ((currentSyncMode & ParallelSync.SyncMode.FastBlocks) == ParallelSync.SyncMode.FastBlocks)
             {
                 WriteFastBlocksReport(currentSyncMode);
             }
-            
-            if ((currentSyncMode & SyncMode.Full) == SyncMode.Full)
+
+            if ((currentSyncMode & ParallelSync.SyncMode.Full) == ParallelSync.SyncMode.Full)
             {
                 WriteFullSyncReport();
             }
 
-            if ((currentSyncMode & SyncMode.FastSync) == SyncMode.FastSync)
+            if ((currentSyncMode & ParallelSync.SyncMode.FastSync) == ParallelSync.SyncMode.FastSync)
             {
                 WriteFullSyncReport();
             }
 
-            if ((currentSyncMode & SyncMode.BeaconHeaders) == SyncMode.BeaconHeaders)
+            if ((currentSyncMode & ParallelSync.SyncMode.BeaconHeaders) == ParallelSync.SyncMode.BeaconHeaders)
             {
                 WriteBeaconSyncReport();
             }
@@ -229,7 +229,7 @@ namespace Nethermind.Synchronization.Reporting
         {
             if (!_logger.IsTrace) return;
 
-            bool isFastSync = _syncConfig.FastSync;
+            bool isFastSync = (_syncConfig.SyncMode == StateSyncMode.FastSync);
             bool isFastBlocks = _syncConfig.FastBlocks;
             bool bodiesInFastBlocks = _syncConfig.DownloadBodiesInFastSync;
             bool receiptsInFastBlocks = _syncConfig.DownloadReceiptsInFastSync;
@@ -290,22 +290,22 @@ namespace Nethermind.Synchronization.Reporting
             _logger.Info($"Downloaded {Pad(FullSyncBlocksDownloaded.CurrentValue,_blockPaddingLength)} / {Pad(FullSyncBlocksKnown,_blockPaddingLength)} | current {Pad(FullSyncBlocksDownloaded.CurrentPerSecond, SpeedPaddingLength)}bps | total {Pad(FullSyncBlocksDownloaded.TotalPerSecond, SpeedPaddingLength)}bps");
             FullSyncBlocksDownloaded.SetMeasuringPoint();
         }
-    
-        private void WriteFastBlocksReport(SyncMode currentSyncMode)
+
+        private void WriteFastBlocksReport(ParallelSync.SyncMode currentSyncMode)
         {
-            if ((currentSyncMode & SyncMode.FastHeaders) == SyncMode.FastHeaders)
+            if ((currentSyncMode & ParallelSync.SyncMode.FastHeaders) == ParallelSync.SyncMode.FastHeaders)
             {
                 _logger.Info($"Old Headers  {Pad(FastBlocksHeaders.CurrentValue, _blockPaddingLength)} / {_paddedPivot} | queue {Pad(HeadersInQueue.CurrentValue, SpeedPaddingLength)} | current {Pad(FastBlocksHeaders.CurrentPerSecond, SpeedPaddingLength)}bps | total {Pad(FastBlocksHeaders.TotalPerSecond, SpeedPaddingLength)}bps");
                 FastBlocksHeaders.SetMeasuringPoint();
             }
 
-            if ((currentSyncMode & SyncMode.FastBodies) == SyncMode.FastBodies)
+            if ((currentSyncMode & ParallelSync.SyncMode.FastBodies) == ParallelSync.SyncMode.FastBodies)
             {
                 _logger.Info($"Old Bodies   {Pad(FastBlocksBodies.CurrentValue, _blockPaddingLength)} / {_paddedPivot} | queue {Pad(BodiesInQueue.CurrentValue, SpeedPaddingLength)} | current {Pad(FastBlocksBodies.CurrentPerSecond, SpeedPaddingLength)}bps | total {Pad(FastBlocksBodies.TotalPerSecond, SpeedPaddingLength)}bps");
                 FastBlocksBodies.SetMeasuringPoint();
             }
 
-            if ((currentSyncMode & SyncMode.FastReceipts) == SyncMode.FastReceipts)
+            if ((currentSyncMode & ParallelSync.SyncMode.FastReceipts) == ParallelSync.SyncMode.FastReceipts)
             {
                 _logger.Info($"Old Receipts {Pad(FastBlocksReceipts.CurrentValue, _blockPaddingLength)} / {_paddedPivot} | queue {Pad(ReceiptsInQueue.CurrentValue, SpeedPaddingLength)} | current {Pad(FastBlocksReceipts.CurrentPerSecond, SpeedPaddingLength)}bps | total {Pad(FastBlocksReceipts.TotalPerSecond, SpeedPaddingLength)}bps");
                 FastBlocksReceipts.SetMeasuringPoint();

--- a/src/Nethermind/Nethermind.Synchronization/Reporting/SyncReport.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Reporting/SyncReport.cs
@@ -162,7 +162,7 @@ namespace Nethermind.Synchronization.Reporting
                 return;
             }
 
-            ParallelSync.SyncMode currentSyncMode = _syncModeSelector.Current;
+            SyncMode currentSyncMode = _syncModeSelector.Current;
             if (_logger.IsDebug) WriteSyncConfigReport();
 
             if (!_reportedFastBlocksSummary && FastBlocksHeaders.HasEnded && FastBlocksBodies.HasEnded && FastBlocksReceipts.HasEnded)
@@ -171,7 +171,7 @@ namespace Nethermind.Synchronization.Reporting
                 WriteFastBlocksReport(currentSyncMode);
             }
 
-            if ((currentSyncMode | ParallelSync.SyncMode.Full) != ParallelSync.SyncMode.Full)
+            if ((currentSyncMode | SyncMode.Full) != SyncMode.Full)
             {
                 if (_reportId % PeerCountFrequency == 0)
                 {
@@ -179,17 +179,17 @@ namespace Nethermind.Synchronization.Reporting
                 }
             }
 
-            if (currentSyncMode == ParallelSync.SyncMode.Disconnected && _syncConfig.SynchronizationEnabled)
+            if (currentSyncMode == SyncMode.Disconnected && _syncConfig.SynchronizationEnabled)
             {
                 WriteNotStartedReport();
             }
 
-            if (currentSyncMode == ParallelSync.SyncMode.DbLoad)
+            if (currentSyncMode == SyncMode.DbLoad)
             {
                 WriteDbSyncReport();
             }
 
-            if ((currentSyncMode & ParallelSync.SyncMode.StateNodes) == ParallelSync.SyncMode.StateNodes)
+            if ((currentSyncMode & SyncMode.StateNodes) == SyncMode.StateNodes)
             {
                 if (_reportId % NoProgressStateSyncReportFrequency == 0)
                 {
@@ -197,22 +197,22 @@ namespace Nethermind.Synchronization.Reporting
                 }
             }
 
-            if ((currentSyncMode & ParallelSync.SyncMode.FastBlocks) == ParallelSync.SyncMode.FastBlocks)
+            if ((currentSyncMode & SyncMode.FastBlocks) == SyncMode.FastBlocks)
             {
                 WriteFastBlocksReport(currentSyncMode);
             }
 
-            if ((currentSyncMode & ParallelSync.SyncMode.Full) == ParallelSync.SyncMode.Full)
+            if ((currentSyncMode & SyncMode.Full) == SyncMode.Full)
             {
                 WriteFullSyncReport();
             }
 
-            if ((currentSyncMode & ParallelSync.SyncMode.FastSync) == ParallelSync.SyncMode.FastSync)
+            if ((currentSyncMode & SyncMode.FastSync) == SyncMode.FastSync)
             {
                 WriteFullSyncReport();
             }
 
-            if ((currentSyncMode & ParallelSync.SyncMode.BeaconHeaders) == ParallelSync.SyncMode.BeaconHeaders)
+            if ((currentSyncMode & SyncMode.BeaconHeaders) == SyncMode.BeaconHeaders)
             {
                 WriteBeaconSyncReport();
             }
@@ -229,7 +229,7 @@ namespace Nethermind.Synchronization.Reporting
         {
             if (!_logger.IsTrace) return;
 
-            bool isFastSync = (_syncConfig.SyncMode == StateSyncMode.FastSync);
+            bool isFastSync = (_syncConfig.SyncMode.HasFlag(StateSyncMode.FastSync));
             bool isFastBlocks = _syncConfig.FastBlocks;
             bool bodiesInFastBlocks = _syncConfig.DownloadBodiesInFastSync;
             bool receiptsInFastBlocks = _syncConfig.DownloadReceiptsInFastSync;

--- a/src/Nethermind/Nethermind.Synchronization/Reporting/SyncReport.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Reporting/SyncReport.cs
@@ -80,8 +80,8 @@ namespace Nethermind.Synchronization.Reporting
 
         private void SyncModeSelectorOnChanged(object? sender, SyncModeChangedEventArgs e)
         {
-            if (e.Previous.NotSyncing() && e.Current == ParallelSync.SyncMode.Full ||
-                e.Previous == ParallelSync.SyncMode.Full && e.Current.NotSyncing())
+            if (e.Previous.NotSyncing() && e.Current == SyncMode.Full ||
+                e.Previous == SyncMode.Full && e.Current.NotSyncing())
             {
                 return;
             }
@@ -229,7 +229,7 @@ namespace Nethermind.Synchronization.Reporting
         {
             if (!_logger.IsTrace) return;
 
-            bool isFastSync = (_syncConfig.SyncMode.HasFlag(StateSyncMode.FastSync));
+            bool isFastSync = _syncConfig.SyncMode.HasFlag(StateSyncMode.FastSync);
             bool isFastBlocks = _syncConfig.FastBlocks;
             bool bodiesInFastBlocks = _syncConfig.DownloadBodiesInFastSync;
             bool receiptsInFastBlocks = _syncConfig.DownloadReceiptsInFastSync;
@@ -291,21 +291,21 @@ namespace Nethermind.Synchronization.Reporting
             FullSyncBlocksDownloaded.SetMeasuringPoint();
         }
 
-        private void WriteFastBlocksReport(ParallelSync.SyncMode currentSyncMode)
+        private void WriteFastBlocksReport(SyncMode currentSyncMode)
         {
-            if ((currentSyncMode & ParallelSync.SyncMode.FastHeaders) == ParallelSync.SyncMode.FastHeaders)
+            if ((currentSyncMode & SyncMode.FastHeaders) == SyncMode.FastHeaders)
             {
                 _logger.Info($"Old Headers  {Pad(FastBlocksHeaders.CurrentValue, _blockPaddingLength)} / {_paddedPivot} | queue {Pad(HeadersInQueue.CurrentValue, SpeedPaddingLength)} | current {Pad(FastBlocksHeaders.CurrentPerSecond, SpeedPaddingLength)}bps | total {Pad(FastBlocksHeaders.TotalPerSecond, SpeedPaddingLength)}bps");
                 FastBlocksHeaders.SetMeasuringPoint();
             }
 
-            if ((currentSyncMode & ParallelSync.SyncMode.FastBodies) == ParallelSync.SyncMode.FastBodies)
+            if ((currentSyncMode & SyncMode.FastBodies) == SyncMode.FastBodies)
             {
                 _logger.Info($"Old Bodies   {Pad(FastBlocksBodies.CurrentValue, _blockPaddingLength)} / {_paddedPivot} | queue {Pad(BodiesInQueue.CurrentValue, SpeedPaddingLength)} | current {Pad(FastBlocksBodies.CurrentPerSecond, SpeedPaddingLength)}bps | total {Pad(FastBlocksBodies.TotalPerSecond, SpeedPaddingLength)}bps");
                 FastBlocksBodies.SetMeasuringPoint();
             }
 
-            if ((currentSyncMode & ParallelSync.SyncMode.FastReceipts) == ParallelSync.SyncMode.FastReceipts)
+            if ((currentSyncMode & SyncMode.FastReceipts) == SyncMode.FastReceipts)
             {
                 _logger.Info($"Old Receipts {Pad(FastBlocksReceipts.CurrentValue, _blockPaddingLength)} / {_paddedPivot} | queue {Pad(ReceiptsInQueue.CurrentValue, SpeedPaddingLength)} | current {Pad(FastBlocksReceipts.CurrentPerSecond, SpeedPaddingLength)}bps | total {Pad(FastBlocksReceipts.TotalPerSecond, SpeedPaddingLength)}bps");
                 FastBlocksReceipts.SetMeasuringPoint();

--- a/src/Nethermind/Nethermind.Synchronization/SyncServer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SyncServer.cs
@@ -197,8 +197,8 @@ namespace Nethermind.Synchronization
             }
 
             ValidateSeal(block, nodeWhoSentTheBlock);
-            if ((_syncModeSelector.Current & (SyncMode.FastSync | SyncMode.StateNodes)) == SyncMode.None
-                || (_syncModeSelector.Current & SyncMode.Full) != SyncMode.None)
+            if ((_syncModeSelector.Current & (ParallelSync.SyncMode.FastSync | ParallelSync.SyncMode.StateNodes)) == ParallelSync.SyncMode.None
+                || (_syncModeSelector.Current & ParallelSync.SyncMode.Full) != ParallelSync.SyncMode.None)
             {
                 LogBlockAuthorNicely(block, nodeWhoSentTheBlock);
                 SyncBlock(block, nodeWhoSentTheBlock);

--- a/src/Nethermind/Nethermind.Synchronization/SyncServer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SyncServer.cs
@@ -197,8 +197,8 @@ namespace Nethermind.Synchronization
             }
 
             ValidateSeal(block, nodeWhoSentTheBlock);
-            if ((_syncModeSelector.Current & (ParallelSync.SyncMode.FastSync | ParallelSync.SyncMode.StateNodes)) == ParallelSync.SyncMode.None
-                || (_syncModeSelector.Current & ParallelSync.SyncMode.Full) != ParallelSync.SyncMode.None)
+            if ((_syncModeSelector.Current & (SyncMode.FastSync | SyncMode.StateNodes)) == SyncMode.None
+                || (_syncModeSelector.Current & SyncMode.Full) != SyncMode.None)
             {
                 LogBlockAuthorNicely(block, nodeWhoSentTheBlock);
                 SyncBlock(block, nodeWhoSentTheBlock);

--- a/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
@@ -110,7 +110,7 @@ namespace Nethermind.Synchronization
 
             StartFullSyncComponents();
 
-            if (_syncConfig.SyncMode == StateSyncMode.FastSync)
+            if (_syncConfig.SyncMode.HasFlag(StateSyncMode.FastSync))
             {
                 if (_syncConfig.FastBlocks)
                 {
@@ -119,7 +119,7 @@ namespace Nethermind.Synchronization
 
                 StartFastSyncComponents();
 
-                if (_syncConfig.SyncMode == StateSyncMode.SnapSync)
+                if (_syncConfig.SyncMode.HasFlag(StateSyncMode.SnapSync))
                 {
                     StartSnapSyncComponents();
                 }
@@ -148,7 +148,7 @@ namespace Nethermind.Synchronization
 
         private void StartStateSyncComponents()
         {
-            TreeSync treeSync = new(ParallelSync.SyncMode.StateNodes, _dbProvider.CodeDb, _dbProvider.StateDb, _blockTree, _logManager);
+            TreeSync treeSync = new(SyncMode.StateNodes, _dbProvider.CodeDb, _dbProvider.StateDb, _blockTree, _logManager);
             _stateSyncFeed = new StateSyncFeed(_syncMode, treeSync, _logManager);
             StateSyncDispatcher stateSyncDispatcher = new(_stateSyncFeed!, _syncPeerPool, new StateSyncAllocationStrategyFactory(), _logManager);
             Task syncDispatcherTask = stateSyncDispatcher.Start(_syncCancellation.Token).ContinueWith(t =>

--- a/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
@@ -110,7 +110,7 @@ namespace Nethermind.Synchronization
 
             StartFullSyncComponents();
 
-            if (_syncConfig.FastSync)
+            if (_syncConfig.SyncMode == StateSyncMode.FastSync)
             {
                 if (_syncConfig.FastBlocks)
                 {
@@ -119,7 +119,7 @@ namespace Nethermind.Synchronization
 
                 StartFastSyncComponents();
 
-                if (_syncConfig.SnapSync)
+                if (_syncConfig.SyncMode == StateSyncMode.SnapSync)
                 {
                     StartSnapSyncComponents();
                 }
@@ -148,7 +148,7 @@ namespace Nethermind.Synchronization
 
         private void StartStateSyncComponents()
         {
-            TreeSync treeSync = new(SyncMode.StateNodes, _dbProvider.CodeDb, _dbProvider.StateDb, _blockTree, _logManager);
+            TreeSync treeSync = new(ParallelSync.SyncMode.StateNodes, _dbProvider.CodeDb, _dbProvider.StateDb, _blockTree, _logManager);
             _stateSyncFeed = new StateSyncFeed(_syncMode, treeSync, _logManager);
             StateSyncDispatcher stateSyncDispatcher = new(_stateSyncFeed!, _syncPeerPool, new StateSyncAllocationStrategyFactory(), _logManager);
             Task syncDispatcherTask = stateSyncDispatcher.Start(_syncCancellation.Token).ContinueWith(t =>


### PR DESCRIPTION
Fixes  #4008

The goal is to change the boolean flags FastSync, FastBlocks, SnapSync to an enumeration within the SyncConfig, and mark those boolean flags as obsolete. An enumeration was added, and all calls to the booleans have been replaced in the codebase with checks against the enumeration value instead. Additionally those who still use old configuration files (that use those boolean values) will have a deprecration warning printed to the console.

## Changes:
- Added StateSyncMode enumeration with FastSync, SnapSync, FullSync, and NotConfigured values
- Replaced all uses of FastSync, SnapSync booleans in code base to use StateSyncMode instead

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No

**Comments about testing , should you have some** (optional)

## Further comments (optional)

n/a