### PR TITLE
Fix disconnecting peer with only eth67 protocol

### DIFF
--- a/src/Nethermind/Nethermind.Network.Stats/Model/InitiateDisconnectReason.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/Model/InitiateDisconnectReason.cs
@@ -15,7 +15,6 @@ public enum InitiateDisconnectReason : byte
 
     SnapServerNotImplemented,
     IncompatibleP2PVersion,
-    InvalidCapability,
     InvalidChainId,
     InvalidGenesis,
     ProtocolInitTimeout,
@@ -62,8 +61,6 @@ public static class InitiateDisconnectReasonExtension
                 return DisconnectReason.UselessPeer;
             case InitiateDisconnectReason.IncompatibleP2PVersion:
                 return DisconnectReason.IncompatibleP2PVersion;
-            case InitiateDisconnectReason.InvalidCapability:
-                return DisconnectReason.UselessPeer;
             case InitiateDisconnectReason.InvalidChainId:
                 return DisconnectReason.UselessPeer;
             case InitiateDisconnectReason.InvalidGenesis:

--- a/src/Nethermind/Nethermind.Network/ProtocolValidator.cs
+++ b/src/Nethermind/Nethermind.Network/ProtocolValidator.cs
@@ -44,15 +44,6 @@ namespace Nethermind.Network
                         return false;
                     }
 
-                    if (!ValidateCapabilities(args.Capabilities))
-                    {
-                        if (_logger.IsTrace) _logger.Trace($"Initiating disconnect with peer: {session.RemoteNodeId}, no Eth62 capability, supported capabilities: [{string.Join(",", args.Capabilities.Select(x => $"{x.ProtocolCode}v{x.Version}"))}]");
-                        _nodeStatsManager.ReportFailedValidation(session.Node, CompatibilityValidationType.Capabilities);
-                        Disconnect(session, InitiateDisconnectReason.InvalidCapability, "capabilities");
-                        if (session.Node.IsStatic && _logger.IsWarn) _logger.Warn($"Disconnected an invalid static node: {session.Node.Host}:{session.Node.Port}, reason: {DisconnectReason.UselessPeer} (capabilities)");
-                        return false;
-                    }
-
                     break;
                 case Protocol.Eth:
                 case Protocol.Les:
@@ -89,19 +80,6 @@ namespace Nethermind.Network
         private bool ValidateP2PVersion(byte p2PVersion)
         {
             return p2PVersion == 4 || p2PVersion == 5;
-        }
-
-        private static bool ValidateCapabilities(IEnumerable<Capability> capabilities)
-        {
-            // TODO: this is duplicated from P2PProtocolHandler.HandleHello. One should probably be removed
-            return capabilities.Any(x =>
-                // x.ProtocolCode == Protocol.Les ||
-                x.ProtocolCode == Protocol.Eth && (
-                    x.Version == 62 ||
-                    x.Version == 63 ||
-                    x.Version == 64 ||
-                    x.Version == 65 ||
-                    x.Version == 66));
         }
 
         private bool ValidateChainId(ulong chainId)


### PR DESCRIPTION
- Stumbled upon a disconnect where the peer have only eth67 enabled. I'm guessing its besu as besu can specify min eth level. Geth still have eth66. 
- As mentioned in the comment, this check is redundant as we have capability check later down the line. The code would be `NoMatchingCapability` instead of `InvalidCapability`.

## Changes

- Remove duplicated check.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No: removing things. 

#### Notes on testing

- Still can get nodes.