### PR TITLE
HexPrefix object no longer needed

### DIFF
--- a/src/Nethermind/Nethermind.State.Test/SnapSync/Storage/SnapStorageTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/SnapSync/Storage/SnapStorageTests.cs
@@ -16,6 +16,8 @@ namespace Nethermind.Store.Test.SnapSync.Storage
     [TestFixture]
     public class SnapStorageTests
     {
+        private static readonly byte[] EmptyPath = Array.Empty<byte>();
+
         [Test]
         public void AddAccounts_OneLayer_GetRange()
         {
@@ -25,7 +27,7 @@ namespace Nethermind.Store.Test.SnapSync.Storage
             {
                 byte[] accountBytes = TestItem.GenerateIndexedAccountRlp(i);
                 Keccak randomKeccak = TestItem.GetRandomKeccak();
-                TrieNode leaf = TrieNodeFactory.CreateLeaf(new HexPrefix(true), accountBytes);
+                TrieNode leaf = TrieNodeFactory.CreateLeaf(EmptyPath, accountBytes);
 
                 list.Add(randomKeccak, leaf);
             }
@@ -58,7 +60,7 @@ namespace Nethermind.Store.Test.SnapSync.Storage
             {
                 byte[] accountBytes = TestItem.GenerateIndexedAccountRlp(i);
                 Keccak randomKeccak = TestItem.GetRandomKeccak();
-                TrieNode leaf = TrieNodeFactory.CreateLeaf(new HexPrefix(true), accountBytes);
+                TrieNode leaf = TrieNodeFactory.CreateLeaf(EmptyPath, accountBytes);
 
                 list.Add(randomKeccak, leaf);
             }
@@ -73,11 +75,11 @@ namespace Nethermind.Store.Test.SnapSync.Storage
 
             // block 1002
             byte[] updateAccountBytes_1002 = TestItem.GenerateRandomAccountRlp();
-            TrieNode updateAccount_1002 = TrieNodeFactory.CreateLeaf(new HexPrefix(true), updateAccountBytes_1002);
+            TrieNode updateAccount_1002 = TrieNodeFactory.CreateLeaf(EmptyPath, updateAccountBytes_1002);
             storage.AddLeafNode(list.Keys[21], updateAccount_1002, 1002);
 
             byte[] newAccountBytes_1002 = TestItem.GenerateRandomAccountRlp();
-            TrieNode newAccount_1002 = TrieNodeFactory.CreateLeaf(new HexPrefix(true), newAccountBytes_1002);
+            TrieNode newAccount_1002 = TrieNodeFactory.CreateLeaf(EmptyPath, newAccountBytes_1002);
             Keccak newAddress = TestItem.GetRandomKeccak();
             while(newAddress <= list.Keys[21] || newAddress >= list.Keys[22])
             {

--- a/src/Nethermind/Nethermind.State/Proofs/AccountProofCollector.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/AccountProofCollector.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -92,7 +92,7 @@ namespace Nethermind.State.Proofs
 
                 _accountProof.StorageProofs[i] = new StorageProof();
                 // we don't know the key (index)
-                //_accountProof.StorageProofs[i].Key = storageKeys[i];  
+                //_accountProof.StorageProofs[i].Key = storageKeys[i];
                 _accountProof.StorageProofs[i].Value = new byte[] { 0 };
             }
         }
@@ -130,7 +130,7 @@ namespace Nethermind.State.Proofs
         {
             _accountProof.Address = _address = address ?? throw new ArgumentNullException(nameof(address));
         }
-        
+
         public AccountProofCollector(Address address, UInt256[] storageKeys)
             : this(address, storageKeys.Select(ToKey).ToArray())
         {
@@ -193,7 +193,7 @@ namespace Nethermind.State.Proofs
                             bumpedIndexes.Add((byte) childIndex);
                             _storageNodeInfos[childHash].PathIndex = _pathTraversalIndex + 1;
                         }
-                        
+
                         _storageNodeInfos[childHash].StorageIndices.Add(storageIndex);
                         _nodeToVisitFilter.Add(childHash);
                     }
@@ -216,7 +216,7 @@ namespace Nethermind.State.Proofs
             if (trieVisitContext.IsStorage)
             {
                 _storageNodeInfos[childHash] = new StorageNodeInfo();
-                _storageNodeInfos[childHash].PathIndex = _pathTraversalIndex + node.Path.Length;
+                _storageNodeInfos[childHash].PathIndex = _pathTraversalIndex + node.Key.Length;
 
                 foreach (int storageIndex in _storageNodeInfos[node.Keccak].StorageIndices)
                 {
@@ -232,7 +232,7 @@ namespace Nethermind.State.Proofs
             if (IsPathMatched(node, _fullAccountPath))
             {
                 _nodeToVisitFilter.Add(childHash); // always accept so can optimize
-                _pathTraversalIndex += node.Path.Length;
+                _pathTraversalIndex += node.Key.Length;
             }
         }
 
@@ -319,9 +319,9 @@ namespace Nethermind.State.Proofs
         private bool IsPathMatched(TrieNode node, Nibble[] path)
         {
             bool isPathMatched = true;
-            for (int i = _pathTraversalIndex; i < node.Path.Length + _pathTraversalIndex; i++)
+            for (int i = _pathTraversalIndex; i < node.Key.Length + _pathTraversalIndex; i++)
             {
-                if ((byte) path[i] != node.Path[i - _pathTraversalIndex])
+                if ((byte) path[i] != node.Key[i - _pathTraversalIndex])
                 {
                     isPathMatched = false;
                     break;

--- a/src/Nethermind/Nethermind.State/Proofs/ProofCollector.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/ProofCollector.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -33,7 +33,7 @@ namespace Nethermind.State.Proofs
         private Nibble[] Prefix => Nibbles.FromBytes(_key);
 
         private HashSet<Keccak> _visitingFilter = new();
-        
+
         private List<byte[]> _proofBits = new();
 
         public ProofCollector(byte[] key)
@@ -41,7 +41,7 @@ namespace Nethermind.State.Proofs
             _key = key;
         }
 
-        
+
         public byte[][] BuildResult() => _proofBits.ToArray();
 
         public bool ShouldVisit(Keccak nextNode) => _visitingFilter.Contains(nextNode);
@@ -71,7 +71,7 @@ namespace Nethermind.State.Proofs
             Keccak childHash = node.GetChildHash(0);
             _visitingFilter.Add(childHash); // always accept so can optimize
 
-            _pathIndex += node.Path.Length;
+            _pathIndex += node.Key.Length;
         }
 
         protected virtual void AddProofBits(TrieNode node)

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
@@ -291,7 +291,7 @@ namespace Nethermind.Synchronization.FastSync
 
         public (bool continueProcessing, bool finishSyncRound) ValidatePrepareRequest(SyncMode currentSyncMode)
         {
-            if (_rootSaved == 1)    
+            if (_rootSaved == 1)
             {
                 VerifyPostSyncCleanUp();
                 return (false, true);
@@ -699,9 +699,9 @@ namespace Nethermind.Synchronization.FastSync
                     {
                         DependentItem dependentItem = new(currentStateSyncItem, currentResponseItem, 1);
 
-                        Span<byte> childPath = stackalloc byte[currentStateSyncItem.PathNibbles.Length + trieNode.Path!.Length];
+                        Span<byte> childPath = stackalloc byte[currentStateSyncItem.PathNibbles.Length + trieNode.Key!.Length];
                         currentStateSyncItem.PathNibbles.CopyTo(childPath.Slice(0, currentStateSyncItem.PathNibbles.Length));
-                        trieNode.Path!.CopyTo(childPath.Slice(currentStateSyncItem.PathNibbles.Length));
+                        trieNode.Key!.CopyTo(childPath.Slice(currentStateSyncItem.PathNibbles.Length));
 
                         AddNodeResult addResult = AddNodeToPending(
                             new StateSyncItem(
@@ -709,7 +709,7 @@ namespace Nethermind.Synchronization.FastSync
                                 currentStateSyncItem.AccountPathNibbles,
                                 childPath.ToArray(),
                                 nodeDataType,
-                                currentStateSyncItem.Level + trieNode.Path!.Length,
+                                currentStateSyncItem.Level + trieNode.Key!.Length,
                                 CalculateRightness(trieNode.NodeType, currentStateSyncItem, 0))
                             { ParentBranchChildIndex = currentStateSyncItem.BranchChildIndex },
                             dependentItem,

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProviderHelper.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProviderHelper.cs
@@ -136,7 +136,7 @@ namespace Nethermind.Synchronization.SnapSync
             {
                 return (AddRangeResult.MissingRootHashInProofs, null, true);
             }
-            
+
             Span<byte> leftBoundary = stackalloc byte[64];
             Nibbles.BytesToNibbleBytes(startingHash.Bytes, leftBoundary);
             Span<byte> rightBoundary = stackalloc byte[64];
@@ -164,8 +164,8 @@ namespace Nethermind.Synchronization.SnapSync
                         {
                             node.SetChild(0, child);
 
-                            pathIndex += node.Path.Length;
-                            path.AddRange(node.Path);
+                            pathIndex += node.Key.Length;
+                            path.AddRange(node.Key);
                             proofNodesToProcess.Push((node, child, pathIndex, path));
                             sortedBoundaryList.Add(child);
                         }

--- a/src/Nethermind/Nethermind.Trie.Test/HexPrefixTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/HexPrefixTests.cs
@@ -1,16 +1,16 @@
 ﻿//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -25,18 +25,18 @@ namespace Nethermind.Trie.Test
         [TestCase(true, (byte)3, (byte)51)]
         public void Encode_gives_correct_output_when_one(bool flag, byte nibble1, byte byte1)
         {
-            HexPrefix hexPrefix = new(flag, nibble1);
-            byte[] output = hexPrefix.ToBytes();
+            byte[] output = HexPrefix.ToBytes(new[] { nibble1 }, flag);
             Assert.AreEqual(1, output.Length);
             Assert.AreEqual(byte1, output[0]);
         }
 
         [TestCase(false, (byte)3, (byte)7, (byte)13, (byte)19, (byte)125)]
         [TestCase(true, (byte)3, (byte)7, (byte)13, (byte)51, (byte)125)]
-        public void Encode_gives_correct_output_when_odd(bool flag, byte nibble1, byte nibble2, byte nibble3, byte byte1, byte byte2)
+        public void Encode_gives_correct_output_when_odd(bool flag, byte nibble1, byte nibble2, byte nibble3,
+            byte byte1, byte byte2)
         {
-            HexPrefix hexPrefix = new(flag, nibble1, nibble2, nibble3);
-            byte[] output = hexPrefix.ToBytes();
+            byte[] output = HexPrefix.ToBytes(new[] { nibble1, nibble2, nibble3 }, flag);
+
             Assert.AreEqual(2, output.Length);
             Assert.AreEqual(byte1, output[0]);
             Assert.AreEqual(byte2, output[1]);
@@ -46,8 +46,8 @@ namespace Nethermind.Trie.Test
         [TestCase(true, (byte)3, (byte)7, (byte)32, (byte)55)]
         public void Encode_gives_correct_output_when_even(bool flag, byte nibble1, byte nibble2, byte byte1, byte byte2)
         {
-            HexPrefix hexPrefix = new(flag, nibble1, nibble2);
-            byte[] output = hexPrefix.ToBytes();
+            byte[] output = HexPrefix.ToBytes(new[] { nibble1, nibble2 }, flag);
+
             Assert.AreEqual(2, output.Length);
             Assert.AreEqual(byte1, output[0]);
             Assert.AreEqual(byte2, output[1]);
@@ -55,35 +55,38 @@ namespace Nethermind.Trie.Test
 
         [TestCase(false, (byte)3, (byte)7, (byte)0, (byte)55)]
         [TestCase(true, (byte)3, (byte)7, (byte)32, (byte)55)]
-        public void Decode_gives_correct_output_when_even(bool expectedFlag, byte nibble1, byte nibble2, byte byte1, byte byte2)
+        public void Decode_gives_correct_output_when_even(bool expectedFlag, byte nibble1, byte nibble2, byte byte1,
+            byte byte2)
         {
-            HexPrefix hexPrefix = HexPrefix.FromBytes(new[] { byte1, byte2 });
-            Assert.AreEqual(expectedFlag, hexPrefix.IsLeaf);
-            Assert.AreEqual(2, hexPrefix.Path.Length);
-            Assert.AreEqual(nibble1, hexPrefix.Path[0]);
-            Assert.AreEqual(nibble2, hexPrefix.Path[1]);
+            (byte[] key, bool isLeaf) = HexPrefix.FromBytes(new[] { byte1, byte2 });
+            Assert.AreEqual(expectedFlag, isLeaf);
+            Assert.AreEqual(2, key.Length);
+            Assert.AreEqual(nibble1, key[0]);
+            Assert.AreEqual(nibble2, key[1]);
         }
 
         [TestCase(false, (byte)3, (byte)19)]
         [TestCase(true, (byte)3, (byte)51)]
         public void Decode_gives_correct_output_when_one(bool expectedFlag, byte nibble1, byte byte1)
         {
-            HexPrefix hexPrefix = HexPrefix.FromBytes(new[] { byte1 });
-            Assert.AreEqual(expectedFlag, hexPrefix.IsLeaf);
-            Assert.AreEqual(1, hexPrefix.Path.Length);
-            Assert.AreEqual(nibble1, hexPrefix.Path[0]);
+            (byte[] key, bool isLeaf) = HexPrefix.FromBytes(new[] { byte1 });
+
+            Assert.AreEqual(expectedFlag, isLeaf);
+            Assert.AreEqual(1, key.Length);
+            Assert.AreEqual(nibble1, key[0]);
         }
 
         [TestCase(false, (byte)3, (byte)7, (byte)13, (byte)19, (byte)125)]
         [TestCase(true, (byte)3, (byte)7, (byte)13, (byte)51, (byte)125)]
-        public void Decode_gives_correct_output_when_odd(bool expectedFlag, byte nibble1, byte nibble2, byte nibble3, byte byte1, byte byte2)
+        public void Decode_gives_correct_output_when_odd(bool expectedFlag, byte nibble1, byte nibble2, byte nibble3,
+            byte byte1, byte byte2)
         {
-            HexPrefix hexPrefix = HexPrefix.FromBytes(new[] { byte1, byte2 });
-            Assert.AreEqual(expectedFlag, hexPrefix.IsLeaf);
-            Assert.AreEqual(3, hexPrefix.Path.Length);
-            Assert.AreEqual(nibble1, hexPrefix.Path[0]);
-            Assert.AreEqual(nibble2, hexPrefix.Path[1]);
-            Assert.AreEqual(nibble3, hexPrefix.Path[2]);
+            (byte[] key, bool isLeaf) = HexPrefix.FromBytes(new[] { byte1, byte2 });
+            Assert.AreEqual(expectedFlag, isLeaf);
+            Assert.AreEqual(3, key.Length);
+            Assert.AreEqual(nibble1, key[0]);
+            Assert.AreEqual(nibble2, key[1]);
+            Assert.AreEqual(nibble3, key[2]);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -62,7 +62,7 @@ namespace Nethermind.Trie.Test
         public void Throws_trie_exception_when_setting_value_on_branch()
         {
             TrieNode trieNode = new(NodeType.Branch);
-            Assert.Throws<TrieException>(() => trieNode.Value = new byte[] {1, 2, 3});
+            Assert.Throws<TrieException>(() => trieNode.Value = new byte[] { 1, 2, 3 });
         }
 
         [Test]
@@ -97,7 +97,7 @@ namespace Nethermind.Trie.Test
         public void Encoding_leaf_without_key_throws_trie_exception()
         {
             TrieNode trieNode = new(NodeType.Leaf);
-            trieNode.Value = new byte[] {1, 2, 3};
+            trieNode.Value = new byte[] { 1, 2, 3 };
             Assert.Throws<TrieException>(() => trieNode.RlpEncode(NullTrieNodeResolver.Instance));
         }
 
@@ -184,7 +184,7 @@ namespace Nethermind.Trie.Test
             decodedTiniest.ResolveNode(NullTrieNodeResolver.Instance);
 
             Assert.AreEqual(ctx.TiniestLeaf.Value, decodedTiniest.Value, "value");
-            Assert.AreEqual(ctx.TiniestLeaf.Key!.ToBytes(), decodedTiniest.Key!.ToBytes(), "key");
+            Assert.AreEqual(HexPrefix.ToBytes(ctx.TiniestLeaf.Key!, true), HexPrefix.ToBytes(decodedTiniest.Key!, true), "key");
         }
 
         [Test]
@@ -208,7 +208,7 @@ namespace Nethermind.Trie.Test
         {
             Context ctx = new();
             TrieNode trieNode = new(NodeType.Extension);
-            trieNode.Key = new HexPrefix(false, 5);
+            trieNode.Key = new byte[] { 5 };
             trieNode.SetChild(0, ctx.TiniestLeaf);
 
             byte[] rlp = trieNode.RlpEncode(NullTrieNodeResolver.Instance);
@@ -219,7 +219,8 @@ namespace Nethermind.Trie.Test
             decodedTiniest?.ResolveNode(NullTrieNodeResolver.Instance);
 
             Assert.AreEqual(ctx.TiniestLeaf.Value, decodedTiniest.Value, "value");
-            Assert.AreEqual(ctx.TiniestLeaf.Key!.ToBytes(), decodedTiniest.Key!.ToBytes(), "key");
+            Assert.AreEqual(HexPrefix.ToBytes(ctx.TiniestLeaf.Key!, true), HexPrefix.ToBytes(decodedTiniest.Key!, true),
+                "key");
         }
 
         [Test]
@@ -227,7 +228,7 @@ namespace Nethermind.Trie.Test
         {
             Context ctx = new();
             TrieNode trieNode = new(NodeType.Extension);
-            trieNode.Key = new HexPrefix(false, 5);
+            trieNode.Key = new byte[] { 5 };
             trieNode.SetChild(0, ctx.HeavyLeaf);
 
             byte[] rlp = trieNode.RlpEncode(NullTrieNodeResolver.Instance);
@@ -243,8 +244,8 @@ namespace Nethermind.Trie.Test
         public void Can_set_and_get_children_using_indexer()
         {
             TrieNode tiniest = new(NodeType.Leaf);
-            tiniest.Key = new HexPrefix(true, 5);
-            tiniest.Value = new byte[] {10};
+            tiniest.Key = new byte[] { 5 };
+            tiniest.Value = new byte[] { 10 };
 
             TrieNode trieNode = new(NodeType.Branch);
             trieNode[11] = tiniest;
@@ -285,7 +286,7 @@ namespace Nethermind.Trie.Test
             Context ctx = new();
             TrieNode trieNode = new(NodeType.Extension);
             trieNode[0] = ctx.HeavyLeaf;
-            trieNode.Key = new HexPrefix(false, 5);
+            trieNode.Key = new byte[] { 5 };
             byte[] rlp = trieNode.RlpEncode(NullTrieNodeResolver.Instance);
             TrieNode decoded = new(NodeType.Extension, rlp);
 
@@ -299,7 +300,7 @@ namespace Nethermind.Trie.Test
             Context ctx = new();
             TrieNode trieNode = new(NodeType.Extension);
             trieNode[0] = ctx.TiniestLeaf;
-            trieNode.Key = new HexPrefix(false, 5);
+            trieNode.Key = new byte[] { 5 };
             byte[] rlp = trieNode.RlpEncode(NullTrieNodeResolver.Instance);
             TrieNode decoded = new(NodeType.Extension, rlp);
 
@@ -312,8 +313,8 @@ namespace Nethermind.Trie.Test
         {
             ITreeVisitor visitor = Substitute.For<ITreeVisitor>();
             TrieVisitContext context = new();
-            TrieNode ignore = TrieNodeFactory.CreateLeaf(HexPrefix.Leaf("ccc"), Array.Empty<byte>());
-            TrieNode node = TrieNodeFactory.CreateExtension(HexPrefix.Extension("aa"), ignore);
+            TrieNode ignore = TrieNodeFactory.CreateLeaf(Bytes.FromHexString("ccc"), Array.Empty<byte>());
+            TrieNode node = TrieNodeFactory.CreateExtension(Bytes.FromHexString("aa"), ignore);
 
             node.Accept(visitor, NullTrieNodeResolver.Instance, context);
 
@@ -339,7 +340,7 @@ namespace Nethermind.Trie.Test
             TrieVisitContext context = new();
             Account account = new(100);
             AccountDecoder decoder = new();
-            TrieNode node = TrieNodeFactory.CreateLeaf(HexPrefix.Leaf("aa"), decoder.Encode(account).Bytes);
+            TrieNode node = TrieNodeFactory.CreateLeaf(Bytes.FromHexString("aa"), decoder.Encode(account).Bytes);
 
             node.Accept(visitor, NullTrieNodeResolver.Instance, context);
 
@@ -353,7 +354,7 @@ namespace Nethermind.Trie.Test
             TrieVisitContext context = new();
             Account account = new(1, 100, Keccak.EmptyTreeHash, Keccak.OfAnEmptyString);
             AccountDecoder decoder = new();
-            TrieNode node = TrieNodeFactory.CreateLeaf(HexPrefix.Leaf("aa"), decoder.Encode(account).Bytes);
+            TrieNode node = TrieNodeFactory.CreateLeaf(Bytes.FromHexString("aa"), decoder.Encode(account).Bytes);
 
             node.Accept(visitor, NullTrieNodeResolver.Instance, context);
 
@@ -369,7 +370,7 @@ namespace Nethermind.Trie.Test
             TrieVisitContext context = new();
             Account account = new(1, 100, Keccak.EmptyTreeHash, Keccak.Zero);
             AccountDecoder decoder = new();
-            TrieNode node = TrieNodeFactory.CreateLeaf(HexPrefix.Leaf("aa"), decoder.Encode(account).Bytes);
+            TrieNode node = TrieNodeFactory.CreateLeaf(Bytes.FromHexString("aa"), decoder.Encode(account).Bytes);
 
             node.Accept(visitor, NullTrieNodeResolver.Instance, context);
 
@@ -385,7 +386,7 @@ namespace Nethermind.Trie.Test
             TrieVisitContext context = new();
             Account account = new(1, 100, Keccak.Zero, Keccak.OfAnEmptyString);
             AccountDecoder decoder = new();
-            TrieNode node = TrieNodeFactory.CreateLeaf(HexPrefix.Leaf("aa"), decoder.Encode(account).Bytes);
+            TrieNode node = TrieNodeFactory.CreateLeaf(Bytes.FromHexString("aa"), decoder.Encode(account).Bytes);
 
             node.Accept(visitor, NullTrieNodeResolver.Instance, context);
 
@@ -400,7 +401,7 @@ namespace Nethermind.Trie.Test
             visitor.ShouldVisit(Arg.Any<Keccak>()).Returns(true);
 
             TrieVisitContext context = new();
-            TrieNode node = TrieNodeFactory.CreateExtension(HexPrefix.Extension("aa"), ctx.AccountLeaf);
+            TrieNode node = TrieNodeFactory.CreateExtension(Bytes.FromHexString("aa"), ctx.AccountLeaf);
 
             node.Accept(visitor, NullTrieNodeResolver.Instance, context);
 
@@ -505,8 +506,8 @@ namespace Nethermind.Trie.Test
         {
             TrieNode node = new(NodeType.Branch);
             TrieNode randomTrieNode = new(NodeType.Leaf);
-            randomTrieNode.Key = new HexPrefix(true, new byte[] {1, 2, 3});
-            randomTrieNode.Value = new byte[] {1, 2, 3};
+            randomTrieNode.Key = new byte[] { 1, 2, 3 };
+            randomTrieNode.Value = new byte[] { 1, 2, 3 };
             for (int i = 0; i < 16; i++)
             {
                 node.SetChild(i, randomTrieNode);
@@ -523,14 +524,14 @@ namespace Nethermind.Trie.Test
         public void Size_of_a_heavy_leaf_is_correct()
         {
             Context ctx = new();
-            Assert.AreEqual(184, ctx.HeavyLeaf.GetMemorySize(false));
+            Assert.AreEqual(224, ctx.HeavyLeaf.GetMemorySize(false));
         }
 
         [Test]
         public void Size_of_a_tiny_leaf_is_correct()
         {
             Context ctx = new();
-            Assert.AreEqual(120, ctx.TiniestLeaf.GetMemorySize(false));
+            Assert.AreEqual(144, ctx.TiniestLeaf.GetMemorySize(false));
         }
 
         [Test]
@@ -538,13 +539,13 @@ namespace Nethermind.Trie.Test
         {
             Context ctx = new();
             TrieNode node = new(NodeType.Branch);
-            node.Key = new HexPrefix(false, 1);
+            node.Key = new byte[] { 1 };
             for (int i = 0; i < 16; i++)
             {
                 node.SetChild(i, ctx.AccountLeaf);
             }
 
-            Assert.AreEqual(3152, node.GetMemorySize(true));
+            Assert.AreEqual(3664, node.GetMemorySize(true));
             Assert.AreEqual(208, node.GetMemorySize(false));
         }
 
@@ -553,10 +554,10 @@ namespace Nethermind.Trie.Test
         {
             Context ctx = new();
             TrieNode trieNode = new(NodeType.Extension);
-            trieNode.Key = new HexPrefix(false, 1);
+            trieNode.Key = new byte[] { 1 };
             trieNode.SetChild(0, ctx.TiniestLeaf);
 
-            Assert.AreEqual(96, trieNode.GetMemorySize(false));
+            Assert.AreEqual(120, trieNode.GetMemorySize(false));
         }
 
         [Test]
@@ -564,11 +565,11 @@ namespace Nethermind.Trie.Test
         {
             Context ctx = new();
             TrieNode trieNode = new(NodeType.Extension);
-            trieNode.Key = new HexPrefix(false, 1);
+            trieNode.Key = new byte[] { 1 };
             trieNode.SetChild(0, ctx.TiniestLeaf);
 
-            Assert.AreEqual(216, trieNode.GetMemorySize(true));
-            Assert.AreEqual(96, trieNode.GetMemorySize(false));
+            Assert.AreEqual(264, trieNode.GetMemorySize(true));
+            Assert.AreEqual(120, trieNode.GetMemorySize(false));
         }
 
         [Test]
@@ -651,13 +652,6 @@ namespace Nethermind.Trie.Test
         }
 
         [Test]
-        public void Size_of_hex_prefix_is_correct()
-        {
-            HexPrefix hexPrefix = new(true, new byte[5]);
-            hexPrefix.MemorySize.Should().Be(64);
-        }
-
-        [Test]
         public void Cannot_seal_already_sealed()
         {
             TrieNode trieNode = new(NodeType.Leaf, Keccak.Zero);
@@ -676,7 +670,7 @@ namespace Nethermind.Trie.Test
         {
             TrieNode trieNode = new(NodeType.Leaf, Keccak.Zero);
             Assert.Throws<InvalidOperationException>(
-                () => trieNode.Key = HexPrefix.FromBytes(Bytes.FromHexString("aaa")));
+                () => trieNode.Key = Bytes.FromHexString("aaa"));
         }
 
         [Test]
@@ -695,7 +689,7 @@ namespace Nethermind.Trie.Test
             trieNode.SetChild(0, child);
 
             trieNode.PrunePersistedRecursively(1);
-            trieNode.Key = HexPrefix.Extension("abcd");
+            trieNode.Key = Bytes.FromHexString("abcd");
             trieNode.RlpEncode(NullTrieStore.Instance);
         }
 
@@ -740,7 +734,7 @@ namespace Nethermind.Trie.Test
             TrieNode child = new(NodeType.Unknown, Keccak.Zero);
             TrieNode trieNode = new(NodeType.Extension);
             trieNode.SetChild(0, child);
-            trieNode.Key = HexPrefix.Extension("abcd");
+            trieNode.Key = Bytes.FromHexString("abcd");
             trieNode.ResolveKey(NullTrieStore.Instance, false);
 
             trieNode.PrunePersistedRecursively(1);
@@ -752,13 +746,13 @@ namespace Nethermind.Trie.Test
         {
             TrieNode child = new(NodeType.Leaf);
             child.Value = Bytes.FromHexString("a");
-            child.Key = HexPrefix.Leaf("b");
+            child.Key = Bytes.FromHexString("b");
             child.ResolveKey(NullTrieStore.Instance, false);
             child.IsPersisted = true;
 
             TrieNode trieNode = new(NodeType.Extension);
             trieNode.SetChild(0, child);
-            trieNode.Key = HexPrefix.Extension("abcd");
+            trieNode.Key = Bytes.FromHexString("abcd");
             trieNode.ResolveKey(NullTrieStore.Instance, false);
 
             trieNode.PrunePersistedRecursively(2);
@@ -835,7 +829,7 @@ namespace Nethermind.Trie.Test
         public void Batch_not_db_regression()
         {
             TrieNode child = new(NodeType.Leaf);
-            child.Key = HexPrefix.Leaf("abc");
+            child.Key = Bytes.FromHexString("abc");
             child.Value = new byte[200];
             child.Seal();
 
@@ -852,7 +846,7 @@ namespace Nethermind.Trie.Test
             trieNode.GetChild(trieStore, 0);
             Assert.Throws<TrieException>(() => trieNode.GetChild(trieStore, 0).ResolveNode(trieStore));
         }
-        
+
         [Ignore("This does not fail on the build server")]
         [Test]
         public async Task Trie_node_is_not_thread_safe()
@@ -888,7 +882,7 @@ namespace Nethermind.Trie.Test
                 task.Start();
                 tasks.Add(task);
             }
-            
+
             Assert.ThrowsAsync<AssertionException>(() => Task.WhenAll(tasks));
             await Task.CompletedTask;
         }
@@ -899,14 +893,14 @@ namespace Nethermind.Trie.Test
             TrieStore trieStore = new(new MemDb(), NullLogManager.Instance);
 
             TrieNode leaf1 = new(NodeType.Leaf);
-            leaf1.Key = new HexPrefix(true, Bytes.FromHexString("abc"));
+            leaf1.Key = Bytes.FromHexString("abc");
             leaf1.Value = new byte[111];
             leaf1.ResolveKey(trieStore, false);
             leaf1.Seal();
             trieStore.CommitNode(0, new NodeCommitInfo(leaf1));
 
             TrieNode leaf2 = new(NodeType.Leaf);
-            leaf2.Key = new HexPrefix(true, Bytes.FromHexString("abd"));
+            leaf2.Key = Bytes.FromHexString("abd");
             leaf2.Value = new byte[222];
             leaf2.ResolveKey(trieStore, false);
             leaf2.Seal();
@@ -934,8 +928,8 @@ namespace Nethermind.Trie.Test
             for (int i = 0; i < 16; i++)
             {
                 TrieNode randomTrieNode = new(NodeType.Leaf);
-                randomTrieNode.Key = new HexPrefix(true, new byte[] {(byte)i, 2, 3});
-                randomTrieNode.Value = new byte[] {1, 2, 3};
+                randomTrieNode.Key = new byte[] { (byte)i, 2, 3 };
+                randomTrieNode.Value = new byte[] { 1, 2, 3 };
                 node.SetChild(i, randomTrieNode);
             }
 
@@ -955,17 +949,17 @@ namespace Nethermind.Trie.Test
             public Context()
             {
                 TiniestLeaf = new TrieNode(NodeType.Leaf);
-                TiniestLeaf.Key = new HexPrefix(true, 5);
-                TiniestLeaf.Value = new byte[] {10};
+                TiniestLeaf.Key =  new byte[] { 5 };
+                TiniestLeaf.Value = new byte[] { 10 };
 
                 HeavyLeaf = new TrieNode(NodeType.Leaf);
-                HeavyLeaf.Key = new HexPrefix(true, new byte[20]);
+                HeavyLeaf.Key = new byte[20];
                 HeavyLeaf.Value = Keccak.EmptyTreeHash.Bytes.Concat(Keccak.EmptyTreeHash.Bytes).ToArray();
 
                 Account account = new(100);
                 AccountDecoder decoder = new();
                 AccountLeaf = TrieNodeFactory.CreateLeaf(
-                    HexPrefix.Leaf("bbb"),
+                    Bytes.FromHexString("bbb"),
                     decoder.Encode(account).Bytes);
             }
         }

--- a/src/Nethermind/Nethermind.Trie/HexPrefix.cs
+++ b/src/Nethermind/Nethermind.Trie/HexPrefix.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -22,81 +22,48 @@ using Nethermind.Core.Extensions;
 
 namespace Nethermind.Trie
 {
-    public class HexPrefix
+    public static class HexPrefix
     {
-        [DebuggerStepThrough]
-        public HexPrefix(bool isLeaf, params byte[] path)
-        {
-            IsLeaf = isLeaf;
-            Path = path;
-        }
+        // public long MemorySize
+        // {
+        //     get
+        //     {
+        //         long unaligned = MemorySizes.SmallObjectOverhead +
+        //                         MemorySizes.Align(MemorySizes.ArrayOverhead + Path.Length) +
+        //                         1;
+        //         return MemorySizes.Align(unaligned);
+        //     }
+        // }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static HexPrefix Leaf(params byte[] path)
+        public static byte[] ToBytes(byte[] path, bool isLeaf)
         {
-            return new(true, path);
-        }
-
-        public static HexPrefix Leaf(string path)
-        {
-            return new(true, Bytes.FromHexString(path));
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static HexPrefix Extension(params byte[] path)
-        {
-            return new(false, path);
-        }
-
-        public static HexPrefix Extension(string path)
-        {
-            return new(false, Bytes.FromHexString(path));
-        }
-
-        public byte[] Path { get; private set; }
-        public bool IsLeaf { get; }
-        public bool IsExtension => !IsLeaf;
-
-        public long MemorySize
-        {
-            get
+            byte[] output = new byte[path.Length / 2 + 1];
+            output[0] = (byte) (isLeaf ? 0x20 : 0x000);
+            if (path.Length % 2 != 0)
             {
-                long unaligned = MemorySizes.SmallObjectOverhead +
-                                MemorySizes.Align(MemorySizes.ArrayOverhead + Path.Length) +
-                                1;
-                return MemorySizes.Align(unaligned);
-            }
-        }
-
-        public byte[] ToBytes()
-        {
-            byte[] output = new byte[Path.Length / 2 + 1];
-            output[0] = (byte) (IsLeaf ? 0x20 : 0x000);
-            if (Path.Length % 2 != 0)
-            {
-                output[0] += (byte) (0x10 + Path[0]);
+                output[0] += (byte) (0x10 + path[0]);
             }
 
-            for (int i = 0; i < Path.Length - 1; i = i + 2)
+            for (int i = 0; i < path.Length - 1; i = i + 2)
             {
                 output[i / 2 + 1] =
-                    Path.Length % 2 == 0
-                        ? (byte) (16 * Path[i] + Path[i + 1])
-                        : (byte) (16 * Path[i + 1] + Path[i + 2]);
+                    path.Length % 2 == 0
+                        ? (byte) (16 * path[i] + path[i + 1])
+                        : (byte) (16 * path[i + 1] + path[i + 2]);
             }
 
             return output;
         }
 
-        public static HexPrefix FromBytes(ReadOnlySpan<byte> bytes)
+        public static (byte[] key, bool isLeaf) FromBytes(ReadOnlySpan<byte> bytes)
         {
-            HexPrefix hexPrefix = new(bytes[0] >= 32);
+            bool isLeaf = bytes[0] >= 32;
             bool isEven = (bytes[0] & 16) == 0;
             int nibblesCount = bytes.Length * 2 - (isEven ? 2 : 1);
-            hexPrefix.Path = new byte[nibblesCount];
+            byte[] path = new byte[nibblesCount];
             for (int i = 0; i < nibblesCount; i++)
             {
-                hexPrefix.Path[i] =
+                path[i] =
                     isEven
                         ? i % 2 == 0
                             ? (byte) ((bytes[1 + i / 2] & 240) / 16)
@@ -106,12 +73,7 @@ namespace Nethermind.Trie
                             : (byte) ((bytes[1 + i / 2] & 240) / 16);
             }
 
-            return hexPrefix;
-        }
-
-        public override string ToString()
-        {
-            return ToBytes().ToHexString(false);
+            return (path, isLeaf);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Trie/TreeDumper.cs
+++ b/src/Nethermind/Nethermind.Trie/TreeDumper.cs
@@ -65,7 +65,7 @@ namespace Nethermind.Trie
 
         public void VisitExtension(TrieNode node, TrieVisitContext trieVisitContext)
         {
-            _builder.AppendLine($"{GetPrefix(trieVisitContext)}EXTENSION {Nibbles.FromBytes(node.Path).ToPackedByteArray().ToHexString(false)} -> {(node.Keccak?.Bytes ?? node.FullRlp)?.ToHexString()}");
+            _builder.AppendLine($"{GetPrefix(trieVisitContext)}EXTENSION {Nibbles.FromBytes(node.Key).ToPackedByteArray().ToHexString(false)} -> {(node.Keccak?.Bytes ?? node.FullRlp)?.ToHexString()}");
         }
 
         private AccountDecoder decoder = new();
@@ -73,7 +73,7 @@ namespace Nethermind.Trie
         public void VisitLeaf(TrieNode node, TrieVisitContext trieVisitContext, byte[] value = null)
         {
             string leafDescription = trieVisitContext.IsStorage ? "LEAF " : "ACCOUNT ";
-            _builder.AppendLine($"{GetPrefix(trieVisitContext)}{leafDescription} {Nibbles.FromBytes(node.Path).ToPackedByteArray().ToHexString(false)} -> {(node.Keccak?.Bytes ?? node.FullRlp)?.ToHexString()}");
+            _builder.AppendLine($"{GetPrefix(trieVisitContext)}{leafDescription} {Nibbles.FromBytes(node.Key).ToPackedByteArray().ToHexString(false)} -> {(node.Keccak?.Bytes ?? node.FullRlp)?.ToHexString()}");
             if (!trieVisitContext.IsStorage)
             {
                 Account account = decoder.Decode(new RlpStream(value));

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -56,12 +56,12 @@ namespace Nethermind.Trie
                     $"Node passed to {nameof(EncodeExtension)} is {item.NodeType}");
                 Debug.Assert(item.Key != null,
                     "Extension key is null when encoding");
-                
-                byte[] keyBytes = item.Key.ToBytes();
+
+                byte[] keyBytes = HexPrefix.ToBytes(item.Key, false);
                 TrieNode nodeRef = item.GetChild(tree, 0);
                 Debug.Assert(nodeRef != null,
                     "Extension child is null when encoding.");
-                
+
                 nodeRef.ResolveKey(tree, false);
 
                 int contentLength = Rlp.LengthOf(keyBytes) + (nodeRef.Keccak is null ? nodeRef.FullRlp.Length : Rlp.LengthOfKeccakRlp);
@@ -74,7 +74,7 @@ namespace Nethermind.Trie
                     // I think it can only happen if we have a short extension to a branch with a short extension as the only child?
                     // so |
                     // so |
-                    // so E - - - - - - - - - - - - - - - 
+                    // so E - - - - - - - - - - - - - - -
                     // so |
                     // so |
                     rlpStream.Write(nodeRef.FullRlp);
@@ -94,7 +94,7 @@ namespace Nethermind.Trie
                     throw new TrieException($"Hex prefix of a leaf node is null at node {node.Keccak}");
                 }
 
-                byte[] keyBytes = node.Key.ToBytes();
+                byte[] keyBytes = HexPrefix.ToBytes(node.Key, true);
                 int contentLength = Rlp.LengthOf(keyBytes) + Rlp.LengthOf(node.Value);
                 int totalLength = Rlp.LengthOfSequence(contentLength);
                 RlpStream rlpStream = new(totalLength);

--- a/src/Nethermind/Nethermind.Trie/TrieNodeFactory.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNodeFactory.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -27,34 +27,26 @@ namespace Nethermind.Trie
             return node;
         }
 
-        public static TrieNode CreateLeaf(HexPrefix key, byte[]? value)
+        public static TrieNode CreateLeaf(byte[] path, byte[]? value)
         {
-            Debug.Assert(
-                key.IsLeaf,
-                $"{nameof(NodeType.Leaf)} should always be created with a leaf {nameof(HexPrefix)}");
-
             TrieNode node = new(NodeType.Leaf);
-            node.Key = key;
+            node.Key = path;
             node.Value = value;
             return node;
         }
 
-        public static TrieNode CreateExtension(HexPrefix key)
+        public static TrieNode CreateExtension(byte[] path)
         {
             TrieNode node = new(NodeType.Extension);
-            node.Key = key;
+            node.Key = path;
             return node;
         }
 
-        public static TrieNode CreateExtension(HexPrefix key, TrieNode child)
+        public static TrieNode CreateExtension(byte[] path, TrieNode child)
         {
-            Debug.Assert(
-                key.IsExtension,
-                $"{nameof(NodeType.Extension)} should always be created with an extension {nameof(HexPrefix)}");
-
             TrieNode node = new(NodeType.Extension);
             node.SetChild(0, child);
-            node.Key = key;
+            node.Key = path;
             return node;
         }
     }


### PR DESCRIPTION
This PR removes the `HexPrefix` from a `TrieNode`. `HexPrefix` was an object that was wrapping a path to either an extension or a leaf. It resulted in several overheads introduced:

1. information duplication - the flag of being a leaf or not was stored both in node as well as in `HexPrefix` (4 bytes)
1. additional reference resolution - `node.data[0].path` to get path. where now it is `node.data[0]`
1. memory overhead - reduced by object header for `HexPrefix` (4byte - 8 bytes) and the `IsLeaf` flag (4 bytes).

The memory is reported as higher in `GetMemorySize` as previously there was no check for `HexPrefix` in the loop! The `HexPrefix` was not reported at all (see below)

https://github.com/NethermindEth/nethermind/blob/3a24246cfa57a0746dcb46c14077d3b46833f9a7/src/Nethermind/Nethermind.Trie/TrieNode.cs#L540-L564

## Changes:

- `HexPrefix` object usage removed from the code
- unification of `Path` & `Key` to `Key` properties
- TrieNode memory reported more accurately

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [x] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No