### PR TITLE
Bugfix/eip3860 reject invalid TXs from TxPool

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionSelectorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionSelectorTests.cs
@@ -71,7 +71,7 @@ namespace Nethermind.Blockchain.Test
 
                 ProperTransactionsSelectedTestCase balanceCheckWithTxValue = new()
                 {
-                    Eip1559Enabled = true,
+                    ReleaseSpec = London.Instance,
                     BaseFee = 5,
                     AccountStates = { { TestItem.AddressA, (300, 1) } },
                     Transactions =
@@ -111,7 +111,7 @@ namespace Nethermind.Blockchain.Test
 
                 ProperTransactionsSelectedTestCase balanceCheckWithTxValue = new()
                 {
-                    Eip1559Enabled = true,
+                    ReleaseSpec = London.Instance,
                     BaseFee = 5,
                     AccountStates = { { TestItem.AddressA, (400, 1) } },
                     Transactions =
@@ -129,7 +129,7 @@ namespace Nethermind.Blockchain.Test
 
                 ProperTransactionsSelectedTestCase balanceCheckWithGasPremium = new()
                 {
-                    Eip1559Enabled = true,
+                    ReleaseSpec = London.Instance,
                     BaseFee = 5,
                     AccountStates = { { TestItem.AddressA, (400, 1) } },
                     Transactions =
@@ -182,10 +182,7 @@ namespace Nethermind.Blockchain.Test
             IBlockTree blockTree = Substitute.For<IBlockTree>();
             Block block = Build.A.Block.WithNumber(0).TestObject;
             blockTree.Head.Returns(block);
-            IReleaseSpec spec = new ReleaseSpec()
-            {
-                IsEip1559Enabled = testCase.Eip1559Enabled
-            };
+            IReleaseSpec spec = testCase.ReleaseSpec;
             specProvider.GetSpec(Arg.Any<long>(), Arg.Any<ulong?>()).Returns(spec);
             specProvider.GetSpec(Arg.Any<BlockHeader>()).Returns(spec);
             specProvider.GetSpec(Arg.Any<ForkActivation>()).Returns(spec);
@@ -233,7 +230,7 @@ namespace Nethermind.Blockchain.Test
         public List<Transaction> ExpectedSelectedTransactions { get; } = new();
         public UInt256 MinGasPriceForMining { get; set; } = 1;
 
-        public bool Eip1559Enabled { get; set; }
+        public IReleaseSpec ReleaseSpec { get; set; }
 
         public UInt256 BaseFee { get; set; }
 
@@ -250,13 +247,14 @@ namespace Nethermind.Blockchain.Test
                     Build.A.Transaction.WithSenderAddress(TestItem.AddressA).WithNonce(2).WithValue(10)
                         .WithGasPrice(10).WithGasLimit(10).SignedAndResolved(TestItem.PrivateKeyA).TestObject
                 },
-                GasLimit = 10000000
+                GasLimit = 10000000,
+                ReleaseSpec = Berlin.Instance
             };
 
         public static ProperTransactionsSelectedTestCase Eip1559DefaultLegacyTransactions =>
             new()
             {
-                Eip1559Enabled = true,
+                ReleaseSpec = London.Instance,
                 BaseFee = 1.GWei(),
                 AccountStates = { { TestItem.AddressA, (1000, 1) } },
                 Transactions =
@@ -274,7 +272,7 @@ namespace Nethermind.Blockchain.Test
         public static ProperTransactionsSelectedTestCase Eip1559Default =>
             new()
             {
-                Eip1559Enabled = true,
+                ReleaseSpec = London.Instance,
                 BaseFee = 1.GWei(),
                 AccountStates = { { TestItem.AddressA, (1000, 1) } },
                 Transactions =

--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionsExecutorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionsExecutorTests.cs
@@ -187,28 +187,7 @@ namespace Nethermind.Blockchain.Test
             }
         }
 
-        public static IEnumerable Eip3860TestCases
-        {
-            get
-            {
-                ProperTransactionsSelectedTestCase balanceBelowMaxFeeTimesGasLimit = new()
-                {
-                    ReleaseSpec = Shanghai.Instance,
-                    BaseFee = 5,
-                    AccountStates = { { TestItem.AddressA, (400, 1) } },
-                    Transactions =
-                    {
-                        Build.A.Transaction.WithSenderAddress(TestItem.AddressA).WithNonce(1)
-                            .WithMaxFeePerGas(45).WithMaxPriorityFeePerGas(25).WithGasLimit(10).WithType(TxType.EIP1559).WithValue(60).SignedAndResolved(TestItem.PrivateKeyA).TestObject
-                    },
-                    GasLimit = 10000000
-                };
-                yield return new TestCaseData(balanceBelowMaxFeeTimesGasLimit).SetName("EIP3860 Transactions");
-            }
-        }
-
         [TestCaseSource(nameof(ProperTransactionsSelectedTestCases))]
-        [TestCaseSource(nameof(Eip3860TestCases))]
         public void Proper_transactions_selected(ProperTransactionsSelectedTestCase testCase)
         {
             MemDb stateDb = new();

--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionsExecutorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionsExecutorTests.cs
@@ -283,41 +283,5 @@ namespace Nethermind.Blockchain.Test
             txExecutor.ProcessTransactions(blockToProduce, ProcessingOptions.ProducingBlock, receiptsTracer, spec);
             blockToProduce.Transactions.Should().BeEquivalentTo(testCase.ExpectedSelectedTransactions);
         }
-        //
-        // [Test]
-        // public void Cannot_pick_transaction_with_initicode_above_maxinitcode_when_EIP3860_enabled()
-        // {
-        //     MemDb stateDb = new();
-        //     MemDb codeDb = new();
-        //     TrieStore trieStore = new(stateDb, LimboLogs.Instance);
-        //     StateProvider stateProvider = new(trieStore, codeDb, LimboLogs.Instance);
-        //     IStorageProvider storageProvider = Substitute.For<IStorageProvider>();
-        //     ISpecProvider specProvider = Substitute.For<ISpecProvider>();
-        //     ITransactionProcessor transactionProcessor = Substitute.For<ITransactionProcessor>();
-        //     var txArray =
-        //     {
-        //         Build.A.Transaction.WithSenderAddress(TestItem.AddressA).WithNonce(3)
-        //             .WithGasPrice(60).WithGasLimit(10).SignedAndResolved(TestItem.PrivateKeyA).TestObject,
-        //         Build.A.Transaction.WithSenderAddress(TestItem.AddressA).WithNonce(1)
-        //             .WithGasPrice(30).WithGasLimit(10).SignedAndResolved(TestItem.PrivateKeyA).TestObject,
-        //         Build.A.Transaction.WithSenderAddress(TestItem.AddressA).WithNonce(2)
-        //             .WithGasPrice(20).WithGasLimit(10).SignedAndResolved(TestItem.PrivateKeyA).TestObject
-        //     };
-        //     BlockProcessor.BlockProductionTransactionsExecutor txExecutor =
-        //         new(
-        //             transactionProcessor,
-        //             stateProvider,
-        //             storageProvider,
-        //             specProvider,
-        //             LimboLogs.Instance);
-        //     Block block = Build.A.Block
-        //         .WithNumber(0)
-        //         .WithTransactions(txArray)
-        //         .TestObject;
-        //     BlockToProduce blockToProduce = new(block.Header, block.Transactions, block.Uncles);
-        //     txExecutor.ProcessTransactions(blockToProduce, ProcessingOptions.ProducingBlock, NullTxTracer.Instance, spec);
-        //     blockToProduce.Transactions.Should().BeEquivalentTo(testCase.ExpectedSelectedTransactions);
-        //
-        // }
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
@@ -217,12 +217,14 @@ namespace Nethermind.Blockchain.Test.Validators
             return txValidator.IsWellFormed(tx, London.Instance);
         }
 
-        [TestCase(true)]
-        [TestCase(false)]
-        public void Transaction_with_init_code_above_max_value_is_rejected_when_eip3860Enabled(bool eip3860Enabled)
+        [TestCase(true, 1, false)]
+        [TestCase(false, 1, true)]
+        [TestCase(true, -1, true)]
+        [TestCase(false, -1, true)]
+        public void Transaction_with_init_code_above_max_value_is_rejected_when_eip3860Enabled(bool eip3860Enabled, int dataSizeAboveInitCode, bool expectedResult)
         {
             IReleaseSpec releaseSpec = eip3860Enabled ? Shanghai.Instance : GrayGlacier.Instance;
-            byte[] initCode = Enumerable.Repeat((byte)0x20, (int)releaseSpec.MaxInitCodeSize + 1).ToArray();
+            byte[] initCode = Enumerable.Repeat((byte)0x20, (int)releaseSpec.MaxInitCodeSize + dataSizeAboveInitCode).ToArray();
             byte[] sigData = new byte[65];
             sigData[31] = 1; // correct r
             sigData[63] = 1; // correct s
@@ -236,7 +238,7 @@ namespace Nethermind.Blockchain.Test.Validators
                 .WithData(initCode).TestObject;
 
             TxValidator txValidator = new(1);
-            txValidator.IsWellFormed(tx, releaseSpec).Should().Be(!eip3860Enabled);
+            txValidator.IsWellFormed(tx, releaseSpec).Should().Be(expectedResult);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
@@ -44,7 +44,7 @@ namespace Nethermind.Consensus.Validators
 
         private bool Validate3860Rules(Transaction transaction, IReleaseSpec releaseSpec)
         {
-            bool aboveInitCode = transaction.IsContractCreation && releaseSpec.IsEip3860Enabled && (transaction.Data?.Length ?? 0) > releaseSpec.MaxInitCodeSize;
+            bool aboveInitCode = transaction.IsContractCreation && releaseSpec.IsEip3860Enabled && transaction.DataLength > releaseSpec.MaxInitCodeSize;
             return !aboveInitCode;
         }
 

--- a/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
@@ -38,7 +38,13 @@ namespace Nethermind.Consensus.Validators
                       while for an init it will be empty */
                    ValidateSignature(transaction.Signature, releaseSpec) &&
                    ValidateChainId(transaction) &&
-                   Validate1559GasFields(transaction, releaseSpec);
+                   Validate1559GasFields(transaction, releaseSpec) &&
+                   Validate3860Rules(transaction, releaseSpec);
+        }
+
+        private bool Validate3860Rules(Transaction transaction, IReleaseSpec releaseSpec)
+        {
+            return !(transaction.IsContractCreation && releaseSpec.IsEip3860Enabled && (transaction.Data?.Length ?? 0) > releaseSpec.MaxInitCodeSize);
         }
 
         private bool ValidateTxType(Transaction transaction, IReleaseSpec releaseSpec)

--- a/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
@@ -44,7 +44,8 @@ namespace Nethermind.Consensus.Validators
 
         private bool Validate3860Rules(Transaction transaction, IReleaseSpec releaseSpec)
         {
-            return !(transaction.IsContractCreation && releaseSpec.IsEip3860Enabled && (transaction.Data?.Length ?? 0) > releaseSpec.MaxInitCodeSize);
+            bool aboveInitCode = transaction.IsContractCreation && releaseSpec.IsEip3860Enabled && (transaction.Data?.Length ?? 0) > releaseSpec.MaxInitCodeSize;
+            return !aboveInitCode;
         }
 
         private bool ValidateTxType(Transaction transaction, IReleaseSpec releaseSpec)

--- a/src/Nethermind/Nethermind.Core.Test/Builders/TransactionBuilder.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Builders/TransactionBuilder.cs
@@ -45,7 +45,7 @@ namespace Nethermind.Core.Test.Builders
             return this;
         }
 
-        public TransactionBuilder<T> To(Address address)
+        public TransactionBuilder<T> To(Address? address)
         {
             TestObjectInternal.To = address;
             return this;

--- a/src/Nethermind/Nethermind.Core/Transaction.cs
+++ b/src/Nethermind/Nethermind.Core/Transaction.cs
@@ -43,6 +43,8 @@ namespace Nethermind.Core
         public PublicKey? DeliveredBy { get; set; } // tks: this is added so we do not send the pending tx back to original sources, not used yet
         public UInt256 Timestamp { get; set; }
 
+        public int DataLength => Data?.Length ?? 0;
+
         public AccessList? AccessList { get; set; } // eip2930
 
         /// <summary>

--- a/src/Nethermind/Nethermind.Evm/IntrinsicGasCalculator.cs
+++ b/src/Nethermind/Nethermind.Evm/IntrinsicGasCalculator.cs
@@ -39,7 +39,7 @@ namespace Nethermind.Evm
             long dataCost = 0;
             if (transaction.Data is not null)
             {
-                for (int i = 0; i < transaction.Data.Length; i++)
+                for (int i = 0; i < transaction.DataLength; i++)
                 {
                     dataCost += transaction.Data[i] == 0 ? GasCostOf.TxDataZero : txDataNonZeroGasCost;
                 }
@@ -47,7 +47,7 @@ namespace Nethermind.Evm
 
             if (transaction.IsContractCreation && releaseSpec.IsEip3860Enabled)
             {
-                dataCost += EvmPooledMemory.Div32Ceiling((UInt256)transaction.Data.Length) * GasCostOf.InitCodeWord;
+                dataCost += EvmPooledMemory.Div32Ceiling((UInt256)transaction.DataLength) * GasCostOf.InitCodeWord;
             }
 
             return dataCost;

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -191,7 +191,7 @@ namespace Nethermind.Evm.TransactionProcessing
                 }
             }
 
-            if (transaction.IsContractCreation && spec.IsEip3860Enabled && transaction.Data.Length > spec.MaxInitCodeSize)
+            if (transaction.IsContractCreation && spec.IsEip3860Enabled && (transaction.Data?.Length ?? 0) > spec.MaxInitCodeSize)
             {
                 TraceLogInvalidTx(transaction, $"CREATE_TRANSACTION_SIZE_EXCEEDS_MAX_INIT_CODE_SIZE {transaction.Data.Length} > {spec.MaxInitCodeSize}");
                 QuickFail(transaction, block, txTracer, eip658NotEnabled, "eip-3860 - transaction size over max init code size");

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -191,9 +191,9 @@ namespace Nethermind.Evm.TransactionProcessing
                 }
             }
 
-            if (transaction.IsContractCreation && spec.IsEip3860Enabled && (transaction.Data?.Length ?? 0) > spec.MaxInitCodeSize)
+            if (transaction.IsContractCreation && spec.IsEip3860Enabled && (transaction.DataLength) > spec.MaxInitCodeSize)
             {
-                TraceLogInvalidTx(transaction, $"CREATE_TRANSACTION_SIZE_EXCEEDS_MAX_INIT_CODE_SIZE {transaction.Data.Length} > {spec.MaxInitCodeSize}");
+                TraceLogInvalidTx(transaction, $"CREATE_TRANSACTION_SIZE_EXCEEDS_MAX_INIT_CODE_SIZE {transaction.DataLength} > {spec.MaxInitCodeSize}");
                 QuickFail(transaction, block, txTracer, eip658NotEnabled, "eip-3860 - transaction size over max init code size");
                 return;
             }


### PR DESCRIPTION
The incorrect transactions should be removed from TxPool.

[TransactionSelectorTests.cs](https://github.com/NethermindEth/nethermind/compare/bugfix/eip3860_badBlock?expand=1#diff-0aeb6aa49e73b456afe5d8fc101788ef2463dadc1ba83c29858a24adfe4abdb7) and [TransactionsExecutorTests.cs](https://github.com/NethermindEth/nethermind/compare/bugfix/eip3860_badBlock?expand=1#diff-35501d8b35eb4f35e5fc254b4b578ed1d2a4714bb59bf0fe0e84c52ea9639fae) was refactored because I planned to add these changes to BlockProcessor.BlockProductionTransactionPicker.cs https://github.com/NethermindEth/nethermind/blob/master/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionPicker.cs
However, TxValidator will be the better place, because we will reject the blocks sooner in the pipeline and reject them from our TxPool.