### PR TITLE
Fix modexp_d37 tests (4 hive consensus tests)

### DIFF
--- a/src/Nethermind/Nethermind.Evm/Precompiles/ModExpPrecompile.cs
+++ b/src/Nethermind/Nethermind.Evm/Precompiles/ModExpPrecompile.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -124,16 +124,16 @@ namespace Nethermind.Evm.Precompiles
             byte[] modulusData = inputData.Span.SliceWithZeroPaddingEmptyOnError(96 + baseLength + expLength, modulusLength);
             using mpz_t modulusInt = ImportDataToGmp(modulusData);
 
-            if (gmp_lib.mpz_sgn(modulusInt) == 0)
-            {
-                return (new byte[modulusLength], true);
-            }
-
             byte[] baseData = inputData.Span.SliceWithZeroPaddingEmptyOnError(96, baseLength);
             using mpz_t baseInt = ImportDataToGmp(baseData);
 
             byte[] expData = inputData.Span.SliceWithZeroPaddingEmptyOnError(96 + baseLength, expLength);
             using mpz_t expInt = ImportDataToGmp(expData);
+
+            if (gmp_lib.mpz_sgn(modulusInt) == 0)
+            {
+                return (new byte[modulusLength], true);
+            }
 
             using mpz_t powmResult = new();
             gmp_lib.mpz_init(powmResult);
@@ -194,7 +194,7 @@ namespace Nethermind.Evm.Precompiles
         /// if exponent_length &lt;= 32 and exponent == 0: iteration_count = 0
         /// elif exponent_length &lt;= 32: iteration_count = exponent.bit_length() - 1
         /// elif exponent_length > 32: iteration_count = (8 * (exponent_length - 32)) + ((exponent & (2**256 - 1)).bit_length() - 1)
-        /// return max(iteration_count, 1) 
+        /// return max(iteration_count, 1)
         /// </summary>
         /// <param name="exponentLength"></param>
         /// <param name="exponent"></param>


### PR DESCRIPTION
Fixes | Closes | Resolves #

It is fixing 4 hive tests (`modexp_d37xxxx_Istanbul`) which were failing since introduced in July 2022:
https://github.com/ethereum/tests/commit/83a3982dd62fa6159d940c8a9c8b80e9e9ce5a21

## Changes:
- refactor `ModExp` precompile

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [x] No

Tested on hive tests and proved that this PR is making `modexp_d37` (and keep all other `modexp`) tests green:
https://github.com/NethermindEth/nethermind/actions/runs/3188801894/jobs/5201878163