### PR TITLE
Fix strange ClientQuitting disconnect reason metric

### DIFF
--- a/src/Nethermind/Nethermind.Network/Rlpx/RlpxHost.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/RlpxHost.cs
@@ -213,10 +213,11 @@ namespace Nethermind.Network.Rlpx
             }
             pipeline.AddLast("enc-handshake-handler", handshakeHandler);
 
-            channel.CloseCompletion.ContinueWith(x =>
+            channel.CloseCompletion.ContinueWith(async x =>
             {
+                await Task.Delay(TimeSpan.FromSeconds(1));
                 if (_logger.IsTrace) _logger.Trace($"|NetworkTrace| {session} channel disconnected");
-                session.MarkDisconnected(DisconnectReason.ClientQuitting, DisconnectType.Remote, "channel disconnected");
+                session.MarkDisconnected(DisconnectReason.TcpSubSystemError, DisconnectType.Remote, "channel disconnected");
             });
         }
 

--- a/src/Nethermind/Nethermind.Network/Rlpx/RlpxHost.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/RlpxHost.cs
@@ -215,7 +215,11 @@ namespace Nethermind.Network.Rlpx
 
             channel.CloseCompletion.ContinueWith(async x =>
             {
+                // The close completion is completed before actual closing or remaining packet is processed.
+                // So usually, we do get a disconnect reason from peer, we just receive it after this. So w need to
+                // add some delay to account for whatever that is holding the network pipeline.
                 await Task.Delay(TimeSpan.FromSeconds(1));
+
                 if (_logger.IsTrace) _logger.Trace($"|NetworkTrace| {session} channel disconnected");
                 session.MarkDisconnected(DisconnectReason.TcpSubSystemError, DisconnectType.Remote, "channel disconnected");
             });


### PR DESCRIPTION
> Have you ever wondered why during sync nearly half of the disconnect reason is ClientQuitting? Well wonder no more! Because its not... Its just the status we use when the connection got abruptly disconnected. Also, most of it is actually not abruptly disconnect. The peer send `TooManyPeer` status, but the status was processed after the close completion handler, which is why it does not show up on metric.

## Changes

- Add a one second delay to allow actually disconnect message to be processed.
- Change the status to `TcpSubsystemError` instead, which make significantly more sense. It does not look like anyone is using it...

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No: Need significant refactor to unit test this.

#### Notes on testing

- Tested mannually. Some abrupt disconnect remains. Most of it turns out to be `TooManyPeers`.
