### PR TITLE
Fix/4687 eth get filter logs different output for same params

### DIFF
--- a/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
@@ -301,6 +301,11 @@ namespace Nethermind.Facade
             return _logFinder.FindLogs(filter, cancellationToken);
         }
 
+        public IEnumerable<FilterLog> GetLogs(int filterId, CancellationToken cancellationToken = default)
+        {
+            return _logFinder.FindLogs(_filterStore.GetFilter<LogFilter>(filterId), cancellationToken);
+        }
+
         public int NewFilter(BlockParameter fromBlock, BlockParameter toBlock,
             object? address = null, IEnumerable<object>? topics = null)
         {

--- a/src/Nethermind/Nethermind.Facade/Filters/FilterStore.cs
+++ b/src/Nethermind/Nethermind.Facade/Filters/FilterStore.cs
@@ -56,6 +56,13 @@ namespace Nethermind.Blockchain.Filters
         public IEnumerable<T> GetFilters<T>() where T : FilterBase =>
             _filters.Select(f => f.Value).OfType<T>();
 
+        public T GetFilter<T>(int filterId) where T : FilterBase
+        {
+            return _filters.TryGetValue(filterId, out var filter)
+                ? filter as T
+                : throw new InvalidOperationException($"Filter with ID {filterId} not found");
+        }
+
         public BlockFilter CreateBlockFilter(long startBlockNumber, bool setId = true) =>
             new(GetFilterId(setId), startBlockNumber);
 

--- a/src/Nethermind/Nethermind.Facade/Filters/IFilterStore.cs
+++ b/src/Nethermind/Nethermind.Facade/Filters/IFilterStore.cs
@@ -24,6 +24,7 @@ namespace Nethermind.Blockchain.Filters
     {
         bool FilterExists(int filterId);
         IEnumerable<T> GetFilters<T>() where T : FilterBase;
+        T GetFilter<T>(int filterId) where T : FilterBase;
         BlockFilter CreateBlockFilter(long startBlockNumber, bool setId = true);
         PendingTransactionFilter CreatePendingTransactionFilter(bool setId = true);
 

--- a/src/Nethermind/Nethermind.Facade/Filters/NullFilterStore.cs
+++ b/src/Nethermind/Nethermind.Facade/Filters/NullFilterStore.cs
@@ -68,6 +68,11 @@ namespace Nethermind.Blockchain.Filters
             throw new InvalidOperationException($"{nameof(NullFilterStore)} does not support filter creation");
         }
 
+        public T GetFilter<T>(int filterId) where T : FilterBase
+        {
+            throw new InvalidOperationException($"Filter with ID {filterId} not found");
+        }
+
         public event EventHandler<FilterEventArgs> FilterRemoved
         {
             add { }

--- a/src/Nethermind/Nethermind.Facade/IBlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/IBlockchainBridge.cs
@@ -54,6 +54,7 @@ namespace Nethermind.Facade
         FilterLog[] GetFilterLogs(int filterId);
 
         IEnumerable<FilterLog> GetLogs(BlockParameter fromBlock, BlockParameter toBlock, object? address = null, IEnumerable<object>? topics = null, CancellationToken cancellationToken = default);
+        IEnumerable<FilterLog> GetLogs(int filterId, CancellationToken cancellationToken = default);
         void RunTreeVisitor(ITreeVisitor treeVisitor, Keccak stateRoot);
 
     }


### PR DESCRIPTION
Fixes #4687

## Changes:
Changed eth_getFilterLogs implementation to give same results as eth_getLogs for same input options.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No

**Comments about testing , should you have some** (optional)

## Further comments (optional)
https://docs.alchemy.com/reference/eth-getfilterlogs