### PR TITLE
Disable WitnessProtocol from default configs

### DIFF
--- a/src/Nethermind/Nethermind.Runner.Test/ConfigFilesTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/ConfigFilesTests.cs
@@ -420,8 +420,8 @@ namespace Nethermind.Runner.Test
 
         [TestCase("^mainnet ^goerli", false)]
         [TestCase("^pruned ^goerli.cfg ^mainnet.cfg", false)]
-        [TestCase("mainnet.cfg", true)]
-        [TestCase("goerli.cfg", true)]
+        [TestCase("mainnet.cfg", false)]
+        [TestCase("goerli.cfg", false)]
         public void Witness_defaults_are_correct(string configWildcard, bool witnessProtocolEnabled)
         {
             Test<ISyncConfig, bool>(configWildcard, c => c.WitnessProtocolEnabled, witnessProtocolEnabled);

--- a/src/Nethermind/Nethermind.Runner/Properties/launchSettings.json
+++ b/src/Nethermind/Nethermind.Runner/Properties/launchSettings.json
@@ -280,6 +280,13 @@
     "Docker": {
       "commandName": "Docker",
       "commandLineArgs": "-c goerli -dd /data --JsonRpc.Enabled true --JsonRpc.Host 0.0.0.0"
+    },
+    "Denver": {
+      "commandName": "Project",
+      "commandLineArgs": "-c denver -dd %NETHERMIND_DATA_DIR%",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
     }
   }
 }

--- a/src/Nethermind/Nethermind.Runner/configs/goerli.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/goerli.cfg
@@ -20,7 +20,6 @@
     "PivotTotalDifficulty": "10785833",
     "FastBlocks": true,
     "UseGethLimitsInFastBlocks": true,
-    "WitnessProtocolEnabled": true,
     "FastSyncCatchUpHeightDelta": "10000000000"
   },
   "EthStats": {

--- a/src/Nethermind/Nethermind.Runner/configs/goerli_mev.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/goerli_mev.cfg
@@ -19,7 +19,6 @@
     "PivotHash": "0xff2f0569e6e73bd4eb237b2dc771f73e98383d35b2fddfffdcd93561df7b63b5",
     "PivotTotalDifficulty": "10785833",
     "FastBlocks": true,
-    "WitnessProtocolEnabled": true,
     "FastSyncCatchUpHeightDelta": "10000000000"
   },
   "EthStats": {

--- a/src/Nethermind/Nethermind.Runner/configs/goerli_shadowfork.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/goerli_shadowfork.cfg
@@ -40,7 +40,6 @@
     "DownloadBodiesInFastSync": true,
     "DownloadReceiptsInFastSync": true,
     "UseGethLimitsInFastBlocks": true,
-    "WitnessProtocolEnabled": true,
     "FastSyncCatchUpHeightDelta": "10000000000"
   },
   "EthStats": {

--- a/src/Nethermind/Nethermind.Runner/configs/mainnet.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/mainnet.cfg
@@ -18,7 +18,6 @@
     "FastBlocks": true,
     "AncientBodiesBarrier": 11052984,
     "AncientReceiptsBarrier": 11052984,
-    "WitnessProtocolEnabled": true,
     "FastSyncCatchUpHeightDelta": "10000000000"
   },
   "EthStats": {

--- a/src/Nethermind/Nethermind.Runner/configs/mainnet_aa.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/mainnet_aa.cfg
@@ -35,7 +35,6 @@
     "FastBlocks": true,
     "AncientBodiesBarrier": 11052984,
     "AncientReceiptsBarrier": 11052984,
-    "WitnessProtocolEnabled": true,
     "FastSyncCatchUpHeightDelta": "10000000000"
   },
   "EthStats": {

--- a/src/Nethermind/Nethermind.Runner/configs/mainnet_mev.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/mainnet_mev.cfg
@@ -15,7 +15,6 @@
     "FastBlocks": true,
     "AncientBodiesBarrier": 11052984,
     "AncientReceiptsBarrier": 11052984,
-    "WitnessProtocolEnabled": true,
     "FastSyncCatchUpHeightDelta": "10000000000"
   },
   "EthStats": {

--- a/src/Nethermind/Nethermind.Runner/configs/mainnet_shadowfork.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/mainnet_shadowfork.cfg
@@ -20,7 +20,6 @@
     "AncientReceiptsBarrier": 11052984,
 	"DownloadBodiesInFastSync": true,
     "DownloadReceiptsInFastSync": true,
-    "WitnessProtocolEnabled": true,
     "FastSyncCatchUpHeightDelta": "10000000000"
   },
   "JsonRpc": {


### PR DESCRIPTION
Resolves #4443

## Changes:
- Disable WitnessProtocol from default configs, this is due to Besu cannot parse our Hello message and cannot connect to us (issue on Besu side)

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Other (please describe): config change

## Testing
**Requires testing**

- [ ] Yes
- [x] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [x] No