### PR TITLE
Fix issue 4666

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.DelayBlockImprovementContextFactory.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.DelayBlockImprovementContextFactory.cs
@@ -41,8 +41,14 @@ public partial class EngineModuleTests
             _delay = delay;
         }
 
-        public IBlockImprovementContext StartBlockImprovementContext(Block currentBestBlock, BlockHeader parentHeader, PayloadAttributes payloadAttributes, DateTimeOffset startDateTime) =>
-            new DelayBlockImprovementContext(currentBestBlock, _productionTrigger, _timeout, parentHeader, payloadAttributes, _delay, startDateTime);
+        public IBlockImprovementContext StartBlockImprovementContext(Block currentBestBlock, BlockHeader parentHeader, PayloadAttributes payloadAttributes, TimeSpan startTimeStamp) =>
+            new DelayBlockImprovementContext(currentBestBlock,
+                _productionTrigger,
+                _timeout,
+                parentHeader,
+                payloadAttributes,
+                _delay,
+                startTimeStamp);
     }
 
     private class DelayBlockImprovementContext : IBlockImprovementContext
@@ -55,11 +61,11 @@ public partial class EngineModuleTests
             BlockHeader parentHeader,
             PayloadAttributes payloadAttributes,
             TimeSpan delay,
-            DateTimeOffset startDateTime)
+            TimeSpan startTimeStamp)
         {
             _cancellationTokenSource = new CancellationTokenSource(timeout);
             CurrentBestBlock = currentBestBlock;
-            StartDateTime = startDateTime;
+            StartTimeStamp = startTimeStamp;
             ImprovementTask = BuildBlock(blockProductionTrigger, parentHeader, payloadAttributes, delay, _cancellationTokenSource.Token);
         }
 
@@ -83,7 +89,7 @@ public partial class EngineModuleTests
         public Task<Block?> ImprovementTask { get; }
         public Block? CurrentBestBlock { get; private set; }
         public bool Disposed { get; private set; }
-        public DateTimeOffset StartDateTime { get; }
+        public TimeSpan StartTimeStamp { get; }
 
         public void Dispose()
         {

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.MockBlockImprovementContextFactory.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.MockBlockImprovementContextFactory.cs
@@ -30,16 +30,16 @@ public partial class EngineModuleTests
 {
     private class MockBlockImprovementContextFactory : IBlockImprovementContextFactory
     {
-        public IBlockImprovementContext StartBlockImprovementContext(Block currentBestBlock, BlockHeader parentHeader, PayloadAttributes payloadAttributes, DateTimeOffset startDateTime) =>
-            new MockBlockImprovementContext(currentBestBlock, startDateTime);
+        public IBlockImprovementContext StartBlockImprovementContext(Block currentBestBlock, BlockHeader parentHeader, PayloadAttributes payloadAttributes, TimeSpan startTimeStamp) =>
+            new MockBlockImprovementContext(currentBestBlock, startTimeStamp);
     }
 
     private class MockBlockImprovementContext : IBlockImprovementContext
     {
-        public MockBlockImprovementContext(Block currentBestBlock, DateTimeOffset startDateTime)
+        public MockBlockImprovementContext(Block currentBestBlock, TimeSpan startDateTime)
         {
             CurrentBestBlock = currentBestBlock;
-            StartDateTime = startDateTime;
+            StartTimeStamp = startDateTime;
             ImprovementTask = Task.FromResult((Block?)currentBestBlock);
         }
 
@@ -47,6 +47,6 @@ public partial class EngineModuleTests
         public Task<Block?> ImprovementTask { get; }
         public Block? CurrentBestBlock { get; }
         public bool Disposed { get; private set; }
-        public DateTimeOffset StartDateTime { get; }
+        public TimeSpan StartTimeStamp { get; }
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.StoringBlockImprovementContextFactory.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.StoringBlockImprovementContextFactory.cs
@@ -41,9 +41,13 @@ public partial class EngineModuleTests
             _blockImprovementContextFactory = blockImprovementContextFactory;
         }
 
-        public IBlockImprovementContext StartBlockImprovementContext(Block currentBestBlock, BlockHeader parentHeader, PayloadAttributes payloadAttributes, DateTimeOffset startDateTime)
+        public IBlockImprovementContext StartBlockImprovementContext(
+            Block currentBestBlock,
+            BlockHeader parentHeader,
+            PayloadAttributes payloadAttributes,
+            TimeSpan startTimeStamp)
         {
-            IBlockImprovementContext blockImprovementContext = _blockImprovementContextFactory.StartBlockImprovementContext(currentBestBlock, parentHeader, payloadAttributes, startDateTime);
+            IBlockImprovementContext blockImprovementContext = _blockImprovementContextFactory.StartBlockImprovementContext(currentBestBlock, parentHeader, payloadAttributes, startTimeStamp);
             CreatedContexts.Add(blockImprovementContext);
             Task.Run(() => ImprovementStarted?.Invoke(this, new ImprovementStartedEventArgs(blockImprovementContext)));
             return blockImprovementContext;

--- a/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/BlockImprovementContext.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/BlockImprovementContext.cs
@@ -34,11 +34,11 @@ public class BlockImprovementContext : IBlockImprovementContext
         TimeSpan timeout,
         BlockHeader parentHeader,
         PayloadAttributes payloadAttributes,
-        DateTimeOffset startDateTime)
+        TimeSpan startTimeStamp)
     {
         _cancellationTokenSource = new CancellationTokenSource(timeout);
         CurrentBestBlock = currentBestBlock;
-        StartDateTime = startDateTime;
+        StartTimeStamp = startTimeStamp;
         ImprovementTask = blockProductionTrigger
             .BuildBlock(parentHeader, _cancellationTokenSource.Token, NullBlockTracer.Instance, payloadAttributes)
             .ContinueWith(SetCurrentBestBlock, _cancellationTokenSource.Token);
@@ -62,7 +62,7 @@ public class BlockImprovementContext : IBlockImprovementContext
     }
 
     public bool Disposed { get; private set; }
-    public DateTimeOffset StartDateTime { get; }
+    public TimeSpan StartTimeStamp { get; }
 
     public void Dispose()
     {

--- a/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/BlockImprovementContextFactory.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/BlockImprovementContextFactory.cs
@@ -27,7 +27,8 @@ public class BlockImprovementContextFactory : IBlockImprovementContextFactory
     private readonly IManualBlockProductionTrigger _blockProductionTrigger;
     private readonly TimeSpan _timeout;
 
-    public BlockImprovementContextFactory(IManualBlockProductionTrigger blockProductionTrigger, TimeSpan timeout)
+    public BlockImprovementContextFactory(IManualBlockProductionTrigger blockProductionTrigger,
+        TimeSpan timeout)
     {
         _blockProductionTrigger = blockProductionTrigger;
         _timeout = timeout;
@@ -37,6 +38,6 @@ public class BlockImprovementContextFactory : IBlockImprovementContextFactory
         Block currentBestBlock,
         BlockHeader parentHeader,
         PayloadAttributes payloadAttributes,
-        DateTimeOffset startDateTime) =>
-        new BlockImprovementContext(currentBestBlock, _blockProductionTrigger, _timeout, parentHeader, payloadAttributes, startDateTime);
+        TimeSpan startTimeStamp) =>
+        new BlockImprovementContext(currentBestBlock, _blockProductionTrigger, _timeout, parentHeader, payloadAttributes, startTimeStamp);
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/Boost/BoostBlockImprovementContext.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/Boost/BoostBlockImprovementContext.cs
@@ -43,13 +43,13 @@ public class BoostBlockImprovementContext : IBlockImprovementContext
         PayloadAttributes payloadAttributes,
         IBoostRelay boostRelay,
         IStateReader stateReader,
-        DateTimeOffset startDateTime)
+        TimeSpan startTimeStamp)
     {
         _boostRelay = boostRelay;
         _stateReader = stateReader;
         _cancellationTokenSource = new CancellationTokenSource(timeout);
         CurrentBestBlock = currentBestBlock;
-        StartDateTime = startDateTime;
+        StartTimeStamp = startTimeStamp;
         ImprovementTask = StartImprovingBlock(blockProductionTrigger, parentHeader, payloadAttributes, _cancellationTokenSource.Token);
     }
 
@@ -76,7 +76,7 @@ public class BoostBlockImprovementContext : IBlockImprovementContext
     public Task<Block?> ImprovementTask { get; }
     public Block? CurrentBestBlock { get; private set; }
     public bool Disposed { get; private set; }
-    public DateTimeOffset StartDateTime { get; }
+    public TimeSpan StartTimeStamp { get; }
 
     public void Dispose()
     {

--- a/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/Boost/BoostBlockImprovementContextFactory.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/Boost/BoostBlockImprovementContextFactory.cs
@@ -43,6 +43,13 @@ public class BoostBlockImprovementContextFactory : IBlockImprovementContextFacto
         Block currentBestBlock,
         BlockHeader parentHeader,
         PayloadAttributes payloadAttributes,
-        DateTimeOffset startDateTime) =>
-        new BoostBlockImprovementContext(currentBestBlock, _blockProductionTrigger, _timeout, parentHeader, payloadAttributes, _boostRelay, _stateReader, startDateTime);
+        TimeSpan startTimeStamp) =>
+        new BoostBlockImprovementContext(currentBestBlock,
+            _blockProductionTrigger,
+            _timeout,
+            parentHeader,
+            payloadAttributes,
+            _boostRelay,
+            _stateReader,
+            startTimeStamp);
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/IBlockImprovementContext.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/IBlockImprovementContext.cs
@@ -26,5 +26,5 @@ public interface IBlockImprovementContext : IDisposable
     Task<Block?> ImprovementTask { get; }
     Block? CurrentBestBlock { get; }
     bool Disposed { get; }
-    DateTimeOffset StartDateTime { get; }
+    TimeSpan StartTimeStamp { get; }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/IBlockImprovementContextFactory.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/IBlockImprovementContextFactory.cs
@@ -27,5 +27,5 @@ public interface IBlockImprovementContextFactory
         Block currentBestBlock,
         BlockHeader parentHeader,
         PayloadAttributes payloadAttributes,
-        DateTimeOffset startDateTime);
+        TimeSpan startTimeStamp);
 }


### PR DESCRIPTION
Now using Stopwatch [independent](https://stackoverflow.com/a/12509159/1973207) of system Date time settings.

Resolves #4666

## Changes:
- Switched from DateTimeOffset bound to UtcNow to a single Stopwatch bound to the PayloadPreparationService
- Updated, relevant use cases

## Types of changes
Introduced the use of a Stopwatch to in PayloadPreparationService instead of UtcNow as @LukaszRozmej suggested. No UtcNow passing is needed for it now.

As suggested in #4666 approach to utilize N best blocks was not required and was not employed due to heavy dependency on TimeSpans of surrounding code.

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**
related to block creation.

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**
No new tests were created in this PR, as old code coverage is relevant.
- [ ] Yes
- [x] No