### PR TITLE
Improve ByteArrayToHexViaLookup32Safe

### DIFF
--- a/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
@@ -562,17 +562,17 @@ namespace Nethermind.Core.Extensions
 
                 int toProcess = state.Bytes.Length;
 
-                var lookup32 = Lookup32;
+                ref var lookup32 = ref Lookup32[0];
                 while (toProcess > 8)
                 {
-                    output = lookup32[input];
-                    Unsafe.Add(ref output, 1) = lookup32[Unsafe.Add(ref input, 1)];
-                    Unsafe.Add(ref output, 2) = lookup32[Unsafe.Add(ref input, 2)];
-                    Unsafe.Add(ref output, 3) = lookup32[Unsafe.Add(ref input, 3)];
-                    Unsafe.Add(ref output, 4) = lookup32[Unsafe.Add(ref input, 4)];
-                    Unsafe.Add(ref output, 5) = lookup32[Unsafe.Add(ref input, 5)];
-                    Unsafe.Add(ref output, 6) = lookup32[Unsafe.Add(ref input, 6)];
-                    Unsafe.Add(ref output, 7) = lookup32[Unsafe.Add(ref input, 7)];
+                    output = Unsafe.Add(ref lookup32, input);
+                    Unsafe.Add(ref output, 1) = Unsafe.Add(ref lookup32, Unsafe.Add(ref input, 1));
+                    Unsafe.Add(ref output, 2) = Unsafe.Add(ref lookup32, Unsafe.Add(ref input, 2));
+                    Unsafe.Add(ref output, 3) = Unsafe.Add(ref lookup32, Unsafe.Add(ref input, 3));
+                    Unsafe.Add(ref output, 4) = Unsafe.Add(ref lookup32, Unsafe.Add(ref input, 4));
+                    Unsafe.Add(ref output, 5) = Unsafe.Add(ref lookup32, Unsafe.Add(ref input, 5));
+                    Unsafe.Add(ref output, 6) = Unsafe.Add(ref lookup32, Unsafe.Add(ref input, 6));
+                    Unsafe.Add(ref output, 7) = Unsafe.Add(ref lookup32, Unsafe.Add(ref input, 7));
 
                     output = ref Unsafe.Add(ref output, 8);
                     input = ref Unsafe.Add(ref input, 8);
@@ -582,7 +582,7 @@ namespace Nethermind.Core.Extensions
 
                 while (toProcess > 0)
                 {
-                    output = lookup32[input];
+                    output = Unsafe.Add(ref lookup32, input);
 
                     output = ref Unsafe.Add(ref output, 1);
                     input = ref Unsafe.Add(ref input, 1);


### PR DESCRIPTION
As requested in https://github.com/NethermindEth/nethermind/pull/5009#pullrequestreview-1217191082

## Changes:
- Since only ever using a byte (0-255) to look up value in 256 length array, and Unsafe in function, switch to using it for the hex char look up also
- Removes 8 conditional branches from the method, collapsing sets of 4 asm instructions to 1 instruction (see diff at end)

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [x] No

## Further comments (optional)

Asm diff
```patch
...
  
G_M000_IG05:
        movzx    rdx, byte  ptr [rsi]
-       mov      ecx, dword ptr [rax+08H]
-       cmp      edx, ecx
-       jae      G_M000_IG10
-       mov      edx, edx
-       mov      edx, dword ptr [rax+4*rdx+10H]
+       mov      edx, dword ptr [rax+4*rdx]
        mov      dword ptr [rbx], edx
        movzx    rdx, byte  ptr [rsi+01H]
-       cmp      edx, ecx
-       jae      G_M000_IG10
-       mov      edx, edx
-       mov      edx, dword ptr [rax+4*rdx+10H]
+       mov      edx, dword ptr [rax+4*rdx]
        mov      dword ptr [rbx+04H], edx
        movzx    rdx, byte  ptr [rsi+02H]
-       cmp      edx, ecx
-       jae      G_M000_IG10
-       mov      edx, edx
-       mov      edx, dword ptr [rax+4*rdx+10H]
+       mov      edx, dword ptr [rax+4*rdx]
        mov      dword ptr [rbx+08H], edx
        movzx    rdx, byte  ptr [rsi+03H]
-       cmp      edx, ecx
-       jae      G_M000_IG10
-       mov      edx, edx
-       mov      edx, dword ptr [rax+4*rdx+10H]
+       mov      edx, dword ptr [rax+4*rdx]
        mov      dword ptr [rbx+0CH], edx
        movzx    rdx, byte  ptr [rsi+04H]
-       cmp      edx, ecx
-       jae      G_M000_IG10
-       mov      edx, edx
-       mov      edx, dword ptr [rax+4*rdx+10H]
+       mov      edx, dword ptr [rax+4*rdx]
        mov      dword ptr [rbx+10H], edx
        movzx    rdx, byte  ptr [rsi+05H]
-       cmp      edx, ecx
-       jae      SHORT G_M000_IG10
-       mov      edx, edx
-       mov      edx, dword ptr [rax+4*rdx+10H]
+       mov      edx, dword ptr [rax+4*rdx]
        mov      dword ptr [rbx+14H], edx
        movzx    rdx, byte  ptr [rsi+06H]
-       cmp      edx, ecx
-       jae      SHORT G_M000_IG10
-       mov      edx, edx
-       mov      edx, dword ptr [rax+4*rdx+10H]
+       mov      edx, dword ptr [rax+4*rdx]
        mov      dword ptr [rbx+18H], edx
        movzx    rdx, byte  ptr [rsi+07H]
-       cmp      edx, ecx
-       jae      SHORT G_M000_IG10
-       mov      ecx, edx
-       mov      edx, dword ptr [rax+4*rcx+10H]
+       mov      edx, dword ptr [rax+4*rdx]
        mov      dword ptr [rbx+1CH], edx
        add      rbx, 32
        add      rsi, 8
        add      edi, -8
        cmp      edi, 8
+       jg       SHORT G_M000_IG05
  
-G_M000_IG06:
-       jg       G_M000_IG05
- 
-G_M000_IG07:
+G_M000_IG06:
        test     edi, edi
-       jle      SHORT G_M000_IG09
-       align    [11 bytes for IG08]
+       jle      SHORT G_M000_IG08
+       align    [4 bytes for IG07]
  
-G_M000_IG08:
+G_M000_IG07:
        movzx    rdx, byte  ptr [rsi]
-       mov      ecx, dword ptr [rax+08H]
-       cmp      edx, ecx
-       jae      SHORT G_M000_IG10
-       mov      edx, edx
-       mov      edx, dword ptr [rax+4*rdx+10H]
+       mov      edx, dword ptr [rax+4*rdx]
        mov      dword ptr [rbx], edx
        add      rbx, 4
        inc      rsi
        dec      edi
        test     edi, edi
-       jg       SHORT G_M000_IG08
+       jg       SHORT G_M000_IG07

...
  
-; Total bytes of code 333
\ No newline at end of file
+; Total bytes of code 243
\ No newline at end of file
```