### PR TITLE
Update ethereum tests, add Eip3855Tests

### DIFF
--- a/src/Nethermind/Ethereum.Blockchain.Test/Eip3855Tests.cs
+++ b/src/Nethermind/Ethereum.Blockchain.Test/Eip3855Tests.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Collections.Generic;

--- a/src/Nethermind/Ethereum.Blockchain.Test/Eip3855Tests.cs
+++ b/src/Nethermind/Ethereum.Blockchain.Test/Eip3855Tests.cs
@@ -1,0 +1,25 @@
+﻿// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Generic;
+using Ethereum.Test.Base;
+using NUnit.Framework;
+
+namespace Ethereum.Blockchain.Test;
+
+[TestFixture]
+[Parallelizable(ParallelScope.All)]
+public class Eip3855Tests : GeneralStateTestBase
+{
+    [TestCaseSource(nameof(LoadTests))]
+    public void Test(GeneralStateTest test)
+    {
+        Assert.True(RunTest(test).Pass);
+    }
+
+    public static IEnumerable<GeneralStateTest> LoadTests()
+    {
+        var loader = new TestsSourceLoader(new LoadGeneralStateTestsStrategy(), "stEIP3855");
+        return (IEnumerable<GeneralStateTest>)loader.LoadTests();
+    }
+}

--- a/src/Nethermind/Ethereum.Blockchain.Test/Ethereum.Blockchain.Test.csproj
+++ b/src/Nethermind/Ethereum.Blockchain.Test/Ethereum.Blockchain.Test.csproj
@@ -31,6 +31,10 @@
       <Link>%(RecursiveDir)%(FileName)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
+    <EmbeddedResource Include="..\..\tests\GeneralStateTests\EIPTests\stEIP*\**\*.*">
+      <Link>%(RecursiveDir)%(FileName)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Ethereum.Test.Base\Ethereum.Test.Base.csproj" />


### PR DESCRIPTION
## Changes

- standard update of ethereum tests
- added class `Eip3855Tests`
- added path to `EIPTests`, moved to different directory in tests repo

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: standard update of ethereum tests

## Testing

#### Requires testing

- [ ] Yes
- [x] No