### PR TITLE
Allow sending some trace to seq

### DIFF
--- a/src/Nethermind/Nethermind.Runner/Logging/NLogConfigurator.cs
+++ b/src/Nethermind/Nethermind.Runner/Logging/NLogConfigurator.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -44,7 +44,7 @@ namespace Nethermind.Runner.Logging
                         {
                             foreach (Target? ruleTarget in rule.Targets)
                             {
-                                if (ruleTarget.Name == "seq")
+                                if (ruleTarget.Name == "seq" && rule.LoggerNamePattern == "*")
                                 {
                                     rule.EnableLoggingForLevels(LogLevel.FromString(minLevel), LogLevel.Fatal);
                                 }
@@ -56,6 +56,15 @@ namespace Nethermind.Runner.Logging
                 // // // re-initialize single target
                 loggingConfiguration.AllTargets?.OfType<SeqTarget>().ToList().ForEach(t => t.Dispose());
                 LogManager.ReconfigExistingLoggers();
+            }
+        }
+
+        public static void ClearSeqTarget()
+        {
+            LoggingConfiguration loggingConfiguration = LogManager.Configuration;
+            if (loggingConfiguration != null)
+            {
+                loggingConfiguration.RemoveTarget("seq");
             }
         }
 

--- a/src/Nethermind/Nethermind.Runner/NLog.config
+++ b/src/Nethermind/Nethermind.Runner/NLog.config
@@ -116,8 +116,6 @@
     <!-- for a detailed pruning analysis -->
     <!-- <logger name="Trie.*" minlevel="Trace" writeTo="all" final="true" /> -->
 
-    <logger name="Synchronization.ParallelSync.MultiSyncModeSelector" minlevel="Trace" writeTo="all" final="true" />
-
     <!-- note: minLevel will get replaced by `Seq.MinLevel` -->
     <logger name="*" minlevel="Off" writeTo="seq" />
     <logger name="*" minlevel="Info" writeTo="file-async" />

--- a/src/Nethermind/Nethermind.Runner/NLog.config
+++ b/src/Nethermind/Nethermind.Runner/NLog.config
@@ -83,8 +83,7 @@
 
     ## In case you want to send to only two but not all three, skip the final attribute so that it will try the next rule
     <logger name="Merge.Plugin.PoSSwitcher" minlevel="Trace" writeTo="seq" />
-    <logger name="Merge.Plugin.PoSSwitcher" minlevel="Trace" writeTo="file-async" />
-    <logger name="Merge.Plugin.PoSSwitcher" minlevel="Trace" final="true" />
+    <logger name="Merge.Plugin.PoSSwitcher" minlevel="Trace" writeTo="file-async" final="true" />
 
     You can also use wilcards
     <logger name="Merge.Plugin.*" minlevel="Trace" writeTo="all" final="true" />
@@ -93,16 +92,22 @@
 
 
     <!-- <logger name="Merge.Plugin.Synchronization.*" minlevel="Trace" writeTo="all" final="true" /> -->
+
     <!-- <logger name="Synchronization.*" minlevel="Trace" writeTo="all" final="true" /> -->
+
     <!-- <logger name="Network.*" minlevel="Trace" writeTo="all" final="true" /> -->
+
     <!-- <logger name="Consensus.Validators.BlockValidator" minlevel="Trace" writeTo="all" final="true" /> -->
+
     <!-- <logger name="Consensus.Validators.HeaderValidator" minlevel="Trace" writeTo="all" final="true" /> -->
 
     <!-- big chance that you do not like the peers report - you can disable it here -->
     <!-- <logger name="Synchronization.Peers.SyncPeersReport" minlevel="Error" writeTo="all" final="true" /> -->
 
     <!-- <logger name="Blockchain.BlockTree" minlevel="Trace" writeTo="all" final="true" /> -->
+
     <!-- <logger name="Synchronization.Blocks.BlockDownloader" minlevel="Trace" writeTo="all" final="true" /> -->
+
     <!-- <logger name="Consensus.Processing.BlockchainProcessor" minlevel="Trace" writeTo="all" final="true" /> -->
 
     <!-- if sync get stuck this is the best thing to enable the Trace on -->

--- a/src/Nethermind/Nethermind.Runner/NLog.config
+++ b/src/Nethermind/Nethermind.Runner/NLog.config
@@ -33,6 +33,8 @@
       <highlight-row backgroundColor="NoChange" condition="level == LogLevel.Debug" foregroundColor="Gray" />
       <highlight-row backgroundColor="NoChange" condition="level == LogLevel.Trace" foregroundColor="Magenta" />
     </target>
+
+    <!-- note: you need to specify `Seq.MinLevel` or this target will be removed. `Seq.ServerUrl` will always replace url here. -->
     <target xsi:type="BufferingWrapper" name="seq" bufferSize="1000" flushTimeout="2000">
       <target xsi:type="Seq" serverUrl="http://localhost:5341" apiKey="">
         <property name="ThreadId" value="${threadid}" as="number" />
@@ -47,6 +49,12 @@
         <property name="Version" value="${gdc:item=version}" />
       </target>
     </target>
+
+    <target name="all" xsi:type="SplitGroup">
+      <target-ref xsi:name="auto-colored-console-async" />
+      <target-ref xsi:name="seq" />
+      <target-ref xsi:name="file-async" />
+    </target>
   </targets>
 
   <rules>
@@ -56,68 +64,61 @@
     <logger name="JsonWebAPI*" minlevel="Error" writeTo="auto-colored-console-async" final="true" />
     <logger name="JsonWebAPI*" final="true" />
 
-    <!-- <logger name="Merge.Plugin.PoSSwitcher" minlevel="Trace" writeTo="file-async"/> -->
-    <!--    <logger name="Merge.Plugin.PoSSwitcher" minlevel="Trace" writeTo="auto-colored-console-async"/> -->
-    <!--    <logger name="Merge.Plugin.PoSSwitcher" final="true"/> -->
-    <!-- -->
+    <!--
 
-	<!-- <logger name="Merge.Plugin.Synchronization.*" minlevel="Trace" writeTo="file-async"/> -->
-    <!-- <logger name="Merge.Plugin.Synchronization.*" minlevel="Trace" writeTo="auto-colored-console-async"/> -->
-    <!-- <logger name="Merge.Plugin.Synchronization.*" final="true"/> -->
+    Sample config
+    =============
 
-    <!-- <logger name="Synchronization.*" minlevel="Trace" writeTo="file-async"/> -->
-    <!-- <logger name="Synchronization.*" minlevel="Trace" writeTo="auto-colored-console-async"/> -->
-    <!-- <logger name="Synchronization.*" final="true"/> -->
+    ## Only send to console
+    <logger name="Merge.Plugin.PoSSwitcher" minlevel="Trace" writeTo="auto-colored-console-async" final="true" />
 
-    <!-- <logger name="Network.*" minlevel="Trace" writeTo="file-async"/> -->
-    <!-- <logger name="Network.*" minlevel="Trace" writeTo="auto-colored-console-async"/> -->
-    <!-- <logger name="Network.*" final="true"/> -->
+    ## Only send to seq
+    <logger name="Merge.Plugin.PoSSwitcher" minlevel="Trace" writeTo="seq" final="true" />
 
-    <!-- <logger name="Consensus.Validators.BlockValidator" minlevel="Debug" writeTo="file-async"/> -->
-    <!-- <logger name="Consensus.Validators.BlockValidator" minlevel="Debug" writeTo="auto-colored-console-async"/> -->
-    <!-- <logger name="Consensus.Validators.BlockValidator" final="true"/> -->
-    <!-- -->
-    <!-- <logger name="Consensus.Validators.HeaderValidator" minlevel="Debug" writeTo="file-async"/> -->
-    <!-- <logger name="Consensus.Validators.HeaderValidator" minlevel="Debug" writeTo="auto-colored-console-async"/> -->
-    <!-- <logger name="Consensus.Validators.HeaderValidator" final="true"/> -->
+    ## Only send to file
+    <logger name="Merge.Plugin.PoSSwitcher" minlevel="Trace" writeTo="file-async" final="true" />
 
+    ## Send to all three output
+    <logger name="Merge.Plugin.PoSSwitcher" minlevel="Trace" writeTo="all" final="true" />
+
+    ## In case you want to send to only two but not all three, skip the final attribute so that it will try the next rule
+    <logger name="Merge.Plugin.PoSSwitcher" minlevel="Trace" writeTo="seq" />
+    <logger name="Merge.Plugin.PoSSwitcher" minlevel="Trace" writeTo="file-async" />
+    <logger name="Merge.Plugin.PoSSwitcher" minlevel="Trace" final="true" />
+
+    You can also use wilcards
+    <logger name="Merge.Plugin.*" minlevel="Trace" writeTo="all" final="true" />
+
+    -->
+
+
+    <!-- <logger name="Merge.Plugin.Synchronization.*" minlevel="Trace" writeTo="all" final="true" /> -->
+    <!-- <logger name="Synchronization.*" minlevel="Trace" writeTo="all" final="true" /> -->
+    <!-- <logger name="Network.*" minlevel="Trace" writeTo="all" final="true" /> -->
+    <!-- <logger name="Consensus.Validators.BlockValidator" minlevel="Trace" writeTo="all" final="true" /> -->
+    <!-- <logger name="Consensus.Validators.HeaderValidator" minlevel="Trace" writeTo="all" final="true" /> -->
 
     <!-- big chance that you do not like the peers report - you can disable it here -->
-    <!-- <logger name="Synchronization.Peers.SyncPeersReport" minlevel="Error" writeTo="file-async"/> -->
-    <!-- <logger name="Synchronization.Peers.SyncPeersReport" minlevel="Error" writeTo="auto-colored-console-async"/> -->
-    <!-- <logger name="Synchronization.Peers.SyncPeersReport" final="true"/> -->
+    <!-- <logger name="Synchronization.Peers.SyncPeersReport" minlevel="Error" writeTo="all" final="true" /> -->
 
-    <!-- <logger name="Blockchain.BlockTree" minlevel="Trace" writeTo="file-async"/> -->
-    <!-- <logger name="Blockchain.BlockTree" minlevel="Trace" writeTo="auto-colored-console-async"/> -->
-    <!-- <logger name="Blockchain.BlockTree" final="true"/> -->
-    <!-- -->
-    <!-- <logger name="Synchronization.Blocks.BlockDownloader" minlevel="Trace" writeTo="file-async"/> -->
-    <!-- <logger name="Synchronization.Blocks.BlockDownloader" minlevel="Trace" writeTo="auto-colored-console-async"/> -->
-    <!-- <logger name="Synchronization.Blocks.BlockDownloader" final="true"/> -->
-
-    <!-- <logger name="Consensus.Processing.BlockchainProcessor" minlevel="Trace" writeTo="file-async"/> -->
-    <!--  <logger name="Consensus.Processing.BlockchainProcessor" minlevel="Trace" writeTo="auto-colored-console-async"/> -->
-    <!--  <logger name="Consensus.Processing.BlockchainProcessor" final="true"/> -->
+    <!-- <logger name="Blockchain.BlockTree" minlevel="Trace" writeTo="all" final="true" /> -->
+    <!-- <logger name="Synchronization.Blocks.BlockDownloader" minlevel="Trace" writeTo="all" final="true" /> -->
+    <!-- <logger name="Consensus.Processing.BlockchainProcessor" minlevel="Trace" writeTo="all" final="true" /> -->
 
     <!-- if sync get stuck this is the best thing to enable the Trace on -->
-    <!-- <logger name="Synchronization.ParallelSync.MultiSyncModeSelector" minlevel="Trace" writeTo="file-async"/> -->
-    <!-- <logger name="Synchronization.ParallelSync.MultiSyncModeSelector" minlevel="Trace" writeTo="auto-colored-console-async"/> -->
-    <!-- <logger name="Synchronization.ParallelSync.MultiSyncModeSelector" final="true"/> -->
+    <!-- <logger name="Synchronization.ParallelSync.MultiSyncModeSelector" minlevel="Trace" writeTo="all" final="true" /> -->
 
     <!-- if sync get stuck this is the best thing to enable the Trace on -->
-    <!-- <logger name="Synchronization.SyncServer" minlevel="Trace" writeTo="file-async"/> -->
-    <!-- <logger name="Synchronization.SyncServer" minlevel="Trace" writeTo="auto-colored-console-async"/> -->
-    <!-- <logger name="Synchronization.SyncServer" final="true"/> -->
+    <!-- <logger name="Synchronization.SyncServer" minlevel="Trace" writeTo="all" final="true" /> -->
 
-    <!-- <logger name="Network.*" minlevel="Trace" writeTo="file-async"/> -->
-    <!-- <logger name="Network.*" minlevel="Trace" writeTo="auto-colored-console-async"/> -->
-    <!-- <logger name="Network.*" final="true"/> -->
+    <!-- <logger name="Network.*" minlevel="Trace" writeTo="all" final="true" /> -->
 
     <!-- for a detailed pruning analysis -->
-    <!-- <logger name="Trie.*" minlevel="Trace" writeTo="file-async"/> -->
-    <!-- <logger name="Trie.*" minlevel="Trace" writeTo="auto-colored-console-async"/> -->
-    <!-- <logger name="Trie.*" final="true"/> -->
+    <!-- <logger name="Trie.*" minlevel="Trace" writeTo="all" final="true" /> -->
 
+    <logger name="Synchronization.ParallelSync.MultiSyncModeSelector" minlevel="Trace" writeTo="all" final="true" />
+
+    <!-- note: minLevel will get replaced by `Seq.MinLevel` -->
     <logger name="*" minlevel="Off" writeTo="seq" />
     <logger name="*" minlevel="Info" writeTo="file-async" />
     <logger name="*" minlevel="Info" writeTo="auto-colored-console-async" />

--- a/src/Nethermind/Nethermind.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Runner/Program.cs
@@ -535,6 +535,11 @@ namespace Nethermind.Runner
                     _logger.Info($"Seq Logging enabled on host: {seqConfig.ServerUrl} with level: {seqConfig.MinLevel}");
                 NLogConfigurator.ConfigureSeqBufferTarget(seqConfig.ServerUrl, seqConfig.ApiKey, seqConfig.MinLevel);
             }
+            else
+            {
+                // Clear it up, otherwise internally it will keep requesting to localhost as `all` target include this.
+                NLogConfigurator.ClearSeqTarget();
+            }
         }
 
         private static string GetProductInfo()


### PR DESCRIPTION
- Created an 'all' target group in NLog, which include seq.
- In NLogConfigurator, only replace loglevel if pattern == '*'.
- This mean we can specify specific rule to have trace/debug log and publish them to seq.
- Also cleanup NLog.config a bit.

## Changes:
- Add `all` target group in NLog.
- Add rule to only replace seq rule with pattern == '*'.
- Add logic to disable seq if MinLevel is off.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [X] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [X] No

**Comments about testing , should you have some** (optional)

- Tested to be able to specify multisyncmodeselector trace and it appear in seq.

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...