### PR TITLE
Revise last known block handling in `engine_getPayloadBodiesByRangeV1`

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V2.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V2.cs
@@ -487,7 +487,7 @@ public partial class EngineModuleTests
     {
         var blockTree = Substitute.For<IBlockTree>();
 
-        blockTree.BestSuggestedBody.Returns(Build.A.Block.WithNumber(5).TestObject);
+        blockTree.Head.Returns(Build.A.Block.WithNumber(5).TestObject);
         blockTree.FindBlock(Arg.Any<long>()).Returns(input.Impl);
 
         using var chain = await CreateShanghaiBlockChain();
@@ -506,7 +506,7 @@ public partial class EngineModuleTests
 
         blockTree.FindBlock(Arg.Any<long>())
             .Returns(i => Build.A.Block.WithNumber(i.ArgAt<long>(0)).TestObject);
-        blockTree.BestSuggestedBody.Returns(Build.A.Block.WithNumber(5).TestObject);
+        blockTree.Head.Returns(Build.A.Block.WithNumber(5).TestObject);
 
         using var chain = await CreateShanghaiBlockChain();
         chain.BlockTree = blockTree;

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetPayloadBodiesByRangeV1Handler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetPayloadBodiesByRangeV1Handler.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Nethermind.Blockchain;
 using Nethermind.JsonRpc;
@@ -45,10 +44,10 @@ public class GetPayloadBodiesByRangeV1Handler : IGetPayloadBodiesByRangeV1Handle
             return ResultWrapper<IEnumerable<ExecutionPayloadBodyV1Result?>>.Fail(error, MergeErrorCodes.TooLargeRequest);
         }
 
-        var bestSuggestedNumber = _blockTree.BestSuggestedBody?.Number ?? 0;
+        var headNumber = _blockTree.Head?.Number ?? 0;
         var payloadBodies = new List<ExecutionPayloadBodyV1Result?>((int)count);
 
-        for (long i = start, c = Math.Min(start + count, bestSuggestedNumber + 1); i < c; i++)
+        for (long i = start, c = Math.Min(start + count - 1, headNumber); i <= c; i++)
         {
             var block = _blockTree.FindBlock(i);
 


### PR DESCRIPTION
## Changes

Revised the last known block handling in `engine_getPayloadBodiesByRangeV1`: Replaced the `IBlockTree.BestSuggestedBody` with `IBlockTree.Head`.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

## Remarks

Hive tests [passing](https://github.com/NethermindEth/nethermind/actions/runs/4127444345)