### PR TITLE
Fix enode parsing

### DIFF
--- a/src/Nethermind/Nethermind.Config/Enode.cs
+++ b/src/Nethermind/Nethermind.Config/Enode.cs
@@ -1,16 +1,16 @@
 //  Copyright (c) 2021 Demerzel Solutions Limited
 //  This file is part of the Nethermind library.
-// 
+//
 //  The Nethermind library is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU Lesser General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
-// 
+//
 //  The Nethermind library is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //  GNU Lesser General Public License for more details.
-// 
+//
 //  You should have received a copy of the GNU Lesser General Public License
 //  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
 
@@ -28,11 +28,12 @@ namespace Nethermind.Config
     {
         private readonly PublicKey _nodeKey;
 
-        public Enode(PublicKey nodeKey, IPAddress hostIp, int port)
+        public Enode(PublicKey nodeKey, IPAddress hostIp, int port, int? udpPort = null)
         {
             _nodeKey = nodeKey;
             HostIp = hostIp;
             Port = port;
+            UdpPort = udpPort ?? port;
         }
 
         public Enode(string enodeString)
@@ -47,12 +48,34 @@ namespace Nethermind.Config
             string[] enodeParts2 = enodeParts[1].Split('@');
             _nodeKey = new PublicKey(enodeParts2[0].TrimStart('/'));
             string host = enodeParts2[1];
-            if (enodeParts.Length <= 2 || !int.TryParse(enodeParts[2], out int port))
+            string[] portParts = enodeParts[2].Split("?discport=");
+
+            if (enodeParts.Length <= 2 || portParts.Length < 1)
             {
                 throw GetPortException(host);
-
             }
-            Port = port;
+
+            switch (portParts.Length)
+            {
+                case 1:
+                    if (int.TryParse(portParts[0], out int port))
+                    {
+                        Port = port;
+                        UdpPort = port;
+                    }
+                    else throw GetPortException(host);
+                    break;
+                case 2:
+                    if (int.TryParse(portParts[0], out int tcpPort) && int.TryParse(portParts[1], out int udpPort))
+                    {
+                        Port = tcpPort;
+                        UdpPort = udpPort;
+                    }
+                    else throw GetPortException(host);
+                    break;
+                default:
+                    throw GetPortException(host);
+            }
 
             try
             {
@@ -84,7 +107,10 @@ namespace Nethermind.Config
         public Address Address => _nodeKey.Address;
         public IPAddress HostIp { get; }
         public int Port { get; }
-        public string Info => $"enode://{_nodeKey.ToString(false)}@{HostIp}:{Port}";
+        public int UdpPort { get; }
+        public string Info => UdpPort == Port
+            ? $"enode://{_nodeKey.ToString(false)}@{HostIp}:{Port}"
+            : $"enode://{_nodeKey.ToString(false)}@{HostIp}:{Port}?discport={UdpPort}";
 
         public override string ToString() => Info;
     }

--- a/src/Nethermind/Nethermind.Config/Enode.cs
+++ b/src/Nethermind/Nethermind.Config/Enode.cs
@@ -67,9 +67,9 @@ namespace Nethermind.Config
                     else throw GetPortException(host);
                     break;
                 case 2:
-                    if (int.TryParse(portParts[0], out int tcpPort) && int.TryParse(portParts[1], out int discoveryPort))
+                    if (int.TryParse(portParts[0], out int listeningPort) && int.TryParse(portParts[1], out int discoveryPort))
                     {
-                        Port = tcpPort;
+                        Port = listeningPort;
                         DiscoveryPort = discoveryPort;
                     }
                     else throw GetPortException(host);

--- a/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
@@ -75,6 +75,9 @@ namespace Nethermind.Network.Test
         private const string enode7String =
             "enode://3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333b@52.141.78.53:12345?somethingwrong=6789";
 
+        private const string enode8String =
+            "enode://3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333b@52.141.78.53:12345?discport=6789?discport=67899";
+
         [Test, Retry(10)]
         public async Task Will_connect_to_a_candidate_node()
         {
@@ -127,7 +130,7 @@ namespace Nethermind.Network.Test
         }
 
         [Test]
-        public void Will_parse_udpPort_correctly()
+        public void Will_parse_ports_correctly_when_there_are_two_different_ports()
         {
             Enode enode = new(enode5String);
             enode.Port.Should().Be(12345);
@@ -135,7 +138,7 @@ namespace Nethermind.Network.Test
         }
 
         [Test]
-        public void Will_parse_ports_correctly_when_there_is_only_one()
+        public void Will_parse_port_correctly_when_there_is_only_one()
         {
             Enode enode = new(enode6String);
             enode.Port.Should().Be(12345);
@@ -148,6 +151,15 @@ namespace Nethermind.Network.Test
             Assert.Throws<ArgumentException>(delegate
             {
                 Enode unused = new(enode7String);
+            });
+        }
+
+        [Test]
+        public void Will_throw_on_duplicated_udpPort_part()
+        {
+            Assert.Throws<ArgumentException>(delegate
+            {
+                Enode unused = new(enode8String);
             });
         }
 

--- a/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
@@ -66,6 +66,15 @@ namespace Nethermind.Network.Test
         private const string enode4String =
             "enode://3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333b@some.url:434";
 
+        private const string enode5String =
+            "enode://3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333b@52.141.78.53:12345";
+
+        private const string enode6String =
+            "enode://3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333b@52.141.78.53:12345?discport=6789";
+
+        private const string enode7String =
+            "enode://3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333b@52.141.78.53:12345?somethingwrong=6789";
+
         [Test, Retry(10)]
         public async Task Will_connect_to_a_candidate_node()
         {
@@ -114,6 +123,31 @@ namespace Nethermind.Network.Test
             Assert.Throws<ArgumentException>(delegate
             {
                 Enode unused = new(enode3String);
+            });
+        }
+
+        [Test]
+        public void Will_parse_udpPort_correctly()
+        {
+            Enode enode = new(enode5String);
+            enode.Port.Should().Be(12345);
+            enode.UdpPort.Should().Be(12345);
+        }
+
+        [Test]
+        public void Will_parse_ports_correctly_when_there_is_only_one()
+        {
+            Enode enode = new(enode6String);
+            enode.Port.Should().Be(12345);
+            enode.UdpPort.Should().Be(6789);
+        }
+
+        [Test]
+        public void Will_throw_on_wrong_ports_part()
+        {
+            Assert.Throws<ArgumentException>(delegate
+            {
+                Enode unused = new(enode7String);
             });
         }
 

--- a/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
@@ -67,16 +67,22 @@ namespace Nethermind.Network.Test
             "enode://3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333b@some.url:434";
 
         private const string enode5String =
-            "enode://3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333b@52.141.78.53:12345";
+            "enode://3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333b@52.141.78.53";
 
         private const string enode6String =
-            "enode://3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333b@52.141.78.53:12345?discport=6789";
+            "enode://3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333b@52.141.78.53:12345";
 
         private const string enode7String =
-            "enode://3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333b@52.141.78.53:12345?somethingwrong=6789";
+            "enode://3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333b@52.141.78.53:12345?discport=6789";
 
         private const string enode8String =
+            "enode://3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333b@52.141.78.53:12345?somethingwrong=6789";
+
+        private const string enode9String =
             "enode://3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333b@52.141.78.53:12345?discport=6789?discport=67899";
+
+        private const string enode10String =
+            "enode://3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333b@52.141.78.53:12345:discport=6789";
 
         [Test, Retry(10)]
         public async Task Will_connect_to_a_candidate_node()
@@ -130,32 +136,41 @@ namespace Nethermind.Network.Test
         }
 
         [Test]
+        public void Will_return_exception_in_dns()
+        {
+            Assert.Throws<ArgumentException>(delegate
+            {
+                Enode unused = new(enode4String);
+            });
+        }
+
+        [Test]
+        public void Will_return_exception_when_there_is_no_port()
+        {
+            Assert.Throws<ArgumentException>(delegate
+            {
+                Enode unused = new(enode5String);
+            });
+        }
+
+        [Test]
         public void Will_parse_ports_correctly_when_there_are_two_different_ports()
         {
-            Enode enode = new(enode5String);
+            Enode enode = new(enode6String);
             enode.Port.Should().Be(12345);
-            enode.UdpPort.Should().Be(12345);
+            enode.DiscoveryPort.Should().Be(12345);
         }
 
         [Test]
         public void Will_parse_port_correctly_when_there_is_only_one()
         {
-            Enode enode = new(enode6String);
+            Enode enode = new(enode7String);
             enode.Port.Should().Be(12345);
-            enode.UdpPort.Should().Be(6789);
+            enode.DiscoveryPort.Should().Be(6789);
         }
 
         [Test]
-        public void Will_throw_on_wrong_ports_part()
-        {
-            Assert.Throws<ArgumentException>(delegate
-            {
-                Enode unused = new(enode7String);
-            });
-        }
-
-        [Test]
-        public void Will_throw_on_duplicated_udpPort_part()
+        public void Will_return_exception_on_wrong_ports_part()
         {
             Assert.Throws<ArgumentException>(delegate
             {
@@ -164,11 +179,20 @@ namespace Nethermind.Network.Test
         }
 
         [Test]
-        public void Will_return_exception_in_dns()
+        public void Will_return_exception_on_duplicated_discovery_port_part()
         {
             Assert.Throws<ArgumentException>(delegate
             {
-                Enode unused = new(enode4String);
+                Enode unused = new(enode9String);
+            });
+        }
+
+        [Test]
+        public void Will_return_exception_on_wrong_form_of_discovery_port_part()
+        {
+            Assert.Throws<ArgumentException>(delegate
+            {
+                Enode unused = new(enode10String);
             });
         }
 


### PR DESCRIPTION
Fixes | Closes | Resolves #4876

## Changes:
- parse `DiscoveryPort` if `enode` contains it, according to spec https://ethereum.org/en/developers/docs/networking-layer/network-addresses/#enode
- add plenty of tests

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No