### PR TITLE
Improve pre-release version deployment

### DIFF
--- a/.github/workflows/release-nethermind.yml
+++ b/.github/workflows/release-nethermind.yml
@@ -25,6 +25,7 @@ jobs:
       BUILD_TIMESTAMP: ${{ steps.build-runner.outputs.BUILD_TIMESTAMP }}
       COMMIT_HASH: ${{ steps.build-runner.outputs.COMMIT_HASH }}
       PACKAGE_PREFIX: ${{ steps.archive.outputs.PACKAGE_PREFIX }}
+      PRERELEASE: ${{ contains(github.event.inputs.tag, '-') }}
     steps:
     - name: Check out Nethermind repository
       uses: actions/checkout@v3
@@ -90,6 +91,7 @@ jobs:
     name: Update Homebrew to the latest version
     runs-on: ubuntu-latest
     needs: build
+    if: needs.build.outputs.PRERELEASE == 'false'
     steps:
     - name: Restore packages from cache
       uses: actions/cache@v3
@@ -157,12 +159,14 @@ jobs:
         GIT_TAG: ${{ github.event.inputs.tag }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         PACKAGE_PREFIX: ${{ needs.build.outputs.PACKAGE_PREFIX }}
+        PRERELEASE: ${{ needs.build.outputs.PRERELEASE }}
       run: $SCRIPTS_PATH/publish-github.sh
 
   publish-downloads:
     name: Publish packages to Downloads page
     runs-on: ubuntu-latest
     needs: trigger-publish
+    if: needs.build.outputs.PRERELEASE == 'false'
     steps:
     - name: Restore packages from cache
       uses: actions/cache@v3
@@ -205,12 +209,12 @@ jobs:
       run: |
         echo "${{ secrets.DOCKER_ACCESS_TOKEN }}" | docker login --username "${{ secrets.DOCKER_USERNAME }}" --password-stdin
     - name: Build and push image to Docker registry (major) / trigger DAppNode build
-      if: ${{ !contains(github.event.inputs.tag, '-') }}
+      if: needs.build.outputs.PRERELEASE == 'false'
       run: |
         docker buildx build --platform=linux/amd64,linux/arm64 -t "${{ env.DOCKER_IMAGE }}:latest" -t "${{ env.DOCKER_IMAGE }}:${{ github.event.inputs.tag }}" -f Dockerfile --build-arg COMMIT_HASH=${{ needs.build.outputs.COMMIT_HASH }} --build-arg BUILD_TIMESTAMP=${{ needs.build.outputs.BUILD_TIMESTAMP }} . --push
         curl -s -X POST -u "${{ secrets.REPOSITORY_DISPATCH_TOKEN }}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" -d '{"event_type":"dappnode","client_payload":{"tag":"${{ github.event.inputs.tag }}"}}' https://api.github.com/repos/$GITHUB_REPOSITORY/dispatches
     - name: Build and push image to Docker registry  (patch)
-      if: ${{ contains(github.event.inputs.tag, '-') }}
+      if: needs.build.outputs.PRERELEASE == 'true'
       run: |
         docker buildx build --platform=linux/amd64,linux/arm64 -t "${{ env.DOCKER_IMAGE }}:${{ github.event.inputs.tag }}" -f Dockerfile --build-arg COMMIT_HASH=${{ needs.build.outputs.COMMIT_HASH }} --build-arg BUILD_TIMESTAMP=${{ needs.build.outputs.BUILD_TIMESTAMP }} . --push
     - name: Clear Docker cache
@@ -222,6 +226,7 @@ jobs:
     name: Publish Nethermind to PPA repository
     runs-on: ubuntu-latest
     needs: trigger-publish
+    if: needs.build.outputs.PRERELEASE == 'false'
     env:
       PPA_GPG_KEYID: ${{ secrets.PPA_GPG_KEYID }}
       VERSION: ${{ github.event.inputs.tag }}

--- a/.github/workflows/release-nethermind.yml
+++ b/.github/workflows/release-nethermind.yml
@@ -99,7 +99,7 @@ jobs:
       run: echo "Waiting for approval..."
 
   update-homebrew:
-    name: Update Homebrew to the latest version
+    name: Update Homebrew formula
     runs-on: ubuntu-latest
     needs: approval
     if: needs.build.outputs.PRERELEASE == 'false'
@@ -116,7 +116,7 @@ jobs:
       with:
         repository: NethermindEth/homebrew-nethermind
         path: homebrew-nethermind
-    - name: Update Homebrew file
+    - name: Update formula file
       env:
         PACKAGE_PREFIX: ${{ needs.build.outputs.PACKAGE_PREFIX }}
         VERSION: ${{ github.event.inputs.tag }}
@@ -134,7 +134,7 @@ jobs:
       uses: peter-evans/create-pull-request@v4
       with:
         token: ${{ secrets.REPOSITORY_DISPATCH_TOKEN }}
-        commit-message: Update Homebrew to latest release
+        commit-message: Update Homebrew formula
         title: '[Release] Update Homebrew'
         reviewers: falcoxyz, AntiD2ta, matilote
         draft: false
@@ -143,7 +143,7 @@ jobs:
           nethermind.rb
 
   publish-github:
-    name: Publish packages to GitHub Releases
+    name: Publish to GitHub
     runs-on: ubuntu-latest
     needs: approval
     steps:
@@ -164,7 +164,7 @@ jobs:
       run: $SCRIPTS_PATH/publish-github.sh
 
   publish-downloads:
-    name: Publish packages to Downloads page
+    name: Publish to Downloads page
     runs-on: ubuntu-latest
     needs: approval
     if: needs.build.outputs.PRERELEASE == 'false'
@@ -189,7 +189,7 @@ jobs:
       run: $SCRIPTS_PATH/publish-downloads.sh
 
   publish-dockers:
-    name: Publish Docker images to Docker Hub
+    name: Publish to Docker Hub
     runs-on: ubuntu-latest
     needs: approval
     env:
@@ -224,7 +224,7 @@ jobs:
         rm -f $HOME/.docker/config.json
 
   publish-ppa:
-    name: Publish Nethermind to PPA repository
+    name: Publish to PPA
     runs-on: ubuntu-latest
     needs: approval
     if: needs.build.outputs.PRERELEASE == 'false'

--- a/.github/workflows/release-nethermind.yml
+++ b/.github/workflows/release-nethermind.yml
@@ -216,7 +216,7 @@ jobs:
     - name: Build and push image to Docker registry  (patch)
       if: needs.build.outputs.PRERELEASE == 'true'
       run: |
-        docker buildx build --platform=linux/amd64,linux/arm64 -t "${{ env.DOCKER_IMAGE }}:${{ github.event.inputs.tag }}" -f Dockerfile --build-arg COMMIT_HASH=${{ needs.build.outputs.COMMIT_HASH }} --build-arg BUILD_TIMESTAMP=${{ needs.build.outputs.BUILD_TIMESTAMP }} . --push
+        docker buildx build --platform=linux/amd64,linux/arm64 -t "${{ env.DOCKER_IMAGE }}:unstable" -t "${{ env.DOCKER_IMAGE }}:${{ github.event.inputs.tag }}" -f Dockerfile --build-arg COMMIT_HASH=${{ needs.build.outputs.COMMIT_HASH }} --build-arg BUILD_TIMESTAMP=${{ needs.build.outputs.BUILD_TIMESTAMP }} . --push
     - name: Clear Docker cache
       if: always()
       run: |

--- a/.github/workflows/release-nethermind.yml
+++ b/.github/workflows/release-nethermind.yml
@@ -66,8 +66,8 @@ jobs:
     - name: Build Nethermind.Launcher
       run: $SCRIPTS_PATH/build-launcher.sh
     - name: Build Nethermind.Launcher for Linux arm64
+      working-directory: nethermind
       run: |
-        cd nethermind
         docker buildx build --platform=linux/arm64 -t tmp-launcher -f Dockerfile.launcher . --load
         docker run --platform=linux/arm64 -v $PWD:/opt/mount --rm tmp-launcher bash -c "cp /nethermind/Nethermind.Launcher /opt/mount/"
         mv Nethermind.Launcher $GITHUB_WORKSPACE/$PUB_DIR/linux-arm64/Nethermind.Launcher
@@ -198,7 +198,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ github.event.inputs.tag }}
-        fetch-depth: 0
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
     - name: Set up Docker Buildx

--- a/.github/workflows/release-nethermind.yml
+++ b/.github/workflows/release-nethermind.yml
@@ -30,7 +30,6 @@ jobs:
     - name: Check out Nethermind repository
       uses: actions/checkout@v3
       with:
-        submodules: recursive
         path: nethermind
         ref: ${{ github.event.inputs.tag }}
     - name: Check out Nethermind Launcher repository
@@ -250,6 +249,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         path: nethermind
+        ref: ${{ github.event.inputs.tag }}
     - name: Publish to PPA
       run: | 
         chmod +x $SCRIPTS_PATH/publish-ppa.sh

--- a/.github/workflows/release-nethermind.yml
+++ b/.github/workflows/release-nethermind.yml
@@ -86,11 +86,22 @@ jobs:
           ${{ github.workspace }}/${{ env.PACKAGE_DIR }}/
           ${{ env.SCRIPTS_PATH }}/
         key: packages-${{ steps.build-runner.outputs.COMMIT_HASH }}
+        
+  approval:
+    name: Approve
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: Releases
+      url: https://github.com/NethermindEth/nethermind/releases/tag/${{ github.event.inputs.tag }}
+    steps:
+    - name: Wait for approval
+      run: echo "Waiting for approval..."
 
   update-homebrew:
     name: Update Homebrew to the latest version
     runs-on: ubuntu-latest
-    needs: build
+    needs: approval
     if: needs.build.outputs.PRERELEASE == 'false'
     steps:
     - name: Restore packages from cache
@@ -131,20 +142,10 @@ jobs:
         add-paths: |
           nethermind.rb
 
-  trigger-publish:
-    name: Trigger publish event to different sources
-    runs-on: ubuntu-latest
-    needs: update-homebrew
-    environment:
-      name: Releases
-      url: https://github.com/NethermindEth/nethermind/releases/tag/${{ github.event.inputs.tag }}
-    steps:
-    - run: echo "Just a middle-man job"
-
   publish-github:
     name: Publish packages to GitHub Releases
     runs-on: ubuntu-latest
-    needs: trigger-publish
+    needs: approval
     steps:
     - name: Restore packages from cache
       uses: actions/cache@v3
@@ -165,7 +166,7 @@ jobs:
   publish-downloads:
     name: Publish packages to Downloads page
     runs-on: ubuntu-latest
-    needs: trigger-publish
+    needs: approval
     if: needs.build.outputs.PRERELEASE == 'false'
     steps:
     - name: Restore packages from cache
@@ -190,7 +191,7 @@ jobs:
   publish-dockers:
     name: Publish Docker images to Docker Hub
     runs-on: ubuntu-latest
-    needs: trigger-publish
+    needs: approval
     env:
       DOCKER_IMAGE: nethermind/nethermind
     steps:
@@ -225,7 +226,7 @@ jobs:
   publish-ppa:
     name: Publish Nethermind to PPA repository
     runs-on: ubuntu-latest
-    needs: trigger-publish
+    needs: approval
     if: needs.build.outputs.PRERELEASE == 'false'
     env:
       PPA_GPG_KEYID: ${{ secrets.PPA_GPG_KEYID }}

--- a/scripts/deployment/publish-github.sh
+++ b/scripts/deployment/publish-github.sh
@@ -9,8 +9,8 @@ echo "Publishing packages to GitHub"
 PACKAGE_PATH=$GITHUB_WORKSPACE/$PACKAGE_DIR
 
 BODY=$(printf \
-  '{"tag_name": "%s", "target_commitish": "%s", "name": "v%s", "body": "## Release notes\\n\\n", "draft": true, "prerelease": false}' \
-  $GIT_TAG $GIT_COMMIT $GIT_TAG)
+  '{"tag_name": "%s", "target_commitish": "%s", "name": "v%s", "body": "## Release notes\\n\\n", "draft": true, "prerelease": %s}' \
+  $GIT_TAG $GIT_COMMIT $GIT_TAG $PRERELEASE)
 
 echo "Drafting release $GIT_TAG"
 


### PR DESCRIPTION
## Changes

- Updated release workflow to handle pre-release versions
- Publishing pre-release versions to GitHub and Docker Hub only
- Require approval for any step after the build: `Build -> Approval -> Publish to Homebrew, GitHub, Downloads, Docker, PPA`
- Revised some namings

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or a feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional or API changes)
- [x] Build-related changes
- [ ] Other: _description_ 

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

To test, tag a pre-release like `x.y.z-label` and run the workflow.

## Remarks

Maybe it's worth adding a default tag for pre-release Docker images. Say, `latest-preview`, `latest-unstable`, or just `unstable`.
