### PR TITLE
Removes tag ref from checkout on download publish step

### DIFF
--- a/.github/workflows/release-nethermind.yml
+++ b/.github/workflows/release-nethermind.yml
@@ -234,7 +234,6 @@ jobs:
     - name: Checking out Nethermind repository
       uses: actions/checkout@master
       with:
-        ref: ${{ github.event.inputs.tag }}
         path: nethermind
     - uses: actions/download-artifact@master
       name: Downloading Nethermind darwin package


### PR DESCRIPTION
## Changes:
- Removes the "ref" from checkout on publish-downloads step. This is to make sure it will use the latest script from master instead of a script based on a tag. 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [X] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [ ] No