### PR TITLE
Remove 14MB from RunPeerCommit allocations

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Visitors/StartupTreeFixerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Visitors/StartupTreeFixerTests.cs
@@ -87,7 +87,7 @@ namespace Nethermind.Blockchain.Test.Visitors
             tree.BestKnownNumber.Should().Be(2);
         }
 
-
+        [Retry(3)]
         [Timeout(Timeout.MaxTestTime * 4)]
         [TestCase(0)]
         [TestCase(1)]

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncPeersReportTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncPeersReportTests.cs
@@ -161,10 +161,10 @@ namespace Nethermind.Synchronization.Test
             syncPeerPool.AllPeers.Returns(peers);
 
             string expectedResult =
-                "== Header ==\n" +
-                "===[Active][Sleep ][Peer(ProtocolVersion/Head/Host:Port/Direction)][Transfer Speeds (L/H/B/R/N/S)      ][Client Info (Name/Version/Operating System/Language)     ]\n" +
-                "--------------------------------------------------------------------------------------------------------------------------------------------------------------\n" +
-                "   [HBRNSW][      ][Peer|eth99|    9999|      127.0.0.1: 3030| Out][     |     |     |     |     |     ][]\n" +
+                "== Header ==" + Environment.NewLine +
+                "===[Active][Sleep ][Peer(ProtocolVersion/Head/Host:Port/Direction)][Transfer Speeds (L/H/B/R/N/S)      ][Client Info (Name/Version/Operating System/Language)     ]" + Environment.NewLine +
+                "--------------------------------------------------------------------------------------------------------------------------------------------------------------" + Environment.NewLine +
+                "   [HBRNSW][      ][Peer|eth99|    9999|      127.0.0.1: 3030| Out][     |     |     |     |     |     ][]" + Environment.NewLine +
                 "   [      ][HBRNSW][Peer|eth99|    9999|      127.0.0.1: 3030|  In][     |     |     |     |     |     ][]";
 
             SyncPeersReport report = new(syncPeerPool, Substitute.For<INodeStatsManager>(), NoErrorLimboLogs.Instance);


### PR DESCRIPTION
Rebased #5271 as was having issues with github 🤔

## Changes

- Only full refresh and parse from DB when nodes change
- Don't allocate fresh node prior to checking if node already exists (compare prior rather then post)
- Reduces by about ~10MB/min (see trace below)

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

<img width="859" alt="image" src="https://user-images.githubusercontent.com/1142958/218250658-ddcd0c0a-50f5-4c60-ad97-b2be05fe371b.png">
