### PR TITLE
Increase by x4.8 performance of ToHexString

### DIFF
--- a/src/Nethermind/Nethermind.Benchmark.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Benchmark.Runner/Program.cs
@@ -58,7 +58,7 @@ namespace Nethermind.Benchmark.Runner
             {
                 foreach (Assembly assembly in additionalJobAssemblies)
                 {
-                    BenchmarkRunner.Run(assembly, new DashboardConfig(Job.MediumRun.WithRuntime(CoreRuntime.Core60)), args);
+                    BenchmarkRunner.Run(assembly, new DashboardConfig(Job.MediumRun.WithRuntime(CoreRuntime.Core70)), args);
                 }
 
                 foreach (Assembly assembly in simpleJobAssemblies)

--- a/src/Nethermind/Nethermind.Benchmark.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Benchmark.Runner/Program.cs
@@ -22,6 +22,7 @@ namespace Nethermind.Benchmark.Runner
                 AddJob(job);
             }
 
+            AddColumnProvider(BenchmarkDotNet.Columns.DefaultColumnProviders.Descriptor);
             AddColumnProvider(BenchmarkDotNet.Columns.DefaultColumnProviders.Statistics);
             AddColumnProvider(BenchmarkDotNet.Columns.DefaultColumnProviders.Params);
             AddLogger(BenchmarkDotNet.Loggers.ConsoleLogger.Default);
@@ -57,12 +58,12 @@ namespace Nethermind.Benchmark.Runner
             {
                 foreach (Assembly assembly in additionalJobAssemblies)
                 {
-                    BenchmarkRunner.Run(assembly, new DashboardConfig(Job.MediumRun.WithRuntime(CoreRuntime.Core60)));
+                    BenchmarkRunner.Run(assembly, new DashboardConfig(Job.MediumRun.WithRuntime(CoreRuntime.Core60)), args);
                 }
 
                 foreach (Assembly assembly in simpleJobAssemblies)
                 {
-                    BenchmarkRunner.Run(assembly, new DashboardConfig());
+                    BenchmarkRunner.Run(assembly, new DashboardConfig(), args);
                 }
             }
         }

--- a/src/Nethermind/Nethermind.Benchmark/Core/ByteArrayToHexBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Core/ByteArrayToHexBenchmarks.cs
@@ -19,9 +19,17 @@ namespace Nethermind.Benchmarks.Core
         }
 
         [Benchmark]
-        public string SafeLookup()
+        public string Improved()
         {
             return Bytes.ByteArrayToHexViaLookup32Safe(array, false);
+        }
+
+        [Benchmark]
+        public string SafeLookup()
+        {
+#pragma warning disable CS0612 // Type or member is obsolete
+            return Bytes.ByteArrayToHexViaLookup32SafeOld(array, false);
+#pragma warning restore CS0612 // Type or member is obsolete
         }
 
         [Benchmark(Baseline = true)]

--- a/src/Nethermind/Nethermind.Benchmark/Core/FromHexBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Core/FromHexBenchmarks.cs
@@ -26,7 +26,9 @@ namespace Nethermind.Benchmarks.Core
         [Benchmark]
         public byte[] Improved()
         {
+#pragma warning disable CS0612 // Type or member is obsolete
             return Bytes.FromHexStringOld(array);
+#pragma warning restore CS0612 // Type or member is obsolete
         }
     }
 }

--- a/src/Nethermind/Nethermind.Core.Test/BytesTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/BytesTests.cs
@@ -41,7 +41,9 @@ namespace Nethermind.Core.Test
         [TestCase("0123", 1)]
         public void FromHexString(string hexString, byte expectedResult)
         {
+#pragma warning disable CS0612 // Type or member is obsolete
             byte[] bytesOld = Bytes.FromHexStringOld(hexString);
+#pragma warning restore CS0612 // Type or member is obsolete
             Assert.AreEqual(bytesOld[0], expectedResult, "old");
 
             byte[] bytes = Bytes.FromHexString(hexString);
@@ -52,14 +54,50 @@ namespace Nethermind.Core.Test
         [TestCase("0x07", "7", false, true)]
         [TestCase("0x07", "0x07", true, false)]
         [TestCase("0x07", "07", false, false)]
+        [TestCase("0x77", "0x77", true, true)]
+        [TestCase("0x77", "77", false, true)]
+        [TestCase("0x77", "0x77", true, false)]
+        [TestCase("0x77", "77", false, false)]
         [TestCase("0x0007", "0x7", true, true)]
         [TestCase("0x0007", "7", false, true)]
         [TestCase("0x0007", "0x0007", true, false)]
         [TestCase("0x0007", "0007", false, false)]
+        [TestCase("0x0077", "0x77", true, true)]
+        [TestCase("0x0077", "77", false, true)]
+        [TestCase("0x0077", "0x0077", true, false)]
+        [TestCase("0x0077", "0077", false, false)]
+        [TestCase("0x0f", "0xF", true, true)]
+        [TestCase("0x0F", "F", false, true)]
+        [TestCase("0xFf", "0xFf", true, true)]
+        [TestCase("0xff", "Ff", false, true)]
+        [TestCase("0xfff", "0xFFF", true, true)]
+        [TestCase("0xFFF", "FFF", false, true)]
+        [TestCase("0xf7f", "0xf7F", true, true)]
+        [TestCase("0xf7F", "f7F", false, true)]
+        [TestCase("0xffffffaf9f", "0xfFFffFaF9F", true, true)]
+        [TestCase("0xfFFffFaF9F", "fFFffFaF9F", false, true)]
+        [TestCase("0xcfffffaff9f", "0xcFfFFFafF9F", true, true)]
+        [TestCase("0xcFfFFFafF9F", "cFfFFFafF9F", false, true)]
         public void ToHexString(string input, string expectedResult, bool with0x, bool noLeadingZeros)
         {
             byte[] bytes = Bytes.FromHexString(input);
-            Assert.AreEqual(expectedResult, bytes.ToHexString(with0x, noLeadingZeros));
+            if (!noLeadingZeros)
+            {
+                Assert.AreEqual(expectedResult.ToLower(), Bytes.ByteArrayToHexViaLookup32Safe(bytes, with0x));
+            }
+            Assert.AreEqual(expectedResult.ToLower(), bytes.ToHexString(with0x, noLeadingZeros));
+            Assert.AreEqual(expectedResult.ToLower(), bytes.AsSpan().ToHexString(with0x, noLeadingZeros, withEip55Checksum: false));
+#pragma warning disable CS0612 // Type or member is obsolete
+            Assert.AreEqual(bytes.ToHexStringOld(with0x, noLeadingZeros), bytes.ToHexString(with0x, noLeadingZeros));
+#pragma warning restore CS0612 // Type or member is obsolete
+
+            Assert.AreEqual(expectedResult, bytes.ToHexString(with0x, noLeadingZeros, withEip55Checksum: true));
+#pragma warning disable CS0612 // Type or member is obsolete
+            Assert.AreEqual(bytes.ToHexStringOld(with0x, noLeadingZeros, withEip55Checksum: true),
+                bytes.ToHexString(with0x, noLeadingZeros, withEip55Checksum: true));
+#pragma warning restore CS0612 // Type or member is obsolete
+            Assert.AreEqual(bytes.ToHexString(with0x, noLeadingZeros, withEip55Checksum: true),
+                bytes.AsSpan().ToHexString(with0x, noLeadingZeros, withEip55Checksum: true));
         }
 
         [TestCase("0x", "0x", true)]

--- a/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
@@ -564,7 +564,7 @@ namespace Nethermind.Core.Extensions
             int length = bytes.Length * 2 + (withZeroX ? 2 : 0);
             StateSmall stateToPass = new(bytes, withZeroX);
 
-            return string.Create(length, stateToPass, (chars, state) =>
+            return string.Create(length, stateToPass, static (chars, state) =>
             {
                 ref char charsRef = ref MemoryMarshal.GetReference(chars);
 
@@ -595,7 +595,7 @@ namespace Nethermind.Core.Extensions
             int length = bytes.Length * 2 + (withZeroX ? 2 : 0);
             StateSmall stateToPass = new(bytes, withZeroX);
 
-            return string.Create(length, stateToPass, (chars, state) =>
+            return string.Create(length, stateToPass, static (chars, state) =>
             {
                 ref var charsRef = ref MemoryMarshal.GetReference(chars);
 
@@ -829,7 +829,7 @@ namespace Nethermind.Core.Extensions
             }
 
             StateOld stateToPass = new(bytes, leadingZerosFirstCheck, withZeroX, withEip55Checksum);
-            return string.Create(length, stateToPass, (chars, state) =>
+            return string.Create(length, stateToPass, static (chars, state) =>
             {
                 string? hashHex = null;
                 bool isWithChecksum = state.WithEip55Checksum;

--- a/src/Nethermind/Nethermind.Core/Extensions/Int64Extensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/Int64Extensions.cs
@@ -126,6 +126,10 @@ namespace Nethermind.Core.Extensions
             return bytes;
         }
 
+        [ThreadStatic]
+        private static byte[]? t_byteBuffer64;
+        private static byte[] GetByteBuffer64() => t_byteBuffer64 ??= new byte[8];
+
         public static string ToHexString(this long value, bool skipLeadingZeros)
         {
             if (value == UInt256.Zero)
@@ -133,7 +137,7 @@ namespace Nethermind.Core.Extensions
                 return "0x";
             }
 
-            byte[] bytes = new byte[8];
+            byte[] bytes = GetByteBuffer64();
             BinaryPrimitives.WriteInt64BigEndian(bytes, value);
             return bytes.ToHexString(true, skipLeadingZeros, false);
         }
@@ -145,10 +149,14 @@ namespace Nethermind.Core.Extensions
                 return "0x";
             }
 
-            byte[] bytes = new byte[8];
+            byte[] bytes = GetByteBuffer64();
             BinaryPrimitives.WriteUInt64BigEndian(bytes, value);
             return bytes.ToHexString(true, skipLeadingZeros, false);
         }
+
+        [ThreadStatic]
+        private static byte[]? t_byteBuffer256;
+        private static byte[] GetByteBuffer256() => t_byteBuffer256 ??= new byte[32];
 
         public static string ToHexString(this in UInt256 value, bool skipLeadingZeros)
         {
@@ -165,9 +173,30 @@ namespace Nethermind.Core.Extensions
                 }
             }
 
-            byte[] bytes = new byte[32];
+            byte[] bytes = GetByteBuffer256();
             value.ToBigEndian(bytes);
             return bytes.ToHexString(true, skipLeadingZeros, false);
+        }
+
+        [Obsolete]
+        public static string ToHexStringOld(this in UInt256 value, bool skipLeadingZeros)
+        {
+            if (skipLeadingZeros)
+            {
+                if (value == UInt256.Zero)
+                {
+                    return "0x";
+                }
+
+                if (value == UInt256.One)
+                {
+                    return "0x1";
+                }
+            }
+
+            byte[] bytes = new byte[32];
+            value.ToBigEndian(bytes);
+            return bytes.ToHexStringOld(true, skipLeadingZeros, false);
         }
 
         public static long ToLongFromBigEndianByteArrayWithoutLeadingZeros(this byte[]? bytes)

--- a/src/Nethermind/Nethermind.Core/Extensions/SpanExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/SpanExtensions.cs
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Buffers;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
 using Nethermind.Core.Crypto;
 
 namespace Nethermind.Core.Extensions
@@ -25,91 +29,87 @@ namespace Nethermind.Core.Extensions
         }
 
         [DebuggerStepThrough]
-        private static string ToHexViaLookup(in Span<byte> span, bool withZeroX, bool skipLeadingZeros, bool withEip55Checksum)
+        private static string ToHexViaLookup(Span<byte> bytes, bool withZeroX, bool skipLeadingZeros, bool withEip55Checksum)
         {
-            int leadingZeros = skipLeadingZeros ? CountLeadingZeros(span) : 0;
-            char[] result = new char[span.Length * 2 + (withZeroX ? 2 : 0) - leadingZeros];
-            string? hashHex = null;
             if (withEip55Checksum)
             {
-                hashHex = Keccak.Compute(span.ToHexString(false)).ToString(false);
+                return ToHexStringWithEip55Checksum(bytes, withZeroX, skipLeadingZeros);
             }
 
-            if (withZeroX)
-            {
-                result[0] = '0';
-                result[1] = 'x';
-            }
+            int leadingZeros = skipLeadingZeros ? Bytes.CountLeadingZeros(bytes) : 0;
+            int length = bytes.Length * 2 + (withZeroX ? 2 : 0) - leadingZeros;
 
-            for (int i = 0; i < span.Length; i++)
-            {
-                uint val = Lookup32[span[i]];
-                char char1 = (char)val;
-                char char2 = (char)(val >> 16);
+            char[] charArray = ArrayPool<char>.Shared.Rent(length);
 
-                if (leadingZeros <= i * 2)
-                {
-                    result[2 * i + (withZeroX ? 2 : 0) - leadingZeros] =
-                        withEip55Checksum && char.IsLetter(char1) && hashHex![2 * i] > '7'
-                            ? char.ToUpper(char1)
-                            : char1;
-                }
+            ref byte input = ref Unsafe.Add(ref MemoryMarshal.GetReference(bytes), leadingZeros / 2);
+            Bytes.OutputBytesToCharHex(ref input, bytes.Length, ref charArray[0], withZeroX, leadingZeros);
 
-                if (leadingZeros <= i * 2 + 1)
-                {
-                    result[2 * i + 1 + (withZeroX ? 2 : 0) - leadingZeros] =
-                        withEip55Checksum && char.IsLetter(char2) && hashHex![2 * i + 1] > '7'
-                            ? char.ToUpper(char2)
-                            : char2;
-                }
-            }
-
-            if (skipLeadingZeros && result.Length == (withZeroX ? 2 : 0))
-            {
-                return withZeroX ? "0x0" : "0";
-            }
-
-            return new string(result);
-        }
-
-        private static readonly uint[] Lookup32 = CreateLookup32("x2");
-
-        private static uint[] CreateLookup32(string format)
-        {
-            uint[] result = new uint[256];
-            for (int i = 0; i < 256; i++)
-            {
-                string s = i.ToString(format);
-                result[i] = s[0] + ((uint)s[1] << 16);
-            }
+            string result = new string(charArray.AsSpan(0, length));
+            ArrayPool<char>.Shared.Return(charArray);
 
             return result;
         }
 
-        private static int CountLeadingZeros(in Span<byte> span)
+        private static string ToHexStringWithEip55Checksum(Span<byte> bytes, bool withZeroX, bool skipLeadingZeros)
         {
-            int leadingZeros = 0;
-            for (int i = 0; i < span.Length; i++)
+            string hashHex = Keccak.Compute(bytes.ToHexString(false)).ToString(false);
+
+            int leadingZeros = skipLeadingZeros ? Bytes.CountLeadingZeros(bytes) : 0;
+            int length = bytes.Length * 2 + (withZeroX ? 2 : 0) - leadingZeros;
+            if (leadingZeros >= 2)
             {
-                if ((span[i] & 240) == 0)
-                {
-                    leadingZeros++;
-                    if ((span[i] & 15) == 0)
-                    {
-                        leadingZeros++;
-                    }
-                    else
-                    {
-                        break;
-                    }
-                }
-                else
-                {
-                    break;
-                }
+                bytes = bytes[(leadingZeros / 2)..];
+            }
+            char[] charArray = ArrayPool<char>.Shared.Rent(length);
+
+            Span<char> chars = charArray.AsSpan(0, length);
+
+            if (withZeroX)
+            {
+                // In reverse, bounds check on [1] will elide bounds check on [0]
+                chars[1] = 'x';
+                chars[0] = '0';
+                // Trim off the two chars from the span
+                chars = chars[2..];
             }
 
-            return leadingZeros;
+            uint[] lookup32 = Bytes.Lookup32;
+
+            bool odd = (leadingZeros & 1) != 0;
+            int oddity = odd ? 2 : 0;
+            if (odd)
+            {
+                // Odd number of hex chars, handle the first
+                // seperately so loop can work in pairs
+                uint val = lookup32[bytes[0]];
+                char char2 = (char)(val >> 16);
+                chars[0] = char.IsLetter(char2) && hashHex[1] > '7'
+                            ? char.ToUpper(char2)
+                            : char2;
+
+                // Trim off the first byte and char from the spans
+                chars = chars[1..];
+                bytes = bytes[1..];
+            }
+
+            for (int i = 0; i < chars.Length; i += 2)
+            {
+                uint val = lookup32[bytes[i / 2]];
+                char char1 = (char)val;
+                char char2 = (char)(val >> 16);
+
+                chars[i] = char.IsLetter(char1) && hashHex[i + oddity] > '7'
+                            ? char.ToUpper(char1)
+                            : char1;
+                chars[i + 1] = char.IsLetter(char2) && hashHex[i + 1 + oddity] > '7'
+                            ? char.ToUpper(char2)
+                            : char2;
+            }
+
+            string result = new string(charArray.AsSpan(0, length));
+            ArrayPool<char>.Shared.Return(charArray);
+
+            return result;
         }
 
         public static bool IsNullOrEmpty<T>(this in Span<T> span) => span == null || span.Length == 0;

--- a/src/Nethermind/Nethermind.JsonRpc.Benchmark/UInt256ToHexStringBenchmark.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Benchmark/UInt256ToHexStringBenchmark.cs
@@ -58,7 +58,9 @@ namespace Nethermind.JsonRpc.Benchmark
         [Benchmark(Baseline = true)]
         public string Current()
         {
-            return string.Concat("0x", _scenarios[ScenarioIndex].ToString("x").TrimStart('0'));
+#pragma warning disable CS0612 // Type or member is obsolete
+            return _scenarios[ScenarioIndex].ToHexStringOld(true);
+#pragma warning restore CS0612 // Type or member is obsolete
         }
     }
 }


### PR DESCRIPTION
## Changes:

Is now x4.8 times faster, and Bytes.ByteArrayToHexViaLookup32Safe, Bytes.ToHexString and SpanExtensions.ToHexString all share the same implementation, rather than having 3 different ones

|   Method | ScenarioIndex |       Mean |     Error |    StdDev | Ratio | RatioSD |
|--------- |-------------- |-----------:|----------:|----------:|------:|--------:|
| Improved |             0 |  45.281 ns | 0.3482 ns | 0.4993 ns |  0.21 |    0.00 |
|  Current |             0 | 215.867 ns | 0.6967 ns | 0.9991 ns |  1.00 |    0.00 |
|          |               |            |           |           |       |         |
| Improved |             1 |   2.206 ns | 0.2604 ns | 0.3897 ns |  0.91 |    0.17 |
|  Current |             1 |   2.417 ns | 0.0265 ns | 0.0388 ns |  1.00 |    0.00 |
|          |               |            |           |           |       |         |
| Improved |             2 |  49.155 ns | 0.4488 ns | 0.6717 ns |  0.23 |    0.00 |
|  Current |             2 | 217.019 ns | 0.8983 ns | 1.3445 ns |  1.00 |    0.00 |
|          |               |            |           |           |       |         |
| Improved |             3 |  47.063 ns | 0.8300 ns | 1.1903 ns |  0.22 |    0.00 |
|  Current |             3 | 217.265 ns | 1.1834 ns | 1.7346 ns |  1.00 |    0.00 |
## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No

**Comments about testing , should you have some** (optional)

Added some odd/even leading zeros tests

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...