### PR TITLE
Remove Download[Bodies/Receipts]InFastSync set to false in mainnet_archive - unable to start syncing with it.

### DIFF
--- a/src/Nethermind/Nethermind.Runner/configs/mainnet_archive.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/mainnet_archive.cfg
@@ -9,10 +9,6 @@
   "Network": {
     "ActivePeersMaxCount": 100
   },
-  "Sync": {
-    "DownloadBodiesInFastSync": false,
-    "DownloadReceiptsInFastSync": false
-  },
   "EthStats": {
     "Server": "wss://ethstats.net/api"
   },


### PR DESCRIPTION
## Changes

- Remove DownloadBodiesInFastSync and DownloadReceiptsInFastSync from config since with it I'm unable to even start syncing

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No
