### PR TITLE
Do not disconnect peer on timeout

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/PeerRefresher.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/PeerRefresher.cs
@@ -131,7 +131,7 @@ public class PeerRefresher : IPeerRefresher, IAsyncDisposable
         }
         catch (AggregateException exception) when (exception.InnerException is OperationCanceledException)
         {
-            _syncPeerPool.ReportRefreshFailed(syncPeer, "FCU timeout", exception);
+            _syncPeerPool.ReportRefreshFailed(syncPeer, "FCU timeout", exception.InnerException);
             return;
         }
         catch (OperationCanceledException exception)

--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
@@ -699,7 +699,7 @@ namespace Nethermind.Synchronization.Peers
             if (_logger.IsTrace) _logger.Trace($"Refresh failed reported: {syncPeer.Node:c}, {reason}, {exception}");
             _stats.ReportSyncEvent(syncPeer.Node, syncPeer.IsInitialized ? NodeStatsEventType.SyncFailed : NodeStatsEventType.SyncInitFailed);
 
-            if (exception is OperationCanceledException)
+            if (exception is OperationCanceledException || exception is TimeoutException)
             {
                 // We don't want to disconnect on timeout. It could be that we are downloading from the peer,
                 // or we have some connection issue

--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
@@ -592,7 +592,7 @@ namespace Nethermind.Synchronization.Peers
                     {
                         if (firstToComplete == delayTask)
                         {
-                            ReportRefreshFailed(syncPeer, "timeout");
+                            ReportRefreshFailed(syncPeer, "timeout", new TimeoutException());
                         }
                         else if (firstToComplete.IsFaulted)
                         {

--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
@@ -698,7 +698,17 @@ namespace Nethermind.Synchronization.Peers
         {
             if (_logger.IsTrace) _logger.Trace($"Refresh failed reported: {syncPeer.Node:c}, {reason}, {exception}");
             _stats.ReportSyncEvent(syncPeer.Node, syncPeer.IsInitialized ? NodeStatsEventType.SyncFailed : NodeStatsEventType.SyncInitFailed);
-            syncPeer.Disconnect(DisconnectReason.DisconnectRequested, $"refresh peer info fault - {reason}");
+
+            if (exception is OperationCanceledException)
+            {
+                // We don't want to disconnect on timeout. It could be that we are downloading from the peer,
+                // or we have some connection issue
+                ReportWeakPeer(new PeerInfo(syncPeer), AllocationContexts.All);
+            }
+            else
+            {
+                syncPeer.Disconnect(DisconnectReason.DisconnectRequested, $"refresh peer info fault - {reason}");
+            }
         }
 
         public void Dispose()


### PR DESCRIPTION
- Do not disconnect peer on timeout. 

## Changes:
- If passed exception in ReportRefreshFailed is an OperationCanceledException, do not disconnect the peer.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [X] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [X] Yes
- [ ] No

Running smoke....

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...