### PR TITLE
Log on precompiled contract error

### DIFF
--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -590,8 +590,9 @@ namespace Nethermind.Evm
                 CallResult callResult = new(output.ToArray(), success, !success);
                 return callResult;
             }
-            catch (Exception)
+            catch (Exception exception)
             {
+                if (_logger.IsDebug) _logger.Error($"Precompiled contract ({precompile.GetType()}) execution exception", exception);
                 CallResult callResult = new(Array.Empty<byte>(), false, true);
                 return callResult;
             }


### PR DESCRIPTION
- It seems that we hide precompile contract exceptions. This should allow it to show up. Not sure if we should directly enable it all the time or only when debug is enabled.
- We should've crash completely IMO.

## Changes:
- Log exception on debug.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [X] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [X] No

**Comments about testing , should you have some** (optional)

- Shows up in hive test.

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...