### PR TITLE
StorageTree opitimization

### DIFF
--- a/src/Nethermind/Nethermind.Benchmark/State/StorageTreeBenchmark.cs
+++ b/src/Nethermind/Nethermind.Benchmark/State/StorageTreeBenchmark.cs
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Diagnostics.Tracing.Parsers.MicrosoftAntimalwareEngine;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Int256;
+using Nethermind.Logging;
+using Nethermind.State;
+using Nethermind.Trie;
+using Nethermind.Trie.Pruning;
+
+namespace Nethermind.Benchmarks.State
+{
+    [MemoryDiagnoser]
+    public class StorageTreeBenchmark
+    {
+        private static readonly UInt256 _index = new(0, 1, 2, 3);
+        private static readonly byte[] _value = { 17, 19, 23 };
+
+        private StorageTree _tree;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _tree = new StorageTree(NullTrieStore.Instance, NullLogManager.Instance);
+        }
+
+        [Benchmark]
+        public void Set_index()
+        {
+            _tree.Set(_index, _value);
+        }
+
+        [Benchmark]
+        public byte[] Get_index()
+        {
+            return _tree.Get(_index);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.State/Nethermind.State.csproj
+++ b/src/Nethermind/Nethermind.State/Nethermind.State.csproj
@@ -6,6 +6,7 @@
     <Deterministic>true</Deterministic>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Nethermind.Core\Nethermind.Core.csproj">

--- a/src/Nethermind/Nethermind.State/StorageTree.cs
+++ b/src/Nethermind/Nethermind.State/StorageTree.cs
@@ -59,6 +59,8 @@ namespace Nethermind.State
             KeccakHash.ComputeHashBytesToSpan(key, key);
         }
 
+
+        [SkipLocalsInit]
         public byte[] Get(in UInt256 index, Keccak? storageRoot = null)
         {
             Span<byte> key = stackalloc byte[32];
@@ -74,6 +76,7 @@ namespace Nethermind.State
             return rlp.DecodeByteArray();
         }
 
+        [SkipLocalsInit]
         public void Set(in UInt256 index, byte[] value)
         {
             Span<byte> key = stackalloc byte[32];

--- a/src/Nethermind/Nethermind.State/StorageTree.cs
+++ b/src/Nethermind/Nethermind.State/StorageTree.cs
@@ -3,9 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
-using Nethermind.Db;
 using Nethermind.Logging;
 using Nethermind.Int256;
 using Nethermind.Serialization.Rlp;
@@ -45,23 +45,25 @@ namespace Nethermind.State
             TrieType = TrieType.Storage;
         }
 
-        public static Span<byte> GetKey(in UInt256 index)
+        private static void GetKey(in UInt256 index, in Span<byte> key)
         {
             if (index < CacheSize)
             {
-                return Cache[index];
+                Cache[index].CopyTo(key);
+                return;
             }
 
-            Span<byte> span = stackalloc byte[32];
-            index.ToBigEndian(span);
+            index.ToBigEndian(key);
 
-            // (1% allocations on archive sync) this ToArray can be pooled or just directly converted to nibbles
-            return ValueKeccak.Compute(span).BytesAsSpan.ToArray();
+            // in situ calculation
+            KeccakHash.ComputeHashBytesToSpan(key, key);
         }
 
         public byte[] Get(in UInt256 index, Keccak? storageRoot = null)
         {
-            Span<byte> key = GetKey(index);
+            Span<byte> key = stackalloc byte[32];
+            GetKey(index, key);
+
             byte[]? value = Get(key, storageRoot);
             if (value is null)
             {
@@ -74,7 +76,8 @@ namespace Nethermind.State
 
         public void Set(in UInt256 index, byte[] value)
         {
-            var key = GetKey(index);
+            Span<byte> key = stackalloc byte[32];
+            GetKey(index, key);
             SetInternal(key, value);
         }
 


### PR DESCRIPTION
This PR optimizes `StorageTree` component, removing some allocations and making it a bit faster in general. Please be minded that benchmarks are capped by the Keccak calculation so for precached indexes (1-1024) the gains will be much bigger.

## Changes

- `StorageTree.Get` & `StorageTree.Set` 
  - got rid off the allocation
  - reuse buffer

## Benchmarks

```bash
BenchmarkDotNet=v0.13.4, OS=Windows 11 (10.0.22621.1105)
12th Gen Intel Core i9-12900HK, 1 CPU, 20 logical and 14 physical cores
.NET SDK=7.0.100
  [Host]     : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
  DefaultJob : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
```


|    Method |     Mean |    Error |   StdDev |   Median |   Gen0 | Allocated |
|---------- |---------:|---------:|---------:|---------:|-------:|----------:|
| Set_index (before) | 494.3 ns | 23.55 ns | 67.94 ns | 520.3 ns | 0.0086 |     112 B |
| Get_index (before) | 405.9 ns | 21.54 ns | 62.50 ns | 419.9 ns | 0.0067 |      88 B |
| Set_index (no alloc) | 365.5 ns |  4.49 ns |  3.75 ns | 365.2 ns | 0.0043 |      56 B |
| Get_index (no alloc) | 364.7 ns | 23.29 ns | 68.66 ns | 394.2 ns | 0.0024 |      32 B |

## Types of changes

Performance work

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Benchmarks provided.

