### PR TITLE
Trie HexPrefix optimizations using Raw Path

### DIFF
--- a/src/Nethermind/Nethermind.Benchmark/Store/HexPrefixAgainstRawPathBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Store/HexPrefixAgainstRawPathBenchmarks.cs
@@ -1,0 +1,48 @@
+﻿//  Copyright (c) 2021 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+//
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+using BenchmarkDotNet.Attributes;
+using Nethermind.Core.Extensions;
+using Nethermind.Trie;
+
+namespace Nethermind.Benchmarks.Store;
+
+// a coarse grained benchmark, showing the RLP -> HexPrefix -> combine paths -> HexPrefix -> RLP
+[MemoryDiagnoser]
+public class HexPrefixAgainstRawPathBenchmarks
+{
+    private const byte Prefix = 0;
+    private byte[] _even = HexPrefix.Leaf(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 }).ToBytes();
+    private byte[] _odd = HexPrefix.Leaf(new byte[] { 1, 2, 3, 4, 5, 6, 7 }).ToBytes();
+
+    [Benchmark]
+    public byte[] RawPath()
+    {
+        // RLP copy
+        byte[] even = _even.AsSpan().ToArray();
+
+        // combine and it's ready
+        return HexPrefix.RawPath.Combine(Prefix, even);
+    }
+
+    [Benchmark(Baseline = true)]
+    public byte[] Current()
+    {
+        return HexPrefix.Leaf(Bytes.Concat(Prefix, HexPrefix.FromBytes(_even).Path)).ToBytes();
+    }
+}

--- a/src/Nethermind/Nethermind.Benchmark/Store/HexPrefixFromBytesBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Store/HexPrefixFromBytesBenchmarks.cs
@@ -1,16 +1,16 @@
 ﻿//  Copyright (c) 2018 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 

--- a/src/Nethermind/Nethermind.Trie.Test/HexPrefixTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/HexPrefixTests.cs
@@ -1,20 +1,22 @@
 ﻿//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
 using NUnit.Framework;
+using Org.BouncyCastle.Utilities;
+using Bytes = Nethermind.Core.Extensions.Bytes;
 
 namespace Nethermind.Trie.Test
 {
@@ -84,6 +86,22 @@ namespace Nethermind.Trie.Test
             Assert.AreEqual(nibble1, hexPrefix.Path[0]);
             Assert.AreEqual(nibble2, hexPrefix.Path[1]);
             Assert.AreEqual(nibble3, hexPrefix.Path[2]);
+        }
+
+        [TestCase(new byte[] { 1, 2 }, TestName = "Even nibble count")]
+        [TestCase(new byte[] { 3,4,5 }, TestName = "Odd nibble count")]
+        public void RawPath_Combine(byte[] path)
+        {
+            const byte child = 6;
+
+            // Extension, has no flag, easier to test
+            HexPrefix leaf1 = HexPrefix.Extension(child);
+            HexPrefix leaf2 = HexPrefix.Extension(path);
+
+            byte[] expected = HexPrefix.Extension(Bytes.Concat(leaf1.Path, leaf2.Path)).ToBytes();
+            byte[] combined = HexPrefix.RawPath.Combine(child, leaf2.ToBytes());
+
+            CollectionAssert.AreEqual(expected, combined);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Trie/HexPrefix.cs
+++ b/src/Nethermind/Nethermind.Trie/HexPrefix.cs
@@ -28,6 +28,7 @@ namespace Nethermind.Trie
         private const int LeafFlag = 0x20;
         private const int ExtensionFlag = 0x000;
         private const int OddFlag = 0x10;
+        private const int OddShift = 4;
 
         // nibbles
         private const int LowNibbleMask = 0x0F;
@@ -72,8 +73,8 @@ namespace Nethermind.Trie
             get
             {
                 long unaligned = MemorySizes.SmallObjectOverhead +
-                                MemorySizes.Align(MemorySizes.ArrayOverhead + Path.Length) +
-                                1;
+                                 MemorySizes.Align(MemorySizes.ArrayOverhead + Path.Length) +
+                                 1;
                 return MemorySizes.Align(unaligned);
             }
         }
@@ -81,18 +82,18 @@ namespace Nethermind.Trie
         public byte[] ToBytes()
         {
             byte[] output = new byte[Path.Length / 2 + 1];
-            output[0] = (byte) (IsLeaf ? LeafFlag : ExtensionFlag);
+            output[0] = (byte)(IsLeaf ? LeafFlag : ExtensionFlag);
             if (Path.Length % 2 != 0)
             {
-                output[0] += (byte) (OddFlag + Path[0]);
+                output[0] += (byte)(OddFlag + Path[0]);
             }
 
             for (int i = 0; i < Path.Length - 1; i = i + 2)
             {
                 output[i / 2 + 1] =
                     Path.Length % 2 == 0
-                        ? (byte) (NibbleSize * Path[i] + Path[i + 1])
-                        : (byte) (NibbleSize * Path[i + 1] + Path[i + 2]);
+                        ? (byte)(NibbleSize * Path[i] + Path[i + 1])
+                        : (byte)(NibbleSize * Path[i + 1] + Path[i + 2]);
             }
 
             return output;
@@ -109,11 +110,11 @@ namespace Nethermind.Trie
                 hexPrefix.Path[i] =
                     isEven
                         ? i % 2 == 0
-                            ? (byte) ((bytes[1 + i / 2] & HighNibbleMask) / NibbleSize)
-                            : (byte) (bytes[1 + i / 2] & LowNibbleMask)
+                            ? (byte)((bytes[1 + i / 2] & HighNibbleMask) / NibbleSize)
+                            : (byte)(bytes[1 + i / 2] & LowNibbleMask)
                         : i % 2 == 0
-                            ? (byte) (bytes[i / 2] & LowNibbleMask)
-                            : (byte) ((bytes[1 + i / 2] & HighNibbleMask) / NibbleSize);
+                            ? (byte)(bytes[i / 2] & LowNibbleMask)
+                            : (byte)((bytes[1 + i / 2] & HighNibbleMask) / NibbleSize);
             }
 
             return hexPrefix;
@@ -122,6 +123,21 @@ namespace Nethermind.Trie
         public override string ToString()
         {
             return ToBytes().ToHexString(false);
+        }
+
+        public static byte[] CombinePaths(byte[] nodePath, byte[] nextNodePath)
+        {
+            return Bytes.Concat(nodePath, nextNodePath);
+        }
+
+        public static byte[] CombinePaths(byte child, byte[] nextNodePath)
+        {
+            return Bytes.Concat(child, nextNodePath);
+        }
+
+        public static bool PathsAreEqual(Span<byte> a, Span<byte> b)
+        {
+            return Bytes.AreEqual(a, b);
         }
     }
 }


### PR DESCRIPTION
This is an experimental PR that changes how `HexPrefix` works with paths. Instead of decoding them to nibbles when reading `RPL` and encoding them back when encoding, it works with raw encoded data. Highly experimental stuff.

Initial benchmark, that does full cycle of RLP -> decode -> extend path by concat -> encode -> RLP looks really promising allocation wise and good performance wise.

|  Method |     Mean |    Error |   StdDev |   Median | Ratio | RatioSD |  Gen 0 | Allocated |
|-------- |---------:|---------:|---------:|---------:|------:|--------:|-------:|----------:|
| RawPath | 36.16 ns | 0.550 ns | 0.430 ns | 36.27 ns |  0.89 |    0.02 | 0.0051 |      64 B |
| Current | 41.17 ns | 0.793 ns | 1.410 ns | 40.50 ns |  1.00 |    0.00 | 0.0134 |     168 B |

## Changes:

- [ ] TBD ...

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No