### PR TITLE
Make state test runner output state root, fixes #4973

### DIFF
--- a/src/Nethermind/Ethereum.Test.Base/EthereumTestResult.cs
+++ b/src/Nethermind/Ethereum.Test.Base/EthereumTestResult.cs
@@ -35,6 +35,6 @@ namespace Ethereum.Test.Base
 
         [JsonIgnore] public int TimeInMs { get; set; }
 
-        [JsonIgnore] public Keccak StateRoot { get; set; } = Keccak.EmptyTreeHash;
+        public Keccak StateRoot { get; set; } = Keccak.EmptyTreeHash;
     }
 }


### PR DESCRIPTION
Fixes  #4973


## Changes:

This PR changes the state test result, so the (already present) stateroot is not ignored by the json outputter. 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes (?)
- [ ] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [x] No

**Comments about testing , should you have some** (optional)

Tested locally; 
```
user@debian-work:~/workspace/nethermind/src/Nethermind/Nethermind.State.Test.Runner$ ./bin/release/net6.0/linux-x64/publish/nethtest -n -i  ~/QubesIncoming/work/statetest_filled.json
[
  {
    "name": "randomStatetestmartin-Wed_10_02_29-14338-0_d0g0v0_",
    "pass": true,
    "fork": "Byzantium",
    "stateRoot": "0xa2b3391f7a85bf1ad08dc541a1b99da3c591c156351391f26ec88c557ff12134"
  }
]
user@debian-work:~/workspace/nethermind/src/Nethermind/Nethermind.State.Test.Runner$ ./bin/release/net6.0/linux-x64/publish/nethtest -n -i  ~/QubesIncoming/work/statetest1.json
[
  {
    "name": "randomStatetestmartin-Wed_10_02_29-14338-0_d0g0v0_",
    "pass": false,
    "fork": "Byzantium",
    "stateRoot": "0xa2b3391f7a85bf1ad08dc541a1b99da3c591c156351391f26ec88c557ff12134"
  }
]

```

