### PR TITLE
Fix downloader hangs in some case

### DIFF
--- a/src/Nethermind/Nethermind.Core/Block.cs
+++ b/src/Nethermind/Nethermind.Core/Block.cs
@@ -1,16 +1,16 @@
 ﻿//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -47,7 +47,7 @@ namespace Nethermind.Core
         public Block WithReplacedHeader(BlockHeader newHeader) => new(newHeader, Body);
 
         public Block WithReplacedBody(BlockBody newBody) => new(Header, newBody);
-        
+
         public Block WithReplacedBodyCloned(BlockBody newBody) => new(Header.Clone(), newBody);
 
         public BlockHeader Header { get; }
@@ -97,10 +97,12 @@ namespace Nethermind.Core
         public UInt256 Difficulty => Header.Difficulty; // do not add setter here
 
         public UInt256? TotalDifficulty => Header.TotalDifficulty; // do not add setter here
-        
+
         public UInt256 BaseFeePerGas => Header.BaseFeePerGas; // do not add setter here
-        
+
         public bool IsPostMerge => Header.IsPostMerge; // do not add setter here
+
+        public bool IsBodyMissing => Header.HasBody && Body.IsEmpty;
 
         public override string ToString()
         {

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeBlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeBlockDownloader.cs
@@ -181,6 +181,11 @@ namespace Nethermind.Merge.Plugin.Synchronization
                     Block currentBlock = blocks[blockIndex];
                     if (_logger.IsTrace) _logger.Trace($"Received {currentBlock} from {bestPeer}");
 
+                    if (currentBlock.Header.HasBody && currentBlock.Body.IsEmpty)
+                    {
+                        throw new EthSyncException($"{bestPeer} didn't send body for block {currentBlock.ToString(Block.Format.Short)}.");
+                    }
+
                     // can move this to block tree now?
                     if (!_blockValidator.ValidateSuggestedBlock(currentBlock))
                     {

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeBlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeBlockDownloader.cs
@@ -181,7 +181,7 @@ namespace Nethermind.Merge.Plugin.Synchronization
                     Block currentBlock = blocks[blockIndex];
                     if (_logger.IsTrace) _logger.Trace($"Received {currentBlock} from {bestPeer}");
 
-                    if (currentBlock.Header.HasBody && currentBlock.Body.IsEmpty)
+                    if (currentBlock.IsBodyMissing)
                     {
                         throw new EthSyncException($"{bestPeer} didn't send body for block {currentBlock.ToString(Block.Format.Short)}.");
                     }

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloadContext.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloadContext.cs
@@ -34,7 +34,8 @@ namespace Nethermind.Synchronization.Blocks
         private readonly bool _downloadReceipts;
         private readonly IReceiptsRecovery _receiptsRecovery;
 
-        public BlockDownloadContext(ISpecProvider specProvider, PeerInfo syncPeer, BlockHeader?[] headers, bool downloadReceipts, IReceiptsRecovery receiptsRecovery)
+        public BlockDownloadContext(ISpecProvider specProvider, PeerInfo syncPeer, BlockHeader?[] headers,
+            bool downloadReceipts, IReceiptsRecovery receiptsRecovery)
         {
             _indexMapping = new Dictionary<int, int>();
             _downloadReceipts = downloadReceipts;
@@ -127,6 +128,12 @@ namespace Nethermind.Synchronization.Blocks
             }
 
             return result;
+        }
+
+        public Block GetBlockByRequestIdx(int index)
+        {
+            int mappedIndex = _indexMapping[index];
+            return Blocks[mappedIndex];
         }
 
         private void ValidateReceipts(Block block, TxReceipt[] blockReceipts)

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
@@ -342,7 +342,7 @@ namespace Nethermind.Synchronization.Blocks
                     Block currentBlock = blocks[blockIndex];
                     if (_logger.IsTrace) _logger.Trace($"Received {currentBlock} from {bestPeer}");
 
-                    if (currentBlock.Header.HasBody && currentBlock.Body.IsEmpty)
+                    if (currentBlock.IsBodyMissing)
                     {
                         throw new EthSyncException($"{bestPeer} didn't send body for block {currentBlock.ToString(Block.Format.Short)}.");
                     }
@@ -487,7 +487,7 @@ namespace Nethermind.Synchronization.Blocks
                 {
                     TxReceipt[] txReceipts = result[i];
                     Block block = context.GetBlockByRequestIdx(i + offset);
-                    if (block.Header.HasBody && block.Body.IsEmpty)
+                    if (block.IsBodyMissing)
                     {
                         if (_logger.IsTrace) _logger.Trace($"Found incomplete blocks. {block.Hash}");
                         return;

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
@@ -342,6 +342,11 @@ namespace Nethermind.Synchronization.Blocks
                     Block currentBlock = blocks[blockIndex];
                     if (_logger.IsTrace) _logger.Trace($"Received {currentBlock} from {bestPeer}");
 
+                    if (currentBlock.Header.HasBody && currentBlock.Body.IsEmpty)
+                    {
+                        throw new EthSyncException($"{bestPeer} didn't send body for block {currentBlock.ToString(Block.Format.Short)}.");
+                    }
+
                     // can move this to block tree now?
                     if (!_blockValidator.ValidateSuggestedBlock(currentBlock))
                     {
@@ -457,6 +462,12 @@ namespace Nethermind.Synchronization.Blocks
                     context.SetBody(i + offset, result[i]);
                 }
 
+                if (result.Length == 0)
+                {
+                    if (_logger.IsTrace) _logger.Trace($"Peer sent no bodies. Peer: {peer}, Request: {hashesToRequest.Count}");
+                    return;
+                }
+
                 offset += result.Length;
             }
         }
@@ -475,7 +486,13 @@ namespace Nethermind.Synchronization.Blocks
                 for (int i = 0; i < result.Length; i++)
                 {
                     TxReceipt[] txReceipts = result[i];
-                    if (!context.TrySetReceipts(i + offset, txReceipts, out Block block))
+                    Block block = context.GetBlockByRequestIdx(i + offset);
+                    if (block.Header.HasBody && block.Transactions.Length == 0)
+                    {
+                        if (_logger.IsTrace) _logger.Trace($"Found incomplete blocks. {block.Hash}");
+                        return;
+                    }
+                    if (!context.TrySetReceipts(i + offset, txReceipts, out block))
                     {
                         throw new EthSyncException($"{peer} sent invalid receipts for block {block.ToString(Block.Format.Short)}.");
                     }

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
@@ -487,7 +487,7 @@ namespace Nethermind.Synchronization.Blocks
                 {
                     TxReceipt[] txReceipts = result[i];
                     Block block = context.GetBlockByRequestIdx(i + offset);
-                    if (block.Header.HasBody && block.Transactions.Length == 0)
+                    if (block.Header.HasBody && block.Body.IsEmpty)
                     {
                         if (_logger.IsTrace) _logger.Trace($"Found incomplete blocks. {block.Hash}");
                         return;


### PR DESCRIPTION
Fix downloader hangs when peer response with no body.

## Changes:
- Allow downloader and merge block downloader to process block partially.
- In RequestBodies, exit early if peer response with no body at all.
- In RequestReceipts, exit early if block does not have body when it should have body.
- In DownloadBodies, throw exception when block should have body but does not.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [X] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [X] Yes
- [ ] No

**Comments about testing , should you have some** (optional)

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...