### PR TITLE
state test runner: remove blocking wait for input

### DIFF
--- a/src/Nethermind/Nethermind.State.Test.Runner/StateTestRunner.cs
+++ b/src/Nethermind/Nethermind.State.Test.Runner/StateTestRunner.cs
@@ -82,7 +82,6 @@ namespace Nethermind.State.Test.Runner
 
             WriteOut(results);
 
-            Console.ReadLine();
             return results;
         }
     }


### PR DESCRIPTION

## Changes:

This PR removes the 'hang' that happens in the state test runner, which for some reason blocks, waiting for an <enter>-press after execution. 

Note: I do not know the reason why it was added, but it has annoyed me for years. In case it is highly important, for some obscure reason, let me point out that the same effect can be achieved via the `-w` option. 

## Types of changes

What types of changes does your code introduce?

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

I mean, maybe (?) 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [x] No

I mean, I didn't _write_ tests, but here's me testing that it works, first, and then testing that `-w` achieves the same blocking wait. 
```
user@debian-work:~/workspace/nethermind/src/Nethermind/Nethermind.State.Test.Runner$ ./bin/release/net6.0/linux-x64/publish/nethtest -n -i  ~/QubesIncoming/work/statetest1.json 
[
  {
    "name": "randomStatetestmartin-Wed_10_02_29-14338-0_d0g0v0_",
    "pass": false,
    "fork": "Byzantium"
  }
]user@debian-work:~/workspace/nethermind/src/Nethermind/Nethermind.State.Test.Runner$ ./bin/release/net6.0/linux-x64/publish/nethtest -n -i  ~/QubesIncoming/work/statetest1.json -w
[
  {
    "name": "randomStatetestmartin-Wed_10_02_29-14338-0_d0g0v0_",
    "pass": false,
    "fork": "Byzantium"
  }
]lalala
```

