### PR TITLE
Fix/beacon header hang with negative progress

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/BeaconHeadersSyncTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/BeaconHeadersSyncTests.cs
@@ -339,7 +339,7 @@ public class BeaconHeadersSyncTests
             PivotTotalDifficulty = "0"
         };
 
-        int chainLength = 1000;
+        int chainLength = 111;
         int pivotNumber = 100;
 
         Context ctx = new()
@@ -348,8 +348,7 @@ public class BeaconHeadersSyncTests
         };
         ctx.SetupRemoteBlockTreeOfLength(chainLength);
 
-        BlockHeader pivot = ctx.RemoteBlockTree.FindHeader(pivotNumber);
-        ctx.BeaconPivot.EnsurePivot(pivot);
+        ctx.BeaconPivot.EnsurePivot(ctx.RemoteBlockTree.FindHeader(pivotNumber));
 
         ctx.Feed.InitializeFeed();
 
@@ -376,8 +375,8 @@ public class BeaconHeadersSyncTests
             .ToArray();
         ctx.Feed.HandleResponse(request);
 
+        // It should complete successfully
         ctx.BeaconSync.IsBeaconSyncHeadersFinished().Should().BeTrue();
-
         request = await ctx.Feed.PrepareRequest();
         request.Should().BeNull();
     }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/BeaconHeadersSyncTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/BeaconHeadersSyncTests.cs
@@ -1,6 +1,10 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Nethermind.Blockchain;
@@ -45,6 +49,7 @@ public class BeaconHeadersSyncTests
                     Block genesis = Build.A.Block.Genesis.TestObject;
                     _blockTree = new BlockTree(new MemDb(), new MemDb(), blockInfoDb, new ChainLevelInfoRepository(blockInfoDb), MainnetSpecProvider.Instance, NullBloomStorage.Instance, LimboLogs.Instance);
                     _blockTree.SuggestBlock(genesis);
+                    _blockTree.UpdateMainChain(new []{genesis}, true); // MSMS do validity check on this
                 }
 
                 return _blockTree;
@@ -150,6 +155,21 @@ public class BeaconHeadersSyncTests
 
         private IBlockCacheService? _blockCacheService;
         public IBlockCacheService BlockCacheService => _blockCacheService ??= new BlockCacheService();
+
+        private IBlockTree? _remoteBlockTree;
+        public IBlockTree RemoteBlockTree
+        {
+            get
+            {
+                return _remoteBlockTree ??= Build.A.BlockTree().TestObject;
+            }
+            set => _remoteBlockTree = value;
+        }
+
+        public void SetupRemoteBlockTreeOfLength(int chainLength)
+        {
+            RemoteBlockTree = Build.A.BlockTree().OfChainLength(chainLength).TestObject;
+        }
     }
 
     [Test]
@@ -305,6 +325,61 @@ public class BeaconHeadersSyncTests
         invalidChainTracker.OnInvalidBlock(headerToInvalidate, lastValidHeader);
         invalidChainTracker.IsOnKnownInvalidChain(lastHeader, out Keccak storedLastValidHash).Should().BeTrue();
         storedLastValidHash.Should().Be(lastValidHeader);
+    }
+
+    [Test]
+    public async Task When_pivot_changed_during_header_sync_after_chain_merged__do_not_return_null_request()
+    {
+        ISyncConfig syncConfig = new SyncConfig
+        {
+            FastSync = true,
+            FastBlocks = true,
+            PivotNumber = "0",
+            PivotHash = Keccak.Zero.ToString(),
+            PivotTotalDifficulty = "0"
+        };
+
+        int chainLength = 1000;
+        int pivotNumber = 100;
+
+        Context ctx = new()
+        {
+            SyncConfig = syncConfig,
+        };
+        ctx.SetupRemoteBlockTreeOfLength(chainLength);
+
+        BlockHeader pivot = ctx.RemoteBlockTree.FindHeader(pivotNumber);
+        ctx.BeaconPivot.EnsurePivot(pivot);
+
+        ctx.Feed.InitializeFeed();
+
+        // First batch, should be enough to merge chain
+        HeadersSyncBatch? request = await ctx.Feed.PrepareRequest();
+        request.Should().NotBeNull();
+        request.Response = Enumerable.Range((int)request.StartNumber, request.RequestSize)
+            .Select((blockNumber) => ctx.RemoteBlockTree.FindHeader(blockNumber))
+            .ToArray();
+
+        ctx.Feed.HandleResponse(request);
+
+        // Ensure pivot happens which reset lowest inserted beacon header further ahead.
+        ctx.BeaconPivot.EnsurePivot(ctx.RemoteBlockTree.FindHeader(pivotNumber + 10));
+        ctx.BeaconSync.IsBeaconSyncHeadersFinished().Should().BeFalse();
+
+        // The sync feed must adapt to this
+        request = await ctx.Feed.PrepareRequest();
+        request.Should().NotBeNull();
+
+        // We respond it again
+        request.Response = Enumerable.Range((int)request.StartNumber, request.RequestSize)
+            .Select((blockNumber) => ctx.RemoteBlockTree.FindHeader(blockNumber))
+            .ToArray();
+        ctx.Feed.HandleResponse(request);
+
+        ctx.BeaconSync.IsBeaconSyncHeadersFinished().Should().BeTrue();
+
+        request = await ctx.Feed.PrepareRequest();
+        request.Should().BeNull();
     }
 
     private async void BuildAndProcessHeaderSyncBatches(


### PR DESCRIPTION
- Fixes issue where beacon header sync hangs with negative progress.
- This is likely to happen when the pivot changed in the middle of beacon header sync. This happens because sometimes the CL will send a batch of NP and then a batch of FcU, instead of interleaving NP and FcU. 
- When the beacon pivot changed right after header sync feed's `_chainMerged` was flagged, but before the feed fall asleep, MultiSyncModeSelector will continue to assume beacon header should be on, but feed will not send more request as it need to fall asleep to reinitialize to new pivot.
- This change simply detect if the pivot changed and run the associated log.

## Changes:
- If pivot changed, run feed cleanup and reinitialize.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [X] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [X] Yes
- [ ] No

**Comments about testing , should you have some** (optional)

- Goerly beacon sync completed fine.
- Running hive....

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...