### PR TITLE
Fix publish-downloads.sh script 

### DIFF
--- a/scripts/deployment/publish-downloads.sh
+++ b/scripts/deployment/publish-downloads.sh
@@ -44,7 +44,7 @@ extension=${LIN_FILE##*.}
 
 mv $LIN_FILE $filename_lin.$extension
 mv $LIN_FILE.asc $filename_lin.$extension.asc
-curl --fail-with-body -# -F "files=@${PWD}/${filename_lin}.${extension}" -F "files=@${PWD}/${filename_lin}.${extension}.asc" https://downloads.nethermind.io/files?apikey=$DOWNLOADS_PAGE
+curl --fail -# -F "files=@${PWD}/${filename_lin}.${extension}" -F "files=@${PWD}/${filename_lin}.${extension}.asc" https://downloads.nethermind.io/files?apikey=$DOWNLOADS_PAGE
 cd ..
 
 cd $WIN_RELEASE
@@ -53,7 +53,7 @@ filename_win=${WIN_FILE::-13}
 mv $WIN_FILE $filename_win.$extension
 mv $WIN_FILE.asc $filename_win.$extension.asc
 
-curl --fail-with-body -# -F "files=@${PWD}/${filename_win}.${extension}" -F "files=@${PWD}/${filename_win}.${extension}.asc" https://downloads.nethermind.io/files?apikey=$DOWNLOADS_PAGE
+curl --fail -# -F "files=@${PWD}/${filename_win}.${extension}" -F "files=@${PWD}/${filename_win}.${extension}.asc" https://downloads.nethermind.io/files?apikey=$DOWNLOADS_PAGE
 cd ..
 
 cd $OSX_RELEASE
@@ -62,7 +62,7 @@ filename_osx=${OSX_FILE::-13}
 mv $OSX_FILE $filename_osx.$extension
 mv $OSX_FILE.asc $filename_osx.$extension.asc
 
-curl --fail-with-body -# -F "files=@${PWD}/${filename_osx}.${extension}" -F "files=@${PWD}/${filename_osx}.${extension}.asc" https://downloads.nethermind.io/files?apikey=$DOWNLOADS_PAGE
+curl --fail -# -F "files=@${PWD}/${filename_osx}.${extension}" -F "files=@${PWD}/${filename_osx}.${extension}.asc" https://downloads.nethermind.io/files?apikey=$DOWNLOADS_PAGE
 cd ..
 
 cd $LIN_ARM64_RELEASE
@@ -70,7 +70,7 @@ filename_lin_arm64=${LIN_ARM64_FILE::-13}
 
 mv $LIN_ARM64_FILE $filename_lin_arm64.$extension
 mv $LIN_ARM64_FILE.asc $filename_lin_arm64.$extension.asc
-curl --fail-with-body -# -F "files=@${PWD}/${filename_lin_arm64}.${extension}" -F "files=@${PWD}/${filename_lin_arm64}.${extension}.asc" https://downloads.nethermind.io/files?apikey=$DOWNLOADS_PAGE
+curl --fail -# -F "files=@${PWD}/${filename_lin_arm64}.${extension}" -F "files=@${PWD}/${filename_lin_arm64}.${extension}.asc" https://downloads.nethermind.io/files?apikey=$DOWNLOADS_PAGE
 cd ..
 
 cd $OSX_ARM64_RELEASE
@@ -78,7 +78,7 @@ filename_osx_arm64=${OSX_ARM64_FILE::-13}
 
 mv $OSX_ARM64_FILE $filename_osx_arm64.$extension
 mv $OSX_ARM64_FILE.asc $filename_osx_arm64.$extension.asc
-curl --fail-with-body -# -F "files=@${PWD}/${filename_osx_arm64}.${extension}" -F "files=@${PWD}/${filename_osx_arm64}.${extension}.asc" https://downloads.nethermind.io/files?apikey=$DOWNLOADS_PAGE
+curl --fail -# -F "files=@${PWD}/${filename_osx_arm64}.${extension}" -F "files=@${PWD}/${filename_osx_arm64}.${extension}.asc" https://downloads.nethermind.io/files?apikey=$DOWNLOADS_PAGE
 cd ..
 
 echo =======================================================


### PR DESCRIPTION
## Changes:
- Changes **--fail-with-body** to **--fail** because the Ubuntu 20 runner is using an older curl version that doens't support --fail-with-body. (Ubuntu 22 runner does support this)

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [X] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [ ] No