### PR TITLE
Minor pipeline allocator cleanup

### DIFF
--- a/src/Nethermind/Nethermind.Network.Test/Rlpx/Handshake/NettyHandshakeHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/Rlpx/Handshake/NettyHandshakeHandlerTests.cs
@@ -131,6 +131,7 @@ namespace Nethermind.Network.Test.Rlpx.Handshake
         {
             NettyHandshakeHandler handler = CreateHandler(HandshakeRole.Initiator);
             bool received = false;
+            _channelHandlerContext.Allocator.Returns(UnpooledByteBufferAllocator.Default);
             _channelHandlerContext.When(x => x.WriteAndFlushAsync(Arg.Is<IByteBuffer>(b => Bytes.AreEqual(b.Array.Slice(b.ArrayOffset, NetTestVectors.AuthEip8.Length), NetTestVectors.AuthEip8))))
                 .Do(c => received = true);
             handler.ChannelActive(_channelHandlerContext);
@@ -203,6 +204,7 @@ namespace Nethermind.Network.Test.Rlpx.Handshake
         {
             bool received = false;
             NettyHandshakeHandler handler = CreateHandler();
+            _channelHandlerContext.Allocator.Returns(UnpooledByteBufferAllocator.Default);
             _channelHandlerContext.When(x => x.WriteAndFlushAsync(Arg.Is<IByteBuffer>(b => Bytes.AreEqual(b.Array.Slice(b.ArrayOffset, NetTestVectors.AckEip8.Length), NetTestVectors.AckEip8))))
                 .Do(_ => received = true);
             handler.ChannelRead(_channelHandlerContext, Unpooled.Buffer(0, 0));

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroNettyP2PHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroNettyP2PHandler.cs
@@ -58,7 +58,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
                 }
 
 
-                IByteBuffer output = PooledByteBufferAllocator.Default.Buffer(uncompressedLength);
+                IByteBuffer output = ctx.Allocator.Buffer(uncompressedLength);
 
                 try
                 {

--- a/src/Nethermind/Nethermind.Network/Rlpx/NettyHandshakeHandler.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/NettyHandshakeHandler.cs
@@ -7,9 +7,7 @@ using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using DotNetty.Buffers;
-using DotNetty.Codecs;
 using DotNetty.Common.Concurrency;
-using DotNetty.Common.Utilities;
 using DotNetty.Handlers.Timeout;
 using DotNetty.Transport.Channels;
 using Nethermind.Core.Crypto;
@@ -65,7 +63,7 @@ namespace Nethermind.Network.Rlpx
                 Packet auth = _service.Auth(RemoteId, _handshake);
 
                 if (_logger.IsTrace) _logger.Trace($"Sending AUTH to {RemoteId} @ {context.Channel.RemoteAddress}");
-                IByteBuffer buffer = PooledByteBufferAllocator.Default.Buffer(auth.Data.Length);
+                IByteBuffer buffer = context.Allocator.Buffer(auth.Data.Length);
                 buffer.WriteBytes(auth.Data);
                 context.WriteAndFlushAsync(buffer);
                 Interlocked.Add(ref Metrics.P2PBytesSent, auth.Data.Length);
@@ -145,7 +143,7 @@ namespace Nethermind.Network.Rlpx
 
                 //_p2PSession.RemoteNodeId = _remoteId;
                 if (_logger.IsTrace) _logger.Trace($"Sending ACK to {RemoteId} @ {context.Channel.RemoteAddress}");
-                IByteBuffer buffer = PooledByteBufferAllocator.Default.Buffer(ack.Data.Length);
+                IByteBuffer buffer = context.Allocator.Buffer(ack.Data.Length);
                 buffer.WriteBytes(ack.Data);
                 context.WriteAndFlushAsync(buffer);
                 Interlocked.Add(ref Metrics.P2PBytesSent, ack.Data.Length);

--- a/src/Nethermind/Nethermind.Network/Rlpx/ZeroFrameDecoder.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/ZeroFrameDecoder.cs
@@ -23,7 +23,7 @@ namespace Nethermind.Network.Rlpx
         private readonly byte[] _decryptedBytes = new byte[Frame.BlockSize];
 
         private FrameDecoderState _state = FrameDecoderState.WaitingForHeader;
-        private IByteBuffer _innerBuffer;
+        private IByteBuffer? _innerBuffer;
         private int _frameSize;
         private int _remainingPayloadBlocks;
 
@@ -32,6 +32,12 @@ namespace Nethermind.Network.Rlpx
             _cipher = frameCipher ?? throw new ArgumentNullException(nameof(frameCipher));
             _authenticator = frameMacProcessor ?? throw new ArgumentNullException(nameof(frameMacProcessor));
             _logger = logManager?.GetClassLogger<ZeroFrameDecoder>() ?? throw new ArgumentNullException(nameof(logManager));
+        }
+
+        public override void HandlerRemoved(IChannelHandlerContext context)
+        {
+            base.HandlerRemoved(context);
+            _innerBuffer?.Release();
         }
 
         protected override void Decode(IChannelHandlerContext context, IByteBuffer input, List<object> output)


### PR DESCRIPTION
- Minor pipeline cleanup.
- Use context allocator where context is available. Its possible to configure the allocator specially for the channel which can be useful in the future to reduce memory limit for example.
- Make sure bytebuffer is released on handler removed.

## Types of changes

#### What types of changes does your code introduce?

- [X] Refactoring (no functional or API changes)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

- Seems to run