### PR TITLE
Fix incremental sync hive test with fast sync

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/BlockTreeTests.cs
@@ -396,7 +396,7 @@ public partial class BlockTreeTests
 
             public ScenarioBuilder SuggestBlocksUsingChainLevels(int maxCount = 2, long maxHeaderNumber = long.MaxValue)
             {
-                BlockHeader[] headers = _chainLevelHelper!.GetNextHeaders(maxCount, maxHeaderNumber);
+                BlockHeader[] headers = _chainLevelHelper!.GetNextHeaders(maxCount, maxHeaderNumber, 0);
                 while (headers != null && headers.Length > 1)
                 {
                     BlockDownloadContext blockDownloadContext = new(
@@ -427,7 +427,7 @@ public partial class BlockTreeTests
                         Assert.True(AddBlockResult.Added == insertResult, $"BeaconBlock {beaconBlock!.ToString(Block.Format.FullHashAndNumber)}");
                     }
 
-                    headers = _chainLevelHelper!.GetNextHeaders(maxCount, maxHeaderNumber);
+                    headers = _chainLevelHelper!.GetNextHeaders(maxCount, maxHeaderNumber, 0);
                 }
 
                 return this;

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconSync.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconSync.cs
@@ -117,6 +117,15 @@ namespace Nethermind.Merge.Plugin.Synchronization
         /// <param name="blockHeader"></param>
         /// <returns></returns>
         public bool IsBeaconSyncFinished(BlockHeader? blockHeader) => !_beaconPivot.BeaconPivotExists() || (blockHeader is not null && _blockTree.WasProcessed(blockHeader.Number, blockHeader.GetOrCalculateHash()));
+
+        public long? GetTargetBlockHeight()
+        {
+            if (_beaconPivot.BeaconPivotExists())
+            {
+                return _beaconPivot.ProcessDestination?.Number ?? _beaconPivot.PivotNumber;
+            }
+            return null;
+        }
     }
 
     public interface IMergeSyncController

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/ChainLevelHelper.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/ChainLevelHelper.cs
@@ -28,7 +28,7 @@ namespace Nethermind.Merge.Plugin.Synchronization;
 
 public interface IChainLevelHelper
 {
-    BlockHeader[]? GetNextHeaders(int maxCount, long maxHeaderNumber, int blocksRequestNumberOfLatestBlocksToBeIgnored);
+    BlockHeader[]? GetNextHeaders(int maxCount, long maxHeaderNumber, int lastBlockToIgnore);
 
     bool TrySetNextBlocks(int maxCount, BlockDownloadContext context);
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/ChainLevelHelper.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/ChainLevelHelper.cs
@@ -28,7 +28,7 @@ namespace Nethermind.Merge.Plugin.Synchronization;
 
 public interface IChainLevelHelper
 {
-    BlockHeader[]? GetNextHeaders(int maxCount, long maxHeaderNumber, int lastBlockToIgnore);
+    BlockHeader[]? GetNextHeaders(int maxCount, long maxHeaderNumber, int skipLastBlockCount = 0);
 
     bool TrySetNextBlocks(int maxCount, BlockDownloadContext context);
 }
@@ -52,7 +52,7 @@ public class ChainLevelHelper : IChainLevelHelper
         _logger = logManager.GetClassLogger();
     }
 
-    public BlockHeader[]? GetNextHeaders(int maxCount, long maxHeaderNumber, int lastBlockToIgnore)
+    public BlockHeader[]? GetNextHeaders(int maxCount, long maxHeaderNumber, int skipLastBlockCount = 0)
     {
         long? startingPoint = GetStartingPoint();
         if (startingPoint == null)
@@ -64,7 +64,7 @@ public class ChainLevelHelper : IChainLevelHelper
 
         if (_logger.IsTrace) _logger.Trace($"ChainLevelHelper.GetNextHeaders - starting point is {startingPoint}");
 
-        int effectiveMax = maxCount + lastBlockToIgnore;
+        int effectiveMax = maxCount + skipLastBlockCount;
         List<BlockHeader> headers = new(effectiveMax);
         int i = 0;
 
@@ -130,7 +130,7 @@ public class ChainLevelHelper : IChainLevelHelper
             ++startingPoint;
         }
 
-        int toTake = headers.Count - lastBlockToIgnore;
+        int toTake = headers.Count - skipLastBlockCount;
         if (toTake <= 0)
         {
             headers.Clear();

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeBlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeBlockDownloader.cs
@@ -119,8 +119,7 @@ namespace Nethermind.Merge.Plugin.Synchronization
                     _logger.Trace(
                         $"Full sync request {currentNumber}+{headersToRequest} to peer {bestPeer} with {bestPeer.HeadNumber} blocks. Got {currentNumber} and asking for {headersToRequest} more.");
 
-                // Note: blocksRequest.NumberOfLatestBlocksToBeIgnored not accounted for
-                headers = _chainLevelHelper.GetNextHeaders(headersToRequest, bestPeer.HeadNumber);
+                headers = _chainLevelHelper.GetNextHeaders(headersToRequest, bestPeer.HeadNumber, blocksRequest.NumberOfLatestBlocksToBeIgnored ?? 0);
                 if (headers == null || headers.Length <= 1)
                 {
                     if (_logger.IsTrace)

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorFastSyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorFastSyncTests.cs
@@ -258,6 +258,16 @@ namespace Nethermind.Synchronization.Test.ParallelSync
         }
 
         [Test]
+        public void Finished_fast_sync_via_fast_sync_lag_but_not_state_sync()
+        {
+            Scenario.GoesLikeThis(_needToWaitForHeaders)
+                .WhenBeaconProcessDestinationWithinFastSyncLag()
+                .AndGoodPeersAreKnown()
+                .WhenFastSyncWithFastBlocksIsConfigured()
+                .TheSyncModeShouldBe(SyncMode.StateNodes);
+        }
+
+        [Test]
         public void Finished_fast_sync_but_not_state_sync_and_fast_blocks_in_progress()
         {
             Scenario.GoesLikeThis(_needToWaitForHeaders)

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorTests.Scenario.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorTests.Scenario.cs
@@ -759,6 +759,22 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                     return this;
                 }
 
+                public ScenarioBuilder WhenBeaconProcessDestinationWithinFastSyncLag()
+                {
+                    _syncProgressSetups.Add(
+                        () =>
+                        {
+                            BeaconSyncStrategy = Substitute.For<IBeaconSyncStrategy>();
+                            BeaconSyncStrategy.GetTargetBlockHeight().Returns(ChainHead.Number);
+                            SyncProgressResolver.FindBestHeader().Returns(ChainHead.Number - MultiSyncModeSelector.FastSyncLag);
+                            SyncProgressResolver.IsFastBlocksHeadersFinished().Returns(true);
+                            return "beacon process destination with fast sync lag";
+                        }
+                    );
+
+                    return this;
+                }
+
                 public void TheSyncModeShouldBe(SyncMode syncMode)
                 {
                     void Test()

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorTests.Scenario.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorTests.Scenario.cs
@@ -719,6 +719,18 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                     return this;
                 }
 
+                public ScenarioBuilder WhenFastSyncWithFastBlocksIsConfigured()
+                {
+                    _configActions.Add(() =>
+                    {
+                        SyncConfig.FastSync = true;
+                        SyncConfig.FastBlocks = true;
+                        return "fast sync with fast blocks";
+                    });
+
+                    return this;
+                }
+
                 public ScenarioBuilder WhenSnapSyncWithoutFastBlocksIsConfigured()
                 {
                     _configActions.Add(() =>

--- a/src/Nethermind/Nethermind.Synchronization/IBeaconSyncStrategy.cs
+++ b/src/Nethermind/Nethermind.Synchronization/IBeaconSyncStrategy.cs
@@ -1,19 +1,19 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using System.Configuration;
 using Nethermind.Core;
@@ -32,6 +32,7 @@ namespace Nethermind.Synchronization
         public bool ShouldBeInBeaconModeControl() => false;
 
         public bool IsBeaconSyncFinished(BlockHeader? blockHeader) => true;
+        public long? GetTargetBlockHeight() => null;
     }
 
     public interface IBeaconSyncStrategy
@@ -39,5 +40,7 @@ namespace Nethermind.Synchronization
         bool ShouldBeInBeaconHeaders();
         bool ShouldBeInBeaconModeControl();
         bool IsBeaconSyncFinished(BlockHeader? blockHeader);
+
+        public long? GetTargetBlockHeight();
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
@@ -295,7 +295,7 @@ namespace Nethermind.Synchronization.ParallelSync
         /// <param name="best">Snapshot of the best known states</param>
         /// <returns>A string describing the state of sync</returns>
         private static string BuildStateString(Snapshot best) =>
-            $"processed:{best.Processed}|state:{best.State}|block:{best.Block}|header:{best.Header}|chain difficulty:{best.ChainDifficulty}|peer block:{best.TargetBlock}|peer block:{best.Peer.Block}|peer total difficulty:{best.Peer.TotalDifficulty}";
+            $"processed:{best.Processed}|state:{best.State}|block:{best.Block}|header:{best.Header}|chain difficulty:{best.ChainDifficulty}|target block:{best.TargetBlock}|peer block:{best.Peer.Block}|peer total difficulty:{best.Peer.TotalDifficulty}";
 
         private bool IsInAStickyFullSyncMode(Snapshot best)
         {

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
@@ -295,7 +295,14 @@ namespace Nethermind.Synchronization.ParallelSync
         /// <param name="best">Snapshot of the best known states</param>
         /// <returns>A string describing the state of sync</returns>
         private static string BuildStateString(Snapshot best) =>
-            $"processed:{best.Processed}|state:{best.State}|block:{best.Block}|header:{best.Header}|chain difficulty:{best.ChainDifficulty}|target block:{best.TargetBlock}|peer block:{best.Peer.Block}|peer total difficulty:{best.Peer.TotalDifficulty}";
+            $"processed:{best.Processed}|" +
+            $"state:{best.State}|" +
+            $"block:{best.Block}|" +
+            $"header:{best.Header}|" +
+            $"chain difficulty:{best.ChainDifficulty}|" +
+            $"target block:{best.TargetBlock}|" +
+            $"peer block:{best.Peer.Block}|" +
+            $"peer total difficulty:{best.Peer.TotalDifficulty}";
 
         private bool IsInAStickyFullSyncMode(Snapshot best)
         {


### PR DESCRIPTION
Fix incremental sync when fast sync is enabled by adding fast sync lag post merge.

## Changes:
- Added `lastBlockToIgnore` param to chain level helper get headers.
  - Implemented by fetching extra header, then removing them before returning the header list.
- In multisyncmodeselector, Replace `best.Peer.Block` to `best.TargetBlock` which is the `BeaconPivot.ProcessDestination`. 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [X] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [X] Yes
- [ ] No

**Comments about testing , should you have some** (optional)

- Hive test passes. Sync test all passed. Only one from transition test as expected.
- Goerli can sync to head.

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...