### PR TITLE
Add msbuild target to create gnosis configs from xdai configs

### DIFF
--- a/src/Nethermind/Nethermind.Runner/Nethermind.Runner.csproj
+++ b/src/Nethermind/Nethermind.Runner/Nethermind.Runner.csproj
@@ -137,6 +137,19 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <XdaiConfigFiles Include="configs\*xdai*.cfg" />
+  </ItemGroup>
+
+  <Target Name="AliasingGnosisAndXdaiConfigFiles" BeforeTargets="BeforeBuild">
+    <ItemGroup>
+      <XdaiConfigFiles>
+        <GnosisConfigFile>$([System.String]::Copy('%(Filename)').Replace('xdai', 'gnosis'))</GnosisConfigFile>
+      </XdaiConfigFiles>
+    </ItemGroup>
+    <Message Text="---&gt; Creating aliases for xdai and gnosis config files @(XdaiConfigFiles->'%(GnosisConfigFile)')" Importance="High" />
+    <Copy SourceFiles="@(XdaiConfigFiles)" DestinationFiles="@(XdaiConfigFiles->'$(OutDir)\configs\%(GnosisConfigFile).cfg')" />
+  </Target>
 
   <Target Name="StoreGitHashBeforeBuild" BeforeTargets="BeforeBuild">
     <Message Text="---&gt; Generating Git Hash file Before Build" Importance="High" />


### PR DESCRIPTION
Resolves #4309 

## Changes:
- Adds a msbuild target that copies all configs containing xdai in the name, replacing xdai by gnosis in the name.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [x] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [ ] No