### PR TITLE
possible fix to `safe` nullRef issue

### DIFF
--- a/src/Nethermind/Nethermind.Evm/Tracing/ParityStyle/ParityLikeTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/ParityStyle/ParityLikeTxTracer.cs
@@ -231,12 +231,13 @@ namespace Nethermind.Evm.Tracing.ParityStyle
                 throw new InvalidOperationException($"Closing trace at level {_currentAction.TraceAddress?.Length ?? 0}");
             }
 
-            if (_trace.Action.TraceAddress.Length == 0)
+            if (_trace.Action?.TraceAddress?.Length == 0)
             {
                 _trace.Output = output;
             }
-
-            _trace.Action.Result.Output = output;
+            
+            if (_trace.Action?.Result is not null )
+                _trace.Action.Result.Output = output;
         }
 
         public void MarkAsFailed(Address recipient, long gasSpent, byte[] output, string error, Keccak stateRoot = null)

--- a/src/Nethermind/Nethermind.Evm/Tracing/ParityStyle/ParityLikeTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/ParityStyle/ParityLikeTxTracer.cs
@@ -235,8 +235,8 @@ namespace Nethermind.Evm.Tracing.ParityStyle
             {
                 _trace.Output = output;
             }
-            
-            if (_trace.Action?.Result is not null )
+
+            if (_trace.Action?.Result is not null)
                 _trace.Action.Result.Output = output;
         }
 


### PR DESCRIPTION
## Changes

- null checking at MarkAsSuccess in the ParityLikeTxTracer

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No
