### PR TITLE
Added Overridable Chainspec to Run and Execute Functions

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/VirtualMachineTestsBase.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/VirtualMachineTestsBase.cs
@@ -32,6 +32,7 @@ using Nethermind.Logging;
 using Nethermind.State;
 using Nethermind.Trie.Pruning;
 using NUnit.Framework;
+using FluentAssertions.Execution;
 
 namespace Nethermind.Evm.Test
 {
@@ -85,49 +86,63 @@ namespace Nethermind.Evm.Test
             _processor = new TransactionProcessor(SpecProvider, TestState, Storage, Machine, logManager);
         }
 
+
+
         protected GethLikeTxTrace ExecuteAndTrace(params byte[] code)
+            => ExecuteAndTrace(null, code);
+        protected GethLikeTxTrace ExecuteAndTrace(IReleaseSpec overridedSpec , params byte[] code)
         {
             GethLikeTxTracer tracer = new(GethTraceOptions.Default);
             (Block block, Transaction transaction) = PrepareTx(BlockNumber, 100000, code);
-            _processor.Execute(transaction, block.Header, tracer);
+            _processor.Execute(transaction, block.Header, tracer, overridedSpec);
             return tracer.BuildResult();
         }
 
         protected GethLikeTxTrace ExecuteAndTrace(long blockNumber, long gasLimit, params byte[] code)
+            => ExecuteAndTrace(blockNumber, gasLimit, null, code);
+        protected GethLikeTxTrace ExecuteAndTrace(long blockNumber, long gasLimit, IReleaseSpec overridedSpec, params byte[] code)
         {
             GethLikeTxTracer tracer = new(GethTraceOptions.Default);
             (Block block, Transaction transaction) = PrepareTx(blockNumber, gasLimit, code);
-            _processor.Execute(transaction, block.Header, tracer);
+            _processor.Execute(transaction, block.Header, tracer, overridedSpec);
             return tracer.BuildResult();
         }
 
         protected TestAllTracerWithOutput Execute(long blockNumber, ulong timestamp, params byte[] code)
+            => Execute(blockNumber, timestamp, null, code);
+        protected TestAllTracerWithOutput Execute(long blockNumber, ulong timestamp, IReleaseSpec overridedSpec , params byte[] code)
         {
             (Block block, Transaction transaction) = PrepareTx(blockNumber, 100000, code, timestamp: timestamp);
             TestAllTracerWithOutput tracer = CreateTracer();
-            _processor.Execute(transaction, block.Header, tracer);
+            _processor.Execute(transaction, block.Header, tracer, overridedSpec);
             return tracer;
         }
 
         protected TestAllTracerWithOutput Execute(params byte[] code)
+            => Execute(null, code);
+        protected TestAllTracerWithOutput Execute(IReleaseSpec overridedSpec, params byte[] code)
         {
-            return Execute(BlockNumber, Timestamp, code);
+            return Execute(BlockNumber, Timestamp, overridedSpec, code);
         }
 
         protected virtual TestAllTracerWithOutput CreateTracer() => new();
 
         protected T Execute<T>(T tracer, params byte[] code) where T : ITxTracer
+            => Execute<T>(tracer, null, code);
+        protected T Execute<T>(T tracer, IReleaseSpec overridedSpec, params byte[] code) where T : ITxTracer
         {
             (Block block, Transaction transaction) = PrepareTx(BlockNumber, 100000, code, timestamp: Timestamp);
-            _processor.Execute(transaction, block.Header, tracer);
+            _processor.Execute(transaction, block.Header, tracer, overridedSpec);
             return tracer;
         }
 
         protected TestAllTracerWithOutput Execute(long blockNumber, long gasLimit, byte[] code, long blockGasLimit = DefaultBlockGasLimit, ulong timestamp = 0)
+            => Execute(blockNumber, gasLimit, code, null, blockGasLimit, timestamp);
+        protected TestAllTracerWithOutput Execute(long blockNumber, long gasLimit, byte[] code, IReleaseSpec overridedSpec, long blockGasLimit = DefaultBlockGasLimit, ulong timestamp = 0)
         {
             (Block block, Transaction transaction) = PrepareTx(blockNumber, gasLimit, code, blockGasLimit: blockGasLimit, timestamp: timestamp);
             TestAllTracerWithOutput tracer = CreateTracer();
-            _processor.Execute(transaction, block.Header, tracer);
+            _processor.Execute(transaction, block.Header, tracer, overridedSpec);
             return tracer;
         }
 

--- a/src/Nethermind/Nethermind.Evm/IVirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/IVirtualMachine.cs
@@ -24,7 +24,7 @@ namespace Nethermind.Evm
 {
     public interface IVirtualMachine
     {
-        TransactionSubstate Run(EvmState state, IWorldState worldState, ITxTracer tracer);
+        TransactionSubstate Run(EvmState state, IWorldState worldState, ITxTracer tracer, IReleaseSpec spec = null);
 
         CodeInfo GetCachedCodeInfo(IWorldState worldState, Address codeSource, IReleaseSpec spec);
     }

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/ITransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/ITransactionProcessor.cs
@@ -15,6 +15,7 @@
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
 using Nethermind.Core;
+using Nethermind.Core.Specs;
 using Nethermind.Evm.Tracing;
 
 namespace Nethermind.Evm.TransactionProcessing
@@ -24,21 +25,21 @@ namespace Nethermind.Evm.TransactionProcessing
         /// <summary>
         /// Execute transaction, commit state
         /// </summary>
-        void Execute(Transaction transaction, BlockHeader block, ITxTracer txTracer);
+        void Execute(Transaction transaction, BlockHeader block, ITxTracer txTracer, IReleaseSpec spec = null);
 
         /// <summary>
         /// Call transaction, rollback state
         /// </summary>
-        void CallAndRestore(Transaction transaction, BlockHeader block, ITxTracer txTracer);
+        void CallAndRestore(Transaction transaction, BlockHeader block, ITxTracer txTracer, IReleaseSpec spec = null);
 
         /// <summary>
         /// Execute transaction, keep the state uncommitted
         /// </summary>
-        void BuildUp(Transaction transaction, BlockHeader block, ITxTracer txTracer);
+        void BuildUp(Transaction transaction, BlockHeader block, ITxTracer txTracer, IReleaseSpec spec = null);
 
         /// <summary>
         /// Call transaction, no validations, commit state
         /// </summary>
-        void Trace(Transaction transaction, BlockHeader block, ITxTracer txTracer);
+        void Trace(Transaction transaction, BlockHeader block, ITxTracer txTracer, IReleaseSpec spec = null);
     }
 }

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/ReadOnlyTransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/ReadOnlyTransactionProcessor.cs
@@ -17,6 +17,7 @@
 using System;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Specs;
 using Nethermind.Db;
 using Nethermind.Evm.Tracing;
 using Nethermind.State;
@@ -41,17 +42,17 @@ namespace Nethermind.Evm.TransactionProcessing
             _stateProvider.StateRoot = startState ?? throw new ArgumentNullException(nameof(startState));
         }
 
-        public void Execute(Transaction transaction, BlockHeader block, ITxTracer txTracer) =>
-            _transactionProcessor.Execute(transaction, block, txTracer);
+        public void Execute(Transaction transaction, BlockHeader block, ITxTracer txTracer, IReleaseSpec spec = null) =>
+            _transactionProcessor.Execute(transaction, block, txTracer, spec);
 
-        public void CallAndRestore(Transaction transaction, BlockHeader block, ITxTracer txTracer) =>
-            _transactionProcessor.CallAndRestore(transaction, block, txTracer);
+        public void CallAndRestore(Transaction transaction, BlockHeader block, ITxTracer txTracer, IReleaseSpec spec = null) =>
+            _transactionProcessor.CallAndRestore(transaction, block, txTracer, spec);
 
-        public void BuildUp(Transaction transaction, BlockHeader block, ITxTracer txTracer) =>
-            _transactionProcessor.BuildUp(transaction, block, txTracer);
+        public void BuildUp(Transaction transaction, BlockHeader block, ITxTracer txTracer, IReleaseSpec spec = null) =>
+            _transactionProcessor.BuildUp(transaction, block, txTracer, spec);
 
-        public void Trace(Transaction transaction, BlockHeader block, ITxTracer txTracer) =>
-            _transactionProcessor.Trace(transaction, block, txTracer);
+        public void Trace(Transaction transaction, BlockHeader block, ITxTracer txTracer, IReleaseSpec spec = null) =>
+            _transactionProcessor.Trace(transaction, block, txTracer, spec);
 
 
         public bool IsContractDeployed(Address address) => _stateProvider.IsContract(address);
@@ -63,5 +64,6 @@ namespace Nethermind.Evm.TransactionProcessing
             _storageProvider.Reset();
             _codeDb.ClearTempChanges();
         }
+
     }
 }

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -92,7 +92,7 @@ namespace Nethermind.Evm
             InitializePrecompiledContracts();
         }
 
-        public TransactionSubstate Run(EvmState state, IWorldState worldState, ITxTracer txTracer)
+        public TransactionSubstate Run(EvmState state, IWorldState worldState, ITxTracer txTracer, IReleaseSpec overridedSpec = null)
         {
             _txTracer = txTracer;
 
@@ -100,7 +100,7 @@ namespace Nethermind.Evm
             _storage = worldState.StorageProvider;
             _worldState = worldState;
 
-            IReleaseSpec spec = _specProvider.GetSpec(state.Env.TxExecutionContext.Header.Number, state.Env.TxExecutionContext.Header.Timestamp);
+            IReleaseSpec spec = overridedSpec ?? _specProvider.GetSpec(state.Env.TxExecutionContext.Header.Number, state.Env.TxExecutionContext.Header.Timestamp);
             EvmState currentState = state;
             byte[] previousCallResult = null;
             ZeroPaddedSpan previousCallOutput = ZeroPaddedSpan.Empty;


### PR DESCRIPTION
…alMachine.Run

Fixes | Closes | Resolves #
Eases the Testing process when trying to use custom Chainspecs to run transactions instead of relying on ISpecProvider,

> Anything marked as optional that you didn't need to fill in, please remove it from the PR description. Choose one of the keywords above to refer to the issue this PR solves, followed by the issue number (e.g Fixes # 666). If there is no issue, remove the line. Remove this note after reading.

## Changes:
- Adds an optional Argument of type IReleaseSpec to the IVirtualMachine.Run and ITransactionsProcessor.Execute that is defaulted to null
- Exposes the updated Execute functions in the VirtualMachineTestsBase class

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [x] No

**Comments about testing , should you have some** (optional)

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...