### PR TITLE
Fix forward sync may stuck on slow peer

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeBlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeBlockDownloader.cs
@@ -1,4 +1,4 @@
-//  Copyright (c) 2021 Demerzel Solutions Limited
+﻿//  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
 //
 //  The Nethermind library is free software: you can redistribute it and/or modify
@@ -17,6 +17,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -53,8 +54,7 @@ namespace Nethermind.Merge.Plugin.Synchronization
         private readonly IPoSSwitcher _poSSwitcher;
         private readonly ISyncProgressResolver _syncProgressResolver;
 
-        public MergeBlockDownloader(
-            IPoSSwitcher posSwitcher,
+        public MergeBlockDownloader(IPoSSwitcher posSwitcher,
             IBeaconPivot beaconPivot,
             ISyncFeed<BlocksRequest?>? feed,
             ISyncPeerPool? syncPeerPool,
@@ -67,10 +67,11 @@ namespace Nethermind.Merge.Plugin.Synchronization
             IBetterPeerStrategy betterPeerStrategy,
             IChainLevelHelper chainLevelHelper,
             ISyncProgressResolver syncProgressResolver,
-            ILogManager logManager)
+            ILogManager logManager,
+            SyncBatchSize? syncBatchSize = null)
             : base(feed, syncPeerPool, blockTree, blockValidator, sealValidator, syncReport, receiptStorage,
                 specProvider, new MergeBlocksSyncPeerAllocationStrategyFactory(posSwitcher, beaconPivot, logManager),
-                betterPeerStrategy, logManager)
+                betterPeerStrategy, logManager, syncBatchSize)
         {
             _blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
             _specProvider = specProvider ?? throw new ArgumentNullException(nameof(specProvider));
@@ -89,7 +90,11 @@ namespace Nethermind.Merge.Plugin.Synchronization
             CancellationToken cancellation)
         {
             if (_beaconPivot.BeaconPivotExists() == false && _poSSwitcher.HasEverReachedTerminalBlock() == false)
+            {
+                if (_logger.IsDebug)
+                    _logger.Debug("Using pre merge block downloader");
                 return await base.DownloadBlocks(bestPeer, blocksRequest, cancellation);
+            }
 
             if (bestPeer == null)
             {
@@ -105,8 +110,8 @@ namespace Nethermind.Merge.Plugin.Synchronization
 
             int blocksSynced = 0;
             long currentNumber = _blockTree.BestKnownNumber;
-            if (_logger.IsTrace)
-                _logger.Trace(
+            if (_logger.IsDebug)
+                _logger.Debug(
                     $"MergeBlockDownloader GetCurrentNumber: currentNumber {currentNumber}, beaconPivotExists: {_beaconPivot.BeaconPivotExists()}, BestSuggestedBody: {_blockTree.BestSuggestedBody?.Number}, BestKnownNumber: {_blockTree.BestKnownNumber}, BestPeer: {bestPeer}, BestKnownBeaconNumber {_blockTree.BestKnownBeaconNumber}");
 
             bool HasMoreToSync(out BlockHeader[]? headers, out int headersToRequest)
@@ -132,6 +137,11 @@ namespace Nethermind.Merge.Plugin.Synchronization
 
             while (HasMoreToSync(out BlockHeader[]? headers, out int headersToRequest))
             {
+                if (HasBetterPeer)
+                {
+                    if (_logger.IsDebug) _logger.Debug("Has better peer, stopping");
+                    break;
+                }
 
                 if (cancellation.IsCancellationRequested) return blocksSynced; // check before every heavy operation
                 Block[]? blocks = null;
@@ -147,6 +157,7 @@ namespace Nethermind.Merge.Plugin.Synchronization
 
                 if (cancellation.IsCancellationRequested) return blocksSynced; // check before every heavy operation
 
+                Stopwatch sw = Stopwatch.StartNew();
                 await RequestBodies(bestPeer, cancellation, context);
 
                 if (downloadReceipts)
@@ -156,12 +167,7 @@ namespace Nethermind.Merge.Plugin.Synchronization
                     await RequestReceipts(bestPeer, cancellation, context);
                 }
 
-                _sinceLastTimeout++;
-                if (_sinceLastTimeout > 2)
-                {
-                    _syncBatchSize.Expand();
-
-                }
+                AdjustSyncBatchSize(sw.Elapsed);
 
                 blocks = context.Blocks;
                 receipts = context.ReceiptsForBlocks;
@@ -206,7 +212,7 @@ namespace Nethermind.Merge.Plugin.Synchronization
                         if (isFastSyncTransition)
                         {
                             long bestFullState = _syncProgressResolver.FindBestFullState();
-                            shouldProcess = currentBlock.Number > bestFullState && bestFullState != 0;
+                            shouldProcess = currentBlock.Number > bestFullState && bestFullState!=0;
                             if (!shouldProcess)
                             {
                                 if (_logger.IsInfo) _logger.Info($"Skipping processing during fastSyncTransition, currentBlock: {currentBlock}, bestFullState: {bestFullState}");

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeBlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeBlockDownloader.cs
@@ -212,7 +212,7 @@ namespace Nethermind.Merge.Plugin.Synchronization
                         if (isFastSyncTransition)
                         {
                             long bestFullState = _syncProgressResolver.FindBestFullState();
-                            shouldProcess = currentBlock.Number > bestFullState && bestFullState!=0;
+                            shouldProcess = currentBlock.Number > bestFullState && bestFullState != 0;
                             if (!shouldProcess)
                             {
                                 if (_logger.IsInfo) _logger.Info($"Skipping processing during fastSyncTransition, currentBlock: {currentBlock}, bestFullState: {bestFullState}");

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncBatchSizeTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncBatchSizeTests.cs
@@ -1,19 +1,20 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
+using System;
 using Nethermind.Logging;
 using Nethermind.Synchronization.Blocks;
 using NUnit.Framework;
@@ -29,10 +30,10 @@ namespace Nethermind.Synchronization.Test
             SyncBatchSize syncBatchSize = new(LimboLogs.Instance);
             int beforeShrink = syncBatchSize.Current;
             syncBatchSize.Shrink();
-            Assert.AreEqual(beforeShrink / 2, syncBatchSize.Current);
+            Assert.AreEqual(Math.Floor(beforeShrink / SyncBatchSize.AdjustmentFactor), syncBatchSize.Current);
             int beforeExpand = syncBatchSize.Current;
             syncBatchSize.Expand();
-            Assert.AreEqual(beforeExpand * 2, syncBatchSize.Current);
+            Assert.AreEqual(Math.Ceiling(beforeExpand * SyncBatchSize.AdjustmentFactor), syncBatchSize.Current);
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -40,6 +41,10 @@ namespace Nethermind.Synchronization.Blocks
     {
         public const int MaxReorganizationLength = SyncBatchSize.Max * 2;
 
+        // This includes both body and receipt
+        public static readonly TimeSpan SyncBatchDownloadTimeUpperBound = TimeSpan.FromMilliseconds(8000);
+        public static readonly TimeSpan SyncBatchDownloadTimeLowerBound = TimeSpan.FromMilliseconds(5000);
+
         private readonly IBlockTree _blockTree;
         private readonly IBlockValidator _blockValidator;
         private readonly ISealValidator _sealValidator;
@@ -52,7 +57,8 @@ namespace Nethermind.Synchronization.Blocks
         private readonly Random _rnd = new();
 
         private bool _cancelDueToBetterPeer;
-        private AllocationWithCancellation _allocationWithCancellation;
+        private AllocationWithCancellation _allocationWithCancellation = new(null, new CancellationTokenSource());
+        protected bool HasBetterPeer => _allocationWithCancellation.Cancellation.IsCancellationRequested;
 
         protected SyncBatchSize _syncBatchSize;
         protected int _sinceLastTimeout;
@@ -69,7 +75,8 @@ namespace Nethermind.Synchronization.Blocks
             ISpecProvider? specProvider,
             IPeerAllocationStrategyFactory<BlocksRequest?> blockSyncPeerAllocationStrategyFactory,
             IBetterPeerStrategy betterPeerStrategy,
-            ILogManager? logManager)
+            ILogManager? logManager,
+            SyncBatchSize? syncBatchSize = null)
             : base(feed, syncPeerPool, blockSyncPeerAllocationStrategyFactory, logManager)
         {
             _blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
@@ -82,7 +89,7 @@ namespace Nethermind.Synchronization.Blocks
             _logger = logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
 
             _receiptsRecovery = new ReceiptsRecovery(new EthereumEcdsa(_specProvider.ChainId, logManager), _specProvider);
-            _syncBatchSize = new SyncBatchSize(logManager);
+            _syncBatchSize = syncBatchSize ?? new SyncBatchSize(logManager);
             _blockTree.NewHeadBlock += BlockTreeOnNewHeadBlock;
         }
 
@@ -98,6 +105,8 @@ namespace Nethermind.Synchronization.Blocks
             _syncReport.FullSyncBlocksKnown = Math.Max(_syncReport.FullSyncBlocksKnown, e.Block.Number);
         }
 
+        private PeerInfo? _previousBestPeer = null;
+
         protected override async Task Dispatch(
             PeerInfo bestPeer,
             BlocksRequest? blocksRequest,
@@ -110,10 +119,12 @@ namespace Nethermind.Synchronization.Blocks
             }
 
             if (!_blockTree.CanAcceptNewBlocks) return;
-            CancellationTokenSource linkedCancellation =
-                CancellationTokenSource.CreateLinkedTokenSource(
-                    cancellation,
-                    _allocationWithCancellation.Cancellation.Token);
+
+            if (_previousBestPeer != bestPeer)
+            {
+                _syncBatchSize.Reset();
+            }
+            _previousBestPeer = bestPeer;
 
             try
             {
@@ -121,14 +132,14 @@ namespace Nethermind.Synchronization.Blocks
                 if ((blocksRequest.Options & DownloaderOptions.WithBodies) == DownloaderOptions.WithBodies)
                 {
                     if (Logger.IsDebug) Logger.Debug("Downloading bodies");
-                    await DownloadBlocks(bestPeer, blocksRequest, linkedCancellation.Token)
+                    await DownloadBlocks(bestPeer, blocksRequest, cancellation)
                         .ContinueWith(t => HandleSyncRequestResult(t, bestPeer), cancellation);
                     if (Logger.IsDebug) Logger.Debug("Finished downloading bodies");
                 }
                 else
                 {
                     if (Logger.IsDebug) Logger.Debug("Downloading headers");
-                    await DownloadHeaders(bestPeer, blocksRequest, linkedCancellation.Token)
+                    await DownloadHeaders(bestPeer, blocksRequest, cancellation)
                         .ContinueWith(t => HandleSyncRequestResult(t, bestPeer), cancellation);
                     if (Logger.IsDebug) Logger.Debug("Finished downloading headers");
                 }
@@ -136,7 +147,6 @@ namespace Nethermind.Synchronization.Blocks
             finally
             {
                 _allocationWithCancellation.Dispose();
-                linkedCancellation.Dispose();
             }
         }
 
@@ -157,6 +167,7 @@ namespace Nethermind.Synchronization.Blocks
                 => currentNumber <= bestPeer!.HeadNumber;
             while (ImprovementRequirementSatisfied(bestPeer) && HasMoreToSync())
             {
+                if (HasBetterPeer) break;
                 int headersSyncedInPreviousRequests = headersSynced;
                 if (_logger.IsTrace) _logger.Trace($"Continue headers sync with {bestPeer} (our best {_blockTree.BestKnownNumber})");
 
@@ -168,6 +179,7 @@ namespace Nethermind.Synchronization.Blocks
                 }
 
                 if (_logger.IsDebug) _logger.Debug($"Headers request {currentNumber}+{headersToRequest} to peer {bestPeer} with {bestPeer.HeadNumber} blocks. Got {currentNumber} and asking for {headersToRequest} more.");
+                Stopwatch sw = Stopwatch.StartNew();
                 BlockHeader?[] headers = await RequestHeaders(bestPeer, cancellation, currentNumber, headersToRequest);
 
                 Keccak? startHeaderHash = headers[0]?.Hash;
@@ -188,12 +200,7 @@ namespace Nethermind.Synchronization.Blocks
                 }
 
                 ancestorLookupLevel = 0;
-                _sinceLastTimeout++;
-                if (_sinceLastTimeout >= 2)
-                {
-                    // if peers are not timing out then we can try to be slightly more eager
-                    _syncBatchSize.Expand();
-                }
+                AdjustSyncBatchSize(sw.Elapsed);
 
                 for (int i = 1; i < headers.Length; i++)
                 {
@@ -272,6 +279,7 @@ namespace Nethermind.Synchronization.Blocks
                 => currentNumber <= bestPeer!.HeadNumber;
             while (ImprovementRequirementSatisfied(bestPeer!) && HasMoreToSync())
             {
+                if (HasBetterPeer) break;
                 if (_logger.IsDebug) _logger.Debug($"Continue full sync with {bestPeer} (our best {_blockTree.BestKnownNumber})");
 
                 long upperDownloadBoundary = bestPeer.HeadNumber - (blocksRequest.NumberOfLatestBlocksToBeIgnored ?? 0);
@@ -296,6 +304,8 @@ namespace Nethermind.Synchronization.Blocks
                 BlockDownloadContext context = new(_specProvider, bestPeer, headers, downloadReceipts, _receiptsRecovery);
 
                 if (cancellation.IsCancellationRequested) return blocksSynced; // check before every heavy operation
+
+                Stopwatch sw = Stopwatch.StartNew();
                 await RequestBodies(bestPeer, cancellation, context);
 
                 if (downloadReceipts)
@@ -304,11 +314,7 @@ namespace Nethermind.Synchronization.Blocks
                     await RequestReceipts(bestPeer, cancellation, context);
                 }
 
-                _sinceLastTimeout++;
-                if (_sinceLastTimeout > 2)
-                {
-                    _syncBatchSize.Expand();
-                }
+                AdjustSyncBatchSize(sw.Elapsed);
 
                 Block[] blocks = context.Blocks;
                 Block blockZero = blocks[0];
@@ -416,10 +422,9 @@ namespace Nethermind.Synchronization.Blocks
         {
             if (downloadTask.IsFaulted)
             {
-                _sinceLastTimeout = 0;
                 if (downloadTask.Exception?.Flatten().InnerExceptions.Any(x => x is TimeoutException) ?? false)
                 {
-                    if (_logger.IsTrace) _logger.Error($"Failed to retrieve {entities} when synchronizing (Timeout)", downloadTask.Exception);
+                    if (_logger.IsDebug) _logger.Error($"Failed to retrieve {entities} when synchronizing (Timeout)", downloadTask.Exception);
                     _syncBatchSize.Shrink();
                 }
 
@@ -691,6 +696,25 @@ namespace Nethermind.Synchronization.Blocks
                     }
 
                     break;
+            }
+        }
+
+        /// <summary>
+        /// Adjust the sync batch size according to how much time it take to download the batch.
+        /// </summary>
+        /// <param name="downloadTime"></param>
+        protected void AdjustSyncBatchSize(TimeSpan downloadTime)
+        {
+            // We shrink the batch size to prevent timeout. Timeout are wasted bandwith.
+            if (downloadTime > SyncBatchDownloadTimeUpperBound)
+            {
+                _syncBatchSize.Shrink();
+            }
+
+            // We also want as high batch size as we can afford.
+            if (downloadTime < SyncBatchDownloadTimeLowerBound)
+            {
+                _syncBatchSize.Expand();
             }
         }
 

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/SyncBatchSize.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/SyncBatchSize.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -25,8 +25,13 @@ namespace Nethermind.Synchronization.Blocks
     {
         private ILogger _logger;
 
-        public const int Max = 512;
+        // The batch size is kinda also used for downloading bodies which is large. Peers can return less body
+        // than required, however, they still tend to timeout, so we try to limit this from our side.
+        public const int Max = 128;
         public const int Min = 2;
+        public const int Start = 32;
+
+        public const double AdjustmentFactor = 1.5;
 
         public int Current { get; private set; }
 
@@ -38,8 +43,7 @@ namespace Nethermind.Synchronization.Blocks
         {
             _logger = logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
 
-            /* headers batch could start at max as headers are predictable in size, unlike blocks */
-            Current = Max / 2;
+            Current = Start;
         }
 
         public void Expand()
@@ -49,14 +53,27 @@ namespace Nethermind.Synchronization.Blocks
                 return;
             }
 
-            Current = Math.Min(Max, Current * 2);
+            Current = Math.Min(Max, (int) Math.Ceiling(Current * AdjustmentFactor));
             if (_logger.IsDebug) _logger.Debug($"Changing sync batch size to {Current}");
+        }
+
+        public void ExpandUntilMax()
+        {
+            while (Current != Max)
+            {
+                Expand();
+            }
         }
 
         public void Shrink()
         {
-            Current = Math.Max(Min, Current / 2);
+            Current = Math.Max(Min, (int) (Current / AdjustmentFactor));
             if (_logger.IsDebug) _logger.Debug($"Changing sync batch size to {Current}");
+        }
+
+        public void Reset()
+        {
+            Current = Start;
         }
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization/Peers/AllocationStrategies/BySpeedStrategy.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/AllocationStrategies/BySpeedStrategy.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Nethermind.Blockchain;
 using Nethermind.Stats;
 
@@ -27,18 +28,32 @@ namespace Nethermind.Synchronization.Peers.AllocationStrategies
         private readonly bool _priority;
         private readonly decimal _minDiffPercentageForSpeedSwitch;
         private readonly int _minDiffForSpeedSwitch;
+        private readonly Random _random = new();
+
+        // Randomly pick a different peer that is not of the best speed. Encourage updating speed.
+        // Does not seems to matter much. But its here if you want to tweak it.
+        private readonly double _recalculateSpeedProbability;
+
+        // If the number of peer with known speed is less than this, then always try new peer.
+        // The idea is that, if we have at least this amount of peers with known speed, at least one of them should
+        // be fast, but we don't want to spend more time trying out other peers.
+        private readonly long _desiredPeersWithKnownSpeed;
 
         public BySpeedStrategy(
             TransferSpeedType speedType,
             bool priority,
             decimal minDiffPercentageForSpeedSwitch = 0.0m,
-            int minDiffForSpeedSwitch = 0
+            int minDiffForSpeedSwitch = 0,
+            double recalculateSpeedProbability = 0.025,
+            long desiredPeersWithKnownSpeed = 5
         )
         {
             _speedType = speedType;
             _priority = priority;
             _minDiffPercentageForSpeedSwitch = minDiffPercentageForSpeedSwitch;
             _minDiffForSpeedSwitch = minDiffForSpeedSwitch;
+            _recalculateSpeedProbability = recalculateSpeedProbability;
+            _desiredPeersWithKnownSpeed = desiredPeersWithKnownSpeed;
         }
 
         public bool CanBeReplaced => false;
@@ -46,20 +61,41 @@ namespace Nethermind.Synchronization.Peers.AllocationStrategies
         public PeerInfo? Allocate(PeerInfo? currentPeer, IEnumerable<PeerInfo> peers, INodeStatsManager nodeStatsManager, IBlockTree blockTree)
         {
             long nullSpeed = _priority ? -1 : long.MaxValue;
-            long peerCount = 0;
+            List<PeerInfo> peersAsList = peers.ToList();
+
+            long peerCount = peersAsList.Count();
+            long noSpeedPeerCount = peersAsList.Count(p => nodeStatsManager.GetOrAdd(p.SyncPeer.Node).GetAverageTransferSpeed(_speedType) == null);
+            bool shouldRediscoverSpeed = _random.NextDouble() < _recalculateSpeedProbability;
+            bool shouldDiscoverSpeed = (peerCount - noSpeedPeerCount) < _desiredPeersWithKnownSpeed;
+
             long currentSpeed = currentPeer == null ? nullSpeed : nodeStatsManager.GetOrAdd(currentPeer.SyncPeer.Node).GetAverageTransferSpeed(_speedType) ?? nullSpeed;
             (PeerInfo? Info, long TransferSpeed) bestPeer = (currentPeer, currentSpeed);
+            bool forceTake = false;
 
-            foreach (PeerInfo info in peers)
+            long peerLeft = peerCount;
+            foreach (PeerInfo info in peersAsList)
             {
-                peerCount++;
                 (this as IPeerAllocationStrategy).CheckAsyncState(info);
 
-                long averageTransferSpeed = nodeStatsManager.GetOrAdd(info.SyncPeer.Node).GetAverageTransferSpeed(_speedType) ?? 0;
-                if (_priority ? averageTransferSpeed > bestPeer.TransferSpeed : averageTransferSpeed < bestPeer.TransferSpeed)
+                long? speed = nodeStatsManager.GetOrAdd(info.SyncPeer.Node).GetAverageTransferSpeed(_speedType);
+                long averageTransferSpeed = speed ?? 0;
+
+                if (speed == null && shouldDiscoverSpeed)
+                {
+                    forceTake = true;
+                }
+                else if (shouldRediscoverSpeed && _random.NextDouble() < (1.0 / peerLeft))
+                {
+                    forceTake = true;
+                }
+
+                if (forceTake || (_priority ? averageTransferSpeed > bestPeer.TransferSpeed : averageTransferSpeed < bestPeer.TransferSpeed))
                 {
                     bestPeer = (info, averageTransferSpeed);
                 }
+
+                if (forceTake) break;
+                peerLeft--;
             }
 
             if (peerCount == 0)
@@ -67,9 +103,9 @@ namespace Nethermind.Synchronization.Peers.AllocationStrategies
                 return currentPeer;
             }
 
-            decimal speedRatio = bestPeer.TransferSpeed / (decimal)Math.Max(1L, currentSpeed);
-            if (speedRatio > 1m + _minDiffPercentageForSpeedSwitch
-                && bestPeer.TransferSpeed - currentSpeed > _minDiffForSpeedSwitch)
+            bool speedRatioExceeded = bestPeer.TransferSpeed / (decimal)Math.Max(1L, currentSpeed) > 1m + _minDiffPercentageForSpeedSwitch;
+            bool minSpeedChangeExceeded = bestPeer.TransferSpeed - currentSpeed > _minDiffForSpeedSwitch;
+            if (forceTake || (speedRatioExceeded && minSpeedChangeExceeded))
             {
                 return bestPeer.Info;
             }


### PR DESCRIPTION
- Fix forward sync stuck on slow peer as it will keep picking peers with speed, which will always be one as only one was tried.

## Changes:
- Modified BySpeedStrategy to pick peer with no speed as long as number of peer with known speed is less than 5.
- Modified BlockDownloader to not cancel current download immediately. It will continue processing downloaded blocks before checking if a better peer is available.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [X] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [X] Yes
- [ ] No

**Comments about testing , should you have some** (optional)

- About 24 to 32 mainnet smoke tests. None stucked on slow peers.

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...