### PR TITLE
Fix sepolia invalid block

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncProgressResolverTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncProgressResolverTests.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -139,6 +139,31 @@ namespace Nethermind.Synchronization.Test
             Assert.True(syncProgressResolver.IsFastBlocksHeadersFinished());
             Assert.True(syncProgressResolver.IsFastBlocksBodiesFinished());
             Assert.True(syncProgressResolver.IsFastBlocksReceiptsFinished());
+        }
+
+        [Test]
+        public void Best_state_is_zero_if_snap_sync_range_is_not_complete()
+        {
+            IBlockTree blockTree = Substitute.For<IBlockTree>();
+            IReceiptStorage receiptStorage = Substitute.For<IReceiptStorage>();
+            IDb stateDb = Substitute.For<IDb>();
+            SyncConfig syncConfig = new();
+            syncConfig.PivotNumber = "1";
+            syncConfig.SnapSync = true;
+
+            ProgressTracker progressTracker = new(blockTree, stateDb, LimboLogs.Instance);
+            progressTracker.MoreAccountsToRight = true;
+
+            SyncProgressResolver syncProgressResolver = new(blockTree, receiptStorage, stateDb, NullTrieNodeResolver.Instance, progressTracker, syncConfig, LimboLogs.Instance);
+            var head = Build.A.Block.WithHeader(Build.A.BlockHeader.WithNumber(5).WithStateRoot(TestItem.KeccakA).TestObject).TestObject;
+            var suggested = Build.A.BlockHeader.WithNumber(6).WithStateRoot(TestItem.KeccakB).TestObject;
+            blockTree.Head.Returns(head);
+            blockTree.BestSuggestedHeader.Returns(suggested);
+            blockTree.FindHeader(Arg.Any<Keccak>(), BlockTreeLookupOptions.TotalDifficultyNotNeeded).Returns(head.Header);
+            stateDb.Get(head.StateRoot).Returns(new byte[] { 1 });
+            stateDb.Get(suggested.StateRoot).Returns(new byte[] { 1 });
+
+            Assert.AreEqual(0, syncProgressResolver.FindBestFullState());
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncProgressResolver.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncProgressResolver.cs
@@ -102,6 +102,13 @@ namespace Nethermind.Synchronization.ParallelSync
             BlockHeader initialBestSuggested = _blockTree.BestSuggestedHeader; // just storing here for debugging sake
             BlockHeader bestSuggested = initialBestSuggested;
 
+            // On a small network snap sync's address range request may complete very quickly meaning it will recalculate
+            // and store a valid state root. However, codes and storage may not be downloaded yet, so we need this check.
+            if (_syncConfig.SnapSync && !_progressTracker.IsSnapGetRangesFinished())
+            {
+                return 0;
+            }
+
             long bestFullState = 0;
             if (head != null)
             {


### PR DESCRIPTION
Fix #4526 

On sepolia, it seems that the whole range of address can be downloaded in a single get address range request, meaning it will store a valid state root immediately, causing `FindBestFullState` to found a valid state root when snap sync have not downloaded storage or codes. Verified by logging the tree root after `AddAccountRange`, which matches a block state root.

## Changes:
-Add a check for `IsSnapGetRangesFinished`.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [X] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [X] Yes
- [ ] No

**Comments about testing , should you have some** (optional)

Resynced sepolia a couple of time. Issues is no longer reproducable.

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...