### PR TITLE
Important logging fixes

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcLocalStats.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcLocalStats.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -60,14 +60,14 @@ namespace Nethermind.JsonRpc
 
         public void ReportCall(string method, long handlingTimeMicroseconds, bool success) =>
             ReportCall(new RpcReport(method, handlingTimeMicroseconds, success));
-        
+
         public void ReportCall(in RpcReport report, long elapsedMicroseconds = 0, long? size = null)
         {
             if(string.IsNullOrWhiteSpace(report.Method))
             {
                 return;
             }
-            
+
             DateTime thisTime = _timestamper.UtcNow;
             if (thisTime - _lastReport > _reportingInterval)
             {
@@ -116,7 +116,7 @@ namespace Nethermind.JsonRpc
             const string reportHeader = "method                                  | " +
                                         "successes | " +
                                         " avg time | " +
-                                        " max time | " +
+                                        "  | " +
                                         "   errors | " +
                                         " avg time | " +
                                         " max time |" +

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcLocalStats.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcLocalStats.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-//
+// 
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-//
+// 
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-//
+// 
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -60,14 +60,14 @@ namespace Nethermind.JsonRpc
 
         public void ReportCall(string method, long handlingTimeMicroseconds, bool success) =>
             ReportCall(new RpcReport(method, handlingTimeMicroseconds, success));
-
+        
         public void ReportCall(in RpcReport report, long elapsedMicroseconds = 0, long? size = null)
         {
             if(string.IsNullOrWhiteSpace(report.Method))
             {
                 return;
             }
-
+            
             DateTime thisTime = _timestamper.UtcNow;
             if (thisTime - _lastReport > _reportingInterval)
             {
@@ -116,7 +116,7 @@ namespace Nethermind.JsonRpc
             const string reportHeader = "method                                  | " +
                                         "successes | " +
                                         " avg time | " +
-                                        "  | " +
+                                        " max time | " +
                                         "   errors | " +
                                         " avg time | " +
                                         " max time |" +

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcUrlCollection.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcUrlCollection.cs
@@ -91,9 +91,9 @@ namespace Nethermind.JsonRpc
                 return;
             }
 
-            if (_jsonRpcConfig.EnginePort == null || string.IsNullOrWhiteSpace(_jsonRpcConfig.EngineHost))
+            if (_jsonRpcConfig.EnginePort == null || string.IsNullOrWhiteSpace(_jsonRpcConfig.EngineHost)) // by default EngineHost is not null
             {
-                if (_logger.IsWarn) _logger.Warn("Json RPC EnginePort and EngineHost should be specified");
+                if (_logger.IsTrace) _logger.Trace("Json RPC EnginePort and EngineHost should be specified");
                 return;
             }
             JsonRpcUrl url = new(Uri.UriSchemeHttp, _jsonRpcConfig.EngineHost, _jsonRpcConfig.EnginePort.Value,
@@ -133,7 +133,7 @@ namespace Nethermind.JsonRpc
                     if (url.IsModuleEnabled(ModuleType.Engine) && _jsonRpcConfig.EnginePort != null &&
                         !string.IsNullOrWhiteSpace(_jsonRpcConfig.EngineHost))
                     {
-                        if (_logger.IsTrace) _logger.Trace($"EngineUrl specified. Additional JSON RPC URL '{url}' has engine module enabled. skipping...");
+                        if (_logger.IsInfo) _logger.Info($"EngineUrl specified. EnginePort {_jsonRpcConfig.EnginePort} EngineHost {_jsonRpcConfig.EngineHost}. Additional JSON RPC URL '{url}' has engine module enabled. skipping...");
                         continue;
                     }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/V1/NewPayloadV1Handler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/V1/NewPayloadV1Handler.cs
@@ -195,6 +195,7 @@ namespace Nethermind.Merge.Plugin.Handlers.V1
 
             if (result == ValidationResult.Invalid)
             {
+                if (_logger.IsInfo) _logger.Info($"Invalid block found. Validation message: {message}. Result of {requestStr}.");
                 _invalidChainTracker.OnInvalidBlock(blockHash, request.ParentHash);
                 return ResultWrapper<PayloadStatusV1>.Success(BuildInvalidPayloadStatusV1(request, message));
             }


### PR DESCRIPTION
by default our EngineHost is not null so we were always logging:
"Json RPC EnginePort and EngineHost should be specified" as warning with default configuration. 

What is more, I added logger for one path without logger in newPayload