### PR TITLE
Feature/max open files flag and write rates limit

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnsDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnsDb.cs
@@ -16,7 +16,7 @@ public class ColumnsDb<T> : DbOnTheRocks, IColumnsDb<T> where T : struct, Enum
     private readonly IDictionary<T, IDbWithSpan> _columnDbs = new Dictionary<T, IDbWithSpan>();
 
     public ColumnsDb(string basePath, RocksDbSettings settings, IDbConfig dbConfig, ILogManager logManager, IReadOnlyList<T> keys)
-        : base(basePath, settings, dbConfig, logManager, GetColumnFamilies(dbConfig, settings.DbName, GetEnumKeys(keys)))
+        : base(basePath, settings, dbConfig, logManager, GetColumnFamilies(dbConfig, settings, GetEnumKeys(keys)))
     {
         keys = GetEnumKeys(keys);
 
@@ -36,12 +36,12 @@ public class ColumnsDb<T> : DbOnTheRocks, IColumnsDb<T> where T : struct, Enum
         return keys;
     }
 
-    private static ColumnFamilies GetColumnFamilies(IDbConfig dbConfig, string name, IReadOnlyList<T> keys)
+    private static ColumnFamilies GetColumnFamilies(IDbConfig dbConfig, RocksDbSettings settings, IReadOnlyList<T> keys)
     {
         InitCache(dbConfig);
 
         ColumnFamilies result = new();
-        ulong blockCacheSize = ReadConfig<ulong>(dbConfig, nameof(dbConfig.BlockCacheSize), name);
+        ulong blockCacheSize = new PerTableDbConfig(dbConfig, settings).BlockCacheSize;
         foreach (T key in keys)
         {
             ColumnFamilyOptions columnFamilyOptions = new();

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
@@ -14,8 +14,8 @@ public class DbConfig : IDbConfig
     public ulong BlockCacheSize { get; set; } = (ulong)64.MiB();
     public bool CacheIndexAndFilterBlocks { get; set; } = false;
     public int? MaxOpenFiles { get; set; }
-
     public long? MaxWriteBytesPerSec { get; set; }
+
     public ulong ReceiptsDbWriteBufferSize { get; set; } = (ulong)8.MiB();
     public uint ReceiptsDbWriteBufferNumber { get; set; } = 4;
     public ulong ReceiptsDbBlockCacheSize { get; set; } = (ulong)32.MiB();

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
@@ -13,57 +13,79 @@ public class DbConfig : IDbConfig
     public uint WriteBufferNumber { get; set; } = 4;
     public ulong BlockCacheSize { get; set; } = (ulong)64.MiB();
     public bool CacheIndexAndFilterBlocks { get; set; } = false;
+    public int? MaxOpenFiles { get; set; }
 
+    public long? MaxWriteBytesPerSec { get; set; }
     public ulong ReceiptsDbWriteBufferSize { get; set; } = (ulong)8.MiB();
     public uint ReceiptsDbWriteBufferNumber { get; set; } = 4;
     public ulong ReceiptsDbBlockCacheSize { get; set; } = (ulong)32.MiB();
     public bool ReceiptsDbCacheIndexAndFilterBlocks { get; set; } = false;
+    public int? ReceiptsDbMaxOpenFiles { get; set; }
+    public long? ReceiptsDbMaxWriteBytesPerSec { get; set; }
 
     public ulong BlocksDbWriteBufferSize { get; set; } = (ulong)8.MiB();
     public uint BlocksDbWriteBufferNumber { get; set; } = 4;
     public ulong BlocksDbBlockCacheSize { get; set; } = (ulong)32.MiB();
     public bool BlocksDbCacheIndexAndFilterBlocks { get; set; } = false;
+    public int? BlocksDbMaxOpenFiles { get; set; }
+    public long? BlocksDbMaxWriteBytesPerSec { get; set; }
 
     public ulong HeadersDbWriteBufferSize { get; set; } = (ulong)8.MiB();
     public uint HeadersDbWriteBufferNumber { get; set; } = 4;
     public ulong HeadersDbBlockCacheSize { get; set; } = (ulong)32.MiB();
     public bool HeadersDbCacheIndexAndFilterBlocks { get; set; } = false;
+    public int? HeadersDbMaxOpenFiles { get; set; }
+    public long? HeadersDbMaxWriteBytesPerSec { get; set; }
 
     public ulong BlockInfosDbWriteBufferSize { get; set; } = (ulong)8.MiB();
     public uint BlockInfosDbWriteBufferNumber { get; set; } = 4;
     public ulong BlockInfosDbBlockCacheSize { get; set; } = (ulong)32.MiB();
     public bool BlockInfosDbCacheIndexAndFilterBlocks { get; set; } = false;
+    public int? BlockInfosDbMaxOpenFiles { get; set; }
+    public long? BlockInfosDbMaxWriteBytesPerSec { get; set; }
 
     public ulong PendingTxsDbWriteBufferSize { get; set; } = (ulong)4.MiB();
     public uint PendingTxsDbWriteBufferNumber { get; set; } = 4;
     public ulong PendingTxsDbBlockCacheSize { get; set; } = (ulong)16.MiB();
     public bool PendingTxsDbCacheIndexAndFilterBlocks { get; set; } = false;
+    public int? PendingTxsDbMaxOpenFiles { get; set; }
+    public long? PendingTxsDbMaxWriteBytesPerSec { get; set; }
 
     public ulong CodeDbWriteBufferSize { get; set; } = (ulong)2.MiB();
     public uint CodeDbWriteBufferNumber { get; set; } = 4;
     public ulong CodeDbBlockCacheSize { get; set; } = (ulong)8.MiB();
     public bool CodeDbCacheIndexAndFilterBlocks { get; set; } = false;
+    public int? CodeDbMaxOpenFiles { get; set; }
+    public long? CodeDbMaxWriteBytesPerSec { get; set; }
 
     public ulong BloomDbWriteBufferSize { get; set; } = (ulong)1.KiB();
     public uint BloomDbWriteBufferNumber { get; set; } = 4;
     public ulong BloomDbBlockCacheSize { get; set; } = (ulong)1.KiB();
     public bool BloomDbCacheIndexAndFilterBlocks { get; set; } = false;
+    public int? BloomDbMaxOpenFiles { get; set; }
+    public long? BloomDbMaxWriteBytesPerSec { get; set; }
 
     public ulong WitnessDbWriteBufferSize { get; set; } = (ulong)1.KiB();
     public uint WitnessDbWriteBufferNumber { get; set; } = 4;
     public ulong WitnessDbBlockCacheSize { get; set; } = (ulong)1.KiB();
     public bool WitnessDbCacheIndexAndFilterBlocks { get; set; } = false;
+    public int? WitnessDbMaxOpenFiles { get; set; }
+    public long? WitnessDbMaxWriteBytesPerSec { get; set; }
 
     // TODO - profile and customize
     public ulong CanonicalHashTrieDbWriteBufferSize { get; set; } = (ulong)2.MB();
     public uint CanonicalHashTrieDbWriteBufferNumber { get; set; } = 4;
     public ulong CanonicalHashTrieDbBlockCacheSize { get; set; } = (ulong)8.MB();
     public bool CanonicalHashTrieDbCacheIndexAndFilterBlocks { get; set; } = true;
+    public int? CanonicalHashTrieDbMaxOpenFiles { get; set; }
+    public long? CanonicalHashTrieDbMaxWriteBytesPerSec { get; set; }
 
     public ulong MetadataDbWriteBufferSize { get; set; } = (ulong)1.KiB();
     public uint MetadataDbWriteBufferNumber { get; set; } = 4;
     public ulong MetadataDbBlockCacheSize { get; set; } = (ulong)1.KiB();
     public bool MetadataDbCacheIndexAndFilterBlocks { get; set; } = true;
+    public int? MetadataDbMaxOpenFiles { get; set; }
+    public long? MetadataDbMaxWriteBytesPerSec { get; set; }
 
     public uint RecycleLogFileNum { get; set; } = 0;
     public bool WriteAheadLogSync { get; set; } = false;

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/IDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/IDbConfig.cs
@@ -12,58 +12,80 @@ public interface IDbConfig : IConfig
     uint WriteBufferNumber { get; set; }
     ulong BlockCacheSize { get; set; }
     bool CacheIndexAndFilterBlocks { get; set; }
-
+    int? MaxOpenFiles { get; set; }
     uint RecycleLogFileNum { get; set; }
     bool WriteAheadLogSync { get; set; }
+    long? MaxWriteBytesPerSec { get; set; }
+
     ulong ReceiptsDbWriteBufferSize { get; set; }
     uint ReceiptsDbWriteBufferNumber { get; set; }
     ulong ReceiptsDbBlockCacheSize { get; set; }
     bool ReceiptsDbCacheIndexAndFilterBlocks { get; set; }
+    int? ReceiptsDbMaxOpenFiles { get; set; }
+    long? ReceiptsDbMaxWriteBytesPerSec { get; set; }
 
     ulong BlocksDbWriteBufferSize { get; set; }
     uint BlocksDbWriteBufferNumber { get; set; }
     ulong BlocksDbBlockCacheSize { get; set; }
     bool BlocksDbCacheIndexAndFilterBlocks { get; set; }
+    int? BlocksDbMaxOpenFiles { get; set; }
+    long? BlocksDbMaxWriteBytesPerSec { get; set; }
 
     ulong HeadersDbWriteBufferSize { get; set; }
     uint HeadersDbWriteBufferNumber { get; set; }
     ulong HeadersDbBlockCacheSize { get; set; }
     bool HeadersDbCacheIndexAndFilterBlocks { get; set; }
+    int? HeadersDbMaxOpenFiles { get; set; }
+    long? HeadersDbMaxWriteBytesPerSec { get; set; }
 
     ulong BlockInfosDbWriteBufferSize { get; set; }
     uint BlockInfosDbWriteBufferNumber { get; set; }
     ulong BlockInfosDbBlockCacheSize { get; set; }
     bool BlockInfosDbCacheIndexAndFilterBlocks { get; set; }
+    int? BlockInfosDbMaxOpenFiles { get; set; }
+    long? BlockInfosDbMaxWriteBytesPerSec { get; set; }
 
     ulong PendingTxsDbWriteBufferSize { get; set; }
     uint PendingTxsDbWriteBufferNumber { get; set; }
     ulong PendingTxsDbBlockCacheSize { get; set; }
     bool PendingTxsDbCacheIndexAndFilterBlocks { get; set; }
+    int? PendingTxsDbMaxOpenFiles { get; set; }
+    long? PendingTxsDbMaxWriteBytesPerSec { get; set; }
 
     ulong CodeDbWriteBufferSize { get; set; }
     uint CodeDbWriteBufferNumber { get; set; }
     ulong CodeDbBlockCacheSize { get; set; }
     bool CodeDbCacheIndexAndFilterBlocks { get; set; }
+    int? CodeDbMaxOpenFiles { get; set; }
+    long? CodeDbMaxWriteBytesPerSec { get; set; }
 
     ulong BloomDbWriteBufferSize { get; set; }
     uint BloomDbWriteBufferNumber { get; set; }
     ulong BloomDbBlockCacheSize { get; set; }
     bool BloomDbCacheIndexAndFilterBlocks { get; set; }
+    int? BloomDbMaxOpenFiles { get; set; }
+    long? BloomDbMaxWriteBytesPerSec { get; set; }
 
     ulong WitnessDbWriteBufferSize { get; set; }
     uint WitnessDbWriteBufferNumber { get; set; }
     ulong WitnessDbBlockCacheSize { get; set; }
     bool WitnessDbCacheIndexAndFilterBlocks { get; set; }
+    int? WitnessDbMaxOpenFiles { get; set; }
+    long? WitnessDbMaxWriteBytesPerSec { get; set; }
 
     ulong CanonicalHashTrieDbWriteBufferSize { get; set; }
     uint CanonicalHashTrieDbWriteBufferNumber { get; set; }
     ulong CanonicalHashTrieDbBlockCacheSize { get; set; }
     bool CanonicalHashTrieDbCacheIndexAndFilterBlocks { get; set; }
+    int? CanonicalHashTrieDbMaxOpenFiles { get; set; }
+    long? CanonicalHashTrieDbMaxWriteBytesPerSec { get; set; }
 
     ulong MetadataDbWriteBufferSize { get; set; }
     uint MetadataDbWriteBufferNumber { get; set; }
     ulong MetadataDbBlockCacheSize { get; set; }
     bool MetadataDbCacheIndexAndFilterBlocks { get; set; }
+    int? MetadataDbMaxOpenFiles { get; set; }
+    long? MetadataDbMaxWriteBytesPerSec { get; set; }
 
     /// <summary>
     /// Enables DB Statistics - https://github.com/facebook/rocksdb/wiki/Statistics

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/IDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/IDbConfig.cs
@@ -5,7 +5,7 @@ using Nethermind.Config;
 
 namespace Nethermind.Db.Rocks.Config;
 
-[ConfigCategory(DisabledForCli = true, HiddenFromDocs = true)]
+[ConfigCategory(HiddenFromDocs = true)]
 public interface IDbConfig : IConfig
 {
     ulong WriteBufferSize { get; set; }

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/PerTableDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/PerTableDbConfig.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Reflection;
+using Nethermind.Core.Extensions;
 
 namespace Nethermind.Db.Rocks.Config;
 
@@ -20,21 +21,16 @@ public class PerTableDbConfig
         _tableName = _settings.DbName;
     }
 
-    public bool CacheIndexAndFilterBlocks => _settings.CacheIndexAndFilterBlocks.HasValue
-            ? _settings.CacheIndexAndFilterBlocks.Value
-            : ReadConfig<bool>(nameof(_dbConfig.CacheIndexAndFilterBlocks));
+    public bool CacheIndexAndFilterBlocks => _settings.CacheIndexAndFilterBlocks ?? ReadConfig<bool>(nameof(CacheIndexAndFilterBlocks));
 
-    public ulong BlockCacheSize => _settings.BlockCacheSize.HasValue
-            ? _settings.BlockCacheSize.Value
-            : ReadConfig<ulong>(nameof(_dbConfig.BlockCacheSize));
+    public ulong BlockCacheSize => _settings.BlockCacheSize ?? ReadConfig<ulong>(nameof(BlockCacheSize));
 
-    public ulong WriteBufferSize => _settings.WriteBufferSize.HasValue
-            ? _settings.WriteBufferSize.Value
-            : ReadConfig<ulong>(nameof(_dbConfig.WriteBufferSize));
+    public ulong WriteBufferSize => _settings.WriteBufferSize ?? ReadConfig<ulong>(nameof(WriteBufferSize));
 
-    public ulong WriteBufferNumber => _settings.WriteBufferNumber.HasValue
-            ? _settings.WriteBufferNumber.Value
-            : ReadConfig<uint>(nameof(_dbConfig.WriteBufferNumber));
+    public ulong WriteBufferNumber => _settings.WriteBufferNumber ?? ReadConfig<uint>(nameof(WriteBufferNumber));
+
+    public int? MaxOpenFiles => ReadConfig<int?>(nameof(MaxOpenFiles));
+    public long? MaxWriteBytesPerSec => ReadConfig<long?>(nameof(MaxWriteBytesPerSec));
 
     private T? ReadConfig<T>(string propertyName)
     {
@@ -49,6 +45,20 @@ public class PerTableDbConfig
         {
             Type type = dbConfig.GetType();
             PropertyInfo? propertyInfo = type.GetProperty(prefixed, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
+
+            if (propertyInfo != null && propertyInfo.PropertyType.CanBeAssignedNull())
+            {
+                // If its nullable check if its null first
+                T? val = (T?)propertyInfo?.GetValue(dbConfig);
+                if (val != null)
+                {
+                    return val;
+                }
+
+                // Use generic one even if its available
+                propertyInfo = type.GetProperty(propertyName, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
+            }
+
             // if no custom db property default to generic one
             propertyInfo ??= type.GetProperty(propertyName, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
             return (T?)propertyInfo?.GetValue(dbConfig);

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/PerTableDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/PerTableDbConfig.cs
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.IO;
+using System.Reflection;
+
+namespace Nethermind.Db.Rocks.Config;
+
+public class PerTableDbConfig
+{
+    private readonly string _tableName;
+    private readonly IDbConfig _dbConfig;
+    private readonly RocksDbSettings _settings;
+
+    public PerTableDbConfig(IDbConfig dbConfig, RocksDbSettings rocksDbSettings)
+    {
+        _dbConfig = dbConfig;
+        _settings = rocksDbSettings;
+        _tableName = _settings.DbName;
+    }
+
+    public bool CacheIndexAndFilterBlocks => _settings.CacheIndexAndFilterBlocks.HasValue
+            ? _settings.CacheIndexAndFilterBlocks.Value
+            : ReadConfig<bool>(nameof(_dbConfig.CacheIndexAndFilterBlocks));
+
+    public ulong BlockCacheSize => _settings.BlockCacheSize.HasValue
+            ? _settings.BlockCacheSize.Value
+            : ReadConfig<ulong>(nameof(_dbConfig.BlockCacheSize));
+
+    public ulong WriteBufferSize => _settings.WriteBufferSize.HasValue
+            ? _settings.WriteBufferSize.Value
+            : ReadConfig<ulong>(nameof(_dbConfig.WriteBufferSize));
+
+    public ulong WriteBufferNumber => _settings.WriteBufferNumber.HasValue
+            ? _settings.WriteBufferNumber.Value
+            : ReadConfig<uint>(nameof(_dbConfig.WriteBufferNumber));
+
+    private T? ReadConfig<T>(string propertyName)
+    {
+        return ReadConfig<T>(_dbConfig, propertyName, _tableName);
+    }
+
+    private static T? ReadConfig<T>(IDbConfig dbConfig, string propertyName, string tableName)
+    {
+        string prefixed = string.Concat(tableName.StartsWith("State") ? string.Empty : string.Concat(tableName, "Db"),
+            propertyName);
+        try
+        {
+            Type type = dbConfig.GetType();
+            PropertyInfo? propertyInfo = type.GetProperty(prefixed, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
+            // if no custom db property default to generic one
+            propertyInfo ??= type.GetProperty(propertyName, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
+            return (T?)propertyInfo?.GetValue(dbConfig);
+        }
+        catch (Exception e)
+        {
+            throw new InvalidDataException($"Unable to read {prefixed} property from DB config", e);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -48,6 +48,8 @@ public class DbOnTheRocks : IDbWithSpan
 
     private readonly RocksDbSettings _settings;
 
+    protected readonly PerTableDbConfig _perTableDbConfig;
+
     private readonly IFileSystem _fileSystem;
 
     private readonly RocksDbSharp.Native _rocksDbNative;
@@ -77,6 +79,7 @@ public class DbOnTheRocks : IDbWithSpan
         Name = _settings.DbName;
         _fileSystem = fileSystem ?? new FileSystem();
         _rocksDbNative = rocksDbNative ?? RocksDbSharp.Native.Instance;
+        _perTableDbConfig = new PerTableDbConfig(dbConfig, _settings);
         _db = Init(basePath, rocksDbSettings.DbPath, dbConfig, logManager, columnFamilies, rocksDbSettings.DeleteOnStart);
     }
 
@@ -186,41 +189,18 @@ public class DbOnTheRocks : IDbWithSpan
             Metrics.OtherDbWrites++;
     }
 
-    private T? ReadConfig<T>(IDbConfig dbConfig, string propertyName)
-    {
-        return ReadConfig<T>(dbConfig, propertyName, Name);
-    }
-
-    protected static T? ReadConfig<T>(IDbConfig dbConfig, string propertyName, string tableName)
-    {
-        string prefixed = string.Concat(tableName.StartsWith("State") ? string.Empty : string.Concat(tableName, "Db"),
-            propertyName);
-        try
-        {
-            Type type = dbConfig.GetType();
-            PropertyInfo? propertyInfo = type.GetProperty(prefixed, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
-            // if no custom db property default to generic one
-            propertyInfo ??= type.GetProperty(propertyName, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
-            return (T?)propertyInfo?.GetValue(dbConfig);
-        }
-        catch (Exception e)
-        {
-            throw new InvalidDataException($"Unable to read {prefixed} property from DB config", e);
-        }
-    }
-
     protected virtual DbOptions BuildOptions(IDbConfig dbConfig)
     {
         _maxThisDbSize = 0;
         BlockBasedTableOptions tableOptions = new();
         tableOptions.SetBlockSize(16 * 1024);
         tableOptions.SetPinL0FilterAndIndexBlocksInCache(true);
-        tableOptions.SetCacheIndexAndFilterBlocks(GetCacheIndexAndFilterBlocks(dbConfig));
+        tableOptions.SetCacheIndexAndFilterBlocks(_perTableDbConfig.CacheIndexAndFilterBlocks);
 
         tableOptions.SetFilterPolicy(BloomFilterPolicy.Create());
         tableOptions.SetFormatVersion(4);
 
-        ulong blockCacheSize = GetBlockCacheSize(dbConfig);
+        ulong blockCacheSize = _perTableDbConfig.BlockCacheSize;
 
         tableOptions.SetBlockCache(_cache);
 
@@ -246,9 +226,9 @@ public class DbOnTheRocks : IDbWithSpan
         options.SetMaxBackgroundCompactions(Environment.ProcessorCount);
 
         //options.SetMaxOpenFiles(32);
-        ulong writeBufferSize = GetWriteBufferSize(dbConfig);
+        ulong writeBufferSize = _perTableDbConfig.WriteBufferSize;
         options.SetWriteBufferSize(writeBufferSize);
-        int writeBufferNumber = (int)GetWriteBufferNumber(dbConfig);
+        int writeBufferNumber = (int)_perTableDbConfig.WriteBufferNumber;
         options.SetMaxWriteBufferNumber(writeBufferNumber);
         options.SetMinWriteBufferNumberToMerge(2);
 
@@ -283,35 +263,6 @@ public class DbOnTheRocks : IDbWithSpan
 
         return options;
     }
-
-    private bool GetCacheIndexAndFilterBlocks(IDbConfig dbConfig)
-    {
-        return _settings.CacheIndexAndFilterBlocks.HasValue
-            ? _settings.CacheIndexAndFilterBlocks.Value
-            : ReadConfig<bool>(dbConfig, nameof(dbConfig.CacheIndexAndFilterBlocks));
-    }
-
-    private ulong GetBlockCacheSize(IDbConfig dbConfig)
-    {
-        return _settings.BlockCacheSize.HasValue
-            ? _settings.BlockCacheSize.Value
-            : ReadConfig<ulong>(dbConfig, nameof(dbConfig.BlockCacheSize));
-    }
-
-    private ulong GetWriteBufferSize(IDbConfig dbConfig)
-    {
-        return _settings.WriteBufferSize.HasValue
-            ? _settings.WriteBufferSize.Value
-            : ReadConfig<ulong>(dbConfig, nameof(dbConfig.WriteBufferSize));
-    }
-
-    private ulong GetWriteBufferNumber(IDbConfig dbConfig)
-    {
-        return _settings.WriteBufferNumber.HasValue
-            ? _settings.WriteBufferNumber.Value
-            : ReadConfig<uint>(dbConfig, nameof(dbConfig.WriteBufferNumber));
-    }
-
 
     public byte[]? this[byte[] key]
     {

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -32,6 +32,8 @@ public class DbOnTheRocks : IDbWithSpan
     private readonly ConcurrentHashSet<IBatch> _currentBatches = new();
 
     internal readonly RocksDb _db;
+
+    private IntPtr? _rateLimiter;
     internal WriteOptions? WriteOptions { get; private set; }
 
     internal DbOptions? DbOptions { get; private set; }
@@ -55,7 +57,6 @@ public class DbOnTheRocks : IDbWithSpan
     private readonly RocksDbSharp.Native _rocksDbNative;
 
     private string CorruptMarkerPath => Path.Join(_fullPath, "corrupt.marker");
-    private IntPtr? _rateLimiter = null;
 
     protected static void InitCache(IDbConfig dbConfig)
     {

--- a/src/Nethermind/Nethermind.Db.Test/Config/PerTableDbConfigTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/Config/PerTableDbConfigTests.cs
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using FluentAssertions;
+using Nethermind.Db.Rocks.Config;
+using NUnit.Framework;
+
+namespace Nethermind.Db.Test.Config;
+
+public class PerTableDbConfigTests
+{
+    [Test]
+    public void CanReadAllConfigForAllTable()
+    {
+        DbConfig dbConfig = new DbConfig();
+        string[] tables = new []
+        {
+            DbNames.Storage,
+            DbNames.State,
+            DbNames.Code,
+            DbNames.Blocks,
+            DbNames.Headers,
+            DbNames.Receipts,
+            DbNames.BlockInfos,
+            DbNames.Bloom,
+            DbNames.Witness,
+            DbNames.CHT,
+            DbNames.Metadata,
+        };
+
+        foreach (string table in tables)
+        {
+            PerTableDbConfig config = new PerTableDbConfig(dbConfig, new RocksDbSettings(table, ""));
+
+            object _ = config.CacheIndexAndFilterBlocks;
+            _ = config.BlockCacheSize;
+            _ = config.WriteBufferSize;
+            _ = config.WriteBufferNumber;
+            _ = config.MaxOpenFiles;
+        }
+    }
+
+    [Test]
+    public void When_PerTableConfigIsAvailable_UsePerTableConfig()
+    {
+        DbConfig dbConfig = new DbConfig();
+        dbConfig.MaxOpenFiles = 2;
+        dbConfig.ReceiptsDbMaxOpenFiles = 3;
+
+        PerTableDbConfig config = new PerTableDbConfig(dbConfig, new RocksDbSettings(DbNames.Receipts, ""));
+        config.MaxOpenFiles.Should().Be(3);
+    }
+
+    [Test]
+    public void When_PerTableConfigIsNotAvailable_UseGeneralConfig()
+    {
+        DbConfig dbConfig = new DbConfig();
+        dbConfig.MaxOpenFiles = 2;
+
+        PerTableDbConfig config = new PerTableDbConfig(dbConfig, new RocksDbSettings(DbNames.Receipts, ""));
+        config.MaxOpenFiles.Should().Be(2);
+    }
+}

--- a/src/Nethermind/Nethermind.Db.Test/Config/PerTableDbConfigTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/Config/PerTableDbConfigTests.cs
@@ -13,7 +13,7 @@ public class PerTableDbConfigTests
     public void CanReadAllConfigForAllTable()
     {
         DbConfig dbConfig = new DbConfig();
-        string[] tables = new []
+        string[] tables = new[]
         {
             DbNames.Storage,
             DbNames.State,

--- a/tools/HiveCompare/HiveCompare/Models/HiveTestResult.cs
+++ b/tools/HiveCompare/HiveCompare/Models/HiveTestResult.cs
@@ -10,7 +10,7 @@ namespace HiveCompare.Models
 {
     public class HiveTestResult
     {
-        public Dictionary<string, TestCase> TestCases { get; set;} = default!;
+        public Dictionary<string, TestCase> TestCases { get; set; } = default!;
     }
 
     public class TestCase


### PR DESCRIPTION
- Expose max open file settings.
  - Useful to prevent crash under very heavy compaction.
- Expose write rate limit.
  - Useful to limit the effect of compaction writes whose otherwise can't be controlled easily.

## Changes

- Extract db settings handling to its own file.
- Expose max open files settings.
- Expose write rate limit settings.

## Types of changes

#### What types of changes does your code introduce?

- [X] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Open files handle seems to be capped when checking via collectd.
- Write rates limit seems to work also, but not very smooth.
