### PR TITLE
Feature/DB repair on corruption

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -182,6 +182,7 @@ public class DbOnTheRocks : IDbWithSpan
         if (_logger.IsWarn) _logger.Warn($"Corrupted DB marker detected for db {_fullPath}. Attempting repair...");
         _rocksDbNative.rocksdb_repair_db(dbOptions.Handle, _fullPath);
 
+        if (_logger.IsWarn) _logger.Warn($"Repair completed. Some data may be lost. Consider a full resync.");
         _fileSystem.File.Delete(corruptMarker);
     }
 

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Abstractions;
 using System.Reflection;
 using System.Threading;
 using ConcurrentCollections;
@@ -25,6 +26,7 @@ using Nethermind.Core;
 using Nethermind.Db.Rocks.Config;
 using Nethermind.Db.Rocks.Statistics;
 using Nethermind.Logging;
+using Org.BouncyCastle.Crypto.Digests;
 using RocksDbSharp;
 
 namespace Nethermind.Db.Rocks;
@@ -59,6 +61,12 @@ public class DbOnTheRocks : IDbWithSpan
 
     private readonly RocksDbSettings _settings;
 
+    private readonly IFileSystem _fileSystem;
+
+    private readonly Func<string, (DbOptions Options, ColumnFamilies? Families), RocksDb> _rocksDbFactory;
+
+    private readonly RocksDbSharp.Native _rocksDbNative;
+
     protected static void InitCache(IDbConfig dbConfig)
     {
         if (Interlocked.CompareExchange(ref _cacheInitialized, 1, 0) == 0)
@@ -68,24 +76,41 @@ public class DbOnTheRocks : IDbWithSpan
         }
     }
 
-    public DbOnTheRocks(string basePath, RocksDbSettings rocksDbSettings, IDbConfig dbConfig,
-        ILogManager logManager, ColumnFamilies? columnFamilies = null)
+    public DbOnTheRocks(
+        string basePath,
+        RocksDbSettings rocksDbSettings,
+        IDbConfig dbConfig,
+        ILogManager logManager,
+        ColumnFamilies? columnFamilies = null,
+        Func<string, (DbOptions Options, ColumnFamilies? Families), RocksDb>? rocksDbFactory = null,
+        RocksDbSharp.Native? rocksDbNative = null,
+        IFileSystem? fileSystem = null)
     {
         _logger = logManager.GetClassLogger();
         _settings = rocksDbSettings;
         Name = _settings.DbName;
+        _fileSystem = fileSystem ?? new FileSystem();
+        _rocksDbFactory = rocksDbFactory ?? DefaultFactory;
+        _rocksDbNative = rocksDbNative ?? RocksDbSharp.Native.Instance;
         _db = Init(basePath, rocksDbSettings.DbPath, dbConfig, logManager, columnFamilies, rocksDbSettings.DeleteOnStart);
+    }
+
+    private static RocksDb DefaultFactory(string path, (DbOptions Options, ColumnFamilies? Families) db)
+    {
+        (DbOptions options, ColumnFamilies? families) = db;
+        return families is null ? RocksDb.Open(options, path) : RocksDb.Open(options, path, families);
+    }
+
+    private RocksDb Open(string path, (DbOptions Options, ColumnFamilies? Families) db)
+    {
+        RepairIfCorrupted(path, db.Options);
+
+        return _rocksDbFactory.Invoke(path, db);
     }
 
     private RocksDb Init(string basePath, string dbPath, IDbConfig dbConfig, ILogManager? logManager,
         ColumnFamilies? columnFamilies = null, bool deleteOnStart = false)
     {
-        static RocksDb Open(string path, (DbOptions Options, ColumnFamilies? Families) db)
-        {
-            (DbOptions options, ColumnFamilies? families) = db;
-            return families is null ? RocksDb.Open(options, path) : RocksDb.Open(options, path, families);
-        }
-
         _fullPath = GetFullDbPath(dbPath, basePath);
         _logger = logManager?.GetClassLogger() ?? NullLogger.Instance;
         if (!Directory.Exists(_fullPath))
@@ -106,7 +131,7 @@ public class DbOnTheRocks : IDbWithSpan
 
             // ReSharper disable once VirtualMemberCallInConstructor
             if (_logger.IsDebug) _logger.Debug($"Loading DB {Name,-13} from {_fullPath} with max memory footprint of {_maxThisDbSize / 1000 / 1000}MB");
-            RocksDb db = _dbsByPath.GetOrAdd(_fullPath, static (s, tuple) => Open(s, tuple), (DbOptions, columnFamilies));
+            RocksDb db = _dbsByPath.GetOrAdd(_fullPath, (s, tuple) => Open(s, tuple), (DbOptions, columnFamilies));
 
             if (dbConfig.EnableMetricsUpdater)
             {
@@ -127,6 +152,36 @@ public class DbOnTheRocks : IDbWithSpan
             if (_logger.IsWarn) _logger.Warn("If your database did not close properly you need to call 'find -type f -name '*LOCK*' -delete' from the databse folder");
             throw;
         }
+        catch (RocksDbSharpException x)
+        {
+            CreateMarkerIfCorrupt(x);
+            throw;
+        }
+
+    }
+
+    private void CreateMarkerIfCorrupt(RocksDbSharpException rocksDbException)
+    {
+        if (rocksDbException.Message.Contains("Corruption:"))
+        {
+            if (_logger.IsWarn) _logger.Warn($"Corrupted DB detected on path {_fullPath}. Please restart Nethermind to attempt repair.");
+            _fileSystem.File.WriteAllText(Path.Join(_fullPath, "corrupt.marker"), "marker");
+        }
+    }
+
+    private void RepairIfCorrupted(string dbPath, DbOptions dbOptions)
+    {
+        string corruptMarker = Path.Join(dbPath, "corrupt.marker");
+
+        if (!_fileSystem.File.Exists(corruptMarker))
+        {
+            return;
+        }
+
+        if (_logger.IsWarn) _logger.Warn($"Corrupted DB marker detected for db {dbPath}. Attempting repair...");
+        _rocksDbNative.rocksdb_repair_db(dbOptions.Handle, dbPath);
+
+        _fileSystem.File.Delete(corruptMarker);
     }
 
     protected internal void UpdateReadMetrics()
@@ -280,7 +335,16 @@ public class DbOnTheRocks : IDbWithSpan
             }
 
             UpdateReadMetrics();
-            return _db.Get(key);
+
+            try
+            {
+                return _db.Get(key);
+            }
+            catch (RocksDbSharpException e)
+            {
+                CreateMarkerIfCorrupt(e);
+                throw;
+            }
         }
         set
         {
@@ -291,18 +355,40 @@ public class DbOnTheRocks : IDbWithSpan
 
             UpdateWriteMetrics();
 
-            if (value is null)
+            try
             {
-                _db.Remove(key, null, WriteOptions);
+                if (value is null)
+                {
+                    _db.Remove(key, null, WriteOptions);
+                }
+                else
+                {
+                    _db.Put(key, value, null, WriteOptions);
+                }
             }
-            else
+            catch (RocksDbSharpException e)
             {
-                _db.Put(key, value, null, WriteOptions);
+                CreateMarkerIfCorrupt(e);
+                throw;
             }
         }
     }
 
-    public KeyValuePair<byte[], byte[]?>[] this[byte[][] keys] => _db.MultiGet(keys);
+    public KeyValuePair<byte[], byte[]?>[] this[byte[][] keys]
+    {
+        get
+        {
+            try
+            {
+                return _db.MultiGet(keys);
+            }
+            catch (RocksDbSharpException e)
+            {
+                CreateMarkerIfCorrupt(e);
+                throw;
+            }
+        }
+    }
 
     public Span<byte> GetSpan(byte[] key)
     {
@@ -313,7 +399,15 @@ public class DbOnTheRocks : IDbWithSpan
 
         UpdateReadMetrics();
 
-        return _db.GetSpan(key);
+        try
+        {
+            return _db.GetSpan(key);
+        }
+        catch (RocksDbSharpException e)
+        {
+            CreateMarkerIfCorrupt(e);
+            throw;
+        }
     }
 
     public void DangerousReleaseMemory(in Span<byte> span) => _db.DangerousReleaseMemory(span);
@@ -325,7 +419,15 @@ public class DbOnTheRocks : IDbWithSpan
             throw new ObjectDisposedException($"Attempted to delete form a disposed database {Name}");
         }
 
-        _db.Remove(key, null, WriteOptions);
+        try
+        {
+            _db.Remove(key, null, WriteOptions);
+        }
+        catch (RocksDbSharpException e)
+        {
+            CreateMarkerIfCorrupt(e);
+            throw;
+        }
     }
 
     public IEnumerable<KeyValuePair<byte[], byte[]>> GetAll(bool ordered = false)
@@ -343,7 +445,15 @@ public class DbOnTheRocks : IDbWithSpan
     {
         ReadOptions readOptions = new();
         readOptions.SetTailing(!ordered);
-        return _db.NewIterator(ch, readOptions);
+
+        try {
+            return _db.NewIterator(ch, readOptions);
+        }
+        catch (RocksDbSharpException e)
+        {
+            CreateMarkerIfCorrupt(e);
+            throw;
+        }
     }
 
     public IEnumerable<byte[]> GetAllValues(bool ordered = false)
@@ -359,14 +469,36 @@ public class DbOnTheRocks : IDbWithSpan
 
     internal IEnumerable<byte[]> GetAllValuesCore(Iterator iterator)
     {
-        iterator.SeekToFirst();
+        try {
+            iterator.SeekToFirst();
+        }
+        catch (RocksDbSharpException e)
+        {
+            CreateMarkerIfCorrupt(e);
+            throw;
+        }
+
         while (iterator.Valid())
         {
             yield return iterator.Value();
-            iterator.Next();
+            try {
+                iterator.Next();
+            }
+            catch (RocksDbSharpException e)
+            {
+                CreateMarkerIfCorrupt(e);
+                throw;
+            }
         }
 
-        iterator.Dispose();
+        try {
+            iterator.Dispose();
+        }
+        catch (RocksDbSharpException e)
+        {
+            CreateMarkerIfCorrupt(e);
+            throw;
+        }
     }
 
     public IEnumerable<KeyValuePair<byte[], byte[]>> GetAllCore(Iterator iterator)
@@ -376,14 +508,37 @@ public class DbOnTheRocks : IDbWithSpan
             throw new ObjectDisposedException($"Attempted to read form a disposed database {Name}");
         }
 
-        iterator.SeekToFirst();
+        try {
+            iterator.SeekToFirst();
+        }
+        catch (RocksDbSharpException e)
+        {
+            CreateMarkerIfCorrupt(e);
+            throw;
+        }
+
         while (iterator.Valid())
         {
             yield return new KeyValuePair<byte[], byte[]>(iterator.Key(), iterator.Value());
-            iterator.Next();
+
+            try {
+                iterator.Next();
+            }
+            catch (RocksDbSharpException e)
+            {
+                CreateMarkerIfCorrupt(e);
+                throw;
+            }
         }
 
-        iterator.Dispose();
+        try {
+            iterator.Dispose();
+        }
+        catch (RocksDbSharpException e)
+        {
+            CreateMarkerIfCorrupt(e);
+            throw;
+        }
     }
 
     public bool KeyExists(byte[] key)
@@ -393,9 +548,16 @@ public class DbOnTheRocks : IDbWithSpan
             throw new ObjectDisposedException($"Attempted to read form a disposed database {Name}");
         }
 
-        // seems it has no performance impact
-        return _db.Get(key) is not null;
-        //            return _db.Get(key, 32, _keyExistsBuffer, 0, 0, null, null) != -1;
+        try {
+            // seems it has no performance impact
+            return _db.Get(key) is not null;
+            // return _db.Get(key, 32, _keyExistsBuffer, 0, 0, null, null) != -1;
+        }
+        catch (RocksDbSharpException e)
+        {
+            CreateMarkerIfCorrupt(e);
+            throw;
+        }
     }
 
     public IBatch StartBatch()
@@ -437,9 +599,17 @@ public class DbOnTheRocks : IDbWithSpan
             }
             _isDisposed = true;
 
-            _dbOnTheRocks._db.Write(_rocksBatch, _dbOnTheRocks.WriteOptions);
-            _dbOnTheRocks._currentBatches.TryRemove(this);
-            _rocksBatch.Dispose();
+            try
+            {
+                _dbOnTheRocks._db.Write(_rocksBatch, _dbOnTheRocks.WriteOptions);
+                _dbOnTheRocks._currentBatches.TryRemove(this);
+                _rocksBatch.Dispose();
+            }
+            catch (RocksDbSharpException e)
+            {
+                _dbOnTheRocks.CreateMarkerIfCorrupt(e);
+                throw;
+            }
         }
 
         public byte[]? this[byte[] key]
@@ -480,7 +650,14 @@ public class DbOnTheRocks : IDbWithSpan
 
     private void InnerFlush()
     {
-        RocksDbSharp.Native.Instance.rocksdb_flush(_db.Handle, FlushOptions.DefaultFlushOptions.Handle);
+        try
+        {
+            RocksDbSharp.Native.Instance.rocksdb_flush(_db.Handle, FlushOptions.DefaultFlushOptions.Handle);
+        }
+        catch (RocksDbSharpException e)
+        {
+            CreateMarkerIfCorrupt(e);
+        }
     }
 
     public void Clear()

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -447,7 +447,8 @@ public class DbOnTheRocks : IDbWithSpan
         ReadOptions readOptions = new();
         readOptions.SetTailing(!ordered);
 
-        try {
+        try
+        {
             return _db.NewIterator(ch, readOptions);
         }
         catch (RocksDbSharpException e)
@@ -470,7 +471,8 @@ public class DbOnTheRocks : IDbWithSpan
 
     internal IEnumerable<byte[]> GetAllValuesCore(Iterator iterator)
     {
-        try {
+        try
+        {
             iterator.SeekToFirst();
         }
         catch (RocksDbSharpException e)
@@ -482,7 +484,8 @@ public class DbOnTheRocks : IDbWithSpan
         while (iterator.Valid())
         {
             yield return iterator.Value();
-            try {
+            try
+            {
                 iterator.Next();
             }
             catch (RocksDbSharpException e)
@@ -492,7 +495,8 @@ public class DbOnTheRocks : IDbWithSpan
             }
         }
 
-        try {
+        try
+        {
             iterator.Dispose();
         }
         catch (RocksDbSharpException e)
@@ -509,7 +513,8 @@ public class DbOnTheRocks : IDbWithSpan
             throw new ObjectDisposedException($"Attempted to read form a disposed database {Name}");
         }
 
-        try {
+        try
+        {
             iterator.SeekToFirst();
         }
         catch (RocksDbSharpException e)
@@ -522,7 +527,8 @@ public class DbOnTheRocks : IDbWithSpan
         {
             yield return new KeyValuePair<byte[], byte[]>(iterator.Key(), iterator.Value());
 
-            try {
+            try
+            {
                 iterator.Next();
             }
             catch (RocksDbSharpException e)
@@ -532,7 +538,8 @@ public class DbOnTheRocks : IDbWithSpan
             }
         }
 
-        try {
+        try
+        {
             iterator.Dispose();
         }
         catch (RocksDbSharpException e)
@@ -549,7 +556,8 @@ public class DbOnTheRocks : IDbWithSpan
             throw new ObjectDisposedException($"Attempted to read form a disposed database {Name}");
         }
 
-        try {
+        try
+        {
             // seems it has no performance impact
             return _db.Get(key) is not null;
             // return _db.Get(key, 32, _keyExistsBuffer, 0, 0, null, null) != -1;


### PR DESCRIPTION
- Added logic similar to parity where it create a marker if db corruption is detected, then repair on restart.

## Changes:
- Added corrupted marker when corruption exception was encountered.
- Call repair if marker is detected.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [X] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [X] Yes
- [ ] No

**Comments about testing , should you have some** (optional)

- On mainnet db, does not seems to work. It would failed with `force_consistency_checks` error. Same error if using `ldb` tool directly. Tried on state and block db.
- On chiado db, seems to work if I delete an sst file in blocks db.
- So it does not always work.

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...