### PR TITLE
Ensure scrypt does not fail

### DIFF
--- a/src/Nethermind/Nethermind.KeyStore/FileKeyStore.cs
+++ b/src/Nethermind/Nethermind.KeyStore/FileKeyStore.cs
@@ -147,7 +147,9 @@ namespace Nethermind.KeyStore
                     int r = kdfParams.R.Value;
                     int p = kdfParams.P.Value;
                     int n = kdfParams.N.Value;
-                    derivedKey = SCrypt.ComputeDerivedKey(passBytes, salt, n, r, p, null, kdfParams.DkLen);
+                    // ComputeDerivedKey uses too little stack size in case of multithread processing, which may cause stack overflow.
+                    // Switch to single thread if "cost" is too high, see Scrypt.ThreadSMixCalls internals
+                    derivedKey = SCrypt.ComputeDerivedKey(passBytes, salt, n, r, p, n > 8192 ? 1 : null, kdfParams.DkLen);
                     break;
                 case "pbkdf2":
                     int c = kdfParams.C.Value;


### PR DESCRIPTION
File key store fails when Scrypt is used and parameters high enough to cause stack overflow are passed

## Changes:
- Make Scrypt more stable

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [x] No (enough tests exist)