### PR TITLE
Concurrent Bloom file access

### DIFF
--- a/src/Nethermind/Nethermind.Db/Blooms/FileReader.cs
+++ b/src/Nethermind/Nethermind.Db/Blooms/FileReader.cs
@@ -4,33 +4,27 @@
 using System;
 using System.IO;
 
+using Microsoft.Win32.SafeHandles;
+
 namespace Nethermind.Db.Blooms
 {
     public class FileReader : IFileReader
     {
         private readonly int _elementSize;
-        private readonly FileStream _file;
+        private readonly SafeFileHandle _file;
 
         public FileReader(string filePath, int elementSize)
         {
             _elementSize = elementSize;
-            _file = File.Open(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            _file = File.OpenHandle(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
         }
 
         public int Read(long index, Span<byte> element)
         {
-            SeekIndex(index);
-            return _file.Read(element);
+            return RandomAccess.Read(_file, element, GetPosition(index));
         }
 
-        private void SeekIndex(long index)
-        {
-            long seekPosition = index * _elementSize;
-            if (_file.Position != seekPosition)
-            {
-                _file.Position = seekPosition;
-            }
-        }
+        private long GetPosition(long index) => index * _elementSize;
 
         public void Dispose()
         {


### PR DESCRIPTION
Use the new "Thread-Safe File IO" introduced in .NET 6.0 rather than maintaining a position and locking https://devblogs.microsoft.com/dotnet/file-io-improvements-in-dotnet-6/#thread-safe-file-io


## Changes:
- Use the [RandomAccess](https://learn.microsoft.com/en-us/dotnet/api/system.io.randomaccess?view=net-7.0) class to do reads and writes with specified offsets rather than maintain a separate position needing locking
- Parallalize stores that operate on different logs

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [x] Yes
- [ ] No
