### PR TITLE
Do not trace precompile calls when they happen from inside of a contract

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/ParityLikeTxTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/ParityLikeTxTracerTests.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -258,7 +258,7 @@ namespace Nethermind.Evm.Test.Tracing
                 1, 1, 1, 1, 1, 1, 1, 1, // STACK FOR CALL
                 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, // CALL
                 3, 3, 3, 3, 3, 3, // CREATE
-                2, // STOP 
+                2, // STOP
                 1, // STOP
             };
 
@@ -298,7 +298,7 @@ namespace Nethermind.Evm.Test.Tracing
                 1, 1, 1, 1, 1, 1, 1, 1, // STACK FOR CALL
                 2, 2, 2, 2, 2, 2, 2, 2, 2, // DELEGATE CALL
                 3, 3, 3, 3, 3, 3, // CREATE
-                2, // STOP 
+                2, // STOP
                 1, // STOP
             };
 
@@ -335,13 +335,13 @@ namespace Nethermind.Evm.Test.Tracing
                 1, 1, 1, 1, 1, 1, 1, 1, // STACK FOR CALL
                 2, 2, 2, 2, 2, 2, 2, 2, 2, // CALL CODE
                 3, 3, 3, 3, 3, 3, // CREATE
-                2, // STOP 
+                2, // STOP
                 1, // STOP
             };
 
             Assert.AreEqual("callcode", trace.Action.Subtraces[0].CallType, "[0] type");
         }
-        
+
         [Test]
         public void Can_trace_call_code_calls_with_large_data_offset()
         {
@@ -578,7 +578,7 @@ namespace Nethermind.Evm.Test.Tracing
                 1, 1, 1, 1, 1, 1, 1, 1, // STACK FOR CALL
                 2, 2, 2, 2, 2, 2, 2, 2, 2, // CALL CODE
                 3, 3, 3, 3, 3, 3, // CREATE
-                2, // STOP 
+                2, // STOP
                 1, // STOP
             };
 
@@ -598,12 +598,59 @@ namespace Nethermind.Evm.Test.Tracing
             {
                 1, 1, 1, 1, 1, 1, 1, 1, // STACK FOR CALL
                 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, // CALL
-                2, // STOP 
+                2, // STOP
                 1, // STOP
             };
 
             Assert.AreEqual("call", trace.Action.Subtraces[0].CallType, "[0] type");
             Assert.AreEqual(IdentityPrecompile.Instance.Address, trace.Action.Subtraces[0].To, "[0] to");
+        }
+
+        [Test]
+        public void Can_ignore_precompile_calls_in_contract()
+        {
+            byte[] deployedCode = Prepare.EvmCode
+                .Call(IdentityPrecompile.Instance.Address, 50000)
+                .Op(Instruction.STOP)
+                .Done;
+
+            byte[] initCode = Prepare.EvmCode
+                .ForInitOf(deployedCode)
+                .Done;
+
+            byte[] createCode = Prepare.EvmCode
+                .Create(initCode, 0)
+                .Op(Instruction.STOP)
+                .Done;
+
+            TestState.CreateAccount(TestItem.AddressC, 1.Ether());
+            Keccak createCodeHash = TestState.UpdateCode(createCode);
+            TestState.UpdateCodeHash(TestItem.AddressC, createCodeHash, Spec);
+
+            byte[] code = Prepare.EvmCode
+                .Call(IdentityPrecompile.Instance.Address, 50000)
+                .Call(TestItem.AddressC, 40000)
+                .Op(Instruction.STOP)
+                .Done;
+
+            (ParityLikeTxTrace trace, Block block, Transaction tx) = ExecuteAndTraceParityCall(code);
+
+            // One call to precompile and the other call to AddressC
+            Assert.AreEqual(2, trace.Action.Subtraces.Count, "[] subtraces");
+            Assert.AreEqual("call", trace.Action.CallType, "[] type");
+
+            // Precompile call
+            Assert.AreEqual(0, trace.Action.Subtraces[0].Subtraces.Count, "[0] subtraces");
+            Assert.AreEqual("call", trace.Action.Subtraces[0].CallType, "[0] type");
+            Assert.AreEqual(IdentityPrecompile.Instance.Address, trace.Action.Subtraces[0].To, "[0] to");
+
+            // AddressC call - only one call
+            Assert.AreEqual(1, trace.Action.Subtraces[1].Subtraces.Count, "[1] subtraces");
+            Assert.AreEqual("call", trace.Action.Subtraces[1].CallType, "[1] type");
+
+            // Check the subtrace - not a precompile call
+            Assert.AreEqual(0, trace.Action.Subtraces[1].Subtraces[0].Subtraces.Count, "[1, 0] subtraces");
+            Assert.AreEqual("create", trace.Action.Subtraces[1].Subtraces[0].CallType, "[1, 0] type");
         }
 
         [Test]
@@ -638,7 +685,7 @@ namespace Nethermind.Evm.Test.Tracing
                 3, 3, 3, 3, 3, 3, // CREATE
                 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, // CALL
                 3, 3, 3, 3, 3, 3, // CREATE
-                2, // STOP 
+                2, // STOP
                 1, // STOP
             };
 

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -99,7 +99,7 @@ namespace Nethermind.Evm
             _state = worldState.StateProvider;
             _storage = worldState.StorageProvider;
             _worldState = worldState;
-            
+
             IReleaseSpec spec = _specProvider.GetSpec(state.Env.TxExecutionContext.Header.Number);
             EvmState currentState = state;
             byte[] previousCallResult = null;
@@ -119,7 +119,10 @@ namespace Nethermind.Evm
                     {
                         if (_txTracer.IsTracingActions)
                         {
-                            _txTracer.ReportAction(currentState.GasAvailable, currentState.Env.Value, currentState.From, currentState.To, currentState.Env.InputData, currentState.ExecutionType, true);
+                            if (!(currentState.IsTopLevel && currentState.Env.Value==UInt256.Zero))
+                            {
+                                _txTracer.ReportAction(currentState.GasAvailable, currentState.Env.Value, currentState.From, currentState.To, currentState.Env.InputData, currentState.ExecutionType, true);
+                            }
                         }
 
                         callResult = ExecutePrecompile(currentState, spec);
@@ -189,7 +192,7 @@ namespace Nethermind.Evm
                         if (_txTracer.IsTracingActions)
                         {
                             long codeDepositGasCost = CodeDepositHandler.CalculateCost(callResult.Output.Length, spec);
-                            
+
                             if (callResult.IsException)
                             {
                                 _txTracer.ReportActionError(callResult.ExceptionType);
@@ -231,11 +234,11 @@ namespace Nethermind.Evm
                         }
 
                         return new TransactionSubstate(
-                            callResult.Output, 
-                            currentState.Refund, 
-                            (IReadOnlyCollection<Address>)currentState.DestroyList, 
-                            (IReadOnlyCollection<LogEntry>)currentState.Logs, 
-                            callResult.ShouldRevert, 
+                            callResult.Output,
+                            currentState.Refund,
+                            (IReadOnlyCollection<Address>)currentState.DestroyList,
+                            (IReadOnlyCollection<LogEntry>)currentState.Logs,
+                            callResult.ShouldRevert,
                             _txTracer != NullTxTracer.Instance);
                     }
 
@@ -386,7 +389,7 @@ namespace Nethermind.Evm
                 {
                     throw new InvalidOperationException("EVM precompile have not been initialized properly.");
                 }
-                
+
                 return _precompiles[codeSource];
             }
 
@@ -395,7 +398,7 @@ namespace Nethermind.Evm
             if (cachedCodeInfo == null)
             {
                 byte[] code = state.GetCode(codeHash);
-                
+
                 if (code == null)
                 {
                     throw new NullReferenceException($"Code {codeHash} missing in the state for address {codeSource}");
@@ -462,11 +465,11 @@ namespace Nethermind.Evm
         {
             gasAvailable += refund;
         }
-        
+
         private bool ChargeAccountAccessGas(ref long gasAvailable, EvmState vmState, Address address, IReleaseSpec spec, bool chargeForWarm = true)
         {
             // Console.WriteLine($"Accessing {address}");
-            
+
             bool result = true;
             if (spec.UseHotAndColdStorage)
             {
@@ -474,7 +477,7 @@ namespace Nethermind.Evm
                 {
                     vmState.WarmUp(address);
                 }
-                
+
                 if (vmState.IsCold(address) && !address.IsPrecompile(spec))
                 {
                     result = UpdateGas(GasCostOf.ColdAccountAccess, ref gasAvailable);
@@ -494,7 +497,7 @@ namespace Nethermind.Evm
             SLOAD,
             SSTORE
         }
-        
+
         private bool ChargeStorageAccessGas(
             ref long gasAvailable,
             EvmState vmState,
@@ -503,7 +506,7 @@ namespace Nethermind.Evm
             IReleaseSpec spec)
         {
             // Console.WriteLine($"Accessing {storageCell} {storageAccessType}");
-            
+
             bool result = true;
             if (spec.UseHotAndColdStorage)
             {
@@ -547,7 +550,7 @@ namespace Nethermind.Evm
             {
                 _state.AddToBalance(state.Env.ExecutingAccount, transferValue, spec);
             }
-            
+
             // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-161.md
             // An additional issue was found in Parity,
             // where the Parity client incorrectly failed
@@ -599,7 +602,7 @@ namespace Nethermind.Evm
             bool traceOpcodes = _txTracer.IsTracingInstructions;
             ExecutionEnvironment env = vmState.Env;
             TxExecutionContext txCtx = env.TxExecutionContext;
-            
+
             if (!vmState.IsContinuation)
             {
                 if (!_state.AccountExists(env.ExecutingAccount))
@@ -627,7 +630,7 @@ namespace Nethermind.Evm
             long gasAvailable = vmState.GasAvailable;
             int programCounter = vmState.ProgramCounter;
             Span<byte> code = env.CodeInfo.MachineCode.AsSpan();
-            
+
 
             static void UpdateCurrentState(EvmState state, in int pc, in long gas, in int stackHead)
             {
@@ -702,7 +705,7 @@ namespace Nethermind.Evm
                 {
                     throw new InvalidOperationException("EVM memory has not been initialized properly.");
                 }
-                
+
                 long memoryCost = vmState.Memory.CalculateMemoryCost(in position, length);
                 if (memoryCost != 0L)
                 {
@@ -725,16 +728,16 @@ namespace Nethermind.Evm
             {
                 UInt256 localPreviousDest = previousCallOutputDestination;
                 UpdateMemoryCost(in localPreviousDest, (ulong) previousCallOutput.Length);
-                
+
                 if (vmState.Memory is null)
                 {
                     throw new InvalidOperationException("EVM memory has not been initialized properly.");
                 }
-                
+
                 vmState.Memory.Save(in localPreviousDest, previousCallOutput);
 //                if(_txTracer.IsTracingInstructions) _txTracer.ReportMemoryChange((long)localPreviousDest, previousCallOutput);
             }
-            
+
             while (programCounter < code.Length)
             {
                 Instruction instruction = (Instruction) code[programCounter];
@@ -1348,7 +1351,7 @@ namespace Nethermind.Evm
                             EndInstructionTraceError(EvmExceptionType.OutOfGas);
                             return CallResult.OutOfGasException;
                         }
-                        
+
                         UInt256 balance = _state.GetBalance(address);
                         stack.PushUInt256(in balance);
                         break;
@@ -1426,7 +1429,7 @@ namespace Nethermind.Evm
                         if(length > UInt256.Zero)
                         {
                             UpdateMemoryCost(in dest, length);
-                            
+
                             ZeroPaddedMemory callDataSlice = env.InputData.SliceWithZeroPadding(src, (int) length);
                             vmState.Memory.Save(in dest, callDataSlice);
                             if (_txTracer.IsTracingInstructions)
@@ -1434,7 +1437,7 @@ namespace Nethermind.Evm
                                 _txTracer.ReportMemoryChange((long)dest, callDataSlice);
                             }
                         }
-                        
+
                         break;
                     }
                     case Instruction.CODESIZE:
@@ -1459,16 +1462,16 @@ namespace Nethermind.Evm
                             EndInstructionTraceError(EvmExceptionType.OutOfGas);
                             return CallResult.OutOfGasException;
                         }
-                        
+
                         if (length > UInt256.Zero)
                         {
                             UpdateMemoryCost(in dest, length);
-                            
+
                             ZeroPaddedSpan codeSlice = code.SliceWithZeroPadding(src, (int) length);
                             vmState.Memory.Save(in dest, codeSlice);
                             if (_txTracer.IsTracingInstructions) _txTracer.ReportMemoryChange((long) dest, codeSlice);
                         }
-                        
+
                         break;
                     }
                     case Instruction.GASPRICE:
@@ -1518,7 +1521,7 @@ namespace Nethermind.Evm
                             EndInstructionTraceError(EvmExceptionType.OutOfGas);
                             return CallResult.OutOfGasException;
                         }
-                        
+
                         if (!ChargeAccountAccessGas(ref gasAvailable, vmState, address, spec))
                         {
                             EndInstructionTraceError(EvmExceptionType.OutOfGas);
@@ -1528,7 +1531,7 @@ namespace Nethermind.Evm
                         if (length > UInt256.Zero)
                         {
                             UpdateMemoryCost(in dest, length);
-                            
+
                             byte[] externalCode = GetCachedCodeInfo(_worldState, address, spec).MachineCode;
                             ZeroPaddedSpan callDataSlice = externalCode.SliceWithZeroPadding(src, (int) length);
                             vmState.Memory.Save(in dest, callDataSlice);
@@ -1579,7 +1582,7 @@ namespace Nethermind.Evm
                         {
                             return CallResult.AccessViolationException;
                         }
-                        
+
                         if (length > UInt256.Zero)
                         {
                             UpdateMemoryCost(in dest, length);
@@ -1822,15 +1825,15 @@ namespace Nethermind.Evm
                             EndInstructionTraceError(EvmExceptionType.OutOfGas);
                             return CallResult.OutOfGasException;
                         }
-                        
+
                         byte[] value = _storage.Get(storageCell);
                         stack.PushBytes(value);
-                        
+
                         if (_txTracer.IsTracingOpLevelStorage)
                         {
                             _txTracer.LoadOperationStorage(storageCell.Address, storageIndex, value);
                         }
-                        
+
                         break;
                     }
                     case Instruction.SSTORE:
@@ -1842,14 +1845,14 @@ namespace Nethermind.Evm
                             EndInstructionTraceError(EvmExceptionType.StaticCallViolation);
                             return CallResult.StaticCallViolationException;
                         }
-                        
+
                         // fail fast before the first storage read if gas is not enough even for reset
                         if (!spec.UseNetGasMetering && !UpdateGas(spec.GetSStoreResetCost(), ref gasAvailable))
                         {
                             EndInstructionTraceError(EvmExceptionType.OutOfGas);
                             return CallResult.OutOfGasException;
                         }
-                        
+
                         if (spec.UseNetGasMeteringWithAStipendFix)
                         {
                             if (_txTracer.IsTracingRefunds) _txTracer.ReportExtraGasPressure(GasCostOf.CallStipend - spec.GetNetMeteredSStoreCost() + 1);
@@ -1884,7 +1887,7 @@ namespace Nethermind.Evm
                             EndInstructionTraceError(EvmExceptionType.OutOfGas);
                             return CallResult.OutOfGasException;
                         }
-                        
+
                         Span<byte> currentValue = _storage.Get(storageCell);
                         // Console.WriteLine($"current: {currentValue.ToHexString()} newValue {newValue.ToHexString()}");
                         bool currentIsZero = currentValue.IsZero();
@@ -2060,7 +2063,7 @@ namespace Nethermind.Evm
                             EndInstructionTraceError(EvmExceptionType.StaticCallViolation);
                             return CallResult.StaticCallViolationException;
                         }
-                        
+
                         long gasCost = GasCostOf.TStore;
                         if (!UpdateGas(gasCost, ref gasAvailable))
                         {
@@ -2372,7 +2375,7 @@ namespace Nethermind.Evm
                         }
 
                         Span<byte> initCode = vmState.Memory.LoadSpan(in memoryPositionOfInitCode, initCodeLength);
-                        
+
                         UInt256 balance = _state.GetBalance(env.ExecutingAccount);
                         if (value > balance)
                         {
@@ -2380,7 +2383,7 @@ namespace Nethermind.Evm
                             stack.PushZero();
                             break;
                         }
-                        
+
                         UInt256 accountNonce = _state.GetNonce(env.ExecutingAccount);
                         UInt256 maxNonce = ulong.MaxValue;
                         if (accountNonce >= maxNonce)
@@ -2444,7 +2447,7 @@ namespace Nethermind.Evm
                         callEnv.InputData = ReadOnlyMemory<byte>.Empty;
                         callEnv.TransferValue = value;
                         callEnv.Value = value;
-                        
+
                         EvmState callState = new(
                             callGas,
                             callEnv,
@@ -2489,14 +2492,14 @@ namespace Nethermind.Evm
 
                         stack.PopUInt256(out UInt256 gasLimit);
                         Address codeSource = stack.PopAddress();
-                        
+
                         // Console.WriteLine($"CALLIN {codeSource}");
                         if (!ChargeAccountAccessGas(ref gasAvailable, vmState, codeSource, spec))
                         {
                             EndInstructionTraceError(EvmExceptionType.OutOfGas);
                             return CallResult.OutOfGasException;
                         }
-                        
+
                         UInt256 callValue;
                         switch (instruction)
                         {
@@ -2697,7 +2700,7 @@ namespace Nethermind.Evm
                             EndInstructionTraceError(EvmExceptionType.OutOfGas);
                             return CallResult.OutOfGasException;
                         }
-                        
+
                         vmState.DestroyList.Add(env.ExecutingAccount);
 
                         UInt256 ownerBalance = _state.GetBalance(env.ExecutingAccount);
@@ -2851,7 +2854,7 @@ namespace Nethermind.Evm
                             EndInstructionTraceError(EvmExceptionType.OutOfGas);
                             return CallResult.OutOfGasException;
                         }
-                        
+
                         if (!_state.AccountExists(address) || _state.IsDeadAccount(address))
                         {
                             stack.PushZero();
@@ -2991,8 +2994,8 @@ namespace Nethermind.Evm
             public static CallResult StaticCallViolationException => new(EvmExceptionType.StaticCallViolation);
             public static CallResult StackOverflowException => new(EvmExceptionType.StackOverflow); // TODO: use these to avoid CALL POP attacks
             public static CallResult StackUnderflowException => new(EvmExceptionType.StackUnderflow); // TODO: use these to avoid CALL POP attacks
-            
-            public static CallResult InvalidCodeException => new(EvmExceptionType.InvalidCode); 
+
+            public static CallResult InvalidCodeException => new(EvmExceptionType.InvalidCode);
             public static CallResult Empty => new(Array.Empty<byte>(), null);
 
             public CallResult(EvmState stateToExecute)


### PR DESCRIPTION
Resolves #4410 
Users migrating from OpenEthereum expects trace_* call to behave in a similar fashion.
Ref: https://github.com/openethereum/openethereum/blob/main/crates/ethcore/src/trace/executive_tracer.rs#L47

## Changes:
-

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No

**Comments about testing , should you have some** (optional)

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...