### PR TITLE
Update ethereum tests, add class `MergeToShanghaiTests`

### DIFF
--- a/src/Nethermind/Ethereum.Transition.Test/MergeToShanghaiTests.cs
+++ b/src/Nethermind/Ethereum.Transition.Test/MergeToShanghaiTests.cs
@@ -1,0 +1,26 @@
+﻿// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Ethereum.Test.Base;
+using NUnit.Framework;
+
+namespace Ethereum.Transition.Test;
+
+[TestFixture]
+[Parallelizable(ParallelScope.All)]
+public class MergeToShanghaiTests : BlockchainTestBase
+{
+    [TestCaseSource(nameof(LoadTests))]
+    public async Task Test(BlockchainTest test)
+    {
+        await RunTest(test);
+    }
+
+    public static IEnumerable<BlockchainTest> LoadTests()
+    {
+        var loader = new TestsSourceLoader(new LoadBlockchainTestsStrategy(), "bcMergeToShanghai");
+        return (IEnumerable<BlockchainTest>)loader.LoadTests();
+    }
+}

--- a/src/Nethermind/Ethereum.Transition.Test/MergeToShanghaiTests.cs
+++ b/src/Nethermind/Ethereum.Transition.Test/MergeToShanghaiTests.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Collections.Generic;


### PR DESCRIPTION
## Changes

- add class `MergeToShanghaiTests`
- standard update of ethereum tests. New tests:
<img width="741" alt="newhivetests" src="https://user-images.githubusercontent.com/77129288/210369604-943f0096-220f-41c3-b92d-4a1df1084a41.PNG">

## Types of changes

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or a feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional or API changes)
- [ ] Build-related changes
- [x] Other:  update ethereum tests

## Testing

#### Requires testing

- [ ] Yes
- [x] No