### PR TITLE
Fix hive load chainfile after sync started

### DIFF
--- a/src/Nethermind/Nethermind.Hive/HivePlugin.cs
+++ b/src/Nethermind/Nethermind.Hive/HivePlugin.cs
@@ -3,10 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Api;
 using Nethermind.Api.Extensions;
-using Nethermind.Core;
-using Nethermind.Core.Crypto;
 using Nethermind.Logging;
-using Nethermind.Synchronization.Peers;
 
 namespace Nethermind.Hive
 {
@@ -41,17 +38,7 @@ namespace Nethermind.Hive
             return Task.CompletedTask;
         }
 
-        public Task InitNetworkProtocol()
-        {
-            if (Enabled)
-            {
-                if (_api.SyncPeerPool == null) throw new ArgumentNullException(nameof(_api.SyncPeerPool));
-            }
-
-            return Task.CompletedTask;
-        }
-
-        public async Task InitRpcModules()
+        public async Task InitNetworkProtocol()
         {
             if (Enabled)
             {
@@ -75,10 +62,11 @@ namespace Nethermind.Hive
 
                 await hiveRunner.Start(_disposeCancellationToken.Token);
             }
-            else
-            {
-                if (_logger.IsInfo) _logger.Info("Skipping Hive plugin");
-            }
+        }
+
+        public Task InitRpcModules()
+        {
+            return Task.CompletedTask;
         }
 
         private bool Enabled { get; set; }


### PR DESCRIPTION
- It seems that the chainfile is loaded after syncing has started causing the loading to fail on some case.
- `InitRpcModules` is run by `RegisterRpcModules` which is run after `InitializeNetwork` which is where `StartSync` is called.
- `InitNetworkProtocol` is called by `InitializeNetwork` right before `StartSync`. 

## Changes:
- Move the hive runner from `InitRpcModules` to `InitNetworkProtocol`.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [X] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [X] No

**Comments about testing , should you have some** (optional)

- On test `Two Block Post-PoS Re-org to Higher-Total-Difficulty PoW Chain (local-nethermind)"` confirmed that the chainfile is loaded before syncing start.
- Change should not affect production code.
- No hive test regression.

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...