### PR TITLE
Set local IP explicitly for P2P.

### DIFF
--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -491,6 +491,7 @@ public class InitializeNetwork : IStep
         _api.RlpxPeer = new RlpxHost(
             _api.MessageSerializationService,
             _api.NodeKey.PublicKey,
+            _networkConfig.LocalIp!,
             _networkConfig.P2PPort,
             encryptionHandshakeServiceA,
             _api.SessionMonitor,

--- a/src/Nethermind/Nethermind.Network.Test/Rlpx/RlpxPeerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/Rlpx/RlpxPeerTests.cs
@@ -37,7 +37,9 @@ namespace Nethermind.Network.Test.Rlpx
         {
             RlpxHost host = new(
                 Substitute.For<IMessageSerializationService>(),
-                TestItem.PublicKeyA, GegAvailableLocalPort(),
+                TestItem.PublicKeyA,
+                IPAddress.Loopback.ToString(),
+                GegAvailableLocalPort(),
                 Substitute.For<IHandshakeService>(),
                 Substitute.For<ISessionMonitor>(),
                 NullDisconnectsAnalyzer.Instance,

--- a/src/Nethermind/Nethermind.Network/Rlpx/RlpxHost.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/RlpxHost.cs
@@ -48,6 +48,7 @@ namespace Nethermind.Network.Rlpx
         private bool _isInitialized;
         public PublicKey LocalNodeId { get; }
         public int LocalPort { get; }
+        public string LocalIp { get; }
         private readonly IHandshakeService _handshakeService;
         private readonly IMessageSerializationService _serializationService;
         private readonly ILogManager _logManager;
@@ -59,6 +60,7 @@ namespace Nethermind.Network.Rlpx
 
         public RlpxHost(IMessageSerializationService serializationService,
             PublicKey localNodeId,
+            string localIp,
             int localPort,
             IHandshakeService handshakeService,
             ISessionMonitor sessionMonitor,
@@ -90,6 +92,7 @@ namespace Nethermind.Network.Rlpx
             _disconnectsAnalyzer = disconnectsAnalyzer ?? throw new ArgumentNullException(nameof(disconnectsAnalyzer));
             _handshakeService = handshakeService ?? throw new ArgumentNullException(nameof(handshakeService));
             LocalNodeId = localNodeId ?? throw new ArgumentNullException(nameof(localNodeId));
+            LocalIp = localIp;
             LocalPort = localPort;
             _sendLatency = sendLatency;
         }
@@ -122,7 +125,7 @@ namespace Nethermind.Network.Rlpx
                         InitializeChannel(ch, session);
                     }));
 
-                _bootstrapChannel = await bootstrap.BindAsync(LocalPort).ContinueWith(t =>
+                _bootstrapChannel = await bootstrap.BindAsync(IPAddress.Parse(LocalIp!), LocalPort).ContinueWith(t =>
                 {
                     if (t.IsFaulted)
                     {


### PR DESCRIPTION
- Fix issue with user complaining that P2P port not following specified local ip.

## Changes:
- Specified local IP for P2P listening port, like https://github.com/NethermindEth/nethermind/blob/master/src/Nethermind/Nethermind.Network.Discovery/DiscoveryApp.cs#L161

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [X] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [X] No

**Comments about testing , should you have some** (optional)

- Confirmed can sync normally without specifying IP.
- Confirmed if I specify IP that is not available, it will fail to start.
- Confirmed I can specify local ip explicitly.

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...