### PR TITLE
Reduce number of reads from AccountState inside TxPool::SubmitTx

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/TxFilterAdapter.cs
+++ b/src/Nethermind/Nethermind.Consensus/TxFilterAdapter.cs
@@ -1,19 +1,19 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using System;
 using Nethermind.Blockchain;
@@ -38,7 +38,7 @@ namespace Nethermind.Consensus
             _blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
         }
 
-        public AcceptTxResult Accept(Transaction tx, TxHandlingOptions txHandlingOptions)
+        public AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions txHandlingOptions)
         {
             if (tx is not GeneratedTransaction)
             {

--- a/src/Nethermind/Nethermind.TxPool/Filters/AlreadyKnownTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/AlreadyKnownTxFilter.cs
@@ -1,19 +1,19 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using Nethermind.Core;
 
@@ -34,7 +34,7 @@ namespace Nethermind.TxPool.Filters
             _hashCache = hashCache;
         }
 
-        public AcceptTxResult Accept(Transaction tx, TxHandlingOptions handlingOptions)
+        public AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions handlingOptions)
         {
             if (_hashCache.Get(tx.Hash!))
             {

--- a/src/Nethermind/Nethermind.TxPool/Filters/DeployedCodeFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/DeployedCodeFilter.cs
@@ -1,19 +1,19 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using Nethermind.Core;
 using Nethermind.Core.Specs;
@@ -33,7 +33,7 @@ namespace Nethermind.TxPool.Filters
             _specProvider = specProvider;
             _stateProvider = stateProvider;
         }
-        public AcceptTxResult Accept(Transaction tx, TxHandlingOptions txHandlingOptions) =>
+        public AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions txHandlingOptions) =>
             _stateProvider.IsInvalidContractSender(_specProvider.GetCurrentHeadSpec(), tx.SenderAddress!)
                 ? AcceptTxResult.SenderIsContract
                 : AcceptTxResult.Accepted;

--- a/src/Nethermind/Nethermind.TxPool/Filters/FeeTooLowFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/FeeTooLowFilter.cs
@@ -31,23 +31,19 @@ namespace Nethermind.TxPool.Filters
     {
         private readonly IChainHeadSpecProvider _specProvider;
         private readonly IChainHeadInfoProvider _headInfo;
-        private readonly IAccountStateProvider _accounts;
         private readonly TxDistinctSortedPool _txs;
         private readonly ILogger _logger;
 
-        public FeeTooLowFilter(IChainHeadInfoProvider headInfo, IAccountStateProvider accountStateProvider, TxDistinctSortedPool txs, ILogManager logManager)
+        public FeeTooLowFilter(IChainHeadInfoProvider headInfo, TxDistinctSortedPool txs, ILogManager logManager)
         {
             _specProvider = headInfo.SpecProvider;
             _headInfo = headInfo;
-            _accounts = accountStateProvider;
             _txs = txs;
             _logger = logManager.GetClassLogger();
         }
 
         public AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions handlingOptions)
         {
-            state.SenderAccount ??= _accounts.GetAccount(tx.SenderAddress!);
-
             IReleaseSpec spec = _specProvider.GetCurrentHeadSpec();
             UInt256 balance = state.SenderAccount.Balance;
             UInt256 affordableGasPrice = tx.CalculateAffordableGasPrice(spec.IsEip1559Enabled, _headInfo.CurrentBaseFee, balance);

--- a/src/Nethermind/Nethermind.TxPool/Filters/FeeTooLowFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/FeeTooLowFilter.cs
@@ -1,19 +1,19 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using System.Diagnostics;
 using Nethermind.Core;
@@ -44,10 +44,12 @@ namespace Nethermind.TxPool.Filters
             _logger = logManager.GetClassLogger();
         }
 
-        public AcceptTxResult Accept(Transaction tx, TxHandlingOptions handlingOptions)
+        public AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions handlingOptions)
         {
+            state.SenderAccount ??= _accounts.GetAccount(tx.SenderAddress!);
+
             IReleaseSpec spec = _specProvider.GetCurrentHeadSpec();
-            Account account = _accounts.GetAccount(tx.SenderAddress!);
+            Account account = state.SenderAccount;
             UInt256 balance = account.Balance;
             UInt256 affordableGasPrice = tx.CalculateAffordableGasPrice(spec.IsEip1559Enabled, _headInfo.CurrentBaseFee, balance);
             bool isNotLocal = (handlingOptions & TxHandlingOptions.PersistentBroadcast) != TxHandlingOptions.PersistentBroadcast;

--- a/src/Nethermind/Nethermind.TxPool/Filters/FeeTooLowFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/FeeTooLowFilter.cs
@@ -49,8 +49,7 @@ namespace Nethermind.TxPool.Filters
             state.SenderAccount ??= _accounts.GetAccount(tx.SenderAddress!);
 
             IReleaseSpec spec = _specProvider.GetCurrentHeadSpec();
-            Account account = state.SenderAccount;
-            UInt256 balance = account.Balance;
+            UInt256 balance = state.SenderAccount.Balance;
             UInt256 affordableGasPrice = tx.CalculateAffordableGasPrice(spec.IsEip1559Enabled, _headInfo.CurrentBaseFee, balance);
             bool isNotLocal = (handlingOptions & TxHandlingOptions.PersistentBroadcast) != TxHandlingOptions.PersistentBroadcast;
 

--- a/src/Nethermind/Nethermind.TxPool/Filters/GapNonceFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/GapNonceFilter.cs
@@ -29,20 +29,16 @@ namespace Nethermind.TxPool.Filters
     internal class GapNonceFilter : IIncomingTxFilter
     {
         private readonly TxDistinctSortedPool _txs;
-        private readonly IAccountStateProvider _accounts;
         private readonly ILogger _logger;
 
-        public GapNonceFilter(IAccountStateProvider accountStateProvider, TxDistinctSortedPool txs, ILogger logger)
+        public GapNonceFilter(TxDistinctSortedPool txs, ILogger logger)
         {
             _txs = txs;
-            _accounts = accountStateProvider;
             _logger = logger;
         }
 
         public AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions handlingOptions)
         {
-            state.SenderAccount ??= _accounts.GetAccount(tx.SenderAddress!);
-
             int numberOfSenderTxsInPending = _txs.GetBucketCount(tx.SenderAddress);
             bool isTxPoolFull = _txs.IsFull();
             UInt256 currentNonce = state.SenderAccount.Nonce;

--- a/src/Nethermind/Nethermind.TxPool/Filters/GapNonceFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/GapNonceFilter.cs
@@ -1,19 +1,19 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using Nethermind.Core;
 using Nethermind.Int256;
@@ -39,11 +39,13 @@ namespace Nethermind.TxPool.Filters
             _logger = logger;
         }
 
-        public AcceptTxResult Accept(Transaction tx, TxHandlingOptions handlingOptions)
+        public AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions handlingOptions)
         {
+            state.SenderAccount ??= _accounts.GetAccount(tx.SenderAddress!);
+
             int numberOfSenderTxsInPending = _txs.GetBucketCount(tx.SenderAddress);
             bool isTxPoolFull = _txs.IsFull();
-            UInt256 currentNonce = _accounts.GetAccount(tx.SenderAddress!).Nonce;
+            UInt256 currentNonce = state.SenderAccount.Nonce;
             long nextNonceInOrder = (long)currentNonce + numberOfSenderTxsInPending;
             bool isTxNonceNextInOrder = tx.Nonce <= nextNonceInOrder;
             if (isTxPoolFull && !isTxNonceNextInOrder)

--- a/src/Nethermind/Nethermind.TxPool/Filters/GasLimitTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/GasLimitTxFilter.cs
@@ -1,19 +1,19 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using System;
 using Nethermind.Core;
@@ -38,7 +38,7 @@ namespace Nethermind.TxPool.Filters
             _configuredGasLimit = txPoolConfig.GasLimit ?? long.MaxValue;
         }
 
-        public AcceptTxResult Accept(Transaction tx, TxHandlingOptions handlingOptions)
+        public AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions handlingOptions)
         {
             long gasLimit = Math.Min(_chainHeadInfoProvider.BlockGasLimit ?? long.MaxValue, _configuredGasLimit);
             if (tx.GasLimit > gasLimit)

--- a/src/Nethermind/Nethermind.TxPool/Filters/IIncomingTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/IIncomingTxFilter.cs
@@ -1,19 +1,19 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using Nethermind.Core;
 
@@ -25,6 +25,6 @@ namespace Nethermind.TxPool.Filters
     /// </summary>
     public interface IIncomingTxFilter
     {
-        AcceptTxResult Accept(Transaction tx, TxHandlingOptions txHandlingOptions);
+        AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions txHandlingOptions);
     }
 }

--- a/src/Nethermind/Nethermind.TxPool/Filters/LowNonceFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/LowNonceFilter.cs
@@ -1,19 +1,19 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using Nethermind.Core;
 using Nethermind.Int256;
@@ -35,13 +35,15 @@ namespace Nethermind.TxPool.Filters
             _logger = logger;
         }
 
-        public AcceptTxResult Accept(Transaction tx, TxHandlingOptions handlingOptions)
+        public AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions handlingOptions)
         {
             // As we have limited number of transaction that we store in mem pool its fairly easy to fill it up with
             // high-priority garbage transactions. We need to filter them as much as possible to use the tx pool space
             // efficiently. One call to get account from state is not that costly and it only happens after previous checks.
             // This was modeled by OpenEthereum behavior.
-            Account account = _accounts.GetAccount(tx.SenderAddress!);
+            state.SenderAccount ??= _accounts.GetAccount(tx.SenderAddress!);
+
+            Account account = state.SenderAccount;
             UInt256 currentNonce = account.Nonce;
             if (tx.Nonce < currentNonce)
             {

--- a/src/Nethermind/Nethermind.TxPool/Filters/LowNonceFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/LowNonceFilter.cs
@@ -26,12 +26,10 @@ namespace Nethermind.TxPool.Filters
     /// </summary>
     internal class LowNonceFilter : IIncomingTxFilter
     {
-        private readonly IAccountStateProvider _accounts;
         private readonly ILogger _logger;
 
-        public LowNonceFilter(IAccountStateProvider accountStateProvider, ILogger logger)
+        public LowNonceFilter(ILogger logger)
         {
-            _accounts = accountStateProvider;
             _logger = logger;
         }
 
@@ -41,8 +39,6 @@ namespace Nethermind.TxPool.Filters
             // high-priority garbage transactions. We need to filter them as much as possible to use the tx pool space
             // efficiently. One call to get account from state is not that costly and it only happens after previous checks.
             // This was modeled by OpenEthereum behavior.
-            state.SenderAccount ??= _accounts.GetAccount(tx.SenderAddress!);
-
             Account account = state.SenderAccount;
             UInt256 currentNonce = account.Nonce;
             if (tx.Nonce < currentNonce)

--- a/src/Nethermind/Nethermind.TxPool/Filters/MalformedTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/MalformedTxFilter.cs
@@ -1,19 +1,19 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using Nethermind.Core;
 using Nethermind.Core.Specs;
@@ -37,7 +37,7 @@ namespace Nethermind.TxPool.Filters
             _logger = logger;
         }
 
-        public AcceptTxResult Accept(Transaction tx, TxHandlingOptions txHandlingOptions)
+        public AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions txHandlingOptions)
         {
             IReleaseSpec spec = _specProvider.GetCurrentHeadSpec();
             if (!_txValidator.IsWellFormed(tx, spec))

--- a/src/Nethermind/Nethermind.TxPool/Filters/NullHashTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/NullHashTxFilter.cs
@@ -1,19 +1,19 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using Nethermind.Core;
 
@@ -26,7 +26,7 @@ namespace Nethermind.TxPool.Filters
     /// </summary>
     internal class NullHashTxFilter : IIncomingTxFilter
     {
-        public AcceptTxResult Accept(Transaction tx, TxHandlingOptions handlingOptions)
+        public AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions handlingOptions)
         {
             if (tx.Hash is null)
             {

--- a/src/Nethermind/Nethermind.TxPool/Filters/NullIncomingTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/NullIncomingTxFilter.cs
@@ -1,19 +1,19 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using Nethermind.Core;
 
@@ -25,7 +25,7 @@ namespace Nethermind.TxPool.Filters
 
         public static IIncomingTxFilter Instance { get; } = new NullIncomingTxFilter();
 
-        public AcceptTxResult Accept(Transaction tx, TxHandlingOptions txHandlingOptions)
+        public AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions txHandlingOptions)
         {
             return AcceptTxResult.Accepted;
         }

--- a/src/Nethermind/Nethermind.TxPool/Filters/ReusedOwnNonceTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/ReusedOwnNonceTxFilter.cs
@@ -1,19 +1,19 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using System.Collections.Concurrent;
 using Nethermind.Core;
@@ -40,10 +40,12 @@ namespace Nethermind.TxPool.Filters
             _logger = logger;
         }
 
-        public AcceptTxResult Accept(Transaction tx, TxHandlingOptions handlingOptions)
+        public AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions handlingOptions)
         {
+            state.SenderAccount ??= _accounts.GetAccount(tx.SenderAddress!);
+
             bool managedNonce = (handlingOptions & TxHandlingOptions.ManagedNonce) == TxHandlingOptions.ManagedNonce;
-            Account account = _accounts.GetAccount(tx.SenderAddress!);
+            Account account = state.SenderAccount;
             UInt256 currentNonce = account.Nonce;
 
             if (managedNonce && CheckOwnTransactionAlreadyUsed(tx, currentNonce))

--- a/src/Nethermind/Nethermind.TxPool/Filters/ReusedOwnNonceTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/ReusedOwnNonceTxFilter.cs
@@ -29,21 +29,17 @@ namespace Nethermind.TxPool.Filters
     internal class ReusedOwnNonceTxFilter : IIncomingTxFilter
     {
         private readonly object _locker = new();
-        private readonly IAccountStateProvider _accounts;
         private readonly ConcurrentDictionary<Address, TxPool.AddressNonces> _nonces;
         private readonly ILogger _logger;
 
-        public ReusedOwnNonceTxFilter(IAccountStateProvider accountStateProvider, ConcurrentDictionary<Address, TxPool.AddressNonces> nonces, ILogger logger)
+        public ReusedOwnNonceTxFilter(ConcurrentDictionary<Address, TxPool.AddressNonces> nonces, ILogger logger)
         {
-            _accounts = accountStateProvider;
             _nonces = nonces;
             _logger = logger;
         }
 
         public AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions handlingOptions)
         {
-            state.SenderAccount ??= _accounts.GetAccount(tx.SenderAddress!);
-
             bool managedNonce = (handlingOptions & TxHandlingOptions.ManagedNonce) == TxHandlingOptions.ManagedNonce;
             Account account = state.SenderAccount;
             UInt256 currentNonce = account.Nonce;

--- a/src/Nethermind/Nethermind.TxPool/Filters/TooExpensiveTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/TooExpensiveTxFilter.cs
@@ -31,22 +31,18 @@ namespace Nethermind.TxPool.Filters
         private readonly IChainHeadSpecProvider _specProvider;
         private readonly IChainHeadInfoProvider _headInfo;
         private readonly TxDistinctSortedPool _txs;
-        private readonly IAccountStateProvider _accounts;
         private readonly ILogger _logger;
 
-        public TooExpensiveTxFilter(IChainHeadInfoProvider headInfo, IAccountStateProvider accountStateProvider, TxDistinctSortedPool txs, ILogger logger)
+        public TooExpensiveTxFilter(IChainHeadInfoProvider headInfo, TxDistinctSortedPool txs, ILogger logger)
         {
             _specProvider = headInfo.SpecProvider;
             _headInfo = headInfo;
             _txs = txs;
-            _accounts = accountStateProvider;
             _logger = logger;
         }
 
         public AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions handlingOptions)
         {
-            state.SenderAccount ??= _accounts.GetAccount(tx.SenderAddress!);
-
             IReleaseSpec spec = _specProvider.GetCurrentHeadSpec();
             Account account = state.SenderAccount;
             UInt256 balance = account.Balance;

--- a/src/Nethermind/Nethermind.TxPool/Filters/TooExpensiveTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/TooExpensiveTxFilter.cs
@@ -1,19 +1,19 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using Nethermind.Core;
 using Nethermind.Core.Specs;
@@ -43,10 +43,12 @@ namespace Nethermind.TxPool.Filters
             _logger = logger;
         }
 
-        public AcceptTxResult Accept(Transaction tx, TxHandlingOptions handlingOptions)
+        public AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions handlingOptions)
         {
+            state.SenderAccount ??= _accounts.GetAccount(tx.SenderAddress!);
+
             IReleaseSpec spec = _specProvider.GetCurrentHeadSpec();
-            Account account = _accounts.GetAccount(tx.SenderAddress!);
+            Account account = state.SenderAccount;
             UInt256 balance = account.Balance;
             UInt256 cumulativeCost = UInt256.Zero;
             bool overflow = false;

--- a/src/Nethermind/Nethermind.TxPool/Filters/UnknownSenderFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/UnknownSenderFilter.cs
@@ -35,7 +35,7 @@ namespace Nethermind.TxPool.Filters
             _logger = logger;
         }
 
-        public AcceptTxResult Accept(Transaction tx, TxHandlingOptions handlingOptions)
+        public AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions handlingOptions)
         {
             /* We have encountered multiple transactions that do not resolve sender address properly.
              * We need to investigate what these txs are and why the sender address is resolved to null.

--- a/src/Nethermind/Nethermind.TxPool/TxFilteringState.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxFilteringState.cs
@@ -2,7 +2,18 @@ using Nethermind.Core;
 
 namespace Nethermind.TxPool;
 
-public struct TxFilteringState
+public class TxFilteringState
 {
-    public Account? SenderAccount { get; set; }
+
+    private readonly IAccountStateProvider _accounts;
+    private readonly Transaction _tx;
+
+    public TxFilteringState(Transaction tx, IAccountStateProvider accounts)
+    {
+        _accounts = accounts;
+        _tx = tx;
+    }
+
+    private Account? _senderAccount = null;
+    public Account SenderAccount { get { return _senderAccount ??= _accounts.GetAccount(_tx.SenderAddress!); } }
 }

--- a/src/Nethermind/Nethermind.TxPool/TxFilteringState.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxFilteringState.cs
@@ -1,0 +1,8 @@
+using Nethermind.Core;
+
+namespace Nethermind.TxPool;
+
+public struct TxFilteringState
+{
+    public Account? SenderAccount { get; set; }
+}

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -113,11 +113,11 @@ namespace Nethermind.TxPool
             _filterPipeline.Add(new MalformedTxFilter(_specProvider, validator, _logger));
             _filterPipeline.Add(new GasLimitTxFilter(_headInfo, txPoolConfig, _logger));
             _filterPipeline.Add(new UnknownSenderFilter(ecdsa, _logger));
-            _filterPipeline.Add(new LowNonceFilter(_accounts, _logger)); // has to be after UnknownSenderFilter as it uses sender
-            _filterPipeline.Add(new GapNonceFilter(_accounts, _transactions, _logger));
-            _filterPipeline.Add(new TooExpensiveTxFilter(_headInfo, _accounts, _transactions, _logger));
-            _filterPipeline.Add(new FeeTooLowFilter(_headInfo, _accounts, _transactions, logManager));
-            _filterPipeline.Add(new ReusedOwnNonceTxFilter(_accounts, _nonces, _logger));
+            _filterPipeline.Add(new LowNonceFilter(_logger)); // has to be after UnknownSenderFilter as it uses sender
+            _filterPipeline.Add(new GapNonceFilter(_transactions, _logger));
+            _filterPipeline.Add(new TooExpensiveTxFilter(_headInfo, _transactions, _logger));
+            _filterPipeline.Add(new FeeTooLowFilter(_headInfo, _transactions, logManager));
+            _filterPipeline.Add(new ReusedOwnNonceTxFilter(_nonces, _logger));
             if (incomingTxFilter is not null)
             {
                 _filterPipeline.Add(incomingTxFilter);
@@ -279,7 +279,7 @@ namespace Nethermind.TxPool
                 _logger.Trace(
                     $"Adding transaction {tx.ToString("  ")} - managed nonce: {managedNonce} | persistent broadcast {startBroadcast}");
 
-            TxFilteringState state = new();
+            TxFilteringState state = new(tx, _accounts);
             for (int i = 0; i < _filterPipeline.Count; i++)
             {
                 IIncomingTxFilter incomingTxFilter = _filterPipeline[i];

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -279,10 +279,11 @@ namespace Nethermind.TxPool
                 _logger.Trace(
                     $"Adding transaction {tx.ToString("  ")} - managed nonce: {managedNonce} | persistent broadcast {startBroadcast}");
 
+            TxFilteringState state = new ();
             for (int i = 0; i < _filterPipeline.Count; i++)
             {
                 IIncomingTxFilter incomingTxFilter = _filterPipeline[i];
-                AcceptTxResult accepted = incomingTxFilter.Accept(tx, handlingOptions);
+                AcceptTxResult accepted = incomingTxFilter.Accept(tx, state, handlingOptions);
                 if (!accepted)
                 {
                     Metrics.PendingTransactionsDiscarded++;

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -279,7 +279,7 @@ namespace Nethermind.TxPool
                 _logger.Trace(
                     $"Adding transaction {tx.ToString("  ")} - managed nonce: {managedNonce} | persistent broadcast {startBroadcast}");
 
-            TxFilteringState state = new ();
+            TxFilteringState state = new();
             for (int i = 0; i < _filterPipeline.Count; i++)
             {
                 IIncomingTxFilter incomingTxFilter = _filterPipeline[i];


### PR DESCRIPTION
Fixes | Closes | Resolves #

## Changes:
- First filter that reads SenderAccount from state will save a copy of this data inside new struct: TxFilteringState. If any other filter needs account data it will read it from TxFilteringState. So we read account data only once.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ x ] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [ x ] No