### PR TITLE
If batch size is too large, return an error

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc/IJsonRpcConfig.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/IJsonRpcConfig.cs
@@ -125,5 +125,10 @@ namespace Nethermind.JsonRpc
             Description = "Defines which RPC modules should be enabled Execution Engine port. Built in modules are: Admin, Baseline, Clique, Consensus, Db, Debug, Deposit, Erc20, Eth, Evm, Health Mev, NdmConsumer, NdmProvider, Net, Nft, Parity, Personal, Proof, Subscribe, Trace, TxPool, Vault, Web3.",
             DefaultValue = "[Net, Eth, Subscribe, Web3]")]
         string[] EngineEnabledModules { get; set; }
+
+        [ConfigItem(
+            Description = "Limit batch size for batched json rpc call",
+            DefaultValue = "100")]
+        int MaxBatchSize { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcConfig.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcConfig.cs
@@ -43,6 +43,7 @@ namespace Nethermind.JsonRpc
         public string EngineHost { get; set; } = "127.0.0.1";
         public int? EnginePort { get; set; } = null;
         public string[] EngineEnabledModules { get; set; } = ModuleType.DefaultEngineModules.ToArray();
+        public int MaxBatchSize { get; set; } = 100;
     };
 };
 

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
@@ -191,6 +191,14 @@ namespace Nethermind.JsonRpc
                     {
                         if (_logger.IsDebug) _logger.Debug($"{rpcRequest.Collection.Count} JSON RPC requests");
 
+                        if (rpcRequest.Collection.Count > _jsonRpcConfig.MaxBatchSize)
+                        {
+                            JsonRpcErrorResponse? response = _jsonRpcService.GetErrorResponse(ErrorCodes.LimitExceeded, "Batch size limit exceeded");
+
+                            yield return RecordResponse(JsonRpcResult.Single(response, new RpcReport("# error #", 0, false)));
+                            continue;
+                        }
+
                         var responses = new List<JsonRpcResponse>(rpcRequest.Collection.Count);
                         var reports = new List<RpcReport>(rpcRequest.Collection.Count);
                         int requestIndex = 0;


### PR DESCRIPTION
## Changes

- Add limit to batched jsonrpc request, set to 100.

## Types of changes

#### What types of changes does your code introduce?

- [X] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

Manually tested via a python script.