### PR TITLE
Reduce old receipts response time

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -39,14 +39,14 @@ namespace Nethermind.Blockchain.Receipts
         private static readonly Keccak MigrationBlockNumberKey = Keccak.Compute(nameof(MigratedBlockNumber));
         private long _migratedBlockNumber;
         private static readonly ReceiptStorageDecoder StorageDecoder = ReceiptStorageDecoder.Instance;
-        
+
         private const int CacheSize = 64;
         private readonly ICache<Keccak, TxReceipt[]> _receiptsCache = new LruCache<Keccak, TxReceipt[]>(CacheSize, CacheSize, "receipts");
 
         public PersistentReceiptStorage(IColumnsDb<ReceiptsColumns> receiptsDb, ISpecProvider specProvider, IReceiptsRecovery receiptsRecovery)
         {
             long Get(Keccak key, long defaultValue) => _database.Get(key)?.ToLongFromBigEndianByteArrayWithoutLeadingZeros() ?? defaultValue;
-            
+
             _database = receiptsDb ?? throw new ArgumentNullException(nameof(receiptsDb));
             _specProvider = specProvider ?? throw new ArgumentNullException(nameof(specProvider));
             _receiptsRecovery = receiptsRecovery ?? throw new ArgumentNullException(nameof(receiptsRecovery));
@@ -110,14 +110,14 @@ namespace Nethermind.Blockchain.Receipts
 
             return Get(block.Hash);
         }
-        
+
         public TxReceipt[] Get(Keccak blockHash)
         {
             if (_receiptsCache.TryGet(blockHash, out TxReceipt[]? receipts))
             {
                 return receipts ?? Array.Empty<TxReceipt>();
             }
-            
+
             Span<byte> receiptsData = _blocksDb.GetSpan(blockHash);
             try
             {
@@ -161,7 +161,7 @@ namespace Nethermind.Blockchain.Receipts
                 iterator = new ReceiptsIterator(receipts);
                 return true;
             }
-            
+
             var result = CanGetReceiptsByHash(blockNumber);
             var receiptsData = _blocksDb.GetSpan(blockHash);
             iterator = result ? new ReceiptsIterator(receiptsData, _blocksDb) : new ReceiptsIterator();
@@ -172,7 +172,7 @@ namespace Nethermind.Blockchain.Receipts
         {
             txReceipts ??= Array.Empty<TxReceipt>();
             int txReceiptsLength = txReceipts.Length;
-            
+
             if (block.Transactions.Length != txReceiptsLength)
             {
                 throw new InvalidDataException(
@@ -181,7 +181,7 @@ namespace Nethermind.Blockchain.Receipts
             }
 
             _receiptsRecovery.TryRecover(block, txReceipts, false);
-            
+
             var blockNumber = block.Number;
             var spec = _specProvider.GetSpec(blockNumber);
             RlpBehaviors behaviors = spec.IsEip658Enabled ? RlpBehaviors.Eip658Receipts | RlpBehaviors.Storage : RlpBehaviors.Storage;
@@ -191,7 +191,7 @@ namespace Nethermind.Blockchain.Receipts
             {
                 MigratedBlockNumber = blockNumber;
             }
-            
+
             _receiptsCache.Set(block.Hash, txReceipts);
 
             if (ensureCanonical)
@@ -212,7 +212,7 @@ namespace Nethermind.Blockchain.Receipts
                 }
             }
         }
-        
+
         public long MigratedBlockNumber
         {
             get => _migratedBlockNumber;
@@ -227,7 +227,7 @@ namespace Nethermind.Blockchain.Receipts
         {
             _receiptsCache.Clear();
         }
-        
+
         public bool HasBlock(Keccak hash)
         {
             return _receiptsCache.Contains(hash) || _blocksDb.KeyExists(hash);
@@ -236,9 +236,10 @@ namespace Nethermind.Blockchain.Receipts
         public void EnsureCanonical(Block block)
         {
             TxReceipt[] receipts = Get(block);
+            using IBatch batch = _transactionDb.StartBatch();
             foreach (TxReceipt txReceipt in receipts)
             {
-                _transactionDb.Set(txReceipt.TxHash, block.Hash.Bytes);
+                batch[txReceipt.TxHash.Bytes] = block.Hash.Bytes;
             }
         }
     }

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -20,6 +20,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Threading;
+using ConcurrentCollections;
 using Nethermind.Core;
 using Nethermind.Db.Rocks.Config;
 using Nethermind.Db.Rocks.Statistics;
@@ -38,7 +39,7 @@ public class DbOnTheRocks : IDbWithSpan
 
     private bool _isDisposed;
 
-    private readonly HashSet<IBatch> _currentBatches = new();
+    private readonly ConcurrentHashSet<IBatch> _currentBatches = new();
 
     internal readonly RocksDb _db;
     internal WriteOptions? WriteOptions { get; private set; }
@@ -399,10 +400,7 @@ public class DbOnTheRocks : IDbWithSpan
     public IBatch StartBatch()
     {
         IBatch batch = new RocksDbBatch(this);
-        lock (_currentBatches)
-        {
-            _currentBatches.Add(batch);
-        }
+        _currentBatches.Add(batch);
         return batch;
     }
 
@@ -432,10 +430,7 @@ public class DbOnTheRocks : IDbWithSpan
             }
 
             _dbOnTheRocks._db.Write(_rocksBatch, _dbOnTheRocks.WriteOptions);
-            lock (_dbOnTheRocks._currentBatches)
-            {
-                _dbOnTheRocks._currentBatches.Remove(this);
-            }
+            _dbOnTheRocks._currentBatches.Remove(this);
             _rocksBatch.Dispose();
         }
 

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -430,7 +430,7 @@ public class DbOnTheRocks : IDbWithSpan
             }
 
             _dbOnTheRocks._db.Write(_rocksBatch, _dbOnTheRocks.WriteOptions);
-            _dbOnTheRocks._currentBatches.Remove(this);
+            _dbOnTheRocks._currentBatches.TryRemove(this);
             _rocksBatch.Dispose();
         }
 

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -399,7 +399,10 @@ public class DbOnTheRocks : IDbWithSpan
     public IBatch StartBatch()
     {
         IBatch batch = new RocksDbBatch(this);
-        _currentBatches.Add(batch);
+        lock (_currentBatches)
+        {
+            _currentBatches.Add(batch);
+        }
         return batch;
     }
 
@@ -429,7 +432,10 @@ public class DbOnTheRocks : IDbWithSpan
             }
 
             _dbOnTheRocks._db.Write(_rocksBatch, _dbOnTheRocks.WriteOptions);
-            _dbOnTheRocks._currentBatches.Remove(this);
+            lock (_dbOnTheRocks._currentBatches)
+            {
+                _dbOnTheRocks._currentBatches.Remove(this);
+            }
             _rocksBatch.Dispose();
         }
 

--- a/src/Nethermind/Nethermind.Db.Rocks/Nethermind.Db.Rocks.csproj
+++ b/src/Nethermind/Nethermind.Db.Rocks/Nethermind.Db.Rocks.csproj
@@ -13,6 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <PackageReference Include="ConcurrentHashSet" Version="1.3.0" />
       <PackageReference Include="FastEnum" Version="1.7.0" />
       <PackageReference Include="RocksDB" Version="6.29.3.26014" />
     </ItemGroup>


### PR DESCRIPTION
It seems that write receipt was a significant bottleneck during old receipts, which was also a recent change. A small change reduces it significantly. Still running smoke test to see if the sync time change. I'm seems to be limited by something else I guess, not much change on my sync time.

![Screenshot from 2022-09-23 15-06-31](https://user-images.githubusercontent.com/1841324/191909133-73d8e351-21c4-4433-bef6-5d582d025db4.svg)

## Changes:
- Uses write batch to save transaction to block mapping.
- Added a lock to batch list or it will throw as sync dispatch runs in prallel.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [X] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [X] No

**Comments about testing , should you have some** (optional)

Running smoke....

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...