### PR TITLE
Precalculate ForkId's rather than calculate them on every connection

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Builders/BlockBuilder.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Builders/BlockBuilder.cs
@@ -80,12 +80,9 @@ namespace Nethermind.Core.Test.Builders
                 receipts[i] = Build.A.Receipt.TestObject;
             }
 
-            long number = TestObjectInternal.Number;
-            ulong timestamp = TestObjectInternal.Timestamp;
-            ReceiptTrie receiptTrie = new(specProvider.GetSpec(number, timestamp), receipts);
-            receiptTrie.UpdateRootHash();
-
             BlockBuilder result = WithTransactions(txs);
+            ReceiptTrie receiptTrie = new(specProvider.GetSpec(TestObjectInternal.Header), receipts);
+            receiptTrie.UpdateRootHash();
             TestObjectInternal.Header.ReceiptsRoot = receiptTrie.RootHash;
             return result;
         }

--- a/src/Nethermind/Nethermind.Core/Specs/ForkActivation.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/ForkActivation.cs
@@ -9,6 +9,7 @@ public readonly struct ForkActivation : IEquatable<ForkActivation>, IComparable<
 {
     public long BlockNumber { get; }
     public ulong? Timestamp { get; }
+    public ulong Activation => Timestamp ?? (ulong)BlockNumber;
 
     public ForkActivation(long blockNumber, ulong? timestamp = null)
     {

--- a/src/Nethermind/Nethermind.Core/Specs/ISpecProvider.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/ISpecProvider.cs
@@ -57,7 +57,6 @@ namespace Nethermind.Core.Specs
         /// <param name="forkActivation"></param>
         /// <returns>A spec that is valid at the given chain height</returns>
         IReleaseSpec GetSpec(ForkActivation forkActivation);
-
         IReleaseSpec GetSpec(long blockNumber, ulong? timestamp) => GetSpec((blockNumber, timestamp));
         IReleaseSpec GetSpec(BlockHeader blockHeader) => GetSpec((blockHeader.Number, blockHeader.Timestamp));
     }

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -167,7 +167,7 @@ public class InitializeNetwork : IStep
 
         _api.DisposeStack.Push(_api.Synchronizer);
 
-        _api.SyncServer = new SyncServer(
+        ISyncServer syncServer = _api.SyncServer = new SyncServer(
             _api.TrieStore!,
             _api.DbProvider.CodeDb,
             _api.BlockTree!,
@@ -183,8 +183,8 @@ public class InitializeNetwork : IStep
             _api.LogManager,
             cht);
 
-        _ = _api.SyncServer.BuildCHT();
-        _api.DisposeStack.Push(_api.SyncServer);
+        _ = syncServer.BuildCHT();
+        _api.DisposeStack.Push(syncServer);
 
         InitDiscovery();
         if (cancellationToken.IsCancellationRequested)
@@ -507,9 +507,10 @@ public class InitializeNetwork : IStep
 
         ProtocolValidator protocolValidator = new(_api.NodeStatsManager!, _api.BlockTree!, _api.LogManager);
         PooledTxsRequestor pooledTxsRequestor = new(_api.TxPool!);
+        ISyncServer syncServer = _api.SyncServer!;
         _api.ProtocolsManager = new ProtocolsManager(
             _api.SyncPeerPool!,
-            _api.SyncServer!,
+            syncServer,
             _api.TxPool,
             pooledTxsRequestor,
             _api.DiscoveryApp!,
@@ -518,7 +519,7 @@ public class InitializeNetwork : IStep
             _api.NodeStatsManager,
             protocolValidator,
             peerStorage,
-            _api.SpecProvider!,
+            new ForkInfo(_api.SpecProvider!, syncServer.Genesis.Hash!),
             _api.GossipPolicy,
             _api.LogManager);
 

--- a/src/Nethermind/Nethermind.Network.Test/ForkInfoTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/ForkInfoTests.cs
@@ -217,7 +217,7 @@ namespace Nethermind.Network.Test
         {
             byte[] expectedForkHash = Bytes.FromHexString(forkHashHex);
 
-            ForkId forkId = ForkInfo.CalculateForkId(specProvider, head, headTimestamp, genesisHash);
+            ForkId forkId = new ForkInfo(specProvider, genesisHash).GetForkId(head, headTimestamp);
             byte[] forkHash = forkId.ForkHash;
             forkHash.Should().BeEquivalentTo(expectedForkHash, description);
 

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandlerTests.cs
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
-// SPDX-License-Identifier: LGPL-3.0-only 
+// SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Net;
 using FluentAssertions;
@@ -60,7 +60,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V65
                 _transactionPool,
                 _pooledTxsRequestor,
                 Policy.FullGossip,
-                _specProvider,
+                new ForkInfo(_specProvider, _genesisBlock.Header.Hash!),
                 LimboLogs.Instance);
             _handler.Init();
         }

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandlerTests.cs
@@ -82,7 +82,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V66
                 _transactionPool,
                 _pooledTxsRequestor,
                 _gossipPolicy,
-                _specProvider,
+                new ForkInfo(_specProvider, _genesisBlock.Header.Hash!),
                 LimboLogs.Instance);
             _handler.Init();
         }

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V67/Eth67ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V67/Eth67ProtocolHandlerTests.cs
@@ -69,7 +69,7 @@ public class Eth67ProtocolHandlerTests
             _transactionPool,
             _pooledTxsRequestor,
             _gossipPolicy,
-            _specProvider,
+            new ForkInfo(_specProvider, _genesisBlock.Header.Hash!),
             LimboLogs.Instance);
         _handler.Init();
     }

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandlerTests.cs
@@ -71,7 +71,7 @@ public class Eth68ProtocolHandlerTests
             _transactionPool,
             _pooledTxsRequestor,
             _gossipPolicy,
-            _specProvider,
+            new ForkInfo(_specProvider, _genesisBlock.Header.Hash!),
             LimboLogs.Instance);
         _handler.Init();
     }

--- a/src/Nethermind/Nethermind.Network.Test/ProtocolsManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/ProtocolsManagerTests.cs
@@ -107,7 +107,7 @@ namespace Nethermind.Network.Test
                     _nodeStatsManager,
                     _protocolValidator,
                     _peerStorage,
-                    MainnetSpecProvider.Instance,
+                    new ForkInfo(MainnetSpecProvider.Instance, _syncServer.Genesis.Hash!),
                     _gossipPolicy,
                     LimboLogs.Instance);
 

--- a/src/Nethermind/Nethermind.Network/ForkInfo.cs
+++ b/src/Nethermind/Nethermind.Network/ForkInfo.cs
@@ -1,64 +1,75 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Buffers.Binary;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Force.Crc32;
+using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
+using Nethermind.Specs;
 
 namespace Nethermind.Network
 {
-    public static class ForkInfo
+    public class ForkInfo
     {
-        private const long ImpossibleBlockNumberWithSpaceForImpossibleForks = long.MaxValue - 100;
-        private const ulong ImpossibleTimestampWithSpaceForImpossibleForks = ulong.MaxValue - 100;
+        private (ForkActivation Activation, ForkId Id)[] Forks { get; }
 
-        public static byte[] CalculateForkHash(ISpecProvider specProvider, long headNumber, ulong headTimestamp, Keccak genesisHash)
+        public ForkInfo(ISpecProvider specProvider, Keccak genesisHash)
         {
-            uint crc = 0;
-            ForkActivation[] transitionBlocks = specProvider.TransitionActivations;
+            ForkActivation[] transitionActivations = specProvider.TransitionActivations;
+            Forks = new (ForkActivation Activation, ForkId Id)[transitionActivations.Length + 1];
             byte[] blockNumberBytes = new byte[8];
-            crc = Crc32Algorithm.Append(crc, genesisHash.Bytes);
-            for (int i = 0; i < transitionBlocks.Length; i++)
+            uint crc = 0;
+            byte[] hash = CalculateHash(ref crc, genesisHash.Bytes);
+            // genesis fork activation
+            Forks[0] = ((0, null), new ForkId(hash, transitionActivations.Length > 0 ? transitionActivations[0].Activation : 0));
+            for (int index = 0; index < transitionActivations.Length; index++)
             {
-                if (transitionBlocks[i] > (headNumber, headTimestamp))
-                    break;
-                ulong numberToAddToCrc = transitionBlocks[i].Timestamp ?? (ulong)transitionBlocks[i].BlockNumber;
-                BinaryPrimitives.WriteUInt64BigEndian(blockNumberBytes, numberToAddToCrc);
-                crc = Crc32Algorithm.Append(crc, blockNumberBytes);
+                ForkActivation forkActivation = transitionActivations[index];
+                BinaryPrimitives.WriteUInt64BigEndian(blockNumberBytes, forkActivation.Activation);
+                hash = CalculateHash(ref crc, blockNumberBytes);
+                Forks[index + 1] = (forkActivation, new ForkId(hash, GetNextActivation(index, transitionActivations)));
             }
+        }
 
+        private static byte[] CalculateHash(ref uint crc, byte[] bytes)
+        {
+            crc = Crc32Algorithm.Append(crc, bytes);
             byte[] forkHash = new byte[4];
             BinaryPrimitives.TryWriteUInt32BigEndian(forkHash, crc);
             return forkHash;
         }
 
-        public static ForkId CalculateForkId(ISpecProvider specProvider, long headNumber, ulong headTimestamp, Keccak genesisHash)
+        private static ulong GetNextActivation(int index, ForkActivation[] transitionActivations)
         {
-
-            byte[] forkHash = CalculateForkHash(specProvider, headNumber, headTimestamp, genesisHash);
-            ulong next = 0;
-            ForkActivation[] transitionBlocks = specProvider.TransitionActivations;
-            for (int i = 0; i < transitionBlocks.Length; i++)
+            ulong nextActivation;
+            int nextIndex = index + 1;
+            if (nextIndex < transitionActivations.Length)
             {
-                ulong transition = transitionBlocks[i].Timestamp ?? (ulong)transitionBlocks[i].BlockNumber;
-                bool useTimestamp = transitionBlocks[i].Timestamp is not null;
-
-                if ((useTimestamp && transition >= ImpossibleTimestampWithSpaceForImpossibleForks)
-                    || (!useTimestamp && transition >= ImpossibleBlockNumberWithSpaceForImpossibleForks))
-                {
-                    continue;
-                }
-                if ((useTimestamp && transition > headTimestamp)
-                    || (!useTimestamp && transition > (ulong)headNumber))
-                {
-                    next = transition;
-                    break;
-                }
+                ForkActivation nextForkActivation = transitionActivations[nextIndex];
+                nextActivation = nextForkActivation.Timestamp ?? (ulong)nextForkActivation.BlockNumber;
+            }
+            else
+            {
+                nextActivation = 0;
             }
 
-            return new ForkId(forkHash, next);
+            return nextActivation;
         }
+
+        public ForkId GetForkId(long headNumber, ulong headTimestamp)
+        {
+            return Forks.TryGetSearchedItem(
+                new ForkActivation(headNumber, headTimestamp),
+                CompareTransitionOnActivation, out (ForkActivation Activation, ForkId Id) fork)
+                ? fork.Id
+                : throw new InvalidOperationException("Fork not found");
+        }
+
+        private static int CompareTransitionOnActivation(ForkActivation activation, (ForkActivation Activation, ForkId _) transition) =>
+            activation.CompareTo(transition.Activation);
     }
 }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V64/Eth64ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V64/Eth64ProtocolHandler.cs
@@ -27,10 +27,10 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V64
             ISyncServer syncServer,
             ITxPool txPool,
             IGossipPolicy gossipPolicy,
-            ISpecProvider specProvider,
+            ForkInfo forkInfo,
             ILogManager logManager) : base(session, serializer, nodeStatsManager, syncServer, txPool, gossipPolicy, logManager)
         {
-            _forkInfo = new ForkInfo(specProvider ?? throw new ArgumentNullException(nameof(specProvider)), SyncServer.Genesis.Hash!);
+            _forkInfo = forkInfo ?? throw new ArgumentNullException(nameof(forkInfo));
         }
 
         public override string Name => "eth64";

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V64/Eth64ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V64/Eth64ProtocolHandler.cs
@@ -19,7 +19,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V64
     /// </summary>
     public class Eth64ProtocolHandler : Eth63ProtocolHandler
     {
-        private readonly ISpecProvider _specProvider;
+        private readonly ForkInfo _forkInfo;
 
         public Eth64ProtocolHandler(ISession session,
             IMessageSerializationService serializer,
@@ -30,7 +30,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V64
             ISpecProvider specProvider,
             ILogManager logManager) : base(session, serializer, nodeStatsManager, syncServer, txPool, gossipPolicy, logManager)
         {
-            _specProvider = specProvider ?? throw new ArgumentNullException(nameof(specProvider));
+            _forkInfo = new ForkInfo(specProvider ?? throw new ArgumentNullException(nameof(specProvider)), SyncServer.Genesis.Hash!);
         }
 
         public override string Name => "eth64";
@@ -40,8 +40,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V64
         protected override void EnrichStatusMessage(StatusMessage statusMessage)
         {
             base.EnrichStatusMessage(statusMessage);
-            statusMessage.ForkId =
-                ForkInfo.CalculateForkId(_specProvider, SyncServer.Head.Number, SyncServer.Head.Timestamp, SyncServer.Genesis.Hash);
+            statusMessage.ForkId = _forkInfo.GetForkId(SyncServer.Head!.Number, SyncServer.Head.Timestamp);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandler.cs
@@ -34,9 +34,9 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V65
             ITxPool txPool,
             IPooledTxsRequestor pooledTxsRequestor,
             IGossipPolicy gossipPolicy,
-            ISpecProvider specProvider,
+            ForkInfo forkInfo,
             ILogManager logManager)
-            : base(session, serializer, nodeStatsManager, syncServer, txPool, gossipPolicy, specProvider, logManager)
+            : base(session, serializer, nodeStatsManager, syncServer, txPool, gossipPolicy, forkInfo, logManager)
         {
             _pooledTxsRequestor = pooledTxsRequestor;
         }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandler.cs
@@ -41,9 +41,9 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
             ITxPool txPool,
             IPooledTxsRequestor pooledTxsRequestor,
             IGossipPolicy gossipPolicy,
-            ISpecProvider specProvider,
+            ForkInfo forkInfo,
             ILogManager logManager)
-            : base(session, serializer, nodeStatsManager, syncServer, txPool, pooledTxsRequestor, gossipPolicy, specProvider, logManager)
+            : base(session, serializer, nodeStatsManager, syncServer, txPool, pooledTxsRequestor, gossipPolicy, forkInfo, logManager)
         {
             _headersRequests66 = new MessageDictionary<GetBlockHeadersMessage, V62.Messages.GetBlockHeadersMessage, BlockHeader[]>(Send);
             _bodiesRequests66 = new MessageDictionary<GetBlockBodiesMessage, V62.Messages.GetBlockBodiesMessage, BlockBody[]>(Send);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V67/Eth67ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V67/Eth67ProtocolHandler.cs
@@ -25,9 +25,9 @@ public class Eth67ProtocolHandler : Eth66ProtocolHandler
         ITxPool txPool,
         IPooledTxsRequestor pooledTxsRequestor,
         IGossipPolicy gossipPolicy,
-        ISpecProvider specProvider,
+        ForkInfo forkInfo,
         ILogManager logManager)
-        : base(session, serializer, nodeStatsManager, syncServer, txPool, pooledTxsRequestor, gossipPolicy, specProvider, logManager)
+        : base(session, serializer, nodeStatsManager, syncServer, txPool, pooledTxsRequestor, gossipPolicy, forkInfo, logManager)
     {
     }
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
@@ -36,10 +36,10 @@ public class Eth68ProtocolHandler : Eth67ProtocolHandler
         ITxPool txPool,
         IPooledTxsRequestor pooledTxsRequestor,
         IGossipPolicy gossipPolicy,
-        ISpecProvider specProvider,
+        ForkInfo forkInfo,
         ILogManager logManager)
         : base(session, serializer, nodeStatsManager, syncServer, txPool, pooledTxsRequestor, gossipPolicy,
-            specProvider, logManager)
+            forkInfo, logManager)
     {
         _pooledTxsRequestor = pooledTxsRequestor;
     }

--- a/src/Nethermind/Nethermind.Network/ProtocolsManager.cs
+++ b/src/Nethermind/Nethermind.Network/ProtocolsManager.cs
@@ -47,7 +47,7 @@ namespace Nethermind.Network
         private readonly INodeStatsManager _stats;
         private readonly IProtocolValidator _protocolValidator;
         private readonly INetworkStorage _peerStorage;
-        private readonly ISpecProvider _specProvider;
+        private readonly ForkInfo _forkInfo;
         private readonly IGossipPolicy _gossipPolicy;
         private readonly ILogManager _logManager;
         private readonly ILogger _logger;
@@ -66,7 +66,7 @@ namespace Nethermind.Network
             INodeStatsManager nodeStatsManager,
             IProtocolValidator protocolValidator,
             INetworkStorage peerStorage,
-            ISpecProvider specProvider,
+            ForkInfo forkInfo,
             IGossipPolicy gossipPolicy,
             ILogManager logManager)
         {
@@ -80,7 +80,7 @@ namespace Nethermind.Network
             _stats = nodeStatsManager ?? throw new ArgumentNullException(nameof(nodeStatsManager));
             _protocolValidator = protocolValidator ?? throw new ArgumentNullException(nameof(protocolValidator));
             _peerStorage = peerStorage ?? throw new ArgumentNullException(nameof(peerStorage));
-            _specProvider = specProvider ?? throw new ArgumentNullException(nameof(specProvider));
+            _forkInfo = forkInfo ?? throw new ArgumentNullException(nameof(forkInfo));
             _gossipPolicy = gossipPolicy ?? throw new ArgumentNullException(nameof(gossipPolicy));
             _logManager = logManager ?? throw new ArgumentNullException(nameof(logManager));
             _logger = _logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
@@ -183,9 +183,9 @@ namespace Nethermind.Network
                 {
                     var ethHandler = version switch
                     {
-                        66 => new Eth66ProtocolHandler(session, _serializer, _stats, _syncServer, _txPool, _pooledTxsRequestor, _gossipPolicy, _specProvider, _logManager),
-                        67 => new Eth67ProtocolHandler(session, _serializer, _stats, _syncServer, _txPool, _pooledTxsRequestor, _gossipPolicy, _specProvider, _logManager),
-                        68 => new Eth68ProtocolHandler(session, _serializer, _stats, _syncServer, _txPool, _pooledTxsRequestor, _gossipPolicy, _specProvider, _logManager),
+                        66 => new Eth66ProtocolHandler(session, _serializer, _stats, _syncServer, _txPool, _pooledTxsRequestor, _gossipPolicy, _forkInfo, _logManager),
+                        67 => new Eth67ProtocolHandler(session, _serializer, _stats, _syncServer, _txPool, _pooledTxsRequestor, _gossipPolicy, _forkInfo, _logManager),
+                        68 => new Eth68ProtocolHandler(session, _serializer, _stats, _syncServer, _txPool, _pooledTxsRequestor, _gossipPolicy, _forkInfo, _logManager),
                         _ => throw new NotSupportedException($"Eth protocol version {version} is not supported.")
                     };
 

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
@@ -273,9 +273,6 @@ namespace Nethermind.Specs.ChainSpecStyle
         private static int CompareTransitionOnActivation(ForkActivation activation, (ForkActivation Activation, ReleaseSpec Spec) transition) =>
             activation.CompareTo(transition.Activation);
 
-        private static int CompareTransitionOnTimestamp(ForkActivation activation, (ForkActivation Activation, ReleaseSpec Spec) transition) =>
-            activation.Timestamp!.Value.CompareTo(transition.Activation.Timestamp);
-
         public long? DaoBlockNumber => _chainSpec.DaoForkBlockNumber;
 
         public ulong ChainId => _chainSpec.ChainId;

--- a/src/Nethermind/Nethermind.Specs/MainNetSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Specs/MainNetSpecProvider.cs
@@ -77,8 +77,6 @@ namespace Nethermind.Specs
             //(GrayGlacierBlockNumber, PragueBlockTimestamp), (GrayGlacierBlockNumber, OsakaBlockTimestamp)
         };
 
-        public MainnetSpecProvider() { }
-
         public static readonly MainnetSpecProvider Instance = new();
     }
 }


### PR DESCRIPTION
## Changes

- Don't calculate ForkId's on every call with linear scan.
- Calculate them on startup
- Then use binary search to find correct one

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or a feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional or API changes)
- [ ] Build-related changes
- [ ] Other: _description_ 

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Passes all existing tests.