### PR TITLE
Respond to GetNodeData with unpersisted nodes

### DIFF
--- a/src/Nethermind/Nethermind.Core/Crypto/Keccak.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/Keccak.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -27,13 +27,13 @@ namespace Nethermind.Core.Crypto
         public fixed byte Bytes[Size];
 
         public Span<byte> BytesAsSpan => MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref this, 1));
-        
+
         /// <returns>
         ///     <string>0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470</string>
         /// </returns>
         public static readonly ValueKeccak OfAnEmptyString = InternalCompute(new byte[] { });
-        
-        
+
+
         [DebuggerStepThrough]
         public static ValueKeccak Compute(ReadOnlySpan<byte> input)
         {
@@ -48,7 +48,7 @@ namespace Nethermind.Core.Crypto
             KeccakHash.ComputeHashBytesToSpan(input, output);
             return result;
         }
-        
+
         private static ValueKeccak InternalCompute(byte[] input)
         {
             ValueKeccak result = new();
@@ -68,7 +68,7 @@ namespace Nethermind.Core.Crypto
             MemorySizes.SmallObjectOverhead +
             MemorySizes.RefSize +
             MemorySizes.ArrayOverhead +
-            Size - 
+            Size -
             MemorySizes.SmallObjectFreeDataSize;
 
         /// <returns>
@@ -105,8 +105,7 @@ namespace Nethermind.Core.Crypto
         {
             if (bytes.Length != Size)
             {
-                throw new ArgumentException($"{nameof(Keccak)} must be {Size} bytes and was {bytes.Length} bytes",
-                    nameof(bytes));
+                throw new ArgumentException($"{nameof(Keccak)} must be {Size} bytes and was {bytes.Length} bytes", nameof(bytes));
             }
 
             Bytes = bytes;
@@ -116,7 +115,7 @@ namespace Nethermind.Core.Crypto
         {
             return ToString(true);
         }
-        
+
         public string ToShortString(bool withZeroX = true)
         {
             string hash = Bytes.ToHexString(withZeroX);
@@ -178,8 +177,8 @@ namespace Nethermind.Core.Crypto
 
         public int CompareTo(Keccak? other)
         {
-            return Extensions.Bytes.Comparer.Compare(Bytes, other?.Bytes);  
-        } 
+            return Extensions.Bytes.Comparer.Compare(Bytes, other?.Bytes);
+        }
 
         public override bool Equals(object? obj)
         {
@@ -233,7 +232,7 @@ namespace Nethermind.Core.Crypto
 
         public KeccakStructRef ToStructRef() => new(Bytes);
     }
-    
+
     public ref struct KeccakStructRef
     {
         public const int Size = 32;
@@ -256,7 +255,7 @@ namespace Nethermind.Core.Crypto
         {
             return ToString(true);
         }
-        
+
         public string ToShortString(bool withZeroX = true)
         {
             string hash = Bytes.ToHexString(withZeroX);
@@ -323,7 +322,7 @@ namespace Nethermind.Core.Crypto
 
             return Core.Extensions.Bytes.AreEqual(other.Bytes, Bytes);
         }
-        
+
         public bool Equals(KeccakStructRef other) => Core.Extensions.Bytes.AreEqual(other.Bytes, Bytes);
 
         public override bool Equals(object? obj)
@@ -345,7 +344,7 @@ namespace Nethermind.Core.Crypto
 
             return Core.Extensions.Bytes.AreEqual(a.Bytes, b.Bytes);
         }
-        
+
         public static bool operator ==(Keccak? a, KeccakStructRef b)
         {
             if (ReferenceEquals(a, null))
@@ -355,7 +354,7 @@ namespace Nethermind.Core.Crypto
 
             return Core.Extensions.Bytes.AreEqual(a.Bytes, b.Bytes);
         }
-        
+
         public static bool operator ==(KeccakStructRef a, KeccakStructRef b)
         {
             return Core.Extensions.Bytes.AreEqual(a.Bytes, b.Bytes);
@@ -365,12 +364,12 @@ namespace Nethermind.Core.Crypto
         {
             return !(a == b);
         }
-        
+
         public static bool operator !=(Keccak a, KeccakStructRef b)
         {
             return !(a == b);
-        } 
-        
+        }
+
         public static bool operator !=(KeccakStructRef a, KeccakStructRef b)
         {
             return !(a == b);

--- a/src/Nethermind/Nethermind.Core/IKeyValueStore.cs
+++ b/src/Nethermind/Nethermind.Core/IKeyValueStore.cs
@@ -1,23 +1,28 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
 namespace Nethermind.Core
 {
-    public interface IKeyValueStore
+    public interface IKeyValueStore : IReadOnlyKeyValueStore
     {
-        byte[]? this[byte[] key] { get; set; }
+        new byte[]? this[byte[] key] { get; set; }
+    }
+
+    public interface IReadOnlyKeyValueStore
+    {
+        byte[]? this[byte[] key] { get; }
     }
 }

--- a/src/Nethermind/Nethermind.Db/DbExtensions.cs
+++ b/src/Nethermind/Nethermind.Db/DbExtensions.cs
@@ -1,22 +1,23 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Nethermind.Core;
 using Nethermind.Core.Caching;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
@@ -30,13 +31,13 @@ namespace Nethermind.Db
         {
             return new(db, createInMemoryWriteStore);
         }
-        
+
         public static void Set(this IDb db, Keccak key, byte[] value)
          {
              db[key.Bytes] = value;
          }
-        
-        public static byte[]? Get(this IDb db, Keccak key)
+
+        public static byte[]? Get(this IReadOnlyKeyValueStore db, Keccak key)
         {
             #if DEBUG
             if (key == Keccak.OfAnEmptyString)
@@ -44,18 +45,18 @@ namespace Nethermind.Db
                 throw new InvalidOperationException();
             }
             #endif
-            
+
             return db[key.Bytes];
         }
-        
+
         public static KeyValuePair<byte[], byte[]>[] MultiGet(this IDb db, IEnumerable<Keccak> keys)
         {
             var k = keys.Select(k => k.Bytes).ToArray();
             return db[k];
         }
-        
+
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="db"></param>
         /// <param name="key"></param>
@@ -69,10 +70,10 @@ namespace Nethermind.Db
                 throw new InvalidOperationException();
             }
 #endif
-            
+
             return db.GetSpan(key.Bytes);
         }
-        
+
         public static bool KeyExists(this IDb db, Keccak key)
         {
 #if DEBUG
@@ -81,7 +82,7 @@ namespace Nethermind.Db
                 throw new InvalidOperationException();
             }
 #endif
-            
+
             return db.KeyExists(key.Bytes);
         }
 
@@ -89,28 +90,28 @@ namespace Nethermind.Db
         {
             return db.KeyExists(key.ToBigEndianByteArrayWithoutLeadingZeros());
         }
-        
+
         public static void Delete(this IDb db, Keccak key)
         {
             db.Remove(key.Bytes);
         }
-        
+
         public static void Set(this IDb db, byte[] key, byte[] value)
         {
             db[key] = value;
         }
-        
+
         public static void Set(this IDb db, long key, byte[] value)
         {
             db[key.ToBigEndianByteArrayWithoutLeadingZeros()] = value;
         }
-        
+
         public static byte[]? Get(this IDb db, long key) => db[key.ToBigEndianByteArrayWithoutLeadingZeros()];
-        
+
         public static byte[]? Get(this IDb db, byte[] key) => db[key];
-        
+
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="db"></param>
         /// <param name="key"></param>
@@ -162,10 +163,10 @@ namespace Nethermind.Db
             {
                 cache.Set(key, item);
             }
-            
+
             return item;
         }
-        
+
         public static TItem? Get<TItem>(this IDb db, long key, IRlpStreamDecoder<TItem>? decoder, ICache<long, TItem>? cache = null, bool shouldCache = true) where TItem : class
         {
             TItem? item = cache?.Get(key);
@@ -200,7 +201,7 @@ namespace Nethermind.Db
                     item = decoder.Decode(data.AsRlpStream(), RlpBehaviors.AllowExtraData);
                 }
             }
-            
+
             if (shouldCache && cache != null && item != null)
             {
                 cache.Set(key, item);

--- a/src/Nethermind/Nethermind.Db/DbExtensions.cs
+++ b/src/Nethermind/Nethermind.Db/DbExtensions.cs
@@ -37,7 +37,7 @@ namespace Nethermind.Db
              db[key.Bytes] = value;
          }
 
-        public static byte[]? Get(this IReadOnlyKeyValueStore db, Keccak key)
+        public static byte[]? Get(this IDb db, Keccak key)
         {
             #if DEBUG
             if (key == Keccak.OfAnEmptyString)

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -179,7 +179,7 @@ namespace Nethermind.Init.Steps
             _api.DisposeStack.Push(_api.Synchronizer);
 
             _api.SyncServer = new SyncServer(
-                _api.DbProvider.StateDb,
+                _api.TrieStore!,
                 _api.DbProvider.CodeDb,
                 _api.BlockTree!,
                 _api.ReceiptStorage!,

--- a/src/Nethermind/Nethermind.Synchronization.Test/OldStyleFullSynchronizerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/OldStyleFullSynchronizerTests.cs
@@ -60,8 +60,7 @@ namespace Nethermind.Synchronization.Test
             _stateDb = dbProvider.StateDb;
             _codeDb = dbProvider.CodeDb;
             _receiptStorage = Substitute.For<IReceiptStorage>();
-            SyncConfig quickConfig = new();
-            quickConfig.FastSync = false;
+            SyncConfig quickConfig = new() { FastSync = false };
 
             ITimerFactory timerFactory = Substitute.For<ITimerFactory>();
             NodeStatsManager stats = new(timerFactory, LimboLogs.Instance);
@@ -70,11 +69,12 @@ namespace Nethermind.Synchronization.Test
             ProgressTracker progressTracker = new(_blockTree, dbProvider.StateDb, LimboLogs.Instance);
             SnapProvider snapProvider = new(progressTracker, dbProvider, LimboLogs.Instance);
 
+            TrieStore trieStore = new(_stateDb, LimboLogs.Instance);
             SyncProgressResolver resolver = new(
                 _blockTree,
                 _receiptStorage,
                 _stateDb,
-                new TrieStore(_stateDb, LimboLogs.Instance),
+                trieStore,
                 progressTracker,
                 syncConfig,
                 LimboLogs.Instance);
@@ -107,7 +107,7 @@ namespace Nethermind.Synchronization.Test
                 syncReport,
                 LimboLogs.Instance);
             _syncServer = new SyncServer(
-                _stateDb,
+                trieStore,
                 _codeDb,
                 _blockTree,
                 _receiptStorage,

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncThreadTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncThreadTests.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -287,7 +287,7 @@ namespace Nethermind.Synchronization.Test
             ITransactionComparerProvider transactionComparerProvider =
                 new TransactionComparerProvider(specProvider, tree);
 
-            TxPool.TxPool txPool = new(ecdsa, new ChainHeadInfoProvider(specProvider, tree, stateReader), 
+            TxPool.TxPool txPool = new(ecdsa, new ChainHeadInfoProvider(specProvider, tree, stateReader),
                 new TxPoolConfig(), new TxValidator(specProvider.ChainId), logManager, transactionComparerProvider.GetDefaultComparer());
             BlockhashProvider blockhashProvider = new(tree, LimboLogs.Instance);
             VirtualMachine virtualMachine = new(blockhashProvider, specProvider, logManager);
@@ -349,7 +349,7 @@ namespace Nethermind.Synchronization.Test
             DevBlockProducer producer = new(
                 transactionSelector,
                 devChainProcessor,
-                stateProvider, 
+                stateProvider,
                 tree,
                 new BuildBlocksRegularly(TimeSpan.FromMilliseconds(50)).IfPoolIsNotEmpty(txPool),
                 Timestamper.Default,
@@ -390,7 +390,7 @@ namespace Nethermind.Synchronization.Test
                 syncReport,
                 logManager);
             SyncServer syncServer = new(
-                stateDb,
+                trieStore,
                 codeDb,
                 tree,
                 receiptStorage,

--- a/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
@@ -334,11 +334,12 @@ namespace Nethermind.Synchronization.Test
                 ProgressTracker progressTracker = new(BlockTree, dbProvider.StateDb, LimboLogs.Instance);
                 SnapProvider snapProvider = new(progressTracker, dbProvider, LimboLogs.Instance);
 
+                TrieStore trieStore = new(stateDb, LimboLogs.Instance);
                 SyncProgressResolver syncProgressResolver = new(
                     BlockTree,
                     NullReceiptStorage.Instance,
                     stateDb,
-                    new TrieStore(stateDb, LimboLogs.Instance),
+                    trieStore,
                     progressTracker,
                     syncConfig,
                     _logManager);
@@ -433,7 +434,7 @@ namespace Nethermind.Synchronization.Test
                 }
 
                 SyncServer = new SyncServer(
-                    stateDb,
+                    trieStore,
                     codeDb,
                     BlockTree,
                     NullReceiptStorage.Instance,

--- a/src/Nethermind/Nethermind.Synchronization/SyncServer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SyncServer.cs
@@ -374,12 +374,12 @@ namespace Nethermind.Synchronization
                 values[i] = null;
                 if ((includedTypes & NodeDataType.State) == NodeDataType.State)
                 {
-                    values[i] = _stateDb.Get(keys[i]);
+                    values[i] = _stateDb[keys[i].Bytes];
                 }
 
                 if (values[i] == null && (includedTypes & NodeDataType.Code) == NodeDataType.Code)
                 {
-                    values[i] = _codeDb.Get(keys[i]);
+                    values[i] = _codeDb[keys[i].Bytes];
                 }
             }
 

--- a/src/Nethermind/Nethermind.Synchronization/SyncServer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SyncServer.cs
@@ -53,8 +53,8 @@ namespace Nethermind.Synchronization
         private readonly IReceiptFinder _receiptFinder;
         private readonly IBlockValidator _blockValidator;
         private readonly ISealValidator _sealValidator;
-        private readonly IDb _stateDb;
-        private readonly IDb _codeDb;
+        private readonly IReadOnlyKeyValueStore _stateDb;
+        private readonly IReadOnlyKeyValueStore _codeDb;
         private readonly ISyncConfig _syncConfig;
         private readonly IWitnessRepository _witnessRepository;
         private readonly IGossipPolicy _gossipPolicy;
@@ -71,8 +71,8 @@ namespace Nethermind.Synchronization
         private BlockHeader? _pivotHeader;
 
         public SyncServer(
-            IDb stateDb,
-            IDb codeDb,
+            IReadOnlyKeyValueStore stateDb,
+            IReadOnlyKeyValueStore codeDb,
             IBlockTree blockTree,
             IReceiptFinder receiptFinder,
             IBlockValidator blockValidator,
@@ -366,8 +366,7 @@ namespace Nethermind.Synchronization
             return _blockTree.FindHeaders(hash, numberOfBlocks, skip, reverse);
         }
 
-        public byte[]?[] GetNodeData(IReadOnlyList<Keccak> keys,
-            NodeDataType includedTypes = NodeDataType.State | NodeDataType.Code)
+        public byte[]?[] GetNodeData(IReadOnlyList<Keccak> keys, NodeDataType includedTypes = NodeDataType.State | NodeDataType.Code)
         {
             byte[]?[] values = new byte[keys.Count][];
             for (int i = 0; i < keys.Count; i++)

--- a/src/Nethermind/Nethermind.Trie/Pruning/ITrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ITrieStore.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -20,16 +20,16 @@ using Nethermind.Core.Crypto;
 
 namespace Nethermind.Trie.Pruning
 {
-    public interface ITrieStore : ITrieNodeResolver, IDisposable
+    public interface ITrieStore : ITrieNodeResolver, IReadOnlyKeyValueStore, IDisposable
     {
         void CommitNode(long blockNumber, NodeCommitInfo nodeCommitInfo);
-        
+
         void FinishBlockCommit(TrieType trieType, long blockNumber, TrieNode? root);
 
         bool IsPersisted(Keccak keccak);
-        
+
         IReadOnlyTrieStore AsReadOnly(IKeyValueStore? keyValueStore);
-        
+
         event EventHandler<ReorgBoundaryReached>? ReorgBoundaryReached;
     }
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/NullTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/NullTrieStore.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2020 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -29,9 +29,9 @@ namespace Nethermind.Trie.Pruning
         public void CommitNode(long blockNumber, NodeCommitInfo nodeCommitInfo) { }
 
         public void FinishBlockCommit(TrieType trieType, long blockNumber, TrieNode? root) { }
-        
+
         public void HackPersistOnShutdown() { }
-        
+
         public IReadOnlyTrieStore AsReadOnly(IKeyValueStore keyValueStore)
         {
             return this;
@@ -56,5 +56,7 @@ namespace Nethermind.Trie.Pruning
         public bool IsPersisted(Keccak keccak) => true;
 
         public void Dispose() { }
+
+        public byte[]? this[byte[] key] => null;
     }
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStore.cs
@@ -1,21 +1,22 @@
 //  Copyright (c) 2020 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using System;
+using System.Reflection.Metadata.Ecma335;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 
@@ -35,7 +36,7 @@ namespace Nethermind.Trie.Pruning
             _readOnlyStore = readOnlyStore;
         }
 
-        public TrieNode FindCachedOrUnknown(Keccak hash) => 
+        public TrieNode FindCachedOrUnknown(Keccak hash) =>
             _trieStore.FindCachedOrUnknown(hash, true);
 
         public byte[] LoadRlp(Keccak hash) => _trieStore.LoadRlp(hash, _readOnlyStore);
@@ -52,12 +53,14 @@ namespace Nethermind.Trie.Pruning
         public void FinishBlockCommit(TrieType trieType, long blockNumber, TrieNode? root) { }
 
         public void HackPersistOnShutdown() { }
-        
+
         public event EventHandler<ReorgBoundaryReached> ReorgBoundaryReached
         {
             add { }
             remove { }
         }
         public void Dispose() { }
+
+        public byte[]? this[byte[] key] => _trieStore[key];
     }
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -15,10 +15,8 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
 using System;
-using System.Buffers;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
@@ -805,6 +803,16 @@ namespace Nethermind.Trie.Pruning
 
                 if (_logger.IsInfo) _logger.Info($"Full Pruning Persist Cache finished: {stopwatch.Elapsed} {persistedNodes / (double)million:N} mln nodes persisted.");
             });
+        }
+
+        public byte[]? this[byte[] key]
+        {
+            get => _dirtyNodes.AllNodes.TryGetValue(new Keccak(key), out TrieNode? trieNode)
+                   && trieNode is not null
+                   && trieNode.NodeType != NodeType.Unknown
+                   && trieNode.FullRlp is not null
+                ? trieNode.FullRlp
+                : _currentBatch?[key] ?? _keyValueStore[key];
         }
     }
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -807,7 +807,8 @@ namespace Nethermind.Trie.Pruning
 
         public byte[]? this[byte[] key]
         {
-            get => _dirtyNodes.AllNodes.TryGetValue(new Keccak(key), out TrieNode? trieNode)
+            get => _pruningStrategy.PruningEnabled
+                   && _dirtyNodes.AllNodes.TryGetValue(new Keccak(key), out TrieNode? trieNode)
                    && trieNode is not null
                    && trieNode.NodeType != NodeType.Unknown
                    && trieNode.FullRlp is not null


### PR DESCRIPTION
## Changes:
- SyncServer.GetNodeData goes through keystore in order to be able to return not persisted data
- Add IReadOnlyKeyStore to better handle abstractions

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No