### PR TITLE
Fix corrupted frame exception

### DIFF
--- a/src/Nethermind/Nethermind.Network.Test/Rlpx/Handshake/NettyHandshakeHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/Rlpx/Handshake/NettyHandshakeHandlerTests.cs
@@ -123,7 +123,7 @@ namespace Nethermind.Network.Test.Rlpx.Handshake
             NettyHandshakeHandler handler = CreateHandler(HandshakeRole.Initiator);
             handler.ChannelRead(_channelHandlerContext, Unpooled.Buffer(0, 0));
 
-            _pipeline.Received(1).Remove<LengthFieldBasedFrameDecoder>();
+            _pipeline.Received(1).Remove<OneTimeLengthFieldBasedFrameDecoder>();
         }
 
         [Test]
@@ -195,7 +195,7 @@ namespace Nethermind.Network.Test.Rlpx.Handshake
             NettyHandshakeHandler handler = CreateHandler();
             handler.ChannelRead(_channelHandlerContext, Unpooled.Buffer(0, 0));
 
-            _pipeline.Received(1).Remove<LengthFieldBasedFrameDecoder>();
+            _pipeline.Received(1).Remove<OneTimeLengthFieldBasedFrameDecoder>();
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Network.Test/Rlpx/OneTimeLengthFieldBasedFrameDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/Rlpx/OneTimeLengthFieldBasedFrameDecoderTests.cs
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using DotNetty.Buffers;
+using DotNetty.Transport.Channels;
+using Nethermind.Core.Extensions;
+using Nethermind.Network.Rlpx;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Network.Test.Rlpx;
+
+public class OneTimeLengthFieldBasedFrameDecoderTests
+{
+    [Test]
+    public void Will_pass_frame_only_once()
+    {
+        OneTimeLengthFieldBasedFrameDecoder frameDecoder = new();
+        IChannelHandlerContext ctx = Substitute.For<IChannelHandlerContext>();
+
+        frameDecoder.ChannelRead(ctx, Unpooled.CopiedBuffer(Bytes.FromHexString("0x0001ff")));
+        frameDecoder.ChannelRead(ctx, Unpooled.CopiedBuffer(Bytes.FromHexString("0x0001ff")));
+
+        ctx.Received(1).FireChannelRead(Arg.Is(Unpooled.CopiedBuffer(Bytes.FromHexString("0x0001ff"))));
+    }
+}

--- a/src/Nethermind/Nethermind.Network/Rlpx/NettyHandshakeHandler.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/NettyHandshakeHandler.cs
@@ -167,8 +167,8 @@ namespace Nethermind.Network.Rlpx
 
             if (_role == HandshakeRole.Recipient)
             {
-                if (_logger.IsTrace) _logger.Trace($"Registering {nameof(LengthFieldBasedFrameDecoder)}  for {RemoteId} @ {context.Channel.RemoteAddress}");
-                context.Channel.Pipeline.AddLast("enc-handshake-dec", new LengthFieldBasedFrameDecoder(ByteOrder.BigEndian, ushort.MaxValue, 0, 2, 0, 0, true));
+                if (_logger.IsTrace) _logger.Trace($"Registering {nameof(OneTimeLengthFieldBasedFrameDecoder)}  for {RemoteId} @ {context.Channel.RemoteAddress}");
+                context.Channel.Pipeline.AddLast("enc-handshake-dec", new OneTimeLengthFieldBasedFrameDecoder());
             }
             if (_logger.IsTrace) _logger.Trace($"Registering {nameof(ReadTimeoutHandler)} for {RemoteId} @ {context.Channel.RemoteAddress}");
             context.Channel.Pipeline.AddLast(new ReadTimeoutHandler(TimeSpan.FromSeconds(30))); // read timeout instead of session monitoring
@@ -193,8 +193,8 @@ namespace Nethermind.Network.Rlpx
 
             if (_logger.IsTrace) _logger.Trace($"Removing {nameof(NettyHandshakeHandler)}");
             context.Channel.Pipeline.Remove(this);
-            if (_logger.IsTrace) _logger.Trace($"Removing {nameof(LengthFieldBasedFrameDecoder)}");
-            context.Channel.Pipeline.Remove<LengthFieldBasedFrameDecoder>();
+            if (_logger.IsTrace) _logger.Trace($"Removing {nameof(OneTimeLengthFieldBasedFrameDecoder)}");
+            context.Channel.Pipeline.Remove<OneTimeLengthFieldBasedFrameDecoder>();
         }
 
         public override void HandlerRemoved(IChannelHandlerContext context)

--- a/src/Nethermind/Nethermind.Network/Rlpx/OneTimeLengthFieldBasedFrameDecoder.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/OneTimeLengthFieldBasedFrameDecoder.cs
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using DotNetty.Buffers;
+using DotNetty.Codecs;
+using DotNetty.Transport.Channels;
+
+namespace Nethermind.Network.Rlpx;
+
+public class OneTimeLengthFieldBasedFrameDecoder: LengthFieldBasedFrameDecoder
+{
+    private bool _decoded;
+
+    public OneTimeLengthFieldBasedFrameDecoder() : base(ByteOrder.BigEndian, ushort.MaxValue, 0, 2, 0, 0, true)
+    {
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected override void Decode(IChannelHandlerContext context, IByteBuffer input, List<object> output)
+    {
+        if (_decoded) return;
+        base.Decode(context, input, output);
+
+        // Base class decode one at a time only
+        _decoded = output.Count > 0;
+    }
+}

--- a/src/Nethermind/Nethermind.Network/Rlpx/OneTimeLengthFieldBasedFrameDecoder.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/OneTimeLengthFieldBasedFrameDecoder.cs
@@ -9,7 +9,7 @@ using DotNetty.Transport.Channels;
 
 namespace Nethermind.Network.Rlpx;
 
-public class OneTimeLengthFieldBasedFrameDecoder: LengthFieldBasedFrameDecoder
+public class OneTimeLengthFieldBasedFrameDecoder : LengthFieldBasedFrameDecoder
 {
     private bool _decoded;
 

--- a/src/Nethermind/Nethermind.Network/Rlpx/RlpxHost.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/RlpxHost.cs
@@ -209,7 +209,7 @@ namespace Nethermind.Network.Rlpx
 
             if (session.Direction == ConnectionDirection.Out)
             {
-                pipeline.AddLast("enc-handshake-dec", new LengthFieldBasedFrameDecoder(ByteOrder.BigEndian, ushort.MaxValue, 0, 2, 0, 0, true));
+                pipeline.AddLast("enc-handshake-dec", new OneTimeLengthFieldBasedFrameDecoder());
             }
             pipeline.AddLast("enc-handshake-handler", handshakeHandler);
 


### PR DESCRIPTION
- Fix random `CorruptedFrameException`.
- Seems to be due to the `MessageLengthFieldBasedFrameDecoder` docoding more than one message, while it was intended to only be used during handshake, hence, one packet.

## Changes

- Create a subclass that decode only one message.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or a feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional or API changes)
- [ ] Build-related changes
- [ ] Other: _description_ 

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Clear metrics indicating that this exception no longer happens.
