### PR TITLE
AncientBarriers for old bodies & old receipts logging

### DIFF
--- a/src/Nethermind/Nethermind.Core/Timers/TimerFactory.cs
+++ b/src/Nethermind/Nethermind.Core/Timers/TimerFactory.cs
@@ -1,19 +1,19 @@
 //  Copyright (c) 2018 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using System;
 using System.Timers;
@@ -24,6 +24,7 @@ namespace Nethermind.Core.Timers
     {
         public static readonly ITimerFactory Default = new TimerFactory();
 
-        public ITimer CreateTimer(TimeSpan interval) => new TimerWrapper(new Timer()) { Interval = interval };
+        public ITimer CreateTimer(TimeSpan interval) => new
+            TimerWrapper(new Timer()) { Interval = interval };
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncReportTest.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncReportTest.cs
@@ -96,16 +96,14 @@ namespace Nethermind.Synchronization.Test
             }
 
             SyncReport syncReport = new(pool, Substitute.For<INodeStatsManager>(), selector, syncConfig, Substitute.For<IPivot>(), logManager, timerFactory);
-            selector.Current.Returns((ci) => _syncModes.Count > 0 ? _syncModes.Dequeue() : SyncMode.Full);
-            timer.Elapsed += Raise.Event();
-            timer.Elapsed += Raise.Event();
+            selector.Current.Returns((ci) => SyncMode.FastHeaders | SyncMode.FastBodies | SyncMode.FastReceipts);
             timer.Elapsed += Raise.Event();
 
             if (setBarriers)
             {
                 logger.Received(1).Info("Old Headers    0 / 100 | queue     0 | current     0.00bps | total     0.00bps");
-                logger.Received(1).Info("Old Bodies      0 / 70 | queue     0 | current     0.00bps | total     0.00bps");
-                logger.Received(1).Info("Old Receipts    0 / 65 | queue     0 | current     0.00bps | total     0.00bps");
+                logger.Received(1).Info("Old Bodies     0 / 70 | queue     0 | current     0.00bps | total     0.00bps");
+                logger.Received(1).Info("Old Receipts   0 / 65 | queue     0 | current     0.00bps | total     0.00bps");
             }
             else
             {

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncReportTest.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncReportTest.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -51,6 +51,32 @@ namespace Nethermind.Synchronization.Test
             SyncConfig syncConfig = new();
             syncConfig.FastBlocks = fastBlocks;
             syncConfig.FastSync = fastSync;
+
+            SyncReport syncReport = new(pool, Substitute.For<INodeStatsManager>(), selector, syncConfig, Substitute.For<IPivot>(), LimboLogs.Instance, 10);
+            selector.Current.Returns((ci) => _syncModes.Count > 0 ? _syncModes.Dequeue() : SyncMode.Full);
+            await Task.Delay(200);
+            syncReport.FastBlocksHeaders.MarkEnd();
+            syncReport.FastBlocksBodies.MarkEnd();
+            syncReport.FastBlocksReceipts.MarkEnd();
+            await Task.Delay(20);
+        }
+
+        [Test]
+        public async Task Smoke()
+        {
+            ISyncModeSelector selector = Substitute.For<ISyncModeSelector>();
+            ISyncPeerPool pool = Substitute.For<ISyncPeerPool>();
+            pool.InitializedPeersCount.Returns(1);
+
+            Queue<SyncMode> _syncModes = new();
+            _syncModes.Enqueue(SyncMode.FastHeaders);
+            _syncModes.Enqueue(SyncMode.FastBodies);
+            _syncModes.Enqueue(SyncMode.FastReceipts);
+
+            SyncConfig syncConfig = new();
+            syncConfig.FastBlocks = true;
+            syncConfig.FastSync = true;
+            syncConfig.PivotNumber = "100";
 
             SyncReport syncReport = new(pool, Substitute.For<INodeStatsManager>(), selector, syncConfig, Substitute.For<IPivot>(), LimboLogs.Instance, 10);
             selector.Current.Returns((ci) => _syncModes.Count > 0 ? _syncModes.Dequeue() : SyncMode.Full);

--- a/src/Nethermind/Nethermind.Synchronization/Reporting/SyncReport.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Reporting/SyncReport.cs
@@ -60,8 +60,10 @@ namespace Nethermind.Synchronization.Reporting
             _fastBlocksPivotNumber = _syncConfig.PivotNumberParsed;
             _blockPaddingLength = _fastBlocksPivotNumber.ToString().Length;
             _paddedPivot = $"{Pad(_fastBlocksPivotNumber, _blockPaddingLength)}";
-            _paddedAmountOfOldBodiesToDownload = $"{Pad(_fastBlocksPivotNumber - syncConfig.AncientBodiesBarrier, _blockPaddingLength)}";
-            _paddedAmountOfOldReceiptsToDownload = $"{Pad(_fastBlocksPivotNumber - syncConfig.AncientReceiptsBarrier, _blockPaddingLength)}";
+            long amountOfBodiesToDownload = _fastBlocksPivotNumber - syncConfig.AncientBodiesBarrier;
+            _paddedAmountOfOldBodiesToDownload = $"{Pad(amountOfBodiesToDownload, $"{_blockPaddingLength}".Length)}";
+            long amountOfReceiptsToDownload = _fastBlocksPivotNumber - syncConfig.AncientReceiptsBarrier;
+            _paddedAmountOfOldReceiptsToDownload = $"{Pad(_fastBlocksPivotNumber - syncConfig.AncientReceiptsBarrier, $"{_blockPaddingLength}".Length)}";
 
             StartTime = DateTime.UtcNow;
 

--- a/src/Nethermind/Nethermind.Synchronization/Reporting/SyncReport.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Reporting/SyncReport.cs
@@ -61,9 +61,9 @@ namespace Nethermind.Synchronization.Reporting
             _blockPaddingLength = _fastBlocksPivotNumber.ToString().Length;
             _paddedPivot = $"{Pad(_fastBlocksPivotNumber, _blockPaddingLength)}";
             long amountOfBodiesToDownload = _fastBlocksPivotNumber - syncConfig.AncientBodiesBarrier;
-            _paddedAmountOfOldBodiesToDownload = $"{Pad(amountOfBodiesToDownload, $"{_blockPaddingLength}".Length)}";
+            _paddedAmountOfOldBodiesToDownload = $"{Pad(amountOfBodiesToDownload, $"{amountOfBodiesToDownload}".Length)}";
             long amountOfReceiptsToDownload = _fastBlocksPivotNumber - syncConfig.AncientReceiptsBarrier;
-            _paddedAmountOfOldReceiptsToDownload = $"{Pad(_fastBlocksPivotNumber - syncConfig.AncientReceiptsBarrier, $"{_blockPaddingLength}".Length)}";
+            _paddedAmountOfOldReceiptsToDownload = $"{Pad(_fastBlocksPivotNumber - syncConfig.AncientReceiptsBarrier, $"{amountOfReceiptsToDownload}".Length)}";
 
             StartTime = DateTime.UtcNow;
 

--- a/src/Nethermind/Nethermind.Synchronization/Reporting/SyncReport.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Reporting/SyncReport.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -62,6 +62,8 @@ namespace Nethermind.Synchronization.Reporting
             _fastBlocksPivotNumber = _syncConfig.PivotNumberParsed;
             _blockPaddingLength = _fastBlocksPivotNumber.ToString().Length;
             _paddedPivot = $"{Pad(_fastBlocksPivotNumber, _blockPaddingLength)}";
+            _paddedAmountOfOldBodiesToDownload = $"{Pad(_fastBlocksPivotNumber - syncConfig.AncientBodiesBarrier, _blockPaddingLength)}";
+            _paddedAmountOfOldReceiptsToDownload = $"{Pad(_fastBlocksPivotNumber - syncConfig.AncientReceiptsBarrier, _blockPaddingLength)}";
 
             StartTime = DateTime.UtcNow;
 
@@ -152,6 +154,8 @@ namespace Nethermind.Synchronization.Reporting
         private bool _reportedFastBlocksSummary;
         private readonly int _blockPaddingLength;
         private readonly string _paddedPivot;
+        private readonly string _paddedAmountOfOldBodiesToDownload;
+        private readonly string _paddedAmountOfOldReceiptsToDownload;
 
         private void WriteSyncReport()
         {


### PR DESCRIPTION
Fixes #4622

Fixing incorrect logs for old receipts and old bodies. The ancient barriers were ignored.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No
