### PR TITLE
Reduce allocations in Queue and Memory estimations

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconHeadersSyncFeed.cs
@@ -113,7 +113,7 @@ public sealed class BeaconHeadersSyncFeed : HeadersSyncFeed
     {
         HeadersSyncProgressReport.Update(_pivotNumber - HeadersDestinationNumber + 1);
         HeadersSyncProgressReport.MarkEnd();
-        _dependencies.Clear(); // there may be some dependencies from wrong branches
+        ClearDependencies(); // there may be some dependencies from wrong branches
         _pending.Clear(); // there may be pending wrong branches
         _sent.Clear(); // we my still be waiting for some bad branches
         HeadersSyncQueueReport.Update(0L);

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
@@ -60,7 +60,12 @@ namespace Nethermind.Synchronization.FastBlocks
         /// <summary>
         /// Responses received from peers but waiting in a queue for some other requests to be handled first
         /// </summary>
-        protected readonly ConcurrentDictionary<long, HeadersSyncBatch> _dependencies = new();
+        private readonly ConcurrentDictionary<long, HeadersSyncBatch> _dependencies = new();
+        // Stop gap method to reduce allocations from non-struct enumerator
+        // https://github.com/dotnet/runtime/pull/38296
+        private IEnumerator<KeyValuePair<long, HeadersSyncBatch>>? _enumerator;
+        private ulong _memoryEstimate;
+        private long _headersEstimate;
 
         protected virtual BlockHeader? LowestInsertedBlockHeader => _blockTree.LowestInsertedHeader;
 
@@ -71,12 +76,80 @@ namespace Nethermind.Synchronization.FastBlocks
         protected virtual bool AllHeadersDownloaded => (LowestInsertedBlockHeader?.Number ?? long.MaxValue) == 1;
         private bool AnyHeaderDownloaded => LowestInsertedBlockHeader is not null;
 
-        private long HeadersInQueue => _dependencies.Sum(hd => hd.Value.Response?.Length ?? 0);
+        private long HeadersInQueue
+        {
+            get
+            {
+                var headersEstimate = Volatile.Read(ref _headersEstimate);
+                if (headersEstimate < 0)
+                {
+                    headersEstimate = CalculateHeadersInQueue();
+                    Volatile.Write(ref _headersEstimate, headersEstimate);
+                }
 
-        private ulong MemoryInQueue => (ulong)_dependencies
-            .Sum(d => (d.Value.Response ?? Array.Empty<BlockHeader>()).Sum(h =>
-                // ReSharper disable once ConvertClosureToMethodGroup
-                MemorySizeEstimator.EstimateSize(h)));
+                return headersEstimate;
+            }
+        }
+
+        private long CalculateHeadersInQueue()
+        {
+            // Reuse the enumerator
+            var enumerator = Interlocked.Exchange(ref _enumerator, null) ?? _dependencies.GetEnumerator();
+
+            long count = 0;
+            while (enumerator.MoveNext())
+            {
+                count += enumerator.Current.Value.Response?.Length ?? 0;
+            }
+
+            // Stop gap method to reduce allocations from non-struct enumerator
+            // https://github.com/dotnet/runtime/pull/38296
+            enumerator.Reset();
+            _enumerator = enumerator;
+
+            return count;
+        }
+
+        private ulong MemoryInQueue
+        {
+            get
+            {
+                var memoryEstimate = Volatile.Read(ref _memoryEstimate);
+                if (memoryEstimate == ulong.MaxValue)
+                {
+                    memoryEstimate = CalculateMemoryInQueue();
+                    Volatile.Write(ref _memoryEstimate, memoryEstimate);
+                }
+
+                return memoryEstimate;
+            }
+        }
+
+        private ulong CalculateMemoryInQueue()
+        {
+            // Reuse the enumerator
+            var enumerator = Interlocked.Exchange(ref _enumerator, null) ?? _dependencies.GetEnumerator();
+
+            ulong amount = 0;
+            while (enumerator.MoveNext())
+            {
+                var responses = enumerator.Current.Value.Response;
+                if (responses is not null)
+                {
+                    foreach (var response in responses)
+                    {
+                        amount += (ulong)MemorySizeEstimator.EstimateSize(response);
+                    }
+                }
+            }
+
+            // Stop gap method to reduce allocations from non-struct enumerator
+            // https://github.com/dotnet/runtime/pull/38296
+            enumerator.Reset();
+            _enumerator = enumerator;
+
+            return amount;
+        }
 
         public HeadersSyncFeed(
             ISyncModeSelector syncModeSelector,
@@ -158,11 +231,17 @@ namespace Nethermind.Synchronization.FastBlocks
             PostFinishCleanUp();
         }
 
+        protected void ClearDependencies()
+        {
+            _dependencies.Clear();
+            MarkDirty();
+        }
+
         protected virtual void PostFinishCleanUp()
         {
             HeadersSyncProgressReport.Update(_pivotNumber);
             HeadersSyncProgressReport.MarkEnd();
-            _dependencies.Clear(); // there may be some dependencies from wrong branches
+            ClearDependencies(); // there may be some dependencies from wrong branches
             _pending.Clear(); // there may be pending wrong branches
             _sent.Clear(); // we my still be waiting for some bad branches
             HeadersSyncQueueReport.Update(0L);
@@ -174,6 +253,7 @@ namespace Nethermind.Synchronization.FastBlocks
             long? lowest = LowestInsertedBlockHeader?.Number;
             while (lowest.HasValue && _dependencies.TryRemove(lowest.Value - 1, out HeadersSyncBatch? dependentBatch))
             {
+                MarkDirty();
                 InsertHeaders(dependentBatch!);
                 lowest = LowestInsertedBlockHeader?.Number;
                 cancellationToken.ThrowIfCancellationRequested();
@@ -437,6 +517,7 @@ namespace Nethermind.Synchronization.FastBlocks
 
                         HeadersSyncBatch dependentBatch = BuildDependentBatch(batch, addedLast, addedEarliest);
                         _dependencies[header.Number] = dependentBatch;
+                        MarkDirty();
                         if (_logger.IsDebug) _logger.Debug($"{batch} -> DEPENDENCY {dependentBatch}");
 
                         // but we cannot do anything with it yet
@@ -527,6 +608,12 @@ namespace Nethermind.Synchronization.FastBlocks
 
             HeadersSyncQueueReport.Update(HeadersInQueue);
             return added;
+        }
+
+        private void MarkDirty()
+        {
+            Volatile.Write(ref _headersEstimate, -1);
+            Volatile.Write(ref _memoryEstimate, ulong.MaxValue);
         }
 
         protected readonly IDictionary<long, ulong>? _expectedDifficultyOverride;


### PR DESCRIPTION
## Changes:
- Cache counts and reuse if ConcurrentDictionary not changed
- Reuse ConcurrentDictionary enumerator
- Iterate rather than using Linq when calculating

Removes the allocations from `ShouldBuildANewBatch`

<img width="516" alt="image" src="https://user-images.githubusercontent.com/1142958/208265676-9a118cab-902a-44c9-a013-48cb956dc52e.png">


## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [x] No