### PR TITLE
StorageCell byref

### DIFF
--- a/src/Nethermind/Nethermind.AccountAbstraction/Executor/UserOperationTracer.cs
+++ b/src/Nethermind/Nethermind.AccountAbstraction/Executor/UserOperationTracer.cs
@@ -107,12 +107,12 @@ namespace Nethermind.AccountAbstraction.Executor
         {
         }
 
-        public void ReportStorageChange(StorageCell storageCell, byte[] before, byte[] after)
+        public void ReportStorageChange(in StorageCell storageCell, byte[] before, byte[] after)
         {
             throw new NotImplementedException();
         }
 
-        public void ReportStorageRead(StorageCell storageCell)
+        public void ReportStorageRead(in StorageCell storageCell)
         {
             throw new NotImplementedException();
         }

--- a/src/Nethermind/Nethermind.Benchmark/State/StorageCellBenchmark.cs
+++ b/src/Nethermind/Nethermind.Benchmark/State/StorageCellBenchmark.cs
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using Nethermind.Core;
+using Nethermind.Int256;
+using Nethermind.State;
+
+namespace Nethermind.Benchmarks.State
+{
+    public class StorageCellBenchmark
+    {
+        private static IStorageTracer _tracer;
+        private static StorageCell _cell = new(Address.SystemUser, new UInt256(1, 2, 3, 4));
+
+        private const int OperationsPerInvoke = 1000;
+
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _tracer = new StorageTracer();
+        }
+
+        [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+        public void Parameter_Passing()
+        {
+            for (int i = 0; i < OperationsPerInvoke / 10; i++)
+            {
+                _tracer.ReportStorageRead(_cell);
+                _tracer.ReportStorageRead(_cell);
+                _tracer.ReportStorageRead(_cell);
+                _tracer.ReportStorageRead(_cell);
+                _tracer.ReportStorageRead(_cell);
+                _tracer.ReportStorageRead(_cell);
+                _tracer.ReportStorageRead(_cell);
+                _tracer.ReportStorageRead(_cell);
+                _tracer.ReportStorageRead(_cell);
+                _tracer.ReportStorageRead(_cell);
+            }
+        }
+
+        private class StorageTracer : IStorageTracer
+        {
+            public bool IsTracingStorage => throw new NotImplementedException();
+
+            public void ReportStorageChange(in ReadOnlySpan<byte> key, in ReadOnlySpan<byte> value) =>
+                throw new NotImplementedException();
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            public void ReportStorageChange(in StorageCell storageCell, byte[] before, byte[] after) { }
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            public void ReportStorageRead(in StorageCell storageCell) { }
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Evm.Test/TestAllTracerWithOutput.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/TestAllTracerWithOutput.cs
@@ -117,11 +117,11 @@ namespace Nethermind.Evm.Test
         {
         }
 
-        public void ReportStorageChange(StorageCell storageCell, byte[] before, byte[] after)
+        public void ReportStorageChange(in StorageCell storageCell, byte[] before, byte[] after)
         {
         }
 
-        public void ReportStorageRead(StorageCell storageCell)
+        public void ReportStorageRead(in StorageCell storageCell)
         {
         }
 

--- a/src/Nethermind/Nethermind.Evm/Tracing/AccessTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/AccessTxTracer.cs
@@ -57,12 +57,12 @@ namespace Nethermind.Evm.Tracing
             throw new NotImplementedException();
         }
 
-        public void ReportStorageChange(StorageCell storageCell, byte[] before, byte[] after)
+        public void ReportStorageChange(in StorageCell storageCell, byte[] before, byte[] after)
         {
             throw new NotImplementedException();
         }
 
-        public void ReportStorageRead(StorageCell storageCell)
+        public void ReportStorageRead(in StorageCell storageCell)
         {
             throw new NotImplementedException();
         }

--- a/src/Nethermind/Nethermind.Evm/Tracing/AlwaysCancelTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/AlwaysCancelTxTracer.cs
@@ -77,9 +77,9 @@ namespace Nethermind.Evm.Tracing
 
         public void ReportAccountRead(Address address) => throw new OperationCanceledException(ErrorMessage);
 
-        public void ReportStorageChange(StorageCell storageCell, byte[] before, byte[] after) => throw new OperationCanceledException(ErrorMessage);
+        public void ReportStorageChange(in StorageCell storageCell, byte[] before, byte[] after) => throw new OperationCanceledException(ErrorMessage);
 
-        public void ReportStorageRead(StorageCell storageCell) => throw new OperationCanceledException(ErrorMessage);
+        public void ReportStorageRead(in StorageCell storageCell) => throw new OperationCanceledException(ErrorMessage);
 
         public void ReportAction(long gas, UInt256 value, Address @from, Address to, ReadOnlyMemory<byte> input, ExecutionType callType, bool isPrecompileCall = false) => throw new OperationCanceledException(ErrorMessage);
 

--- a/src/Nethermind/Nethermind.Evm/Tracing/BlockReceiptsTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/BlockReceiptsTracer.cs
@@ -135,10 +135,10 @@ namespace Nethermind.Evm.Tracing
         public void ReportAccountRead(Address address) =>
             _currentTxTracer.ReportAccountRead(address);
 
-        public void ReportStorageChange(StorageCell storageCell, byte[] before, byte[] after) =>
+        public void ReportStorageChange(in StorageCell storageCell, byte[] before, byte[] after) =>
             _currentTxTracer.ReportStorageChange(storageCell, before, after);
 
-        public void ReportStorageRead(StorageCell storageCell) =>
+        public void ReportStorageRead(in StorageCell storageCell) =>
             _currentTxTracer.ReportStorageRead(storageCell);
 
         public void ReportAction(long gas, UInt256 value, Address @from, Address to, ReadOnlyMemory<byte> input, ExecutionType callType, bool isPrecompileCall = false) =>

--- a/src/Nethermind/Nethermind.Evm/Tracing/CallOutputTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/CallOutputTracer.cs
@@ -129,12 +129,12 @@ namespace Nethermind.Evm.Tracing
             throw new NotSupportedException();
         }
 
-        public void ReportStorageChange(StorageCell storageCell, byte[] before, byte[] after)
+        public void ReportStorageChange(in StorageCell storageCell, byte[] before, byte[] after)
         {
             throw new NotSupportedException();
         }
 
-        public void ReportStorageRead(StorageCell storageCell)
+        public void ReportStorageRead(in StorageCell storageCell)
         {
             throw new NotImplementedException();
         }

--- a/src/Nethermind/Nethermind.Evm/Tracing/CancellationTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/CancellationTxTracer.cs
@@ -151,7 +151,7 @@ namespace Nethermind.Evm.Tracing
             }
         }
 
-        public void ReportStorageChange(StorageCell storageCell, byte[] before, byte[] after)
+        public void ReportStorageChange(in StorageCell storageCell, byte[] before, byte[] after)
         {
             _token.ThrowIfCancellationRequested();
             if (_innerTracer.IsTracingStorage)
@@ -160,7 +160,7 @@ namespace Nethermind.Evm.Tracing
             }
         }
 
-        public void ReportStorageRead(StorageCell storageCell)
+        public void ReportStorageRead(in StorageCell storageCell)
         {
             _token.ThrowIfCancellationRequested();
             if (_innerTracer.IsTracingStorage)

--- a/src/Nethermind/Nethermind.Evm/Tracing/CompositeTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/CompositeTxTracer.cs
@@ -101,7 +101,7 @@ namespace Nethermind.Evm.Tracing
             }
         }
 
-        public void ReportStorageChange(StorageCell storageCell, byte[] before, byte[] after)
+        public void ReportStorageChange(in StorageCell storageCell, byte[] before, byte[] after)
         {
             for (int index = 0; index < _txTracers.Count; index++)
             {
@@ -113,7 +113,7 @@ namespace Nethermind.Evm.Tracing
             }
         }
 
-        public void ReportStorageRead(StorageCell storageCell)
+        public void ReportStorageRead(in StorageCell storageCell)
         {
             for (int index = 0; index < _txTracers.Count; index++)
             {

--- a/src/Nethermind/Nethermind.Evm/Tracing/EstimateGasTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/EstimateGasTracer.cs
@@ -141,12 +141,12 @@ namespace Nethermind.Evm.Tracing
             throw new NotSupportedException();
         }
 
-        public void ReportStorageChange(StorageCell storageCell, byte[] before, byte[] after)
+        public void ReportStorageChange(in StorageCell storageCell, byte[] before, byte[] after)
         {
             throw new NotSupportedException();
         }
 
-        public void ReportStorageRead(StorageCell storageCell)
+        public void ReportStorageRead(in StorageCell storageCell)
         {
             throw new NotSupportedException();
         }

--- a/src/Nethermind/Nethermind.Evm/Tracing/FeesTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/FeesTracer.cs
@@ -75,12 +75,12 @@ public class FeesTracer : IBlockTracer, ITxTracer
     {
         throw new NotImplementedException();
     }
-    public void ReportStorageChange(StorageCell storageCell, byte[] before, byte[] after)
+    public void ReportStorageChange(in StorageCell storageCell, byte[] before, byte[] after)
     {
         throw new NotImplementedException();
     }
 
-    public void ReportStorageRead(StorageCell storageCell)
+    public void ReportStorageRead(in StorageCell storageCell)
     {
         throw new NotImplementedException();
     }

--- a/src/Nethermind/Nethermind.Evm/Tracing/GasEstimator.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/GasEstimator.cs
@@ -190,12 +190,12 @@ namespace Nethermind.Evm.Tracing
             {
             }
 
-            public void ReportStorageChange(StorageCell storageCell, byte[] before, byte[] after)
+            public void ReportStorageChange(in StorageCell storageCell, byte[] before, byte[] after)
             {
                 throw new NotSupportedException();
             }
 
-            public void ReportStorageRead(StorageCell storageCell)
+            public void ReportStorageRead(in StorageCell storageCell)
             {
                 throw new NotSupportedException();
             }

--- a/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/GethLikeTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/GethLikeTxTracer.cs
@@ -161,12 +161,12 @@ namespace Nethermind.Evm.Tracing.GethStyle
         {
         }
 
-        public void ReportStorageChange(StorageCell storageCell, byte[] before, byte[] after)
+        public void ReportStorageChange(in StorageCell storageCell, byte[] before, byte[] after)
         {
             throw new NotSupportedException();
         }
 
-        public void ReportStorageRead(StorageCell storageCell)
+        public void ReportStorageRead(in StorageCell storageCell)
         {
             throw new NotSupportedException();
         }

--- a/src/Nethermind/Nethermind.Evm/Tracing/NullTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/NullTxTracer.cs
@@ -83,9 +83,9 @@ namespace Nethermind.Evm.Tracing
         public void ReportAccountRead(Address address)
             => throw new InvalidOperationException(ErrorMessage);
 
-        public void ReportStorageChange(StorageCell storageCell, byte[] before, byte[] after)
+        public void ReportStorageChange(in StorageCell storageCell, byte[] before, byte[] after)
             => throw new InvalidOperationException(ErrorMessage);
-        public void ReportStorageRead(StorageCell storageCell)
+        public void ReportStorageRead(in StorageCell storageCell)
             => throw new InvalidOperationException(ErrorMessage);
 
         public void ReportAction(long gas, UInt256 value, Address @from, Address to, ReadOnlyMemory<byte> input, ExecutionType callType, bool isPrecompileCall = false)

--- a/src/Nethermind/Nethermind.Evm/Tracing/ParityStyle/ParityLikeTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/ParityStyle/ParityLikeTxTracer.cs
@@ -387,7 +387,7 @@ namespace Nethermind.Evm.Tracing.ParityStyle
         {
         }
 
-        public void ReportStorageChange(StorageCell storageCell, byte[] before, byte[] after)
+        public void ReportStorageChange(in StorageCell storageCell, byte[] before, byte[] after)
         {
             Dictionary<UInt256, ParityStateChange<byte[]>> storage = null;
             if (!_trace.StateChanges.ContainsKey(storageCell.Address))
@@ -405,7 +405,7 @@ namespace Nethermind.Evm.Tracing.ParityStyle
             storage[storageCell.Index] = new ParityStateChange<byte[]>(before, after);
         }
 
-        public void ReportStorageRead(StorageCell storageCell)
+        public void ReportStorageRead(in StorageCell storageCell)
         {
         }
 

--- a/src/Nethermind/Nethermind.Evm/Tracing/Proofs/ProofTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/Proofs/ProofTxTracer.cs
@@ -105,14 +105,14 @@ namespace Nethermind.Evm.Tracing.Proofs
             Accounts.Add(address);
         }
 
-        public void ReportStorageChange(StorageCell storageCell, byte[] before, byte[] after)
+        public void ReportStorageChange(in StorageCell storageCell, byte[] before, byte[] after)
         {
             // implicit knowledge here that if we read storage then for sure we have at least asked for the account's balance
             // and so we do not need to add account to Accounts
             Storages.Add(storageCell);
         }
 
-        public void ReportStorageRead(StorageCell storageCell)
+        public void ReportStorageRead(in StorageCell storageCell)
         {
             // implicit knowledge here that if we read storage then for sure we have at least asked for the account's balance
             // and so we do not need to add account to Accounts

--- a/src/Nethermind/Nethermind.Mev/BeneficiaryTracer.cs
+++ b/src/Nethermind/Nethermind.Mev/BeneficiaryTracer.cs
@@ -50,8 +50,8 @@ namespace Nethermind.Mev
         public void ReportCodeChange(Address address, byte[]? before, byte[]? after) { }
         public void ReportNonceChange(Address address, UInt256? before, UInt256? after) { }
         public void ReportAccountRead(Address address) { }
-        public void ReportStorageChange(StorageCell storageCell, byte[] before, byte[] after) { }
-        public void ReportStorageRead(StorageCell storageCell) { }
+        public void ReportStorageChange(in StorageCell storageCell, byte[] before, byte[] after) { }
+        public void ReportStorageRead(in StorageCell storageCell) { }
         public void MarkAsSuccess(Address recipient, long gasSpent, byte[] output, LogEntry[] logs, Keccak? stateRoot = null) { }
         public void MarkAsFailed(Address recipient, long gasSpent, byte[] output, string error, Keccak? stateRoot = null) { }
         public void StartOperation(int depth, long gas, Instruction opcode, int pc, bool isPostMerge = false) { }

--- a/src/Nethermind/Nethermind.Mev/Execution/TxBundleSimulator.cs
+++ b/src/Nethermind/Nethermind.Mev/Execution/TxBundleSimulator.cs
@@ -312,12 +312,12 @@ namespace Nethermind.Mev.Execution
             {
             }
 
-            public void ReportStorageChange(StorageCell storageCell, byte[] before, byte[] after)
+            public void ReportStorageChange(in StorageCell storageCell, byte[] before, byte[] after)
             {
                 throw new NotSupportedException();
             }
 
-            public void ReportStorageRead(StorageCell storageCell)
+            public void ReportStorageRead(in StorageCell storageCell)
             {
                 throw new NotImplementedException();
             }

--- a/src/Nethermind/Nethermind.State.Test.Runner/StateTestTxTracer.cs
+++ b/src/Nethermind/Nethermind.State.Test.Runner/StateTestTxTracer.cs
@@ -143,12 +143,12 @@ namespace Nethermind.State.Test.Runner
             throw new NotImplementedException();
         }
 
-        public void ReportStorageChange(StorageCell storageAddress, byte[] before, byte[] after)
+        public void ReportStorageChange(in StorageCell storageAddress, byte[] before, byte[] after)
         {
             throw new NotSupportedException();
         }
 
-        public void ReportStorageRead(StorageCell storageCell)
+        public void ReportStorageRead(in StorageCell storageCell)
         {
             throw new NotImplementedException();
         }

--- a/src/Nethermind/Nethermind.State/IStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/IStorageProvider.cs
@@ -16,35 +16,35 @@ namespace Nethermind.State
         /// </summary>
         /// <param name="storageCell"></param>
         /// <returns></returns>
-        byte[] GetOriginal(StorageCell storageCell);
+        byte[] GetOriginal(in StorageCell storageCell);
 
         /// <summary>
         /// Get the persistent storage value at the specified storage cell
         /// </summary>
         /// <param name="storageCell">Storage location</param>
         /// <returns>Value at cell</returns>
-        byte[] Get(StorageCell storageCell);
+        byte[] Get(in StorageCell storageCell);
 
         /// <summary>
         /// Set the provided value to persistent storage at the specified storage cell
         /// </summary>
         /// <param name="storageCell">Storage location</param>
         /// <param name="newValue">Value to store</param>
-        void Set(StorageCell storageCell, byte[] newValue);
+        void Set(in StorageCell storageCell, byte[] newValue);
 
         /// <summary>
         /// Get the transient storage value at the specified storage cell
         /// </summary>
         /// <param name="storageCell">Storage location</param>
         /// <returns>Value at cell</returns>
-        byte[] GetTransientState(StorageCell storageCell);
+        byte[] GetTransientState(in StorageCell storageCell);
 
         /// <summary>
         /// Set the provided value to transient storage at the specified storage cell
         /// </summary>
         /// <param name="storageCell">Storage location</param>
         /// <param name="newValue">Value to store</param>
-        void SetTransientState(StorageCell storageCell, byte[] newValue);
+        void SetTransientState(in StorageCell storageCell, byte[] newValue);
 
         /// <summary>
         /// Reset all storage

--- a/src/Nethermind/Nethermind.State/IStorageTracer.cs
+++ b/src/Nethermind/Nethermind.State/IStorageTracer.cs
@@ -33,13 +33,13 @@ namespace Nethermind.State
         /// <param name="before"></param>
         /// <param name="after"></param>
         /// <remarks>Depends on <see cref="IsTracingStorage"/></remarks>
-        void ReportStorageChange(StorageCell storageCell, byte[] before, byte[] after);
+        void ReportStorageChange(in StorageCell storageCell, byte[] before, byte[] after);
 
         /// <summary>
         /// Reports storage access
         /// </summary>
         /// <param name="storageCell"></param>
         /// <remarks>Depends on <see cref="IsTracingStorage"/></remarks>
-        void ReportStorageRead(StorageCell storageCell);
+        void ReportStorageRead(in StorageCell storageCell);
     }
 }

--- a/src/Nethermind/Nethermind.State/NullStorageTracer.cs
+++ b/src/Nethermind/Nethermind.State/NullStorageTracer.cs
@@ -18,10 +18,10 @@ namespace Nethermind.State
         public void ReportStorageChange(in ReadOnlySpan<byte> key, in ReadOnlySpan<byte> value)
             => throw new InvalidOperationException(ErrorMessage);
 
-        public void ReportStorageChange(StorageCell storageCell, byte[] before, byte[] after)
+        public void ReportStorageChange(in StorageCell storageCell, byte[] before, byte[] after)
             => throw new InvalidOperationException(ErrorMessage);
 
-        public void ReportStorageRead(StorageCell storageCell)
+        public void ReportStorageRead(in StorageCell storageCell)
             => throw new InvalidOperationException(ErrorMessage);
     }
 }

--- a/src/Nethermind/Nethermind.State/PartialStorageProviderBase.cs
+++ b/src/Nethermind/Nethermind.State/PartialStorageProviderBase.cs
@@ -40,7 +40,7 @@ namespace Nethermind.State
         /// </summary>
         /// <param name="storageCell">Storage location</param>
         /// <returns>Value at cell</returns>
-        public byte[] Get(StorageCell storageCell)
+        public byte[] Get(in StorageCell storageCell)
         {
             return GetCurrentValue(storageCell);
         }
@@ -50,7 +50,7 @@ namespace Nethermind.State
         /// </summary>
         /// <param name="storageCell">Storage location</param>
         /// <param name="newValue">Value to store</param>
-        public void Set(StorageCell storageCell, byte[] newValue)
+        public void Set(in StorageCell storageCell, byte[] newValue)
         {
             PushUpdate(storageCell, newValue);
         }
@@ -213,7 +213,7 @@ namespace Nethermind.State
         /// <param name="storageCell">Storage location</param>
         /// <param name="bytes">Resulting value</param>
         /// <returns>True if value has been set</returns>
-        protected bool TryGetCachedValue(StorageCell storageCell, out byte[]? bytes)
+        protected bool TryGetCachedValue(in StorageCell storageCell, out byte[]? bytes)
         {
             if (_intraBlockCache.TryGetValue(storageCell, out StackList<int> stack))
             {
@@ -233,14 +233,14 @@ namespace Nethermind.State
         /// </summary>
         /// <param name="storageCell">Storage location</param>
         /// <returns>Value at location</returns>
-        protected abstract byte[] GetCurrentValue(StorageCell storageCell);
+        protected abstract byte[] GetCurrentValue(in StorageCell storageCell);
 
         /// <summary>
         /// Update the storage cell with provided value
         /// </summary>
         /// <param name="cell">Storage location</param>
         /// <param name="value">Value to set</param>
-        private void PushUpdate(StorageCell cell, byte[] value)
+        private void PushUpdate(in StorageCell cell, byte[] value)
         {
             SetupRegistry(cell);
             IncrementChangePosition();
@@ -249,7 +249,7 @@ namespace Nethermind.State
         }
 
         /// <summary>
-        /// Increment position and size (if needed) of _changes 
+        /// Increment position and size (if needed) of _changes
         /// </summary>
         protected void IncrementChangePosition()
         {
@@ -260,7 +260,7 @@ namespace Nethermind.State
         /// Initialize the StackList at the storage cell position if needed
         /// </summary>
         /// <param name="cell"></param>
-        protected void SetupRegistry(StorageCell cell)
+        protected void SetupRegistry(in StorageCell cell)
         {
             if (!_intraBlockCache.ContainsKey(cell))
             {

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -53,7 +53,7 @@ namespace Nethermind.State
         /// </summary>
         /// <param name="storageCell">Storage location</param>
         /// <returns>Value at location</returns>
-        protected override byte[] GetCurrentValue(StorageCell storageCell) =>
+        protected override byte[] GetCurrentValue(in StorageCell storageCell) =>
             TryGetCachedValue(storageCell, out byte[]? bytes) ? bytes! : LoadFromTree(storageCell);
 
         /// <summary>
@@ -61,7 +61,7 @@ namespace Nethermind.State
         /// </summary>
         /// <param name="storageCell"></param>
         /// <returns></returns>
-        public byte[] GetOriginal(StorageCell storageCell)
+        public byte[] GetOriginal(in StorageCell storageCell)
         {
             if (!_originalValues.ContainsKey(storageCell))
             {
@@ -226,7 +226,7 @@ namespace Nethermind.State
             return _storages[address];
         }
 
-        private byte[] LoadFromTree(StorageCell storageCell)
+        private byte[] LoadFromTree(in StorageCell storageCell)
         {
             StorageTree tree = GetOrCreateStorage(storageCell.Address);
 
@@ -236,7 +236,7 @@ namespace Nethermind.State
             return value;
         }
 
-        private void PushToRegistryOnly(StorageCell cell, byte[] value)
+        private void PushToRegistryOnly(in StorageCell cell, byte[] value)
         {
             SetupRegistry(cell);
             IncrementChangePosition();

--- a/src/Nethermind/Nethermind.State/StorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/StorageProvider.cs
@@ -41,17 +41,17 @@ namespace Nethermind.State
             _persistentStorageProvider.CommitTrees(blockNumber);
         }
 
-        public byte[] Get(StorageCell storageCell)
+        public byte[] Get(in StorageCell storageCell)
         {
             return _persistentStorageProvider.Get(storageCell);
         }
 
-        public byte[] GetOriginal(StorageCell storageCell)
+        public byte[] GetOriginal(in StorageCell storageCell)
         {
             return _persistentStorageProvider.GetOriginal(storageCell);
         }
 
-        public byte[] GetTransientState(StorageCell storageCell)
+        public byte[] GetTransientState(in StorageCell storageCell)
         {
             return _transientStorageProvider.Get(storageCell);
         }
@@ -77,12 +77,12 @@ namespace Nethermind.State
             _transientStorageProvider.Restore(snapshot.TransientStorageSnapshot);
         }
 
-        public void Set(StorageCell storageCell, byte[] newValue)
+        public void Set(in StorageCell storageCell, byte[] newValue)
         {
             _persistentStorageProvider.Set(storageCell, newValue);
         }
 
-        public void SetTransientState(StorageCell storageCell, byte[] newValue)
+        public void SetTransientState(in StorageCell storageCell, byte[] newValue)
         {
             _transientStorageProvider.Set(storageCell, newValue);
         }

--- a/src/Nethermind/Nethermind.State/TransientStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/TransientStorageProvider.cs
@@ -20,7 +20,7 @@ namespace Nethermind.State
         /// </summary>
         /// <param name="storageCell">Storage location</param>
         /// <returns>Value at cell</returns>
-        protected override byte[] GetCurrentValue(StorageCell storageCell) =>
+        protected override byte[] GetCurrentValue(in StorageCell storageCell) =>
             TryGetCachedValue(storageCell, out byte[]? bytes) ? bytes! : _zeroValue;
     }
 }


### PR DESCRIPTION
This PR changes the semantics of `readonly struct StorageCell` passing from by-value to by-ref. The change is visible in the decompiled ASM where an example call to the trace. Effectively, the whole copy over vector registers is skipped.

This might look like a small change but as the `StorageCell` is involved in several calls down the line (see `StorageProvider.Get), it can save some time on not copying the readonly value and just pass it by ref.

```asm
;before
vmovdqu   ymm0,ymmword ptr [rbx]
vmovdqu   ymmword ptr [rsp+28],ymm0
mov       rdx,[rbx+20]
mov       [rsp+48],rdx
lea       rdx,[rsp+28]
mov       r11,7FF938B00488
call      qword ptr [r11]

;after
mov       rdx,rdi
mov       rcx,[rbx]
mov       r11,7FF938AF0498
call      qword ptr [r11]
```

## Changes

- use `in`  modifier, a.k.a by-ref semantics for `StorageCell` passing

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Just one benchmark to see the numbers and ASM

