### PR TITLE
Minor code cleanup on peer transfer speed report

### DIFF
--- a/src/Nethermind/Nethermind.Network.Stats/INodeStats.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/INodeStats.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -32,8 +32,6 @@ namespace Nethermind.Stats
 
         void AddTransferSpeedCaptureEvent(TransferSpeedType speedType, long bytesPerMillisecond);
         long? GetAverageTransferSpeed(TransferSpeedType speedType);
-        string GetPaddedAverageTransferSpeed(TransferSpeedType transferSpeedType);
-
         (bool Result, NodeStatsEventType? DelayReason) IsConnectionDelayed();
 
         long CurrentNodeReputation { get; }

--- a/src/Nethermind/Nethermind.Network.Stats/NodeStatsLight.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/NodeStatsLight.cs
@@ -195,20 +195,6 @@ namespace Nethermind.Stats
             });
         }
 
-        public string GetPaddedAverageTransferSpeed(TransferSpeedType transferSpeedType)
-        {
-            return (transferSpeedType switch
-            {
-                TransferSpeedType.Latency => $"{_averageLatency ?? -1,5:0}",
-                TransferSpeedType.NodeData => $"{_averageNodesTransferSpeed ?? -1,5:0}",
-                TransferSpeedType.Headers => $"{_averageHeadersTransferSpeed ?? -1,5:0}",
-                TransferSpeedType.Bodies => $"{_averageBodiesTransferSpeed ?? -1,5:0}",
-                TransferSpeedType.Receipts => $"{_averageReceiptsTransferSpeed ?? -1,5:0}",
-                TransferSpeedType.SnapRanges => $"{_averageSnapRangesTransferSpeed ?? -1,5:0}",
-                _ => throw new ArgumentOutOfRangeException()
-            });
-        }
-
         public (bool Result, NodeStatsEventType? DelayReason) IsConnectionDelayed()
         {
             if (IsDelayedDueToDisconnect())

--- a/src/Nethermind/Nethermind.Network.Test/NodeStatsTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/NodeStatsTests.cs
@@ -61,9 +61,6 @@ namespace Nethermind.Network.Test
             var av = _nodeStats.GetAverageTransferSpeed(speedType);
             Assert.AreEqual(122, av);
 
-            var paddedAv = _nodeStats.GetPaddedAverageTransferSpeed(speedType);
-            Assert.AreEqual("  122", paddedAv);
-
             _nodeStats.AddTransferSpeedCaptureEvent(speedType, 0);
             _nodeStats.AddTransferSpeedCaptureEvent(speedType, 0);
 

--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeersReport.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeersReport.cs
@@ -116,14 +116,19 @@ namespace Nethermind.Synchronization.Peers
         {
             INodeStats stats = _stats.GetOrAdd(peerInfo.SyncPeer.Node);
             _stringBuilder.Append("   ").Append(peerInfo);
-            _stringBuilder.Append('[').Append(stats.GetPaddedAverageTransferSpeed(TransferSpeedType.Latency));
-            _stringBuilder.Append('|').Append(stats.GetPaddedAverageTransferSpeed(TransferSpeedType.Headers));
-            _stringBuilder.Append('|').Append(stats.GetPaddedAverageTransferSpeed(TransferSpeedType.Bodies));
-            _stringBuilder.Append('|').Append(stats.GetPaddedAverageTransferSpeed(TransferSpeedType.Receipts));
-            _stringBuilder.Append('|').Append(stats.GetPaddedAverageTransferSpeed(TransferSpeedType.NodeData));
-            _stringBuilder.Append('|').Append(stats.GetPaddedAverageTransferSpeed(TransferSpeedType.SnapRanges));
+            _stringBuilder.Append('[').Append(GetPaddedAverageTransferSpeed(stats, TransferSpeedType.Latency));
+            _stringBuilder.Append('|').Append(GetPaddedAverageTransferSpeed(stats, TransferSpeedType.Headers));
+            _stringBuilder.Append('|').Append(GetPaddedAverageTransferSpeed(stats, TransferSpeedType.Bodies));
+            _stringBuilder.Append('|').Append(GetPaddedAverageTransferSpeed(stats, TransferSpeedType.Receipts));
+            _stringBuilder.Append('|').Append(GetPaddedAverageTransferSpeed(stats, TransferSpeedType.NodeData));
+            _stringBuilder.Append('|').Append(GetPaddedAverageTransferSpeed(stats, TransferSpeedType.SnapRanges));
             _stringBuilder.Append(']');
             _stringBuilder.Append('[').Append(peerInfo.SyncPeer.ClientId).Append(']');
+        }
+
+        private string GetPaddedAverageTransferSpeed(INodeStats nodeStats, TransferSpeedType transferSpeedType)
+        {
+            return $"{nodeStats.GetAverageTransferSpeed(transferSpeedType) ?? -1,5:0}";
         }
 
         private void AddPeerHeader()


### PR DESCRIPTION
Move `GetPaddedAverageTransferSpeed` out to `SyncPeerReport` since its a presentation concern.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [X] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [X] No

**Comments about testing , should you have some** (optional)

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...