### PR TITLE
Don't disconnect peers on fast sync criteria

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerPoolTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerPoolTests.cs
@@ -169,16 +169,6 @@ namespace Nethermind.Synchronization.Test
             }
         }
 
-        [Test]
-        public async Task Will_disconnect_one_when_at_max()
-        {
-            await using Context ctx = new();
-            var peers = await SetupPeers(ctx, 25);
-            await WaitForPeersInitialization(ctx);
-            ctx.Pool.DropUselessPeers(true);
-            Assert.True(peers.Any(p => p.DisconnectRequested));
-        }
-
         [TestCase(true, false)]
         [TestCase(false, true)]
         public async Task Will_disconnect_when_refresh_exception_is_not_cancelled(bool isExceptionOperationCanceled, bool isDisconnectRequested)
@@ -190,48 +180,6 @@ namespace Nethermind.Synchronization.Test
             var refreshException = isExceptionOperationCanceled ? new OperationCanceledException() : new Exception();
             ctx.Pool.ReportRefreshFailed(peer, "test with cancellation", refreshException);
             peer.DisconnectRequested.Should().Be(isDisconnectRequested);
-        }
-
-        [TestCase(0)]
-        [TestCase(10)]
-        [TestCase(24)]
-        public async Task Will_not_disconnect_any_priority_peer_if_their_amount_is_lower_than_max(byte number)
-        {
-            const int peersMaxCount = 25;
-            const int priorityPeersMaxCount = 25;
-            await using Context ctx = new();
-            ctx.Pool = new SyncPeerPool(ctx.BlockTree, ctx.Stats, ctx.PeerStrategy, peersMaxCount, priorityPeersMaxCount, 50, LimboLogs.Instance);
-            var peers = await SetupPeers(ctx, peersMaxCount);
-
-            // setting priority to all peers except one - peers[number]
-            for (int i = 0; i < priorityPeersMaxCount; i++)
-            {
-                if (i != number)
-                {
-                    ctx.Pool.SetPeerPriority(peers[i].Id);
-                }
-            }
-            await WaitForPeersInitialization(ctx);
-            ctx.Pool.DropUselessPeers(true);
-            Assert.True(peers[number].DisconnectRequested);
-        }
-
-        [Test]
-        public async Task Can_disconnect_priority_peer_if_their_amount_is_max()
-        {
-            const int peersMaxCount = 25;
-            const int priorityPeersMaxCount = 25;
-            await using Context ctx = new();
-            ctx.Pool = new SyncPeerPool(ctx.BlockTree, ctx.Stats, ctx.PeerStrategy, peersMaxCount, priorityPeersMaxCount, 50, LimboLogs.Instance);
-            var peers = await SetupPeers(ctx, peersMaxCount);
-
-            foreach (SimpleSyncPeerMock peer in peers)
-            {
-                ctx.Pool.SetPeerPriority(peer.Id);
-            }
-            await WaitForPeersInitialization(ctx);
-            ctx.Pool.DropUselessPeers(true);
-            Assert.True(peers.Any(p => p.DisconnectRequested));
         }
 
         [Test]


### PR DESCRIPTION
## Changes

- Stop disconnecting peers based on fast sync criteria
- This should go after #5172 in order for us not to have useless peers

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Should be tested on actual networks