### PR TITLE
Remove tracer from HiveRunner

### DIFF
--- a/src/Nethermind/Nethermind.Hive/HivePlugin.cs
+++ b/src/Nethermind/Nethermind.Hive/HivePlugin.cs
@@ -69,9 +69,9 @@ namespace Nethermind.Hive
             {
                 if (_api.BlockTree == null) throw new ArgumentNullException(nameof(_api.BlockTree));
                 if (_api.BlockProcessingQueue == null) throw new ArgumentNullException(nameof(_api.BlockProcessingQueue));
-                if (_api.ReceiptStorage == null) throw new ArgumentNullException(nameof(_api.ReceiptStorage));
-                if (_api.SpecProvider == null) throw new ArgumentNullException(nameof(_api.SpecProvider));
-                if (_api.DbProvider == null) throw new ArgumentNullException(nameof(_api.DbProvider));
+                if (_api.ConfigProvider == null) throw new ArgumentNullException(nameof(_api.ConfigProvider));
+                if (_api.LogManager == null) throw new ArgumentNullException(nameof(_api.LogManager));
+                if (_api.FileSystem == null) throw new ArgumentNullException(nameof(_api.FileSystem));
                 if (_api.BlockValidator == null) throw new ArgumentNullException(nameof(_api.BlockValidator));
 
                 HiveRunner hiveRunner = new(

--- a/src/Nethermind/Nethermind.Hive/HivePlugin.cs
+++ b/src/Nethermind/Nethermind.Hive/HivePlugin.cs
@@ -3,13 +3,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Api;
 using Nethermind.Api.Extensions;
-using Nethermind.Blockchain;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
-using Nethermind.Consensus.Processing;
-using Nethermind.Consensus.Rewards;
-using Nethermind.Consensus.Tracing;
-using Nethermind.Db;
 using Nethermind.Logging;
 using Nethermind.Synchronization.Peers;
 
@@ -30,11 +25,11 @@ namespace Nethermind.Hive
         }
 
         public string Name => "Hive";
-        
+
         public string Description => "Plugin used for executing Hive Ethereum Tests";
-        
+
         public string Author => "Nethermind";
-        
+
         public Task Init(INethermindApi api)
         {
             _api = api ?? throw new ArgumentNullException(nameof(api));
@@ -69,47 +64,27 @@ namespace Nethermind.Hive
         }
 
         public async Task InitRpcModules()
-        { 
+        {
             if (Enabled)
             {
                 if (_api.BlockTree == null) throw new ArgumentNullException(nameof(_api.BlockTree));
+                if (_api.BlockProcessingQueue == null) throw new ArgumentNullException(nameof(_api.BlockProcessingQueue));
                 if (_api.ReceiptStorage == null) throw new ArgumentNullException(nameof(_api.ReceiptStorage));
                 if (_api.SpecProvider == null) throw new ArgumentNullException(nameof(_api.SpecProvider));
                 if (_api.DbProvider == null) throw new ArgumentNullException(nameof(_api.DbProvider));
                 if (_api.BlockValidator == null) throw new ArgumentNullException(nameof(_api.BlockValidator));
 
-                ReadOnlyDbProvider readonlyDbProvider = _api.DbProvider.AsReadOnly(false);
-                ReadOnlyTxProcessingEnv txProcessingEnv =
-                    new(readonlyDbProvider, _api.ReadOnlyTrieStore, _api.BlockTree.AsReadOnly(), _api.SpecProvider,
-                        _api.LogManager);
-
-                IRewardCalculator rewardCalculator =
-                    _api.RewardCalculatorSource!.Get(txProcessingEnv.TransactionProcessor);
-
-                ReadOnlyChainProcessingEnv chainProcessingEnv = new(
-                    txProcessingEnv,
-                    _api.BlockValidator,
-                    _api.BlockPreprocessor,
-                    rewardCalculator,
-                    _api.ReceiptStorage,
-                    readonlyDbProvider,
-                    _api.SpecProvider,
-                    _api.LogManager);
-
-                Tracer tracer = new(chainProcessingEnv.StateProvider, chainProcessingEnv.ChainProcessor,
-                    ProcessingOptions.DoNotUpdateHead | ProcessingOptions.ReadOnlyChain);
-
                 HiveRunner hiveRunner = new(
                     _api.BlockTree,
+                    _api.BlockProcessingQueue,
                     _api.ConfigProvider,
                     _api.LogManager.GetClassLogger(),
                     _api.FileSystem,
-                    _api.BlockValidator,
-                    tracer
+                    _api.BlockValidator
                 );
-                
+
                 if (_logger.IsInfo) _logger.Info("Hive is starting");
-                
+
                 await hiveRunner.Start(_disposeCancellationToken.Token);
             }
             else

--- a/src/Nethermind/Nethermind.Hive/HiveRunner.cs
+++ b/src/Nethermind/Nethermind.Hive/HiveRunner.cs
@@ -197,7 +197,7 @@ namespace Nethermind.Hive
 
         private async Task WaitForBlockProcessing(SemaphoreSlim semaphore)
         {
-            if (!await semaphore.WaitAsync(5000))
+            if (!await semaphore.WaitAsync(-1))
             {
                 throw new InvalidOperationException();
             }


### PR DESCRIPTION
## Changes:
- remove tracer from HiveRunner - we will not process blocks twice anymore
- drop `BlockAddedToMain` event. Now we can collect info about not-processed blocks from recently added `BlockProcessingQueue` event: `BlockRemoved`
- after this change we are passing hive engine test `Long PoW Chain Sync`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [x] No
