### PR TITLE
fix to CancellationTokenSource has been disposed.

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
@@ -785,7 +785,7 @@ namespace Nethermind.Synchronization.Blocks
 
             public void Cancel()
             {
-                lock(Cancellation)
+                lock (Cancellation)
                 {
                     if (!_isDisposed)
                     {
@@ -798,7 +798,7 @@ namespace Nethermind.Synchronization.Blocks
 
             public void Dispose()
             {
-                lock(Cancellation)
+                lock (Cancellation)
                 {
                     if (!_isDisposed)
                     {

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
@@ -785,9 +785,12 @@ namespace Nethermind.Synchronization.Blocks
 
             public void Cancel()
             {
-                if (!_isDisposed)
+                lock(Cancellation)
                 {
-                    Cancellation.Cancel();
+                    if (!_isDisposed)
+                    {
+                        Cancellation.Cancel();
+                    }
                 }
             }
 
@@ -795,10 +798,13 @@ namespace Nethermind.Synchronization.Blocks
 
             public void Dispose()
             {
-                if (!_isDisposed)
+                lock(Cancellation)
                 {
-                    _isDisposed = true;
-                    Cancellation.Dispose();
+                    if (!_isDisposed)
+                    {
+                        _isDisposed = true;
+                        Cancellation.Dispose();
+                    }
                 }
             }
         }

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
@@ -45,7 +45,7 @@ namespace Nethermind.Synchronization.Blocks
 
         private bool _cancelDueToBetterPeer;
         private AllocationWithCancellation _allocationWithCancellation = new(null, new CancellationTokenSource());
-        protected bool HasBetterPeer => _allocationWithCancellation.Cancellation.IsCancellationRequested;
+        protected bool HasBetterPeer => _allocationWithCancellation.IsCancellationRequested;
 
         protected SyncBatchSize _syncBatchSize;
         protected int _sinceLastTimeout;
@@ -780,7 +780,8 @@ namespace Nethermind.Synchronization.Blocks
                 _isDisposed = false;
             }
 
-            public CancellationTokenSource Cancellation { get; }
+            private CancellationTokenSource Cancellation { get; }
+            public bool IsCancellationRequested => Cancellation.IsCancellationRequested;
             public SyncPeerAllocation Allocation { get; }
 
             public void Cancel()


### PR DESCRIPTION
Fixes #5021

The issue seems to be a very rare race condition. either we should lock or try catch and ignore the exception.

## Changes

- locks the cancellationTokenSource before cancellation or disposing.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or a feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional or API changes)
- [ ] Build-related changes
- [ ] Other: _description_ 

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing
its almost impossible to simulate this situation