### PR TITLE
ValidateSignature move from BigInteger to UInt256

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
@@ -3,6 +3,8 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Numerics;
+
 using FluentAssertions;
 using Nethermind.Consensus.Validators;
 using Nethermind.Core;
@@ -26,6 +28,19 @@ namespace Nethermind.Blockchain.Test.Validators
         [SetUp]
         public void Setup()
         {
+        }
+
+        [Test]
+        public void Curve_is_correct()
+        {
+            BigInteger N = BigInteger.Parse("115792089237316195423570985008687907852837564279074904382605163141518161494337");
+            BigInteger HalfN = N / 2;
+
+            Secp256K1Curve.N.Convert(out BigInteger n);
+            Secp256K1Curve.HalfN.Convert(out BigInteger halfN);
+
+            (N == n).Should().BeTrue();
+            (HalfN == halfN).Should().BeTrue();
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
@@ -1,13 +1,12 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System.Numerics;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
-using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Crypto;
 using Nethermind.Evm;
+using Nethermind.Int256;
 using Nethermind.TxPool;
 
 namespace Nethermind.Consensus.Validators
@@ -88,15 +87,15 @@ namespace Nethermind.Consensus.Validators
                 return false;
             }
 
-            BigInteger sValue = signature.SAsSpan.ToUnsignedBigInteger();
-            BigInteger rValue = signature.RAsSpan.ToUnsignedBigInteger();
+            UInt256 sValue = new(signature.SAsSpan, isBigEndian: true);
+            UInt256 rValue = new(signature.RAsSpan, isBigEndian: true);
 
-            if (sValue.IsZero || sValue >= (spec.IsEip2Enabled ? Secp256K1Curve.HalfN + 1 : Secp256K1Curve.N))
+            if (sValue.IsZero || sValue >= (spec.IsEip2Enabled ? Secp256K1Curve.HalfNPlusOne : Secp256K1Curve.N))
             {
                 return false;
             }
 
-            if (rValue.IsZero || rValue >= Secp256K1Curve.N - 1)
+            if (rValue.IsZero || rValue >= Secp256K1Curve.NMinusOne)
             {
                 return false;
             }

--- a/src/Nethermind/Nethermind.Crypto/Secp256K1Curve.cs
+++ b/src/Nethermind/Nethermind.Crypto/Secp256K1Curve.cs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System.Numerics;
+using Nethermind.Int256;
 
 namespace Nethermind.Crypto
 {
@@ -18,8 +18,9 @@ namespace Nethermind.Crypto
             - BigInteger.Pow(2, 4)
             - 1; */
 
-        public static readonly BigInteger N = BigInteger.Parse("115792089237316195423570985008687907852837564279074904382605163141518161494337");
-
-        public static readonly BigInteger HalfN = N / 2;
+        public static readonly UInt256 N = UInt256.Parse("115792089237316195423570985008687907852837564279074904382605163141518161494337");
+        public static readonly UInt256 NMinusOne = N - 1;
+        public static readonly UInt256 HalfN = N / 2;
+        public static readonly UInt256 HalfNPlusOne = HalfN + 1;
     }
 }


### PR DESCRIPTION
## Changes

- Move from `BigInteger` to `UInt256` in `TxValidator.ValidateSignature`

## Types of changes

Removes all per txn allocations for TxValidator:

![image](https://user-images.githubusercontent.com/1142958/220319281-2159c0e4-093d-440a-af24-213af0780527.png)

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No
