### PR TITLE
Fix memory size reporting. Closes #4955

### DIFF
--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -647,11 +647,7 @@ namespace Nethermind.Evm
             {
                 if (traceOpcodes)
                 {
-                    if (_txTracer.IsTracingMemory)
-                    {
-                        _txTracer.SetOperationMemorySize(vmState.Memory?.Size ?? 0);
-                    }
-
+                    _txTracer.SetOperationMemorySize(vmState.Memory?.Size ?? 0);
                     _txTracer.ReportOperationRemainingGas(gasAvailable);
                 }
             }

--- a/src/Nethermind/Nethermind.State.Test.Runner/StateTestTxTracer.cs
+++ b/src/Nethermind/Nethermind.State.Test.Runner/StateTestTxTracer.cs
@@ -91,6 +91,10 @@ namespace Nethermind.State.Test.Runner
         public void SetOperationMemorySize(ulong newSize)
         {
             _traceEntry.UpdateMemorySize(newSize);
+	    if (!IsTracingMemory)
+	    {
+		return;
+	    }
             int diff = (int)_traceEntry.MemSize * 2 - (_traceEntry.Memory.Length - 2);
             if (diff > 0)
             {


### PR DESCRIPTION
Fixes #4955

## Changes:

This changes the memory reporting, so that even if `-m` is used (disable memory), the `memSize` is still accurate. 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No

My tests, with and without memory reporting enabled, showing that `memSize` is correct in both cases: 

```
user@debian-work:~/workspace/nethermind/src/Nethermind/Nethermind.State.Test.Runner$ ./nethtest --trace --input ./00016209-naivefuzz-0.json 2>&1 | head
{"pc":0,"op":96,"gas":"0x79bdd8","gasCost":"0x3","memory":"0x","memSize":"0x0","stack":[],"depth":1,"refund":0,"opname":"PUSH1","error":""}
{"pc":2,"op":96,"gas":"0x79bdd5","gasCost":"0x3","memory":"0x","memSize":"0x0","stack":["0x0"],"depth":1,"refund":0,"opname":"PUSH1","error":""}
{"pc":4,"op":96,"gas":"0x79bdd2","gasCost":"0x3","memory":"0x","memSize":"0x0","stack":["0x0","0x1"],"depth":1,"refund":0,"opname":"PUSH1","error":""}
{"pc":6,"op":96,"gas":"0x79bdcf","gasCost":"0x3","memory":"0x","memSize":"0x0","stack":["0x0","0x1","0x1"],"depth":1,"refund":0,"opname":"PUSH1","error":""}
{"pc":8,"op":96,"gas":"0x79bdcc","gasCost":"0x3","memory":"0x","memSize":"0x0","stack":["0x0","0x1","0x1","0x2"],"depth":1,"refund":0,"opname":"PUSH1","error":""}
{"pc":10,"op":97,"gas":"0x79bdc9","gasCost":"0x3","memory":"0x","memSize":"0x0","stack":["0x0","0x1","0x1","0x2","0x2"],"depth":1,"refund":0,"opname":"PUSH2","error":""}
{"pc":13,"op":97,"gas":"0x79bdc6","gasCost":"0x3","memory":"0x","memSize":"0x0","stack":["0x0","0x1","0x1","0x2","0x2","0x1f4"],"depth":1,"refund":0,"opname":"PUSH2","error":""}
{"pc":16,"op":133,"gas":"0x79bdc3","gasCost":"0x3","memory":"0x","memSize":"0x0","stack":["0x0","0x1","0x1","0x2","0x2","0x1f4","0xffff"],"depth":1,"refund":0,"opname":"DUP6","error":""}
{"pc":17,"op":89,"gas":"0x79bdc0","gasCost":"0x2","memory":"0x","memSize":"0x0","stack":["0x0","0x1","0x1","0x2","0x2","0x1f4","0xffff","0x1"],"depth":1,"refund":0,"opname":"MSIZE","error":""}
{"pc":18,"op":162,"gas":"0x79bdbe","gasCost":"0x470","memory":"0x0000000000000000000000000000000000000000000000000000000000000000","memSize":"0x20","stack":["0x0","0x1","0x1","0x2","0x2","0x1f4","0xffff","0x1","0x0"],"depth":1,"refund":0,"opname":"LOG2","error":""}

user@debian-work:~/workspace/nethermind/src/Nethermind/Nethermind.State.Test.Runner$ ./nethtest -m --trace --input ./00016209-naivefuzz-0.json 2>&1 | head
{"pc":0,"op":96,"gas":"0x79bdd8","gasCost":"0x3","memSize":"0x0","stack":[],"depth":1,"refund":0,"opname":"PUSH1","error":""}
{"pc":2,"op":96,"gas":"0x79bdd5","gasCost":"0x3","memSize":"0x0","stack":["0x0"],"depth":1,"refund":0,"opname":"PUSH1","error":""}
{"pc":4,"op":96,"gas":"0x79bdd2","gasCost":"0x3","memSize":"0x0","stack":["0x0","0x1"],"depth":1,"refund":0,"opname":"PUSH1","error":""}
{"pc":6,"op":96,"gas":"0x79bdcf","gasCost":"0x3","memSize":"0x0","stack":["0x0","0x1","0x1"],"depth":1,"refund":0,"opname":"PUSH1","error":""}
{"pc":8,"op":96,"gas":"0x79bdcc","gasCost":"0x3","memSize":"0x0","stack":["0x0","0x1","0x1","0x2"],"depth":1,"refund":0,"opname":"PUSH1","error":""}
{"pc":10,"op":97,"gas":"0x79bdc9","gasCost":"0x3","memSize":"0x0","stack":["0x0","0x1","0x1","0x2","0x2"],"depth":1,"refund":0,"opname":"PUSH2","error":""}
{"pc":13,"op":97,"gas":"0x79bdc6","gasCost":"0x3","memSize":"0x0","stack":["0x0","0x1","0x1","0x2","0x2","0x1f4"],"depth":1,"refund":0,"opname":"PUSH2","error":""}
{"pc":16,"op":133,"gas":"0x79bdc3","gasCost":"0x3","memSize":"0x0","stack":["0x0","0x1","0x1","0x2","0x2","0x1f4","0xffff"],"depth":1,"refund":0,"opname":"DUP6","error":""}
{"pc":17,"op":89,"gas":"0x79bdc0","gasCost":"0x2","memSize":"0x0","stack":["0x0","0x1","0x1","0x2","0x2","0x1f4","0xffff","0x1"],"depth":1,"refund":0,"opname":"MSIZE","error":""}
{"pc":18,"op":162,"gas":"0x79bdbe","gasCost":"0x470","memSize":"0x20","stack":["0x0","0x1","0x1","0x2","0x2","0x1f4","0xffff","0x1","0x0"],"depth":1,"refund":0,"opname":"LOG2","error":""}

```
