### PR TITLE
.AsSpan().Slice(x,y) => .AsSpan(x,y)

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.Clique/SnapshotManager.cs
+++ b/src/Nethermind/Nethermind.Consensus.Clique/SnapshotManager.cs
@@ -55,7 +55,7 @@ namespace Nethermind.Consensus.Clique
                 throw new BlockchainException($"Clique block without sealer extra data{Environment.NewLine}{header.ToString(BlockHeader.Format.Full)}");
             }
 
-            Span<byte> signatureBytes = header.ExtraData.AsSpan().Slice(header.ExtraData.Length - extraSeal, extraSeal);
+            Span<byte> signatureBytes = header.ExtraData.AsSpan(header.ExtraData.Length - extraSeal, extraSeal);
             Signature signature = new(signatureBytes);
             signature.V += Signature.VOffset;
             Keccak message = CalculateCliqueHeaderHash(header);

--- a/src/Nethermind/Nethermind.Core/Crypto/Signature.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/Signature.cs
@@ -42,8 +42,8 @@ namespace Nethermind.Core.Crypto
                 throw new ArgumentException(nameof(v));
             }
 
-            r.CopyTo(Bytes.AsSpan().Slice(32 - r.Length, r.Length));
-            s.CopyTo(Bytes.AsSpan().Slice(64 - s.Length, s.Length));
+            r.CopyTo(Bytes.AsSpan(32 - r.Length, r.Length));
+            s.CopyTo(Bytes.AsSpan(64 - s.Length, s.Length));
             V = v;
         }
 
@@ -54,8 +54,8 @@ namespace Nethermind.Core.Crypto
                 throw new ArgumentException(nameof(v));
             }
 
-            r.ToBigEndian(Bytes.AsSpan().Slice(0, 32));
-            s.ToBigEndian(Bytes.AsSpan().Slice(32, 32));
+            r.ToBigEndian(Bytes.AsSpan(0, 32));
+            s.ToBigEndian(Bytes.AsSpan(32, 32));
 
             V = v;
         }
@@ -73,9 +73,9 @@ namespace Nethermind.Core.Crypto
         public byte RecoveryId => V <= VOffset + 1 ? (byte)(V - VOffset) : (byte)(1 - V % 2);
 
         public byte[] R => Bytes.Slice(0, 32);
-        public Span<byte> RAsSpan => Bytes.AsSpan().Slice(0, 32);
+        public Span<byte> RAsSpan => Bytes.AsSpan(0, 32);
         public byte[] S => Bytes.Slice(32, 32);
-        public Span<byte> SAsSpan => Bytes.AsSpan().Slice(32, 32);
+        public Span<byte> SAsSpan => Bytes.AsSpan(32, 32);
 
         [Todo("Change signature to store 65 bytes and just slice it for normal Bytes.")]
         public byte[] BytesWithRecovery

--- a/src/Nethermind/Nethermind.Core/Extensions/ByteArrayExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/ByteArrayExtensions.cs
@@ -66,7 +66,7 @@ namespace Nethermind.Core.Extensions
 
             byte[] slice = new byte[length];
 
-            bytes.Slice(startIndex, copiedFragmentLength).CopyTo(slice.AsSpan().Slice(0, copiedFragmentLength));
+            bytes.Slice(startIndex, copiedFragmentLength).CopyTo(slice.AsSpan(0, copiedFragmentLength));
             return slice;
         }
     }

--- a/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
@@ -236,6 +236,11 @@ namespace Nethermind.Core.Extensions
 
         public static byte[] PadLeft(this byte[] bytes, int length, byte padding = 0)
         {
+            if (bytes.Length == length)
+            {
+                return bytes;
+            }
+
             return PadLeft(bytes.AsSpan(), length, padding);
         }
 
@@ -252,7 +257,7 @@ namespace Nethermind.Core.Extensions
             }
 
             byte[] result = new byte[length];
-            bytes.CopyTo(result.AsSpan().Slice(length - bytes.Length));
+            bytes.CopyTo(result.AsSpan(length - bytes.Length));
 
             if (padding != 0)
             {

--- a/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
@@ -235,14 +235,7 @@ namespace Nethermind.Core.Extensions
         }
 
         public static byte[] PadLeft(this byte[] bytes, int length, byte padding = 0)
-        {
-            if (bytes.Length == length)
-            {
-                return bytes;
-            }
-
-            return PadLeft(bytes.AsSpan(), length, padding);
-        }
+            => bytes.Length == length ? bytes : bytes.AsSpan().PadLeft(length, padding);
 
         public static byte[] PadLeft(this Span<byte> bytes, int length, byte padding = 0)
         {

--- a/src/Nethermind/Nethermind.Crypto/EciesCipher.cs
+++ b/src/Nethermind/Nethermind.Crypto/EciesCipher.cs
@@ -39,7 +39,7 @@ namespace Nethermind.Crypto
                 return (false, null);
             }
 
-            Span<byte> ephemBytes = cipherText.AsSpan().Slice(0, ephemBytesLength);
+            Span<byte> ephemBytes = cipherText.AsSpan(0, ephemBytesLength);
             byte[] iv = cipherText.Slice(ephemBytesLength, KeySize / 8);
             byte[] cipherBody = cipherText.Slice(ephemBytesLength + KeySize / 8);
 

--- a/src/Nethermind/Nethermind.Crypto/OptimizedKdf.cs
+++ b/src/Nethermind/Nethermind.Crypto/OptimizedKdf.cs
@@ -18,7 +18,7 @@ namespace Nethermind.Crypto
         {
             byte[] counterData = BitConverter.IsLittleEndian ? Bytes.Reverse(BitConverter.GetBytes(1)) : BitConverter.GetBytes(1);
             byte[] dataToHash = new byte[36];
-            counterData.AsSpan().CopyTo(dataToHash.AsSpan().Slice(0, 4));
+            counterData.AsSpan().CopyTo(dataToHash.AsSpan(0, 4));
             return dataToHash;
         }
 
@@ -30,7 +30,7 @@ namespace Nethermind.Crypto
         public byte[] Derive(byte[] key)
         {
             byte[] dataToHash = _dataToHash.Value;
-            key.AsSpan().CopyTo(dataToHash.AsSpan().Slice(4, 32));
+            key.AsSpan().CopyTo(dataToHash.AsSpan(4, 32));
             return _sha256.Value.ComputeHash(dataToHash);
         }
     }

--- a/src/Nethermind/Nethermind.Evm/EvmPooledMemory.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmPooledMemory.cs
@@ -90,8 +90,8 @@ namespace Nethermind.Evm
             UpdateSize(in location, (UInt256)value.Length);
 
             int intLocation = (int)location;
-            value.Span.CopyTo(_memory.AsSpan().Slice(intLocation, value.Span.Length));
-            _memory.AsSpan().Slice(intLocation + value.Span.Length, value.PaddingLength).Clear();
+            value.Span.CopyTo(_memory.AsSpan(intLocation, value.Span.Length));
+            _memory.AsSpan(intLocation + value.Span.Length, value.PaddingLength).Clear();
         }
 
         public void Save(in UInt256 location, ZeroPaddedMemory value)
@@ -106,7 +106,7 @@ namespace Nethermind.Evm
 
             int intLocation = (int)location;
             value.Memory.CopyTo(_memory.AsMemory().Slice(intLocation, value.Memory.Length));
-            _memory.AsSpan().Slice(intLocation + value.Memory.Length, value.PaddingLength).Clear();
+            _memory.AsSpan(intLocation + value.Memory.Length, value.PaddingLength).Clear();
         }
 
         public Span<byte> LoadSpan(scoped in UInt256 location)
@@ -211,7 +211,7 @@ namespace Nethermind.Evm
                 int sizeAvailable = Math.Min(WordSize, (_memory?.Length ?? 0) - traceLocation);
                 if (sizeAvailable > 0)
                 {
-                    Span<byte> bytes = _memory.AsSpan().Slice(traceLocation, sizeAvailable);
+                    Span<byte> bytes = _memory.AsSpan(traceLocation, sizeAvailable);
                     memoryTrace.Add(bytes.ToHexString());
                 }
                 else // Memory might not be initialized

--- a/src/Nethermind/Nethermind.Evm/ZeroPaddedSpan.cs
+++ b/src/Nethermind/Nethermind.Evm/ZeroPaddedSpan.cs
@@ -28,7 +28,7 @@ namespace Nethermind.Evm
         public readonly byte[] ToArray()
         {
             byte[] result = new byte[Span.Length + PaddingLength];
-            Span.CopyTo(result.AsSpan().Slice(PadDirection == PadDirection.Right ? 0 : PaddingLength, Span.Length));
+            Span.CopyTo(result.AsSpan(PadDirection == PadDirection.Right ? 0 : PaddingLength, Span.Length));
             return result;
         }
     }

--- a/src/Nethermind/Nethermind.Network.Benchmark/InFlowBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Network.Benchmark/InFlowBenchmarks.cs
@@ -88,7 +88,7 @@ namespace Nethermind.Network.Benchmarks
                 return (IByteBuffer)result[0];
             }
 
-            public TestZeroDecoder(IFrameCipher frameCipher, IFrameMacProcessor frameMacProcessor)
+            public TestZeroDecoder(IFrameCipher frameCipher, FrameMacProcessor frameMacProcessor)
                 : base(frameCipher, frameMacProcessor, LimboLogs.Instance)
             {
             }

--- a/src/Nethermind/Nethermind.Network.Test/Rlpx/Handshake/EciesCipherTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/Rlpx/Handshake/EciesCipherTests.cs
@@ -44,7 +44,7 @@ namespace Nethermind.Network.Test.Rlpx.Handshake
                       "f0fce91676fd64c7773bac6a003f481fddd0bae0a1f31aa27504e2a533af4cef3b623f4791b2cca6" +
                       "d490");
 
-            Span<byte> sizeBytes = allBytes.AsSpan().Slice(0, 2);
+            Span<byte> sizeBytes = allBytes.AsSpan(0, 2);
             int size = sizeBytes.ReadEthInt32();
 
             (_, byte[] deciphered) = _eciesCipher.Decrypt(NetTestVectors.StaticKeyB, allBytes.Slice(2, size), sizeBytes.ToArray());
@@ -98,7 +98,7 @@ namespace Nethermind.Network.Test.Rlpx.Handshake
                       "2aa067241aaa433f0bb053c7b31a838504b148f570c0ad62837129e547678c5190341e4f1693956c" +
                       "3bf7678318e2d5b5340c9e488eefea198576344afbdf66db5f51204a6961a63ce072c8926c");
 
-            Span<byte> sizeBytes = allBytes.AsSpan().Slice(0, 2);
+            Span<byte> sizeBytes = allBytes.AsSpan(0, 2);
             int size = sizeBytes.ReadEthInt32();
 
             ICryptoRandom cryptoRandom = new CryptoRandom();
@@ -156,7 +156,7 @@ namespace Nethermind.Network.Test.Rlpx.Handshake
                       "1778d809bdf60232ae21ce8a437eca8223f45ac37f6487452ce626f549b3b5fdee26afd2072e4bc7" +
                       "5833c2464c805246155289f4");
 
-            Span<byte> sizeBytes = allBytes.AsSpan().Slice(0, 2);
+            Span<byte> sizeBytes = allBytes.AsSpan(0, 2);
             int size = sizeBytes.ReadEthInt32();
 
             ICryptoRandom cryptoRandom = new CryptoRandom();
@@ -192,7 +192,7 @@ namespace Nethermind.Network.Test.Rlpx.Handshake
                       "39a2336a61ef9fda549180d4ccde21514d117b6c6fd07a9102b5efe710a32af4eeacae2cb3b1dec0" +
                       "35b9593b48b9d3ca4c13d245d5f04169b0b1");
 
-            Span<byte> sizeBytes = allBytes.AsSpan().Slice(0, 2);
+            Span<byte> sizeBytes = allBytes.AsSpan(0, 2);
             int size = sizeBytes.ReadEthInt32();
 
             ICryptoRandom cryptoRandom = new CryptoRandom();

--- a/src/Nethermind/Nethermind.Network.Test/Rlpx/HobbitTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/Rlpx/HobbitTests.cs
@@ -30,10 +30,10 @@ namespace Nethermind.Network.Test.Rlpx
         private byte[] _frame;
 
         private IFrameCipher _frameCipherA;
-        private IFrameMacProcessor _macProcessorA;
+        private FrameMacProcessor _macProcessorA;
 
         private IFrameCipher _frameCipherB;
-        private IFrameMacProcessor _macProcessorB;
+        private FrameMacProcessor _macProcessorB;
 
         [SetUp]
         public void Setup()

--- a/src/Nethermind/Nethermind.Network.Test/Rlpx/TestWrappers/ZeroFrameDecoderTestWrapper.cs
+++ b/src/Nethermind/Nethermind.Network.Test/Rlpx/TestWrappers/ZeroFrameDecoderTestWrapper.cs
@@ -16,7 +16,7 @@ namespace Nethermind.Network.Test.Rlpx.TestWrappers
     {
         private readonly IChannelHandlerContext _context;
 
-        public ZeroFrameDecoderTestWrapper(IFrameCipher frameCipher, IFrameMacProcessor frameMacProcessor) : base(frameCipher, frameMacProcessor, LimboLogs.Instance)
+        public ZeroFrameDecoderTestWrapper(IFrameCipher frameCipher, FrameMacProcessor frameMacProcessor) : base(frameCipher, frameMacProcessor, LimboLogs.Instance)
         {
             _context = Substitute.For<IChannelHandlerContext>();
             _context.Allocator.Returns(PooledByteBufferAllocator.Default);

--- a/src/Nethermind/Nethermind.Network.Test/Rlpx/ZeroNettyFrameDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/Rlpx/ZeroNettyFrameDecoderTests.cs
@@ -25,7 +25,7 @@ namespace Nethermind.Network.Test.Rlpx
         private byte[] _frame;
         private byte[] _shortFrame;
         private IFrameCipher _frameCipher;
-        private IFrameMacProcessor _macProcessor;
+        private FrameMacProcessor _macProcessor;
 
         [SetUp]
         public void Setup()

--- a/src/Nethermind/Nethermind.Network/Rlpx/FrameMacProcessor.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/FrameMacProcessor.cs
@@ -17,7 +17,7 @@ namespace Nethermind.Network.Rlpx
     /// <summary>
     /// partially adapted from ethereumJ
     /// </summary>
-    public class FrameMacProcessor : IFrameMacProcessor
+    public sealed class FrameMacProcessor : IFrameMacProcessor
     {
         private readonly PublicKey _remoteNodeId;
         private readonly KeccakDigest _egressMac;
@@ -53,7 +53,7 @@ namespace Nethermind.Network.Rlpx
         {
             if (isHeader)
             {
-                input.AsSpan().Slice(0, 32).CopyTo(_addMacBuffer);
+                input.AsSpan(0, 32).CopyTo(_addMacBuffer);
                 UpdateMac(_egressMac, _egressMacCopy, _addMacBuffer, offset, input, offset + length, true); // TODO: confirm header is seed 
             }
             else
@@ -75,7 +75,7 @@ namespace Nethermind.Network.Rlpx
         {
             if (isHeader)
             {
-                input.AsSpan().CopyTo(_checkMacBuffer.AsSpan().Slice(0, 16));
+                input.AsSpan().CopyTo(_checkMacBuffer.AsSpan(0, 16));
             }
             else
             {
@@ -93,7 +93,7 @@ namespace Nethermind.Network.Rlpx
         {
             if (isHeader)
             {
-                input.AsSpan().Slice(0, 16).CopyTo(_addMacBuffer.AsSpan().Slice(0, 16));
+                input.AsSpan(0, 16).CopyTo(_addMacBuffer);
                 UpdateMac(_egressMac, _egressMacCopy, _addMacBuffer, offset, output, outputOffset, true); // TODO: confirm header is seed 
             }
             else
@@ -151,7 +151,7 @@ namespace Nethermind.Network.Rlpx
         {
             if (isHeader)
             {
-                input.AsSpan().Slice(0, 32).CopyTo(_checkMacBuffer.AsSpan());
+                input.AsSpan(0, 32).CopyTo(_checkMacBuffer);
                 UpdateMac(_ingressMac, _ingressMacCopy, _checkMacBuffer, offset, input, offset + length, false);
             }
             else

--- a/src/Nethermind/Nethermind.Network/Rlpx/Handshake/AckMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/Handshake/AckMessageSerializer.cs
@@ -34,7 +34,7 @@ namespace Nethermind.Network.Rlpx.Handshake
             }
 
             AckMessage authMessage = new();
-            authMessage.EphemeralPublicKey = new PublicKey(msgBytes.AsSpan().Slice(EphemeralPublicKeyOffset, EphemeralPublicKeyLength));
+            authMessage.EphemeralPublicKey = new PublicKey(msgBytes.AsSpan(EphemeralPublicKeyOffset, EphemeralPublicKeyLength));
             authMessage.Nonce = msgBytes.Slice(NonceOffset, NonceLength);
             authMessage.IsTokenUsed = msgBytes[IsTokenUsedOffset] == 0x01;
             return authMessage;

--- a/src/Nethermind/Nethermind.Network/Rlpx/Handshake/AuthMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/Handshake/AuthMessageSerializer.cs
@@ -54,9 +54,9 @@ namespace Nethermind.Network.Rlpx.Handshake
             }
 
             AuthMessage authMessage = new();
-            authMessage.Signature = new Signature(msgBytes.AsSpan().Slice(SigOffset, SigLength - 1), msgBytes[64]);
+            authMessage.Signature = new Signature(msgBytes.AsSpan(SigOffset, SigLength - 1), msgBytes[64]);
             authMessage.EphemeralPublicHash = new Keccak(msgBytes.Slice(EphemeralHashOffset, EphemeralHashLength));
-            authMessage.PublicKey = new PublicKey(msgBytes.AsSpan().Slice(PublicKeyOffset, PublicKeyLength));
+            authMessage.PublicKey = new PublicKey(msgBytes.AsSpan(PublicKeyOffset, PublicKeyLength));
             authMessage.Nonce = msgBytes.Slice(NonceOffset, NonceLength);
             authMessage.IsTokenUsed = msgBytes[IsTokenUsedOffset] == 0x01;
             return authMessage;

--- a/src/Nethermind/Nethermind.Network/Rlpx/ZeroFrameDecoder.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/ZeroFrameDecoder.cs
@@ -15,7 +15,7 @@ namespace Nethermind.Network.Rlpx
     {
         private readonly ILogger _logger;
         private readonly IFrameCipher _cipher;
-        private readonly IFrameMacProcessor _authenticator;
+        private readonly FrameMacProcessor _authenticator;
 
         private readonly byte[] _headerBytes = new byte[Frame.HeaderSize];
         private readonly byte[] _macBytes = new byte[Frame.MacSize];
@@ -27,7 +27,7 @@ namespace Nethermind.Network.Rlpx
         private int _frameSize;
         private int _remainingPayloadBlocks;
 
-        public ZeroFrameDecoder(IFrameCipher frameCipher, IFrameMacProcessor frameMacProcessor, ILogManager logManager)
+        public ZeroFrameDecoder(IFrameCipher frameCipher, FrameMacProcessor frameMacProcessor, ILogManager logManager)
         {
             _cipher = frameCipher ?? throw new ArgumentNullException(nameof(frameCipher));
             _authenticator = frameMacProcessor ?? throw new ArgumentNullException(nameof(frameMacProcessor));

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
@@ -193,7 +193,7 @@ namespace Nethermind.Trie
                     if (rlpStream is not null && item._data![i] is null)
                     {
                         int length = rlpStream.PeekNextRlpLength();
-                        Span<byte> nextItem = rlpStream.Data.AsSpan().Slice(rlpStream.Position, length);
+                        Span<byte> nextItem = rlpStream.Data.AsSpan(rlpStream.Position, length);
                         nextItem.CopyTo(destination.Slice(position, nextItem.Length));
                         position += nextItem.Length;
                         rlpStream.SkipItem();


### PR DESCRIPTION
## Changes

- `.AsSpan().Slice(x,y)` => `.AsSpan(x,y)` rather than creating span then slicing, do all in one operation
- Strongly typed `FrameMacProcessor` to change to direct calls from interface calls as it is called a lot (also to see if they'd naturally inline which they didn't)
- return input array when `PadLeft(this byte[] bytes` causes no changes

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

