### PR TITLE
Added time unit (microseconds) to JSON RPC report (log)

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcLocalStats.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcLocalStats.cs
@@ -125,11 +125,11 @@ namespace Nethermind.JsonRpc
 
             const string reportHeader = "method                                  | " +
                                         "successes | " +
-                                        " avg time | " +
-                                        " max time | " +
+                                        " avg time (µs) | " +
+                                        " max time (µs) | " +
                                         "   errors | " +
-                                        " avg time | " +
-                                        " max time |" +
+                                        " avg time (µs) | " +
+                                        " max time (µs) |" +
                                         " avg size |" +
                                         " total size |";
 
@@ -178,11 +178,11 @@ namespace Nethermind.JsonRpc
         {
             string reportLine = $"{key.PadRight(40)}| " +
                                 $"{methodStats.Successes.ToString().PadLeft(9)} | " +
-                                $"{methodStats.AvgTimeOfSuccesses.ToString("0", CultureInfo.InvariantCulture).PadLeft(9)} | " +
-                                $"{methodStats.MaxTimeOfSuccess.ToString(CultureInfo.InvariantCulture).PadLeft(9)} | " +
+                                $"{methodStats.AvgTimeOfSuccesses.ToString("0", CultureInfo.InvariantCulture).PadLeft(14)} | " +
+                                $"{methodStats.MaxTimeOfSuccess.ToString(CultureInfo.InvariantCulture).PadLeft(14)} | " +
                                 $"{methodStats.Errors.ToString().PadLeft(9)} | " +
-                                $"{methodStats.AvgTimeOfErrors.ToString("0", CultureInfo.InvariantCulture).PadLeft(9)} | " +
-                                $"{methodStats.MaxTimeOfError.ToString(CultureInfo.InvariantCulture).PadLeft(9)} | " +
+                                $"{methodStats.AvgTimeOfErrors.ToString("0", CultureInfo.InvariantCulture).PadLeft(14)} | " +
+                                $"{methodStats.MaxTimeOfError.ToString(CultureInfo.InvariantCulture).PadLeft(14)} | " +
                                 $"{methodStats.AvgSize.ToString("0", CultureInfo.InvariantCulture).PadLeft(8)} | " +
                                 $"{methodStats.TotalSize.ToString("0", CultureInfo.InvariantCulture).PadLeft(10)} | ";
 

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcLocalStats.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcLocalStats.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -168,23 +168,21 @@ namespace Nethermind.JsonRpc
 
         private void Swap()
         {
-            var temp = _currentStats;
-            _currentStats = _previousStats;
-            _previousStats = temp;
+            (_currentStats, _previousStats) = (_previousStats, _currentStats);
         }
 
         [Pure]
         private string PrepareReportLine(in string key, MethodStats methodStats)
         {
-            string reportLine = $"{key.PadRight(40)}| " +
-                                $"{methodStats.Successes.ToString().PadLeft(9)} | " +
-                                $"{methodStats.AvgTimeOfSuccesses.ToString("0", CultureInfo.InvariantCulture).PadLeft(14)} | " +
-                                $"{methodStats.MaxTimeOfSuccess.ToString(CultureInfo.InvariantCulture).PadLeft(14)} | " +
-                                $"{methodStats.Errors.ToString().PadLeft(9)} | " +
-                                $"{methodStats.AvgTimeOfErrors.ToString("0", CultureInfo.InvariantCulture).PadLeft(14)} | " +
-                                $"{methodStats.MaxTimeOfError.ToString(CultureInfo.InvariantCulture).PadLeft(14)} | " +
-                                $"{methodStats.AvgSize.ToString("0", CultureInfo.InvariantCulture).PadLeft(8)} | " +
-                                $"{methodStats.TotalSize.ToString("0", CultureInfo.InvariantCulture).PadLeft(10)} | ";
+            string reportLine = $"{key,-40}| " +
+                                $"{methodStats.Successes.ToString(),9} | " +
+                                $"{methodStats.AvgTimeOfSuccesses.ToString("0", CultureInfo.InvariantCulture),14} | " +
+                                $"{methodStats.MaxTimeOfSuccess.ToString(CultureInfo.InvariantCulture),14} | " +
+                                $"{methodStats.Errors.ToString(),9} | " +
+                                $"{methodStats.AvgTimeOfErrors.ToString("0", CultureInfo.InvariantCulture),14} | " +
+                                $"{methodStats.MaxTimeOfError.ToString(CultureInfo.InvariantCulture),14} | " +
+                                $"{methodStats.AvgSize.ToString("0", CultureInfo.InvariantCulture),8} | " +
+                                $"{methodStats.TotalSize.ToString("0", CultureInfo.InvariantCulture),10} | ";
 
             return reportLine;
         }


### PR DESCRIPTION
Resolves #4618 

## Changes:
- Added time unit to JSON RPC report (part of log)

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [x] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [x] No

**Comments about testing , should you have some** (optional)

## Further comments (optional)

Although this is a very simple change, the micro sign (µ) might not display correctly in the console log as it appears that Nlog console target uses OS dependent encoding by default. If this turns out to be a problem, a further change might be done to change Nlog configuration to use utf-8 encoding.