### PR TITLE
Set C# version to 10.0

### DIFF
--- a/src/Nethermind/Nethermind.Abi.Test/Nethermind.Abi.Test.csproj
+++ b/src/Nethermind/Nethermind.Abi.Test/Nethermind.Abi.Test.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <IsPackable>false</IsPackable>
-        <LangVersion>latest</LangVersion>
+        <LangVersion>10.0</LangVersion>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 

--- a/src/Nethermind/Nethermind.Abi/Nethermind.Abi.csproj
+++ b/src/Nethermind/Nethermind.Abi/Nethermind.Abi.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>latest</LangVersion>
+        <LangVersion>10.0</LangVersion>
         <Nullable>enable</Nullable>
         <Deterministic>true</Deterministic>
         <ProduceReferenceAssembly>true</ProduceReferenceAssembly>

--- a/src/Nethermind/Nethermind.Blockchain.Test/Nethermind.Blockchain.Test.csproj
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Nethermind.Blockchain.Test.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Nethermind/Nethermind.Blockchain/Nethermind.Blockchain.csproj
+++ b/src/Nethermind/Nethermind.Blockchain/Nethermind.Blockchain.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <Deterministic>true</Deterministic>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <Nullable>annotations</Nullable>

--- a/src/Nethermind/Nethermind.Cli/Nethermind.Cli.csproj
+++ b/src/Nethermind/Nethermind.Cli/Nethermind.Cli.csproj
@@ -7,7 +7,7 @@
         <PackageId>Nethermind CLI</PackageId>
         <Authors>Nethermind</Authors>
         <PackageVersion>1.0.0</PackageVersion>
-        <LangVersion>latest</LangVersion>
+        <LangVersion>10.0</LangVersion>
         <Nullable>enable</Nullable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>

--- a/src/Nethermind/Nethermind.Clique.Test/Nethermind.Clique.Test.csproj
+++ b/src/Nethermind/Nethermind.Clique.Test/Nethermind.Clique.Test.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <IsPackable>false</IsPackable>
-        <LangVersion>latest</LangVersion>
+        <LangVersion>10.0</LangVersion>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 

--- a/src/Nethermind/Nethermind.Config.Test/Nethermind.Config.Test.csproj
+++ b/src/Nethermind/Nethermind.Config.Test/Nethermind.Config.Test.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/src/Nethermind/Nethermind.Config/Nethermind.Config.csproj
+++ b/src/Nethermind/Nethermind.Config/Nethermind.Config.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <Deterministic>true</Deterministic>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Nethermind/Nethermind.Consensus.Clique/Nethermind.Consensus.Clique.csproj
+++ b/src/Nethermind/Nethermind.Consensus.Clique/Nethermind.Consensus.Clique.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>latest</LangVersion>
+        <LangVersion>10.0</LangVersion>
         <Nullable>annotations</Nullable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>

--- a/src/Nethermind/Nethermind.Consensus.Ethash/Nethermind.Consensus.Ethash.csproj
+++ b/src/Nethermind/Nethermind.Consensus.Ethash/Nethermind.Consensus.Ethash.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <OutputType>Library</OutputType>
     <Nullable>annotations</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Nethermind/Nethermind.Core.Test/Nethermind.Core.Test.csproj
+++ b/src/Nethermind/Nethermind.Core.Test/Nethermind.Core.Test.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Nethermind/Nethermind.Core/Nethermind.Core.csproj
+++ b/src/Nethermind/Nethermind.Core/Nethermind.Core.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
     <Deterministic>true</Deterministic>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>

--- a/src/Nethermind/Nethermind.Db.Rpc/Nethermind.Db.Rpc.csproj
+++ b/src/Nethermind/Nethermind.Db.Rpc/Nethermind.Db.Rpc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/src/Nethermind/Nethermind.Db.Test/Nethermind.Db.Test.csproj
+++ b/src/Nethermind/Nethermind.Db.Test/Nethermind.Db.Test.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Nullable>annotations</Nullable>
   </PropertyGroup>

--- a/src/Nethermind/Nethermind.Db/Nethermind.Db.csproj
+++ b/src/Nethermind/Nethermind.Db/Nethermind.Db.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <Deterministic>true</Deterministic>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <Nullable>annotations</Nullable>

--- a/src/Nethermind/Nethermind.EthStats/Nethermind.EthStats.csproj
+++ b/src/Nethermind/Nethermind.EthStats/Nethermind.EthStats.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>latest</LangVersion>
+        <LangVersion>10.0</LangVersion>
         <Nullable>enable</Nullable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>

--- a/src/Nethermind/Nethermind.Evm.Test/Nethermind.Evm.Test.csproj
+++ b/src/Nethermind/Nethermind.Evm.Test/Nethermind.Evm.Test.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/src/Nethermind/Nethermind.Evm/Nethermind.Evm.csproj
+++ b/src/Nethermind/Nethermind.Evm/Nethermind.Evm.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Deterministic>true</Deterministic>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>

--- a/src/Nethermind/Nethermind.Facade/Nethermind.Facade.csproj
+++ b/src/Nethermind/Nethermind.Facade/Nethermind.Facade.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>latest</LangVersion>
+        <LangVersion>10.0</LangVersion>
         <Deterministic>true</Deterministic>
         <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
         <Nullable>annotations</Nullable>

--- a/src/Nethermind/Nethermind.Grpc/Nethermind.Grpc.csproj
+++ b/src/Nethermind/Nethermind.Grpc/Nethermind.Grpc.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>latest</LangVersion>
+        <LangVersion>10.0</LangVersion>
         <Deterministic>true</Deterministic>
         <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Nethermind.JsonRpc.Test.csproj
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Nethermind.JsonRpc.Test.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/Nethermind/Nethermind.JsonRpc/Nethermind.JsonRpc.csproj
+++ b/src/Nethermind/Nethermind.JsonRpc/Nethermind.JsonRpc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <Deterministic>true</Deterministic>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <Nullable>annotations</Nullable>

--- a/src/Nethermind/Nethermind.KeyStore.Test/Nethermind.KeyStore.Test.csproj
+++ b/src/Nethermind/Nethermind.KeyStore.Test/Nethermind.KeyStore.Test.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Nethermind/Nethermind.KeyStore/Nethermind.KeyStore.csproj
+++ b/src/Nethermind/Nethermind.KeyStore/Nethermind.KeyStore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <Deterministic>true</Deterministic>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Nethermind/Nethermind.Logging.Microsoft/Nethermind.Logging.Microsoft.csproj
+++ b/src/Nethermind/Nethermind.Logging.Microsoft/Nethermind.Logging.Microsoft.csproj
@@ -5,7 +5,7 @@
         <Product>Nethermind Eth2.0 blockchain</Product>
         <Copyright>Copyright © 2019 Demerzel Solutions Limited</Copyright>
         <Version>0.0.1</Version>
-        <LangVersion>latest</LangVersion>
+        <LangVersion>10.0</LangVersion>
         <Nullable>enable</Nullable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>

--- a/src/Nethermind/Nethermind.Logging/Nethermind.Logging.csproj
+++ b/src/Nethermind/Nethermind.Logging/Nethermind.Logging.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>latest</LangVersion>
+        <LangVersion>10.0</LangVersion>
         <Deterministic>true</Deterministic>
         <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Nethermind/Nethermind.Mining.Test/Nethermind.Mining.Test.csproj
+++ b/src/Nethermind/Nethermind.Mining.Test/Nethermind.Mining.Test.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Nethermind/Nethermind.Monitoring/Nethermind.Monitoring.csproj
+++ b/src/Nethermind/Nethermind.Monitoring/Nethermind.Monitoring.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <Deterministic>true</Deterministic>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Nethermind/Nethermind.Network.Stats/Nethermind.Network.Stats.csproj
+++ b/src/Nethermind/Nethermind.Network.Stats/Nethermind.Network.Stats.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <RootNamespace>Nethermind.Stats</RootNamespace>
     <Deterministic>true</Deterministic>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>

--- a/src/Nethermind/Nethermind.Network.Test/Nethermind.Network.Test.csproj
+++ b/src/Nethermind/Nethermind.Network.Test/Nethermind.Network.Test.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/src/Nethermind/Nethermind.Network/Nethermind.Network.csproj
+++ b/src/Nethermind/Nethermind.Network/Nethermind.Network.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <Deterministic>true</Deterministic>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <Nullable>annotations</Nullable>

--- a/src/Nethermind/Nethermind.Overseer.Test/Nethermind.Overseer.Test.csproj
+++ b/src/Nethermind/Nethermind.Overseer.Test/Nethermind.Overseer.Test.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <IsPackable>false</IsPackable>
-        <LangVersion>latest</LangVersion>
+        <LangVersion>10.0</LangVersion>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 

--- a/src/Nethermind/Nethermind.Runner/Nethermind.Runner.csproj
+++ b/src/Nethermind/Nethermind.Runner/Nethermind.Runner.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>

--- a/src/Nethermind/Nethermind.Secp256k1.Test/Nethermind.Secp256k1.Test.csproj
+++ b/src/Nethermind/Nethermind.Secp256k1.Test/Nethermind.Secp256k1.Test.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/src/Nethermind/Nethermind.Secp256k1/Nethermind.Secp256k1.csproj
+++ b/src/Nethermind/Nethermind.Secp256k1/Nethermind.Secp256k1.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/src/Nethermind/Nethermind.Seq/Nethermind.Seq.csproj
+++ b/src/Nethermind/Nethermind.Seq/Nethermind.Seq.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/src/Nethermind/Nethermind.Sockets/Nethermind.Sockets.csproj
+++ b/src/Nethermind/Nethermind.Sockets/Nethermind.Sockets.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>latest</LangVersion>
+        <LangVersion>10.0</LangVersion>
         <Deterministic>true</Deterministic>
         <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
         <Nullable>enable</Nullable>

--- a/src/Nethermind/Nethermind.State.Test/Nethermind.State.Test.csproj
+++ b/src/Nethermind/Nethermind.State.Test/Nethermind.State.Test.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <RootNamespace>Nethermind.Store.Test</RootNamespace>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/src/Nethermind/Nethermind.State/Nethermind.State.csproj
+++ b/src/Nethermind/Nethermind.State/Nethermind.State.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <Nullable>annotations</Nullable>
     <Deterministic>true</Deterministic>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>

--- a/src/Nethermind/Nethermind.Wallet.Test/Nethermind.Wallet.Test.csproj
+++ b/src/Nethermind/Nethermind.Wallet.Test/Nethermind.Wallet.Test.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Nethermind/Nethermind.Wallet/Nethermind.Wallet.csproj
+++ b/src/Nethermind/Nethermind.Wallet/Nethermind.Wallet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <Deterministic>true</Deterministic>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>


### PR DESCRIPTION
Fixes compiler errors when compiling with C# 11. This change is required for Visual Studio v17.4 and above as it uses C# 11 as the latest language version. The change should be reverted after the code is updated to meet C# 11 requirements.

## Changes
- Replaced `<LangVersion>latest</LangVersion>` with `<LangVersion>10.0</LangVersion>` in project files

## Types of changes

What types of changes does your code introduce?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [x] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [x] No

## Further comments (optional)

More info [here](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/breaking-changes/compiler%20breaking%20changes%20-%20dotnet%207).