### PR TITLE
Remove 28MB of permanent allocations from SyncStatusList (32MB -> 8MB)

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/SyncStatusListTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/SyncStatusListTests.cs
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+
+using DotNetty.Codecs;
+
+using Nethermind.Synchronization.FastBlocks;
+using NUnit.Framework;
+
+namespace Nethermind.Synchronization.Test.FastBlocks
+{
+    [Parallelizable(ParallelScope.Self)]
+    [TestFixture]
+    public class SyncStatusListTests
+    {
+        [Test]
+        public void Out_of_range_access_throws()
+        {
+            FastBlockStatusList list = new(1);
+
+            FastBlockStatus a = list[0];
+            list[0] = a;
+
+            Assert.Throws<IndexOutOfRangeException>(() => { FastBlockStatus a = list[-1]; });
+            Assert.Throws<IndexOutOfRangeException>(() => { FastBlockStatus a = list[1]; });
+            Assert.Throws<IndexOutOfRangeException>(() => { list[-1] = FastBlockStatus.Unknown; });
+            Assert.Throws<IndexOutOfRangeException>(() => { list[1] = FastBlockStatus.Unknown; });
+        }
+
+        [Test]
+        public void Can_read_back_all_set_values()
+        {
+            const long length = 500;
+
+            FastBlockStatusList list = new(length);
+            for (int i = 0; i < length; i++)
+            {
+                list[i] = (FastBlockStatus)(i % 3);
+            }
+            for (int i = 0; i < length; i++)
+            {
+                Assert.IsTrue((FastBlockStatus)(i % 3) == list[i]);
+            }
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastBlockStatus.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastBlockStatus.cs
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.Synchronization.FastBlocks;
+
+internal enum FastBlockStatus : byte
+{
+    Unknown = 0,
+    Sent = 1,
+    Inserted = 2,
+}

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastBlockStatusList.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastBlockStatusList.cs
@@ -59,10 +59,3 @@ internal class FastBlockStatusList
         throw new IndexOutOfRangeException();
     }
 }
-
-internal enum FastBlockStatus : byte
-{
-    Unknown = 0,
-    Sent = 1,
-    Inserted = 2,
-}

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastBlockStatusList.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastBlockStatusList.cs
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Nethermind.Synchronization.Test")]
+namespace Nethermind.Synchronization.FastBlocks;
+
+internal class FastBlockStatusList
+{
+    private readonly byte[] _statuses;
+    private readonly long _length;
+
+    public FastBlockStatusList(long length)
+    {
+        // Can fit 4 statuses per byte, however need to round up the division
+        long size = length / 4;
+        if (size * 4 < length)
+        {
+            size++;
+        }
+
+        _statuses = new byte[size];
+        _length = length;
+    }
+
+    public FastBlockStatus this[long index]
+    {
+        get
+        {
+            if ((ulong)index >= (ulong)_length)
+            {
+                ThrowIndexOutOfRange();
+            }
+
+            (long q, long r) = Math.DivRem(index, 4);
+
+            byte status = _statuses[q];
+            return (FastBlockStatus)((status >> (int)(r * 2)) & 0b11);
+        }
+        set
+        {
+            if ((ulong)index >= (ulong)_length)
+            {
+                ThrowIndexOutOfRange();
+            }
+
+            (long q, long r) = Math.DivRem(index, 4);
+            r *= 2;
+
+            ref byte status = ref _statuses[q];
+            status = (byte)((status & ~(0b11 << (int)r)) | ((int)value << (int)r));
+        }
+    }
+
+    private static void ThrowIndexOutOfRange()
+    {
+        throw new IndexOutOfRangeException();
+    }
+}
+
+internal enum FastBlockStatus : byte
+{
+    Unknown = 0,
+    Sent = 1,
+    Inserted = 2,
+}

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/SyncStatusList.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/SyncStatusList.cs
@@ -12,7 +12,7 @@ namespace Nethermind.Synchronization.FastBlocks
     {
         private long _queueSize;
         private readonly IBlockTree _blockTree;
-        private readonly FastBlockStatus[] _statuses;
+        private readonly FastBlockStatusList _statuses;
 
         public long LowestInsertWithoutGaps { get; private set; }
         public long QueueSize => _queueSize;
@@ -20,7 +20,7 @@ namespace Nethermind.Synchronization.FastBlocks
         public SyncStatusList(IBlockTree blockTree, long pivotNumber, long? lowestInserted)
         {
             _blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
-            _statuses = new FastBlockStatus[pivotNumber + 1];
+            _statuses = new FastBlockStatusList(pivotNumber + 1);
 
             LowestInsertWithoutGaps = lowestInserted ?? pivotNumber;
         }
@@ -81,13 +81,6 @@ namespace Nethermind.Synchronization.FastBlocks
             {
                 _statuses[blockNumber] = FastBlockStatus.Unknown;
             }
-        }
-
-        private enum FastBlockStatus : byte
-        {
-            Unknown = 0,
-            Sent = 1,
-            Inserted = 2,
         }
     }
 }


### PR DESCRIPTION
## Changes

- Pack 4 x `FastBlockStatus` per byte rather than 1, saving ~24MB in total from `ReceiptsSyncFeed` and `BodiesSyncFeed` combined

<img width="565" alt="image" src="https://user-images.githubusercontent.com/1142958/219825221-e57e29fc-6a92-4a04-98f0-eb6e0aa0893a.png">

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
