### PR TITLE
Fix Nethermind.sln

### DIFF
--- a/src/Nethermind/Nethermind.sln
+++ b/src/Nethermind/Nethermind.sln
@@ -160,8 +160,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nethermind.Analytics", "Net
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nethermind.Cli.Test", "Nethermind.Cli.Test\Nethermind.Cli.Test.csproj", "{A06EBCB5-D56A-47D9-ACC2-B1A27F74E94B}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nethermind.Int256", "..\int256\src\Nethermind.Int256\Nethermind.Int256.csproj", "{B27A33D7-CBF0-4CD5-A056-14C16819586E}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nethermind.Crypto", "Nethermind.Crypto\Nethermind.Crypto.csproj", "{50485E9D-C8A4-4543-9CD6-38BF65F9E3D7}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nethermind.HealthChecks", "Nethermind.HealthChecks\Nethermind.HealthChecks.csproj", "{19105CF0-2602-4F5A-85F3-B3B7BA5B6C40}"
@@ -173,8 +171,6 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nethermind.Ethash.Test", "Nethermind.Ethash.Test\Nethermind.Ethash.Test.csproj", "{8089024B-6744-4034-8F4A-0FD86C1491E2}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nethermind.Specs.Test", "Nethermind.Specs.Test\Nethermind.Specs.Test.csproj", "{0EC840BB-CC6A-4AB1-9E2A-625C777EBAB6}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MathGmp.Native", "..\Math.Gmp.Native\MathGmp.Native\MathGmp.Native.csproj", "{11A5D908-1FB6-4492-BFA8-676A096AC089}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nethermind.Api.Test", "Nethermind.Api.Test\Nethermind.Api.Test.csproj", "{DF891F59-5764-4F39-B42B-6263499B0464}"
 EndProject
@@ -492,10 +488,6 @@ Global
 		{A06EBCB5-D56A-47D9-ACC2-B1A27F74E94B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A06EBCB5-D56A-47D9-ACC2-B1A27F74E94B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A06EBCB5-D56A-47D9-ACC2-B1A27F74E94B}.Release|Any CPU.Build.0 = Release|Any CPU
-		{B27A33D7-CBF0-4CD5-A056-14C16819586E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{B27A33D7-CBF0-4CD5-A056-14C16819586E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{B27A33D7-CBF0-4CD5-A056-14C16819586E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{B27A33D7-CBF0-4CD5-A056-14C16819586E}.Release|Any CPU.Build.0 = Release|Any CPU
 		{50485E9D-C8A4-4543-9CD6-38BF65F9E3D7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{50485E9D-C8A4-4543-9CD6-38BF65F9E3D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{50485E9D-C8A4-4543-9CD6-38BF65F9E3D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -520,10 +512,6 @@ Global
 		{0EC840BB-CC6A-4AB1-9E2A-625C777EBAB6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0EC840BB-CC6A-4AB1-9E2A-625C777EBAB6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0EC840BB-CC6A-4AB1-9E2A-625C777EBAB6}.Release|Any CPU.Build.0 = Release|Any CPU
-		{11A5D908-1FB6-4492-BFA8-676A096AC089}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{11A5D908-1FB6-4492-BFA8-676A096AC089}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{11A5D908-1FB6-4492-BFA8-676A096AC089}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{11A5D908-1FB6-4492-BFA8-676A096AC089}.Release|Any CPU.Build.0 = Release|Any CPU
 		{DF891F59-5764-4F39-B42B-6263499B0464}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{DF891F59-5764-4F39-B42B-6263499B0464}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DF891F59-5764-4F39-B42B-6263499B0464}.Release|Any CPU.ActiveCfg = Release|Any CPU


### PR DESCRIPTION
## Changes:
- remove stale references from `Nethermind.sln`
Locally I wasn't able to build solution without removing it. It is a problem in case of fresh clone - otherwise `Gmp` and `Int` files still exist in `src` folder, pulling changes doesn't remove it

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [x] No