### PR TITLE
Fixes in new payload handler

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
@@ -1,4 +1,4 @@
-﻿//  Copyright (c) 2021 Demerzel Solutions Limited
+//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
 //
 //  The Nethermind library is free software: you can redistribute it and/or modify
@@ -59,7 +59,7 @@ namespace Nethermind.Merge.Plugin.Test
         protected async Task<MergeTestBlockchain> CreateBlockChain(IMergeConfig mergeConfig = null, IPayloadPreparationService? mockedPayloadService = null)
             => await CreateBaseBlockChain(mergeConfig, mockedPayloadService).Build(new SingleReleaseSpecProvider(London.Instance, 1));
 
-        private IEngineRpcModule CreateEngineModule(MergeTestBlockchain chain, ISyncConfig? syncConfig = null, TimeSpan? newPayloadTimeout = null)
+        private IEngineRpcModule CreateEngineModule(MergeTestBlockchain chain, ISyncConfig? syncConfig = null, TimeSpan? newPayloadTimeout = null, int newPayloadCacheSize = 50)
         {
             IPeerRefresher peerRefresher = Substitute.For<IPeerRefresher>();
 
@@ -90,7 +90,8 @@ namespace Nethermind.Merge.Plugin.Test
                     chain.BeaconSync,
                     chain.SpecProvider,
                     chain.LogManager,
-                    newPayloadTimeout),
+                    newPayloadTimeout,
+                    newPayloadCacheSize),
                 new ForkchoiceUpdatedV1Handler(
                     chain.BlockTree,
                     chain.BlockFinalizationManager,

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
@@ -836,6 +836,42 @@ namespace Nethermind.Merge.Plugin.Test
             (await rpc.engine_newPayloadV1(new ExecutionPayloadV1(b5))).Data.Status.Should().Be(PayloadStatus.Valid);
         }
 
+        [Test, NonParallelizable]
+        public async Task Invalid_block_on_processing_wont_be_accepted_if_sent_twice_in_a_row_when_block_processing_queue_is_not_empty()
+        {
+            using MergeTestBlockchain? chain = await CreateBlockChain();
+
+            IEngineRpcModule? rpc = CreateEngineModule(chain, newPayloadTimeout: TimeSpan.FromMilliseconds(100), newPayloadCacheSize: 10);
+            Block? head = chain.BlockTree.Head!;
+
+            // make sure AddressA has enough balance to send tx
+            chain.State.GetBalance(TestItem.AddressA).Should().BeGreaterThan(UInt256.One);
+
+            // block is an invalid block, but it is impossible to detect until we process it.
+            // it is invalid because after you processs its transactions, the root of the state trie
+            // doesn't match the state root in the block
+            Block? block = Build.A.Block
+                .WithNumber(head.Number + 1)
+                .WithParent(head)
+                .WithNonce(0)
+                .WithDifficulty(0)
+                .WithTransactions(
+                    Build.A.Transaction
+                    .WithTo(TestItem.AddressD)
+                    .WithValue(100.GWei())
+                    .SignedAndResolved(TestItem.PrivateKeyA)
+                    .TestObject
+                )
+                .WithGasUsed(21000)
+                // after processing transaction, this state root is wrong
+                .WithStateRoot(head.StateRoot!)
+                .TestObject;
+
+            chain.ThrottleBlockProcessor(1000); // throttle the block processor enough so that the block processing queue is never empty
+            (await rpc.engine_newPayloadV1(new ExecutionPayloadV1(block))).Data.Status.Should().Be(PayloadStatus.Syncing);
+            (await rpc.engine_newPayloadV1(new ExecutionPayloadV1(block))).Data.Status.Should().BeOneOf(PayloadStatus.Syncing);
+        }
+
         [Test]
         public async Task forkchoiceUpdatedV1_should_change_head_when_all_parameters_are_the_newHeadHash()
         {

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/V1/NewPayloadV1Handler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/V1/NewPayloadV1Handler.cs
@@ -362,7 +362,14 @@ namespace Nethermind.Merge.Plugin.Handlers.V1
                     _ => null
                 };
 
-                if (!result.HasValue)
+                // the right condition in the OR feels hacky, if the block is already known
+                // then we should either it was processed with valid or invalid result or it hasn't
+                // been processed. the problem is that right now BlockTree.WasProcessed will only be
+                // true if it was processed with a valid result, so if we check this we would be unable
+                // to distinguish the block not being processed yet from the block being invalid during processing.
+                // one possible way to fix this is by adding a Contains method to the processing queue and if the block wasn't
+                // processed then we check the processing queue to see whether it was invalid during processing or if it's still pending in the queue.
+                if (!result.HasValue || (result & ValidationResult.AlreadyKnown) != 0)
                 {
                     _processingQueue.Enqueue(block, processingOptions);
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/V1/NewPayloadV1Handler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/V1/NewPayloadV1Handler.cs
@@ -271,7 +271,7 @@ namespace Nethermind.Merge.Plugin.Handlers.V1
                 // notice that it is not correct to add information to the cache
                 // if we return SYNCING for example, and don't know yet whether
                 // the block is valid or invalid because we haven't processed it yet
-                if (result != ValidationResult.Syncing)
+                if (result == ValidationResult.Valid || result == ValidationResult.Invalid)
                     _latestBlocks?.Set(block.GetOrCalculateHash(), result == ValidationResult.Valid);
                 return result;
             }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/V1/NewPayloadV1Handler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/V1/NewPayloadV1Handler.cs
@@ -266,7 +266,7 @@ namespace Nethermind.Merge.Plugin.Handlers.V1
 
         private async Task<(ValidationResult, string?)> ValidateBlockAndProcess(Block block, BlockHeader parent, ProcessingOptions processingOptions)
         {
-            ValidationResult CacheResult(ValidationResult result)
+            ValidationResult TryCacheResult(ValidationResult result)
             {
                 // notice that it is not correct to add information to the cache
                 // if we return SYNCING for example, and don't know yet whether
@@ -293,7 +293,7 @@ namespace Nethermind.Merge.Plugin.Handlers.V1
             // Validate
             if (!ValidateWithBlockValidator(block, parent))
             {
-                return (CacheResult(ValidationResult.Invalid), string.Empty);
+                return (TryCacheResult(ValidationResult.Invalid), string.Empty);
             }
 
             TaskCompletionSource<ValidationResult?> blockProcessedTaskCompletionSource = new();
@@ -380,7 +380,7 @@ namespace Nethermind.Merge.Plugin.Handlers.V1
                 _processingQueue.BlockRemoved -= GetProcessingQueueOnBlockRemoved;
             }
 
-            return (CacheResult(result ?? ValidationResult.Syncing), validationMessage);
+            return (TryCacheResult(result ?? ValidationResult.Syncing), validationMessage);
         }
 
         private bool ValidateWithBlockValidator(Block block, BlockHeader parent)


### PR DESCRIPTION
## Changes:
- Add failing test for case where we get the same new payload but we don't cache it, so we returned SYNCING instead of processing and returning VALID or INVALID
   - Fix: Check if block was processed when result is `AlreadyKnown`
- Add failing test for case where we get the same new payload, which is invalid but won't be detected until processing, if the block processing queue is not empty we correctly return syncing the first time we get it, but we'll cache the wrong value for that payload, so the second time, if we still haven't processed the block we will return valid, even though the block is invalid and has not been processed.
    - Fix: we were setting the value in the cache to the result of the payload pre-processing validation and we were just ignoring the result of the processing.
- After the above fixes, the `AlreadyKnown` case was unreachable, so the code was simplified a little thanks to this.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No

**Comments about testing**

Probably good to run a few nodes?