### PR TITLE
Reduce TrieNodeDecoder allocations

### DIFF
--- a/src/Nethermind/Nethermind.Trie/Nethermind.Trie.csproj
+++ b/src/Nethermind/Nethermind.Trie/Nethermind.Trie.csproj
@@ -6,6 +6,7 @@
         <Deterministic>true</Deterministic>
         <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Changes

- stackalloc `HexPrefix` serialisation

## Types of changes

Before

<img width="500" alt="image" src="https://user-images.githubusercontent.com/1142958/213879077-55f91465-4505-4339-989f-d590390ae37e.png">


After

<img width="479" alt="image" src="https://user-images.githubusercontent.com/1142958/213879093-b82803eb-2c5e-4052-9d14-7d371477ce62.png">


#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or a feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional or API changes)
- [ ] Build-related changes
- [x] Other: Performance

## Testing

#### Requires testing

- [ ] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No