### PR TITLE
fix: change regex to get correct changelog value

### DIFF
--- a/.github/workflows/run-discord-announcement.yml
+++ b/.github/workflows/run-discord-announcement.yml
@@ -14,7 +14,7 @@ jobs:
     - name: CURL Discord API with announcement
       shell: bash
       run: |
-        CHANGELOG=$(curl -s https://api.github.com/repos/nethermindeth/nethermind/releases | jq '.[0].body' | grep -Po '(?<=\\n\\r\\n)(.*?)(?=\##)')
+        CHANGELOG=$(curl -s https://api.github.com/repos/nethermindeth/nethermind/releases | jq '.[0].body' | grep -Po '(?<=## )(.*?)(?=\##))
         read VERSION LINK < <(echo $(curl -s 'https://api.github.com/repos/nethermindeth/nethermind/releases' | jq -r '.[0].name, .[0].html_url'))
         MESSAGE="**New Nethermind release version: ${VERSION}**\n\n${CHANGELOG}<${LINK}>"
         curl -s -H "Content-Type: application/json" -d '{"username": "Nethermind", "content": "'"$MESSAGE"'"}' $WEBHOOK_URL > /dev/null 2>&1

--- a/.github/workflows/run-discord-announcement.yml
+++ b/.github/workflows/run-discord-announcement.yml
@@ -14,7 +14,7 @@ jobs:
     - name: CURL Discord API with announcement
       shell: bash
       run: |
-        CHANGELOG=$(curl -s https://api.github.com/repos/nethermindeth/nethermind/releases | jq '.[0].body' | grep -Po '(?<=## )(.*?)(?=\##))
+        CHANGELOG=$(curl -s https://api.github.com/repos/nethermindeth/nethermind/releases | jq '.[0].body' | grep -Po '(?<=## )(.*?)(?=\##)')
         read VERSION LINK < <(echo $(curl -s 'https://api.github.com/repos/nethermindeth/nethermind/releases' | jq -r '.[0].name, .[0].html_url'))
         MESSAGE="**New Nethermind release version: ${VERSION}**\n\n${CHANGELOG}<${LINK}>"
         curl -s -H "Content-Type: application/json" -d '{"username": "Nethermind", "content": "'"$MESSAGE"'"}' $WEBHOOK_URL > /dev/null 2>&1


### PR DESCRIPTION
Changes the regex to match the changelog in github releases properly.


## Changes:
- changed the regex in the discord announcement action to better match the changelog. 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [X] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [X] No

**Comments about testing , should you have some** (optional)

## Further comments (optional)

Tested locally with multiple release changelogs (1.13.2 till 1.13.6) and works as it should. 