### PR TITLE
TrieNode further memory optimizations

### DIFF
--- a/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
@@ -253,7 +253,7 @@ namespace Nethermind.Trie.Test.Pruning
 
             using TrieStore trieStore = new(memDb, new MemoryLimit(16.MB()), new ConstantInterval(4), _logManager);
 
-            trieStore.CommitNode(0, new NodeCommitInfo(a));
+            trieStore.CommitNode(1, new NodeCommitInfo(a));
             trieStore.FinishBlockCommit(TrieType.State, 0, a);
             trieStore.FinishBlockCommit(TrieType.State, 1, a);
             trieStore.FinishBlockCommit(TrieType.State, 2, a);
@@ -274,7 +274,7 @@ namespace Nethermind.Trie.Test.Pruning
 
             using TrieStore trieStore = new(memDb, new MemoryLimit(16.MB()), No.Persistence, _logManager);
 
-            trieStore.CommitNode(0, new NodeCommitInfo(a));
+            trieStore.CommitNode(1, new NodeCommitInfo(a));
             trieStore.FinishBlockCommit(TrieType.State, 0, a);
             trieStore.FinishBlockCommit(TrieType.State, 1, a);
             trieStore.FinishBlockCommit(TrieType.State, 2, a);
@@ -560,7 +560,7 @@ namespace Nethermind.Trie.Test.Pruning
             WitnessCollector witnessCollector = new WitnessCollector(new MemDb(), LimboLogs.Instance);
             IKeyValueStoreWithBatching store = originalStore.WitnessedBy(witnessCollector);
             using TrieStore trieStore = new(store, new TestPruningStrategy(false), No.Persistence, _logManager);
-            trieStore.CommitNode(0, new NodeCommitInfo(node));
+            trieStore.CommitNode(1, new NodeCommitInfo(node));
             trieStore.FinishBlockCommit(TrieType.State, 0, node);
 
             IReadOnlyTrieStore readOnlyTrieStore = trieStore.AsReadOnly(originalStore);
@@ -636,7 +636,7 @@ namespace Nethermind.Trie.Test.Pruning
             node.ResolveKey(NullTrieNodeResolver.Instance, true);
 
             using TrieStore trieStore = new(new MemDb(), new TestPruningStrategy(pruning), No.Persistence, _logManager);
-            trieStore.CommitNode(0, new NodeCommitInfo(node));
+            trieStore.CommitNode(1, new NodeCommitInfo(node));
             trieStore.FinishBlockCommit(TrieType.State, 0, node);
             var originalNode = trieStore.FindCachedOrUnknown(node.Keccak);
 

--- a/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
@@ -171,7 +171,8 @@ namespace Nethermind.Trie.Test
             decodedTiniest.ResolveNode(NullTrieNodeResolver.Instance);
 
             Assert.AreEqual(ctx.TiniestLeaf.Value, decodedTiniest.Value, "value");
-            Assert.AreEqual(HexPrefix.ToBytes(ctx.TiniestLeaf.Key!, true), HexPrefix.ToBytes(decodedTiniest.Key!, true), "key");
+            Assert.AreEqual(HexPrefix.ToBytes(ctx.TiniestLeaf.Key!, true), HexPrefix.ToBytes(decodedTiniest.Key!, true),
+                "key");
         }
 
         [Test]
@@ -511,14 +512,14 @@ namespace Nethermind.Trie.Test
         public void Size_of_a_heavy_leaf_is_correct()
         {
             Context ctx = new();
-            Assert.AreEqual(240, ctx.HeavyLeaf.GetMemorySize(false));
+            Assert.AreEqual(232, ctx.HeavyLeaf.GetMemorySize(false));
         }
 
         [Test]
         public void Size_of_a_tiny_leaf_is_correct()
         {
             Context ctx = new();
-            Assert.AreEqual(160, ctx.TiniestLeaf.GetMemorySize(false));
+            Assert.AreEqual(152, ctx.TiniestLeaf.GetMemorySize(false));
         }
 
         [Test]
@@ -532,8 +533,8 @@ namespace Nethermind.Trie.Test
                 node.SetChild(i, ctx.AccountLeaf);
             }
 
-            Assert.AreEqual(3792, node.GetMemorySize(true));
-            Assert.AreEqual(208, node.GetMemorySize(false));
+            Assert.AreEqual(3656, node.GetMemorySize(true));
+            Assert.AreEqual(200, node.GetMemorySize(false));
         }
 
         [Test]
@@ -544,7 +545,7 @@ namespace Nethermind.Trie.Test
             trieNode.Key = new byte[] { 1 };
             trieNode.SetChild(0, ctx.TiniestLeaf);
 
-            Assert.AreEqual(128, trieNode.GetMemorySize(false));
+            Assert.AreEqual(120, trieNode.GetMemorySize(false));
         }
 
         [Test]
@@ -555,22 +556,22 @@ namespace Nethermind.Trie.Test
             trieNode.Key = new byte[] { 1 };
             trieNode.SetChild(0, ctx.TiniestLeaf);
 
-            Assert.AreEqual(288, trieNode.GetMemorySize(true));
-            Assert.AreEqual(128, trieNode.GetMemorySize(false));
+            Assert.AreEqual(272, trieNode.GetMemorySize(true));
+            Assert.AreEqual(120, trieNode.GetMemorySize(false));
         }
 
         [Test]
         public void Size_of_an_unknown_empty_node_is_correct()
         {
             TrieNode trieNode = new(NodeType.Unknown);
-            trieNode.GetMemorySize(false).Should().Be(56);
+            trieNode.GetMemorySize(false).Should().Be(48);
         }
 
         [Test]
         public void Size_of_an_unknown_node_with_keccak_is_correct()
         {
             TrieNode trieNode = new(NodeType.Unknown, Keccak.Zero);
-            trieNode.GetMemorySize(false).Should().Be(136);
+            trieNode.GetMemorySize(false).Should().Be(128);
         }
 
         [Test]
@@ -578,7 +579,7 @@ namespace Nethermind.Trie.Test
         {
             TrieNode trieNode = new(NodeType.Extension);
             trieNode.SetChild(0, null);
-            trieNode.GetMemorySize(false).Should().Be(96);
+            trieNode.GetMemorySize(false).Should().Be(88);
         }
 
         [Test]
@@ -586,7 +587,7 @@ namespace Nethermind.Trie.Test
         {
             TrieNode trieNode = new(NodeType.Branch);
             trieNode.SetChild(0, null);
-            trieNode.GetMemorySize(false).Should().Be(208);
+            trieNode.GetMemorySize(false).Should().Be(200);
         }
 
         [Test]
@@ -594,14 +595,14 @@ namespace Nethermind.Trie.Test
         {
             TrieNode trieNode = new(NodeType.Leaf);
             trieNode.Value = new byte[7];
-            trieNode.GetMemorySize(false).Should().Be(136);
+            trieNode.GetMemorySize(false).Should().Be(128);
         }
 
         [Test]
         public void Size_of_an_unknown_node_with_full_rlp_is_correct()
         {
             TrieNode trieNode = new(NodeType.Unknown, new byte[7]);
-            trieNode.GetMemorySize(false).Should().Be(120);
+            trieNode.GetMemorySize(false).Should().Be(80);
         }
 
         [Test]
@@ -699,7 +700,7 @@ namespace Nethermind.Trie.Test
             trieNode.SetChild(0, child);
 
             trieNode.PrunePersistedRecursively(1);
-            trieNode.GetMemorySize(false).Should().Be(176);
+            trieNode.GetMemorySize(false).Should().Be(168);
         }
 
         [Test]
@@ -712,7 +713,7 @@ namespace Nethermind.Trie.Test
             trieNode.PrunePersistedRecursively(1);
             TrieNode cloned = trieNode.Clone();
 
-            cloned.GetMemorySize(false).Should().Be(176);
+            cloned.GetMemorySize(false).Should().Be(168);
         }
 
         [Test]
@@ -884,14 +885,14 @@ namespace Nethermind.Trie.Test
             leaf1.Value = new byte[111];
             leaf1.ResolveKey(trieStore, false);
             leaf1.Seal();
-            trieStore.CommitNode(0, new NodeCommitInfo(leaf1));
+            trieStore.CommitNode(1, new NodeCommitInfo(leaf1));
 
             TrieNode leaf2 = new(NodeType.Leaf);
             leaf2.Key = Bytes.FromHexString("abd");
             leaf2.Value = new byte[222];
             leaf2.ResolveKey(trieStore, false);
             leaf2.Seal();
-            trieStore.CommitNode(0, new NodeCommitInfo(leaf2));
+            trieStore.CommitNode(1, new NodeCommitInfo(leaf2));
 
             TrieNode trieNode = new(NodeType.Branch);
             trieNode.SetChild(1, leaf1);

--- a/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
@@ -511,14 +511,14 @@ namespace Nethermind.Trie.Test
         public void Size_of_a_heavy_leaf_is_correct()
         {
             Context ctx = new();
-            Assert.AreEqual(232, ctx.HeavyLeaf.GetMemorySize(false));
+            Assert.AreEqual(240, ctx.HeavyLeaf.GetMemorySize(false));
         }
 
         [Test]
         public void Size_of_a_tiny_leaf_is_correct()
         {
             Context ctx = new();
-            Assert.AreEqual(152, ctx.TiniestLeaf.GetMemorySize(false));
+            Assert.AreEqual(160, ctx.TiniestLeaf.GetMemorySize(false));
         }
 
         [Test]
@@ -532,7 +532,7 @@ namespace Nethermind.Trie.Test
                 node.SetChild(i, ctx.AccountLeaf);
             }
 
-            Assert.AreEqual(3664, node.GetMemorySize(true));
+            Assert.AreEqual(3792, node.GetMemorySize(true));
             Assert.AreEqual(208, node.GetMemorySize(false));
         }
 
@@ -555,7 +555,7 @@ namespace Nethermind.Trie.Test
             trieNode.Key = new byte[] { 1 };
             trieNode.SetChild(0, ctx.TiniestLeaf);
 
-            Assert.AreEqual(280, trieNode.GetMemorySize(true));
+            Assert.AreEqual(288, trieNode.GetMemorySize(true));
             Assert.AreEqual(128, trieNode.GetMemorySize(false));
         }
 
@@ -594,7 +594,7 @@ namespace Nethermind.Trie.Test
         {
             TrieNode trieNode = new(NodeType.Leaf);
             trieNode.Value = new byte[7];
-            trieNode.GetMemorySize(false).Should().Be(128);
+            trieNode.GetMemorySize(false).Should().Be(136);
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
@@ -602,7 +602,7 @@ namespace Nethermind.Trie.Test
         public void Size_of_an_unknown_node_with_full_rlp_is_correct()
         {
             TrieNode trieNode = new(NodeType.Unknown, new byte[7]);
-            trieNode.GetMemorySize(false).Should().Be(80);
+            trieNode.GetMemorySize(false).Should().Be(112);
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Trie/TrieNode.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.cs
@@ -572,6 +572,7 @@ namespace Nethermind.Trie
                     : MemorySizes.Align(_data.Length * MemorySizes.RefSize + MemorySizes.ArrayOverhead));
             int objectOverhead = MemorySizes.SmallObjectOverhead - MemorySizes.SmallObjectFreeDataSize;
 
+            // _value
             int valuesOverhead = 8;
 
             for (int i = 0; i < (_data?.Length ?? 0); i++)

--- a/src/Nethermind/Nethermind.Trie/TrieNode.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.cs
@@ -562,8 +562,7 @@ namespace Nethermind.Trie
                     ? MemorySizes.RefSize
                     : MemorySizes.RefSize + Keccak.MemorySize;
             long rlpStreamSize =
-                MemorySizes.RefSize + (_rlpStream?.MemorySize ?? 0)
-                - (FullRlp is null ? 0 : MemorySizes.Align(FullRlp.Length + MemorySizes.ArrayOverhead));
+                MemorySizes.RefSize + (_rlpStream?.MemorySize ?? 0);
             long dataSize =
                 MemorySizes.RefSize +
                 (_data is null

--- a/src/Nethermind/Nethermind.Trie/TrieNode.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.cs
@@ -803,6 +803,9 @@ namespace Nethermind.Trie
                         _data = new object[AllowBranchValues ? BranchesCount + 1 : BranchesCount];
                         break;
                     case NodeType.Leaf:
+                        // _data[0] - path,
+                        // _data[1] - value,
+                        // _data[2] -> StorageRoot
                         _data = new object[3];
                         break;
                     default:


### PR DESCRIPTION
This PR pushes further with memory optimizations of `TrieNode`, that were initiated in #5259. `TrieNode` is an object that is cached in memory and usually has ~350,000 objects of this type allocated. This PR cuts another 16 bytes from the class.

## Changes

- make `storageRoot` a part of data so that only leaves allocate it (reduce footprint by 8 bytes for non-leaves)
- remove `FullRlp` reference and delegate to `_rlpStream.Data`
- amend `GetMemorySize` as it was previously (**thorough review required**) double counting the data (once under FullRlp, once under rlpstream)

## Benchmarks

```bash
BenchmarkDotNet=v0.13.4, OS=Windows 11 (10.0.22621.1105)
12th Gen Intel Core i9-12900HK, 1 CPU, 20 logical and 14 physical cores
.NET SDK=7.0.100
  [Host]     : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
  DefaultJob : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
```

|        Method |     Mean |     Error |    StdDev |   Gen0 | Allocated |
|-------------- |---------:|----------:|----------:|-------:|----------:|
| PropertiesSet (master) | 7.509 ns | 0.0954 ns | 0.0846 ns | 0.0064 |     64 B  |
| PropertiesSet ([85ec8ef](https://github.com/NethermindEth/nethermind/pull/5262/commits/85ec8ef97c95e39dc13f3b85281ac287e6a07772))  - storageRoot| 7.223 ns | 0.1418 ns | 0.2407 ns | 0.0045 |      56 B |
| PropertiesSet ([e3049e0](https://github.com/NethermindEth/nethermind/pull/5262/commits/e3049e02732a8dd8a26c07116fee860d06a970a1)) - FullRlp ref | 7.089 ns | 0.1305 ns | 0.1221 ns | 0.0038 |      48 B |

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

No functional changes

## Remarks

Low level optimizations make code a bit ugly. Still, something that is allocated ~350,000 times can be a bit uglier.
