### PR TITLE
Unify Engine API failure responses

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Producers/PayloadAttributes.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/PayloadAttributes.cs
@@ -20,12 +20,8 @@ public class PayloadAttributes
 
     public IList<Withdrawal>? Withdrawals { get; set; }
 
-    /// <summary>
-    /// GasLimit
-    /// </summary>
-    /// <remarks>
-    /// Only used for MEV-Boost
-    /// </remarks>
+    /// <summary>Gets or sets the gas limit.</summary>
+    /// <remarks>Used for MEV-Boost only.</remarks>
     public long? GasLimit { get; set; }
 
     public override string ToString() => ToString(string.Empty);
@@ -48,7 +44,7 @@ public class PayloadAttributes
     }
 }
 
-public static class PayloadAttributesVersioningExtensions
+public static class PayloadAttributesExtensions
 {
     public static int GetVersion(this PayloadAttributes executionPayload) =>
         executionPayload.Withdrawals is null ? 1 : 2;

--- a/src/Nethermind/Nethermind.Core/Specs/ForkActivation.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/ForkActivation.cs
@@ -16,6 +16,17 @@ public readonly struct ForkActivation : IEquatable<ForkActivation>, IComparable<
         BlockNumber = blockNumber;
         Timestamp = timestamp;
     }
+
+    /// <summary>
+    /// Fork activation for forks past The Merge/Paris
+    /// </summary>
+    /// <param name="timestamp">Timestamp of the fork or check</param>
+    /// <returns>Post merge fork activation</returns>
+    /// <remarks>
+    /// Post Merge are based only on timestamp and we can ignore block number.
+    /// </remarks>
+    public static ForkActivation TimestampOnly(ulong timestamp) => new(long.MaxValue, timestamp);
+
     public void Deconstruct(out long blockNumber, out ulong? timestamp)
     {
         blockNumber = BlockNumber;
@@ -30,60 +41,28 @@ public readonly struct ForkActivation : IEquatable<ForkActivation>, IComparable<
     public static implicit operator (long blocknumber, ulong? timestamp)(ForkActivation forkActivation)
         => (forkActivation.BlockNumber, forkActivation.Timestamp);
 
-    public bool Equals(ForkActivation other)
-    {
-        return BlockNumber == other.BlockNumber && Timestamp == other.Timestamp;
-    }
+    public bool Equals(ForkActivation other) => BlockNumber == other.BlockNumber && Timestamp == other.Timestamp;
 
-    public override bool Equals(object? obj)
-    {
-        return obj is ForkActivation other && Equals(other);
-    }
+    public override bool Equals(object? obj) => obj is ForkActivation other && Equals(other);
 
-    public override int GetHashCode()
-    {
-        return HashCode.Combine(BlockNumber, Timestamp);
-    }
+    public override int GetHashCode() => HashCode.Combine(BlockNumber, Timestamp);
 
-    public override string ToString()
-    {
-        return $"{BlockNumber} {Timestamp}";
-    }
+    public override string ToString() => $"{BlockNumber} {Timestamp}";
 
-    public int CompareTo(ForkActivation other)
-    {
-        return Timestamp is null || other.Timestamp is null
+    public int CompareTo(ForkActivation other) =>
+        Timestamp is null || other.Timestamp is null
             ? BlockNumber.CompareTo(other.BlockNumber)
             : Timestamp.Value.CompareTo(other.Timestamp.Value);
-    }
 
-    public static bool operator ==(ForkActivation first, ForkActivation second)
-    {
-        return first.Equals(second);
-    }
+    public static bool operator ==(ForkActivation first, ForkActivation second) => first.Equals(second);
 
-    public static bool operator !=(ForkActivation first, ForkActivation second)
-    {
-        return !first.Equals(second);
-    }
+    public static bool operator !=(ForkActivation first, ForkActivation second) => !first.Equals(second);
 
-    public static bool operator <(ForkActivation first, ForkActivation second)
-    {
-        return first.CompareTo(second) < 0;
-    }
+    public static bool operator <(ForkActivation first, ForkActivation second) => first.CompareTo(second) < 0;
 
-    public static bool operator >(ForkActivation first, ForkActivation second)
-    {
-        return first.CompareTo(second) > 0;
-    }
+    public static bool operator >(ForkActivation first, ForkActivation second) => first.CompareTo(second) > 0;
 
-    public static bool operator <=(ForkActivation first, ForkActivation second)
-    {
-        return first.CompareTo(second) <= 0;
-    }
+    public static bool operator <=(ForkActivation first, ForkActivation second) => first.CompareTo(second) <= 0;
 
-    public static bool operator >=(ForkActivation first, ForkActivation second)
-    {
-        return first.CompareTo(second) >= 0;
-    }
+    public static bool operator >=(ForkActivation first, ForkActivation second) => first.CompareTo(second) >= 0;
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
@@ -15,7 +15,6 @@ using Nethermind.Consensus.Processing;
 using Nethermind.Consensus.Producers;
 using Nethermind.Consensus.Rewards;
 using Nethermind.Consensus.Validators;
-using Nethermind.Consensus.Withdrawals;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
@@ -34,252 +33,249 @@ using Nethermind.Specs.Forks;
 using Nethermind.State;
 using NSubstitute;
 
-namespace Nethermind.Merge.Plugin.Test
+namespace Nethermind.Merge.Plugin.Test;
+
+public partial class EngineModuleTests
 {
-    public partial class EngineModuleTests
+    protected virtual MergeTestBlockchain CreateBaseBlockChain(IMergeConfig? mergeConfig = null, IPayloadPreparationService? mockedPayloadService = null) =>
+        new(mergeConfig, mockedPayloadService);
+
+    protected async Task<MergeTestBlockchain> CreateShanghaiBlockChain(IMergeConfig? mergeConfig = null, IPayloadPreparationService? mockedPayloadService = null)
+        => await CreateBlockChain(mergeConfig, mockedPayloadService, Shanghai.Instance);
+
+    protected async Task<MergeTestBlockchain> CreateBlockChain(IMergeConfig? mergeConfig = null, IPayloadPreparationService? mockedPayloadService = null, IReleaseSpec? releaseSpec = null)
+        => await CreateBaseBlockChain(mergeConfig, mockedPayloadService).Build(new SingleReleaseSpecProvider(releaseSpec ?? London.Instance, 1));
+
+    protected async Task<MergeTestBlockchain> CreateBlockChain(ISpecProvider specProvider)
+        => await CreateBaseBlockChain(null, null).Build(specProvider);
+
+    private IEngineRpcModule CreateEngineModule(MergeTestBlockchain chain, ISyncConfig? syncConfig = null, TimeSpan? newPayloadTimeout = null, int newPayloadCacheSize = 50)
     {
-        protected virtual MergeTestBlockchain CreateBaseBlockChain(IMergeConfig? mergeConfig = null, IPayloadPreparationService? mockedPayloadService = null) =>
-            new(mergeConfig, mockedPayloadService);
+        IPeerRefresher peerRefresher = Substitute.For<IPeerRefresher>();
 
-        protected async Task<MergeTestBlockchain> CreateShanghaiBlockChain(IMergeConfig? mergeConfig = null, IPayloadPreparationService? mockedPayloadService = null)
-            => await CreateBlockChain(mergeConfig, mockedPayloadService, Shanghai.Instance);
-
-        protected async Task<MergeTestBlockchain> CreateBlockChain(IMergeConfig? mergeConfig = null, IPayloadPreparationService? mockedPayloadService = null, IReleaseSpec? releaseSpec = null)
-            => await CreateBaseBlockChain(mergeConfig, mockedPayloadService).Build(new SingleReleaseSpecProvider(releaseSpec ?? London.Instance, 1));
-
-        protected async Task<MergeTestBlockchain> CreateBlockChain(ISpecProvider specProvider)
-            => await CreateBaseBlockChain(null, null).Build(specProvider);
-
-        private IEngineRpcModule CreateEngineModule(MergeTestBlockchain chain, ISyncConfig? syncConfig = null, TimeSpan? newPayloadTimeout = null, int newPayloadCacheSize = 50)
-        {
-            IPeerRefresher peerRefresher = Substitute.For<IPeerRefresher>();
-
-            chain.BeaconPivot = new BeaconPivot(syncConfig ?? new SyncConfig(), new MemDb(), chain.BlockTree, chain.LogManager);
-            BlockCacheService blockCacheService = new();
-            InvalidChainTracker.InvalidChainTracker invalidChainTracker = new(
-                chain.PoSSwitcher,
+        chain.BeaconPivot = new BeaconPivot(syncConfig ?? new SyncConfig(), new MemDb(), chain.BlockTree, chain.LogManager);
+        BlockCacheService blockCacheService = new();
+        InvalidChainTracker.InvalidChainTracker invalidChainTracker = new(
+            chain.PoSSwitcher,
+            chain.BlockTree,
+            blockCacheService,
+            chain.LogManager);
+        invalidChainTracker.SetupBlockchainProcessorInterceptor(chain.BlockchainProcessor);
+        chain.BeaconSync = new BeaconSync(chain.BeaconPivot, chain.BlockTree, syncConfig ?? new SyncConfig(), blockCacheService, chain.LogManager);
+        return new EngineRpcModule(
+            new GetPayloadV1Handler(
+                chain.PayloadPreparationService!,
+                chain.LogManager),
+            new GetPayloadV2Handler(
+                chain.PayloadPreparationService!,
+                chain.LogManager),
+            new NewPayloadHandler(
+                chain.BlockValidator,
                 chain.BlockTree,
+                new InitConfig(),
+                new SyncConfig(),
+                chain.PoSSwitcher,
+                chain.BeaconSync,
+                chain.BeaconPivot,
                 blockCacheService,
-                chain.LogManager);
-            invalidChainTracker.SetupBlockchainProcessorInterceptor(chain.BlockchainProcessor);
-            chain.BeaconSync = new BeaconSync(chain.BeaconPivot, chain.BlockTree, syncConfig ?? new SyncConfig(), blockCacheService, chain.LogManager);
-            return new EngineRpcModule(
-                new GetPayloadV1Handler(
-                    chain.PayloadPreparationService!,
-                    chain.LogManager),
-                new GetPayloadV2Handler(
-                    chain.PayloadPreparationService!,
-                    chain.LogManager),
-                new NewPayloadHandler(
-                    chain.BlockValidator,
-                    chain.BlockTree,
-                    new InitConfig(),
-                    new SyncConfig(),
-                    chain.PoSSwitcher,
-                    chain.BeaconSync,
-                    chain.BeaconPivot,
-                    blockCacheService,
-                    chain.BlockProcessingQueue,
-                    invalidChainTracker,
-                    chain.BeaconSync,
-                    chain.LogManager,
-                    newPayloadTimeout,
-                    newPayloadCacheSize),
-                new ForkchoiceUpdatedHandler(
-                    chain.BlockTree,
-                    chain.BlockFinalizationManager,
-                    chain.PoSSwitcher,
-                    chain.PayloadPreparationService!,
-                    chain.BlockProcessingQueue,
-                    blockCacheService,
-                    invalidChainTracker,
-                    chain.BeaconSync,
-                    chain.BeaconPivot,
-                    peerRefresher,
-                    chain.SpecProvider,
-                    chain.LogManager),
-                new ExecutionStatusHandler(chain.BlockTree),
-                new GetPayloadBodiesByHashV1Handler(chain.BlockTree, chain.LogManager),
-                new GetPayloadBodiesByRangeV1Handler(chain.BlockTree, chain.LogManager),
-                new ExchangeTransitionConfigurationV1Handler(chain.PoSSwitcher, chain.LogManager),
-                chain.SpecProvider,
-                chain.LogManager);
-        }
-
-        public class MergeTestBlockchain : TestBlockchain
-        {
-            public IMergeConfig MergeConfig { get; set; }
-
-            public PostMergeBlockProducer? PostMergeBlockProducer { get; set; }
-
-            public IPayloadPreparationService? PayloadPreparationService { get; set; }
-
-            public ISealValidator? SealValidator { get; set; }
-
-            public IBeaconPivot? BeaconPivot { get; set; }
-
-            public BeaconSync? BeaconSync { get; set; }
-
-            private int _blockProcessingThrottle = 0;
-
-            public MergeTestBlockchain ThrottleBlockProcessor(int delayMs)
-            {
-                _blockProcessingThrottle = delayMs;
-                if (BlockProcessor is TestBlockProcessorInterceptor testBlockProcessor)
-                {
-                    testBlockProcessor.DelayMs = delayMs;
-                }
-                return this;
-            }
-
-            public MergeTestBlockchain(IMergeConfig? mergeConfig = null, IPayloadPreparationService? mockedPayloadPreparationService = null)
-            {
-                GenesisBlockBuilder = Core.Test.Builders.Build.A.Block.Genesis.Genesis.WithTimestamp(1UL);
-                MergeConfig = mergeConfig ?? new MergeConfig() { TerminalTotalDifficulty = "0" };
-                PayloadPreparationService = mockedPayloadPreparationService;
-            }
-
-            protected override Task AddBlocksOnStart() => Task.CompletedTask;
-
-            public sealed override ILogManager LogManager { get; } = LimboLogs.Instance;
-
-            public IEthSyncingInfo? EthSyncingInfo { get; protected set; }
-
-            protected override IBlockProducer CreateTestBlockProducer(TxPoolTxSource txPoolTxSource, ISealer sealer, ITransactionComparerProvider transactionComparerProvider)
-            {
-                SealEngine = new MergeSealEngine(SealEngine, PoSSwitcher, SealValidator!, LogManager);
-                IBlockProducer preMergeBlockProducer =
-                    base.CreateTestBlockProducer(txPoolTxSource, sealer, transactionComparerProvider);
-                BlocksConfig blocksConfig = new() { MinGasPrice = 0 };
-                TargetAdjustedGasLimitCalculator targetAdjustedGasLimitCalculator = new(SpecProvider, blocksConfig);
-                ISyncConfig syncConfig = new SyncConfig();
-                EthSyncingInfo = new EthSyncingInfo(BlockTree, ReceiptStorage, syncConfig, LogManager);
-                PostMergeBlockProducerFactory? blockProducerFactory = new(
-                    SpecProvider,
-                    SealEngine,
-                    Timestamper,
-                    blocksConfig,
-                    LogManager,
-                    targetAdjustedGasLimitCalculator);
-
-                BlockProducerEnvFactory blockProducerEnvFactory = new(
-                    DbProvider,
-                    BlockTree,
-                    ReadOnlyTrieStore,
-                    SpecProvider,
-                    BlockValidator,
-                    NoBlockRewards.Instance,
-                    ReceiptStorage,
-                    BlockPreprocessorStep,
-                    TxPool,
-                    transactionComparerProvider,
-                    blocksConfig,
-                    LogManager);
-
-
-                BlockProducerEnv blockProducerEnv = blockProducerEnvFactory.Create();
-                PostMergeBlockProducer? postMergeBlockProducer = blockProducerFactory.Create(
-                    blockProducerEnv, BlockProductionTrigger);
-                PostMergeBlockProducer = postMergeBlockProducer;
-                PayloadPreparationService ??= new PayloadPreparationService(
-                    postMergeBlockProducer,
-                    new BlockImprovementContextFactory(BlockProductionTrigger, TimeSpan.FromSeconds(MergeConfig.SecondsPerSlot)),
-                    TimerFactory.Default,
-                    LogManager,
-                    TimeSpan.FromSeconds(MergeConfig.SecondsPerSlot));
-                return new MergeBlockProducer(preMergeBlockProducer, postMergeBlockProducer, PoSSwitcher);
-            }
-
-            protected override IBlockProcessor CreateBlockProcessor()
-            {
-                BlockValidator = CreateBlockValidator();
-                IBlockProcessor processor = new BlockProcessor(
-                    SpecProvider,
-                    BlockValidator,
-                    NoBlockRewards.Instance,
-                    new BlockProcessor.BlockValidationTransactionsExecutor(TxProcessor, State),
-                    State,
-                    Storage,
-                    ReceiptStorage,
-                    NullWitnessCollector.Instance,
-                    LogManager);
-
-                return new TestBlockProcessorInterceptor(processor, _blockProcessingThrottle);
-            }
-
-            private IBlockValidator CreateBlockValidator()
-            {
-                IBlockCacheService blockCacheService = new BlockCacheService();
-                PoSSwitcher = new PoSSwitcher(MergeConfig, SyncConfig.Default, new MemDb(), BlockTree, SpecProvider, LogManager);
-                SealValidator = new MergeSealValidator(PoSSwitcher, Always.Valid);
-                HeaderValidator preMergeHeaderValidator = new HeaderValidator(BlockTree, SealValidator, SpecProvider, LogManager);
-                HeaderValidator = new MergeHeaderValidator(PoSSwitcher, preMergeHeaderValidator, BlockTree, SpecProvider, SealValidator, LogManager);
-
-                return new BlockValidator(
-                    new TxValidator(SpecProvider.ChainId),
-                    HeaderValidator,
-                    Always.Valid,
-                    SpecProvider,
-                    LogManager);
-            }
-            public IManualBlockFinalizationManager BlockFinalizationManager { get; } = new ManualBlockFinalizationManager();
-
-            protected override async Task<TestBlockchain> Build(ISpecProvider? specProvider = null, UInt256? initialValues = null)
-            {
-                TestBlockchain chain = await base.Build(specProvider, initialValues);
-                return chain;
-            }
-
-            public async Task<MergeTestBlockchain> Build(ISpecProvider? specProvider = null) =>
-                (MergeTestBlockchain)await Build(specProvider, null);
-        }
+                chain.BlockProcessingQueue,
+                invalidChainTracker,
+                chain.BeaconSync,
+                chain.LogManager,
+                newPayloadTimeout,
+                newPayloadCacheSize),
+            new ForkchoiceUpdatedHandler(
+                chain.BlockTree,
+                chain.BlockFinalizationManager,
+                chain.PoSSwitcher,
+                chain.PayloadPreparationService!,
+                chain.BlockProcessingQueue,
+                blockCacheService,
+                invalidChainTracker,
+                chain.BeaconSync,
+                chain.BeaconPivot,
+                peerRefresher,
+                chain.LogManager),
+            new ExecutionStatusHandler(chain.BlockTree),
+            new GetPayloadBodiesByHashV1Handler(chain.BlockTree, chain.LogManager),
+            new GetPayloadBodiesByRangeV1Handler(chain.BlockTree, chain.LogManager),
+            new ExchangeTransitionConfigurationV1Handler(chain.PoSSwitcher, chain.LogManager),
+            chain.SpecProvider,
+            chain.LogManager);
     }
 
-    internal class TestBlockProcessorInterceptor : IBlockProcessor
+    public class MergeTestBlockchain : TestBlockchain
     {
-        private readonly IBlockProcessor _blockProcessorImplementation;
-        public int DelayMs { get; set; }
-        public Exception? ExceptionToThrow { get; set; }
+        public IMergeConfig MergeConfig { get; set; }
 
-        public TestBlockProcessorInterceptor(IBlockProcessor baseBlockProcessor, int delayMs)
-        {
-            _blockProcessorImplementation = baseBlockProcessor;
-            DelayMs = delayMs;
-        }
+        public PostMergeBlockProducer? PostMergeBlockProducer { get; set; }
 
-        public Block[] Process(Keccak newBranchStateRoot, List<Block> suggestedBlocks, ProcessingOptions processingOptions,
-            IBlockTracer blockTracer)
+        public IPayloadPreparationService? PayloadPreparationService { get; set; }
+
+        public ISealValidator? SealValidator { get; set; }
+
+        public IBeaconPivot? BeaconPivot { get; set; }
+
+        public BeaconSync? BeaconSync { get; set; }
+
+        private int _blockProcessingThrottle = 0;
+
+        public MergeTestBlockchain ThrottleBlockProcessor(int delayMs)
         {
-            if (DelayMs > 0)
+            _blockProcessingThrottle = delayMs;
+            if (BlockProcessor is TestBlockProcessorInterceptor testBlockProcessor)
             {
-                Thread.Sleep(DelayMs);
+                testBlockProcessor.DelayMs = delayMs;
             }
-
-            if (ExceptionToThrow is not null)
-            {
-                throw ExceptionToThrow;
-            }
-
-            return _blockProcessorImplementation.Process(newBranchStateRoot, suggestedBlocks, processingOptions, blockTracer);
+            return this;
         }
 
-        public event EventHandler<BlocksProcessingEventArgs>? BlocksProcessing
+        public MergeTestBlockchain(IMergeConfig? mergeConfig = null, IPayloadPreparationService? mockedPayloadPreparationService = null)
         {
-            add => _blockProcessorImplementation.BlocksProcessing += value;
-            remove => _blockProcessorImplementation.BlocksProcessing -= value;
+            GenesisBlockBuilder = Core.Test.Builders.Build.A.Block.Genesis.Genesis.WithTimestamp(1UL);
+            MergeConfig = mergeConfig ?? new MergeConfig() { TerminalTotalDifficulty = "0" };
+            PayloadPreparationService = mockedPayloadPreparationService;
         }
 
-        public event EventHandler<BlockProcessedEventArgs>? BlockProcessed
+        protected override Task AddBlocksOnStart() => Task.CompletedTask;
+
+        public sealed override ILogManager LogManager { get; } = LimboLogs.Instance;
+
+        public IEthSyncingInfo? EthSyncingInfo { get; protected set; }
+
+        protected override IBlockProducer CreateTestBlockProducer(TxPoolTxSource txPoolTxSource, ISealer sealer, ITransactionComparerProvider transactionComparerProvider)
         {
-            add => _blockProcessorImplementation.BlockProcessed += value;
-            remove => _blockProcessorImplementation.BlockProcessed -= value;
+            SealEngine = new MergeSealEngine(SealEngine, PoSSwitcher, SealValidator!, LogManager);
+            IBlockProducer preMergeBlockProducer =
+                base.CreateTestBlockProducer(txPoolTxSource, sealer, transactionComparerProvider);
+            BlocksConfig blocksConfig = new() { MinGasPrice = 0 };
+            TargetAdjustedGasLimitCalculator targetAdjustedGasLimitCalculator = new(SpecProvider, blocksConfig);
+            ISyncConfig syncConfig = new SyncConfig();
+            EthSyncingInfo = new EthSyncingInfo(BlockTree, ReceiptStorage, syncConfig, LogManager);
+            PostMergeBlockProducerFactory? blockProducerFactory = new(
+                SpecProvider,
+                SealEngine,
+                Timestamper,
+                blocksConfig,
+                LogManager,
+                targetAdjustedGasLimitCalculator);
+
+            BlockProducerEnvFactory blockProducerEnvFactory = new(
+                DbProvider,
+                BlockTree,
+                ReadOnlyTrieStore,
+                SpecProvider,
+                BlockValidator,
+                NoBlockRewards.Instance,
+                ReceiptStorage,
+                BlockPreprocessorStep,
+                TxPool,
+                transactionComparerProvider,
+                blocksConfig,
+                LogManager);
+
+
+            BlockProducerEnv blockProducerEnv = blockProducerEnvFactory.Create();
+            PostMergeBlockProducer? postMergeBlockProducer = blockProducerFactory.Create(
+                blockProducerEnv, BlockProductionTrigger);
+            PostMergeBlockProducer = postMergeBlockProducer;
+            PayloadPreparationService ??= new PayloadPreparationService(
+                postMergeBlockProducer,
+                new BlockImprovementContextFactory(BlockProductionTrigger, TimeSpan.FromSeconds(MergeConfig.SecondsPerSlot)),
+                TimerFactory.Default,
+                LogManager,
+                TimeSpan.FromSeconds(MergeConfig.SecondsPerSlot));
+            return new MergeBlockProducer(preMergeBlockProducer, postMergeBlockProducer, PoSSwitcher);
         }
 
-        public event EventHandler<TxProcessedEventArgs>? TransactionProcessed
+        protected override IBlockProcessor CreateBlockProcessor()
         {
-            add => _blockProcessorImplementation.TransactionProcessed += value;
-            remove => _blockProcessorImplementation.TransactionProcessed -= value;
+            BlockValidator = CreateBlockValidator();
+            IBlockProcessor processor = new BlockProcessor(
+                SpecProvider,
+                BlockValidator,
+                NoBlockRewards.Instance,
+                new BlockProcessor.BlockValidationTransactionsExecutor(TxProcessor, State),
+                State,
+                Storage,
+                ReceiptStorage,
+                NullWitnessCollector.Instance,
+                LogManager);
+
+            return new TestBlockProcessorInterceptor(processor, _blockProcessingThrottle);
         }
+
+        private IBlockValidator CreateBlockValidator()
+        {
+            IBlockCacheService blockCacheService = new BlockCacheService();
+            PoSSwitcher = new PoSSwitcher(MergeConfig, SyncConfig.Default, new MemDb(), BlockTree, SpecProvider, LogManager);
+            SealValidator = new MergeSealValidator(PoSSwitcher, Always.Valid);
+            HeaderValidator preMergeHeaderValidator = new HeaderValidator(BlockTree, SealValidator, SpecProvider, LogManager);
+            HeaderValidator = new MergeHeaderValidator(PoSSwitcher, preMergeHeaderValidator, BlockTree, SpecProvider, SealValidator, LogManager);
+
+            return new BlockValidator(
+                new TxValidator(SpecProvider.ChainId),
+                HeaderValidator,
+                Always.Valid,
+                SpecProvider,
+                LogManager);
+        }
+        public IManualBlockFinalizationManager BlockFinalizationManager { get; } = new ManualBlockFinalizationManager();
+
+        protected override async Task<TestBlockchain> Build(ISpecProvider? specProvider = null, UInt256? initialValues = null)
+        {
+            TestBlockchain chain = await base.Build(specProvider, initialValues);
+            return chain;
+        }
+
+        public async Task<MergeTestBlockchain> Build(ISpecProvider? specProvider = null) =>
+            (MergeTestBlockchain)await Build(specProvider, null);
+    }
+}
+
+internal class TestBlockProcessorInterceptor : IBlockProcessor
+{
+    private readonly IBlockProcessor _blockProcessorImplementation;
+    public int DelayMs { get; set; }
+    public Exception? ExceptionToThrow { get; set; }
+
+    public TestBlockProcessorInterceptor(IBlockProcessor baseBlockProcessor, int delayMs)
+    {
+        _blockProcessorImplementation = baseBlockProcessor;
+        DelayMs = delayMs;
     }
 
+    public Block[] Process(Keccak newBranchStateRoot, List<Block> suggestedBlocks, ProcessingOptions processingOptions,
+        IBlockTracer blockTracer)
+    {
+        if (DelayMs > 0)
+        {
+            Thread.Sleep(DelayMs);
+        }
+
+        if (ExceptionToThrow is not null)
+        {
+            throw ExceptionToThrow;
+        }
+
+        return _blockProcessorImplementation.Process(newBranchStateRoot, suggestedBlocks, processingOptions, blockTracer);
+    }
+
+    public event EventHandler<BlocksProcessingEventArgs>? BlocksProcessing
+    {
+        add => _blockProcessorImplementation.BlocksProcessing += value;
+        remove => _blockProcessorImplementation.BlocksProcessing -= value;
+    }
+
+    public event EventHandler<BlockProcessedEventArgs>? BlockProcessed
+    {
+        add => _blockProcessorImplementation.BlockProcessed += value;
+        remove => _blockProcessorImplementation.BlockProcessed -= value;
+    }
+
+    public event EventHandler<TxProcessedEventArgs>? TransactionProcessed
+    {
+        add => _blockProcessorImplementation.TransactionProcessed += value;
+        remove => _blockProcessorImplementation.TransactionProcessed -= value;
+    }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
@@ -82,7 +82,6 @@ namespace Nethermind.Merge.Plugin.Test
                     chain.BlockProcessingQueue,
                     invalidChainTracker,
                     chain.BeaconSync,
-                    chain.SpecProvider,
                     chain.LogManager,
                     newPayloadTimeout,
                     newPayloadCacheSize),
@@ -103,6 +102,7 @@ namespace Nethermind.Merge.Plugin.Test
                 new GetPayloadBodiesByHashV1Handler(chain.BlockTree, chain.LogManager),
                 new GetPayloadBodiesByRangeV1Handler(chain.BlockTree, chain.LogManager),
                 new ExchangeTransitionConfigurationV1Handler(chain.PoSSwitcher, chain.LogManager),
+                chain.SpecProvider,
                 chain.LogManager);
         }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V2.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V2.cs
@@ -194,7 +194,7 @@ public partial class EngineModuleTests
         errorResponse.Should().NotBeNull();
         errorResponse!.Error.Should().NotBeNull();
         errorResponse!.Error!.Code.Should().Be(ErrorCodes.InvalidParams);
-        errorResponse!.Error!.Message.Should().Contain("Withdrawals not supported");
+        errorResponse!.Error!.Message.Should().Be("PayloadAttributesV1 expected");
     }
 
     [TestCaseSource(nameof(GetWithdrawalValidationValues))]
@@ -231,8 +231,8 @@ public partial class EngineModuleTests
 
         errorResponse.Should().NotBeNull();
         errorResponse!.Error.Should().NotBeNull();
-        errorResponse!.Error!.Code.Should().Be(MergeErrorCodes.InvalidPayloadAttributes);
-        errorResponse!.Error!.Message.Should().Be(string.Format(input.ErrorMessage, string.Empty));
+        errorResponse!.Error!.Code.Should().Be(ErrorCodes.InvalidParams);
+        errorResponse!.Error!.Message.Should().Be(string.Format(input.ErrorMessage, "PayloadAttributes"));
     }
 
     [Test]
@@ -336,7 +336,7 @@ public partial class EngineModuleTests
         errorResponse.Should().NotBeNull();
         errorResponse!.Error.Should().NotBeNull();
         errorResponse!.Error!.Code.Should().Be(ErrorCodes.InvalidParams);
-        errorResponse!.Error!.Message.Should().Contain("Withdrawals not supported");
+        errorResponse!.Error!.Message.Should().Be("ExecutionPayloadV1 expected");
     }
 
     [TestCaseSource(nameof(GetWithdrawalValidationValues))]
@@ -375,19 +375,12 @@ public partial class EngineModuleTests
 
         string response = RpcTest.TestSerializedRequest(rpcModule, "engine_newPayloadV2",
             chain.JsonSerializer.Serialize(expectedPayload));
-        JsonRpcSuccessResponse? successResponse = chain.JsonSerializer.Deserialize<JsonRpcSuccessResponse>(response);
+        JsonRpcErrorResponse? errorResponse = chain.JsonSerializer.Deserialize<JsonRpcErrorResponse>(response);
 
-        successResponse.Should().NotBeNull();
-        response.Should().Be(chain.JsonSerializer.Serialize(new JsonRpcSuccessResponse
-        {
-            Id = successResponse.Id,
-            Result = new PayloadStatusV1
-            {
-                LatestValidHash = startingHead,
-                Status = PayloadStatus.Invalid,
-                ValidationError = string.Format(input.ErrorMessage, $"in block {blockHash} ")
-            }
-        }));
+        errorResponse.Should().NotBeNull();
+        errorResponse!.Error.Should().NotBeNull();
+        errorResponse!.Error!.Code.Should().Be(ErrorCodes.InvalidParams);
+        errorResponse!.Error!.Message.Should().Be(string.Format(input.ErrorMessage, "ExecutionPayload"));
     }
 
     protected static IEnumerable<(
@@ -399,12 +392,12 @@ public partial class EngineModuleTests
     {
         yield return (
             Shanghai.Instance,
-            "Withdrawals cannot be null {0}when EIP-4895 activated.",
+            "{0}V2 expected",
             null,
             "0x6817d4b48be0bc14f144cc242cdc47a5ccc40de34b9c3934acad45057369f576");
         yield return (
             London.Instance,
-            "Withdrawals must be null {0}when EIP-4895 not activated.",
+            "{0}V1 expected",
             Enumerable.Empty<Withdrawal>(),
             "0xaa4aa15951a28e6adab430a795e36a84649bbafb1257eda23e38b9131cbd3b98");
     }
@@ -419,7 +412,11 @@ public partial class EngineModuleTests
         IEngineRpcModule rpc = CreateEngineModule(chain);
         ExecutionPayload executionPayload = CreateBlockRequest(CreateParentBlockRequestOnHead(chain.BlockTree), TestItem.AddressD, input.Withdrawals);
         ResultWrapper<PayloadStatusV1> resultWrapper = await rpc.engine_newPayloadV2(executionPayload);
-        resultWrapper.Data.Status.Should().Be(input.IsValid ? PayloadStatus.Valid : PayloadStatus.Invalid);
+
+        if (input.IsValid)
+            resultWrapper.Data.Status.Should().Be(PayloadStatus.Valid);
+        else
+            resultWrapper.ErrorCode.Should().Be(ErrorCodes.InvalidParams);
     }
 
     protected static IEnumerable<(

--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayload.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayload.cs
@@ -3,9 +3,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Specs;
 using Nethermind.Int256;
 using Nethermind.Serialization.Rlp;
 using Nethermind.State.Proofs;
@@ -143,4 +145,37 @@ public class ExecutionPayload
         .ToArray();
 
     public override string ToString() => $"{BlockNumber} ({BlockHash})";
+}
+
+public static class ExecutionPayloadVersioningExtensions
+{
+    public static int GetVersion(this ExecutionPayload executionPayload) =>
+        executionPayload.Withdrawals is null ? 1 : 2;
+
+    public static bool Validate(
+        this ExecutionPayload executionPayload,
+        IReleaseSpec spec,
+        int version,
+        [NotNullWhen(false)] out string? error)
+    {
+        int actualVersion = executionPayload.GetVersion();
+
+        error = actualVersion switch
+        {
+            1 when spec.WithdrawalsEnabled => "ExecutionPayloadV2 expected",
+            > 1 when !spec.WithdrawalsEnabled => "ExecutionPayloadV1 expected",
+            _ => actualVersion > version ? $"ExecutionPayloadV{version} expected" : null
+        };
+
+        return error is null;
+    }
+
+    public static bool Validate(this ExecutionPayload executionPayload,
+        ISpecProvider specProvider,
+        int version,
+        [NotNullWhen(false)] out string? error) =>
+        executionPayload.Validate(
+            specProvider.GetSpec(executionPayload.BlockNumber, executionPayload.Timestamp),
+            version,
+            out error);
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayload.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayload.cs
@@ -147,7 +147,7 @@ public class ExecutionPayload
     public override string ToString() => $"{BlockNumber} ({BlockHash})";
 }
 
-public static class ExecutionPayloadVersioningExtensions
+public static class ExecutionPayloadExtensions
 {
     public static int GetVersion(this ExecutionPayload executionPayload) =>
         executionPayload.Withdrawals is null ? 1 : 2;

--- a/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.Paris.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.Paris.cs
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Nethermind.Consensus.Producers;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Specs;
+using Nethermind.JsonRpc;
+using Nethermind.Logging;
+using Nethermind.Merge.Plugin.Data;
+using Nethermind.Merge.Plugin.Handlers;
+
+namespace Nethermind.Merge.Plugin
+{
+    public partial class EngineRpcModule : IEngineRpcModule
+    {
+        private readonly IAsyncHandler<byte[], ExecutionPayload?> _getPayloadHandlerV1;
+        private readonly IAsyncHandler<ExecutionPayload, PayloadStatusV1> _newPayloadV1Handler;
+        private readonly IForkchoiceUpdatedHandler _forkchoiceUpdatedV1Handler;
+        private readonly IHandler<TransitionConfigurationV1, TransitionConfigurationV1> _transitionConfigurationHandler;
+        private readonly SemaphoreSlim _locker = new(1, 1);
+        private readonly TimeSpan _timeout = TimeSpan.FromSeconds(8);
+
+        public Task<ResultWrapper<ExecutionPayload?>> engine_getPayloadV1(byte[] payloadId) =>
+            _getPayloadHandlerV1.HandleAsync(payloadId);
+
+        public async Task<ResultWrapper<PayloadStatusV1>> engine_newPayloadV1(ExecutionPayload executionPayload)
+            => await NewPayload(executionPayload, 1);
+
+        public async Task<ResultWrapper<ForkchoiceUpdatedV1Result>> engine_forkchoiceUpdatedV1(ForkchoiceStateV1 forkchoiceState, PayloadAttributes? payloadAttributes = null)
+            => await ForkchoiceUpdated(forkchoiceState, payloadAttributes, 1);
+
+        public ResultWrapper<TransitionConfigurationV1> engine_exchangeTransitionConfigurationV1(
+            TransitionConfigurationV1 beaconTransitionConfiguration) => _transitionConfigurationHandler.Handle(beaconTransitionConfiguration);
+
+        private async Task<ResultWrapper<ForkchoiceUpdatedV1Result>> ForkchoiceUpdated(ForkchoiceStateV1 forkchoiceState, PayloadAttributes? payloadAttributes, int version)
+        {
+            if (payloadAttributes?.Validate(_specProvider, version, out string? error) == false)
+            {
+                if (_logger.IsWarn) _logger.Warn(error);
+                return ResultWrapper<ForkchoiceUpdatedV1Result>.Fail(error, ErrorCodes.InvalidParams);
+            }
+
+            if (await _locker.WaitAsync(_timeout))
+            {
+                Stopwatch watch = Stopwatch.StartNew();
+                try
+                {
+                    return await _forkchoiceUpdatedV1Handler.Handle(forkchoiceState, payloadAttributes);
+                }
+                finally
+                {
+                    watch.Stop();
+                    Metrics.ForkchoiceUpdedExecutionTime = watch.ElapsedMilliseconds;
+                    _locker.Release();
+                }
+            }
+            else
+            {
+                if (_logger.IsWarn) _logger.Warn($"engine_forkchoiceUpdated{version} timed out");
+                return ResultWrapper<ForkchoiceUpdatedV1Result>.Fail("Timed out", ErrorCodes.Timeout);
+            }
+        }
+
+        private async Task<ResultWrapper<PayloadStatusV1>> NewPayload(ExecutionPayload executionPayload, int version)
+        {
+            if (!executionPayload.Validate(_specProvider, version, out string? error))
+            {
+                if (_logger.IsWarn) _logger.Warn(error);
+                return ResultWrapper<PayloadStatusV1>.Fail(error, ErrorCodes.InvalidParams);
+            }
+
+            if (await _locker.WaitAsync(_timeout))
+            {
+                Stopwatch watch = Stopwatch.StartNew();
+                try
+                {
+                    return await _newPayloadV1Handler.HandleAsync(executionPayload);
+                }
+                catch (Exception exception)
+                {
+                    if (_logger.IsError) _logger.Error($"engine_newPayloadV{version} failed: {exception}");
+                    return ResultWrapper<PayloadStatusV1>.Fail(exception.Message);
+                }
+                finally
+                {
+                    watch.Stop();
+                    Metrics.NewPayloadExecutionTime = watch.ElapsedMilliseconds;
+                    _locker.Release();
+                }
+            }
+            else
+            {
+                if (_logger.IsWarn) _logger.Warn($"engine_newPayloadV{version} timed out");
+                return ResultWrapper<PayloadStatusV1>.Fail("Timed out", ErrorCodes.Timeout);
+            }
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.Paris.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.Paris.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
@@ -6,97 +6,93 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Consensus.Producers;
-using Nethermind.Core.Crypto;
-using Nethermind.Core.Specs;
 using Nethermind.JsonRpc;
-using Nethermind.Logging;
 using Nethermind.Merge.Plugin.Data;
 using Nethermind.Merge.Plugin.Handlers;
 
-namespace Nethermind.Merge.Plugin
+namespace Nethermind.Merge.Plugin;
+
+public partial class EngineRpcModule : IEngineRpcModule
 {
-    public partial class EngineRpcModule : IEngineRpcModule
+    private readonly IAsyncHandler<byte[], ExecutionPayload?> _getPayloadHandlerV1;
+    private readonly IAsyncHandler<ExecutionPayload, PayloadStatusV1> _newPayloadV1Handler;
+    private readonly IForkchoiceUpdatedHandler _forkchoiceUpdatedV1Handler;
+    private readonly IHandler<TransitionConfigurationV1, TransitionConfigurationV1> _transitionConfigurationHandler;
+    private readonly SemaphoreSlim _locker = new(1, 1);
+    private readonly TimeSpan _timeout = TimeSpan.FromSeconds(8);
+
+    public ResultWrapper<TransitionConfigurationV1> engine_exchangeTransitionConfigurationV1(
+        TransitionConfigurationV1 beaconTransitionConfiguration) => _transitionConfigurationHandler.Handle(beaconTransitionConfiguration);
+
+    public async Task<ResultWrapper<ForkchoiceUpdatedV1Result>> engine_forkchoiceUpdatedV1(ForkchoiceStateV1 forkchoiceState, PayloadAttributes? payloadAttributes = null)
+        => await ForkchoiceUpdated(forkchoiceState, payloadAttributes, 1);
+
+    public Task<ResultWrapper<ExecutionPayload?>> engine_getPayloadV1(byte[] payloadId) =>
+        _getPayloadHandlerV1.HandleAsync(payloadId);
+
+    public async Task<ResultWrapper<PayloadStatusV1>> engine_newPayloadV1(ExecutionPayload executionPayload)
+        => await NewPayload(executionPayload, 1);
+
+    private async Task<ResultWrapper<ForkchoiceUpdatedV1Result>> ForkchoiceUpdated(ForkchoiceStateV1 forkchoiceState, PayloadAttributes? payloadAttributes, int version)
     {
-        private readonly IAsyncHandler<byte[], ExecutionPayload?> _getPayloadHandlerV1;
-        private readonly IAsyncHandler<ExecutionPayload, PayloadStatusV1> _newPayloadV1Handler;
-        private readonly IForkchoiceUpdatedHandler _forkchoiceUpdatedV1Handler;
-        private readonly IHandler<TransitionConfigurationV1, TransitionConfigurationV1> _transitionConfigurationHandler;
-        private readonly SemaphoreSlim _locker = new(1, 1);
-        private readonly TimeSpan _timeout = TimeSpan.FromSeconds(8);
-
-        public Task<ResultWrapper<ExecutionPayload?>> engine_getPayloadV1(byte[] payloadId) =>
-            _getPayloadHandlerV1.HandleAsync(payloadId);
-
-        public async Task<ResultWrapper<PayloadStatusV1>> engine_newPayloadV1(ExecutionPayload executionPayload)
-            => await NewPayload(executionPayload, 1);
-
-        public async Task<ResultWrapper<ForkchoiceUpdatedV1Result>> engine_forkchoiceUpdatedV1(ForkchoiceStateV1 forkchoiceState, PayloadAttributes? payloadAttributes = null)
-            => await ForkchoiceUpdated(forkchoiceState, payloadAttributes, 1);
-
-        public ResultWrapper<TransitionConfigurationV1> engine_exchangeTransitionConfigurationV1(
-            TransitionConfigurationV1 beaconTransitionConfiguration) => _transitionConfigurationHandler.Handle(beaconTransitionConfiguration);
-
-        private async Task<ResultWrapper<ForkchoiceUpdatedV1Result>> ForkchoiceUpdated(ForkchoiceStateV1 forkchoiceState, PayloadAttributes? payloadAttributes, int version)
+        if (payloadAttributes?.Validate(_specProvider, version, out string? error) == false)
         {
-            if (payloadAttributes?.Validate(_specProvider, version, out string? error) == false)
-            {
-                if (_logger.IsWarn) _logger.Warn(error);
-                return ResultWrapper<ForkchoiceUpdatedV1Result>.Fail(error, ErrorCodes.InvalidParams);
-            }
-
-            if (await _locker.WaitAsync(_timeout))
-            {
-                Stopwatch watch = Stopwatch.StartNew();
-                try
-                {
-                    return await _forkchoiceUpdatedV1Handler.Handle(forkchoiceState, payloadAttributes);
-                }
-                finally
-                {
-                    watch.Stop();
-                    Metrics.ForkchoiceUpdedExecutionTime = watch.ElapsedMilliseconds;
-                    _locker.Release();
-                }
-            }
-            else
-            {
-                if (_logger.IsWarn) _logger.Warn($"engine_forkchoiceUpdated{version} timed out");
-                return ResultWrapper<ForkchoiceUpdatedV1Result>.Fail("Timed out", ErrorCodes.Timeout);
-            }
+            if (_logger.IsWarn) _logger.Warn(error);
+            return ResultWrapper<ForkchoiceUpdatedV1Result>.Fail(error, ErrorCodes.InvalidParams);
         }
 
-        private async Task<ResultWrapper<PayloadStatusV1>> NewPayload(ExecutionPayload executionPayload, int version)
+        if (await _locker.WaitAsync(_timeout))
         {
-            if (!executionPayload.Validate(_specProvider, version, out string? error))
+            Stopwatch watch = Stopwatch.StartNew();
+            try
             {
-                if (_logger.IsWarn) _logger.Warn(error);
-                return ResultWrapper<PayloadStatusV1>.Fail(error, ErrorCodes.InvalidParams);
+                return await _forkchoiceUpdatedV1Handler.Handle(forkchoiceState, payloadAttributes);
             }
+            finally
+            {
+                watch.Stop();
+                Metrics.ForkchoiceUpdedExecutionTime = watch.ElapsedMilliseconds;
+                _locker.Release();
+            }
+        }
+        else
+        {
+            if (_logger.IsWarn) _logger.Warn($"engine_forkchoiceUpdated{version} timed out");
+            return ResultWrapper<ForkchoiceUpdatedV1Result>.Fail("Timed out", ErrorCodes.Timeout);
+        }
+    }
 
-            if (await _locker.WaitAsync(_timeout))
+    private async Task<ResultWrapper<PayloadStatusV1>> NewPayload(ExecutionPayload executionPayload, int version)
+    {
+        if (!executionPayload.Validate(_specProvider, version, out string? error))
+        {
+            if (_logger.IsWarn) _logger.Warn(error);
+            return ResultWrapper<PayloadStatusV1>.Fail(error, ErrorCodes.InvalidParams);
+        }
+
+        if (await _locker.WaitAsync(_timeout))
+        {
+            Stopwatch watch = Stopwatch.StartNew();
+            try
             {
-                Stopwatch watch = Stopwatch.StartNew();
-                try
-                {
-                    return await _newPayloadV1Handler.HandleAsync(executionPayload);
-                }
-                catch (Exception exception)
-                {
-                    if (_logger.IsError) _logger.Error($"engine_newPayloadV{version} failed: {exception}");
-                    return ResultWrapper<PayloadStatusV1>.Fail(exception.Message);
-                }
-                finally
-                {
-                    watch.Stop();
-                    Metrics.NewPayloadExecutionTime = watch.ElapsedMilliseconds;
-                    _locker.Release();
-                }
+                return await _newPayloadV1Handler.HandleAsync(executionPayload);
             }
-            else
+            catch (Exception exception)
             {
-                if (_logger.IsWarn) _logger.Warn($"engine_newPayloadV{version} timed out");
-                return ResultWrapper<PayloadStatusV1>.Fail("Timed out", ErrorCodes.Timeout);
+                if (_logger.IsError) _logger.Error($"engine_newPayloadV{version} failed: {exception}");
+                return ResultWrapper<PayloadStatusV1>.Fail(exception.Message);
             }
+            finally
+            {
+                watch.Stop();
+                Metrics.NewPayloadExecutionTime = watch.ElapsedMilliseconds;
+                _locker.Release();
+            }
+        }
+        else
+        {
+            if (_logger.IsWarn) _logger.Warn($"engine_newPayloadV{version} timed out");
+            return ResultWrapper<PayloadStatusV1>.Fail("Timed out", ErrorCodes.Timeout);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.Shanghai.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.Shanghai.cs
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Nethermind.Consensus.Producers;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Specs;
+using Nethermind.JsonRpc;
+using Nethermind.Logging;
+using Nethermind.Merge.Plugin.Data;
+using Nethermind.Merge.Plugin.Handlers;
+
+namespace Nethermind.Merge.Plugin
+{
+    public partial class EngineRpcModule : IEngineRpcModule
+    {
+        private readonly IAsyncHandler<byte[], GetPayloadV2Result?> _getPayloadHandlerV2;
+
+        public async Task<ResultWrapper<GetPayloadV2Result?>> engine_getPayloadV2(byte[] payloadId) =>
+            await _getPayloadHandlerV2.HandleAsync(payloadId);
+
+        public Task<ResultWrapper<PayloadStatusV1>> engine_newPayloadV2(ExecutionPayload executionPayload)
+            => NewPayload(executionPayload, 2);
+
+        public Task<ResultWrapper<ForkchoiceUpdatedV1Result>> engine_forkchoiceUpdatedV2(ForkchoiceStateV1 forkchoiceState, PayloadAttributes? payloadAttributes = null)
+            => ForkchoiceUpdated(forkchoiceState, payloadAttributes, 2);
+    }
+}

--- a/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.Shanghai.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.Shanghai.cs
@@ -1,31 +1,24 @@
-// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
-using System.Diagnostics;
-using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Consensus.Producers;
-using Nethermind.Core.Crypto;
-using Nethermind.Core.Specs;
 using Nethermind.JsonRpc;
-using Nethermind.Logging;
 using Nethermind.Merge.Plugin.Data;
 using Nethermind.Merge.Plugin.Handlers;
 
-namespace Nethermind.Merge.Plugin
+namespace Nethermind.Merge.Plugin;
+
+public partial class EngineRpcModule : IEngineRpcModule
 {
-    public partial class EngineRpcModule : IEngineRpcModule
-    {
-        private readonly IAsyncHandler<byte[], GetPayloadV2Result?> _getPayloadHandlerV2;
+    private readonly IAsyncHandler<byte[], GetPayloadV2Result?> _getPayloadHandlerV2;
 
-        public async Task<ResultWrapper<GetPayloadV2Result?>> engine_getPayloadV2(byte[] payloadId) =>
-            await _getPayloadHandlerV2.HandleAsync(payloadId);
+    public Task<ResultWrapper<ForkchoiceUpdatedV1Result>> engine_forkchoiceUpdatedV2(ForkchoiceStateV1 forkchoiceState, PayloadAttributes? payloadAttributes = null)
+        => ForkchoiceUpdated(forkchoiceState, payloadAttributes, 2);
 
-        public Task<ResultWrapper<PayloadStatusV1>> engine_newPayloadV2(ExecutionPayload executionPayload)
-            => NewPayload(executionPayload, 2);
+    public async Task<ResultWrapper<GetPayloadV2Result?>> engine_getPayloadV2(byte[] payloadId) =>
+        await _getPayloadHandlerV2.HandleAsync(payloadId);
 
-        public Task<ResultWrapper<ForkchoiceUpdatedV1Result>> engine_forkchoiceUpdatedV2(ForkchoiceStateV1 forkchoiceState, PayloadAttributes? payloadAttributes = null)
-            => ForkchoiceUpdated(forkchoiceState, payloadAttributes, 2);
-    }
+    public Task<ResultWrapper<PayloadStatusV1>> engine_newPayloadV2(ExecutionPayload executionPayload)
+        => NewPayload(executionPayload, 2);
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.cs
@@ -15,18 +15,11 @@ using Nethermind.Merge.Plugin.Handlers;
 
 namespace Nethermind.Merge.Plugin
 {
-    public class EngineRpcModule : IEngineRpcModule
+    public partial class EngineRpcModule : IEngineRpcModule
     {
-        private readonly IAsyncHandler<byte[], ExecutionPayload?> _getPayloadHandlerV1;
-        private readonly IAsyncHandler<byte[], GetPayloadV2Result?> _getPayloadHandlerV2;
-        private readonly IAsyncHandler<ExecutionPayload, PayloadStatusV1> _newPayloadV1Handler;
-        private readonly IForkchoiceUpdatedHandler _forkchoiceUpdatedV1Handler;
         private readonly IHandler<ExecutionStatusResult> _executionStatusHandler;
         private readonly IAsyncHandler<Keccak[], ExecutionPayloadBodyV1Result?[]> _executionGetPayloadBodiesByHashV1Handler;
         private readonly IGetPayloadBodiesByRangeV1Handler _executionGetPayloadBodiesByRangeV1Handler;
-        private readonly IHandler<TransitionConfigurationV1, TransitionConfigurationV1> _transitionConfigurationHandler;
-        private readonly SemaphoreSlim _locker = new(1, 1);
-        private readonly TimeSpan _timeout = TimeSpan.FromSeconds(8);
         private readonly ISpecProvider _specProvider;
         private readonly ILogger _logger;
 
@@ -55,117 +48,6 @@ namespace Nethermind.Merge.Plugin
         }
 
         public ResultWrapper<ExecutionStatusResult> engine_executionStatus() => _executionStatusHandler.Handle();
-
-        public Task<ResultWrapper<ExecutionPayload?>> engine_getPayloadV1(byte[] payloadId) =>
-            _getPayloadHandlerV1.HandleAsync(payloadId);
-
-        public async Task<ResultWrapper<GetPayloadV2Result?>> engine_getPayloadV2(byte[] payloadId) =>
-            await _getPayloadHandlerV2.HandleAsync(payloadId);
-
-        public async Task<ResultWrapper<PayloadStatusV1>> engine_newPayloadV1(ExecutionPayload executionPayload)
-        {
-            if (executionPayload.Withdrawals is not null)
-            {
-                var error = "ExecutionPayloadV1 expected";
-
-                if (_logger.IsWarn) _logger.Warn(error);
-
-                return ResultWrapper<PayloadStatusV1>.Fail(error, ErrorCodes.InvalidParams);
-            }
-
-            return await NewPayload(executionPayload, nameof(engine_newPayloadV1));
-        }
-
-        public Task<ResultWrapper<PayloadStatusV1>> engine_newPayloadV2(ExecutionPayload executionPayload)
-        {
-            var spec = _specProvider.GetSpec((executionPayload.BlockNumber, executionPayload.Timestamp));
-            string? error = null;
-
-            if (spec.WithdrawalsEnabled && executionPayload.Withdrawals is null)
-                error = "ExecutionPayloadV2 expected";
-            else if (!spec.WithdrawalsEnabled && executionPayload.Withdrawals is not null)
-                error = "ExecutionPayloadV1 expected";
-
-            if (error is not null)
-            {
-                if (_logger.IsWarn) _logger.Warn(error);
-
-                return ResultWrapper<PayloadStatusV1>.Fail(error, ErrorCodes.InvalidParams);
-            }
-
-            return NewPayload(executionPayload, nameof(engine_newPayloadV2));
-        }
-
-        public async Task<ResultWrapper<ForkchoiceUpdatedV1Result>> engine_forkchoiceUpdatedV1(ForkchoiceStateV1 forkchoiceState, PayloadAttributes? payloadAttributes = null)
-        {
-            if (payloadAttributes?.Withdrawals is not null)
-            {
-                var error = "PayloadAttributesV1 expected";
-
-                if (_logger.IsWarn) _logger.Warn(error);
-
-                return ResultWrapper<ForkchoiceUpdatedV1Result>.Fail(error, ErrorCodes.InvalidParams);
-            }
-
-            return await ForkchoiceUpdated(forkchoiceState, payloadAttributes, nameof(engine_forkchoiceUpdatedV1));
-        }
-
-        public Task<ResultWrapper<ForkchoiceUpdatedV1Result>> engine_forkchoiceUpdatedV2(ForkchoiceStateV1 forkchoiceState, PayloadAttributes? payloadAttributes = null)
-            => ForkchoiceUpdated(forkchoiceState, payloadAttributes, nameof(engine_forkchoiceUpdatedV2));
-
-        public ResultWrapper<TransitionConfigurationV1> engine_exchangeTransitionConfigurationV1(
-            TransitionConfigurationV1 beaconTransitionConfiguration) => _transitionConfigurationHandler.Handle(beaconTransitionConfiguration);
-
-        private async Task<ResultWrapper<ForkchoiceUpdatedV1Result>> ForkchoiceUpdated(ForkchoiceStateV1 forkchoiceState, PayloadAttributes? payloadAttributes, string methodName)
-        {
-            if (await _locker.WaitAsync(_timeout))
-            {
-                Stopwatch watch = Stopwatch.StartNew();
-                try
-                {
-                    return await _forkchoiceUpdatedV1Handler.Handle(forkchoiceState, payloadAttributes);
-                }
-                finally
-                {
-                    watch.Stop();
-                    Metrics.ForkchoiceUpdedExecutionTime = watch.ElapsedMilliseconds;
-                    _locker.Release();
-                }
-            }
-            else
-            {
-                if (_logger.IsWarn) _logger.Warn($"{methodName} timed out");
-                return ResultWrapper<ForkchoiceUpdatedV1Result>.Fail("Timed out", ErrorCodes.Timeout);
-            }
-        }
-
-        private async Task<ResultWrapper<PayloadStatusV1>> NewPayload(ExecutionPayload executionPayload, string methodName)
-        {
-            if (await _locker.WaitAsync(_timeout))
-            {
-                Stopwatch watch = Stopwatch.StartNew();
-                try
-                {
-                    return await _newPayloadV1Handler.HandleAsync(executionPayload);
-                }
-                catch (Exception exception)
-                {
-                    if (_logger.IsError) _logger.Error($"{methodName} failed: {exception}");
-                    return ResultWrapper<PayloadStatusV1>.Fail(exception.Message);
-                }
-                finally
-                {
-                    watch.Stop();
-                    Metrics.NewPayloadExecutionTime = watch.ElapsedMilliseconds;
-                    _locker.Release();
-                }
-            }
-            else
-            {
-                if (_logger.IsWarn) _logger.Warn($"{methodName} timed out");
-                return ResultWrapper<PayloadStatusV1>.Fail("Timed out", ErrorCodes.Timeout);
-            }
-        }
 
         public async Task<ResultWrapper<ExecutionPayloadBodyV1Result?[]>> engine_getPayloadBodiesByHashV1(Keccak[] blockHashes)
         {

--- a/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.cs
@@ -2,10 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Diagnostics;
-using System.Threading;
 using System.Threading.Tasks;
-using Nethermind.Consensus.Producers;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.JsonRpc;
@@ -13,50 +10,49 @@ using Nethermind.Logging;
 using Nethermind.Merge.Plugin.Data;
 using Nethermind.Merge.Plugin.Handlers;
 
-namespace Nethermind.Merge.Plugin
+namespace Nethermind.Merge.Plugin;
+
+public partial class EngineRpcModule : IEngineRpcModule
 {
-    public partial class EngineRpcModule : IEngineRpcModule
+    private readonly IHandler<ExecutionStatusResult> _executionStatusHandler;
+    private readonly IAsyncHandler<Keccak[], ExecutionPayloadBodyV1Result?[]> _executionGetPayloadBodiesByHashV1Handler;
+    private readonly IGetPayloadBodiesByRangeV1Handler _executionGetPayloadBodiesByRangeV1Handler;
+    private readonly ISpecProvider _specProvider;
+    private readonly ILogger _logger;
+
+    public EngineRpcModule(
+        IAsyncHandler<byte[], ExecutionPayload?> getPayloadHandlerV1,
+        IAsyncHandler<byte[], GetPayloadV2Result?> getPayloadHandlerV2,
+        IAsyncHandler<ExecutionPayload, PayloadStatusV1> newPayloadV1Handler,
+        IForkchoiceUpdatedHandler forkchoiceUpdatedV1Handler,
+        IHandler<ExecutionStatusResult> executionStatusHandler,
+        IAsyncHandler<Keccak[], ExecutionPayloadBodyV1Result?[]> executionGetPayloadBodiesByHashV1Handler,
+        IGetPayloadBodiesByRangeV1Handler executionGetPayloadBodiesByRangeV1Handler,
+        IHandler<TransitionConfigurationV1, TransitionConfigurationV1> transitionConfigurationHandler,
+        ISpecProvider specProvider,
+        ILogManager logManager)
     {
-        private readonly IHandler<ExecutionStatusResult> _executionStatusHandler;
-        private readonly IAsyncHandler<Keccak[], ExecutionPayloadBodyV1Result?[]> _executionGetPayloadBodiesByHashV1Handler;
-        private readonly IGetPayloadBodiesByRangeV1Handler _executionGetPayloadBodiesByRangeV1Handler;
-        private readonly ISpecProvider _specProvider;
-        private readonly ILogger _logger;
+        _getPayloadHandlerV1 = getPayloadHandlerV1;
+        _getPayloadHandlerV2 = getPayloadHandlerV2;
+        _newPayloadV1Handler = newPayloadV1Handler;
+        _forkchoiceUpdatedV1Handler = forkchoiceUpdatedV1Handler;
+        _executionStatusHandler = executionStatusHandler;
+        _executionGetPayloadBodiesByHashV1Handler = executionGetPayloadBodiesByHashV1Handler;
+        _executionGetPayloadBodiesByRangeV1Handler = executionGetPayloadBodiesByRangeV1Handler;
+        _transitionConfigurationHandler = transitionConfigurationHandler;
+        _specProvider = specProvider ?? throw new ArgumentNullException(nameof(specProvider));
+        _logger = logManager.GetClassLogger();
+    }
 
-        public EngineRpcModule(
-            IAsyncHandler<byte[], ExecutionPayload?> getPayloadHandlerV1,
-            IAsyncHandler<byte[], GetPayloadV2Result?> getPayloadHandlerV2,
-            IAsyncHandler<ExecutionPayload, PayloadStatusV1> newPayloadV1Handler,
-            IForkchoiceUpdatedHandler forkchoiceUpdatedV1Handler,
-            IHandler<ExecutionStatusResult> executionStatusHandler,
-            IAsyncHandler<Keccak[], ExecutionPayloadBodyV1Result?[]> executionGetPayloadBodiesByHashV1Handler,
-            IGetPayloadBodiesByRangeV1Handler executionGetPayloadBodiesByRangeV1Handler,
-            IHandler<TransitionConfigurationV1, TransitionConfigurationV1> transitionConfigurationHandler,
-            ISpecProvider specProvider,
-            ILogManager logManager)
-        {
-            _getPayloadHandlerV1 = getPayloadHandlerV1;
-            _getPayloadHandlerV2 = getPayloadHandlerV2;
-            _newPayloadV1Handler = newPayloadV1Handler;
-            _forkchoiceUpdatedV1Handler = forkchoiceUpdatedV1Handler;
-            _executionStatusHandler = executionStatusHandler;
-            _executionGetPayloadBodiesByHashV1Handler = executionGetPayloadBodiesByHashV1Handler;
-            _executionGetPayloadBodiesByRangeV1Handler = executionGetPayloadBodiesByRangeV1Handler;
-            _transitionConfigurationHandler = transitionConfigurationHandler;
-            _specProvider = specProvider ?? throw new ArgumentNullException(nameof(specProvider));
-            _logger = logManager.GetClassLogger();
-        }
+    public ResultWrapper<ExecutionStatusResult> engine_executionStatus() => _executionStatusHandler.Handle();
 
-        public ResultWrapper<ExecutionStatusResult> engine_executionStatus() => _executionStatusHandler.Handle();
+    public async Task<ResultWrapper<ExecutionPayloadBodyV1Result?[]>> engine_getPayloadBodiesByHashV1(Keccak[] blockHashes)
+    {
+        return await _executionGetPayloadBodiesByHashV1Handler.HandleAsync(blockHashes);
+    }
 
-        public async Task<ResultWrapper<ExecutionPayloadBodyV1Result?[]>> engine_getPayloadBodiesByHashV1(Keccak[] blockHashes)
-        {
-            return await _executionGetPayloadBodiesByHashV1Handler.HandleAsync(blockHashes);
-        }
-
-        public async Task<ResultWrapper<ExecutionPayloadBodyV1Result?[]>> engine_getPayloadBodiesByRangeV1(long start, long count)
-        {
-            return await _executionGetPayloadBodiesByRangeV1Handler.Handle(start, count);
-        }
+    public async Task<ResultWrapper<ExecutionPayloadBodyV1Result?[]>> engine_getPayloadBodiesByRangeV1(long start, long count)
+    {
+        return await _executionGetPayloadBodiesByRangeV1Handler.Handle(start, count);
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
@@ -235,20 +235,20 @@ public class ForkchoiceUpdatedHandler : IForkchoiceUpdatedHandler
 
             if (spec.WithdrawalsEnabled && payloadAttributes.Withdrawals is null)
             {
-                var error = "Withdrawals cannot be null when EIP-4895 activated.";
+                var error = "PayloadAttributesV2 expected";
 
                 if (_logger.IsInfo) _logger.Warn($"Invalid payload attributes: {error}");
 
-                return ForkchoiceUpdatedV1Result.Error(error, MergeErrorCodes.InvalidPayloadAttributes);
+                return ForkchoiceUpdatedV1Result.Error(error, ErrorCodes.InvalidParams);
             }
 
             if (!spec.WithdrawalsEnabled && payloadAttributes.Withdrawals is not null)
             {
-                var error = "Withdrawals must be null when EIP-4895 not activated.";
+                var error = "PayloadAttributesV1 expected";
 
                 if (_logger.IsInfo) _logger.Warn($"Invalid payload attributes: {error}");
 
-                return ForkchoiceUpdatedV1Result.Error(error, MergeErrorCodes.InvalidPayloadAttributes);
+                return ForkchoiceUpdatedV1Result.Error(error, ErrorCodes.InvalidParams);
             }
 
             payloadAttributes.GasLimit = null;

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
@@ -235,26 +235,6 @@ public class ForkchoiceUpdatedHandler : IForkchoiceUpdatedHandler
                 return ForkchoiceUpdatedV1Result.Error(error, MergeErrorCodes.InvalidPayloadAttributes);
             }
 
-            var spec = _specProvider.GetSpec(newHeadBlock.Number + 1, payloadAttributes.Timestamp);
-
-            if (spec.WithdrawalsEnabled && payloadAttributes.Withdrawals is null)
-            {
-                var error = "PayloadAttributesV2 expected";
-
-                if (_logger.IsInfo) _logger.Warn($"Invalid payload attributes: {error}");
-
-                return ForkchoiceUpdatedV1Result.Error(error, ErrorCodes.InvalidParams);
-            }
-
-            if (!spec.WithdrawalsEnabled && payloadAttributes.Withdrawals is not null)
-            {
-                var error = "PayloadAttributesV1 expected";
-
-                if (_logger.IsInfo) _logger.Warn($"Invalid payload attributes: {error}");
-
-                return ForkchoiceUpdatedV1Result.Error(error, ErrorCodes.InvalidParams);
-            }
-
             payloadAttributes.GasLimit = null;
             payloadId = _payloadPreparationService.StartPreparingPayload(newHeadBlock.Header, payloadAttributes);
         }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
@@ -11,7 +11,6 @@ using Nethermind.Consensus.Processing;
 using Nethermind.Consensus.Producers;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
-using Nethermind.Core.Specs;
 using Nethermind.Crypto;
 using Nethermind.JsonRpc;
 using Nethermind.Logging;
@@ -43,7 +42,6 @@ public class ForkchoiceUpdatedHandler : IForkchoiceUpdatedHandler
     private readonly IBeaconPivot _beaconPivot;
     private readonly ILogger _logger;
     private readonly IPeerRefresher _peerRefresher;
-    private readonly ISpecProvider _specProvider;
 
     public ForkchoiceUpdatedHandler(
         IBlockTree blockTree,
@@ -56,7 +54,6 @@ public class ForkchoiceUpdatedHandler : IForkchoiceUpdatedHandler
         IMergeSyncController mergeSyncController,
         IBeaconPivot beaconPivot,
         IPeerRefresher peerRefresher,
-        ISpecProvider specProvider,
         ILogManager logManager)
     {
         _blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
@@ -69,7 +66,6 @@ public class ForkchoiceUpdatedHandler : IForkchoiceUpdatedHandler
         _mergeSyncController = mergeSyncController;
         _beaconPivot = beaconPivot;
         _peerRefresher = peerRefresher;
-        _specProvider = specProvider;
         _logger = logManager.GetClassLogger();
     }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
@@ -23,9 +23,13 @@ using Nethermind.Merge.Plugin.Synchronization;
 namespace Nethermind.Merge.Plugin.Handlers;
 
 /// <summary>
-/// Propagates the change in the fork choice to the execution client. May initiate creating new payload.
-/// <see href="https://github.com/ethereum/execution-apis/blob/main/src/engine/shanghai.md#engine_forkchoiceupdatedv2">engine_forkchoiceupdatedv2</see>.
+/// Provides a fork choice update handler as defined in Engine API
+/// <see href="https://github.com/ethereum/execution-apis/blob/main/src/engine/shanghai.md#engine_forkchoiceupdatedv2">
+/// Shanghai</see> specification.
 /// </summary>
+/// <remarks>
+/// May initiate a new payload creation.
+/// </remarks>
 public class ForkchoiceUpdatedHandler : IForkchoiceUpdatedHandler
 {
     private readonly IBlockTree _blockTree;

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/NewPayloadHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/NewPayloadHandler.cs
@@ -13,7 +13,6 @@ using Nethermind.Consensus.Validators;
 using Nethermind.Core;
 using Nethermind.Core.Caching;
 using Nethermind.Core.Crypto;
-using Nethermind.Core.Specs;
 using Nethermind.Crypto;
 using Nethermind.Int256;
 using Nethermind.JsonRpc;
@@ -41,7 +40,6 @@ public class NewPayloadHandler : IAsyncHandler<ExecutionPayload, PayloadStatusV1
     private readonly IBlockCacheService _blockCacheService;
     private readonly IBlockProcessingQueue _processingQueue;
     private readonly IMergeSyncController _mergeSyncController;
-    private readonly ISpecProvider _specProvider;
     private readonly IInvalidChainTracker _invalidChainTracker;
     private readonly ILogger _logger;
     private readonly LruCache<Keccak, bool>? _latestBlocks;
@@ -60,7 +58,6 @@ public class NewPayloadHandler : IAsyncHandler<ExecutionPayload, PayloadStatusV1
         IBlockProcessingQueue processingQueue,
         IInvalidChainTracker invalidChainTracker,
         IMergeSyncController mergeSyncController,
-        ISpecProvider specProvider,
         ILogManager logManager,
         TimeSpan? timeout = null,
         int cacheSize = 50)
@@ -75,7 +72,6 @@ public class NewPayloadHandler : IAsyncHandler<ExecutionPayload, PayloadStatusV1
         _processingQueue = processingQueue;
         _invalidChainTracker = invalidChainTracker;
         _mergeSyncController = mergeSyncController;
-        _specProvider = specProvider;
         _logger = logManager.GetClassLogger();
         _defaultProcessingOptions = initConfig.StoreReceipts ? ProcessingOptions.EthereumMerge | ProcessingOptions.StoreReceipts : ProcessingOptions.EthereumMerge;
         _timeout = timeout ?? TimeSpan.FromSeconds(7);
@@ -111,13 +107,6 @@ public class NewPayloadHandler : IAsyncHandler<ExecutionPayload, PayloadStatusV1
         {
             if (_logger.IsInfo) _logger.Info($"Invalid - block {request} is known to be a part of an invalid chain.");
             return NewPayloadV1Result.Invalid(lastValidHash, $"Block {request} is known to be a part of an invalid chain.");
-        }
-
-        if (!_blockValidator.ValidateWithdrawals(block, out var error))
-        {
-            if (_logger.IsWarn) _logger.Warn($"Invalid: {error}");
-
-            return NewPayloadV1Result.Invalid(lastValidHash ?? block.ParentHash, error);
         }
 
         if (block.Header.Number <= _syncConfig.PivotNumberParsed)

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/NewPayloadHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/NewPayloadHandler.cs
@@ -25,9 +25,9 @@ using Nethermind.Synchronization;
 namespace Nethermind.Merge.Plugin.Handlers;
 
 /// <summary>
-/// Defines a class that handles the execution payload according to the
-/// <see href="https://eips.ethereum.org/EIPS/eip-3675">EIP-3675</see>.
-/// <see href="https://github.com/ethereum/execution-apis/blob/main/src/engine/shanghai.md#engine_newpayloadv2">engine_newpayloadv2</see>.
+/// Provides an execution payload handler as defined in Engine API
+/// <see href="https://github.com/ethereum/execution-apis/blob/main/src/engine/shanghai.md#engine_newpayloadv2">
+/// Shanghai</see> specification.
 /// </summary>
 public class NewPayloadHandler : IAsyncHandler<ExecutionPayload, PayloadStatusV1>
 {

--- a/src/Nethermind/Nethermind.Merge.Plugin/IEngineRpcModule.Paris.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/IEngineRpcModule.Paris.cs
@@ -1,39 +1,37 @@
-// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Threading.Tasks;
 using Nethermind.Consensus.Producers;
-using Nethermind.Core.Crypto;
 using Nethermind.JsonRpc;
 using Nethermind.JsonRpc.Modules;
 using Nethermind.Merge.Plugin.Data;
 
-namespace Nethermind.Merge.Plugin
+namespace Nethermind.Merge.Plugin;
+
+public partial interface IEngineRpcModule : IRpcModule
 {
-    public partial interface IEngineRpcModule : IRpcModule
-    {
-        [JsonRpcMethod(
-            Description = "Returns the most recent version of an execution payload with respect to the transaction set contained by the mempool.",
-            IsSharable = true,
-            IsImplemented = true)]
-        Task<ResultWrapper<ExecutionPayload?>> engine_getPayloadV1(byte[] payloadId);
+    [JsonRpcMethod(
+        Description = "Returns PoS transition configuration.",
+        IsSharable = true,
+        IsImplemented = true)]
+    ResultWrapper<TransitionConfigurationV1> engine_exchangeTransitionConfigurationV1(TransitionConfigurationV1 beaconTransitionConfiguration);
 
-        [JsonRpcMethod(
-            Description = "Verifies the payload according to the execution environment rules and returns the verification status and hash of the last valid block.",
-            IsSharable = true,
-            IsImplemented = true)]
-        Task<ResultWrapper<PayloadStatusV1>> engine_newPayloadV1(ExecutionPayload executionPayload);
+    [JsonRpcMethod(
+        Description = "Verifies the payload according to the execution environment rules and returns the verification status and hash of the last valid block.",
+        IsSharable = true,
+        IsImplemented = true)]
+    Task<ResultWrapper<ForkchoiceUpdatedV1Result>> engine_forkchoiceUpdatedV1(ForkchoiceStateV1 forkchoiceState, PayloadAttributes? payloadAttributes = null);
 
-        [JsonRpcMethod(
-            Description = "Verifies the payload according to the execution environment rules and returns the verification status and hash of the last valid block.",
-            IsSharable = true,
-            IsImplemented = true)]
-        Task<ResultWrapper<ForkchoiceUpdatedV1Result>> engine_forkchoiceUpdatedV1(ForkchoiceStateV1 forkchoiceState, PayloadAttributes? payloadAttributes = null);
+    [JsonRpcMethod(
+        Description = "Returns the most recent version of an execution payload with respect to the transaction set contained by the mempool.",
+        IsSharable = true,
+        IsImplemented = true)]
+    Task<ResultWrapper<ExecutionPayload?>> engine_getPayloadV1(byte[] payloadId);
 
-        [JsonRpcMethod(
-            Description = "Returns PoS transition configuration.",
-            IsSharable = true,
-            IsImplemented = true)]
-        ResultWrapper<TransitionConfigurationV1> engine_exchangeTransitionConfigurationV1(TransitionConfigurationV1 beaconTransitionConfiguration);
-    }
+    [JsonRpcMethod(
+        Description = "Verifies the payload according to the execution environment rules and returns the verification status and hash of the last valid block.",
+        IsSharable = true,
+        IsImplemented = true)]
+    Task<ResultWrapper<PayloadStatusV1>> engine_newPayloadV1(ExecutionPayload executionPayload);
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/IEngineRpcModule.Paris.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/IEngineRpcModule.Paris.cs
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Threading.Tasks;
+using Nethermind.Consensus.Producers;
+using Nethermind.Core.Crypto;
+using Nethermind.JsonRpc;
+using Nethermind.JsonRpc.Modules;
+using Nethermind.Merge.Plugin.Data;
+
+namespace Nethermind.Merge.Plugin
+{
+    public partial interface IEngineRpcModule : IRpcModule
+    {
+        [JsonRpcMethod(
+            Description = "Returns the most recent version of an execution payload with respect to the transaction set contained by the mempool.",
+            IsSharable = true,
+            IsImplemented = true)]
+        Task<ResultWrapper<ExecutionPayload?>> engine_getPayloadV1(byte[] payloadId);
+
+        [JsonRpcMethod(
+            Description = "Verifies the payload according to the execution environment rules and returns the verification status and hash of the last valid block.",
+            IsSharable = true,
+            IsImplemented = true)]
+        Task<ResultWrapper<PayloadStatusV1>> engine_newPayloadV1(ExecutionPayload executionPayload);
+
+        [JsonRpcMethod(
+            Description = "Verifies the payload according to the execution environment rules and returns the verification status and hash of the last valid block.",
+            IsSharable = true,
+            IsImplemented = true)]
+        Task<ResultWrapper<ForkchoiceUpdatedV1Result>> engine_forkchoiceUpdatedV1(ForkchoiceStateV1 forkchoiceState, PayloadAttributes? payloadAttributes = null);
+
+        [JsonRpcMethod(
+            Description = "Returns PoS transition configuration.",
+            IsSharable = true,
+            IsImplemented = true)]
+        ResultWrapper<TransitionConfigurationV1> engine_exchangeTransitionConfigurationV1(TransitionConfigurationV1 beaconTransitionConfiguration);
+    }
+}

--- a/src/Nethermind/Nethermind.Merge.Plugin/IEngineRpcModule.Shanghai.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/IEngineRpcModule.Shanghai.cs
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Threading.Tasks;
+using Nethermind.Consensus.Producers;
+using Nethermind.Core.Crypto;
+using Nethermind.JsonRpc;
+using Nethermind.JsonRpc.Modules;
+using Nethermind.Merge.Plugin.Data;
+
+namespace Nethermind.Merge.Plugin
+{
+    public partial interface IEngineRpcModule : IRpcModule
+    {
+        [JsonRpcMethod(
+            Description = "Returns the most recent version of an execution payload and fees with respect to the transaction set contained by the mempool.",
+            IsSharable = true,
+            IsImplemented = true)]
+        public Task<ResultWrapper<GetPayloadV2Result?>> engine_getPayloadV2(byte[] payloadId);
+
+        [JsonRpcMethod(
+            Description = "Verifies the payload according to the execution environment rules and returns the verification status and hash of the last valid block.",
+            IsSharable = true,
+            IsImplemented = true)]
+        Task<ResultWrapper<PayloadStatusV1>> engine_newPayloadV2(ExecutionPayload executionPayload);
+
+        [JsonRpcMethod(
+            Description = "Verifies the payload according to the execution environment rules and returns the verification status and hash of the last valid block.",
+            IsSharable = true,
+            IsImplemented = true)]
+        Task<ResultWrapper<ForkchoiceUpdatedV1Result>> engine_forkchoiceUpdatedV2(ForkchoiceStateV1 forkchoiceState, PayloadAttributes? payloadAttributes = null);
+    }
+}

--- a/src/Nethermind/Nethermind.Merge.Plugin/IEngineRpcModule.Shanghai.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/IEngineRpcModule.Shanghai.cs
@@ -1,33 +1,31 @@
-// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Threading.Tasks;
 using Nethermind.Consensus.Producers;
-using Nethermind.Core.Crypto;
 using Nethermind.JsonRpc;
 using Nethermind.JsonRpc.Modules;
 using Nethermind.Merge.Plugin.Data;
 
-namespace Nethermind.Merge.Plugin
+namespace Nethermind.Merge.Plugin;
+
+public partial interface IEngineRpcModule : IRpcModule
 {
-    public partial interface IEngineRpcModule : IRpcModule
-    {
-        [JsonRpcMethod(
-            Description = "Returns the most recent version of an execution payload and fees with respect to the transaction set contained by the mempool.",
-            IsSharable = true,
-            IsImplemented = true)]
-        public Task<ResultWrapper<GetPayloadV2Result?>> engine_getPayloadV2(byte[] payloadId);
+    [JsonRpcMethod(
+        Description = "Verifies the payload according to the execution environment rules and returns the verification status and hash of the last valid block.",
+        IsSharable = true,
+        IsImplemented = true)]
+    Task<ResultWrapper<ForkchoiceUpdatedV1Result>> engine_forkchoiceUpdatedV2(ForkchoiceStateV1 forkchoiceState, PayloadAttributes? payloadAttributes = null);
 
-        [JsonRpcMethod(
-            Description = "Verifies the payload according to the execution environment rules and returns the verification status and hash of the last valid block.",
-            IsSharable = true,
-            IsImplemented = true)]
-        Task<ResultWrapper<PayloadStatusV1>> engine_newPayloadV2(ExecutionPayload executionPayload);
+    [JsonRpcMethod(
+        Description = "Returns the most recent version of an execution payload and fees with respect to the transaction set contained by the mempool.",
+        IsSharable = true,
+        IsImplemented = true)]
+    public Task<ResultWrapper<GetPayloadV2Result?>> engine_getPayloadV2(byte[] payloadId);
 
-        [JsonRpcMethod(
-            Description = "Verifies the payload according to the execution environment rules and returns the verification status and hash of the last valid block.",
-            IsSharable = true,
-            IsImplemented = true)]
-        Task<ResultWrapper<ForkchoiceUpdatedV1Result>> engine_forkchoiceUpdatedV2(ForkchoiceStateV1 forkchoiceState, PayloadAttributes? payloadAttributes = null);
-    }
+    [JsonRpcMethod(
+        Description = "Verifies the payload according to the execution environment rules and returns the verification status and hash of the last valid block.",
+        IsSharable = true,
+        IsImplemented = true)]
+    Task<ResultWrapper<PayloadStatusV1>> engine_newPayloadV2(ExecutionPayload executionPayload);
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/IEngineRpcModule.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/IEngineRpcModule.cs
@@ -11,7 +11,7 @@ using Nethermind.Merge.Plugin.Data;
 namespace Nethermind.Merge.Plugin
 {
     [RpcModule(ModuleType.Engine)]
-    public interface IEngineRpcModule : IRpcModule
+    public partial interface IEngineRpcModule : IRpcModule
     {
         [JsonRpcMethod(
             Description =
@@ -19,42 +19,6 @@ namespace Nethermind.Merge.Plugin
             IsSharable = true,
             IsImplemented = true)]
         ResultWrapper<ExecutionStatusResult> engine_executionStatus();
-
-        [JsonRpcMethod(
-            Description = "Returns the most recent version of an execution payload with respect to the transaction set contained by the mempool.",
-            IsSharable = true,
-            IsImplemented = true)]
-        Task<ResultWrapper<ExecutionPayload?>> engine_getPayloadV1(byte[] payloadId);
-
-        [JsonRpcMethod(
-            Description = "Returns the most recent version of an execution payload and fees with respect to the transaction set contained by the mempool.",
-            IsSharable = true,
-            IsImplemented = true)]
-        public Task<ResultWrapper<GetPayloadV2Result?>> engine_getPayloadV2(byte[] payloadId);
-
-        [JsonRpcMethod(
-            Description = "Verifies the payload according to the execution environment rules and returns the verification status and hash of the last valid block.",
-            IsSharable = true,
-            IsImplemented = true)]
-        Task<ResultWrapper<PayloadStatusV1>> engine_newPayloadV1(ExecutionPayload executionPayload);
-
-        [JsonRpcMethod(
-            Description = "Verifies the payload according to the execution environment rules and returns the verification status and hash of the last valid block.",
-            IsSharable = true,
-            IsImplemented = true)]
-        Task<ResultWrapper<PayloadStatusV1>> engine_newPayloadV2(ExecutionPayload executionPayload);
-
-        [JsonRpcMethod(
-            Description = "Verifies the payload according to the execution environment rules and returns the verification status and hash of the last valid block.",
-            IsSharable = true,
-            IsImplemented = true)]
-        Task<ResultWrapper<ForkchoiceUpdatedV1Result>> engine_forkchoiceUpdatedV1(ForkchoiceStateV1 forkchoiceState, PayloadAttributes? payloadAttributes = null);
-
-        [JsonRpcMethod(
-            Description = "Verifies the payload according to the execution environment rules and returns the verification status and hash of the last valid block.",
-            IsSharable = true,
-            IsImplemented = true)]
-        Task<ResultWrapper<ForkchoiceUpdatedV1Result>> engine_forkchoiceUpdatedV2(ForkchoiceStateV1 forkchoiceState, PayloadAttributes? payloadAttributes = null);
 
         [JsonRpcMethod(
             Description = "Returns an array of execution payload bodies for the list of provided block hashes.",
@@ -67,11 +31,5 @@ namespace Nethermind.Merge.Plugin
             IsSharable = true,
             IsImplemented = true)]
         Task<ResultWrapper<ExecutionPayloadBodyV1Result?[]>> engine_getPayloadBodiesByRangeV1(long start, long count);
-
-        [JsonRpcMethod(
-            Description = "Returns PoS transition configuration.",
-            IsSharable = true,
-            IsImplemented = true)]
-        ResultWrapper<TransitionConfigurationV1> engine_exchangeTransitionConfigurationV1(TransitionConfigurationV1 beaconTransitionConfiguration);
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/IEngineRpcModule.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/IEngineRpcModule.cs
@@ -2,34 +2,32 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Threading.Tasks;
-using Nethermind.Consensus.Producers;
 using Nethermind.Core.Crypto;
 using Nethermind.JsonRpc;
 using Nethermind.JsonRpc.Modules;
 using Nethermind.Merge.Plugin.Data;
 
-namespace Nethermind.Merge.Plugin
+namespace Nethermind.Merge.Plugin;
+
+[RpcModule(ModuleType.Engine)]
+public partial interface IEngineRpcModule : IRpcModule
 {
-    [RpcModule(ModuleType.Engine)]
-    public partial interface IEngineRpcModule : IRpcModule
-    {
-        [JsonRpcMethod(
-            Description =
-                "Responds with information on the state of the execution client to either engine_consensusStatus or any other call if consistency failure has occurred.",
-            IsSharable = true,
-            IsImplemented = true)]
-        ResultWrapper<ExecutionStatusResult> engine_executionStatus();
+    [JsonRpcMethod(
+        Description =
+            "Responds with information on the state of the execution client to either engine_consensusStatus or any other call if consistency failure has occurred.",
+        IsSharable = true,
+        IsImplemented = true)]
+    ResultWrapper<ExecutionStatusResult> engine_executionStatus();
 
-        [JsonRpcMethod(
-            Description = "Returns an array of execution payload bodies for the list of provided block hashes.",
-            IsSharable = true,
-            IsImplemented = true)]
-        Task<ResultWrapper<ExecutionPayloadBodyV1Result?[]>> engine_getPayloadBodiesByHashV1(Keccak[] blockHashes);
+    [JsonRpcMethod(
+        Description = "Returns an array of execution payload bodies for the list of provided block hashes.",
+        IsSharable = true,
+        IsImplemented = true)]
+    Task<ResultWrapper<ExecutionPayloadBodyV1Result?[]>> engine_getPayloadBodiesByHashV1(Keccak[] blockHashes);
 
-        [JsonRpcMethod(
-            Description = "Returns an array of execution payload bodies for the provided number range",
-            IsSharable = true,
-            IsImplemented = true)]
-        Task<ResultWrapper<ExecutionPayloadBodyV1Result?[]>> engine_getPayloadBodiesByRangeV1(long start, long count);
-    }
+    [JsonRpcMethod(
+        Description = "Returns an array of execution payload bodies for the provided number range",
+        IsSharable = true,
+        IsImplemented = true)]
+    Task<ResultWrapper<ExecutionPayloadBodyV1Result?[]>> engine_getPayloadBodiesByRangeV1(long start, long count);
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
@@ -317,7 +317,6 @@ namespace Nethermind.Merge.Plugin
                         _api.BlockProcessingQueue,
                         _invalidChainTracker,
                         _beaconSync,
-                        _api.SpecProvider,
                         _api.LogManager),
                     new ForkchoiceUpdatedHandler(
                         _api.BlockTree,
@@ -336,6 +335,7 @@ namespace Nethermind.Merge.Plugin
                     new GetPayloadBodiesByHashV1Handler(_api.BlockTree, _api.LogManager),
                     new GetPayloadBodiesByRangeV1Handler(_api.BlockTree, _api.LogManager),
                     new ExchangeTransitionConfigurationV1Handler(_poSSwitcher, _api.LogManager),
+                    _api.SpecProvider,
                     _api.LogManager);
 
                 _api.RpcModuleProvider.RegisterSingle(engineRpcModule);

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Linq;
 using System.Net.Http;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Api;
@@ -30,422 +29,420 @@ using Nethermind.Merge.Plugin.Synchronization;
 using Nethermind.Synchronization.ParallelSync;
 using Nethermind.Synchronization.Reporting;
 
-namespace Nethermind.Merge.Plugin
+namespace Nethermind.Merge.Plugin;
+
+public partial class MergePlugin : IConsensusWrapperPlugin, ISynchronizationPlugin
 {
-    public partial class MergePlugin : IConsensusWrapperPlugin, ISynchronizationPlugin
+    protected INethermindApi _api = null!;
+    private ILogger _logger = null!;
+    protected IMergeConfig _mergeConfig = null!;
+    private ISyncConfig _syncConfig = null!;
+    protected IBlocksConfig _blocksConfig = null!;
+    protected IPoSSwitcher _poSSwitcher = NoPoS.Instance;
+    private IBeaconPivot? _beaconPivot;
+    private BeaconSync? _beaconSync;
+    private IBlockCacheService _blockCacheService = null!;
+    private InvalidChainTracker.InvalidChainTracker _invalidChainTracker = null!;
+    private IPeerRefresher _peerRefresher = null!;
+
+    private ManualBlockFinalizationManager _blockFinalizationManager = null!;
+    private IMergeBlockProductionPolicy? _mergeBlockProductionPolicy;
+
+    public virtual string Name => "Merge";
+    public virtual string Description => "Merge plugin for ETH1-ETH2";
+    public string Author => "Nethermind";
+
+    public virtual bool MergeEnabled => _mergeConfig.Enabled &&
+                                        !IsPreMergeConsensusAuRa(_api); // AuRa has dedicated plugin AuRaMergePlugin
+    protected bool IsPreMergeConsensusAuRa(INethermindApi api)
     {
-        protected INethermindApi _api = null!;
-        private ILogger _logger = null!;
-        protected IMergeConfig _mergeConfig = null!;
-        private ISyncConfig _syncConfig = null!;
-        protected IBlocksConfig _blocksConfig = null!;
-        protected IPoSSwitcher _poSSwitcher = NoPoS.Instance;
-        private IBeaconPivot? _beaconPivot;
-        private BeaconSync? _beaconSync;
-        private IBlockCacheService _blockCacheService = null!;
-        private InvalidChainTracker.InvalidChainTracker _invalidChainTracker = null!;
-        private IPeerRefresher _peerRefresher = null!;
+        return api.ChainSpec?.SealEngineType == SealEngineType.AuRa;
+    }
 
-        private ManualBlockFinalizationManager _blockFinalizationManager = null!;
-        private IMergeBlockProductionPolicy? _mergeBlockProductionPolicy;
+    // Don't remove default constructor. It is used by reflection when we're loading plugins
+    public MergePlugin() { }
 
-        public virtual string Name => "Merge";
-        public virtual string Description => "Merge plugin for ETH1-ETH2";
-        public string Author => "Nethermind";
+    public virtual Task Init(INethermindApi nethermindApi)
+    {
+        _api = nethermindApi;
+        _mergeConfig = nethermindApi.Config<IMergeConfig>();
+        _syncConfig = nethermindApi.Config<ISyncConfig>();
+        _blocksConfig = nethermindApi.Config<IBlocksConfig>();
 
-        public virtual bool MergeEnabled => _mergeConfig.Enabled &&
-                                            !IsPreMergeConsensusAuRa(_api); // AuRa has dedicated plugin AuRaMergePlugin
-        protected bool IsPreMergeConsensusAuRa(INethermindApi api)
+        MigrateSecondsPerSlot(_blocksConfig, _mergeConfig);
+
+        _logger = _api.LogManager.GetClassLogger();
+
+        if (MergeEnabled)
         {
-            return api.ChainSpec?.SealEngineType == SealEngineType.AuRa;
+            if (_api.DbProvider is null) throw new ArgumentException(nameof(_api.DbProvider));
+            if (_api.BlockTree is null) throw new ArgumentException(nameof(_api.BlockTree));
+            if (_api.SpecProvider is null) throw new ArgumentException(nameof(_api.SpecProvider));
+            if (_api.ChainSpec is null) throw new ArgumentException(nameof(_api.ChainSpec));
+            if (_api.SealValidator is null) throw new ArgumentException(nameof(_api.SealValidator));
+
+            EnsureJsonRpcUrl();
+            EnsureReceiptAvailable();
+
+            _blockCacheService = new BlockCacheService();
+            _poSSwitcher = new PoSSwitcher(
+                _mergeConfig,
+                _syncConfig,
+                _api.DbProvider.GetDb<IDb>(DbNames.Metadata),
+                _api.BlockTree,
+                _api.SpecProvider,
+                _api.LogManager);
+            _invalidChainTracker = new InvalidChainTracker.InvalidChainTracker(
+                _poSSwitcher,
+                _api.BlockTree,
+                _blockCacheService,
+                _api.LogManager);
+            _api.PoSSwitcher = _poSSwitcher;
+            _api.DisposeStack.Push(_invalidChainTracker);
+            _blockFinalizationManager = new ManualBlockFinalizationManager();
+
+            _api.RewardCalculatorSource = new MergeRewardCalculatorSource(
+               _api.RewardCalculatorSource ?? NoBlockRewards.Instance, _poSSwitcher);
+            _api.SealValidator = new InvalidHeaderSealInterceptor(
+                new MergeSealValidator(_poSSwitcher, _api.SealValidator),
+                _invalidChainTracker,
+                _api.LogManager);
+
+            _api.GossipPolicy = new MergeGossipPolicy(_api.GossipPolicy, _poSSwitcher, _blockCacheService);
+
+            _api.BlockPreprocessor.AddFirst(new MergeProcessingRecoveryStep(_poSSwitcher));
         }
 
-        // Don't remove default constructor. It is used by reflection when we're loading plugins
-        public MergePlugin() { }
+        return Task.CompletedTask;
+    }
 
-        public virtual Task Init(INethermindApi nethermindApi)
+    internal static void MigrateSecondsPerSlot(IBlocksConfig blocksConfig, IMergeConfig mergeConfig)
+    {
+        ulong defaultValue = blocksConfig.GetDefaultValue<ulong>(nameof(IBlocksConfig.SecondsPerSlot));
+        if (blocksConfig.SecondsPerSlot != mergeConfig.SecondsPerSlot)
         {
-            _api = nethermindApi;
-            _mergeConfig = nethermindApi.Config<IMergeConfig>();
-            _syncConfig = nethermindApi.Config<ISyncConfig>();
-            _blocksConfig = nethermindApi.Config<IBlocksConfig>();
-
-            MigrateSecondsPerSlot(_blocksConfig, _mergeConfig);
-
-            _logger = _api.LogManager.GetClassLogger();
-
-            if (MergeEnabled)
+            if (blocksConfig.SecondsPerSlot == defaultValue)
             {
-                if (_api.DbProvider is null) throw new ArgumentException(nameof(_api.DbProvider));
-                if (_api.BlockTree is null) throw new ArgumentException(nameof(_api.BlockTree));
-                if (_api.SpecProvider is null) throw new ArgumentException(nameof(_api.SpecProvider));
-                if (_api.ChainSpec is null) throw new ArgumentException(nameof(_api.ChainSpec));
-                if (_api.SealValidator is null) throw new ArgumentException(nameof(_api.SealValidator));
-
-                EnsureJsonRpcUrl();
-                EnsureReceiptAvailable();
-
-                _blockCacheService = new BlockCacheService();
-                _poSSwitcher = new PoSSwitcher(
-                    _mergeConfig,
-                    _syncConfig,
-                    _api.DbProvider.GetDb<IDb>(DbNames.Metadata),
-                    _api.BlockTree,
-                    _api.SpecProvider,
-                    _api.LogManager);
-                _invalidChainTracker = new InvalidChainTracker.InvalidChainTracker(
-                    _poSSwitcher,
-                    _api.BlockTree,
-                    _blockCacheService,
-                    _api.LogManager);
-                _api.PoSSwitcher = _poSSwitcher;
-                _api.DisposeStack.Push(_invalidChainTracker);
-                _blockFinalizationManager = new ManualBlockFinalizationManager();
-
-                _api.RewardCalculatorSource = new MergeRewardCalculatorSource(
-                   _api.RewardCalculatorSource ?? NoBlockRewards.Instance, _poSSwitcher);
-                _api.SealValidator = new InvalidHeaderSealInterceptor(
-                    new MergeSealValidator(_poSSwitcher, _api.SealValidator),
-                    _invalidChainTracker,
-                    _api.LogManager);
-
-                _api.GossipPolicy = new MergeGossipPolicy(_api.GossipPolicy, _poSSwitcher, _blockCacheService);
-
-                _api.BlockPreprocessor.AddFirst(new MergeProcessingRecoveryStep(_poSSwitcher));
+                blocksConfig.SecondsPerSlot = mergeConfig.SecondsPerSlot;
             }
-
-            return Task.CompletedTask;
-        }
-
-        internal static void MigrateSecondsPerSlot(IBlocksConfig blocksConfig, IMergeConfig mergeConfig)
-        {
-            ulong defaultValue = blocksConfig.GetDefaultValue<ulong>(nameof(IBlocksConfig.SecondsPerSlot));
-            if (blocksConfig.SecondsPerSlot != mergeConfig.SecondsPerSlot)
+            else if (mergeConfig.SecondsPerSlot == defaultValue)
             {
-                if (blocksConfig.SecondsPerSlot == defaultValue)
-                {
-                    blocksConfig.SecondsPerSlot = mergeConfig.SecondsPerSlot;
-                }
-                else if (mergeConfig.SecondsPerSlot == defaultValue)
-                {
-                    mergeConfig.SecondsPerSlot = blocksConfig.SecondsPerSlot;
-                }
-                else
-                {
-                    throw new InvalidConfigurationException($"Configuration mismatch at {nameof(IBlocksConfig.SecondsPerSlot)} " +
-                                                                $"with conflicting values {blocksConfig.SecondsPerSlot} and {mergeConfig.SecondsPerSlot}",
-                            ExitCodes.ConflictingConfigurations);
-                }
-            }
-        }
-
-        private void EnsureReceiptAvailable()
-        {
-            if (HasTtd() == false) // by default we have Merge.Enabled = true, for chains that are not post-merge, we can skip this check, but we can still working with MergePlugin
-                return;
-
-            if (_syncConfig.FastSync)
-            {
-                if (!_syncConfig.DownloadReceiptsInFastSync || !_syncConfig.DownloadBodiesInFastSync)
-                {
-                    throw new InvalidConfigurationException(
-                        "Receipt and body must be available for merge to function. The following configs values should be set to true: Sync.DownloadReceiptsInFastSync, Sync.DownloadBodiesInFastSync",
-                        ExitCodes.NoDownloadOldReceiptsOrBlocks);
-                }
-            }
-        }
-
-        private void EnsureJsonRpcUrl()
-        {
-            if (HasTtd() == false) // by default we have Merge.Enabled = true, for chains that are not post-merge, wwe can skip this check, but we can still working with MergePlugin
-                return;
-
-            IJsonRpcConfig jsonRpcConfig = _api.Config<IJsonRpcConfig>();
-            if (!jsonRpcConfig.Enabled)
-            {
-                if (_logger.IsInfo)
-                    _logger.Info("JsonRpc not enabled. Turning on JsonRpc URL with engine API.");
-
-                jsonRpcConfig.Enabled = true;
-
-                EnsureEngineModuleIsConfigured();
-
-                if (!jsonRpcConfig.EnabledModules.Contains("engine"))
-                {
-                    // Disable it
-                    jsonRpcConfig.EnabledModules = new string[] { };
-                }
-
-                jsonRpcConfig.AdditionalRpcUrls = jsonRpcConfig.AdditionalRpcUrls
-                    .Where((url) => JsonRpcUrl.Parse(url).EnabledModules.Contains("engine"))
-                    .ToArray();
+                mergeConfig.SecondsPerSlot = blocksConfig.SecondsPerSlot;
             }
             else
             {
-                EnsureEngineModuleIsConfigured();
+                throw new InvalidConfigurationException($"Configuration mismatch at {nameof(IBlocksConfig.SecondsPerSlot)} " +
+                                                            $"with conflicting values {blocksConfig.SecondsPerSlot} and {mergeConfig.SecondsPerSlot}",
+                        ExitCodes.ConflictingConfigurations);
             }
         }
+    }
 
-        private void EnsureEngineModuleIsConfigured()
+    private void EnsureReceiptAvailable()
+    {
+        if (HasTtd() == false) // by default we have Merge.Enabled = true, for chains that are not post-merge, we can skip this check, but we can still working with MergePlugin
+            return;
+
+        if (_syncConfig.FastSync)
         {
-            JsonRpcUrlCollection urlCollection = new(_api.LogManager, _api.Config<IJsonRpcConfig>(), false);
-            bool hasEngineApiConfigured = urlCollection
-                .Values
-                .Any(rpcUrl => rpcUrl.EnabledModules.Contains("engine"));
-
-            if (!hasEngineApiConfigured)
+            if (!_syncConfig.DownloadReceiptsInFastSync || !_syncConfig.DownloadBodiesInFastSync)
             {
                 throw new InvalidConfigurationException(
-                    "Engine module wasn't configured on any port. Nethermind can't work without engine port configured. Verify your RPC configuration. You can find examples in our docs: https://docs.nethermind.io/nethermind/ethereum-client/engine-jsonrpc-configuration-examples",
-                    ExitCodes.NoEngineModule);
+                    "Receipt and body must be available for merge to function. The following configs values should be set to true: Sync.DownloadReceiptsInFastSync, Sync.DownloadBodiesInFastSync",
+                    ExitCodes.NoDownloadOldReceiptsOrBlocks);
             }
         }
-
-        private bool HasTtd()
-        {
-            return _api.SpecProvider?.TerminalTotalDifficulty is not null || _mergeConfig.TerminalTotalDifficulty is not null;
-        }
-
-        public Task InitNetworkProtocol()
-        {
-            if (MergeEnabled)
-            {
-                if (_api.BlockTree is null) throw new ArgumentNullException(nameof(_api.BlockTree));
-                if (_api.SpecProvider is null) throw new ArgumentNullException(nameof(_api.SpecProvider));
-                if (_api.UnclesValidator is null) throw new ArgumentNullException(nameof(_api.UnclesValidator));
-                if (_api.BlockProductionPolicy is null) throw new ArgumentException(nameof(_api.BlockProductionPolicy));
-                if (_api.SealValidator is null) throw new ArgumentException(nameof(_api.SealValidator));
-                if (_api.HeaderValidator is null) throw new ArgumentException(nameof(_api.HeaderValidator));
-
-                MergeHeaderValidator headerValidator = new(
-                        _poSSwitcher,
-                        _api.HeaderValidator,
-                        _api.BlockTree,
-                        _api.SpecProvider,
-                        _api.SealValidator,
-                        _api.LogManager);
-
-                _api.HeaderValidator = new InvalidHeaderInterceptor(
-                    headerValidator,
-                    _invalidChainTracker,
-                    _api.LogManager);
-
-                _api.UnclesValidator = new MergeUnclesValidator(_poSSwitcher, _api.UnclesValidator);
-                _api.BlockValidator = new InvalidBlockInterceptor(
-                    new BlockValidator(_api.TxValidator, _api.HeaderValidator, _api.UnclesValidator,
-                        _api.SpecProvider, _api.LogManager),
-                    _invalidChainTracker,
-                    _api.LogManager);
-                _api.HealthHintService =
-                    new MergeHealthHintService(_api.HealthHintService, _poSSwitcher, _blocksConfig);
-                _mergeBlockProductionPolicy = new MergeBlockProductionPolicy(_api.BlockProductionPolicy);
-                _api.BlockProductionPolicy = _mergeBlockProductionPolicy;
-
-                _api.FinalizationManager = new MergeFinalizationManager(_blockFinalizationManager, _api.FinalizationManager, _poSSwitcher);
-
-                // Need to do it here because blockprocessor is not available in init
-                _invalidChainTracker.SetupBlockchainProcessorInterceptor(_api.BlockchainProcessor!);
-            }
-
-            return Task.CompletedTask;
-        }
-
-        public Task InitRpcModules()
-        {
-            if (MergeEnabled)
-            {
-                if (_api.RpcModuleProvider is null) throw new ArgumentNullException(nameof(_api.RpcModuleProvider));
-                if (_api.BlockTree is null) throw new ArgumentNullException(nameof(_api.BlockTree));
-                if (_api.BlockchainProcessor is null) throw new ArgumentNullException(nameof(_api.BlockchainProcessor));
-                if (_api.StateProvider is null) throw new ArgumentNullException(nameof(_api.StateProvider));
-                if (_api.HeaderValidator is null) throw new ArgumentNullException(nameof(_api.HeaderValidator));
-                if (_api.EthSyncingInfo is null) throw new ArgumentNullException(nameof(_api.EthSyncingInfo));
-                if (_api.Sealer is null) throw new ArgumentNullException(nameof(_api.Sealer));
-                if (_api.BlockValidator is null) throw new ArgumentNullException(nameof(_api.BlockValidator));
-                if (_api.BlockProcessingQueue is null) throw new ArgumentNullException(nameof(_api.BlockProcessingQueue));
-                if (_api.SyncProgressResolver is null) throw new ArgumentNullException(nameof(_api.SyncProgressResolver));
-                if (_api.SpecProvider is null) throw new ArgumentNullException(nameof(_api.SpecProvider));
-                if (_api.StateReader is null) throw new ArgumentNullException(nameof(_api.StateReader));
-                if (_beaconPivot is null) throw new ArgumentNullException(nameof(_beaconPivot));
-                if (_beaconSync is null) throw new ArgumentNullException(nameof(_beaconSync));
-                if (_blockProductionTrigger is null) throw new ArgumentNullException(nameof(_blockProductionTrigger));
-                if (_peerRefresher is null) throw new ArgumentNullException(nameof(_peerRefresher));
-
-
-                if (_postMergeBlockProducer is null) throw new ArgumentNullException(nameof(_postMergeBlockProducer));
-                if (_blockProductionTrigger is null) throw new ArgumentNullException(nameof(_blockProductionTrigger));
-
-                // ToDo: ugly temporary hack to not receive engine API messages before end of processing of all blocks after restart. Then we will wait 5s more to ensure everything is processed
-                while (!_api.BlockProcessingQueue.IsEmpty)
-                {
-                    Thread.Sleep(100);
-                }
-                Thread.Sleep(5000);
-
-                IBlockImprovementContextFactory improvementContextFactory;
-                if (string.IsNullOrEmpty(_mergeConfig.BuilderRelayUrl))
-                {
-                    improvementContextFactory = new BlockImprovementContextFactory(_blockProductionTrigger, TimeSpan.FromSeconds(_blocksConfig.SecondsPerSlot));
-                }
-                else
-                {
-                    DefaultHttpClient httpClient = new(new HttpClient(), _api.EthereumJsonSerializer, _api.LogManager, retryDelayMilliseconds: 100);
-                    IBoostRelay boostRelay = new BoostRelay(httpClient, _mergeConfig.BuilderRelayUrl);
-                    BoostBlockImprovementContextFactory boostBlockImprovementContextFactory = new(_blockProductionTrigger, TimeSpan.FromSeconds(_blocksConfig.SecondsPerSlot), boostRelay, _api.StateReader);
-                    improvementContextFactory = boostBlockImprovementContextFactory;
-                }
-
-                PayloadPreparationService payloadPreparationService = new(
-                    _postMergeBlockProducer,
-                    improvementContextFactory,
-                    _api.TimerFactory,
-                    _api.LogManager,
-                    TimeSpan.FromSeconds(_blocksConfig.SecondsPerSlot));
-
-                IEngineRpcModule engineRpcModule = new EngineRpcModule(
-                    new GetPayloadV1Handler(payloadPreparationService, _api.LogManager),
-                    new GetPayloadV2Handler(payloadPreparationService, _api.LogManager),
-                    new NewPayloadHandler(
-                        _api.BlockValidator,
-                        _api.BlockTree,
-                        _api.Config<IInitConfig>(),
-                        _syncConfig,
-                        _poSSwitcher,
-                        _beaconSync,
-                        _beaconPivot,
-                        _blockCacheService,
-                        _api.BlockProcessingQueue,
-                        _invalidChainTracker,
-                        _beaconSync,
-                        _api.LogManager),
-                    new ForkchoiceUpdatedHandler(
-                        _api.BlockTree,
-                        _blockFinalizationManager,
-                        _poSSwitcher,
-                        payloadPreparationService,
-                        _api.BlockProcessingQueue,
-                        _blockCacheService,
-                        _invalidChainTracker,
-                        _beaconSync,
-                        _beaconPivot,
-                        _peerRefresher,
-                        _api.SpecProvider,
-                        _api.LogManager),
-                    new ExecutionStatusHandler(_api.BlockTree),
-                    new GetPayloadBodiesByHashV1Handler(_api.BlockTree, _api.LogManager),
-                    new GetPayloadBodiesByRangeV1Handler(_api.BlockTree, _api.LogManager),
-                    new ExchangeTransitionConfigurationV1Handler(_poSSwitcher, _api.LogManager),
-                    _api.SpecProvider,
-                    _api.LogManager);
-
-                _api.RpcModuleProvider.RegisterSingle(engineRpcModule);
-                if (_logger.IsInfo) _logger.Info("Engine Module has been enabled");
-            }
-
-            return Task.CompletedTask;
-        }
-
-        public Task InitSynchronization()
-        {
-            if (MergeEnabled)
-            {
-                if (_api.SpecProvider is null) throw new ArgumentNullException(nameof(_api.SpecProvider));
-                if (_api.SyncPeerPool is null) throw new ArgumentNullException(nameof(_api.SyncPeerPool));
-                if (_api.BlockTree is null) throw new ArgumentNullException(nameof(_api.BlockTree));
-                if (_api.DbProvider is null) throw new ArgumentNullException(nameof(_api.DbProvider));
-                if (_api.SyncProgressResolver is null) throw new ArgumentNullException(nameof(_api.SyncProgressResolver));
-                if (_api.BlockProcessingQueue is null) throw new ArgumentNullException(nameof(_api.BlockProcessingQueue));
-                if (_blockCacheService is null) throw new ArgumentNullException(nameof(_blockCacheService));
-                if (_api.BetterPeerStrategy is null) throw new ArgumentNullException(nameof(_api.BetterPeerStrategy));
-                if (_api.SealValidator is null) throw new ArgumentNullException(nameof(_api.SealValidator));
-                if (_api.UnclesValidator is null) throw new ArgumentNullException(nameof(_api.UnclesValidator));
-                if (_api.NodeStatsManager is null) throw new ArgumentNullException(nameof(_api.NodeStatsManager));
-                if (_api.HeaderValidator is null) throw new ArgumentNullException(nameof(_api.HeaderValidator));
-                if (_api.PeerDifficultyRefreshPool is null) throw new ArgumentNullException(nameof(_api.PeerDifficultyRefreshPool));
-
-                // ToDo strange place for validators initialization
-                PeerRefresher peerRefresher = new(_api.PeerDifficultyRefreshPool, _api.TimerFactory, _api.LogManager);
-                _peerRefresher = peerRefresher;
-                _api.DisposeStack.Push(peerRefresher);
-                _beaconPivot = new BeaconPivot(_syncConfig, _api.DbProvider.MetadataDb, _api.BlockTree, _api.LogManager);
-
-                MergeHeaderValidator headerValidator = new(
-                        _poSSwitcher,
-                        _api.HeaderValidator,
-                        _api.BlockTree,
-                        _api.SpecProvider,
-                        _api.SealValidator,
-                        _api.LogManager);
-
-                _api.HeaderValidator = new InvalidHeaderInterceptor(
-                    headerValidator,
-                    _invalidChainTracker,
-                    _api.LogManager);
-
-                _api.UnclesValidator = new MergeUnclesValidator(_poSSwitcher, _api.UnclesValidator);
-                _api.BlockValidator = new InvalidBlockInterceptor(
-                    new BlockValidator(
-                        _api.TxValidator,
-                        _api.HeaderValidator,
-                        _api.UnclesValidator,
-                        _api.SpecProvider,
-                        _api.LogManager),
-                    _invalidChainTracker,
-                    _api.LogManager);
-                _beaconSync = new BeaconSync(_beaconPivot, _api.BlockTree, _syncConfig, _blockCacheService, _api.LogManager);
-
-                _api.BetterPeerStrategy = new MergeBetterPeerStrategy(_api.BetterPeerStrategy, _poSSwitcher, _beaconPivot, _api.LogManager);
-
-                _api.SyncModeSelector = new MultiSyncModeSelector(
-                    _api.SyncProgressResolver,
-                    _api.SyncPeerPool,
-                    _syncConfig,
-                    _beaconSync,
-                    _api.BetterPeerStrategy!,
-                    _api.LogManager);
-                _api.Pivot = _beaconPivot;
-
-                SyncReport syncReport = new(_api.SyncPeerPool, _api.NodeStatsManager, _api.SyncModeSelector, _syncConfig, _beaconPivot, _api.LogManager);
-
-                _api.BlockDownloaderFactory = new MergeBlockDownloaderFactory(
-                    _poSSwitcher,
-                    _beaconPivot,
-                    _api.SpecProvider,
-                    _api.BlockTree,
-                    _blockCacheService,
-                    _api.ReceiptStorage!,
-                    _api.BlockValidator!,
-                    _api.SealValidator!,
-                    _api.SyncPeerPool,
-                    _syncConfig,
-                    _api.BetterPeerStrategy!,
-                    syncReport,
-                    _api.SyncProgressResolver,
-                    _api.LogManager);
-                _api.Synchronizer = new MergeSynchronizer(
-                    _api.DbProvider,
-                    _api.SpecProvider!,
-                    _api.BlockTree!,
-                    _api.ReceiptStorage!,
-                    _api.SyncPeerPool,
-                    _api.NodeStatsManager!,
-                    _api.SyncModeSelector,
-                    _syncConfig,
-                    _api.SnapProvider,
-                    _api.BlockDownloaderFactory,
-                    _api.Pivot,
-                    _poSSwitcher,
-                    _mergeConfig,
-                    _invalidChainTracker,
-                    _api.LogManager,
-                    syncReport);
-            }
-
-            return Task.CompletedTask;
-        }
-
-        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
-
-        public bool MustInitialize { get => true; }
     }
+
+    private void EnsureJsonRpcUrl()
+    {
+        if (HasTtd() == false) // by default we have Merge.Enabled = true, for chains that are not post-merge, wwe can skip this check, but we can still working with MergePlugin
+            return;
+
+        IJsonRpcConfig jsonRpcConfig = _api.Config<IJsonRpcConfig>();
+        if (!jsonRpcConfig.Enabled)
+        {
+            if (_logger.IsInfo)
+                _logger.Info("JsonRpc not enabled. Turning on JsonRpc URL with engine API.");
+
+            jsonRpcConfig.Enabled = true;
+
+            EnsureEngineModuleIsConfigured();
+
+            if (!jsonRpcConfig.EnabledModules.Contains("engine"))
+            {
+                // Disable it
+                jsonRpcConfig.EnabledModules = new string[] { };
+            }
+
+            jsonRpcConfig.AdditionalRpcUrls = jsonRpcConfig.AdditionalRpcUrls
+                .Where((url) => JsonRpcUrl.Parse(url).EnabledModules.Contains("engine"))
+                .ToArray();
+        }
+        else
+        {
+            EnsureEngineModuleIsConfigured();
+        }
+    }
+
+    private void EnsureEngineModuleIsConfigured()
+    {
+        JsonRpcUrlCollection urlCollection = new(_api.LogManager, _api.Config<IJsonRpcConfig>(), false);
+        bool hasEngineApiConfigured = urlCollection
+            .Values
+            .Any(rpcUrl => rpcUrl.EnabledModules.Contains("engine"));
+
+        if (!hasEngineApiConfigured)
+        {
+            throw new InvalidConfigurationException(
+                "Engine module wasn't configured on any port. Nethermind can't work without engine port configured. Verify your RPC configuration. You can find examples in our docs: https://docs.nethermind.io/nethermind/ethereum-client/engine-jsonrpc-configuration-examples",
+                ExitCodes.NoEngineModule);
+        }
+    }
+
+    private bool HasTtd()
+    {
+        return _api.SpecProvider?.TerminalTotalDifficulty is not null || _mergeConfig.TerminalTotalDifficulty is not null;
+    }
+
+    public Task InitNetworkProtocol()
+    {
+        if (MergeEnabled)
+        {
+            if (_api.BlockTree is null) throw new ArgumentNullException(nameof(_api.BlockTree));
+            if (_api.SpecProvider is null) throw new ArgumentNullException(nameof(_api.SpecProvider));
+            if (_api.UnclesValidator is null) throw new ArgumentNullException(nameof(_api.UnclesValidator));
+            if (_api.BlockProductionPolicy is null) throw new ArgumentException(nameof(_api.BlockProductionPolicy));
+            if (_api.SealValidator is null) throw new ArgumentException(nameof(_api.SealValidator));
+            if (_api.HeaderValidator is null) throw new ArgumentException(nameof(_api.HeaderValidator));
+
+            MergeHeaderValidator headerValidator = new(
+                    _poSSwitcher,
+                    _api.HeaderValidator,
+                    _api.BlockTree,
+                    _api.SpecProvider,
+                    _api.SealValidator,
+                    _api.LogManager);
+
+            _api.HeaderValidator = new InvalidHeaderInterceptor(
+                headerValidator,
+                _invalidChainTracker,
+                _api.LogManager);
+
+            _api.UnclesValidator = new MergeUnclesValidator(_poSSwitcher, _api.UnclesValidator);
+            _api.BlockValidator = new InvalidBlockInterceptor(
+                new BlockValidator(_api.TxValidator, _api.HeaderValidator, _api.UnclesValidator,
+                    _api.SpecProvider, _api.LogManager),
+                _invalidChainTracker,
+                _api.LogManager);
+            _api.HealthHintService =
+                new MergeHealthHintService(_api.HealthHintService, _poSSwitcher, _blocksConfig);
+            _mergeBlockProductionPolicy = new MergeBlockProductionPolicy(_api.BlockProductionPolicy);
+            _api.BlockProductionPolicy = _mergeBlockProductionPolicy;
+
+            _api.FinalizationManager = new MergeFinalizationManager(_blockFinalizationManager, _api.FinalizationManager, _poSSwitcher);
+
+            // Need to do it here because blockprocessor is not available in init
+            _invalidChainTracker.SetupBlockchainProcessorInterceptor(_api.BlockchainProcessor!);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task InitRpcModules()
+    {
+        if (MergeEnabled)
+        {
+            if (_api.RpcModuleProvider is null) throw new ArgumentNullException(nameof(_api.RpcModuleProvider));
+            if (_api.BlockTree is null) throw new ArgumentNullException(nameof(_api.BlockTree));
+            if (_api.BlockchainProcessor is null) throw new ArgumentNullException(nameof(_api.BlockchainProcessor));
+            if (_api.StateProvider is null) throw new ArgumentNullException(nameof(_api.StateProvider));
+            if (_api.HeaderValidator is null) throw new ArgumentNullException(nameof(_api.HeaderValidator));
+            if (_api.EthSyncingInfo is null) throw new ArgumentNullException(nameof(_api.EthSyncingInfo));
+            if (_api.Sealer is null) throw new ArgumentNullException(nameof(_api.Sealer));
+            if (_api.BlockValidator is null) throw new ArgumentNullException(nameof(_api.BlockValidator));
+            if (_api.BlockProcessingQueue is null) throw new ArgumentNullException(nameof(_api.BlockProcessingQueue));
+            if (_api.SyncProgressResolver is null) throw new ArgumentNullException(nameof(_api.SyncProgressResolver));
+            if (_api.SpecProvider is null) throw new ArgumentNullException(nameof(_api.SpecProvider));
+            if (_api.StateReader is null) throw new ArgumentNullException(nameof(_api.StateReader));
+            if (_beaconPivot is null) throw new ArgumentNullException(nameof(_beaconPivot));
+            if (_beaconSync is null) throw new ArgumentNullException(nameof(_beaconSync));
+            if (_blockProductionTrigger is null) throw new ArgumentNullException(nameof(_blockProductionTrigger));
+            if (_peerRefresher is null) throw new ArgumentNullException(nameof(_peerRefresher));
+
+
+            if (_postMergeBlockProducer is null) throw new ArgumentNullException(nameof(_postMergeBlockProducer));
+            if (_blockProductionTrigger is null) throw new ArgumentNullException(nameof(_blockProductionTrigger));
+
+            // ToDo: ugly temporary hack to not receive engine API messages before end of processing of all blocks after restart. Then we will wait 5s more to ensure everything is processed
+            while (!_api.BlockProcessingQueue.IsEmpty)
+            {
+                Thread.Sleep(100);
+            }
+            Thread.Sleep(5000);
+
+            IBlockImprovementContextFactory improvementContextFactory;
+            if (string.IsNullOrEmpty(_mergeConfig.BuilderRelayUrl))
+            {
+                improvementContextFactory = new BlockImprovementContextFactory(_blockProductionTrigger, TimeSpan.FromSeconds(_blocksConfig.SecondsPerSlot));
+            }
+            else
+            {
+                DefaultHttpClient httpClient = new(new HttpClient(), _api.EthereumJsonSerializer, _api.LogManager, retryDelayMilliseconds: 100);
+                IBoostRelay boostRelay = new BoostRelay(httpClient, _mergeConfig.BuilderRelayUrl);
+                BoostBlockImprovementContextFactory boostBlockImprovementContextFactory = new(_blockProductionTrigger, TimeSpan.FromSeconds(_blocksConfig.SecondsPerSlot), boostRelay, _api.StateReader);
+                improvementContextFactory = boostBlockImprovementContextFactory;
+            }
+
+            PayloadPreparationService payloadPreparationService = new(
+                _postMergeBlockProducer,
+                improvementContextFactory,
+                _api.TimerFactory,
+                _api.LogManager,
+                TimeSpan.FromSeconds(_blocksConfig.SecondsPerSlot));
+
+            IEngineRpcModule engineRpcModule = new EngineRpcModule(
+                new GetPayloadV1Handler(payloadPreparationService, _api.LogManager),
+                new GetPayloadV2Handler(payloadPreparationService, _api.LogManager),
+                new NewPayloadHandler(
+                    _api.BlockValidator,
+                    _api.BlockTree,
+                    _api.Config<IInitConfig>(),
+                    _syncConfig,
+                    _poSSwitcher,
+                    _beaconSync,
+                    _beaconPivot,
+                    _blockCacheService,
+                    _api.BlockProcessingQueue,
+                    _invalidChainTracker,
+                    _beaconSync,
+                    _api.LogManager),
+                new ForkchoiceUpdatedHandler(
+                    _api.BlockTree,
+                    _blockFinalizationManager,
+                    _poSSwitcher,
+                    payloadPreparationService,
+                    _api.BlockProcessingQueue,
+                    _blockCacheService,
+                    _invalidChainTracker,
+                    _beaconSync,
+                    _beaconPivot,
+                    _peerRefresher,
+                    _api.LogManager),
+                new ExecutionStatusHandler(_api.BlockTree),
+                new GetPayloadBodiesByHashV1Handler(_api.BlockTree, _api.LogManager),
+                new GetPayloadBodiesByRangeV1Handler(_api.BlockTree, _api.LogManager),
+                new ExchangeTransitionConfigurationV1Handler(_poSSwitcher, _api.LogManager),
+                _api.SpecProvider,
+                _api.LogManager);
+
+            _api.RpcModuleProvider.RegisterSingle(engineRpcModule);
+            if (_logger.IsInfo) _logger.Info("Engine Module has been enabled");
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task InitSynchronization()
+    {
+        if (MergeEnabled)
+        {
+            if (_api.SpecProvider is null) throw new ArgumentNullException(nameof(_api.SpecProvider));
+            if (_api.SyncPeerPool is null) throw new ArgumentNullException(nameof(_api.SyncPeerPool));
+            if (_api.BlockTree is null) throw new ArgumentNullException(nameof(_api.BlockTree));
+            if (_api.DbProvider is null) throw new ArgumentNullException(nameof(_api.DbProvider));
+            if (_api.SyncProgressResolver is null) throw new ArgumentNullException(nameof(_api.SyncProgressResolver));
+            if (_api.BlockProcessingQueue is null) throw new ArgumentNullException(nameof(_api.BlockProcessingQueue));
+            if (_blockCacheService is null) throw new ArgumentNullException(nameof(_blockCacheService));
+            if (_api.BetterPeerStrategy is null) throw new ArgumentNullException(nameof(_api.BetterPeerStrategy));
+            if (_api.SealValidator is null) throw new ArgumentNullException(nameof(_api.SealValidator));
+            if (_api.UnclesValidator is null) throw new ArgumentNullException(nameof(_api.UnclesValidator));
+            if (_api.NodeStatsManager is null) throw new ArgumentNullException(nameof(_api.NodeStatsManager));
+            if (_api.HeaderValidator is null) throw new ArgumentNullException(nameof(_api.HeaderValidator));
+            if (_api.PeerDifficultyRefreshPool is null) throw new ArgumentNullException(nameof(_api.PeerDifficultyRefreshPool));
+
+            // ToDo strange place for validators initialization
+            PeerRefresher peerRefresher = new(_api.PeerDifficultyRefreshPool, _api.TimerFactory, _api.LogManager);
+            _peerRefresher = peerRefresher;
+            _api.DisposeStack.Push(peerRefresher);
+            _beaconPivot = new BeaconPivot(_syncConfig, _api.DbProvider.MetadataDb, _api.BlockTree, _api.LogManager);
+
+            MergeHeaderValidator headerValidator = new(
+                    _poSSwitcher,
+                    _api.HeaderValidator,
+                    _api.BlockTree,
+                    _api.SpecProvider,
+                    _api.SealValidator,
+                    _api.LogManager);
+
+            _api.HeaderValidator = new InvalidHeaderInterceptor(
+                headerValidator,
+                _invalidChainTracker,
+                _api.LogManager);
+
+            _api.UnclesValidator = new MergeUnclesValidator(_poSSwitcher, _api.UnclesValidator);
+            _api.BlockValidator = new InvalidBlockInterceptor(
+                new BlockValidator(
+                    _api.TxValidator,
+                    _api.HeaderValidator,
+                    _api.UnclesValidator,
+                    _api.SpecProvider,
+                    _api.LogManager),
+                _invalidChainTracker,
+                _api.LogManager);
+            _beaconSync = new BeaconSync(_beaconPivot, _api.BlockTree, _syncConfig, _blockCacheService, _api.LogManager);
+
+            _api.BetterPeerStrategy = new MergeBetterPeerStrategy(_api.BetterPeerStrategy, _poSSwitcher, _beaconPivot, _api.LogManager);
+
+            _api.SyncModeSelector = new MultiSyncModeSelector(
+                _api.SyncProgressResolver,
+                _api.SyncPeerPool,
+                _syncConfig,
+                _beaconSync,
+                _api.BetterPeerStrategy!,
+                _api.LogManager);
+            _api.Pivot = _beaconPivot;
+
+            SyncReport syncReport = new(_api.SyncPeerPool, _api.NodeStatsManager, _api.SyncModeSelector, _syncConfig, _beaconPivot, _api.LogManager);
+
+            _api.BlockDownloaderFactory = new MergeBlockDownloaderFactory(
+                _poSSwitcher,
+                _beaconPivot,
+                _api.SpecProvider,
+                _api.BlockTree,
+                _blockCacheService,
+                _api.ReceiptStorage!,
+                _api.BlockValidator!,
+                _api.SealValidator!,
+                _api.SyncPeerPool,
+                _syncConfig,
+                _api.BetterPeerStrategy!,
+                syncReport,
+                _api.SyncProgressResolver,
+                _api.LogManager);
+            _api.Synchronizer = new MergeSynchronizer(
+                _api.DbProvider,
+                _api.SpecProvider!,
+                _api.BlockTree!,
+                _api.ReceiptStorage!,
+                _api.SyncPeerPool,
+                _api.NodeStatsManager!,
+                _api.SyncModeSelector,
+                _syncConfig,
+                _api.SnapProvider,
+                _api.BlockDownloaderFactory,
+                _api.Pivot,
+                _poSSwitcher,
+                _mergeConfig,
+                _invalidChainTracker,
+                _api.LogManager,
+                syncReport);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    public bool MustInitialize { get => true; }
 }


### PR DESCRIPTION
## Changes

Implemented https://github.com/ethereum/execution-apis/pull/337 that unifies Engine API failure responses.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or a feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional or API changes)
- [ ] Build-related changes
- [ ] Other: _description_ 

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Withdrawals Hive tests passing.
