### PR TITLE
Reset UtcEndTime when new data comes in

### DIFF
--- a/src/Nethermind/Nethermind.Core/MeasuredProgress.cs
+++ b/src/Nethermind/Nethermind.Core/MeasuredProgress.cs
@@ -16,10 +16,8 @@ namespace Nethermind.Core
 
         public void Update(long value)
         {
-            if (UtcEndTime.HasValue)
-            {
-                UtcEndTime = null;
-            }
+            UtcEndTime = null;
+
             if (!UtcStartTime.HasValue)
             {
                 UtcStartTime = _timestamper.UtcNow;
@@ -31,14 +29,12 @@ namespace Nethermind.Core
 
         public void SetMeasuringPoint()
         {
+            UtcEndTime = null;
+
             if (UtcStartTime is not null)
             {
                 LastMeasurement = _timestamper.UtcNow;
                 LastValue = CurrentValue;
-            }
-            if (UtcEndTime.HasValue)
-            {
-                UtcEndTime = null;
             }
         }
 

--- a/src/Nethermind/Nethermind.Core/MeasuredProgress.cs
+++ b/src/Nethermind/Nethermind.Core/MeasuredProgress.cs
@@ -16,6 +16,10 @@ namespace Nethermind.Core
 
         public void Update(long value)
         {
+            if (UtcEndTime.HasValue)
+            {
+                UtcEndTime = null;
+            }
             if (!UtcStartTime.HasValue)
             {
                 UtcStartTime = _timestamper.UtcNow;
@@ -31,6 +35,10 @@ namespace Nethermind.Core
             {
                 LastMeasurement = _timestamper.UtcNow;
                 LastValue = CurrentValue;
+            }
+            if (UtcEndTime.HasValue)
+            {
+                UtcEndTime = null;
             }
         }
 


### PR DESCRIPTION
Resolves #5183

`InitializeFeed()` now calls `PostFinishCleanUp()` which sets `UtcEndTime` and stops updating current

Before

![image](https://user-images.githubusercontent.com/1142958/213592195-c6cedfbf-c01d-4252-98ed-10e17571c5d4.png)

After

![image](https://user-images.githubusercontent.com/1142958/213592627-da860ea8-9b11-43dd-bdda-72016c00cf00.png)


## Changes

- Resets `UtcEndTime` when new data comes in

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or a feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional or API changes)
- [ ] Build-related changes
- [ ] Other: _description_ 
