### PR TITLE
TxPool optimization - moving DeployedCodeFilter

### DIFF
--- a/src/Nethermind/Nethermind.TxPool/Filters/UnknownSenderFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/UnknownSenderFilter.cs
@@ -1,19 +1,19 @@
-//  Copyright (c) 2021 Demerzel Solutions Limited
+﻿//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using Nethermind.Core;
 using Nethermind.Crypto;
@@ -41,6 +41,7 @@ namespace Nethermind.TxPool.Filters
              * We need to investigate what these txs are and why the sender address is resolved to null.
              * Then we need to decide whether we really want to broadcast them.
              */
+            ++Metrics.PendingTransactionsWithExpensiveFiltering;
             if (tx.SenderAddress is null)
             {
                 tx.SenderAddress = _ecdsa.RecoverAddress(tx);

--- a/src/Nethermind/Nethermind.TxPool/Metrics.cs
+++ b/src/Nethermind/Nethermind.TxPool/Metrics.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -37,6 +37,9 @@ namespace Nethermind.TxPool
 
         [Description("Number of pending transactions received that were ignored because of effective fee lower than the lowest effective fee in transaction pool.")]
         public static long PendingTransactionsTooLowFee { get; set; }
+
+        [Description("Number of pending transactions that reached filters which are resource expensive")]
+        public static long PendingTransactionsWithExpensiveFiltering { get; set; }
 
         [Description("Number of already known pending transactions.")]
         public static long PendingTransactionsKnown { get; set; }

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -113,8 +113,7 @@ namespace Nethermind.TxPool
             _filterPipeline.Add(new MalformedTxFilter(_specProvider, validator, _logger));
             _filterPipeline.Add(new GasLimitTxFilter(_headInfo, txPoolConfig, _logger));
             _filterPipeline.Add(new UnknownSenderFilter(ecdsa, _logger));
-            _filterPipeline.Add(new DeployedCodeFilter(_specProvider, _accounts)); // has to be after UnknownSenderFilter as it uses sender
-            _filterPipeline.Add(new LowNonceFilter(_accounts, _logger));
+            _filterPipeline.Add(new LowNonceFilter(_accounts, _logger)); // has to be after UnknownSenderFilter as it uses sender
             _filterPipeline.Add(new GapNonceFilter(_accounts, _transactions, _logger));
             _filterPipeline.Add(new TooExpensiveTxFilter(_headInfo, _accounts, _transactions, _logger));
             _filterPipeline.Add(new FeeTooLowFilter(_headInfo, _accounts, _transactions, logManager));
@@ -123,6 +122,7 @@ namespace Nethermind.TxPool
             {
                 _filterPipeline.Add(incomingTxFilter);
             }
+            _filterPipeline.Add(new DeployedCodeFilter(_specProvider, _accounts));
 
             ProcessNewHeads();
         }


### PR DESCRIPTION
- Moved DeployedCodeFilter to the end of txPool checks. It is reducing CPU and disk reads quite significantly. 
- Added new TxPool metric: PendingTransactionsWithExpensiveFiltering

As a next thing, we could work on building better filters without state access. Things have improved for sure, but I'm still observing occasional load from the first filter, which is reading the state:
![image](https://user-images.githubusercontent.com/9356351/193831650-fdbbcdda-9b11-472c-9faf-3c0956e08aca.png)
 
