### PR TITLE
Trie node memory optimization

### DIFF
--- a/src/Nethermind/Nethermind.Benchmark/Store/TrieNodeBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Store/TrieNodeBenchmarks.cs
@@ -1,0 +1,70 @@
+//  Copyright (c) 2018 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+//
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Test.Builders;
+using Nethermind.State;
+using Nethermind.Db.Blooms;
+using Nethermind.Trie;
+
+namespace Nethermind.Benchmarks.Store
+{
+    [MemoryDiagnoser]
+    public class TrieNodeBenchmarks
+    {
+        [Benchmark]
+        public void PropertiesSet()
+        {
+            TrieNode node = new(NodeType.Extension);
+
+            node.LastSeen = 1;
+            node.IsPersisted = true;
+            node.IsBoundaryProofNode = true;
+
+            node.LastSeen = 0xFF;
+            node.IsPersisted = false;
+            node.IsBoundaryProofNode = false;
+
+            node.LastSeen = 0xFFFF;
+            node.IsPersisted = true;
+            node.IsBoundaryProofNode = true;
+
+            node.LastSeen = 0xFFFFFF;
+            node.IsPersisted = false;
+            node.IsBoundaryProofNode = false;
+
+            node.LastSeen = 0xFFFFFFFF;
+            node.IsPersisted = true;
+            node.IsBoundaryProofNode = true;
+
+            node.LastSeen = 0xFFFFFFFFFF;
+            node.IsPersisted = false;
+            node.IsBoundaryProofNode = false;
+
+            node.LastSeen = 0xFF_FFFF_FFFF;
+            node.IsPersisted = true;
+            node.IsBoundaryProofNode = true;
+
+            node.LastSeen = 0xFFFF_FFFF_FFFF;
+            node.IsPersisted = false;
+            node.IsBoundaryProofNode = false;
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
@@ -511,14 +511,14 @@ namespace Nethermind.Trie.Test
         public void Size_of_a_heavy_leaf_is_correct()
         {
             Context ctx = new();
-            Assert.AreEqual(224, ctx.HeavyLeaf.GetMemorySize(false));
+            Assert.AreEqual(232, ctx.HeavyLeaf.GetMemorySize(false));
         }
 
         [Test]
         public void Size_of_a_tiny_leaf_is_correct()
         {
             Context ctx = new();
-            Assert.AreEqual(144, ctx.TiniestLeaf.GetMemorySize(false));
+            Assert.AreEqual(152, ctx.TiniestLeaf.GetMemorySize(false));
         }
 
         [Test]
@@ -544,7 +544,7 @@ namespace Nethermind.Trie.Test
             trieNode.Key = new byte[] { 1 };
             trieNode.SetChild(0, ctx.TiniestLeaf);
 
-            Assert.AreEqual(120, trieNode.GetMemorySize(false));
+            Assert.AreEqual(128, trieNode.GetMemorySize(false));
         }
 
         [Test]
@@ -555,8 +555,8 @@ namespace Nethermind.Trie.Test
             trieNode.Key = new byte[] { 1 };
             trieNode.SetChild(0, ctx.TiniestLeaf);
 
-            Assert.AreEqual(264, trieNode.GetMemorySize(true));
-            Assert.AreEqual(120, trieNode.GetMemorySize(false));
+            Assert.AreEqual(280, trieNode.GetMemorySize(true));
+            Assert.AreEqual(128, trieNode.GetMemorySize(false));
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Trie/NodeType.cs
+++ b/src/Nethermind/Nethermind.Trie/NodeType.cs
@@ -5,9 +5,9 @@ namespace Nethermind.Trie
 {
     public enum NodeType : byte
     {
-        Unknown,
-        Branch,
-        Extension,
-        Leaf
+        Unknown = 0,
+        Branch = 1,
+        Extension = 2,
+        Leaf = 3
     }
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -224,13 +224,13 @@ namespace Nethermind.Trie.Pruning
                     throw new TrieStoreException($"{nameof(CurrentPackage)} is NULL when committing {node} at {blockNumber}.");
                 }
 
-                if (node!.LastSeen.HasValue)
+                if (node!.LastSeen != TrieNode.LastSeenNotSet)
                 {
                     throw new TrieStoreException($"{nameof(TrieNode.LastSeen)} set on {node} committed at {blockNumber}.");
                 }
 
                 node = SaveOrReplaceInDirtyNodesCache(nodeCommitInfo, node);
-                node.LastSeen = Math.Max(blockNumber, node.LastSeen ?? 0);
+                node.LastSeen = Math.Max(blockNumber, node.LastSeen);
 
                 if (!_pruningStrategy.PruningEnabled)
                 {
@@ -648,7 +648,7 @@ namespace Nethermind.Trie.Pruning
 
             if (currentNode.Keccak is not null)
             {
-                Debug.Assert(currentNode.LastSeen.HasValue, $"Cannot persist a dangling node (without {(nameof(TrieNode.LastSeen))} value set).");
+                Debug.Assert(currentNode.LastSeen != TrieNode.LastSeenNotSet, $"Cannot persist a dangling node (without {(nameof(TrieNode.LastSeen))} value set).");
                 // Note that the LastSeen value here can be 'in the future' (greater than block number
                 // if we replaced a newly added node with an older copy and updated the LastSeen value.
                 // Here we reach it from the old root so it appears to be out of place but it is correct as we need
@@ -657,7 +657,7 @@ namespace Nethermind.Trie.Pruning
                 if (_logger.IsTrace) _logger.Trace($"Persisting {nameof(TrieNode)} {currentNode} in snapshot {blockNumber}.");
                 _currentBatch[currentNode.Keccak.Bytes] = currentNode.FullRlp;
                 currentNode.IsPersisted = true;
-                currentNode.LastSeen = Math.Max(blockNumber, currentNode.LastSeen ?? 0);
+                currentNode.LastSeen = Math.Max(blockNumber, currentNode.LastSeen);
                 PersistedNodesCount++;
             }
             else
@@ -669,7 +669,7 @@ namespace Nethermind.Trie.Pruning
 
         private bool IsNoLongerNeeded(TrieNode node)
         {
-            Debug.Assert(node.LastSeen.HasValue, $"Any node that is cache should have {nameof(TrieNode.LastSeen)} set.");
+            Debug.Assert(node.LastSeen != TrieNode.LastSeenNotSet, $"Any node that is cache should have {nameof(TrieNode.LastSeen)} set.");
             return node.LastSeen < LastPersistedBlockNumber
                    && node.LastSeen < LatestCommittedBlockNumber - Reorganization.MaxDepth;
         }

--- a/src/Nethermind/Nethermind.Trie/TrieNode.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.cs
@@ -58,9 +58,8 @@ namespace Nethermind.Trie
         private const int DirtyShift = 2;
         private const long PersistedMask = 0b1000;
         private const int PersistedShift = 3;
-        private const long HasLastSeenMask = 0b1_0000;
-        private const int HasLastSeenShift = 4;
-        private const int LastSeenShiftRight = 8;
+
+        private const int LastSeenShift = 8;
 
         private const long IsBoundaryProofNodeMask = 0b10_0000;
         private const int IsBoundaryProofNodeShift = 5;
@@ -95,23 +94,12 @@ namespace Nethermind.Trie
         public bool IsBranch => NodeType == NodeType.Branch;
         public bool IsExtension => NodeType == NodeType.Extension;
 
-        public long? LastSeen
+        public const long LastSeenNotSet = 0L;
+
+        public long LastSeen
         {
-            get
-            {
-                return (_value & HasLastSeenMask) > 0 ? _value >> LastSeenShiftRight : default(long?);
-            }
-            set
-            {
-                if (value == null)
-                {
-                    _value = (_value & ~HasLastSeenMask);
-                }
-                else
-                {
-                    _value = _value | (1L << HasLastSeenShift) | (value.Value << LastSeenShiftRight);
-                }
-            }
+            get => _value >> LastSeenShift;
+            set => _value = (_value & ((1L << LastSeenShift) - 1)) | (value << LastSeenShift);
         }
 
         public byte[]? Key

--- a/src/Nethermind/Nethermind.Trie/TrieNode.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.cs
@@ -25,8 +25,6 @@ namespace Nethermind.Trie
 
         public int Id = Interlocked.Increment(ref _idCounter);
 #endif
-        public bool IsBoundaryProofNode { get; set; }
-
         private TrieNode? _storageRoot;
         private static object _nullNode = new();
         private static TrieNodeDecoder _nodeDecoder = new();
@@ -49,21 +47,72 @@ namespace Nethermind.Trie
         /// </summary>
         public bool IsSealed => !IsDirty;
 
-        public bool IsPersisted { get; set; }
-
         public Keccak? Keccak { get; internal set; }
 
         public byte[]? FullRlp { get; internal set; }
 
-        public NodeType NodeType { get; private set; }
+        private long _value;
 
-        public bool IsDirty { get; private set; }
+        private const long NodeTypeMask = 0b11;
+        private const long DirtyMask = 0b100;
+        private const int DirtyShift = 2;
+        private const long PersistedMask = 0b1000;
+        private const int PersistedShift = 3;
+        private const long HasLastSeenMask = 0b1_0000;
+        private const int HasLastSeenShift = 4;
+        private const int LastSeenShiftRight = 8;
+
+        private const long IsBoundaryProofNodeMask = 0b10_0000;
+        private const int IsBoundaryProofNodeShift = 5;
+
+        // 6, 7 bits are free to use
+
+        public NodeType NodeType
+        {
+            get => (NodeType)(_value & NodeTypeMask);
+            private set => _value = (_value & ~NodeTypeMask) | (long)value;
+        }
+
+        public bool IsDirty
+        {
+            get => (_value & DirtyMask) > 0;
+            private set => _value = (_value & ~DirtyMask) | (value ? 1L << DirtyShift : 0L);
+        }
+
+        public bool IsPersisted
+        {
+            get => (_value & PersistedMask) > 0;
+            set => _value = (_value & ~PersistedMask) | (value ? (1L << PersistedShift) : 0L);
+        }
+
+        public bool IsBoundaryProofNode
+        {
+            get => (_value & IsBoundaryProofNodeMask) > 0;
+            set => _value = (_value & ~IsBoundaryProofNodeMask) | (value ? (1L << IsBoundaryProofNodeShift) : 0L);
+        }
 
         public bool IsLeaf => NodeType == NodeType.Leaf;
         public bool IsBranch => NodeType == NodeType.Branch;
         public bool IsExtension => NodeType == NodeType.Extension;
 
-        public long? LastSeen { get; set; }
+        public long? LastSeen
+        {
+            get
+            {
+                return (_value & HasLastSeenMask) > 0 ? _value >> LastSeenShiftRight : default(long?);
+            }
+            set
+            {
+                if (value == null)
+                {
+                    _value = (_value & ~HasLastSeenMask);
+                }
+                else
+                {
+                    _value = _value | (1L << HasLastSeenShift) | (value.Value << LastSeenShiftRight);
+                }
+            }
+        }
 
         public byte[]? Key
         {
@@ -256,7 +305,8 @@ namespace Nethermind.Trie
                 _rlpStream = FullRlp.AsRlpStream();
                 if (_rlpStream is null)
                 {
-                    throw new InvalidAsynchronousStateException($"{nameof(_rlpStream)} is null when {nameof(NodeType)} is {NodeType}");
+                    throw new InvalidAsynchronousStateException(
+                        $"{nameof(_rlpStream)} is null when {nameof(NodeType)} is {NodeType}");
                 }
 
                 Metrics.TreeNodeRlpDecodings++;
@@ -294,7 +344,8 @@ namespace Nethermind.Trie
                 }
                 else
                 {
-                    throw new TrieException($"Unexpected number of items = {numberOfItems} when decoding a node from RLP ({FullRlp?.ToHexString()})");
+                    throw new TrieException(
+                        $"Unexpected number of items = {numberOfItems} when decoding a node from RLP ({FullRlp?.ToHexString()})");
                 }
             }
             catch (RlpException rlpException)
@@ -461,7 +512,8 @@ namespace Nethermind.Trie
                 // we need to investigate this case when it happens again
                 bool isKeccakCalculated = Keccak is not null && FullRlp is not null;
                 bool isKeccakCorrect = isKeccakCalculated && Keccak == Keccak.Compute(FullRlp);
-                throw new TrieException($"Unexpected type found at position {childIndex} of {this} with {nameof(_data)} of length {_data?.Length}. Expected a {nameof(TrieNode)} or {nameof(Keccak)} but found {childOrRef?.GetType()} with a value of {childOrRef}. Keccak calculated? : {isKeccakCalculated}; Keccak correct? : {isKeccakCorrect}");
+                throw new TrieException(
+                    $"Unexpected type found at position {childIndex} of {this} with {nameof(_data)} of length {_data?.Length}. Expected a {nameof(TrieNode)} or {nameof(Keccak)} but found {childOrRef?.GetType()} with a value of {childOrRef}. Keccak calculated? : {isKeccakCalculated}; Keccak correct? : {isKeccakCorrect}");
             }
 
             // pruning trick so we never store long persisted paths
@@ -517,9 +569,8 @@ namespace Nethermind.Trie
                     ? 0
                     : MemorySizes.Align(_data.Length * MemorySizes.RefSize + MemorySizes.ArrayOverhead));
             int objectOverhead = MemorySizes.SmallObjectOverhead - MemorySizes.SmallObjectFreeDataSize;
-            int isDirtySize = 1;
-            int nodeTypeSize = 1;
-            /* _isDirty + NodeType aligned to 4 (is it 8?) and end up in object overhead*/
+
+            int valuesOverhead = 8;
 
             for (int i = 0; i < (_data?.Length ?? 0); i++)
             {
@@ -551,8 +602,7 @@ namespace Nethermind.Trie
                              fullRlpSize +
                              rlpStreamSize +
                              dataSize +
-                             isDirtySize +
-                             nodeTypeSize +
+                             valuesOverhead +
                              objectOverhead;
 
             return MemorySizes.Align(unaligned);


### PR DESCRIPTION
This PR reduces the size of a single node by `16 bytes`, from `80 bytes` to `64 bytes`. This impact the timing though. 
Replaces #4581

```bash
BenchmarkDotNet=v0.13.4, OS=Windows 11 (10.0.22621.1105)
12th Gen Intel Core i9-12900HK, 1 CPU, 20 logical and 14 physical cores
.NET SDK=7.0.100
  [Host]     : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
  DefaultJob : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
```

|        Method |     Mean |     Error |    StdDev |   Gen0 | Allocated |
|-------------- |---------:|----------:|----------:|-------:|----------:|
| PropertiesSet (before) | 7.509 ns | 0.0954 ns | 0.0846 ns | 0.0064 |      80 B |
| PropertiesSet (after) | 7.081 ns | 0.0677 ns | 0.0633 ns | 0.0051 |      64 B |

## Changes:

- collapsing numeric values into a single field reduces object size from `80B` to `72B` 
- collapsing `IsBoundaryProofNode` moves it from `72B` to `64B`
- fixing `GetMemorySize` which previously was sharing a wrong value (no `LastSeen` reported at all!)
- `LastSeen` made non-nullable which makes the bit operations much easier

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Testing
**Requires testing**

- [ ] Yes
- [x] No

**In case you checked yes, did you write tests??**

- [x] Yes
- [ ] No

