### PR TITLE
Fix some randomly failing test

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Producers/BuildBlocksOnlyWhenNotProcessing.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/BuildBlocksOnlyWhenNotProcessing.cs
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
-// SPDX-License-Identifier: LGPL-3.0-only 
+// SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
 using System.Diagnostics;
@@ -100,6 +100,7 @@ namespace Nethermind.Consensus.Producers
                 if (_logger.IsDebug) _logger.Debug($"Delaying producing block, chain not processed yet. BlockProcessingQueue count {_blockProcessingQueue.Count}.");
                 await Task.Delay(ChainNotYetProcessedMillisecondsDelay, cancellationToken);
             }
+            cancellationToken.ThrowIfCancellationRequested();
 
             if (!cancellationToken.IsCancellationRequested)
             {

--- a/src/Nethermind/Nethermind.Consensus/Producers/BuildBlocksOnlyWhenNotProcessing.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/BuildBlocksOnlyWhenNotProcessing.cs
@@ -95,17 +95,13 @@ namespace Nethermind.Consensus.Producers
         {
             CancellationToken cancellationToken = e.CancellationToken;
             // retry production until its allowed or its cancelled
-            while (!CanTriggerBlockProduction && !cancellationToken.IsCancellationRequested)
+            while (!CanTriggerBlockProduction)
             {
                 if (_logger.IsDebug) _logger.Debug($"Delaying producing block, chain not processed yet. BlockProcessingQueue count {_blockProcessingQueue.Count}.");
                 await Task.Delay(ChainNotYetProcessedMillisecondsDelay, cancellationToken);
             }
-            cancellationToken.ThrowIfCancellationRequested();
 
-            if (!cancellationToken.IsCancellationRequested)
-            {
-                TriggerBlockProduction?.Invoke(this, e);
-            }
+            TriggerBlockProduction?.Invoke(this, e);
 
             return await e.BlockProductionTask;
         }

--- a/src/Nethermind/Nethermind.Network.Test/P2P/SessionTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/SessionTests.cs
@@ -513,6 +513,7 @@ namespace Nethermind.Network.Test.P2P
         }
 
         [Test, Retry(3)]
+        [Parallelizable(ParallelScope.None)] // It touches global metrics
         public void Can_receive_messages()
         {
             Metrics.P2PBytesReceived = 0;

--- a/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
@@ -521,14 +521,14 @@ namespace Nethermind.Synchronization.Test
             PeerInfo peerInfo = new(syncPeer);
 
             CancellationTokenSource cancellation = new();
-            cancellation.CancelAfter(1000);
+            cancellation.CancelAfter(990);
             Task task = downloader.DownloadHeaders(peerInfo, new BlocksRequest(DownloaderOptions.WithBodies, 0), cancellation.Token);
             await task.ContinueWith(t => Assert.True(t.IsCanceled, "headers"));
 
             syncPeer.HeadNumber.Returns(2000);
             // peerInfo.HeadNumber *= 2;
             cancellation = new CancellationTokenSource();
-            cancellation.CancelAfter(1000);
+            cancellation.CancelAfter(990);
             task = downloader.DownloadHeaders(peerInfo, new BlocksRequest(DownloaderOptions.WithBodies, 0), cancellation.Token);
             await task.ContinueWith(t => Assert.True(t.IsCanceled, "blocks"));
         }


### PR DESCRIPTION
Fix randomly failing `should_cancel_triggering_block_production` unit test, and some other.

## Changes:
- Make sure cancellation token throws.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [X] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [X] No: Tested by adding `Repeat(100)` annotation to the unit test. Previously it consistently failed.

**Comments about testing , should you have some** (optional)

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...