### PR TITLE
EIP-3860 - when init code size is exceeded do not deduct per word cos…

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/Eip3860Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip3860Tests.cs
@@ -45,8 +45,8 @@ namespace Nethermind.Evm.Test
             Assert.AreEqual(expectedGasUsage, tracer.GasSpent - _transactionCallCost);
         }
 
-        [TestCase("60006000F0", 44299)] //static and dynamic cost deducted: 32000 (call) + 3074 (word cost) + 9225 (memory cost) = 44299
-        [TestCase("60006000F5", 53521)] //static and dynamic cost deducted: 32000 (call) + 3074 (word cost) + 9222 (hash cost) + 9225 (memory cost) = 53521
+        [TestCase("60006000F0", 41225)] //static and dynamic cost deducted: 32000 (call) + 9225 (memory cost) = 41225 // 3074 (word cost) NOT deducted
+        [TestCase("60006000F5", 50447)] //static and dynamic cost deducted: 32000 (call) + 9222 (hash cost) + 9225 (memory cost) = 50447 // 3074 (word cost) NOT deducted
         public void Test_EIP_3860_InitCode_Create_Exceeds_Limit(string createCode, long expectedGasUsage)
         {
             string dataLenghtHex = (Spec.MaxInitCodeSize + 1).ToString("X");
@@ -69,7 +69,7 @@ namespace Nethermind.Evm.Test
             //Assert.AreEqual(StatusCode.FailureBytes, tracer.ReturnValue);
             Assert.AreEqual(Array.Empty<byte>(), tracer.ReturnValue);
             Assert.AreEqual(expectedGasUsage, tracer.GasSpent - _transactionCallCost - (isCreate2 ? 4 : 3) * GasCostOf.VeryLow);
-            Assert.AreEqual((UInt256)1, TestState.GetAccount(TestItem.AddressC).Nonce);
+            Assert.AreEqual((UInt256)0, TestState.GetAccount(TestItem.AddressC).Nonce);
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -2354,7 +2354,6 @@ namespace Nethermind.Evm
                             }
 
                             long gasCost = GasCostOf.Create +
-                                (spec.IsEip3860Enabled ? GasCostOf.InitCodeWord * EvmPooledMemory.Div32Ceiling(initCodeLength) : 0) +
                                 (instruction == Instruction.CREATE2 ? GasCostOf.Sha3Word * EvmPooledMemory.Div32Ceiling(initCodeLength) : 0);
 
                             if (!UpdateGas(gasCost, ref gasAvailable))
@@ -2364,6 +2363,25 @@ namespace Nethermind.Evm
                             }
 
                             UpdateMemoryCost(in memoryPositionOfInitCode, initCodeLength);
+
+                            //EIP-3860
+                            if (spec.IsEip3860Enabled)
+                            {
+                                if (initCodeLength > spec.MaxInitCodeSize)
+                                {
+                                    _returnDataBuffer = Array.Empty<byte>();
+                                    stack.PushZero();
+                                    break;
+                                }
+                                else
+                                {
+                                    if (!UpdateGas(GasCostOf.InitCodeWord * EvmPooledMemory.Div32Ceiling(initCodeLength), ref gasAvailable))
+                                    {
+                                        EndInstructionTraceError(EvmExceptionType.OutOfGas);
+                                        return CallResult.OutOfGasException;
+                                    }
+                                }
+                            }
 
                             // TODO: copy pasted from CALL / DELEGATECALL, need to move it outside?
                             if (env.CallDepth >= MaxCallDepth) // TODO: fragile ordering / potential vulnerability for different clients
@@ -2388,16 +2406,6 @@ namespace Nethermind.Evm
                             UInt256 maxNonce = ulong.MaxValue;
                             if (accountNonce >= maxNonce)
                             {
-                                _returnDataBuffer = Array.Empty<byte>();
-                                stack.PushZero();
-                                break;
-                            }
-
-                            //EIP-3860
-                            if (spec.IsEip3860Enabled && initCodeLength > spec.MaxInitCodeSize)
-                            {
-                                //currently this needs to update nonce - may be a change in spec
-                                _state.IncrementNonce(env.ExecutingAccount);
                                 _returnDataBuffer = Array.Empty<byte>();
                                 stack.PushZero();
                                 break;


### PR DESCRIPTION
…t and do not  increment nonce.

Fixes | Closes | Resolves #4940

## Changes:
 - CREATE/CREATE2 call cost shall be deducted as before 3860 (without new per word charge) when 3860 init code size limit is exceeded
- nonce should NOT be incremented when 3860 init code size limit is exceeded

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No