### PR TITLE
Fix invalid block interceptor intercepted wrong block

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/InvalidChainTracker/InvalidBlockInterceptorTest.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/InvalidChainTracker/InvalidBlockInterceptorTest.cs
@@ -1,20 +1,21 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
+using System;
 using Nethermind.Consensus.Validators;
 using Nethermind.Core;
 using Nethermind.Core.Test.Builders;
@@ -41,7 +42,7 @@ public class InvalidBlockInterceptorTest
             _tracker,
             NullLogManager.Instance);
     }
-        
+
     [TestCase(true, false)]
     [TestCase(false, true)]
     public void TestValidateSuggestedBlock(bool baseReturnValue, bool isInvalidBlockReported)
@@ -49,7 +50,7 @@ public class InvalidBlockInterceptorTest
         Block block = Build.A.Block.TestObject;
         _baseValidator.ValidateSuggestedBlock(block).Returns(baseReturnValue);
         _invalidBlockInterceptor.ValidateSuggestedBlock(block);
-        
+
         _tracker.Received().SetChildParent(block.Hash, block.ParentHash);
         if (isInvalidBlockReported)
         {
@@ -60,25 +61,26 @@ public class InvalidBlockInterceptorTest
             _tracker.DidNotReceive().OnInvalidBlock(block.Hash, block.ParentHash);
         }
     }
-    
+
     [TestCase(true, false)]
     [TestCase(false, true)]
     public void TestValidateProcessedBlock(bool baseReturnValue, bool isInvalidBlockReported)
     {
         Block block = Build.A.Block.TestObject;
+        Block suggestedBlock = Build.A.Block.WithExtraData(new byte[]{ 1 }).TestObject;
         TxReceipt[] txs = { };
-        _baseValidator.ValidateProcessedBlock(block, txs, block).Returns(baseReturnValue);
-        _invalidBlockInterceptor.ValidateProcessedBlock(block, txs, block);
-        
-        _tracker.Received().SetChildParent(block.Hash, block.ParentHash);
+        _baseValidator.ValidateProcessedBlock(block, txs, suggestedBlock).Returns(baseReturnValue);
+        _invalidBlockInterceptor.ValidateProcessedBlock(block, txs, suggestedBlock);
+
+        _tracker.Received().SetChildParent(suggestedBlock.Hash, suggestedBlock.ParentHash);
         if (isInvalidBlockReported)
         {
-            _tracker.Received().OnInvalidBlock(block.Hash, block.ParentHash);
+            _tracker.Received().OnInvalidBlock(suggestedBlock.Hash, suggestedBlock.ParentHash);
         }
         else
         {
-            _tracker.DidNotReceive().OnInvalidBlock(block.Hash, block.ParentHash);
+            _tracker.DidNotReceive().OnInvalidBlock(suggestedBlock.Hash, suggestedBlock.ParentHash);
         }
     }
-    
+
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/InvalidChainTracker/InvalidBlockInterceptor.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/InvalidChainTracker/InvalidBlockInterceptor.cs
@@ -1,19 +1,19 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using Nethermind.Consensus.Validators;
 using Nethermind.Core;
@@ -36,7 +36,7 @@ public class InvalidBlockInterceptor: IBlockValidator
         _invalidChainTracker = invalidChainTracker;
         _logger = logManager.GetClassLogger(typeof(InvalidBlockInterceptor));
     }
-    
+
     public bool Validate(BlockHeader header, BlockHeader? parent, bool isUncle = false)
     {
         _invalidChainTracker.SetChildParent(header.Hash!, header.ParentHash!);
@@ -76,12 +76,12 @@ public class InvalidBlockInterceptor: IBlockValidator
 
     public bool ValidateProcessedBlock(Block block, TxReceipt[] receipts, Block suggestedBlock)
     {
-        _invalidChainTracker.SetChildParent(block.Hash!, block.ParentHash!);
+        _invalidChainTracker.SetChildParent(suggestedBlock.Hash!, suggestedBlock.ParentHash!);
         bool result = _baseValidator.ValidateProcessedBlock(block, receipts, suggestedBlock);
         if (!result)
         {
             if (_logger.IsTrace) _logger.Trace($"Intercepted a bad block {block}");
-            _invalidChainTracker.OnInvalidBlock(block.Hash!, block.ParentHash);
+            _invalidChainTracker.OnInvalidBlock(suggestedBlock.Hash!, suggestedBlock.ParentHash);
         }
 
         return result;


### PR DESCRIPTION
Fix invalid block interceptor intercep generated block instead of suggested block. This is a problem because well crafted block can essentially hang block processing by sending an invalid block which when processed result in a hash of a valid block on main chain.

## Changes:
- Mark suggested block as invalid instead of generated block.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing

- [X] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [X] Yes
- [ ] No

**Comments about testing , should you have some** (optional)

This seems to be a cause of failed hive test on a different branch when trying to move NP to `ACCEPTED` where possible, but for some reason, not on master.