### PR TITLE
Throttle persisted tx broadcast to once per second.

### DIFF
--- a/src/Nethermind/Nethermind.TxPool.Test/TxBroadcasterTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxBroadcasterTests.cs
@@ -1,10 +1,11 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
-// SPDX-License-Identifier: LGPL-3.0-only 
+// SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Nethermind.Blockchain;
 using Nethermind.Consensus.Comparers;
@@ -46,6 +47,56 @@ public class TxBroadcasterTests
         _comparer = new TransactionComparerProvider(_specProvider, _blockTree).GetDefaultComparer();
         _txPoolConfig = new TxPoolConfig();
         _headInfo = Substitute.For<IChainHeadInfoProvider>();
+    }
+
+    [Test]
+    public async Task should_not_broadcast_persisted_tx_to_peer_too_quickly()
+    {
+        _txPoolConfig = new TxPoolConfig() { PeerNotificationThreshold = 100 };
+        _broadcaster = new TxBroadcaster(_comparer, TimerFactory.Default, _txPoolConfig, _headInfo, _logManager);
+        _headInfo.CurrentBaseFee.Returns(0.GWei());
+
+        int addedTxsCount = TestItem.PrivateKeys.Length;
+        Transaction[] transactions = new Transaction[addedTxsCount];
+
+        for (int i = 0; i < addedTxsCount; i++)
+        {
+            transactions[i] = Build.A.Transaction
+                .WithGasPrice(i.GWei())
+                .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeys[i])
+                .TestObject;
+
+            _broadcaster.Broadcast(transactions[i], true);
+        }
+
+        _broadcaster.GetSnapshot().Length.Should().Be(addedTxsCount);
+
+        ITxPoolPeer peer = Substitute.For<ITxPoolPeer>();
+        peer.Id.Returns(TestItem.PublicKeyA);
+
+        _broadcaster.AddPeer(peer);
+
+        peer.Received(0).SendNewTransactions(Arg.Any<IEnumerable<Transaction>>(), true);
+
+        _broadcaster.BroadcastPersistentTxs();
+        _broadcaster.BroadcastPersistentTxs();
+        _broadcaster.BroadcastPersistentTxs();
+        _broadcaster.BroadcastPersistentTxs();
+        _broadcaster.BroadcastPersistentTxs();
+
+        peer.Received(1).SendNewTransactions(Arg.Any<IEnumerable<Transaction>>(), true);
+
+        await Task.Delay(TimeSpan.FromMilliseconds(1001));
+
+        peer.Received(1).SendNewTransactions(Arg.Any<IEnumerable<Transaction>>(), true);
+
+        _broadcaster.BroadcastPersistentTxs();
+        _broadcaster.BroadcastPersistentTxs();
+        _broadcaster.BroadcastPersistentTxs();
+        _broadcaster.BroadcastPersistentTxs();
+        _broadcaster.BroadcastPersistentTxs();
+
+        peer.Received(2).SendNewTransactions(Arg.Any<IEnumerable<Transaction>>(), true);
     }
 
     [TestCase(1)]

--- a/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
@@ -60,6 +60,13 @@ namespace Nethermind.TxPool
         /// </summary>
         private ResettableList<Transaction> _txsToSend;
 
+        /// <summary>
+        /// Used to throttle tx broadcast. Particularly during forward sync where the head changes a lot which triggers
+        /// a lot of broadcast. There are no transaction in pool but its quite spammy on the log.
+        /// </summary>
+        private DateTimeOffset _lastPersistedTxBroadcast = DateTimeOffset.UnixEpoch;
+        private readonly TimeSpan _minTimeBetweenPersistedTxBroadcast = TimeSpan.FromSeconds(1);
+
         private readonly ILogger _logger;
 
         public TxBroadcaster(IComparer<Transaction> comparer,
@@ -117,6 +124,13 @@ namespace Nethermind.TxPool
 
         public void BroadcastPersistentTxs()
         {
+            if (_lastPersistedTxBroadcast + _minTimeBetweenPersistedTxBroadcast > DateTimeOffset.Now)
+            {
+                if (_logger.IsTrace) _logger.Trace($"Minimum time between persistent tx broadcast not reached.");
+                return;
+            }
+            _lastPersistedTxBroadcast = DateTimeOffset.Now;
+
             if (_txPoolConfig.PeerNotificationThreshold > 0)
             {
                 IList<Transaction> persistentTxsToSend = GetPersistentTxsToSend();

--- a/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
@@ -124,12 +124,13 @@ namespace Nethermind.TxPool
 
         public void BroadcastPersistentTxs()
         {
-            if (_lastPersistedTxBroadcast + _minTimeBetweenPersistedTxBroadcast > DateTimeOffset.Now)
+            DateTimeOffset now = DateTimeOffset.Now;
+            if (_lastPersistedTxBroadcast + _minTimeBetweenPersistedTxBroadcast > now)
             {
                 if (_logger.IsTrace) _logger.Trace($"Minimum time between persistent tx broadcast not reached.");
                 return;
             }
-            _lastPersistedTxBroadcast = DateTimeOffset.Now;
+            _lastPersistedTxBroadcast = now;
 
             if (_txPoolConfig.PeerNotificationThreshold > 0)
             {


### PR DESCRIPTION
- The log line in broadcast persistent tx is spammy during sync as the head changes a lot, which causes this function to be triggered a lot.
- Not sure if this is needed, but it would be nice.

## Changes:
- Limit persistent tx broadcast rate to once per second.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [X] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [X] Yes
- [ ] No

**Comments about testing , should you have some** (optional)

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...