### PR TITLE
Not recover tx senders when not needed

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
@@ -407,7 +407,7 @@ public partial class EthRpcModule : IEthRpcModule
         }
 
         Block? block = searchResult.Object;
-        if (block != null)
+        if (returnFullTransactionObjects && block != null)
         {
             _blockchainBridge.RecoverTxSenders(block);
         }


### PR DESCRIPTION
This simple change will optimize requests from ~30-60 ms to ~1.7 ms when returnFullTransactionObjects: false

This is super important PR for CLs integrations. 
| BEFORE/AFTER| Number of requests | Avg Request time (microseconds)|
| ------------- | ------------- |  ------------- |
BEFORE eth_getBlockByNumber | 9008 | 32600 | 
AFTER eth_getBlockByNumber | 73010 | 1673 | 

I will think how we can handle case when returnFullTransactionObjects: true as a next thing,.