### PR TITLE
Release non-null empty spans

### DIFF
--- a/src/Nethermind/Nethermind.Core/Extensions/SpanExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/SpanExtensions.cs
@@ -111,7 +111,7 @@ namespace Nethermind.Core.Extensions
 
             return result;
         }
-        
+
         public static bool IsNullOrEmpty<T>(this in Span<T> span) => span.Length == 0;
         public static bool IsNull<T>(this in Span<T> span) => Unsafe.IsNullRef(ref MemoryMarshal.GetReference(span));
     }

--- a/src/Nethermind/Nethermind.Core/Extensions/SpanExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/SpanExtensions.cs
@@ -111,7 +111,8 @@ namespace Nethermind.Core.Extensions
 
             return result;
         }
-
-        public static bool IsNullOrEmpty<T>(this in Span<T> span) => span == null || span.Length == 0;
+        
+        public static bool IsNullOrEmpty<T>(this in Span<T> span) => span.Length == 0;
+        public static bool IsNull<T>(this in Span<T> span) => Unsafe.IsNullRef(ref MemoryMarshal.GetReference(span));
     }
 }

--- a/src/Nethermind/Nethermind.Db.Rocks/RocksDbExtensions.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/RocksDbExtensions.cs
@@ -38,7 +38,7 @@ internal static class RocksDbExtensions
             throw new RocksDbException(error);
 
         if (result == IntPtr.Zero)
-            return null;
+            return default;
 
         var span = new Span<byte>((void*)result, (int)valueLength);
 

--- a/src/Nethermind/Nethermind.Db/DbExtensions.cs
+++ b/src/Nethermind/Nethermind.Db/DbExtensions.cs
@@ -131,8 +131,13 @@ namespace Nethermind.Db
                 if (db is IDbWithSpan spanDb && decoder is IRlpValueDecoder<TItem> valueDecoder)
                 {
                     Span<byte> data = spanDb.GetSpan(key);
-                    if (data.IsNullOrEmpty())
+                    if (data.IsNull())
                     {
+                        return null;
+                    }
+                    else if (data.Length == 0)
+                    {
+                        spanDb.DangerousReleaseMemory(data);
                         return null;
                     }
 
@@ -174,8 +179,13 @@ namespace Nethermind.Db
                 if (db is IDbWithSpan spanDb && decoder is IRlpValueDecoder<TItem> valueDecoder)
                 {
                     Span<byte> data = spanDb.GetSpan(key);
-                    if (data.IsNullOrEmpty())
+                    if (data.IsNull())
                     {
+                        return null;
+                    }
+                    else if (data.Length == 0)
+                    {
+                        spanDb.DangerousReleaseMemory(data);
                         return null;
                     }
 

--- a/src/Nethermind/Nethermind.Db/DbExtensions.cs
+++ b/src/Nethermind/Nethermind.Db/DbExtensions.cs
@@ -135,14 +135,14 @@ namespace Nethermind.Db
                     {
                         return null;
                     }
-                    else if (data.Length == 0)
-                    {
-                        spanDb.DangerousReleaseMemory(data);
-                        return null;
-                    }
 
                     try
                     {
+                        if (data.Length == 0)
+                        {
+                            return null;
+                        }
+
                         var rlpValueContext = data.AsRlpValueContext();
                         item = valueDecoder.Decode(ref rlpValueContext, RlpBehaviors.AllowExtraBytes);
                     }
@@ -183,14 +183,14 @@ namespace Nethermind.Db
                     {
                         return null;
                     }
-                    else if (data.Length == 0)
-                    {
-                        spanDb.DangerousReleaseMemory(data);
-                        return null;
-                    }
 
                     try
                     {
+                        if (data.Length == 0)
+                        {
+                            return null;
+                        }
+
                         var rlpValueContext = data.AsRlpValueContext();
                         item = valueDecoder.Decode(ref rlpValueContext, RlpBehaviors.AllowExtraBytes);
                     }


### PR DESCRIPTION
## Changes

- RocksDb *may* return a non-null empty item, deallocate also when pointer is not null
- Not sure if this is actually an issue (does it always return `null` for zero length items?), so just for completeness

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

_Optional. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
