### PR TITLE
Fix unit tests does not pass consistently

### DIFF
--- a/src/Nethermind/Nethermind.AccountAbstraction.Test/AccountAbstractionRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.AccountAbstraction.Test/AccountAbstractionRpcModuleTests.cs
@@ -254,13 +254,13 @@ namespace Nethermind.AccountAbstraction.Test
             {
                 Assert.That(
                     () => _contracts.GetCount(chain, counterAddress[0]!, walletAddress[0]!),
-                    Is.EqualTo(UInt256.One).After(500, 50));
+                    Is.EqualTo(UInt256.One).After(2000, 50));
             }
             else
             {
                 Assert.That(
                     () => _contracts.GetCount(chain, counterAddress[0]!, walletAddress[0]!),
-                    Is.EqualTo(UInt256.Zero).After(500, 50));
+                    Is.EqualTo(UInt256.Zero).After(2000, 50));
             }
         }
 

--- a/src/Nethermind/Nethermind.AccountAbstraction.Test/AccountAbstractionRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.AccountAbstraction.Test/AccountAbstractionRpcModuleTests.cs
@@ -1,19 +1,19 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using System;
 using System.Collections.Generic;
@@ -250,14 +250,17 @@ namespace Nethermind.AccountAbstraction.Test
             }
             await chain.AddBlock(true);
 
-            UInt256 countAfter = _contracts.GetCount(chain, counterAddress[0]!, walletAddress[0]!);
             if (success)
             {
-                countAfter.Should().Be(1);
+                Assert.That(
+                    () => _contracts.GetCount(chain, counterAddress[0]!, walletAddress[0]!),
+                    Is.EqualTo(UInt256.One).After(500, 50));
             }
             else
             {
-                countAfter.Should().Be(0);
+                Assert.That(
+                    () => _contracts.GetCount(chain, counterAddress[0]!, walletAddress[0]!),
+                    Is.EqualTo(UInt256.Zero).After(500, 50));
             }
         }
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPrunerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPrunerTests.cs
@@ -1,19 +1,19 @@
-//  Copyright (c) 2021 Demerzel Solutions Limited
+﻿//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using System;
 using System.Threading;
@@ -111,7 +111,7 @@ namespace Nethermind.Blockchain.Test.FullPruning
             byte[] key = { 0, 1, 2 };
             test.FullPruningDb[key] = key;
             test.FullPruningDb.Context.WaitForFinish.Set();
-            await test.FullPruningDb.Context.DisposeEvent.WaitOneAsync(TimeSpan.FromMilliseconds(10), CancellationToken.None);
+            await test.FullPruningDb.Context.DisposeEvent.WaitOneAsync(TimeSpan.FromMilliseconds(500), CancellationToken.None);
 
             test.FullPruningDb[key].Should().BeEquivalentTo(key);
         }
@@ -171,7 +171,7 @@ namespace Nethermind.Blockchain.Test.FullPruning
                 bool result = await WaitForPruningEnd(context);
                 if (result && _clearPrunedDb)
                 {
-                    await FullPruningDb.WaitForClearDb.WaitOneAsync(TimeSpan.FromMilliseconds(10), CancellationToken.None);
+                    await FullPruningDb.WaitForClearDb.WaitOneAsync(TimeSpan.FromMilliseconds(500), CancellationToken.None);
                 }
 
                 return result;
@@ -179,9 +179,9 @@ namespace Nethermind.Blockchain.Test.FullPruning
 
             public async Task<bool> WaitForPruningEnd(TestFullPruningDb.TestPruningContext context)
             {
-                await context.WaitForFinish.WaitOneAsync(TimeSpan.FromMilliseconds(10), CancellationToken.None);
+                await context.WaitForFinish.WaitOneAsync(TimeSpan.FromMilliseconds(500), CancellationToken.None);
                 AddBlocks(1);
-                return await context.DisposeEvent.WaitOneAsync(TimeSpan.FromMilliseconds(10), CancellationToken.None);
+                return await context.DisposeEvent.WaitOneAsync(TimeSpan.FromMilliseconds(500), CancellationToken.None);
             }
 
             public TestFullPruningDb.TestPruningContext WaitForPruningStart()

--- a/src/Nethermind/Nethermind.Blockchain.Test/ReorgTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/ReorgTests.cs
@@ -120,8 +120,6 @@ namespace Nethermind.Blockchain.Test
         {
             List<Block> events = new();
 
-            AutoResetEvent resetEvent = new AutoResetEvent(false);
-
             Block block0 = Build.A.Block.Genesis.WithDifficulty(1).WithTotalDifficulty(1L).TestObject;
             Block block1 = Build.A.Block.WithParent(block0).WithDifficulty(2).WithTotalDifficulty(2L).TestObject;
             Block block2 = Build.A.Block.WithParent(block1).WithDifficulty(1).WithTotalDifficulty(3L).TestObject;
@@ -132,11 +130,6 @@ namespace Nethermind.Blockchain.Test
             _blockTree.BlockAddedToMain += (_, args) =>
             {
                 events.Add(args.Block);
-
-                if (args.Block == block2B)
-                {
-                    resetEvent.Set();
-                }
             };
 
             _blockchainProcessor.Start();
@@ -148,9 +141,8 @@ namespace Nethermind.Blockchain.Test
             _blockTree.SuggestBlock(block1B);
             _blockTree.SuggestBlock(block2B);
 
-            resetEvent.WaitOne(2000);
+            Assert.That(() => _blockTree.Head, Is.EqualTo(block2B).After(10000, 500));
 
-            _blockTree.Head.Should().Be(block2B);
             events.Should().HaveCount(6);
             events[4].Hash.Should().Be(block1B.Hash);
             events[5].Hash.Should().Be(block2B.Hash);

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
@@ -106,7 +106,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             _blockTree.FindHeader(Arg.Any<BlockParameter>(), true).Returns(toBlock);
         }
 
-        private JsonRpcResult GetBlockAddedToMainResult(BlockReplacementEventArgs blockReplacementEventArgs, out string subscriptionId, TransactionsOption? options = null)
+        private JsonRpcResult GetBlockAddedToMainResult(BlockReplacementEventArgs blockReplacementEventArgs, out string subscriptionId, TransactionsOption? options = null, bool shouldReceiveResult = true)
         {
             NewHeadSubscription newHeadSubscription = new(_jsonRpcDuplexClient, _blockTree, _logManager, _specProvider, options);
 
@@ -120,7 +120,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             }));
 
             _blockTree.BlockAddedToMain += Raise.EventWith(new object(), blockReplacementEventArgs);
-            manualResetEvent.WaitOne(TimeSpan.FromMilliseconds(100));
+            manualResetEvent.WaitOne(TimeSpan.FromMilliseconds(1000)).Should().Be(shouldReceiveResult);
 
             subscriptionId = newHeadSubscription.Id;
             return jsonRpcResult;
@@ -286,7 +286,7 @@ namespace Nethermind.JsonRpc.Test.Modules
         {
             BlockReplacementEventArgs blockReplacementEventArgs = new(null);
 
-            JsonRpcResult jsonRpcResult = GetBlockAddedToMainResult(blockReplacementEventArgs, out _);
+            JsonRpcResult jsonRpcResult = GetBlockAddedToMainResult(blockReplacementEventArgs, out _, shouldReceiveResult: false);
 
             jsonRpcResult.Response.Should().BeNull();
         }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Synchronization.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Synchronization.cs
@@ -729,10 +729,13 @@ public partial class EngineModuleTests
 
         await bestBlockProcessed.WaitAsync();
 
-        // beacon sync should be finished
+        // beacon sync should be finished, eventually
         bestBeaconBlockRequest = CreateBlockRequest(bestBeaconBlockRequest, Address.Zero);
-        payloadStatus = await rpc.engine_newPayloadV1(bestBeaconBlockRequest);
-        payloadStatus.Data.Status.Should().Be(PayloadStatus.Valid);
+        Assert.That(
+            () => rpc.engine_newPayloadV1(bestBeaconBlockRequest).Result.Data.Status,
+            Is.EqualTo(PayloadStatus.Valid).After(1000, 100)
+            );
+
         chain.BeaconSync.ShouldBeInBeaconHeaders().Should().BeFalse();
         chain.BeaconSync.IsBeaconSyncHeadersFinished().Should().BeTrue();
         chain.BeaconSync.IsBeaconSyncFinished(chain.BlockTree.BestSuggestedBeaconHeader).Should().BeTrue();

--- a/src/Nethermind/Nethermind.Network.Test/P2P/SessionTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/SessionTests.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -430,6 +430,7 @@ namespace Nethermind.Network.Test.P2P
         }
 
         [Test]
+        [NonParallelizable]
         public void Can_deliver_messages()
         {
             Metrics.P2PBytesSent = 0;

--- a/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/EthereumStepsManagerTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/EthereumStepsManagerTests.cs
@@ -87,7 +87,7 @@ namespace Nethermind.Runner.Test.Ethereum.Steps
                 runnerContext,
                 LimboLogs.Instance);
 
-            using CancellationTokenSource source = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+            using CancellationTokenSource source = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
             try
             {

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncServerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncServerTests.cs
@@ -509,6 +509,7 @@ namespace Nethermind.Synchronization.Test
         }
 
         [Test]
+        [Retry(3)]
         public async Task Broadcast_NewBlock_on_arrival_to_sqrt_of_peers([Values(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20, 50, 100)] int peerCount)
         {
             int expectedPeers = (int)Math.Ceiling(Math.Sqrt(peerCount - 1)); // -1 because of ignoring sender

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncServerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncServerTests.cs
@@ -542,9 +542,9 @@ namespace Nethermind.Synchronization.Test
             ctx.PeerPool.AllPeers.Returns(peers);
             ctx.PeerPool.PeerCount.Returns(peers.Length);
             ctx.SyncServer.AddNewBlock(remoteBlockTree.Head!, peers[0].SyncPeer);
-            await Task.Delay(100); // notifications fire on separate task
+
+            Assert.That(() => count, Is.EqualTo(expectedPeers).After(5000, 100));
             await Task.WhenAll(peers.Select(p => ((SyncPeerMock)p.SyncPeer).Close()).ToArray());
-            count.Should().Be(expectedPeers);
         }
 
         [Test]


### PR DESCRIPTION
Fix unit tests never pass consistently. When combined with #4686 and #4685 all unit tests was able to pass on a single run, most of the time, usually three consecutive succesful runs, before something fails randomly. Tests no longer hangs. On a lenovo legion 5 with Ryzen 7 5800H, all tests runs betwen 1 minute to 1 minute 15 second with CPU utilization almost 100% all the time.

## Changes:
- If failing is waiting for manual reset event, increase timeout in general.
- If can convert to `Assert.That(() => *, Is.After(*))` convert to that.
- Some test have event handler registered after call that triggers that handler,
- If all fails, add [Retry(3)].

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [X] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [X] No

**Comments about testing , should you have some** (optional)

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...