### PR TITLE
Reduce LocateNodes allocations

### DIFF
--- a/src/Nethermind/Nethermind.Network.Discovery.Test/DiscoveryManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/DiscoveryManagerTests.cs
@@ -34,7 +34,7 @@ namespace Nethermind.Network.Discovery.Test
         private readonly INetworkConfig _networkConfig = new NetworkConfig();
         private IDiscoveryManager _discoveryManager = null!;
         private IMsgSender _msgSender = null!;
-        private INodeTable _nodeTable = null!;
+        private NodeTable _nodeTable = null!;
         private const int Port = 1;
         private const string Host = "192.168.1.17";
         private Node[] _nodes = null!;

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/NodeLifecycleManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/NodeLifecycleManagerTests.cs
@@ -37,7 +37,7 @@ namespace Nethermind.Network.Discovery.Test
         private IDiscoveryManager _discoveryManager = null!;
         private IDiscoveryManager _discoveryManagerMock = null!;
         private IDiscoveryConfig _discoveryConfigMock = null!;
-        private INodeTable _nodeTable = null!;
+        private NodeTable _nodeTable = null!;
         private IEvictionManager _evictionManagerMock = null!;
         private ILogger _loggerMock = null!;
         private int _port = 1;
@@ -173,7 +173,7 @@ namespace Nethermind.Network.Discovery.Test
             }
 
             //table should contain 3 active nodes
-            IEnumerable<Node> closestNodes = _nodeTable.GetClosestNodes().ToArray();
+            Node[] closestNodes = _nodeTable.GetClosestNodes().ToArray();
             Assert.IsTrue(closestNodes.Count(x => x.Host == managers[0].ManagedNode.Host) == 0);
             Assert.IsTrue(closestNodes.Count(x => x.Host == managers[1].ManagedNode.Host) == 0);
             Assert.IsTrue(closestNodes.Count(x => x.Host == managers[2].ManagedNode.Host) == 0);
@@ -204,7 +204,7 @@ namespace Nethermind.Network.Discovery.Test
 
             //Assert.AreEqual(NodeLifecycleState.ActiveExcluded, candidateManager.State);
             //Assert.AreEqual(NodeLifecycleState.Active, evictionCandidate.State);
-            closestNodes = _nodeTable.GetClosestNodes();
+            closestNodes = _nodeTable.GetClosestNodes().ToArray();
             Assert.That(() => closestNodes.Count(x => x.Host == managers[0].ManagedNode.Host) == 1, Is.True.After(100, 50));
             Assert.That(() => closestNodes.Count(x => x.Host == managers[1].ManagedNode.Host) == 1, Is.True.After(100, 50));
             Assert.That(() => closestNodes.Count(x => x.Host == managers[2].ManagedNode.Host) == 1, Is.True.After(100, 50));

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/NodesLocatorTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/NodesLocatorTests.cs
@@ -87,7 +87,7 @@ namespace Nethermind.Network.Discovery.Test
         [Test]
         public void Throws_when_uninitialized()
         {
-            Assert.ThrowsAsync<InvalidOperationException>(() => _nodesLocator!.LocateNodesAsync(CancellationToken.None));
+            Assert.ThrowsAsync<InvalidOperationException>(async () => await _nodesLocator!.LocateNodesAsync(CancellationToken.None));
         }
     }
 }

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/RoutingTable/NodeBucketTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/RoutingTable/NodeBucketTests.cs
@@ -26,7 +26,7 @@ namespace Nethermind.Network.Discovery.Test.RoutingTable
             nodeBucket.AddNode(_node);
             nodeBucket.AddNode(_node2);
             nodeBucket.AddNode(_node3);
-            nodeBucket.BondedItemsCount.Should().Be(3);
+            nodeBucket.Count.Should().Be(3);
         }
 
         [Test]
@@ -36,7 +36,7 @@ namespace Nethermind.Network.Discovery.Test.RoutingTable
             nodeBucket.AddNode(_node);
             nodeBucket.AddNode(_node2);
             nodeBucket.AddNode(_node3);
-            nodeBucket.BondedItems.Should().HaveCount(3);
+            nodeBucket.Should().HaveCount(3);
         }
 
         [Test]
@@ -52,8 +52,8 @@ namespace Nethermind.Network.Discovery.Test.RoutingTable
             NodeBucket nodeBucket = new(1, 16);
             AddNodes(nodeBucket, 32);
 
-            nodeBucket.BondedItemsCount.Should().Be(16);
-            nodeBucket.BondedItems.Should().HaveCount(16);
+            nodeBucket.Count.Should().Be(16);
+            nodeBucket.Should().HaveCount(16);
         }
 
         [Test]
@@ -67,12 +67,12 @@ namespace Nethermind.Network.Discovery.Test.RoutingTable
                 IPAddress.Broadcast.ToString(),
                 30001);
 
-            Node existing = nodeBucket.BondedItems.First().Node!;
+            Node existing = nodeBucket.First().Node!;
             nodeBucket.ReplaceNode(existing, node);
-            nodeBucket.BondedItemsCount.Should().Be(16);
-            nodeBucket.BondedItems.Should().HaveCount(16);
-            nodeBucket.BondedItems.Should().Contain(bi => bi.Node == node);
-            nodeBucket.BondedItems.Should().NotContain(bi => bi.Node == existing);
+            nodeBucket.Count.Should().Be(16);
+            nodeBucket.Should().HaveCount(16);
+            nodeBucket.Should().Contain(bi => bi.Node == node);
+            nodeBucket.Should().NotContain(bi => bi.Node == existing);
         }
 
         [TestCase(2)]
@@ -83,10 +83,10 @@ namespace Nethermind.Network.Discovery.Test.RoutingTable
             NodeBucket nodeBucket = new(1, 16);
             AddNodes(nodeBucket, nodesInTheBucket);
 
-            Node existing1 = nodeBucket.BondedItems.First().Node!;
+            Node existing1 = nodeBucket.First().Node!;
             nodeBucket.RefreshNode(existing1);
 
-            nodeBucket.BondedItems.Should().HaveCount(Math.Min(nodeBucket.BucketSize, nodesInTheBucket));
+            nodeBucket.Should().HaveCount(Math.Min(nodeBucket.BucketSize, nodesInTheBucket));
         }
 
         [TestCase(0)]

--- a/src/Nethermind/Nethermind.Network.Discovery/DiscoveryApp.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/DiscoveryApp.cs
@@ -300,7 +300,12 @@ public class DiscoveryApp : IDiscoveryApp
                 if (_logger.IsDebug) _logger.Debug($"Running discovery with interval {_discoveryTimer.Interval}");
                 _discoveryTimer.Enabled = false;
                 RunDiscoveryProcess();
-                int nodesCountAfterDiscovery = _nodeTable.Buckets.Sum(x => x.BondedItemsCount);
+                int nodesCountAfterDiscovery = 0;
+                foreach (NodeBucket bucket in _nodeTable.Buckets)
+                {
+                    nodesCountAfterDiscovery += bucket.Count;
+                }
+
                 _discoveryTimer.Interval =
                     nodesCountAfterDiscovery < 16
                         ? 10

--- a/src/Nethermind/Nethermind.Network.Discovery/DiscoveryManager.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/DiscoveryManager.cs
@@ -176,7 +176,7 @@ public class DiscoveryManager : IDiscoveryManager
         }
     }
 
-    public async Task<bool> WasMessageReceived(Keccak senderIdHash, MsgType msgType, int timeout)
+    public async ValueTask<bool> WasMessageReceived(Keccak senderIdHash, MsgType msgType, int timeout)
     {
         TaskCompletionSource<DiscoveryMsg> completionSource = GetCompletionSource(senderIdHash, (int)msgType);
         CancellationTokenSource delayCancellation = new();

--- a/src/Nethermind/Nethermind.Network.Discovery/IDiscoveryManager.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/IDiscoveryManager.cs
@@ -13,7 +13,7 @@ public interface IDiscoveryManager : IDiscoveryMsgListener
     IMsgSender MsgSender { set; }
     INodeLifecycleManager? GetNodeLifecycleManager(Node node, bool isPersisted = false);
     void SendMessage(DiscoveryMsg discoveryMsg);
-    Task<bool> WasMessageReceived(Keccak senderIdHash, MsgType msgType, int timeout);
+    ValueTask<bool> WasMessageReceived(Keccak senderIdHash, MsgType msgType, int timeout);
     event EventHandler<NodeEventArgs> NodeDiscovered;
 
     IReadOnlyCollection<INodeLifecycleManager> GetNodeLifecycleManagers();

--- a/src/Nethermind/Nethermind.Network.Discovery/INodesLocator.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/INodesLocator.cs
@@ -10,12 +10,12 @@ public interface INodesLocator
     /// <summary>
     /// locate nodes for master node
     /// </summary>
-    Task LocateNodesAsync(CancellationToken cancellationToken);
+    ValueTask LocateNodesAsync(CancellationToken cancellationToken);
 
     /// <summary>
     /// locate nodes for specified node id
     /// </summary>
-    Task LocateNodesAsync(byte[] searchedNodeId, CancellationToken cancellationToken);
+    ValueTask LocateNodesAsync(byte[] searchedNodeId, CancellationToken cancellationToken);
 
     void Initialize(Node masterNode);
 }

--- a/src/Nethermind/Nethermind.Network.Discovery/Lifecycle/NodeLifecycleManager.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Lifecycle/NodeLifecycleManager.cs
@@ -17,7 +17,7 @@ namespace Nethermind.Network.Discovery.Lifecycle;
 public class NodeLifecycleManager : INodeLifecycleManager
 {
     private readonly IDiscoveryManager _discoveryManager;
-    private readonly INodeTable _nodeTable;
+    private readonly NodeTable _nodeTable;
     private readonly ILogger _logger;
     private readonly IDiscoveryConfig _discoveryConfig;
     private readonly ITimestamper _timestamper;
@@ -39,7 +39,7 @@ public class NodeLifecycleManager : INodeLifecycleManager
 
     public NodeLifecycleManager(Node node,
         IDiscoveryManager discoveryManager,
-        INodeTable nodeTable,
+        NodeTable nodeTable,
         IEvictionManager evictionManager,
         INodeStats nodeStats,
         NodeRecord nodeRecord,
@@ -197,7 +197,14 @@ public class NodeLifecycleManager : INodeLifecycleManager
         NodeStats.AddNodeStatsEvent(NodeStatsEventType.DiscoveryFindNodeIn);
         RefreshNodeContactTime();
 
-        Node[] nodes = _nodeTable.GetClosestNodes(msg.SearchedNodeId).ToArray();
+        int maxSize = _discoveryConfig.BucketSize;
+        Node[] nodes = new Node[maxSize];
+        int count = _nodeTable.FillClosestNodes(msg.SearchedNodeId, nodes);
+        if (count < maxSize)
+        {
+            Array.Resize(ref nodes, count);
+        }
+
         SendNeighbors(nodes);
     }
 

--- a/src/Nethermind/Nethermind.Network.Discovery/Lifecycle/NodeLifecycleManagerFactory.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Lifecycle/NodeLifecycleManagerFactory.cs
@@ -12,7 +12,7 @@ namespace Nethermind.Network.Discovery.Lifecycle;
 
 public class NodeLifecycleManagerFactory : INodeLifecycleManagerFactory
 {
-    private readonly INodeTable _nodeTable;
+    private readonly NodeTable _nodeTable;
     private readonly ILogger _logger;
     private readonly IDiscoveryConfig _discoveryConfig;
     private readonly ITimestamper _timestamper;
@@ -20,7 +20,7 @@ public class NodeLifecycleManagerFactory : INodeLifecycleManagerFactory
     private readonly INodeStatsManager _nodeStatsManager;
     private readonly NodeRecord _selfNodeRecord;
 
-    public NodeLifecycleManagerFactory(INodeTable nodeTable,
+    public NodeLifecycleManagerFactory(NodeTable nodeTable,
         IEvictionManager evictionManager,
         INodeStatsManager nodeStatsManager,
         NodeRecord self,

--- a/src/Nethermind/Nethermind.Network.Discovery/RoutingTable/INodeTable.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/RoutingTable/INodeTable.cs
@@ -18,10 +18,10 @@ public interface INodeTable
     /// <summary>
     /// GetClosestNodes to MasterNode
     /// </summary>
-    IEnumerable<Node> GetClosestNodes();
+    IEnumerable<Node> GetClosestNodes(HashSet<Keccak>? filter = null);
 
     /// <summary>
     /// GetClosestNodes to provided Node
     /// </summary>
-    IEnumerable<Node> GetClosestNodes(byte[] nodeId);
+    IEnumerable<Node> GetClosestNodes(byte[] nodeId, HashSet<Keccak>? filter = null);
 }


### PR DESCRIPTION
## Changes

- Don't allocate `Keccak`
- Don't allocate multiple enumerators (add struct enumerators)
- Remove Linq allocations
- Maintain separate Count for fast-path rather than following linked list to determine count
- Reuse array rather than reallocating and copying to previous array
- Use pooled ValueTask async
- Reuse HashSet across invocations
- Use strong types rather than interfaces (are always the same type)

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [X] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

Tests in this area are disabled an need updating (so draft for now)

## Remarks

Mechanical performance optimization; unsure of correctness as not sure of original correctness and tests are disabled
