### PR TITLE
Make StateTestTxTracer always trace memory size

### DIFF
--- a/src/Nethermind/Nethermind.State.Test.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.State.Test.Runner/Program.cs
@@ -57,19 +57,20 @@ namespace Nethermind.State.Test.Runner
                 whenTrace = WhenTrace.Always;
             }
 
-            String input = options.Input;
+            string input = options.Input;
             if (options.Stdin)
             {
                 input = Console.ReadLine();
             }
 
-	    while ( !string.IsNullOrWhiteSpace(input) )
+            while (!string.IsNullOrWhiteSpace(input))
             {
                 RunSingleTest(input, source => new StateTestsRunner(source, whenTrace, !options.ExcludeMemory, !options.ExcludeStack));
                 if (!options.Stdin)
                 {
                     break;
                 }
+
                 input = Console.ReadLine();
             }
 

--- a/src/Nethermind/Nethermind.State.Test.Runner/StateTestRunner.cs
+++ b/src/Nethermind/Nethermind.State.Test.Runner/StateTestRunner.cs
@@ -66,7 +66,7 @@ namespace Nethermind.State.Test.Runner
                 if (_whenTrace != WhenTrace.Never && !(result?.Pass ?? false))
                 {
                     StateTestTxTracer txTracer = new();
-                    txTracer.IsTracingMemory = _traceMemory;
+                    txTracer.IsTracingDetailedMemory = _traceMemory;
                     txTracer.IsTracingStack = _traceStack;
                     result = RunTest(test, txTracer);
 

--- a/src/Nethermind/Nethermind.State.Test.Runner/StateTestTxTracer.cs
+++ b/src/Nethermind/Nethermind.State.Test.Runner/StateTestTxTracer.cs
@@ -22,7 +22,8 @@ namespace Nethermind.State.Test.Runner
         public bool IsTracingReceipt => true;
         bool ITxTracer.IsTracingActions => false;
         public bool IsTracingOpLevelStorage => true;
-        public bool IsTracingMemory { get; set; } = true;
+        public bool IsTracingMemory => true;
+        public bool IsTracingDetailedMemory { get; set; } = true;
         bool ITxTracer.IsTracingInstructions => true;
         public bool IsTracingRefunds { get; } = false;
         public bool IsTracingCode => false;
@@ -91,12 +92,14 @@ namespace Nethermind.State.Test.Runner
         public void SetOperationMemorySize(ulong newSize)
         {
             _traceEntry.UpdateMemorySize((int)newSize);
-            int diff = (int)_traceEntry.MemSize * 2 - (_traceEntry.Memory.Length - 2);
-            if (diff > 0)
+            if (IsTracingDetailedMemory)
             {
-                _traceEntry.Memory += new string('0', diff);
+                int diff = _traceEntry.MemSize * 2 - (_traceEntry.Memory.Length - 2);
+                if (diff > 0)
+                {
+                    _traceEntry.Memory += new string('0', diff);
+                }
             }
-
         }
 
         public void ReportMemoryChange(long offset, in ReadOnlySpan<byte> data)
@@ -226,7 +229,10 @@ namespace Nethermind.State.Test.Runner
 
         public void SetOperationMemory(List<string> memoryTrace)
         {
-            _traceEntry.Memory = string.Concat("0x", string.Join("", memoryTrace.Select(mt => mt.Replace("0x", string.Empty))));
+            if (IsTracingDetailedMemory)
+            {
+                _traceEntry.Memory = string.Concat("0x", string.Join("", memoryTrace.Select(mt => mt.Replace("0x", string.Empty))));
+            }
         }
 
         public StateTestTxTrace BuildResult()


### PR DESCRIPTION
Fixes #4955
Closes #4998

## Changes:
- This changes the memory reporting, so that even if -m is used (disable memory), the memSize is still accurate.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [x] No
