### PR TITLE
Remove depreated testnets from syncSettings.py

### DIFF
--- a/scripts/syncSettings.py
+++ b/scripts/syncSettings.py
@@ -24,23 +24,8 @@ configs = {
     "goerli": {
         "url": "api-goerli.etherscan.io",
         "blockReduced": 8192,
-        "multiplierRequirement": 30000 
-    },
-    "ropsten": {
-        "url": "api-ropsten.etherscan.io",
-        "blockReduced": 8192,
-        "multiplierRequirement": 10000
-    },
-    "rinkeby": {
-        "url": "api-rinkeby.etherscan.io",
-        "blockReduced": 8192,
         "multiplierRequirement": 30000
     },
-    "kovan": {
-        "url": "api-kovan.etherscan.io",
-        "blockReduced": 8192,
-        "multiplierRequirement": 10000
-    },     
     "poacore": {
         "url": "https://core.poa.network",
         "blockReduced": 8192,
@@ -75,7 +60,7 @@ configs = {
         "url": "https://volta-rpc.energyweb.org",
         "blockReduced": 8192,
         "multiplierRequirement": 10000
-    },   
+    },
     # mev section
     "mainnet_mev": {
         "url": "api.etherscan.io",
@@ -85,7 +70,7 @@ configs = {
     "goerli_mev": {
         "url": "api-goerli.etherscan.io",
         "blockReduced": 8192,
-        "multiplierRequirement": 30000 
+        "multiplierRequirement": 30000
     },
     "xdai_mev": {
         "url": "https://rpc.gnosischain.com",
@@ -101,7 +86,7 @@ configs = {
     "goerli_aa": {
         "url": "api-goerli.etherscan.io",
         "blockReduced": 8192,
-        "multiplierRequirement": 30000 
+        "multiplierRequirement": 30000
     },
     "xdai_aa": {
         "url": "https://rpc.gnosischain.com",


### PR DESCRIPTION
## Changes:
- Removes deprecated testnets (rinkeby, ropsten and kovan) from syncSettings.py since etherscan api is no longer available for this networks and this is causing the gh action to fail. See https://github.com/NethermindEth/nethermind/actions/runs/3212233312/jobs/5250917933

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [x] No