### PR TITLE
Fix/sync hang when handle response failed with no peer

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/BeaconHeadersSyncTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/BeaconHeadersSyncTests.cs
@@ -313,7 +313,7 @@ public class BeaconHeadersSyncTests
             ctx.BlockTree, ctx.BlockCacheService, LimboLogs.Instance);
         ctx.InvalidChainTracker = invalidChainTracker;
 
-        BlockTree syncedBlockTree = Build.A.BlockTree().OfChainLength(100, splitVariant: (int) BlockHeaderBuilder.DefaultDifficulty).TestObject;
+        BlockTree syncedBlockTree = Build.A.BlockTree().OfChainLength(100, splitVariant: (int)BlockHeaderBuilder.DefaultDifficulty).TestObject;
         ctx.BeaconPivot = PreparePivot(99, new SyncConfig(), ctx.BlockTree,
             syncedBlockTree.FindHeader(99, BlockTreeLookupOptions.None));
         ctx.Feed.InitializeFeed();

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/BeaconHeadersSyncTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/BeaconHeadersSyncTests.cs
@@ -313,15 +313,17 @@ public class BeaconHeadersSyncTests
             ctx.BlockTree, ctx.BlockCacheService, LimboLogs.Instance);
         ctx.InvalidChainTracker = invalidChainTracker;
 
-        BlockTree syncedBlockTree = Build.A.BlockTree().OfChainLength(100).TestObject;
-        HeadersSyncBatch batch = new HeadersSyncBatch();
-        batch.RequestSize = 100;
-        batch.Response = syncedBlockTree.FindHeaders(syncedBlockTree.GenesisHash, 100, 0, false);
+        BlockTree syncedBlockTree = Build.A.BlockTree().OfChainLength(100, splitVariant: (int) BlockHeaderBuilder.DefaultDifficulty).TestObject;
+        ctx.BeaconPivot = PreparePivot(99, new SyncConfig(), ctx.BlockTree,
+            syncedBlockTree.FindHeader(99, BlockTreeLookupOptions.None));
+        ctx.Feed.InitializeFeed();
+        HeadersSyncBatch batch = ctx.Feed.PrepareRequest().Result;
+        batch.Response = syncedBlockTree.FindHeaders(syncedBlockTree.FindHeader(batch.StartNumber, BlockTreeLookupOptions.None)!.Hash, batch.RequestSize, 0, false);
         ctx.Feed.HandleResponse(batch);
 
-        Keccak lastHeader = syncedBlockTree.FindHeader(99, BlockTreeLookupOptions.None).Hash;
-        Keccak headerToInvalidate = syncedBlockTree.FindHeader(10, BlockTreeLookupOptions.None).Hash;
-        Keccak lastValidHeader = syncedBlockTree.FindHeader(9, BlockTreeLookupOptions.None).Hash;
+        Keccak lastHeader = syncedBlockTree.FindHeader(batch.EndNumber, BlockTreeLookupOptions.None).Hash;
+        Keccak headerToInvalidate = syncedBlockTree.FindHeader(batch.StartNumber + 10, BlockTreeLookupOptions.None).Hash;
+        Keccak lastValidHeader = syncedBlockTree.FindHeader(batch.StartNumber + 9, BlockTreeLookupOptions.None).Hash;
         invalidChainTracker.OnInvalidBlock(headerToInvalidate, lastValidHeader);
         invalidChainTracker.IsOnKnownInvalidChain(lastHeader, out Keccak storedLastValidHash).Should().BeTrue();
         storedLastValidHash.Should().Be(lastValidHeader);

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/FastHeadersSyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/FastHeadersSyncTests.cs
@@ -61,7 +61,7 @@ namespace Nethermind.Synchronization.Test.FastBlocks
             syncReport.HeadersInQueue.Returns(new MeasuredProgress());
 
             BlockHeader pivot = remoteBlockTree.FindHeader(500, BlockTreeLookupOptions.None)!;
-            ResettableHeaderSyncFeed feed = new(Substitute.For<ISyncModeSelector>(), blockTree, Substitute.For<ISyncPeerPool>(), new SyncConfig { FastSync = true, FastBlocks = true, PivotNumber = "500", PivotHash = pivot.Hash.Bytes.ToHexString(), PivotTotalDifficulty = pivot.TotalDifficulty!.ToString()}, syncReport, LimboLogs.Instance);
+            ResettableHeaderSyncFeed feed = new(Substitute.For<ISyncModeSelector>(), blockTree, Substitute.For<ISyncPeerPool>(), new SyncConfig { FastSync = true, FastBlocks = true, PivotNumber = "500", PivotHash = pivot.Hash.Bytes.ToHexString(), PivotTotalDifficulty = pivot.TotalDifficulty!.ToString() }, syncReport, LimboLogs.Instance);
             feed.InitializeFeed();
 
             void FulfillBatch(HeadersSyncBatch batch)
@@ -118,7 +118,7 @@ namespace Nethermind.Synchronization.Test.FastBlocks
             measuredProgress.HasEnded.Should().BeTrue();
         }
 
-        private class ResettableHeaderSyncFeed: HeadersSyncFeed
+        private class ResettableHeaderSyncFeed : HeadersSyncFeed
         {
             public ResettableHeaderSyncFeed(ISyncModeSelector syncModeSelector, IBlockTree? blockTree, ISyncPeerPool? syncPeerPool, ISyncConfig? syncConfig, ISyncReport? syncReport, ILogManager? logManager, bool alwaysStartHeaderSync = false) : base(syncModeSelector, blockTree, syncPeerPool, syncConfig, syncReport, logManager, alwaysStartHeaderSync)
             {

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/FastHeadersSyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/FastHeadersSyncTests.cs
@@ -2,18 +2,21 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
 using Nethermind.Db.Blooms;
 using Nethermind.Logging;
 using Nethermind.Specs;
 using Nethermind.State.Repositories;
+using Nethermind.Stats;
 using Nethermind.Synchronization.FastBlocks;
 using Nethermind.Synchronization.ParallelSync;
 using Nethermind.Synchronization.Peers;
@@ -45,6 +48,58 @@ namespace Nethermind.Synchronization.Test.FastBlocks
             HeadersSyncBatch? batch1 = await feed.PrepareRequest();
             HeadersSyncBatch? batch2 = await feed.PrepareRequest();
             HeadersSyncBatch? batch3 = await feed.PrepareRequest();
+        }
+
+        [Test]
+        public async Task Can_prepare_several_request_and_ignore_request_from_previous_sequence()
+        {
+            IDbProvider memDbProvider = await TestMemDbProvider.InitAsync();
+            BlockTree remoteBlockTree = Build.A.BlockTree().OfHeadersOnly.OfChainLength(501).TestObject;
+
+            BlockTree blockTree = new(memDbProvider.BlocksDb, memDbProvider.HeadersDb, memDbProvider.BlockInfosDb, new ChainLevelInfoRepository(memDbProvider.BlockInfosDb), MainnetSpecProvider.Instance, NullBloomStorage.Instance, LimboLogs.Instance);
+
+            ISyncReport syncReport = Substitute.For<ISyncReport>();
+            syncReport.FastBlocksHeaders.Returns(new MeasuredProgress());
+            syncReport.HeadersInQueue.Returns(new MeasuredProgress());
+
+            BlockHeader pivot = remoteBlockTree.FindHeader(500, BlockTreeLookupOptions.None)!;
+            RestartableHeaderSyncFeed feed = new(Substitute.For<ISyncModeSelector>(), blockTree, Substitute.For<ISyncPeerPool>(), new SyncConfig { FastSync = true, FastBlocks = true, PivotNumber = "500", PivotHash = pivot.Hash.Bytes.ToHexString(), PivotTotalDifficulty = pivot.TotalDifficulty!.ToString()}, syncReport, LimboLogs.Instance);
+            feed.InitializeFeed();
+
+            void FulfillBatch(HeadersSyncBatch batch)
+            {
+                batch.Response = new BlockHeader[batch.RequestSize];
+                for (long i = batch.StartNumber; i <= batch.EndNumber; i++)
+                {
+                    batch.Response[i - batch.StartNumber] = remoteBlockTree.FindHeader(i, BlockTreeLookupOptions.None)!;
+                }
+            }
+
+            await feed.PrepareRequest();
+            HeadersSyncBatch? batch1 = await feed.PrepareRequest();
+            FulfillBatch(batch1);
+
+            feed.Reset();
+
+            await feed.PrepareRequest();
+            HeadersSyncBatch? batch2 = await feed.PrepareRequest();
+            FulfillBatch(batch2);
+
+            feed.HandleResponse(batch2);
+            feed.HandleResponse(batch1);
+        }
+
+        internal class RestartableHeaderSyncFeed: HeadersSyncFeed
+        {
+            public RestartableHeaderSyncFeed(ISyncModeSelector syncModeSelector, IBlockTree? blockTree, ISyncPeerPool? syncPeerPool, ISyncConfig? syncConfig, ISyncReport? syncReport, ILogManager? logManager, bool alwaysStartHeaderSync = false) : base(syncModeSelector, blockTree, syncPeerPool, syncConfig, syncReport, logManager, alwaysStartHeaderSync)
+            {
+            }
+
+            public void Reset()
+            {
+                base.PostFinishCleanUp();
+                InitializeFeed();
+            }
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/ISyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/ISyncFeed.cs
@@ -14,7 +14,7 @@ namespace Nethermind.Synchronization.ParallelSync
         SyncFeedState CurrentState { get; }
         event EventHandler<SyncFeedStateEventArgs> StateChanged;
         Task<T> PrepareRequest(CancellationToken token = default);
-        SyncResponseHandlingResult HandleResponse(T response, PeerInfo peer = null);
+        SyncResponseHandlingResult HandleResponse(T response, PeerInfo? peer = null);
 
         /// <summary>
         /// Multifeed can prepare and handle multiple requests concurrently.

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncDispatcher.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncDispatcher.cs
@@ -101,8 +101,7 @@ namespace Nethermind.Synchronization.ParallelSync
                         else
                         {
                             Logger.Debug($"DISPATCHER - {this.GetType().Name}: peer NOT allocated");
-                            SyncResponseHandlingResult result = Feed.HandleResponse(request);
-                            ReactToHandlingResult(request, result, null);
+                            DoHandleResponse(null, request);
                         }
                     }
                     else if (currentStateLocal == SyncFeedState.Finished)
@@ -142,6 +141,18 @@ namespace Nethermind.Synchronization.ParallelSync
                     return;
                 }
 
+                DoHandleResponse(allocatedPeer, request);
+            }
+            finally
+            {
+                Free(allocation);
+            }
+        }
+
+        private void DoHandleResponse(PeerInfo? allocatedPeer, T request)
+        {
+            try
+            {
                 SyncResponseHandlingResult result = Feed.HandleResponse(request, allocatedPeer);
                 ReactToHandlingResult(request, result, allocatedPeer);
             }
@@ -154,10 +165,6 @@ namespace Nethermind.Synchronization.ParallelSync
                 // possibly clear the response and handle empty response batch here (to avoid missing parts)
                 // this practically corrupts sync
                 if (Logger.IsError) Logger.Error("Error when handling response", e);
-            }
-            finally
-            {
-                Free(allocation);
             }
         }
 

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncDispatcher.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncDispatcher.cs
@@ -101,7 +101,7 @@ namespace Nethermind.Synchronization.ParallelSync
                         else
                         {
                             Logger.Debug($"DISPATCHER - {this.GetType().Name}: peer NOT allocated");
-                            DoHandleResponse(null, request);
+                            DoHandleResponse(request);
                         }
                     }
                     else if (currentStateLocal == SyncFeedState.Finished)
@@ -141,7 +141,7 @@ namespace Nethermind.Synchronization.ParallelSync
                     return;
                 }
 
-                DoHandleResponse(allocatedPeer, request);
+                DoHandleResponse(request, allocatedPeer);
             }
             finally
             {
@@ -149,7 +149,7 @@ namespace Nethermind.Synchronization.ParallelSync
             }
         }
 
-        private void DoHandleResponse(PeerInfo? allocatedPeer, T request)
+        private void DoHandleResponse(T request, PeerInfo? allocatedPeer = null)
         {
             try
             {


### PR DESCRIPTION
- Fix sync hang when beacon header request `HandleResponse` failed with no peer. 
- This is because the sync dispatcher does not swallow exception from `HandleResponse` if peer is not allocated, unlike if peer is allocated.
- The exception is due to fast header sync feed processing batch that was send before it was reset, causing the `Only one header dependency expected` exception. It was reset on a recent change to beacon header sync which need to make sure that it sync to the latest pivot which can be missed when FcU was called in quick sussession. 

## Changes

- Extract `HandleResponse` call with wrapper that swallow exception from it in SyncDispatcher so that a failed `HandleResponse` does not crash the dispatcher.
- Check header sync batch is within `_sent` dictionary before processing it. `_sent` is cleared when the header sync feed is reset.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or a feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional or API changes)
- [ ] Build-related changes
- [ ] Other: _description_ 

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

Beacon haeder and old header in Goerli seems to sync.