### PR TITLE
Fix randomly failing receipt deserialization

### DIFF
--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V63/Messages/ReceiptsMessage.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V63/Messages/ReceiptsMessage.cs
@@ -12,6 +12,9 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V63.Messages
         public override int PacketType { get; } = Eth63MessageCode.Receipts;
         public override string Protocol { get; } = "eth";
 
+        private static ReceiptsMessage? _empty;
+        public static ReceiptsMessage Empty => _empty ??= new ReceiptsMessage(null);
+
         public ReceiptsMessage(TxReceipt[][] txReceipts)
         {
             TxReceipts = txReceipts ?? new TxReceipt[0][];

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V63/Messages/ReceiptsMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V63/Messages/ReceiptsMessageSerializer.cs
@@ -40,7 +40,16 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V63.Messages
 
         public ReceiptsMessage Deserialize(IByteBuffer byteBuffer)
         {
-            if (byteBuffer.ReadableBytes == 0 || byteBuffer.GetByte(byteBuffer.ReaderIndex) == Rlp.OfEmptySequence[0]) return new ReceiptsMessage(null);
+            if (byteBuffer.ReadableBytes == 0)
+            {
+                return new ReceiptsMessage(null);
+            }
+
+            if (byteBuffer.GetByte(byteBuffer.ReaderIndex) == Rlp.OfEmptySequence[0])
+            {
+                byteBuffer.ReadByte();
+                return new ReceiptsMessage(null);
+            }
 
             RlpStream rlpStream = new NettyRlpStream(byteBuffer);
             return Deserialize(rlpStream);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V63/Messages/ReceiptsMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V63/Messages/ReceiptsMessageSerializer.cs
@@ -31,7 +31,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V63.Messages
                         b.Select(
                             n => n is null
                                 ? Rlp.OfEmptySequence
-                                // for TxReceipt there is no timestamp, as such, we are using IReceiptSpec. wonder how we can metigate this later if future EIPs affecting this are added. 
+                                // for TxReceipt there is no timestamp, as such, we are using IReceiptSpec. wonder how we can metigate this later if future EIPs affecting this are added.
                                 : _decoder.Encode(n, _specProvider.GetReceiptSpec(n.BlockNumber).IsEip658Enabled ? RlpBehaviors.Eip658Receipts : RlpBehaviors.None)).ToArray())).ToArray());
 
             RlpStream rlpStream = new NettyRlpStream(byteBuffer);
@@ -40,7 +40,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V63.Messages
 
         public ReceiptsMessage Deserialize(IByteBuffer byteBuffer)
         {
-            if (byteBuffer.Array.Length == 0 || byteBuffer.Array.First() == Rlp.OfEmptySequence[0]) return new ReceiptsMessage(null);
+            if (byteBuffer.ReadableBytes == 0 || byteBuffer.GetByte(byteBuffer.ReaderIndex) == Rlp.OfEmptySequence[0]) return new ReceiptsMessage(null);
 
             RlpStream rlpStream = new NettyRlpStream(byteBuffer);
             return Deserialize(rlpStream);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V63/Messages/ReceiptsMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V63/Messages/ReceiptsMessageSerializer.cs
@@ -42,13 +42,13 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V63.Messages
         {
             if (byteBuffer.ReadableBytes == 0)
             {
-                return new ReceiptsMessage(null);
+                return ReceiptsMessage.Empty;
             }
 
             if (byteBuffer.GetByte(byteBuffer.ReaderIndex) == Rlp.OfEmptySequence[0])
             {
                 byteBuffer.ReadByte();
-                return new ReceiptsMessage(null);
+                return ReceiptsMessage.Empty;
             }
 
             RlpStream rlpStream = new NettyRlpStream(byteBuffer);


### PR DESCRIPTION
Fix #5116

- Occationally there are unexplainable run with lots of dropping peers. 
- Closer inspection shows that the node is disconnecting peers due to error in forward sync, specifically empty receipt received.
- Anyway, it turns out that there is a bug in the receipt deserialization logic which can get triggered if the first element of the byte buffer allocated in ZeroNettyP2PHandler is equal to Rlp.OfEmptySequence[0].

## Changes

- Fix deserialization bug.
- Added extra check in ProtocolHandlerBase that helped me debug this issue.

## Types of changes

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Can by triggered manually by something like this in `ZeroNettyP2PHandler`.

```
                IByteBuffer output = PooledByteBufferAllocator.Default.Buffer(uncompressedLength + 1);
                output.WriteByte(Rlp.OfEmptySequence[0]);
                output.ReadByte();
```
