### PR TITLE
Fixed Building Gauge Names

### DIFF
--- a/src/Nethermind/Nethermind.Monitoring/Metrics/MetricsController.cs
+++ b/src/Nethermind/Nethermind.Monitoring/Metrics/MetricsController.cs
@@ -18,11 +18,12 @@ namespace Nethermind.Monitoring.Metrics
     {
         private readonly int _intervalSeconds;
         private Timer _timer;
-        private Dictionary<string, Gauge> _gauges = new();
-        private Dictionary<Type, (PropertyInfo, string)[]> _propertiesCache = new();
-        private Dictionary<Type, (FieldInfo, string)[]> _fieldsCache = new();
-        private Dictionary<Type, (string DictName, IDictionary<string, long> Dict)> _dynamicPropCache = new();
-        private HashSet<Type> _metricTypes = new();
+        private readonly Dictionary<Type, (PropertyInfo, string)[]> _propertiesCache = new();
+        private readonly Dictionary<Type, (FieldInfo, string)[]> _fieldsCache = new();
+        private readonly Dictionary<Type, (string DictName, IDictionary<string, long> Dict)> _dynamicPropCache = new();
+        private readonly HashSet<Type> _metricTypes = new();
+
+        public readonly Dictionary<string, Gauge> _gauges = new();
 
         public void RegisterMetrics(Type type)
         {
@@ -102,7 +103,7 @@ namespace Nethermind.Monitoring.Metrics
             propertyInfo.GetCustomAttribute<DataMemberAttribute>()?.Name ?? BuildGaugeName(propertyInfo.Name);
 
         private static string BuildGaugeName(string propertyName) =>
-            Regex.Replace(propertyName, @"(\p{Ll})(\p{Lu})", "nethermind_$1_$2").ToLowerInvariant();
+            $"nethermind_{Regex.Replace(propertyName, @"(\p{Ll})(\p{Lu})", "$1_$2").ToLowerInvariant()}";
 
         private static Gauge CreateGauge(string name, string help = "", GaugeConfiguration configuration = null)
             => Prometheus.Metrics.CreateGauge(name, help, configuration);


### PR DESCRIPTION
Fixed Building Gauge Names, Added unit tests.

Resolves Prometheus Gauge Names issue

Naming was messed up for standard metrics gauges. Now fixed and test covered. 

## Changes:
- regexp fix
- added unit test of default and developer-specified Gauge Names

Default:
![image](https://user-images.githubusercontent.com/2915361/203584891-cf9d6efb-765f-42e2-9ecf-0c2150e8d5d4.png)

Developer-specified:
![image](https://user-images.githubusercontent.com/2915361/203585091-30527432-c7d2-4d08-8b5a-f3e695316ab3.png)

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [x] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No