### PR TITLE
Fix/PutSpan in column db not working

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using DotNetty.Buffers;
 using Nethermind.Core;
 using Nethermind.Core.Caching;
 using Nethermind.Core.Crypto;
@@ -172,7 +173,10 @@ namespace Nethermind.Blockchain.Receipts
             var blockNumber = block.Number;
             var spec = _specProvider.GetSpec(block.Header);
             RlpBehaviors behaviors = spec.IsEip658Enabled ? RlpBehaviors.Eip658Receipts | RlpBehaviors.Storage : RlpBehaviors.Storage;
-            _blocksDb.Set(block.Hash!, StorageDecoder.Encode(txReceipts, behaviors).Bytes);
+            using (NettyRlpStream stream = StorageDecoder.EncodeToNewNettyStream(txReceipts, behaviors))
+            {
+                _blocksDb.Set(block.Hash!, stream.AsSpan());
+            }
 
             if (blockNumber < MigratedBlockNumber)
             {

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/ReceiptDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/ReceiptDecoderTests.cs
@@ -215,6 +215,24 @@ namespace Nethermind.Core.Test.Encoding
             AssertStorageReceipt(txReceipt, deserialized);
         }
 
+        [Test]
+        public void Netty_and_rlp_array_encoding_should_be_the_same()
+        {
+            TxReceipt[] receipts = new[]
+            {
+                Build.A.Receipt.WithAllFieldsFilled.TestObject,
+                Build.A.Receipt.WithAllFieldsFilled.TestObject
+            };
+
+            ReceiptStorageDecoder decoder = new();
+            Rlp rlp = decoder.Encode(receipts);
+            using (NettyRlpStream nettyRlpStream = decoder.EncodeToNewNettyStream(receipts))
+            {
+                byte[] nettyBytes = nettyRlpStream.AsSpan().ToArray();
+                nettyBytes.Should().BeEquivalentTo(rlp.Bytes);
+            }
+        }
+
         public static IEnumerable<(TxReceipt, string)> TestCaseSource()
         {
             Bloom bloom = new();
@@ -273,6 +291,5 @@ namespace Nethermind.Core.Test.Encoding
             Assert.AreEqual(txReceipt.Recipient, deserialized.Recipient, "recipient");
             Assert.AreEqual(txReceipt.StatusCode, deserialized.StatusCode, "status");
         }
-
     }
 }

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -128,7 +128,7 @@ public class ColumnDb : IDbWithSpan
 
     public void PutSpan(byte[] keyBytes, ReadOnlySpan<byte> value)
     {
-        _rocksDb.Put(keyBytes, value);
+        _rocksDb.Put(keyBytes, value, _columnFamily, _mainDb.WriteOptions);
     }
 
     public void DangerousReleaseMemory(in Span<byte> span) => _rocksDb.DangerousReleaseMemory(span);

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -126,5 +126,10 @@ public class ColumnDb : IDbWithSpan
 
     public Span<byte> GetSpan(byte[] key) => _rocksDb.GetSpan(key, _columnFamily);
 
+    public void PutSpan(byte[] keyBytes, ReadOnlySpan<byte> value)
+    {
+        _rocksDb.Put(keyBytes, value);
+    }
+
     public void DangerousReleaseMemory(in Span<byte> span) => _rocksDb.DangerousReleaseMemory(span);
 }

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -401,6 +401,26 @@ public class DbOnTheRocks : IDbWithSpan
         }
     }
 
+    public void PutSpan(byte[] key, ReadOnlySpan<byte> value)
+    {
+        if (_isDisposing)
+        {
+            throw new ObjectDisposedException($"Attempted to write form a disposed database {Name}");
+        }
+
+        UpdateWriteMetrics();
+
+        try
+        {
+            _db.Put(key, value, null, WriteOptions);
+        }
+        catch (RocksDbSharpException e)
+        {
+            CreateMarkerIfCorrupt(e);
+            throw;
+        }
+    }
+
     public void DangerousReleaseMemory(in Span<byte> span)
     {
         if (!span.IsNullOrEmpty())

--- a/src/Nethermind/Nethermind.Db.Rpc/RpcColumnsDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rpc/RpcColumnsDb.cs
@@ -23,6 +23,10 @@ namespace Nethermind.Db.Rpc
         public IEnumerable<T> ColumnKeys { get; } = Array.Empty<T>();
 
         public Span<byte> GetSpan(byte[] key) => this[key].AsSpan();
+        public void PutSpan(byte[] keyBytes, ReadOnlySpan<byte> value)
+        {
+            this[keyBytes] = value.ToArray();
+        }
 
         public void DangerousReleaseMemory(in Span<byte> span)
         {

--- a/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
@@ -21,7 +21,7 @@ using RocksDbSharp;
 namespace Nethermind.Db.Test
 {
     [TestFixture]
-    [Parallelizable(ParallelScope.All)]
+    [Parallelizable(ParallelScope.None)]
     public class DbOnTheRocksTests
     {
         [Test]
@@ -31,6 +31,19 @@ namespace Nethermind.Db.Test
             DbOnTheRocks db = new("blocks", GetRocksDbSettings("blocks", "Blocks"), config, LimboLogs.Instance);
             db[new byte[] { 1, 2, 3 }] = new byte[] { 4, 5, 6 };
             Assert.AreEqual(new byte[] { 4, 5, 6 }, db[new byte[] { 1, 2, 3 }]);
+        }
+
+        [Test]
+        public void Smoke_test_span()
+        {
+            IDbConfig config = new DbConfig();
+            DbOnTheRocks db = new("blocks", GetRocksDbSettings("blocks", "Blocks"), config, LimboLogs.Instance);
+            byte[] key = new byte[] { 1, 2, 3 };
+            byte[] value = new byte[] { 4, 5, 6 };
+            db.PutSpan(key, value);
+            Span<byte> readSpan = db.GetSpan(key);
+            Assert.AreEqual(new byte[] { 4, 5, 6 }, readSpan.ToArray());
+            db.DangerousReleaseMemory(readSpan);
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Db/DbExtensions.cs
+++ b/src/Nethermind/Nethermind.Db/DbExtensions.cs
@@ -36,6 +36,18 @@ namespace Nethermind.Db
             return db[key.Bytes];
         }
 
+        public static void Set(this IDb db, Keccak key, Span<byte> value)
+        {
+            if (db is IDbWithSpan dbWithSpan)
+            {
+                dbWithSpan.PutSpan(key.Bytes, value);
+            }
+            else
+            {
+                db[key.Bytes] = value.ToArray();
+            }
+        }
+
         public static KeyValuePair<byte[], byte[]>[] MultiGet(this IDb db, IEnumerable<Keccak> keys)
         {
             var k = keys.Select(k => k.Bytes).ToArray();

--- a/src/Nethermind/Nethermind.Db/IDbWithSpan.cs
+++ b/src/Nethermind/Nethermind.Db/IDbWithSpan.cs
@@ -8,11 +8,12 @@ namespace Nethermind.Db
     public interface IDbWithSpan : IDb
     {
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="key"></param>
         /// <returns>Can return null or empty Span on missing key</returns>
         Span<byte> GetSpan(byte[] key);
+        void PutSpan(byte[] keyBytes, ReadOnlySpan<byte> value);
         void DangerousReleaseMemory(in Span<byte> span);
     }
 }

--- a/src/Nethermind/Nethermind.Db/MemDb.cs
+++ b/src/Nethermind/Nethermind.Db/MemDb.cs
@@ -121,6 +121,11 @@ namespace Nethermind.Db
             return this[key].AsSpan();
         }
 
+        public void PutSpan(byte[] key, ReadOnlySpan<byte> value)
+        {
+            this[key] = value.ToArray();
+        }
+
         public void DangerousReleaseMemory(in Span<byte> span)
         {
         }

--- a/src/Nethermind/Nethermind.Db/ReadOnlyDb.cs
+++ b/src/Nethermind/Nethermind.Db/ReadOnlyDb.cs
@@ -90,6 +90,15 @@ namespace Nethermind.Db
         }
 
         public Span<byte> GetSpan(byte[] key) => this[key].AsSpan();
+        public void PutSpan(byte[] keyBytes, ReadOnlySpan<byte> value)
+        {
+            if (!_createInMemWriteStore)
+            {
+                throw new InvalidOperationException($"This {nameof(ReadOnlyDb)} did not expect any writes.");
+            }
+
+            _memDb[keyBytes] = value.ToArray();
+        }
 
         public void DangerousReleaseMemory(in Span<byte> span) { }
     }

--- a/src/Nethermind/Nethermind.Network.Benchmark/InFlowBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Network.Benchmark/InFlowBenchmarks.cs
@@ -14,6 +14,7 @@ using Nethermind.Network.P2P.Subprotocols.Eth.V62;
 using Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages;
 using Nethermind.Network.Rlpx;
 using Nethermind.Network.Test;
+using Nethermind.Serialization.Rlp;
 
 namespace Nethermind.Network.Benchmarks
 {

--- a/src/Nethermind/Nethermind.Network.Test/P2P/SerializerTester.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/SerializerTester.cs
@@ -8,6 +8,7 @@ using FluentAssertions.Equivalency;
 using Nethermind.Core.Extensions;
 using Nethermind.Network.P2P.Messages;
 using Nethermind.Network.P2P.Subprotocols.Snap.Messages;
+using Nethermind.Serialization.Rlp;
 using NUnit.Framework;
 
 namespace Nethermind.Network.Test.P2P

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/ZeroNewBlockMessageSerializerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/ZeroNewBlockMessageSerializerTests.cs
@@ -6,6 +6,7 @@ using Nethermind.Core;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages;
+using Nethermind.Serialization.Rlp;
 using NUnit.Framework;
 
 namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62

--- a/src/Nethermind/Nethermind.Network.Test/Rlpx/HobbitTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/Rlpx/HobbitTests.cs
@@ -18,6 +18,7 @@ using Nethermind.Logging;
 using Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages;
 using Nethermind.Network.P2P.Subprotocols.Eth.V63.Messages;
 using Nethermind.Network.Rlpx;
+using Nethermind.Serialization.Rlp;
 using NUnit.Framework;
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 

--- a/src/Nethermind/Nethermind.Network.Test/Rlpx/SnappyTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/Rlpx/SnappyTests.cs
@@ -8,6 +8,7 @@ using DotNetty.Buffers;
 using Nethermind.Core.Extensions;
 using Nethermind.Logging;
 using Nethermind.Network.Rlpx;
+using Nethermind.Serialization.Rlp;
 using NUnit.Framework;
 
 namespace Nethermind.Network.Test.Rlpx

--- a/src/Nethermind/Nethermind.Network.Test/Rlpx/ZeroNettyFrameMergerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/Rlpx/ZeroNettyFrameMergerTests.cs
@@ -8,6 +8,7 @@ using Nethermind.Logging;
 using Nethermind.Network.P2P.Messages;
 using Nethermind.Network.Rlpx;
 using Nethermind.Network.Test.Rlpx.TestWrappers;
+using Nethermind.Serialization.Rlp;
 using NSubstitute;
 using NUnit.Framework;
 

--- a/src/Nethermind/Nethermind.Network/MessageSerializationService.cs
+++ b/src/Nethermind/Nethermind.Network/MessageSerializationService.cs
@@ -8,6 +8,7 @@ using DotNetty.Buffers;
 using Nethermind.Network.P2P;
 using Nethermind.Network.P2P.Messages;
 using Nethermind.Network.P2P.Subprotocols.Les;
+using Nethermind.Serialization.Rlp;
 
 namespace Nethermind.Network
 {

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/Messages/PooledTransactionsMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/Messages/PooledTransactionsMessageSerializer.cs
@@ -4,6 +4,7 @@
 using DotNetty.Buffers;
 using Nethermind.Core;
 using Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages;
+using Nethermind.Serialization.Rlp;
 
 namespace Nethermind.Network.P2P.Subprotocols.Eth.V65.Messages
 {

--- a/src/Nethermind/Nethermind.Network/Rlpx/Packet.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/Packet.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Diagnostics;
+using Nethermind.Serialization.Rlp;
 
 namespace Nethermind.Network.Rlpx
 {

--- a/src/Nethermind/Nethermind.Network/ZeroMessageSerializerExtensions.cs
+++ b/src/Nethermind/Nethermind.Network/ZeroMessageSerializerExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using DotNetty.Buffers;
 using DotNetty.Common.Utilities;
+using Nethermind.Serialization.Rlp;
 
 namespace Nethermind.Network
 {

--- a/src/Nethermind/Nethermind.Serialization.Rlp/IByteBufferExtensions.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/IByteBufferExtensions.cs
@@ -1,10 +1,11 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using DotNetty.Buffers;
 using Nethermind.Core.Extensions;
 
-namespace Nethermind.Network
+namespace Nethermind.Serialization.Rlp
 {
     public static class IByteBufferExtensions
     {
@@ -40,6 +41,21 @@ namespace Nethermind.Network
                     output.EnsureWritable(length, true);
                 }
             }
+        }
+
+        /// <summary>
+        /// Return readable space of this byte buffer as a span.
+        /// </summary>
+        /// <param name="buffer"></param>
+        /// <param name="startIndex">Optional start index of the underlying buffer.</param>
+        /// <returns></returns>
+        /// <exception cref="InvalidOperationException"></exception>
+        public static Span<byte> AsSpan(this IByteBuffer buffer, int? startIndex = null)
+        {
+            if (!buffer.HasArray) throw new InvalidOperationException("Byte buffer does not have array backing");
+            int startIdx = startIndex ?? buffer.ReaderIndex;
+            return buffer.Array.AsSpan()
+                .Slice(buffer.ArrayOffset + startIdx, buffer.WriterIndex - startIdx);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Nethermind.Serialization.Rlp.csproj
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Nethermind.Serialization.Rlp.csproj
@@ -10,4 +10,8 @@
       <ProjectReference Include="..\Nethermind.Core\Nethermind.Core.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <PackageReference Include="Nethermind.DotNetty.Buffers" Version="1.0.0" />
+    </ItemGroup>
+
 </Project>

--- a/src/Nethermind/Nethermind.Serialization.Rlp/NettyRlpStream.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/NettyRlpStream.cs
@@ -4,11 +4,11 @@
 using System;
 using System.Collections.Generic;
 using DotNetty.Buffers;
-using Nethermind.Serialization.Rlp;
+using DotNetty.Common.Utilities;
 
-namespace Nethermind.Network.P2P
+namespace Nethermind.Serialization.Rlp
 {
-    public class NettyRlpStream : RlpStream
+    public class NettyRlpStream : RlpStream, IDisposable
     {
         private readonly IByteBuffer _buffer;
 
@@ -102,5 +102,16 @@ namespace Nethermind.Network.P2P
         public override bool HasBeenRead => _buffer.ReadableBytes > 0;
 
         protected override string Description => "|NettyRlpStream|description missing|";
+
+        /// <summary>
+        /// Note: this include already read bytes, not just the remaining one.
+        /// </summary>
+        /// <returns></returns>
+        public Span<byte> AsSpan() => _buffer.AsSpan(_initialPosition);
+
+        public void Dispose()
+        {
+            _buffer.SafeRelease();
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpDecoderExtensions.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpDecoderExtensions.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Collections.Generic;
+using DotNetty.Buffers;
 
 namespace Nethermind.Serialization.Rlp
 {
@@ -45,6 +46,50 @@ namespace Nethermind.Serialization.Rlp
             }
 
             return Rlp.Encode(rlpSequence);
+        }
+
+        public static NettyRlpStream EncodeToNewNettyStream<T>(this IRlpStreamDecoder<T> decoder, T? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+        {
+            NettyRlpStream rlpStream;
+            if (item is null)
+            {
+                rlpStream = new NettyRlpStream(PooledByteBufferAllocator.Default.Buffer(1));
+                rlpStream.WriteByte(Rlp.NullObjectByte);
+                return rlpStream;
+            }
+
+            rlpStream = new NettyRlpStream(PooledByteBufferAllocator.Default.Buffer(decoder.GetLength(item, rlpBehaviors)));
+            decoder.Encode(rlpStream, item, rlpBehaviors);
+            return rlpStream;
+        }
+
+        public static NettyRlpStream EncodeToNewNettyStream<T>(this IRlpStreamDecoder<T> decoder, T?[]? items, RlpBehaviors behaviors = RlpBehaviors.None)
+        {
+            NettyRlpStream rlpStream;
+            if (items is null)
+            {
+                rlpStream = new NettyRlpStream(PooledByteBufferAllocator.Default.Buffer(1));
+                rlpStream.WriteByte(Rlp.NullObjectByte);
+                return rlpStream;
+            }
+
+            int totalLength = 0;
+            for (int i = 0; i < items.Length; i++)
+            {
+                totalLength += decoder.GetLength(items[i], behaviors);
+            }
+
+            int bufferLength = Rlp.LengthOfSequence(totalLength);
+
+            rlpStream = new NettyRlpStream(PooledByteBufferAllocator.Default.Buffer(bufferLength));
+            rlpStream.StartSequence(totalLength);
+
+            for (int i = 0; i < items.Length; i++)
+            {
+                decoder.Encode(rlpStream, items[i], behaviors);
+            }
+
+            return rlpStream;
         }
 
         public static Rlp Encode<T>(this IRlpObjectDecoder<T> decoder, IReadOnlyCollection<T?>? items, RlpBehaviors behaviors = RlpBehaviors.None)


### PR DESCRIPTION
- Fix issue with receipt not stored.
- `PutSpan` was new and in ColumnDb, its column family was missed, causing the key to be saved without column which will not get fetched correctly.
- There is a cache in receipt store so it will appear as if the log is available for new block, which is probably why it working sometimes.

## Changes

- Add the column family.
- Add unit test.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No
