### PR TITLE
Implement support for the "blockHash" parameter

### DIFF
--- a/src/Nethermind/Nethermind.AccountAbstraction/Subscribe/UserOperationSubscriptionParam.cs
+++ b/src/Nethermind/Nethermind.AccountAbstraction/Subscribe/UserOperationSubscriptionParam.cs
@@ -13,27 +13,25 @@
 // 
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
 
 using System;
 using Nethermind.Core;
 using Nethermind.JsonRpc;
 using Newtonsoft.Json;
 
-namespace Nethermind.AccountAbstraction.Subscribe
-{
-    public class UserOperationSubscriptionParam : IJsonRpcParam
-    {
-        public Address[] EntryPoints { get; set; } = Array.Empty<Address>();
-        public bool IncludeUserOperations { get; set; }
-    
-        public void FromJson(JsonSerializer serializer, string jsonValue)
-        {
-            UserOperationSubscriptionParam ep = serializer.Deserialize<UserOperationSubscriptionParam>(jsonValue.ToJsonTextReader())
-                                  ?? throw new ArgumentException($"Invalid 'entryPoints' filter: {jsonValue}");
-            EntryPoints = ep.EntryPoints;
-            IncludeUserOperations = ep.IncludeUserOperations;
+namespace Nethermind.AccountAbstraction.Subscribe;
 
-        }
+public class UserOperationSubscriptionParam : IJsonRpcParam
+{
+    public Address[] EntryPoints { get; set; } = Array.Empty<Address>();
+    public bool IncludeUserOperations { get; set; }
+
+    public void ReadJson(JsonSerializer serializer, string jsonValue)
+    {
+        UserOperationSubscriptionParam ep = serializer.Deserialize<UserOperationSubscriptionParam>(jsonValue.ToJsonTextReader())
+                              ?? throw new ArgumentException($"Invalid 'entryPoints' filter: {jsonValue}");
+        EntryPoints = ep.EntryPoints;
+        IncludeUserOperations = ep.IncludeUserOperations;
+
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/FilterTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/FilterTests.cs
@@ -13,12 +13,11 @@
 // 
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
 
-using System;
 using System.Collections;
 using FluentAssertions;
 using Nethermind.Blockchain.Find;
+using Nethermind.JsonRpc.Data;
 using Nethermind.JsonRpc.Modules.Eth;
 using Newtonsoft.Json;
 using NUnit.Framework;
@@ -32,39 +31,92 @@ public class FilterTests
         get
         {
             yield return new TestCaseData("{}",
-                new Filter()
+                new Filter
                 {
-                    Address = null,
                     FromBlock = BlockParameter.Latest,
                     ToBlock = BlockParameter.Latest,
-                    Topics = Array.Empty<object>()
-                });
-            
-            yield return new TestCaseData("{\"fromBlock\":\"earliest\",\"toBlock\":\"pending\",\"topics\":[null, \"0xe194ef610f9150a2db4110b3db5116fd623175dca3528d7ae7046a1042f84fe7\", [\"0x000500002bd87daa34d8ff0daf3465c96044d8f6667614850000000000000001\", \"0xe194ef610f9150a2db4110b3db5116fd623175dca3528d7ae7046a1042f84fe7\"]]}",
-                new Filter()
-                {
-                    Address = null,
-                    FromBlock = BlockParameter.Earliest,
-                    ToBlock = BlockParameter.Pending,
-                    Topics = new object?[] { null, "0xe194ef610f9150a2db4110b3db5116fd623175dca3528d7ae7046a1042f84fe7", new [] {"0x000500002bd87daa34d8ff0daf3465c96044d8f6667614850000000000000001", "0xe194ef610f9150a2db4110b3db5116fd623175dca3528d7ae7046a1042f84fe7" } }
                 });
 
-            yield return new TestCaseData("{\"address\":\"0xc2d77d118326c33bbe36ebeabf4f7ed6bc2dda5c\",\"fromBlock\":\"0x1143ade\",\"toBlock\":\"latest\",\"topics\":[\"0xe194ef610f9150a2db4110b3db5116fd623175dca3528d7ae7046a1042f84fe7\",null,null,\"0x000500002bd87daa34d8ff0daf3465c96044d8f6667614850000000000000001\"]}]",
-                new Filter()
+            yield return new TestCaseData(
+                JsonConvert.SerializeObject(
+                    new
+                    {
+                        fromBlock = "earliest",
+                        toBlock = "pending",
+                        topics = new object?[]
+                        {
+                            null,
+                            "0xe194ef610f9150a2db4110b3db5116fd623175dca3528d7ae7046a1042f84fe7",
+                            new[]
+                            {
+                                "0x000500002bd87daa34d8ff0daf3465c96044d8f6667614850000000000000001",
+                                "0xe194ef610f9150a2db4110b3db5116fd623175dca3528d7ae7046a1042f84fe7"
+                            }
+                        }
+                    }),
+                new Filter
+                {
+                    FromBlock = BlockParameter.Earliest,
+                    ToBlock = BlockParameter.Pending,
+                    Topics = new object?[]
+                    {
+                        null,
+                        "0xe194ef610f9150a2db4110b3db5116fd623175dca3528d7ae7046a1042f84fe7",
+                        new[]
+                        {
+                            "0x000500002bd87daa34d8ff0daf3465c96044d8f6667614850000000000000001",
+                            "0xe194ef610f9150a2db4110b3db5116fd623175dca3528d7ae7046a1042f84fe7"
+                        }
+                    }
+                });
+
+            yield return new TestCaseData(
+                JsonConvert.SerializeObject(
+                    new
+                    {
+                        address = "0xc2d77d118326c33bbe36ebeabf4f7ed6bc2dda5c",
+                        fromBlock = "0x1143ade",
+                        toBlock = "latest",
+                        topics = new object?[]
+                        {
+                            "0xe194ef610f9150a2db4110b3db5116fd623175dca3528d7ae7046a1042f84fe7",
+                            null,
+                            null,
+                            "0x000500002bd87daa34d8ff0daf3465c96044d8f6667614850000000000000001"
+                        }
+                    }),
+                new Filter
                 {
                     Address = "0xc2d77d118326c33bbe36ebeabf4f7ed6bc2dda5c",
                     FromBlock = new BlockParameter(0x1143ade),
                     ToBlock = BlockParameter.Latest,
-                    Topics = new object?[] { "0xe194ef610f9150a2db4110b3db5116fd623175dca3528d7ae7046a1042f84fe7", null, null, "0x000500002bd87daa34d8ff0daf3465c96044d8f6667614850000000000000001" }
+                    Topics = new object?[]
+                    {
+                        "0xe194ef610f9150a2db4110b3db5116fd623175dca3528d7ae7046a1042f84fe7",
+                        null,
+                        null,
+                        "0x000500002bd87daa34d8ff0daf3465c96044d8f6667614850000000000000001"
+                    }
+                });
+
+            var blockhash = "0x892a8b3ccc78359e059e67ec44c83bfed496721d48c2d1dd929d6e4cd6559d35";
+            var blockParam = BlockParameterConverter.GetBlockParameter(blockhash);
+
+            yield return new TestCaseData(
+                JsonConvert.SerializeObject(new { blockhash }),
+                new Filter
+                {
+                    FromBlock = blockParam,
+                    ToBlock = blockParam,
                 });
         }
     }
-    
+
     [TestCaseSource(nameof(JsonTests))]
     public void FromJson_parses_correctly(string json, Filter expectation)
     {
         Filter filter = new();
-        filter.FromJson(new JsonSerializer(), json);
+        filter.FromJson(JsonSerializer.CreateDefault(), json);
         filter.Should().BeEquivalentTo(expectation);
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/FilterTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/FilterTests.cs
@@ -99,11 +99,11 @@ public class FilterTests
                     }
                 });
 
-            var blockhash = "0x892a8b3ccc78359e059e67ec44c83bfed496721d48c2d1dd929d6e4cd6559d35";
-            var blockParam = BlockParameterConverter.GetBlockParameter(blockhash);
+            var blockHash = "0x892a8b3ccc78359e059e67ec44c83bfed496721d48c2d1dd929d6e4cd6559d35";
+            var blockParam = BlockParameterConverter.GetBlockParameter(blockHash);
 
             yield return new TestCaseData(
-                JsonConvert.SerializeObject(new { blockhash }),
+                JsonConvert.SerializeObject(new { blockHash }),
                 new Filter
                 {
                     FromBlock = blockParam,

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/FilterTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/FilterTests.cs
@@ -116,7 +116,7 @@ public class FilterTests
     public void FromJson_parses_correctly(string json, Filter expectation)
     {
         Filter filter = new();
-        filter.FromJson(JsonSerializer.CreateDefault(), json);
+        filter.ReadJson(JsonSerializer.CreateDefault(), json);
         filter.Should().BeEquivalentTo(expectation);
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/IJsonRpcParam.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/IJsonRpcParam.cs
@@ -1,4 +1,4 @@
-﻿//  Copyright (c) 2021 Demerzel Solutions Limited
+//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
 // 
 //  The Nethermind library is free software: you can redistribute it and/or modify
@@ -16,10 +16,9 @@
 
 using Newtonsoft.Json;
 
-namespace Nethermind.JsonRpc
+namespace Nethermind.JsonRpc;
+
+public interface IJsonRpcParam
 {
-    public interface IJsonRpcParam
-    {
-        void FromJson(JsonSerializer serializer, string jsonValue);
-    }
+    void ReadJson(JsonSerializer serializer, string jsonValue);
 }

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
@@ -23,7 +23,6 @@ using System.Text;
 using System.Threading.Tasks;
 using Nethermind.Core;
 using Nethermind.Core.Attributes;
-using Nethermind.Core.Extensions;
 using Nethermind.JsonRpc.Data;
 using Nethermind.JsonRpc.Modules;
 using Nethermind.Logging;
@@ -32,417 +31,416 @@ using Nethermind.State;
 using Newtonsoft.Json;
 using JsonSerializer = Newtonsoft.Json.JsonSerializer;
 
-namespace Nethermind.JsonRpc
+namespace Nethermind.JsonRpc;
+
+[Todo(Improve.Refactor, "Use JsonConverters and JSON serialization everywhere")]
+public class JsonRpcService : IJsonRpcService
 {
-    [Todo(Improve.Refactor, "Use JsonConverters and JSON serialization everywhere")]
-    public class JsonRpcService : IJsonRpcService
+    private readonly ILogger _logger;
+    private readonly IRpcModuleProvider _rpcModuleProvider;
+    private readonly JsonSerializer _serializer;
+    private readonly HashSet<string> _methodsLoggingFiltering;
+    private readonly int _maxLoggedRequestParametersCharacters;
+
+    public JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogManager logManager, IJsonRpcConfig jsonRpcConfig)
     {
-        private readonly ILogger _logger;
-        private readonly IRpcModuleProvider _rpcModuleProvider;
-        private readonly JsonSerializer _serializer;
-        private readonly HashSet<string> _methodsLoggingFiltering;
-        private readonly int _maxLoggedRequestParametersCharacters;
+        _logger = logManager.GetClassLogger();
+        _rpcModuleProvider = rpcModuleProvider;
+        _serializer = rpcModuleProvider.Serializer;
+        _methodsLoggingFiltering = (jsonRpcConfig.MethodsLoggingFiltering ?? Array.Empty<string>()).ToHashSet();
+        _maxLoggedRequestParametersCharacters = jsonRpcConfig.MaxLoggedRequestParametersCharacters ?? int.MaxValue;
 
-        public JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogManager logManager, IJsonRpcConfig jsonRpcConfig)
+        List<JsonConverter> converterList = new();
+        foreach (JsonConverter converter in rpcModuleProvider.Converters)
         {
-            _logger = logManager.GetClassLogger();
-            _rpcModuleProvider = rpcModuleProvider;
-            _serializer = rpcModuleProvider.Serializer;
-            _methodsLoggingFiltering = (jsonRpcConfig.MethodsLoggingFiltering ?? Array.Empty<string>()).ToHashSet();
-            _maxLoggedRequestParametersCharacters = jsonRpcConfig.MaxLoggedRequestParametersCharacters ?? int.MaxValue;
-
-            List<JsonConverter> converterList = new();
-            foreach (JsonConverter converter in rpcModuleProvider.Converters)
-            {
-                if (_logger.IsDebug) _logger.Debug($"Registering {converter.GetType().Name} inside {nameof(JsonRpcService)}");
-                _serializer.Converters.Add(converter);
-                converterList.Add(converter);
-            }
-
-            foreach (JsonConverter converter in EthereumJsonSerializer.CommonConverters)
-            {
-                if (_logger.IsDebug) _logger.Debug($"Registering {converter.GetType().Name} (default)");
-                _serializer.Converters.Add(converter);
-                converterList.Add(converter);
-            }
-
-            BlockParameterConverter blockParameterConverter = new();
-            _serializer.Converters.Add(blockParameterConverter);
-            converterList.Add(blockParameterConverter);
-
-            Converters = converterList.ToArray();
+            if (_logger.IsDebug) _logger.Debug($"Registering {converter.GetType().Name} inside {nameof(JsonRpcService)}");
+            _serializer.Converters.Add(converter);
+            converterList.Add(converter);
         }
 
-        public async Task<JsonRpcResponse> SendRequestAsync(JsonRpcRequest rpcRequest, JsonRpcContext context)
+        foreach (JsonConverter converter in EthereumJsonSerializer.CommonConverters)
         {
+            if (_logger.IsDebug) _logger.Debug($"Registering {converter.GetType().Name} (default)");
+            _serializer.Converters.Add(converter);
+            converterList.Add(converter);
+        }
+
+        BlockParameterConverter blockParameterConverter = new();
+        _serializer.Converters.Add(blockParameterConverter);
+        converterList.Add(blockParameterConverter);
+
+        Converters = converterList.ToArray();
+    }
+
+    public async Task<JsonRpcResponse> SendRequestAsync(JsonRpcRequest rpcRequest, JsonRpcContext context)
+    {
+        try
+        {
+            (int? errorCode, string errorMessage) = Validate(rpcRequest, context);
+            if (errorCode.HasValue)
+            {
+                return GetErrorResponse(rpcRequest.Method, errorCode.Value, errorMessage, null, rpcRequest.Id);
+            }
+
             try
             {
-                (int? errorCode, string errorMessage) = Validate(rpcRequest, context);
-                if (errorCode.HasValue)
-                {
-                    return GetErrorResponse(rpcRequest.Method, errorCode.Value, errorMessage, null, rpcRequest.Id);
-                }
-
-                try
-                {
-                    return await ExecuteRequestAsync(rpcRequest, context);
-                }
-                catch (TargetInvocationException ex)
-                {
-                    if (_logger.IsError) _logger.Error($"Error during method execution, request: {rpcRequest}", ex.InnerException);
-                    return GetErrorResponse(rpcRequest.Method, ErrorCodes.InternalError, "Internal error", ex.InnerException?.ToString(), rpcRequest.Id);
-                }
-                catch (ModuleRentalTimeoutException ex)
-                {
-                    if (_logger.IsError) _logger.Error($"Error during method execution, request: {rpcRequest}", ex);
-                    return GetErrorResponse(rpcRequest.Method, ErrorCodes.ModuleTimeout, "Timeout", ex.ToString(), rpcRequest.Id);
-                }
-                catch (Exception ex)
-                {
-                    if (_logger.IsError) _logger.Error($"Error during method execution, request: {rpcRequest}", ex);
-                    return GetErrorResponse(rpcRequest.Method, ErrorCodes.InternalError, "Internal error", ex.ToString(), rpcRequest.Id);
-                }
+                return await ExecuteRequestAsync(rpcRequest, context);
+            }
+            catch (TargetInvocationException ex)
+            {
+                if (_logger.IsError) _logger.Error($"Error during method execution, request: {rpcRequest}", ex.InnerException);
+                return GetErrorResponse(rpcRequest.Method, ErrorCodes.InternalError, "Internal error", ex.InnerException?.ToString(), rpcRequest.Id);
+            }
+            catch (ModuleRentalTimeoutException ex)
+            {
+                if (_logger.IsError) _logger.Error($"Error during method execution, request: {rpcRequest}", ex);
+                return GetErrorResponse(rpcRequest.Method, ErrorCodes.ModuleTimeout, "Timeout", ex.ToString(), rpcRequest.Id);
             }
             catch (Exception ex)
             {
-                if (_logger.IsError) _logger.Error($"Error during validation, request: {rpcRequest}", ex);
-                return GetErrorResponse(ErrorCodes.ParseError, "Parse error");
+                if (_logger.IsError) _logger.Error($"Error during method execution, request: {rpcRequest}", ex);
+                return GetErrorResponse(rpcRequest.Method, ErrorCodes.InternalError, "Internal error", ex.ToString(), rpcRequest.Id);
             }
         }
-
-        private async Task<JsonRpcResponse> ExecuteRequestAsync(JsonRpcRequest rpcRequest, JsonRpcContext context)
+        catch (Exception ex)
         {
-            string methodName = rpcRequest.Method.Trim();
-
-            (MethodInfo MethodInfo, bool ReadOnly) result = _rpcModuleProvider.Resolve(methodName);
-            return result.MethodInfo != null 
-                ? await ExecuteAsync(rpcRequest, methodName, result, context) 
-                : GetErrorResponse(methodName, ErrorCodes.MethodNotFound, "Method not found", $"{rpcRequest.Method}", rpcRequest.Id);
+            if (_logger.IsError) _logger.Error($"Error during validation, request: {rpcRequest}", ex);
+            return GetErrorResponse(ErrorCodes.ParseError, "Parse error");
         }
+    }
 
-        private async Task<JsonRpcResponse> ExecuteAsync(JsonRpcRequest request, string methodName,
-            (MethodInfo Info, bool ReadOnly) method, JsonRpcContext context)
+    private async Task<JsonRpcResponse> ExecuteRequestAsync(JsonRpcRequest rpcRequest, JsonRpcContext context)
+    {
+        string methodName = rpcRequest.Method.Trim();
+
+        (MethodInfo MethodInfo, bool ReadOnly) result = _rpcModuleProvider.Resolve(methodName);
+        return result.MethodInfo != null 
+            ? await ExecuteAsync(rpcRequest, methodName, result, context) 
+            : GetErrorResponse(methodName, ErrorCodes.MethodNotFound, "Method not found", $"{rpcRequest.Method}", rpcRequest.Id);
+    }
+
+    private async Task<JsonRpcResponse> ExecuteAsync(JsonRpcRequest request, string methodName,
+        (MethodInfo Info, bool ReadOnly) method, JsonRpcContext context)
+    {
+        ParameterInfo[] expectedParameters = method.Info.GetParameters();
+        string?[] providedParameters = request.Params ?? Array.Empty<string>();
+        
+        LogRequest(methodName, providedParameters, expectedParameters);
+
+        int missingParamsCount = expectedParameters.Length - providedParameters.Length + (providedParameters.Count(string.IsNullOrWhiteSpace));
+        int explicitNullableParamsCount = 0;
+
+        if (missingParamsCount != 0)
         {
-            ParameterInfo[] expectedParameters = method.Info.GetParameters();
-            string?[] providedParameters = request.Params ?? Array.Empty<string>();
-            
-            LogRequest(methodName, providedParameters, expectedParameters);
-
-            int missingParamsCount = expectedParameters.Length - providedParameters.Length + (providedParameters.Count(string.IsNullOrWhiteSpace));
-            int explicitNullableParamsCount = 0;
-
-            if (missingParamsCount != 0)
+            bool hasIncorrectParameters = true;
+            if (missingParamsCount > 0)
             {
-                bool hasIncorrectParameters = true;
-                if (missingParamsCount > 0)
+                hasIncorrectParameters = false;
+                for (int i = 0; i < missingParamsCount; i++)
                 {
-                    hasIncorrectParameters = false;
-                    for (int i = 0; i < missingParamsCount; i++)
+                    int parameterIndex = expectedParameters.Length - missingParamsCount + i;
+                    bool nullable = IsNullableParameter(expectedParameters[parameterIndex]);
+                    
+                    // if the null is the default parameter it could be passed in an explicit way as "" or null
+                    // or we can treat null as a missing parameter. Two tests for this cases:
+                    // Eth_call_is_working_with_implicit_null_as_the_last_argument and Eth_call_is_working_with_explicit_null_as_the_last_argument
+                    bool isExplicit = providedParameters.Length >= parameterIndex + 1;
+                    if (nullable && isExplicit)
                     {
-                        int parameterIndex = expectedParameters.Length - missingParamsCount + i;
-                        bool nullable = IsNullableParameter(expectedParameters[parameterIndex]);
-                        
-                        // if the null is the default parameter it could be passed in an explicit way as "" or null
-                        // or we can treat null as a missing parameter. Two tests for this cases:
-                        // Eth_call_is_working_with_implicit_null_as_the_last_argument and Eth_call_is_working_with_explicit_null_as_the_last_argument
-                        bool isExplicit = providedParameters.Length >= parameterIndex + 1;
-                        if (nullable && isExplicit)
-                        {
-                            explicitNullableParamsCount += 1;
-                        }
-                        if (!expectedParameters[expectedParameters.Length - missingParamsCount + i].IsOptional && !nullable)
-                        {
-                            hasIncorrectParameters = true;
-                            break;
-                        }
+                        explicitNullableParamsCount += 1;
                     }
-                }
-
-                if (hasIncorrectParameters)
-                {
-                    return GetErrorResponse(methodName, ErrorCodes.InvalidParams, "Invalid params", $"Incorrect parameters count, expected: {expectedParameters.Length}, actual: {expectedParameters.Length - missingParamsCount}", request.Id);
-                }
-            }
-
-            missingParamsCount -= explicitNullableParamsCount;
-
-            //prepare parameters
-            object[]? parameters = null;
-            if (expectedParameters.Length > 0)
-            {
-                parameters = DeserializeParameters(expectedParameters, providedParameters, missingParamsCount);
-                if (parameters == null)
-                {
-                    if (_logger.IsWarn) _logger.Warn($"Incorrect JSON RPC parameters when calling {methodName} with params [{string.Join(", ", providedParameters)}]");
-                    return GetErrorResponse(methodName, ErrorCodes.InvalidParams, "Invalid params", null, request.Id);
-                }
-            }
-
-            //execute method
-            IResultWrapper resultWrapper = null;
-            IRpcModule rpcModule = await _rpcModuleProvider.Rent(methodName, method.ReadOnly);
-            if (rpcModule is IContextAwareRpcModule contextAwareModule)
-            {
-                contextAwareModule.Context = context;
-            }
-            bool returnImmediately = methodName != "eth_getLogs";
-            Action? returnAction = returnImmediately ? (Action) null : () => _rpcModuleProvider.Return(methodName, rpcModule);
-            try
-            {
-                object invocationResult = method.Info.Invoke(rpcModule, parameters);
-                switch (invocationResult)
-                {
-                    case IResultWrapper wrapper:
-                        resultWrapper = wrapper;
-                        break;
-                    case Task task:
-                        await task;
-                        resultWrapper = task.GetType().GetProperty("Result")?.GetValue(task) as IResultWrapper;
-                        break;
-                }
-            }
-            catch (TargetParameterCountException e)
-            {
-                return GetErrorResponse(methodName, ErrorCodes.InvalidParams, e.Message, e.Data, request.Id, returnAction);
-            }
-            catch (TargetInvocationException e) when (e.InnerException is JsonException)
-            {
-                return GetErrorResponse(methodName, ErrorCodes.InvalidParams, "Invalid params", null, request.Id, returnAction);
-            }            
-            catch (Exception e) when (e.InnerException is OperationCanceledException)
-            {
-                string errorMessage = $"{methodName} request was canceled due to enabled timeout.";
-                return GetErrorResponse(methodName, ErrorCodes.Timeout, errorMessage, null, request.Id, returnAction);
-            }
-            catch (Exception e) when (e.InnerException is InsufficientBalanceException)
-            {
-                return GetErrorResponse(methodName, ErrorCodes.InvalidInput, e.InnerException.Message, null, request.Id, returnAction);
-            }
-            finally
-            {
-                if (returnImmediately)
-                {
-                    _rpcModuleProvider.Return(methodName, rpcModule);
-                }
-            }
-
-            if (resultWrapper is null)
-            {
-                string errorMessage = $"Method {methodName} execution result does not implement IResultWrapper";
-                if (_logger.IsError) _logger.Error(errorMessage);
-                return GetErrorResponse(methodName, ErrorCodes.InternalError, errorMessage, null, request.Id, returnAction);
-            }
-
-            Result? result = resultWrapper.GetResult();
-            if (result == null)
-            {
-                if (_logger.IsError) _logger.Error($"Error during method: {methodName} execution: no result");
-                return GetErrorResponse(methodName, resultWrapper.GetErrorCode(), "Internal error", resultWrapper.GetData(), request.Id, returnAction);
-            }
-
-            if (result.ResultType == ResultType.Failure)
-            {
-                return GetErrorResponse(methodName, resultWrapper.GetErrorCode(), result.Error, resultWrapper.GetData(), request.Id, returnAction);
-            }
-
-            return GetSuccessResponse(methodName, resultWrapper.GetData(), request.Id, returnAction);
-        }
-
-        private void LogRequest(string methodName, string?[] providedParameters, ParameterInfo[] expectedParameters)
-        {
-            if (_logger.IsInfo && !_methodsLoggingFiltering.Contains(methodName))
-            {
-                StringBuilder builder = new StringBuilder();
-                builder.Append("Executing JSON RPC call ");
-                builder.Append(methodName);
-                builder.Append(" with params [");
-
-                int paramsLength = 0;
-                int paramsCount = 0;
-                const string separator = ", ";
-
-                for (int i = 0; i < providedParameters.Length; i++)
-                {
-                    string? parameter = expectedParameters.ElementAtOrDefault(i)?.Name == "passphrase"
-                        ? "{passphrase}"
-                        : providedParameters[i];
-
-                    if (paramsLength > _maxLoggedRequestParametersCharacters)
+                    if (!expectedParameters[expectedParameters.Length - missingParamsCount + i].IsOptional && !nullable)
                     {
-                        int toRemove = paramsLength - _maxLoggedRequestParametersCharacters;
-                        builder.Remove(builder.Length - toRemove, toRemove);
-                        builder.Append("...");
+                        hasIncorrectParameters = true;
                         break;
                     }
-
-                    if (paramsCount != 0)
-                    {
-                        builder.Append(separator);
-                        paramsLength += separator.Length;
-                    }
-
-                    builder.Append(parameter);
-                    paramsLength += (parameter?.Length ?? 0);
-                    paramsCount++;
                 }
-                builder.Append(']');
-                string log = builder.ToString();
-                _logger.Info(log);
+            }
+
+            if (hasIncorrectParameters)
+            {
+                return GetErrorResponse(methodName, ErrorCodes.InvalidParams, "Invalid params", $"Incorrect parameters count, expected: {expectedParameters.Length}, actual: {expectedParameters.Length - missingParamsCount}", request.Id);
             }
         }
 
-        private object[]? DeserializeParameters(ParameterInfo[] expectedParameters, string?[] providedParameters, int missingParamsCount)
+        missingParamsCount -= explicitNullableParamsCount;
+
+        //prepare parameters
+        object[]? parameters = null;
+        if (expectedParameters.Length > 0)
         {
-            try
+            parameters = DeserializeParameters(expectedParameters, providedParameters, missingParamsCount);
+            if (parameters == null)
             {
-                List<object> executionParameters = new List<object>();
-                for (int i = 0; i < providedParameters.Length; i++)
+                if (_logger.IsWarn) _logger.Warn($"Incorrect JSON RPC parameters when calling {methodName} with params [{string.Join(", ", providedParameters)}]");
+                return GetErrorResponse(methodName, ErrorCodes.InvalidParams, "Invalid params", null, request.Id);
+            }
+        }
+
+        //execute method
+        IResultWrapper resultWrapper = null;
+        IRpcModule rpcModule = await _rpcModuleProvider.Rent(methodName, method.ReadOnly);
+        if (rpcModule is IContextAwareRpcModule contextAwareModule)
+        {
+            contextAwareModule.Context = context;
+        }
+        bool returnImmediately = methodName != "eth_getLogs";
+        Action? returnAction = returnImmediately ? (Action) null : () => _rpcModuleProvider.Return(methodName, rpcModule);
+        try
+        {
+            object invocationResult = method.Info.Invoke(rpcModule, parameters);
+            switch (invocationResult)
+            {
+                case IResultWrapper wrapper:
+                    resultWrapper = wrapper;
+                    break;
+                case Task task:
+                    await task;
+                    resultWrapper = task.GetType().GetProperty("Result")?.GetValue(task) as IResultWrapper;
+                    break;
+            }
+        }
+        catch (TargetParameterCountException e)
+        {
+            return GetErrorResponse(methodName, ErrorCodes.InvalidParams, e.Message, e.Data, request.Id, returnAction);
+        }
+        catch (TargetInvocationException e) when (e.InnerException is JsonException)
+        {
+            return GetErrorResponse(methodName, ErrorCodes.InvalidParams, "Invalid params", null, request.Id, returnAction);
+        }            
+        catch (Exception e) when (e.InnerException is OperationCanceledException)
+        {
+            string errorMessage = $"{methodName} request was canceled due to enabled timeout.";
+            return GetErrorResponse(methodName, ErrorCodes.Timeout, errorMessage, null, request.Id, returnAction);
+        }
+        catch (Exception e) when (e.InnerException is InsufficientBalanceException)
+        {
+            return GetErrorResponse(methodName, ErrorCodes.InvalidInput, e.InnerException.Message, null, request.Id, returnAction);
+        }
+        finally
+        {
+            if (returnImmediately)
+            {
+                _rpcModuleProvider.Return(methodName, rpcModule);
+            }
+        }
+
+        if (resultWrapper is null)
+        {
+            string errorMessage = $"Method {methodName} execution result does not implement IResultWrapper";
+            if (_logger.IsError) _logger.Error(errorMessage);
+            return GetErrorResponse(methodName, ErrorCodes.InternalError, errorMessage, null, request.Id, returnAction);
+        }
+
+        Result? result = resultWrapper.GetResult();
+        if (result == null)
+        {
+            if (_logger.IsError) _logger.Error($"Error during method: {methodName} execution: no result");
+            return GetErrorResponse(methodName, resultWrapper.GetErrorCode(), "Internal error", resultWrapper.GetData(), request.Id, returnAction);
+        }
+
+        if (result.ResultType == ResultType.Failure)
+        {
+            return GetErrorResponse(methodName, resultWrapper.GetErrorCode(), result.Error, resultWrapper.GetData(), request.Id, returnAction);
+        }
+
+        return GetSuccessResponse(methodName, resultWrapper.GetData(), request.Id, returnAction);
+    }
+
+    private void LogRequest(string methodName, string?[] providedParameters, ParameterInfo[] expectedParameters)
+    {
+        if (_logger.IsInfo && !_methodsLoggingFiltering.Contains(methodName))
+        {
+            StringBuilder builder = new StringBuilder();
+            builder.Append("Executing JSON RPC call ");
+            builder.Append(methodName);
+            builder.Append(" with params [");
+
+            int paramsLength = 0;
+            int paramsCount = 0;
+            const string separator = ", ";
+
+            for (int i = 0; i < providedParameters.Length; i++)
+            {
+                string? parameter = expectedParameters.ElementAtOrDefault(i)?.Name == "passphrase"
+                    ? "{passphrase}"
+                    : providedParameters[i];
+
+                if (paramsLength > _maxLoggedRequestParametersCharacters)
                 {
-                    string providedParameter = providedParameters[i];
-                    ParameterInfo expectedParameter = expectedParameters[i];
-                    Type paramType = expectedParameter.ParameterType;
-                    if (paramType.IsByRef)
-                    {
-                        paramType = paramType.GetElementType();
-                    }
+                    int toRemove = paramsLength - _maxLoggedRequestParametersCharacters;
+                    builder.Remove(builder.Length - toRemove, toRemove);
+                    builder.Append("...");
+                    break;
+                }
 
-                    if (string.IsNullOrWhiteSpace(providedParameter))
-                    {
-                        if (providedParameter == null && IsNullableParameter(expectedParameter))
-                        {
-                            executionParameters.Add(null);
-                        }
-                        else
-                        {
-                            executionParameters.Add(Type.Missing);
-                        }
-                        continue;
-                    }
+                if (paramsCount != 0)
+                {
+                    builder.Append(separator);
+                    paramsLength += separator.Length;
+                }
 
-                    object? executionParam;
-                    if (typeof(IJsonRpcParam).IsAssignableFrom(paramType))
+                builder.Append(parameter);
+                paramsLength += (parameter?.Length ?? 0);
+                paramsCount++;
+            }
+            builder.Append(']');
+            string log = builder.ToString();
+            _logger.Info(log);
+        }
+    }
+
+    private object[]? DeserializeParameters(ParameterInfo[] expectedParameters, string?[] providedParameters, int missingParamsCount)
+    {
+        try
+        {
+            List<object> executionParameters = new List<object>();
+            for (int i = 0; i < providedParameters.Length; i++)
+            {
+                string providedParameter = providedParameters[i];
+                ParameterInfo expectedParameter = expectedParameters[i];
+                Type paramType = expectedParameter.ParameterType;
+                if (paramType.IsByRef)
+                {
+                    paramType = paramType.GetElementType();
+                }
+
+                if (string.IsNullOrWhiteSpace(providedParameter))
+                {
+                    if (providedParameter == null && IsNullableParameter(expectedParameter))
                     {
-                        IJsonRpcParam jsonRpcParam = (IJsonRpcParam)Activator.CreateInstance(paramType);
-                        jsonRpcParam!.FromJson(_serializer, providedParameter);
-                        executionParam = jsonRpcParam;
-                    }
-                    else if (paramType == typeof(string))
-                    {
-                        executionParam = providedParameter;
-                    }
-                    else if (paramType == typeof(string[]))
-                    {
-                        executionParam = _serializer.Deserialize<string[]>(new JsonTextReader(new StringReader(providedParameter)));
+                        executionParameters.Add(null);
                     }
                     else
                     {
-                        if (providedParameter.StartsWith('[') || providedParameter.StartsWith('{'))
-                        {
-                            executionParam = _serializer.Deserialize(new JsonTextReader(new StringReader(providedParameter)), paramType);
-                        }
-                        else
-                        {
-                            executionParam = _serializer.Deserialize(new JsonTextReader(new StringReader($"\"{providedParameter}\"")), paramType);
-                        }
+                        executionParameters.Add(Type.Missing);
                     }
-
-                    executionParameters.Add(executionParam);
+                    continue;
                 }
 
-                for (int i = 0; i < missingParamsCount; i++)
+                object? executionParam;
+                if (typeof(IJsonRpcParam).IsAssignableFrom(paramType))
                 {
-                    executionParameters.Add(Type.Missing);
+                    IJsonRpcParam jsonRpcParam = (IJsonRpcParam)Activator.CreateInstance(paramType);
+                    jsonRpcParam!.ReadJson(_serializer, providedParameter);
+                    executionParam = jsonRpcParam;
+                }
+                else if (paramType == typeof(string))
+                {
+                    executionParam = providedParameter;
+                }
+                else if (paramType == typeof(string[]))
+                {
+                    executionParam = _serializer.Deserialize<string[]>(new JsonTextReader(new StringReader(providedParameter)));
+                }
+                else
+                {
+                    if (providedParameter.StartsWith('[') || providedParameter.StartsWith('{'))
+                    {
+                        executionParam = _serializer.Deserialize(new JsonTextReader(new StringReader(providedParameter)), paramType);
+                    }
+                    else
+                    {
+                        executionParam = _serializer.Deserialize(new JsonTextReader(new StringReader($"\"{providedParameter}\"")), paramType);
+                    }
                 }
 
-                return executionParameters.ToArray();
+                executionParameters.Add(executionParam);
             }
-            catch (Exception e)
-            {
-                if (_logger.IsWarn) _logger.Warn("Error while parsing JSON RPC request parameters " + e);
-                return null;
-            }
-        }
 
-        private bool IsNullableParameter(ParameterInfo parameterInfo)
+            for (int i = 0; i < missingParamsCount; i++)
+            {
+                executionParameters.Add(Type.Missing);
+            }
+
+            return executionParameters.ToArray();
+        }
+        catch (Exception e)
         {
-            Type parameterType = parameterInfo.ParameterType;
-            if (parameterType.IsValueType)
-            {
-                return Nullable.GetUnderlyingType(parameterType) != null;
-            }
-
-            CustomAttributeData nullableAttribute = parameterInfo.CustomAttributes
-                .FirstOrDefault(x => x.AttributeType.FullName == "System.Runtime.CompilerServices.NullableAttribute");
-            if (nullableAttribute != null)
-            {
-                CustomAttributeTypedArgument attributeArgument = nullableAttribute.ConstructorArguments.FirstOrDefault();
-                if (attributeArgument.ArgumentType == typeof(byte))
-                {
-                    return (byte)attributeArgument.Value! == 2;
-                }
-            }
-            return false;
+            if (_logger.IsWarn) _logger.Warn("Error while parsing JSON RPC request parameters " + e);
+            return null;
         }
+    }
 
-        private JsonRpcResponse GetSuccessResponse(string methodName, object result, object id, Action? disposableAction)
+    private bool IsNullableParameter(ParameterInfo parameterInfo)
+    {
+        Type parameterType = parameterInfo.ParameterType;
+        if (parameterType.IsValueType)
         {
-            JsonRpcResponse response = new JsonRpcSuccessResponse(disposableAction)
-            {
-                Result = result,
-                Id = id,
-                MethodName = methodName
-            };
-
-            return response;
+            return Nullable.GetUnderlyingType(parameterType) != null;
         }
 
-        public JsonRpcErrorResponse GetErrorResponse(int errorCode, string errorMessage) => 
-            GetErrorResponse(null, errorCode, errorMessage, null, null);
-
-        public JsonConverter[] Converters { get; }
-
-        private JsonRpcErrorResponse GetErrorResponse(string? methodName, int errorCode, string? errorMessage, object? errorData, object? id, Action? disposableAction = null)
+        CustomAttributeData nullableAttribute = parameterInfo.CustomAttributes
+            .FirstOrDefault(x => x.AttributeType.FullName == "System.Runtime.CompilerServices.NullableAttribute");
+        if (nullableAttribute != null)
         {
-            if (_logger.IsDebug) _logger.Debug($"Sending error response, method: {methodName ?? "none"}, id: {id}, errorType: {errorCode}, message: {errorMessage}");
-            JsonRpcErrorResponse response = new(disposableAction)
+            CustomAttributeTypedArgument attributeArgument = nullableAttribute.ConstructorArguments.FirstOrDefault();
+            if (attributeArgument.ArgumentType == typeof(byte))
             {
-                Error = new Error
-                {
-                    Code = errorCode,
-                    Message = errorMessage,
-                    Data = errorData,
-                },
-                Id = id,
-                MethodName = methodName
-            };
-
-            return response;
+                return (byte)attributeArgument.Value! == 2;
+            }
         }
+        return false;
+    }
 
-        private (int? ErrorType, string ErrorMessage) Validate(JsonRpcRequest? rpcRequest, JsonRpcContext context)
+    private JsonRpcResponse GetSuccessResponse(string methodName, object result, object id, Action? disposableAction)
+    {
+        JsonRpcResponse response = new JsonRpcSuccessResponse(disposableAction)
         {
-            if (rpcRequest == null)
-            {
-                return (ErrorCodes.InvalidRequest, "Invalid request");
-            }
+            Result = result,
+            Id = id,
+            MethodName = methodName
+        };
 
-            string methodName = rpcRequest.Method;
-            if (string.IsNullOrWhiteSpace(methodName))
-            {
-                return (ErrorCodes.InvalidRequest, "Method is required");
-            }
+        return response;
+    }
 
-            methodName = methodName.Trim();
+    public JsonRpcErrorResponse GetErrorResponse(int errorCode, string errorMessage) => 
+        GetErrorResponse(null, errorCode, errorMessage, null, null);
 
-            ModuleResolution result = _rpcModuleProvider.Check(methodName, context);
-            return result switch
+    public JsonConverter[] Converters { get; }
+
+    private JsonRpcErrorResponse GetErrorResponse(string? methodName, int errorCode, string? errorMessage, object? errorData, object? id, Action? disposableAction = null)
+    {
+        if (_logger.IsDebug) _logger.Debug($"Sending error response, method: {methodName ?? "none"}, id: {id}, errorType: {errorCode}, message: {errorMessage}");
+        JsonRpcErrorResponse response = new(disposableAction)
+        {
+            Error = new Error
             {
-                ModuleResolution.Unknown => ((int?) ErrorCodes.MethodNotFound, $"Method {methodName} is not supported"),
-                ModuleResolution.Disabled => (ErrorCodes.InvalidRequest, $"{methodName} found but the containing module is disabled for the url '{context.Url?.ToString() ?? string.Empty}', consider adding module in JsonRpcConfig.AdditionalRpcUrls for additional url, or to JsonRpcConfig.EnabledModules for default url"),
-                ModuleResolution.EndpointDisabled => (ErrorCodes.InvalidRequest, $"{methodName} found for the url '{context.Url?.ToString() ?? string.Empty}' but is disabled for {context.RpcEndpoint}"),
-                ModuleResolution.NotAuthenticated => (ErrorCodes.InvalidRequest, $"Method {methodName} should be authenticated"),
-                _ => (null, null)
-            };
+                Code = errorCode,
+                Message = errorMessage,
+                Data = errorData,
+            },
+            Id = id,
+            MethodName = methodName
+        };
+
+        return response;
+    }
+
+    private (int? ErrorType, string ErrorMessage) Validate(JsonRpcRequest? rpcRequest, JsonRpcContext context)
+    {
+        if (rpcRequest == null)
+        {
+            return (ErrorCodes.InvalidRequest, "Invalid request");
         }
+
+        string methodName = rpcRequest.Method;
+        if (string.IsNullOrWhiteSpace(methodName))
+        {
+            return (ErrorCodes.InvalidRequest, "Method is required");
+        }
+
+        methodName = methodName.Trim();
+
+        ModuleResolution result = _rpcModuleProvider.Check(methodName, context);
+        return result switch
+        {
+            ModuleResolution.Unknown => ((int?) ErrorCodes.MethodNotFound, $"Method {methodName} is not supported"),
+            ModuleResolution.Disabled => (ErrorCodes.InvalidRequest, $"{methodName} found but the containing module is disabled for the url '{context.Url?.ToString() ?? string.Empty}', consider adding module in JsonRpcConfig.AdditionalRpcUrls for additional url, or to JsonRpcConfig.EnabledModules for default url"),
+            ModuleResolution.EndpointDisabled => (ErrorCodes.InvalidRequest, $"{methodName} found for the url '{context.Url?.ToString() ?? string.Empty}' but is disabled for {context.RpcEndpoint}"),
+            ModuleResolution.NotAuthenticated => (ErrorCodes.InvalidRequest, $"Method {methodName} should be authenticated"),
+            _ => (null, null)
+        };
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/Filter.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/Filter.cs
@@ -1,4 +1,4 @@
-﻿//  Copyright (c) 2021 Demerzel Solutions Limited
+//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
 // 
 //  The Nethermind library is free software: you can redistribute it and/or modify
@@ -15,58 +15,63 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
 using System.Collections.Generic;
-using System.Runtime.Serialization;
-using Nethermind.Blockchain;
 using Nethermind.Blockchain.Find;
 using Nethermind.JsonRpc.Data;
-using Nethermind.Serialization.Json;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-namespace Nethermind.JsonRpc.Modules.Eth
+namespace Nethermind.JsonRpc.Modules.Eth;
+
+public class Filter : IJsonRpcParam
 {
-    public class Filter : IJsonRpcParam
+    public object? Address { get; set; }
+
+    public BlockParameter? FromBlock { get; set; }
+
+    public BlockParameter? ToBlock { get; set; }
+
+    public IEnumerable<object?>? Topics { get; set; }
+
+    public void FromJson(JsonSerializer serializer, string json)
     {
-        public BlockParameter FromBlock { get; set; }
-        public BlockParameter ToBlock { get; set; }
-        public object? Address { get; set; }
-        public IEnumerable<object?> Topics { get; set; }
+        var filter = serializer.Deserialize<JObject>(json.ToJsonTextReader());
+        var blockHash = filter["blockhash"]?.Value<string>();
 
-        public void FromJson(JsonSerializer serializer, string jsonValue)
+        if (blockHash is null)
         {
-            JObject jObject = serializer.Deserialize<JObject>(jsonValue.ToJsonTextReader());
-            FromBlock = BlockParameterConverter.GetBlockParameter(jObject["fromBlock"]?.ToObject<string>());
-            ToBlock = BlockParameterConverter.GetBlockParameter(jObject["toBlock"]?.ToObject<string>());
-            Address = GetAddress(jObject["address"]);
-            Topics = GetTopics(jObject["topics"] as JArray);
+            FromBlock = BlockParameterConverter.GetBlockParameter(filter["fromBlock"]?.Value<string>());
+            ToBlock = BlockParameterConverter.GetBlockParameter(filter["toBlock"]?.Value<string>());
+        }
+        else
+            FromBlock =
+                ToBlock = BlockParameterConverter.GetBlockParameter(blockHash);
+
+        Address = GetAddress(filter["address"]);
+
+        var topics = filter["topics"] as JArray;
+
+        Topics = topics == null ? null : GetTopics(filter["topics"] as JArray);
+    }
+
+    private static object? GetAddress(JToken? token) => GetSingleOrMany(token);
+
+    private static IEnumerable<object?> GetTopics(JArray? array)
+    {
+        if (array is null)
+        {
+            yield break;
         }
 
-        private static object? GetAddress(JToken? token) => GetSingleOrMany(token);
-
-        private static IEnumerable<object?> GetTopics(JArray? array)
+        foreach (JToken token in array)
         {
-            if (array is null)
-            {
-                yield break;
-            }
-
-            foreach (JToken token in array)
-            {
-                yield return GetSingleOrMany(token);
-            }
-        }
-
-        private static object? GetSingleOrMany(JToken? token)
-        {
-            switch (token)
-            {
-                case null:
-                    return null;
-                case JArray _:
-                    return token.ToObject<IEnumerable<string>>();
-                default:
-                    return token.ToObject<string>();
-            }
+            yield return GetSingleOrMany(token);
         }
     }
+
+    private static object? GetSingleOrMany(JToken? token) => token switch
+    {
+        null => null,
+        JArray _ => token.ToObject<IEnumerable<string>>(),
+        _ => token.Value<string>(),
+    };
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/Filter.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/Filter.cs
@@ -32,7 +32,7 @@ public class Filter : IJsonRpcParam
 
     public IEnumerable<object?>? Topics { get; set; }
 
-    public void FromJson(JsonSerializer serializer, string json)
+    public void ReadJson(JsonSerializer serializer, string json)
     {
         var filter = serializer.Deserialize<JObject>(json.ToJsonTextReader());
         var blockHash = filter["blockhash"]?.Value<string>();

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/Filter.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/Filter.cs
@@ -35,7 +35,7 @@ public class Filter : IJsonRpcParam
     public void ReadJson(JsonSerializer serializer, string json)
     {
         var filter = serializer.Deserialize<JObject>(json.ToJsonTextReader());
-        var blockHash = filter["blockhash"]?.Value<string>();
+        var blockHash = filter["blockHash"]?.Value<string>();
 
         if (blockHash is null)
         {

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/TransactionsOption.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/TransactionsOption.cs
@@ -13,9 +13,7 @@
 // 
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
 
-using Nethermind.Serialization.Json;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -25,20 +23,15 @@ public class TransactionsOption : IJsonRpcParam
 {
     public bool IncludeTransactions { get; set; }
         
-    public void FromJson(JsonSerializer serializer, string jsonValue)
+    public void ReadJson(JsonSerializer serializer, string jsonValue)
     {
         JObject jObject = serializer.Deserialize<JObject>(jsonValue.ToJsonTextReader());
         IncludeTransactions = GetIncludeTransactions(jObject["includeTransactions"]);
     }
-    
-    private static bool GetIncludeTransactions(JToken? token)
+
+    private static bool GetIncludeTransactions(JToken? token) => token switch
     {
-        switch (token)
-        {
-            case null:
-                return false;
-            default:
-                return token.ToObject<bool>();
-        }
-    }
+        null => false,
+        _ => token.ToObject<bool>(),
+    };
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/SubscriptionFactory.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/SubscriptionFactory.cs
@@ -13,14 +13,12 @@
 // 
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
 
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Filters;
-using Nethermind.Blockchain.Receipts;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Facade.Eth;
@@ -29,109 +27,108 @@ using Nethermind.Logging;
 using Nethermind.TxPool;
 using Newtonsoft.Json;
 
-namespace Nethermind.JsonRpc.Modules.Subscribe
+namespace Nethermind.JsonRpc.Modules.Subscribe;
+
+/// <summary>
+/// Creates different types of subscriptions.
+/// </summary>
+/// <remarks>
+/// Uses a dictionary which holds the constructors to the different subscription types, using the name
+/// of the respective RPC request as key-strings.
+/// When SubscriptionFactory is constructed, the basic subscription types are automatically loaded.
+/// Plugins may import additional subscription types by calling <see cref="RegisterSubscriptionType"/>.
+/// </remarks>
+public class SubscriptionFactory : ISubscriptionFactory
 {
-    /// <summary>
-    /// Creates different types of subscriptions.
-    /// </summary>
-    /// <remarks>
-    /// Uses a dictionary which holds the constructors to the different subscription types, using the name
-    /// of the respective RPC request as key-strings.
-    /// When SubscriptionFactory is constructed, the basic subscription types are automatically loaded.
-    /// Plugins may import additional subscription types by calling <see cref="RegisterSubscriptionType"/>.
-    /// </remarks>
-    public class SubscriptionFactory : ISubscriptionFactory
+    private readonly JsonSerializer _jsonSerializer;
+    private readonly ConcurrentDictionary<string, CustomSubscriptionType> _subscriptionConstructors;
+
+    public SubscriptionFactory(ILogManager? logManager,
+        IBlockTree? blockTree,
+        ITxPool? txPool,
+        IReceiptMonitor receiptCanonicalityMonitor,
+        IFilterStore? filterStore,
+        IEthSyncingInfo ethSyncingInfo,
+        ISpecProvider specProvider, 
+        JsonSerializer jsonSerializer)
     {
-        private readonly JsonSerializer _jsonSerializer;
-        private readonly ConcurrentDictionary<string, CustomSubscriptionType> _subscriptionConstructors;
-
-        public SubscriptionFactory(ILogManager? logManager,
-            IBlockTree? blockTree,
-            ITxPool? txPool,
-            IReceiptMonitor receiptCanonicalityMonitor,
-            IFilterStore? filterStore,
-            IEthSyncingInfo ethSyncingInfo,
-            ISpecProvider specProvider, 
-            JsonSerializer jsonSerializer)
-        {
-            _jsonSerializer = jsonSerializer;
-            logManager = logManager ?? throw new ArgumentNullException(nameof(logManager));
-            blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
-            txPool = txPool ?? throw new ArgumentNullException(nameof(txPool));
-            receiptCanonicalityMonitor = receiptCanonicalityMonitor ?? throw new ArgumentNullException(nameof(receiptCanonicalityMonitor));
-            filterStore = filterStore ?? throw new ArgumentNullException(nameof(filterStore));
-            ethSyncingInfo = ethSyncingInfo ?? throw new ArgumentNullException(nameof(ethSyncingInfo));
-            specProvider = specProvider ?? throw new ArgumentNullException(nameof(specProvider));
-            
-            _subscriptionConstructors = new ConcurrentDictionary<string, CustomSubscriptionType> {
-                
-                //Register the standard subscription types in the dictionary.
-                [SubscriptionType.NewHeads] = CreateSubscriptionType<TransactionsOption?>((jsonRpcDuplexClient, args) => 
-                    new NewHeadSubscription(jsonRpcDuplexClient, blockTree, logManager, specProvider, args)),
-                
-                [SubscriptionType.Logs] = CreateSubscriptionType<Filter?>((jsonRpcDuplexClient, filter) => 
-                    new LogsSubscription(jsonRpcDuplexClient, receiptCanonicalityMonitor, filterStore, blockTree, logManager, filter)),
-                
-                [SubscriptionType.NewPendingTransactions] = CreateSubscriptionType<TransactionsOption?>((jsonRpcDuplexClient, args) => 
-                    new NewPendingTransactionsSubscription(jsonRpcDuplexClient, txPool, logManager, args)),
-                
-                [SubscriptionType.DroppedPendingTransactions] = CreateSubscriptionType(jsonRpcDuplexClient => 
-                    new DroppedPendingTransactionsSubscription(jsonRpcDuplexClient, txPool, logManager)),
-                
-                [SubscriptionType.Syncing] = CreateSubscriptionType(jsonRpcDuplexClient => 
-                    new SyncingSubscription(jsonRpcDuplexClient, blockTree, ethSyncingInfo, logManager))
-            };
-        }
-
-        public Subscription CreateSubscription(IJsonRpcDuplexClient jsonRpcDuplexClient, string subscriptionType, string? args = null)
-        {
-            if (_subscriptionConstructors.TryGetValue(subscriptionType, out CustomSubscriptionType customSubscription))
-            {
-                Type? paramType = customSubscription.ParamType;
-                
-                IJsonRpcParam? param = null;
-                bool thereIsParameter = paramType is not null;
-                bool thereAreArgs = args is not null;
-                if (thereIsParameter && (thereAreArgs || paramType.CannotBeAssignedNull()))
-                {
-                    param = (IJsonRpcParam)Activator.CreateInstance(paramType);
-                    if (thereAreArgs)
-                    {
-                        param!.FromJson(_jsonSerializer, args);
-                    }
-                }
-                
-                return customSubscription.Constructor(jsonRpcDuplexClient, param);
-            }
-
-            throw new KeyNotFoundException($"{subscriptionType} is an invalid or unregistered subscription type");
-        }
-
-        public void RegisterSubscriptionType<T>(string subscriptionType, Func<IJsonRpcDuplexClient, T, Subscription> customSubscriptionDelegate) 
-            where T : IJsonRpcParam?, new() =>
-            _subscriptionConstructors[subscriptionType] = CreateSubscriptionType(customSubscriptionDelegate);
+        _jsonSerializer = jsonSerializer;
+        logManager = logManager ?? throw new ArgumentNullException(nameof(logManager));
+        blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
+        txPool = txPool ?? throw new ArgumentNullException(nameof(txPool));
+        receiptCanonicalityMonitor = receiptCanonicalityMonitor ?? throw new ArgumentNullException(nameof(receiptCanonicalityMonitor));
+        filterStore = filterStore ?? throw new ArgumentNullException(nameof(filterStore));
+        ethSyncingInfo = ethSyncingInfo ?? throw new ArgumentNullException(nameof(ethSyncingInfo));
+        specProvider = specProvider ?? throw new ArgumentNullException(nameof(specProvider));
         
+        _subscriptionConstructors = new ConcurrentDictionary<string, CustomSubscriptionType> {
+            
+            //Register the standard subscription types in the dictionary.
+            [SubscriptionType.NewHeads] = CreateSubscriptionType<TransactionsOption?>((jsonRpcDuplexClient, args) => 
+                new NewHeadSubscription(jsonRpcDuplexClient, blockTree, logManager, specProvider, args)),
+            
+            [SubscriptionType.Logs] = CreateSubscriptionType<Filter?>((jsonRpcDuplexClient, filter) => 
+                new LogsSubscription(jsonRpcDuplexClient, receiptCanonicalityMonitor, filterStore, blockTree, logManager, filter)),
+            
+            [SubscriptionType.NewPendingTransactions] = CreateSubscriptionType<TransactionsOption?>((jsonRpcDuplexClient, args) => 
+                new NewPendingTransactionsSubscription(jsonRpcDuplexClient, txPool, logManager, args)),
+            
+            [SubscriptionType.DroppedPendingTransactions] = CreateSubscriptionType(jsonRpcDuplexClient => 
+                new DroppedPendingTransactionsSubscription(jsonRpcDuplexClient, txPool, logManager)),
+            
+            [SubscriptionType.Syncing] = CreateSubscriptionType(jsonRpcDuplexClient => 
+                new SyncingSubscription(jsonRpcDuplexClient, blockTree, ethSyncingInfo, logManager))
+        };
+    }
 
-        private static CustomSubscriptionType CreateSubscriptionType<T>(Func<IJsonRpcDuplexClient, T, Subscription> customSubscriptionDelegate) 
-            where T : IJsonRpcParam?, new() =>
-            new(((client, args) => customSubscriptionDelegate(client, (T)args)), typeof(T));
-
-        public void RegisterSubscriptionType(string subscriptionType, Func<IJsonRpcDuplexClient, Subscription> customSubscriptionDelegate) =>
-            _subscriptionConstructors[subscriptionType] = CreateSubscriptionType(customSubscriptionDelegate);
-
-        private static CustomSubscriptionType CreateSubscriptionType(Func<IJsonRpcDuplexClient, Subscription> customSubscriptionDelegate) => 
-            new(((client, _) => customSubscriptionDelegate(client)));
-
-        private struct CustomSubscriptionType
+    public Subscription CreateSubscription(IJsonRpcDuplexClient jsonRpcDuplexClient, string subscriptionType, string? args = null)
+    {
+        if (_subscriptionConstructors.TryGetValue(subscriptionType, out CustomSubscriptionType customSubscription))
         {
-            public Func<IJsonRpcDuplexClient, object, Subscription> Constructor { get; }
-            public Type? ParamType { get; }
-
-            public CustomSubscriptionType(Func<IJsonRpcDuplexClient, object, Subscription> constructor, Type? paramType = null)
+            Type? paramType = customSubscription.ParamType;
+            
+            IJsonRpcParam? param = null;
+            bool thereIsParameter = paramType is not null;
+            bool thereAreArgs = args is not null;
+            if (thereIsParameter && (thereAreArgs || paramType.CannotBeAssignedNull()))
             {
-                Constructor = constructor;
-                ParamType = paramType;
+                param = (IJsonRpcParam)Activator.CreateInstance(paramType);
+                if (thereAreArgs)
+                {
+                    param!.ReadJson(_jsonSerializer, args);
+                }
             }
+            
+            return customSubscription.Constructor(jsonRpcDuplexClient, param);
+        }
+
+        throw new KeyNotFoundException($"{subscriptionType} is an invalid or unregistered subscription type");
+    }
+
+    public void RegisterSubscriptionType<T>(string subscriptionType, Func<IJsonRpcDuplexClient, T, Subscription> customSubscriptionDelegate) 
+        where T : IJsonRpcParam?, new() =>
+        _subscriptionConstructors[subscriptionType] = CreateSubscriptionType(customSubscriptionDelegate);
+    
+
+    private static CustomSubscriptionType CreateSubscriptionType<T>(Func<IJsonRpcDuplexClient, T, Subscription> customSubscriptionDelegate) 
+        where T : IJsonRpcParam?, new() =>
+        new(((client, args) => customSubscriptionDelegate(client, (T)args)), typeof(T));
+
+    public void RegisterSubscriptionType(string subscriptionType, Func<IJsonRpcDuplexClient, Subscription> customSubscriptionDelegate) =>
+        _subscriptionConstructors[subscriptionType] = CreateSubscriptionType(customSubscriptionDelegate);
+
+    private static CustomSubscriptionType CreateSubscriptionType(Func<IJsonRpcDuplexClient, Subscription> customSubscriptionDelegate) => 
+        new(((client, _) => customSubscriptionDelegate(client)));
+
+    private struct CustomSubscriptionType
+    {
+        public Func<IJsonRpcDuplexClient, object, Subscription> Constructor { get; }
+        public Type? ParamType { get; }
+
+        public CustomSubscriptionType(Func<IJsonRpcDuplexClient, object, Subscription> constructor, Type? paramType = null)
+        {
+            Constructor = constructor;
+            ParamType = paramType;
         }
     }
 }


### PR DESCRIPTION
Fixes #4384

## Changes
Added support for the `blockHash` parameter to the `eth_getLogs` RPC method. When this parameter is specified, the `fromBlock` and `toBlock` parameters are ignored if provided.

## Types of changes

What types of changes does your code introduce?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No