### PR TITLE
Remove 15MB of string allocations in SimpleDb.LoadData

### DIFF
--- a/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
@@ -854,6 +854,19 @@ namespace Nethermind.Core.Extensions
         }
 
         [DebuggerStepThrough]
+        public static byte[] FromUtf8HexString(ReadOnlySpan<byte> hexString)
+        {
+            if (hexString.Length == 0)
+            {
+                return Array.Empty<byte>();
+            }
+
+            int oddMod = hexString.Length % 2;
+            byte[] result = GC.AllocateUninitializedArray<byte>((hexString.Length >> 1) + oddMod);
+            return HexConverter.TryDecodeFromUtf8(hexString, result, oddMod == 1) ? result : throw new FormatException("Incorrect hex string");
+        }
+
+        [DebuggerStepThrough]
         public static byte[] FromHexString(string hexString)
         {
             if (hexString is null)

--- a/src/Nethermind/Nethermind.Db/SimpleFilePublicKeyDb.cs
+++ b/src/Nethermind/Nethermind.Db/SimpleFilePublicKeyDb.cs
@@ -13,7 +13,6 @@ using Microsoft.Win32.SafeHandles;
 
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
-using Nethermind.Db;
 using Nethermind.Logging;
 
 namespace Nethermind.Db

--- a/src/Nethermind/Nethermind.Db/SimpleFilePublicKeyDb.cs
+++ b/src/Nethermind/Nethermind.Db/SimpleFilePublicKeyDb.cs
@@ -2,10 +2,15 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Buffers;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
+
+using Microsoft.Win32.SafeHandles;
+
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
 using Nethermind.Db;
@@ -175,6 +180,8 @@ namespace Nethermind.Db
 
         private void LoadData()
         {
+            const int maxLineLength = 2048;
+
             _cache = new ConcurrentDictionary<byte[], byte[]>(Bytes.EqualityComparer);
 
             if (!File.Exists(DbPath))
@@ -182,17 +189,88 @@ namespace Nethermind.Db
                 return;
             }
 
-            string[] lines = File.ReadAllLines(DbPath);
-            foreach (string line in lines)
+            using SafeFileHandle fileHandle = File.OpenHandle(DbPath, FileMode.OpenOrCreate);
+
+            byte[] rentedBuffer = ArrayPool<byte>.Shared.Rent(maxLineLength);
+            int read = RandomAccess.Read(fileHandle, rentedBuffer, 0);
+
+            long offset = 0L;
+            Span<byte> bytes = default;
+            while (read > 0)
             {
-                string[] values = line.Split(",");
-                if (values.Length != 2)
+                offset += read;
+                bytes = rentedBuffer.AsSpan(0, read + bytes.Length);
+                while (true)
                 {
-                    if (_logger.IsError) _logger.Error($"Error when loading data from {Name} - expected two items separated by a comma and got '{line}')");
-                    continue;
+                    // Store the original span incase need to undo the key slicing if end of line not found
+                    Span<byte> iterationSpan = bytes;
+                    int commaIndex = bytes.IndexOf((byte)',');
+                    Span<byte> key = default;
+                    if (commaIndex >= 0)
+                    {
+                        key = bytes[..commaIndex];
+                        bytes = bytes[(commaIndex + 1)..];
+                    }
+                    int lineEndIndex = bytes.IndexOf((byte)'\n');
+                    if (lineEndIndex < 0)
+                    {
+                        // Restore the iteration start span
+                        bytes = iterationSpan;
+                        break;
+                    }
+
+                    Span<byte> value;
+                    if (bytes[lineEndIndex - 1] == (byte)'\r')
+                    {
+                        // Windows \r\n
+                        value = bytes[..(lineEndIndex - 1)];
+                    }
+                    else
+                    {
+                        // Linux \n
+                        value = bytes[..lineEndIndex];
+                    }
+
+                    if (commaIndex < 0)
+                    {
+                        // End of line but no comma
+                        RecordError(value);
+                    }
+                    else if (lineEndIndex >= 0)
+                    {
+                        _cache[Bytes.FromUtf8HexString(key)] = Bytes.FromUtf8HexString(value);
+                    }
+                    // Move to after end of line
+                    bytes = bytes[(lineEndIndex + 1)..];
                 }
 
-                _cache[Bytes.FromHexString(values[0])] = Bytes.FromHexString(values[1]);
+                if (bytes.Length > 0)
+                {
+                    // Move up any remaining to start of buffer
+                    bytes.CopyTo(rentedBuffer);
+                }
+
+                read = RandomAccess.Read(fileHandle, rentedBuffer.AsSpan(bytes.Length), offset);
+            }
+
+            ArrayPool<byte>.Shared.Return(rentedBuffer);
+            if (bytes.Length > 0)
+            {
+                ThrowInvalidDataException();
+            }
+
+            void RecordError(Span<byte> data)
+            {
+                if (_logger.IsError)
+                {
+                    string line = Encoding.UTF8.GetString(data);
+                    _logger.Error($"Error when loading data from {Name} - expected two items separated by a comma and got '{line}')");
+                }
+            }
+
+            static void ThrowInvalidDataException()
+            {
+                throw new InvalidDataException("Malformed data");
             }
         }
 


### PR DESCRIPTION
## Changes

- Operate over `Span<byte>` rather than allocating strings via `ReadAllLines` and `string.Split`

## Types of changes

Before

<img width="465" alt="image" src="https://user-images.githubusercontent.com/1142958/219903243-54a9be21-f39a-4e60-aeaa-5e619431c139.png">

After

<img width="475" alt="image" src="https://user-images.githubusercontent.com/1142958/219903260-9fd36982-d33b-4805-81ce-0ecf0b7c5016.png">



#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes - adjusted existing tests
- [ ] No
