### PR TITLE
Fix stuck when restarting with a new pivot

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -94,5 +94,8 @@ namespace Nethermind.Blockchain.Synchronization
         [ConfigItem(Description = "[ONLY FOR MISSING RECEIPTS ISSUE] Turns on receipts validation that checks for ones that might be missing due to previous bug. It downloads them from network if needed." +
                                   "If used please check that PivotNumber is same as original used when syncing the node as its used as a cut-off point.", DefaultValue = "false")]
         public bool FixReceipts { get; set; }
+
+        [ConfigItem(Description = "Disable some optimization and run a more extensive check. Useful for broken sync state but normally not needed", DefaultValue = "false")]
+        public bool StrictMode { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
@@ -95,7 +95,7 @@ namespace Nethermind.Blockchain.Synchronization
                                   "If used please check that PivotNumber is same as original used when syncing the node as its used as a cut-off point.", DefaultValue = "false")]
         public bool FixReceipts { get; set; }
 
-        [ConfigItem(Description = "Disable some optimization and run a more extensive check. Useful for broken sync state but normally not needed", DefaultValue = "false")]
+        [ConfigItem(Description = "Disable some optimization and run a more extensive sync. Useful for broken sync state but normally not needed", DefaultValue = "false")]
         public bool StrictMode { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
@@ -56,6 +56,8 @@ namespace Nethermind.Blockchain.Synchronization
         public bool WitnessProtocolEnabled { get; set; } = false;
         public bool SnapSync { get; set; } = false;
         public bool FixReceipts { get; set; } = false;
+
+        public bool StrictMode { get; set; } = false;
         public bool BlockGossipEnabled { get; set; } = true;
 
         public override string ToString()

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
@@ -56,7 +56,6 @@ namespace Nethermind.Blockchain.Synchronization
         public bool WitnessProtocolEnabled { get; set; } = false;
         public bool SnapSync { get; set; } = false;
         public bool FixReceipts { get; set; } = false;
-
         public bool StrictMode { get; set; } = false;
         public bool BlockGossipEnabled { get; set; } = true;
 

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/BeaconPivotTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/BeaconPivotTests.cs
@@ -1,24 +1,26 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
+using System.Collections.Generic;
 using FluentAssertions;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
 using Nethermind.Logging;
 using Nethermind.Merge.Plugin.Synchronization;

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconHeadersSyncFeed.cs
@@ -43,6 +43,7 @@ public sealed class BeaconHeadersSyncFeed : HeadersSyncFeed
     private readonly IMergeConfig _mergeConfig;
     private readonly ILogger _logger;
     private bool _chainMerged;
+
     protected override long HeadersDestinationNumber => _pivot.PivotDestinationNumber;
 
     protected override bool AllHeadersDownloaded => (_blockTree.LowestInsertedBeaconHeader?.Number ?? long.MaxValue) <=
@@ -180,7 +181,8 @@ public sealed class BeaconHeadersSyncFeed : HeadersSyncFeed
         // Found existing block in the block tree
         if (_blockTree.IsKnownBlock(header.Number, header.GetOrCalculateHash()))
         {
-            _chainMerged = true;
+            if (!_syncConfig.StrictMode)
+                _chainMerged = true;
             if (_logger.IsTrace)
                 _logger.Trace(
                     $"Found header to join dangling beacon chain {header.ToString(BlockHeader.Format.FullHashAndNumber)}");

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconHeadersSyncFeed.cs
@@ -179,10 +179,9 @@ public sealed class BeaconHeadersSyncFeed : HeadersSyncFeed
         }
 
         // Found existing block in the block tree
-        if (_blockTree.IsKnownBlock(header.Number, header.GetOrCalculateHash()))
+        if (!_syncConfig.StrictMode && _blockTree.IsKnownBlock(header.Number, header.GetOrCalculateHash()))
         {
-            if (!_syncConfig.StrictMode)
-                _chainMerged = true;
+            _chainMerged = true;
             if (_logger.IsTrace)
                 _logger.Trace(
                     $"Found header to join dangling beacon chain {header.ToString(BlockHeader.Format.FullHashAndNumber)}");

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconPivot.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconPivot.cs
@@ -80,9 +80,16 @@ namespace Nethermind.Merge.Plugin.Synchronization
         public UInt256? PivotTotalDifficulty => CurrentBeaconPivot is null ?
             _syncConfig.PivotTotalDifficultyParsed : CurrentBeaconPivot.TotalDifficulty;
 
-        public long PivotDestinationNumber => CurrentBeaconPivot is null
-            ? 0
-            : _syncConfig.PivotNumberParsed + 1;
+        // The stopping point for the reverse beacon header sync. If head is not null, that means we processed some block before.
+        // It is possible that the head is lower than the sync pivot (restart with a new pivot) so we need to account for that.
+        public long PivotDestinationNumber
+        {
+            get
+            {
+                return ((_blockTree.Head?.Number ?? 0) != 0) ? (_blockTree.Head?.Number ?? 0 + 1) : (_syncConfig.PivotNumberParsed + 1);
+            }
+        }
+
         public void EnsurePivot(BlockHeader? blockHeader, bool updateOnlyIfNull = false)
         {
             bool beaconPivotExists = BeaconPivotExists();

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconPivot.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconPivot.cs
@@ -81,7 +81,7 @@ namespace Nethermind.Merge.Plugin.Synchronization
         public UInt256? PivotTotalDifficulty => CurrentBeaconPivot is null ?
             _syncConfig.PivotTotalDifficultyParsed : CurrentBeaconPivot.TotalDifficulty;
 
-        // The stopping point for the reverse beacon header sync.
+        // The stopping point (inclusive) for the reverse beacon header sync.
         public long PivotDestinationNumber
         {
             get
@@ -98,7 +98,7 @@ namespace Nethermind.Merge.Plugin.Synchronization
                 {
                     // However, the head may not be canon, so the destination need to be before that.
                     long safeNumber = _blockTree.Head!.Number - Reorganization.MaxDepth + 1;
-                    return Math.Max(0, safeNumber);
+                    return Math.Max(1, safeNumber);
                 }
 
                 return _syncConfig.PivotNumberParsed + 1;

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconPivot.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconPivot.cs
@@ -15,6 +15,7 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 //
 
+using System;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core;
@@ -80,13 +81,21 @@ namespace Nethermind.Merge.Plugin.Synchronization
         public UInt256? PivotTotalDifficulty => CurrentBeaconPivot is null ?
             _syncConfig.PivotTotalDifficultyParsed : CurrentBeaconPivot.TotalDifficulty;
 
-        // The stopping point for the reverse beacon header sync. If head is not null, that means we processed some block before.
-        // It is possible that the head is lower than the sync pivot (restart with a new pivot) so we need to account for that.
+        // The stopping point for the reverse beacon header sync.
         public long PivotDestinationNumber
         {
             get
             {
-                return ((_blockTree.Head?.Number ?? 0) != 0) ? (_blockTree.Head?.Number ?? 0 + 1) : (_syncConfig.PivotNumberParsed + 1);
+                // If head is not null, that means we processed some block before.
+                // It is possible that the head is lower than the sync pivot (restart with a new pivot) so we need to account for that.
+                if (_blockTree.Head?.Number != 0)
+                {
+                    // However, the head may not be canon, so the destination need to be before that.
+                    long safeNumber = (_blockTree.Head?.Number ?? 0) - Reorganization.MaxDepth + 1;
+                    return Math.Max(0, safeNumber);
+                }
+
+                return _syncConfig.PivotNumberParsed + 1;
             }
         }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconPivot.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconPivot.cs
@@ -86,12 +86,18 @@ namespace Nethermind.Merge.Plugin.Synchronization
         {
             get
             {
+                if (CurrentBeaconPivot is null)
+                {
+                    // Need to rethink if this is expected. Maybe it need to forward sync without a pivot.
+                    return 0;
+                }
+
                 // If head is not null, that means we processed some block before.
                 // It is possible that the head is lower than the sync pivot (restart with a new pivot) so we need to account for that.
-                if (_blockTree.Head?.Number != 0)
+                if (_blockTree.Head != null && _blockTree.Head?.Number != 0)
                 {
                     // However, the head may not be canon, so the destination need to be before that.
-                    long safeNumber = (_blockTree.Head?.Number ?? 0) - Reorganization.MaxDepth + 1;
+                    long safeNumber = _blockTree.Head!.Number - Reorganization.MaxDepth + 1;
                     return Math.Max(0, safeNumber);
                 }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconSync.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconSync.cs
@@ -94,8 +94,8 @@ namespace Nethermind.Merge.Plugin.Synchronization
                 lowestInsertedBeaconHeader != null &&
                 _blockTree.IsKnownBlock(lowestInsertedBeaconHeader.Number - 1, lowestInsertedBeaconHeader.ParentHash!);
             bool finished = lowestInsertedBeaconHeader == null
-                            || lowestInsertedBeaconHeader.Number <= _syncConfig.PivotNumberParsed + 1
-                            || chainMerged;
+                            || lowestInsertedBeaconHeader.Number <= _beaconPivot.PivotDestinationNumber
+                            || (!_syncConfig.StrictMode && chainMerged);
 
             if (_logger.IsTrace) _logger.Trace(
                 $"IsBeaconSyncHeadersFinished: {finished}," +
@@ -104,6 +104,7 @@ namespace Nethermind.Merge.Plugin.Synchronization
                 $" LowestInsertedBeaconHeaderNumber: {_blockTree.LowestInsertedBeaconHeader?.Number}," +
                 $" BestSuggestedHeader: {_blockTree.BestSuggestedHeader?.Number}," +
                 $" ChainMerged: {chainMerged}," +
+                $" StrictMode: {_syncConfig.StrictMode}," +
                 $" BeaconPivot: {_beaconPivot.PivotNumber}," +
                 $" BeaconPivotDestinationNumber: {_beaconPivot.PivotDestinationNumber}");
             return finished;

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/ChainLevelHelper.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/ChainLevelHelper.cs
@@ -177,7 +177,7 @@ public class ChainLevelHelper : IChainLevelHelper
         long startingPoint = Math.Min(_blockTree.BestKnownNumber + 1, _beaconPivot.ProcessDestination?.Number ?? long.MaxValue);
         bool shouldContinue;
 
-        if (_logger.IsTrace) _logger.Trace($"ChainLevelHelper. starting point's starting point is {startingPoint}. Best known number: {_blockTree.BestKnownNumber}, process destination: {_beaconPivot.ProcessDestination?.Number}");
+        if (_logger.IsTrace) _logger.Trace($"ChainLevelHelper. starting point's starting point is {startingPoint}. Best known number: {_blockTree.BestKnownNumber}, Process destination: {_beaconPivot.ProcessDestination?.Number}");
 
         BlockInfo? beaconMainChainBlock = GetBeaconMainChainBlockInfo(startingPoint);
         if (beaconMainChainBlock == null) return null;

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/ChainLevelHelper.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/ChainLevelHelper.cs
@@ -213,7 +213,7 @@ public class ChainLevelHelper : IChainLevelHelper
             // MergeBlockDownloader does not download the first header so this is deliberate
             --startingPoint;
             currentHash = header.ParentHash!;
-            if (_syncConfig.FastSync && startingPoint <= _beaconPivot.PivotDestinationNumber)
+            if (_syncConfig.FastSync && startingPoint < _beaconPivot.PivotDestinationNumber)
             {
                 if (_logger.IsTrace) _logger.Trace($"Reached syncConfig pivot. Starting point: {startingPoint}");
                 break;

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/ChainLevelHelper.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/ChainLevelHelper.cs
@@ -177,7 +177,7 @@ public class ChainLevelHelper : IChainLevelHelper
         long startingPoint = Math.Min(_blockTree.BestKnownNumber + 1, _beaconPivot.ProcessDestination?.Number ?? long.MaxValue);
         bool shouldContinue;
 
-        if (_logger.IsTrace) _logger.Trace($"ChainLevelHelper. starting point's starting point is {startingPoint}");
+        if (_logger.IsTrace) _logger.Trace($"ChainLevelHelper. starting point's starting point is {startingPoint}. Best known number: {_blockTree.BestKnownNumber}, process destination: {_beaconPivot.ProcessDestination?.Number}");
 
         BlockInfo? beaconMainChainBlock = GetBeaconMainChainBlockInfo(startingPoint);
         if (beaconMainChainBlock == null) return null;
@@ -213,7 +213,7 @@ public class ChainLevelHelper : IChainLevelHelper
             // MergeBlockDownloader does not download the first header so this is deliberate
             --startingPoint;
             currentHash = header.ParentHash!;
-            if (_syncConfig.FastSync && startingPoint <= _syncConfig.PivotNumberParsed)
+            if (_syncConfig.FastSync && startingPoint <= _beaconPivot.PivotDestinationNumber)
             {
                 if (_logger.IsTrace) _logger.Trace($"Reached syncConfig pivot. Starting point: {startingPoint}");
                 break;


### PR DESCRIPTION
Fix issue where when restarting after some time, and sync pivot is updated to be ahead of what has already synced, beacon header sync will not download back to processed block as it stopped at sync pivot.  ChainLevelHelper also assume this.

## Changes:
- Make `BeaconPivot.PivotDestination` the head if head is not genesis.
- Added a config `Sync.StrictMode` that disable `chainMerged` optimization so that node can recover without resync.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [X] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [X] Yes
- [ ] No

**Comments about testing , should you have some** (optional)

Hive test passed with strict mode off.
Running with it on...

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...