### PR TITLE
Reduce SyncStatusList lock contention

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/SyncStatusListTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/SyncStatusListTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Threading.Tasks;
 
 using DotNetty.Codecs;
 
@@ -31,16 +32,51 @@ namespace Nethermind.Synchronization.Test.FastBlocks
         [Test]
         public void Can_read_back_all_set_values()
         {
-            const long length = 500;
-
-            FastBlockStatusList list = new(length);
-            for (int i = 0; i < length; i++)
+            for (var len = 0; len < 500; len++)
             {
-                list[i] = (FastBlockStatus)(i % 3);
+                FastBlockStatusList list = new(len);
+                for (int i = 0; i < len; i++)
+                {
+                    list[i] = (FastBlockStatus)(i % 3);
+                }
+                for (int i = 0; i < len; i++)
+                {
+                    Assert.IsTrue((FastBlockStatus)(i % 3) == list[i]);
+                }
             }
-            for (int i = 0; i < length; i++)
+        }
+
+        [Test]
+        public void Can_read_back_all_atomic_set_values()
+        {
+            for (var len = 0; len < 500; len++)
             {
-                Assert.IsTrue((FastBlockStatus)(i % 3) == list[i]);
+                FastBlockStatusList list = new(len);
+                for (int i = 0; i < len; i++)
+                {
+                    list.AtomicWrite(i, (FastBlockStatus)(i % 3));
+                }
+                for (int i = 0; i < len; i++)
+                {
+                    Assert.IsTrue((FastBlockStatus)(i % 3) == list[i]);
+                }
+            }
+        }
+
+        [Test]
+        public void Can_read_back_all_parallel_set_values()
+        {
+            for (var len = 0; len < 500; len++)
+            {
+                FastBlockStatusList list = new(len);
+                Parallel.For(0, len, (i) =>
+                {
+                    list.AtomicWrite(i, (FastBlockStatus)(i % 3));
+                });
+                Parallel.For(0, len, (i) =>
+                {
+                    Assert.IsTrue((FastBlockStatus)(i % 3) == list[i]);
+                });
             }
         }
     }

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastBlockStatusList.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastBlockStatusList.cs
@@ -3,25 +3,26 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using System.Threading;
 
 [assembly: InternalsVisibleTo("Nethermind.Synchronization.Test")]
 namespace Nethermind.Synchronization.FastBlocks;
 
 internal class FastBlockStatusList
 {
-    private readonly byte[] _statuses;
+    private readonly int[] _statuses;
     private readonly long _length;
 
     public FastBlockStatusList(long length)
     {
-        // Can fit 4 statuses per byte, however need to round up the division
-        long size = length / 4;
-        if (size * 4 < length)
+        // Can fit 16 statuses per int, however need to round up the division
+        long size = length / 16;
+        if (size * 16 < length)
         {
             size++;
         }
 
-        _statuses = new byte[size];
+        _statuses = new int[size];
         _length = length;
     }
 
@@ -34,9 +35,9 @@ internal class FastBlockStatusList
                 ThrowIndexOutOfRange();
             }
 
-            (long q, long r) = Math.DivRem(index, 4);
+            (long q, long r) = Math.DivRem(index, 16);
 
-            byte status = _statuses[q];
+            int status = _statuses[q];
             return (FastBlockStatus)((status >> (int)(r * 2)) & 0b11);
         }
         set
@@ -46,12 +47,51 @@ internal class FastBlockStatusList
                 ThrowIndexOutOfRange();
             }
 
-            (long q, long r) = Math.DivRem(index, 4);
+            (long q, long r) = Math.DivRem(index, 16);
             r *= 2;
 
-            ref byte status = ref _statuses[q];
-            status = (byte)((status & ~(0b11 << (int)r)) | ((int)value << (int)r));
+            ref int status = ref _statuses[q];
+            status = (int)((status & ~(0b11 << (int)r)) | ((int)value << (int)r));
         }
+    }
+
+    public FastBlockStatus AtomicRead(long index)
+    {
+        if ((ulong)index >= (ulong)_length)
+        {
+            ThrowIndexOutOfRange();
+        }
+
+        (long q, long r) = Math.DivRem(index, 16);
+
+        int status = Volatile.Read(ref _statuses[q]);
+        return (FastBlockStatus)((status >> (int)(r * 2)) & 0b11);
+    }
+
+    public void AtomicWrite(long index, FastBlockStatus value)
+    {
+        if ((ulong)index >= (ulong)_length)
+        {
+            ThrowIndexOutOfRange();
+        }
+
+        (long q, long r) = Math.DivRem(index, 16);
+        r *= 2;
+
+        ref int status = ref _statuses[q];
+        int oldValue = Volatile.Read(ref status);
+        do
+        {
+            int newValue = (int)((oldValue & ~(0b11 << (int)r)) | ((int)value << (int)r));
+            int currentValue = Interlocked.CompareExchange(ref status, newValue, oldValue);
+            if (currentValue == oldValue || currentValue == newValue)
+            {
+                // Change has happened
+                break;
+            }
+            // Change not done, set old value to current value
+            oldValue = currentValue;
+        } while (true);
     }
 
     private static void ThrowIndexOutOfRange()

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/SyncStatusList.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/SyncStatusList.cs
@@ -65,8 +65,8 @@ namespace Nethermind.Synchronization.FastBlocks
 
         public void MarkInserted(in long blockNumber)
         {
-            Interlocked.Increment(ref _queueSize);
             _statuses.AtomicWrite(blockNumber, FastBlockStatus.Inserted);
+            Interlocked.Increment(ref _queueSize);
         }
 
         public void MarkUnknown(in long blockNumber)


### PR DESCRIPTION
## Changes

- Remove lock in `SyncStatusList` and add atomic setting for `FastBlockStatusList`

## Types of changes

`MarkInserted` gets set to sleep due to lock contention, remove the contention and that thread inserting can make forward progress

Before

![image](https://user-images.githubusercontent.com/1142958/221367308-ab7f9935-c456-49ca-87b4-7a59d6980185.png)

After

<img width="478" alt="image" src="https://user-images.githubusercontent.com/1142958/221367347-c29d078e-97d8-429e-b553-8c6d080b344b.png">


#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No
