### PR TITLE
Revert "Fix rocksdb test will hang sometimes (#4686)"

### DIFF
--- a/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
@@ -14,9 +14,7 @@
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
-using System;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Nethermind.Core;
@@ -64,39 +62,25 @@ namespace Nethermind.Db.Test
             IDbConfig config = new DbConfig();
             DbOnTheRocks db = new("testDispose1", GetRocksDbSettings("testDispose1", "TestDispose1"), config, LimboLogs.Instance);
 
-            CancellationTokenSource cancelSource = new();
-            ManualResetEventSlim firstWriteWait = new();
-            firstWriteWait.Reset();
-            bool writeCompleted = false;
-
             Task task = new(() =>
             {
-                for (int i = 0; i < 10000; i++)
+                while (true)
                 {
+                    // ReSharper disable once AccessToDisposedClosure
                     db.Set(Keccak.Zero, new byte[] { 1, 2, 3 });
-                    if (i == 0) firstWriteWait.Set();
-
-                    if (cancelSource.IsCancellationRequested)
-                    {
-                        return;
-                    }
                 }
 
-                writeCompleted = true;
+                // ReSharper disable once FunctionNeverReturns
             });
 
             task.Start();
 
-            firstWriteWait.Wait(TimeSpan.FromSeconds(1)).Should().BeTrue();
+            await Task.Delay(100);
 
             db.Dispose();
 
             await Task.Delay(100);
 
-            cancelSource.Cancel();
-            writeCompleted.Should().BeFalse();
-
-            task.IsFaulted.Should().BeTrue();
             task.Dispose();
         }
 


### PR DESCRIPTION
This reverts commit 720c3f061c1208ae2cfdfdb7471249db5bfe2b8f.

We cannot sync, looks like we can have access to disposed batch in read-only mode

```
System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'Attempted to read a disposed batch State0'.
   at Nethermind.Db.Rocks.DbOnTheRocks.RocksDbBatch.get_Item(Byte[] key) in /root/src/nethermind/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs:line 451
   at Nethermind.Trie.Pruning.TrieStore.IsPersisted(Keccak keccak) in /root/src/nethermind/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs:line 352
   at Nethermind.Synchronization.SnapSync.SnapProviderHelper.IsChildPersisted(TrieNode node, Int32 childIndex, ITrieStore store) in /root/src/nethermind/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProviderHelper.cs:line 308
   at Nethermind.Synchronization.SnapSync.SnapProviderHelper.StitchBoundaries(IList`1 sortedBoundaryList, ITrieStore store) in /root/src/nethermind/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProviderHelper.cs:line 278
   at Nethermind.Synchronization.SnapSync.SnapProviderHelper.AddAccountRange(StateTree tree, Int64 blockNumber, Keccak expectedRootHash, Keccak startingHash, PathWithAccount[] accounts, Byte[][] proofs) in /root/src/nethermind/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProviderHelper.cs:line 71
   at Nethermind.Synchronization.SnapSync.SnapProvider.AddAccountRange(Int64 blockNumber, Keccak expectedRootHash, Keccak startingHash, PathWithAccount[] accounts, Byte[][] proofs) in /root/src/nethermind/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProvider.cs:line 73
   at Nethermind.Synchronization.SnapSync.SnapProvider.AddAccountRange(AccountRange request, AccountsAndProofs response) in /root/src/nethermind/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProvider.cs:line 56
   at Nethermind.Synchronization.SnapSync.SnapSyncFeed.HandleResponse(SnapSyncBatch batch, PeerInfo peer) in /root/src/nethermind/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncFeed.cs:line 96
   at Nethermind.Synchronization.ParallelSync.SyncDispatcher`1.<>c__DisplayClass17_1.<Start>b__0(Task t) in /root/src/nethermind/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncDispatcher.cs:line 117
```