### PR TITLE
Cancel sync properly on shutdown

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
@@ -205,7 +205,7 @@ namespace Nethermind.Synchronization.Test.ParallelSync
 
             private int _pendingRequests;
 
-            public override async Task<TestBatch> PrepareRequest()
+            public override async Task<TestBatch> PrepareRequest(CancellationToken token = default)
             {
                 TestBatch testBatch;
                 if (_returned.TryDequeue(out TestBatch returned))

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/FastSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/FastSyncFeed.cs
@@ -15,6 +15,7 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Logging;
@@ -53,7 +54,7 @@ namespace Nethermind.Synchronization.Blocks
             return options;
         }
 
-        public override Task<BlocksRequest> PrepareRequest() => Task.FromResult(_blocksRequest);
+        public override Task<BlocksRequest> PrepareRequest(CancellationToken token = default) => Task.FromResult(_blocksRequest);
 
         public override SyncResponseHandlingResult HandleResponse(BlocksRequest response, PeerInfo peer = null)
         {

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/FullSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/FullSyncFeed.cs
@@ -14,6 +14,7 @@
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
+using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Logging;
 using Nethermind.Synchronization.ParallelSync;
@@ -36,7 +37,7 @@ namespace Nethermind.Synchronization.Blocks
         private static DownloaderOptions BuildOptions() => DownloaderOptions.WithBodies | DownloaderOptions.Process;
 
         // ReSharper disable once RedundantTypeArgumentsOfMethod
-        public override Task<BlocksRequest?> PrepareRequest() => Task.FromResult<BlocksRequest?>(_blocksRequest);
+        public override Task<BlocksRequest?> PrepareRequest(CancellationToken token = default) => Task.FromResult<BlocksRequest?>(_blocksRequest);
 
         public override SyncResponseHandlingResult HandleResponse(BlocksRequest? response, PeerInfo peer = null)
         {

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
@@ -15,6 +15,7 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Synchronization;
@@ -107,7 +108,7 @@ namespace Nethermind.Synchronization.FastBlocks
             _syncReport.BodiesInQueue.MarkEnd();
         }
 
-        public override Task<BodiesSyncBatch?> PrepareRequest()
+        public override Task<BodiesSyncBatch?> PrepareRequest(CancellationToken token = default)
         {
             BodiesSyncBatch? batch = null;
             if (ShouldBuildANewBatch())

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
@@ -19,6 +19,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Synchronization;
@@ -180,19 +181,20 @@ namespace Nethermind.Synchronization.FastBlocks
             _syncReport.HeadersInQueue.MarkEnd();
         }
 
-        private void HandleDependentBatches()
+        private void HandleDependentBatches(CancellationToken cancellationToken)
         {
             long? lowest = LowestInsertedBlockHeader?.Number;
             while (lowest.HasValue && _dependencies.TryRemove(lowest.Value - 1, out HeadersSyncBatch? dependentBatch))
             {
                 InsertHeaders(dependentBatch!);
                 lowest = LowestInsertedBlockHeader?.Number;
+                cancellationToken.ThrowIfCancellationRequested();
             }
         }
 
-        public override Task<HeadersSyncBatch?> PrepareRequest()
+        public override Task<HeadersSyncBatch?> PrepareRequest(CancellationToken cancellationToken = default)
         {
-            HandleDependentBatches();
+            HandleDependentBatches(cancellationToken);
 
             if (_pending.TryDequeue(out HeadersSyncBatch? batch))
             {

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/ReceiptsSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/ReceiptsSyncFeed.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Receipts;
@@ -124,7 +125,7 @@ namespace Nethermind.Synchronization.FastBlocks
             _syncReport.ReceiptsInQueue.MarkEnd();
         }
 
-        public override Task<ReceiptsSyncBatch?> PrepareRequest()
+        public override Task<ReceiptsSyncBatch?> PrepareRequest(CancellationToken token = default)
         {
             ReceiptsSyncBatch? batch = null;
             if (ShouldBuildANewBatch())

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/StateSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/StateSyncFeed.cs
@@ -19,6 +19,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Logging;
 using Nethermind.Synchronization.ParallelSync;
@@ -51,7 +52,7 @@ namespace Nethermind.Synchronization.FastSync
             _logger = logManager.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
         }
 
-        public override async Task<StateSyncBatch?> PrepareRequest()
+        public override async Task<StateSyncBatch?> PrepareRequest(CancellationToken token = default)
         {
             try
             {

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/ISyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/ISyncFeed.cs
@@ -15,6 +15,7 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Synchronization.Peers;
 
@@ -25,7 +26,7 @@ namespace Nethermind.Synchronization.ParallelSync
         int FeedId { get; }
         SyncFeedState CurrentState { get; }
         event EventHandler<SyncFeedStateEventArgs> StateChanged;
-        Task<T> PrepareRequest();
+        Task<T> PrepareRequest(CancellationToken token = default);
         SyncResponseHandlingResult HandleResponse(T response, PeerInfo peer = null);
         
         /// <summary>

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncDispatcher.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncDispatcher.cs
@@ -108,7 +108,8 @@ namespace Nethermind.Synchronization.ParallelSync
 
                                 if (cancellationToken.IsCancellationRequested)
                                 {
-                                    if (Logger.IsInfo) Logger.Info("Ignoring sync response as shutdown is requested.");
+                                    if (Logger.IsDebug) Logger.Debug("Ignoring sync response as shutdown is requested.");
+                                    return;
                                 }
 
                                 try

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncDispatcher.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncDispatcher.cs
@@ -106,14 +106,14 @@ namespace Nethermind.Synchronization.ParallelSync
                                     if (Logger.IsWarn) Logger.Warn($"Failure when executing request {t.Exception}");
                                 }
 
-                                if (cancellationToken.IsCancellationRequested)
-                                {
-                                    if (Logger.IsDebug) Logger.Debug("Ignoring sync response as shutdown is requested.");
-                                    return;
-                                }
-
                                 try
                                 {
+                                    if (cancellationToken.IsCancellationRequested)
+                                    {
+                                        if (Logger.IsDebug) Logger.Debug("Ignoring sync response as shutdown is requested.");
+                                        return;
+                                    }
+
                                     SyncResponseHandlingResult result = Feed.HandleResponse(request, allocatedPeer);
                                     ReactToHandlingResult(request, result, allocatedPeer);
                                 }

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncDispatcher.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncDispatcher.cs
@@ -80,7 +80,7 @@ namespace Nethermind.Synchronization.ParallelSync
                     else if (currentStateLocal == SyncFeedState.Active)
                     {
                         cancellationToken.ThrowIfCancellationRequested();
-                        T request = await (Feed.PrepareRequest() ?? Task.FromResult<T>(default!)); // just to avoid null refs
+                        T request = await (Feed.PrepareRequest(cancellationToken) ?? Task.FromResult<T>(default!)); // just to avoid null refs
                         if (request == null)
                         {
                             if (!Feed.IsMultiFeed)

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncFeed.cs
@@ -24,7 +24,7 @@ namespace Nethermind.Synchronization.ParallelSync
     public abstract class SyncFeed<T> : ISyncFeed<T>
     {
         private readonly TaskCompletionSource _taskCompletionSource = new();
-        public abstract Task<T> PrepareRequest();
+        public abstract Task<T> PrepareRequest(CancellationToken token = default);
         public abstract SyncResponseHandlingResult HandleResponse(T response, PeerInfo peer = null);
         public abstract bool IsMultiFeed { get; }
         public abstract AllocationContexts Contexts { get; }

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncFeed.cs
@@ -55,8 +55,8 @@ namespace Nethermind.Synchronization.SnapSync
 
             _syncModeSelector.Changed += SyncModeSelectorOnChanged;
         }
-        
-        public override Task<SnapSyncBatch?> PrepareRequest()
+
+        public override Task<SnapSyncBatch?> PrepareRequest(CancellationToken token = default)
         {
             try
             {

--- a/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
@@ -39,7 +39,7 @@ namespace Nethermind.Synchronization
 {
     public class Synchronizer : ISynchronizer
     {
-        private const int FeedsTerminationTimeout = 5_000;
+        private const int FeedsTerminationTimeout = 7_000;
 
         private readonly ISpecProvider _specProvider;
         private readonly IReceiptStorage _receiptStorage;

--- a/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
@@ -39,7 +39,7 @@ namespace Nethermind.Synchronization
 {
     public class Synchronizer : ISynchronizer
     {
-        private const int FeedsTerminationTimeout = 7_000;
+        private const int FeedsTerminationTimeout = 5_000;
 
         private readonly ISpecProvider _specProvider;
         private readonly IReceiptStorage _receiptStorage;


### PR DESCRIPTION
Fixes | Closes | Resolves #4049

Fast headers sync requires heavy database writes on request preparation which was not interruptible before this fix

## Changes:
- Interrupt fast headers sync properly

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No

