### PR TITLE
Fix `nethermind_blocks` update when a trace block is called.

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
@@ -282,7 +282,13 @@ namespace Nethermind.Consensus.Processing
                     else
                     {
                         if (_logger.IsTrace) _logger.Trace($"Processed block {block.ToString(Block.Format.Full)}");
-                        _stats.UpdateStats(block, _blockTree, _recoveryQueue.Count, _blockQueue.Count);
+
+                        bool readOnlyChain = blockRef.ProcessingOptions.ContainsFlag(ProcessingOptions.ReadOnlyChain);
+                        if (!readOnlyChain)
+                        {
+                            _stats.UpdateStats(block, _blockTree, _recoveryQueue.Count, _blockQueue.Count);
+                        }
+
                         BlockRemoved?.Invoke(this, new BlockHashEventArgs(blockRef.BlockHash, ProcessingResult.Success));
                     }
                 }
@@ -366,8 +372,8 @@ namespace Nethermind.Consensus.Processing
                 _blockTree.UpdateMainChain(processingBranch.Blocks, true);
             }
 
-            bool notReadOnlyChain = !options.ContainsFlag(ProcessingOptions.ReadOnlyChain);
-            if (notReadOnlyChain)
+            bool readonlyChain = options.ContainsFlag(ProcessingOptions.ReadOnlyChain);
+            if (!readonlyChain)
             {
                 Metrics.LastBlockProcessingTimeInMs = _stopwatch.ElapsedMilliseconds;
             }
@@ -380,9 +386,8 @@ namespace Nethermind.Consensus.Processing
                 Metrics.LastBlockProcessingTimeInMs = _stopwatch.ElapsedMilliseconds;
             }
 
-            if (!notReadOnlyChain)
+            if (!readonlyChain)
             {
-
                 _stats.UpdateStats(lastProcessed, _blockTree, _recoveryQueue.Count, _blockQueue.Count);
             }
 


### PR DESCRIPTION
Fix #4943 

- When calling trace, the blockchainproccessor is run, and the metrics is (probably?) wrongly updated. This seems to be an unexpected behaviour.
- Additionally `nethermind_blocks` mentioned in its description as total number of block processed. Strictly speaking, this is not what we implement, which is the current block height. Even our own dashboard uses this as block height instead of total blocks processed. So I'm not gonna change this behaviour.

## Changes:
- If readonly chain, don't update metrics.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [X] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [X] No

**Comments about testing , should you have some** (optional)

- Tested manually, before `trace_block` would cause metric on my dashboard to change, now `trace_block` no longer change the metric.

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...