### PR TITLE
Flags to allow sync bodies/receipts before state sync

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
@@ -84,5 +84,11 @@ namespace Nethermind.Blockchain.Synchronization
 
         [ConfigItem(Description = "Disable some optimization and run a more extensive sync. Useful for broken sync state but normally not needed", DefaultValue = "false")]
         public bool StrictMode { get; set; }
+
+        [ConfigItem(Description = "If enabled allows to start syncing bodies before state sync finished.", DefaultValue = "false", HiddenFromDocs = true)]
+        bool AllowBodiesSyncBeforeStateFinish { get; set; }
+
+        [ConfigItem(Description = "If enabled allows to start syncing receipts before state sync finished.", DefaultValue = "false", HiddenFromDocs = true)]
+        bool AllowReceiptsSyncBeforeStateFinish { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
@@ -45,6 +45,8 @@ namespace Nethermind.Blockchain.Synchronization
         public bool FixReceipts { get; set; } = false;
         public bool StrictMode { get; set; } = false;
         public bool BlockGossipEnabled { get; set; } = true;
+        public bool AllowBodiesSyncBeforeStateFinish { get; set; } = false;
+        public bool AllowReceiptsSyncBeforeStateFinish { get; set; } = false;
 
         public override string ToString()
         {

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
@@ -463,7 +463,7 @@ namespace Nethermind.Synchronization.ParallelSync
         {
             bool fastBodiesNotFinished = !FastBlocksBodiesFinished;
             bool fastHeadersFinished = FastBlocksHeadersFinished;
-            bool notInStateSync = !best.IsInStateSync;
+            bool notInStateSync = !best.IsInStateSync || _syncConfig.AllowBodiesSyncBeforeStateFinish;
             bool stateSyncFinished = best.State > 0 || _syncConfig.AllowBodiesSyncBeforeStateFinish;
 
             // fast blocks bodies can run if there are peers until it is done
@@ -486,7 +486,7 @@ namespace Nethermind.Synchronization.ParallelSync
         {
             bool fastReceiptsNotFinished = !FastBlocksReceiptsFinished;
             bool fastBodiesFinished = FastBlocksBodiesFinished;
-            bool notInStateSync = !best.IsInStateSync;
+            bool notInStateSync = !best.IsInStateSync || _syncConfig.AllowReceiptsSyncBeforeStateFinish;
             bool stateSyncFinished = best.State > 0 || _syncConfig.AllowReceiptsSyncBeforeStateFinish;
 
             // fast blocks receipts can run if there are peers until it is done

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
@@ -464,7 +464,7 @@ namespace Nethermind.Synchronization.ParallelSync
             bool fastBodiesNotFinished = !FastBlocksBodiesFinished;
             bool fastHeadersFinished = FastBlocksHeadersFinished;
             bool notInStateSync = !best.IsInStateSync;
-            bool stateSyncFinished = best.State > 0;
+            bool stateSyncFinished = best.State > 0 || _syncConfig.AllowBodiesSyncBeforeStateFinish;
 
             // fast blocks bodies can run if there are peers until it is done
             // fast blocks bodies can run in parallel with full sync when headers are finished
@@ -487,7 +487,7 @@ namespace Nethermind.Synchronization.ParallelSync
             bool fastReceiptsNotFinished = !FastBlocksReceiptsFinished;
             bool fastBodiesFinished = FastBlocksBodiesFinished;
             bool notInStateSync = !best.IsInStateSync;
-            bool stateSyncFinished = best.State > 0;
+            bool stateSyncFinished = best.State > 0 || _syncConfig.AllowReceiptsSyncBeforeStateFinish;
 
             // fast blocks receipts can run if there are peers until it is done
             // fast blocks receipts can run in parallel with full sync when bodies are finished


### PR DESCRIPTION
## Changes

- New dev-only (for now) flags to allow sync bodies and receipts during snap/state

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [X] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No
Not yet - if it will work, then I'll add new cases to cover
