### PR TITLE
Make sure reset state root is in a lock

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
@@ -127,27 +127,28 @@ namespace Nethermind.Synchronization.FastSync
             }
 
             if (_logger.IsTrace) _logger.Trace($"Removing pending request {batch}");
-            if (!_pendingRequests.TryRemove(batch, out _))
-            {
-                if (_logger.IsDebug) _logger.Debug($"Cannot remove pending request {batch}");
-                return SyncResponseHandlingResult.OK;
-            }
-
-            int requestLength = batch.RequestedNodes?.Length ?? 0;
-            int responseLength = batch.Responses?.Length ?? 0;
-
-            void AddAgainAllItems()
-            {
-                for (int i = 0; i < requestLength; i++)
-                {
-                    AddNodeToPending(batch.RequestedNodes![i], null, "missing", true);
-                }
-            }
 
             try
             {
                 lock (_handleWatch)
                 {
+                    if (!_pendingRequests.TryRemove(batch, out _))
+                    {
+                        if (_logger.IsDebug) _logger.Debug($"Cannot remove pending request {batch}");
+                        return SyncResponseHandlingResult.OK;
+                    }
+
+                    int requestLength = batch.RequestedNodes?.Length ?? 0;
+                    int responseLength = batch.Responses?.Length ?? 0;
+
+                    void AddAgainAllItems()
+                    {
+                        for (int i = 0; i < requestLength; i++)
+                        {
+                            AddNodeToPending(batch.RequestedNodes![i], null, "missing", true);
+                        }
+                    }
+
                     if (DateTime.UtcNow - _lastReview > TimeSpan.FromSeconds(60))
                     {
                         _lastReview = DateTime.UtcNow;
@@ -366,63 +367,66 @@ namespace Nethermind.Synchronization.FastSync
 
         public void ResetStateRoot(long blockNumber, Keccak stateRoot, SyncFeedState currentState)
         {
-            if (currentState != SyncFeedState.Dormant)
+            lock (_handleWatch)
             {
-                throw new InvalidOperationException("Cannot reset state sync on an active feed");
-            }
-
-            Interlocked.Exchange(ref _hintsToResetRoot, 0);
-
-            if (_logger.IsInfo) _logger.Info($"Setting state sync state root to {blockNumber} {stateRoot}");
-            _currentSyncStart = DateTime.UtcNow;
-            _currentSyncStartSecondsInSync = _data.SecondsInSync;
-
-            _data.LastReportTime = (DateTime.UtcNow, DateTime.UtcNow);
-            _data.LastSavedNodesCount = _data.SavedNodesCount;
-            _data.LastRequestedNodesCount = _data.RequestedNodesCount;
-            if (_rootNode != stateRoot)
-            {
-                _branchProgress = new BranchProgress(blockNumber, _logger);
-                _blockNumber = blockNumber;
-                _rootNode = stateRoot;
-                lock (_dependencies) _dependencies.Clear();
-                lock (_codesSameAsNodes) _codesSameAsNodes.Clear();
-
-                if (_logger.IsDebug) _logger.Debug($"Clearing node stacks ({_pendingItems.Description})");
-                _pendingItems.Clear();
-                Interlocked.Exchange(ref _rootSaved, 0);
-            }
-            else
-            {
-                foreach ((StateSyncBatch pendingRequest, _) in _pendingRequests)
+                if (currentState != SyncFeedState.Dormant)
                 {
-                    // re-add the pending request
-                    for (int i = 0; i < pendingRequest.RequestedNodes.Length; i++)
-                    {
-                        AddNodeToPending(pendingRequest.RequestedNodes[i], null, "pending request", true);
-                    }
+                    throw new InvalidOperationException("Cannot reset state sync on an active feed");
                 }
-            }
 
-            _pendingRequests.Clear();
+                Interlocked.Exchange(ref _hintsToResetRoot, 0);
 
-            bool hasOnlyRootNode = false;
+                if (_logger.IsInfo) _logger.Info($"Setting state sync state root to {blockNumber} {stateRoot}");
+                _currentSyncStart = DateTime.UtcNow;
+                _currentSyncStartSecondsInSync = _data.SecondsInSync;
 
-            if (_rootNode != Keccak.EmptyTreeHash)
-            {
-                if (_pendingItems.Count == 1)
+                _data.LastReportTime = (DateTime.UtcNow, DateTime.UtcNow);
+                _data.LastSavedNodesCount = _data.SavedNodesCount;
+                _data.LastRequestedNodesCount = _data.RequestedNodesCount;
+                if (_rootNode != stateRoot)
                 {
-                    // state root can only be located on state stream
-                    StateSyncItem? potentialRoot = _pendingItems.PeekState();
-                    if (potentialRoot?.Hash == _rootNode)
+                    _branchProgress = new BranchProgress(blockNumber, _logger);
+                    _blockNumber = blockNumber;
+                    _rootNode = stateRoot;
+                    lock (_dependencies) _dependencies.Clear();
+                    lock (_codesSameAsNodes) _codesSameAsNodes.Clear();
+
+                    if (_logger.IsDebug) _logger.Debug($"Clearing node stacks ({_pendingItems.Description})");
+                    _pendingItems.Clear();
+                    Interlocked.Exchange(ref _rootSaved, 0);
+                }
+                else
+                {
+                    foreach ((StateSyncBatch pendingRequest, _) in _pendingRequests)
                     {
-                        hasOnlyRootNode = true;
+                        // re-add the pending request
+                        for (int i = 0; i < pendingRequest.RequestedNodes.Length; i++)
+                        {
+                            AddNodeToPending(pendingRequest.RequestedNodes[i], null, "pending request", true);
+                        }
                     }
                 }
 
-                if (!hasOnlyRootNode)
+                _pendingRequests.Clear();
+
+                bool hasOnlyRootNode = false;
+
+                if (_rootNode != Keccak.EmptyTreeHash)
                 {
-                    AddNodeToPending(new StateSyncItem(_rootNode, null, null, NodeDataType.State), null, "initial");
+                    if (_pendingItems.Count == 1)
+                    {
+                        // state root can only be located on state stream
+                        StateSyncItem? potentialRoot = _pendingItems.PeekState();
+                        if (potentialRoot?.Hash == _rootNode)
+                        {
+                            hasOnlyRootNode = true;
+                        }
+                    }
+
+                    if (!hasOnlyRootNode)
+                    {
+                        AddNodeToPending(new StateSyncItem(_rootNode, null, null, NodeDataType.State), null, "initial");
+                    }
                 }
             }
         }


### PR DESCRIPTION
Probably fixes #4776

- Missed lock on `ResetStateRoot` which may cause the pending request to happen at the same time as a current state sync processing, which may explain fast sync corruption.

## Changes:
- Wrap with loc.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [X] Yes
- [ ]No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [X] No

**Comments about testing , should you have some** (optional)

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...