### PR TITLE
Version Metrics updated (#4860)

### DIFF
--- a/src/Nethermind/Nethermind.Config.Test/JsonConfigProviderTests.cs
+++ b/src/Nethermind/Nethermind.Config.Test/JsonConfigProviderTests.cs
@@ -17,6 +17,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using Nethermind.Core.Collections;
 using Nethermind.JsonRpc;
 using Nethermind.JsonRpc.Modules;
 using Nethermind.KeyStore.Config;
@@ -67,7 +68,7 @@ namespace Nethermind.Config.Test
                 Assert.IsTrue(jsonRpcConfig.EnabledModules.Contains(x));
             }
 
-            new[] { ModuleType.Eth, ModuleType.Debug }.ToList().ForEach(CheckIfEnabled);
+            new[] { ModuleType.Eth, ModuleType.Debug }.ForEach(CheckIfEnabled);
 
             Assert.AreEqual(4, networkConfig.Concurrency);
         }

--- a/src/Nethermind/Nethermind.Core/Collections/EnuberableExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/EnuberableExtensions.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Nethermind.Core.Collections;
+
+public static class EnuberableExtensions
+{
+    public static void ForEach<T>(this IEnumerable<T> list, Action<T> action)
+    {
+        list.ToList().ForEach(action);
+    }
+}

--- a/src/Nethermind/Nethermind.Init/Metrics.cs
+++ b/src/Nethermind/Nethermind.Init/Metrics.cs
@@ -15,12 +15,19 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
 using System.ComponentModel;
+using Nethermind.Core;
+using Nethermind.Monitoring.Metrics;
 
 namespace Nethermind.Init
 {
     public static class Metrics
     {
         [Description("Version number")]
+        [MetricsStaticDescriptionTag(nameof(ProductInfo.Version), typeof(ProductInfo))]
+        [MetricsStaticDescriptionTag(nameof(ProductInfo.Commit), typeof(ProductInfo))]
+        [MetricsStaticDescriptionTag(nameof(ProductInfo.Runtime), typeof(ProductInfo))]
+        [MetricsStaticDescriptionTag(nameof(ProductInfo.BuildTimestamp), typeof(ProductInfo))]
         public static long Version { get; set; }
+        
     }
 }

--- a/src/Nethermind/Nethermind.KeyStore.Test/KeyStoreJsonTests.cs
+++ b/src/Nethermind/Nethermind.KeyStore.Test/KeyStoreJsonTests.cs
@@ -19,6 +19,7 @@ using System.IO;
 using System.Linq;
 using System.Security;
 using Nethermind.Core;
+using Nethermind.Core.Collections;
 using Nethermind.Crypto;
 using Nethermind.KeyStore.Config;
 using Nethermind.Logging;
@@ -104,7 +105,7 @@ namespace Nethermind.KeyStore.Test
             try
             {
                 var securedPass = new SecureString();
-                testModel.Password.ToCharArray().ToList().ForEach(x => securedPass.AppendChar(x));
+                testModel.Password.ToCharArray().ForEach(x => securedPass.AppendChar(x));
                 securedPass.MakeReadOnly();
                 (PrivateKey key, Result result) = _store.GetKey(address, securedPass);
 

--- a/src/Nethermind/Nethermind.Monitoring.Test/MetricsTests.cs
+++ b/src/Nethermind/Nethermind.Monitoring.Test/MetricsTests.cs
@@ -55,8 +55,8 @@ namespace Nethermind.Monitoring.Test
                 typeof(Nethermind.Trie.Metrics),
                 typeof(Nethermind.Trie.Pruning.Metrics),
             };
-            MetricsUpdater metricsUpdater = new(metricsConfig);
-            MonitoringService monitoringService = new(metricsUpdater, metricsConfig, LimboLogs.Instance);
+            MetricsController metricsController = new(metricsConfig);
+            MonitoringService monitoringService = new(metricsController, metricsConfig, LimboLogs.Instance);
             List<Type> metrics = new TypeDiscovery().FindNethermindTypes(nameof(Metrics)).ToList();
             metrics.AddRange(knownMetricsTypes);
 
@@ -67,7 +67,7 @@ namespace Nethermind.Monitoring.Test
                     monitoringService.RegisterMetrics(metric);
                 }
 
-                metricsUpdater.UpdateMetrics(null);
+                metricsController.UpdateMetrics(null);
             });
         }
 

--- a/src/Nethermind/Nethermind.Monitoring/Metrics/IMetricsController.cs
+++ b/src/Nethermind/Nethermind.Monitoring/Metrics/IMetricsController.cs
@@ -18,7 +18,7 @@ using System;
 
 namespace Nethermind.Monitoring.Metrics
 {
-    public interface IMetricsUpdater
+    public interface IMetricsController
     {
         void RegisterMetrics(Type type);
         void StartUpdating();

--- a/src/Nethermind/Nethermind.Monitoring/Metrics/MetricsController.cs
+++ b/src/Nethermind/Nethermind.Monitoring/Metrics/MetricsController.cs
@@ -28,7 +28,7 @@ using Prometheus;
 
 namespace Nethermind.Monitoring.Metrics
 {
-    public class MetricsController : IMetricsUpdater
+    public class MetricsController : IMetricsController
     {
         public static readonly Dictionary<string, string> StaticTags= new();
 
@@ -73,9 +73,20 @@ namespace Nethermind.Monitoring.Metrics
         {
             Type type = givenInformer;
             PropertyInfo[] tagsData = type.GetProperties(BindingFlags.Static | BindingFlags.Public);
-            var info = tagsData.FirstOrDefault(info => info.Name == givenName);
-            var value = info?.GetValue(null)?.ToString();
-            tagValues.Add(info.Name, value);
+            PropertyInfo info = tagsData.FirstOrDefault(info => info.Name == givenName);
+            if (info == null)
+            {
+                throw new Exception("Developer error: a requested static description field was not implemented!");
+            }
+
+            object value = info.GetValue(null);
+            if (value == null)
+            {
+                throw new Exception("Developer error: a requested static description field was not initialised!");
+            }
+
+            string data = value.ToString();
+            tagValues.Add(info.Name, data);
         }
 
         private void EnsurePropertiesCached(Type type)

--- a/src/Nethermind/Nethermind.Monitoring/Metrics/MetricsStaticDescriptionTagAttribute.cs
+++ b/src/Nethermind/Nethermind.Monitoring/Metrics/MetricsStaticDescriptionTagAttribute.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace Nethermind.Monitoring.Metrics;
+
+/// <summary>
+/// A static label informer for labeling monitoring gages
+/// Note: Assumes that static values are set by the time metrics are registered
+/// </summary>
+[AttributeUsage(
+    AttributeTargets.Field | AttributeTargets.Property,
+    AllowMultiple = true)]
+public class MetricsStaticDescriptionTagAttribute : Attribute
+{
+    public string Label { get; }
+
+    public Type Informer { get; }
+
+    /// <summary>
+    /// Collects type and its static field name for future metrics registration
+    /// </summary>
+    /// <param name="metricsStaticLabel">static field name</param>
+    /// <param name="informer">type</param>
+    public MetricsStaticDescriptionTagAttribute(string metricsStaticLabel, Type informer)
+    {
+        Label = metricsStaticLabel;
+        Informer = informer;
+    }
+}

--- a/src/Nethermind/Nethermind.Monitoring/MonitoringService.cs
+++ b/src/Nethermind/Nethermind.Monitoring/MonitoringService.cs
@@ -29,7 +29,7 @@ namespace Nethermind.Monitoring
 {
     public class MonitoringService : IMonitoringService
     {
-        private readonly IMetricsUpdater _metricsUpdater;
+        private readonly IMetricsController _metricsController;
         private readonly ILogger _logger;
         private readonly Options _options;
 
@@ -39,9 +39,9 @@ namespace Nethermind.Monitoring
         private readonly string _pushGatewayUrl;
         private readonly int _intervalSeconds;
 
-        public MonitoringService(IMetricsUpdater metricsUpdater, IMetricsConfig metricsConfig, ILogManager logManager)
+        public MonitoringService(IMetricsController metricsController, IMetricsConfig metricsConfig, ILogManager logManager)
         {
-            _metricsUpdater = metricsUpdater ?? throw new ArgumentNullException(nameof(metricsUpdater));
+            _metricsController = metricsController ?? throw new ArgumentNullException(nameof(metricsController));
 
             int? exposePort = metricsConfig.ExposePort;
             string nodeName = metricsConfig.NodeName;
@@ -92,24 +92,26 @@ namespace Nethermind.Monitoring
                 MetricPusher metricPusher = new MetricPusher(pusherOptions);
 
                 metricPusher.Start();
+
+
             }
             if (_exposePort != null)
             {
-                IMetricServer metricServer = new MetricServer(_exposePort.Value, "metrics/");
+                IMetricServer metricServer = new KestrelMetricServer(_exposePort.Value);
                 metricServer.Start();
             }
-            await Task.Factory.StartNew(() => _metricsUpdater.StartUpdating(), TaskCreationOptions.LongRunning);
+            await Task.Factory.StartNew(() => _metricsController.StartUpdating(), TaskCreationOptions.LongRunning);
             if (_logger.IsInfo) _logger.Info($"Started monitoring for the group: {_options.Group}, instance: {_options.Instance}");
         }
 
         public void RegisterMetrics(Type type)
         {
-            _metricsUpdater.RegisterMetrics(type);
+            _metricsController.RegisterMetrics(type);
         }
 
         public Task StopAsync()
         {
-            _metricsUpdater.StopUpdating();
+            _metricsController.StopUpdating();
 
             return Task.CompletedTask;
         }

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/NettyDiscoveryHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/NettyDiscoveryHandlerTests.cs
@@ -74,7 +74,7 @@ namespace Nethermind.Network.Discovery.Test
         [TearDown]
         public async Task CleanUp()
         {
-            _channels.ToList().ForEach(x => { x.CloseAsync(); });
+            _channels.ForEach(x => { x.CloseAsync(); });
             await Task.Delay(50);
         }
 

--- a/src/Nethermind/Nethermind.Runner/Logging/NLogConfigurator.cs
+++ b/src/Nethermind/Nethermind.Runner/Logging/NLogConfigurator.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Linq;
 using Microsoft.Extensions.CommandLineUtils;
+using Nethermind.Core.Collections;
 using NLog;
 using NLog.Config;
 using NLog.Targets;
@@ -54,7 +55,7 @@ namespace Nethermind.Runner.Logging
                 }
 
                 // // // re-initialize single target
-                loggingConfiguration.AllTargets?.OfType<SeqTarget>().ToList().ForEach(t => t.Dispose());
+                loggingConfiguration.AllTargets?.OfType<SeqTarget>().ForEach(t => t.Dispose());
                 LogManager.ReconfigExistingLoggers();
             }
         }


### PR DESCRIPTION
Implemented a system for resolving #4860 needs

Resolves #4860

Added a system that allows for Static Metrics labelling.

Now versioning looks like this:
![Screenshot 2022-11-07 142426](https://user-images.githubusercontent.com/2915361/200340483-48e12675-f06c-43f0-a81e-b6ec3c8128ee.png)



## Changes:
- Added attributes for static properties labelling with data from static class properties
- Fixed metrics "Help" fields passing in the Metric descriptions 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
Cosmetic data publishing change for external metric tools. Code covered by previously existing tests

- [ ] Yes
- [x] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [x] No

Tested on local Prometheus 