### PR TITLE
Fix Goerli transition issue

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -39,8 +39,7 @@ using Nethermind.Db.Blooms;
 
 namespace Nethermind.Blockchain
 {
-    [Todo(Improve.Refactor,
-        "After the fast sync work there are some duplicated code parts for the 'by header' and 'by block' approaches.")]
+    [Todo(Improve.Refactor, "After the fast sync work there are some duplicated code parts for the 'by header' and 'by block' approaches.")]
     public partial class BlockTree : IBlockTree
     {
         // there is not much logic in the addressing here
@@ -67,8 +66,8 @@ namespace Nethermind.Blockchain
         private readonly IDb _blockInfoDb;
         private readonly IDb _metadataDb;
 
-        private ICache<long, HashSet<Keccak>> _invalidBlocks =
-            new LruCache<long, HashSet<Keccak>>(128, 128, "invalid blocks");
+        private readonly ICache<Keccak, Block> _invalidBlocks =
+            new LruCache<Keccak, Block>(128, 128, "invalid blocks");
 
         private readonly BlockDecoder _blockDecoder = new();
         private readonly HeaderDecoder _headerDecoder = new();
@@ -725,8 +724,7 @@ namespace Nethermind.Blockchain
                 return AddBlockResult.CannotAccept;
             }
 
-            HashSet<Keccak> invalidBlocksWithThisNumber = _invalidBlocks.Get(header.Number);
-            if (invalidBlocksWithThisNumber?.Contains(header.Hash) ?? false)
+            if (_invalidBlocks.Contains(header.Hash))
             {
                 return AddBlockResult.InvalidBlock;
             }
@@ -848,17 +846,20 @@ namespace Nethermind.Blockchain
             BlockHeader? header = _headerDb.Get(blockHash, _headerDecoder, _headerCache, false);
             if (header is null)
             {
-                return null;
+                bool allowInvalid = (options & BlockTreeLookupOptions.AllowInvalid) == BlockTreeLookupOptions.AllowInvalid;
+                if (allowInvalid && _invalidBlocks.TryGet(blockHash, out Block block))
+                {
+                    header = block.Header;
+                }
+
+                return header;
             }
 
             header.Hash ??= blockHash;
 
-            bool totalDifficultyNeeded = (options & BlockTreeLookupOptions.TotalDifficultyNotNeeded) ==
-                                         BlockTreeLookupOptions.None;
-            bool calculateTotalDifficulty = (options & BlockTreeLookupOptions.DoNotCalculateTotalDifficulty) ==
-                                            BlockTreeLookupOptions.None;
-            bool requiresCanonical = (options & BlockTreeLookupOptions.RequireCanonical) ==
-                                     BlockTreeLookupOptions.RequireCanonical;
+            bool totalDifficultyNeeded = (options & BlockTreeLookupOptions.TotalDifficultyNotNeeded) == BlockTreeLookupOptions.None;
+            bool calculateTotalDifficulty = (options & BlockTreeLookupOptions.DoNotCalculateTotalDifficulty) == BlockTreeLookupOptions.None;
+            bool requiresCanonical = (options & BlockTreeLookupOptions.RequireCanonical) == BlockTreeLookupOptions.RequireCanonical;
 
             if ((totalDifficultyNeeded && header.TotalDifficulty is null) || requiresCanonical)
             {
@@ -867,9 +868,7 @@ namespace Nethermind.Blockchain
                 {
                     // TODO: this is here because storing block data is not transactional
                     // TODO: would be great to remove it, he?
-                    if (_logger.IsTrace)
-                        _logger.Trace(
-                            $"Entering missing block info in {nameof(FindHeader)} scope when head is {Head?.ToString(Block.Format.Short)}");
+                    if (_logger.IsTrace) _logger.Trace($"Entering missing block info in {nameof(FindHeader)} scope when head is {Head?.ToString(Block.Format.Short)}");
                     if (calculateTotalDifficulty)
                     {
                         SetTotalDifficulty(header);
@@ -1026,10 +1025,8 @@ namespace Nethermind.Blockchain
                 && firstDescendant.Hash != secondDescendant.Hash)
             {
                 if (currentSearchDepth++ >= maxSearchDepth) return null;
-                firstDescendant =
-                    this.FindParentHeader(firstDescendant, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
-                secondDescendant =
-                    this.FindParentHeader(secondDescendant, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
+                firstDescendant = this.FindParentHeader(firstDescendant, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
+                secondDescendant = this.FindParentHeader(secondDescendant, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
             }
 
             return firstDescendant;
@@ -1090,18 +1087,13 @@ namespace Nethermind.Blockchain
         {
             if (invalidBlock.Hash is null)
             {
-                if (_logger.IsWarn)
-                    _logger.Warn($"{nameof(DeleteInvalidBlock)} call has been made for a block without a null hash.");
+                if (_logger.IsWarn) _logger.Warn($"{nameof(DeleteInvalidBlock)} call has been made for a block without a null hash.");
                 return;
             }
 
-            if (_logger.IsDebug)
-                _logger.Debug($"Deleting invalid block {invalidBlock.ToString(Block.Format.FullHashAndNumber)}");
+            if (_logger.IsDebug) _logger.Debug($"Deleting invalid block {invalidBlock.ToString(Block.Format.FullHashAndNumber)}");
 
-            HashSet<Keccak>? invalidBlocksWithThisNumber =
-                _invalidBlocks.Get(invalidBlock.Number) ?? new HashSet<Keccak>();
-            invalidBlocksWithThisNumber.Add(invalidBlock.Hash);
-            _invalidBlocks.Set(invalidBlock.Number, invalidBlocksWithThisNumber);
+            _invalidBlocks.Set(invalidBlock.Hash, invalidBlock);
 
             BestSuggestedHeader = Head?.Header;
             BestSuggestedBody = Head;
@@ -1123,17 +1115,13 @@ namespace Nethermind.Blockchain
             BlockHeader? deleteHeader = FindHeader(deletePointer, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
             if (deleteHeader is null)
             {
-                if (_logger.IsWarn)
-                    _logger.Warn(
-                        $"Cannot delete invalid block {deletePointer} - block has not been added to the database or has already been deleted.");
+                if (_logger.IsWarn) _logger.Warn($"Cannot delete invalid block {deletePointer} - block has not been added to the database or has already been deleted.");
                 return;
             }
 
             if (deleteHeader.Hash is null)
             {
-                if (_logger.IsWarn)
-                    _logger.Warn(
-                        $"Cannot delete invalid block {deletePointer} - black has a null hash.");
+                if (_logger.IsWarn) _logger.Warn($"Cannot delete invalid block {deletePointer} - black has a null hash.");
                 return;
             }
 
@@ -1157,8 +1145,7 @@ namespace Nethermind.Blockchain
                     }
                     else
                     {
-                        currentLevel.BlockInfos =
-                            currentLevel.BlockInfos.Where(bi => bi.BlockHash != currentHash).ToArray();
+                        currentLevel.BlockInfos = currentLevel.BlockInfos.Where(bi => bi.BlockHash != currentHash).ToArray();
                     }
                 }
 
@@ -1203,13 +1190,10 @@ namespace Nethermind.Blockchain
             for (int i = 0; i < level.BlockInfos.Length; i++)
             {
                 Keccak potentialChildHash = level.BlockInfos[i].BlockHash;
-                BlockHeader? potentialChild =
-                    FindHeader(potentialChildHash, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
+                BlockHeader? potentialChild = FindHeader(potentialChildHash, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
                 if (potentialChild is null)
                 {
-                    if (_logger.IsWarn)
-                        _logger.Warn(
-                            $"Block with hash {potentialChildHash} has been found on chain level but its header is missing from the DB.");
+                    if (_logger.IsWarn) _logger.Warn($"Block with hash {potentialChildHash} has been found on chain level but its header is missing from the DB.");
                     return null;
                 }
 
@@ -1235,8 +1219,7 @@ namespace Nethermind.Blockchain
             BlockHeader? header = FindHeader(blockHash, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
             if (header is null)
             {
-                throw new InvalidOperationException(
-                    $"Not able to retrieve block number for an unknown block {blockHash}");
+                throw new InvalidOperationException($"Not able to retrieve block number for an unknown block {blockHash}");
             }
 
             return IsMainChain(header);
@@ -1389,9 +1372,13 @@ namespace Nethermind.Blockchain
                     for (int i = 0; i < level.BlockInfos.Length; ++i)
                     {
                         if (level.BlockInfos[i].BlockHash == blockInfo.BlockHash)
+                        {
                             level.BlockInfos[i].Metadata |= BlockMetadata.BeaconMainChain;
+                        }
                         else
+                        {
                             level.BlockInfos[i].Metadata &= ~BlockMetadata.BeaconMainChain;
+                        }
                     }
 
                     _chainLevelInfoRepository.PersistLevel(levelNumber, level, batch);
@@ -1886,7 +1873,13 @@ namespace Nethermind.Blockchain
             Block block = _blockDb.Get(blockHash, _blockDecoder, _blockCache, false);
             if (block is null)
             {
-                return null;
+                bool allowInvalid = (options & BlockTreeLookupOptions.AllowInvalid) == BlockTreeLookupOptions.AllowInvalid;
+                if (allowInvalid)
+                {
+                    _invalidBlocks.TryGet(blockHash, out block);
+                }
+
+                return block;
             }
 
             bool totalDifficultyNeeded = (options & BlockTreeLookupOptions.TotalDifficultyNotNeeded) ==

--- a/src/Nethermind/Nethermind.Blockchain/BlockTreeMethodOptions.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTreeMethodOptions.cs
@@ -19,9 +19,6 @@ using System;
 
 namespace Nethermind.Blockchain;
 
-/// <summary>
-/// This class has been introduced for performance reasons only (in order to minimize expensive DB lookups where not necessary).
-/// </summary>
 [Flags]
 public enum BlockTreeLookupOptions
 {
@@ -29,7 +26,8 @@ public enum BlockTreeLookupOptions
     TotalDifficultyNotNeeded = 1,
     RequireCanonical = 2,
     DoNotCalculateTotalDifficulty = 4,
-    All = 7
+    AllowInvalid = 8,
+    All = 15
 }
 
 [Flags]

--- a/src/Nethermind/Nethermind.Blockchain/Find/IBlockFinder.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Find/IBlockFinder.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -27,9 +27,9 @@ namespace Nethermind.Blockchain.Find
         Keccak GenesisHash { get; }
 
         Keccak? PendingHash { get; }
-        
+
         Keccak? FinalizedHash { get; }
-        
+
         Keccak? SafeHash { get; }
 
         Block? Head { get; }
@@ -70,36 +70,27 @@ namespace Nethermind.Blockchain.Find
 
         public Block? FindLatestBlock() => FindHeadBlock();
 
-        public Block? FindPendingBlock() =>
-            PendingHash == null ? null : FindBlock(PendingHash, BlockTreeLookupOptions.None);
-        
-        public Block? FindFinalizedBlock() =>
-            FinalizedHash == null ? null : FindBlock(FinalizedHash, BlockTreeLookupOptions.None);
-        
-        public Block? FindSafeBlock() =>
-            SafeHash == null ? null : FindBlock(SafeHash, BlockTreeLookupOptions.None);
+        public Block? FindPendingBlock() => PendingHash == null ? null : FindBlock(PendingHash, BlockTreeLookupOptions.None);
+
+        public Block? FindFinalizedBlock() => FinalizedHash == null ? null : FindBlock(FinalizedHash, BlockTreeLookupOptions.None);
+
+        public Block? FindSafeBlock() => SafeHash == null ? null : FindBlock(SafeHash, BlockTreeLookupOptions.None);
 
         public BlockHeader? FindHeader(Keccak blockHash) => FindHeader(blockHash, BlockTreeLookupOptions.None);
 
-        public BlockHeader? FindHeader(long blockNumber) =>
-            FindHeader(blockNumber, BlockTreeLookupOptions.RequireCanonical);
+        public BlockHeader? FindHeader(long blockNumber) => FindHeader(blockNumber, BlockTreeLookupOptions.RequireCanonical);
 
-        public BlockHeader FindGenesisHeader() =>
-            FindHeader(GenesisHash, BlockTreeLookupOptions.RequireCanonical)
-            ?? throw new Exception("Genesis header could not be found");
+        public BlockHeader FindGenesisHeader() => FindHeader(GenesisHash, BlockTreeLookupOptions.RequireCanonical) ?? throw new Exception("Genesis header could not be found");
 
         public BlockHeader FindEarliestHeader() => FindGenesisHeader();
 
         public BlockHeader? FindLatestHeader() => Head?.Header;
 
-        public BlockHeader? FindPendingHeader() =>
-            PendingHash == null ? null : FindHeader(PendingHash, BlockTreeLookupOptions.None);
+        public BlockHeader? FindPendingHeader() => PendingHash == null ? null : FindHeader(PendingHash, BlockTreeLookupOptions.None);
 
-        public BlockHeader? FindFinalizedHeader() =>
-            FinalizedHash == null ? null : FindHeader(FinalizedHash, BlockTreeLookupOptions.None);
+        public BlockHeader? FindFinalizedHeader() => FinalizedHash == null ? null : FindHeader(FinalizedHash, BlockTreeLookupOptions.None);
 
-        public BlockHeader? FindSafeHeader() =>
-            SafeHash == null ? null : FindHeader(SafeHash, BlockTreeLookupOptions.None);
+        public BlockHeader? FindSafeHeader() => SafeHash == null ? null : FindHeader(SafeHash, BlockTreeLookupOptions.None);
 
         BlockHeader FindBestSuggestedHeader();
 
@@ -158,7 +149,7 @@ namespace Nethermind.Blockchain.Find
                 _ => throw new ArgumentException($"{nameof(BlockParameterType)} not supported: {blockParameter.Type}")
             };
         }
-        
+
         /// <summary>
         /// Highest state persisted
         /// </summary>

--- a/src/Nethermind/Nethermind.Blockchain/IBlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/IBlockTree.cs
@@ -70,7 +70,6 @@ namespace Nethermind.Blockchain
         /// </summary>
         long BestKnownNumber { get; }
 
-
         long BestKnownBeaconNumber { get; }
 
         /// <summary>

--- a/src/Nethermind/Nethermind.Blockchain/InvalidBlockException.cs
+++ b/src/Nethermind/Nethermind.Blockchain/InvalidBlockException.cs
@@ -1,31 +1,32 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
+using Nethermind.Core;
 using Nethermind.Core.Crypto;
 
 namespace Nethermind.Blockchain
 {
     public class InvalidBlockException : BlockchainException
     {
-        public Keccak InvalidBlockHash { get; }
+        public Block InvalidBlock { get; }
 
-        public InvalidBlockException(Keccak invalidBlockHash) 
-            : base($"Invalid block: {invalidBlockHash}")
+        public InvalidBlockException(Block invalidBlock)
+            : base($"Invalid block: {invalidBlock}")
         {
-            InvalidBlockHash = invalidBlockHash;
+            InvalidBlock = invalidBlock;
         }
     }
 }

--- a/src/Nethermind/Nethermind.Consensus.AuRa/AuRaBlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/AuRaBlockProcessor.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -114,7 +114,7 @@ namespace Nethermind.Consensus.AuRa
             }
         }
 
-        private BlockHeader GetParentHeader(Block block) => 
+        private BlockHeader GetParentHeader(Block block) =>
             _blockTree.FindParentHeader(block.Header, BlockTreeLookupOptions.None)!;
 
         private void ValidateGasLimit(Block block)
@@ -124,7 +124,7 @@ namespace Nethermind.Consensus.AuRa
             if (_gasLimitOverride?.IsGasLimitValid(parentHeader, block.GasLimit, out expectedGasLimit) == false)
             {
                 if (_logger.IsWarn) _logger.Warn($"Invalid gas limit for block {block.Number}, hash {block.Hash}, expected value from contract {expectedGasLimit}, but found {block.GasLimit}.");
-                throw new InvalidBlockException(block.Hash);
+                throw new InvalidBlockException(block);
             }
         }
 
@@ -137,16 +137,16 @@ namespace Nethermind.Consensus.AuRa
                 if (args.Action != TxAction.Add)
                 {
                     if (_logger.IsWarn) _logger.Warn($"Proposed block is not valid {block.ToString(Block.Format.FullHashAndNumber)}. {tx.ToShortString()} doesn't have required permissions. Reason: {args.Reason}.");
-                    throw new InvalidBlockException(block.Hash);
+                    throw new InvalidBlockException(block);
                 }
             }
         }
-        
+
         private void OnAddingTransaction(object? sender, AddingTxEventArgs e)
         {
             CheckTxPosdaoRules(e);
         }
-        
+
         private AddingTxEventArgs CheckTxPosdaoRules(AddingTxEventArgs args)
         {
             AcceptTxResult? TryRecoverSenderAddress(Transaction tx, BlockHeader header)

--- a/src/Nethermind/Nethermind.Consensus.AuRa/Validators/AuRaValidatorBase.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/Validators/AuRaValidatorBase.cs
@@ -1,16 +1,16 @@
 ﻿//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -26,10 +26,10 @@ namespace Nethermind.Consensus.AuRa.Validators
     public abstract class AuRaValidatorBase : IAuRaValidator
     {
         public const long DefaultStartBlockNumber = 1;
-        
+
         private readonly IValidSealerStrategy _validSealerStrategy;
         private readonly ILogger _logger;
-        
+
         protected AuRaValidatorBase(
             IValidSealerStrategy validSealerStrategy,
             IValidatorStore validatorStore,
@@ -43,9 +43,9 @@ namespace Nethermind.Consensus.AuRa.Validators
             InitBlockNumber = startBlockNumber;
             ForSealing = forSealing;
         }
-        
+
         public Address[] Validators { get; protected internal set; }
-        
+
         protected long InitBlockNumber { get; }
         protected internal bool ForSealing { get; }
         protected IValidatorStore ValidatorStore { get; }
@@ -67,7 +67,7 @@ namespace Nethermind.Consensus.AuRa.Validators
                 {
                     if (_logger.IsError) _logger.Error($"Block from incorrect proposer at block {block.ToString(Block.Format.FullHashAndNumber)}, step {auRaStep} from author {block.Beneficiary}.");
                     this.GetReportingValidator().ReportBenign(block.Beneficiary, block.Number, IReportingValidator.BenignCause.IncorrectProposer);
-                    throw new InvalidBlockException(block.Hash);
+                    throw new InvalidBlockException(block);
                 }
             }
         }

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -93,11 +93,11 @@ namespace Nethermind.Consensus.Processing
             BlocksProcessing?.Invoke(this, new BlocksProcessingEventArgs(suggestedBlocks));
 
             /* We need to save the snapshot state root before reorganization in case the new branch has invalid blocks.
-               In case of invalid blocks on the new branch we will discard the entire branch and come back to 
+               In case of invalid blocks on the new branch we will discard the entire branch and come back to
                the previous head state.*/
             Keccak previousBranchStateRoot = CreateCheckpoint();
             InitBranch(newBranchStateRoot);
-            
+
             bool notReadOnly = !options.ContainsFlag(ProcessingOptions.ReadOnlyChain);
             int blocksCount = suggestedBlocks.Count;
             Block[] processedBlocks = new Block[blocksCount];
@@ -196,7 +196,7 @@ namespace Nethermind.Consensus.Processing
             _stateProvider.StateRoot = branchingPointStateRoot;
             if (_logger.IsTrace) _logger.Trace($"Restored the branch checkpoint - {branchingPointStateRoot} | {_stateProvider.StateRoot}");
         }
-        
+
         // TODO: block processor pipeline
         private (Block Block, TxReceipt[] Receipts) ProcessOne(Block suggestedBlock, ProcessingOptions options, IBlockTracer blockTracer)
         {
@@ -210,7 +210,7 @@ namespace Nethermind.Consensus.Processing
             {
                 StoreTxReceipts(block, receipts);
             }
-            
+
             return (block, receipts);
         }
 
@@ -221,23 +221,23 @@ namespace Nethermind.Consensus.Processing
             {
                 if (_logger.IsError) _logger.Error($"Processed block is not valid {suggestedBlock.ToString(Block.Format.FullHashAndNumber)}");
                 if (_logger.IsError) _logger.Error($"Suggested block TD: {suggestedBlock.TotalDifficulty}, Suggested block IsPostMerge {suggestedBlock.IsPostMerge}, Block TD: {block.TotalDifficulty}, Block IsPostMerge {block.IsPostMerge}");
-                throw new InvalidBlockException(suggestedBlock.Hash);
+                throw new InvalidBlockException(suggestedBlock);
             }
         }
 
         // TODO: block processor pipeline
         protected virtual TxReceipt[] ProcessBlock(
-            Block block, 
-            IBlockTracer blockTracer, 
+            Block block,
+            IBlockTracer blockTracer,
             ProcessingOptions options)
         {
             IReleaseSpec spec = _specProvider.GetSpec(block.Number);
-            
+
             _receiptsTracer.SetOtherTracer(blockTracer);
             _receiptsTracer.StartNewBlockTrace(block);
             TxReceipt[] receipts = _blockTransactionsExecutor.ProcessTransactions(block, options, _receiptsTracer, spec);
             _receiptsTracer.EndBlockTrace();
-            
+
             block.Header.ReceiptsRoot = receipts.GetReceiptsRoot(spec, block.ReceiptsRoot);
             ApplyMinerRewards(block, blockTracer, spec);
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
@@ -428,7 +428,7 @@ namespace Nethermind.Consensus.Processing
                 }
                 catch (InvalidBlockException ex)
                 {
-                    BlockTraceDumper.LogDiagnosticTrace(blockTracer, ex.InvalidBlockHash, _logger);
+                    BlockTraceDumper.LogDiagnosticTrace(blockTracer, ex.InvalidBlock.Hash!, _logger);
                 }
                 catch (Exception ex)
                 {
@@ -465,10 +465,10 @@ namespace Nethermind.Consensus.Processing
             {
                 InvalidBlock?.Invoke(this, new IBlockchainProcessor.InvalidBlockEventArgs
                 {
-                    InvalidBlockHash = ex.InvalidBlockHash,
+                    InvalidBlock = ex.InvalidBlock,
                 });
 
-                invalidBlockHash = ex.InvalidBlockHash;
+                invalidBlockHash = ex.InvalidBlock.Hash;
                 TraceFailingBranch(
                     processingBranch,
                     options,

--- a/src/Nethermind/Nethermind.Consensus/Processing/IBlockchainProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/IBlockchainProcessor.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -28,18 +28,18 @@ namespace Nethermind.Consensus.Processing
         ITracerBag Tracers { get; }
 
         void Start();
-        
+
         Task StopAsync(bool processRemainingBlocks = false);
-        
+
         Block? Process(Block block, ProcessingOptions options, IBlockTracer tracer);
 
         bool IsProcessingBlocks(ulong? maxProcessingInterval);
-        
+
         event EventHandler<InvalidBlockEventArgs> InvalidBlock;
 
         public class InvalidBlockEventArgs : EventArgs
         {
-            public Keccak InvalidBlockHash { get; init; }
+            public Block InvalidBlock { get; init; }
         }
     }
 }

--- a/src/Nethermind/Nethermind.Consensus/Processing/ProcessingOptions.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ProcessingOptions.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -22,55 +22,55 @@ namespace Nethermind.Consensus.Processing
     public enum ProcessingOptions
     {
         None = 0,
-        
+
         /// <summary>
         /// It will not update the storage data (will discard any changes).
         /// </summary>
         ReadOnlyChain = 1 | DoNotUpdateHead,
-        
+
         /// <summary>
         /// Will process the block even if it was processed in the past.
         /// </summary>
         ForceProcessing = 2,
-        
+
         /// <summary>
         /// After processing will store all tx receipts in the storage.
         /// </summary>
         StoreReceipts = 4,
-        
+
         /// <summary>
         /// Will process the block even if it is invalid.
         /// </summary>
         NoValidation = 8,
-        
+
         /// <summary>
         /// Allows to process the block even if its parent is not on canonical chain.
         /// </summary>
         IgnoreParentNotOnMainChain = 16,
-        
+
         /// <summary>
         /// Does not verify transaction nonces during processing.
         /// </summary>
         DoNotVerifyNonce = 32,
-        
+
         /// <summary>
         /// After processing it will not update the block tree head even if the processed block has the highest
         /// total difficulty.
         /// </summary>
         DoNotUpdateHead = 64,
-        
+
         /// <summary>
         /// Used in EngineApi in NewPayload method for marking blocks as processed
         /// </summary>
         MarkAsProcessed = 128,
-        
+
         All = 255,
-        
+
         /// <summary>
         /// Combination of switches for block producers when they preprocess block for state root calculation.
         /// </summary>
         ProducingBlock = NoValidation | ReadOnlyChain | ForceProcessing | DoNotUpdateHead,
-        
+
         /// <summary>
         /// EVM tracing needs to process blocks without storing the data on chain.
         /// </summary>

--- a/src/Nethermind/Nethermind.Core/Extensions/EnumExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/EnumExtensions.cs
@@ -1,0 +1,89 @@
+﻿//  Copyright (c) 2021 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+//
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FastEnumUtility;
+
+namespace Nethermind.Core.Extensions;
+
+public static class EnumExtensions
+{
+    /// <summary>
+    /// Returns all combinations of enum values of type <see cref="T"/>.
+    /// </summary>
+    /// <typeparam name="T">Type of enumeration.</typeparam>
+    /// <returns>All combinations of defined enum values.</returns>
+    /// <remarks>
+    /// For normal enums this is equivalent to all defined values.
+    /// For <see cref="FlagsAttribute"/> enums this produces all combination of defined values.
+    /// </remarks>
+    public static IReadOnlyList<T> AllValuesCombinations<T>() where T : struct, Enum
+    {
+        // The return type of Enum.GetValues is Array but it is effectively int[] per docs
+        // This bit converts to int[]
+        IReadOnlyList<T> values = FastEnum.GetValues<T>();
+
+        if (!typeof(T).GetCustomAttributes(typeof(FlagsAttribute), false).Any())
+        {
+            // We don't have flags so just return the result of GetValues
+            return values;
+        }
+
+        // TODO: in .net 7 rewrite with generic INumber based on FastEnum.GetUnderlyingType<T>()
+        int[] valuesBinary = values.Cast<int>().ToArray();
+
+        int[] valuesInverted = valuesBinary.Select(v => ~v).ToArray();
+        int max = 0;
+        for (int i = 0; i < valuesBinary.Length; i++)
+        {
+            max |= valuesBinary[i];
+        }
+
+        List<T> result = new();
+        for (int i = 0; i <= max; i++)
+        {
+            int unaccountedBits = i;
+            for (int j = 0; j < valuesInverted.Length; j++)
+            {
+                // This step removes each flag that is set in one of the Enums thus ensuring that an Enum with missing bits won't be passed an int that has those bits set
+                unaccountedBits &= valuesInverted[j];
+                if (unaccountedBits == 0)
+                {
+                    result.Add((T)(object)i);
+                    break;
+                }
+            }
+        }
+
+        //Check for zero
+        try
+        {
+            if (string.IsNullOrEmpty(Enum.GetName(typeof(T), (T)(object)0)))
+            {
+                result.Remove((T)(object)0);
+            }
+        }
+        catch
+        {
+            result.Remove((T)(object)0);
+        }
+
+        return result;
+    }
+}

--- a/src/Nethermind/Nethermind.Core/Nethermind.Core.csproj
+++ b/src/Nethermind/Nethermind.Core/Nethermind.Core.csproj
@@ -16,6 +16,7 @@
       <Project>{75B8BE8D-18B0-493C-8BA5-083D4B952BF9}</Project>
       <Name>Nethermind.HashLib</Name>
     </ProjectReference>
+    <PackageReference Include="FastEnum" Version="1.7.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.18.0" />
     <ProjectReference Include="..\Nethermind.Logging\Nethermind.Logging.csproj" />
     <ProjectReference Include="..\Nethermind.Secp256k1\Nethermind.Secp256k1.csproj" />

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
@@ -70,6 +70,7 @@ namespace Nethermind.Merge.Plugin.Test
                 chain.BlockTree,
                 blockCacheService,
                 new TestErrorLogManager());
+            invalidChainTracker.SetupBlockchainProcessorInterceptor(chain.BlockchainProcessor);
             chain.BeaconSync = new BeaconSync(chain.BeaconPivot, chain.BlockTree, syncConfig ?? new SyncConfig(), blockCacheService, chain.LogManager);
             return new EngineRpcModule(
                 new GetPayloadV1Handler(

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
@@ -893,7 +893,6 @@ namespace Nethermind.Merge.Plugin.Test
             new ExecutionPayloadV1(chain.BlockTree.BestSuggestedBody).Should().BeEquivalentTo(executionPayload);
         }
 
-
         [Test]
         public async Task executePayloadV1_on_top_of_not_processed_invalid_terminal_block()
         {

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/V1/NewPayloadV1Handler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/V1/NewPayloadV1Handler.cs
@@ -17,7 +17,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Api;
 using Nethermind.Blockchain;
@@ -30,6 +29,7 @@ using Nethermind.Core.Caching;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.Crypto;
+using Nethermind.Int256;
 using Nethermind.JsonRpc;
 using Nethermind.Logging;
 using Nethermind.Merge.Plugin.Data.V1;
@@ -59,7 +59,7 @@ namespace Nethermind.Merge.Plugin.Handlers.V1
         private readonly IInvalidChainTracker _invalidChainTracker;
         private readonly ILogger _logger;
         private readonly LruCache<Keccak, bool> _latestBlocks = new(50, "LatestBlocks");
-        private readonly ProcessingOptions _processingOptions;
+        private readonly ProcessingOptions _defaultProcessingOptions;
         private readonly TimeSpan _timeout;
 
         public NewPayloadV1Handler(
@@ -90,7 +90,7 @@ namespace Nethermind.Merge.Plugin.Handlers.V1
             _mergeSyncController = mergeSyncController;
             _specProvider = specProvider;
             _logger = logManager.GetClassLogger();
-            _processingOptions = initConfig.StoreReceipts ? ProcessingOptions.EthereumMerge | ProcessingOptions.StoreReceipts : ProcessingOptions.EthereumMerge;
+            _defaultProcessingOptions = initConfig.StoreReceipts ? ProcessingOptions.EthereumMerge | ProcessingOptions.StoreReceipts : ProcessingOptions.EthereumMerge;
             _timeout = timeout ?? TimeSpan.FromSeconds(7);
         }
 
@@ -150,20 +150,7 @@ namespace Nethermind.Merge.Plugin.Handlers.V1
                 return NewPayloadV1Result.Valid(block.Hash);
             }
 
-            BlockInfo parentBlockInfo = _blockTree.GetInfo(parentHeader.Number, parentHeader.GetOrCalculateHash()).Info;
-            bool parentProcessed = parentBlockInfo.WasProcessed;
-
-            // edge-case detected on GSF5 - during the transition we want to try process all transition blocks from CL client
-            // The last condition: !parentBlockInfo.IsBeaconInfo will be true for terminal blocks. Checking _posSwitcher.IsTerminal might not be the best, because we're loading parentHeader with DoNotCalculateTotalDifficulty option
-            bool weAreCloseToHead = (_blockTree.Head?.Number ?? 0) + 8 >= block.Number;
-            bool forceProcessing = !_poSSwitcher.TransitionFinished && weAreCloseToHead && !parentBlockInfo.IsBeaconInfo;
-            if (parentProcessed == false && forceProcessing) // add extra logging for this edge case
-            {
-                if (_logger.IsInfo) _logger.Info($"Forced processing block {block}, block TD: {block.TotalDifficulty}, parent: {parentHeader}, parent TD: {parentHeader.TotalDifficulty}");
-            }
-
-            bool tryProcessBlock = parentProcessed || forceProcessing;
-            if (!tryProcessBlock)
+            if (!ShouldProcessBlock(block, parentHeader, out ProcessingOptions processingOptions)) // we shouldn't process block
             {
                 if (!_blockValidator.ValidateSuggestedBlock(block))
                 {
@@ -197,7 +184,7 @@ namespace Nethermind.Merge.Plugin.Handlers.V1
             _mergeSyncController.StopSyncing();
 
             // Try to execute block
-            (ValidationResult result, string? message) = await ValidateBlockAndProcess(block, parentHeader);
+            (ValidationResult result, string? message) = await ValidateBlockAndProcess(block, parentHeader, processingOptions);
 
             if ((result & ValidationResult.AlreadyKnown) == ValidationResult.AlreadyKnown || result == ValidationResult.Invalid)
             {
@@ -227,7 +214,58 @@ namespace Nethermind.Merge.Plugin.Handlers.V1
             return NewPayloadV1Result.Valid(request.BlockHash);
         }
 
-        private async Task<(ValidationResult, string? Message)> ValidateBlockAndProcess(Block block, BlockHeader parent)
+        /// <summary>
+        /// Decides if we should process the block or try syncing to it. It also returns what options to process the block with.
+        /// </summary>
+        /// <param name="block">Block</param>
+        /// <param name="parent">Parent header</param>
+        /// <param name="processingOptions">Options that should be used for processing</param>
+        /// <returns>Options which should be used for block processing. Null if we shouldn't process the block.</returns>
+        /// <remarks>
+        /// We decide to process blocks in two situations:
+        /// 1. The block parent was already processed. Then we process with ProcessingOptions.EthereumMerge with potentially also StoringReceipts.
+        ///    This contains ProcessingOptions.IgnoreParentNotOnMainChain flag in order not to collect whole branch for processing, but only process this block directly on parent.
+        ///    As parent was processed the state to process on should also be available.
+        ///
+        /// 2. If the parent wasn't processed, but it was a PoW block (terminal block) and we are not syncing PoW chain and are in the deep past.
+        ///    In this case we remove ~ProcessingOptions.IgnoreParentNotOnMainChain flag in order to collect whole branch for processing.
+        ///    If we didn't support this edge case then we couldn't process this block and would have to return Syncing, which is not desired during transition.
+        ///
+        /// Scenario 2 proved to be quite common on testnets which produced multiple transition blocks.
+        /// </remarks>
+        private bool ShouldProcessBlock(Block block, BlockHeader parent, out ProcessingOptions processingOptions)
+        {
+            processingOptions = _defaultProcessingOptions;
+
+            BlockInfo parentBlockInfo = _blockTree.GetInfo(parent.Number, parent.GetOrCalculateHash()).Info;
+            bool parentProcessed = parentBlockInfo.WasProcessed;
+
+            // During the transition we can have a case of NP built over a transition block that wasn't processed.
+            // We want to force process the whole branch then, but not longer than few blocks.
+            // But we don't want this to trigger when we are in beacon sync.
+            // The last condition: !parentBlockInfo.IsBeaconInfo will be true for terminal blocks.
+            // Checking _posSwitcher.IsTerminal might not be the best, because we're loading parentHeader with DoNotCalculateTotalDifficulty option
+            bool weHaveOnlyFewBlocksToProcess = (_blockTree.Head?.Number ?? 0) + 8 >= block.Number;
+            bool parentIsPoWBlock = parent.Difficulty != UInt256.Zero;
+            bool processTerminalBlock = !_poSSwitcher.TransitionFinished // we haven't finished transition
+                                        && weHaveOnlyFewBlocksToProcess // we won't try to process too much blocks (if we are behind the transition block and still processing blocks)
+                                        && !parentBlockInfo.IsBeaconInfo // we are not in beacon sync
+                                        && parentIsPoWBlock; // parent was PoW block -> so it was a transition block
+
+            if (!parentProcessed && processTerminalBlock) // so if parent wasn't processed
+            {
+                if (_logger.IsInfo) _logger.Info($"Forced processing block {block}, block TD: {block.TotalDifficulty}, parent: {parent}, parent TD: {parent.TotalDifficulty}");
+
+                // if parent wasn't processed and we want to force processing terminal block then we need to allow to process whole branch, not just one block
+                // in all other cases when parent is processed ProcessingOptions.IgnoreParentNotOnMainChain allows us to process just this block ignoring that its not on Head
+                // this option is part of ProcessingOptions.EthereumMerge option
+                processingOptions &= ~ProcessingOptions.IgnoreParentNotOnMainChain;
+            }
+
+            return parentProcessed || processTerminalBlock;
+        }
+
+        private async Task<(ValidationResult, string? Message)> ValidateBlockAndProcess(Block block, BlockHeader parent, ProcessingOptions processingOptions)
         {
             ValidationResult ToValid(bool valid) => valid ? ValidationResult.Valid : ValidationResult.Invalid;
             string? validationMessage = null;
@@ -316,7 +354,7 @@ namespace Nethermind.Merge.Plugin.Handlers.V1
 
                 if (!result.HasValue)
                 {
-                    _processingQueue.Enqueue(block, _processingOptions);
+                    _processingQueue.Enqueue(block, processingOptions);
 
                     result = await blockProcessed.TimeoutOn(timeoutTask);
                 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/InvalidChainTracker/IInvalidChainTracker.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/InvalidChainTracker/IInvalidChainTracker.cs
@@ -1,19 +1,19 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using System;
 using Nethermind.Core.Crypto;
@@ -35,7 +35,7 @@ public interface IInvalidChainTracker: IDisposable
     /// <param name="failedBlock"></param>
     /// <param name="parent"></param>
     void OnInvalidBlock(Keccak failedBlock, Keccak? parent);
-    
+
     /// <summary>
     /// Return last valid hash if this block is known to be on an invalid chain.
     /// Return null otherwise

--- a/src/Nethermind/Nethermind.Merge.Plugin/InvalidChainTracker/InvalidChainTracker.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/InvalidChainTracker/InvalidChainTracker.cs
@@ -66,7 +66,7 @@ public class InvalidChainTracker: IInvalidChainTracker
         });
     }
 
-    private void OnBlockchainProcessorInvalidBlock(object? sender, IBlockchainProcessor.InvalidBlockEventArgs args) => OnInvalidBlock(args.InvalidBlockHash, null);
+    private void OnBlockchainProcessorInvalidBlock(object? sender, IBlockchainProcessor.InvalidBlockEventArgs args) => OnInvalidBlock(args.InvalidBlock.Hash!, args.InvalidBlock.ParentHash);
 
     public void SetChildParent(Keccak child, Keccak parent)
     {
@@ -99,8 +99,7 @@ public class InvalidChainTracker: IInvalidChainTracker
     {
         Queue<Node> bfsQue = new();
         bfsQue.Enqueue(node);
-        HashSet<Node> visited = new();
-        visited.Add(node);
+        HashSet<Node> visited = new() { node };
 
         while (bfsQue.Count > 0)
         {
@@ -125,22 +124,24 @@ public class InvalidChainTracker: IInvalidChainTracker
 
     }
 
-    private BlockHeader? TryGetBlockHeader(Keccak hash)
+    private BlockHeader? TryGetBlockHeaderIncludingInvalid(Keccak hash)
     {
         if (_blockCacheService.BlockCache.TryGetValue(hash, out Block? block))
         {
             return block.Header;
         }
 
-        return _blockFinder.FindHeader(hash);
+        return _blockFinder.FindHeader(hash, BlockTreeLookupOptions.AllowInvalid | BlockTreeLookupOptions.TotalDifficultyNotNeeded | BlockTreeLookupOptions.DoNotCalculateTotalDifficulty);
     }
 
     public void OnInvalidBlock(Keccak failedBlock, Keccak? parent)
     {
         if(_logger.IsDebug) _logger.Debug($"OnInvalidBlock: {failedBlock} {parent}");
+
+        // TODO: This port can now be removed? We should never get null here?
         if (parent == null)
         {
-            BlockHeader? failedBlockHeader = TryGetBlockHeader(failedBlock);
+            BlockHeader? failedBlockHeader = TryGetBlockHeaderIncludingInvalid(failedBlock);
             if (failedBlockHeader == null)
             {
                 if(_logger.IsWarn) _logger.Warn($"Unable to resolve block to determine parent. Block {failedBlock}");
@@ -151,7 +152,7 @@ public class InvalidChainTracker: IInvalidChainTracker
         }
 
         Keccak effectiveParent = parent;
-        BlockHeader? parentHeader = TryGetBlockHeader(parent);
+        BlockHeader? parentHeader = TryGetBlockHeaderIncludingInvalid(parent);
         if (parentHeader != null)
         {
             if (!_poSSwitcher.IsPostMerge(parentHeader))


### PR DESCRIPTION
## Changes:
- NewPayloadV1Handler ShouldProcessBlock method was introduced. This decides if block should be processed and with what ProcessingOptions flags it will be processed. For reorging terminal blocks it removes IgnoreParentNotOnMainChain flag. **This is main fix for Goerli transition issue.** We are also waiting for the hive tests to get more sophisticated in order to be able to catch this issues in them.
- BlockchainProcessor to return full block on InvalidBlock exception and event.
- BlockTreeLookupOptions.AllowInvalid to also look into (latest) invalid blocks.
- BlockTree will keep full recent invalid blocks instead of just hashes.
- InvalidChainTracker to use invalid block parent directly rather than doing lookup.
- InvalidChainTracker will use BlockTreeLookupOptions.AllowInvalid | BlockTreeLookupOptions.TotalDifficultyNotNeeded BlockTreeLookupOptions.DoNotCalculateTotalDifficulty options when looking up a block header.
- Hookup InvalidChainTracker SetupBlockchainProcessorInterceptor in EngineModuleTests.
- Added EnumExtensions.AllValuesCombinations (for testing purposes).

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No