### PR TITLE
Fix/no bodies error on chiado

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.PayloadProduction.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.PayloadProduction.cs
@@ -281,7 +281,7 @@ public partial class EngineModuleTests
         improvementContextFactory.CreatedContexts.Should().OnlyContain(i => i.Disposed);
     }
 
-    [Test]
+    [Test, Retry(3)]
     public async Task getPayloadV1_picks_transactions_from_pool_constantly_improving_blocks()
     {
         using SemaphoreSlim blockImprovementLock = new(0);
@@ -307,13 +307,13 @@ public partial class EngineModuleTests
                 new PayloadAttributes { Timestamp = 100, PrevRandao = TestItem.KeccakA, SuggestedFeeRecipient = Address.Zero })
             .Result.Data.PayloadId!;
 
-        await blockImprovementLock.WaitAsync(100);
+        await blockImprovementLock.WaitAsync(100 * TestContext.CurrentContext.CurrentRepeatCount);
         chain.AddTransactions(BuildTransactions(chain, startingHead, TestItem.PrivateKeyC, TestItem.AddressA, 3, 10, out _, out _));
 
-        await blockImprovementLock.WaitAsync(100);
+        await blockImprovementLock.WaitAsync(100 * TestContext.CurrentContext.CurrentRepeatCount);
         chain.AddTransactions(BuildTransactions(chain, startingHead, TestItem.PrivateKeyA, TestItem.AddressC, 5, 10, out _, out _));
 
-        await blockImprovementLock.WaitAsync(100);
+        await blockImprovementLock.WaitAsync(100 * TestContext.CurrentContext.CurrentRepeatCount);
 
         ExecutionPayloadV1 getPayloadResult = (await rpc.engine_getPayloadV1(Bytes.FromHexString(payloadId))).Data!;
 

--- a/src/Nethermind/Nethermind.Network.Test/P2P/SessionTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/SessionTests.cs
@@ -308,6 +308,23 @@ namespace Nethermind.Network.Test.P2P
             session.Init(5, _channelHandlerContext, _packetSender);
             session.InitiateDisconnect(DisconnectReason.Other);
             Assert.True(wasCalled);
+            Assert.True(session.IsClosing);
+        }
+
+        [Test]
+        public void Do_not_disconnects_after_initiating_disconnect_on_static_node()
+        {
+            bool wasCalled = false;
+            Node node = new Node(TestItem.PublicKeyA, "127.0.0.1", 8545);
+            node.IsStatic = true;
+            Session session = new(30312, node, _channel, NullDisconnectsAnalyzer.Instance, LimboLogs.Instance);
+            session.Disconnecting += (s, e) => wasCalled = true;
+
+            session.Handshake(TestItem.PublicKeyA);
+            session.Init(5, _channelHandlerContext, _packetSender);
+            session.InitiateDisconnect(DisconnectReason.TooManyPeers);
+            Assert.False(wasCalled);
+            Assert.False(session.IsClosing);
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
@@ -312,6 +312,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
 
                 if (sizeEstimate > SoftOutgoingMessageSizeLimit)
                 {
+                    Array.Resize(ref blocks, i + 1);
                     break;
                 }
             }

--- a/src/Nethermind/Nethermind.Network/P2P/Session.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Session.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -379,6 +379,12 @@ namespace Nethermind.Network.P2P
                 }
             }
 
+            if (Node?.IsStatic == true && !ShouldDisconnectStaticNode())
+            {
+                if (_logger.IsTrace) _logger.Trace($"{this} not disconnecting for static peer on {disconnectReason} ({details})");
+                return;
+            }
+
             lock (_sessionStateLock)
             {
                 if (IsClosing)
@@ -387,12 +393,6 @@ namespace Nethermind.Network.P2P
                 }
 
                 State = SessionState.DisconnectingProtocols;
-            }
-
-            if (Node?.IsStatic == true && !ShouldDisconnectStaticNode())
-            {
-                if (_logger.IsTrace) _logger.Trace($"{this} not disconnecting for static peer on {disconnectReason} ({details})");
-                return;
             }
 
             if (_logger.IsTrace) _logger.Trace($"{this} disconnecting protocols");


### PR DESCRIPTION
- It seems that nethermind will pad response with null for too many bodies instead of truncating the response meaning if a nethermind instance request too many body from another nethermind instance it will disconnect it.

## Changes:
- Allow processing null padded get bodies response.
- Fix static peers state changed to 'disconnecting' when it skipped disconnecting, causing messages to get skipped.
- Truncate array when responding body.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [X] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [X] Yes
- [ ] No

**Comments about testing , should you have some** (optional)

- Tested by running two nethermind instance on chiado, one synced normally and another one with only one static peer, which is the other one.
- Issue no longer appear after change.

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...