### PR TITLE
Set result to failure on block processing exception

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
@@ -569,6 +569,21 @@ namespace Nethermind.Merge.Plugin.Test
             chain.BlockFinder.SearchForBlock(new BlockParameter(getPayloadResult.BlockHash)).IsError.Should().BeTrue();
         }
 
+        [Test]
+        public async Task executePayloadV1_result_is_fail_when_blockchainprocessor_report_exception()
+        {
+            using MergeTestBlockchain chain = await CreateBaseBlockChain(null, null)
+                .Build(new SingleReleaseSpecProvider(London.Instance, 1));
+            IEngineRpcModule rpc = CreateEngineModule(chain);
+
+            ((TestBlockProcessorInterceptor)chain.BlockProcessor).ExceptionToThrow =
+                new Exception("unxpected exception");
+
+            ExecutionPayloadV1 executionPayload = CreateBlockRequest(CreateParentBlockRequestOnHead(chain.BlockTree), TestItem.AddressD);
+            ResultWrapper<PayloadStatusV1> resultWrapper = await rpc.engine_newPayloadV1(executionPayload);
+            resultWrapper.Result.ResultType.Should().Be(ResultType.Failure);
+        }
+
 
         [TestCase(true)]
         [TestCase(false)]

--- a/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.cs
@@ -1,19 +1,19 @@
 ﻿//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using System;
 using System.Threading;
@@ -75,6 +75,11 @@ namespace Nethermind.Merge.Plugin
                 try
                 {
                     return await _newPayloadV1Handler.HandleAsync(executionPayload);
+                }
+                catch (Exception exception)
+                {
+                    if (_logger.IsError) _logger.Error($"{nameof(engine_newPayloadV1)} threw an unexpected exception. {exception}");
+                    return ResultWrapper<PayloadStatusV1>.Fail($"{nameof(engine_newPayloadV1)} threw an unexpected exception. {exception}");
                 }
                 finally
                 {

--- a/src/Nethermind/Nethermind.Merge.Plugin/TimeoutUtils.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/TimeoutUtils.cs
@@ -1,0 +1,35 @@
+//  Copyright (c) 2021 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+//
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+using System.Threading.Tasks;
+
+namespace Nethermind.Merge.Plugin;
+
+public static class TimeoutUtils
+{
+    public static async Task<T> TimeoutOn<T>(this Task<T> task, Task timeoutTask)
+    {
+        Task firstToComplete = await Task.WhenAny(timeoutTask, task);
+        if (firstToComplete == timeoutTask)
+        {
+            throw new TimeoutException();
+        }
+
+        return await task;
+    }
+}


### PR DESCRIPTION
Fixes NewPayload return Invalid on block processing failure (not validation failure)

## Changes:
- Created a `TimeoutOn` extension method to simplify timeout handling.
- Uses await where possible instead of using task state, also does not handle unknown exception until in `EngineModule`.
- Set result type to failure on exception.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [X] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [X] Yes
- [ ] No

**Comments about testing , should you have some** (optional)

- Ran on ropsten. New block processed normally.

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...