### PR TITLE
DirtyNodesCache optimizations

### DIFF
--- a/src/Nethermind/Nethermind.Benchmark/Store/TrieStoreBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Store/TrieStoreBenchmarks.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using BenchmarkDotNet.Attributes;

--- a/src/Nethermind/Nethermind.Benchmark/Store/TrieStoreBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Store/TrieStoreBenchmarks.cs
@@ -1,0 +1,37 @@
+﻿// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using BenchmarkDotNet.Attributes;
+using Nethermind.Core.Crypto;
+using Nethermind.Db;
+using Nethermind.Logging;
+using Nethermind.Trie.Pruning;
+
+namespace Nethermind.Benchmarks.Store
+{
+    [MemoryDiagnoser]
+    public class TrieStoreBenchmarks
+    {
+        private TrieStore.DirtyNodesCache _cache;
+        private static readonly Keccak _key = Keccak.Compute("");
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _cache = new(new TrieStore(new MemDb("test"), NullLogManager.Instance));
+
+            // fill it up
+            for (int i = 0; i < 10000; i++)
+            {
+                _cache.FindCachedOrUnknown(Keccak.Compute(i.ToString()));
+            }
+        }
+
+        [Benchmark]
+        public void DirtyNodesCache_FindCachedOrUnknown_And_Delete()
+        {
+            _cache.FindCachedOrUnknown(_key);
+            _cache.Remove(_key);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -21,7 +21,7 @@ namespace Nethermind.Trie.Pruning
     /// </summary>
     public class TrieStore : ITrieStore
     {
-        private class DirtyNodesCache
+        public class DirtyNodesCache
         {
             private readonly TrieStore _trieStore;
 


### PR DESCRIPTION
This PR optimizes two call sites of `ConcurrentDictionary` in the `DirtyNodesCache` of `TrieStore`. These methods are called heavily when pruning and adding nodes.

## Benchmarks

BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.22621.1265/22H2/2022Update/SunValley2)
12th Gen Intel Core i9-12900HK, 1 CPU, 20 logical and 14 physical cores
.NET SDK=7.0.100
  [Host]     : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
  DefaultJob : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2


|                                         Method |     Mean |    Error |   StdDev |   Gen0 | Allocated |
|----------------------------------------------- |---------:|---------:|---------:|-------:|----------:|
| FindCachedOrUnknown_And_Delete (before) | 72.78 ns | 0.788 ns | 0.658 ns | 0.0076 |      96 B |
| FindCachedOrUnknown_And_Delete (after) | 63.21 ns | 1.045 ns | 0.926 ns | 0.0076 |      96 B |

## Changes

- remove `Remove` with native `TryRemove`
- `GetOrAdd` instead of two calls to the cache

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No