### PR TITLE
Sleep peer if can't get account range

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapSyncFeed/AnalyzeResponsePerPeerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapSyncFeed/AnalyzeResponsePerPeerTests.cs
@@ -22,7 +22,7 @@ namespace Nethermind.Synchronization.Test.SnapSync.SnapSyncFeed
             ISyncModeSelector selector = Substitute.For<ISyncModeSelector>();
             ISnapProvider snapProvider = Substitute.For<ISnapProvider>();
 
-            Synchronization.SnapSync.SnapSyncFeed feed = new(selector, snapProvider, null!, LimboLogs.Instance);
+            Synchronization.SnapSync.SnapSyncFeed feed = new(selector, snapProvider, LimboLogs.Instance);
 
             feed.AnalyzeResponsePerPeer(AddRangeResult.OK, peer1);
             feed.AnalyzeResponsePerPeer(AddRangeResult.OK, peer1);
@@ -57,7 +57,7 @@ namespace Nethermind.Synchronization.Test.SnapSync.SnapSyncFeed
             ISyncModeSelector selector = Substitute.For<ISyncModeSelector>();
             ISnapProvider snapProvider = Substitute.For<ISnapProvider>();
 
-            Synchronization.SnapSync.SnapSyncFeed feed = new(selector, snapProvider, null!, LimboLogs.Instance);
+            Synchronization.SnapSync.SnapSyncFeed feed = new(selector, snapProvider, LimboLogs.Instance);
 
             feed.AnalyzeResponsePerPeer(AddRangeResult.OK, peer1);
             feed.AnalyzeResponsePerPeer(AddRangeResult.OK, peer1);
@@ -92,7 +92,7 @@ namespace Nethermind.Synchronization.Test.SnapSync.SnapSyncFeed
             ISyncModeSelector selector = Substitute.For<ISyncModeSelector>();
             ISnapProvider snapProvider = Substitute.For<ISnapProvider>();
 
-            Synchronization.SnapSync.SnapSyncFeed feed = new(selector, snapProvider, null!, LimboLogs.Instance);
+            Synchronization.SnapSync.SnapSyncFeed feed = new(selector, snapProvider, LimboLogs.Instance);
 
             feed.AnalyzeResponsePerPeer(AddRangeResult.OK, peer2);
             feed.AnalyzeResponsePerPeer(AddRangeResult.OK, peer1);
@@ -117,7 +117,7 @@ namespace Nethermind.Synchronization.Test.SnapSync.SnapSyncFeed
             ISyncModeSelector selector = Substitute.For<ISyncModeSelector>();
             ISnapProvider snapProvider = Substitute.For<ISnapProvider>();
 
-            Synchronization.SnapSync.SnapSyncFeed feed = new(selector, snapProvider, null!, LimboLogs.Instance);
+            Synchronization.SnapSync.SnapSyncFeed feed = new(selector, snapProvider, LimboLogs.Instance);
 
             for (int i = 0; i < 200; i++)
             {

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapSyncFeed/SnapSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapSyncFeed/SnapSyncFeedTests.cs
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using FluentAssertions;
+using Nethermind.Blockchain.Synchronization;
+using Nethermind.Core.Crypto;
+using Nethermind.Logging;
+using Nethermind.State.Snap;
+using Nethermind.Synchronization.ParallelSync;
+using Nethermind.Synchronization.Peers;
+using Nethermind.Synchronization.SnapSync;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Synchronization.Test.SnapSync.SnapSyncFeed;
+
+public class SnapSyncFeedTests
+{
+    [Test]
+    public void WhenAccountRequestEmpty_ReturnNoProgress()
+    {
+        ISnapProvider snapProvider = Substitute.For<ISnapProvider>();
+        Synchronization.SnapSync.SnapSyncFeed feed = new(
+            Substitute.For<ISyncModeSelector>(), snapProvider, LimboLogs.Instance);
+
+        snapProvider.AddAccountRange(Arg.Any<AccountRange>(), Arg.Any<AccountsAndProofs>())
+            .Returns(AddRangeResult.ExpiredRootHash);
+
+        SnapSyncBatch response = new SnapSyncBatch();
+        response.AccountRangeRequest = new AccountRange(Keccak.Zero, Keccak.Zero);
+        response.AccountRangeResponse = new AccountsAndProofs();
+
+        PeerInfo peer = new PeerInfo(Substitute.For<ISyncPeer>());
+
+        feed.HandleResponse(response, peer).Should().Be(SyncResponseHandlingResult.NoProgress);
+    }
+}

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncFeed.cs
@@ -33,7 +33,7 @@ namespace Nethermind.Synchronization.SnapSync
         public override bool IsMultiFeed => true;
         public override AllocationContexts Contexts => AllocationContexts.Snap;
 
-        public SnapSyncFeed(ISyncModeSelector syncModeSelector, ISnapProvider snapProvider, IBlockTree blockTree, ILogManager logManager)
+        public SnapSyncFeed(ISyncModeSelector syncModeSelector, ISnapProvider snapProvider, ILogManager logManager)
         {
             _syncModeSelector = syncModeSelector;
             _snapProvider = snapProvider;
@@ -186,6 +186,11 @@ namespace Nethermind.Synchronization.SnapSync
                             }
                         }
                     }
+                }
+
+                if (result == AddRangeResult.ExpiredRootHash)
+                {
+                    return SyncResponseHandlingResult.NoProgress;
                 }
 
                 return SyncResponseHandlingResult.OK;

--- a/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
@@ -153,7 +153,7 @@ namespace Nethermind.Synchronization
 
         private void StartSnapSyncComponents()
         {
-            _snapSyncFeed = new SnapSyncFeed(_syncMode, _snapProvider, _blockTree, _logManager);
+            _snapSyncFeed = new SnapSyncFeed(_syncMode, _snapProvider, _logManager);
             SnapSyncDispatcher dispatcher = new(_snapSyncFeed!, _syncPeerPool, new SnapSyncAllocationStrategyFactory(), _logManager);
 
             Task _ = dispatcher.Start(_syncCancellation!.Token).ContinueWith(t =>


### PR DESCRIPTION
- Sometimes, depending on your luck, a proportion of the snap account range response returns nothing, which get interpreted as ExpiredRootHash. Sometimes its a lot, but I can't reproduce it.
- For geth, this happen if the state root is missing which will happen if we request too newer state root or geth is lagging behind.
- No idea about besu.
- In any case, I'd recommend just return `NoProgress` which should sleep the peer, which should cause the account range request to go to other peer, at least temporarily, which should help a bit with snap sync request if you get unlucky.

![Screenshot from 2023-02-23 14-09-43](https://user-images.githubusercontent.com/1841324/220832955-663ccce7-d88c-4ee8-988f-13a283c537c8.png)


## Changes

- Slight cleanup on snap sync feed constructor.
- Add a small clause to return `NoProgress` 

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)
- [X] Optimization

## Testing

#### Requires testing

- [X] Yesx

#### If yes, did you write tests?

- [X] Yes