### PR TITLE
Fix/separate beacon header queue report

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/BeaconHeadersSyncTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/BeaconHeadersSyncTests.cs
@@ -137,7 +137,7 @@ public class BeaconHeadersSyncTests
                     _report = Substitute.For<ISyncReport>();
                     MeasuredProgress measuredProgress = new MeasuredProgress();
                     Report.BeaconHeaders.Returns(measuredProgress);
-                    Report.HeadersInQueue.Returns(measuredProgress);
+                    Report.BeaconHeadersInQueue.Returns(measuredProgress);
                 }
 
                 return _report;
@@ -185,7 +185,7 @@ public class BeaconHeadersSyncTests
         IBlockTree blockTree = Substitute.For<IBlockTree>();
         blockTree.LowestInsertedBeaconHeader.Returns(Build.A.BlockHeader.WithNumber(2000).TestObject);
         ISyncReport report = Substitute.For<ISyncReport>();
-        report.HeadersInQueue.Returns(new MeasuredProgress());
+        report.BeaconHeadersInQueue.Returns(new MeasuredProgress());
         MeasuredProgress measuredProgress = new();
         report.BeaconHeaders.Returns(measuredProgress);
         ISyncConfig syncConfig = new SyncConfig

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconHeadersSyncFeed.cs
@@ -117,8 +117,8 @@ public sealed class BeaconHeadersSyncFeed : HeadersSyncFeed
         _dependencies.Clear(); // there may be some dependencies from wrong branches
         _pending.Clear(); // there may be pending wrong branches
         _sent.Clear(); // we my still be waiting for some bad branches
-        _syncReport.HeadersInQueue.Update(0L);
-        _syncReport.HeadersInQueue.MarkEnd();
+        HeadersSyncQueueReport.Update(0L);
+        HeadersSyncQueueReport.MarkEnd();
     }
 
     protected override int InsertHeaders(HeadersSyncBatch batch)

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconHeadersSyncFeed.cs
@@ -38,6 +38,8 @@ public sealed class BeaconHeadersSyncFeed : HeadersSyncFeed
     protected override BlockHeader? LowestInsertedBlockHeader => _blockTree.LowestInsertedBeaconHeader;
     protected override MeasuredProgress HeadersSyncProgressReport => _syncReport.BeaconHeaders;
 
+    protected override MeasuredProgress HeadersSyncQueueReport => _syncReport.BeaconHeadersInQueue;
+
     public BeaconHeadersSyncFeed(
         IPoSSwitcher poSSwitcher,
         ISyncModeSelector syncModeSelector,

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
@@ -65,6 +65,7 @@ namespace Nethermind.Synchronization.FastBlocks
         protected virtual BlockHeader? LowestInsertedBlockHeader => _blockTree.LowestInsertedHeader;
 
         protected virtual MeasuredProgress HeadersSyncProgressReport => _syncReport.FastBlocksHeaders;
+        protected virtual MeasuredProgress HeadersSyncQueueReport => _syncReport.HeadersInQueue;
 
         protected virtual long HeadersDestinationNumber => 0;
         protected virtual bool AllHeadersDownloaded => (LowestInsertedBlockHeader?.Number ?? long.MaxValue) == 1;
@@ -164,8 +165,8 @@ namespace Nethermind.Synchronization.FastBlocks
             _dependencies.Clear(); // there may be some dependencies from wrong branches
             _pending.Clear(); // there may be pending wrong branches
             _sent.Clear(); // we my still be waiting for some bad branches
-            _syncReport.HeadersInQueue.Update(0L);
-            _syncReport.HeadersInQueue.MarkEnd();
+            HeadersSyncQueueReport.Update(0L);
+            HeadersSyncQueueReport.MarkEnd();
         }
 
         private void HandleDependentBatches(CancellationToken cancellationToken)
@@ -524,7 +525,7 @@ namespace Nethermind.Synchronization.FastBlocks
 
             if (_logger.IsDebug) _logger.Debug($"LOWEST_INSERTED {LowestInsertedBlockHeader?.Number} | HANDLED {batch}");
 
-            _syncReport.HeadersInQueue.Update(HeadersInQueue);
+            HeadersSyncQueueReport.Update(HeadersInQueue);
             return added;
         }
 

--- a/src/Nethermind/Nethermind.Synchronization/Reporting/ISyncReport.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Reporting/ISyncReport.cs
@@ -25,5 +25,7 @@ namespace Nethermind.Synchronization.Reporting
         MeasuredProgress FastBlocksReceipts { get; }
 
         MeasuredProgress BeaconHeaders { get; }
+
+        MeasuredProgress BeaconHeadersInQueue { get; }
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization/Reporting/NullSyncReport.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Reporting/NullSyncReport.cs
@@ -22,5 +22,6 @@ namespace Nethermind.Synchronization.Reporting
         public MeasuredProgress FastBlocksBodies { get; } = new();
         public MeasuredProgress FastBlocksReceipts { get; } = new();
         public MeasuredProgress BeaconHeaders { get; } = new();
+        public MeasuredProgress BeaconHeadersInQueue { get; }
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization/Reporting/SyncReport.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Reporting/SyncReport.cs
@@ -122,6 +122,8 @@ namespace Nethermind.Synchronization.Reporting
 
         public MeasuredProgress BeaconHeaders { get; } = new();
 
+        public MeasuredProgress BeaconHeadersInQueue { get; } = new();
+
         public long FullSyncBlocksKnown { get; set; }
 
         private static string Pad(decimal value, int length)
@@ -306,7 +308,7 @@ namespace Nethermind.Synchronization.Reporting
             long numHeadersToDownload = _pivot.PivotNumber - _pivot.PivotDestinationNumber + 1;
             int paddingLength = numHeadersToDownload.ToString().Length;
             _logger.Info($"Beacon Headers from block {_pivot.PivotDestinationNumber} to block {_pivot.PivotNumber} | "
-                         + $"{Pad(BeaconHeaders.CurrentValue, paddingLength)} / {Pad(numHeadersToDownload, paddingLength)} | queue {Pad(HeadersInQueue.CurrentValue, SpeedPaddingLength)} | current {Pad(BeaconHeaders.CurrentPerSecond, SpeedPaddingLength)}bps | total {Pad(BeaconHeaders.TotalPerSecond, SpeedPaddingLength)}bps");
+                         + $"{Pad(BeaconHeaders.CurrentValue, paddingLength)} / {Pad(numHeadersToDownload, paddingLength)} | queue {Pad(BeaconHeadersInQueue.CurrentValue, SpeedPaddingLength)} | current {Pad(BeaconHeaders.CurrentPerSecond, SpeedPaddingLength)}bps | total {Pad(BeaconHeaders.TotalPerSecond, SpeedPaddingLength)}bps");
             BeaconHeaders.SetMeasuringPoint();
         }
 


### PR DESCRIPTION
> Beacon header queue report was the same as old headers queue report making for a confusing debugging session. This split tem so that beacon header queue report is diffesent.

## Changes:
- Separate beacon header queue report from fast header queue report.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [X] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [X] No: Previous tests modified.

**Comments about testing , should you have some** (optional)

Confirmed queue report to show up

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...