### PR TITLE
Only init TrieNode when values are set

### DIFF
--- a/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
@@ -579,7 +579,7 @@ namespace Nethermind.Trie.Test
         {
             TrieNode trieNode = new(NodeType.Extension);
             trieNode.SetChild(0, null);
-            trieNode.GetMemorySize(false).Should().Be(48);
+            trieNode.GetMemorySize(false).Should().Be(64);
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
@@ -587,7 +587,7 @@ namespace Nethermind.Trie.Test
         {
             TrieNode trieNode = new(NodeType.Branch);
             trieNode.SetChild(0, null);
-            trieNode.GetMemorySize(false).Should().Be(48);
+            trieNode.GetMemorySize(false).Should().Be(64);
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
@@ -579,7 +579,7 @@ namespace Nethermind.Trie.Test
         {
             TrieNode trieNode = new(NodeType.Extension);
             trieNode.SetChild(0, null);
-            trieNode.GetMemorySize(false).Should().Be(88);
+            trieNode.GetMemorySize(false).Should().Be(48);
         }
 
         [Test]
@@ -587,7 +587,7 @@ namespace Nethermind.Trie.Test
         {
             TrieNode trieNode = new(NodeType.Branch);
             trieNode.SetChild(0, null);
-            trieNode.GetMemorySize(false).Should().Be(200);
+            trieNode.GetMemorySize(false).Should().Be(48);
         }
 
         [Test]


### PR DESCRIPTION
## Changes

- Only allocate TrieNode `object[]` when values are being set to non `null`
- Use `ushort _nullNodes` to represent values set to `_nullNode` without initializing array (doesn't add to packed `class` size)
  - i.e. the two `bool`s are 2 bytes and leave empty space in the class which `ushort` can fill without expanding the class

## Types of changes

Resolving empty nodes doesn't allocate backing arrays

Allocation sources before

<img width="602" alt="image" src="https://user-images.githubusercontent.com/1142958/221153055-99272f3d-3d4a-4edb-82f5-0507a69bc56d.png">

Allocations sources after (ignore absolute amounts, ran for longer period)

<img width="470" alt="image" src="https://user-images.githubusercontent.com/1142958/221153292-987c54b3-a2e5-459a-a89f-bd6d8cc8d04d.png">


#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes (Changed existing tests)
- [ ] No