### PR TITLE
Use IsEmpty for ConcurrentCollections rather than doing work to .Count

### DIFF
--- a/src/Nethermind/Nethermind.Config/ConfigProvider.cs
+++ b/src/Nethermind/Nethermind.Config/ConfigProvider.cs
@@ -111,7 +111,7 @@ namespace Nethermind.Config
 
         public (string ErrorMsg, IList<(IConfigSource Source, string Category, string Name)> Errors) FindIncorrectSettings()
         {
-            if (_instances.Count == 0)
+            if (_instances.IsEmpty)
             {
                 Initialize();
             }

--- a/src/Nethermind/Nethermind.Grpc/Servers/GrpcServer.cs
+++ b/src/Nethermind/Nethermind.Grpc/Servers/GrpcServer.cs
@@ -69,7 +69,7 @@ namespace Nethermind.Grpc.Servers
                 return Task.CompletedTask;
             }
 
-            if (_clientResults.Count == 0)
+            if (_clientResults.IsEmpty)
             {
                 return Task.CompletedTask;
             }

--- a/src/Nethermind/Nethermind.Mev/Source/BundlePool.cs
+++ b/src/Nethermind/Nethermind.Mev/Source/BundlePool.cs
@@ -412,7 +412,7 @@ namespace Nethermind.Mev.Source
                     }
                 }
 
-                if (simulations.Count == 0)
+                if (simulations.IsEmpty)
                 {
                     _simulatedBundles.Remove(bundle.BlockNumber, out _);
                 }

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
@@ -575,7 +575,7 @@ namespace Nethermind.Synchronization.Blocks
 
             if (_logger.IsTrace) _logger.Trace("Seal validation complete");
 
-            if (exceptions.Count > 0)
+            if (!exceptions.IsEmpty)
             {
                 if (_logger.IsDebug) _logger.Debug("Seal validation failure");
                 throw new AggregateException(exceptions);

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/PendingSyncItems.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/PendingSyncItems.cs
@@ -165,7 +165,7 @@ namespace Nethermind.Synchronization.FastSync
             List<StateSyncItem> requestItems = new(length);
 
             // Codes have priority over State Nodes
-            if (CodeItems.Count > 0)
+            if (!CodeItems.IsEmpty)
             {
                 int codeMaxCount = Math.Min(length, CodeItems.Count);
 

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
@@ -83,7 +83,7 @@ namespace Nethermind.Synchronization.SnapSync
 
             SnapSyncBatch request = new();
 
-            if (AccountsToRefresh.Count > 0)
+            if (!AccountsToRefresh.IsEmpty)
             {
                 Interlocked.Increment(ref _activeAccRefreshRequests);
 
@@ -125,7 +125,7 @@ namespace Nethermind.Synchronization.SnapSync
 
                 return (request, false);
             }
-            else if (StoragesToRetrieve.Count > 0)
+            else if (!StoragesToRetrieve.IsEmpty)
             {
                 Interlocked.Increment(ref _activeStorageRequests);
 
@@ -150,7 +150,7 @@ namespace Nethermind.Synchronization.SnapSync
 
                 return (request, false);
             }
-            else if (CodesToRetrieve.Count > 0)
+            else if (!CodesToRetrieve.IsEmpty)
             {
                 Interlocked.Increment(ref _activeCodeRequests);
 
@@ -257,10 +257,10 @@ namespace Nethermind.Synchronization.SnapSync
         public bool IsSnapGetRangesFinished()
         {
             return !MoreAccountsToRight
-                && StoragesToRetrieve.Count == 0
-                && NextSlotRange.Count == 0
-                && CodesToRetrieve.Count == 0
-                && AccountsToRefresh.Count == 0
+                && StoragesToRetrieve.IsEmpty
+                && NextSlotRange.IsEmpty
+                && CodesToRetrieve.IsEmpty
+                && AccountsToRefresh.IsEmpty
                 && _activeAccountRequests == 0
                 && _activeStorageRequests == 0
                 && _activeCodeRequests == 0

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -230,7 +230,7 @@ namespace Nethermind.Trie
                             }
                         });
 
-                        if (_commitExceptions.Count > 0)
+                        if (!_commitExceptions.IsEmpty)
                         {
                             throw new AggregateException(_commitExceptions);
                         }


### PR DESCRIPTION
## Changes

Rather than doing extra work to get and exact count (which can be freezing/locks or cause allocations); use `IsEmpty` for ConcurrentCollections which is more light weight as it doesn't need to synchronise to count.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or a feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional or API changes)
- [ ] Build-related changes
- [ ] Other: _description_ 

## Testing

#### Requires testing

- [ ] Yes
- [x] No
