### PR TITLE
Fix secured commands appearance in cli history

### DIFF
--- a/src/Nethermind/Nethermind.Cli.Test/StatementHistoryManagerTests.cs
+++ b/src/Nethermind/Nethermind.Cli.Test/StatementHistoryManagerTests.cs
@@ -62,7 +62,7 @@ public class StatementHistoryManagerTests
     {
         _file.Exists(Arg.Any<string>()).Returns(true);
 
-        List<string> fileContents = new(){ "ab", "cd", "efg" };
+        List<string> fileContents = new() { "ab", "cd", "efg" };
         _file.ReadLines(Arg.Any<string>()).Returns(fileContents);
 
         _historyManager.Init();

--- a/src/Nethermind/Nethermind.Cli.Test/StatementHistoryManagerTests.cs
+++ b/src/Nethermind/Nethermind.Cli.Test/StatementHistoryManagerTests.cs
@@ -38,23 +38,23 @@ public class StatementHistoryManagerTests
 
         _historyManager.UpdateHistory("notSecured");
 
-        CollectionAssert.AreEqual(new []{"notSecured"}, fileContents);
-        CollectionAssert.AreEqual(new []{"notSecured"}, ReadLine.GetHistory());
+        CollectionAssert.AreEqual(new[] { "notSecured" }, fileContents);
+        CollectionAssert.AreEqual(new[] { "notSecured" }, ReadLine.GetHistory());
 
         _historyManager.UpdateHistory("unlockAccount");
 
-        CollectionAssert.AreEqual(new []{"notSecured"}, fileContents);
-        CollectionAssert.AreEqual(new []{"notSecured", "*removed*"}, ReadLine.GetHistory());
+        CollectionAssert.AreEqual(new[] { "notSecured" }, fileContents);
+        CollectionAssert.AreEqual(new[] { "notSecured", "*removed*" }, ReadLine.GetHistory());
 
         _historyManager.UpdateHistory("notSecured2");
 
-        CollectionAssert.AreEqual(new []{"notSecured", "notSecured2"}, fileContents);
-        CollectionAssert.AreEqual(new []{"notSecured", "*removed*", "notSecured2"}, ReadLine.GetHistory());
+        CollectionAssert.AreEqual(new[] { "notSecured", "notSecured2" }, fileContents);
+        CollectionAssert.AreEqual(new[] { "notSecured", "*removed*", "notSecured2" }, ReadLine.GetHistory());
 
         _historyManager.UpdateHistory("newAccount");
 
-        CollectionAssert.AreEqual(new []{"notSecured", "notSecured2"}, fileContents);
-        CollectionAssert.AreEqual(new []{"notSecured", "*removed*", "notSecured2", "*removed*"}, ReadLine.GetHistory());
+        CollectionAssert.AreEqual(new[] { "notSecured", "notSecured2" }, fileContents);
+        CollectionAssert.AreEqual(new[] { "notSecured", "*removed*", "notSecured2", "*removed*" }, ReadLine.GetHistory());
     }
 
     [Test]
@@ -62,7 +62,7 @@ public class StatementHistoryManagerTests
     {
         _file.Exists(Arg.Any<string>()).Returns(true);
 
-        List<string> fileContents = new(){"ab", "cd", "efg"};
+        List<string> fileContents = new(){ "ab", "cd", "efg" };
         _file.ReadLines(Arg.Any<string>()).Returns(fileContents);
 
         _historyManager.Init();

--- a/src/Nethermind/Nethermind.Cli.Test/StatementHistoryManagerTests.cs
+++ b/src/Nethermind/Nethermind.Cli.Test/StatementHistoryManagerTests.cs
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.IO.Abstractions;
+using Nethermind.Cli.Console;
+using NSubstitute;
+
+namespace Nethermind.Cli.Test;
+
+using NUnit.Framework;
+
+public class StatementHistoryManagerTests
+{
+    private ICliConsole _console;
+    private IFileSystem _fileSystem;
+    private IFile _file;
+    private StatementHistoryManager _historyManager;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _console = Substitute.For<ICliConsole>();
+        _fileSystem = Substitute.For<IFileSystem>();
+        _file = Substitute.For<IFile>();
+        _fileSystem.File.Returns(_file);
+        _historyManager = new(_console, _fileSystem);
+    }
+
+
+    [Test]
+    public void should_write_removed_to_history_if_secured_command_received()
+    {
+        List<string> fileContents = new();
+        _file.Exists(Arg.Any<string>()).Returns(true);
+        _file.AppendAllLines(Arg.Any<string>(), Arg.Do<string[]>(x => fileContents.AddRange(x)));
+
+        _historyManager.UpdateHistory("notSecured");
+
+        CollectionAssert.AreEqual(new []{"notSecured"}, fileContents);
+        CollectionAssert.AreEqual(new []{"notSecured"}, ReadLine.GetHistory());
+
+        _historyManager.UpdateHistory("unlockAccount");
+
+        CollectionAssert.AreEqual(new []{"notSecured"}, fileContents);
+        CollectionAssert.AreEqual(new []{"notSecured", "*removed*"}, ReadLine.GetHistory());
+
+        _historyManager.UpdateHistory("notSecured2");
+
+        CollectionAssert.AreEqual(new []{"notSecured", "notSecured2"}, fileContents);
+        CollectionAssert.AreEqual(new []{"notSecured", "*removed*", "notSecured2"}, ReadLine.GetHistory());
+
+        _historyManager.UpdateHistory("newAccount");
+
+        CollectionAssert.AreEqual(new []{"notSecured", "notSecured2"}, fileContents);
+        CollectionAssert.AreEqual(new []{"notSecured", "*removed*", "notSecured2", "*removed*"}, ReadLine.GetHistory());
+    }
+
+    [Test]
+    public void Init_should_read_history_from_file()
+    {
+        _file.Exists(Arg.Any<string>()).Returns(true);
+
+        List<string> fileContents = new(){"ab", "cd", "efg"};
+        _file.ReadLines(Arg.Any<string>()).Returns(fileContents);
+
+        _historyManager.Init();
+
+        CollectionAssert.AreEqual(fileContents, ReadLine.GetHistory());
+    }
+}

--- a/src/Nethermind/Nethermind.Cli.Test/StatementHistoryManagerTests.cs
+++ b/src/Nethermind/Nethermind.Cli.Test/StatementHistoryManagerTests.cs
@@ -26,6 +26,7 @@ public class StatementHistoryManagerTests
         _file = Substitute.For<IFile>();
         _fileSystem.File.Returns(_file);
         _historyManager = new(_console, _fileSystem);
+        ReadLine.ClearHistory();
     }
 
 

--- a/src/Nethermind/Nethermind.Cli/Console/StatementHistoryManager.cs
+++ b/src/Nethermind/Nethermind.Cli/Console/StatementHistoryManager.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
+using System.IO.Abstractions;
 using System.Linq;
 
 namespace Nethermind.Cli.Console
@@ -11,10 +11,10 @@ namespace Nethermind.Cli.Console
     internal class StatementHistoryManager
     {
         private readonly ICliConsole _cliConsole;
-        private const string HistoryFilePath = "cli.cmd.history";
-        private bool writeFailNotReported = true;
+        private readonly IFileSystem _fileSystem;
 
-        private List<string> _historyCloned = new List<string>();
+        private const string HistoryFilePath = "cli.cmd.history";
+        private bool _writeFailNotReported = true;
 
         private static IEnumerable<string> SecuredCommands
         {
@@ -25,20 +25,21 @@ namespace Nethermind.Cli.Console
             }
         }
 
-        private const string _removedString = "*removed*";
+        private const string RemovedString = "*removed*";
 
-        public StatementHistoryManager(ICliConsole cliConsole)
+        public StatementHistoryManager(ICliConsole cliConsole, IFileSystem fileSystem)
         {
             _cliConsole = cliConsole;
+            _fileSystem = fileSystem;
         }
 
         public void UpdateHistory(string statement)
         {
             try
             {
-                if (!File.Exists(HistoryFilePath))
+                if (!_fileSystem.File.Exists(HistoryFilePath))
                 {
-                    File.Create(HistoryFilePath).Dispose();
+                    _fileSystem.File.Create(HistoryFilePath).Dispose();
                 }
 
                 if (!SecuredCommands.Any(statement.Contains))
@@ -47,22 +48,19 @@ namespace Nethermind.Cli.Console
                     if (history.LastOrDefault() != statement)
                     {
                         ReadLine.AddHistory(statement);
-                        _historyCloned.Insert(0, statement);
+                        _fileSystem.File.AppendAllLines(HistoryFilePath, new[] { statement });
                     }
                 }
                 else
                 {
-                    ReadLine.AddHistory(_removedString);
-                    _historyCloned.Insert(0, _removedString);
+                    ReadLine.AddHistory(RemovedString);
                 }
-
-                File.WriteAllLines(HistoryFilePath, _historyCloned.Distinct().Reverse().ToArray());
             }
             catch (Exception e)
             {
-                if (writeFailNotReported)
+                if (_writeFailNotReported)
                 {
-                    writeFailNotReported = false;
+                    _writeFailNotReported = false;
                     _cliConsole.WriteErrorLine($"Could not write cmd history to {HistoryFilePath} {e.Message}");
                 }
             }
@@ -73,17 +71,13 @@ namespace Nethermind.Cli.Console
             try
             {
                 _cliConsole.WriteInteresting(
-                    $"Loading history file from {Path.Combine(AppDomain.CurrentDomain.BaseDirectory!, HistoryFilePath)}" + Environment.NewLine);
+                    $"Loading history file from {_fileSystem.Path.Combine(AppDomain.CurrentDomain.BaseDirectory!, HistoryFilePath)}" + Environment.NewLine);
 
-                if (File.Exists(HistoryFilePath))
+                if (_fileSystem.File.Exists(HistoryFilePath))
                 {
-                    foreach (string line in File.ReadLines(HistoryFilePath).Distinct().TakeLast(60))
+                    foreach (string line in _fileSystem.File.ReadLines(HistoryFilePath).TakeLast(60))
                     {
-                        if (line != _removedString)
-                        {
-                            ReadLine.AddHistory(line);
-                            _historyCloned.Insert(0, line);
-                        }
+                        ReadLine.AddHistory(line);
                     }
                 }
             }

--- a/src/Nethermind/Nethermind.Cli/Console/StatementHistoryManager.cs
+++ b/src/Nethermind/Nethermind.Cli/Console/StatementHistoryManager.cs
@@ -53,7 +53,7 @@ namespace Nethermind.Cli.Console
                 else
                 {
                     ReadLine.AddHistory(_removedString);
-                    _historyCloned.Insert(0, statement);
+                    _historyCloned.Insert(0, _removedString);
                 }
 
                 File.WriteAllLines(HistoryFilePath, _historyCloned.Distinct().Reverse().ToArray());

--- a/src/Nethermind/Nethermind.Cli/Program.cs
+++ b/src/Nethermind/Nethermind.Cli/Program.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Abstractions;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Jint.Native;
@@ -38,7 +39,7 @@ namespace Nethermind.Cli
                     ? new ColorfulCliConsole(cs)
                     : new CliConsole();
 
-                var historyManager = new StatementHistoryManager(cliConsole);
+                var historyManager = new StatementHistoryManager(cliConsole, new FileSystem());
                 ILogManager logManager = new OneLoggerLogManager(new CliLogger(cliConsole));
                 ICliEngine engine = new CliEngine(cliConsole);
                 INodeManager nodeManager = new NodeManager(engine, Serializer, cliConsole, logManager);


### PR DESCRIPTION
Fixes #4910

## Changes

- Nothing is added to a file when a secured command is received.
- Minor optimizations
- IFileSystem interface for mock testing

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or a feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional or API changes)
- [ ] Build-related changes
- [ ] Other: _description_ 

## Testing

#### Requires testing

- [ ] Yes
- [x] No
