### PR TITLE
Do not validate timestamp for uncles (fix 6 hive tests)

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/TestSealValidator.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/TestSealValidator.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -45,7 +45,7 @@ namespace Nethermind.Blockchain.Test.Validators
             _processedValidationResults = processedValidationResults ?? throw new ArgumentNullException(nameof(processedValidationResults));
         }
 
-        public bool ValidateParams(BlockHeader parent, BlockHeader header)
+        public bool ValidateParams(BlockHeader parent, BlockHeader header, bool isUncle)
         {
             return _alwaysSameResultForParams ?? _suggestedValidationResults.Dequeue();
         }

--- a/src/Nethermind/Nethermind.Consensus.AuRa/AuRaSealValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/AuRaSealValidator.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -51,7 +51,7 @@ namespace Nethermind.Consensus.AuRa
 
         public IReportingValidator ReportingValidator { get; set; } = NullReportingValidator.Instance;
 
-        public bool ValidateParams(BlockHeader parent, BlockHeader header)
+        public bool ValidateParams(BlockHeader parent, BlockHeader header, bool isUncle = false)
         {
             const long rejectedStepDrift = 4;
 

--- a/src/Nethermind/Nethermind.Consensus.Clique/CliqueSealValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus.Clique/CliqueSealValidator.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -34,7 +34,7 @@ namespace Nethermind.Consensus.Clique
             _logger = logManager.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
         }
 
-        public bool ValidateParams(BlockHeader parent, BlockHeader header)
+        public bool ValidateParams(BlockHeader parent, BlockHeader header, bool isUncle = false)
         {
             long number = header.Number;
             // Retrieve the snapshot needed to validate this header and cache it

--- a/src/Nethermind/Nethermind.Consensus.Ethash/EthashSealValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus.Ethash/EthashSealValidator.cs
@@ -86,7 +86,7 @@ namespace Nethermind.Consensus.Ethash
             _ethash.HintRange(guid, start, end);
         }
 
-        public bool ValidateParams(BlockHeader parent, BlockHeader header)
+        public bool ValidateParams(BlockHeader parent, BlockHeader header, bool isUncle = false)
         {
             bool extraDataNotTooLong = header.ExtraData.Length <= 32;
             if (!extraDataNotTooLong)
@@ -105,7 +105,7 @@ namespace Nethermind.Consensus.Ethash
 
             ulong unixTimeSeconds = _timestamper.UnixTime.Seconds;
             bool blockTooFarIntoFuture = header.Timestamp > unixTimeSeconds + AllowedFutureBlockTimeSeconds;
-            if (blockTooFarIntoFuture)
+            if (!isUncle && blockTooFarIntoFuture)
             {
                 if (_logger.IsWarn) _logger.Warn($"Invalid block header ({header.ToString(BlockHeader.Format.Full)}) - incorrect timestamp {header.Timestamp - unixTimeSeconds} seconds into the future");
                 return false;

--- a/src/Nethermind/Nethermind.Consensus.Ethash/EthashSealValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus.Ethash/EthashSealValidator.cs
@@ -88,42 +88,42 @@ namespace Nethermind.Consensus.Ethash
 
         public bool ValidateParams(BlockHeader parent, BlockHeader header, bool isUncle = false)
         {
-            return ValidateExtraData()
-                   && ValidateDifficulty()
-                   && (isUncle || ValidateTimestamp());
+            return ValidateExtraData(header)
+                   && ValidateDifficulty(parent, header)
+                   && (isUncle || ValidateTimestamp(header));
 
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            bool ValidateExtraData()
+            bool ValidateExtraData(BlockHeader blockHeader)
             {
-                bool extraDataNotTooLong = header.ExtraData.Length <= 32;
+                bool extraDataNotTooLong = blockHeader.ExtraData.Length <= 32;
                 if (!extraDataNotTooLong && _logger.IsWarn)
                     _logger.Warn(
-                        $"Invalid block header ({header.ToString(BlockHeader.Format.Full)}) - extra data too long {header.ExtraData.Length}");
+                        $"Invalid block header ({blockHeader.ToString(BlockHeader.Format.Full)}) - extra data too long {blockHeader.ExtraData.Length}");
 
                 return extraDataNotTooLong;
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            bool ValidateDifficulty()
+            bool ValidateDifficulty(BlockHeader parentHeader, BlockHeader blockHeader)
             {
-                UInt256 difficulty = _difficultyCalculator.Calculate(header, parent);
-                bool isDifficultyCorrect = difficulty == header.Difficulty;
+                UInt256 difficulty = _difficultyCalculator.Calculate(blockHeader, parentHeader);
+                bool isDifficultyCorrect = difficulty == blockHeader.Difficulty;
                 if (!isDifficultyCorrect && _logger.IsWarn)
                     _logger.Warn(
-                        $"Invalid block header ({header.ToString(BlockHeader.Format.Full)}) - incorrect difficulty {header.Difficulty} instead of {difficulty}");
+                        $"Invalid block header ({blockHeader.ToString(BlockHeader.Format.Full)}) - incorrect difficulty {blockHeader.Difficulty} instead of {difficulty}");
 
                 return isDifficultyCorrect;
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            bool ValidateTimestamp()
+            bool ValidateTimestamp(BlockHeader blockHeader)
             {
                 ulong unixTimeSeconds = _timestamper.UnixTime.Seconds;
-                bool blockTooFarIntoFuture = header.Timestamp > unixTimeSeconds + AllowedFutureBlockTimeSeconds;
+                bool blockTooFarIntoFuture = blockHeader.Timestamp > unixTimeSeconds + AllowedFutureBlockTimeSeconds;
                 if (blockTooFarIntoFuture && _logger.IsWarn)
                     _logger.Warn(
-                        $"Invalid block header ({header.ToString(BlockHeader.Format.Full)}) - incorrect timestamp {header.Timestamp - unixTimeSeconds} seconds into the future");
+                        $"Invalid block header ({blockHeader.ToString(BlockHeader.Format.Full)}) - incorrect timestamp {blockHeader.Timestamp - unixTimeSeconds} seconds into the future");
 
                 return !blockTooFarIntoFuture;
             }

--- a/src/Nethermind/Nethermind.Consensus/ISealValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/ISealValidator.cs
@@ -1,19 +1,19 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using System;
 using Nethermind.Core;
@@ -22,7 +22,7 @@ namespace Nethermind.Consensus
 {
     public interface ISealValidator
     {
-        bool ValidateParams(BlockHeader parent, BlockHeader header);
+        bool ValidateParams(BlockHeader parent, BlockHeader header, bool isUncle = false);
 
         /// <summary>
         /// Validates block header seal.

--- a/src/Nethermind/Nethermind.Consensus/NethDevSealEngine.cs
+++ b/src/Nethermind/Nethermind.Consensus/NethDevSealEngine.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -43,7 +43,7 @@ namespace Nethermind.Consensus
 
         public Address Address { get; }
 
-        public bool ValidateParams(BlockHeader parent, BlockHeader header)
+        public bool ValidateParams(BlockHeader parent, BlockHeader header, bool isUncle = false)
         {
             return true;
         }

--- a/src/Nethermind/Nethermind.Consensus/NullSealEngine.cs
+++ b/src/Nethermind/Nethermind.Consensus/NullSealEngine.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -41,7 +41,7 @@ namespace Nethermind.Consensus
             return true;
         }
 
-        public bool ValidateParams(BlockHeader parent, BlockHeader header)
+        public bool ValidateParams(BlockHeader parent, BlockHeader header, bool isUncle = false)
         {
             return true;
         }

--- a/src/Nethermind/Nethermind.Consensus/SealEngine.cs
+++ b/src/Nethermind/Nethermind.Consensus/SealEngine.cs
@@ -1,19 +1,19 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
 using System;
 using System.Threading;
@@ -42,8 +42,8 @@ namespace Nethermind.Consensus
 
         public Address Address => _sealer.Address;
 
-        public bool ValidateParams(BlockHeader parent, BlockHeader header) =>
-            _sealValidator.ValidateParams(parent, header);
+        public bool ValidateParams(BlockHeader parent, BlockHeader header, bool isUncle) =>
+            _sealValidator.ValidateParams(parent, header, isUncle);
 
         public bool ValidateSeal(BlockHeader header, bool force) =>
             _sealValidator.ValidateSeal(header, force);

--- a/src/Nethermind/Nethermind.Consensus/Validators/AlwaysValid.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/AlwaysValid.cs
@@ -67,7 +67,7 @@ namespace Nethermind.Consensus.Validators
             return _result;
         }
 
-        public bool ValidateParams(BlockHeader parent, BlockHeader header)
+        public bool ValidateParams(BlockHeader parent, BlockHeader header, bool isUncle = false)
         {
             return _result;
         }

--- a/src/Nethermind/Nethermind.Consensus/Validators/HeaderValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/HeaderValidator.cs
@@ -96,7 +96,7 @@ namespace Nethermind.Consensus.Validators
 
             bool totalDifficultyCorrect = ValidateTotalDifficulty(parent, header);
 
-            bool sealParamsCorrect = _sealValidator.ValidateParams(parent, header);
+            bool sealParamsCorrect = _sealValidator.ValidateParams(parent, header, isUncle);
             if (!sealParamsCorrect)
             {
                 if (_logger.IsWarn) _logger.Warn($"Invalid block header ({header.Hash}) - seal parameters incorrect");

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/MergeSealEngine.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/MergeSealEngine.cs
@@ -65,8 +65,8 @@ namespace Nethermind.Merge.Plugin.Handlers
 
         public Address Address => _poSSwitcher.HasEverReachedTerminalBlock() ? Address.Zero : _preMergeSealValidator.Address;
 
-        public bool ValidateParams(BlockHeader parent, BlockHeader header) =>
-            _preMergeSealValidator.ValidateParams(parent, header);
+        public bool ValidateParams(BlockHeader parent, BlockHeader header, bool isUncle) =>
+            _preMergeSealValidator.ValidateParams(parent, header, isUncle);
 
         public bool ValidateSeal(BlockHeader header, bool force) => _mergeSealValidator.ValidateSeal(header, force);
     }

--- a/src/Nethermind/Nethermind.Merge.Plugin/InvalidChainTracker/InvalidHeaderSealInterceptor.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/InvalidChainTracker/InvalidHeaderSealInterceptor.cs
@@ -34,9 +34,9 @@ public class InvalidHeaderSealInterceptor : ISealValidator
         _logger = logManager.GetClassLogger(typeof(InvalidHeaderInterceptor));
     }
 
-    public bool ValidateParams(BlockHeader parent, BlockHeader header)
+    public bool ValidateParams(BlockHeader parent, BlockHeader header, bool isUncle = false)
     {
-        bool result = _baseValidator.ValidateParams(parent, header);
+        bool result = _baseValidator.ValidateParams(parent, header, isUncle);
         if (!result)
         {
             if (_logger.IsDebug) _logger.Debug($"Intercepted a header with bad seal param {header}");

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergeSealValidator.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergeSealValidator.cs
@@ -34,8 +34,8 @@ public class MergeSealValidator : ISealValidator
         _poSSwitcher = poSSwitcher;
         _preMergeSealValidator = preMergeSealValidator;
     }
-    public bool ValidateParams(BlockHeader parent, BlockHeader header) =>
-        _poSSwitcher.IsPostMerge(header) || _preMergeSealValidator.ValidateParams(parent, header);
+    public bool ValidateParams(BlockHeader parent, BlockHeader header, bool isUncle) =>
+        _poSSwitcher.IsPostMerge(header) || _preMergeSealValidator.ValidateParams(parent, header, isUncle);
 
     public bool ValidateSeal(BlockHeader header, bool force)
     {

--- a/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
@@ -438,7 +438,7 @@ namespace Nethermind.Synchronization.Test
 
         private class SlowSealValidator : ISealValidator
         {
-            public bool ValidateParams(BlockHeader parent, BlockHeader header)
+            public bool ValidateParams(BlockHeader parent, BlockHeader header, bool isUncle = false)
             {
                 Thread.Sleep(1000);
                 return true;


### PR DESCRIPTION
## Changes:
- skip timestamp validation if `header` is `uncle` (as in comment: https://github.com/ethereum/tests/blob/develop/BlockchainTests/InvalidBlocks/bcUncleHeaderValidity/incorrectUncleTimestamp4.json#L4)
- refactor `EthashSealValidator`

This PR is fixing 6 hive consensus tests:
- 3x`incorrectUncleTimestamp4` (https://github.com/ethereum/tests/blob/develop/BlockchainTests/InvalidBlocks/bcUncleHeaderValidity/incorrectUncleTimestamp4.json)
- 3x`incorrectUncleTimestamp5` (https://github.com/ethereum/tests/blob/develop/BlockchainTests/InvalidBlocks/bcUncleHeaderValidity/incorrectUncleTimestamp5.json)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [x] No

It's covered by hive tests