### PR TITLE
Remove pre `eth66` network items

### DIFF
--- a/src/Nethermind/Nethermind.Network.Test/P2P/P2PProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/P2PProtocolHandlerTests.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -80,7 +80,7 @@ namespace Nethermind.Network.Test.P2P
             p2PProtocolHandler.AddSupportedCapability(new Capability(Protocol.Wit, 0));
             p2PProtocolHandler.Init();
 
-            string[] expectedCapabilities = { "eth62", "eth63", "eth64", "eth65", "eth66", "wit0" };
+            string[] expectedCapabilities = { "eth66", "wit0" };
             _session.Received(1).DeliverMessage(
                 Arg.Is<HelloMessage>(m => m.Capabilities.Select(c => c.ToString()).SequenceEqual(expectedCapabilities)));
         }

--- a/src/Nethermind/Nethermind.Network.Test/P2P/P2PProtocolInfoProviderTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/P2PProtocolInfoProviderTests.cs
@@ -1,19 +1,19 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using Nethermind.Network.P2P;
 using NUnit.Framework;
@@ -35,7 +35,7 @@ namespace Nethermind.Network.Test.P2P
         public void DefaultCapabilitiesToString_ReturnExpectedResult()
         {
             string result = P2PProtocolInfoProvider.DefaultCapabilitiesToString();
-            Assert.AreEqual("eth/66,eth/65,eth/64,eth/63,eth/62", result);
+            Assert.AreEqual("eth/66", result);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Network.Test/ProtocolsManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/ProtocolsManagerTests.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -26,12 +26,10 @@ using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Core.Timers;
 using Nethermind.Logging;
-using Nethermind.Network.Discovery;
 using Nethermind.Network.P2P;
 using Nethermind.Network.P2P.Analyzers;
 using Nethermind.Network.P2P.Messages;
 using Nethermind.Network.P2P.ProtocolHandlers;
-using Nethermind.Network.P2P.Subprotocols.Eth;
 using Nethermind.Network.P2P.Subprotocols.Eth.V62;
 using Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages;
 using Nethermind.Network.P2P.Subprotocols.Eth.V65;
@@ -212,7 +210,7 @@ namespace Nethermind.Network.Test
                 msg.ChainId = 1;
                 msg.GenesisHash = _blockTree.Genesis.Hash;
                 msg.BestHash = _blockTree.Genesis.Hash;
-                msg.ProtocolVersion = 63;
+                msg.ProtocolVersion = 66;
 
                 return ReceiveStatus(msg);
             }
@@ -231,7 +229,7 @@ namespace Nethermind.Network.Test
                 INodeStats stats = _nodeStatsManager.GetOrAdd(_currentSession.Node);
                 Assert.AreEqual(1, stats.EthNodeDetails.ChainId);
                 Assert.AreEqual(_blockTree.Genesis.Hash, stats.EthNodeDetails.GenesisHash);
-                Assert.AreEqual(63, stats.EthNodeDetails.ProtocolVersion);
+                Assert.AreEqual(66, stats.EthNodeDetails.ProtocolVersion);
                 Assert.AreEqual(BigInteger.One, stats.EthNodeDetails.TotalDifficulty);
                 return this;
             }
@@ -246,7 +244,7 @@ namespace Nethermind.Network.Test
             public Context ReceiveHello(byte p2pVersion = 5)
             {
                 HelloMessage msg = new();
-                msg.Capabilities = new List<Capability> { new("eth", 62) };
+                msg.Capabilities = new List<Capability> { new("eth", 66) };
                 msg.NodeId = TestItem.PublicKeyB;
                 msg.ClientId = "other client v1";
                 msg.P2PVersion = p2pVersion;
@@ -282,7 +280,7 @@ namespace Nethermind.Network.Test
 
             public Context ReceiveHelloWrongEth()
             {
-                return ReceiveHelloEth(61);
+                return ReceiveHelloEth(65);
             }
 
             public Context ReceiveStatusWrongChain()
@@ -292,7 +290,7 @@ namespace Nethermind.Network.Test
                 msg.ChainId = 2;
                 msg.GenesisHash = TestItem.KeccakA;
                 msg.BestHash = TestItem.KeccakA;
-                msg.ProtocolVersion = 63;
+                msg.ProtocolVersion = 66;
 
                 return ReceiveStatus(msg);
             }
@@ -304,7 +302,7 @@ namespace Nethermind.Network.Test
                 msg.ChainId = 1;
                 msg.GenesisHash = TestItem.KeccakB;
                 msg.BestHash = TestItem.KeccakB;
-                msg.ProtocolVersion = 63;
+                msg.ProtocolVersion = 66;
 
                 return ReceiveStatus(msg);
             }

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandler.cs
@@ -53,12 +53,7 @@ public class P2PProtocolHandler : ProtocolHandlerBase, IPingSender, IP2PProtocol
 
     public static readonly IEnumerable<Capability> DefaultCapabilities = new Capability[]
     {
-        new(Protocol.Eth, 62),
-        new(Protocol.Eth, 63),
-        new(Protocol.Eth, 64),
-        new(Protocol.Eth, 65),
-        new(Protocol.Eth, 66),
-        // new Capability(Protocol.Les, 3)
+        new(Protocol.Eth, 66)
     };
 
     public IReadOnlyList<Capability> AgreedCapabilities { get { return _agreedCapabilities; } }

--- a/src/Nethermind/Nethermind.Network/ProtocolsManager.cs
+++ b/src/Nethermind/Nethermind.Network/ProtocolsManager.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -26,9 +26,6 @@ using Nethermind.Network.P2P;
 using Nethermind.Network.P2P.EventArg;
 using Nethermind.Network.P2P.Messages;
 using Nethermind.Network.P2P.ProtocolHandlers;
-using Nethermind.Network.P2P.Subprotocols.Eth.V62;
-using Nethermind.Network.P2P.Subprotocols.Eth.V63;
-using Nethermind.Network.P2P.Subprotocols.Eth.V64;
 using Nethermind.Network.P2P.Subprotocols.Eth.V65;
 using Nethermind.Network.P2P.Subprotocols.Eth.V66;
 using Nethermind.Network.P2P.Subprotocols.Les;
@@ -197,10 +194,6 @@ namespace Nethermind.Network
                 {
                     var ethHandler = version switch
                     {
-                        62 => new Eth62ProtocolHandler(session, _serializer, _stats, _syncServer, _txPool, _gossipPolicy, _logManager),
-                        63 => new Eth63ProtocolHandler(session, _serializer, _stats, _syncServer, _txPool, _gossipPolicy, _logManager),
-                        64 => new Eth64ProtocolHandler(session, _serializer, _stats, _syncServer, _txPool, _gossipPolicy, _specProvider, _logManager),
-                        65 => new Eth65ProtocolHandler(session, _serializer, _stats, _syncServer, _txPool, _pooledTxsRequestor, _gossipPolicy, _specProvider, _logManager),
                         66 => new Eth66ProtocolHandler(session, _serializer, _stats, _syncServer, _txPool, _pooledTxsRequestor, _gossipPolicy, _specProvider, _logManager),
                         _ => throw new NotSupportedException($"Eth protocol version {version} is not supported.")
                     };


### PR DESCRIPTION
Fixes | Closes | Resolves https://github.com/NethermindEth/nethermind/issues/3491

## Changes:
- drop old `eth` capabilities (`eth62`, `eth63`, `eth64`, `eth65`)
- remove handlers
- adjust tests

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes (adjusted existing ones)
- [ ] No