### PR TITLE
Add cap to arena count

### DIFF
--- a/src/Nethermind/Nethermind.Init/MemoryHintMan.cs
+++ b/src/Nethermind/Nethermind.Init/MemoryHintMan.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using DotNetty.Buffers;
 using Nethermind.Api;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core.Extensions;
@@ -64,6 +65,7 @@ namespace Nethermind.Init
                 UpdateDbConfig(cpuCount, syncConfig, dbConfig, initConfig);
                 _remainingMemory -= DbMemory;
                 if (_logger.IsInfo) _logger.Info($"  DB memory:          {DbMemory / 1000 / 1000}MB");
+
             }
         }
 
@@ -384,6 +386,36 @@ namespace Nethermind.Init
             }
 
             NettyMemory = estimate;
+
+            // Need to set these early, or otherwise if the allocator is used ahead of these setting, these config
+            // will not take affect
+
+            Environment.SetEnvironmentVariable("io.netty.allocator.maxOrder", networkConfig.NettyArenaOrder.ToString());
+
+            // Arena count is capped because if its too high, the memory budget per arena can get too low causing
+            // a very small chunk size. Any allocation of size higher than a chunk will essentially be unpooled triggering LOH.
+            // For example, on 16C32T machine, the default arena count is 64. Goerli with its default 128MB budget will
+            // cause the chunk size to be 2 MB. Mainnet with its 383MB budget will cause the chunk size to be 4 MB (lower
+            // power of two from 5.9 MB).
+            //
+            // When a thread first try to allocate from the pooled byte buffer, a threadlocal is created and pick
+            // one of the many arena, binding the thread to it. So arena count is like sharding.
+            //
+            // An arena consist of a list of chunks. Usually only one remain most of the time per arena.
+            // Multiple allocation will share a chunk as long as there is enough space. If no chunk with enough space
+            // is available, a new chunk is created, triggering a LOH allocation. There are also a thread level cache,
+            // so a chunk usually is not immediately freed once buffer allocated to it is released.
+            //
+            // Heap arena frees a chunk by just dereferencing, leaving GC to take it later.
+            // Direct arena holds a pinned `GCHandle` per chunk and calls `GCHandle.Free` to release the chunk.
+            // We never use any direct arena, but it does not take up memory because of that.
+            Environment.SetEnvironmentVariable("io.netty.allocator.numHeapArenas", arenaCount.ToString());
+            Environment.SetEnvironmentVariable("io.netty.allocator.numDirectArenas", arenaCount.ToString());
+
+            if (PooledByteBufferAllocator.Default.Metric.HeapArenas().Count != arenaCount)
+            {
+                _logger.Warn("unable to set netty pooled byte buffer config");
+            }
         }
 
         private static void ValidateCpuCount(uint cpuCount)

--- a/src/Nethermind/Nethermind.Init/MemoryHintMan.cs
+++ b/src/Nethermind/Nethermind.Init/MemoryHintMan.cs
@@ -370,8 +370,8 @@ namespace Nethermind.Init
             }
             else
             {
-                int targetNettyArenaOrder = INetworkConfig.DefaultNettyArenaOrder;
-                for (int i = networkConfig.NettyArenaOrder; i > 0; i--)
+                int targetNettyArenaOrder = INetworkConfig.MaxNettyArenaOrder;
+                for (int i = INetworkConfig.MaxNettyArenaOrder; i > 0; i--)
                 {
                     estimate = NettyMemoryEstimator.Estimate(arenaCount, i);
                     long maxAvailableFoNetty = NettyMemory;

--- a/src/Nethermind/Nethermind.Init/MemoryHintMan.cs
+++ b/src/Nethermind/Nethermind.Init/MemoryHintMan.cs
@@ -16,7 +16,7 @@ using Nethermind.TxPool;
 namespace Nethermind.Init
 {
     /// <summary>
-    /// Applies changes to the NetworkConfig and the DbConfig so to adhere to the max memory limit hint. 
+    /// Applies changes to the NetworkConfig and the DbConfig so to adhere to the max memory limit hint.
     /// </summary>
     public class MemoryHintMan
     {
@@ -350,9 +350,13 @@ namespace Nethermind.Init
 
         private void AssignNettyMemory(INetworkConfig networkConfig, uint cpuCount)
         {
-            NettyMemory = Math.Min(512.MB(), (long)(0.2 * _remainingMemory));
-            long estimate = NettyMemoryEstimator.Estimate(cpuCount, networkConfig.NettyArenaOrder);
             ValidateCpuCount(cpuCount);
+
+            NettyMemory = Math.Min(512.MB(), (long)(0.2 * _remainingMemory));
+
+            uint arenaCount = (uint)Math.Min(cpuCount * 2, networkConfig.MaxNettyArenaCount);
+
+            long estimate = NettyMemoryEstimator.Estimate(arenaCount, networkConfig.NettyArenaOrder);
 
             /* first of all we assume that the mainnet will be heavier than any other chain on the side */
             /* we will leave the arena order as in config if it is set to a non-default value */
@@ -367,7 +371,7 @@ namespace Nethermind.Init
                 int targetNettyArenaOrder = INetworkConfig.DefaultNettyArenaOrder;
                 for (int i = networkConfig.NettyArenaOrder; i > 0; i--)
                 {
-                    estimate = NettyMemoryEstimator.Estimate(cpuCount, i);
+                    estimate = NettyMemoryEstimator.Estimate(arenaCount, i);
                     long maxAvailableFoNetty = NettyMemory;
                     if (estimate <= maxAvailableFoNetty)
                     {

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -116,7 +116,7 @@ public class InitializeNetwork : IStep
         // Heap arena frees a chunk by just dereferencing, leaving GC to take it later.
         // Direct arena holds a pinned `GCHandle` per chunk and calls `GCHandle.Free` to release the chunk.
         // We never use any direct arena, but it does not take up memory because of that.
-        int arenaCount = Math.Min(_networkConfig.MaxNettyArenaCount, Environment.ProcessorCount * 2);
+        uint arenaCount = Math.Min(_networkConfig.MaxNettyArenaCount, (uint) (Environment.ProcessorCount * 2));
         Environment.SetEnvironmentVariable("io.netty.allocator.numHeapArenas", arenaCount.ToString());
         Environment.SetEnvironmentVariable("io.netty.allocator.numDirectArenas", arenaCount.ToString());
 

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -46,10 +46,9 @@ public static class NettyMemoryEstimator
     // Environment.SetEnvironmentVariable("io.netty.allocator.pageSize", "8192");
     private const uint PageSize = 8192;
 
-    public static long Estimate(uint cpuCount, int arenaOrder)
+    public static long Estimate(uint arenaCount, int arenaOrder)
     {
-        // do not remember why there is 2 in front
-        return 2L * cpuCount * (1L << arenaOrder) * PageSize;
+        return arenaCount * (1L << arenaOrder) * PageSize;
     }
 }
 
@@ -99,6 +98,28 @@ public class InitializeNetwork : IStep
         }
 
         Environment.SetEnvironmentVariable("io.netty.allocator.maxOrder", _networkConfig.NettyArenaOrder.ToString());
+
+        // Arena count is capped because if its too high, the memory budget per arena can get too low causing
+        // a very small chunk size. Any allocation of size higher than a chunk will essentially be unpooled triggering LOH.
+        // For example, on 16C32T machine, the default arena count is 64. Goerli with its default 128MB budget will
+        // cause the chunk size to be 2 MB. Mainnet with its 383MB budget will cause the chunk size to be 4 MB (lower
+        // power of two from 5.9 MB).
+        //
+        // When a thread first try to allocate from the pooled byte buffer, a threadlocal is created and pick
+        // one of the many arena, binding the thread to it. So arena count is like sharding.
+        //
+        // An arena consist of a list of chunks. Usually only one remain most of the time per arena.
+        // Multiple allocation will share a chunk as long as there is enough space. If no chunk with enough space
+        // is available, a new chunk is created, triggering a LOH allocation. There are also a thread level cache,
+        // so a chunk usually is not immediately freed once buffer allocated to it is released.
+        //
+        // Heap arena frees a chunk by just dereferencing, leaving GC to take it later.
+        // Direct arena holds a pinned `GCHandle` per chunk and calls `GCHandle.Free` to release the chunk.
+        // We never use any direct arena, but it does not take up memory because of that.
+        int arenaCount = Math.Min(_networkConfig.MaxNettyArenaCount, Environment.ProcessorCount * 2);
+        Environment.SetEnvironmentVariable("io.netty.allocator.numHeapArenas", arenaCount.ToString());
+        Environment.SetEnvironmentVariable("io.netty.allocator.numDirectArenas", arenaCount.ToString());
+
         CanonicalHashTrie cht = new CanonicalHashTrie(_api.DbProvider!.ChtDb);
 
         ProgressTracker progressTracker = new(_api.BlockTree!, _api.DbProvider.StateDb, _api.LogManager);

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -116,7 +116,7 @@ public class InitializeNetwork : IStep
         // Heap arena frees a chunk by just dereferencing, leaving GC to take it later.
         // Direct arena holds a pinned `GCHandle` per chunk and calls `GCHandle.Free` to release the chunk.
         // We never use any direct arena, but it does not take up memory because of that.
-        uint arenaCount = Math.Min(_networkConfig.MaxNettyArenaCount, (uint) (Environment.ProcessorCount * 2));
+        uint arenaCount = Math.Min(_networkConfig.MaxNettyArenaCount, (uint)(Environment.ProcessorCount * 2));
         Environment.SetEnvironmentVariable("io.netty.allocator.numHeapArenas", arenaCount.ToString());
         Environment.SetEnvironmentVariable("io.netty.allocator.numDirectArenas", arenaCount.ToString());
 

--- a/src/Nethermind/Nethermind.Network/Config/INetworkConfig.cs
+++ b/src/Nethermind/Nethermind.Network/Config/INetworkConfig.cs
@@ -7,7 +7,8 @@ namespace Nethermind.Network.Config
 {
     public interface INetworkConfig : IConfig
     {
-        public const int DefaultNettyArenaOrder = 11;
+        public const int DefaultNettyArenaOrder = -1;
+        public const int MaxNettyArenaOrder = 14;
         public const int DefaultMaxNettyArenaCount = 8;
 
         [ConfigItem(Description = "Use only if your node cannot resolve external IP automatically.", DefaultValue = "null")]
@@ -67,7 +68,7 @@ namespace Nethermind.Network.Config
         [ConfigItem(DefaultValue = "false", Description = "Enabled very verbose diag network tracing files for DEV purposes (Nethermind specific)")]
         bool DiagTracerEnabled { get; set; }
 
-        [ConfigItem(DefaultValue = "11", Description = "[TECHNICAL] Defines the size of a netty chunk size - default is 8192 << 11 so 16MB where order is 11, but will get overridden by memory hint if not specified.")]
+        [ConfigItem(DefaultValue = "-1", Description = "[TECHNICAL] Defines the size of a netty arena order. Default depends on memory hint.")]
         int NettyArenaOrder { get; set; }
 
         [ConfigItem(DefaultValue = "8", Description = "[TECHNICAL] Defines maximum netty arena count. Increasing this on high core machine without increasing memory budget may reduce chunk size so much that it causes significant netty huge allocation.")]

--- a/src/Nethermind/Nethermind.Network/Config/INetworkConfig.cs
+++ b/src/Nethermind/Nethermind.Network/Config/INetworkConfig.cs
@@ -71,7 +71,7 @@ namespace Nethermind.Network.Config
         int NettyArenaOrder { get; set; }
 
         [ConfigItem(DefaultValue = "8", Description = "[TECHNICAL] Defines maximum netty arena count. Increasing this on high core machine without increasing memory budget may reduce chunk size so much that it causes significant netty huge allocation.")]
-        int MaxNettyArenaCount { get; set; }
+        uint MaxNettyArenaCount { get; set; }
 
         [ConfigItem(DefaultValue = "", Description = "Bootnodes")]
         string Bootnodes { get; set; }

--- a/src/Nethermind/Nethermind.Network/Config/INetworkConfig.cs
+++ b/src/Nethermind/Nethermind.Network/Config/INetworkConfig.cs
@@ -8,6 +8,7 @@ namespace Nethermind.Network.Config
     public interface INetworkConfig : IConfig
     {
         public const int DefaultNettyArenaOrder = 11;
+        public const int DefaultMaxNettyArenaCount = 8;
 
         [ConfigItem(Description = "Use only if your node cannot resolve external IP automatically.", DefaultValue = "null")]
         string? ExternalIp { get; set; }
@@ -66,8 +67,11 @@ namespace Nethermind.Network.Config
         [ConfigItem(DefaultValue = "false", Description = "Enabled very verbose diag network tracing files for DEV purposes (Nethermind specific)")]
         bool DiagTracerEnabled { get; set; }
 
-        [ConfigItem(DefaultValue = "11", Description = "[TECHNICAL] Defines the size of a buffer allocated to each peer - default is 8192 << 11 so 16MB where order is 11.")]
+        [ConfigItem(DefaultValue = "11", Description = "[TECHNICAL] Defines the size of a netty chunk size - default is 8192 << 11 so 16MB where order is 11, but will get overridden by memory hint if not specified.")]
         int NettyArenaOrder { get; set; }
+
+        [ConfigItem(DefaultValue = "8", Description = "[TECHNICAL] Defines maximum netty arena count. Increasing this on high core machine without increasing memory budget may reduce chunk size so much that it causes significant netty huge allocation.")]
+        int MaxNettyArenaCount { get; set; }
 
         [ConfigItem(DefaultValue = "", Description = "Bootnodes")]
         string Bootnodes { get; set; }

--- a/src/Nethermind/Nethermind.Network/Config/NetworkConfig.cs
+++ b/src/Nethermind/Nethermind.Network/Config/NetworkConfig.cs
@@ -28,6 +28,7 @@ namespace Nethermind.Network.Config
         public int CandidatePeerCountCleanupThreshold { get; set; } = 11000;
         public bool DiagTracerEnabled { get; set; } = false;
         public int NettyArenaOrder { get; set; } = INetworkConfig.DefaultNettyArenaOrder;
+        public int MaxNettyArenaCount { get; set; } = INetworkConfig.DefaultMaxNettyArenaCount;
         public string Bootnodes { get; set; } = string.Empty;
         public bool EnableUPnP { get; set; } = false;
         public int DiscoveryPort { get; set; } = 30303;

--- a/src/Nethermind/Nethermind.Network/Config/NetworkConfig.cs
+++ b/src/Nethermind/Nethermind.Network/Config/NetworkConfig.cs
@@ -28,7 +28,7 @@ namespace Nethermind.Network.Config
         public int CandidatePeerCountCleanupThreshold { get; set; } = 11000;
         public bool DiagTracerEnabled { get; set; } = false;
         public int NettyArenaOrder { get; set; } = INetworkConfig.DefaultNettyArenaOrder;
-        public int MaxNettyArenaCount { get; set; } = INetworkConfig.DefaultMaxNettyArenaCount;
+        public uint MaxNettyArenaCount { get; set; } = INetworkConfig.DefaultMaxNettyArenaCount;
         public string Bootnodes { get; set; } = string.Empty;
         public bool EnableUPnP { get; set; } = false;
         public int DiscoveryPort { get; set; } = 30303;

--- a/src/Nethermind/Nethermind.Runner.Test/ConfigFilesTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/ConfigFilesTests.cs
@@ -377,7 +377,7 @@ namespace Nethermind.Runner.Test
         [TestCase("*")]
         public void Arena_order_is_default(string configWildcard)
         {
-            Test<INetworkConfig, int>(configWildcard, c => c.NettyArenaOrder, 11);
+            Test<INetworkConfig, int>(configWildcard, c => c.NettyArenaOrder, -1);
         }
 
         [TestCase("^mainnet ^goerli", false)]

--- a/src/Nethermind/Nethermind.Runner.Test/MemoryHintManTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/MemoryHintManTests.cs
@@ -50,19 +50,22 @@ namespace Nethermind.Runner.Test
                 cpuCount);
         }
 
-        [TestCase(4 * GB, 2u, 11)]
-        [TestCase(4 * GB, 4u, 11)]
-        [TestCase(8 * GB, 1u, 11)]
-        [TestCase(1 * GB, 4u, 11)]
-        [TestCase(512 * MB, 4u, 10)]
-        [TestCase(256 * MB, 6u, 8)]
-        [TestCase(1000 * MB, 12u, 9)]
-        [TestCase(2000 * MB, 12u, 10)]
-        public void Netty_arena_order_is_configured_correctly(long memoryHint, uint cpuCount, int expectedArenaOrder)
+        [TestCase(4 * GB, 2u, 4u, 11)]
+        [TestCase(4 * GB, 4u, 8u, 11)]
+        [TestCase(8 * GB, 1u, 2u, 11)]
+        [TestCase(1 * GB, 4u, 8u, 11)]
+        [TestCase(512 * MB, 4u, 8u, 10)]
+        [TestCase(256 * MB, 6u, 12u, 8)]
+        [TestCase(1000 * MB, 12u, 24u, 9)]
+        [TestCase(2000 * MB, 12u,24u, 10)]
+        [TestCase(1000 * MB, 12u, 8u, 11)]
+        [TestCase(2000 * MB, 12u, 8u, 11)]
+        public void Netty_arena_order_is_configured_correctly(long memoryHint, uint cpuCount, uint maxArenaCount, int expectedArenaOrder)
         {
             _txPoolConfig.Size = 128;
             _initConfig.DiagnosticMode = DiagnosticMode.MemDb;
             _initConfig.MemoryHint = (long)memoryHint;
+            _networkConfig.MaxNettyArenaCount = maxArenaCount;
             SetMemoryAllowances(cpuCount);
             _networkConfig.NettyArenaOrder.Should().Be(expectedArenaOrder);
         }

--- a/src/Nethermind/Nethermind.Runner.Test/MemoryHintManTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/MemoryHintManTests.cs
@@ -57,7 +57,7 @@ namespace Nethermind.Runner.Test
         [TestCase(512 * MB, 4u, 8u, 10)]
         [TestCase(256 * MB, 6u, 12u, 8)]
         [TestCase(1000 * MB, 12u, 24u, 9)]
-        [TestCase(2000 * MB, 12u,24u, 10)]
+        [TestCase(2000 * MB, 12u, 24u, 10)]
         [TestCase(1000 * MB, 12u, 8u, 11)]
         [TestCase(2000 * MB, 12u, 8u, 11)]
         public void Netty_arena_order_is_configured_correctly(long memoryHint, uint cpuCount, uint maxArenaCount, int expectedArenaOrder)


### PR DESCRIPTION
- Add a cap to netty arena count to prevent high LOH allocation on high core count machine.
- Note that there seems to be a bug where previous dotnetty config was not getting applied sometimes. If that was the case, the dotnetty default config is 16MB chunk size, with (logical cpu count * 2) arena count. 
- Graph is goerli sync, 1st has 8 arena, 2nd has 64 arena, 3rd has 4 arena. Chunk size would be 16MB, 2MB, 32MB.

![Screenshot from 2023-02-08 22-28-25](https://user-images.githubusercontent.com/1841324/217558863-607f7ec1-7ca7-4547-9c34-b33e61ffd06c.png)

- Note, all three run uses the same 128MB budget, but during old blocks, all allocate more than 1 chunk per arena. For 8 and 4 arena, LOH for bytes array reduced significantly. GC stats is less smooth likely because GC count is lower. No significant difference between 8 and 4 arena. Note, during bodies sync new chunks are created in all case, however, with 8 and 4 arena, it is not released quickly after sync, doubling the memory allocated to it, it could be that it will get release after some times. 

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)
- [X] Optimization

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No: Changes global state. Can't unit test this. Need to restart process to change config.

#### Notes on testing

- Have not tested yet.
