### PR TITLE
Do not save stateroot in snap phase 1

### DIFF
--- a/src/Nethermind/Nethermind.State.Test/PatriciaTreeTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/PatriciaTreeTests.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using FluentAssertions;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
@@ -8,6 +9,7 @@ using Nethermind.Db;
 using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.State;
+using Nethermind.Trie;
 using Nethermind.Trie.Pruning;
 using NUnit.Framework;
 
@@ -68,6 +70,30 @@ namespace Nethermind.Store.Test
             stateTree.Commit(0);
 
             Assert.AreEqual(2, db.Keys.Count);
+        }
+
+        [TestCase(true, false)]
+        [TestCase(false, true)]
+        public void Commit_with_skip_root_should_skip_root(bool skipRoot, bool hasRoot)
+        {
+            MemDb db = new();
+            TrieStore trieStore = new TrieStore(db, LimboLogs.Instance);
+            Account account = new(1);
+
+            StateTree stateTree = new(trieStore, LimboLogs.Instance);
+            stateTree.Set(TestItem.AddressA, account);
+            stateTree.UpdateRootHash();
+            Keccak stateRoot = stateTree.RootHash;
+            stateTree.Commit(0, skipRoot);
+
+            if (hasRoot)
+            {
+                trieStore.LoadRlp(stateRoot).Length.Should().BeGreaterThan(0);
+            }
+            else
+            {
+                trieStore.Invoking(ts => ts.LoadRlp(stateRoot)).Should().Throw<TrieException>();
+            }
         }
     }
 }

--- a/src/Nethermind/Nethermind.State.Test/SnapSync/RecreateStateFromAccountRangesTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/SnapSync/RecreateStateFromAccountRangesTests.cs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#nullable disable 
+#nullable disable
 
 using System;
 using System.Collections.Generic;
@@ -120,8 +120,8 @@ namespace Nethermind.Store.Test
             AddRangeResult result = snapProvider.AddAccountRange(1, rootHash, Keccak.Zero, TestItem.Tree.AccountsWithPaths, firstProof!.Concat(lastProof!).ToArray());
 
             Assert.AreEqual(AddRangeResult.OK, result);
-            Assert.AreEqual(11, db.Keys.Count);  // we persist proof nodes (boundary nodes) via stitching
-            Assert.IsTrue(db.KeyExists(rootHash));
+            Assert.AreEqual(10, db.Keys.Count);  // we persist proof nodes (boundary nodes) via stitching
+            Assert.IsFalse(db.KeyExists(rootHash));
         }
 
         [Test]
@@ -144,8 +144,8 @@ namespace Nethermind.Store.Test
             var result = snapProvider.AddAccountRange(1, rootHash, TestItem.Tree.AccountsWithPaths[0].Path, TestItem.Tree.AccountsWithPaths, firstProof!.Concat(lastProof!).ToArray());
 
             Assert.AreEqual(AddRangeResult.OK, result);
-            Assert.AreEqual(11, db.Keys.Count);  // we persist proof nodes (boundary nodes) via stitching
-            Assert.IsTrue(db.KeyExists(rootHash));
+            Assert.AreEqual(10, db.Keys.Count);  // we persist proof nodes (boundary nodes) via stitching
+            Assert.IsFalse(db.KeyExists(rootHash));
         }
 
         [Test]
@@ -161,8 +161,8 @@ namespace Nethermind.Store.Test
             var result = snapProvider.AddAccountRange(1, rootHash, TestItem.Tree.AccountsWithPaths[0].Path, TestItem.Tree.AccountsWithPaths);
 
             Assert.AreEqual(AddRangeResult.OK, result);
-            Assert.AreEqual(11, db.Keys.Count);  // we don't have the proofs so we persist all nodes
-            Assert.IsTrue(db.KeyExists(rootHash)); // the root node is NOT a part of the proof nodes
+            Assert.AreEqual(10, db.Keys.Count);  // we don't have the proofs so we persist all nodes
+            Assert.IsFalse(db.KeyExists(rootHash)); // the root node is NOT a part of the proof nodes
         }
 
         [Test]
@@ -211,8 +211,8 @@ namespace Nethermind.Store.Test
             Assert.AreEqual(AddRangeResult.OK, result1);
             Assert.AreEqual(AddRangeResult.OK, result2);
             Assert.AreEqual(AddRangeResult.OK, result3);
-            Assert.AreEqual(11, db.Keys.Count);  // we persist proof nodes (boundary nodes) via stitching
-            Assert.IsTrue(db.KeyExists(rootHash));
+            Assert.AreEqual(10, db.Keys.Count);  // we persist proof nodes (boundary nodes) via stitching
+            Assert.IsFalse(db.KeyExists(rootHash));
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedHealingTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedHealingTests.cs
@@ -38,7 +38,9 @@ namespace Nethermind.Synchronization.Test.FastSync
 
             dbContext.CompareTrees("END");
             Assert.AreEqual(dbContext.RemoteStateTree.RootHash, dbContext.LocalStateTree.RootHash);
-            Assert.AreEqual(0, data.RequestedNodesCount);   // 4 boundary proof nodes stitched together => 0
+
+            // I guess state root will be requested regardless
+            Assert.AreEqual(1, data.RequestedNodesCount);   // 4 boundary proof nodes stitched together => 0
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/RecreateStateFromAccountRangesTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/RecreateStateFromAccountRangesTests.cs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#nullable disable 
+#nullable disable
 
 using System;
 using System.Collections.Generic;
@@ -120,8 +120,8 @@ namespace Nethermind.Synchronization.Test.SnapSync
             var result = snapProvider.AddAccountRange(1, rootHash, Keccak.Zero, TestItem.Tree.AccountsWithPaths, firstProof!.Concat(lastProof!).ToArray());
 
             Assert.AreEqual(AddRangeResult.OK, result);
-            Assert.AreEqual(11, db.Keys.Count);  // we persist proof nodes (boundary nodes) via stitching
-            Assert.IsTrue(db.KeyExists(rootHash));
+            Assert.AreEqual(10, db.Keys.Count);  // we persist proof nodes (boundary nodes) via stitching
+            Assert.IsFalse(db.KeyExists(rootHash));
         }
 
         [Test]
@@ -144,8 +144,8 @@ namespace Nethermind.Synchronization.Test.SnapSync
             var result = snapProvider.AddAccountRange(1, rootHash, TestItem.Tree.AccountsWithPaths[0].Path, TestItem.Tree.AccountsWithPaths, firstProof!.Concat(lastProof!).ToArray());
 
             Assert.AreEqual(AddRangeResult.OK, result);
-            Assert.AreEqual(11, db.Keys.Count);  // we persist proof nodes (boundary nodes) via stitching
-            Assert.IsTrue(db.KeyExists(rootHash));
+            Assert.AreEqual(10, db.Keys.Count);  // we persist proof nodes (boundary nodes) via stitching
+            Assert.IsFalse(db.KeyExists(rootHash));
         }
 
         [Test]
@@ -161,8 +161,8 @@ namespace Nethermind.Synchronization.Test.SnapSync
             var result = snapProvider.AddAccountRange(1, rootHash, TestItem.Tree.AccountsWithPaths[0].Path, TestItem.Tree.AccountsWithPaths);
 
             Assert.AreEqual(AddRangeResult.OK, result);
-            Assert.AreEqual(11, db.Keys.Count);  // we don't have the proofs so we persist all nodes
-            Assert.IsTrue(db.KeyExists(rootHash)); // the root node is NOT a part of the proof nodes
+            Assert.AreEqual(10, db.Keys.Count);  // we don't have the proofs so we persist all nodes
+            Assert.IsFalse(db.KeyExists(rootHash)); // the root node is NOT a part of the proof nodes
         }
 
         [Test]
@@ -211,8 +211,8 @@ namespace Nethermind.Synchronization.Test.SnapSync
             Assert.AreEqual(AddRangeResult.OK, result1);
             Assert.AreEqual(AddRangeResult.OK, result2);
             Assert.AreEqual(AddRangeResult.OK, result3);
-            Assert.AreEqual(11, db.Keys.Count);  // we persist proof nodes (boundary nodes) via stitching
-            Assert.IsTrue(db.KeyExists(rootHash));
+            Assert.AreEqual(10, db.Keys.Count);  // we persist proof nodes (boundary nodes) via stitching
+            Assert.IsFalse(db.KeyExists(rootHash));
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProviderHelper.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProviderHelper.cs
@@ -75,7 +75,7 @@ namespace Nethermind.Synchronization.SnapSync
 
             lock (_syncCommit)
             {
-                tree.Commit(blockNumber);
+                tree.Commit(blockNumber, skipRoot: true);
             }
 
             return (AddRangeResult.OK, moreChildrenToRight, accountsWithStorage, codeHashes);


### PR DESCRIPTION
Fixes #4831

- The sepolia fix now depends on snap range flag being stored to prevent it from restarting snap range as snap range is enabled at start up.
- This remove the sepolia fix and prevent snap ranges from saving state root.

## Changes:
- Revert sepolia fix.
- Add flag to skip saving state root on snap range.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [X] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [X] No

**Comments about testing , should you have some** (optional)

- Confirm sepolia issue is still reproducable if root hash was set.
- With change, can sync up to validating block 5 consecutive time.

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...