### PR TITLE
Temporarily switch to `ubuntu-20.04` image

### DIFF
--- a/.github/workflows/run-nethermind-tests-with-code-coverage.yml
+++ b/.github/workflows/run-nethermind-tests-with-code-coverage.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
     steps:
     - uses: actions/checkout@v2
       with: 
@@ -187,7 +187,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
     steps:
     - uses: actions/checkout@v2
     - name: Setting up dotnet

--- a/.github/workflows/run-nethermind-tests.yml
+++ b/.github/workflows/run-nethermind-tests.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   neth-tests:
     name: Running Nethermind Tests 1
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
       with:
@@ -165,7 +165,7 @@ jobs:
 
   neth-tests5:
     name: Running Nethermind Tests 5
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
       with:
@@ -202,7 +202,7 @@ jobs:
 
   neth-tests6:
     name: Running Nethermind Tests 6
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
## Changes
Temporarily changed some of the test workflow runner images from `ubuntu-latest` to `ubuntu-20.04` because of `libdl` issues coming from RocksDB v6.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Other (please describe): Workflow update

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [x] No

## Further comments (optional)

These changes should be reverted with the migration to RocksDB v7.