### PR TITLE
Use Concurrent RandomAccess File access

### DIFF
--- a/src/Nethermind/Nethermind.Db/Blooms/FileReader.cs
+++ b/src/Nethermind/Nethermind.Db/Blooms/FileReader.cs
@@ -4,33 +4,27 @@
 using System;
 using System.IO;
 
+using Microsoft.Win32.SafeHandles;
+
 namespace Nethermind.Db.Blooms
 {
     public class FileReader : IFileReader
     {
         private readonly int _elementSize;
-        private readonly FileStream _file;
+        private readonly SafeFileHandle _file;
 
         public FileReader(string filePath, int elementSize)
         {
             _elementSize = elementSize;
-            _file = File.Open(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            _file = File.OpenHandle(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
         }
 
         public int Read(long index, Span<byte> element)
         {
-            SeekIndex(index);
-            return _file.Read(element);
+            return RandomAccess.Read(_file, element, GetPosition(index));
         }
 
-        private void SeekIndex(long index)
-        {
-            long seekPosition = index * _elementSize;
-            if (_file.Position != seekPosition)
-            {
-                _file.Position = seekPosition;
-            }
-        }
+        private long GetPosition(long index) => index * _elementSize;
 
         public void Dispose()
         {


### PR DESCRIPTION
Use the new "Thread-Safe File IO" introduced in .NET 6.0 rather than maintaining a position and locking https://devblogs.microsoft.com/dotnet/file-io-improvements-in-dotnet-6/#thread-safe-file-io

On startup during this period
```
2022-12-15 04:59:25.0449|Old Headers    320331 / 16156000 | queue  2880 | current   188.83bps | total    70.16bps
2022-12-15 04:59:26.0525|Old Headers    320559 / 16156000 | queue  3456 | current   226.27bps | total   112.33bps
2022-12-15 04:59:27.0635|Old Headers    320715 / 16156000 | queue  3456 | current   154.31bps | total   121.28bps
2022-12-15 04:59:28.0779|Old Headers    320907 / 16156000 | queue  3264 | current   189.29bps | total   133.27bps
2022-12-15 04:59:29.0858|Old Headers    321099 / 16156000 | queue  3456 | current   190.52bps | total   141.80bps
2022-12-15 04:59:30.0958|Old Headers    321099 / 16156000 | queue  5184 | current     0.00bps | total   123.37bps
2022-12-15 04:59:31.1097|Old Headers    321099 / 16156000 | queue  7296 | current     0.00bps | total   109.14bps
```
~~My SDD goes from 2% currently to 99% usage. Not sure how to evaluate it that's a good thing though 😅~~
~~Maybe its doing too many forced disk flushes now?~~

Looks like that was excessive disk flushing

## Changes:
- Use the [RandomAccess](https://learn.microsoft.com/en-us/dotnet/api/system.io.randomaccess?view=net-7.0) class to do reads and writes with specified offsets rather than maintain a separate position needing locking
- ~~Have a separate `FileStream` on the `SafeFileHandle` as there seems to be no way of doing a forced to disk flush directly on the Handle /cc @adamsitnik~~

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [ ] No

**Comments about testing , should you have some** (optional)

## Further comments (optional)

Not sure if this will cause issue with overlapping writes or if they occur? (i.e. ordering)