### PR TITLE
Fix node speed does not update

### DIFF
--- a/src/Nethermind/Nethermind.Network.Test/NodeStatsTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/NodeStatsTests.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -42,7 +42,7 @@ namespace Nethermind.Network.Test
         [TestCase(TransferSpeedType.NodeData)]
         public void TransferSpeedCaptureTest(TransferSpeedType speedType)
         {
-            _nodeStats = new NodeStatsLight(_node);
+            _nodeStats = new NodeStatsLight(_node, 0.5m);
 
             _nodeStats.AddTransferSpeedCaptureEvent(speedType, 30);
             _nodeStats.AddTransferSpeedCaptureEvent(speedType, 51);
@@ -59,10 +59,16 @@ namespace Nethermind.Network.Test
             _nodeStats.AddTransferSpeedCaptureEvent(speedType, 133);
 
             var av = _nodeStats.GetAverageTransferSpeed(speedType);
-            Assert.AreEqual(102, av);
+            Assert.AreEqual(122, av);
 
             var paddedAv = _nodeStats.GetPaddedAverageTransferSpeed(speedType);
-            Assert.AreEqual("  102", paddedAv);
+            Assert.AreEqual("  122", paddedAv);
+
+            _nodeStats.AddTransferSpeedCaptureEvent(speedType, 0);
+            _nodeStats.AddTransferSpeedCaptureEvent(speedType, 0);
+
+            av = _nodeStats.GetAverageTransferSpeed(speedType);
+            Assert.AreEqual(30, av);
         }
 
         [Test]


### PR DESCRIPTION
Fix node speed does not update after some time as observation count increase. This means node that suddenly become slower does not get its speed reflected.

## Changes:
- Uses different speed calculation.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [X] Yes
- []  No

**In case you checked yes, did you write tests??**

- [X] Yes
- [ ] No

**Comments about testing , should you have some** (optional)

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...