### PR TITLE
Fix rocksdb test will hang sometimes

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -37,6 +37,7 @@ public class DbOnTheRocks : IDbWithSpan
 
     private static readonly ConcurrentDictionary<string, RocksDb> _dbsByPath = new();
 
+    private bool _isDisposing;
     private bool _isDisposed;
 
     private readonly ConcurrentHashSet<IBatch> _currentBatches = new();
@@ -273,7 +274,7 @@ public class DbOnTheRocks : IDbWithSpan
     {
         get
         {
-            if (_isDisposed)
+            if (_isDisposing)
             {
                 throw new ObjectDisposedException($"Attempted to read form a disposed database {Name}");
             }
@@ -283,7 +284,7 @@ public class DbOnTheRocks : IDbWithSpan
         }
         set
         {
-            if (_isDisposed)
+            if (_isDisposing)
             {
                 throw new ObjectDisposedException($"Attempted to write to a disposed database {Name}");
             }
@@ -305,7 +306,7 @@ public class DbOnTheRocks : IDbWithSpan
 
     public Span<byte> GetSpan(byte[] key)
     {
-        if (_isDisposed)
+        if (_isDisposing)
         {
             throw new ObjectDisposedException($"Attempted to read form a disposed database {Name}");
         }
@@ -319,7 +320,7 @@ public class DbOnTheRocks : IDbWithSpan
 
     public void Remove(byte[] key)
     {
-        if (_isDisposed)
+        if (_isDisposing)
         {
             throw new ObjectDisposedException($"Attempted to delete form a disposed database {Name}");
         }
@@ -329,7 +330,7 @@ public class DbOnTheRocks : IDbWithSpan
 
     public IEnumerable<KeyValuePair<byte[], byte[]>> GetAll(bool ordered = false)
     {
-        if (_isDisposed)
+        if (_isDisposing)
         {
             throw new ObjectDisposedException($"Attempted to create an iterator on a disposed database {Name}");
         }
@@ -347,7 +348,7 @@ public class DbOnTheRocks : IDbWithSpan
 
     public IEnumerable<byte[]> GetAllValues(bool ordered = false)
     {
-        if (_isDisposed)
+        if (_isDisposing)
         {
             throw new ObjectDisposedException($"Attempted to read form a disposed database {Name}");
         }
@@ -370,7 +371,7 @@ public class DbOnTheRocks : IDbWithSpan
 
     public IEnumerable<KeyValuePair<byte[], byte[]>> GetAllCore(Iterator iterator)
     {
-        if (_isDisposed)
+        if (_isDisposing)
         {
             throw new ObjectDisposedException($"Attempted to read form a disposed database {Name}");
         }
@@ -387,7 +388,7 @@ public class DbOnTheRocks : IDbWithSpan
 
     public bool KeyExists(byte[] key)
     {
-        if (_isDisposed)
+        if (_isDisposing)
         {
             throw new ObjectDisposedException($"Attempted to read form a disposed database {Name}");
         }
@@ -407,6 +408,7 @@ public class DbOnTheRocks : IDbWithSpan
     internal class RocksDbBatch : IBatch
     {
         private readonly DbOnTheRocks _dbOnTheRocks;
+        private bool _isDisposed;
 
         internal readonly WriteBatch _rocksBatch;
 
@@ -414,7 +416,7 @@ public class DbOnTheRocks : IDbWithSpan
         {
             _dbOnTheRocks = dbOnTheRocks;
 
-            if (_dbOnTheRocks._isDisposed)
+            if (_dbOnTheRocks._isDisposing)
             {
                 throw new ObjectDisposedException($"Attempted to create a batch on a disposed database {_dbOnTheRocks.Name}");
             }
@@ -429,6 +431,12 @@ public class DbOnTheRocks : IDbWithSpan
                 throw new ObjectDisposedException($"Attempted to commit a batch on a disposed database {_dbOnTheRocks.Name}");
             }
 
+            if (_isDisposed)
+            {
+                return;
+            }
+            _isDisposed = true;
+
             _dbOnTheRocks._db.Write(_rocksBatch, _dbOnTheRocks.WriteOptions);
             _dbOnTheRocks._currentBatches.TryRemove(this);
             _rocksBatch.Dispose();
@@ -436,9 +444,22 @@ public class DbOnTheRocks : IDbWithSpan
 
         public byte[]? this[byte[] key]
         {
-            get => _dbOnTheRocks[key];
+            get
+            {
+                if (_isDisposed)
+                {
+                    throw new ObjectDisposedException($"Attempted to read a disposed batch {_dbOnTheRocks.Name}");
+                }
+
+                return _dbOnTheRocks[key];
+            }
             set
             {
+                if (_isDisposed)
+                {
+                    throw new ObjectDisposedException($"Attempted to write a disposed batch {_dbOnTheRocks.Name}");
+                }
+
                 if (value == null)
                 {
                     _rocksBatch.Delete(key);
@@ -453,11 +474,16 @@ public class DbOnTheRocks : IDbWithSpan
 
     public void Flush()
     {
-        if (_isDisposed)
+        if (_isDisposing)
         {
             throw new ObjectDisposedException($"Attempted to flush a disposed database {Name}");
         }
 
+        InnerFlush();
+    }
+
+    private void InnerFlush()
+    {
         RocksDbSharp.Native.Instance.rocksdb_flush(_db.Handle, FlushOptions.DefaultFlushOptions.Handle);
     }
 
@@ -529,13 +555,14 @@ public class DbOnTheRocks : IDbWithSpan
 
     public void Dispose()
     {
-        if (!_isDisposed)
-        {
-            if (_logger.IsInfo) _logger.Info($"Disposing DB {Name}");
-            Flush();
-            ReleaseUnmanagedResources();
-            _dbsByPath.Remove(_fullPath!, out _);
-        }
+        if (_isDisposing) return;
+        _isDisposing = true;
+
+        if (_logger.IsInfo) _logger.Info($"Disposing DB {Name}");
+        InnerFlush();
+        ReleaseUnmanagedResources();
+
+        _dbsByPath.Remove(_fullPath!, out _);
 
         _isDisposed = true;
     }

--- a/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
@@ -14,7 +14,9 @@
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
+using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Nethermind.Core;
@@ -62,25 +64,37 @@ namespace Nethermind.Db.Test
             IDbConfig config = new DbConfig();
             DbOnTheRocks db = new("testDispose1", GetRocksDbSettings("testDispose1", "TestDispose1"), config, LimboLogs.Instance);
 
+            CancellationTokenSource cancelSource = new();
+            ManualResetEventSlim firstWriteWait = new();
+            firstWriteWait.Reset();
+            bool writeCompleted = false;
+
             Task task = new(() =>
             {
                 for (int i = 0; i < 10000; i++)
                 {
-                    // ReSharper disable once AccessToDisposedClosure
                     db.Set(Keccak.Zero, new byte[] { 1, 2, 3 });
+                    if (i == 0) firstWriteWait.Set();
+
+                    if (cancelSource.IsCancellationRequested)
+                    {
+                        return;
+                    }
                 }
 
-                // ReSharper disable once FunctionNeverReturns
+                writeCompleted = true;
             });
 
             task.Start();
 
-            await Task.Delay(100);
+            firstWriteWait.Wait(TimeSpan.FromSeconds(1)).Should().BeTrue();
 
             db.Dispose();
 
             await Task.Delay(100);
 
+            cancelSource.Cancel();
+            writeCompleted.Should().BeFalse();
             task.Dispose();
         }
 

--- a/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
@@ -95,6 +95,8 @@ namespace Nethermind.Db.Test
 
             cancelSource.Cancel();
             writeCompleted.Should().BeFalse();
+
+            task.IsFaulted.Should().BeTrue();
             task.Dispose();
         }
 

--- a/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
@@ -64,7 +64,7 @@ namespace Nethermind.Db.Test
 
             Task task = new(() =>
             {
-                while (true)
+                for (int i = 0; i < 10000; i++)
                 {
                     // ReSharper disable once AccessToDisposedClosure
                     db.Set(Keccak.Zero, new byte[] { 1, 2, 3 });


### PR DESCRIPTION
- Hangs seems to originate from native code. 
- So, best I can do is to make sure no writes happens after dispose is called.

## Changes:
- Add write limit.
- Make sure no set happens after `Dispose`.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [X] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [X] No

**Comments about testing , should you have some** (optional)

- Randomly exit a synced sepolia node.
- Randomly exit a syncing sepolia node.

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...