### PR TITLE
TreeSync remove two .ToArray allocations

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/ISnapSyncPeer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/ISnapSyncPeer.cs
@@ -16,7 +16,7 @@ namespace Nethermind.Blockchain.Synchronization
     {
         Task<AccountsAndProofs> GetAccountRange(AccountRange range, CancellationToken token);
         Task<SlotsAndProofs> GetStorageRange(StorageRange range, CancellationToken token);
-        Task<byte[][]> GetByteCodes(Keccak[] codeHashes, CancellationToken token);
+        Task<byte[][]> GetByteCodes(IReadOnlyList<Keccak> codeHashes, CancellationToken token);
         Task<byte[][]> GetTrieNodes(AccountsToRefreshRequest request, CancellationToken token);
         Task<byte[][]> GetTrieNodes(GetTrieNodesRequest request, CancellationToken token);
     }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/GetByteCodesMessage.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/GetByteCodesMessage.cs
@@ -14,7 +14,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap.Messages
         /// <summary>
         /// Code hashes to retrieve the code for
         /// </summary>
-        public Keccak[] Hashes { get; set; }
+        public IReadOnlyList<Keccak> Hashes { get; set; }
 
         /// <summary>
         /// Soft limit at which to stop returning data

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/SnapProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/SnapProtocolHandler.cs
@@ -2,13 +2,12 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
-using DotNetty.Buffers;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core.Crypto;
-using Nethermind.Core.Extensions;
 using Nethermind.Logging;
 using Nethermind.Network.P2P.EventArg;
 using Nethermind.Network.P2P.ProtocolHandlers;
@@ -211,7 +210,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap
             return new SlotsAndProofs() { PathsAndSlots = response.Slots, Proofs = response.Proofs };
         }
 
-        public async Task<byte[][]> GetByteCodes(Keccak[] codeHashes, CancellationToken token)
+        public async Task<byte[][]> GetByteCodes(IReadOnlyList<Keccak> codeHashes, CancellationToken token)
         {
             var request = new GetByteCodesMessage()
             {

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -1525,6 +1525,18 @@ namespace Nethermind.Serialization.Rlp
             return value;
         }
 
+        public static int LengthOf(IReadOnlyList<Keccak> keccaks, bool includeLengthOfSequenceStart = false)
+        {
+            int value = keccaks?.Count * LengthOfKeccakRlp ?? 0;
+
+            if (includeLengthOfSequenceStart)
+            {
+                value = LengthOfSequence(value);
+            }
+
+            return value;
+        }
+
         public static int LengthOf(Address? item)
         {
             return item is null ? 1 : 21;

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpStream.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpStream.cs
@@ -215,6 +215,24 @@ namespace Nethermind.Serialization.Rlp
             }
         }
 
+        public void Encode(IReadOnlyList<Keccak> keccaks)
+        {
+            if (keccaks is null)
+            {
+                EncodeNullObject();
+            }
+            else
+            {
+                var length = Rlp.LengthOf(keccaks);
+                StartSequence(length);
+                var count = keccaks.Count;
+                for (int i = 0; i < count; i++)
+                {
+                    Encode(keccaks[i]);
+                }
+            }
+        }
+
         public void Encode(Address? address)
         {
             if (address is null)

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/StateSyncBatch.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/StateSyncBatch.cs
@@ -1,15 +1,16 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Collections.Generic;
 using System.Diagnostics;
 using Nethermind.Core.Crypto;
 
 namespace Nethermind.Synchronization.FastSync
 {
-    [DebuggerDisplay("Requested Nodes: {RequestedNodes?.Length ?? 0}, Responses: {Responses?.Length ?? 0}, Assigned: {AssignedPeer?.Current}")]
+    [DebuggerDisplay("Requested Nodes: {RequestedNodes?.Count ?? 0}, Responses: {Responses?.Length ?? 0}, Assigned: {AssignedPeer?.Current}")]
     public class StateSyncBatch
     {
-        public StateSyncBatch(Keccak stateRoot, NodeDataType nodeDataType, StateSyncItem[] requestedNodes)
+        public StateSyncBatch(Keccak stateRoot, NodeDataType nodeDataType, IList<StateSyncItem> requestedNodes)
         {
             StateRoot = stateRoot;
             NodeDataType = nodeDataType;
@@ -20,7 +21,7 @@ namespace Nethermind.Synchronization.FastSync
 
         public Keccak StateRoot;
 
-        public StateSyncItem[]? RequestedNodes { get; }
+        public IList<StateSyncItem>? RequestedNodes { get; }
 
         public byte[][]? Responses { get; set; }
 
@@ -28,7 +29,7 @@ namespace Nethermind.Synchronization.FastSync
 
         public override string ToString()
         {
-            return $"{RequestedNodes?.Length ?? 0} state sync requests with {Responses?.Length ?? 0} responses";
+            return $"{RequestedNodes?.Count ?? 0} state sync requests with {Responses?.Length ?? 0} responses";
         }
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
@@ -100,10 +100,9 @@ namespace Nethermind.Synchronization.FastSync
 
                 if (requestItems.Count > 0)
                 {
-                    StateSyncItem[] requestedNodes = requestItems.ToArray();
-                    StateSyncBatch result = new(_rootNode, requestItems[0].NodeDataType, requestedNodes);
+                    StateSyncBatch result = new(_rootNode, requestItems[0].NodeDataType, requestItems);
 
-                    Interlocked.Add(ref _data.RequestedNodesCount, result.RequestedNodes.Length);
+                    Interlocked.Add(ref _data.RequestedNodesCount, result.RequestedNodes.Count);
                     Interlocked.Exchange(ref _data.SecondsInSync, _currentSyncStartSecondsInSync + secondsInCurrentSync);
 
                     if (_logger.IsTrace) _logger.Trace($"After preparing a request of {requestItems.Count} from ({_pendingItems.Description}) nodes | {_dependencies.Count}");
@@ -150,7 +149,7 @@ namespace Nethermind.Synchronization.FastSync
                         return SyncResponseHandlingResult.OK;
                     }
 
-                    int requestLength = batch.RequestedNodes?.Length ?? 0;
+                    int requestLength = batch.RequestedNodes?.Count ?? 0;
                     int responseLength = batch.Responses?.Length ?? 0;
 
                     void AddAgainAllItems()
@@ -195,7 +194,7 @@ namespace Nethermind.Synchronization.FastSync
                         _logger.Trace($"Received node data - {responseLength} items in response to {requestLength}");
                     int nonEmptyResponses = 0;
                     int invalidNodes = 0;
-                    for (int i = 0; i < batch.RequestedNodes!.Length; i++)
+                    for (int i = 0; i < batch.RequestedNodes!.Count; i++)
                     {
                         StateSyncItem currentStateSyncItem = batch.RequestedNodes[i];
 
@@ -261,7 +260,7 @@ namespace Nethermind.Synchronization.FastSync
 
                     if (_logger.IsTrace)
                         _logger.Trace(
-                            $"After handling response (non-empty responses {nonEmptyResponses}) of {batch.RequestedNodes.Length} from ({_pendingItems.Description}) nodes");
+                            $"After handling response (non-empty responses {nonEmptyResponses}) of {batch.RequestedNodes.Count} from ({_pendingItems.Description}) nodes");
 
                     /* magic formula is ratio of our desired batch size - 1024 to Geth max batch size 384 times some missing nodes ratio */
                     bool isEmptish = (decimal)nonEmptyResponses / Math.Max(requestLength, 1) < 384m / 1024m * 0.75m;
@@ -285,7 +284,7 @@ namespace Nethermind.Synchronization.FastSync
                     {
                         if (_logger.IsDebug)
                             _logger.Debug(
-                                $"Peer sent no data in response to a request of length {batch.RequestedNodes.Length}");
+                                $"Peer sent no data in response to a request of length {batch.RequestedNodes.Count}");
                         return SyncResponseHandlingResult.NoProgress;
                     }
 
@@ -454,7 +453,7 @@ namespace Nethermind.Synchronization.FastSync
                     foreach ((StateSyncBatch pendingRequest, _) in _pendingRequests)
                     {
                         // re-add the pending request
-                        for (int i = 0; i < pendingRequest.RequestedNodes.Length; i++)
+                        for (int i = 0; i < pendingRequest.RequestedNodes.Count; i++)
                         {
                             AddNodeToPending(pendingRequest.RequestedNodes[i], null, "pending request", true);
                         }

--- a/src/Nethermind/Nethermind.Synchronization/StateSync/StateSyncDispatcher.cs
+++ b/src/Nethermind/Nethermind.Synchronization/StateSync/StateSyncDispatcher.cs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Blockchain.Synchronization;
@@ -27,26 +27,27 @@ namespace Nethermind.Synchronization.StateSync
 
         protected override async Task Dispatch(PeerInfo peerInfo, StateSyncBatch batch, CancellationToken cancellationToken)
         {
-            if (batch?.RequestedNodes is null || batch.RequestedNodes.Length == 0)
+            if (batch?.RequestedNodes is null || batch.RequestedNodes.Count == 0)
             {
                 return;
             }
 
             ISyncPeer peer = peerInfo.SyncPeer;
-            Keccak[]? a = batch.RequestedNodes.Select(n => n.Hash).ToArray();
             Task<byte[][]> task = null;
-
+            HashList? hashList = null;
             // Use GETNODEDATA if possible
             if (peer.Node.EthDetails.Equals("eth66"))
             {
-                task = peer.GetNodeData(a, cancellationToken);
+                hashList = HashList.Rent(batch.RequestedNodes);
+                task = peer.GetNodeData(hashList, cancellationToken);
             }
             // GETNODEDATA is not supported so we try with SNAP protocol
             else if (peer.TryGetSatelliteProtocol("snap", out ISnapSyncPeer handler))
             {
                 if (batch.NodeDataType == NodeDataType.Code)
                 {
-                    task = handler.GetByteCodes(a, cancellationToken);
+                    hashList = HashList.Rent(batch.RequestedNodes);
+                    task = handler.GetByteCodes(hashList, cancellationToken);
                 }
                 else
                 {
@@ -63,6 +64,8 @@ namespace Nethermind.Synchronization.StateSync
             try
             {
                 batch.Responses = await task;
+
+                if (hashList is not null) HashList.Return(hashList);
             }
             catch (Exception e)
             {
@@ -135,14 +138,62 @@ namespace Nethermind.Synchronization.StateSync
                 accountPathIndex++;
             }
 
-            if (batch.RequestedNodes.Length != requestedNodeIndex)
+            if (batch.RequestedNodes.Count != requestedNodeIndex)
             {
-                Logger.Warn($"INCORRECT number of paths RequestedNodes.Length:{batch.RequestedNodes.Length} <> requestedNodeIndex:{requestedNodeIndex}");
+                Logger.Warn($"INCORRECT number of paths RequestedNodes.Length:{batch.RequestedNodes.Count} <> requestedNodeIndex:{requestedNodeIndex}");
             }
 
             return request;
         }
 
         private static byte[] EncodePath(byte[] input) => input.Length == 64 ? Nibbles.ToBytes(input) : Nibbles.ToCompactHexEncoding(input);
+
+        /// <summary>
+        /// Present an array of StateSyncItem[] as IReadOnlyList<Keccak> to avoid allocating secondary array
+        /// Also Rent and Return cache for single item to try and avoid allocating the HashList in common case
+        /// </summary>
+        private sealed class HashList : IReadOnlyList<Keccak>
+        {
+            private static HashList s_cache;
+
+            private IList<StateSyncItem> _items;
+
+            public static HashList Rent(IList<StateSyncItem> items)
+            {
+                HashList hashList = Interlocked.Exchange(ref s_cache, null) ?? new HashList();
+                hashList.Initialize(items);
+                return hashList;
+            }
+
+            public static void Return(HashList hashList)
+            {
+                hashList.Reset();
+                Volatile.Write(ref s_cache, hashList);
+            }
+
+            public void Initialize(IList<StateSyncItem> items)
+            {
+                _items = items;
+            }
+
+            public void Reset()
+            {
+                _items = null;
+            }
+
+            public Keccak this[int index] => _items[index].Hash;
+
+            public int Count => _items.Count;
+
+            public IEnumerator<Keccak> GetEnumerator()
+            {
+                foreach (StateSyncItem item in _items)
+                {
+                    yield return item.Hash;
+                }
+            }
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
     }
 }


### PR DESCRIPTION
Resolves #4377

## Changes

- Pass the .Chunk => `List<>` directly through rather than `.ToArray`ing it since its only locally used can be modified directly
- Introduce a private class that presents `List<StateSyncItem>` as `IReadOnlyList<Keccak>` and use a static class of one for less common allocations; rather than Linq `.Select(x => x.hash).ToArray()`

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or a feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional or API changes)
- [ ] Build-related changes
- [x] Other: Reduce allocations

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No
