### PR TITLE
If two peer have same speed, randomly try the other one.

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/AllocationStrategies/BySpeedStrategyTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/AllocationStrategies/BySpeedStrategyTests.cs
@@ -1,14 +1,10 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Security.Cryptography.X509Certificates;
 using FluentAssertions;
 using Nethermind.Blockchain.Synchronization;
-using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Test.Builders;
-using Nethermind.Crypto;
-using Nethermind.Overseer.Test.JsonRpc.Dto;
 using Nethermind.Stats;
 using Nethermind.Stats.Model;
 using Nethermind.Synchronization.Peers;
@@ -91,12 +87,29 @@ public class BySpeedStrategyTests
         int selectedPeerIdx = peers.IndexOf(selectedPeer);
         if (pickedNewPeer)
         {
-            selectedPeerIdx.Should().Be(peerWithKnownSpeed);
+            selectedPeerIdx.Should().Be(peerWithKnownSpeed); // It picked the first peer with unknown speed
         }
         else
         {
-            selectedPeerIdx.Should().Be(0);
+            selectedPeerIdx.Should().BeLessThan(peerWithKnownSpeed); // It picked earlier peers which have known speed
         }
+    }
+
+    [Test]
+    public void TestWhenSameSpeed_RandomlyTryOtherPeer()
+    {
+        INodeStatsManager nodeStatsManager = Substitute.For<INodeStatsManager>();
+
+        List<PeerInfo> peers = Enumerable.Repeat<long?>(10, 50)
+            .Concat(Enumerable.Repeat<long?>(100, 50))
+            .Select((speed) => CreatePeerInfoWithSpeed(speed, nodeStatsManager))
+            .ToList();
+
+        BySpeedStrategy strategy = new(TransferSpeedType.Bodies, true, 0, 0, 0, 0);
+
+        PeerInfo? selectedPeer = strategy.Allocate(null, peers, nodeStatsManager, Build.A.BlockTree().TestObject);
+        int selectedPeerIdx = peers.IndexOf(selectedPeer);
+        selectedPeerIdx.Should().BeGreaterThan(50);
     }
 
     [TestCase(10, 0, 0, 0)]

--- a/src/Nethermind/Nethermind.Synchronization/Peers/AllocationStrategies/BySpeedStrategy.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/AllocationStrategies/BySpeedStrategy.cs
@@ -79,12 +79,13 @@ namespace Nethermind.Synchronization.Peers.AllocationStrategies
                 if (forceTake ||
                     (averageTransferSpeed == bestPeer.TransferSpeed ?
 
-                         // If its the same speed, just randomly try it. Prevent getting stuck on the same peer on small network.
-                        _random.NextSingle() < 0.25:
+                        // If its the same speed, just randomly try it. Prevent getting stuck on the same peer on small network.
+                        _random.NextSingle() < 0.25 :
 
                         (_priority ? averageTransferSpeed > bestPeer.TransferSpeed : averageTransferSpeed < bestPeer.TransferSpeed)
                     )
-                ) {
+                )
+                {
                     bestPeer = (info, averageTransferSpeed);
                 }
 

--- a/src/Nethermind/Nethermind.Synchronization/Peers/AllocationStrategies/BySpeedStrategy.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/AllocationStrategies/BySpeedStrategy.cs
@@ -76,8 +76,15 @@ namespace Nethermind.Synchronization.Peers.AllocationStrategies
                     forceTake = true;
                 }
 
-                if (forceTake || (_priority ? averageTransferSpeed > bestPeer.TransferSpeed : averageTransferSpeed < bestPeer.TransferSpeed))
-                {
+                if (forceTake ||
+                    (averageTransferSpeed == bestPeer.TransferSpeed ?
+
+                         // If its the same speed, just randomly try it. Prevent getting stuck on the same peer on small network.
+                        _random.NextSingle() < 0.25:
+
+                        (_priority ? averageTransferSpeed > bestPeer.TransferSpeed : averageTransferSpeed < bestPeer.TransferSpeed)
+                    )
+                ) {
                     bestPeer = (info, averageTransferSpeed);
                 }
 


### PR DESCRIPTION
Fix #5014

- It was observed in sepolia where during snap sync sometimes nethermind account request timed out on a peer. The peer got sleep as expected, it then try another peer, which also timed out, which then got sleep, then got allocated back to the first peer, then timeout again. 
- This should change the peer allocation to try other peer also if it has the same speed.

## Changes:
- Add a clause to randomly try other peer if it has the same speed.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [X] Yes
- [ ] No

**In case you checked yes, did you write tests??**

- [X] Yes
- [ ] No

**Comments about testing , should you have some** (optional)

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...