### PR TITLE
Fix/ppa publish

### DIFF
--- a/scripts/deployment/publish-ppa.sh
+++ b/scripts/deployment/publish-ppa.sh
@@ -6,6 +6,7 @@ set -e
 echo $VERSION > ver
 FIXED_VERSION=$(awk -F. '{ print $1"."$2$3$4"0"}' ver)
 
+cd $RELEASE_DIRECTORY/nethermind/
 for release in ${RELEASES}; do
 
   echo "nethermind ($FIXED_VERSION) $release; urgency=high
@@ -13,13 +14,13 @@ for release in ${RELEASES}; do
   * Nethermind client ($FIXED_VERSION release)
 
  -- Nethermind <devops@nethermind.io>  $( date -R )" > $RELEASE_DIRECTORY/nethermind/build/debian/changelog
-  cd nethermind/build/
+  cd build/
   debuild -S -uc -us
   cd ..
   echo 'Signing package'
   debsign -p 'gpg --batch --yes --no-tty --pinentry-mode loopback --passphrase-file /home/runner/work/nethermind/PASSPHRASE' -S -k$PPA_GPG_KEYID nethermind_${FIXED_VERSION}_source.changes
   echo 'Uploading'
-  dput -s -u ppa:nethermindeth/nethermind nethermind_${FIXED_VERSION}_source.changes
+  dput -f ppa:nethermindeth/nethermind nethermind_${FIXED_VERSION}_source.changes
   echo "Publishing $release release to PPA complete"
   echo 'Cleanup'
   rm nethermind_$FIXED_VERSION*

--- a/scripts/deployment/publish-ppa.sh
+++ b/scripts/deployment/publish-ppa.sh
@@ -1,22 +1,26 @@
 #!/bin/bash
 #exit when any command fails
+RELEASES="bionic focal impish jammy"
 
 set -e
 echo $VERSION > ver
 FIXED_VERSION=$(awk -F. '{ print $1"."$2$3$4"0"}' ver)
-echo "nethermind ($FIXED_VERSION) bionic focal impish jammy; urgency=high
+
+for release in ${RELEASES}; do
+
+  echo "nethermind ($FIXED_VERSION) $release; urgency=high
 
   * Nethermind client ($FIXED_VERSION release)
 
  -- Nethermind <devops@nethermind.io>  $( date -R )" > $RELEASE_DIRECTORY/nethermind/build/debian/changelog
-
-cd nethermind/build/
-debuild -S -uc -us
-cd ..
-
-echo 'Signing package'
-debsign -p 'gpg --batch --yes --no-tty --pinentry-mode loopback --passphrase-file /home/runner/work/nethermind/PASSPHRASE' -S -k$PPA_GPG_KEYID nethermind_${FIXED_VERSION}_source.changes
-
-echo 'Uploading'
-dput -f ppa:nethermindeth/nethermind nethermind_${FIXED_VERSION}_source.changes
-echo 'Publishing to PPA complete'
+  cd nethermind/build/
+  debuild -S -uc -us
+  cd ..
+  echo 'Signing package'
+  debsign -p 'gpg --batch --yes --no-tty --pinentry-mode loopback --passphrase-file /home/runner/work/nethermind/PASSPHRASE' -S -k$PPA_GPG_KEYID nethermind_${FIXED_VERSION}_source.changes
+  echo 'Uploading'
+  dput -s -u ppa:nethermindeth/nethermind nethermind_${FIXED_VERSION}_source.changes
+  echo "Publishing $release release to PPA complete"
+  echo 'Cleanup'
+  rm nethermind_$FIXED_VERSION*
+done


### PR DESCRIPTION
Updates the PPA script to add a for loop to support multiple Ubuntu distros. The previous script tried uploading to several distros at once, which failed. It will now loop through a list of 4 distros and publishes it. 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [X] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [X] No

## Further comments (optional)

Tested locally on my own machine using simulated dput upload and lintian. Besides the for loop, nothing changed in the build/upload process.  