### PR TITLE
state runner: make memsize int

### DIFF
--- a/src/Nethermind/Nethermind.State.Test.Runner/StateTestTxTracer.cs
+++ b/src/Nethermind/Nethermind.State.Test.Runner/StateTestTxTracer.cs
@@ -90,7 +90,7 @@ namespace Nethermind.State.Test.Runner
 
         public void SetOperationMemorySize(ulong newSize)
         {
-            _traceEntry.UpdateMemorySize(newSize);
+            _traceEntry.UpdateMemorySize((int)newSize);
             int diff = (int)_traceEntry.MemSize * 2 - (_traceEntry.Memory.Length - 2);
             if (diff > 0)
             {

--- a/src/Nethermind/Nethermind.State.Test.Runner/StateTxTraceEntry.cs
+++ b/src/Nethermind/Nethermind.State.Test.Runner/StateTxTraceEntry.cs
@@ -29,7 +29,7 @@ namespace Nethermind.State.Test.Runner
         public string Memory { get; set; }
 
         [JsonProperty(PropertyName = "memSize")]
-        public ulong MemSize { get; set; }
+        public int MemSize { get; set; }
 
         [JsonProperty(PropertyName = "stack")]
         public List<string> Stack { get; set; }
@@ -48,7 +48,7 @@ namespace Nethermind.State.Test.Runner
 
         //        public Dictionary<string, string> Storage { get; set; }
 
-        internal void UpdateMemorySize(ulong size)
+        internal void UpdateMemorySize(int size)
         {
             MemSize = size;
         }


### PR DESCRIPTION
Related to #4955

https://github.com/NethermindEth/nethermind/issues/4955#issuecomment-1335243073

## Changes:

This changes the output `memSize` to be an integer, which is aligned with geth, erigon and besu. 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No

Results below
```
user@debian-work:~/workspace/nethermind/src/Nethermind/Nethermind.State.Test.Runner$ ./nethtest -m --trace --input ./00000006-naivefuzz-0.json  2>&1 | head -n 3 
{"pc":0,"op":96,"gas":"0xb4213","gasCost":"0x3","memSize":0,"stack":[],"depth":1,"refund":0,"opname":"PUSH1","error":""}
{"pc":2,"op":96,"gas":"0xb4210","gasCost":"0x3","memSize":0,"stack":["0x2"],"depth":1,"refund":0,"opname":"PUSH1","error":""}
{"pc":4,"op":85,"gas":"0xb420d","gasCost":"0x5654","memSize":0,"stack":["0x2","0x3"],"depth":1,"refund":0,"opname":"SSTORE","error":""}
```
