### PR TITLE
Update ethereum tests, add `Eip3651Tests`

### DIFF
--- a/src/Nethermind/Ethereum.Blockchain.Test/Eip3651Tests.cs
+++ b/src/Nethermind/Ethereum.Blockchain.Test/Eip3651Tests.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Collections.Generic;

--- a/src/Nethermind/Ethereum.Blockchain.Test/Eip3651Tests.cs
+++ b/src/Nethermind/Ethereum.Blockchain.Test/Eip3651Tests.cs
@@ -1,0 +1,25 @@
+﻿// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Generic;
+using Ethereum.Test.Base;
+using NUnit.Framework;
+
+namespace Ethereum.Blockchain.Test;
+
+[TestFixture]
+[Parallelizable(ParallelScope.All)]
+public class Eip3651Tests : GeneralStateTestBase
+{
+    [TestCaseSource(nameof(LoadTests))]
+    public void Test(GeneralStateTest test)
+    {
+        Assert.True(RunTest(test).Pass);
+    }
+
+    public static IEnumerable<GeneralStateTest> LoadTests()
+    {
+        var loader = new TestsSourceLoader(new LoadGeneralStateTestsStrategy(), "stEIP3651");
+        return (IEnumerable<GeneralStateTest>)loader.LoadTests();
+    }
+}


### PR DESCRIPTION
## Changes

- standard update of ethereum tests
- added class `Eip3651Tests`

Intentionally `stEOF` tests are not inclluded - it is not merged yet and we are failing it

## Types of changes

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: standard update of ethereum tests

## Testing

#### Requires testing

- [ ] Yes
- [x] No
