### PR TITLE
Refactor TxBroadcaster to limit messages by size

### DIFF
--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandlerTests.cs
@@ -25,6 +25,7 @@ using Nethermind.Network.P2P.Subprotocols.Eth.V62;
 using Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages;
 using Nethermind.Network.Rlpx;
 using Nethermind.Network.Test.Builders;
+using Nethermind.Serialization.Rlp;
 using Nethermind.Stats;
 using Nethermind.Stats.Model;
 using Nethermind.Synchronization;
@@ -44,6 +45,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
         private Block _genesisBlock;
         private Eth62ProtocolHandler _handler;
         private IGossipPolicy _gossipPolicy;
+        private readonly TxDecoder _txDecoder = new();
 
         [SetUp]
         public void Setup()
@@ -448,10 +450,10 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
             _handler.SubprotocolRequested -= HandlerOnSubprotocolRequested;
         }
 
-        [TestCase(1)]
-        [TestCase(255)]
-        [TestCase(256)]
-        public void should_send_up_to_256_txs_in_one_TransactionsMessage(int txCount)
+        [TestCase(1, true)]
+        [TestCase(1055, true)]
+        [TestCase(1056, false)]
+        public void should_send_txs_with_size_up_to_MaxPacketSize_in_one_TransactionsMessage(int txCount, bool shouldBeSentInJustOneMessage)
         {
             Transaction[] txs = new Transaction[txCount];
 
@@ -462,17 +464,30 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
 
             _handler.SendNewTransactions(txs);
 
-            _session.Received(1).DeliverMessage(Arg.Is<TransactionsMessage>(m => m.Transactions.Count == txCount));
+            if (shouldBeSentInJustOneMessage)
+            {
+                _session.Received(1).DeliverMessage(Arg.Is<TransactionsMessage>(m => m.Transactions.Count == txCount));
+
+            }
+            else
+            {
+                _session.Received(2).DeliverMessage(Arg.Any<TransactionsMessage>());
+            }
         }
 
         [TestCase(257)]
         [TestCase(300)]
+        [TestCase(1055)]
+        [TestCase(1056)]
         [TestCase(1500)]
         [TestCase(10000)]
-        public void should_send_more_than_256_txs_in_more_than_one_TransactionsMessage(int txCount)
+        public void should_send_txs_with_size_exceeding_MaxPacketSize_in_more_than_one_TransactionsMessage(int txCount)
         {
-            int messagesCount = txCount / 256 + 1;
-            int nonFullMsgTxsCount = txCount % 256;
+            int sizeOfOneTestTransaction = _txDecoder.GetLength(Build.A.Transaction.SignedAndResolved().TestObject);
+            int maxNumberOfTxsInOneMsg = TransactionsMessage.MaxPacketSize / sizeOfOneTestTransaction; // it's 1055
+            int nonFullMsgTxsCount = txCount % maxNumberOfTxsInOneMsg;
+            int messagesCount = txCount / maxNumberOfTxsInOneMsg + (nonFullMsgTxsCount > 0 ? 1 : 0);
+
             Transaction[] txs = new Transaction[txCount];
 
             for (int i = 0; i < txCount; i++)
@@ -482,7 +497,34 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
 
             _handler.SendNewTransactions(txs);
 
-            _session.Received(messagesCount).DeliverMessage(Arg.Is<TransactionsMessage>(m => m.Transactions.Count == 256 || m.Transactions.Count == nonFullMsgTxsCount));
+            _session.Received(messagesCount).DeliverMessage(Arg.Is<TransactionsMessage>(m => m.Transactions.Count == maxNumberOfTxsInOneMsg || m.Transactions.Count == nonFullMsgTxsCount));
+        }
+
+        [TestCase(0)]
+        [TestCase(128)]
+        [TestCase(4096)]
+        [TestCase(100000)]
+        [TestCase(102400)]
+        [TestCase(222222)]
+        public void should_send_single_transaction_even_if_exceed_MaxPacketSize(int dataSize)
+        {
+            int txCount = 512; //we will try to send 512 txs
+            Transaction tx = Build.A.Transaction.WithData(new byte[dataSize]).SignedAndResolved().TestObject;
+            int sizeOfOneTx = tx.GetLength(new TxDecoder());
+            int numberOfTxsInOneMsg = Math.Max(TransactionsMessage.MaxPacketSize / sizeOfOneTx, 1);
+            int nonFullMsgTxsCount = txCount % numberOfTxsInOneMsg;
+            int messagesCount = Math.Min(txCount / numberOfTxsInOneMsg + (nonFullMsgTxsCount > 0 ? 1 : 0), txCount);
+
+            Transaction[] txs = new Transaction[txCount];
+
+            for (int i = 0; i < txCount; i++)
+            {
+                txs[i] = tx;
+            }
+
+            _handler.SendNewTransactions(txs);
+
+            _session.Received(messagesCount).DeliverMessage(Arg.Is<TransactionsMessage>(m => m.Transactions.Count == numberOfTxsInOneMsg || m.Transactions.Count == nonFullMsgTxsCount));
         }
 
         private void HandleZeroMessage<T>(T msg, int messageCode) where T : MessageBase

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandlerTests.cs
@@ -467,7 +467,6 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
             if (shouldBeSentInJustOneMessage)
             {
                 _session.Received(1).DeliverMessage(Arg.Is<TransactionsMessage>(m => m.Transactions.Count == txCount));
-
             }
             else
             {
@@ -513,7 +512,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
             int sizeOfOneTx = tx.GetLength(new TxDecoder());
             int numberOfTxsInOneMsg = Math.Max(TransactionsMessage.MaxPacketSize / sizeOfOneTx, 1);
             int nonFullMsgTxsCount = txCount % numberOfTxsInOneMsg;
-            int messagesCount = Math.Min(txCount / numberOfTxsInOneMsg + (nonFullMsgTxsCount > 0 ? 1 : 0), txCount);
+            int messagesCount = txCount / numberOfTxsInOneMsg + (nonFullMsgTxsCount > 0 ? 1 : 0);
 
             Transaction[] txs = new Transaction[txCount];
 

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandlerTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using System.Net;
 using FluentAssertions;
 using Nethermind.Consensus;
@@ -138,7 +139,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V65
                     return true;
                 });
             GetPooledTransactionsMessage request = new(TestItem.Keccaks);
-            PooledTransactionsMessage response = _handler.FulfillPooledTransactionsRequest(request);
+            PooledTransactionsMessage response = _handler.FulfillPooledTransactionsRequest(request, new List<Transaction>());
             response.Transactions.Count.Should().Be(numberOfTxsInOneMsg);
         }
 
@@ -162,7 +163,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V65
                     return true;
                 });
             GetPooledTransactionsMessage request = new(new Keccak[2048]);
-            PooledTransactionsMessage response = _handler.FulfillPooledTransactionsRequest(request);
+            PooledTransactionsMessage response = _handler.FulfillPooledTransactionsRequest(request, new List<Transaction>());
             response.Transactions.Count.Should().Be(numberOfTxsInOneMsg);
         }
     }

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandlerTests.cs
@@ -1,18 +1,22 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Net;
 using FluentAssertions;
 using Nethermind.Consensus;
 using Nethermind.Core;
+using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Core.Timers;
 using Nethermind.Logging;
 using Nethermind.Network.P2P;
+using Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages;
 using Nethermind.Network.P2P.Subprotocols.Eth.V65;
 using Nethermind.Network.P2P.Subprotocols.Eth.V65.Messages;
 using Nethermind.Network.Test.Builders;
+using Nethermind.Serialization.Rlp;
 using Nethermind.Stats;
 using Nethermind.Stats.Model;
 using Nethermind.Synchronization;
@@ -101,13 +105,14 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V65
             _session.Received(1).DeliverMessage(Arg.Is<NewPooledTransactionHashesMessage>(m => m.Hashes.Count == txCount));
         }
 
-        [TestCase(3201)]
+        [TestCase(NewPooledTransactionHashesMessage.MaxCount - 1)]
+        [TestCase(NewPooledTransactionHashesMessage.MaxCount)]
         [TestCase(10000)]
         [TestCase(20000)]
         public void should_send_more_than_MaxCount_hashes_in_more_than_one_NewPooledTransactionHashesMessage(int txCount)
         {
-            int messagesCount = txCount / NewPooledTransactionHashesMessage.MaxCount + 1;
             int nonFullMsgTxsCount = txCount % NewPooledTransactionHashesMessage.MaxCount;
+            int messagesCount = txCount / NewPooledTransactionHashesMessage.MaxCount + (nonFullMsgTxsCount > 0 ? 1 : 0);
             Transaction[] txs = new Transaction[txCount];
 
             for (int i = 0; i < txCount; i++)
@@ -118,6 +123,47 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V65
             _handler.SendNewTransactions(txs, false);
 
             _session.Received(messagesCount).DeliverMessage(Arg.Is<NewPooledTransactionHashesMessage>(m => m.Hashes.Count == NewPooledTransactionHashesMessage.MaxCount || m.Hashes.Count == nonFullMsgTxsCount));
+        }
+
+        [Test]
+        public void should_send_requested_PooledTransactions_up_to_MaxPacketSize()
+        {
+            Transaction tx = Build.A.Transaction.WithData(new byte[1024]).SignedAndResolved().TestObject;
+            int sizeOfOneTx = tx.GetLength(new TxDecoder());
+            int numberOfTxsInOneMsg = TransactionsMessage.MaxPacketSize / sizeOfOneTx;
+            _transactionPool.TryGetPendingTransaction(Arg.Any<Keccak>(), out Arg.Any<Transaction>())
+                .Returns(x =>
+                {
+                    x[1] = tx;
+                    return true;
+                });
+            GetPooledTransactionsMessage request = new(TestItem.Keccaks);
+            PooledTransactionsMessage response = _handler.FulfillPooledTransactionsRequest(request);
+            response.Transactions.Count.Should().Be(numberOfTxsInOneMsg);
+        }
+
+        [TestCase(0)]
+        [TestCase(1)]
+        [TestCase(2)]
+        [TestCase(32)]
+        [TestCase(4096)]
+        [TestCase(100000)]
+        [TestCase(102400)]
+        [TestCase(222222)]
+        public void should_send_single_requested_PooledTransaction_even_if_exceed_MaxPacketSize(int dataSize)
+        {
+            Transaction tx = Build.A.Transaction.WithData(new byte[dataSize]).SignedAndResolved().TestObject;
+            int sizeOfOneTx = tx.GetLength(new TxDecoder());
+            int numberOfTxsInOneMsg = Math.Max(TransactionsMessage.MaxPacketSize / sizeOfOneTx, 1);
+            _transactionPool.TryGetPendingTransaction(Arg.Any<Keccak>(), out Arg.Any<Transaction>())
+                .Returns(x =>
+                {
+                    x[1] = tx;
+                    return true;
+                });
+            GetPooledTransactionsMessage request = new(new Keccak[2048]);
+            PooledTransactionsMessage response = _handler.FulfillPooledTransactionsRequest(request);
+            response.Transactions.Count.Should().Be(numberOfTxsInOneMsg);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandlerTests.cs
@@ -168,13 +168,14 @@ public class Eth68ProtocolHandlerTests
         _session.Received(1).DeliverMessage(Arg.Is<NewPooledTransactionHashesMessage68>(m => m.Hashes.Count == txCount));
     }
 
-    [TestCase(3201)]
+    [TestCase(NewPooledTransactionHashesMessage68.MaxCount - 1)]
+    [TestCase(NewPooledTransactionHashesMessage68.MaxCount)]
     [TestCase(10000)]
     [TestCase(20000)]
     public void should_send_more_than_MaxCount_hashes_in_more_than_one_NewPooledTransactionHashesMessage68(int txCount)
     {
-        int messagesCount = txCount / NewPooledTransactionHashesMessage68.MaxCount + 1;
         int nonFullMsgTxsCount = txCount % NewPooledTransactionHashesMessage68.MaxCount;
+        int messagesCount = txCount / NewPooledTransactionHashesMessage68.MaxCount + (nonFullMsgTxsCount > 0 ? 1 : 0);
         Transaction[] txs = new Transaction[txCount];
 
         for (int i = 0; i < txCount; i++)

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandlerTests.cs
@@ -151,6 +151,42 @@ public class Eth68ProtocolHandlerTests
             Arg.Any<IReadOnlyList<Keccak>>());
     }
 
+    [TestCase(1)]
+    [TestCase(NewPooledTransactionHashesMessage68.MaxCount - 1)]
+    [TestCase(NewPooledTransactionHashesMessage68.MaxCount)]
+    public void should_send_up_to_MaxCount_hashes_in_one_NewPooledTransactionHashesMessage68(int txCount)
+    {
+        Transaction[] txs = new Transaction[txCount];
+
+        for (int i = 0; i < txCount; i++)
+        {
+            txs[i] = Build.A.Transaction.SignedAndResolved().TestObject;
+        }
+
+        _handler.SendNewTransactions(txs, false);
+
+        _session.Received(1).DeliverMessage(Arg.Is<NewPooledTransactionHashesMessage68>(m => m.Hashes.Count == txCount));
+    }
+
+    [TestCase(3201)]
+    [TestCase(10000)]
+    [TestCase(20000)]
+    public void should_send_more_than_MaxCount_hashes_in_more_than_one_NewPooledTransactionHashesMessage68(int txCount)
+    {
+        int messagesCount = txCount / NewPooledTransactionHashesMessage68.MaxCount + 1;
+        int nonFullMsgTxsCount = txCount % NewPooledTransactionHashesMessage68.MaxCount;
+        Transaction[] txs = new Transaction[txCount];
+
+        for (int i = 0; i < txCount; i++)
+        {
+            txs[i] = Build.A.Transaction.SignedAndResolved().TestObject;
+        }
+
+        _handler.SendNewTransactions(txs, false);
+
+        _session.Received(messagesCount).DeliverMessage(Arg.Is<NewPooledTransactionHashesMessage68>(m => m.Hashes.Count == NewPooledTransactionHashesMessage68.MaxCount || m.Hashes.Count == nonFullMsgTxsCount));
+    }
+
     private void HandleIncomingStatusMessage()
     {
         var statusMsg = new StatusMessage();

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core;
-using Nethermind.Core.Attributes;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
@@ -17,9 +16,9 @@ using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.Network.P2P.Subprotocols.Eth.V62;
 using Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages;
-using Nethermind.Network.P2P.Subprotocols.Eth.V63;
 using Nethermind.Network.P2P.Subprotocols.Eth.V63.Messages;
 using Nethermind.Network.Rlpx;
+using Nethermind.Serialization.Rlp;
 using Nethermind.Stats;
 using Nethermind.Stats.Model;
 using Nethermind.Synchronization;
@@ -48,6 +47,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
 
         protected Keccak _remoteHeadBlockHash;
         protected readonly ITimestamper _timestamper;
+        protected readonly TxDecoder _txDecoder;
 
         protected readonly MessageQueue<GetBlockHeadersMessage, BlockHeader[]> _headersRequests;
         protected readonly MessageQueue<GetBlockBodiesMessage, BlockBody[]> _bodiesRequests;
@@ -60,6 +60,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
         {
             SyncServer = syncServer ?? throw new ArgumentNullException(nameof(syncServer));
             _timestamper = Timestamper.Default;
+            _txDecoder = new TxDecoder();
             _headersRequests = new MessageQueue<GetBlockHeadersMessage, BlockHeader[]>(Send);
             _bodiesRequests = new MessageQueue<GetBlockBodiesMessage, BlockBody[]>(Send);
         }
@@ -184,20 +185,24 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
 
         public virtual void SendNewTransactions(IEnumerable<Transaction> txs, bool sendFullTx = false)
         {
-            const int maxCapacity = 256;
-            using ArrayPoolList<Transaction> txsToSend = new(maxCapacity);
+            int packetSizeLeft = TransactionsMessage.MaxPacketSize;
+            using ArrayPoolList<Transaction> txsToSend = new(1024);
 
             foreach (Transaction tx in txs)
             {
-                if (txsToSend.Count == maxCapacity)
+                int txSize = tx.GetLength(_txDecoder);
+
+                if (txSize > packetSizeLeft && txsToSend.Count > 0)
                 {
                     SendMessage(txsToSend);
                     txsToSend.Clear();
+                    packetSizeLeft = TransactionsMessage.MaxPacketSize;
                 }
 
                 if (tx.Hash is not null)
                 {
                     txsToSend.Add(tx);
+                    packetSizeLeft -= txSize;
                     TxPool.Metrics.PendingTransactionsSent++;
                 }
             }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Messages/TransactionsMessage.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Messages/TransactionsMessage.cs
@@ -9,9 +9,12 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages
 {
     public class TransactionsMessage : P2PMessage
     {
+        // This is the target size for the packs of transactions. A pack can get larger than this if a single
+        // transaction exceeds this size. This solution is similar to Geth one.
+        public const int MaxPacketSize = 102400;
+
         public override int PacketType { get; } = Eth62MessageCode.Transactions;
         public override string Protocol { get; } = "eth";
-
         public IList<Transaction> Transactions { get; }
 
         public TransactionsMessage(IList<Transaction> transactions)

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandler.cs
@@ -100,7 +100,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V65
             GetPooledTransactionsMessage msg)
         {
             int packetSizeLeft = TransactionsMessage.MaxPacketSize;
-            using ArrayPoolList<Transaction> txsToSend = new(1024);
+            List<Transaction> txsToSend = new();
             for (int i = 0; i < msg.Hashes.Count; i++)
             {
                 if (_txPool.TryGetPendingTransaction(msg.Hashes[i], out Transaction tx))

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandler.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -9,8 +8,8 @@ using Nethermind.Consensus;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
-using Nethermind.Core.Specs;
 using Nethermind.Logging;
+using Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages;
 using Nethermind.Network.P2P.Subprotocols.Eth.V64;
 using Nethermind.Network.P2P.Subprotocols.Eth.V65.Messages;
 using Nethermind.Network.Rlpx;
@@ -97,20 +96,28 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V65
                              $"in {stopwatch.Elapsed.TotalMilliseconds}ms");
         }
 
-        protected PooledTransactionsMessage FulfillPooledTransactionsRequest(
+        internal PooledTransactionsMessage FulfillPooledTransactionsRequest(
             GetPooledTransactionsMessage msg)
         {
-            List<Transaction> txs = new();
-            int responseSize = Math.Min(256, msg.Hashes.Count);
-            for (int i = 0; i < responseSize; i++)
+            int packetSizeLeft = TransactionsMessage.MaxPacketSize;
+            using ArrayPoolList<Transaction> txsToSend = new(1024);
+            for (int i = 0; i < msg.Hashes.Count; i++)
             {
                 if (_txPool.TryGetPendingTransaction(msg.Hashes[i], out Transaction tx))
                 {
-                    txs.Add(tx);
+                    int txSize = tx.GetLength(_txDecoder);
+
+                    if (txSize > packetSizeLeft && txsToSend.Count > 0)
+                    {
+                        break;
+                    }
+
+                    txsToSend.Add(tx);
+                    packetSizeLeft -= txSize;
                 }
             }
 
-            return new PooledTransactionsMessage(txs);
+            return new PooledTransactionsMessage(txsToSend);
         }
 
         public override void SendNewTransactions(IEnumerable<Transaction> txs, bool sendFullTx)

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandler.cs
@@ -91,7 +91,6 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V65
             Stopwatch stopwatch = Stopwatch.StartNew();
             using ArrayPoolList<Transaction> txsToSend = new(1024);
             Send(FulfillPooledTransactionsRequest(msg, txsToSend));
-            txsToSend.Dispose();
             stopwatch.Stop();
             if (Logger.IsTrace)
                 Logger.Trace($"OUT {Counter:D5} {nameof(GetPooledTransactionsMessage)} to {Node:c} " +

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/Messages/NewPooledTransactionHashesMessage.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/Messages/NewPooledTransactionHashesMessage.cs
@@ -8,6 +8,8 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V65.Messages
 {
     public class NewPooledTransactionHashesMessage : HashesMessage
     {
+        // we are able to safely send message with up to 3102 hashes to not exceed message size of 102400 bytes
+        // which is used by Geth and us as max message size. (3102 items message has 102370 bytes)
         public const int MaxCount = 2048;
 
         public override int PacketType { get; } = Eth65MessageCode.NewPooledTransactionHashes;

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandler.cs
@@ -8,7 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Consensus;
 using Nethermind.Core;
-using Nethermind.Core.Specs;
+using Nethermind.Core.Collections;
 using Nethermind.Logging;
 using Nethermind.Network.P2P.Messages;
 using Nethermind.Network.P2P.Subprotocols.Eth.V65;
@@ -147,9 +147,12 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
 
         private void Handle(GetPooledTransactionsMessage getPooledTransactions)
         {
-            V65.Messages.PooledTransactionsMessage pooledTransactionsMessage =
-                FulfillPooledTransactionsRequest(getPooledTransactions.EthMessage);
-            Send(new PooledTransactionsMessage(getPooledTransactions.RequestId, pooledTransactionsMessage));
+            using ArrayPoolList<Transaction> txsToSend = new(1024);
+
+            Send(new PooledTransactionsMessage(getPooledTransactions.RequestId,
+                FulfillPooledTransactionsRequest(getPooledTransactions.EthMessage, txsToSend)));
+
+            txsToSend.Dispose();
         }
 
         private void Handle(GetReceiptsMessage getReceiptsMessage)

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandler.cs
@@ -151,8 +151,6 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
 
             Send(new PooledTransactionsMessage(getPooledTransactions.RequestId,
                 FulfillPooledTransactionsRequest(getPooledTransactions.EthMessage, txsToSend)));
-
-            txsToSend.Dispose();
         }
 
         private void Handle(GetReceiptsMessage getReceiptsMessage)

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
@@ -7,13 +7,11 @@ using Nethermind.Consensus;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
-using Nethermind.Core.Specs;
 using Nethermind.Logging;
 using Nethermind.Network.P2P.Subprotocols.Eth.V65;
 using Nethermind.Network.P2P.Subprotocols.Eth.V67;
 using Nethermind.Network.P2P.Subprotocols.Eth.V68.Messages;
 using Nethermind.Network.Rlpx;
-using Nethermind.Serialization.Rlp;
 using Nethermind.Stats;
 using Nethermind.Synchronization;
 using Nethermind.TxPool;
@@ -23,7 +21,6 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V68;
 public class Eth68ProtocolHandler : Eth67ProtocolHandler
 {
     private readonly IPooledTxsRequestor _pooledTxsRequestor;
-    private readonly TxDecoder _txDecoder = new();
 
     public override string Name => "eth68";
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Messages/NewPooledTransactionHashesMessage68.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Messages/NewPooledTransactionHashesMessage68.cs
@@ -9,7 +9,9 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V68.Messages
 {
     public class NewPooledTransactionHashesMessage68 : P2PMessage
     {
-        public const int MaxCount = 1024;
+        // we are able to safely send message with up to 2925 hashes+types+lengths to not exceed message size
+        // of 102400 bytes which is used by Geth and us as max message size. (2925 items message has 102385 bytes)
+        public const int MaxCount = 2048;
 
         public override int PacketType { get; } = Eth68MessageCode.NewPooledTransactionHashes;
         public override string Protocol { get; } = "eth";


### PR DESCRIPTION
Closes #4917

## Changes

- increase max count of hashes in `NewPooledTransactionHashesMessage68` from 1024 to 2048 to be the same as in old `eth65` hashes msg
- add field `MaxPacketSize` in `TransactionsMessage`. Max size is 102400 bytes, same as in Geth (https://github.com/ethereum/go-ethereum/blob/793f0f9ec860f6f51e0cec943a268c10863097c7/eth/protocols/eth/broadcast.go#L29)
- refactor `FulfillPooledTransactionsRequest` in `Eth65ProtocolHandler` to limit `PooledTransactionsMessage` by accumulative size of txs instead of tx count
- refactor `SendNewTransactions` in `SyncPeerProtocolHandlerBase` to limit `TransactionsMessage` by accumulative size of txs instead of tx count

## Types of changes

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or a feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional or API changes)
- [ ] Build-related changes
- [ ] Other: _description_ 

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No