### PR TITLE
Update .net version in Gitbook project

### DIFF
--- a/src/Nethermind/Nethermind.GitBook/Nethermind.GitBook.csproj
+++ b/src/Nethermind/Nethermind.GitBook/Nethermind.GitBook.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   


### PR DESCRIPTION
## Changes:
- Update .net version in Gitbook project
I think it should solve the problem with generating docs:
<img width="1280" alt="gitbook" src="https://user-images.githubusercontent.com/77129288/208497987-9c1be7e4-355b-45ae-8985-c19daf08b03b.PNG">
Similar changes like proposed in this PR were made when moving from .net 5 to .net 6

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [x] No