### PR TITLE
Update targeted Ubuntu versions

### DIFF
--- a/scripts/deployment/publish-ppa.sh
+++ b/scripts/deployment/publish-ppa.sh
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: LGPL-3.0-only
 
 #exit when any command fails
-RELEASES="bionic focal impish jammy"
+RELEASES="bionic focal jammy kinetic"
 
 set -e
 echo $VERSION > ver


### PR DESCRIPTION
21.10 Impish is no longer supported as of July, the current short term release is 22.10 Kinetic. cc: https://lists.ubuntu.com/archives/ubuntu-security-announce/2022-July/006681.html https://lists.ubuntu.com/archives/ubuntu-announce/2022-October/000285.html

## Changes:
- Changes scripts/deployment/publish-ppa.sh to current Ubuntu versions.

## Types of changes
Drops Ubuntu 21.10, adds 22.10.

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [x] No

**In case you checked yes, did you write tests??**

- [ ] Yes
- [ ] No

## Further comments (optional)
21.10 EOL announcement: https://lists.ubuntu.com/archives/ubuntu-security-announce/2022-July/006681.html
22.10 release announcement: https://lists.ubuntu.com/archives/ubuntu-announce/2022-October/000285.html