### PR TITLE
Enable multithreading on P2P deserialization workload

### DIFF
--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -486,6 +486,7 @@ public class InitializeNetwork : IStep
             encryptionHandshakeServiceA,
             _api.SessionMonitor,
             _api.DisconnectsAnalyzer,
+            _networkConfig.P2PHandlerThreadCount,
             _api.LogManager);
 
         await _api.RlpxPeer.Init();

--- a/src/Nethermind/Nethermind.Network.Test/Rlpx/RlpxPeerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/Rlpx/RlpxPeerTests.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -40,6 +40,7 @@ namespace Nethermind.Network.Test.Rlpx
                 Substitute.For<IHandshakeService>(),
                 Substitute.For<ISessionMonitor>(),
                 NullDisconnectsAnalyzer.Instance,
+                1,
                 LimboLogs.Instance);
             await host.Init();
             await host.Shutdown();

--- a/src/Nethermind/Nethermind.Network/Config/INetworkConfig.cs
+++ b/src/Nethermind/Nethermind.Network/Config/INetworkConfig.cs
@@ -82,7 +82,7 @@ namespace Nethermind.Network.Config
         [ConfigItem(DefaultValue = "", Description = "Bootnodes")]
         string Bootnodes { get; set; }
 
-        [ConfigItem(DefaultValue = "1", Description = "[EXPERIMENTAL] Set P2P handler thread count. Setting it greater than 1 may improve sync time at the cost of stability.")]
+        [ConfigItem(DefaultValue = "0", Description = "[TECHNICAL] Set P2P handler thread count. Set this to a low number such as 1 or 2 if you have too slow block processing during old bodies or old receipts sync which may cause missed attestation. Defaults to processor count - 2.")]
         int P2PHandlerThreadCount { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.Network/Config/INetworkConfig.cs
+++ b/src/Nethermind/Nethermind.Network/Config/INetworkConfig.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -81,5 +81,8 @@ namespace Nethermind.Network.Config
 
         [ConfigItem(DefaultValue = "", Description = "Bootnodes")]
         string Bootnodes { get; set; }
+
+        [ConfigItem(DefaultValue = "1", Description = "[EXPERIMENTAL] Set P2P handler thread count. Setting it greater than 1 may improve sync time at the cost of stability.")]
+        int P2PHandlerThreadCount { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.Network/Config/NetworkConfig.cs
+++ b/src/Nethermind/Nethermind.Network/Config/NetworkConfig.cs
@@ -42,6 +42,6 @@ namespace Nethermind.Network.Config
         public string Bootnodes { get; set; } = string.Empty;
         public int DiscoveryPort { get; set; } = 30303;
         public int P2PPort { get; set; } = 30303;
-        public int P2PHandlerThreadCount { get; set; } = 1;
+        public int P2PHandlerThreadCount { get; set; } = 0;
     }
 }

--- a/src/Nethermind/Nethermind.Network/Config/NetworkConfig.cs
+++ b/src/Nethermind/Nethermind.Network/Config/NetworkConfig.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -42,5 +42,6 @@ namespace Nethermind.Network.Config
         public string Bootnodes { get; set; } = string.Empty;
         public int DiscoveryPort { get; set; } = 30303;
         public int P2PPort { get; set; } = 30303;
+        public int P2PHandlerThreadCount { get; set; } = 1;
     }
 }

--- a/src/Nethermind/Nethermind.Network/Rlpx/NettyHandshakeHandler.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/NettyHandshakeHandler.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 

--- a/src/Nethermind/Nethermind.Network/Rlpx/RlpxHost.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/RlpxHost.cs
@@ -82,6 +82,14 @@ namespace Nethermind.Network.Rlpx
             //     new LoggerFilterOptions { MinLevel = Microsoft.Extensions.Logging.LogLevel.Warning });
             // InternalLoggerFactory.DefaultFactory = loggerFactory;
 
+            if (handlerThreadCount == 0)
+            {
+                // Using slightly less than processor count to give some compute for other tasks
+                // The thread count is rarely a limit, outside of old bodies/old receipts, but it may improve
+                // some latency as a peer message may get blocked by another peer's message deserialization
+                // if thread count is 1.
+                handlerThreadCount = Math.Max(1, Environment.ProcessorCount - 2);
+            }
             _group = new MultithreadEventLoopGroup(handlerThreadCount);
             _serializationService = serializationService ?? throw new ArgumentNullException(nameof(serializationService));
             _logManager = logManager ?? throw new ArgumentNullException(nameof(logManager));

--- a/src/Nethermind/Nethermind.Network/Rlpx/RlpxHost.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/RlpxHost.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -54,7 +54,9 @@ namespace Nethermind.Network.Rlpx
         private readonly ILogger _logger;
         private readonly ISessionMonitor _sessionMonitor;
         private readonly IDisconnectsAnalyzer _disconnectsAnalyzer;
-        private IEventExecutorGroup _group;
+
+        // Main executor group. Used to execute snappy decompression and message deserialization.
+        private readonly IEventExecutorGroup _group;
 
         public RlpxHost(IMessageSerializationService serializationService,
             PublicKey localNodeId,
@@ -62,6 +64,7 @@ namespace Nethermind.Network.Rlpx
             IHandshakeService handshakeService,
             ISessionMonitor sessionMonitor,
             IDisconnectsAnalyzer disconnectsAnalyzer,
+            int handlerThreadCount,
             ILogManager logManager)
         {
             // .NET Core definitely got the easy logging setup right :D
@@ -79,7 +82,7 @@ namespace Nethermind.Network.Rlpx
             //     new LoggerFilterOptions { MinLevel = Microsoft.Extensions.Logging.LogLevel.Warning });
             // InternalLoggerFactory.DefaultFactory = loggerFactory;
 
-            _group = new SingleThreadEventLoop();
+            _group = new MultithreadEventLoopGroup(handlerThreadCount);
             _serializationService = serializationService ?? throw new ArgumentNullException(nameof(serializationService));
             _logManager = logManager ?? throw new ArgumentNullException(nameof(logManager));
             _logger = logManager.GetClassLogger();


### PR DESCRIPTION
Fixes issue with old bodies download capped by unknown force.

## Changes:
- Add P2PHandlerThreadCount config.
- Set default thread count to ProcessorCount - 2.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [X] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [X] No

Running smoke...

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...