### PR TITLE
state runner: make it execute sequentially and read input from stdin

### DIFF
--- a/src/Nethermind/Nethermind.State.Test.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.State.Test.Runner/Program.cs
@@ -13,7 +13,7 @@ namespace Nethermind.State.Test.Runner
     {
         public class Options
         {
-            [Option('i', "input", Required = true, HelpText = "Set the state test input file or directory.")]
+            [Option('i', "input", Required = false, HelpText = "Set the state test input file or directory. Either 'input' or 'stdin' is required")]
             public string Input { get; set; }
 
             [Option('t', "trace", Required = false, HelpText = "Set to always trace (by default traces are only generated for failing tests).")]
@@ -30,6 +30,9 @@ namespace Nethermind.State.Test.Runner
 
             [Option('s', "stack", Required = false, HelpText = "Exclude stack trace")]
             public bool ExcludeStack { get; set; }
+
+            [Option('x', "stdin", Required = false, HelpText = "If stdin is used, the state runner will read inputs (filenames) from stdin, and continue executing until empty line is read.")]
+            public bool Stdin { get; set; }
         }
 
         public static void Main(params string[] args)
@@ -54,9 +57,20 @@ namespace Nethermind.State.Test.Runner
                 whenTrace = WhenTrace.Always;
             }
 
-            if (!string.IsNullOrWhiteSpace(options.Input))
+            String input = options.Input;
+            if (options.Stdin)
             {
-                RunSingleTest(options.Input, source => new StateTestsRunner(source, whenTrace, !options.ExcludeMemory, !options.ExcludeStack));
+                input = Console.ReadLine();
+            }
+
+	    while ( !string.IsNullOrWhiteSpace(input) )
+            {
+                RunSingleTest(input, source => new StateTestsRunner(source, whenTrace, !options.ExcludeMemory, !options.ExcludeStack));
+                if (!options.Stdin)
+                {
+                    break;
+                }
+                input = Console.ReadLine();
             }
 
             if (options.Wait)


### PR DESCRIPTION
## Changes:

This PR changes the state runner, so that it can execute many tests sequentially. When doing fuzzing, this (hopefully) speeds up the execution time, since the .net framework bootstrap phase is not repeated. 

The intention with this PR is that no existing functionality should change - the old flags should work as before.  

Besu already has this feature, and it improved the execution time quite a lot. 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [x] No

Testing below:
```
user@debian-work:~/workspace/nethermind/src/Nethermind/Nethermind.State.Test.Runner$ ./bin/release/net6.0/linux-x64/publish/nethtest -n  -x 
/home/user/QubesIncoming/work/statetest1.json
[
  {
    "name": "randomStatetestmartin-Wed_10_02_29-14338-0_d0g0v0_",
    "pass": false,
    "fork": "Byzantium"
  }
]
/home/user/QubesIncoming/work/statetest_filled.json
[
  {
    "name": "randomStatetestmartin-Wed_10_02_29-14338-0_d0g0v0_",
    "pass": true,
    "fork": "Byzantium"
  }
]
```
## Further comments (optional)

