### PR TITLE
Refactored SizeExtensions to avoid overflow

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/SizeExtensionsTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/SizeExtensionsTests.cs
@@ -1,0 +1,43 @@
+//  Copyright (c) 2021 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using FluentAssertions;
+using Nethermind.Core.Extensions;
+using NUnit.Framework;
+
+namespace Nethermind.Core.Test
+{
+    [TestFixture]
+    public class SizeExtensionsTests
+    {
+        [TestCase(0)]
+        [TestCase(1000)]
+        [TestCase(9223372036)] // Int64.MaxValue / 1_000_000_000
+        public void CheckOverflow_long(long testCase)
+        {
+            Assert.IsTrue(testCase.GB() >= 0);
+        }
+
+        [TestCase(0)]
+        [TestCase(1000)]
+        [TestCase(2147483647)] // Int32.MaxValue
+        public void CheckOverflow_int(int testCase)
+        {
+            Assert.IsTrue(testCase.GB() >= 0);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Core/Extensions/IntExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/IntExtensions.cs
@@ -20,69 +20,6 @@ using Nethermind.Int256;
 
 namespace Nethermind.Core.Extensions
 {
-    public static class SizeExtensions
-    {
-        public static long GB(this int @this)
-        {
-            return @this * 1_000_000_000L;
-        }
-
-        public static long MB(this int @this)
-        {
-            return @this * 1_000_000L;
-        }
-
-        public static long KB(this int @this)
-        {
-            return @this * 1_000L;
-        }
-
-        public static long GiB(this int @this)
-        {
-            return @this * 1024L * 1024L * 1024L;
-        }
-
-        public static long MiB(this int @this)
-        {
-            return @this * 1024L * 1024L;
-        }
-
-        public static long KiB(this int @this)
-        {
-            return @this * 1024L;
-        }
-
-        public static long GB(this long @this)
-        {
-            return ((int)@this).GB();
-        }
-
-        public static long MB(this long @this)
-        {
-            return ((int)@this).MB();
-        }
-
-        public static long KB(this long @this)
-        {
-            return ((int)@this).KB();
-        }
-
-        public static long GiB(this long @this)
-        {
-            return ((int)@this).GiB();
-        }
-
-        public static long MiB(this long @this)
-        {
-            return ((int)@this).MiB();
-        }
-
-        public static long KiB(this long @this)
-        {
-            return ((int)@this).KiB();
-        }
-    }
-
     public static class IntExtensions
     {
         public static string ToHexString(this int @this)

--- a/src/Nethermind/Nethermind.Core/Extensions/SizeExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/SizeExtensions.cs
@@ -1,0 +1,85 @@
+//  Copyright (c) 2021 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+// 
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+// 
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Buffers.Binary;
+using Nethermind.Int256;
+
+namespace Nethermind.Core.Extensions
+{
+    public static class SizeExtensions
+    {
+        public static long GB(this long @this)
+        {
+            return @this * 1_000_000_000L;
+        }
+
+        public static long MB(this long @this)
+        {
+            return @this * 1_000_000L;
+        }
+
+        public static long KB(this long @this)
+        {
+            return @this * 1_000L;
+        }
+
+        public static long GiB(this long @this)
+        {
+            return @this * 1024L * 1024L * 1024L;
+        }
+
+        public static long MiB(this long @this)
+        {
+            return @this * 1024L * 1024L;
+        }
+
+        public static long KiB(this long @this)
+        {
+            return @this * 1024L;
+        }
+
+        public static long GB(this int @this)
+        {
+            return ((long)@this).GB();
+        }
+
+        public static long MB(this int @this)
+        {
+            return ((long)@this).MB();
+        }
+
+        public static long KB(this int @this)
+        {
+            return ((long)@this).KB();
+        }
+
+        public static long GiB(this int @this)
+        {
+            return ((long)@this).GiB();
+        }
+
+        public static long MiB(this int @this)
+        {
+            return ((long)@this).MiB();
+        }
+
+        public static long KiB(this int @this)
+        {
+            return ((long)@this).KiB();
+        }
+    }
+}


### PR DESCRIPTION
Fixes | Closes | Resolves #

> Anything marked as optional that you didn't need to fill in, please remove it from the PR description. Choose one of the keywords above to refer to the issue this PR solves, followed by the issue number (e.g Fixes # 666). If there is no issue, remove the line. Remove this note after reading.

## Changes:
- Moved SizeExtensions to SeparateFile from IntExtensions, and swapped int methods with long in order to avoid cast overflow.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No

**Comments about testing , should you have some** (optional)

## Further comments (optional)
with the old impl doing the following : 
```
long j = Int64.MaxValue / (1024 * 1024 * 1024);
Console.WriteLine(j.GiB());
```
gives 
```
-1073741824
```
correct answer is : 
```
9223372035781033984
```
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...