### PR TITLE
Refactor broadcasting for a needs of EIP-4844

### DIFF
--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
@@ -177,9 +177,12 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
 
         public abstract void NotifyOfNewBlock(Block block, SendBlockMode mode);
 
-        public void SendNewTransaction(Transaction tx)
+        public virtual void SendNewTransaction(Transaction tx)
         {
-            SendMessage(new[] { tx });
+            if (tx.Type != TxType.Blob) //protect from sending full blob-type txs
+            {
+                SendMessage(new[] { tx });
+            }
         }
 
         public virtual void SendNewTransactions(IEnumerable<Transaction> txs, bool sendFullTx = false)

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
@@ -198,7 +198,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
                     txsToSend.Clear();
                 }
 
-                if (tx.Hash is not null)
+                if (tx.Hash is not null && tx.Type != TxType.Blob) //protect from sending full blob-type txs
                 {
                     txsToSend.Add(tx);
                     TxPool.Metrics.PendingTransactionsSent++;

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
@@ -87,6 +87,18 @@ public class Eth68ProtocolHandler : Eth67ProtocolHandler
                          $"in {stopwatch.Elapsed.TotalMilliseconds}ms");
     }
 
+    public override void SendNewTransaction(Transaction tx)
+    {
+        if (tx.Type != TxType.Blob)
+        {
+            base.SendNewTransaction(tx);
+        }
+        else
+        {
+            SendMessage(new byte[] {(byte)tx.Type}, new int[] {tx.GetLength(_txDecoder)}, new Keccak[] {tx.Hash});
+        }
+    }
+
     public override void SendNewTransactions(IEnumerable<Transaction> txs, bool sendFullTx)
     {
         if (sendFullTx)

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
@@ -95,7 +95,7 @@ public class Eth68ProtocolHandler : Eth67ProtocolHandler
         }
         else
         {
-            SendMessage(new byte[] {(byte)tx.Type}, new int[] {tx.GetLength(_txDecoder)}, new Keccak[] {tx.Hash});
+            SendMessage(new byte[] { (byte)tx.Type }, new int[] { tx.GetLength(_txDecoder) }, new Keccak[] { tx.Hash });
         }
     }
 

--- a/src/Nethermind/Nethermind.TxPool.Test/TxBroadcasterTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxBroadcasterTests.cs
@@ -122,7 +122,7 @@ public class TxBroadcasterTests
         {
             transactions[i] = Build.A.Transaction
                 .WithGasPrice(i.GWei())
-                .WithType(i%10 == 0 ? TxType.Blob : TxType.Legacy) //some part of txs (10%) is blob type
+                .WithType(i % 10 == 0 ? TxType.Blob : TxType.Legacy) //some part of txs (10%) is blob type
                 .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeys[i])
                 .TestObject;
 

--- a/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
@@ -156,7 +156,7 @@ namespace Nethermind.TxPool
             {
                 if (numberOfPersistentTxsToBroadcast > 0)
                 {
-                    if (tx.MaxFeePerGas >= _headInfo.CurrentBaseFee)
+                    if (tx.MaxFeePerGas >= _headInfo.CurrentBaseFee && tx.Type != TxType.Blob)
                     {
                         numberOfPersistentTxsToBroadcast--;
                         persistentTxsToSend.Add(tx);


### PR DESCRIPTION
Closes #4968

## Changes

In sending local tx immediately after receiving it:
- to peers connected via `eth67` or lower, not send blob tx at all (added checks in `SyncPeerProtocolHandlerBase`)
- to peers connected via `eth68` or higher, send hash of blob tx (added logic in `Eth68ProtocolHandler`)

In sending persistent txs after processing every new block:
- just skip blob txs when preparing msg to send (I also consider sending blob txs as hashes here)

Sending new form of `NewPooledTransactionHashesMessage` with hashes of recently added txs (not local) is already implemented in `Eth68ProtocolHandler`

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or a feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional or API changes)
- [ ] Build-related changes
- [ ] Other: _description_ 

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

## Remarks

We might need to add broadcasting hashes of blob txs from persistent broadcast - right now there is actually no point in adding blob txs to persistent txs, as we are not broadcasting it later at all (we broadcast it only once, just after adding). In current implementation we use method `SendNewTransactions` with flag `sendFullTx` and send full txs or just hashes according to it. If we will use it with blob txs which are way heavier than current txs, it might have bad impact for performance. I think we will need to refactor `ITxPoolPeer` - add new method like `SendNewTxHashes` and drop flag `sendFullTx` in `SendNewTransactions`. This way we will be able to allocate only array of hashes of blob txs instead of array of full blob txs. For now I think rebroadcasting blob txs is not must-have functionality, so I sent PR to deliver the most important ones and may need to add it in the future.