### PR TITLE
Fix block header fields in `eth_call` and friends

### DIFF
--- a/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
@@ -258,14 +258,16 @@ namespace Nethermind.Facade
             }
 
             BlockHeader callHeader = new(
-                blockHeader.Hash!,
+                treatBlockHeaderAsParentBlock ? blockHeader.Hash! : blockHeader.ParentHash,
                 Keccak.OfAnEmptySequenceRlp,
-                Address.Zero,
-                0,
+                blockHeader.Beneficiary,
+                blockHeader.Difficulty,
                 treatBlockHeaderAsParentBlock ? blockHeader.Number + 1 : blockHeader.Number,
                 blockHeader.GasLimit,
                 timestamp,
                 Array.Empty<byte>());
+
+            callHeader.MixHash = blockHeader.MixHash;
 
             callHeader.BaseFeePerGas = treatBlockHeaderAsParentBlock
                 ? BaseFeeCalculator.Calculate(blockHeader, _specProvider.GetSpec(callHeader.Number))


### PR DESCRIPTION
## Changes:
- Adds `MixHash` to the fields of the tx header that will be used in the context of tx execution when using `eth_call`
- Fix a few other fields to be use the appropriate values from the header

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [ ] No