### PR TITLE
Fix Code Coverage workflow

### DIFF
--- a/.github/workflows/run-nethermind-tests-with-code-coverage.yml
+++ b/.github/workflows/run-nethermind-tests-with-code-coverage.yml
@@ -160,9 +160,6 @@ jobs:
     - name: Nethermind.Sockets.Test
       run: |
         dotnet test -c Release $EXCLUDE_TEST_PROJECTS src/Nethermind/Nethermind.Sockets.Test
-    - name: MathGmp.Native
-      run: |
-        dotnet test -c Release $EXCLUDE_TEST_PROJECTS src/Math.Gmp.Native/MathGmp.Native.UnitTests                
     - name: Upload Codecov Report
       if: matrix.os == 'ubuntu-latest'
       uses: actions/upload-artifact@v2


### PR DESCRIPTION
## Changes:
- remove `MathGmp` project from `Code Coverage` workflow
After last changes and removing some projects from `src` directory, `Code Coverage` workflow is broken and there is a need to remove stale project.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [x] No

