### PR TITLE
fix GetCriticalLogger with readonly file system exception

### DIFF
--- a/src/Nethermind/Nethermind.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Runner/Program.cs
@@ -97,7 +97,18 @@ namespace Nethermind.Runner
             }
         }
 
-        private static ILogger GetCriticalLogger() => new NLogManager("logs.txt").GetClassLogger();
+        private static ILogger GetCriticalLogger() 
+        {
+            try
+            {
+                return new NLogManager("logs.txt").GetClassLogger();
+            }
+            catch
+            {
+                if (_logger.IsWarn) _logger.Warn("Critical file logging could not be instantiated! Sticking to console logging till config is loaded.");
+                return _logger;
+            }
+        }
 
         private static void Run(string[] args)
         {
@@ -309,11 +320,10 @@ namespace Nethermind.Runner
             CommandOption configsDirectory,
             CommandOption configFile)
         {
-            ILogger logger = SimpleConsoleLogger.Instance;
             if (loggerConfigSource.HasValue())
             {
                 string nLogPath = loggerConfigSource.Value();
-                logger.Info($"Loading NLog configuration file from {nLogPath}.");
+                _logger.Info($"Loading NLog configuration file from {nLogPath}.");
 
                 try
                 {
@@ -321,17 +331,17 @@ namespace Nethermind.Runner
                 }
                 catch (Exception e)
                 {
-                    logger.Info($"Failed to load NLog configuration from {nLogPath}. {e}");
+                    _logger.Info($"Failed to load NLog configuration from {nLogPath}. {e}");
                 }
             }
             else
             {
-                logger.Info($"Loading standard NLog.config file from {"NLog.config".GetApplicationResourcePath()}.");
+                _logger.Info($"Loading standard NLog.config file from {"NLog.config".GetApplicationResourcePath()}.");
                 Stopwatch stopwatch = Stopwatch.StartNew();
                 LogManager.Configuration = new XmlLoggingConfiguration("NLog.config".GetApplicationResourcePath());
                 stopwatch.Stop();
 
-                logger.Info($"NLog.config loaded in {stopwatch.ElapsedMilliseconds}ms.");
+                _logger.Info($"NLog.config loaded in {stopwatch.ElapsedMilliseconds}ms.");
             }
 
             // TODO: dynamically switch log levels from CLI!
@@ -397,16 +407,16 @@ namespace Nethermind.Runner
                 }
             }
 
-            logger.Info($"Reading config file from {configFilePath}");
+            _logger.Info($"Reading config file from {configFilePath}");
             configProvider.AddSource(new JsonConfigSource(configFilePath));
             configProvider.Initialize();
             var incorrectSettings = configProvider.FindIncorrectSettings();
             if(incorrectSettings.Errors.Count() > 0)
             {
-                logger.Warn($"Incorrect config settings found:{Environment.NewLine}{incorrectSettings.ErrorMsg}");
+                _logger.Warn($"Incorrect config settings found:{Environment.NewLine}{incorrectSettings.ErrorMsg}");
             }
 
-            logger.Info("Configuration initialized.");
+            _logger.Info("Configuration initialized.");
             return configProvider;
         }
 


### PR DESCRIPTION
Fixes #4231

## Changes:
if file system is readonly stick to console logging + minor cleanup.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [x] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [x] No
