### PR TITLE
Remove 35MB of allocations in TypeDiscovery

### DIFF
--- a/src/Nethermind/Nethermind.Config.Test/ConfigFileTestsBase.cs
+++ b/src/Nethermind/Nethermind.Config.Test/ConfigFileTestsBase.cs
@@ -28,7 +28,7 @@ namespace Nethermind.Config.Test
         {
             // by pre-caching configs we make the tests do lot less work
 
-            IEnumerable<Type> configTypes = new TypeDiscovery().FindNethermindTypes(typeof(IConfig)).Where(t => t.IsInterface).ToArray();
+            IEnumerable<Type> configTypes = TypeDiscovery.FindNethermindTypes(typeof(IConfig)).Where(t => t.IsInterface).ToArray();
 
             Parallel.ForEach(Resolve("*"), configFile =>
             {

--- a/src/Nethermind/Nethermind.Config/ConfigProvider.cs
+++ b/src/Nethermind/Nethermind.Config/ConfigProvider.cs
@@ -20,8 +20,6 @@ namespace Nethermind.Config
 
         private readonly Dictionary<Type, Type> _implementations = new();
 
-        private readonly TypeDiscovery _typeDiscovery = new();
-
         public T GetConfig<T>() where T : IConfig
         {
             return (T)GetConfig(typeof(T));
@@ -67,7 +65,7 @@ namespace Nethermind.Config
         public void Initialize()
         {
             Type type = typeof(IConfig);
-            IEnumerable<Type> interfaces = _typeDiscovery.FindNethermindTypes(type).Where(x => x.IsInterface);
+            IEnumerable<Type> interfaces = TypeDiscovery.FindNethermindTypes(type).Where(x => x.IsInterface);
 
             foreach (Type @interface in interfaces)
             {

--- a/src/Nethermind/Nethermind.Core/Extensions/TypeExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/TypeExtensions.cs
@@ -16,9 +16,8 @@ namespace Nethermind.Core.Extensions
                 throw new NotSupportedException($"GetDirectInterfaceImplementation method is only allowed to use on interface types, got {interfaceType} instead");
             }
 
-            TypeDiscovery typeDiscovery = new();
             Type[] baseInterfaces = interfaceType.GetInterfaces();
-            IEnumerable<Type> implementations = typeDiscovery.FindNethermindTypes(interfaceType).Where(i => i.IsClass);
+            IEnumerable<Type> implementations = TypeDiscovery.FindNethermindTypes(interfaceType).Where(i => i.IsClass);
 
             foreach (Type implementation in implementations)
             {

--- a/src/Nethermind/Nethermind.Core/TypeDiscovery.cs
+++ b/src/Nethermind/Nethermind.Core/TypeDiscovery.cs
@@ -10,54 +10,120 @@ using System.Threading;
 
 namespace Nethermind.Core
 {
-    public class TypeDiscovery
+    public static class TypeDiscovery
     {
-        private HashSet<Assembly> _nethermindAssemblies = new();
+        private static readonly HashSet<Assembly> _nethermindAssemblies = new();
+        private static readonly object _lock = new object();
+        private static int _allLoaded;
 
-        private int _allLoaded;
-
-        private void LoadAll()
+        private static void LoadAll()
         {
-            if (Interlocked.CompareExchange(ref _allLoaded, 1, 0) == 0)
-            {
-                List<Assembly> loadedAssemblies;
-                do
-                {
-                    loadedAssemblies = AssemblyLoadContext.Default.Assemblies.ToList();
-                } while (LoadOnce(loadedAssemblies) != 0);
+            // Early return if initialised
+            if (Volatile.Read(ref _allLoaded) == 1) return;
 
-                foreach (Assembly assembly in loadedAssemblies.Where(a => a.FullName?.Contains("Nethermind") ?? false))
+            LoadAllImpl();
+        }
+
+        private static void LoadAllImpl()
+        {
+            lock (_lock)
+            {
+                // Early return if initialised while waiting for lock
+                if (Volatile.Read(ref _allLoaded) == 1) return;
+
+                List<Assembly> loadedAssemblies = new(capacity: 48);
+                Dictionary<string, Assembly> considered = new();
+                foreach (Assembly assembly in AssemblyLoadContext.Default.Assemblies)
                 {
-                    _nethermindAssemblies.Add(assembly);
+                    // Skip null names (shouldn't happen)
+                    if (assembly.FullName is null) continue;
+
+                    // Skip top level upstream assemblies that are already loaded
+                    // as they won't reference anything in Nethermind
+                    if (assembly.FullName.StartsWith("System")
+                        || assembly.FullName.StartsWith("Microsoft")
+                        || assembly.FullName.StartsWith("NLog")
+                        || assembly.FullName.StartsWith("netstandard")
+                        || assembly.FullName.StartsWith("TestableIO")
+                        || assembly.FullName.StartsWith("Newtonsoft")
+                        || assembly.FullName.StartsWith("DotNetty"))
+                    {
+                        continue;
+                    }
+
+                    int commaIndex = assembly.FullName.IndexOf(',');
+                    // Skip non full names (shouldn't happen)
+                    if (commaIndex <= 0) continue;
+
+                    // Just add the .Name portion as that's what we'll use to compare with AssemblyName
+                    // as full name (including version, culture, SN hash) is constructed on the fly
+                    // for AssemblyName.FullName so long and allocating
+                    string name = assembly.FullName[..commaIndex];
+                    if (considered.TryAdd(name, assembly))
+                    {
+                        loadedAssemblies.Add(assembly);
+                    }
                 }
+
+                LoadOnce(loadedAssemblies, considered);
+
+                foreach (KeyValuePair<string, Assembly> kv in considered.Where(static kv => kv.Key.StartsWith("Nethermind")))
+                {
+                    _nethermindAssemblies.Add(kv.Value);
+                }
+
+                // Mark initialised before releasing lock
+                Volatile.Write(ref _allLoaded, 1);
             }
         }
 
-        private int LoadOnce(List<Assembly> loadedAssemblies)
+        private static void LoadOnce(List<Assembly> loadedAssemblies, Dictionary<string, Assembly> considered)
         {
             // can potentially use https://docs.microsoft.com/en-us/dotnet/standard/assembly/unloadability
 
-            int loaded = 0;
+            List<AssemblyName> missingRefs = loadedAssemblies
+                .SelectMany(x => x.GetReferencedAssemblies()
+                                  .Where(an => an.Name is not null
+                                               && !considered.ContainsKey(an.Name)
+                                               && an.Name.StartsWith("Nethermind")))
+                .ToList();
 
-            var missingRefs = loadedAssemblies
-                .SelectMany(x => x.GetReferencedAssemblies())
-                .GroupBy(a => a.FullName)
-                .Select(g => g.First())
-                .Where(a => a.Name?.Contains("Nethermind") ?? false);
-
-            foreach (AssemblyName missingRef in missingRefs)
+            // Closure capture the dictionary once
+            Func<AssemblyName, bool> whereFilter = an => Filter(considered, an);
+            for (int i = 0; i < missingRefs.Count; i++)
             {
-                if (loadedAssemblies.All(a => a.FullName != missingRef.FullName))
+                AssemblyName missingRef = missingRefs[i];
+                if (missingRef.Name is null
+                    // Only include new distinct assemblies
+                    || considered.ContainsKey(missingRef.Name))
                 {
-                    AssemblyLoadContext.Default.LoadFromAssemblyName(missingRef);
-                    loaded++;
+                    continue;
                 }
+
+                Assembly assembly = AssemblyLoadContext.Default.LoadFromAssemblyName(missingRef);
+                considered.Add(missingRef.Name, assembly);
+                if (assembly == null)
+                {
+                    // Shouldn't happen (completeness)
+                    continue;
+                }
+
+                // Find the references of references, filtering out any we've already looked at
+                IEnumerable<AssemblyName> newRefs = assembly.GetReferencedAssemblies().Where(whereFilter);
+
+                // Add any extra to end of the list so they will still get picked up from the for loop
+                missingRefs.AddRange(newRefs);
             }
 
-            return loaded;
+            static bool Filter(Dictionary<string, Assembly> considered, AssemblyName an)
+            {
+                return an.Name is not null
+                        && !considered.ContainsKey(an.Name)
+                        && an.Name.StartsWith("Nethermind");
+            }
         }
 
-        public IEnumerable<Type> FindNethermindTypes(Type baseType)
+        public static IEnumerable<Type> FindNethermindTypes(Type baseType)
         {
             LoadAll();
 
@@ -66,7 +132,7 @@ namespace Nethermind.Core
                     .Where(t => baseType.IsAssignableFrom(t) && baseType != t) ?? Array.Empty<Type>());
         }
 
-        public IEnumerable<Type> FindNethermindTypes(string typeName)
+        public static IEnumerable<Type> FindNethermindTypes(string typeName)
         {
             LoadAll();
 

--- a/src/Nethermind/Nethermind.Core/TypeDiscovery.cs
+++ b/src/Nethermind/Nethermind.Core/TypeDiscovery.cs
@@ -81,15 +81,14 @@ namespace Nethermind.Core
         {
             // can potentially use https://docs.microsoft.com/en-us/dotnet/standard/assembly/unloadability
 
-            List<AssemblyName> missingRefs = loadedAssemblies
-                .SelectMany(x => x.GetReferencedAssemblies()
-                                  .Where(an => an.Name is not null
-                                               && !considered.ContainsKey(an.Name)
-                                               && an.Name.StartsWith("Nethermind")))
-                .ToList();
-
             // Closure capture the dictionary once
             Func<AssemblyName, bool> whereFilter = an => Filter(considered, an);
+
+            List<AssemblyName> missingRefs = loadedAssemblies
+                .SelectMany(x => x.GetReferencedAssemblies()
+                                  .Where(whereFilter))
+                .ToList();
+
             for (int i = 0; i < missingRefs.Count; i++)
             {
                 AssemblyName missingRef = missingRefs[i];

--- a/src/Nethermind/Nethermind.Init/Steps/StartMonitoring.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/StartMonitoring.cs
@@ -44,7 +44,7 @@ public class StartMonitoring : IStep
             MetricsController metricsController = new(metricsConfig);
 
             _api.MonitoringService = new MonitoringService(metricsController, metricsConfig, _api.LogManager);
-            IEnumerable<Type> metrics = new TypeDiscovery().FindNethermindTypes(nameof(Metrics));
+            IEnumerable<Type> metrics = TypeDiscovery.FindNethermindTypes(nameof(Metrics));
             foreach (Type metric in metrics)
             {
                 _api.MonitoringService.RegisterMetrics(metric);

--- a/src/Nethermind/Nethermind.Monitoring.Test/MetricsTests.cs
+++ b/src/Nethermind/Nethermind.Monitoring.Test/MetricsTests.cs
@@ -73,7 +73,7 @@ namespace Nethermind.Monitoring.Test
             };
             MetricsController metricsController = new(metricsConfig);
             MonitoringService monitoringService = new(metricsController, metricsConfig, LimboLogs.Instance);
-            List<Type> metrics = new TypeDiscovery().FindNethermindTypes(nameof(Metrics)).ToList();
+            List<Type> metrics = TypeDiscovery.FindNethermindTypes(nameof(Metrics)).ToList();
             metrics.AddRange(knownMetricsTypes);
 
             Assert.DoesNotThrow(() =>

--- a/src/Nethermind/Nethermind.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Runner/Program.cs
@@ -260,7 +260,7 @@ namespace Nethermind.Runner
         private static void BuildOptionsFromConfigFiles(CommandLineApplication app)
         {
             Type configurationType = typeof(IConfig);
-            IEnumerable<Type> configTypes = new TypeDiscovery().FindNethermindTypes(configurationType)
+            IEnumerable<Type> configTypes = TypeDiscovery.FindNethermindTypes(configurationType)
                 .Where(ct => ct.IsInterface);
 
             foreach (Type configType in configTypes.Where(ct => !ct.IsAssignableTo(typeof(INoCategoryConfig))).OrderBy(c => c.Name))


### PR DESCRIPTION
## Changes

- Singleton the discovery with locking (if loading, wait till loaded)
- Use Dictionary to go from O(N^2) to O(N)
- Exclude system and dependency dlls from discovery
- Avoid constructing `.FullName` from `AssemblyName`
- Single pass the dependency of dependency of ... loading
- Skip looking at dependencies of anything already loaded

## Types of changes

Before

<img width="544" alt="image" src="https://user-images.githubusercontent.com/1142958/219941114-b88f48e0-a102-4030-87ec-f671cafd5510.png">

After

<img width="579" alt="image" src="https://user-images.githubusercontent.com/1142958/219998914-ae657a02-9662-4c3d-9896-22d8772d11d8.png">

Also about x3.8 times faster

<img width="533" alt="image" src="https://user-images.githubusercontent.com/1142958/220001498-f36d9bd6-ade5-4801-a9ad-3a904888253d.png">


#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No
