### PR TITLE
Perf/improve snap request concurrency

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
@@ -78,7 +78,7 @@ namespace Nethermind.Blockchain.Synchronization
         [ConfigItem(Description = "Enables SNAP sync protocol.", DefaultValue = "false")]
         public bool SnapSync { get; set; }
 
-        [ConfigItem(Description = "Number of account range partition to create. Increase snap sync request concurrency. ", DefaultValue = "8")]
+        [ConfigItem(Description = "Number of account range partition to create. Increase snap sync request concurrency. Value must be between 1 to 256 (inclusive).", DefaultValue = "8")]
         int SnapSyncAccountRangePartitionCount { get; set; }
 
         [ConfigItem(Description = "[ONLY FOR MISSING RECEIPTS ISSUE] Turns on receipts validation that checks for ones that might be missing due to previous bug. It downloads them from network if needed." +

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
@@ -78,6 +78,9 @@ namespace Nethermind.Blockchain.Synchronization
         [ConfigItem(Description = "Enables SNAP sync protocol.", DefaultValue = "false")]
         public bool SnapSync { get; set; }
 
+        [ConfigItem(Description = "Number of account range partition to create. Increase snap sync request concurrency. ", DefaultValue = "8")]
+        int SnapSyncAccountRangePartitionCount { get; set; }
+
         [ConfigItem(Description = "[ONLY FOR MISSING RECEIPTS ISSUE] Turns on receipts validation that checks for ones that might be missing due to previous bug. It downloads them from network if needed." +
                                   "If used please check that PivotNumber is same as original used when syncing the node as its used as a cut-off point.", DefaultValue = "false")]
         public bool FixReceipts { get; set; }

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
@@ -42,6 +42,7 @@ namespace Nethermind.Blockchain.Synchronization
         public string PivotHash { get; set; }
         public bool WitnessProtocolEnabled { get; set; } = false;
         public bool SnapSync { get; set; } = false;
+        public int SnapSyncAccountRangePartitionCount { get; set; } = 8;
         public bool FixReceipts { get; set; } = false;
         public bool StrictMode { get; set; } = false;
         public bool BlockGossipEnabled { get; set; } = true;

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -100,7 +100,7 @@ public class InitializeNetwork : IStep
 
         CanonicalHashTrie cht = new CanonicalHashTrie(_api.DbProvider!.ChtDb);
 
-        ProgressTracker progressTracker = new(_api.BlockTree!, _api.DbProvider.StateDb, _api.LogManager);
+        ProgressTracker progressTracker = new(_api.BlockTree!, _api.DbProvider.StateDb, _api.LogManager, _syncConfig.SnapSyncAccountRangePartitionCount);
         _api.SnapProvider = new SnapProvider(progressTracker, _api.DbProvider, _api.LogManager);
 
         SyncProgressResolver syncProgressResolver = new(

--- a/src/Nethermind/Nethermind.State.Test/SnapSync/RecreateStateFromAccountRangesTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/SnapSync/RecreateStateFromAccountRangesTests.cs
@@ -3,14 +3,20 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using Nethermind.Core;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
+using Nethermind.Int256;
 using Nethermind.Logging;
+using Nethermind.Serialization.Rlp;
 using Nethermind.State;
 using Nethermind.State.Proofs;
+using Nethermind.State.Snap;
 using Nethermind.Synchronization.SnapSync;
 using Nethermind.Trie;
 using Nethermind.Trie.Pruning;
@@ -29,20 +35,18 @@ namespace Nethermind.Store.Test
             _inputTree = TestItem.Tree.GetStateTree(null);
         }
 
-        private byte[][] CreateProofForPath(byte[] path)
-        {
-            AccountProofCollector accountProofCollector = new(path);
-            _inputTree.Accept(accountProofCollector, _inputTree.RootHash);
-            return accountProofCollector.BuildResult().Proof;
-        }
-
         //[Test]
         public void Test01()
         {
             Keccak rootHash = _inputTree.RootHash;   // "0x8c81279168edc449089449bc0f2136fc72c9645642845755633cf259cd97988b"
 
-            byte[][] firstProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[0].Path.Bytes);
-            byte[][] lastProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[5].Path.Bytes);
+            AccountProofCollector accountProofCollector = new(TestItem.Tree.AccountsWithPaths[0].Path.Bytes);
+            _inputTree.Accept(accountProofCollector, _inputTree.RootHash);
+            byte[][] firstProof = accountProofCollector.BuildResult().Proof;
+
+            accountProofCollector = new(TestItem.Tree.AccountsWithPaths[5].Path.Bytes);
+            _inputTree.Accept(accountProofCollector, _inputTree.RootHash);
+            byte[][] lastProof = accountProofCollector.BuildResult().Proof;
 
             MemDb db = new();
             TrieStore store = new(db, LimboLogs.Instance);
@@ -101,8 +105,12 @@ namespace Nethermind.Store.Test
         {
             Keccak rootHash = _inputTree.RootHash;   // "0x8c81279168edc449089449bc0f2136fc72c9645642845755633cf259cd97988b"
 
-            byte[][] firstProof = CreateProofForPath(Keccak.Zero.Bytes);
-            byte[][] lastProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[5].Path.Bytes);
+            AccountProofCollector accountProofCollector = new(Keccak.Zero.Bytes);
+            _inputTree.Accept(accountProofCollector, _inputTree.RootHash);
+            byte[][] firstProof = accountProofCollector.BuildResult().Proof;
+            accountProofCollector = new(TestItem.Tree.AccountsWithPaths[5].Path.Bytes);
+            _inputTree.Accept(accountProofCollector, _inputTree.RootHash);
+            byte[][] lastProof = accountProofCollector.BuildResult().Proof;
 
             MemDb db = new();
             DbProvider dbProvider = new(DbModeHint.Mem);
@@ -121,8 +129,12 @@ namespace Nethermind.Store.Test
         {
             Keccak rootHash = _inputTree.RootHash;   // "0x8c81279168edc449089449bc0f2136fc72c9645642845755633cf259cd97988b"
 
-            byte[][] firstProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[0].Path.Bytes);
-            byte[][] lastProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[5].Path.Bytes);
+            AccountProofCollector accountProofCollector = new(TestItem.Tree.AccountsWithPaths[0].Path.Bytes);
+            _inputTree.Accept(accountProofCollector, _inputTree.RootHash);
+            byte[][] firstProof = accountProofCollector.BuildResult().Proof;
+            accountProofCollector = new(TestItem.Tree.AccountsWithPaths[5].Path.Bytes);
+            _inputTree.Accept(accountProofCollector, _inputTree.RootHash);
+            byte[][] lastProof = accountProofCollector.BuildResult().Proof;
 
             MemDb db = new();
             DbProvider dbProvider = new(DbModeHint.Mem);
@@ -165,22 +177,34 @@ namespace Nethermind.Store.Test
             ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
             SnapProvider snapProvider = new(progressTracker, dbProvider, LimboLogs.Instance);
 
-            byte[][] firstProof = CreateProofForPath(Keccak.Zero.Bytes);
-            byte[][] lastProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[1].Path.Bytes);
+            AccountProofCollector accountProofCollector = new(Keccak.Zero.Bytes);
+            _inputTree.Accept(accountProofCollector, _inputTree.RootHash);
+            byte[][] firstProof = accountProofCollector.BuildResult().Proof;
+            accountProofCollector = new(TestItem.Tree.AccountsWithPaths[1].Path.Bytes);
+            _inputTree.Accept(accountProofCollector, _inputTree.RootHash);
+            byte[][] lastProof = accountProofCollector.BuildResult().Proof;
 
             var result1 = snapProvider.AddAccountRange(1, rootHash, Keccak.Zero, TestItem.Tree.AccountsWithPaths[0..2], firstProof!.Concat(lastProof!).ToArray());
 
             Assert.AreEqual(2, db.Keys.Count);
 
-            firstProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[2].Path.Bytes);
-            lastProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[3].Path.Bytes);
+            accountProofCollector = new(TestItem.Tree.AccountsWithPaths[2].Path.Bytes);
+            _inputTree.Accept(accountProofCollector, _inputTree.RootHash);
+            firstProof = accountProofCollector.BuildResult().Proof;
+            accountProofCollector = new(TestItem.Tree.AccountsWithPaths[3].Path.Bytes);
+            _inputTree.Accept(accountProofCollector, _inputTree.RootHash);
+            lastProof = accountProofCollector.BuildResult().Proof;
 
             var result2 = snapProvider.AddAccountRange(1, rootHash, TestItem.Tree.AccountsWithPaths[2].Path, TestItem.Tree.AccountsWithPaths[2..4], firstProof!.Concat(lastProof!).ToArray());
 
             Assert.AreEqual(5, db.Keys.Count);  // we don't persist proof nodes (boundary nodes)
 
-            firstProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[4].Path.Bytes);
-            lastProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[5].Path.Bytes);
+            accountProofCollector = new(TestItem.Tree.AccountsWithPaths[4].Path.Bytes);
+            _inputTree.Accept(accountProofCollector, _inputTree.RootHash);
+            firstProof = accountProofCollector.BuildResult().Proof;
+            accountProofCollector = new(TestItem.Tree.AccountsWithPaths[5].Path.Bytes);
+            _inputTree.Accept(accountProofCollector, _inputTree.RootHash);
+            lastProof = accountProofCollector.BuildResult().Proof;
 
             var result3 = snapProvider.AddAccountRange(1, rootHash, TestItem.Tree.AccountsWithPaths[4].Path, TestItem.Tree.AccountsWithPaths[4..6], firstProof!.Concat(lastProof!).ToArray());
 
@@ -203,23 +227,35 @@ namespace Nethermind.Store.Test
             ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
             SnapProvider snapProvider = new(progressTracker, dbProvider, LimboLogs.Instance);
 
-            byte[][] firstProof = CreateProofForPath(Keccak.Zero.Bytes);
-            byte[][] lastProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[1].Path.Bytes);
+            AccountProofCollector accountProofCollector = new(Keccak.Zero.Bytes);
+            _inputTree.Accept(accountProofCollector, _inputTree.RootHash);
+            byte[][] firstProof = accountProofCollector.BuildResult().Proof;
+            accountProofCollector = new(TestItem.Tree.AccountsWithPaths[1].Path.Bytes);
+            _inputTree.Accept(accountProofCollector, _inputTree.RootHash);
+            byte[][] lastProof = accountProofCollector.BuildResult().Proof;
 
             var result1 = snapProvider.AddAccountRange(1, rootHash, Keccak.Zero, TestItem.Tree.AccountsWithPaths[0..2], firstProof!.Concat(lastProof!).ToArray());
 
             Assert.AreEqual(2, db.Keys.Count);
 
-            firstProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[2].Path.Bytes);
-            lastProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[3].Path.Bytes);
+            accountProofCollector = new(TestItem.Tree.AccountsWithPaths[2].Path.Bytes);
+            _inputTree.Accept(accountProofCollector, _inputTree.RootHash);
+            firstProof = accountProofCollector.BuildResult().Proof;
+            accountProofCollector = new(TestItem.Tree.AccountsWithPaths[3].Path.Bytes);
+            _inputTree.Accept(accountProofCollector, _inputTree.RootHash);
+            lastProof = accountProofCollector.BuildResult().Proof;
 
             // missing TestItem.Tree.AccountsWithHashes[2]
             var result2 = snapProvider.AddAccountRange(1, rootHash, TestItem.Tree.AccountsWithPaths[2].Path, TestItem.Tree.AccountsWithPaths[3..4], firstProof!.Concat(lastProof!).ToArray());
 
             Assert.AreEqual(2, db.Keys.Count);
 
-            firstProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[4].Path.Bytes);
-            lastProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[5].Path.Bytes);
+            accountProofCollector = new(TestItem.Tree.AccountsWithPaths[4].Path.Bytes);
+            _inputTree.Accept(accountProofCollector, _inputTree.RootHash);
+            firstProof = accountProofCollector.BuildResult().Proof;
+            accountProofCollector = new(TestItem.Tree.AccountsWithPaths[5].Path.Bytes);
+            _inputTree.Accept(accountProofCollector, _inputTree.RootHash);
+            lastProof = accountProofCollector.BuildResult().Proof;
 
             var result3 = snapProvider.AddAccountRange(1, rootHash, TestItem.Tree.AccountsWithPaths[4].Path, TestItem.Tree.AccountsWithPaths[4..6], firstProof!.Concat(lastProof!).ToArray());
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedHealingTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedHealingTests.cs
@@ -155,6 +155,7 @@ namespace Nethermind.Synchronization.Test.FastSync
         {
             Keccak startingHash = accounts.First().Path;
             Keccak endHash = accounts.Last().Path;
+            Keccak limitHash = Keccak.MaxValue;
 
             AccountProofCollector accountProofCollector = new(startingHash.Bytes);
             remoteStateTree.Accept(accountProofCollector, remoteStateTree.RootHash);
@@ -163,7 +164,7 @@ namespace Nethermind.Synchronization.Test.FastSync
             remoteStateTree.Accept(accountProofCollector, remoteStateTree.RootHash);
             byte[][] lastProof = accountProofCollector.BuildResult().Proof;
 
-            (_, _, _, _) = SnapProviderHelper.AddAccountRange(localStateTree, blockNumber, rootHash, startingHash, accounts, firstProof!.Concat(lastProof!).ToArray());
+            (_, _, _, _) = SnapProviderHelper.AddAccountRange(localStateTree, blockNumber, rootHash, startingHash, limitHash, accounts, firstProof!.Concat(lastProof!).ToArray());
         }
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/ProgressTrackerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/ProgressTrackerTests.cs
@@ -58,18 +58,28 @@ public class ProgressTrackerTests
 
         (SnapSyncBatch request, bool finished) = progressTracker.GetNextRequest();
         request.AccountRangeRequest.Should().NotBeNull();
+        request.AccountRangeRequest!.StartingHash.Bytes[0].Should().Be(0);
+        // Well, its a tiny bit off, because of like, 255/4 != 64 for example. But its fine, as long as its reasonably
+        // evenly divided.
+        request.AccountRangeRequest.LimitHash!.Bytes[0].Should().Be(63);
         finished.Should().BeFalse();
 
         (request, finished) = progressTracker.GetNextRequest();
         request.AccountRangeRequest.Should().NotBeNull();
+        request.AccountRangeRequest!.StartingHash.Bytes[0].Should().Be(63);
+        request.AccountRangeRequest.LimitHash!.Bytes[0].Should().Be(127);
         finished.Should().BeFalse();
 
         (request, finished) = progressTracker.GetNextRequest();
         request.AccountRangeRequest.Should().NotBeNull();
+        request.AccountRangeRequest!.StartingHash.Bytes[0].Should().Be(127);
+        request.AccountRangeRequest.LimitHash!.Bytes[0].Should().Be(191);
         finished.Should().BeFalse();
 
         (request, finished) = progressTracker.GetNextRequest();
         request.AccountRangeRequest.Should().NotBeNull();
+        request.AccountRangeRequest!.StartingHash.Bytes[0].Should().Be(191);
+        request.AccountRangeRequest.LimitHash!.Bytes[0].Should().Be(255);
         finished.Should().BeFalse();
 
         (request, finished) = progressTracker.GetNextRequest();

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/ProgressTrackerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/ProgressTrackerTests.cs
@@ -59,26 +59,24 @@ public class ProgressTrackerTests
         (SnapSyncBatch request, bool finished) = progressTracker.GetNextRequest();
         request.AccountRangeRequest.Should().NotBeNull();
         request.AccountRangeRequest!.StartingHash.Bytes[0].Should().Be(0);
-        // Well, its a tiny bit off, because of like, 255/4 != 64 for example. But its fine, as long as its reasonably
-        // evenly divided.
-        request.AccountRangeRequest.LimitHash!.Bytes[0].Should().Be(63);
+        request.AccountRangeRequest.LimitHash!.Bytes[0].Should().Be(64);
         finished.Should().BeFalse();
 
         (request, finished) = progressTracker.GetNextRequest();
         request.AccountRangeRequest.Should().NotBeNull();
-        request.AccountRangeRequest!.StartingHash.Bytes[0].Should().Be(63);
-        request.AccountRangeRequest.LimitHash!.Bytes[0].Should().Be(127);
+        request.AccountRangeRequest!.StartingHash.Bytes[0].Should().Be(64);
+        request.AccountRangeRequest.LimitHash!.Bytes[0].Should().Be(128);
         finished.Should().BeFalse();
 
         (request, finished) = progressTracker.GetNextRequest();
         request.AccountRangeRequest.Should().NotBeNull();
-        request.AccountRangeRequest!.StartingHash.Bytes[0].Should().Be(127);
-        request.AccountRangeRequest.LimitHash!.Bytes[0].Should().Be(191);
+        request.AccountRangeRequest!.StartingHash.Bytes[0].Should().Be(128);
+        request.AccountRangeRequest.LimitHash!.Bytes[0].Should().Be(192);
         finished.Should().BeFalse();
 
         (request, finished) = progressTracker.GetNextRequest();
         request.AccountRangeRequest.Should().NotBeNull();
-        request.AccountRangeRequest!.StartingHash.Bytes[0].Should().Be(191);
+        request.AccountRangeRequest!.StartingHash.Bytes[0].Should().Be(192);
         request.AccountRangeRequest.LimitHash!.Bytes[0].Should().Be(255);
         finished.Should().BeFalse();
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/ProgressTrackerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/ProgressTrackerTests.cs
@@ -22,7 +22,6 @@ public class ProgressTrackerTests
     {
         BlockTree blockTree = Build.A.BlockTree().WithBlocks(Build.A.Block.TestObject).TestObject;
         ProgressTracker progressTracker = new ProgressTracker(blockTree, new MemDb(), LimboLogs.Instance);
-        progressTracker.MoreAccountsToRight = false;
         progressTracker.EnqueueStorageRange(new StorageRange()
         {
             Accounts = Array.Empty<PathWithAccount>(),

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/ProgressTrackerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/ProgressTrackerTests.cs
@@ -18,7 +18,7 @@ public class ProgressTrackerTests
 {
     [Test]
     [Repeat(3)]
-    public async Task ProgressTracer_did_not_have_race_issue()
+    public async Task Did_not_have_race_issue()
     {
         BlockTree blockTree = Build.A.BlockTree().WithBlocks(Build.A.Block.TestObject).TestObject;
         ProgressTracker progressTracker = new ProgressTracker(blockTree, new MemDb(), LimboLogs.Instance);
@@ -48,5 +48,32 @@ public class ProgressTrackerTests
 
         await requestTask;
         await checkTask;
+    }
+
+    [Test]
+    public void Will_create_multiple_get_address_range_request()
+    {
+        BlockTree blockTree = Build.A.BlockTree().WithBlocks(Build.A.Block.TestObject).TestObject;
+        ProgressTracker progressTracker = new ProgressTracker(blockTree, new MemDb(), LimboLogs.Instance, 4);
+
+        (SnapSyncBatch request, bool finished) = progressTracker.GetNextRequest();
+        request.AccountRangeRequest.Should().NotBeNull();
+        finished.Should().BeFalse();
+
+        (request, finished) = progressTracker.GetNextRequest();
+        request.AccountRangeRequest.Should().NotBeNull();
+        finished.Should().BeFalse();
+
+        (request, finished) = progressTracker.GetNextRequest();
+        request.AccountRangeRequest.Should().NotBeNull();
+        finished.Should().BeFalse();
+
+        (request, finished) = progressTracker.GetNextRequest();
+        request.AccountRangeRequest.Should().NotBeNull();
+        finished.Should().BeFalse();
+
+        (request, finished) = progressTracker.GetNextRequest();
+        request.Should().BeNull();
+        finished.Should().BeFalse();
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/RecreateStateFromAccountRangesTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/RecreateStateFromAccountRangesTests.cs
@@ -199,6 +199,41 @@ namespace Nethermind.Synchronization.Test.SnapSync
         }
 
         [Test]
+        public void RecreateAccountStateFromMultipleRange_InReverseOrder()
+        {
+            Keccak rootHash = _inputTree.RootHash;   // "0x8c81279168edc449089449bc0f2136fc72c9645642845755633cf259cd97988b"
+
+            // output state
+            MemDb db = new();
+            DbProvider dbProvider = new(DbModeHint.Mem);
+            dbProvider.RegisterDb(DbNames.State, db);
+            ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
+            SnapProvider snapProvider = new(progressTracker, dbProvider, LimboLogs.Instance);
+
+            byte[][] firstProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[4].Path.Bytes);
+            byte[][] lastProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[5].Path.Bytes);
+            var result3 = snapProvider.AddAccountRange(1, rootHash, TestItem.Tree.AccountsWithPaths[4].Path, TestItem.Tree.AccountsWithPaths[4..6], firstProof!.Concat(lastProof!).ToArray());
+
+            Assert.AreEqual(4, db.Keys.Count);
+
+            firstProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[2].Path.Bytes);
+            lastProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[3].Path.Bytes);
+            var result2 = snapProvider.AddAccountRange(1, rootHash, TestItem.Tree.AccountsWithPaths[2].Path, TestItem.Tree.AccountsWithPaths[2..4], firstProof!.Concat(lastProof!).ToArray());
+
+            Assert.AreEqual(6, db.Keys.Count);  // we don't persist proof nodes (boundary nodes)
+
+            firstProof = CreateProofForPath(Keccak.Zero.Bytes);
+            lastProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[1].Path.Bytes);
+            var result1 = snapProvider.AddAccountRange(1, rootHash, Keccak.Zero, TestItem.Tree.AccountsWithPaths[0..2], firstProof!.Concat(lastProof!).ToArray());
+
+            Assert.AreEqual(AddRangeResult.OK, result1);
+            Assert.AreEqual(AddRangeResult.OK, result2);
+            Assert.AreEqual(AddRangeResult.OK, result3);
+            Assert.AreEqual(10, db.Keys.Count);  // we persist proof nodes (boundary nodes) via stitching
+            Assert.IsFalse(db.KeyExists(rootHash));
+        }
+
+        [Test]
         public void RecreateAccountStateFromMultipleOverlappingRange()
         {
             Keccak rootHash = _inputTree.RootHash;   // "0x8c81279168edc449089449bc0f2136fc72c9645642845755633cf259cd97988b"
@@ -211,23 +246,23 @@ namespace Nethermind.Synchronization.Test.SnapSync
             SnapProvider snapProvider = new(progressTracker, dbProvider, LimboLogs.Instance);
 
             byte[][] firstProof = CreateProofForPath(Keccak.Zero.Bytes);
-            byte[][] lastProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[1].Path.Bytes);
+            byte[][] lastProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[2].Path.Bytes);
 
-            var result1 = snapProvider.AddAccountRange(1, rootHash, Keccak.Zero, TestItem.Tree.AccountsWithPaths[0..2], firstProof!.Concat(lastProof!).ToArray());
+            var result1 = snapProvider.AddAccountRange(1, rootHash, Keccak.Zero, TestItem.Tree.AccountsWithPaths[0..3], firstProof!.Concat(lastProof!).ToArray());
 
-            Assert.AreEqual(2, db.Keys.Count);
+            Assert.AreEqual(3, db.Keys.Count);
 
             firstProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[2].Path.Bytes);
             lastProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[3].Path.Bytes);
 
-            var result2 = snapProvider.AddAccountRange(1, rootHash, TestItem.Tree.AccountsWithPaths[2].Path, TestItem.Tree.AccountsWithPaths[2..3], firstProof!.Concat(lastProof!).ToArray());
+            var result2 = snapProvider.AddAccountRange(1, rootHash, TestItem.Tree.AccountsWithPaths[2].Path, TestItem.Tree.AccountsWithPaths[2..4], firstProof!.Concat(lastProof!).ToArray());
 
             firstProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[3].Path.Bytes);
             lastProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[4].Path.Bytes);
 
-            var result3 = snapProvider.AddAccountRange(1, rootHash, TestItem.Tree.AccountsWithPaths[3].Path, TestItem.Tree.AccountsWithPaths[3..4], firstProof!.Concat(lastProof!).ToArray());
+            var result3 = snapProvider.AddAccountRange(1, rootHash, TestItem.Tree.AccountsWithPaths[3].Path, TestItem.Tree.AccountsWithPaths[3..5], firstProof!.Concat(lastProof!).ToArray());
 
-            Assert.AreEqual(5, db.Keys.Count);  // we don't persist proof nodes (boundary nodes)
+            Assert.AreEqual(6, db.Keys.Count);  // we don't persist proof nodes (boundary nodes)
 
             firstProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[4].Path.Bytes);
             lastProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[5].Path.Bytes);

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/RecreateStateFromAccountRangesTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/RecreateStateFromAccountRangesTests.cs
@@ -3,17 +3,14 @@
 
 #nullable disable
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using Nethermind.Core;
+using FluentAssertions;
 using Nethermind.Core.Crypto;
-using Nethermind.Core.Extensions;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
 using Nethermind.Int256;
 using Nethermind.Logging;
-using Nethermind.Serialization.Rlp;
 using Nethermind.State;
 using Nethermind.State.Proofs;
 using Nethermind.State.Snap;
@@ -35,18 +32,24 @@ namespace Nethermind.Synchronization.Test.SnapSync
             _inputTree = TestItem.Tree.GetStateTree(null);
         }
 
+        private byte[][] CreateProofForPath(byte[] path, StateTree tree = null)
+        {
+            AccountProofCollector accountProofCollector = new(path);
+            if (tree == null)
+            {
+                tree = _inputTree;
+            }
+            tree.Accept(accountProofCollector, tree.RootHash);
+            return accountProofCollector.BuildResult().Proof;
+        }
+
         //[Test]
         public void Test01()
         {
             Keccak rootHash = _inputTree.RootHash;   // "0x8c81279168edc449089449bc0f2136fc72c9645642845755633cf259cd97988b"
 
-            AccountProofCollector accountProofCollector = new(TestItem.Tree.AccountsWithPaths[0].Path.Bytes);
-            _inputTree.Accept(accountProofCollector, _inputTree.RootHash);
-            byte[][] firstProof = accountProofCollector.BuildResult().Proof;
-
-            accountProofCollector = new(TestItem.Tree.AccountsWithPaths[5].Path.Bytes);
-            _inputTree.Accept(accountProofCollector, _inputTree.RootHash);
-            byte[][] lastProof = accountProofCollector.BuildResult().Proof;
+            byte[][] firstProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[0].Path.Bytes);
+            byte[][] lastProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[5].Path.Bytes);
 
             MemDb db = new();
             TrieStore store = new(db, LimboLogs.Instance);
@@ -105,19 +108,15 @@ namespace Nethermind.Synchronization.Test.SnapSync
         {
             Keccak rootHash = _inputTree.RootHash;   // "0x8c81279168edc449089449bc0f2136fc72c9645642845755633cf259cd97988b"
 
-            AccountProofCollector accountProofCollector = new(Keccak.Zero.Bytes);
-            _inputTree.Accept(accountProofCollector, _inputTree.RootHash);
-            byte[][] firstProof = accountProofCollector.BuildResult().Proof;
-            accountProofCollector = new(TestItem.Tree.AccountsWithPaths[5].Path.Bytes);
-            _inputTree.Accept(accountProofCollector, _inputTree.RootHash);
-            byte[][] lastProof = accountProofCollector.BuildResult().Proof;
+            byte[][] firstProof = CreateProofForPath(Keccak.Zero.Bytes);
+            byte[][] lastProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[5].Path.Bytes);
 
             MemDb db = new();
             DbProvider dbProvider = new(DbModeHint.Mem);
             dbProvider.RegisterDb(DbNames.State, db);
             ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
             SnapProvider snapProvider = new(progressTracker, dbProvider, LimboLogs.Instance);
-            var result = snapProvider.AddAccountRange(1, rootHash, Keccak.Zero, TestItem.Tree.AccountsWithPaths, firstProof!.Concat(lastProof!).ToArray());
+            AddRangeResult result = snapProvider.AddAccountRange(1, rootHash, Keccak.Zero, TestItem.Tree.AccountsWithPaths, firstProof!.Concat(lastProof!).ToArray());
 
             Assert.AreEqual(AddRangeResult.OK, result);
             Assert.AreEqual(10, db.Keys.Count);  // we persist proof nodes (boundary nodes) via stitching
@@ -129,12 +128,8 @@ namespace Nethermind.Synchronization.Test.SnapSync
         {
             Keccak rootHash = _inputTree.RootHash;   // "0x8c81279168edc449089449bc0f2136fc72c9645642845755633cf259cd97988b"
 
-            AccountProofCollector accountProofCollector = new(TestItem.Tree.AccountsWithPaths[0].Path.Bytes);
-            _inputTree.Accept(accountProofCollector, _inputTree.RootHash);
-            byte[][] firstProof = accountProofCollector.BuildResult().Proof;
-            accountProofCollector = new(TestItem.Tree.AccountsWithPaths[5].Path.Bytes);
-            _inputTree.Accept(accountProofCollector, _inputTree.RootHash);
-            byte[][] lastProof = accountProofCollector.BuildResult().Proof;
+            byte[][] firstProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[0].Path.Bytes);
+            byte[][] lastProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[5].Path.Bytes);
 
             MemDb db = new();
             DbProvider dbProvider = new(DbModeHint.Mem);
@@ -177,34 +172,22 @@ namespace Nethermind.Synchronization.Test.SnapSync
             ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
             SnapProvider snapProvider = new(progressTracker, dbProvider, LimboLogs.Instance);
 
-            AccountProofCollector accountProofCollector = new(Keccak.Zero.Bytes);
-            _inputTree.Accept(accountProofCollector, _inputTree.RootHash);
-            byte[][] firstProof = accountProofCollector.BuildResult().Proof;
-            accountProofCollector = new(TestItem.Tree.AccountsWithPaths[1].Path.Bytes);
-            _inputTree.Accept(accountProofCollector, _inputTree.RootHash);
-            byte[][] lastProof = accountProofCollector.BuildResult().Proof;
+            byte[][] firstProof = CreateProofForPath(Keccak.Zero.Bytes);
+            byte[][] lastProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[1].Path.Bytes);
 
             var result1 = snapProvider.AddAccountRange(1, rootHash, Keccak.Zero, TestItem.Tree.AccountsWithPaths[0..2], firstProof!.Concat(lastProof!).ToArray());
 
             Assert.AreEqual(2, db.Keys.Count);
 
-            accountProofCollector = new(TestItem.Tree.AccountsWithPaths[2].Path.Bytes);
-            _inputTree.Accept(accountProofCollector, _inputTree.RootHash);
-            firstProof = accountProofCollector.BuildResult().Proof;
-            accountProofCollector = new(TestItem.Tree.AccountsWithPaths[3].Path.Bytes);
-            _inputTree.Accept(accountProofCollector, _inputTree.RootHash);
-            lastProof = accountProofCollector.BuildResult().Proof;
+            firstProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[2].Path.Bytes);
+            lastProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[3].Path.Bytes);
 
             var result2 = snapProvider.AddAccountRange(1, rootHash, TestItem.Tree.AccountsWithPaths[2].Path, TestItem.Tree.AccountsWithPaths[2..4], firstProof!.Concat(lastProof!).ToArray());
 
             Assert.AreEqual(5, db.Keys.Count);  // we don't persist proof nodes (boundary nodes)
 
-            accountProofCollector = new(TestItem.Tree.AccountsWithPaths[4].Path.Bytes);
-            _inputTree.Accept(accountProofCollector, _inputTree.RootHash);
-            firstProof = accountProofCollector.BuildResult().Proof;
-            accountProofCollector = new(TestItem.Tree.AccountsWithPaths[5].Path.Bytes);
-            _inputTree.Accept(accountProofCollector, _inputTree.RootHash);
-            lastProof = accountProofCollector.BuildResult().Proof;
+            firstProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[4].Path.Bytes);
+            lastProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[5].Path.Bytes);
 
             var result3 = snapProvider.AddAccountRange(1, rootHash, TestItem.Tree.AccountsWithPaths[4].Path, TestItem.Tree.AccountsWithPaths[4..6], firstProof!.Concat(lastProof!).ToArray());
 
@@ -213,6 +196,93 @@ namespace Nethermind.Synchronization.Test.SnapSync
             Assert.AreEqual(AddRangeResult.OK, result3);
             Assert.AreEqual(10, db.Keys.Count);  // we persist proof nodes (boundary nodes) via stitching
             Assert.IsFalse(db.KeyExists(rootHash));
+        }
+
+        [Test]
+        public void RecreateAccountStateFromMultipleOverlappingRange()
+        {
+            Keccak rootHash = _inputTree.RootHash;   // "0x8c81279168edc449089449bc0f2136fc72c9645642845755633cf259cd97988b"
+
+            // output state
+            MemDb db = new();
+            DbProvider dbProvider = new(DbModeHint.Mem);
+            dbProvider.RegisterDb(DbNames.State, db);
+            ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
+            SnapProvider snapProvider = new(progressTracker, dbProvider, LimboLogs.Instance);
+
+            byte[][] firstProof = CreateProofForPath(Keccak.Zero.Bytes);
+            byte[][] lastProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[1].Path.Bytes);
+
+            var result1 = snapProvider.AddAccountRange(1, rootHash, Keccak.Zero, TestItem.Tree.AccountsWithPaths[0..2], firstProof!.Concat(lastProof!).ToArray());
+
+            Assert.AreEqual(2, db.Keys.Count);
+
+            firstProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[2].Path.Bytes);
+            lastProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[3].Path.Bytes);
+
+            var result2 = snapProvider.AddAccountRange(1, rootHash, TestItem.Tree.AccountsWithPaths[2].Path, TestItem.Tree.AccountsWithPaths[2..3], firstProof!.Concat(lastProof!).ToArray());
+
+            firstProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[3].Path.Bytes);
+            lastProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[4].Path.Bytes);
+
+            var result3 = snapProvider.AddAccountRange(1, rootHash, TestItem.Tree.AccountsWithPaths[3].Path, TestItem.Tree.AccountsWithPaths[3..4], firstProof!.Concat(lastProof!).ToArray());
+
+            Assert.AreEqual(5, db.Keys.Count);  // we don't persist proof nodes (boundary nodes)
+
+            firstProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[4].Path.Bytes);
+            lastProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[5].Path.Bytes);
+
+            var result4 = snapProvider.AddAccountRange(1, rootHash, TestItem.Tree.AccountsWithPaths[4].Path, TestItem.Tree.AccountsWithPaths[4..6], firstProof!.Concat(lastProof!).ToArray());
+
+            Assert.AreEqual(AddRangeResult.OK, result1);
+            Assert.AreEqual(AddRangeResult.OK, result2);
+            Assert.AreEqual(AddRangeResult.OK, result3);
+            Assert.AreEqual(AddRangeResult.OK, result4);
+            Assert.AreEqual(10, db.Keys.Count);  // we persist proof nodes (boundary nodes) via stitching
+            Assert.IsFalse(db.KeyExists(rootHash));
+        }
+
+        [Test]
+        public void CorrectlyDetermineHasMoreChildren()
+        {
+            Keccak rootHash = _inputTree.RootHash;   // "0x8c81279168edc449089449bc0f2136fc72c9645642845755633cf259cd97988b"
+
+            // output state
+            MemDb db = new();
+            DbProvider dbProvider = new(DbModeHint.Mem);
+            dbProvider.RegisterDb(DbNames.State, db);
+            ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
+            SnapProvider snapProvider = new(progressTracker, dbProvider, LimboLogs.Instance);
+
+            byte[][] firstProof = CreateProofForPath(Keccak.Zero.Bytes);
+            byte[][] lastProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[1].Path.Bytes);
+            byte[][] proofs = firstProof.Concat(lastProof).ToArray();
+
+            StateTree newTree = new(new TrieStore(new MemDb(), LimboLogs.Instance), LimboLogs.Instance);
+
+            PathWithAccount[] receiptAccounts = TestItem.Tree.AccountsWithPaths[0..2];
+
+            bool HasMoreChildren(Keccak limitHash)
+            {
+                (AddRangeResult _, bool moreChildrenToRight, IList<PathWithAccount> _, IList<Keccak> _) =
+                    SnapProviderHelper.AddAccountRange(newTree, 0, rootHash, Keccak.Zero, limitHash, receiptAccounts, proofs);
+                return moreChildrenToRight;
+            }
+
+            HasMoreChildren(TestItem.Tree.AccountsWithPaths[1].Path).Should().BeFalse();
+            HasMoreChildren(TestItem.Tree.AccountsWithPaths[2].Path).Should().BeFalse();
+            HasMoreChildren(TestItem.Tree.AccountsWithPaths[3].Path).Should().BeTrue();
+            HasMoreChildren(TestItem.Tree.AccountsWithPaths[4].Path).Should().BeTrue();
+
+            UInt256 between2and3 = new UInt256(TestItem.Tree.AccountsWithPaths[1].Path.Bytes, true);
+            between2and3 += 5;
+
+            HasMoreChildren(new Keccak(between2and3.ToBigEndian())).Should().BeFalse();
+
+            between2and3 = new UInt256(TestItem.Tree.AccountsWithPaths[2].Path.Bytes, true);
+            between2and3 -= 1;
+
+            HasMoreChildren(new Keccak(between2and3.ToBigEndian())).Should().BeFalse();
         }
 
         [Test]
@@ -227,35 +297,23 @@ namespace Nethermind.Synchronization.Test.SnapSync
             ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
             SnapProvider snapProvider = new(progressTracker, dbProvider, LimboLogs.Instance);
 
-            AccountProofCollector accountProofCollector = new(Keccak.Zero.Bytes);
-            _inputTree.Accept(accountProofCollector, _inputTree.RootHash);
-            byte[][] firstProof = accountProofCollector.BuildResult().Proof;
-            accountProofCollector = new(TestItem.Tree.AccountsWithPaths[1].Path.Bytes);
-            _inputTree.Accept(accountProofCollector, _inputTree.RootHash);
-            byte[][] lastProof = accountProofCollector.BuildResult().Proof;
+            byte[][] firstProof = CreateProofForPath(Keccak.Zero.Bytes);
+            byte[][] lastProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[1].Path.Bytes);
 
             var result1 = snapProvider.AddAccountRange(1, rootHash, Keccak.Zero, TestItem.Tree.AccountsWithPaths[0..2], firstProof!.Concat(lastProof!).ToArray());
 
             Assert.AreEqual(2, db.Keys.Count);
 
-            accountProofCollector = new(TestItem.Tree.AccountsWithPaths[2].Path.Bytes);
-            _inputTree.Accept(accountProofCollector, _inputTree.RootHash);
-            firstProof = accountProofCollector.BuildResult().Proof;
-            accountProofCollector = new(TestItem.Tree.AccountsWithPaths[3].Path.Bytes);
-            _inputTree.Accept(accountProofCollector, _inputTree.RootHash);
-            lastProof = accountProofCollector.BuildResult().Proof;
+            firstProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[2].Path.Bytes);
+            lastProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[3].Path.Bytes);
 
             // missing TestItem.Tree.AccountsWithHashes[2]
             var result2 = snapProvider.AddAccountRange(1, rootHash, TestItem.Tree.AccountsWithPaths[2].Path, TestItem.Tree.AccountsWithPaths[3..4], firstProof!.Concat(lastProof!).ToArray());
 
             Assert.AreEqual(2, db.Keys.Count);
 
-            accountProofCollector = new(TestItem.Tree.AccountsWithPaths[4].Path.Bytes);
-            _inputTree.Accept(accountProofCollector, _inputTree.RootHash);
-            firstProof = accountProofCollector.BuildResult().Proof;
-            accountProofCollector = new(TestItem.Tree.AccountsWithPaths[5].Path.Bytes);
-            _inputTree.Accept(accountProofCollector, _inputTree.RootHash);
-            lastProof = accountProofCollector.BuildResult().Proof;
+            firstProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[4].Path.Bytes);
+            lastProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[5].Path.Bytes);
 
             var result3 = snapProvider.AddAccountRange(1, rootHash, TestItem.Tree.AccountsWithPaths[4].Path, TestItem.Tree.AccountsWithPaths[4..6], firstProof!.Concat(lastProof!).ToArray());
 

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/ISnapProvider.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/ISnapProvider.cs
@@ -18,7 +18,7 @@ namespace Nethermind.Synchronization.SnapSync
         bool CanSync();
 
         AddRangeResult AddAccountRange(AccountRange request, AccountsAndProofs response);
-        AddRangeResult AddAccountRange(long blockNumber, Keccak expectedRootHash, Keccak startingHash, PathWithAccount[] accounts, byte[][] proofs = null);
+        AddRangeResult AddAccountRange(long blockNumber, Keccak expectedRootHash, Keccak startingHash, PathWithAccount[] accounts, byte[][] proofs = null, Keccak limitHash = null!);
 
         AddRangeResult AddStorageRange(StorageRange request, SlotsAndProofs response);
         AddRangeResult AddStorageRange(long blockNumber, PathWithAccount pathWithAccount, Keccak expectedRootHash, Keccak startingHash, PathWithStorageSlot[] slots, byte[][] proofs = null);

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
@@ -62,6 +62,9 @@ namespace Nethermind.Synchronization.SnapSync
 
             _pivot = new Pivot(blockTree, logManager);
 
+            if (accountRangePartitionCount < 1 || accountRangePartitionCount > 256)
+                throw new ArgumentException("Account range partition must be between 1 to 256.");
+
             _accountRangePartitionCount = accountRangePartitionCount;
             SetupAccountRangePartition();
 
@@ -76,7 +79,6 @@ namespace Nethermind.Synchronization.SnapSync
             // either on proof generation or validation.
             byte curStartingPath = 0;
             int partitionSize = (256 / _accountRangePartitionCount);
-            if (partitionSize == 0) throw new ArgumentException("Too many snap partition");
 
             for (var i = 0; i < _accountRangePartitionCount; i++)
             {

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
@@ -8,11 +8,9 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using Nethermind.Blockchain;
-using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Db;
-using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.State.Snap;
 

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
@@ -72,7 +72,7 @@ namespace Nethermind.Synchronization.SnapSync
         private void SetupAccountRangePartition()
         {
             UInt256 curStartingPath = UInt256.Zero;
-            UInt256 partitionSize = UInt256.MaxValue / new UInt256(0, 0, 0, (ulong) _accountRangePartitionCount);
+            UInt256 partitionSize = UInt256.MaxValue / new UInt256(0, 0, 0, (ulong)_accountRangePartitionCount);
 
             if (partitionSize == 0) throw new ArgumentException("Too many snap partition");
 
@@ -365,7 +365,7 @@ namespace Nethermind.Synchronization.SnapSync
                     totalPathProgress += nextAccount - startAccount;
                 }
 
-                double progress = 100 * totalPathProgress / (double) (256 * 256);
+                double progress = 100 * totalPathProgress / (double)(256 * 256);
 
                 if (_logger.IsInfo) _logger.Info($"SNAP - progress of State Ranges (Phase 1): {progress:f3}% [{new string('*', (int)progress / 10)}{new string(' ', 10 - (int)progress / 10)}]");
             }

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
@@ -72,7 +72,7 @@ namespace Nethermind.Synchronization.SnapSync
         private void SetupAccountRangePartition()
         {
             UInt256 curStartingPath = UInt256.Zero;
-            UInt256 partitionSize = UInt256.MaxValue / new UInt256(0, 0, 0, (ulong)_accountRangePartitionCount);
+            UInt256 partitionSize = UInt256.MaxValue / (ulong)_accountRangePartitionCount;
 
             if (partitionSize == 0) throw new ArgumentException("Too many snap partition");
 

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
@@ -75,7 +75,7 @@ namespace Nethermind.Synchronization.SnapSync
             // The mismatch happens on exactly the same partition every time, suggesting tome kind of boundary issues
             // either on proof generation or validation.
             byte curStartingPath = 0;
-            byte partitionSize = (byte)(256 / _accountRangePartitionCount);
+            int partitionSize = (256 / _accountRangePartitionCount);
             if (partitionSize == 0) throw new ArgumentException("Too many snap partition");
 
             for (var i = 0; i < _accountRangePartitionCount; i++)
@@ -88,7 +88,7 @@ namespace Nethermind.Synchronization.SnapSync
                 partition.NextAccountPath = startingPath;
                 partition.AccountPathStart = startingPath;
 
-                curStartingPath += partitionSize;
+                curStartingPath += (byte)partitionSize;
 
                 Keccak limitPath = new Keccak(Keccak.Zero.Bytes.ToArray());
                 limitPath.Bytes[0] = curStartingPath;

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
@@ -90,13 +90,17 @@ namespace Nethermind.Synchronization.SnapSync
 
                 curStartingPath += (byte)partitionSize;
 
-                Keccak limitPath = new Keccak(Keccak.Zero.Bytes.ToArray());
-                limitPath.Bytes[0] = curStartingPath;
+                Keccak limitPath;
 
                 // Special case for the last partition
                 if (i == _accountRangePartitionCount - 1)
                 {
                     limitPath = Keccak.MaxValue;
+                }
+                else
+                {
+                    limitPath = new Keccak(Keccak.Zero.Bytes.ToArray());
+                    limitPath.Bytes[0] = curStartingPath;
                 }
 
                 partition.AccountPathLimit = limitPath;

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProvider.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProvider.cs
@@ -31,7 +31,7 @@ namespace Nethermind.Synchronization.SnapSync
             _progressTracker = progressTracker ?? throw new ArgumentNullException(nameof(progressTracker));
 
             _store = new TrieStore(
-                _dbProvider.StateDb,
+                dbProvider.StateDb,
                 Trie.Pruning.No.Pruning,
                 Persist.EveryBlock,
                 logManager);
@@ -56,7 +56,7 @@ namespace Nethermind.Synchronization.SnapSync
             }
             else
             {
-                result = AddAccountRange(request.BlockNumber.Value, request.RootHash, request.StartingHash, response.PathAndAccounts, response.Proofs);
+                result = AddAccountRange(request.BlockNumber.Value, request.RootHash, request.StartingHash, response.PathAndAccounts, response.Proofs, hashLimit: request.LimitHash);
 
                 if (result == AddRangeResult.OK)
                 {
@@ -64,17 +64,19 @@ namespace Nethermind.Synchronization.SnapSync
                 }
             }
 
-            _progressTracker.ReportAccountRequestFinished();
+            _progressTracker.ReportAccountSectionFinished(request.LimitHash);
 
             return result;
         }
 
-        public AddRangeResult AddAccountRange(long blockNumber, Keccak expectedRootHash, Keccak startingHash, PathWithAccount[] accounts, byte[][] proofs = null)
+        public AddRangeResult AddAccountRange(long blockNumber, Keccak expectedRootHash, Keccak startingHash, PathWithAccount[] accounts, byte[][] proofs = null, Keccak hashLimit = null!)
         {
             StateTree tree = new(_store, _logManager);
 
+            if (hashLimit == null) hashLimit = Keccak.MaxValue;
+
             (AddRangeResult result, bool moreChildrenToRight, IList<PathWithAccount> accountsWithStorage, IList<Keccak> codeHashes) =
-                SnapProviderHelper.AddAccountRange(tree, blockNumber, expectedRootHash, startingHash, accounts, proofs);
+                SnapProviderHelper.AddAccountRange(tree, blockNumber, expectedRootHash, startingHash, hashLimit, accounts, proofs);
 
             if (result == AddRangeResult.OK)
             {
@@ -84,9 +86,7 @@ namespace Nethermind.Synchronization.SnapSync
                 }
 
                 _progressTracker.EnqueueCodeHashes(codeHashes);
-
-                _progressTracker.NextAccountPath = accounts[accounts.Length - 1].Path;
-                _progressTracker.MoreAccountsToRight = moreChildrenToRight;
+                _progressTracker.UpdateAccountSectionPath(accounts[accounts.Length - 1].Path, hashLimit, moreChildrenToRight);
             }
             else if (result == AddRangeResult.MissingRootHashInProofs)
             {
@@ -272,7 +272,7 @@ namespace Nethermind.Synchronization.SnapSync
         {
             if (batch.AccountRangeRequest is not null)
             {
-                _progressTracker.ReportAccountRequestFinished();
+                _progressTracker.ReportAccountSectionFinished(batch.AccountRangeRequest.LimitHash);
             }
             else if (batch.StorageRangeRequest is not null)
             {
@@ -288,7 +288,10 @@ namespace Nethermind.Synchronization.SnapSync
             }
         }
 
-        public bool IsSnapGetRangesFinished() => _progressTracker.IsSnapGetRangesFinished();
+        public bool IsSnapGetRangesFinished()
+        {
+            return _progressTracker.IsSnapGetRangesFinished();
+        }
 
         public void UpdatePivot()
         {

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProvider.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProvider.cs
@@ -31,7 +31,7 @@ namespace Nethermind.Synchronization.SnapSync
             _progressTracker = progressTracker ?? throw new ArgumentNullException(nameof(progressTracker));
 
             _store = new TrieStore(
-                dbProvider.StateDb,
+                _dbProvider.StateDb,
                 Trie.Pruning.No.Pruning,
                 Persist.EveryBlock,
                 logManager);
@@ -86,7 +86,7 @@ namespace Nethermind.Synchronization.SnapSync
                 }
 
                 _progressTracker.EnqueueCodeHashes(codeHashes);
-                _progressTracker.UpdateAccountRangePartitionProgress(accounts[accounts.Length - 1].Path, hashLimit, moreChildrenToRight);
+                _progressTracker.UpdateAccountRangePartitionProgress(hashLimit, accounts[^1].Path, moreChildrenToRight);
             }
             else if (result == AddRangeResult.MissingRootHashInProofs)
             {
@@ -288,10 +288,7 @@ namespace Nethermind.Synchronization.SnapSync
             }
         }
 
-        public bool IsSnapGetRangesFinished()
-        {
-            return _progressTracker.IsSnapGetRangesFinished();
-        }
+        public bool IsSnapGetRangesFinished() => _progressTracker.IsSnapGetRangesFinished();
 
         public void UpdatePivot()
         {

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProvider.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProvider.cs
@@ -64,7 +64,7 @@ namespace Nethermind.Synchronization.SnapSync
                 }
             }
 
-            _progressTracker.ReportAccountSectionFinished(request.LimitHash);
+            _progressTracker.ReportAccountRangePartitionFinished(request.LimitHash);
 
             return result;
         }
@@ -86,7 +86,7 @@ namespace Nethermind.Synchronization.SnapSync
                 }
 
                 _progressTracker.EnqueueCodeHashes(codeHashes);
-                _progressTracker.UpdateAccountSectionPath(accounts[accounts.Length - 1].Path, hashLimit, moreChildrenToRight);
+                _progressTracker.UpdateAccountRangePartitionProgress(accounts[accounts.Length - 1].Path, hashLimit, moreChildrenToRight);
             }
             else if (result == AddRangeResult.MissingRootHashInProofs)
             {
@@ -272,7 +272,7 @@ namespace Nethermind.Synchronization.SnapSync
         {
             if (batch.AccountRangeRequest is not null)
             {
-                _progressTracker.ReportAccountSectionFinished(batch.AccountRangeRequest.LimitHash);
+                _progressTracker.ReportAccountRangePartitionFinished(batch.AccountRangeRequest.LimitHash);
             }
             else if (batch.StorageRangeRequest is not null)
             {

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProviderHelper.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProviderHelper.cs
@@ -2,22 +2,14 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
-using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
-using Nethermind.Db;
-using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
 using Nethermind.State;
-using Nethermind.State.Proofs;
 using Nethermind.State.Snap;
 using Nethermind.Trie;
 using Nethermind.Trie.Pruning;

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProviderHelper.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProviderHelper.cs
@@ -24,7 +24,7 @@ using Nethermind.Trie.Pruning;
 
 namespace Nethermind.Synchronization.SnapSync
 {
-    internal static class SnapProviderHelper
+    public static class SnapProviderHelper
     {
         private static object _syncCommit = new();
 
@@ -36,7 +36,8 @@ namespace Nethermind.Synchronization.SnapSync
             Keccak limitHash,
             PathWithAccount[] accounts,
             byte[][] proofs = null
-        ) {
+        )
+        {
             // TODO: Check the accounts boundaries and sorting
 
             Keccak lastHash = accounts[^1].Path;
@@ -96,7 +97,8 @@ namespace Nethermind.Synchronization.SnapSync
             PathWithStorageSlot[] slots,
             Keccak expectedRootHash,
             byte[][]? proofs = null
-        ) {
+        )
+        {
             // TODO: Check the slots boundaries and sorting
 
             Keccak lastHash = slots.Last().Path;
@@ -140,7 +142,8 @@ namespace Nethermind.Synchronization.SnapSync
             Keccak limitHash,
             Keccak expectedRootHash,
             byte[][]? proofs = null
-        ) {
+        )
+        {
             if (proofs is null || proofs.Length == 0)
             {
                 return (AddRangeResult.OK, null, false);
@@ -231,7 +234,7 @@ namespace Nethermind.Synchronization.SnapSync
                     {
                         Keccak? childKeccak = node.GetChildHash(ci);
 
-                        moreChildrenToRight |= (ci > right && ci <= limit) && childKeccak is not null;
+                        moreChildrenToRight |= (ci > right && ci < limit) && childKeccak is not null;
 
                         if (ci >= left && ci <= right)
                         {


### PR DESCRIPTION
- Improve snap request concurrency by splitting top level account range into n configurable, fixed sized partition.
- Improve my snap sync time by about 20% to 25%, but more importantly, reliably saturate my ssd, so snap sync now reliably take less than one hour to complete.
- This works as currently only some peers are used in snap sync as it is limited by the top level account range progress to know what else to request. If the network is fast, and nethermind got lucky to get a fast peer (and it dispatch account range request to that peer), the sync will be quick. Otherwise, it does not matter how fast your internet and ssd are.
- This change split the top level account range into n (8 by default) partition and dispatch them concurrently to multiple peer, significantly increase the request rate. 
- Snap protocol already have `limit` parameters, so this works well.

![Screenshot from 2023-02-26 11-23-56](https://user-images.githubusercontent.com/1841324/221390851-b3290de2-46a9-4873-97bf-22cfee0cf0cf.png)

## Changes

- Add config to specify num of partition.
- Dispatch multiple concurrent account range request where possible.

## Types of changes

#### What types of changes does your code introduce?

- [X] Optimization

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Multiple successful mainnet sync.
- Had to stop mainnet VerifyTrie, its taking too much time. Last progress: 2023-02-28 00:03:43.0144|WARN|13|Collected info from 1100001490 nodes. Missing CODE 0 STATE 0 STORAGE 0 .
- Goerli can sync
- ~~Sepolia still looking for peer (known issue) and my new ISP have this nasty habit of not working randomly when I start nethermind.~~ It's synced now. Don't know when, just left it on for the whole day.

#### Other notes
- It seems to be possible to remove the commit lock by creating a new triestore every time. This further reduce sync time by another 20%. I did not include that here as that seems like something that will silently break things, maybe on a different PR.