### PR TITLE
Filter low gas txns early

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Comparers/GasPriceTxComparer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Comparers/GasPriceTxComparer.cs
@@ -6,7 +6,6 @@ using Nethermind.Blockchain.Find;
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
-using Nethermind.Int256;
 
 namespace Nethermind.Consensus.Comparers
 {
@@ -31,7 +30,7 @@ namespace Nethermind.Consensus.Comparers
             // if not, different method of sorting by gas price is needed
             if (x.GasBottleneck is not null && y.GasBottleneck is not null)
             {
-                return y!.GasBottleneck.Value.CompareTo(x!.GasBottleneck);
+                return y!.GasBottleneck.Value.CompareTo(x!.GasBottleneck.GetValueOrDefault());
             }
 
             // When we're adding Tx to TxPool we don't know the base fee of the block in which transaction will be added.
@@ -39,7 +38,7 @@ namespace Nethermind.Consensus.Comparers
             Block block = _blockFinder.Head;
             bool isEip1559Enabled = _specProvider.GetSpecFor1559(block?.Number ?? 0L).IsEip1559Enabled;
 
-            return GasPriceTxComparerHelper.Compare(x, y, block?.Header.BaseFeePerGas ?? UInt256.Zero, isEip1559Enabled);
+            return GasPriceTxComparerHelper.Compare(x, y, (block?.Header.BaseFeePerGas).GetValueOrDefault(), isEip1559Enabled);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Core/Transaction.cs
+++ b/src/Nethermind/Nethermind.Core/Transaction.cs
@@ -43,7 +43,7 @@ namespace Nethermind.Core
         public bool IsSigned => Signature is not null;
         public bool IsContractCreation => To is null;
         public bool IsMessageCall => To is not null;
-        
+
         private Keccak? _hash;
         public Keccak? Hash
         {

--- a/src/Nethermind/Nethermind.Core/Transaction.cs
+++ b/src/Nethermind/Nethermind.Core/Transaction.cs
@@ -1,7 +1,10 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Buffers;
+using System;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Text;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Eip2930;
@@ -40,7 +43,71 @@ namespace Nethermind.Core
         public bool IsSigned => Signature is not null;
         public bool IsContractCreation => To is null;
         public bool IsMessageCall => To is not null;
-        public Keccak? Hash { get; set; }
+        
+        private Keccak? _hash;
+        public Keccak? Hash
+        {
+            get
+            {
+                Keccak? hash = _hash;
+                if (hash is not null) return hash;
+
+                if (_preHash.Length > 0)
+                {
+                    GenerateHash();
+                }
+
+                return _hash;
+
+                void GenerateHash()
+                {
+                    _hash = Keccak.Compute(_preHash.Span);
+                    if (MemoryMarshal.TryGetArray(_preHash, out ArraySegment<byte> rentedArray))
+                    {
+                        ArrayPool<byte>.Shared.Return(rentedArray.Array!);
+                    }
+
+                    _preHash = default;
+                }
+            }
+            set
+            {
+                if (_preHash.Length > 0)
+                {
+                    if (MemoryMarshal.TryGetArray(_preHash, out ArraySegment<byte> rentedArray))
+                    {
+                        ArrayPool<byte>.Shared.Return(rentedArray.Array!);
+                    }
+
+                    _preHash = default;
+                }
+
+                _hash = value;
+            }
+        }
+
+        private ReadOnlyMemory<byte> _preHash;
+        public void SetPreHash(ReadOnlySpan<byte> transactionSequence)
+        {
+            // Used to delay hash generation, as may be filtered as having too low gas etc
+            _hash = null;
+
+            int size = transactionSequence.Length;
+            byte[] preHash = ArrayPool<byte>.Shared.Rent(size);
+            transactionSequence.CopyTo(preHash);
+            _preHash = new ReadOnlyMemory<byte>(preHash, 0, size);
+        }
+
+        public void ClearPreHash()
+        {
+            if (MemoryMarshal.TryGetArray(_preHash, out ArraySegment<byte> rentedArray))
+            {
+                ArrayPool<byte>.Shared.Return(rentedArray.Array!);
+            }
+
+            _preHash = default;
+        }
+
         public PublicKey? DeliveredBy { get; set; } // tks: this is added so we do not send the pending tx back to original sources, not used yet
         public UInt256 Timestamp { get; set; }
 

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
@@ -1074,7 +1074,7 @@ public partial class EthRpcModuleTests
 
         string serialized = ctx.Test.TestEthRpc("eth_sendTransaction", new EthereumJsonSerializer().Serialize(txForRpc));
 
-        Assert.AreEqual("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32010,\"message\":\"InsufficientFunds\"},\"id\":67}", serialized);
+        Assert.AreEqual("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32010,\"message\":\"InsufficientFunds, Balance is zero, cannot pay gas\"},\"id\":67}", serialized);
     }
 
     public enum AccessListProvided

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
@@ -1074,7 +1074,7 @@ public partial class EthRpcModuleTests
 
         string serialized = ctx.Test.TestEthRpc("eth_sendTransaction", new EthereumJsonSerializer().Serialize(txForRpc));
 
-        Assert.AreEqual("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32010,\"message\":\"InsufficientFunds, Account balance: 0, cumulative cost: 31000\"},\"id\":67}", serialized);
+        Assert.AreEqual("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32010,\"message\":\"InsufficientFunds, Account balance: 0\"},\"id\":67}", serialized);
     }
 
     public enum AccessListProvided

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
@@ -1074,7 +1074,7 @@ public partial class EthRpcModuleTests
 
         string serialized = ctx.Test.TestEthRpc("eth_sendTransaction", new EthereumJsonSerializer().Serialize(txForRpc));
 
-        Assert.AreEqual("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32010,\"message\":\"InsufficientFunds, Account balance: 0\"},\"id\":67}", serialized);
+        Assert.AreEqual("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32010,\"message\":\"InsufficientFunds\"},\"id\":67}", serialized);
     }
 
     public enum AccessListProvided

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandler.cs
@@ -264,33 +264,32 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
             bool isTrace = Logger.IsTrace;
             for (int i = 0; i < transactions.Length; i++)
             {
-                Transaction tx = transactions[i];
-                tx.DeliveredBy = Node.Id;
-                tx.Timestamp = _timestamper.UnixTime.Seconds;
-                AcceptTxResult accepted = _txPool.SubmitTx(tx, TxHandlingOptions.None);
-                _floodController.Report(accepted);
-
-                if (isTrace) Log(tx, accepted);
-            }
-
-            void Log(Transaction tx, AcceptTxResult accepted)
-            {
-                Logger.Trace($"{Node:c} sent {tx.Hash} tx and it was {accepted} (chain ID = {tx.Signature?.ChainId})");
+                PrepareAndSubmitTransaction(transactions[i], isTrace);
             }
         }
 
         private void HandleSlow(IList<Transaction> transactions)
         {
-            for (int i = 0; i < transactions.Count; i++)
+            bool isTrace = Logger.IsTrace;
+            int count = transactions.Count;
+            for (int i = 0; i < count; i++)
             {
-                Transaction tx = transactions[i];
-                tx.DeliveredBy = Node.Id;
-                tx.Timestamp = _timestamper.UnixTime.Seconds;
-                AcceptTxResult accepted = _txPool.SubmitTx(tx, TxHandlingOptions.None);
-                _floodController.Report(accepted);
+                PrepareAndSubmitTransaction(transactions[i], isTrace);
+            }
+        }
 
-                if (Logger.IsTrace) Logger.Trace(
-                    $"{Node:c} sent {tx.Hash} tx and it was {accepted} (chain ID = {tx.Signature?.ChainId})");
+        private void PrepareAndSubmitTransaction(Transaction tx, bool isTrace)
+        {
+            tx.DeliveredBy = Node.Id;
+            tx.Timestamp = _timestamper.UnixTime.Seconds;
+            AcceptTxResult accepted = _txPool.SubmitTx(tx, TxHandlingOptions.None);
+            _floodController.Report(accepted);
+
+            if (isTrace) Log(tx, accepted);
+
+            void Log(Transaction tx, in AcceptTxResult accepted)
+            {
+                Logger.Trace($"{Node:c} sent {tx.Hash} tx and it was {accepted} (chain ID = {tx.Signature?.ChainId})");
             }
         }
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/PooledTxsRequestor.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/PooledTxsRequestor.cs
@@ -25,7 +25,8 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V65
 
         public void RequestTransactions(Action<GetPooledTransactionsMessage> send, IReadOnlyList<Keccak> hashes)
         {
-            using ArrayPoolList<Keccak> discoveredTxHashes = new(hashes.Count, GetAndMarkUnknownHashes(hashes));
+            using ArrayPoolList<Keccak> discoveredTxHashes = new(hashes.Count);
+            AddMarkUnknownHashes(hashes, discoveredTxHashes);
 
             if (discoveredTxHashes.Count != 0)
             {
@@ -36,7 +37,8 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V65
 
         public void RequestTransactionsEth66(Action<V66.Messages.GetPooledTransactionsMessage> send, IReadOnlyList<Keccak> hashes)
         {
-            using ArrayPoolList<Keccak> discoveredTxHashes = new(hashes.Count, GetAndMarkUnknownHashes(hashes));
+            using ArrayPoolList<Keccak> discoveredTxHashes = new(hashes.Count);
+            AddMarkUnknownHashes(hashes, discoveredTxHashes);
 
             if (discoveredTxHashes.Count != 0)
             {
@@ -46,14 +48,15 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V65
             }
         }
 
-        private IEnumerable<Keccak> GetAndMarkUnknownHashes(IReadOnlyList<Keccak> hashes)
+        private void AddMarkUnknownHashes(IReadOnlyList<Keccak> hashes, ArrayPoolList<Keccak> discoveredTxHashes)
         {
-            for (int i = 0; i < hashes.Count; i++)
+            int count = hashes.Count;
+            for (int i = 0; i < count; i++)
             {
                 Keccak hash = hashes[i];
                 if (!_txPool.IsKnown(hash) && _pendingHashes.Set(hash))
                 {
-                    yield return hash;
+                    discoveredTxHashes.Add(hash);
                 }
             }
         }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandler.cs
@@ -193,7 +193,6 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
 
         protected override void Handle(NewPooledTransactionHashesMessage msg)
         {
-
             bool isTrace = Logger.IsTrace;
             Stopwatch? stopwatch = isTrace ? Stopwatch.StartNew() : null;
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandler.cs
@@ -193,12 +193,14 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
 
         protected override void Handle(NewPooledTransactionHashesMessage msg)
         {
-            Stopwatch stopwatch = Stopwatch.StartNew();
+            
+            bool isTrace = Logger.IsTrace;
+            Stopwatch? stopwatch = isTrace ? Stopwatch.StartNew() : null;
 
             _pooledTxsRequestor.RequestTransactionsEth66(_sendAction, msg.Hashes);
 
-            stopwatch.Stop();
-            if (Logger.IsTrace)
+            stopwatch?.Stop();
+            if (isTrace)
                 Logger.Trace($"OUT {Counter:D5} {nameof(NewPooledTransactionHashesMessage)} to {Node:c} " +
                              $"in {stopwatch.Elapsed.TotalMilliseconds}ms");
         }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandler.cs
@@ -52,6 +52,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
             _nodeDataRequests66 = new MessageDictionary<GetNodeDataMessage, V63.Messages.GetNodeDataMessage, byte[][]>(Send);
             _receiptsRequests66 = new MessageDictionary<GetReceiptsMessage, V63.Messages.GetReceiptsMessage, TxReceipt[][]>(Send);
             _pooledTxsRequestor = pooledTxsRequestor;
+            // Capture Action once rather than per call
             _sendAction = Send;
         }
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandler.cs
@@ -34,6 +34,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
         private readonly MessageDictionary<GetNodeDataMessage, V63.Messages.GetNodeDataMessage, byte[][]> _nodeDataRequests66;
         private readonly MessageDictionary<GetReceiptsMessage, V63.Messages.GetReceiptsMessage, TxReceipt[][]> _receiptsRequests66;
         private readonly IPooledTxsRequestor _pooledTxsRequestor;
+        private readonly Action<GetPooledTransactionsMessage> _sendAction;
 
         public Eth66ProtocolHandler(ISession session,
             IMessageSerializationService serializer,
@@ -51,6 +52,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
             _nodeDataRequests66 = new MessageDictionary<GetNodeDataMessage, V63.Messages.GetNodeDataMessage, byte[][]>(Send);
             _receiptsRequests66 = new MessageDictionary<GetReceiptsMessage, V63.Messages.GetReceiptsMessage, TxReceipt[][]>(Send);
             _pooledTxsRequestor = pooledTxsRequestor;
+            _sendAction = Send;
         }
 
         public override string Name => "eth66";
@@ -192,7 +194,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
         {
             Stopwatch stopwatch = Stopwatch.StartNew();
 
-            _pooledTxsRequestor.RequestTransactionsEth66(Send, msg.Hashes);
+            _pooledTxsRequestor.RequestTransactionsEth66(_sendAction, msg.Hashes);
 
             stopwatch.Stop();
             if (Logger.IsTrace)

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandler.cs
@@ -193,7 +193,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
 
         protected override void Handle(NewPooledTransactionHashesMessage msg)
         {
-            
+
             bool isTrace = Logger.IsTrace;
             Stopwatch? stopwatch = isTrace ? Stopwatch.StartNew() : null;
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
@@ -66,13 +66,14 @@ public class Eth68ProtocolHandler : Eth67ProtocolHandler
 
     private void Handle(NewPooledTransactionHashesMessage68 message)
     {
+        bool isTrace = Logger.IsTrace;
         if (message.Hashes.Count != message.Types.Count || message.Hashes.Count != message.Sizes.Count)
         {
             string errorMessage = $"Wrong format of {nameof(NewPooledTransactionHashesMessage68)} message. " +
                                   $"Hashes count: {message.Hashes.Count} " +
                                   $"Types count: {message.Types.Count} " +
                                   $"Sizes count: {message.Sizes.Count}";
-            if (Logger.IsTrace)
+            if (isTrace)
                 Logger.Trace(errorMessage);
 
             throw new SubprotocolException(errorMessage);
@@ -80,13 +81,13 @@ public class Eth68ProtocolHandler : Eth67ProtocolHandler
 
         Metrics.Eth68NewPooledTransactionHashesReceived++;
 
-        Stopwatch stopwatch = Stopwatch.StartNew();
+        Stopwatch? stopwatch = isTrace ? Stopwatch.StartNew() : null;
 
         _pooledTxsRequestor.RequestTransactionsEth66(_sendAction, message.Hashes);
 
-        stopwatch.Stop();
+        stopwatch?.Stop();
 
-        if (Logger.IsTrace)
+        if (isTrace)
             Logger.Trace($"OUT {Counter:D5} {nameof(NewPooledTransactionHashesMessage68)} to {Node:c} " +
                          $"in {stopwatch.Elapsed.TotalMilliseconds}ms");
     }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using Nethermind.Consensus;
@@ -27,6 +28,8 @@ public class Eth68ProtocolHandler : Eth67ProtocolHandler
 
     public override byte ProtocolVersion => EthVersions.Eth68;
 
+    Action<V66.Messages.GetPooledTransactionsMessage> _sendAction;
+
     public Eth68ProtocolHandler(ISession session,
         IMessageSerializationService serializer,
         INodeStatsManager nodeStatsManager,
@@ -40,6 +43,9 @@ public class Eth68ProtocolHandler : Eth67ProtocolHandler
             forkInfo, logManager)
     {
         _pooledTxsRequestor = pooledTxsRequestor;
+
+        // Capture Action once rather than per call
+        _sendAction = Send<V66.Messages.GetPooledTransactionsMessage>;
     }
 
     public override void HandleMessage(ZeroPacket message)
@@ -76,7 +82,7 @@ public class Eth68ProtocolHandler : Eth67ProtocolHandler
 
         Stopwatch stopwatch = Stopwatch.StartNew();
 
-        _pooledTxsRequestor.RequestTransactionsEth66(Send, message.Hashes);
+        _pooledTxsRequestor.RequestTransactionsEth66(_sendAction, message.Hashes);
 
         stopwatch.Stop();
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
@@ -24,11 +24,11 @@ public class Eth68ProtocolHandler : Eth67ProtocolHandler
 {
     private readonly IPooledTxsRequestor _pooledTxsRequestor;
 
+    private readonly Action<V66.Messages.GetPooledTransactionsMessage> _sendAction;
+
     public override string Name => "eth68";
 
     public override byte ProtocolVersion => EthVersions.Eth68;
-
-    Action<V66.Messages.GetPooledTransactionsMessage> _sendAction;
 
     public Eth68ProtocolHandler(ISession session,
         IMessageSerializationService serializer,

--- a/src/Nethermind/Nethermind.Synchronization/Reporting/SyncReport.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Reporting/SyncReport.cs
@@ -91,7 +91,6 @@ namespace Nethermind.Synchronization.Reporting
             if (_reportId % SyncFullPeersReportFrequency == 0)
             {
                 _syncPeersReport.WriteFullReport();
-                Nethermind.TxPool.TxPool.WriteTxnPoolReport(_logger);
             }
             else if (_reportId % SyncAllocatedPeersReportFrequency == 0)
             {

--- a/src/Nethermind/Nethermind.Synchronization/Reporting/SyncReport.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Reporting/SyncReport.cs
@@ -91,6 +91,7 @@ namespace Nethermind.Synchronization.Reporting
             if (_reportId % SyncFullPeersReportFrequency == 0)
             {
                 _syncPeersReport.WriteFullReport();
+                Nethermind.TxPool.TxPool.WriteTxnPoolReport(_logger);
             }
             else if (_reportId % SyncAllocatedPeersReportFrequency == 0)
             {

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -392,18 +392,20 @@ namespace Nethermind.TxPool.Test
 
         [TestCase(4, 0, nameof(AcceptTxResult.FeeTooLow))]
         [TestCase(4, 11, nameof(AcceptTxResult.FeeTooLow))]
-        [TestCase(4, 12, nameof(AcceptTxResult.InsufficientFunds))]
+        [TestCase(4, 12, nameof(AcceptTxResult.FeeTooLow))]
         [TestCase(5, 0, nameof(AcceptTxResult.FeeTooLow))]
         [TestCase(5, 10, nameof(AcceptTxResult.FeeTooLow))]
-        [TestCase(5, 11, nameof(AcceptTxResult.InsufficientFunds))]
+        [TestCase(5, 11, nameof(AcceptTxResult.FeeTooLow))]
         [TestCase(9, 0, nameof(AcceptTxResult.Accepted))]
         [TestCase(9, 6, nameof(AcceptTxResult.Accepted))]
         [TestCase(9, 7, nameof(AcceptTxResult.InsufficientFunds))]
+        [TestCase(9, 45, nameof(AcceptTxResult.InsufficientFunds))]
         [TestCase(11, 0, nameof(AcceptTxResult.Accepted))]
         [TestCase(11, 4, nameof(AcceptTxResult.Accepted))]
         [TestCase(11, 5, nameof(AcceptTxResult.InsufficientFunds))]
         [TestCase(15, 0, nameof(AcceptTxResult.Accepted))]
         [TestCase(16, 0, nameof(AcceptTxResult.InsufficientFunds))]
+        [TestCase(16, 90, nameof(AcceptTxResult.InsufficientFunds))]
         public void should_handle_adding_tx_to_full_txPool_properly(int gasPrice, int value, string expected)
         {
             _txPool = CreatePool(new TxPoolConfig() { Size = 30 });
@@ -437,10 +439,10 @@ namespace Nethermind.TxPool.Test
         }
 
         [TestCase(5, 10, nameof(AcceptTxResult.FeeTooLow))]
-        [TestCase(5, 11, nameof(AcceptTxResult.InsufficientFunds))]
+        [TestCase(5, 11, nameof(AcceptTxResult.FeeTooLow))]
         [TestCase(10, 0, nameof(AcceptTxResult.FeeTooLow))]
         [TestCase(10, 5, nameof(AcceptTxResult.FeeTooLow))]
-        [TestCase(10, 6, nameof(AcceptTxResult.InsufficientFunds))]
+        [TestCase(10, 6, nameof(AcceptTxResult.FeeTooLow))]
         [TestCase(11, 0, nameof(AcceptTxResult.Accepted))]
         [TestCase(11, 4, nameof(AcceptTxResult.Accepted))]
         [TestCase(11, 5, nameof(AcceptTxResult.InsufficientFunds))]

--- a/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
@@ -159,7 +159,8 @@ namespace Nethermind.TxPool.Collections
         /// </summary>
         public bool TryGetLast(out TValue? last)
         {
-            last = _worstValue is not null ? _worstValue.Value.Key : default;
+            KeyValuePair<TValue,TKey>? worstValue = _worstValue;
+            last = worstValue is not null ? worstValue.Value.Key : default;
             return last is not null;
         }
 
@@ -307,9 +308,10 @@ namespace Nethermind.TxPool.Collections
 
         private void RemoveLast(out TValue? removed)
         {
-            if (_worstValue is not null)
+            KeyValuePair<TValue,TKey>? worstValue = _worstValue;
+            if (worstValue is not null)
             {
-                TryRemove(_worstValue.Value.Value, true, out removed, out _);
+                TryRemove(worstValue.Value.Value, true, out removed, out _);
             }
             else
             {

--- a/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
@@ -159,8 +159,7 @@ namespace Nethermind.TxPool.Collections
         /// </summary>
         public bool TryGetLast(out TValue? last)
         {
-            KeyValuePair<TValue, TKey>? worstValue = _worstValue;
-            last = worstValue is not null ? worstValue.Value.Key : default;
+            last = _worstValue.GetValueOrDefault().Key;
             return last is not null;
         }
 
@@ -308,10 +307,10 @@ namespace Nethermind.TxPool.Collections
 
         private void RemoveLast(out TValue? removed)
         {
-            KeyValuePair<TValue, TKey>? worstValue = _worstValue;
-            if (worstValue is not null)
+            TKey? key = _worstValue.GetValueOrDefault().Value;
+            if (key is not null)
             {
-                TryRemove(worstValue.Value.Value, true, out removed, out _);
+                TryRemove(key, true, out removed, out _);
             }
             else
             {

--- a/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
@@ -159,7 +159,7 @@ namespace Nethermind.TxPool.Collections
         /// </summary>
         public bool TryGetLast(out TValue? last)
         {
-            KeyValuePair<TValue,TKey>? worstValue = _worstValue;
+            KeyValuePair<TValue, TKey>? worstValue = _worstValue;
             last = worstValue is not null ? worstValue.Value.Key : default;
             return last is not null;
         }
@@ -308,7 +308,7 @@ namespace Nethermind.TxPool.Collections
 
         private void RemoveLast(out TValue? removed)
         {
-            KeyValuePair<TValue,TKey>? worstValue = _worstValue;
+            KeyValuePair<TValue, TKey>? worstValue = _worstValue;
             if (worstValue is not null)
             {
                 TryRemove(worstValue.Value.Value, true, out removed, out _);

--- a/src/Nethermind/Nethermind.TxPool/Collections/TxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/TxDistinctSortedPool.cs
@@ -48,7 +48,8 @@ namespace Nethermind.TxPool.Collections
                     {
                         _worstSortedValues.Add(tx, tx.Hash!);
                     }
-                    _worstValue = _worstSortedValues.Max;
+
+                    UpdateWorstValue();
                 }
                 else
                 {

--- a/src/Nethermind/Nethermind.TxPool/Collections/TxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/TxDistinctSortedPool.cs
@@ -48,6 +48,7 @@ namespace Nethermind.TxPool.Collections
                     {
                         _worstSortedValues.Add(tx, tx.Hash!);
                     }
+                    _worstValue = _worstSortedValues.Max;
                 }
                 else
                 {

--- a/src/Nethermind/Nethermind.TxPool/Filters/AlreadyKnownTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/AlreadyKnownTxFilter.cs
@@ -12,7 +12,7 @@ namespace Nethermind.TxPool.Filters
     /// It uses a limited capacity hash cache underneath so there is no strict promise on filtering
     /// transactions.
     /// </summary>
-    internal class AlreadyKnownTxFilter : IIncomingTxFilter
+    internal sealed class AlreadyKnownTxFilter : IIncomingTxFilter
     {
         private readonly HashCache _hashCache;
         private readonly ILogger _logger;

--- a/src/Nethermind/Nethermind.TxPool/Filters/BalanceTooLowFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/BalanceTooLowFilter.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Nethermind.Core;
-using Nethermind.Core.Specs;
 using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.TxPool.Collections;
@@ -74,12 +73,12 @@ namespace Nethermind.TxPool.Filters
                 if (_logger.IsTrace)
                 {
                     _logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, insufficient funds.");
-                    return AcceptTxResult.InsufficientFunds.WithMessage($"Account balance: {balance}, cumulative cost: {cumulativeCost}");
                 }
-                else
-                {
-                    return AcceptTxResult.InsufficientFunds;
-                }
+
+                bool isNotLocal = (handlingOptions & TxHandlingOptions.PersistentBroadcast) == 0;
+                return isNotLocal ?
+                    AcceptTxResult.InsufficientFunds :
+                    AcceptTxResult.InsufficientFunds.WithMessage($"Account balance: {balance}, cumulative cost: {cumulativeCost}");
             }
 
             return AcceptTxResult.Accepted;

--- a/src/Nethermind/Nethermind.TxPool/Filters/BalanceTooLowFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/BalanceTooLowFilter.cs
@@ -45,7 +45,7 @@ namespace Nethermind.TxPool.Filters
                     continue;
                 }
 
-                if (tx.Nonce < tx.Nonce)
+                if (otherTx.Nonce < tx.Nonce)
                 {
                     overflow |= UInt256.MultiplyOverflow(otherTx.MaxFeePerGas, (UInt256)otherTx.GasLimit, out UInt256 maxTxCost);
                     overflow |= UInt256.AddOverflow(cumulativeCost, maxTxCost, out cumulativeCost);

--- a/src/Nethermind/Nethermind.TxPool/Filters/BalanceTooLowFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/BalanceTooLowFilter.cs
@@ -39,16 +39,17 @@ namespace Nethermind.TxPool.Filters
 
             for (int i = 0; i < transactions.Length; i++)
             {
-                if (transactions[i].Nonce < account.Nonce)
+                Transaction otherTx = transactions[i];
+                if (otherTx.Nonce < account.Nonce)
                 {
                     continue;
                 }
 
-                if (transactions[i].Nonce < tx.Nonce)
+                if (tx.Nonce < tx.Nonce)
                 {
-                    overflow |= UInt256.MultiplyOverflow(transactions[i].MaxFeePerGas, (UInt256)transactions[i].GasLimit, out UInt256 maxTxCost);
+                    overflow |= UInt256.MultiplyOverflow(otherTx.MaxFeePerGas, (UInt256)otherTx.GasLimit, out UInt256 maxTxCost);
                     overflow |= UInt256.AddOverflow(cumulativeCost, maxTxCost, out cumulativeCost);
-                    overflow |= UInt256.AddOverflow(cumulativeCost, transactions[i].Value, out cumulativeCost);
+                    overflow |= UInt256.AddOverflow(cumulativeCost, otherTx.Value, out cumulativeCost);
                 }
                 else
                 {

--- a/src/Nethermind/Nethermind.TxPool/Filters/BalanceTooLowFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/BalanceTooLowFilter.cs
@@ -28,12 +28,6 @@ namespace Nethermind.TxPool.Filters
             Account account = state.SenderAccount;
             UInt256 balance = account.Balance;
 
-            if (balance.IsZero)
-            {
-                Metrics.PendingTransactionsZeroBalance++;
-                return AcceptTxResult.InsufficientFunds.WithMessage("Account balance: 0");
-            }
-
             UInt256 cumulativeCost = UInt256.Zero;
             bool overflow = false;
             Transaction[] transactions = _txs.GetBucketSnapshot(tx.SenderAddress!); // since unknownSenderFilter will run before this one

--- a/src/Nethermind/Nethermind.TxPool/Filters/BalanceTooLowFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/BalanceTooLowFilter.cs
@@ -25,6 +25,11 @@ namespace Nethermind.TxPool.Filters
 
         public AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions handlingOptions)
         {
+            if (tx.IsFree())
+            {
+                return AcceptTxResult.Accepted;
+            }
+
             Account account = state.SenderAccount;
             UInt256 balance = account.Balance;
 

--- a/src/Nethermind/Nethermind.TxPool/Filters/BalanceTooLowFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/BalanceTooLowFilter.cs
@@ -68,11 +68,17 @@ namespace Nethermind.TxPool.Filters
 
             if (balance < cumulativeCost)
             {
-                if (_logger.IsTrace)
-                    _logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, insufficient funds.");
-
                 Metrics.PendingTransactionsTooLowBalance++;
-                return AcceptTxResult.InsufficientFunds.WithMessage($"Account balance: {balance}, cumulative cost: {cumulativeCost}");
+
+                if (_logger.IsTrace)
+                {
+                    _logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, insufficient funds.");
+                    return AcceptTxResult.InsufficientFunds.WithMessage($"Account balance: {balance}, cumulative cost: {cumulativeCost}");
+                }
+                else
+                {
+                    return AcceptTxResult.InsufficientFunds.WithMessage("Account balance to low for cumulative cost of queued txs.");
+                }
             }
 
             return AcceptTxResult.Accepted;

--- a/src/Nethermind/Nethermind.TxPool/Filters/BalanceTooLowFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/BalanceTooLowFilter.cs
@@ -77,7 +77,7 @@ namespace Nethermind.TxPool.Filters
                 }
                 else
                 {
-                    return AcceptTxResult.InsufficientFunds.WithMessage("Account balance to low for cumulative cost of queued txs.");
+                    return AcceptTxResult.InsufficientFunds;
                 }
             }
 

--- a/src/Nethermind/Nethermind.TxPool/Filters/BalanceZeroFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/BalanceZeroFilter.cs
@@ -23,7 +23,7 @@ namespace Nethermind.TxPool.Filters
         {
             Account account = state.SenderAccount;
             UInt256 balance = account.Balance;
-            
+
             if (!tx.IsFree() && balance.IsZero)
             {
                 Metrics.PendingTransactionsZeroBalance++;

--- a/src/Nethermind/Nethermind.TxPool/Filters/BalanceZeroFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/BalanceZeroFilter.cs
@@ -23,11 +23,16 @@ namespace Nethermind.TxPool.Filters
         {
             Account account = state.SenderAccount;
             UInt256 balance = account.Balance;
-
-            if (balance.IsZero)
+            
+            if (!tx.IsFree() && balance.IsZero)
             {
                 Metrics.PendingTransactionsZeroBalance++;
                 return AcceptTxResult.InsufficientFunds.WithMessage("Account balance: 0");
+            }
+            if (balance < tx.Value)
+            {
+                Metrics.PendingTransactionsBalanceBelowValue++;
+                return AcceptTxResult.InsufficientFunds.WithMessage($"Account balance {balance} below txn value {tx.Value}");
             }
 
             return AcceptTxResult.Accepted;

--- a/src/Nethermind/Nethermind.TxPool/Filters/BalanceZeroFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/BalanceZeroFilter.cs
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+using Nethermind.Int256;
+using Nethermind.Logging;
+
+namespace Nethermind.TxPool.Filters
+{
+    /// <summary>
+    /// Filters out transactions which gas payments overflow uint256 or simply exceed sender balance
+    /// </summary>
+    internal sealed class BalanceZeroFilter : IIncomingTxFilter
+    {
+        private readonly ILogger _logger;
+
+        public BalanceZeroFilter(ILogger logger)
+        {
+            _logger = logger;
+        }
+
+        public AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions handlingOptions)
+        {
+            Account account = state.SenderAccount;
+            UInt256 balance = account.Balance;
+
+            if (balance.IsZero)
+            {
+                Metrics.PendingTransactionsZeroBalance++;
+                return AcceptTxResult.InsufficientFunds.WithMessage("Account balance: 0");
+            }
+
+            return AcceptTxResult.Accepted;
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.TxPool/Filters/BalanceZeroFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/BalanceZeroFilter.cs
@@ -27,12 +27,12 @@ namespace Nethermind.TxPool.Filters
             if (!tx.IsFree() && balance.IsZero)
             {
                 Metrics.PendingTransactionsZeroBalance++;
-                return AcceptTxResult.InsufficientFunds.WithMessage("Account balance: 0");
+                return AcceptTxResult.InsufficientFunds;
             }
             if (balance < tx.Value)
             {
                 Metrics.PendingTransactionsBalanceBelowValue++;
-                return AcceptTxResult.InsufficientFunds.WithMessage($"Account balance {balance} below txn value {tx.Value}");
+                return AcceptTxResult.InsufficientFunds;
             }
 
             return AcceptTxResult.Accepted;

--- a/src/Nethermind/Nethermind.TxPool/Filters/DeployedCodeFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/DeployedCodeFilter.cs
@@ -9,7 +9,7 @@ namespace Nethermind.TxPool.Filters
     /// <summary>
     /// Filters out transactions that sender has any code deployed. If <see cref="IReleaseSpec.IsEip3607Enabled"/> is enabled.
     /// </summary>
-    internal class DeployedCodeFilter : IIncomingTxFilter
+    internal sealed class DeployedCodeFilter : IIncomingTxFilter
     {
         private readonly IChainHeadSpecProvider _specProvider;
         private readonly IAccountStateProvider _stateProvider;

--- a/src/Nethermind/Nethermind.TxPool/Filters/FeeTooLowFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/FeeTooLowFilter.cs
@@ -44,7 +44,9 @@ namespace Nethermind.TxPool.Filters
             {
                 Metrics.PendingTransactionsTooLowFee++;
                 if (_logger.IsTrace) _logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, too low payable gas price with options {handlingOptions} from {new StackTrace()}");
-                return AcceptTxResult.FeeTooLow;
+                return !isLocal ?
+                    AcceptTxResult.FeeTooLow :
+                    AcceptTxResult.FeeTooLow.WithMessage("Affordable gas price is 0");
             }
 
             if (_txs.IsFull() && _txs.TryGetLast(out Transaction? lastTx)
@@ -54,12 +56,12 @@ namespace Nethermind.TxPool.Filters
                 if (_logger.IsTrace)
                 {
                     _logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, too low payable gas price with options {handlingOptions} from {new StackTrace()}");
-                    return AcceptTxResult.FeeTooLow.WithMessage($"FeePerGas needs to be higher than {lastTx.GasBottleneck.Value} to be added to the TxPool. FeePerGas of rejected tx: {affordableGasPrice}.");
                 }
-                else
-                {
-                    return AcceptTxResult.FeeTooLow;
-                }
+
+                return !isLocal ?
+                    AcceptTxResult.FeeTooLow :
+                    AcceptTxResult.FeeTooLow.WithMessage($"FeePerGas needs to be higher than {lastTx.GasBottleneck.Value} to be added to the TxPool. FeePerGas of rejected tx: {affordableGasPrice}.");
+
             }
 
             return AcceptTxResult.Accepted;

--- a/src/Nethermind/Nethermind.TxPool/Filters/FeeTooLowFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/FeeTooLowFilter.cs
@@ -37,7 +37,7 @@ namespace Nethermind.TxPool.Filters
         public AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions handlingOptions)
         {
             bool isTrace = _logger.IsTrace;
-            if (tx.GasLimit <= 0 || GasLimitToWei(tx.GasLimit) < Transaction.BaseTxGasCost * tx.GasPrice)
+            if (tx.GasLimit <= 0 || tx.GasLimit < Transaction.BaseTxGasCost)
             {
                 // Not high enough GasLimit to run a txn
                 Metrics.PendingTransactionsTooLowFee++;

--- a/src/Nethermind/Nethermind.TxPool/Filters/FeeTooLowFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/FeeTooLowFilter.cs
@@ -51,8 +51,15 @@ namespace Nethermind.TxPool.Filters
                 && affordableGasPrice <= lastTx?.GasBottleneck)
             {
                 Metrics.PendingTransactionsTooLowFee++;
-                if (_logger.IsTrace) _logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, too low payable gas price with options {handlingOptions} from {new StackTrace()}");
-                return AcceptTxResult.FeeTooLow.WithMessage($"FeePerGas needs to be higher than {lastTx.GasBottleneck.Value} to be added to the TxPool. FeePerGas of rejected tx: {affordableGasPrice}.");
+                if (_logger.IsTrace)
+                {
+                    _logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, too low payable gas price with options {handlingOptions} from {new StackTrace()}");
+                    return AcceptTxResult.FeeTooLow.WithMessage($"FeePerGas needs to be higher than {lastTx.GasBottleneck.Value} to be added to the TxPool. FeePerGas of rejected tx: {affordableGasPrice}.");
+                }
+                else
+                {
+                    return AcceptTxResult.FeeTooLow.WithMessage("FeePerGas needs to be higher than lowest gas txn in TxPool.");
+                }
             }
 
             return AcceptTxResult.Accepted;

--- a/src/Nethermind/Nethermind.TxPool/Filters/FeeTooLowFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/FeeTooLowFilter.cs
@@ -44,7 +44,7 @@ namespace Nethermind.TxPool.Filters
             {
                 Metrics.PendingTransactionsTooLowFee++;
                 if (_logger.IsTrace) _logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, too low payable gas price with options {handlingOptions} from {new StackTrace()}");
-                return AcceptTxResult.FeeTooLow.WithMessage("Affordable FeePerGas of 0 rejected.");
+                return AcceptTxResult.FeeTooLow;
             }
 
             if (_txs.IsFull() && _txs.TryGetLast(out Transaction? lastTx)
@@ -58,7 +58,7 @@ namespace Nethermind.TxPool.Filters
                 }
                 else
                 {
-                    return AcceptTxResult.FeeTooLow.WithMessage("FeePerGas needs to be higher than lowest gas txn in TxPool.");
+                    return AcceptTxResult.FeeTooLow;
                 }
             }
 

--- a/src/Nethermind/Nethermind.TxPool/Filters/FeeTooLowFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/FeeTooLowFilter.cs
@@ -45,18 +45,7 @@ namespace Nethermind.TxPool.Filters
             }
 
             IReleaseSpec spec = _specProvider.GetCurrentHeadSpec();
-            bool isEip1559Enabled = spec.IsEip1559Enabled;
-            if (isEip1559Enabled && tx.IsEip1559)
-            {
-                if (tx.GasLimit < spec.MinGasLimit || tx.GasPrice < spec.Eip1559BaseFeeMinValue)
-                {
-                    // Amounts too low for spec
-                    Metrics.PendingTransactionsTooLowFee++;
-                    return AcceptTxResult.FeeTooLow.WithMessage("GasLimit or GasPrice too low for Eip1559 spec");
-                }
-            }
-
-            UInt256 affordableGasPrice = tx.CalculateGasPrice(isEip1559Enabled, _headInfo.CurrentBaseFee);
+            UInt256 affordableGasPrice = tx.CalculateGasPrice(spec.IsEip1559Enabled, _headInfo.CurrentBaseFee);
 
             // Don't accept zero fee txns even if pool is empty as will never run
             if (affordableGasPrice.IsZero)

--- a/src/Nethermind/Nethermind.TxPool/Filters/FeeTooLowFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/FeeTooLowFilter.cs
@@ -13,36 +13,72 @@ namespace Nethermind.TxPool.Filters
     /// <summary>
     /// Filters out transactions where gas fee properties were set too low or where the sender has not enough balance.
     /// </summary>
-    internal class FeeTooLowFilter : IIncomingTxFilter
+    internal sealed class FeeTooLowFilter : IIncomingTxFilter
     {
         private readonly IChainHeadSpecProvider _specProvider;
         private readonly IChainHeadInfoProvider _headInfo;
         private readonly TxDistinctSortedPool _txs;
         private readonly ILogger _logger;
 
-        public FeeTooLowFilter(IChainHeadInfoProvider headInfo, TxDistinctSortedPool txs, ILogManager logManager)
+        public FeeTooLowFilter(IChainHeadInfoProvider headInfo, TxDistinctSortedPool txs, ILogger logger)
         {
             _specProvider = headInfo.SpecProvider;
             _headInfo = headInfo;
             _txs = txs;
-            _logger = logManager.GetClassLogger();
+            _logger = logger;
+        }
+
+        private readonly static UInt256 GweiToWeiFactor = new UInt256(1_000_000_000);
+        private UInt256 GasLimitToWei(long gasLimitGwei)
+        {
+            return GweiToWeiFactor * new UInt256((ulong)gasLimitGwei);
         }
 
         public AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions handlingOptions)
         {
-            IReleaseSpec spec = _specProvider.GetCurrentHeadSpec();
-            UInt256 balance = state.SenderAccount.Balance;
-            UInt256 affordableGasPrice = tx.CalculateAffordableGasPrice(spec.IsEip1559Enabled, _headInfo.CurrentBaseFee, balance);
-            bool isNotLocal = (handlingOptions & TxHandlingOptions.PersistentBroadcast) != TxHandlingOptions.PersistentBroadcast;
+            bool isTrace = _logger.IsTrace;
+            if (tx.GasLimit <= 0 || GasLimitToWei(tx.GasLimit) < Transaction.BaseTxGasCost * tx.GasPrice)
+            {
+                // Not high enough GasLimit to run a txn
+                Metrics.PendingTransactionsTooLowFee++;
+                if (isTrace) _logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, too low gas limit for a txn at price {tx.GasPrice}");
+                return AcceptTxResult.FeeTooLow.WithMessage("GasLimit too low to start txn at GasPrice");
+            }
 
-            if (isNotLocal
-                && _txs.IsFull()
-                && _txs.TryGetLast(out Transaction? lastTx)
+            IReleaseSpec spec = _specProvider.GetCurrentHeadSpec();
+            bool isEip1559Enabled = spec.IsEip1559Enabled;
+            if (isEip1559Enabled && tx.IsEip1559)
+            {
+                if (tx.GasLimit < spec.MinGasLimit || tx.GasPrice < spec.Eip1559BaseFeeMinValue)
+                {
+                    // Amounts too low for spec
+                    Metrics.PendingTransactionsTooLowFee++;
+                    return AcceptTxResult.FeeTooLow.WithMessage("GasLimit or GasPrice too low for Eip1559 spec");
+                }
+            }
+
+            UInt256 affordableGasPrice = tx.CalculateGasPrice(isEip1559Enabled, _headInfo.CurrentBaseFee);
+
+            // Don't accept zero fee txns even if pool is empty as will never run
+            if (affordableGasPrice.IsZero)
+            {
+                Metrics.PendingTransactionsTooLowFee++;
+                if (isTrace) _logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, too low payable gas price with options {handlingOptions} from {new StackTrace()}");
+                return AcceptTxResult.FeeTooLow.WithMessage("Affordable FeePerGas of 0 rejected.");
+            }
+
+            bool isLocal = (handlingOptions & TxHandlingOptions.PersistentBroadcast) != 0;
+            if (isLocal)
+            {
+                return AcceptTxResult.Accepted;
+            }
+
+            if (_txs.IsFull() && _txs.TryGetLast(out Transaction? lastTx)
                 && affordableGasPrice <= lastTx?.GasBottleneck)
             {
                 Metrics.PendingTransactionsTooLowFee++;
-                if (_logger.IsTrace) _logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, too low payable gas price with options {handlingOptions} from {new StackTrace()}");
-                return AcceptTxResult.FeeTooLow.WithMessage($"FeePerGas needs to be higher than {lastTx.GasBottleneck.Value} to be added to the TxPool. Affordable FeePerGas of rejected tx: {affordableGasPrice}.");
+                if (isTrace) _logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, too low payable gas price with options {handlingOptions} from {new StackTrace()}");
+                return AcceptTxResult.FeeTooLow.WithMessage($"FeePerGas needs to be higher than {lastTx.GasBottleneck.Value} to be added to the TxPool. FeePerGas of rejected tx: {affordableGasPrice}.");
             }
 
             return AcceptTxResult.Accepted;

--- a/src/Nethermind/Nethermind.TxPool/Filters/FeeTooLowFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/FeeTooLowFilter.cs
@@ -60,7 +60,7 @@ namespace Nethermind.TxPool.Filters
             UInt256 affordableGasPrice = tx.CalculateGasPrice(isEip1559Enabled, _headInfo.CurrentBaseFee);
 
             // Don't accept zero fee txns even if pool is empty as will never run
-            if (affordableGasPrice.IsZero)
+            if (affordableGasPrice.IsZero && !_headInfo.CurrentBaseFee.IsZero)
             {
                 Metrics.PendingTransactionsTooLowFee++;
                 if (isTrace) _logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, too low payable gas price with options {handlingOptions} from {new StackTrace()}");

--- a/src/Nethermind/Nethermind.TxPool/Filters/GapNonceFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/GapNonceFilter.cs
@@ -41,12 +41,11 @@ namespace Nethermind.TxPool.Filters
                 if (_logger.IsTrace)
                 {
                     _logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, nonce in future.");
-                    return AcceptTxResult.NonceGap.WithMessage($"Future nonce. Expected nonce: {nextNonceInOrder}");
                 }
-                else
-                {
-                    return AcceptTxResult.NonceGap;
-                }
+
+                return !isLocal ?
+                    AcceptTxResult.NonceGap :
+                    AcceptTxResult.NonceGap.WithMessage($"Future nonce. Expected nonce: {nextNonceInOrder}");
             }
 
             return AcceptTxResult.Accepted;

--- a/src/Nethermind/Nethermind.TxPool/Filters/GapNonceFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/GapNonceFilter.cs
@@ -39,8 +39,14 @@ namespace Nethermind.TxPool.Filters
             {
                 Metrics.PendingTransactionsNonceGap++;
                 if (_logger.IsTrace)
+                {
                     _logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, nonce in future.");
-                return AcceptTxResult.NonceGap.WithMessage($"Future nonce. Expected nonce: {nextNonceInOrder}");
+                    return AcceptTxResult.NonceGap.WithMessage($"Future nonce. Expected nonce: {nextNonceInOrder}");
+                }
+                else
+                {
+                    return AcceptTxResult.NonceGap.WithMessage("Future nonce. Not next in order");
+                }
             }
 
             return AcceptTxResult.Accepted;

--- a/src/Nethermind/Nethermind.TxPool/Filters/GapNonceFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/GapNonceFilter.cs
@@ -45,7 +45,7 @@ namespace Nethermind.TxPool.Filters
                 }
                 else
                 {
-                    return AcceptTxResult.NonceGap.WithMessage("Future nonce. Not next in order");
+                    return AcceptTxResult.NonceGap;
                 }
             }
 

--- a/src/Nethermind/Nethermind.TxPool/Filters/GapNonceFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/GapNonceFilter.cs
@@ -12,7 +12,7 @@ namespace Nethermind.TxPool.Filters
     /// Filters out transactions with nonces set too far in the future.
     /// Without this filter it would be possible to fill in TX pool with transactions that have low chance of being executed soon.
     /// </summary>
-    internal class GapNonceFilter : IIncomingTxFilter
+    internal sealed class GapNonceFilter : IIncomingTxFilter
     {
         private readonly TxDistinctSortedPool _txs;
         private readonly ILogger _logger;
@@ -25,13 +25,17 @@ namespace Nethermind.TxPool.Filters
 
         public AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions handlingOptions)
         {
-            bool isNotLocal = (handlingOptions & TxHandlingOptions.PersistentBroadcast) != TxHandlingOptions.PersistentBroadcast;
+            bool isLocal = (handlingOptions & TxHandlingOptions.PersistentBroadcast) != 0;
+            if (isLocal || !_txs.IsFull())
+            {
+                return AcceptTxResult.Accepted;
+            }
+
             int numberOfSenderTxsInPending = _txs.GetBucketCount(tx.SenderAddress!); // since unknownSenderFilter will run before this one
-            bool isTxPoolFull = _txs.IsFull();
             UInt256 currentNonce = state.SenderAccount.Nonce;
             long nextNonceInOrder = (long)currentNonce + numberOfSenderTxsInPending;
             bool isTxNonceNextInOrder = tx.Nonce <= nextNonceInOrder;
-            if (isNotLocal && isTxPoolFull && !isTxNonceNextInOrder)
+            if (!isTxNonceNextInOrder)
             {
                 Metrics.PendingTransactionsNonceGap++;
                 if (_logger.IsTrace)

--- a/src/Nethermind/Nethermind.TxPool/Filters/GasLimitTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/GasLimitTxFilter.cs
@@ -34,12 +34,12 @@ namespace Nethermind.TxPool.Filters
                 if (_logger.IsTrace)
                 {
                     _logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, gas limit exceeded.");
-                    return AcceptTxResult.GasLimitExceeded.WithMessage($"Gas limit: {gasLimit}, gas limit of rejected tx: {tx.GasLimit}");
                 }
-                else
-                {
-                    return AcceptTxResult.GasLimitExceeded;
-                }
+
+                bool isNotLocal = (handlingOptions & TxHandlingOptions.PersistentBroadcast) == 0;
+                return isNotLocal ?
+                    AcceptTxResult.GasLimitExceeded :
+                    AcceptTxResult.GasLimitExceeded.WithMessage($"Gas limit: {gasLimit}, gas limit of rejected tx: {tx.GasLimit}");
             }
 
             return AcceptTxResult.Accepted;

--- a/src/Nethermind/Nethermind.TxPool/Filters/GasLimitTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/GasLimitTxFilter.cs
@@ -10,7 +10,7 @@ namespace Nethermind.TxPool.Filters
     /// <summary>
     /// Ignores transactions that outright exceed block gas limit or configured max block gas limit.
     /// </summary>
-    internal class GasLimitTxFilter : IIncomingTxFilter
+    internal sealed class GasLimitTxFilter : IIncomingTxFilter
     {
         private readonly IChainHeadInfoProvider _chainHeadInfoProvider;
         private readonly ILogger _logger;
@@ -30,6 +30,8 @@ namespace Nethermind.TxPool.Filters
             if (tx.GasLimit > gasLimit)
             {
                 if (_logger.IsTrace) _logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, gas limit exceeded.");
+
+                Metrics.PendingTransactionsGasLimitTooHigh++;
                 return AcceptTxResult.GasLimitExceeded.WithMessage($"Gas limit: {gasLimit}, gas limit of rejected tx: {tx.GasLimit}");
             }
 

--- a/src/Nethermind/Nethermind.TxPool/Filters/GasLimitTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/GasLimitTxFilter.cs
@@ -29,10 +29,17 @@ namespace Nethermind.TxPool.Filters
             long gasLimit = Math.Min(_chainHeadInfoProvider.BlockGasLimit ?? long.MaxValue, _configuredGasLimit);
             if (tx.GasLimit > gasLimit)
             {
-                if (_logger.IsTrace) _logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, gas limit exceeded.");
-
                 Metrics.PendingTransactionsGasLimitTooHigh++;
-                return AcceptTxResult.GasLimitExceeded.WithMessage($"Gas limit: {gasLimit}, gas limit of rejected tx: {tx.GasLimit}");
+
+                if (_logger.IsTrace)
+                {
+                    _logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, gas limit exceeded.");
+                    return AcceptTxResult.GasLimitExceeded.WithMessage($"Gas limit: {gasLimit}, gas limit of rejected tx: {tx.GasLimit}");
+                }
+                else
+                {
+                    return AcceptTxResult.GasLimitExceeded;
+                }
             }
 
             return AcceptTxResult.Accepted;

--- a/src/Nethermind/Nethermind.TxPool/Filters/LowNonceFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/LowNonceFilter.cs
@@ -33,12 +33,12 @@ namespace Nethermind.TxPool.Filters
                 if (_logger.IsTrace)
                 {
                     _logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, nonce already used.");
-                    return AcceptTxResult.OldNonce.WithMessage($"Current nonce: {currentNonce}, nonce of rejected tx: {tx.Nonce}");
                 }
-                else
-                {
-                    return AcceptTxResult.OldNonce;
-                }
+
+                bool isNotLocal = (handlingOptions & TxHandlingOptions.PersistentBroadcast) == 0;
+                return isNotLocal ?
+                    AcceptTxResult.OldNonce :
+                    AcceptTxResult.OldNonce.WithMessage($"Current nonce: {currentNonce}, nonce of rejected tx: {tx.Nonce}");
             }
 
             return AcceptTxResult.Accepted;

--- a/src/Nethermind/Nethermind.TxPool/Filters/LowNonceFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/LowNonceFilter.cs
@@ -29,9 +29,16 @@ namespace Nethermind.TxPool.Filters
             UInt256 currentNonce = account.Nonce;
             if (tx.Nonce < currentNonce)
             {
-                if (_logger.IsTrace) _logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, nonce already used.");
                 Metrics.PendingTransactionsLowNonce++;
-                return AcceptTxResult.OldNonce.WithMessage($"Current nonce: {currentNonce}, nonce of rejected tx: {tx.Nonce}");
+                if (_logger.IsTrace)
+                {
+                    _logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, nonce already used.");
+                    return AcceptTxResult.OldNonce.WithMessage($"Current nonce: {currentNonce}, nonce of rejected tx: {tx.Nonce}");
+                }
+                else
+                {
+                    return AcceptTxResult.OldNonce;
+                }
             }
 
             return AcceptTxResult.Accepted;

--- a/src/Nethermind/Nethermind.TxPool/Filters/LowNonceFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/LowNonceFilter.cs
@@ -10,7 +10,7 @@ namespace Nethermind.TxPool.Filters
     /// <summary>
     /// Filters out transactions where nonce is lower than the current sender account nonce.
     /// </summary>
-    internal class LowNonceFilter : IIncomingTxFilter
+    internal sealed class LowNonceFilter : IIncomingTxFilter
     {
         private readonly ILogger _logger;
 
@@ -30,6 +30,7 @@ namespace Nethermind.TxPool.Filters
             if (tx.Nonce < currentNonce)
             {
                 if (_logger.IsTrace) _logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, nonce already used.");
+                Metrics.PendingTransactionsLowNonce++;
                 return AcceptTxResult.OldNonce.WithMessage($"Current nonce: {currentNonce}, nonce of rejected tx: {tx.Nonce}");
             }
 

--- a/src/Nethermind/Nethermind.TxPool/Filters/MalformedTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/MalformedTxFilter.cs
@@ -28,9 +28,9 @@ namespace Nethermind.TxPool.Filters
             IReleaseSpec spec = _specProvider.GetCurrentHeadSpec();
             if (!_txValidator.IsWellFormed(tx, spec))
             {
+                Metrics.PendingTransactionsMalformed++;
                 // It may happen that other nodes send us transactions that were signed for another chain or don't have enough gas.
                 if (_logger.IsTrace) _logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, invalid transaction.");
-                Metrics.PendingTransactionsMalformed++;
                 return AcceptTxResult.Invalid;
             }
 

--- a/src/Nethermind/Nethermind.TxPool/Filters/MalformedTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/MalformedTxFilter.cs
@@ -10,7 +10,7 @@ namespace Nethermind.TxPool.Filters
     /// <summary>
     /// Filters out transactions that are not well formed (not conforming with the yellowpaper and EIPs)
     /// </summary>
-    internal class MalformedTxFilter : IIncomingTxFilter
+    internal sealed class MalformedTxFilter : IIncomingTxFilter
     {
         private readonly ITxValidator _txValidator;
         private readonly IChainHeadSpecProvider _specProvider;
@@ -30,6 +30,7 @@ namespace Nethermind.TxPool.Filters
             {
                 // It may happen that other nodes send us transactions that were signed for another chain or don't have enough gas.
                 if (_logger.IsTrace) _logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, invalid transaction.");
+                Metrics.PendingTransactionsMalformed++;
                 return AcceptTxResult.Invalid;
             }
 

--- a/src/Nethermind/Nethermind.TxPool/Filters/NullHashTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/NullHashTxFilter.cs
@@ -10,7 +10,7 @@ namespace Nethermind.TxPool.Filters
     /// This generally should never happen as there should be no way for a transaction to be decoded
     /// without hash when coming from devp2p.
     /// </summary>
-    internal class NullHashTxFilter : IIncomingTxFilter
+    internal sealed class NullHashTxFilter : IIncomingTxFilter
     {
         public AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions handlingOptions)
         {

--- a/src/Nethermind/Nethermind.TxPool/Filters/NullHashTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/NullHashTxFilter.cs
@@ -16,7 +16,7 @@ namespace Nethermind.TxPool.Filters
         {
             if (tx.Hash is null)
             {
-                return AcceptTxResult.Invalid.WithMessage("transaction Hash is null");
+                return AcceptTxResult.Invalid;
             }
 
             return AcceptTxResult.Accepted;

--- a/src/Nethermind/Nethermind.TxPool/Filters/NullIncomingTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/NullIncomingTxFilter.cs
@@ -5,7 +5,7 @@ using Nethermind.Core;
 
 namespace Nethermind.TxPool.Filters
 {
-    public class NullIncomingTxFilter : IIncomingTxFilter
+    public sealed class NullIncomingTxFilter : IIncomingTxFilter
     {
         private NullIncomingTxFilter() { }
 

--- a/src/Nethermind/Nethermind.TxPool/Filters/UnknownSenderFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/UnknownSenderFilter.cs
@@ -33,9 +33,10 @@ namespace Nethermind.TxPool.Filters
                 tx.SenderAddress = _ecdsa.RecoverAddress(tx);
                 if (tx.SenderAddress is null)
                 {
+                    Metrics.PendingTransactionsUnresolvableSender++;
+
                     if (_logger.IsTrace) _logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, no sender.");
 
-                    Metrics.PendingTransactionsUnresolvableSender++;
                     return AcceptTxResult.FailedToResolveSender;
                 }
             }

--- a/src/Nethermind/Nethermind.TxPool/Filters/UnknownSenderFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/UnknownSenderFilter.cs
@@ -10,7 +10,7 @@ namespace Nethermind.TxPool.Filters
     /// <summary>
     /// Filters out transactions with the sender address not resolved properly.
     /// </summary>
-    internal class UnknownSenderFilter : IIncomingTxFilter
+    internal sealed class UnknownSenderFilter : IIncomingTxFilter
     {
         private readonly IEthereumEcdsa _ecdsa;
         private readonly ILogger _logger;
@@ -27,13 +27,15 @@ namespace Nethermind.TxPool.Filters
              * We need to investigate what these txs are and why the sender address is resolved to null.
              * Then we need to decide whether we really want to broadcast them.
              */
-            ++Metrics.PendingTransactionsWithExpensiveFiltering;
+            Metrics.PendingTransactionsWithExpensiveFiltering++;
             if (tx.SenderAddress is null)
             {
                 tx.SenderAddress = _ecdsa.RecoverAddress(tx);
                 if (tx.SenderAddress is null)
                 {
                     if (_logger.IsTrace) _logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, no sender.");
+
+                    Metrics.PendingTransactionsUnresolvableSender++;
                     return AcceptTxResult.FailedToResolveSender;
                 }
             }

--- a/src/Nethermind/Nethermind.TxPool/ITxPoolConfig.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxPoolConfig.cs
@@ -20,6 +20,11 @@ namespace Nethermind.TxPool
 
         [ConfigItem(DefaultValue = "null",
             Description = "Max transaction gas allowed.")]
+
         long? GasLimit { get; set; }
+
+        [ConfigItem(DefaultValue = "null",
+            Description = "Minutes between reporting on current state of tx pool.")]
+        int? ReportMinutes { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.TxPool/Metrics.cs
+++ b/src/Nethermind/Nethermind.TxPool/Metrics.cs
@@ -22,14 +22,35 @@ namespace Nethermind.TxPool
         [Description("Number of pending transactions received that were ignored because of not having preceding nonce of this sender in TxPool.")]
         public static long PendingTransactionsNonceGap { get; set; }
 
-        [Description("Number of pending transactions received that were ignored because of effective fee lower than the lowest effective fee in transaction pool.")]
+        [Description("Number of pending transactions received that were ignored because of fee lower than the lowest fee in transaction pool.")]
         public static long PendingTransactionsTooLowFee { get; set; }
+
+        [Description("Number of pending transactions received that were ignored because balance is zero and cannot pay gas.")]
+        public static long PendingTransactionsZeroBalance { get; set; }
+
+        [Description("Number of pending transactions received that were ignored because balance too low for fee to be higher than the lowest fee in transaction pool.")]
+        public static long PendingTransactionsTooLowBalance { get; set; }
+
+        [Description("Number of pending transactions received that were ignored because the sender couldn't be resolved.")]
+        public static long PendingTransactionsUnresolvableSender { get; set; }
+
+        [Description("Number of pending transactions received that were ignored because the gas limit was to high for the block.")]
+        public static long PendingTransactionsGasLimitTooHigh { get; set; }
+
+        [Description("Number of pending transactions received that were ignored after passing early rejections as balance is too low to compete with lowest effective fee in transaction pool.")]
+        public static long PendingTransactionsPassedFiltersButCannotCompeteOnFees { get; set; }
 
         [Description("Number of pending transactions that reached filters which are resource expensive")]
         public static long PendingTransactionsWithExpensiveFiltering { get; set; }
 
         [Description("Number of already known pending transactions.")]
         public static long PendingTransactionsKnown { get; set; }
+
+        [Description("Number of malformed transactions.")]
+        public static long PendingTransactionsMalformed { get; set; }
+
+        [Description("Number of transactions with already used nonce.")]
+        public static long PendingTransactionsLowNonce { get; set; }
 
         [Description("Number of pending transactions added to transaction pool.")]
         public static long PendingTransactionsAdded { get; set; }

--- a/src/Nethermind/Nethermind.TxPool/Metrics.cs
+++ b/src/Nethermind/Nethermind.TxPool/Metrics.cs
@@ -28,6 +28,9 @@ namespace Nethermind.TxPool
         [Description("Number of pending transactions received that were ignored because balance is zero and cannot pay gas.")]
         public static long PendingTransactionsZeroBalance { get; set; }
 
+        [Description("Number of pending transactions received that were ignored because balance is less than txn value.")]
+        public static long PendingTransactionsBalanceBelowValue { get; set; }
+
         [Description("Number of pending transactions received that were ignored because balance too low for fee to be higher than the lowest fee in transaction pool.")]
         public static long PendingTransactionsTooLowBalance { get; set; }
 

--- a/src/Nethermind/Nethermind.TxPool/TransactionExtensions.cs
+++ b/src/Nethermind/Nethermind.TxPool/TransactionExtensions.cs
@@ -11,6 +11,21 @@ namespace Nethermind.TxPool
 {
     internal static class TransactionExtensions
     {
+        public static UInt256 CalculateGasPrice(this Transaction tx, bool eip1559Enabled, in UInt256 baseFee)
+        {
+            if (eip1559Enabled && tx.IsEip1559)
+            {
+                if (tx.GasLimit > 0)
+                {
+                    return tx.CalculateEffectiveGasPrice(eip1559Enabled, baseFee);
+                }
+
+                return 0;
+            }
+
+            return tx.GasPrice;
+        }
+
         public static UInt256 CalculateAffordableGasPrice(this Transaction tx, bool eip1559Enabled, in UInt256 baseFee, in UInt256 balance)
         {
             if (eip1559Enabled && tx.IsEip1559)
@@ -33,7 +48,7 @@ namespace Nethermind.TxPool
                 return 0;
             }
 
-            return tx.GasPrice;
+            return balance <= tx.Value ? default : tx.GasPrice;
         }
     }
 }

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -104,10 +104,10 @@ namespace Nethermind.TxPool
             _headInfo.HeadChanged += OnHeadChange;
 
             _filterNullHashTx = new NullHashTxFilter();
-            _filterFeeTooLow = new FeeTooLowFilter(_headInfo, _transactions, _logger);
-            _filterAlreadyKnownTx = new AlreadyKnownTxFilter(_hashCache, _logger);
             _filterMalformedTx = new MalformedTxFilter(_specProvider, validator, _logger);
             _filterGasLimitTx = new GasLimitTxFilter(_headInfo, txPoolConfig, _logger);
+            _filterFeeTooLow = new FeeTooLowFilter(_headInfo, _transactions, _logger);
+            _filterAlreadyKnownTx = new AlreadyKnownTxFilter(_hashCache, _logger);
             _filterUnknownSender = new UnknownSenderFilter(ecdsa, _logger);
             _filterLowNonce = new LowNonceFilter(_logger); // has to be after UnknownSenderFilter as it uses sender
             _filterBalanceZero = new BalanceZeroFilter(_logger);
@@ -293,16 +293,16 @@ namespace Nethermind.TxPool
             AcceptTxResult accepted = _filterNullHashTx.Accept(tx, state, handlingOptions);
             if (!accepted) return accepted;
 
-            accepted = _filterFeeTooLow.Accept(tx, state, handlingOptions);
-            if (!accepted) return accepted;
-
-            accepted = _filterAlreadyKnownTx.Accept(tx, state, handlingOptions);
+            accepted = _filterGasLimitTx.Accept(tx, state, handlingOptions);
             if (!accepted) return accepted;
 
             accepted = _filterMalformedTx.Accept(tx, state, handlingOptions);
             if (!accepted) return accepted;
 
-            accepted = _filterGasLimitTx.Accept(tx, state, handlingOptions);
+            accepted = _filterFeeTooLow.Accept(tx, state, handlingOptions);
+            if (!accepted) return accepted;
+
+            accepted = _filterAlreadyKnownTx.Accept(tx, state, handlingOptions);
             if (!accepted) return accepted;
 
             accepted = _filterUnknownSender.Accept(tx, state, handlingOptions);
@@ -623,10 +623,10 @@ Sent
 Total Received:         {Metrics.PendingTransactionsReceived,18:0}
 ------------------------------------------
 Discarded at Filter Stage:        
-1.  Too Low Fee:        {Metrics.PendingTransactionsTooLowFee,18:0}
-2.  Duplicate:          {Metrics.PendingTransactionsKnown,18:0}
-3.  Malformed           {Metrics.PendingTransactionsMalformed,18:0}
-4.  GasLimitTooHigh:    {Metrics.PendingTransactionsGasLimitTooHigh,18:0}
+1.  Malformed           {Metrics.PendingTransactionsMalformed,18:0}
+2.  GasLimitTooHigh:    {Metrics.PendingTransactionsGasLimitTooHigh,18:0}
+3.  Too Low Fee:        {Metrics.PendingTransactionsTooLowFee,18:0}
+4.  Duplicate:          {Metrics.PendingTransactionsKnown,18:0}
 5.  Unknown Sender:     {Metrics.PendingTransactionsUnresolvableSender,18:0}
 6.  Nonce used:         {Metrics.PendingTransactionsLowNonce,18:0}
 7.  Zero Balance:       {Metrics.PendingTransactionsZeroBalance,18:0}

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -576,7 +576,7 @@ Total Received:         {Metrics.PendingTransactionsReceived,18:0}
 ------------------------------------------
 Discarded at Filter Stage:        
 1.  Too Low Fee:        {Metrics.PendingTransactionsTooLowFee,18:0}
-2.  Already Known:      {Metrics.PendingTransactionsKnown,18:0}
+2.  Duplicate:          {Metrics.PendingTransactionsKnown,18:0}
 3.  Malformed           {Metrics.PendingTransactionsMalformed,18:0}
 4.  GasLimitTooHigh:    {Metrics.PendingTransactionsGasLimitTooHigh,18:0}
 5.  Unknown Sender:     {Metrics.PendingTransactionsUnresolvableSender,18:0}

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -101,6 +100,7 @@ namespace Nethermind.TxPool
             _filterPipeline.Add(new GasLimitTxFilter(_headInfo, txPoolConfig, _logger));
             _filterPipeline.Add(new UnknownSenderFilter(ecdsa, _logger));
             _filterPipeline.Add(new LowNonceFilter(_logger)); // has to be after UnknownSenderFilter as it uses sender
+            _filterPipeline.Add(new BalanceZeroFilter(_logger));
             _filterPipeline.Add(new GapNonceFilter(_transactions, _logger));
             _filterPipeline.Add(new BalanceTooLowFilter(_transactions, _logger));
             if (incomingTxFilter is not null)
@@ -581,8 +581,8 @@ Discarded at Filter Stage:
 4.  GasLimitTooHigh:    {Metrics.PendingTransactionsGasLimitTooHigh,18:0}
 5.  Unknown Sender:     {Metrics.PendingTransactionsUnresolvableSender,18:0}
 6.  Nonce used:         {Metrics.PendingTransactionsLowNonce,18:0}
-7.  Nonces skipped:     {Metrics.PendingTransactionsNonceGap,18:0}
-8.  Zero Balance:       {Metrics.PendingTransactionsZeroBalance,18:0}
+7.  Zero Balance:       {Metrics.PendingTransactionsZeroBalance,18:0}
+8.  Nonces skipped:     {Metrics.PendingTransactionsNonceGap,18:0}
 9.  Balance Too Low:    {Metrics.PendingTransactionsTooLowBalance,18:0}
 10. Cannot Compete:     {Metrics.PendingTransactionsPassedFiltersButCannotCompeteOnFees,18:0}
 ------------------------------------------

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -96,8 +96,8 @@ namespace Nethermind.TxPool
             _preHashFilters = new IIncomingTxFilter[]
             {
                 new GasLimitTxFilter(_headInfo, txPoolConfig, _logger),
-                new MalformedTxFilter(_specProvider, validator, _logger),
-                new FeeTooLowFilter(_headInfo, _transactions, _logger)
+                new FeeTooLowFilter(_headInfo, _transactions, _logger),
+                new MalformedTxFilter(_specProvider, validator, _logger)
             };
 
             List<IIncomingTxFilter> postHashFilters = new()
@@ -625,8 +625,8 @@ Total Received:         {Metrics.PendingTransactionsReceived,24:N0}
 ------------------------------------------------
 Discarded at Filter Stage:        
 1.  GasLimitTooHigh:    {Metrics.PendingTransactionsGasLimitTooHigh,24:N0}
-2.  Malformed           {Metrics.PendingTransactionsMalformed,24:N0}
-3.  Too Low Fee:        {Metrics.PendingTransactionsTooLowFee,24:N0}
+2.  Too Low Fee:        {Metrics.PendingTransactionsTooLowFee,24:N0}
+3.  Malformed           {Metrics.PendingTransactionsMalformed,24:N0}
 4.  Duplicate:          {Metrics.PendingTransactionsKnown,24:N0}
 5.  Unknown Sender:     {Metrics.PendingTransactionsUnresolvableSender,24:N0}
 6.  Zero Balance:       {Metrics.PendingTransactionsZeroBalance,24:N0}

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -653,44 +653,45 @@ namespace Nethermind.TxPool
             if (float.IsNaN(receivedDiscarded)) receivedDiscarded = 0;
 
             logger.Info(@$"
-Txn Pool State ({Metrics.TransactionCount:0} txns queued)
-------------------------------------------
+Txn Pool State ({Metrics.TransactionCount:N0} txns queued)
+------------------------------------------------
 Sent
-* Transactions:         {Metrics.PendingTransactionsSent,18:0}
-* Hashes:               {Metrics.PendingTransactionsHashesSent,18:0}
-------------------------------------------
-Total Received:         {Metrics.PendingTransactionsReceived,18:0}
-------------------------------------------
+* Transactions:         {Metrics.PendingTransactionsSent,24:N0}
+* Hashes:               {Metrics.PendingTransactionsHashesSent,24:N0}
+------------------------------------------------
+Total Received:         {Metrics.PendingTransactionsReceived,24:N0}
+------------------------------------------------
 Discarded at Filter Stage:        
-1.  GasLimitTooHigh:    {Metrics.PendingTransactionsGasLimitTooHigh,18:0}
-2.  Malformed           {Metrics.PendingTransactionsMalformed,18:0}
-3.  Too Low Fee:        {Metrics.PendingTransactionsTooLowFee,18:0}
-4.  Duplicate:          {Metrics.PendingTransactionsKnown,18:0}
-5.  Unknown Sender:     {Metrics.PendingTransactionsUnresolvableSender,18:0}
-6.  Zero Balance:       {Metrics.PendingTransactionsZeroBalance,18:0}
-7.  Balance < tx.value: {Metrics.PendingTransactionsBalanceBelowValue,18:0}
-8.  Nonce used:         {Metrics.PendingTransactionsLowNonce,18:0}
-9.  Nonces skipped:     {Metrics.PendingTransactionsNonceGap,18:0}
-10. Balance Too Low:    {Metrics.PendingTransactionsTooLowBalance,18:0}
-11. Cannot Compete:     {Metrics.PendingTransactionsPassedFiltersButCannotCompeteOnFees,18:0}
-------------------------------------------
-Validated via State:    {Metrics.PendingTransactionsWithExpensiveFiltering,18:0}
-------------------------------------------
-Total Discarded:        {Metrics.PendingTransactionsDiscarded,18:0}
+1.  GasLimitTooHigh:    {Metrics.PendingTransactionsGasLimitTooHigh,24:N0}
+2.  Malformed           {Metrics.PendingTransactionsMalformed,24:N0}
+3.  Too Low Fee:        {Metrics.PendingTransactionsTooLowFee,24:N0}
+4.  Duplicate:          {Metrics.PendingTransactionsKnown,24:N0}
+5.  Unknown Sender:     {Metrics.PendingTransactionsUnresolvableSender,24:N0}
+6.  Zero Balance:       {Metrics.PendingTransactionsZeroBalance,24:N0}
+7.  Balance < tx.value: {Metrics.PendingTransactionsBalanceBelowValue,24:N0}
+8.  Nonce used:         {Metrics.PendingTransactionsLowNonce,24:N0}
+9.  Nonces skipped:     {Metrics.PendingTransactionsNonceGap,24:N0}
+10. Balance Too Low:    {Metrics.PendingTransactionsTooLowBalance,24:N0}
+11. Cannot Compete:     {Metrics.PendingTransactionsPassedFiltersButCannotCompeteOnFees,24:N0}
+------------------------------------------------
+Validated via State:    {Metrics.PendingTransactionsWithExpensiveFiltering,24:N0}
+------------------------------------------------
+Total Discarded:        {Metrics.PendingTransactionsDiscarded,24:N0}
+------------------------------------------------
+Discard Ratios:
+* Pre-state Discards:   {preStateDiscards,24:P5}
+* Received Discarded:   {receivedDiscarded,24:P5}
+------------------------------------------------
+Total Added:            {Metrics.PendingTransactionsAdded,24:N0}
+* Eip1559 Added:        {Metrics.Pending1559TransactionsAdded,24:N0}
+------------------------------------------------
+Total Evicted:          {Metrics.PendingTransactionsEvicted,24:N0}
+------------------------------------------------
 Ratios:
-* Pre-state Discards:   {preStateDiscards,18:P5}
-* Received Discarded:   {receivedDiscarded,18:P5}
-------------------------------------------
-Total Added:            {Metrics.PendingTransactionsAdded,18:0}
-* Eip1559 Added:        {Metrics.Pending1559TransactionsAdded,18:0}
-------------------------------------------
-Total Evicted:          {Metrics.PendingTransactionsEvicted,18:0}
-------------------------------------------
-Ratios:
-* Eip1559 Transactions: {Metrics.Eip1559TransactionsRatio,18:P5}
-* DarkPool Level1:      {Metrics.DarkPoolRatioLevel1,18:P5}
-* DarkPool Level2:      {Metrics.DarkPoolRatioLevel2,18:P5}
-------------------------------------------
+* Eip1559 Transactions: {Metrics.Eip1559TransactionsRatio,24:P5}
+* DarkPool Level1:      {Metrics.DarkPoolRatioLevel1,24:P5}
+* DarkPool Level2:      {Metrics.DarkPoolRatioLevel2,24:P5}
+------------------------------------------------
 ");
         }
     }

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -630,9 +630,10 @@ Discarded at Filter Stage:
 5.  Unknown Sender:     {Metrics.PendingTransactionsUnresolvableSender,18:0}
 6.  Nonce used:         {Metrics.PendingTransactionsLowNonce,18:0}
 7.  Zero Balance:       {Metrics.PendingTransactionsZeroBalance,18:0}
-8.  Nonces skipped:     {Metrics.PendingTransactionsNonceGap,18:0}
-9.  Balance Too Low:    {Metrics.PendingTransactionsTooLowBalance,18:0}
-10. Cannot Compete:     {Metrics.PendingTransactionsPassedFiltersButCannotCompeteOnFees,18:0}
+8.  Balance < tx.value: {Metrics.PendingTransactionsBalanceBelowValue,18:0}
+9.  Nonces skipped:     {Metrics.PendingTransactionsNonceGap,18:0}
+10. Balance Too Low:    {Metrics.PendingTransactionsTooLowBalance,18:0}
+11. Cannot Compete:     {Metrics.PendingTransactionsPassedFiltersButCannotCompeteOnFees,18:0}
 ------------------------------------------
 Validated via State:    {Metrics.PendingTransactionsWithExpensiveFiltering,18:0}
 ------------------------------------------

--- a/src/Nethermind/Nethermind.TxPool/TxPoolConfig.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPoolConfig.cs
@@ -9,5 +9,6 @@ namespace Nethermind.TxPool
         public int Size { get; set; } = 2048;
         public int HashCacheSize { get; set; } = 512 * 1024;
         public long? GasLimit { get; set; } = null;
+        public int? ReportMinutes { get; set; } = null;
     }
 }


### PR DESCRIPTION
Resolves #4793

Updated #5158 rebased on `Refactor tx filtering` #5281 (main branch)

## Changes

* Changes `FeeTooLowFilter` for `BalanceTooLowFilter`
* Early accept on local or non-full txn pool prior to checking state
* Introduces `FeeTooLowFilter` early which just considers gas fee without accessing state
* Reject transactions with zero balance before checking txns
* Introduce new metric `PendingTransactionsUnresolvableSender`
* Introduce new metric `PendingTransactionsGasLimitTooHigh`
* Introduce new metric `Metrics.PendingTransactionsZeroBalance`
* Introduce new metric `PendingTransactionsTooLowBalance`
* Introduce new metric `PendingTransactionsPassedFiltersButCannotCompeteOnFees`
* Introduce new metric `PendingTransactionsMalformed`
* Introduce new metric `PendingTransactionsLowNonce`
* Add info report on txPool behind config
  `  "TxPool": {
    "ReportMinutes": 1
  }` 

## Types of changes

Stronger tx filtering
```
Txn Pool State (2,048 txns queued)
------------------------------------------------
Sent
* Transactions:                                0
* Hashes:                             12,361,372
------------------------------------------------
Total Received:                          587,284
------------------------------------------------
Discarded at Filter Stage:
1.  GasLimitTooHigh:                           2
2.  Too Low Fee:                         215,506
3.  Malformed                              1,927
4.  Duplicate:                           144,440
5.  Unknown Sender:                            0
6.  Zero Balance:                         14,598
7.  Balance < tx.value:                   27,516
8.  Nonce used:                           45,532
9.  Nonces skipped:                       40,029
10. Balance Too Low:                      20,674
11. Cannot Compete:                          523
------------------------------------------------
Validated via State:                     225,409
------------------------------------------------
Total Discarded:                         510,224
------------------------------------------------
Discard Ratios:
* Pre-state Discards:                  70.54706%
* Received Discarded:                  86.87858%
------------------------------------------------
Total Added:                              76,537
* Eip1559 Added:                          46,851
------------------------------------------------
Total Evicted:                            49,652
------------------------------------------------
Ratios:
* Eip1559 Transactions:                88.88889%
* DarkPool Level1:                      1.48148%
* DarkPool Level2:                      1.48148%
------------------------------------------------
```

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes - changed existing tests
- [ ] No
