### PR TITLE
RLP Encode Long Improvements

### DIFF
--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -412,55 +412,20 @@ namespace Nethermind.Serialization.Rlp
                 return OfEmptyByteArray;
             }
 
-            if (value > 0)
-            {
-                byte byte6 = (byte) (value >> 8);
-                byte byte5 = (byte) (value >> 16);
-                byte byte4 = (byte) (value >> 24);
-                byte byte3 = (byte) (value >> 32);
-                byte byte2 = (byte) (value >> 40);
-                byte byte1 = (byte) (value >> 48);
-                byte byte0 = (byte) (value >> 56);
-
-                if (value < 256L * 256L * 256L * 256L * 256L * 256L * 256L)
+            return value > 0
+                ? value switch
                 {
-                    if (value < 256L * 256L * 256L * 256L * 256L * 256L)
-                    {
-                        if (value < 256L * 256L * 256L * 256L * 256L)
-                        {
-                            if (value < 256L * 256L * 256L * 256L)
-                            {
-                                if (value < 256 * 256 * 256)
-                                {
-                                    if (value < 256 * 256)
-                                    {
-                                        if (value < 128)
-                                        {
-                                            return new Rlp((byte) value);
-                                        }
-
-                                        return value < 256 ? new Rlp(new byte[] {129, (byte) value}) : new Rlp(new byte[] {130, byte6, (byte) value});
-                                    }
-
-                                    return new Rlp(new byte[] {131, byte5, byte6, (byte) value});
-                                }
-
-                                return new Rlp(new byte[] {132, byte4, byte5, byte6, (byte) value});
-                            }
-
-                            return new Rlp(new byte[] {133, byte3, byte4, byte5, byte6, (byte) value});
-                        }
-
-                        return new Rlp(new byte[] {134, byte2, byte3, byte4, byte5, byte6, (byte) value});
-                    }
-
-                    return new Rlp(new byte[] {135, byte1, byte2, byte3, byte4, byte5, byte6, (byte) value});
+                    < 128 => new Rlp((byte)value),
+                    < 256 => new Rlp(new byte[] { 129, (byte)value }),
+                    < 256 * 256 => new Rlp(new byte[] { 130, (byte)(value >> 8), (byte)value }),
+                    < 256 * 256 * 256 => new Rlp(new byte[] { 131, (byte)(value >> 16), (byte)(value >> 8), (byte)value }),
+                    < 256L * 256 * 256 * 256 => new Rlp(new byte[] { 132, (byte)(value >> 24), (byte)(value >> 16), (byte)(value >> 8), (byte)value }),
+                    < 256L * 256 * 256 * 256 * 256 => new Rlp(new byte[] { 133, (byte)(value >> 32), (byte)(value >> 24), (byte)(value >> 16), (byte)(value >> 8), (byte)value }),
+                    < 256L * 256 * 256 * 256 * 256 * 256 => new Rlp(new byte[] { 134, (byte)(value >> 40), (byte)(value >> 32), (byte)(value >> 24), (byte)(value >> 16), (byte)(value >> 8), (byte)value }),
+                    < 256L * 256 * 256 * 256 * 256 * 256 * 256 => new Rlp(new byte[] { 135, (byte)(value >> 48), (byte)(value >> 40), (byte)(value >> 32), (byte)(value >> 24), (byte)(value >> 16), (byte)(value >> 8), (byte)value }),
+                    _ => new Rlp(new byte[] { 136, (byte)(value >> 56), (byte)(value >> 48), (byte)(value >> 40), (byte)(value >> 32), (byte)(value >> 24), (byte)(value >> 16), (byte)(value >> 8), (byte)value })
                 }
-
-                return new Rlp(new byte[] {136, byte0, byte1, byte2, byte3, byte4, byte5, byte6, (byte) value});
-            }
-
-            return Encode(new BigInteger(value), 8);
+                : Encode(new BigInteger(value), 8);
         }
 
         public static Rlp Encode(BigInteger bigInteger, int outputLength = -1)


### PR DESCRIPTION
## Changes:
RLP Encode Long implementation

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No

## Further comments (optional)
Benchmark is as below. you can see a slight improvement in scenario 2-12 (scenarios 1 and 2 are for negative values. the current code does not touch that.) the improvement in performance  becomes less the larger the number.

```
// ***** BenchmarkRunner: Finish  *****

// * Export *
// * Detailed results *
RlpEncodeLongBenchmark.Improved: Job-TCVVKM(Toolchain=InProcessEmitToolchain) [ScenarioIndex=0]
Runtime = ; GC =
Mean = 109.491 ns, StdErr = 0.368 ns (0.34%), N = 13, StdDev = 1.326 ns
Min = 107.897 ns, Q1 = 108.552 ns, Median = 108.987 ns, Q3 = 110.066 ns, Max = 112.685 ns
IQR = 1.514 ns, LowerFence = 106.282 ns, UpperFence = 112.336 ns
ConfidenceInterval = [107.902 ns; 111.079 ns] (CI 99.9%), Margin = 1.589 ns (1.45% of Mean)
Skewness = 0.96, Kurtosis = 3.02, MValue = 2
-------------------- Histogram --------------------
[107.157 ns ; 110.118 ns) | @@@@@@@@@@
[110.118 ns ; 113.426 ns) | @@@
---------------------------------------------------

RlpEncodeLongBenchmark.Current: Job-TCVVKM(Toolchain=InProcessEmitToolchain) [ScenarioIndex=0]
Runtime = ; GC =
Mean = 107.762 ns, StdErr = 0.320 ns (0.30%), N = 13, StdDev = 1.153 ns
Min = 105.640 ns, Q1 = 106.822 ns, Median = 107.795 ns, Q3 = 108.548 ns, Max = 109.639 ns
IQR = 1.726 ns, LowerFence = 104.233 ns, UpperFence = 111.136 ns
ConfidenceInterval = [106.381 ns; 109.142 ns] (CI 99.9%), Margin = 1.381 ns (1.28% of Mean)
Skewness = -0.14, Kurtosis = 1.96, MValue = 2
-------------------- Histogram --------------------
[104.996 ns ; 110.283 ns) | @@@@@@@@@@@@@
---------------------------------------------------

RlpEncodeLongBenchmark.Improved: Job-TCVVKM(Toolchain=InProcessEmitToolchain) [ScenarioIndex=1]
Runtime = ; GC =
Mean = 131.798 ns, StdErr = 0.299 ns (0.23%), N = 14, StdDev = 1.119 ns
Min = 129.897 ns, Q1 = 130.953 ns, Median = 131.776 ns, Q3 = 132.550 ns, Max = 133.686 ns
IQR = 1.597 ns, LowerFence = 128.557 ns, UpperFence = 134.946 ns
ConfidenceInterval = [130.535 ns; 133.061 ns] (CI 99.9%), Margin = 1.263 ns (0.96% of Mean)
Skewness = -0.02, Kurtosis = 1.74, MValue = 2
-------------------- Histogram --------------------
[129.287 ns ; 134.296 ns) | @@@@@@@@@@@@@@
---------------------------------------------------

RlpEncodeLongBenchmark.Current: Job-TCVVKM(Toolchain=InProcessEmitToolchain) [ScenarioIndex=1]
Runtime = ; GC =
Mean = 130.869 ns, StdErr = 0.270 ns (0.21%), N = 15, StdDev = 1.046 ns
Min = 129.014 ns, Q1 = 130.246 ns, Median = 130.536 ns, Q3 = 131.754 ns, Max = 132.737 ns
IQR = 1.507 ns, LowerFence = 127.985 ns, UpperFence = 134.015 ns
ConfidenceInterval = [129.751 ns; 131.987 ns] (CI 99.9%), Margin = 1.118 ns (0.85% of Mean)
Skewness = 0.27, Kurtosis = 1.92, MValue = 2
-------------------- Histogram --------------------
[128.896 ns ; 133.293 ns) | @@@@@@@@@@@@@@@
---------------------------------------------------

RlpEncodeLongBenchmark.Improved: Job-TCVVKM(Toolchain=InProcessEmitToolchain) [ScenarioIndex=2]
Runtime = ; GC =
Mean = 4.655 ns, StdErr = 0.025 ns (0.54%), N = 14, StdDev = 0.095 ns
Min = 4.519 ns, Q1 = 4.579 ns, Median = 4.644 ns, Q3 = 4.730 ns, Max = 4.819 ns
IQR = 0.151 ns, LowerFence = 4.352 ns, UpperFence = 4.957 ns
ConfidenceInterval = [4.548 ns; 4.761 ns] (CI 99.9%), Margin = 0.107 ns (2.29% of Mean)
Skewness = 0.22, Kurtosis = 1.71, MValue = 2
-------------------- Histogram --------------------
[4.468 ns ; 4.658 ns) | @@@@@@@@@
[4.658 ns ; 4.822 ns) | @@@@@
---------------------------------------------------

RlpEncodeLongBenchmark.Current: Job-TCVVKM(Toolchain=InProcessEmitToolchain) [ScenarioIndex=2]
Runtime = ; GC =
Mean = 5.640 ns, StdErr = 0.018 ns (0.33%), N = 12, StdDev = 0.064 ns
Min = 5.560 ns, Q1 = 5.603 ns, Median = 5.632 ns, Q3 = 5.659 ns, Max = 5.775 ns
IQR = 0.056 ns, LowerFence = 5.519 ns, UpperFence = 5.743 ns
ConfidenceInterval = [5.558 ns; 5.722 ns] (CI 99.9%), Margin = 0.082 ns (1.45% of Mean)
Skewness = 0.6, Kurtosis = 2.37, MValue = 2
-------------------- Histogram --------------------
[5.523 ns ; 5.688 ns) | @@@@@@@@@
[5.688 ns ; 5.811 ns) | @@@
---------------------------------------------------

RlpEncodeLongBenchmark.Improved: Job-TCVVKM(Toolchain=InProcessEmitToolchain) [ScenarioIndex=3]
Runtime = ; GC =
Mean = 17.692 ns, StdErr = 0.056 ns (0.32%), N = 14, StdDev = 0.211 ns
Min = 17.431 ns, Q1 = 17.478 ns, Median = 17.711 ns, Q3 = 17.794 ns, Max = 18.058 ns
IQR = 0.316 ns, LowerFence = 17.005 ns, UpperFence = 18.267 ns
ConfidenceInterval = [17.454 ns; 17.930 ns] (CI 99.9%), Margin = 0.238 ns (1.35% of Mean)
Skewness = 0.18, Kurtosis = 1.66, MValue = 2
-------------------- Histogram --------------------
[17.316 ns ; 18.173 ns) | @@@@@@@@@@@@@@
---------------------------------------------------

RlpEncodeLongBenchmark.Current: Job-TCVVKM(Toolchain=InProcessEmitToolchain) [ScenarioIndex=3]
Runtime = ; GC =
Mean = 20.545 ns, StdErr = 0.106 ns (0.51%), N = 14, StdDev = 0.395 ns
Min = 19.924 ns, Q1 = 20.254 ns, Median = 20.492 ns, Q3 = 20.861 ns, Max = 21.297 ns
IQR = 0.607 ns, LowerFence = 19.343 ns, UpperFence = 21.771 ns
ConfidenceInterval = [20.100 ns; 20.991 ns] (CI 99.9%), Margin = 0.446 ns (2.17% of Mean)
Skewness = 0.34, Kurtosis = 1.91, MValue = 2
-------------------- Histogram --------------------
[19.709 ns ; 20.184 ns) | @@
[20.184 ns ; 20.614 ns) | @@@@@@@@
[20.614 ns ; 21.340 ns) | @@@@
---------------------------------------------------

RlpEncodeLongBenchmark.Improved: Job-TCVVKM(Toolchain=InProcessEmitToolchain) [ScenarioIndex=4]
Runtime = ; GC =
Mean = 20.347 ns, StdErr = 0.128 ns (0.63%), N = 40, StdDev = 0.809 ns
Min = 18.953 ns, Q1 = 19.486 ns, Median = 20.583 ns, Q3 = 21.029 ns, Max = 21.763 ns
IQR = 1.543 ns, LowerFence = 17.172 ns, UpperFence = 23.343 ns
ConfidenceInterval = [19.892 ns; 20.802 ns] (CI 99.9%), Margin = 0.455 ns (2.24% of Mean)
Skewness = -0.06, Kurtosis = 1.54, MValue = 3.43
-------------------- Histogram --------------------
[18.643 ns ; 19.172 ns) | @
[19.172 ns ; 19.794 ns) | @@@@@@@@@@@@@@
[19.794 ns ; 20.531 ns) | @@@@
[20.531 ns ; 21.152 ns) | @@@@@@@@@@@@@@
[21.152 ns ; 21.793 ns) | @@@@@@@
---------------------------------------------------

RlpEncodeLongBenchmark.Current: Job-TCVVKM(Toolchain=InProcessEmitToolchain) [ScenarioIndex=4]
Runtime = ; GC =
Mean = 23.229 ns, StdErr = 0.116 ns (0.50%), N = 14, StdDev = 0.433 ns
Min = 22.505 ns, Q1 = 22.870 ns, Median = 23.380 ns, Q3 = 23.580 ns, Max = 23.723 ns
IQR = 0.710 ns, LowerFence = 21.805 ns, UpperFence = 24.644 ns
ConfidenceInterval = [22.741 ns; 23.717 ns] (CI 99.9%), Margin = 0.488 ns (2.10% of Mean)
Skewness = -0.51, Kurtosis = 1.55, MValue = 2
-------------------- Histogram --------------------
[22.418 ns ; 23.203 ns) | @@@@@
[23.203 ns ; 23.959 ns) | @@@@@@@@@
---------------------------------------------------

RlpEncodeLongBenchmark.Improved: Job-TCVVKM(Toolchain=InProcessEmitToolchain) [ScenarioIndex=5]
Runtime = ; GC =
Mean = 20.216 ns, StdErr = 0.125 ns (0.62%), N = 30, StdDev = 0.682 ns
Min = 19.094 ns, Q1 = 19.699 ns, Median = 19.998 ns, Q3 = 20.715 ns, Max = 21.836 ns
IQR = 1.016 ns, LowerFence = 18.175 ns, UpperFence = 22.238 ns
ConfidenceInterval = [19.760 ns; 20.672 ns] (CI 99.9%), Margin = 0.456 ns (2.26% of Mean)
Skewness = 0.72, Kurtosis = 2.76, MValue = 2
-------------------- Histogram --------------------
[18.806 ns ; 19.462 ns) | @@
[19.462 ns ; 20.352 ns) | @@@@@@@@@@@@@@@@@
[20.352 ns ; 20.929 ns) | @@@@@@@
[20.929 ns ; 21.517 ns) | @@
[21.517 ns ; 22.124 ns) | @@
---------------------------------------------------

RlpEncodeLongBenchmark.Current: Job-TCVVKM(Toolchain=InProcessEmitToolchain) [ScenarioIndex=5]
Runtime = ; GC =
Mean = 22.258 ns, StdErr = 0.116 ns (0.52%), N = 15, StdDev = 0.451 ns
Min = 21.619 ns, Q1 = 21.938 ns, Median = 22.114 ns, Q3 = 22.532 ns, Max = 23.338 ns
IQR = 0.595 ns, LowerFence = 21.045 ns, UpperFence = 23.425 ns
ConfidenceInterval = [21.775 ns; 22.740 ns] (CI 99.9%), Margin = 0.482 ns (2.17% of Mean)
Skewness = 0.68, Kurtosis = 2.8, MValue = 2
-------------------- Histogram --------------------
[21.379 ns ; 22.185 ns) | @@@@@@@@
[22.185 ns ; 22.762 ns) | @@@@@@
[22.762 ns ; 23.578 ns) | @
---------------------------------------------------

RlpEncodeLongBenchmark.Improved: Job-TCVVKM(Toolchain=InProcessEmitToolchain) [ScenarioIndex=6]
Runtime = ; GC =
Mean = 19.151 ns, StdErr = 0.094 ns (0.49%), N = 15, StdDev = 0.363 ns
Min = 18.646 ns, Q1 = 18.912 ns, Median = 19.100 ns, Q3 = 19.331 ns, Max = 19.853 ns
IQR = 0.418 ns, LowerFence = 18.285 ns, UpperFence = 19.958 ns
ConfidenceInterval = [18.763 ns; 19.540 ns] (CI 99.9%), Margin = 0.389 ns (2.03% of Mean)
Skewness = 0.52, Kurtosis = 2.04, MValue = 2
-------------------- Histogram --------------------
[18.452 ns ; 19.163 ns) | @@@@@@@@@@
[19.163 ns ; 19.937 ns) | @@@@@
---------------------------------------------------

RlpEncodeLongBenchmark.Current: Job-TCVVKM(Toolchain=InProcessEmitToolchain) [ScenarioIndex=6]
Runtime = ; GC =
Mean = 21.711 ns, StdErr = 0.083 ns (0.38%), N = 14, StdDev = 0.309 ns
Min = 21.216 ns, Q1 = 21.529 ns, Median = 21.634 ns, Q3 = 21.818 ns, Max = 22.374 ns
IQR = 0.289 ns, LowerFence = 21.095 ns, UpperFence = 22.252 ns
ConfidenceInterval = [21.362 ns; 22.059 ns] (CI 99.9%), Margin = 0.349 ns (1.61% of Mean)
Skewness = 0.58, Kurtosis = 2.44, MValue = 2
-------------------- Histogram --------------------
[21.048 ns ; 21.888 ns) | @@@@@@@@@@@
[21.888 ns ; 22.457 ns) | @@@
---------------------------------------------------

RlpEncodeLongBenchmark.Improved: Job-TCVVKM(Toolchain=InProcessEmitToolchain) [ScenarioIndex=7]
Runtime = ; GC =
Mean = 19.595 ns, StdErr = 0.092 ns (0.47%), N = 15, StdDev = 0.354 ns
Min = 18.838 ns, Q1 = 19.458 ns, Median = 19.546 ns, Q3 = 19.822 ns, Max = 20.156 ns
IQR = 0.363 ns, LowerFence = 18.913 ns, UpperFence = 20.367 ns
ConfidenceInterval = [19.216 ns; 19.974 ns] (CI 99.9%), Margin = 0.379 ns (1.93% of Mean)
Skewness = -0.46, Kurtosis = 2.42, MValue = 2
-------------------- Histogram --------------------
[18.753 ns ; 19.435 ns) | @@@
[19.435 ns ; 20.196 ns) | @@@@@@@@@@@@
---------------------------------------------------

RlpEncodeLongBenchmark.Current: Job-TCVVKM(Toolchain=InProcessEmitToolchain) [ScenarioIndex=7]
Runtime = ; GC =
Mean = 21.306 ns, StdErr = 0.072 ns (0.34%), N = 15, StdDev = 0.279 ns
Min = 20.906 ns, Q1 = 21.142 ns, Median = 21.189 ns, Q3 = 21.461 ns, Max = 21.810 ns
IQR = 0.318 ns, LowerFence = 20.665 ns, UpperFence = 21.938 ns
ConfidenceInterval = [21.008 ns; 21.604 ns] (CI 99.9%), Margin = 0.298 ns (1.40% of Mean)
Skewness = 0.61, Kurtosis = 1.92, MValue = 2
-------------------- Histogram --------------------
[20.757 ns ; 21.391 ns) | @@@@@@@@@@@
[21.391 ns ; 21.921 ns) | @@@@
---------------------------------------------------

RlpEncodeLongBenchmark.Improved: Job-TCVVKM(Toolchain=InProcessEmitToolchain) [ScenarioIndex=8]
Runtime = ; GC =
Mean = 20.542 ns, StdErr = 0.074 ns (0.36%), N = 14, StdDev = 0.275 ns
Min = 20.071 ns, Q1 = 20.328 ns, Median = 20.528 ns, Q3 = 20.661 ns, Max = 21.052 ns
IQR = 0.333 ns, LowerFence = 19.828 ns, UpperFence = 21.161 ns
ConfidenceInterval = [20.231 ns; 20.852 ns] (CI 99.9%), Margin = 0.311 ns (1.51% of Mean)
Skewness = 0.21, Kurtosis = 2.07, MValue = 2
-------------------- Histogram --------------------
[19.984 ns ; 21.123 ns) | @@@@@@@@@@@@@@
---------------------------------------------------

RlpEncodeLongBenchmark.Current: Job-TCVVKM(Toolchain=InProcessEmitToolchain) [ScenarioIndex=8]
Runtime = ; GC =
Mean = 21.399 ns, StdErr = 0.067 ns (0.31%), N = 13, StdDev = 0.240 ns
Min = 21.115 ns, Q1 = 21.205 ns, Median = 21.243 ns, Q3 = 21.611 ns, Max = 21.818 ns
IQR = 0.406 ns, LowerFence = 20.597 ns, UpperFence = 22.219 ns
ConfidenceInterval = [21.111 ns; 21.687 ns] (CI 99.9%), Margin = 0.288 ns (1.35% of Mean)
Skewness = 0.41, Kurtosis = 1.45, MValue = 2
-------------------- Histogram --------------------
[20.981 ns ; 21.819 ns) | @@@@@@@@@@@@@
---------------------------------------------------

RlpEncodeLongBenchmark.Improved: Job-TCVVKM(Toolchain=InProcessEmitToolchain) [ScenarioIndex=9]
Runtime = ; GC =
Mean = 20.961 ns, StdErr = 0.051 ns (0.24%), N = 14, StdDev = 0.190 ns
Min = 20.669 ns, Q1 = 20.829 ns, Median = 20.939 ns, Q3 = 21.079 ns, Max = 21.367 ns
IQR = 0.250 ns, LowerFence = 20.454 ns, UpperFence = 21.454 ns
ConfidenceInterval = [20.747 ns; 21.175 ns] (CI 99.9%), Margin = 0.214 ns (1.02% of Mean)
Skewness = 0.39, Kurtosis = 2.29, MValue = 2
-------------------- Histogram --------------------
[20.566 ns ; 21.470 ns) | @@@@@@@@@@@@@@
---------------------------------------------------

RlpEncodeLongBenchmark.Current: Job-TCVVKM(Toolchain=InProcessEmitToolchain) [ScenarioIndex=9]
Runtime = ; GC =
Mean = 30.281 ns, StdErr = 0.053 ns (0.17%), N = 13, StdDev = 0.191 ns
Min = 30.016 ns, Q1 = 30.138 ns, Median = 30.235 ns, Q3 = 30.409 ns, Max = 30.657 ns
IQR = 0.270 ns, LowerFence = 29.733 ns, UpperFence = 30.814 ns
ConfidenceInterval = [30.052 ns; 30.509 ns] (CI 99.9%), Margin = 0.229 ns (0.76% of Mean)
Skewness = 0.55, Kurtosis = 1.98, MValue = 2
-------------------- Histogram --------------------
[29.910 ns ; 30.764 ns) | @@@@@@@@@@@@@
---------------------------------------------------

RlpEncodeLongBenchmark.Improved: Job-TCVVKM(Toolchain=InProcessEmitToolchain) [ScenarioIndex=10]
Runtime = ; GC =
Mean = 21.087 ns, StdErr = 0.066 ns (0.31%), N = 14, StdDev = 0.247 ns
Min = 20.630 ns, Q1 = 20.953 ns, Median = 21.049 ns, Q3 = 21.231 ns, Max = 21.604 ns
IQR = 0.277 ns, LowerFence = 20.537 ns, UpperFence = 21.647 ns
ConfidenceInterval = [20.809 ns; 21.365 ns] (CI 99.9%), Margin = 0.278 ns (1.32% of Mean)
Skewness = 0.32, Kurtosis = 2.53, MValue = 2
-------------------- Histogram --------------------
[20.496 ns ; 21.216 ns) | @@@@@@@@@@
[21.216 ns ; 21.739 ns) | @@@@
---------------------------------------------------

RlpEncodeLongBenchmark.Current: Job-TCVVKM(Toolchain=InProcessEmitToolchain) [ScenarioIndex=10]
Runtime = ; GC =
Mean = 21.909 ns, StdErr = 0.067 ns (0.30%), N = 15, StdDev = 0.258 ns
Min = 21.554 ns, Q1 = 21.735 ns, Median = 21.808 ns, Q3 = 22.047 ns, Max = 22.430 ns
IQR = 0.312 ns, LowerFence = 21.267 ns, UpperFence = 22.516 ns
ConfidenceInterval = [21.633 ns; 22.186 ns] (CI 99.9%), Margin = 0.276 ns (1.26% of Mean)
Skewness = 0.42, Kurtosis = 1.99, MValue = 2
-------------------- Histogram --------------------
[21.464 ns ; 22.567 ns) | @@@@@@@@@@@@@@@
---------------------------------------------------

RlpEncodeLongBenchmark.Improved: Job-TCVVKM(Toolchain=InProcessEmitToolchain) [ScenarioIndex=11]
Runtime = ; GC =
Mean = 22.349 ns, StdErr = 0.110 ns (0.49%), N = 15, StdDev = 0.426 ns
Min = 21.747 ns, Q1 = 21.960 ns, Median = 22.388 ns, Q3 = 22.640 ns, Max = 23.011 ns
IQR = 0.679 ns, LowerFence = 20.942 ns, UpperFence = 23.658 ns
ConfidenceInterval = [21.893 ns; 22.804 ns] (CI 99.9%), Margin = 0.455 ns (2.04% of Mean)
Skewness = 0.03, Kurtosis = 1.45, MValue = 2
-------------------- Histogram --------------------
[21.707 ns ; 22.478 ns) | @@@@@@@@
[22.478 ns ; 23.237 ns) | @@@@@@@
---------------------------------------------------

RlpEncodeLongBenchmark.Current: Job-TCVVKM(Toolchain=InProcessEmitToolchain) [ScenarioIndex=11]
Runtime = ; GC =
Mean = 22.320 ns, StdErr = 0.114 ns (0.51%), N = 15, StdDev = 0.443 ns
Min = 21.742 ns, Q1 = 21.989 ns, Median = 22.247 ns, Q3 = 22.520 ns, Max = 23.193 ns
IQR = 0.531 ns, LowerFence = 21.192 ns, UpperFence = 23.317 ns
ConfidenceInterval = [21.846 ns; 22.794 ns] (CI 99.9%), Margin = 0.474 ns (2.12% of Mean)
Skewness = 0.6, Kurtosis = 2.05, MValue = 2.2
-------------------- Histogram --------------------
[21.506 ns ; 22.355 ns) | @@@@@@@@@@
[22.355 ns ; 22.850 ns) | @@
[22.850 ns ; 23.322 ns) | @@@
---------------------------------------------------

RlpEncodeLongBenchmark.Improved: Job-TCVVKM(Toolchain=InProcessEmitToolchain) [ScenarioIndex=12]
Runtime = ; GC =
Mean = 22.181 ns, StdErr = 0.081 ns (0.37%), N = 13, StdDev = 0.294 ns
Min = 21.867 ns, Q1 = 21.945 ns, Median = 22.093 ns, Q3 = 22.410 ns, Max = 22.763 ns
IQR = 0.465 ns, LowerFence = 21.247 ns, UpperFence = 23.109 ns
ConfidenceInterval = [21.829 ns; 22.532 ns] (CI 99.9%), Margin = 0.352 ns (1.59% of Mean)
Skewness = 0.64, Kurtosis = 1.92, MValue = 2
-------------------- Histogram --------------------
[21.769 ns ; 22.927 ns) | @@@@@@@@@@@@@
---------------------------------------------------

RlpEncodeLongBenchmark.Current: Job-TCVVKM(Toolchain=InProcessEmitToolchain) [ScenarioIndex=12]
Runtime = ; GC =
Mean = 22.311 ns, StdErr = 0.092 ns (0.41%), N = 15, StdDev = 0.356 ns
Min = 21.917 ns, Q1 = 22.029 ns, Median = 22.265 ns, Q3 = 22.516 ns, Max = 23.120 ns
IQR = 0.487 ns, LowerFence = 21.299 ns, UpperFence = 23.247 ns
ConfidenceInterval = [21.931 ns; 22.692 ns] (CI 99.9%), Margin = 0.381 ns (1.71% of Mean)
Skewness = 0.77, Kurtosis = 2.48, MValue = 2
-------------------- Histogram --------------------
[21.870 ns ; 22.686 ns) | @@@@@@@@@@@@@
[22.686 ns ; 23.219 ns) | @@
---------------------------------------------------

// * Summary *

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.22000
AMD Ryzen 9 5950X, 1 CPU, 32 logical and 16 physical cores
.NET SDK=6.0.400-preview.22330.6
  [Host] : .NET 6.0.7 (6.0.722.32202), X64 RyuJIT DEBUG  [AttachedDebugger]

Toolchain=InProcessEmitToolchain

|   Method | ScenarioIndex |       Mean |     Error |    StdDev |
|--------- |-------------- |-----------:|----------:|----------:|
| Improved |             0 | 109.491 ns | 1.5885 ns | 1.3265 ns |
|  Current |             0 | 107.762 ns | 1.3806 ns | 1.1528 ns |
| Improved |             1 | 131.798 ns | 1.2628 ns | 1.1194 ns |
|  Current |             1 | 130.869 ns | 1.1179 ns | 1.0457 ns |
| Improved |             2 |   4.655 ns | 0.1066 ns | 0.0945 ns |
|  Current |             2 |   5.640 ns | 0.0817 ns | 0.0638 ns |
| Improved |             3 |  17.692 ns | 0.2381 ns | 0.2110 ns |
|  Current |             3 |  20.545 ns | 0.4458 ns | 0.3952 ns |
| Improved |             4 |  20.347 ns | 0.4553 ns | 0.8093 ns |
|  Current |             4 |  23.229 ns | 0.4882 ns | 0.4328 ns |
| Improved |             5 |  20.216 ns | 0.4559 ns | 0.6824 ns |
|  Current |             5 |  22.258 ns | 0.4822 ns | 0.4510 ns |
| Improved |             6 |  19.151 ns | 0.3885 ns | 0.3634 ns |
|  Current |             6 |  21.711 ns | 0.3489 ns | 0.3093 ns |
| Improved |             7 |  19.595 ns | 0.3789 ns | 0.3544 ns |
|  Current |             7 |  21.306 ns | 0.2981 ns | 0.2788 ns |
| Improved |             8 |  20.542 ns | 0.3108 ns | 0.2755 ns |
|  Current |             8 |  21.399 ns | 0.2880 ns | 0.2405 ns |
| Improved |             9 |  20.961 ns | 0.2140 ns | 0.1897 ns |
|  Current |             9 |  30.281 ns | 0.2288 ns | 0.1910 ns |
| Improved |            10 |  21.087 ns | 0.2781 ns | 0.2465 ns |
|  Current |            10 |  21.909 ns | 0.2763 ns | 0.2585 ns |
| Improved |            11 |  22.349 ns | 0.4555 ns | 0.4261 ns |
|  Current |            11 |  22.320 ns | 0.4739 ns | 0.4433 ns |
| Improved |            12 |  22.181 ns | 0.3516 ns | 0.2936 ns |
|  Current |            12 |  22.311 ns | 0.3807 ns | 0.3561 ns |
```