### PR TITLE
fixed eip-3860 gas usage and nonce when init code length exceeded

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/Eip3860Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip3860Tests.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using System;
+using Nethermind.Int256;
 
 namespace Nethermind.Evm.Test
 {
@@ -15,6 +16,8 @@ namespace Nethermind.Evm.Test
     {
         protected override long BlockNumber => MainnetSpecProvider.GrayGlacierBlockNumber;
         protected override ulong Timestamp => MainnetSpecProvider.ShanghaiBlockTimestamp;
+
+        private readonly long _transactionCallCost = GasCostOf.Transaction + 100 + 7 * GasCostOf.VeryLow;
 
         [TestCase("0x61013860006000f0", false, 32039)] //length 312
         [TestCase("0x61013860006000f0", true, 32059)] //extra 20 cost
@@ -39,32 +42,34 @@ namespace Nethermind.Evm.Test
 
             var tracer = Execute(BlockNumber, eip3860Enabled ? Timestamp : Timestamp - 1, callCode);
             Assert.AreEqual(StatusCode.Success, tracer.StatusCode);
-            Assert.AreEqual(expectedGasUsage, tracer.GasSpent - (GasCostOf.Transaction + 100 + 7 * GasCostOf.VeryLow));
+            Assert.AreEqual(expectedGasUsage, tracer.GasSpent - _transactionCallCost);
         }
 
-        [Test]
-        public void Test_EIP_3860_InitCode_CREATE_Exceeds_Limit()
+        [TestCase("60006000F0", 44299)] //static and dynamic cost deducted: 32000 (call) + 3074 (word cost) + 9225 (memory cost) = 44299
+        [TestCase("60006000F5", 53521)] //static and dynamic cost deducted: 32000 (call) + 3074 (word cost) + 9222 (hash cost) + 9225 (memory cost) = 53521
+        public void Test_EIP_3860_InitCode_Create_Exceeds_Limit(string createCode, long expectedGasUsage)
         {
             string dataLenghtHex = (Spec.MaxInitCodeSize + 1).ToString("X");
-            var dataPush = Instruction.PUSH1 + (byte)(dataLenghtHex.Length / 2 - 1);
+            Instruction dataPush = Instruction.PUSH1 + (byte)(dataLenghtHex.Length / 2 - 1);
 
-            byte[] byteCode = Prepare.EvmCode
-                .FromCode(dataPush.ToString("X") + dataLenghtHex + "60006000f0")
-                .Done;
+            bool isCreate2 = createCode[^2..] == Instruction.CREATE2.ToString("X");
+            byte[] evmCode = isCreate2
+                ? Prepare.EvmCode.PushSingle(0).FromCode(dataPush.ToString("X") + dataLenghtHex + createCode).Done
+                : Prepare.EvmCode.FromCode(dataPush.ToString("X") + dataLenghtHex + createCode).Done;
 
             TestState.CreateAccount(TestItem.AddressC, 1.Ether());
-            Keccak createCodeHash = TestState.UpdateCode(byteCode);
+            Keccak createCodeHash = TestState.UpdateCode(evmCode);
             TestState.UpdateCodeHash(TestItem.AddressC, createCodeHash, Spec);
 
-            byte[] callCode = Prepare.EvmCode.Call(TestItem.AddressC, 50000).Done;
+            byte[] callCode = Prepare.EvmCode.Call(TestItem.AddressC, 60000).Done;
 
             var tracer = Execute(callCode);
             Assert.AreEqual(StatusCode.Success, tracer.StatusCode);
             //how to test byteCode returned empty (CREATE) not call ?
             //Assert.AreEqual(StatusCode.FailureBytes, tracer.ReturnValue);
             Assert.AreEqual(Array.Empty<byte>(), tracer.ReturnValue);
-            //init code gas cost not deducted, but cost of 3 * push deducted
-            Assert.AreEqual(0, tracer.GasSpent - (GasCostOf.Transaction + 100 + 7 * GasCostOf.VeryLow + 3 * GasCostOf.VeryLow));
+            Assert.AreEqual(expectedGasUsage, tracer.GasSpent - _transactionCallCost - (isCreate2 ? 4 : 3) * GasCostOf.VeryLow);
+            Assert.AreEqual((UInt256)1, TestState.GetAccount(TestItem.AddressC).Nonce);
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -2353,14 +2353,6 @@ namespace Nethermind.Evm
                                 salt = stack.PopBytes();
                             }
 
-                            //EIP-3860
-                            if (spec.IsEip3860Enabled && initCodeLength > spec.MaxInitCodeSize)
-                            {
-                                _returnDataBuffer = Array.Empty<byte>();
-                                stack.PushZero();
-                                break;
-                            }
-
                             long gasCost = GasCostOf.Create +
                                 (spec.IsEip3860Enabled ? GasCostOf.InitCodeWord * EvmPooledMemory.Div32Ceiling(initCodeLength) : 0) +
                                 (instruction == Instruction.CREATE2 ? GasCostOf.Sha3Word * EvmPooledMemory.Div32Ceiling(initCodeLength) : 0);
@@ -2396,6 +2388,16 @@ namespace Nethermind.Evm
                             UInt256 maxNonce = ulong.MaxValue;
                             if (accountNonce >= maxNonce)
                             {
+                                _returnDataBuffer = Array.Empty<byte>();
+                                stack.PushZero();
+                                break;
+                            }
+
+                            //EIP-3860
+                            if (spec.IsEip3860Enabled && initCodeLength > spec.MaxInitCodeSize)
+                            {
+                                //currently this needs to update nonce - may be a change in spec
+                                _state.IncrementNonce(env.ExecutingAccount);
                                 _returnDataBuffer = Array.Empty<byte>();
                                 stack.PushZero();
                                 break;


### PR DESCRIPTION
Fixes | Closes | Resolves #4933 

## Changes:
- changed gas usage and nonce increment for eip-3860, when init code size exceed limit
  - full gas cost of CREATE/CREATE2 opcode should be deducted when 3860 init code size limit is exceeded
  - nonce should be incremented when 3860 init code size limit is exceeded

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No

**Comments about testing , should you have some** (optional)

## Further comments (optional)
As stated in #4933, there may be further changes to EIP3860 which might modify functionality in this scenario.
