### PR TITLE
Fix of saving the best persisted state block number

### DIFF
--- a/src/Nethermind/Nethermind.Init/Steps/InitializeBlockchain.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeBlockchain.cs
@@ -153,9 +153,10 @@ namespace Nethermind.Init.Steps
                     getApi.LogManager);
             }
             
-            getApi.DisposeStack.Push(trieStore);
             TrieStoreBoundaryWatcher trieStoreBoundaryWatcher = new(trieStore, _api.BlockTree!, _api.LogManager);
             getApi.DisposeStack.Push(trieStoreBoundaryWatcher);
+            getApi.DisposeStack.Push(trieStore);
+
             ITrieStore readOnlyTrieStore = setApi.ReadOnlyTrieStore = trieStore.AsReadOnly(cachedStateDb);
 
             IStateProvider stateProvider = setApi.StateProvider = new StateProvider(


### PR DESCRIPTION
Fixes | Closes | Resolves  #4348

The most recently persisted state block number are not saved during shutdown. Need to update the disposal order so it will be saved.

## Changes:
- The most recently persisted state block number is persisted too

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [x] No

Tested manually: persisted state block number changes after restart