### PR TITLE
Fix corruption attempt causes trie exception on state reader causing peer disconnection

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -403,7 +403,13 @@ namespace Nethermind.Blockchain
             long right = Math.Max(0, left) + BestKnownSearchLimit;
             long bestKnownNumberFound = BinarySearchBlockNumber(left, right, LevelExists, findBeacon: true) ?? 0;
 
-            left = Math.Max(Head?.Number ?? 0, LowestInsertedBeaconHeader?.Number ?? 0) - 1;
+            left = Math.Max(
+                Math.Max(
+                    Head?.Number ?? 0,
+                    LowestInsertedBeaconHeader?.Number ?? 0),
+                BestSuggestedHeader?.Number ?? 0
+                ) - 1;
+
             right = Math.Max(0, left) + BestKnownSearchLimit;
             long bestBeaconHeaderNumber = BinarySearchBlockNumber(left, right, HeaderExists, findBeacon: true) ?? 0;
 

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -220,7 +220,7 @@ namespace Nethermind.Blockchain
             {
                 ChainLevelInfo chainLevelInfo = LoadLevel(BestSuggestedHeader.Number);
                 BlockInfo? canonicalBlock = chainLevelInfo?.MainChainBlock;
-                if (canonicalBlock is not null)
+                if (canonicalBlock is not null && canonicalBlock.WasProcessed)
                 {
                     SetHeadBlock(canonicalBlock.BlockHash!);
                 }

--- a/src/Nethermind/Nethermind.Core/Exceptions/IInternalNethermindException.cs
+++ b/src/Nethermind/Nethermind.Core/Exceptions/IInternalNethermindException.cs
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.Core.Exceptions;
+
+/// <summary>
+/// Marker for exception that indicate something abnormal that is definitely an issue in Nethermind.
+/// </summary>
+public interface IInternalNethermindException
+{
+}

--- a/src/Nethermind/Nethermind.Network.Test/Rlpx/ZeroNettyP2PHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/Rlpx/ZeroNettyP2PHandlerTests.cs
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Threading.Tasks;
+using DotNetty.Transport.Channels;
+using Nethermind.Core.Exceptions;
+using Nethermind.Logging;
+using Nethermind.Network.P2P;
+using Nethermind.Network.P2P.ProtocolHandlers;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Network.Test.Rlpx;
+
+public class ZeroNettyP2PHandlerTests
+{
+
+    [Test]
+    public async Task When_exception_is_thrown__then_disconnect_session()
+    {
+        ISession session = Substitute.For<ISession>();
+        IChannelHandlerContext channelHandlerContext = Substitute.For<IChannelHandlerContext>();
+        ZeroNettyP2PHandler handler = new ZeroNettyP2PHandler(session, LimboLogs.Instance);
+
+        handler.ExceptionCaught(channelHandlerContext, new Exception());
+
+        await channelHandlerContext.Received().DisconnectAsync();
+    }
+
+    [Test]
+    public async Task When_internal_nethermind_exception_is_thrown__then_do_not_disconnect_session()
+    {
+        ISession session = Substitute.For<ISession>();
+        IChannelHandlerContext channelHandlerContext = Substitute.For<IChannelHandlerContext>();
+        ZeroNettyP2PHandler handler = new ZeroNettyP2PHandler(session, LimboLogs.Instance);
+
+        handler.ExceptionCaught(channelHandlerContext, new TestInternalNethermindException());
+
+        await channelHandlerContext.DidNotReceive().DisconnectAsync();
+    }
+
+    private class TestInternalNethermindException : Exception, IInternalNethermindException
+    {
+
+    }
+}

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroNettyP2PHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroNettyP2PHandler.cs
@@ -6,6 +6,7 @@ using System.Net.Sockets;
 using DotNetty.Buffers;
 using DotNetty.Common.Utilities;
 using DotNetty.Transport.Channels;
+using Nethermind.Core.Exceptions;
 using Nethermind.Logging;
 using Nethermind.Network.Rlpx;
 using Snappy;
@@ -110,7 +111,11 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
                 if (_logger.IsDebug) _logger.Debug($"Error in communication with {clientId}: {exception}");
             }
 
-            if (_session?.Node?.IsStatic != true)
+            if (exception is IInternalNethermindException)
+            {
+                // Do nothing as we don't want to drop peer for internal issue.
+            }
+            else if (_session?.Node?.IsStatic != true)
             {
                 context.DisconnectAsync().ContinueWith(x =>
                 {

--- a/src/Nethermind/Nethermind.Trie/TrieException.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieException.cs
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using Nethermind.Core.Exceptions;
 
 namespace Nethermind.Trie
 {
-    public class TrieException : Exception
+    public class TrieException : Exception, IInternalNethermindException
     {
         public TrieException()
         {


### PR DESCRIPTION
- Fixes probable cause of sometimes all peer disconnects.
- This is due to `TransactionsMessage` handler which checks for account from state where the root was set to head which was wrongly set in block tree during fixing corruption attempt, which causes trie exception as state was not downloaded yet.
- The fixing corruption attempt is wrongly started due to beacon header binary search left pointer which starts at lowest beacon header which is not moved by forward sync. If the pivot of the bsearch hit a beacon header during the search, the issue does not appear which is the reason why it is random.
- On any exception on handler, by default peer will get disconnected, meaning any peer which try to broadcast transaction to nethermind with this situation will get disconnected.

## Changes:
- Added `IInternalNethermindException` marker which will not disconnect peer if caught.
- Added a check when setting head to check if the block was processed.
- Added `BestSuggestedHeader` as part of the left pointer when finding highest beacon header. 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [X] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [X] Yes
- [ ] No

**Comments about testing , should you have some** (optional)

- Confirmed setting `_tryToRecoverFromHeaderBelowBodyCorruption` to true manually will cause all peer to disconnect.
- Confirmed after modification to exception handling, peer did not get disconnected, trie exception still logged.
- Confirmed when adding `WasProcessed` condition, trie exception did not appear anymore.

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...