### PR TITLE
Refactor JWT authentication

### DIFF
--- a/src/Nethermind/Nethermind.Core/Authentication/JwtAuthentication.cs
+++ b/src/Nethermind/Nethermind.Core/Authentication/JwtAuthentication.cs
@@ -79,8 +79,8 @@ public class JwtAuthentication : IRpcAuthentication
             }
 
             if (logger.IsInfo) logger.Info($"Authentication secret has been written to '{fileInfo.FullName}'.");
-            return new JwtAuthentication(secret, timestamper, logger);
 
+            return new(secret, timestamper, logger);
         }
         else
         {

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/JwtTest.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/JwtTest.cs
@@ -43,8 +43,8 @@ public class JwtTest
     public void long_key_tests(string token, bool expected)
     {
         ManualTimestamper manualTimestamper = new() { UtcNow = DateTimeOffset.FromUnixTimeSeconds(1644994971).UtcDateTime };
-        IRpcAuthentication authentication = JwtAuthentication.CreateFromHexSecret("5166546A576E5A7234753778214125442A472D4A614E645267556B5870327335", manualTimestamper, LimboTraceLogger.Instance);
-        IRpcAuthentication authenticationWithPrefix = JwtAuthentication.CreateFromHexSecret("0x5166546A576E5A7234753778214125442A472D4A614E645267556B5870327335", manualTimestamper, LimboTraceLogger.Instance);
+        IRpcAuthentication authentication = JwtAuthentication.FromSecret("5166546A576E5A7234753778214125442A472D4A614E645267556B5870327335", manualTimestamper, LimboTraceLogger.Instance);
+        IRpcAuthentication authenticationWithPrefix = JwtAuthentication.FromSecret("0x5166546A576E5A7234753778214125442A472D4A614E645267556B5870327335", manualTimestamper, LimboTraceLogger.Instance);
         bool actual = authentication.Authenticate(token);
         Assert.AreEqual(expected, actual);
         actual = authenticationWithPrefix.Authenticate(token);

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/JwtTest.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/JwtTest.cs
@@ -43,8 +43,8 @@ public class JwtTest
     public void long_key_tests(string token, bool expected)
     {
         ManualTimestamper manualTimestamper = new() { UtcNow = DateTimeOffset.FromUnixTimeSeconds(1644994971).UtcDateTime };
-        IRpcAuthentication authentication = MicrosoftJwtAuthentication.CreateFromHexSecret("5166546A576E5A7234753778214125442A472D4A614E645267556B5870327335", manualTimestamper, LimboTraceLogger.Instance);
-        IRpcAuthentication authenticationWithPrefix = MicrosoftJwtAuthentication.CreateFromHexSecret("0x5166546A576E5A7234753778214125442A472D4A614E645267556B5870327335", manualTimestamper, LimboTraceLogger.Instance);
+        IRpcAuthentication authentication = JwtAuthentication.CreateFromHexSecret("5166546A576E5A7234753778214125442A472D4A614E645267556B5870327335", manualTimestamper, LimboTraceLogger.Instance);
+        IRpcAuthentication authenticationWithPrefix = JwtAuthentication.CreateFromHexSecret("0x5166546A576E5A7234753778214125442A472D4A614E645267556B5870327335", manualTimestamper, LimboTraceLogger.Instance);
         bool actual = authentication.Authenticate(token);
         Assert.AreEqual(expected, actual);
         actual = authenticationWithPrefix.Authenticate(token);

--- a/src/Nethermind/Nethermind.Runner/Ethereum/Steps/StartRpc.cs
+++ b/src/Nethermind/Nethermind.Runner/Ethereum/Steps/StartRpc.cs
@@ -58,7 +58,7 @@ namespace Nethermind.Runner.Ethereum.Steps
                 IJsonSerializer jsonSerializer = CreateJsonSerializer(jsonRpcService);
                 IRpcAuthentication auth = jsonRpcConfig.UnsecureDevNoRpcAuthentication || !jsonRpcUrlCollection.Values.Any(u => u.IsAuthenticated)
                     ? NoAuthentication.Instance
-                    : MicrosoftJwtAuthentication.CreateFromFileOrGenerate(jsonRpcConfig.JwtSecretFile, _api.Timestamper, logger);
+                    : JwtAuthentication.CreateFromFileOrGenerate(jsonRpcConfig.JwtSecretFile, _api.Timestamper, logger);
 
 
                 JsonRpcProcessor jsonRpcProcessor = new(

--- a/src/Nethermind/Nethermind.Runner/Ethereum/Steps/StartRpc.cs
+++ b/src/Nethermind/Nethermind.Runner/Ethereum/Steps/StartRpc.cs
@@ -58,7 +58,7 @@ namespace Nethermind.Runner.Ethereum.Steps
                 IJsonSerializer jsonSerializer = CreateJsonSerializer(jsonRpcService);
                 IRpcAuthentication auth = jsonRpcConfig.UnsecureDevNoRpcAuthentication || !jsonRpcUrlCollection.Values.Any(u => u.IsAuthenticated)
                     ? NoAuthentication.Instance
-                    : JwtAuthentication.CreateFromFileOrGenerate(jsonRpcConfig.JwtSecretFile, _api.Timestamper, logger);
+                    : JwtAuthentication.FromFile(jsonRpcConfig.JwtSecretFile, _api.Timestamper, logger);
 
 
                 JsonRpcProcessor jsonRpcProcessor = new(


### PR DESCRIPTION
This PR slightly improves the RPC JWT authentication.

## Changes

- Renamed the `MicrosoftJwtAuthentication` class to `JwtAuthentication` as it's a standard JWT authentication, nothing Microsoft-specific
- Replaced `Random.NextBytes` with the secure `RandomNumberGenerator.GetBytes`
- Slightly optimized string comparisons
- Improved error messages
- Removed duplicated functionality by utilizing the already existing one

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No

## Further comments (optional)

Actually, the class is better called `JwtAuthenticator` and not `JwtAuthentication` but for now, let's leave it as it is.