### PR TITLE
Fix db recovery

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.AcceptVisitor.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.AcceptVisitor.cs
@@ -77,7 +77,7 @@ namespace Nethermind.Blockchain
                         }
                         else
                         {
-                            if (block.Header.TotalDifficulty is null || block.Header.TotalDifficulty == 0)
+                            if (visitor.CalculateTotalDifficultyIfMissing && (block.TotalDifficulty is null || block.TotalDifficulty == 0))
                             {
                                 if (_logger.IsTrace) _logger.Trace($"Setting TD for block {block.Number}. Old TD: {block.TotalDifficulty}.");
                                 SetTotalDifficulty(block.Header);

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.AcceptVisitor.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.AcceptVisitor.cs
@@ -1,19 +1,19 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using System.Threading;
 using System.Threading.Tasks;
@@ -31,7 +31,7 @@ namespace Nethermind.Blockchain
             {
                 BlockAcceptingNewBlocks();
             }
-            
+
             try
             {
                 long levelNumber = visitor.StartLevelInclusive;
@@ -44,7 +44,7 @@ namespace Nethermind.Blockchain
                     }
 
                     ChainLevelInfo level = LoadLevel(levelNumber);
-                    
+
                     LevelVisitOutcome visitOutcome = await visitor.VisitLevelStart(level, levelNumber, cancellationToken);
                     if ((visitOutcome & LevelVisitOutcome.DeleteLevel) == LevelVisitOutcome.DeleteLevel)
                     {
@@ -77,6 +77,12 @@ namespace Nethermind.Blockchain
                         }
                         else
                         {
+                            if (block.Header.TotalDifficulty is null || block.Header.TotalDifficulty == 0)
+                            {
+                                if (_logger.IsTrace) _logger.Trace($"Setting TD for block {block.Number}. Old TD: {block.TotalDifficulty}.");
+                                SetTotalDifficulty(block.Header);
+                                if (_logger.IsTrace) _logger.Trace($"Setting TD for block {block.Number}. New TD: {block.TotalDifficulty}.");
+                            }
                             if (await VisitBlock(visitor, block, cancellationToken)) break;
                         }
                     }

--- a/src/Nethermind/Nethermind.Blockchain/Visitors/DbBlocksLoader.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Visitors/DbBlocksLoader.cs
@@ -1,19 +1,19 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using System;
 using System.IO;
@@ -73,6 +73,7 @@ namespace Nethermind.Blockchain.Visitors
         }
 
         public bool PreventsAcceptingNewBlocks => true;
+        public bool CalculateTotalDifficultyIfMissing => true;
         public long StartLevelInclusive { get; }
 
         public long EndLevelExclusive { get; }

--- a/src/Nethermind/Nethermind.Blockchain/Visitors/IBlockTreeVisitor.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Visitors/IBlockTreeVisitor.cs
@@ -1,19 +1,19 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using System.Threading;
 using System.Threading.Tasks;
@@ -28,7 +28,12 @@ namespace Nethermind.Blockchain.Visitors
         /// Gives a hint to block tree that accepting new blocks should be halted for the length of the visit.
         /// </summary>
         bool PreventsAcceptingNewBlocks { get; }
-        
+
+        /// <summary>
+        /// Allows for setting total difficulty if this value is missing (null or zero).
+        /// </summary>
+        bool CalculateTotalDifficultyIfMissing => false;
+
         /// <summary>
         /// First block tree level to visit
         /// </summary>
@@ -57,7 +62,7 @@ namespace Nethermind.Blockchain.Visitors
         Task<bool> VisitMissing(Keccak hash, CancellationToken cancellationToken);
 
         /// <summary>
-        /// If the block hash is defined on the chain level and only header is available but not block body 
+        /// If the block hash is defined on the chain level and only header is available but not block body
         /// </summary>
         /// <param name="header"></param>
         /// <param name="cancellationToken"></param>

--- a/src/Nethermind/Nethermind.Blockchain/Visitors/StartupBlockTreeFixer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Visitors/StartupBlockTreeFixer.cs
@@ -1,19 +1,19 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using System;
 using System.IO;
@@ -54,7 +54,7 @@ namespace Nethermind.Blockchain.Visitors
         private readonly long _batchSize;
 
         public StartupBlockTreeFixer(
-            ISyncConfig syncConfig, 
+            ISyncConfig syncConfig,
             IBlockTree blockTree,
             IDb stateDb,
             ILogger logger,
@@ -92,6 +92,7 @@ namespace Nethermind.Blockchain.Visitors
         }
 
         public bool PreventsAcceptingNewBlocks => true;
+        public bool CalculateTotalDifficultyIfMissing => true;
         public long StartLevelInclusive => _startNumber;
 
         public long EndLevelExclusive => _startNumber + _blocksToLoad;
@@ -114,7 +115,7 @@ namespace Nethermind.Blockchain.Visitors
             {
                 if(_logger.IsInfo) _logger.Info($"Reviewed {_currentLevelNumber - StartLevelInclusive} blocks out of {EndLevelExclusive - StartLevelInclusive}");
             }
-            
+
             if (_gapStart != null)
             {
                 _currentLevel = null;
@@ -173,14 +174,14 @@ namespace Nethermind.Blockchain.Visitors
             AssertNotVisitingAfterGap();
             _blocksCheckedInCurrentLevel++;
             _bodiesInCurrentLevel++;
-            
+
             if (_firstBlockVisited)
             {
                 _suggestBlocks = CanSuggestBlocks(block);
             }
 
             if (!_suggestBlocks) return BlockVisitOutcome.None;
-            
+
             long i = block.Number - StartLevelInclusive;
             if (i % _batchSize == _batchSize - 1 && i != _blocksToLoad - 1 &&
                 _blockTree.Head.Number + _batchSize < block.Number)
@@ -190,7 +191,7 @@ namespace Nethermind.Blockchain.Visitors
                     _logger.Info(
                         $"Loaded {i + 1} out of {_blocksToLoad} blocks from DB into processing queue, waiting for processor before loading more.");
                 }
-            
+
                 _dbBatchProcessed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
                 await using (cancellationToken.Register(() => _dbBatchProcessed.SetCanceled()))
                 {
@@ -198,7 +199,7 @@ namespace Nethermind.Blockchain.Visitors
                     await _dbBatchProcessed.Task;
                 }
             }
-            
+
             return BlockVisitOutcome.Suggest;
 
         }

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergeProcessingRecoveryStep.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergeProcessingRecoveryStep.cs
@@ -1,19 +1,19 @@
 ﻿//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using Nethermind.Consensus;
 using Nethermind.Consensus.Processing;
@@ -30,13 +30,10 @@ public class MergeProcessingRecoveryStep : IBlockPreprocessorStep
     {
         _poSSwitcher = poSSwitcher;
     }
-    
+
     public void RecoverData(Block block)
     {
-        if (block.TotalDifficulty is not null)
-        {
-            block.Header.IsPostMerge = _poSSwitcher.IsPostMerge(block.Header);
-        }
+        block.Header.IsPostMerge = _poSSwitcher.IsPostMerge(block.Header);
 
         if (block.Author is null && block.IsPostMerge)
         {


### PR DESCRIPTION
## Changes:
- in `MergeProcessingRecoveryStep` check if block is post merge even if it's `TotalDifficulty` is `null`
- during `ReviewBlockTree`, if `block.TotalDifficulty` is `null` or `0`, set correct `TD`

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [x] No

Tested:
- [x] Recovered broken nethermind-teku db delivered by user
- [x] Recovered broken nethermind-prysm db delivered by user
- [x] Checked that `TD` is setting correctly
- [x] Runned hive engine and transition test - no regression