### PR TITLE
Fix workflow to pass parameters to scripts

### DIFF
--- a/.github/workflows/build-nethermind-packages.yml
+++ b/.github/workflows/build-nethermind-packages.yml
@@ -1,6 +1,11 @@
 name: '[BUILD] Nethermind packages'
 
-on: workflow_dispatch
+on: 
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'The version tag'
+        required: true
 
 jobs:
   build-nethermind:
@@ -20,36 +25,43 @@ jobs:
       LINUX_ARM64: linux-arm64
     steps:
     - name: Checking out Nethermind repository
-      uses: actions/checkout@master
+      uses: actions/checkout@v3
       with:
         submodules: recursive
         path: nethermind
-        fetch-depth: 0
+        ref: ${{ github.event.inputs.tag }}
     - name: Checking out Nethermind Launcher repository
-      uses: actions/checkout@master
+      uses: actions/checkout@v3
       with:
         repository: NethermindEth/nethermind.launcher
         path: launcher
     - name: Setting up Node.js
-      uses: actions/setup-node@master
+      uses: actions/setup-node@v3
       with:
         node-version: "14"
     - name: Setting up Build Environment
       run: |
         npm i pkg @vercel/ncc -g
     - name: Setting up dotnet
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v2
       with:
         dotnet-version: '6.0.x'
     - name: Setting up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
     - name: Setting up Docker Buildx
       id: buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
     - name: Setting up Packages
       run: ./nethermind/scripts/deployment/setup-packages.sh
     - name: Building Runner
-      run: ./nethermind/scripts/deployment/build-runner.sh
+      id: build-runner
+      run: |
+        cd nethermind/
+        build_timestamp=$(date '+%s')
+        commit_hash=$(git describe --always --exclude=* --abbrev=40)
+        echo "BUILD_TIMESTAMP=$build_timestamp" >> $GITHUB_OUTPUT
+        echo "COMMIT_HASH=$commit_hash" >> $GITHUB_OUTPUT
+        ./scripts/deployment/build-runner.sh ${{ github.event.inputs.tag }} $commit_hash $build_timestamp
     - name: Building Cli
       run: ./nethermind/scripts/deployment/build-cli.sh
     - name: Building Launcher
@@ -61,28 +73,28 @@ jobs:
         docker run --platform=linux/arm64 -v $PWD:/opt/mount --rm tmp-launcher bash -c "cp /nethermind/Nethermind.Launcher /opt/mount/"
         mv Nethermind.Launcher ${{ env.RELEASE_DIRECTORY }}/${{ env.LIN_ARM64_RELEASE }}/Nethermind.Launcher
     - name: Archiving packages
-      run: ./nethermind/scripts/deployment/archive-packages.sh
-    - uses: actions/upload-artifact@master
+      run: ./nethermind/scripts/deployment/archive-packages.sh ${{ github.event.inputs.tag }} ${{ steps.build-runner.outputs.COMMIT_HASH }} ${{ steps.build-runner.outputs.BUILD_TIMESTAMP}}
+    - uses: actions/upload-artifact@v3
       name: Uploading Nethermind darwin package
       with:
         name: nethermind-darwin-package
         path: ${{ env.RELEASE_DIRECTORY }}/${{ env.OSX_RELEASE }}/nethermind-darwin-amd64-*
-    - uses: actions/upload-artifact@master
+    - uses: actions/upload-artifact@v3
       name: Uploading Nethermind darwin arm64 package
       with:
         name: nethermind-darwin-arm64-package
         path: ${{ env.RELEASE_DIRECTORY }}/${{ env.OSX_ARM64_RELEASE }}/nethermind-darwin-arm64-*
-    - uses: actions/upload-artifact@master
+    - uses: actions/upload-artifact@v3
       name: Uploading Nethermind linux package
       with:
         name: nethermind-linux-package
         path: ${{ env.RELEASE_DIRECTORY }}/${{ env.LIN_RELEASE }}/nethermind-linux-amd64-*
-    - uses: actions/upload-artifact@master
+    - uses: actions/upload-artifact@v3
       name: Uploading Nethermind windows package
       with:
         name: nethermind-windows-package
         path: ${{ env.RELEASE_DIRECTORY }}/${{ env.WIN_RELEASE }}/nethermind-windows-amd64-*
-    - uses: actions/upload-artifact@master
+    - uses: actions/upload-artifact@v3
       name: Uploading Nethermind linux arm64 package
       with:
         name: nethermind-linux-arm64-package


### PR DESCRIPTION
Fixes the broken `build-nethermind-packages.yml` to support product version changes.

## Changes:
- Added a `tag` input parameter to the GitHub Actions workflow script
- Passed commit hash and build timestamp parameters to the underlying deployment scripts

## Types of changes

What types of changes does your code introduce?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [x] No

The `build-nethermind-packages.yml` has been tested manually.
