### PR TITLE
fix eth_call mix_hash and beneficiary

### DIFF
--- a/src/Nethermind/Nethermind.Facade.Test/BlockchainBridgeTests.cs
+++ b/src/Nethermind/Nethermind.Facade.Test/BlockchainBridgeTests.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -153,13 +153,42 @@ namespace Nethermind.Facade.Test
             _timestamper.UtcNow = DateTime.MinValue;
             _timestamper.Add(TimeSpan.FromDays(123));
             BlockHeader header = Build.A.BlockHeader.WithNumber(10).TestObject;
-            Transaction tx = new();
-            tx.GasLimit = Transaction.BaseTxGasCost;
+            Transaction tx = new() { GasLimit = Transaction.BaseTxGasCost };
 
             _blockchainBridge.Call(header, tx, CancellationToken.None);
             _transactionProcessor.Received().CallAndRestore(
                 tx,
                 Arg.Is<BlockHeader>(bh => bh.Number == 10),
+                Arg.Any<ITxTracer>());
+        }
+
+        [Test]
+        public void Call_uses_valid_mix_hash()
+        {
+            _timestamper.UtcNow = DateTime.MinValue;
+            _timestamper.Add(TimeSpan.FromDays(123));
+            BlockHeader header = Build.A.BlockHeader.WithMixHash(TestItem.KeccakA).TestObject;
+            Transaction tx = new() { GasLimit = Transaction.BaseTxGasCost };
+
+            _blockchainBridge.Call(header, tx, CancellationToken.None);
+            _transactionProcessor.Received().CallAndRestore(
+                tx,
+                Arg.Is<BlockHeader>(bh => bh.MixHash == TestItem.KeccakA),
+                Arg.Any<ITxTracer>());
+        }
+
+        [Test]
+        public void Call_uses_valid_beneficiary()
+        {
+            _timestamper.UtcNow = DateTime.MinValue;
+            _timestamper.Add(TimeSpan.FromDays(123));
+            BlockHeader header = Build.A.BlockHeader.WithBeneficiary(TestItem.AddressB).TestObject;
+            Transaction tx = new() { GasLimit = Transaction.BaseTxGasCost };
+
+            _blockchainBridge.Call(header, tx, CancellationToken.None);
+            _transactionProcessor.Received().CallAndRestore(
+                tx,
+                Arg.Is<BlockHeader>(bh => bh.Beneficiary == TestItem.AddressB),
                 Arg.Any<ITxTracer>());
         }
 

--- a/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
@@ -278,9 +278,9 @@ namespace Nethermind.Facade
                     blockHeader.ExtraData)
                 {
                     BaseFeePerGas = blockHeader.BaseFeePerGas,
-                    MixHash = blockHeader.MixHash
                 };
 
+            callHeader.MixHash = blockHeader.MixHash;
             transaction.Hash = transaction.CalculateHash();
             transactionProcessor.CallAndRestore(transaction, callHeader, tracer);
         }

--- a/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
@@ -164,7 +164,7 @@ namespace Nethermind.Facade
         public CallOutput Call(BlockHeader header, Transaction tx, CancellationToken cancellationToken)
         {
             CallOutputTracer callOutputTracer = new();
-            (bool Success, string Error) tryCallResult = TryCallAndRestore(header, header.Timestamp, tx, false,
+            (bool Success, string Error) tryCallResult = TryCallAndRestore(header, tx, false,
                 callOutputTracer.WithCancellation(cancellationToken));
             return new CallOutput
             {
@@ -182,7 +182,6 @@ namespace Nethermind.Facade
             EstimateGasTracer estimateGasTracer = new();
             (bool Success, string Error) tryCallResult = TryCallAndRestore(
                 header,
-                Math.Max(header.Timestamp + 1, _timestamper.UnixTime.Seconds),
                 tx,
                 true,
                 estimateGasTracer.WithCancellation(cancellationToken));
@@ -206,7 +205,7 @@ namespace Nethermind.Facade
                     tx.GetRecipient(tx.IsContractCreation ? _processingEnv.StateReader.GetNonce(header.StateRoot, tx.SenderAddress) : 0))
                 : new();
 
-            (bool Success, string Error) tryCallResult = TryCallAndRestore(header, header.Timestamp, tx, false,
+            (bool Success, string Error) tryCallResult = TryCallAndRestore(header, tx, false,
                 new CompositeTxTracer(callOutputTracer, accessTxTracer).WithCancellation(cancellationToken));
 
             return new CallOutput
@@ -221,14 +220,13 @@ namespace Nethermind.Facade
 
         private (bool Success, string Error) TryCallAndRestore(
             BlockHeader blockHeader,
-            ulong timestamp,
             Transaction transaction,
             bool treatBlockHeaderAsParentBlock,
             ITxTracer tracer)
         {
             try
             {
-                CallAndRestore(blockHeader, timestamp, transaction, treatBlockHeaderAsParentBlock, tracer);
+                CallAndRestore(blockHeader, transaction, treatBlockHeaderAsParentBlock, tracer);
                 return (true, string.Empty);
             }
             catch (InsufficientBalanceException ex)
@@ -239,7 +237,6 @@ namespace Nethermind.Facade
 
         private void CallAndRestore(
             BlockHeader blockHeader,
-            ulong timestamp,
             Transaction transaction,
             bool treatBlockHeaderAsParentBlock,
             ITxTracer tracer)
@@ -257,19 +254,32 @@ namespace Nethermind.Facade
                 transaction.Nonce = GetNonce(stateRoot, transaction.SenderAddress);
             }
 
-            BlockHeader callHeader = new(
-                blockHeader.Hash!,
-                Keccak.OfAnEmptySequenceRlp,
-                Address.Zero,
-                0,
-                treatBlockHeaderAsParentBlock ? blockHeader.Number + 1 : blockHeader.Number,
-                blockHeader.GasLimit,
-                timestamp,
-                Array.Empty<byte>());
-
-            callHeader.BaseFeePerGas = treatBlockHeaderAsParentBlock
-                ? BaseFeeCalculator.Calculate(blockHeader, _specProvider.GetSpec(callHeader.Number))
-                : blockHeader.BaseFeePerGas;
+            BlockHeader callHeader = treatBlockHeaderAsParentBlock
+                ? new(
+                    blockHeader.Hash!,
+                    Keccak.OfAnEmptySequenceRlp,
+                    Address.Zero,
+                    UInt256.Zero,
+                    blockHeader.Number + 1,
+                    blockHeader.GasLimit,
+                    Math.Max(blockHeader.Timestamp + 1, _timestamper.UnixTime.Seconds),
+                    Array.Empty<byte>())
+                {
+                    BaseFeePerGas = BaseFeeCalculator.Calculate(blockHeader, _specProvider.GetSpec(blockHeader.Number + 1)),
+                }
+                : new(
+                    blockHeader.ParentHash!,
+                    blockHeader.UnclesHash!,
+                    blockHeader.Beneficiary!,
+                    blockHeader.Difficulty,
+                    blockHeader.Number,
+                    blockHeader.GasLimit,
+                    blockHeader.Timestamp,
+                    blockHeader.ExtraData)
+                {
+                    BaseFeePerGas = blockHeader.BaseFeePerGas,
+                    MixHash = blockHeader.MixHash
+                };
 
             transaction.Hash = transaction.CalculateHash();
             transactionProcessor.CallAndRestore(transaction, callHeader, tracer);

--- a/src/Nethermind/Nethermind.Logging/PathUtils.cs
+++ b/src/Nethermind/Nethermind.Logging/PathUtils.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -28,15 +28,17 @@ namespace Nethermind.Logging
 
         static PathUtils()
         {
-            var process = Process.GetCurrentProcess();
-            if (process.ProcessName.StartsWith("dotnet", StringComparison.InvariantCultureIgnoreCase))
+            Process process = Process.GetCurrentProcess();
+            if (process.ProcessName.StartsWith("dotnet", StringComparison.InvariantCultureIgnoreCase)
+                || process.ProcessName.Equals("ReSharperTestRunner", StringComparison.InvariantCultureIgnoreCase))
             {
                 ExecutingDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-                return;
             }
-
-            ExecutingDirectory = Path.GetDirectoryName(process.MainModule.FileName);
-            Console.WriteLine($"Resolved executing directory as {ExecutingDirectory}.");
+            else
+            {
+                ExecutingDirectory = Path.GetDirectoryName(process.MainModule.FileName);
+                Console.WriteLine($"Resolved executing directory as {ExecutingDirectory}.");
+            }
         }
 
         public static string GetApplicationResourcePath(this string resourcePath, string overridePrefixPath = null)

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncReportTest.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncReportTest.cs
@@ -96,7 +96,7 @@ namespace Nethermind.Synchronization.Test
             }
 
             SyncReport syncReport = new(pool, Substitute.For<INodeStatsManager>(), selector, syncConfig, Substitute.For<IPivot>(), logManager, timerFactory);
-            selector.Current.Returns((ci) => SyncMode.FastHeaders | SyncMode.FastBodies | SyncMode.FastReceipts);
+            selector.Current.Returns(_ => SyncMode.FastHeaders | SyncMode.FastBodies | SyncMode.FastReceipts);
             timer.Elapsed += Raise.Event();
 
             if (setBarriers)


### PR DESCRIPTION
Fixes https://github.com/gnosischain/pm/issues/143

## Changes:
- Adds MixHash and Beneficiary to the fields of the tx header that will be used in the context of tx execution when using eth_call

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No