### PR TITLE
Remove Obsolete Old methods used for validity checking

### DIFF
--- a/src/Nethermind/Nethermind.Benchmark/Core/ByteArrayToHexBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Core/ByteArrayToHexBenchmarks.cs
@@ -27,9 +27,7 @@ namespace Nethermind.Benchmarks.Core
         [Benchmark]
         public string SafeLookup()
         {
-#pragma warning disable CS0612 // Type or member is obsolete
-            return Bytes.ByteArrayToHexViaLookup32SafeOld(array, false);
-#pragma warning restore CS0612 // Type or member is obsolete
+            return Bytes.ByteArrayToHexViaLookup32Safe(array, false);
         }
 
         [Benchmark(Baseline = true)]

--- a/src/Nethermind/Nethermind.Benchmark/Core/FromHexBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Core/FromHexBenchmarks.cs
@@ -26,9 +26,7 @@ namespace Nethermind.Benchmarks.Core
         [Benchmark]
         public byte[] Improved()
         {
-#pragma warning disable CS0612 // Type or member is obsolete
-            return Bytes.FromHexStringOld(array);
-#pragma warning restore CS0612 // Type or member is obsolete
+            return Bytes.FromHexString(array);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Core.Test/BytesTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/BytesTests.cs
@@ -41,11 +41,6 @@ namespace Nethermind.Core.Test
         [TestCase("0123", 1)]
         public void FromHexString(string hexString, byte expectedResult)
         {
-#pragma warning disable CS0612 // Type or member is obsolete
-            byte[] bytesOld = Bytes.FromHexStringOld(hexString);
-#pragma warning restore CS0612 // Type or member is obsolete
-            Assert.AreEqual(bytesOld[0], expectedResult, "old");
-
             byte[] bytes = Bytes.FromHexString(hexString);
             Assert.AreEqual(bytes[0], expectedResult, "new");
         }
@@ -87,15 +82,8 @@ namespace Nethermind.Core.Test
             }
             Assert.AreEqual(expectedResult.ToLower(), bytes.ToHexString(with0x, noLeadingZeros));
             Assert.AreEqual(expectedResult.ToLower(), bytes.AsSpan().ToHexString(with0x, noLeadingZeros, withEip55Checksum: false));
-#pragma warning disable CS0612 // Type or member is obsolete
-            Assert.AreEqual(bytes.ToHexStringOld(with0x, noLeadingZeros), bytes.ToHexString(with0x, noLeadingZeros));
-#pragma warning restore CS0612 // Type or member is obsolete
 
             Assert.AreEqual(expectedResult, bytes.ToHexString(with0x, noLeadingZeros, withEip55Checksum: true));
-#pragma warning disable CS0612 // Type or member is obsolete
-            Assert.AreEqual(bytes.ToHexStringOld(with0x, noLeadingZeros, withEip55Checksum: true),
-                bytes.ToHexString(with0x, noLeadingZeros, withEip55Checksum: true));
-#pragma warning restore CS0612 // Type or member is obsolete
             Assert.AreEqual(bytes.ToHexString(with0x, noLeadingZeros, withEip55Checksum: true),
                 bytes.AsSpan().ToHexString(with0x, noLeadingZeros, withEip55Checksum: true));
         }

--- a/src/Nethermind/Nethermind.Core/Extensions/Int64Extensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/Int64Extensions.cs
@@ -178,27 +178,6 @@ namespace Nethermind.Core.Extensions
             return bytes.ToHexString(true, skipLeadingZeros, false);
         }
 
-        [Obsolete]
-        public static string ToHexStringOld(this in UInt256 value, bool skipLeadingZeros)
-        {
-            if (skipLeadingZeros)
-            {
-                if (value == UInt256.Zero)
-                {
-                    return "0x";
-                }
-
-                if (value == UInt256.One)
-                {
-                    return "0x1";
-                }
-            }
-
-            byte[] bytes = new byte[32];
-            value.ToBigEndian(bytes);
-            return bytes.ToHexStringOld(true, skipLeadingZeros, false);
-        }
-
         public static long ToLongFromBigEndianByteArrayWithoutLeadingZeros(this byte[]? bytes)
         {
             if (bytes is null)

--- a/src/Nethermind/Nethermind.JsonRpc.Benchmark/UInt256ToHexStringBenchmark.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Benchmark/UInt256ToHexStringBenchmark.cs
@@ -58,9 +58,7 @@ namespace Nethermind.JsonRpc.Benchmark
         [Benchmark(Baseline = true)]
         public string Current()
         {
-#pragma warning disable CS0612 // Type or member is obsolete
-            return _scenarios[ScenarioIndex].ToHexStringOld(true);
-#pragma warning restore CS0612 // Type or member is obsolete
+            return _scenarios[ScenarioIndex].ToHexString(true);
         }
     }
 }


### PR DESCRIPTION
Were used to validate https://github.com/NethermindEth/nethermind/pull/5009; however that's long since been merged

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or a feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional or API changes)
- [ ] Build-related changes
- [ ] Other: _description_ 

## Testing

#### Requires testing

- [ ] Yes
- [x] No
