### PR TITLE
RocksDB read focused config - Make less spikes on block processing

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
@@ -21,7 +21,7 @@ public class DbConfig : IDbConfig
     public uint ReceiptsDbWriteBufferNumber { get; set; } = 4;
     public ulong ReceiptsDbBlockCacheSize { get; set; } = (ulong)32.MiB();
     public bool ReceiptsDbCacheIndexAndFilterBlocks { get; set; } = false;
-    public int? ReceiptsDbMaxOpenFiles { get; set; } = -1; 
+    public int? ReceiptsDbMaxOpenFiles { get; set; } = -1;
     public long? ReceiptsDbMaxWriteBytesPerSec { get; set; }
 
     public ulong BlocksDbWriteBufferSize { get; set; } = (ulong)8.MiB();

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using Nethermind.Core.Extensions;
 
 namespace Nethermind.Db.Rocks.Config;
@@ -13,63 +14,63 @@ public class DbConfig : IDbConfig
     public uint WriteBufferNumber { get; set; } = 4;
     public ulong BlockCacheSize { get; set; } = (ulong)64.MiB();
     public bool CacheIndexAndFilterBlocks { get; set; } = false;
-    public int? MaxOpenFiles { get; set; }
+    public int? MaxOpenFiles { get; set; } = -1;
     public long? MaxWriteBytesPerSec { get; set; }
 
     public ulong ReceiptsDbWriteBufferSize { get; set; } = (ulong)8.MiB();
     public uint ReceiptsDbWriteBufferNumber { get; set; } = 4;
     public ulong ReceiptsDbBlockCacheSize { get; set; } = (ulong)32.MiB();
     public bool ReceiptsDbCacheIndexAndFilterBlocks { get; set; } = false;
-    public int? ReceiptsDbMaxOpenFiles { get; set; }
+    public int? ReceiptsDbMaxOpenFiles { get; set; } = -1; 
     public long? ReceiptsDbMaxWriteBytesPerSec { get; set; }
 
     public ulong BlocksDbWriteBufferSize { get; set; } = (ulong)8.MiB();
     public uint BlocksDbWriteBufferNumber { get; set; } = 4;
     public ulong BlocksDbBlockCacheSize { get; set; } = (ulong)32.MiB();
     public bool BlocksDbCacheIndexAndFilterBlocks { get; set; } = false;
-    public int? BlocksDbMaxOpenFiles { get; set; }
+    public int? BlocksDbMaxOpenFiles { get; set; } = -1;
     public long? BlocksDbMaxWriteBytesPerSec { get; set; }
 
     public ulong HeadersDbWriteBufferSize { get; set; } = (ulong)8.MiB();
     public uint HeadersDbWriteBufferNumber { get; set; } = 4;
     public ulong HeadersDbBlockCacheSize { get; set; } = (ulong)32.MiB();
     public bool HeadersDbCacheIndexAndFilterBlocks { get; set; } = false;
-    public int? HeadersDbMaxOpenFiles { get; set; }
+    public int? HeadersDbMaxOpenFiles { get; set; } = -1;
     public long? HeadersDbMaxWriteBytesPerSec { get; set; }
 
     public ulong BlockInfosDbWriteBufferSize { get; set; } = (ulong)8.MiB();
     public uint BlockInfosDbWriteBufferNumber { get; set; } = 4;
     public ulong BlockInfosDbBlockCacheSize { get; set; } = (ulong)32.MiB();
     public bool BlockInfosDbCacheIndexAndFilterBlocks { get; set; } = false;
-    public int? BlockInfosDbMaxOpenFiles { get; set; }
+    public int? BlockInfosDbMaxOpenFiles { get; set; } = -1;
     public long? BlockInfosDbMaxWriteBytesPerSec { get; set; }
 
     public ulong PendingTxsDbWriteBufferSize { get; set; } = (ulong)4.MiB();
     public uint PendingTxsDbWriteBufferNumber { get; set; } = 4;
     public ulong PendingTxsDbBlockCacheSize { get; set; } = (ulong)16.MiB();
     public bool PendingTxsDbCacheIndexAndFilterBlocks { get; set; } = false;
-    public int? PendingTxsDbMaxOpenFiles { get; set; }
+    public int? PendingTxsDbMaxOpenFiles { get; set; } = -1;
     public long? PendingTxsDbMaxWriteBytesPerSec { get; set; }
 
     public ulong CodeDbWriteBufferSize { get; set; } = (ulong)2.MiB();
     public uint CodeDbWriteBufferNumber { get; set; } = 4;
     public ulong CodeDbBlockCacheSize { get; set; } = (ulong)8.MiB();
     public bool CodeDbCacheIndexAndFilterBlocks { get; set; } = false;
-    public int? CodeDbMaxOpenFiles { get; set; }
+    public int? CodeDbMaxOpenFiles { get; set; } = -1;
     public long? CodeDbMaxWriteBytesPerSec { get; set; }
 
     public ulong BloomDbWriteBufferSize { get; set; } = (ulong)1.KiB();
     public uint BloomDbWriteBufferNumber { get; set; } = 4;
     public ulong BloomDbBlockCacheSize { get; set; } = (ulong)1.KiB();
     public bool BloomDbCacheIndexAndFilterBlocks { get; set; } = false;
-    public int? BloomDbMaxOpenFiles { get; set; }
+    public int? BloomDbMaxOpenFiles { get; set; } = -1;
     public long? BloomDbMaxWriteBytesPerSec { get; set; }
 
     public ulong WitnessDbWriteBufferSize { get; set; } = (ulong)1.KiB();
     public uint WitnessDbWriteBufferNumber { get; set; } = 4;
     public ulong WitnessDbBlockCacheSize { get; set; } = (ulong)1.KiB();
     public bool WitnessDbCacheIndexAndFilterBlocks { get; set; } = false;
-    public int? WitnessDbMaxOpenFiles { get; set; }
+    public int? WitnessDbMaxOpenFiles { get; set; } = -1;
     public long? WitnessDbMaxWriteBytesPerSec { get; set; }
 
     // TODO - profile and customize
@@ -77,14 +78,14 @@ public class DbConfig : IDbConfig
     public uint CanonicalHashTrieDbWriteBufferNumber { get; set; } = 4;
     public ulong CanonicalHashTrieDbBlockCacheSize { get; set; } = (ulong)8.MB();
     public bool CanonicalHashTrieDbCacheIndexAndFilterBlocks { get; set; } = true;
-    public int? CanonicalHashTrieDbMaxOpenFiles { get; set; }
+    public int? CanonicalHashTrieDbMaxOpenFiles { get; set; } = -1;
     public long? CanonicalHashTrieDbMaxWriteBytesPerSec { get; set; }
 
     public ulong MetadataDbWriteBufferSize { get; set; } = (ulong)1.KiB();
     public uint MetadataDbWriteBufferNumber { get; set; } = 4;
     public ulong MetadataDbBlockCacheSize { get; set; } = (ulong)1.KiB();
     public bool MetadataDbCacheIndexAndFilterBlocks { get; set; } = true;
-    public int? MetadataDbMaxOpenFiles { get; set; }
+    public int? MetadataDbMaxOpenFiles { get; set; } = -1;
     public long? MetadataDbMaxWriteBytesPerSec { get; set; }
 
     public uint RecycleLogFileNum { get; set; } = 0;
@@ -93,4 +94,11 @@ public class DbConfig : IDbConfig
     public bool EnableDbStatistics { get; set; } = false;
     public bool EnableMetricsUpdater { get; set; } = false;
     public uint StatsDumpPeriodSec { get; set; } = 600;
+
+    public int DisableAutoCompactions { get; set; } = 1;
+    public bool AdviseRandomOnOpen { get; set; } = true;
+    public bool AllowMmapReads { get; set; } = true;
+    public int MaxBackgroundCompactions { get; set; } = Environment.ProcessorCount;
+
+
 }

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
@@ -21,56 +21,56 @@ public class DbConfig : IDbConfig
     public uint ReceiptsDbWriteBufferNumber { get; set; } = 4;
     public ulong ReceiptsDbBlockCacheSize { get; set; } = (ulong)32.MiB();
     public bool ReceiptsDbCacheIndexAndFilterBlocks { get; set; } = false;
-    public int? ReceiptsDbMaxOpenFiles { get; set; } = -1;
+    public int? ReceiptsDbMaxOpenFiles { get; set; }
     public long? ReceiptsDbMaxWriteBytesPerSec { get; set; }
 
     public ulong BlocksDbWriteBufferSize { get; set; } = (ulong)8.MiB();
     public uint BlocksDbWriteBufferNumber { get; set; } = 4;
     public ulong BlocksDbBlockCacheSize { get; set; } = (ulong)32.MiB();
     public bool BlocksDbCacheIndexAndFilterBlocks { get; set; } = false;
-    public int? BlocksDbMaxOpenFiles { get; set; } = -1;
+    public int? BlocksDbMaxOpenFiles { get; set; }
     public long? BlocksDbMaxWriteBytesPerSec { get; set; }
 
     public ulong HeadersDbWriteBufferSize { get; set; } = (ulong)8.MiB();
     public uint HeadersDbWriteBufferNumber { get; set; } = 4;
     public ulong HeadersDbBlockCacheSize { get; set; } = (ulong)32.MiB();
     public bool HeadersDbCacheIndexAndFilterBlocks { get; set; } = false;
-    public int? HeadersDbMaxOpenFiles { get; set; } = -1;
+    public int? HeadersDbMaxOpenFiles { get; set; }
     public long? HeadersDbMaxWriteBytesPerSec { get; set; }
 
     public ulong BlockInfosDbWriteBufferSize { get; set; } = (ulong)8.MiB();
     public uint BlockInfosDbWriteBufferNumber { get; set; } = 4;
     public ulong BlockInfosDbBlockCacheSize { get; set; } = (ulong)32.MiB();
     public bool BlockInfosDbCacheIndexAndFilterBlocks { get; set; } = false;
-    public int? BlockInfosDbMaxOpenFiles { get; set; } = -1;
+    public int? BlockInfosDbMaxOpenFiles { get; set; }
     public long? BlockInfosDbMaxWriteBytesPerSec { get; set; }
 
     public ulong PendingTxsDbWriteBufferSize { get; set; } = (ulong)4.MiB();
     public uint PendingTxsDbWriteBufferNumber { get; set; } = 4;
     public ulong PendingTxsDbBlockCacheSize { get; set; } = (ulong)16.MiB();
     public bool PendingTxsDbCacheIndexAndFilterBlocks { get; set; } = false;
-    public int? PendingTxsDbMaxOpenFiles { get; set; } = -1;
+    public int? PendingTxsDbMaxOpenFiles { get; set; }
     public long? PendingTxsDbMaxWriteBytesPerSec { get; set; }
 
     public ulong CodeDbWriteBufferSize { get; set; } = (ulong)2.MiB();
     public uint CodeDbWriteBufferNumber { get; set; } = 4;
     public ulong CodeDbBlockCacheSize { get; set; } = (ulong)8.MiB();
     public bool CodeDbCacheIndexAndFilterBlocks { get; set; } = false;
-    public int? CodeDbMaxOpenFiles { get; set; } = -1;
+    public int? CodeDbMaxOpenFiles { get; set; }
     public long? CodeDbMaxWriteBytesPerSec { get; set; }
 
     public ulong BloomDbWriteBufferSize { get; set; } = (ulong)1.KiB();
     public uint BloomDbWriteBufferNumber { get; set; } = 4;
     public ulong BloomDbBlockCacheSize { get; set; } = (ulong)1.KiB();
     public bool BloomDbCacheIndexAndFilterBlocks { get; set; } = false;
-    public int? BloomDbMaxOpenFiles { get; set; } = -1;
+    public int? BloomDbMaxOpenFiles { get; set; }
     public long? BloomDbMaxWriteBytesPerSec { get; set; }
 
     public ulong WitnessDbWriteBufferSize { get; set; } = (ulong)1.KiB();
     public uint WitnessDbWriteBufferNumber { get; set; } = 4;
     public ulong WitnessDbBlockCacheSize { get; set; } = (ulong)1.KiB();
     public bool WitnessDbCacheIndexAndFilterBlocks { get; set; } = false;
-    public int? WitnessDbMaxOpenFiles { get; set; } = -1;
+    public int? WitnessDbMaxOpenFiles { get; set; }
     public long? WitnessDbMaxWriteBytesPerSec { get; set; }
 
     // TODO - profile and customize
@@ -78,14 +78,14 @@ public class DbConfig : IDbConfig
     public uint CanonicalHashTrieDbWriteBufferNumber { get; set; } = 4;
     public ulong CanonicalHashTrieDbBlockCacheSize { get; set; } = (ulong)8.MB();
     public bool CanonicalHashTrieDbCacheIndexAndFilterBlocks { get; set; } = true;
-    public int? CanonicalHashTrieDbMaxOpenFiles { get; set; } = -1;
+    public int? CanonicalHashTrieDbMaxOpenFiles { get; set; }
     public long? CanonicalHashTrieDbMaxWriteBytesPerSec { get; set; }
 
     public ulong MetadataDbWriteBufferSize { get; set; } = (ulong)1.KiB();
     public uint MetadataDbWriteBufferNumber { get; set; } = 4;
     public ulong MetadataDbBlockCacheSize { get; set; } = (ulong)1.KiB();
     public bool MetadataDbCacheIndexAndFilterBlocks { get; set; } = true;
-    public int? MetadataDbMaxOpenFiles { get; set; } = -1;
+    public int? MetadataDbMaxOpenFiles { get; set; }
     public long? MetadataDbMaxWriteBytesPerSec { get; set; }
 
     public uint RecycleLogFileNum { get; set; } = 0;

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/IDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/IDbConfig.cs
@@ -98,4 +98,10 @@ public interface IDbConfig : IConfig
     /// Default: 600 (10 min)
     /// </summary>
     uint StatsDumpPeriodSec { get; set; }
+
+    int DisableAutoCompactions { get; set; }
+    bool AdviseRandomOnOpen { get; set; }
+    bool AllowMmapReads { get; set; }
+    int MaxBackgroundCompactions { get; set; }
+
 }

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -249,7 +249,7 @@ public class DbOnTheRocks : IDbWithSpan
         options.SetWriteBufferSize(writeBufferSize);
         int writeBufferNumber = (int)_perTableDbConfig.WriteBufferNumber;
         options.SetMaxWriteBufferNumber(writeBufferNumber);
-        options.SetMinWriteBufferNumberToMerge(2); 
+        options.SetMinWriteBufferNumberToMerge(2);
 
         lock (_dbsByPath)
         {

--- a/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
@@ -183,16 +183,15 @@ namespace Nethermind.Db.Test
         [Test]
         public void Test_columndb_put_and_get_span_correctly_store_value()
         {
-            string path = Path.Join(Path.GetTempPath(), "test");
+            string path = Path.Join(Path.GetTempPath(), "test_", Path.GetRandomFileName());
+
             Directory.CreateDirectory(path);
             try
             {
                 IDbConfig config = new DbConfig();
                 using ColumnsDb<ReceiptsColumns> columnDb = new(path, GetRocksDbSettings("blocks", "Blocks"), config,
                     LimboLogs.Instance, new List<ReceiptsColumns>() { ReceiptsColumns.Blocks });
-
                 using IDbWithSpan db = columnDb.GetColumnDb(ReceiptsColumns.Blocks);
-
                 Keccak key = Keccak.Compute("something");
                 Keccak value = Keccak.Compute("something");
 


### PR DESCRIPTION
Our research has shown that we have two reliable and repeatable major problems causing spikes: GC-related and DB-read-related. This minimalistic PR addresses DB-read-related ones.

Resolves many arising spikes on some hardware 

## Changes
-  set not to fill the block cache when reading values.
-  allowed memory mapping for reads
-  default to an unlimited number of open files
- All changes to DB are made configurable for advanced use cases

## Types of changes
 - Changes limited to RocksDB config changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [x] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing
The local non-validator test shows consistent improvement in terms of spike count:
Before:
![image](https://user-images.githubusercontent.com/2915361/221989818-3c481fac-7582-40af-b41c-02008d2bc6c2.png)

After (see the top line):
![image](https://user-images.githubusercontent.com/2915361/221989170-88440f66-b85f-4985-b2e8-1a7c62c41b05.png)

#### Requires testing
It needs at least 24h-48h run on main net validator node before merge, docker tag created for the ease of testing: `rocksdb-cfg`.

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing
Awaiting @kamilchodola and @MarekM25 approval for the validator run, guys. Please comment if you think this draft PR can be tested on validator nodes.