### PR TITLE
Add IZeroProtocolHandler interface to ZeroProtocolHandlerBase

### DIFF
--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroProtocolHandlerBase.cs
@@ -12,7 +12,7 @@ using Nethermind.Stats;
 
 namespace Nethermind.Network.P2P.ProtocolHandlers
 {
-    public abstract class ZeroProtocolHandlerBase : ProtocolHandlerBase
+    public abstract class ZeroProtocolHandlerBase : ProtocolHandlerBase, IZeroProtocolHandler
     {
         protected ZeroProtocolHandlerBase(ISession session, INodeStatsManager nodeStats, IMessageSerializationService serializer, ILogManager logManager)
             : base(session, nodeStats, serializer, logManager)


### PR DESCRIPTION
- `ZeroProtocolHandlerBase` does not implement `IZeroProtocolHandler` so subclass (SnapProtocolHandler) will have it's packet copied from a `ZeroPacket` to a `Packet` in `Session`, then copied back again to `ZeroPacket` in `ZeroProtocolHandlerBase`. 

## Changes

- Implement IZeroProtocolHandler.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)
- [X] Perf?

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

- Mainnet can sync
