### PR TITLE
Fix NoMatchingCapability failure does not have disconnect delay

### DIFF
--- a/src/Nethermind/Nethermind.Network.Test/P2P/P2PProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/P2PProtocolHandlerTests.cs
@@ -1,7 +1,9 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Collections.Generic;
 using System.Linq;
+using FluentAssertions;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Core.Timers;
 using Nethermind.Logging;
@@ -24,15 +26,28 @@ namespace Nethermind.Network.Test.P2P
         public void Setup()
         {
             _session = Substitute.For<ISession>();
-            _serializer = Substitute.For<IMessageSerializationService>();
+            _serializer = new MessageSerializationService();
+            _serializer.Register(new HelloMessageSerializer());
+            _serializer.Register(new PingMessageSerializer());
         }
 
         private ISession _session;
         private IMessageSerializationService _serializer;
+        private Node node = new(TestItem.PublicKeyA, "127.0.0.1", 30303);
+        private INodeStatsManager _nodeStatsManager;
 
-        private Packet CreatePacket(P2PMessage message)
+        private Packet CreatePacket<T>(T message) where T: P2PMessage
         {
             return new(message.Protocol, message.PacketType, _serializer.Serialize(message));
+        }
+
+        private Packet CreateZeroPacket<T>(T message) where T: P2PMessage
+        {
+            return new(new ZeroPacket(_serializer.ZeroSerialize(message))
+            {
+                Protocol = message.Protocol,
+                PacketType = (byte) message.PacketType,
+            });
         }
 
         private const int ListenPort = 8003;
@@ -40,13 +55,14 @@ namespace Nethermind.Network.Test.P2P
         private P2PProtocolHandler CreateSession()
         {
             _session.LocalPort.Returns(ListenPort);
-            Node node = new(TestItem.PublicKeyA, "127.0.0.1", 30303);
             _session.Node.Returns(node);
             ITimerFactory timerFactory = Substitute.For<ITimerFactory>();
+            _nodeStatsManager = new NodeStatsManager(timerFactory, LimboLogs.Instance);
+
             return new P2PProtocolHandler(
                 _session,
                 TestItem.PublicKeyA,
-                new NodeStatsManager(timerFactory, LimboLogs.Instance),
+                _nodeStatsManager,
                 _serializer,
                 LimboLogs.Instance);
         }
@@ -73,10 +89,28 @@ namespace Nethermind.Network.Test.P2P
         }
 
         [Test]
+        public void On_hello_with_no_matching_capability()
+        {
+            P2PProtocolHandler p2PProtocolHandler = CreateSession();
+            p2PProtocolHandler.AddSupportedCapability(new Capability(Protocol.Wit, 66));
+
+            Packet message = CreatePacket(new HelloMessage()
+            {
+                Capabilities = new List<Capability>() { new Capability(Protocol.Eth, 63) },
+                NodeId = TestItem.PublicKeyA,
+            });
+
+            p2PProtocolHandler.HandleMessage(message);
+
+            _nodeStatsManager.GetOrAdd(node).FailedCompatibilityValidation.Should().NotBeNull();
+            _session.Received(1).InitiateDisconnect(InitiateDisconnectReason.NoCapabilityMatched, Arg.Any<string>());
+        }
+
+        [Test]
         public void Pongs_to_ping()
         {
             P2PProtocolHandler p2PProtocolHandler = CreateSession();
-            p2PProtocolHandler.HandleMessage(CreatePacket(PingMessage.Instance));
+            p2PProtocolHandler.HandleMessage(CreateZeroPacket(PingMessage.Instance));
             _session.Received(1).DeliverMessage(Arg.Any<PongMessage>());
         }
 

--- a/src/Nethermind/Nethermind.Network.Test/P2P/P2PProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/P2PProtocolHandlerTests.cs
@@ -36,17 +36,17 @@ namespace Nethermind.Network.Test.P2P
         private Node node = new(TestItem.PublicKeyA, "127.0.0.1", 30303);
         private INodeStatsManager _nodeStatsManager;
 
-        private Packet CreatePacket<T>(T message) where T: P2PMessage
+        private Packet CreatePacket<T>(T message) where T : P2PMessage
         {
             return new(message.Protocol, message.PacketType, _serializer.Serialize(message));
         }
 
-        private Packet CreateZeroPacket<T>(T message) where T: P2PMessage
+        private Packet CreateZeroPacket<T>(T message) where T : P2PMessage
         {
             return new(new ZeroPacket(_serializer.ZeroSerialize(message))
             {
                 Protocol = message.Protocol,
-                PacketType = (byte) message.PacketType,
+                PacketType = (byte)message.PacketType,
             });
         }
 

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandler.cs
@@ -219,6 +219,7 @@ public class P2PProtocolHandler : ProtocolHandlerBase, IPingSender, IP2PProtocol
 
         if (_agreedCapabilities.Count == 0)
         {
+            _nodeStatsManager.ReportFailedValidation(Session.Node, CompatibilityValidationType.Capabilities);
             Session.InitiateDisconnect(
                 InitiateDisconnectReason.NoCapabilityMatched,
                 $"capabilities: {string.Join(", ", capabilities)}");


### PR DESCRIPTION
- NoMatchingCapability status seems to be the second highest initiate disconnect reason and it does not have a disconnect delay, meaning it will try again after about 30 second, which it will fail...
- Add the failed validation event so that it won't try the same peer again.
- Does not seems to do much in terms of peer discovery though...

(graph is before, after, before, after)
![Screenshot from 2022-12-31 15-43-37](https://user-images.githubusercontent.com/1841324/210129474-757f4ebc-26c3-4188-8ee7-fa225365bfe3.png)

## Changes
- Add `ReportFailedValidation` call when no capability match.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or a feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional or API changes)
- [ ] Build-related changes
- [ ] Other: _description_ 

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
