### PR TITLE
Fix invalid ancestor reorg

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Visitors/StartupTreeFixerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Visitors/StartupTreeFixerTests.cs
@@ -1,19 +1,19 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using System.Threading;
 using System.Threading.Tasks;
@@ -46,18 +46,18 @@ namespace Nethermind.Blockchain.Test.Visitors
         {
             // for now let us just look at the warnings (before we start adding cleanup)
         }
-        
+
         [Test, Ignore("Not implemented")]
         public void Warns_when_blocks_are_marked_as_processed_but_there_are_no_bodies()
         {
             // for now let us just look at the warnings (before we start adding cleanup)
         }
-        
+
         [Test, Ignore("Not implemented")]
         public void Warns_when_there_is_a_hole_in_processed_blocks()
         {
         }
-        
+
         [Test]
         public void Deletes_everything_after_the_missing_level()
         {
@@ -82,11 +82,11 @@ namespace Nethermind.Blockchain.Test.Visitors
             tree.UpdateMainChain(block0);
             tree.UpdateMainChain(block1);
             tree.UpdateMainChain(block2);
-            
+
             blockInfosDb.Delete(3);
 
             tree = new BlockTree(blocksDb, headersDb, blockInfosDb, new ChainLevelInfoRepository(blockInfosDb), MainnetSpecProvider.Instance, NullBloomStorage.Instance, LimboLogs.Instance);
-            
+
             StartupBlockTreeFixer fixer = new(new SyncConfig(), tree, new MemDb(), LimboNoErrorLogger.Instance);
             tree.Accept(fixer, CancellationToken.None);
 
@@ -96,10 +96,10 @@ namespace Nethermind.Blockchain.Test.Visitors
 
             tree.Head.Header.Should().BeEquivalentTo(block2.Header, options => options.Excluding(t => t.MaybeParent));
             tree.BestSuggestedHeader.Should().BeEquivalentTo(block2.Header, options => options.Excluding(t => t.MaybeParent));
-            tree.BestSuggestedBody.Should().BeEquivalentTo(block2.Body);
+            tree.BestSuggestedBody?.Body.Should().BeEquivalentTo(block2.Body);
             tree.BestKnownNumber.Should().Be(2);
         }
-        
+
         [TestCase(0)]
         [TestCase(1)]
         [TestCase(2)]
@@ -115,13 +115,13 @@ namespace Nethermind.Blockchain.Test.Visitors
             long startingBlockNumber = tree.Head!.Number;
 
             SuggestNumberOfBlocks(tree, suggestedBlocksAmount);
-            
+
             // simulating restarts - we stopped the old blockchain processor and create the new one
             BlockchainProcessor newBlockchainProcessor = new(tree, testRpc.BlockProcessor,
                 testRpc.BlockPreprocessorStep, testRpc.StateReader, LimboLogs.Instance, BlockchainProcessor.Options.Default);
             newBlockchainProcessor.Start();
             testRpc.BlockchainProcessor = newBlockchainProcessor;
-            
+
             // fixing after restart
             StartupBlockTreeFixer fixer = new(new SyncConfig(), tree, testRpc.DbProvider.StateDb, LimboNoErrorLogger.Instance, 5);
             await tree.Accept(fixer, CancellationToken.None);
@@ -136,7 +136,7 @@ namespace Nethermind.Blockchain.Test.Visitors
             await testRpc.AddBlock();
             Assert.AreEqual(startingBlockNumber + suggestedBlocksAmount + 1, tree.Head!.Number);
         }
-        
+
         [TestCase(0)]
         [TestCase(1)]
         [TestCase(2)]
@@ -148,21 +148,21 @@ namespace Nethermind.Blockchain.Test.Visitors
             IBlockTree tree = testRpc.BlockTree;
 
             SuggestNumberOfBlocks(tree, suggestedBlocksAmount);
-            
+
             // simulating restarts - we stopped the old blockchain processor and create the new one
             BlockchainProcessor newBlockchainProcessor = new(tree, testRpc.BlockProcessor,
                 testRpc.BlockPreprocessorStep, testRpc.StateReader, LimboLogs.Instance, BlockchainProcessor.Options.Default);
             newBlockchainProcessor.Start();
             testRpc.BlockchainProcessor = newBlockchainProcessor;
-            
+
             // we create a new empty db for stateDb so we shouldn't suggest new blocks
             MemDb stateDb = new();
             IBlockTreeVisitor fixer = new StartupBlockTreeFixer(new SyncConfig(), tree, stateDb, LimboNoErrorLogger.Instance, 5);
             BlockVisitOutcome result = await fixer.VisitBlock(tree.Head!, CancellationToken.None);
-            
+
             Assert.AreEqual(BlockVisitOutcome.None, result);
         }
-        
+
         [Test]
         public async Task Fixer_should_not_suggest_block_with_null_block()
         {
@@ -171,16 +171,16 @@ namespace Nethermind.Blockchain.Test.Visitors
             IBlockTree tree = testRpc.BlockTree;
 
             SuggestNumberOfBlocks(tree, 1);
-            
+
             // simulating restarts - we stopped the old blockchain processor and create the new one
             BlockchainProcessor newBlockchainProcessor = new(tree, testRpc.BlockProcessor,
                 testRpc.BlockPreprocessorStep, testRpc.StateReader, LimboLogs.Instance, BlockchainProcessor.Options.Default);
             newBlockchainProcessor.Start();
             testRpc.BlockchainProcessor = newBlockchainProcessor;
-            
+
             IBlockTreeVisitor fixer = new StartupBlockTreeFixer(new SyncConfig(), tree, testRpc.DbProvider.StateDb, LimboNoErrorLogger.Instance, 5);
             BlockVisitOutcome result = await fixer.VisitBlock(null, CancellationToken.None);
-            
+
             Assert.AreEqual(BlockVisitOutcome.None, result);
         }
 
@@ -198,7 +198,7 @@ namespace Nethermind.Blockchain.Test.Visitors
                 newParent = newBlock;
             }
         }
-        
+
         [Ignore("It is causing some trouble now. Disabling it while the restarts logic is under review")]
         [Test]
         public void When_head_block_is_followed_by_a_block_bodies_gap_it_should_delete_all_levels_after_the_gap_start()

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -766,25 +766,30 @@ namespace Nethermind.Blockchain
                 NewSuggestedBlock?.Invoke(this, new BlockEventArgs(block!));
             }
 
-            if (header.IsGenesis || BestSuggestedImprovementRequirementsSatisfied(header))
+            if (header.IsGenesis)
             {
-                if (header.IsGenesis)
-                {
-                    Genesis = header;
-                }
-
+                Genesis = header;
                 BestSuggestedHeader = header;
+            }
 
-                if (block is not null && block.IsPostMerge)
-                {
-                    BestSuggestedBody = block;
-                }
-
-                if (block is not null && shouldProcess)
+            if (block is not null)
+            {
+                bool bestSuggestedImprovementSatisfied = BestSuggestedImprovementRequirementsSatisfied(header);
+                if (bestSuggestedImprovementSatisfied)
                 {
                     if (_logger.IsTrace)
                         _logger.Trace(
                             $"New best suggested block. PreviousBestSuggestedBlock {BestSuggestedBody}, BestSuggestedBlock TD {BestSuggestedBody?.TotalDifficulty}, Block TD {block?.TotalDifficulty}, Head: {Head}, Head: {Head?.TotalDifficulty}, Block {block?.ToString(Block.Format.FullHashAndNumber)}");
+                    BestSuggestedHeader = block.Header;
+
+                    if (block.IsPostMerge)
+                    {
+                        BestSuggestedBody = block;
+                    }
+                }
+
+                if (shouldProcess && (bestSuggestedImprovementSatisfied || header.IsGenesis || fillBeaconBlock))
+                {
                     BestSuggestedBody = block;
                     NewBestSuggestedBlock?.Invoke(this, new BlockEventArgs(block));
                 }
@@ -1512,6 +1517,8 @@ namespace Nethermind.Blockchain
 
         private bool BestSuggestedImprovementRequirementsSatisfied(BlockHeader header)
         {
+            if (BestSuggestedHeader == null) return true;
+
             bool reachedTtd = header.IsPostTTD(_specProvider);
             bool isPostMerge = header.IsPoS();
             bool tdImproved = header.TotalDifficulty > (BestSuggestedBody?.TotalDifficulty ?? 0);

--- a/src/Nethermind/Nethermind.Core/BlockBody.cs
+++ b/src/Nethermind/Nethermind.Core/BlockBody.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -50,5 +50,7 @@ namespace Nethermind.Core
         public BlockHeader[] Uncles { get; }
 
         public static readonly BlockBody Empty = new();
+
+        public bool IsEmpty => Transactions.Length == 0 && Uncles.Length == 0;
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
@@ -59,7 +59,7 @@ namespace Nethermind.Merge.Plugin.Test
         protected async Task<MergeTestBlockchain> CreateBlockChain(IMergeConfig mergeConfig = null, IPayloadPreparationService? mockedPayloadService = null)
             => await CreateBaseBlockChain(mergeConfig, mockedPayloadService).Build(new SingleReleaseSpecProvider(London.Instance, 1));
 
-        private IEngineRpcModule CreateEngineModule(MergeTestBlockchain chain, ISyncConfig? syncConfig = null)
+        private IEngineRpcModule CreateEngineModule(MergeTestBlockchain chain, ISyncConfig? syncConfig = null, TimeSpan? newPayloadTimeout = null)
         {
             IPeerRefresher peerRefresher = Substitute.For<IPeerRefresher>();
 
@@ -87,7 +87,8 @@ namespace Nethermind.Merge.Plugin.Test
                     chain.BlockProcessingQueue,
                     invalidChainTracker,
                     chain.BeaconSync,
-                    chain.LogManager),
+                    chain.LogManager,
+                    newPayloadTimeout),
                 new ForkchoiceUpdatedV1Handler(
                     chain.BlockTree,
                     chain.BlockFinalizationManager,

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Synchronization.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Synchronization.cs
@@ -22,6 +22,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Synchronization;
+using Nethermind.Consensus.Validators;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
@@ -775,23 +775,24 @@ namespace Nethermind.Merge.Plugin.Test
             AssertExecutionStatusNotChangedV1(rpc, block.Hash!, startingHead, startingHead);
         }
 
-        [Test]
+        [Test, NonParallelizable]
         public async Task forkChoiceUpdatedV1_block_still_processing()
         {
             using MergeTestBlockchain chain = await CreateBlockChain();
 
-            IEngineRpcModule rpc = CreateEngineModule(chain);
+            IEngineRpcModule rpc = CreateEngineModule(chain, newPayloadTimeout: TimeSpan.FromMilliseconds(100));
             Keccak startingHead = chain.BlockTree.HeadHash;
             Block blockTreeHead = chain.BlockTree.Head!;
             Block block = Build.A.Block.WithNumber(blockTreeHead.Number + 1).WithParent(blockTreeHead).WithNonce(0).WithDifficulty(0).TestObject;
 
-            NewPayloadV1Handler.Timeout = TimeSpan.FromMilliseconds(100);
             chain.ThrottleBlockProcessor(200);
-            ResultWrapper<PayloadStatusV1> newPayloadV1 = await rpc.engine_newPayloadV1(new ExecutionPayloadV1(block));
+            ResultWrapper<PayloadStatusV1> newPayloadV1 =
+                await rpc.engine_newPayloadV1(new ExecutionPayloadV1(block));
             newPayloadV1.Data.Status.Should().Be("SYNCING");
 
             ForkchoiceStateV1 forkchoiceStateV1 = new(block.Hash!, startingHead, startingHead);
-            ResultWrapper<ForkchoiceUpdatedV1Result> forkchoiceUpdatedResult = await rpc.engine_forkchoiceUpdatedV1(forkchoiceStateV1);
+            ResultWrapper<ForkchoiceUpdatedV1Result> forkchoiceUpdatedResult =
+                await rpc.engine_forkchoiceUpdatedV1(forkchoiceStateV1);
             forkchoiceUpdatedResult.Data.PayloadStatus.Status.Should().Be("SYNCING");
 
             AssertExecutionStatusNotChangedV1(rpc, block.Hash!, startingHead, startingHead);
@@ -1013,7 +1014,8 @@ namespace Nethermind.Merge.Plugin.Test
         {
             using MergeTestBlockchain chain = await CreateBlockChain();
             IEngineRpcModule rpc = CreateEngineModule(chain);
-            Keccak lastHash = (await ProduceBranchV1(rpc, chain, count, CreateParentBlockRequestOnHead(chain.BlockTree), true)).LastOrDefault()?.BlockHash ?? Keccak.Zero;
+            Keccak lastHash = (await ProduceBranchV1(rpc, chain, count, CreateParentBlockRequestOnHead(chain.BlockTree), true))
+                .LastOrDefault()?.BlockHash ?? Keccak.Zero;
             chain.BlockTree.HeadHash.Should().Be(lastHash);
             Block? last = RunForAllBlocksInBranch(chain.BlockTree, chain.BlockTree.HeadHash, b => b.IsGenesis, true);
             last.Should().NotBeNull();

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/BeaconHeadersSyncTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/BeaconHeadersSyncTests.cs
@@ -1,19 +1,19 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using System;
 using System.Threading.Tasks;
@@ -56,7 +56,7 @@ public class BeaconHeadersSyncTests
         private readonly IMergeConfig _mergeConfig;
         private readonly ISyncConfig _syncConfig;
         private readonly IDb _metadataDb;
-        
+
         public Context(
             IBlockTree? blockTree = null,
             ISyncConfig? syncConfig = null,
@@ -103,10 +103,11 @@ public class BeaconHeadersSyncTests
             BeaconPivot = beaconPivot ?? new BeaconPivot(_syncConfig, _metadataDb, BlockTree, LimboLogs.Instance);
             BeaconSync = new(BeaconPivot, BlockTree, _syncConfig,  new BlockCacheService(), LimboLogs.Instance);
             ISyncModeSelector selector = new MultiSyncModeSelector(syncProgressResolver, peerPool, _syncConfig, BeaconSync, bestPeerStrategy, LimboLogs.Instance);
-            Feed = new BeaconHeadersSyncFeed(poSSwitcher, selector, blockTree, peerPool, _syncConfig, report, BeaconPivot, _mergeConfig, LimboLogs.Instance);
+            Feed = new BeaconHeadersSyncFeed(poSSwitcher, selector, blockTree, peerPool, _syncConfig, report, BeaconPivot, _mergeConfig,
+                new NoopInvalidChainTracker(), LimboLogs.Instance);
         }
     }
-        
+
     [Test]
     public async Task Can_keep_returning_nulls_after_all_batches_were_prepared()
     {
@@ -114,7 +115,7 @@ public class BeaconHeadersSyncTests
         BlockTree blockTree = new(memDbProvider, new ChainLevelInfoRepository(memDbProvider.BlockInfosDb),
             MainnetSpecProvider.Instance, NullBloomStorage.Instance, LimboLogs.Instance);
         ISyncConfig syncConfig = new SyncConfig
-        { 
+        {
             FastSync = true,
             FastBlocks = true,
             PivotNumber = "1000",
@@ -126,7 +127,7 @@ public class BeaconHeadersSyncTests
         IBeaconPivot pivot = PreparePivot(2000, syncConfig, blockTree);
         BeaconHeadersSyncFeed feed = new(poSSwitcher, Substitute.For<ISyncModeSelector>(), blockTree,
             Substitute.For<ISyncPeerPool>(), syncConfig, Substitute.For<ISyncReport>(),
-            pivot, new MergeConfig() {Enabled = true}, LimboLogs.Instance);
+            pivot, new MergeConfig() {Enabled = true}, new NoopInvalidChainTracker(), LimboLogs.Instance);
         feed.InitializeFeed();
         for (int i = 0; i < 6; i++)
         {
@@ -157,7 +158,9 @@ public class BeaconHeadersSyncTests
         PoSSwitcher poSSwitcher = new(new MergeConfig(), syncConfig, new MemDb(), blockTree!,
             MainnetSpecProvider.Instance, LimboLogs.Instance);
         IBeaconPivot pivot = PreparePivot(2000, syncConfig, blockTree);
-        BeaconHeadersSyncFeed feed = new (poSSwitcher, Substitute.For<ISyncModeSelector>(), blockTree, Substitute.For<ISyncPeerPool>(), syncConfig, report, pivot, new MergeConfig() {Enabled = true},  LimboLogs.Instance);
+        BeaconHeadersSyncFeed feed = new (poSSwitcher, Substitute.For<ISyncModeSelector>(), blockTree,
+            Substitute.For<ISyncPeerPool>(), syncConfig, report, pivot, new MergeConfig() {Enabled = true},
+            new NoopInvalidChainTracker(), LimboLogs.Instance);
         feed.InitializeFeed();
         for (int i = 0; i < 6; i++)
         {
@@ -167,7 +170,7 @@ public class BeaconHeadersSyncTests
         HeadersSyncBatch? result = await feed.PrepareRequest();
         result.Should().BeNull();
         feed.CurrentState.Should().Be(SyncFeedState.Dormant);
-        measuredProgress.CurrentValue.Should().Be(1000);
+        measuredProgress.CurrentValue.Should().Be(999);
     }
 
     [Test]
@@ -190,14 +193,14 @@ public class BeaconHeadersSyncTests
         Context ctx = new (blockTree, syncConfig, pivot);
 
         BuildAndProcessHeaderSyncBatches(ctx, blockTree, syncedBlockTree, pivot, 0, 501);
-        
+
         // move best pointers forward as proxy for chain merge
         Block highestBlock = syncedBlockTree.FindBlock(700, BlockTreeLookupOptions.None)!;
         blockTree.Insert(highestBlock, true);
-        
+
         pivot.EnsurePivot(syncedBlockTree.FindHeader(900, BlockTreeLookupOptions.None));
         BuildAndProcessHeaderSyncBatches(ctx, blockTree, syncedBlockTree, pivot, 700, 701);
-        
+
         highestBlock = syncedBlockTree.FindBlock(900, BlockTreeLookupOptions.None)!;
         blockTree.Insert(highestBlock, true);
         pivot.EnsurePivot(syncedBlockTree.FindHeader(999, BlockTreeLookupOptions.None));
@@ -224,7 +227,7 @@ public class BeaconHeadersSyncTests
             blockTree.SuggestBlock(block);
             parent = block;
         }
-        
+
         ctx.BeaconSync.ShouldBeInBeaconHeaders().Should().BeTrue();
         blockTree.BestKnownNumber.Should().Be(6);
         BuildHeadersSyncBatches(ctx, blockTree, syncedBlockTree, pivot, 2);
@@ -234,7 +237,7 @@ public class BeaconHeadersSyncTests
         ctx.Feed.CurrentState.Should().Be(SyncFeedState.Dormant);
         ctx.BeaconSync.ShouldBeInBeaconHeaders().Should().BeFalse();
     }
-    
+
     private async void BuildAndProcessHeaderSyncBatches(
         Context ctx,
         BlockTree blockTree,
@@ -254,7 +257,7 @@ public class BeaconHeadersSyncTests
         HeadersSyncBatch result = await ctx.Feed.PrepareRequest();
         result.Should().BeNull();
         // check headers are inserted into block tree during sync
-        blockTree.FindHeader(pivot.PivotNumber, BlockTreeLookupOptions.TotalDifficultyNotNeeded).Should().NotBeNull();
+        blockTree.FindHeader(pivot.PivotNumber - 1, BlockTreeLookupOptions.TotalDifficultyNotNeeded).Should().NotBeNull();
         blockTree.LowestInsertedBeaconHeader?.Hash.Should().BeEquivalentTo(syncedBlockTree.FindHeader(endLowestBeaconHeader, BlockTreeLookupOptions.None)?.Hash);
         blockTree.BestKnownNumber.Should().Be(bestPointer);
         blockTree.BestSuggestedHeader.Should().BeEquivalentTo(startBestHeader);
@@ -262,7 +265,7 @@ public class BeaconHeadersSyncTests
         ctx.BeaconSync.ShouldBeInBeaconHeaders().Should().BeFalse();
     }
 
-    private async void BuildHeadersSyncBatches(       
+    private async void BuildHeadersSyncBatches(
         Context ctx,
         BlockTree blockTree,
         BlockTree syncedBlockTree,
@@ -270,7 +273,7 @@ public class BeaconHeadersSyncTests
         long endLowestBeaconHeader)
     {
         ctx.Feed.InitializeFeed();
-        long lowestHeaderNumber = pivot.PivotNumber + 1;
+        long lowestHeaderNumber = pivot.PivotNumber;
         while (lowestHeaderNumber > endLowestBeaconHeader)
         {
             HeadersSyncBatch batch = await ctx.Feed.PrepareRequest();
@@ -280,7 +283,7 @@ public class BeaconHeadersSyncTests
             lowestHeaderNumber = lowestHeaderNumber - batch.RequestSize < endLowestBeaconHeader
                 ? endLowestBeaconHeader
                 : lowestHeaderNumber - batch.RequestSize;
-            
+
             BlockHeader? lowestHeader = syncedBlockTree.FindHeader(lowestHeaderNumber, BlockTreeLookupOptions.None);
             blockTree.LowestInsertedBeaconHeader?.Hash.Should().BeEquivalentTo(lowestHeader?.Hash);
         }
@@ -298,10 +301,9 @@ public class BeaconHeadersSyncTests
         BlockHeader[] headers = blockTree.FindHeaders(startHeader.Hash!, batch.RequestSize, 0, true);
         batch.Response = headers;
     }
-    
+
     private IBeaconPivot PreparePivot(long blockNumber, ISyncConfig syncConfig, IBlockTree blockTree, BlockHeader? pivotHeader = null)
     {
-        IPeerRefresher peerRefresher = Substitute.For<IPeerRefresher>();
         IBeaconPivot pivot = new BeaconPivot(syncConfig, new MemDb(), blockTree, LimboLogs.Instance);
         pivot.EnsurePivot(pivotHeader ?? Build.A.BlockHeader.WithNumber(blockNumber).TestObject);
         return pivot;

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/MergePeerAllocationStrategyTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/MergePeerAllocationStrategyTests.cs
@@ -1,19 +1,19 @@
 ﻿//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Synchronization;
@@ -50,7 +50,7 @@ public class MergePeerAllocationStrategyTests
             syncPeer.IsInitialized.Returns(true);
             Node node = new Node(publicKeys[i], "192.168.1.18", i);
             syncPeer.Node.Returns(node);
-            syncPeer.TotalDifficulty.Returns(new UInt256(totalDifficulties[i])); 
+            syncPeer.TotalDifficulty.Returns(new UInt256(totalDifficulties[i]));
             peers[i] = new PeerInfo(syncPeer);
             INodeStats nodeStats = Substitute.For<INodeStats>();
             nodeStats.GetAverageTransferSpeed(Arg.Any<TransferSpeedType>()).Returns(averageSpeed[i]);
@@ -60,14 +60,17 @@ public class MergePeerAllocationStrategyTests
         poSSwitcher.TerminalTotalDifficulty.Returns(new UInt256(5));
         poSSwitcher.HasEverReachedTerminalBlock().Returns(false);
         poSSwitcher.TransitionFinished.Returns(false);
+
+        IBeaconPivot beaconPivot = Substitute.For<IBeaconPivot>();
+
         IPeerAllocationStrategy mergePeerAllocationStrategy =
-            (new MergeBlocksSyncPeerAllocationStrategyFactory(poSSwitcher, Substitute.For<ILogManager>())).Create(new BlocksRequest());
+            (new MergeBlocksSyncPeerAllocationStrategyFactory(poSSwitcher, beaconPivot, Substitute.For<ILogManager>())).Create(new BlocksRequest());
         IBlockTree _blockTree = Substitute.For<IBlockTree>();
         PeerInfo? info = mergePeerAllocationStrategy.Allocate(null, peers, _nodeStatsManager, _blockTree);
-        
+
         Assert.AreEqual(info,peers[1]); // peer with highest total difficulty
     }
-    
+
     [Test]
         public void Should_allocate_by_speed_post_merge()
         {
@@ -82,7 +85,7 @@ public class MergePeerAllocationStrategyTests
                 syncPeer.IsInitialized.Returns(true);
                 Node node = new Node(publicKeys[i], "192.168.1.18", i);
                 syncPeer.Node.Returns(node);
-                syncPeer.TotalDifficulty.Returns(new UInt256(totalDifficulties[i])); 
+                syncPeer.TotalDifficulty.Returns(new UInt256(totalDifficulties[i]));
                 peers[i] = new PeerInfo(syncPeer);
                 peers[i].HeadNumber.Returns(1);
                 INodeStats nodeStats = Substitute.For<INodeStats>();
@@ -92,12 +95,15 @@ public class MergePeerAllocationStrategyTests
             IPoSSwitcher poSSwitcher = Substitute.For<IPoSSwitcher>();
             poSSwitcher.TerminalTotalDifficulty.Returns(new UInt256(1));
             poSSwitcher.HasEverReachedTerminalBlock().Returns(true);
+
+            IBeaconPivot beaconPivot = Substitute.For<IBeaconPivot>();
+
             IPeerAllocationStrategy mergePeerAllocationStrategy =
-                (new MergeBlocksSyncPeerAllocationStrategyFactory(poSSwitcher, Substitute.For<ILogManager>())).Create(new BlocksRequest());
+                (new MergeBlocksSyncPeerAllocationStrategyFactory(poSSwitcher, beaconPivot, Substitute.For<ILogManager>())).Create(new BlocksRequest());
             IBlockTree _blockTree = Substitute.For<IBlockTree>();
             PeerInfo? info = mergePeerAllocationStrategy.Allocate(null, peers, _nodeStatsManager, _blockTree);
-            
+
             Assert.AreEqual(info,peers[2]); // peer with highest highest speed
         }
-    
+
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/V1/NewPayloadV1Handler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/V1/NewPayloadV1Handler.cs
@@ -17,6 +17,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Api;
 using Nethermind.Blockchain;
@@ -57,7 +58,7 @@ namespace Nethermind.Merge.Plugin.Handlers.V1
         private readonly ILogger _logger;
         private readonly LruCache<Keccak, bool> _latestBlocks = new(50, "LatestBlocks");
         private readonly ProcessingOptions _processingOptions;
-        internal static TimeSpan Timeout = TimeSpan.FromSeconds(7);
+        private readonly TimeSpan _timeout;
 
         public NewPayloadV1Handler(
             IBlockValidator blockValidator,
@@ -71,7 +72,8 @@ namespace Nethermind.Merge.Plugin.Handlers.V1
             IBlockProcessingQueue processingQueue,
             IInvalidChainTracker invalidChainTracker,
             IMergeSyncController mergeSyncController,
-            ILogManager logManager)
+            ILogManager logManager,
+            TimeSpan? timeout = null)
         {
             _blockValidator = blockValidator ?? throw new ArgumentNullException(nameof(blockValidator));
             _blockTree = blockTree;
@@ -85,6 +87,7 @@ namespace Nethermind.Merge.Plugin.Handlers.V1
             _mergeSyncController = mergeSyncController;
             _logger = logManager.GetClassLogger();
             _processingOptions = initConfig.StoreReceipts ? ProcessingOptions.EthereumMerge | ProcessingOptions.StoreReceipts : ProcessingOptions.EthereumMerge;
+            _timeout = timeout ?? TimeSpan.FromSeconds(7);
         }
 
         public async Task<ResultWrapper<PayloadStatusV1>> HandleAsync(ExecutionPayloadV1 request)
@@ -149,7 +152,7 @@ namespace Nethermind.Merge.Plugin.Handlers.V1
             // edge-case detected on GSF5 - during the transition we want to try process all transition blocks from CL client
             // The last condition: !parentBlockInfo.IsBeaconBody will be true for terminal blocks. Checking _posSwitcher.IsTerminal might not be the best, because we're loading parentHeader with DoNotCalculateTotalDifficulty option
             bool weAreCloseToHead = (_blockTree.Head?.Number ?? 0) + 8 >= block.Number;
-            bool forceProcessing = !_poSSwitcher.TransitionFinished && weAreCloseToHead && !parentBlockInfo.IsBeaconBody;
+            bool forceProcessing = !_poSSwitcher.TransitionFinished && weAreCloseToHead && !parentBlockInfo.IsBeaconInfo;
             if (parentProcessed == false && forceProcessing) // add extra logging for this edge case
             {
                 if (_logger.IsInfo) _logger.Info($"Forced processing block {block}, block TD: {block.TotalDifficulty}, parent: {parentHeader}, parent TD: {parentHeader.TotalDifficulty}");
@@ -289,7 +292,7 @@ namespace Nethermind.Merge.Plugin.Handlers.V1
             _processingQueue.BlockRemoved += GetProcessingQueueOnBlockRemoved;
             try
             {
-                Task timeoutTask = Task.Delay(Timeout);
+                Task timeoutTask = Task.Delay(_timeout);
                 AddBlockResult addResult = await _blockTree.SuggestBlockAsync(block, BlockTreeSuggestOptions.ForceDontSetAsMain)
                     .AsTask().TimeoutOn(timeoutTask);
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/InvalidChainTracker/InvalidChainTracker.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/InvalidChainTracker/InvalidChainTracker.cs
@@ -1,19 +1,19 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using System;
 using System.Collections.Generic;
@@ -31,7 +31,7 @@ namespace Nethermind.Merge.Plugin.InvalidChainTracker;
 
 /// <summary>
 /// Tracks if a given hash is on a known invalid chain, as one if it's ancestor have been reported to be invalid.
-/// 
+///
 /// </summary>
 public class InvalidChainTracker: IInvalidChainTracker
 {
@@ -40,12 +40,12 @@ public class InvalidChainTracker: IInvalidChainTracker
     private readonly IBlockCacheService _blockCacheService;
     private readonly ILogger _logger;
     private readonly LruCache<Keccak, Node> _tree;
-    
-    // CompositeDisposable only available on System.Reactive. So this will do for now. 
+
+    // CompositeDisposable only available on System.Reactive. So this will do for now.
     private readonly List<Action> _disposables = new();
 
     public InvalidChainTracker(
-        IPoSSwitcher poSSwitcher, 
+        IPoSSwitcher poSSwitcher,
         IBlockFinder blockFinder,
         IBlockCacheService blockCacheService,
         ILogManager logManager)
@@ -77,7 +77,7 @@ public class InvalidChainTracker: IInvalidChainTracker
             parentNode.Children.Add(child);
             needPropagate = parentNode.LastValidHash != null;
         }
-        
+
         if (needPropagate)
         {
             PropagateLastValidHash(parentNode);
@@ -122,7 +122,7 @@ public class InvalidChainTracker: IInvalidChainTracker
                 }
             }
         }
-        
+
     }
 
     private BlockHeader? TryGetBlockHeader(Keccak hash)
@@ -137,6 +137,7 @@ public class InvalidChainTracker: IInvalidChainTracker
 
     public void OnInvalidBlock(Keccak failedBlock, Keccak? parent)
     {
+        if(_logger.IsDebug) _logger.Debug($"OnInvalidBlock: {failedBlock} {parent}");
         if (parent == null)
         {
             BlockHeader? failedBlockHeader = TryGetBlockHeader(failedBlock);
@@ -148,7 +149,7 @@ public class InvalidChainTracker: IInvalidChainTracker
 
             parent = failedBlockHeader.ParentHash!;
         }
-        
+
         Keccak effectiveParent = parent;
         BlockHeader? parentHeader = TryGetBlockHeader(parent);
         if (parentHeader != null)

--- a/src/Nethermind/Nethermind.Merge.Plugin/InvalidChainTracker/InvalidHeaderInterceptor.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/InvalidChainTracker/InvalidHeaderInterceptor.cs
@@ -1,19 +1,19 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using Nethermind.Consensus.Validators;
 using Nethermind.Core;
@@ -36,7 +36,7 @@ public class InvalidHeaderInterceptor: IHeaderValidator
         _invalidChainTracker = invalidChainTracker;
         _logger = logManager.GetClassLogger(typeof(InvalidHeaderInterceptor));
     }
-    
+
     public bool Validate(BlockHeader header, BlockHeader? parent, bool isUncle = false)
     {
         _invalidChainTracker.SetChildParent(header.Hash!, header.ParentHash!);

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
@@ -344,11 +344,18 @@ namespace Nethermind.Merge.Plugin
                     _api.LogManager);
 
                 _api.UnclesValidator = new MergeUnclesValidator(_poSSwitcher, _api.UnclesValidator);
-                _api.BlockValidator = new BlockValidator(_api.TxValidator, _api.HeaderValidator, _api.UnclesValidator,
-                    _api.SpecProvider, _api.LogManager);
+                _api.BlockValidator = new InvalidBlockInterceptor(
+                    new BlockValidator(
+                        _api.TxValidator,
+                        _api.HeaderValidator,
+                        _api.UnclesValidator,
+                        _api.SpecProvider,
+                        _api.LogManager),
+                    _invalidChainTracker,
+                    _api.LogManager);
                 _beaconSync = new BeaconSync(_beaconPivot, _api.BlockTree, _syncConfig, _blockCacheService, _api.LogManager);
 
-                _api.BetterPeerStrategy = new MergeBetterPeerStrategy(_api.BetterPeerStrategy, _poSSwitcher, _api.LogManager);
+                _api.BetterPeerStrategy = new MergeBetterPeerStrategy(_api.BetterPeerStrategy, _poSSwitcher,  _beaconPivot, _api.LogManager);
 
                 _api.SyncModeSelector = new MultiSyncModeSelector(
                     _api.SyncProgressResolver,
@@ -366,6 +373,7 @@ namespace Nethermind.Merge.Plugin
                     _beaconPivot,
                     _api.SpecProvider,
                     _api.BlockTree,
+                    _blockCacheService,
                     _api.ReceiptStorage!,
                     _api.BlockValidator!,
                     _api.SealValidator!,
@@ -373,7 +381,6 @@ namespace Nethermind.Merge.Plugin
                     _syncConfig,
                     _api.BetterPeerStrategy!,
                     syncReport,
-                    _invalidChainTracker,
                     _api.SyncProgressResolver,
                     _api.LogManager);
                 _api.Synchronizer = new MergeSynchronizer(
@@ -390,6 +397,7 @@ namespace Nethermind.Merge.Plugin
                     _api.Pivot,
                     _poSSwitcher,
                     _mergeConfig,
+                    _invalidChainTracker,
                     _api.LogManager,
                     syncReport);
             }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconHeadersSyncFeed.cs
@@ -24,6 +24,7 @@ using Nethermind.Core.Crypto;
 using Nethermind.Crypto;
 using Nethermind.Int256;
 using Nethermind.Logging;
+using Nethermind.Merge.Plugin.InvalidChainTracker;
 using Nethermind.Synchronization;
 using Nethermind.Synchronization.FastBlocks;
 using Nethermind.Synchronization.ParallelSync;
@@ -35,6 +36,7 @@ namespace Nethermind.Merge.Plugin.Synchronization;
 public sealed class BeaconHeadersSyncFeed : HeadersSyncFeed
 {
     private readonly IPoSSwitcher _poSSwitcher;
+    private readonly IInvalidChainTracker _invalidChainTracker;
     private readonly IPivot _pivot;
     private readonly IMergeConfig _mergeConfig;
     private readonly ILogger _logger;
@@ -56,6 +58,7 @@ public sealed class BeaconHeadersSyncFeed : HeadersSyncFeed
         ISyncReport? syncReport,
         IPivot? pivot,
         IMergeConfig? mergeConfig,
+        IInvalidChainTracker invalidChainTracker,
         ILogManager logManager)
         : base(syncModeSelector, blockTree, syncPeerPool, syncConfig, syncReport, logManager,
             true) // alwaysStartHeaderSync = true => for the merge we're forcing header sync start. It doesn't matter if it is archive sync or fast sync
@@ -63,6 +66,7 @@ public sealed class BeaconHeadersSyncFeed : HeadersSyncFeed
         _poSSwitcher = poSSwitcher ?? throw new ArgumentNullException(nameof(poSSwitcher));
         _pivot = pivot ?? throw new ArgumentNullException(nameof(pivot));
         _mergeConfig = mergeConfig ?? throw new ArgumentNullException(nameof(mergeConfig));
+        _invalidChainTracker = invalidChainTracker;
         _logger = logManager.GetClassLogger();
     }
 
@@ -75,22 +79,36 @@ public sealed class BeaconHeadersSyncFeed : HeadersSyncFeed
 
     public override void InitializeFeed()
     {
-        _pivotNumber = _pivot.PivotNumber;
         _chainMerged = false;
 
+        // First, we assume pivot
+        _pivotNumber = _pivot.PivotNumber;
+        _nextHeaderHash = _pivot.PivotHash ?? Keccak.Zero;
+        _nextHeaderDiff = _poSSwitcher.FinalTotalDifficulty;
+
+        // This is probably whats going to happen. We probably should just set the pivot directly to the parent of FcU head,
+        // but pivot underlying data is a Header, which we may not have. Maybe later we'll clean this up.
+        if (_pivot.PivotParentHash != null)
+        {
+            _pivotNumber = _pivotNumber - 1;
+            _nextHeaderHash = _pivot.PivotParentHash;
+        }
+
+        long startNumber = _pivotNumber;
+
+        // In case we already have beacon sync happened before
         BlockHeader? lowestInserted = LowestInsertedBlockHeader;
-        long startNumber = LowestInsertedBlockHeader?.Number ?? _pivotNumber;
-        Keccak startHeaderHash = lowestInserted?.Hash ?? _pivot.PivotHash ?? Keccak.Zero;
-        UInt256? startTotalDifficulty =
-            lowestInserted?.TotalDifficulty ?? _poSSwitcher.FinalTotalDifficulty ?? null;
+        if (lowestInserted != null && lowestInserted.Number <= _pivotNumber) {
+            startNumber = lowestInserted.Number - 1;
+            _nextHeaderHash = lowestInserted.ParentHash ?? Keccak.Zero;
+            _nextHeaderDiff = lowestInserted.TotalDifficulty - lowestInserted.Difficulty;
+        }
 
-        _nextHeaderHash = startHeaderHash;
-        _nextHeaderDiff = startTotalDifficulty;
-
+        // the base class with starts with _lowestRequestedHeaderNumber - 1, so we offset it here.
         _lowestRequestedHeaderNumber = startNumber + 1;
 
         _logger.Info($"Initialized beacon headers sync. lowestRequestedHeaderNumber: {_lowestRequestedHeaderNumber}," +
-                     $"lowestInsertedBlockHeader: {LowestInsertedBlockHeader?.ToString(BlockHeader.Format.FullHashAndNumber)}, pivotNumber: {_pivotNumber}, pivotDestination: {_pivot.PivotDestinationNumber}");
+                     $"lowestInsertedBlockHeader: {lowestInserted?.ToString(BlockHeader.Format.FullHashAndNumber)}, pivotNumber: {_pivotNumber}, pivotDestination: {_pivot.PivotDestinationNumber}");
     }
 
     protected override void FinishAndCleanUp()
@@ -140,6 +158,8 @@ public sealed class BeaconHeadersSyncFeed : HeadersSyncFeed
                     $"Found header to join dangling beacon chain {header.ToString(BlockHeader.Format.FullHashAndNumber)}");
             return AddBlockResult.AlreadyKnown;
         }
+
+        _invalidChainTracker.SetChildParent(header.Hash!, header.ParentHash!);
 
         AddBlockResult insertOutcome = _blockTree.Insert(header, options);
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconPivot.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconPivot.cs
@@ -70,6 +70,10 @@ namespace Nethermind.Merge.Plugin.Synchronization
 
         public Keccak PivotHash => CurrentBeaconPivot?.Hash ?? _syncConfig.PivotHashParsed;
 
+        // We actually start beacon header sync from the pivot parent hash because hive test.... And because
+        // we can I guess?
+        public Keccak PivotParentHash => CurrentBeaconPivot?.ParentHash ?? _syncConfig.PivotHashParsed;
+
         public UInt256? PivotTotalDifficulty => CurrentBeaconPivot is null ?
             _syncConfig.PivotTotalDifficultyParsed : CurrentBeaconPivot.TotalDifficulty;
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconSync.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconSync.cs
@@ -61,7 +61,7 @@ namespace Nethermind.Merge.Plugin.Synchronization
             _isInBeaconModeControl = true;
         }
 
-        public void InitBeaconHeaderSync(BlockHeader? blockHeader)
+        public void InitBeaconHeaderSync(BlockHeader blockHeader)
         {
             StopBeaconModeControl();
             _beaconPivot.EnsurePivot(blockHeader);
@@ -116,7 +116,7 @@ namespace Nethermind.Merge.Plugin.Synchronization
     {
         void StopSyncing();
 
-        void InitBeaconHeaderSync(BlockHeader? blockHeader);
+        void InitBeaconHeaderSync(BlockHeader blockHeader);
 
         void StopBeaconModeControl();
     }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeBlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeBlockDownloader.cs
@@ -180,10 +180,6 @@ namespace Nethermind.Merge.Plugin.Synchronization
 
                     Block currentBlock = blocks[blockIndex];
                     if (_logger.IsTrace) _logger.Trace($"Received {currentBlock} from {bestPeer}");
-                    if (currentBlock.Header.HasBody && currentBlock.Body.IsEmpty)
-                    {
-                        throw new EthSyncException($"{bestPeer} didn't send transaction for block {currentBlock.ToString(Block.Format.Short)}.");
-                    }
 
                     // can move this to block tree now?
                     if (!_blockValidator.ValidateSuggestedBlock(currentBlock))

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeBlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeBlockDownloader.cs
@@ -16,6 +16,7 @@
 //
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Blockchain;
@@ -49,7 +50,6 @@ namespace Nethermind.Merge.Plugin.Synchronization
         private readonly IReceiptStorage _receiptStorage;
         private readonly IChainLevelHelper _chainLevelHelper;
         private readonly IPoSSwitcher _poSSwitcher;
-        private readonly IInvalidChainTracker _invalidChainTracker;
         private readonly ISyncProgressResolver _syncProgressResolver;
 
         public MergeBlockDownloader(
@@ -65,11 +65,10 @@ namespace Nethermind.Merge.Plugin.Synchronization
             ISpecProvider specProvider,
             IBetterPeerStrategy betterPeerStrategy,
             IChainLevelHelper chainLevelHelper,
-            IInvalidChainTracker invalidChainTracker,
             ISyncProgressResolver syncProgressResolver,
             ILogManager logManager)
             : base(feed, syncPeerPool, blockTree, blockValidator, sealValidator, syncReport, receiptStorage,
-                specProvider, new MergeBlocksSyncPeerAllocationStrategyFactory(posSwitcher, logManager),
+                specProvider, new MergeBlocksSyncPeerAllocationStrategyFactory(posSwitcher, beaconPivot, logManager),
                 betterPeerStrategy, logManager)
         {
             _blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
@@ -81,7 +80,6 @@ namespace Nethermind.Merge.Plugin.Synchronization
             _receiptStorage = receiptStorage ?? throw new ArgumentNullException(nameof(receiptStorage));
             _beaconPivot = beaconPivot;
             _receiptsRecovery = new ReceiptsRecovery(new EthereumEcdsa(specProvider.ChainId, logManager), specProvider);
-            _invalidChainTracker = invalidChainTracker;
             _syncProgressResolver = syncProgressResolver ?? throw new ArgumentNullException(nameof(syncProgressResolver));
             _logger = logManager.GetClassLogger();
         }
@@ -105,24 +103,35 @@ namespace Nethermind.Merge.Plugin.Synchronization
             bool shouldMoveToMain = (options & DownloaderOptions.MoveToMain) == DownloaderOptions.MoveToMain;
 
             int blocksSynced = 0;
-            long currentNumber = _blockTree.BestKnownNumber; // ToDo Ashraf MIN(_blockTree.BestKnownNumber, _blockCache.ProcessDestination.Number ?? 0)
+            long currentNumber = _blockTree.BestKnownNumber;
             if (_logger.IsTrace)
                 _logger.Trace(
                     $"MergeBlockDownloader GetCurrentNumber: currentNumber {currentNumber}, beaconPivotExists: {_beaconPivot.BeaconPivotExists()}, BestSuggestedBody: {_blockTree.BestSuggestedBody?.Number}, BestKnownNumber: {_blockTree.BestKnownNumber}, BestPeer: {bestPeer}, BestKnownBeaconNumber {_blockTree.BestKnownBeaconNumber}");
 
-            bool HasMoreToSync()
-                => currentNumber < _blockTree.BestKnownBeaconNumber &&
-                   bestPeer.HeadNumber > _blockTree.BestKnownNumber;
-
-            while (HasMoreToSync())
+            bool HasMoreToSync(out BlockHeader[]? headers, out int headersToRequest)
             {
                 if (_logger.IsDebug)
                     _logger.Debug($"Continue full sync with {bestPeer} (our best {_blockTree.BestKnownNumber})");
 
-                int headersToRequest = Math.Min(_syncBatchSize.Current, bestPeer.MaxHeadersPerRequest());
+                headersToRequest = Math.Min(_syncBatchSize.Current, bestPeer.MaxHeadersPerRequest());
                 if (_logger.IsTrace)
                     _logger.Trace(
                         $"Full sync request {currentNumber}+{headersToRequest} to peer {bestPeer} with {bestPeer.HeadNumber} blocks. Got {currentNumber} and asking for {headersToRequest} more.");
+
+                // Note: This is slow
+                headers = _chainLevelHelper.GetNextHeaders(headersToRequest, bestPeer.HeadNumber, blocksRequest.NumberOfLatestBlocksToBeIgnored ?? 0);
+                if (headers == null || headers.Length == 0)
+                {
+                    if (_logger.IsTrace)
+                        _logger.Trace("Chain level helper got no headers suggestion");
+                    return false;
+                }
+
+                return true;
+            }
+
+            while (HasMoreToSync(out BlockHeader[]? headers, out int headersToRequest))
+            {
 
                 if (cancellation.IsCancellationRequested) return blocksSynced; // check before every heavy operation
                 Block[]? blocks = null;
@@ -131,13 +140,11 @@ namespace Nethermind.Merge.Plugin.Synchronization
                     _logger.Trace(
                         $"Downloading blocks from peer. CurrentNumber: {currentNumber}, BeaconPivot: {_beaconPivot.PivotNumber}, BestPeer: {bestPeer}, HeaderToRequest: {headersToRequest}");
 
-                BlockHeader[]? headers = _chainLevelHelper.GetNextHeaders(headersToRequest);
-                if (headers == null || headers.Length == 0)
-                    break;
-                BlockDownloadContext context = new(_specProvider, bestPeer, headers, downloadReceipts,
-                    _receiptsRecovery);
+                BlockDownloadContext context = new(_specProvider, bestPeer, headers!, downloadReceipts, _receiptsRecovery);
 
                 if (cancellation.IsCancellationRequested) return blocksSynced; // check before every heavy operation
+                _logger.Info("NonBlockhash " + context.NonEmptyBlockHashes.Count);
+
                 await RequestBodies(bestPeer, cancellation, context);
 
                 if (downloadReceipts)
@@ -158,6 +165,8 @@ namespace Nethermind.Merge.Plugin.Synchronization
 
                 if (!(blocks?.Length > 0))
                 {
+                    if (_logger.IsTrace)
+                        _logger.Trace("Break early due to no blocks.");
                     break;
                 }
 
@@ -171,6 +180,10 @@ namespace Nethermind.Merge.Plugin.Synchronization
 
                     Block currentBlock = blocks[blockIndex];
                     if (_logger.IsTrace) _logger.Trace($"Received {currentBlock} from {bestPeer}");
+                    if (currentBlock.Header.HasBody && currentBlock.Body.IsEmpty)
+                    {
+                        throw new EthSyncException($"{bestPeer} didn't send transaction for block {currentBlock.ToString(Block.Format.Short)}.");
+                    }
 
                     // can move this to block tree now?
                     if (!_blockValidator.ValidateSuggestedBlock(currentBlock))
@@ -219,11 +232,6 @@ namespace Nethermind.Merge.Plugin.Synchronization
                             $"MergeBlockDownloader - SuggestBlock {currentBlock}, IsKnownBeaconBlock {isKnownBeaconBlock} ShouldProcess: {shouldProcess}");
 
                     AddBlockResult addResult = _blockTree.SuggestBlock(currentBlock, suggestOptions);
-                    if (addResult == AddBlockResult.InvalidBlock)
-                    {
-                        _invalidChainTracker.OnInvalidBlock(currentBlock.GetOrCalculateHash(), currentBlock.ParentHash!);
-                    }
-
                     if (HandleAddResult(bestPeer, currentBlock.Header, blockIndex == 0, addResult))
                     {
                         if (shouldProcess == false)

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeBlockDownloaderFactory.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeBlockDownloaderFactory.cs
@@ -1,19 +1,19 @@
 ﻿//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using System;
 using Nethermind.Blockchain;
@@ -47,7 +47,6 @@ namespace Nethermind.Merge.Plugin.Synchronization
         private readonly IBetterPeerStrategy _betterPeerStrategy;
         private readonly ILogManager _logManager;
         private readonly ISyncReport _syncReport;
-        private readonly IInvalidChainTracker _invalidChainTracker;
         private readonly ISyncProgressResolver _syncProgressResolver;
         private readonly IChainLevelHelper _chainLevelHelper;
 
@@ -55,6 +54,7 @@ namespace Nethermind.Merge.Plugin.Synchronization
             IBeaconPivot beaconPivot,
             ISpecProvider specProvider,
             IBlockTree blockTree,
+            IBlockCacheService blockCacheService,
             IReceiptStorage receiptStorage,
             IBlockValidator blockValidator,
             ISealValidator sealValidator,
@@ -62,7 +62,6 @@ namespace Nethermind.Merge.Plugin.Synchronization
             ISyncConfig syncConfig,
             IBetterPeerStrategy betterPeerStrategy,
             ISyncReport syncReport,
-            IInvalidChainTracker invalidChainTracker,
             ISyncProgressResolver syncProgressResolver,
             ILogManager logManager)
         {
@@ -77,15 +76,14 @@ namespace Nethermind.Merge.Plugin.Synchronization
             _betterPeerStrategy = betterPeerStrategy ?? throw new ArgumentNullException(nameof(betterPeerStrategy));
             _logManager = logManager ?? throw new ArgumentNullException(nameof(logManager));
             _syncReport = syncReport ?? throw new ArgumentNullException(nameof(syncReport));
-            _chainLevelHelper = new ChainLevelHelper(_blockTree, syncConfig, _logManager);
-            _invalidChainTracker = invalidChainTracker;
+            _chainLevelHelper = new ChainLevelHelper(_blockTree, blockCacheService, syncConfig, _logManager);
             _syncProgressResolver = syncProgressResolver ?? throw new ArgumentNullException(nameof(syncProgressResolver));;
         }
 
         public BlockDownloader Create(ISyncFeed<BlocksRequest?> syncFeed)
         {
             return new MergeBlockDownloader(_poSSwitcher, _beaconPivot, syncFeed, _syncPeerPool, _blockTree, _blockValidator,
-                _sealValidator, _syncReport, _receiptStorage, _specProvider, _betterPeerStrategy, _chainLevelHelper, _invalidChainTracker,
+                _sealValidator, _syncReport, _receiptStorage, _specProvider, _betterPeerStrategy, _chainLevelHelper,
                 _syncProgressResolver, _logManager);
         }
     }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeBlocksSyncPeerAllocationStrategyFactory.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeBlocksSyncPeerAllocationStrategyFactory.cs
@@ -1,19 +1,19 @@
 ﻿//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using System;
 using Nethermind.Consensus;
@@ -28,15 +28,18 @@ public class MergeBlocksSyncPeerAllocationStrategyFactory : IPeerAllocationStrat
 {
     private readonly IPoSSwitcher _poSSwitcher;
     private readonly ILogManager _logManager;
+    private readonly IBeaconPivot _beaconPivot;
 
     public MergeBlocksSyncPeerAllocationStrategyFactory(
         IPoSSwitcher poSSwitcher,
+        IBeaconPivot beaconPivot,
         ILogManager logManager)
     {
         _poSSwitcher = poSSwitcher;
+        _beaconPivot = beaconPivot;
         _logManager = logManager;
     }
-    
+
     public IPeerAllocationStrategy Create(BlocksRequest? request)
     {
         // because of the way the generics cannot handle T / T?
@@ -45,13 +48,13 @@ public class MergeBlocksSyncPeerAllocationStrategyFactory : IPeerAllocationStrat
             throw new ArgumentNullException(
                 $"NULL received for allocation in {nameof(MergeBlocksSyncPeerAllocationStrategyFactory)}");
         }
-            
+
         IPeerAllocationStrategy baseStrategy = new BlocksSyncPeerAllocationStrategy(request.NumberOfLatestBlocksToBeIgnored);
         TotalDiffStrategy preMergeAllocationStrategy = new(baseStrategy);
-        PostMergeBlocksSyncPeerAllocationStrategy postMergeStrategy = new(request.NumberOfLatestBlocksToBeIgnored);
+        PostMergeBlocksSyncPeerAllocationStrategy postMergeStrategy = new(request.NumberOfLatestBlocksToBeIgnored, _beaconPivot);
         MergePeerAllocationStrategy mergeStrategy =
             new(preMergeAllocationStrategy, postMergeStrategy, _poSSwitcher, _logManager);
-        
+
         return mergeStrategy;
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergePeerAllocationStrategy.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergePeerAllocationStrategy.cs
@@ -1,19 +1,19 @@
 ﻿//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using System.Collections.Generic;
 using System.Linq;
@@ -34,9 +34,9 @@ public class MergePeerAllocationStrategy : IPeerAllocationStrategy
     private readonly IPoSSwitcher _poSSwitcher;
     private readonly ILogger _logger;
     public bool CanBeReplaced => true;
-    
+
     public MergePeerAllocationStrategy(
-        IPeerAllocationStrategy preMergeAllocationStrategy, 
+        IPeerAllocationStrategy preMergeAllocationStrategy,
         IPeerAllocationStrategy postMergeAllocationStrategy,
         IPoSSwitcher poSSwitcher,
         ILogManager logManager)
@@ -50,15 +50,20 @@ public class MergePeerAllocationStrategy : IPeerAllocationStrategy
     public PeerInfo? Allocate(PeerInfo? currentPeer, IEnumerable<PeerInfo> peers, INodeStatsManager nodeStatsManager, IBlockTree blockTree)
     {
         UInt256? terminalTotalDifficulty = _poSSwitcher.TerminalTotalDifficulty;
-        bool isPostMerge = _poSSwitcher.HasEverReachedTerminalBlock() || _poSSwitcher.TransitionFinished;
+        bool isPostMerge = IsPostMerge;
         IEnumerable<PeerInfo> peerInfos = peers as PeerInfo[] ?? peers.ToArray();
-        bool anyPostMergePeers = peerInfos.Any(p => p.TotalDifficulty >= terminalTotalDifficulty);
-        if (_logger.IsTrace) _logger.Trace($"MergePeerAllocationStrategy: IsPostMerge: {isPostMerge} AnyPostMergePeers: {anyPostMergePeers}, CurrentPeer: {currentPeer} Peers: {string.Join(",", peerInfos.Select(peer => peer.ToString()))}");
+        IEnumerable<PeerInfo> postTTDPeers = peerInfos.Where(p => p.TotalDifficulty >= terminalTotalDifficulty);
+        bool anyPostMergePeers = postTTDPeers.Any();
+        if (_logger.IsTrace) _logger.Trace($"{nameof(MergePeerAllocationStrategy)}: IsPostMerge: {isPostMerge} AnyPostMergePeers: {anyPostMergePeers}, CurrentPeer: {currentPeer} Peers: {string.Join(",", peerInfos)}");
         PeerInfo? peerInfo = isPostMerge || anyPostMergePeers
-            ? _postMergeAllocationStrategy.Allocate(currentPeer, peerInfos.Where(p => p.TotalDifficulty >= terminalTotalDifficulty), nodeStatsManager, blockTree)
+            ? _postMergeAllocationStrategy.Allocate(currentPeer, postTTDPeers, nodeStatsManager, blockTree)
             : _preMergeAllocationStrategy.Allocate(currentPeer, peerInfos, nodeStatsManager, blockTree);
 
         if (_logger.IsTrace) _logger.Trace($"MergePeerAllocationStrategy: Result of peer allocation {peerInfo}");
         return peerInfo;
     }
+
+    private bool IsPostMerge => _poSSwitcher.HasEverReachedTerminalBlock() || _poSSwitcher.TransitionFinished;
+
+    public override string ToString() => $"{nameof(MergePeerAllocationStrategy)} ({(IsPostMerge ? _postMergeAllocationStrategy.ToString() : _preMergeAllocationStrategy.ToString())})";
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeSynchronizer.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeSynchronizer.cs
@@ -25,6 +25,7 @@ using Nethermind.Core.Specs;
 using Nethermind.Db;
 using Nethermind.Logging;
 using Nethermind.Merge.Plugin.Handlers;
+using Nethermind.Merge.Plugin.InvalidChainTracker;
 using Nethermind.Stats;
 using Nethermind.Synchronization;
 using Nethermind.Synchronization.Blocks;
@@ -40,6 +41,7 @@ public class MergeSynchronizer : Synchronizer
 {
     private readonly IPoSSwitcher _poSSwitcher;
     private readonly IMergeConfig _mergeConfig;
+    private readonly IInvalidChainTracker _invalidChainTracker;
 
     public MergeSynchronizer(
         IDbProvider dbProvider,
@@ -55,6 +57,7 @@ public class MergeSynchronizer : Synchronizer
         IPivot pivot,
         IPoSSwitcher poSSwitcher,
         IMergeConfig mergeConfig,
+        IInvalidChainTracker invalidChainTracker,
         ILogManager logManager,
         ISyncReport syncReport)
         : base(
@@ -72,6 +75,7 @@ public class MergeSynchronizer : Synchronizer
             syncReport,
             logManager)
     {
+        _invalidChainTracker = invalidChainTracker;
         _poSSwitcher = poSSwitcher;
         _mergeConfig = mergeConfig;
     }
@@ -91,7 +95,7 @@ public class MergeSynchronizer : Synchronizer
     {
         FastBlocksPeerAllocationStrategyFactory fastFactory = new();
         BeaconHeadersSyncFeed beaconHeadersFeed =
-            new(_poSSwitcher, _syncMode, _blockTree, _syncPeerPool, _syncConfig, _syncReport, _pivot, _mergeConfig, _logManager);
+            new(_poSSwitcher, _syncMode, _blockTree, _syncPeerPool, _syncConfig, _syncReport, _pivot, _mergeConfig, _invalidChainTracker, _logManager);
         BeaconHeadersSyncDispatcher beaconHeadersDispatcher =
             new(beaconHeadersFeed!, _syncPeerPool, fastFactory, _logManager);
         beaconHeadersDispatcher.Start(_syncCancellation!.Token).ContinueWith(t =>

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/PeerRefresher.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/PeerRefresher.cs
@@ -1,19 +1,19 @@
 ﻿//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using System;
 using System.Collections.Generic;
@@ -72,7 +72,7 @@ public class PeerRefresher : IPeerRefresher, IAsyncDisposable
     {
         Refresh(_lastBlockhashes.headBlockhash, _lastBlockhashes.headParentBlockhash, _lastBlockhashes.finalizedBlockhash);
     }
-    
+
     private void Refresh(Keccak headBlockhash, Keccak headParentBlockhash, Keccak finalizedBlockhash)
     {
         _lastRefresh = DateTime.Now;
@@ -111,7 +111,7 @@ public class PeerRefresher : IPeerRefresher, IAsyncDisposable
     {
         // headBlockhash is obtained together with headParentBlockhash
         Task<BlockHeader[]> getHeadParentHeaderTask = syncPeer.GetBlockHeaders(headParentBlockhash, 2, 0, token);
-        Task<BlockHeader?> getFinalizedHeaderTask = finalizedBlockhash == Keccak.Zero 
+        Task<BlockHeader?> getFinalizedHeaderTask = finalizedBlockhash == Keccak.Zero
             ? Task.FromResult<BlockHeader?>(null)
             : syncPeer.GetHeadBlockHeader(finalizedBlockhash, token);
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
@@ -54,7 +54,6 @@ using Nethermind.Synchronization.SnapSync;
 using Nethermind.Trie.Pruning;
 using Nethermind.TxPool;
 using NSubstitute;
-using NSubstitute.ExceptionExtensions;
 using NSubstitute.Exceptions;
 using NUnit.Framework;
 using BlockTree = Nethermind.Blockchain.BlockTree;
@@ -246,49 +245,6 @@ namespace Nethermind.Synchronization.Test
             Assert.AreEqual(Math.Max(0, peerInfo.HeadNumber), ctx.BlockTree.BestSuggestedHeader.Number);
         }
 
-        [TestCase(32, 32, true)]
-        [TestCase(32, 16, true)]
-        [TestCase(500, 250, true)]
-        [TestCase(32, 32, false)]
-        [TestCase(32, 16, false)]
-        [TestCase(500, 250, false)]
-        public async Task Can_sync_partially_when_only_some_bodies_is_available(int blockCount, int availableBlock, bool mergeDownloader)
-        {
-            Context ctx = new();
-            BlockDownloader downloader = mergeDownloader ? CreateMergeBlockDownloader(ctx) : CreateBlockDownloader(ctx);
-
-            ISyncPeer syncPeer = Substitute.For<ISyncPeer>();
-            syncPeer.GetBlockHeaders(Arg.Any<long>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
-                .Returns(async ci => await ctx.ResponseBuilder.BuildHeaderResponse(ci.ArgAt<long>(0), ci.ArgAt<int>(1), Response.AllCorrect | Response.WithTransactions & ~Response.AllKnown));
-
-            List<Keccak> requestedHashes = new();
-            syncPeer.GetBlockBodies(Arg.Any<IReadOnlyList<Keccak>>(), Arg.Any<CancellationToken>())
-                .Returns(ci =>
-                {
-                    IList<Keccak> blockHashes = ci.ArgAt<IList<Keccak>>(0);
-                    int toTake = availableBlock - requestedHashes.Count;
-                    blockHashes = blockHashes.Take(toTake).ToList();
-                    requestedHashes.AddRange(blockHashes);
-
-                    if (blockHashes.Count == 0)
-                    {
-                        return Array.Empty<BlockBody>();
-                    }
-
-                    return ctx.ResponseBuilder.BuildBlocksResponse(blockHashes,
-                        Response.AllCorrect | Response.WithTransactions & ~Response.AllKnown).Result;
-                });
-
-            syncPeer.TotalDifficulty.Returns(UInt256.MaxValue);
-            syncPeer.HeadNumber.Returns(blockCount);
-
-            PeerInfo peerInfo = new(syncPeer);
-
-            ctx.BlockTree.BestSuggestedBody.Number.Should().Be(0);
-            await downloader.DownloadBlocks(peerInfo, new BlocksRequest(DownloaderOptions.Process), CancellationToken.None).ContinueWith(t => { });
-            ctx.BlockTree.BestSuggestedBody.Number.Should().Be(availableBlock);
-        }
-
         [Test]
         public async Task Headers_already_known()
         {
@@ -311,6 +267,30 @@ namespace Nethermind.Synchronization.Test
             syncPeer.HeadNumber.Returns(128);
             await downloader.DownloadBlocks(peerInfo, new BlocksRequest(), CancellationToken.None)
                 .ContinueWith(t => Assert.True(t.IsCompletedSuccessfully));
+        }
+
+        [TestCase(33L)]
+        [TestCase(65L)]
+        public async Task Peer_sends_just_one_item_when_advertising_more_blocks(long headNumber)
+        {
+            Context ctx = new();
+            BlockDownloader downloader = CreateBlockDownloader(ctx);
+
+            ISyncPeer syncPeer = Substitute.For<ISyncPeer>();
+            syncPeer.GetBlockHeaders(Arg.Any<long>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+                .Returns(ci => ctx.ResponseBuilder.BuildHeaderResponse(ci.ArgAt<long>(0), ci.ArgAt<int>(1), Response.AllCorrect));
+
+            syncPeer.GetBlockBodies(Arg.Any<IReadOnlyList<Keccak>>(), Arg.Any<CancellationToken>())
+                .Returns(ci => ctx.ResponseBuilder.BuildBlocksResponse(ci.ArgAt<IList<Keccak>>(0), Response.AllCorrect | Response.JustFirst));
+
+            PeerInfo peerInfo = new(syncPeer);
+            syncPeer.TotalDifficulty.Returns(UInt256.MaxValue);
+            syncPeer.HeadNumber.Returns(headNumber);
+
+            Task task = downloader.DownloadBlocks(peerInfo, new BlocksRequest(), CancellationToken.None);
+            await task.ContinueWith(t => Assert.True(t.IsFaulted));
+
+            Assert.AreEqual(0, ctx.BlockTree.BestSuggestedHeader.Number);
         }
 
         [Test]
@@ -654,7 +634,7 @@ namespace Nethermind.Synchronization.Test
             syncPeer.TotalDifficulty.Returns(UInt256.MaxValue);
             Task<BlockHeader[]> buildHeadersResponse = null;
             syncPeer.GetBlockHeaders(Arg.Any<long>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
-                .Returns(ci => buildHeadersResponse = ctx.ResponseBuilder.BuildHeaderResponse(ci.ArgAt<long>(0), ci.ArgAt<int>(1), Response.AllCorrect | Response.WithTransactions));
+                .Returns(ci => buildHeadersResponse = ctx.ResponseBuilder.BuildHeaderResponse(ci.ArgAt<long>(0), ci.ArgAt<int>(1), Response.AllCorrect));
 
             syncPeer.GetBlockBodies(Arg.Any<IReadOnlyList<Keccak>>(), Arg.Any<CancellationToken>())
                 .Returns(Task.FromException<BlockBody[]>(new TimeoutException()));
@@ -686,7 +666,7 @@ namespace Nethermind.Synchronization.Test
 
             Task<BlockHeader[]> buildHeadersResponse = null;
             syncPeer.GetBlockHeaders(Arg.Any<long>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
-                .Returns(ci => buildHeadersResponse = ctx.ResponseBuilder.BuildHeaderResponse(ci.ArgAt<long>(0), ci.ArgAt<int>(1), Response.AllCorrect | Response.WithTransactions));
+                .Returns(ci => buildHeadersResponse = ctx.ResponseBuilder.BuildHeaderResponse(ci.ArgAt<long>(0), ci.ArgAt<int>(1), Response.AllCorrect));
 
             Task<BlockBody[]> buildBlocksResponse = null;
             syncPeer.GetBlockBodies(Arg.Any<IReadOnlyList<Keccak>>(), Arg.Any<CancellationToken>())
@@ -786,7 +766,7 @@ namespace Nethermind.Synchronization.Test
 
             Task<BlockHeader[]> buildHeadersResponse = null;
             syncPeer.GetBlockHeaders(Arg.Any<long>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
-                .Returns(ci => buildHeadersResponse = ctx.ResponseBuilder.BuildHeaderResponse(ci.ArgAt<long>(0), ci.ArgAt<int>(1), Response.AllCorrect | Response.WithTransactions));
+                .Returns(ci => buildHeadersResponse = ctx.ResponseBuilder.BuildHeaderResponse(ci.ArgAt<long>(0), ci.ArgAt<int>(1), Response.AllCorrect));
 
             Task<BlockBody[]> buildBlocksResponse = null;
             syncPeer.GetBlockBodies(Arg.Any<IReadOnlyList<Keccak>>(), Arg.Any<CancellationToken>())
@@ -817,7 +797,7 @@ namespace Nethermind.Synchronization.Test
             syncPeer.TotalDifficulty.Returns(UInt256.MaxValue);
             Task<BlockHeader[]> buildHeadersResponse = null;
             syncPeer.GetBlockHeaders(Arg.Any<long>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
-                .Returns(ci => buildHeadersResponse = ctx.ResponseBuilder.BuildHeaderResponse(ci.ArgAt<long>(0), ci.ArgAt<int>(1), Response.AllCorrect | Response.WithTransactions));
+                .Returns(ci => buildHeadersResponse = ctx.ResponseBuilder.BuildHeaderResponse(ci.ArgAt<long>(0), ci.ArgAt<int>(1), Response.AllCorrect));
 
             Task<BlockBody[]> buildBlocksResponse = null;
             syncPeer.GetBlockBodies(Arg.Any<IReadOnlyList<Keccak>>(), Arg.Any<CancellationToken>())
@@ -1115,7 +1095,7 @@ namespace Nethermind.Synchronization.Test
                 bool justFirst = flags.HasFlag(Response.JustFirst);
                 bool allKnown = flags.HasFlag(Response.AllKnown);
                 bool timeoutOnFullBatch = flags.HasFlag(Response.TimeoutOnFullBatch);
-                bool withTransaction = flags.HasFlag(Response.WithTransactions);
+                bool noBody = flags.HasFlag(Response.NoBody);
 
                 if (timeoutOnFullBatch && number == SyncBatchSize.Max)
                 {
@@ -1130,18 +1110,9 @@ namespace Nethermind.Synchronization.Test
                     for (int i = 1; i < number; i++)
                     {
                         Keccak receiptRoot = i == 1 ? Keccak.EmptyTreeHash : new Keccak("0x9904791428367d3f36f2be68daf170039dd0b3d6b23da00697de816a05fb5cc1");
-                        BlockHeaderBuilder blockHeaderBuilder = consistent
-                            ? Build.A.BlockHeader.WithReceiptsRoot(receiptRoot).WithParent(headers[i - 1])
-                            : Build.A.BlockHeader.WithReceiptsRoot(receiptRoot).WithNumber(headers[i - 1].Number + 1);
-
-                        if (withTransaction)
-                        {
-                            // We don't know the TX root yet, it should be populated by `BuildBlocksResponse` and `BuildReceiptsResponse`.
-                            blockHeaderBuilder.WithTransactionsRoot(Keccak.Compute("something"));
-                            blockHeaderBuilder.WithReceiptsRoot(Keccak.Compute("something"));
-                        }
-
-                        headers[i] = blockHeaderBuilder.TestObject;
+                        headers[i] = consistent
+                            ? Build.A.BlockHeader.WithReceiptsRoot(receiptRoot).WithParent(headers[i - 1]).WithUnclesHash(noBody ? Keccak.OfAnEmptySequenceRlp : Keccak.Zero).TestObject
+                            : Build.A.BlockHeader.WithReceiptsRoot(receiptRoot).WithNumber(headers[i - 1].Number + 1).TestObject;
 
                         if (allKnown)
                         {
@@ -1187,21 +1158,7 @@ namespace Nethermind.Synchronization.Test
 
                 BlockHeader[] blockHeaders = new BlockHeader[blockHashes.Count];
                 BlockBody[] blockBodies = new BlockBody[blockHashes.Count];
-
-                Block BuildBlockForHeader(BlockHeader header, int txSeed)
-                {
-                    BlockBuilder blockBuilder = Build.A.Block.WithHeader(header);
-
-                    if (withTransactions && header.TxRoot != Keccak.EmptyTreeHash)
-                    {
-                        blockBuilder.WithTransactions(Build.A.Transaction.WithValue(txSeed * 2).SignedAndResolved().TestObject,
-                            Build.A.Transaction.WithValue(txSeed * 2 + 1).SignedAndResolved().TestObject);
-                    }
-
-                    return blockBuilder.TestObject;
-                }
-
-                blockBodies[0] = BuildBlockForHeader(startHeader, 0).Body;
+                blockBodies[0] = new BlockBody(new Transaction[0], new BlockHeader[0]);
                 blockHeaders[0] = startHeader;
 
                 _bodies[startHeader.Hash] = blockBodies[0];
@@ -1220,8 +1177,16 @@ namespace Nethermind.Synchronization.Test
                             ? blockHeaders[i]
                             : blockHeaders[i - 1];
 
-                        Block block = BuildBlockForHeader(header, i);
-                        blockBodies[i] = block.Body;
+                        BlockBuilder blockBuilder = Build.A.Block.WithHeader(header);
+
+                        if (withTransactions && header.ReceiptsRoot != Keccak.EmptyTreeHash)
+                        {
+                            blockBuilder.WithTransactions(Build.A.Transaction.WithValue(i * 2).SignedAndResolved().TestObject,
+                                Build.A.Transaction.WithValue(i * 2 + 1).SignedAndResolved().TestObject);
+                        }
+
+                        Block block = blockBuilder.TestObject;
+                        blockBodies[i] = new BlockBody(block.Transactions, block.Uncles);
                         _bodies[blockHashes[i]] = blockBodies[i];
 
                         if (allKnown)

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorBeaconTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorBeaconTests.cs
@@ -1,19 +1,19 @@
 ﻿//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using Nethermind.Synchronization.ParallelSync;
 using NUnit.Framework;
@@ -48,15 +48,15 @@ public class MultiSyncModeSelectorBeaconTests : MultiSyncModeSelectorTestsBase
     /// <returns>Enhanced expectations based on beacon sync mode.</returns>
     private SyncMode GetBeaconSyncExpectations(SyncMode baseExpectations)
     {
-        // when beacon control mode, Disconnected, Fill, FastSync, StateNodes, SnapSync are ignored, instead we are waiting from block from beacon node  
+        // when beacon control mode, Disconnected, Fill, FastSync, StateNodes, SnapSync are ignored, instead we are waiting from block from beacon node
         baseExpectations = ChangeSyncMode(BeaconSync.ControlMode, baseExpectations, SyncMode.WaitingForBlock, true, SyncMode.Disconnected, SyncMode.Full, SyncMode.FastSync, SyncMode.StateNodes, SyncMode.SnapSync);
-        
+
         // when beacon control mode, FastHeaders, FastBodies, FastReceipts, are run in parallel with waiting from block from beacon node
         baseExpectations = ChangeSyncMode(BeaconSync.ControlMode, baseExpectations, SyncMode.WaitingForBlock, false, SyncMode.FastHeaders, SyncMode.FastBodies, SyncMode.FastReceipts);
-        
+
         // when beacon headers, WaitingForBlock, Fill, FastSync, StateNodes, SnapSync are ignored, instead we are syncing beacon headers
         baseExpectations = ChangeSyncMode(BeaconSync.Headers, baseExpectations, SyncMode.BeaconHeaders, true, SyncMode.WaitingForBlock, SyncMode.Full, SyncMode.FastSync, SyncMode.StateNodes, SyncMode.SnapSync);
-        
+
         // when beacon headers, FastHeaders, FastBodies, FastReceipts, are run in parallel with beacon headers
         baseExpectations = ChangeSyncMode(BeaconSync.Headers, baseExpectations, SyncMode.BeaconHeaders, false, SyncMode.FastHeaders, SyncMode.FastBodies, SyncMode.FastReceipts);
         return baseExpectations;

--- a/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
@@ -329,6 +329,7 @@ namespace Nethermind.Synchronization.Test
                 }
                 IBlockCacheService blockCacheService = new BlockCacheService();
                 PoSSwitcher poSSwitcher = new(mergeConfig, syncConfig, dbProvider.MetadataDb, BlockTree, new SingleReleaseSpecProvider(Constantinople.Instance, 1), _logManager);
+                IBeaconPivot beaconPivot = new BeaconPivot(syncConfig, dbProvider.MetadataDb, BlockTree, _logManager);
 
                 ProgressTracker progressTracker = new(BlockTree, dbProvider.StateDb, LimboLogs.Instance);
                 SnapProvider snapProvider = new(progressTracker, dbProvider, LimboLogs.Instance);
@@ -345,7 +346,7 @@ namespace Nethermind.Synchronization.Test
                 if (IsMerge(synchronizerType))
                     SyncPeerPool = new SyncPeerPool(BlockTree, stats,
                         new MergeBetterPeerStrategy(
-                            new TotalDifficultyBetterPeerStrategy(LimboLogs.Instance), poSSwitcher, LimboLogs.Instance), 25, _logManager);
+                            new TotalDifficultyBetterPeerStrategy(LimboLogs.Instance), poSSwitcher, beaconPivot, LimboLogs.Instance), 25, _logManager);
                 else
                     SyncPeerPool = new SyncPeerPool(BlockTree, stats,
                         new TotalDifficultyBetterPeerStrategy(LimboLogs.Instance), 25,
@@ -355,7 +356,7 @@ namespace Nethermind.Synchronization.Test
                 IBetterPeerStrategy bestPeerStrategy;
                 bestPeerStrategy = IsMerge(synchronizerType)
                     ? new MergeBetterPeerStrategy(totalDifficultyBetterPeerStrategy,
-                        poSSwitcher, LimboLogs.Instance)
+                        poSSwitcher, beaconPivot, LimboLogs.Instance)
                     : totalDifficultyBetterPeerStrategy;
 
                 MultiSyncModeSelector syncModeSelector = new(syncProgressResolver, SyncPeerPool,
@@ -366,14 +367,13 @@ namespace Nethermind.Synchronization.Test
                 IBlockDownloaderFactory blockDownloaderFactory;
                 if (IsMerge(synchronizerType))
                 {
-                    IBeaconPivot beaconPivot = new BeaconPivot(syncConfig, dbProvider.MetadataDb,
-                        BlockTree, _logManager);
                     SyncReport syncReport = new(SyncPeerPool, stats, syncModeSelector, syncConfig, beaconPivot, _logManager);
                     blockDownloaderFactory = new MergeBlockDownloaderFactory(
                         poSSwitcher,
                         beaconPivot,
                         MainnetSpecProvider.Instance,
                         BlockTree,
+                        blockCacheService,
                         NullReceiptStorage.Instance,
                         Always.Valid,
                         Always.Valid,
@@ -381,7 +381,6 @@ namespace Nethermind.Synchronization.Test
                         syncConfig,
                         bestPeerStrategy,
                         syncReport,
-                        invalidChainTracker,
                         syncProgressResolver,
                         _logManager
                     );
@@ -399,6 +398,7 @@ namespace Nethermind.Synchronization.Test
                         pivot,
                         poSSwitcher,
                         mergeConfig,
+                        invalidChainTracker,
                         _logManager,
                         syncReport);
                 }

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloadContext.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloadContext.cs
@@ -34,7 +34,8 @@ namespace Nethermind.Synchronization.Blocks
         private readonly bool _downloadReceipts;
         private readonly IReceiptsRecovery _receiptsRecovery;
 
-        public BlockDownloadContext(ISpecProvider specProvider, PeerInfo syncPeer, BlockHeader?[] headers, bool downloadReceipts, IReceiptsRecovery receiptsRecovery)
+        public BlockDownloadContext(ISpecProvider specProvider, PeerInfo syncPeer, BlockHeader?[] headers,
+            bool downloadReceipts, IReceiptsRecovery receiptsRecovery)
         {
             _indexMapping = new Dictionary<int, int>();
             _downloadReceipts = downloadReceipts;
@@ -127,6 +128,12 @@ namespace Nethermind.Synchronization.Blocks
             }
 
             return result;
+        }
+
+        public Block GetBlockByRequestIdx(int index)
+        {
+            int mappedIndex = _indexMapping[index];
+            return Blocks[mappedIndex];
         }
 
         private void ValidateReceipts(Block block, TxReceipt[] blockReceipts)

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloadContext.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloadContext.cs
@@ -34,8 +34,7 @@ namespace Nethermind.Synchronization.Blocks
         private readonly bool _downloadReceipts;
         private readonly IReceiptsRecovery _receiptsRecovery;
 
-        public BlockDownloadContext(ISpecProvider specProvider, PeerInfo syncPeer, BlockHeader?[] headers,
-            bool downloadReceipts, IReceiptsRecovery receiptsRecovery)
+        public BlockDownloadContext(ISpecProvider specProvider, PeerInfo syncPeer, BlockHeader?[] headers, bool downloadReceipts, IReceiptsRecovery receiptsRecovery)
         {
             _indexMapping = new Dictionary<int, int>();
             _downloadReceipts = downloadReceipts;
@@ -128,12 +127,6 @@ namespace Nethermind.Synchronization.Blocks
             }
 
             return result;
-        }
-
-        public Block GetBlockByRequestIdx(int index)
-        {
-            int mappedIndex = _indexMapping[index];
-            return Blocks[mappedIndex];
         }
 
         private void ValidateReceipts(Block block, TxReceipt[] blockReceipts)

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
@@ -341,10 +341,6 @@ namespace Nethermind.Synchronization.Blocks
 
                     Block currentBlock = blocks[blockIndex];
                     if (_logger.IsTrace) _logger.Trace($"Received {currentBlock} from {bestPeer}");
-                    if (currentBlock.Header.HasBody && currentBlock.Body.IsEmpty)
-                    {
-                        throw new EthSyncException($"{bestPeer} didn't send body for block {currentBlock.ToString(Block.Format.Short)}.");
-                    }
 
                     // can move this to block tree now?
                     if (!_blockValidator.ValidateSuggestedBlock(currentBlock))
@@ -461,12 +457,6 @@ namespace Nethermind.Synchronization.Blocks
                     context.SetBody(i + offset, result[i]);
                 }
 
-                if (result.Length == 0)
-                {
-                    if (_logger.IsTrace) _logger.Trace($"Peer sent no bodies. Peer: {peer}, Request: {hashesToRequest.Count}");
-                    return;
-                }
-
                 offset += result.Length;
             }
         }
@@ -485,13 +475,7 @@ namespace Nethermind.Synchronization.Blocks
                 for (int i = 0; i < result.Length; i++)
                 {
                     TxReceipt[] txReceipts = result[i];
-                    Block block = context.GetBlockByRequestIdx(i + offset);
-                    if (block.Header.HasBody && block.Transactions.Length == 0)
-                    {
-                        if (_logger.IsTrace) _logger.Trace($"Found incomplete blocks. {block.Hash}");
-                        return;
-                    }
-                    if (!context.TrySetReceipts(i + offset, txReceipts, out block))
+                    if (!context.TrySetReceipts(i + offset, txReceipts, out Block block))
                     {
                         throw new EthSyncException($"{peer} sent invalid receipts for block {block.ToString(Block.Format.Short)}.");
                     }

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
@@ -341,6 +341,10 @@ namespace Nethermind.Synchronization.Blocks
 
                     Block currentBlock = blocks[blockIndex];
                     if (_logger.IsTrace) _logger.Trace($"Received {currentBlock} from {bestPeer}");
+                    if (currentBlock.Header.HasBody && currentBlock.Body.IsEmpty)
+                    {
+                        throw new EthSyncException($"{bestPeer} didn't send body for block {currentBlock.ToString(Block.Format.Short)}.");
+                    }
 
                     // can move this to block tree now?
                     if (!_blockValidator.ValidateSuggestedBlock(currentBlock))
@@ -457,6 +461,12 @@ namespace Nethermind.Synchronization.Blocks
                     context.SetBody(i + offset, result[i]);
                 }
 
+                if (result.Length == 0)
+                {
+                    if (_logger.IsTrace) _logger.Trace($"Peer sent no bodies. Peer: {peer}, Request: {hashesToRequest.Count}");
+                    return;
+                }
+
                 offset += result.Length;
             }
         }
@@ -475,7 +485,13 @@ namespace Nethermind.Synchronization.Blocks
                 for (int i = 0; i < result.Length; i++)
                 {
                     TxReceipt[] txReceipts = result[i];
-                    if (!context.TrySetReceipts(i + offset, txReceipts, out Block block))
+                    Block block = context.GetBlockByRequestIdx(i + offset);
+                    if (block.Header.HasBody && block.Transactions.Length == 0)
+                    {
+                        if (_logger.IsTrace) _logger.Trace($"Found incomplete blocks. {block.Hash}");
+                        return;
+                    }
+                    if (!context.TrySetReceipts(i + offset, txReceipts, out block))
                     {
                         throw new EthSyncException($"{peer} sent invalid receipts for block {block.ToString(Block.Format.Short)}.");
                     }

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastBlocksSelectionStrategy.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastBlocksSelectionStrategy.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -41,7 +41,7 @@ namespace Nethermind.Synchronization.FastBlocks
             // In order to support that we need to support another pivot
             { ChainId.Kovan, new Dictionary<long, ulong> { {148240, 19430113280} } }
         };
-        
+
         private readonly ILogger _logger;
         private readonly ISyncPeerPool _syncPeerPool;
         protected readonly ISyncReport _syncReport;
@@ -60,12 +60,12 @@ namespace Nethermind.Synchronization.FastBlocks
         protected long _pivotNumber;
 
         /// <summary>
-        /// Requests awaiting to be sent - these are results of partial or invalid responses being queued again 
+        /// Requests awaiting to be sent - these are results of partial or invalid responses being queued again
         /// </summary>
         protected readonly ConcurrentQueue<HeadersSyncBatch> _pending = new();
 
         /// <summary>
-        /// Requests sent to peers for which responses have not been received yet  
+        /// Requests sent to peers for which responses have not been received yet
         /// </summary>
         protected readonly ConcurrentDictionary<HeadersSyncBatch, object> _sent = new();
 
@@ -73,7 +73,7 @@ namespace Nethermind.Synchronization.FastBlocks
         /// Responses received from peers but waiting in a queue for some other requests to be handled first
         /// </summary>
         protected readonly ConcurrentDictionary<long, HeadersSyncBatch> _dependencies = new();
-        
+
         protected virtual BlockHeader? LowestInsertedBlockHeader => _blockTree.LowestInsertedHeader;
 
         protected virtual MeasuredProgress HeadersSyncProgressReport => _syncReport.FastBlocksHeaders;
@@ -83,7 +83,7 @@ namespace Nethermind.Synchronization.FastBlocks
         private bool AnyHeaderDownloaded => LowestInsertedBlockHeader != null;
 
         private long HeadersInQueue => _dependencies.Sum(hd => hd.Value.Response?.Length ?? 0);
-        
+
         private ulong MemoryInQueue => (ulong)_dependencies
             .Sum(d => (d.Value.Response ?? Array.Empty<BlockHeader>()).Sum(h =>
                 // ReSharper disable once ConvertClosureToMethodGroup
@@ -132,13 +132,13 @@ namespace Nethermind.Synchronization.FastBlocks
         }
 
         protected virtual bool StartingFeedCondition() => _syncConfig.FastBlocks;
-        
+
         protected override SyncMode ActivationSyncModes { get; }
             = SyncMode.FastHeaders & ~SyncMode.FastBlocks;
 
         public override bool IsMultiFeed => true;
         public override AllocationContexts Contexts => AllocationContexts.Headers;
-        
+
         private bool ShouldBuildANewBatch()
         {
             bool destinationHeaderRequested = _lowestRequestedHeaderNumber == HeadersDestinationNumber;
@@ -168,7 +168,7 @@ namespace Nethermind.Synchronization.FastBlocks
             Finish();
             PostFinishCleanUp();
         }
-        
+
         protected virtual void PostFinishCleanUp()
         {
             HeadersSyncProgressReport.Update(_pivotNumber);
@@ -272,7 +272,7 @@ namespace Nethermind.Synchronization.FastBlocks
                 if(_logger.IsDebug) _logger.Debug("Received a NULL batch as a response");
                 return SyncResponseHandlingResult.InternalError;
             }
-            
+
             if ((batch.Response?.Length ?? 0) == 0)
             {
                 batch.MarkHandlingStart();
@@ -340,7 +340,7 @@ namespace Nethermind.Synchronization.FastBlocks
             {
                 return 0;
             }
-            
+
             if (batch.Response.Length > batch.RequestSize)
             {
                 if (_logger.IsDebug)

--- a/src/Nethermind/Nethermind.Synchronization/IPivot.cs
+++ b/src/Nethermind/Nethermind.Synchronization/IPivot.cs
@@ -1,19 +1,19 @@
 ﻿//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using Nethermind.Core.Crypto;
 using Nethermind.Int256;
@@ -26,8 +26,10 @@ namespace Nethermind.Synchronization
 
         Keccak? PivotHash { get; }
 
+        Keccak? PivotParentHash { get; }
+
         UInt256? PivotTotalDifficulty { get; }
-        
+
         long PivotDestinationNumber { get; }
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
@@ -188,8 +188,7 @@ namespace Nethermind.Synchronization.ParallelSync
                         }
                         else
                         {
-                            bool anyPeers = peerBlock.Value > 0 && _betterPeerStrategy.IsBetterThanLocalChain((peerDifficulty.Value, peerBlock.Value), (best.ChainDifficulty, best.Block));
-                            if (anyPeers)
+                            if (ShouldBeInFullSyncModeInArchiveMode(best))
                             {
                                 newModes = SyncMode.Full;
                             }
@@ -294,7 +293,7 @@ namespace Nethermind.Synchronization.ParallelSync
         /// <param name="best">Snapshot of the best known states</param>
         /// <returns>A string describing the state of sync</returns>
         private static string BuildStateString(Snapshot best) =>
-            $"processed:{best.Processed}|state:{best.State}|block:{best.Block}|header:{best.Header}|peer block:{best.Peer.Block}";
+            $"processed:{best.Processed}|state:{best.State}|block:{best.Block}|header:{best.Header}|chain difficulty:{best.ChainDifficulty}|peer block:{best.Peer.Block}|peer total difficulty:{best.Peer.TotalDifficulty}";
 
         private bool IsInAStickyFullSyncMode(Snapshot best)
         {
@@ -410,6 +409,30 @@ namespace Nethermind.Synchronization.ParallelSync
                     (nameof(postPivotPeerAvailable), postPivotPeerAvailable),
                     (nameof(hasFastSyncBeenActive), hasFastSyncBeenActive),
                     (nameof(notInFastSync), notInFastSync),
+                    (nameof(notInStateSync), notInStateSync),
+                    (nameof(notNeedToWaitForHeaders), notNeedToWaitForHeaders));
+            }
+
+            return result;
+        }
+
+        private bool ShouldBeInFullSyncModeInArchiveMode(Snapshot best)
+        {
+            bool notInBeaconModes = !best.IsInAnyBeaconMode;
+            bool desiredPeerKnown = AnyDesiredPeerKnown(best);
+            bool notInStateSync = !best.IsInStateSync;
+            bool notNeedToWaitForHeaders = NotNeedToWaitForHeaders;
+
+            bool result = notInBeaconModes &&
+                          desiredPeerKnown &&
+                          notInStateSync &&
+                          notNeedToWaitForHeaders;
+
+            if (_logger.IsTrace)
+            {
+                LogDetailedSyncModeChecks("FULL",
+                    (nameof(notInBeaconModes), notInBeaconModes),
+                    (nameof(desiredPeerKnown), desiredPeerKnown),
                     (nameof(notInStateSync), notInStateSync),
                     (nameof(notNeedToWaitForHeaders), notNeedToWaitForHeaders));
             }

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
@@ -420,21 +420,15 @@ namespace Nethermind.Synchronization.ParallelSync
         {
             bool notInBeaconModes = !best.IsInAnyBeaconMode;
             bool desiredPeerKnown = AnyDesiredPeerKnown(best);
-            bool notInStateSync = !best.IsInStateSync;
-            bool notNeedToWaitForHeaders = NotNeedToWaitForHeaders;
 
             bool result = notInBeaconModes &&
-                          desiredPeerKnown &&
-                          notInStateSync &&
-                          notNeedToWaitForHeaders;
+                          desiredPeerKnown;
 
             if (_logger.IsTrace)
             {
                 LogDetailedSyncModeChecks("FULL",
                     (nameof(notInBeaconModes), notInBeaconModes),
-                    (nameof(desiredPeerKnown), desiredPeerKnown),
-                    (nameof(notInStateSync), notInStateSync),
-                    (nameof(notNeedToWaitForHeaders), notNeedToWaitForHeaders));
+                    (nameof(desiredPeerKnown), desiredPeerKnown));
             }
 
             return result;

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncFeed.cs
@@ -1,20 +1,21 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Synchronization.Peers;
 
@@ -30,7 +31,7 @@ namespace Nethermind.Synchronization.ParallelSync
         public int FeedId { get; } = FeedIdProvider.AssignId();
         public SyncFeedState CurrentState { get; private set; }
         public event EventHandler<SyncFeedStateEventArgs>? StateChanged;
-        
+
         private void ChangeState(SyncFeedState newState)
         {
             if (CurrentState == SyncFeedState.Finished)
@@ -41,7 +42,7 @@ namespace Nethermind.Synchronization.ParallelSync
             CurrentState = newState;
             StateChanged?.Invoke(this, new SyncFeedStateEventArgs(newState));
 
-            if (CurrentState == SyncFeedState.Finished)
+            if (newState == SyncFeedState.Finished)
             {
                 _taskCompletionSource.SetResult();
             }

--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -57,7 +57,7 @@ namespace Nethermind.Synchronization.Peers
 
         private readonly ConcurrentDictionary<PublicKey, CancellationTokenSource> _refreshCancelTokens = new();
         private readonly ConcurrentDictionary<SyncPeerAllocation, object?> _replaceableAllocations = new();
-        
+
         private readonly INodeStatsManager _stats;
         private readonly IBetterPeerStrategy _betterPeerStrategy;
         private readonly int _allocationsUpgradeIntervalInMs;
@@ -82,7 +82,7 @@ namespace Nethermind.Synchronization.Peers
             : this(blockTree, nodeStatsManager, betterPeerStrategy, peersMaxCount, DefaultUpgradeIntervalInMs, logManager)
         {
         }
-        
+
         public SyncPeerPool(IBlockTree blockTree,
             INodeStatsManager nodeStatsManager,
             IBetterPeerStrategy betterPeerStrategy,
@@ -108,7 +108,7 @@ namespace Nethermind.Synchronization.Peers
             PriorityPeerMaxCount = priorityPeerMaxCount;
             _allocationsUpgradeIntervalInMs = allocationsUpgradeIntervalInMsInMs;
             _logger = logManager.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
-            
+
             if (_logger.IsDebug) _logger.Debug($"PeerMaxCount: {PeerMaxCount}, PriorityPeerMaxCount: {PriorityPeerMaxCount}");
         }
 
@@ -201,7 +201,7 @@ namespace Nethermind.Synchronization.Peers
                 foreach ((_, PeerInfo peerInfo) in _peers) yield return peerInfo;
             }
         }
-        
+
         public IEnumerable<PeerInfo> NonStaticPeers
         {
             get
@@ -266,18 +266,18 @@ namespace Nethermind.Synchronization.Peers
                 if (_logger.IsDebug) _logger.Debug($"Sync peer {syncPeer.Node:c} already in peers collection.");
                 return;
             }
-            
+
             PeerInfo peerInfo = new(syncPeer);
             _peers.TryAdd(syncPeer.Node.Id, peerInfo);
             Metrics.SyncPeers = _peers.Count;
-            
+
             if (syncPeer.IsPriority)
             {
                 Interlocked.Increment(ref PriorityPeerCount);
                 Metrics.PriorityPeers = PriorityPeerCount;
             }
             if (_logger.IsDebug) _logger.Debug($"PeerCount: {PeerCount}, PriorityPeerCount: {PriorityPeerCount}");
-            
+
             BlockHeader? header = _blockTree.FindHeader(syncPeer.HeadHash, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
             if (header is not null)
             {
@@ -316,14 +316,14 @@ namespace Nethermind.Synchronization.Peers
             }
 
             Metrics.SyncPeers = _peers.Count;
-            
+
             if (syncPeer.IsPriority)
             {
                 Interlocked.Decrement(ref PriorityPeerCount);
                 Metrics.PriorityPeers = PriorityPeerCount;
             }
             if (_logger.IsDebug) _logger.Debug($"PeerCount: {PeerCount}, PriorityPeerCount: {PriorityPeerCount}");
-            
+
             foreach ((SyncPeerAllocation allocation, _) in _replaceableAllocations)
             {
                 if (allocation.Current?.SyncPeer.Node.Id == id)
@@ -375,7 +375,7 @@ namespace Nethermind.Synchronization.Peers
                 if (timeoutReached) return SyncPeerAllocation.FailedAllocation;
 
                 int waitTime = 10 * tryCount++;
-                
+
                 if (!_signals.SafeWaitHandle.IsClosed)
                 {
                     await _signals.WaitOneAsync(waitTime, _refreshLoopCancellation.Token);

--- a/src/Nethermind/Nethermind.Synchronization/Pivot.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Pivot.cs
@@ -1,19 +1,19 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using System;
 using Nethermind.Blockchain.Synchronization;
@@ -25,7 +25,7 @@ namespace Nethermind.Synchronization;
 public class Pivot : IPivot
 {
     private readonly ISyncConfig _syncconfig;
-    
+
     public Pivot(ISyncConfig syncConfig)
     {
         _syncconfig = syncConfig ?? throw new ArgumentNullException(nameof(syncConfig));
@@ -35,12 +35,14 @@ public class Pivot : IPivot
         PivotTotalDifficulty = _syncconfig.PivotTotalDifficultyParsed;
         PivotDestinationNumber = 0L;
     }
-    
+
     public long PivotNumber { get; }
 
     public Keccak? PivotHash { get; }
 
+    public Keccak? PivotParentHash => null;
+
     public UInt256? PivotTotalDifficulty { get; }
-        
+
     public long PivotDestinationNumber { get; }
 }


### PR DESCRIPTION
Fixes some hive tests, notably several `Invalid Ancestor Reorg`.

## Changes:
- Copied some logic from https://github.com/NethermindEth/nethermind/pull/4279
- BeaconHeaderSync targets pivot-1.
- Peer allocation adjusted accordingly. 
- InvalidChainTracker set child parent on beacon header sync instead of in merge block downloader so that the chain is connected when it start processing later.
- Fixed an issue where if the block downloader downloads bodies from peer where none of the header hash was available, the peer will response with zero bodies which triggers an infinite loop. Fixes by have block downloader stop downloading part way and only insert until it found a block without a body when it should have one.
- Make sure MergeBlockDownloader does not request block higher than what the peer have.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [X] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [X] No

**Comments about testing , should you have some** (optional)

- Only 1 out of 131 hive test failed after https://github.com/ethereum/hive/pull/6217 .
- Ropsten can sync to head.

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...