### PR TITLE
Add session direction to sync peer report

### DIFF
--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
@@ -43,7 +43,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
 
         // this means that we know what the number, hash, and total diff of the head block is
         public bool IsInitialized { get; set; }
-        public override string ToString() => $"[Peer|{Name}|{HeadNumber,8}|{Node:s}|{Session?.Direction,3}]";
+        public override string ToString() => $"[Peer|{Name}|{HeadNumber,8}|{Node:s}|{Session?.Direction,4}]";
 
         protected Keccak _remoteHeadBlockHash;
         protected readonly ITimestamper _timestamper;

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
@@ -43,7 +43,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
 
         // this means that we know what the number, hash, and total diff of the head block is
         public bool IsInitialized { get; set; }
-        public override string ToString() => $"[Peer|{Name}|{HeadNumber,8}|{Node:s}]";
+        public override string ToString() => $"[Peer|{Name}|{HeadNumber,8}|{Node:s}|{Session?.Direction,3}]";
 
         protected Keccak _remoteHeadBlockHash;
         protected readonly ITimestamper _timestamper;

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncPeersReportTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncPeersReportTests.cs
@@ -1,9 +1,20 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
+using FluentAssertions;
+using Nethermind.Blockchain;
 using Nethermind.Blockchain.Synchronization;
+using Nethermind.Core;
+using Nethermind.Core.Test.Builders;
 using Nethermind.Logging;
+using Nethermind.Network;
+using Nethermind.Network.P2P;
+using Nethermind.Network.P2P.EventArg;
+using Nethermind.Network.P2P.ProtocolHandlers;
+using Nethermind.Network.Rlpx;
 using Nethermind.Stats;
+using Nethermind.Stats.Model;
 using Nethermind.Synchronization.Peers;
 using NSubstitute;
 using NUnit.Framework;
@@ -77,11 +88,27 @@ namespace Nethermind.Synchronization.Test
             report.WriteFullReport();
         }
 
-        private static PeerInfo BuildPeer(bool initialized)
+        private static PeerInfo BuildPeer(
+            bool initialized,
+            string ip = "127.0.0.1",
+            int port = 3030,
+            ConnectionDirection direction = ConnectionDirection.Out,
+            int head = 9999,
+            string protocolVersion = "eth99"
+        )
         {
-            ISyncPeer syncPeer = Substitute.For<ISyncPeer>();
+            ISession session = Substitute.For<ISession>();
+            session.Node.Returns(new Node(TestItem.PublicKeyA, ip, port));
+            session.Direction.Returns(direction);
+
+            IMessageSerializationService serializer = Substitute.For<IMessageSerializationService>();
+            INodeStatsManager nodeStatsManager = Substitute.For<INodeStatsManager>();
+            ISyncServer syncServer = Substitute.For<ISyncServer>();
+            ISyncPeer syncPeer = new StubSyncPeer(initialized, protocolVersion, session, serializer, nodeStatsManager, syncServer);
+
+            syncPeer.HeadNumber = head;
+
             PeerInfo peer = new(syncPeer);
-            syncPeer.IsInitialized.Returns(initialized);
             return peer;
         }
 
@@ -94,7 +121,6 @@ namespace Nethermind.Synchronization.Test
 
             var peers = new[] { syncPeer, syncPeer2 };
             syncPeerPool.PeerCount.Returns(peers.Length);
-
             syncPeerPool.AllPeers.Returns(peers);
 
             SyncPeersReport report = new(syncPeerPool, Substitute.For<INodeStatsManager>(), NoErrorLimboLogs.Instance);
@@ -104,6 +130,76 @@ namespace Nethermind.Synchronization.Test
             syncPeer.IsInitialized.Returns(true);
             report.WriteShortReport();
             report.WriteFullReport();
+        }
+
+        [Test]
+        public void PeerFormatIsCorrect()
+        {
+            var syncPeer = BuildPeer(false);
+            syncPeer.TryAllocate(AllocationContexts.All);
+
+            var syncPeer2 = BuildPeer(true, direction: ConnectionDirection.In);
+            syncPeer2.PutToSleep(AllocationContexts.All, DateTime.Now);
+
+            var peers = new[] { syncPeer, syncPeer2 };
+
+            ISyncPeerPool syncPeerPool = Substitute.For<ISyncPeerPool>();
+            syncPeerPool.PeerCount.Returns(peers.Length);
+            syncPeerPool.AllPeers.Returns(peers);
+
+            string expectedResult =
+                "== Header ==\n" +
+                "===[Active][Sleep ][Peer (ProtocolVersion/Head/Host:Port/Direction)    ][Transfer Speeds (L/H/B/R/N/S)      ][Client Info (Name/Version/Operating System/Language)     ]\n" +
+                "--------------------------------------------------------------------------------------------------------------------------------------------------------------\n" +
+                "   [HBRNSW][      ][Peer|eth99|    9999|      127.0.0.1: 3030|Out][     |     |     |     |     |     ][]\n" +
+                "   [      ][HBRNSW][Peer|eth99|    9999|      127.0.0.1: 3030| In][     |     |     |     |     |     ][]";
+
+            SyncPeersReport report = new(syncPeerPool, Substitute.For<INodeStatsManager>(), NoErrorLimboLogs.Instance);
+            string reportStr = report.MakeReportForPeer(peers, "== Header ==");
+            reportStr.Should().Be(expectedResult);
+        }
+
+        private class StubSyncPeer : SyncPeerProtocolHandlerBase
+        {
+            public StubSyncPeer(bool initialized, string protocolVersion, ISession session,
+                IMessageSerializationService serializer, INodeStatsManager statsManager, ISyncServer syncServer) :
+                base(
+                    session,
+                    serializer,
+                    statsManager,
+                    syncServer,
+                    NoErrorLimboLogs.Instance)
+            {
+                IsInitialized = initialized;
+                Name = protocolVersion;
+            }
+
+            public override string Name { get; }
+            public override byte ProtocolVersion { get; }
+            public override string ProtocolCode { get; }
+            public override int MessageIdSpaceSize { get; }
+            public override void Init()
+            {
+                throw new NotImplementedException();
+            }
+
+            public override event EventHandler<ProtocolInitializedEventArgs> ProtocolInitialized;
+            public override event EventHandler<ProtocolEventArgs> SubprotocolRequested;
+            protected override TimeSpan InitTimeout { get; }
+            public override void HandleMessage(ZeroPacket message)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void NotifyOfNewBlock(Block block, SendBlockMode mode)
+            {
+                throw new NotImplementedException();
+            }
+
+            protected override void OnDisposed()
+            {
+                throw new NotImplementedException();
+            }
         }
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncPeersReportTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncPeersReportTests.cs
@@ -164,8 +164,8 @@ namespace Nethermind.Synchronization.Test
                 "== Header ==\n" +
                 "===[Active][Sleep ][Peer(ProtocolVersion/Head/Host:Port/Direction)][Transfer Speeds (L/H/B/R/N/S)      ][Client Info (Name/Version/Operating System/Language)     ]\n" +
                 "--------------------------------------------------------------------------------------------------------------------------------------------------------------\n" +
-                "   [HBRNSW][      ][Peer|eth99|    9999|      127.0.0.1: 3030|Out][     |     |     |     |     |     ][]\n" +
-                "   [      ][HBRNSW][Peer|eth99|    9999|      127.0.0.1: 3030| In][     |     |     |     |     |     ][]";
+                "   [HBRNSW][      ][Peer|eth99|    9999|      127.0.0.1: 3030| Out][     |     |     |     |     |     ][]\n" +
+                "   [      ][HBRNSW][Peer|eth99|    9999|      127.0.0.1: 3030|  In][     |     |     |     |     |     ][]";
 
             SyncPeersReport report = new(syncPeerPool, Substitute.For<INodeStatsManager>(), NoErrorLimboLogs.Instance);
             string reportStr = report.MakeReportForPeer(peers, "== Header ==");

--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeersReport.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeersReport.cs
@@ -121,7 +121,7 @@ namespace Nethermind.Synchronization.Peers
         {
             _stringBuilder.AppendLine();
             _stringBuilder.Append("===")
-                                .Append("[Active][Sleep ][Peer (ProtocolVersion/Head/Host:Port/Direction)    ]")
+                                .Append("[Active][Sleep ][Peer(ProtocolVersion/Head/Host:Port/Direction)]")
                                 .Append("[Transfer Speeds (L/H/B/R/N/S)      ]")
                                 .Append("[Client Info (Name/Version/Operating System/Language)     ]")
                                 .AppendLine();

--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeersReport.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeersReport.cs
@@ -49,21 +49,8 @@ namespace Nethermind.Synchronization.Peers
                 }
 
                 RememberState(out bool _);
-                _stringBuilder.Append($"Sync peers - Initialized: {_currentInitializedPeerCount} | All: {_peerPool.PeerCount} | Max: {_peerPool.PeerMaxCount}");
-                bool headerAdded = false;
-                foreach (PeerInfo peerInfo in OrderedPeers)
-                {
-                    if (!headerAdded)
-                    {
-                        headerAdded = true;
-                        AddPeerHeader();
-                    }
-                    _stringBuilder.AppendLine();
-                    AddPeerInfo(peerInfo);
-                }
 
-                _logger.Info(_stringBuilder.ToString());
-                _stringBuilder.Clear();
+                _logger.Info(MakeReportForPeer(OrderedPeers, $"Sync peers - Initialized: {_currentInitializedPeerCount} | All: {_peerPool.PeerCount} | Max: {_peerPool.PeerMaxCount}"));
             }
         }
 
@@ -75,28 +62,35 @@ namespace Nethermind.Synchronization.Peers
                 {
                     return;
                 }
+
                 RememberState(out bool changed);
                 if (!changed)
                 {
                     return;
                 }
 
-                _stringBuilder.Append($"Sync peers {_currentInitializedPeerCount}({_peerPool.PeerCount})/{_peerPool.PeerMaxCount}");
-                bool headerAdded = false;
-                foreach (PeerInfo peerInfo in OrderedPeers.Where(p => !p.CanBeAllocated(AllocationContexts.All)))
-                {
-                    if (!headerAdded)
-                    {
-                        headerAdded = true;
-                        AddPeerHeader();
-                    }
-                    _stringBuilder.AppendLine();
-                    AddPeerInfo(peerInfo);
-                }
-
-                _logger.Info(_stringBuilder.ToString());
-                _stringBuilder.Clear();
+                _logger.Info(MakeReportForPeer(OrderedPeers.Where(p => !p.CanBeAllocated(AllocationContexts.All)), $"Sync peers {_currentInitializedPeerCount}({_peerPool.PeerCount})/{_peerPool.PeerMaxCount}"));
             }
+        }
+
+        internal string? MakeReportForPeer(IEnumerable<PeerInfo> peers, string header)
+        {
+            _stringBuilder.Append(header);
+            bool headerAdded = false;
+            foreach (PeerInfo peerInfo in peers)
+            {
+                if (!headerAdded)
+                {
+                    headerAdded = true;
+                    AddPeerHeader();
+                }
+                _stringBuilder.AppendLine();
+                AddPeerInfo(peerInfo);
+            }
+
+            string result = _stringBuilder.ToString();
+            _stringBuilder.Clear();
+            return result;
         }
 
         private void AddPeerInfo(PeerInfo peerInfo)
@@ -127,7 +121,7 @@ namespace Nethermind.Synchronization.Peers
         {
             _stringBuilder.AppendLine();
             _stringBuilder.Append("===")
-                                .Append("[Active][Sleep ][Peer (ProtocolVersion/Head/Host:Port)    ]")
+                                .Append("[Active][Sleep ][Peer (ProtocolVersion/Head/Host:Port/Direction)    ]")
                                 .Append("[Transfer Speeds (L/H/B/R/N/S)      ]")
                                 .Append("[Client Info (Name/Version/Operating System/Language)     ]")
                                 .AppendLine();


### PR DESCRIPTION
- Add direction to sync peer report. 
- Make it easy to know if the peer is incoming or outgoing connection.
- Looks like this:

```
===[Active][Sleep ][Peer (ProtocolVersion/Head/Host:Port/Direction)    ][Transfer Speeds (L/H/B/R/N/S)      ][Client Info (Name/Version/Operating System/Language)     ]
--------------------------------------------------------------------------------------------------------------------------------------------------------------
   [H     ][      ][Peer|eth67|16589240|  91.65.190.110:30404|Out][     |  338|     |     |     |     ][Nethermind/v1.16.1+644fe89f/linux-x64/dotnet7.0.2]
   [HBR   ][      ][Peer|eth66|16589240|   72.18.53.167:30303|Out][     |  181| 3608| 5504|     |     ][Nethermind/v1.14.5+380bf9c9/linux-x64/dotnet6.0.10]
   [H     ][      ][Peer|eth67|16589240|   65.109.19.71:30303|Out][     |   15|     |     |     |     ][Geth/v1.10.26-stable-a3c75c85/linux-amd64/go1.18]
   [H     ][      ][Peer|eth67|16589240|168.119.138.215:30303|Out][     |   34|     |     |     |     ][Geth/v1.10.25-stable-69568c55/linux-amd64/go1.18.5]
   [H     ][      ][Peer|eth66|16589240|   89.141.72.87:53284| In][     |  439|     |     |     |     ][besu/v22.10.0/linux-x86_64/openjdk-java-11]
   [H     ][      ][Peer|eth67|16589239|   13.40.154.29:30303|Out][  275|   25|     |     |     |     ][Geth/v1.10.23-stable-5c5b1f66/linux-amd64/go1.18.1]
   [H     ][      ][Peer|eth67|16589151|   95.62.95.185:30325|Out][ 2088|   89|     |     |     |     ][Nethermind/v1.16.1+644fe89f/linux-arm64/dotnet7.0.2]
   [      ][H     ][Peer|eth67|16589151|    84.17.37.24:30000|Out][   38|    0|     |     |     |     ][Geth/v1.10.25-stable/linux-amd64/go1.17.10] 
```

## Changes

- Add direction to ToString.
- Add test.

## Types of changes

#### What types of changes does your code introduce?

- [X] New feature (a non-breaking change that adds functionality)
## Testing

#### Requires testing

- [X] Yes

#### If yes, did you write tests?

- [X] Yes