### PR TITLE
Fix peer that should not get connected was connected

### DIFF
--- a/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
@@ -258,6 +258,22 @@ namespace Nethermind.Network.Test
             }
         }
 
+        [Test]
+        public async Task IfPeerAdded_with_invalid_chain_then_do_not_connect()
+        {
+            await using Context ctx = new();
+            ctx.PeerPool.Start();
+            ctx.PeerManager.Start();
+
+            var networkNode = new NetworkNode(ctx.GenerateEnode());
+            ctx.Stats.ReportFailedValidation(new Node(networkNode), CompatibilityValidationType.ChainId);
+
+            ctx.PeerPool.GetOrAdd(networkNode);
+
+            await Task.Delay(_travisDelay);
+            ctx.PeerPool.ActivePeers.Count.Should().Be(0);
+        }
+
         private int _travisDelay = 100;
 
         private int _travisDelayLong = 1000;


### PR DESCRIPTION
Probably fix #2413 

It was observed that peer that get added via `PeerPoolOnPeerAdded` does not get filtered for disconnect delay or chainid. This result int reconnecting to peers that was already known to be on a different chain id or peer that should have delay.

## Changes:
- Add some basic check for PeerPoolOnPeeradded.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [X] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [X] No

**Comments about testing , should you have some** (optional)

Smoke test can sync to processing normally. No noticable change in peer pool.

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...