### PR TITLE
Support subscriptions in Geth-compatible form

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
@@ -239,7 +239,7 @@ namespace Nethermind.JsonRpc.Test.Modules
         [TestCase("True")]
         [TestCase("false")]
         [TestCase("False")]
-        public void NewHeadSubscription_with_includeTransactions_arg_just_bool(string boolArg)
+        public void NewHeadSubscription_with_bool_arg(string boolArg)
         {
             string serialized = RpcTest.TestSerializedRequest(_subscribeRpcModule, "eth_subscribe", "newHeads", boolArg);
             var expectedResult = string.Concat("{\"jsonrpc\":\"2.0\",\"result\":\"", serialized.Substring(serialized.Length - 44, 34), "\",\"id\":67}");
@@ -738,7 +738,7 @@ namespace Nethermind.JsonRpc.Test.Modules
         }
 
         [Test]
-        public void NewPendingTransactionsSubscription_creating_result_with_arg()
+        public void NewPendingTransactionsSubscription_creating_result_with_includeTransactions_arg()
         {
             string serialized = RpcTest.TestSerializedRequest(_subscribeRpcModule, "eth_subscribe", "newPendingTransactions", "{\"includeTransactions\":true}");
             var expectedResult = string.Concat("{\"jsonrpc\":\"2.0\",\"result\":\"", serialized.Substring(serialized.Length - 44, 34), "\",\"id\":67}");

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
@@ -235,6 +235,17 @@ namespace Nethermind.JsonRpc.Test.Modules
             expectedResult.Should().Be(serialized);
         }
 
+        [TestCase("true")]
+        [TestCase("True")]
+        [TestCase("false")]
+        [TestCase("False")]
+        public void NewHeadSubscription_with_includeTransactions_arg_just_bool(string boolArg)
+        {
+            string serialized = RpcTest.TestSerializedRequest(_subscribeRpcModule, "eth_subscribe", "newHeads", boolArg);
+            var expectedResult = string.Concat("{\"jsonrpc\":\"2.0\",\"result\":\"", serialized.Substring(serialized.Length - 44, 34), "\",\"id\":67}");
+            expectedResult.Should().Be(serialized);
+        }
+
         [Test]
         public void NewHeadSubscription_on_BlockAddedToMain_event2()
         {
@@ -722,6 +733,25 @@ namespace Nethermind.JsonRpc.Test.Modules
         public void NewPendingTransactionsSubscription_creating_result()
         {
             string serialized = RpcTest.TestSerializedRequest(_subscribeRpcModule, "eth_subscribe", "newPendingTransactions");
+            var expectedResult = string.Concat("{\"jsonrpc\":\"2.0\",\"result\":\"", serialized.Substring(serialized.Length - 44, 34), "\",\"id\":67}");
+            expectedResult.Should().Be(serialized);
+        }
+
+        [Test]
+        public void NewPendingTransactionsSubscription_creating_result_with_arg()
+        {
+            string serialized = RpcTest.TestSerializedRequest(_subscribeRpcModule, "eth_subscribe", "newPendingTransactions", "{\"includeTransactions\":true}");
+            var expectedResult = string.Concat("{\"jsonrpc\":\"2.0\",\"result\":\"", serialized.Substring(serialized.Length - 44, 34), "\",\"id\":67}");
+            expectedResult.Should().Be(serialized);
+        }
+
+        [TestCase("true")]
+        [TestCase("True")]
+        [TestCase("false")]
+        [TestCase("False")]
+        public void NewPendingTransactionsSubscription_creating_result_with_bool_arg(string boolArg)
+        {
+            string serialized = RpcTest.TestSerializedRequest(_subscribeRpcModule, "eth_subscribe", "newPendingTransactions", boolArg);
             var expectedResult = string.Concat("{\"jsonrpc\":\"2.0\",\"result\":\"", serialized.Substring(serialized.Length - 44, 34), "\",\"id\":67}");
             expectedResult.Should().Be(serialized);
         }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/TransactionsOption.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/TransactionsOption.cs
@@ -12,8 +12,15 @@ public class TransactionsOption : IJsonRpcParam
 
     public void ReadJson(JsonSerializer serializer, string jsonValue)
     {
-        JObject jObject = serializer.Deserialize<JObject>(jsonValue.ToJsonTextReader());
-        IncludeTransactions = GetIncludeTransactions(jObject["includeTransactions"]);
+        if (jsonValue.ToLower().Equals("true") || jsonValue.ToLower().Equals("false"))
+        {
+            IncludeTransactions = jsonValue.ToLower().Equals("true");
+        }
+        else
+        {
+            JObject jObject = serializer.Deserialize<JObject>(jsonValue.ToJsonTextReader());
+            IncludeTransactions = GetIncludeTransactions(jObject["includeTransactions"]);
+        }
     }
 
     private static bool GetIncludeTransactions(JToken? token) => token switch


### PR DESCRIPTION
## Changes

- allow bool args in `newPendingTransactions` and `newHeads` subscriptions to be compatible with geth:
https://github.com/ethereum/go-ethereum/pull/25186/files#diff-bbe984989be76dbc39ff9214d3a13800c4f876328ca26e98242db6e6774b3761

Newly supported:
`{"method":"eth_subscribe","params":["newPendingTransactions",true],"id":1,"jsonrpc":"2.0"}`
`{"method":"eth_subscribe","params":["newPendingTransactions",false],"id":1,"jsonrpc":"2.0"}`

Old-shape, still supported:
`{"method":"eth_subscribe","params":["newPendingTransactions"],"id":1,"jsonrpc":"2.0"}`
`{"method":"eth_subscribe","params":["newPendingTransactions",{"includeTransactions":true}],"id":1,"jsonrpc":"2.0"}`
`{"method":"eth_subscribe","params":["newPendingTransactions",{"includeTransactions":false}],"id":1,"jsonrpc":"2.0"}`

I tested enabling subscriptions with both, bool arg and old-shaped filter.
**I haven't tested subscribed events and their compatibility with Geth, so functionalities introduced earlier:**
https://github.com/NethermindEth/nethermind/pull/3686

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No