### PR TITLE
Rename engine_getPayloadBodies to adjust latest spec

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
@@ -308,7 +308,7 @@ namespace Nethermind.Merge.Plugin.Test
             chain.AddTransactions(txs);
             ExecutionPayloadV1 executionPayloadV12 = await BuildAndSendNewBlockV1(rpc, chain, true);
             Keccak?[] blockHashes = { executionPayloadV11.BlockHash, TestItem.KeccakA, executionPayloadV12.BlockHash };
-            ExecutionPayloadBodyV1Result[] payloadBodies = rpc.engine_getPayloadBodiesV1(blockHashes).Result.Data;
+            ExecutionPayloadBodyV1Result[] payloadBodies = rpc.engine_getPayloadBodiesByHashV1(blockHashes).Result.Data;
             ExecutionPayloadBodyV1Result[] expected = { new(Array.Empty<Transaction>()), new(txs) };
             payloadBodies.Should().BeEquivalentTo(expected, o => o.WithStrictOrdering());
         }

--- a/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.cs
@@ -114,7 +114,7 @@ namespace Nethermind.Merge.Plugin
             }
         }
 
-        public async Task<ResultWrapper<ExecutionPayloadBodyV1Result[]>> engine_getPayloadBodiesV1(Keccak[] blockHashes)
+        public async Task<ResultWrapper<ExecutionPayloadBodyV1Result[]>> engine_getPayloadBodiesByHashV1(Keccak[] blockHashes)
         {
             return await _executionPayloadBodiesHandler.HandleAsync(blockHashes);
         }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/V1/GetPayloadBodiesV1Handler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/V1/GetPayloadBodiesV1Handler.cs
@@ -1,19 +1,19 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -39,7 +39,7 @@ namespace Nethermind.Merge.Plugin.Handlers.V1
 
         public Task<ResultWrapper<ExecutionPayloadBodyV1Result[]>> HandleAsync(Keccak[] blockHashes)
         {
-            List<ExecutionPayloadBodyV1Result> payloadBodies = new();
+            List<ExecutionPayloadBodyV1Result> payloadBodies = new(blockHashes.Length);
             foreach (Keccak hash in blockHashes)
             {
                 Block? block = _blockTree.FindBlock(hash);

--- a/src/Nethermind/Nethermind.Merge.Plugin/IEngineRpcModule.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/IEngineRpcModule.cs
@@ -59,7 +59,7 @@ namespace Nethermind.Merge.Plugin
             Description = "Returns an array of execution payload bodies for the list of provided block hashes.",
             IsSharable = true,
             IsImplemented = true)]
-        Task<ResultWrapper<ExecutionPayloadBodyV1Result[]>> engine_getPayloadBodiesV1(Keccak[] blockHashes);
+        Task<ResultWrapper<ExecutionPayloadBodyV1Result[]>> engine_getPayloadBodiesByHashV1(Keccak[] blockHashes);
 
         [JsonRpcMethod(
             Description = "Returns PoS transition configuration.",


### PR DESCRIPTION
This method will be needed soon to reduce number of requests between CL <> EL. I renamed it to adjust the latest spec:
https://github.com/ethereum/execution-apis/pull/218/files