### PR TITLE
Fix forward sync may stuck on slow peer

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeBlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeBlockDownloader.cs
@@ -54,8 +54,7 @@ namespace Nethermind.Merge.Plugin.Synchronization
         private readonly IPoSSwitcher _poSSwitcher;
         private readonly ISyncProgressResolver _syncProgressResolver;
 
-        public MergeBlockDownloader(
-            IPoSSwitcher posSwitcher,
+        public MergeBlockDownloader(IPoSSwitcher posSwitcher,
             IBeaconPivot beaconPivot,
             ISyncFeed<BlocksRequest?>? feed,
             ISyncPeerPool? syncPeerPool,
@@ -68,10 +67,11 @@ namespace Nethermind.Merge.Plugin.Synchronization
             IBetterPeerStrategy betterPeerStrategy,
             IChainLevelHelper chainLevelHelper,
             ISyncProgressResolver syncProgressResolver,
-            ILogManager logManager)
+            ILogManager logManager,
+            SyncBatchSize? syncBatchSize = null)
             : base(feed, syncPeerPool, blockTree, blockValidator, sealValidator, syncReport, receiptStorage,
                 specProvider, new MergeBlocksSyncPeerAllocationStrategyFactory(posSwitcher, beaconPivot, logManager),
-                betterPeerStrategy, logManager)
+                betterPeerStrategy, logManager, syncBatchSize)
         {
             _blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
             _specProvider = specProvider ?? throw new ArgumentNullException(nameof(specProvider));

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeBlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeBlockDownloader.cs
@@ -90,7 +90,11 @@ namespace Nethermind.Merge.Plugin.Synchronization
             CancellationToken cancellation)
         {
             if (_beaconPivot.BeaconPivotExists() == false && _poSSwitcher.HasEverReachedTerminalBlock() == false)
+            {
+                if (_logger.IsDebug)
+                    _logger.Debug("Using pre merge block downloader");
                 return await base.DownloadBlocks(bestPeer, blocksRequest, cancellation);
+            }
 
             if (bestPeer == null)
             {
@@ -136,7 +140,7 @@ namespace Nethermind.Merge.Plugin.Synchronization
             {
                 if (HasBetterPeer)
                 {
-                    if (_logger.IsDebug) _logger.Debug("-- Has better peer, stopping...");
+                    if (_logger.IsDebug) _logger.Debug("Has better peer, stopping");
                     break;
                 }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeBlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeBlockDownloader.cs
@@ -133,6 +133,11 @@ namespace Nethermind.Merge.Plugin.Synchronization
 
             while (HasMoreToSync(out BlockHeader[]? headers, out int headersToRequest))
             {
+                if (HasBetterPeer)
+                {
+                    if (_logger.IsDebug) _logger.Debug("-- Has better peer, stopping...");
+                    break;
+                }
 
                 if (cancellation.IsCancellationRequested) return blocksSynced; // check before every heavy operation
                 Block[]? blocks = null;

--- a/src/Nethermind/Nethermind.Network.Stats/NodeStatsLight.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/NodeStatsLight.cs
@@ -33,7 +33,7 @@ namespace Nethermind.Stats
         // 0.5m means that the reported speed will be (oldSpeed + newSpeed)/2;
         // 0.25m here means that the latest weight affect the stored weight a bit for every report, resulting in a smoother
         // modification to account for jitter.
-        private decimal _latestSpeedWeight = 0.25m;
+        private readonly decimal _latestSpeedWeight;
 
         private decimal? _averageNodesTransferSpeed;
         private decimal? _averageHeadersTransferSpeed;
@@ -54,10 +54,11 @@ namespace Nethermind.Stats
 
         private static readonly int _statsLength = FastEnum.GetValues<NodeStatsEventType>().Count;
 
-        public NodeStatsLight(Node node)
+        public NodeStatsLight(Node node, decimal latestSpeedWeight = 0.25m)
         {
             _statCountersArray = new int[_statsLength];
             _statsParameters = StatsParameters.Instance;
+            _latestSpeedWeight = latestSpeedWeight;
             Node = node;
         }
 
@@ -198,12 +199,12 @@ namespace Nethermind.Stats
         {
             return (transferSpeedType switch
             {
-                TransferSpeedType.Latency => $"{_averageLatency ?? 0,5:0}",
-                TransferSpeedType.NodeData => $"{_averageNodesTransferSpeed ?? 0,5:0}",
-                TransferSpeedType.Headers => $"{_averageHeadersTransferSpeed ?? 0,5:0}",
-                TransferSpeedType.Bodies => $"{_averageBodiesTransferSpeed ?? 0,5:0}",
-                TransferSpeedType.Receipts => $"{_averageReceiptsTransferSpeed ?? 0,5:0}",
-                TransferSpeedType.SnapRanges => $"{_averageSnapRangesTransferSpeed ?? 0,5:0}",
+                TransferSpeedType.Latency => $"{_averageLatency ?? -1,5:0}",
+                TransferSpeedType.NodeData => $"{_averageNodesTransferSpeed ?? -1,5:0}",
+                TransferSpeedType.Headers => $"{_averageHeadersTransferSpeed ?? -1,5:0}",
+                TransferSpeedType.Bodies => $"{_averageBodiesTransferSpeed ?? -1,5:0}",
+                TransferSpeedType.Receipts => $"{_averageReceiptsTransferSpeed ?? -1,5:0}",
+                TransferSpeedType.SnapRanges => $"{_averageSnapRangesTransferSpeed ?? -1,5:0}",
                 _ => throw new ArgumentOutOfRangeException()
             });
         }

--- a/src/Nethermind/Nethermind.Network.Stats/NodeStatsLight.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/NodeStatsLight.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -28,12 +28,12 @@ namespace Nethermind.Stats
     {
         private readonly StatsParameters _statsParameters;
 
-        private long _headersTransferSpeedEventCount;
-        private long _bodiesTransferSpeedEventCount;
-        private long _receiptsTransferSpeedEventCount;
-        private long _nodesTransferSpeedEventCount;
-        private long _snapRangesTransferSpeedEventCount;
-        private long _latencyEventCount;
+        // How much weight to put on latest speed.
+        // 1.0m means that the reported speed will always replaced with latest speed.
+        // 0.5m means that the reported speed will be (oldSpeed + newSpeed)/2;
+        // 0.25m here means that the latest weight affect the stored weight a bit for every report, resulting in a smoother
+        // modification to account for jitter.
+        private decimal _latestSpeedWeight = 0.25m;
 
         private decimal? _averageNodesTransferSpeed;
         private decimal? _averageHeadersTransferSpeed;
@@ -152,27 +152,32 @@ namespace Nethermind.Stats
                 switch (transferSpeedType)
                 {
                     case TransferSpeedType.Latency:
-                        _averageLatency = ((_latencyEventCount * (_averageLatency ?? 0)) + bytesPerMillisecond) / (++_latencyEventCount);
+                        UpdateValue(ref _averageLatency, bytesPerMillisecond);
                         break;
                     case TransferSpeedType.NodeData:
-                        _averageNodesTransferSpeed = ((_nodesTransferSpeedEventCount * (_averageNodesTransferSpeed ?? 0)) + bytesPerMillisecond) / (++_nodesTransferSpeedEventCount);
+                        UpdateValue(ref _averageNodesTransferSpeed, bytesPerMillisecond);
                         break;
                     case TransferSpeedType.Headers:
-                        _averageHeadersTransferSpeed = ((_headersTransferSpeedEventCount * (_averageHeadersTransferSpeed ?? 0)) + bytesPerMillisecond) / (++_headersTransferSpeedEventCount);
+                        UpdateValue(ref _averageHeadersTransferSpeed, bytesPerMillisecond);
                         break;
                     case TransferSpeedType.Bodies:
-                        _averageBodiesTransferSpeed = ((_bodiesTransferSpeedEventCount * (_averageBodiesTransferSpeed ?? 0)) + bytesPerMillisecond) / (++_bodiesTransferSpeedEventCount);
+                        UpdateValue(ref _averageBodiesTransferSpeed, bytesPerMillisecond);
                         break;
                     case TransferSpeedType.Receipts:
-                        _averageReceiptsTransferSpeed = ((_receiptsTransferSpeedEventCount * (_averageReceiptsTransferSpeed ?? 0)) + bytesPerMillisecond) / (++_receiptsTransferSpeedEventCount);
+                        UpdateValue(ref _averageReceiptsTransferSpeed, bytesPerMillisecond);
                         break;
                     case TransferSpeedType.SnapRanges:
-                        _averageSnapRangesTransferSpeed = ((_snapRangesTransferSpeedEventCount * (_averageSnapRangesTransferSpeed ?? 0)) + bytesPerMillisecond) / (++_snapRangesTransferSpeedEventCount);
+                        UpdateValue(ref _averageSnapRangesTransferSpeed, bytesPerMillisecond);
                         break;
                     default:
                         throw new ArgumentOutOfRangeException(nameof(transferSpeedType), transferSpeedType, null);
                 }
             }
+        }
+
+        private void UpdateValue(ref decimal? currentValue, decimal newValue)
+        {
+            currentValue = ((currentValue ?? newValue) * ( 1.0m - _latestSpeedWeight)) + (newValue * _latestSpeedWeight);
         }
 
         public long? GetAverageTransferSpeed(TransferSpeedType transferSpeedType)

--- a/src/Nethermind/Nethermind.Network.Test/NodeStatsTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/NodeStatsTests.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -42,8 +42,8 @@ namespace Nethermind.Network.Test
         [TestCase(TransferSpeedType.NodeData)]
         public void TransferSpeedCaptureTest(TransferSpeedType speedType)
         {
-            _nodeStats = new NodeStatsLight(_node);
-            
+            _nodeStats = new NodeStatsLight(_node, 0.5m);
+
             _nodeStats.AddTransferSpeedCaptureEvent(speedType, 30);
             _nodeStats.AddTransferSpeedCaptureEvent(speedType, 51);
             _nodeStats.AddTransferSpeedCaptureEvent(speedType, 140);
@@ -59,20 +59,26 @@ namespace Nethermind.Network.Test
             _nodeStats.AddTransferSpeedCaptureEvent(speedType, 133);
 
             var av = _nodeStats.GetAverageTransferSpeed(speedType);
-            Assert.AreEqual(102, av);
+            Assert.AreEqual(122, av);
 
             var paddedAv = _nodeStats.GetPaddedAverageTransferSpeed(speedType);
-            Assert.AreEqual("  102", paddedAv);
+            Assert.AreEqual("  122", paddedAv);
+
+            _nodeStats.AddTransferSpeedCaptureEvent(speedType, 0);
+            _nodeStats.AddTransferSpeedCaptureEvent(speedType, 0);
+
+            av = _nodeStats.GetAverageTransferSpeed(speedType);
+            Assert.AreEqual(30, av);
         }
 
         [Test]
         public async Task DisconnectDelayTest()
         {
             _nodeStats = new NodeStatsLight(_node);
-            
+
             var isConnDelayed = _nodeStats.IsConnectionDelayed();
             Assert.IsFalse(isConnDelayed.Result, "before disconnect");
-            
+
             _nodeStats.AddNodeStatsDisconnectEvent(DisconnectType.Remote, DisconnectReason.Other);
             isConnDelayed = _nodeStats.IsConnectionDelayed();
             Assert.IsTrue(isConnDelayed.Result, "just after disconnect");
@@ -81,15 +87,15 @@ namespace Nethermind.Network.Test
             isConnDelayed = _nodeStats.IsConnectionDelayed();
             Assert.IsFalse(isConnDelayed.Result, "125ms after disconnect");
         }
-        
+
         [Test]
         public async Task FailedConnectionDelayTest()
         {
             _nodeStats = new NodeStatsLight(_node);
-            
+
             var isConnDelayed = _nodeStats.IsConnectionDelayed();
             Assert.IsFalse(isConnDelayed.Result, "before failure");
-            
+
             _nodeStats.AddNodeStatsEvent(NodeStatsEventType.ConnectionFailed);
             isConnDelayed = _nodeStats.IsConnectionDelayed();
             Assert.IsTrue(isConnDelayed.Result, "just after failure");

--- a/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.Merge.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.Merge.cs
@@ -310,7 +310,8 @@ public partial class BlockDownloaderTests
             CreateMergePeerChoiceStrategy(posSwitcher, beaconPivot),
             new ChainLevelHelper(blockTree, beaconPivot, new SyncConfig(),  LimboLogs.Instance),
             Substitute.For<ISyncProgressResolver>(),
-            LimboLogs.Instance);
+            LimboLogs.Instance,
+            ctx.SyncBatchSize);
     }
 
     private IBetterPeerStrategy CreateMergePeerChoiceStrategy(IPoSSwitcher poSSwitcher, IBeaconPivot beaconPivot)

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncBatchSizeTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncBatchSizeTests.cs
@@ -1,19 +1,20 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
+using System;
 using Nethermind.Logging;
 using Nethermind.Synchronization.Blocks;
 using NUnit.Framework;
@@ -29,10 +30,10 @@ namespace Nethermind.Synchronization.Test
             SyncBatchSize syncBatchSize = new(LimboLogs.Instance);
             int beforeShrink = syncBatchSize.Current;
             syncBatchSize.Shrink();
-            Assert.AreEqual(beforeShrink / 2, syncBatchSize.Current);
+            Assert.AreEqual(Math.Floor(beforeShrink / SyncBatchSize.AdjustmentFactor), syncBatchSize.Current);
             int beforeExpand = syncBatchSize.Current;
             syncBatchSize.Expand();
-            Assert.AreEqual(beforeExpand * 2, syncBatchSize.Current);
+            Assert.AreEqual(Math.Ceiling(beforeExpand * SyncBatchSize.AdjustmentFactor), syncBatchSize.Current);
         }
 
         [Test]
@@ -43,11 +44,11 @@ namespace Nethermind.Synchronization.Test
             {
                 syncBatchSize.Shrink();
             }
-            
+
             Assert.AreEqual(syncBatchSize.Current, SyncBatchSize.Min, "current is min");
             Assert.True(syncBatchSize.IsMin, "is min");
         }
-        
+
         [Test]
         public void Cannot_go_above_max()
         {
@@ -56,7 +57,7 @@ namespace Nethermind.Synchronization.Test
             {
                 syncBatchSize.Expand();
             }
-            
+
             Assert.AreEqual(syncBatchSize.Current, SyncBatchSize.Max, "current is max");
             Assert.True(syncBatchSize.IsMax, "is max");
         }

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
@@ -423,7 +423,7 @@ namespace Nethermind.Synchronization.Blocks
             {
                 if (downloadTask.Exception?.Flatten().InnerExceptions.Any(x => x is TimeoutException) ?? false)
                 {
-                    if (_logger.IsError) _logger.Error($"Failed to retrieve {entities} when synchronizing (Timeout)", downloadTask.Exception);
+                    if (_logger.IsDebug) _logger.Error($"Failed to retrieve {entities} when synchronizing (Timeout)", downloadTask.Exception);
                     _syncBatchSize.Shrink();
                 }
 

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
@@ -74,7 +74,8 @@ namespace Nethermind.Synchronization.Blocks
             ISpecProvider? specProvider,
             IPeerAllocationStrategyFactory<BlocksRequest?> blockSyncPeerAllocationStrategyFactory,
             IBetterPeerStrategy betterPeerStrategy,
-            ILogManager? logManager)
+            ILogManager? logManager,
+            SyncBatchSize? syncBatchSize = null)
             : base(feed, syncPeerPool, blockSyncPeerAllocationStrategyFactory, logManager)
         {
             _blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
@@ -87,7 +88,7 @@ namespace Nethermind.Synchronization.Blocks
             _logger = logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
 
             _receiptsRecovery = new ReceiptsRecovery(new EthereumEcdsa(_specProvider.ChainId, logManager), _specProvider);
-            _syncBatchSize = new SyncBatchSize(logManager);
+            _syncBatchSize = syncBatchSize ?? new SyncBatchSize(logManager);
             _blockTree.NewHeadBlock += BlockTreeOnNewHeadBlock;
         }
 

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
@@ -34,7 +34,6 @@ using Nethermind.Stats.Model;
 using Nethermind.Synchronization.ParallelSync;
 using Nethermind.Synchronization.Peers;
 using Nethermind.Synchronization.Reporting;
-using Prometheus;
 
 namespace Nethermind.Synchronization.Blocks
 {

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
@@ -42,8 +42,8 @@ namespace Nethermind.Synchronization.Blocks
         public const int MaxReorganizationLength = SyncBatchSize.Max * 2;
 
         // This includes both body and receipt
-        public static readonly TimeSpan SyncBatchDownloadTimeUpperBound = TimeSpan.FromMilliseconds(6000);
-        public static readonly TimeSpan SyncBatchDownloadTimeLowerBound = TimeSpan.FromMilliseconds(4000);
+        public static readonly TimeSpan SyncBatchDownloadTimeUpperBound = TimeSpan.FromMilliseconds(8000);
+        public static readonly TimeSpan SyncBatchDownloadTimeLowerBound = TimeSpan.FromMilliseconds(5000);
 
         private readonly IBlockTree _blockTree;
         private readonly IBlockValidator _blockValidator;

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/SyncBatchSize.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/SyncBatchSize.cs
@@ -31,7 +31,7 @@ namespace Nethermind.Synchronization.Blocks
         public const int Min = 2;
         public const int Start = 32;
 
-        private const double AdjustmentFactor = 1.5;
+        public const double AdjustmentFactor = 1.5;
 
         public int Current { get; private set; }
 
@@ -55,6 +55,14 @@ namespace Nethermind.Synchronization.Blocks
 
             Current = Math.Min(Max, (int) Math.Ceiling(Current * AdjustmentFactor));
             if (_logger.IsDebug) _logger.Debug($"Changing sync batch size to {Current}");
+        }
+
+        public void ExpandUntilMax()
+        {
+            while (Current != Max)
+            {
+                Expand();
+            }
         }
 
         public void Shrink()

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/SyncBatchSize.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/SyncBatchSize.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -24,24 +24,28 @@ namespace Nethermind.Synchronization.Blocks
     public struct SyncBatchSize
     {
         private ILogger _logger;
-        
-        public const int Max = 512;
+
+        // The batch size is kinda also used for downloading bodies which is large. Peers can return less body
+        // than required, however, they still tend to timeout, so we try to limit this from our side.
+        public const int Max = 128;
         public const int Min = 2;
+        public const int Start = 32;
+
+        private const double AdjustmentFactor = 1.5;
 
         public int Current { get; private set; }
 
         public bool IsMin => Current == Min;
-        
+
         public bool IsMax => Current == Max;
 
         public SyncBatchSize(ILogManager logManager)
         {
             _logger = logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
-            
-            /* headers batch could start at max as headers are predictable in size, unlike blocks */
-            Current = Max / 2;
+
+            Current = Start;
         }
-        
+
         public void Expand()
         {
             if (Current == Max)
@@ -49,14 +53,19 @@ namespace Nethermind.Synchronization.Blocks
                 return;
             }
 
-            Current = Math.Min(Max, Current * 2);
+            Current = Math.Min(Max, (int) Math.Ceiling(Current * AdjustmentFactor));
             if (_logger.IsDebug) _logger.Debug($"Changing sync batch size to {Current}");
         }
 
         public void Shrink()
         {
-            Current = Math.Max(Min, Current / 2);
+            Current = Math.Max(Min, (int) (Current / AdjustmentFactor));
             if (_logger.IsDebug) _logger.Debug($"Changing sync batch size to {Current}");
+        }
+
+        public void Reset()
+        {
+            Current = Start;
         }
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization/Peers/AllocationStrategies/BySpeedStrategy.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/AllocationStrategies/BySpeedStrategy.cs
@@ -19,7 +19,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Nethermind.Blockchain;
 using Nethermind.Stats;
-using Prometheus;
 
 namespace Nethermind.Synchronization.Peers.AllocationStrategies
 {
@@ -78,12 +77,10 @@ namespace Nethermind.Synchronization.Peers.AllocationStrategies
 
                 if (speed == null && shouldDiscoverSpeed && _random.NextDouble() < 1.0 / noSpeedPeerCount)
                 {
-                    BySpeedStrategyForceDiscovery.WithLabels(_speedType.ToString()).Inc();
                     forceTake = true;
                 }
                 else if (shouldRediscoverSpeed && _random.NextDouble() < (1.0 / peerCount))
                 {
-                    BySpeedStrategyForceRecalculate.WithLabels(_speedType.ToString()).Inc();
                     forceTake = true;
                 }
 

--- a/src/Nethermind/Nethermind.Synchronization/Peers/AllocationStrategies/BySpeedStrategy.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/AllocationStrategies/BySpeedStrategy.cs
@@ -32,6 +32,7 @@ namespace Nethermind.Synchronization.Peers.AllocationStrategies
         private readonly Random _random = new();
 
         // Randomly pick a different peer that is not of the best speed. Encourage updating speed.
+        // Does not seems to matter much. But its here if you want to tweak it.
         private readonly double _recalculateSpeedProbability = 0.025;
 
         // Randomly pick a peer that has no speed to discover peer with better speed. This number will be multiplied by

--- a/src/Nethermind/Nethermind.Synchronization/Peers/AllocationStrategies/BySpeedStrategy.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/AllocationStrategies/BySpeedStrategy.cs
@@ -36,6 +36,8 @@ namespace Nethermind.Synchronization.Peers.AllocationStrategies
         private readonly double _recalculateSpeedProbability = 0.025;
 
         // If the number of peer with known speed is less than this, then always try new peer.
+        // The idea is that, if we have at least this amount of peers with known speed, at least one of them should
+        // be fast, but we don't want to spend more time trying out other peers.
         private readonly long _desiredPeersWithKnownSpeed = 10;
 
         public BySpeedStrategy(


### PR DESCRIPTION
Includes #4546

Fix forward sync may stuck on slow peer due to allocation strategy that always pick the highest speed. Problem is, the speed of other peer are never known (and 0 is always assumed) since other peers are never tried. Meaning, if you are lucky, the first peer is fast and your forward sync is fast, but if not, your first peer is slow and your forward sync is slow. This PR adds logic to BySpeedStrategy to try peer with unknown speed up until a threshold of number of peer with known speed is reached. I've tried various approach, and I settle with this since its simpler. Does not affect PoW as it does not use the same strategy even with #4546.

Additionally, NodeStatsLight may never reduce speed due to the use of average speed. As the number of reading increase, the effect of later speed report become less and less effective as its weight goes down. This means if the best peer suddently get slower, we are still stuck with it as the stats does not reflect it. This change the algorithm to give new speed a fixed weight compared to current stored speed. Not exactly "average", but its good enough for its purpose and easy to implement.

Additionally, BlockDownloader binds the new best peer event with cancellation token. This means current in flight request gets cancelled, which is a wasted bandwith as each loop in block downloader download bodies multiple time until batch is full. This PR remove that binding and use a `HasBetterPeer` check at the start of the loop so that already downloaded bodies get processed first.

Additionally, BlockDownloader's `_syncBatchSize` get adjusted so that the batch size goes up or down based on the time it take to download for the whole batch. This reduces block bodies download timeout, which are wasted bandwith. Additionally it reduces the time for the loop so that it does not take time to try peers without speed which is potentially slow.

![Screenshot from 2022-09-14 17-13-18](https://user-images.githubusercontent.com/1841324/190114717-324a31cd-3d5b-4882-97ac-9b823026e0f4.svg)

## Changes:
- Try peer with unknown speed until a certain number of peer with known speed is reached.
- Change speed calculation on NodeStatsLight so that it can change speed after some time.
- Adjust block downloader/merge block downloader to not immediately cancel download when a better peer is found. Instead it complete and process current download and exit its loop.
- Adjust _syncBatchSize to be smaller and goes up or down based on latency.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [X] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [X] Yes
- [ ] No

**Comments about testing , should you have some** (optional)

- Synched mainnet a couple of time.
- Synched goerli a couple of time.

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...