### PR TITLE
Do not set force restart beacon sync flag if already set

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/ChainLevelHelper.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/ChainLevelHelper.cs
@@ -44,6 +44,8 @@ public class ChainLevelHelper : IChainLevelHelper
         {
             // For some reason, this block number is missing when it should not.
             // anyway, lets just restart the whole sync.
+            if (_beaconPivot.ShouldForceStartNewSync) return;
+
             if (_logger.IsWarn) _logger.Warn($"Unable to find beacon header at height {blockNumber}. This is unexpected, forcing a new beacon sync.");
             _beaconPivot.ShouldForceStartNewSync = true;
         }


### PR DESCRIPTION
- When force restart condition is triggered, the log shows up multiple time as the downloader restart, until an FcU happen, which can take 10 second or until the CL synced.
- This can be alarming.

## Changes:
- Dont set the flag if its already set.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [X] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [X] No: this scenario already have a unit test.

**Comments about testing , should you have some** (optional)

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...