### PR TITLE
Copy plugins correctly first time we build solution

### DIFF
--- a/src/Nethermind/Nethermind.Runner/Nethermind.Runner.csproj
+++ b/src/Nethermind/Nethermind.Runner/Nethermind.Runner.csproj
@@ -130,7 +130,7 @@
     <Copy SourceFiles="@(GitHash)" DestinationFiles="$(PublishDir)\git-hash" ContinueOnError="WarnAndContinue" />
   </Target>
 
-  <Target Name="CollectPlugins">
+  <Target Name="CollectPlugins" AfterTargets="AfterBuild;AfterPublish">
     <ItemGroup>
       <PluginsForBuild Include="$(OutputPath)\Nethermind.Merge.AuRa.*;$(OutputPath)\Nethermind.Merge.Plugin.*;$(OutputPath)\Nethermind.Consensus.AuRa.*;$(OutputPath)\Nethermind.Init.*;$(OutputPath)\Nethermind.Mev.*;$(OutputPath)\Nethermind.HealthChecks.*;$(OutputPath)\Nethermind.Api.*;$(OutputPath)\Nethermind.AccountAbstraction.*;$(OutputPath)\Nethermind.EthStats.*" />
       <PluginsForPublish Include="$(OutputPath)\Nethermind.Merge.AuRa.dll;$(OutputPath)\Nethermind.Merge.Plugin.dll;$(OutputPath)\Nethermind.Consensus.AuRa.dll;$(OutputPath)\Nethermind.Init.dll;$(OutputPath)\Nethermind.Mev.dll;$(OutputPath)\Nethermind.HealthChecks.dll;$(OutputPath)\Nethermind.Api.dll;$(OutputPath)\Nethermind.AccountAbstraction.dll;$(OutputPath)\Nethermind.EthStats.dll" />

--- a/src/Nethermind/Nethermind.Runner/Nethermind.Runner.csproj
+++ b/src/Nethermind/Nethermind.Runner/Nethermind.Runner.csproj
@@ -57,7 +57,6 @@
     <ProjectReference Include="..\Nethermind.Sockets\Nethermind.Sockets.csproj" />
     <ProjectReference Include="..\Nethermind.Seq\Nethermind.Seq.csproj" />
     <ProjectReference Include="..\Nethermind.HealthChecks\Nethermind.HealthChecks.csproj" />
-	  <ProjectReference Include="..\Nethermind.Merge.Plugin\Nethermind.Merge.Plugin.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\..\..\Nethermind Data Marketplace - Terms and Conditions 20190831.pdf">
@@ -113,10 +112,6 @@
     <None Remove="keystore\**" />
   </ItemGroup>
   <ItemGroup>
-    <PluginsForBuild Include="$(OutputPath)\Nethermind.Merge.AuRa.*;&#xD;&#xA;$(OutputPath)\Nethermind.Merge.Plugin.*;&#xD;&#xA;$(OutputPath)\Nethermind.Consensus.AuRa.*;&#xD;&#xA;$(OutputPath)\Nethermind.Init.*;&#xD;&#xA;$(OutputPath)\Nethermind.Mev.*;&#xD;&#xA;$(OutputPath)\Nethermind.HealthChecks.*;&#xD;&#xA;$(OutputPath)\Nethermind.Api.*;&#xD;&#xA;$(OutputPath)\Nethermind.AccountAbstraction.*;&#xD;&#xA;$(OutputPath)\Nethermind.EthStats.*" />
-    <PluginsForPublish Include="$(OutputPath)\Nethermind.Merge.AuRa.dll;&#xD;&#xA;$(OutputPath)\Nethermind.Merge.Plugin.dll;&#xD;&#xA;$(OutputPath)\Nethermind.Consensus.AuRa.dll;&#xD;&#xA;$(OutputPath)\Nethermind.Init.dll;&#xD;&#xA;$(OutputPath)\Nethermind.Mev.dll;&#xD;&#xA;$(OutputPath)\Nethermind.HealthChecks.dll;&#xD;&#xA;$(OutputPath)\Nethermind.Api.dll;&#xD;&#xA;$(OutputPath)\Nethermind.AccountAbstraction.dll;&#xD;&#xA;$(OutputPath)\Nethermind.EthStats.dll" />
-  </ItemGroup>
-  <ItemGroup>
     <GitHash Include="git-hash" />
   </ItemGroup>
   <ItemGroup>
@@ -135,14 +130,21 @@
     <Copy SourceFiles="@(GitHash)" DestinationFiles="$(PublishDir)\git-hash" ContinueOnError="WarnAndContinue" />
   </Target>
 
-  <Target Name="CopyPluginsAfterBuild" AfterTargets="AfterBuild">
+  <Target Name="CollectPlugins">
+    <ItemGroup>
+      <PluginsForBuild Include="$(OutputPath)\Nethermind.Merge.AuRa.*;$(OutputPath)\Nethermind.Merge.Plugin.*;$(OutputPath)\Nethermind.Consensus.AuRa.*;$(OutputPath)\Nethermind.Init.*;$(OutputPath)\Nethermind.Mev.*;$(OutputPath)\Nethermind.HealthChecks.*;$(OutputPath)\Nethermind.Api.*;$(OutputPath)\Nethermind.AccountAbstraction.*;$(OutputPath)\Nethermind.EthStats.*" />
+      <PluginsForPublish Include="$(OutputPath)\Nethermind.Merge.AuRa.dll;$(OutputPath)\Nethermind.Merge.Plugin.dll;$(OutputPath)\Nethermind.Consensus.AuRa.dll;$(OutputPath)\Nethermind.Init.dll;$(OutputPath)\Nethermind.Mev.dll;$(OutputPath)\Nethermind.HealthChecks.dll;$(OutputPath)\Nethermind.Api.dll;$(OutputPath)\Nethermind.AccountAbstraction.dll;$(OutputPath)\Nethermind.EthStats.dll" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="CopyPluginsAfterBuild" AfterTargets="AfterBuild" DependsOnTargets="CollectPlugins">
     <Message Text="---&gt; Copying Plugins After Build" Importance="High" />
     <Copy SourceFiles="@(PluginsForBuild)" DestinationFolder="$(OutDir)\plugins" />
   </Target>
 
-    <Target Name="CopyPluginsAfterPublish" AfterTargets="AfterPublish">
+  <Target Name="CopyPluginsAfterPublish" AfterTargets="AfterPublish" DependsOnTargets="CollectPlugins">
     <Message Text="---&gt; Copying Plugins After Publish" Importance="High" />
     <Copy SourceFiles="@(PluginsForBuild)" DestinationFolder="$(OutDir)\plugins" />
     <Copy SourceFiles="@(PluginsForPublish)" DestinationFolder="$(PublishDir)\plugins" />
   </Target>
- </Project>
+</Project>


### PR DESCRIPTION
## Changes:
- Moves `ItemGroup` that collects plugins dlls to be inside a Target, so that wildcards are only expanded after we have already built the plugins projects

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [x] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [ ] No

## Further comments

**Issue**:
If you just clone the repository for the first time and build the solution either from your ide or by running `dotnet run src/Nethermind/Nethermind.sln`, you'll notice that plugins are not copied to the plugins output folder (`src/Nethermind/Nethermind.Runner/bin/<Release or Debug>/netX.x>/plugins`) as expected. As a workaround, you can just rebuild the `Nethermind.sln` solution or the `Nethermind.Runner` project, this will copy the plugins to the plugins folder as expected.

**Cause**:
The reason for this is that in order to know which dlls to copy to the plugins folder [this](https://github.com/NethermindEth/nethermind/blob/1144136a182e7155e80a6888c59b4c599885d7a5/src/Nethermind/Nethermind.Runner/Nethermind.Runner.csproj#L115-L118) expressions are used. Notice that this is done within an `ItemGroup` definition at the top level of the `csproj` file. What happens is that `ItemGroup`s at the top level are evaluated before any target in the `csproj` gets to run, not even the build target. So the first time you build the solution these expressions are evaluated before anything is built and the wildcards don't match any files because the build hasn't happened yet, hence the `Copy` task later has an empty list of source files and nothing happens.

**Fix**:
The way to fix this issue is to ensure that the expressions used to _collect_ which dlls to copy to the plugins folder are evaluated after the plugins projects have been built and the corresponding dlls already exist. This is done by placing the `ItemGroup` definition inside a target that must run after build, and making the copy task depend on this target.