### PR TITLE
test: fork ids for Gnosis and Chiado

### DIFF
--- a/src/Nethermind/Nethermind.Network.Test/ForkInfoTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/ForkInfoTests.cs
@@ -122,8 +122,20 @@ namespace Nethermind.Network.Test
             Test(head, KnownHashes.SepoliaGenesis, forkHashHex, next, description, SepoliaSpecProvider.Instance, "sepolia.json");
         }
 
-        [TestCase(0, "0xf64909b1", 1604400, "Gnosis Genesis")]
-        [TestCase(21735000, "0x018479d3", 0, "GIP-31")]
+        [TestCase(0, "0xf64909b1", 1604400, "Unsynced, last Frontier, Homestead, Tangerine, Spurious, Byzantium")]
+        [TestCase(1604399, "0xf64909b1", 1604400, "Last Byzantium block")]
+        [TestCase(1604400, "0xfde2d083", 2508800, "First Constantinople block")]
+        [TestCase(2508799, "0xfde2d083", 2508800, "Last Constantinople block")]
+        [TestCase(2508800, "0xfc1d8f2f", 7298030, "First Petersburg block")]
+        [TestCase(7298029, "0xfc1d8f2f", 7298030, "Last Petersburg block")]
+        [TestCase(7298030, "0x54d05e6c", 9186425, "First Istanbul block")]
+        [TestCase(9186424, "0x54d05e6c", 9186425, "Last Istanbul block")]
+        [TestCase(9186425, "0xb6e6cd81", 16101500, "First POSDAO Activation block")]
+        [TestCase(16101499, "0xb6e6cd81", 16101500, "Last POSDAO Activation block")]
+        [TestCase(16101500, "0x069a83d9", 19040000, "First Berlin block")]
+        [TestCase(19039999, "0x069a83d9", 19040000, "Last Berlin block")]
+        [TestCase(19040000, "0x018479d3", 0, "First London block")]
+        [TestCase(21735000, "0x018479d3", 0, "First GIP-31 block")]
         public void Fork_id_and_hash_as_expected_on_gnosis(long head, string forkHashHex, long next, string description)
         {
             ChainSpecLoader loader = new ChainSpecLoader(new EthereumJsonSerializer());

--- a/src/Nethermind/Nethermind.Network.Test/ForkInfoTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/ForkInfoTests.cs
@@ -122,6 +122,24 @@ namespace Nethermind.Network.Test
             Test(head, KnownHashes.SepoliaGenesis, forkHashHex, next, description, SepoliaSpecProvider.Instance, "sepolia.json");
         }
 
+        [TestCase(24000000, "0x018479d3", 0, "")]
+        public void Fork_id_and_hash_as_expected_on_gnosis(long head, string forkHashHex, long next, string description)
+        {
+            ChainSpecLoader loader = new ChainSpecLoader(new EthereumJsonSerializer());
+            ChainSpec spec = loader.Load(File.ReadAllText(Path.Combine("../../../../Chains", "xdai.json")));
+            ChainSpecBasedSpecProvider provider = new ChainSpecBasedSpecProvider(spec);
+            Test(head, KnownHashes.GnosisGenesis, forkHashHex, next, description, provider);
+        }
+
+        [TestCase(0, "0x50d39d7b", 0, "Chiado genesis")]
+        public void Fork_id_and_hash_as_expected_on_chiado(long head, string forkHashHex, long next, string description)
+        {
+            ChainSpecLoader loader = new ChainSpecLoader(new EthereumJsonSerializer());
+            ChainSpec spec = loader.Load(File.ReadAllText(Path.Combine("../../../../Chains", "chiado.json")));
+            ChainSpecBasedSpecProvider provider = new ChainSpecBasedSpecProvider(spec);
+            Test(head, KnownHashes.ChiadoGenesis, forkHashHex, next, description, provider);
+        }
+
         private static void Test(long head, Keccak genesisHash, string forkHashHex, long next, string description, ISpecProvider specProvider, string chainSpec, string path = "../../../../Chains")
         {
             Test(head, genesisHash, forkHashHex, next, description, specProvider);

--- a/src/Nethermind/Nethermind.Network.Test/ForkInfoTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/ForkInfoTests.cs
@@ -122,7 +122,8 @@ namespace Nethermind.Network.Test
             Test(head, KnownHashes.SepoliaGenesis, forkHashHex, next, description, SepoliaSpecProvider.Instance, "sepolia.json");
         }
 
-        [TestCase(24000000, "0x018479d3", 0, "")]
+        [TestCase(0, "0xf64909b1", 1604400, "Gnosis Genesis")]
+        [TestCase(21735000, "0x018479d3", 0, "GIP-31")]
         public void Fork_id_and_hash_as_expected_on_gnosis(long head, string forkHashHex, long next, string description)
         {
             ChainSpecLoader loader = new ChainSpecLoader(new EthereumJsonSerializer());

--- a/src/Nethermind/Nethermind.Specs/KnownHashes.cs
+++ b/src/Nethermind/Nethermind.Specs/KnownHashes.cs
@@ -22,5 +22,8 @@ namespace Nethermind.Specs
         public static readonly Keccak SokolGenesis = new("0x5b28c1bfd3a15230c9a46b399cd0f9a6920d432e85381cc6a140b06e8410112f");
 
         public static readonly Keccak SepoliaGenesis = new("0x25a5cc106eea7138acab33231d7160d69cb777ee0c2c553fcddf5138993e6dd9");
+
+        public static readonly Keccak GnosisGenesis = new("0x4f1dd23188aab3a76b463e4af801b52b1248ef073c648cbdc4c9333d3da79756");
+        public static readonly Keccak ChiadoGenesis = new("0xada44fd8d2ecab8b08f256af07ad3e777f17fb434f8f8e678b312f576212ba9a");
     }
 }


### PR DESCRIPTION
## Changes:

- Add fork id tests for Gnosis and Chiado

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Other (please describe): test changes

## Testing
**Requires testing**

- [ ] Yes
- [x] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No

## Further comments (optional)

The exact same tests were implemented in Erigon (https://github.com/ledgerwatch/erigon/pull/6110) and merged already.

I also had a comment regarding the unchanged fork id after the latest hardfork (block 21735000, GIP-31):

> Feels like there's an issue with the latest hardfork (https://docs.gnosischain.com/specs/hard-forks/21735000), as the fork id didn't change?

Not sure if that's intentional because it's not a major hardfork (i.e. Berlin, London, etc) or a bug?