### PR TITLE
TrieStore Rlp cache

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncProgressResolver.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncProgressResolver.cs
@@ -64,7 +64,7 @@ namespace Nethermind.Synchronization.ParallelSync
                 return true;
             }
 
-            TrieNode trieNode = _trieNodeResolver.FindCachedOrUnknown(stateRoot);
+            TrieNode trieNode = _trieNodeResolver.FindCachedOrUnknown(stateRoot, SearchHint.None);
             bool stateRootIsInMemory = trieNode.NodeType != NodeType.Unknown;
             // We check whether one of below happened:
             //   1) the block has been processed but not yet persisted (pruning) OR

--- a/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
@@ -102,9 +102,9 @@ namespace Nethermind.Trie.Test.Pruning
         public void Pruning_off_cache_should_not_find_cached_or_unknown()
         {
             using TrieStore trieStore = new(new MemDb(), No.Pruning, No.Persistence, _logManager);
-            TrieNode returnedNode = trieStore.FindCachedOrUnknown(TestItem.KeccakA);
-            TrieNode returnedNode2 = trieStore.FindCachedOrUnknown(TestItem.KeccakB);
-            TrieNode returnedNode3 = trieStore.FindCachedOrUnknown(TestItem.KeccakC);
+            TrieNode returnedNode = trieStore.FindCachedOrUnknown(TestItem.KeccakA, SearchHint.None);
+            TrieNode returnedNode2 = trieStore.FindCachedOrUnknown(TestItem.KeccakB, SearchHint.None);
+            TrieNode returnedNode3 = trieStore.FindCachedOrUnknown(TestItem.KeccakC, SearchHint.None);
             Assert.AreEqual(NodeType.Unknown, returnedNode.NodeType);
             Assert.AreEqual(NodeType.Unknown, returnedNode2.NodeType);
             Assert.AreEqual(NodeType.Unknown, returnedNode3.NodeType);
@@ -116,17 +116,17 @@ namespace Nethermind.Trie.Test.Pruning
         {
             using TrieStore trieStore = new(new MemDb(), new TestPruningStrategy(true), No.Persistence, _logManager);
             long startSize = trieStore.MemoryUsedByDirtyCache;
-            trieStore.FindCachedOrUnknown(TestItem.KeccakA);
+            trieStore.FindCachedOrUnknown(TestItem.KeccakA, SearchHint.None);
             TrieNode trieNode = new(NodeType.Leaf, Keccak.Zero);
             long oneKeccakSize = trieNode.GetMemorySize(false);
             Assert.AreEqual(startSize + oneKeccakSize, trieStore.MemoryUsedByDirtyCache);
-            trieStore.FindCachedOrUnknown(TestItem.KeccakB);
+            trieStore.FindCachedOrUnknown(TestItem.KeccakB, SearchHint.None);
             Assert.AreEqual(2 * oneKeccakSize + startSize, trieStore.MemoryUsedByDirtyCache);
-            trieStore.FindCachedOrUnknown(TestItem.KeccakB);
+            trieStore.FindCachedOrUnknown(TestItem.KeccakB, SearchHint.None);
             Assert.AreEqual(2 * oneKeccakSize + startSize, trieStore.MemoryUsedByDirtyCache);
-            trieStore.FindCachedOrUnknown(TestItem.KeccakC);
+            trieStore.FindCachedOrUnknown(TestItem.KeccakC, SearchHint.None);
             Assert.AreEqual(3 * oneKeccakSize + startSize, trieStore.MemoryUsedByDirtyCache);
-            trieStore.FindCachedOrUnknown(TestItem.KeccakD, true);
+            trieStore.FindCachedOrUnknown(TestItem.KeccakD, true, SearchHint.None);
             Assert.AreEqual(3 * oneKeccakSize + startSize, trieStore.MemoryUsedByDirtyCache);
         }
 
@@ -598,7 +598,7 @@ namespace Nethermind.Trie.Test.Pruning
                 {
                     try
                     {
-                        trieStore.FindCachedOrUnknown(trieNode.Keccak).GetChildHash(i % 16).Should().BeEquivalentTo(TestItem.Keccaks[i % 16], i.ToString());
+                        trieStore.FindCachedOrUnknown(trieNode.Keccak, SearchHint.None).GetChildHash(i % 16).Should().BeEquivalentTo(TestItem.Keccaks[i % 16], i.ToString());
                     }
                     catch (Exception)
                     {
@@ -638,10 +638,10 @@ namespace Nethermind.Trie.Test.Pruning
             using TrieStore trieStore = new(new MemDb(), new TestPruningStrategy(pruning), No.Persistence, _logManager);
             trieStore.CommitNode(1, new NodeCommitInfo(node));
             trieStore.FinishBlockCommit(TrieType.State, 0, node);
-            var originalNode = trieStore.FindCachedOrUnknown(node.Keccak);
+            var originalNode = trieStore.FindCachedOrUnknown(node.Keccak, SearchHint.None);
 
             IReadOnlyTrieStore readOnlyTrieStore = trieStore.AsReadOnly();
-            var readOnlyNode = readOnlyTrieStore.FindCachedOrUnknown(node.Keccak);
+            var readOnlyNode = readOnlyTrieStore.FindCachedOrUnknown(node.Keccak, SearchHint.None);
 
             readOnlyNode.Should().NotBe(originalNode);
             readOnlyNode.Should().BeEquivalentTo(originalNode,

--- a/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
@@ -794,7 +794,7 @@ namespace Nethermind.Trie.Test
 
             trieNode.PrunePersistedRecursively(1);
             var trieStore = Substitute.For<ITrieNodeResolver>();
-            trieStore.FindCachedOrUnknown(Arg.Any<Keccak>()).Returns(child);
+            trieStore.FindCachedOrUnknown(Arg.Any<Keccak>(), SearchHint.None).Returns(child);
             trieNode.GetChild(trieStore, 0).Should().Be(child);
             trieNode.GetChild(trieStore, 1).Should().BeNull();
             trieNode.GetChild(trieStore, 4).Should().Be(child);
@@ -809,7 +809,7 @@ namespace Nethermind.Trie.Test
 
             trieNode.PrunePersistedRecursively(1);
             var trieStore = Substitute.For<ITrieNodeResolver>();
-            trieStore.FindCachedOrUnknown(Arg.Any<Keccak>()).Returns(child);
+            trieStore.FindCachedOrUnknown(Arg.Any<Keccak>(), SearchHint.None).Returns(child);
             trieNode.GetChild(trieStore, 0).Should().Be(child);
         }
 
@@ -830,7 +830,7 @@ namespace Nethermind.Trie.Test
             child.ResolveKey(trieStore, false);
             child.IsPersisted = true;
 
-            trieStore.FindCachedOrUnknown(Arg.Any<Keccak>()).Returns(new TrieNode(NodeType.Unknown, child.Keccak!));
+            trieStore.FindCachedOrUnknown(Arg.Any<Keccak>(), SearchHint.None).Returns(new TrieNode(NodeType.Unknown, child.Keccak!));
             trieNode.GetChild(trieStore, 0);
             Assert.Throws<TrieException>(() => trieNode.GetChild(trieStore, 0).ResolveNode(trieStore));
         }

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -293,7 +293,8 @@ namespace Nethermind.Trie
             }
             else if (resetObjects)
             {
-                RootRef = TrieStore.FindCachedOrUnknown(_rootHash);
+                RootRef = TrieStore.FindCachedOrUnknown(_rootHash,
+                    TrieType == TrieType.State ? SearchHint.StateRoot : SearchHint.StorageRoot);
             }
         }
 
@@ -373,7 +374,7 @@ namespace Nethermind.Trie
             if (startRootHash is not null)
             {
                 if (_logger.IsTrace) _logger.Trace($"Starting from {startRootHash} - {traverseContext.ToString()}");
-                TrieNode startNode = TrieStore.FindCachedOrUnknown(startRootHash);
+                TrieNode startNode = TrieStore.FindCachedOrUnknown(startRootHash, SearchHint.None); // this reads from a separate root so no much value for future gets
                 startNode.ResolveNode(TrieStore);
                 result = TraverseNode(startNode, traverseContext);
             }
@@ -997,7 +998,7 @@ namespace Nethermind.Trie
             TrieNode rootRef = null;
             if (!rootHash.Equals(Keccak.EmptyTreeHash))
             {
-                rootRef = RootHash == rootHash ? RootRef : TrieStore.FindCachedOrUnknown(rootHash);
+                rootRef = RootHash == rootHash ? RootRef : TrieStore.FindCachedOrUnknown(rootHash, TrieType == TrieType.State ? SearchHint.StateRoot : SearchHint.StorageRoot);
                 try
                 {
                     rootRef!.ResolveNode(TrieStore);

--- a/src/Nethermind/Nethermind.Trie/Pruning/ITrieNodeResolver.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ITrieNodeResolver.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 
@@ -14,8 +15,9 @@ namespace Nethermind.Trie.Pruning
         /// its RLP data from the state database.
         /// </summary>
         /// <param name="hash">Keccak hash of the RLP of the node.</param>
+        /// <param name="hint">The additional context that can be used for searching the node.</param>
         /// <returns></returns>
-        TrieNode FindCachedOrUnknown(Keccak hash);
+        TrieNode FindCachedOrUnknown(Keccak hash, SearchHint hint);
 
         /// <summary>
         /// Loads RLP of the node.
@@ -23,5 +25,32 @@ namespace Nethermind.Trie.Pruning
         /// <param name="hash"></param>
         /// <returns></returns>
         byte[]? LoadRlp(Keccak hash);
+    }
+
+    /// <summary>
+    /// Provides a hint for the purpose of <see cref="ITrieNodeResolver.FindCachedOrUnknown"/> getting found that
+    /// can be memoized further as a hint for caching the node or not.
+    /// </summary>
+    public enum SearchHint : byte
+    {
+        /// <summary>
+        /// No meaningful hint can be provided about the node.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// The node is a child node of another node.
+        /// </summary>
+        StorageChildNode = 1,
+
+        /// <summary>
+        /// The node is of <see cref="TrieType.Storage"/> trie.
+        /// </summary>
+        StorageRoot = 2,
+
+        /// <summary>
+        /// The node is a root of <see cref="TrieType.State"/> trie.
+        /// </summary>
+        StateRoot = 3,
     }
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/Metrics.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/Metrics.cs
@@ -51,5 +51,11 @@ namespace Nethermind.Trie.Pruning
 
         [Description("Estimated memory used by cache.")]
         public static long MemoryUsedByCache { get; set; }
+
+        [Description("RLP cache hit")]
+        public static long RlpCacheHit { get; set; }
+
+        [Description("RLP cache miss")]
+        public static long RlpCacheMiss { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/Metrics.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/Metrics.cs
@@ -52,6 +52,12 @@ namespace Nethermind.Trie.Pruning
         [Description("Estimated memory used by cache.")]
         public static long MemoryUsedByCache { get; set; }
 
+        [Description("RLP cache write attempts")]
+        public static long RlpCacheWriteAttempts { get; set; }
+
+        [Description("RLP cache write performed")]
+        public static long RlpCacheWrites { get; set; }
+
         [Description("RLP cache hit")]
         public static long RlpCacheHit { get; set; }
 

--- a/src/Nethermind/Nethermind.Trie/Pruning/NullTrieNodeResolver.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/NullTrieNodeResolver.cs
@@ -12,7 +12,7 @@ namespace Nethermind.Trie.Pruning
 
         public static readonly NullTrieNodeResolver Instance = new();
 
-        public TrieNode FindCachedOrUnknown(Keccak hash) => new(NodeType.Unknown, hash);
+        public TrieNode FindCachedOrUnknown(Keccak hash, SearchHint hint) => new(NodeType.Unknown, hash);
 
         public byte[]? LoadRlp(Keccak hash) => null;
     }

--- a/src/Nethermind/Nethermind.Trie/Pruning/NullTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/NullTrieStore.cs
@@ -30,7 +30,7 @@ namespace Nethermind.Trie.Pruning
             remove { }
         }
 
-        public TrieNode FindCachedOrUnknown(Keccak hash)
+        public TrieNode FindCachedOrUnknown(Keccak hash, SearchHint hint)
         {
             return new(NodeType.Unknown, hash);
         }

--- a/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStore.cs
@@ -22,8 +22,8 @@ namespace Nethermind.Trie.Pruning
             _readOnlyStore = readOnlyStore;
         }
 
-        public TrieNode FindCachedOrUnknown(Keccak hash) =>
-            _trieStore.FindCachedOrUnknown(hash, true);
+        public TrieNode FindCachedOrUnknown(Keccak hash, SearchHint hint) =>
+            _trieStore.FindCachedOrUnknown(hash, true, hint);
 
         public byte[] LoadRlp(Keccak hash) => _trieStore.LoadRlp(hash, _readOnlyStore);
 

--- a/src/Nethermind/Nethermind.Trie/Pruning/RlpCache.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/RlpCache.cs
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Nethermind.Core.Crypto;
+
+namespace Nethermind.Trie.Pruning;
+
+public class RlpCache
+{
+    private readonly int _size;
+    private const int DefaultRlpCacheSize = 2048;
+    private readonly RlpCacheItem[] _items;
+    private readonly BitArray _rlpCacheSet;
+
+    public RlpCache(int size = DefaultRlpCacheSize)
+    {
+        _size = size;
+        _items = new RlpCacheItem[size];
+        _rlpCacheSet = new BitArray(size);
+    }
+
+    private record RlpCacheItem(Keccak Keccak, byte[] Rlp);
+
+    /// <summary>
+    /// Tries to store the rlp cache.
+    /// </summary>
+    /// <param name="node"></param>
+    public void SetRlpCache(TrieNode node)
+    {
+        if (node.CacheHint is SearchHint.StorageRoot or SearchHint.StorageChildNode)
+        {
+            int bucket = GetRlpCacheBucket(node.Keccak!);
+
+            Metrics.RlpCacheWriteAttempts++;
+
+            if (_rlpCacheSet.Get(bucket) == false)
+            {
+                // nothing written this round, write and set
+                Volatile.Write(ref _items[bucket], new RlpCacheItem(node.Keccak, node.FullRlp!));
+
+                Metrics.RlpCacheWrites++;
+
+                _rlpCacheSet.Set(bucket, true);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Reads through the Rlp cache.
+    /// </summary>
+    /// <param name="keccak"></param>
+    /// <returns></returns>
+    public byte[]? GetRlpCache(Keccak keccak)
+    {
+        RlpCacheItem item = Volatile.Read(ref _items[GetRlpCacheBucket(keccak)]);
+        if (item != null && item.Keccak == keccak)
+        {
+            Metrics.RlpCacheHit++;
+            return item.Rlp;
+        }
+
+        Metrics.RlpCacheMiss++;
+        return default;
+    }
+
+    private int GetRlpCacheBucket(Keccak keccak) => (int)(MemoryMarshal.Read<uint>(keccak.Bytes) % _size);
+
+    /// <summary>
+    /// Clears the set flags, so that all the cache items can be written again.
+    /// </summary>
+    public void ClearSetFlags() => _rlpCacheSet.SetAll(false);
+
+    public void Clear()
+    {
+        Array.Clear(_items);
+        ClearSetFlags();
+    }
+}

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -576,7 +576,7 @@ namespace Nethermind.Trie.Pruning
         }
 
         /// <summary>
-        /// Tries to store the rlp cache
+        /// Tries to store the rlp cache.
         /// </summary>
         /// <param name="node"></param>
         private void SetRlpCache(TrieNode node)
@@ -612,7 +612,7 @@ namespace Nethermind.Trie.Pruning
             return default;
         }
 
-        private static int GetRlpCacheBucket(Keccak keccak) => MemoryMarshal.Read<short>(keccak.Bytes) % RlpCacheSize;
+        private static int GetRlpCacheBucket(Keccak keccak) => (int)(MemoryMarshal.Read<uint>(keccak.Bytes) % RlpCacheSize);
 
         /// <summary>
         /// This method is here to support testing.


### PR DESCRIPTION
This PR introduces RLP Cache on the `TrieStore` level. It uses a hint mechanism to pass through the hint through `TrieNode` instance till it's collected by dirty cache pruning. Then, when a node `IsPersisted` and eviced, an RLP caching attempt is performed. The hint allows for a decision based on the type of the trie and the depth where the node belongs. Currently, the only nodes that have their RLP cached are `Storage` root and the first level of storage root children. The reason for not doing this for the `State` trie is that it's fresh copy is mostly kept in memory (it's constantly updated so that it never is persisted nor it goes beyond `LastSeen`).

Four metrics added to measure the cache:

1. `RlpCacheWriteAttempts` - to check whether the cache writes are even attempted

        [Description("RLP cache write performed")]
        public static long RlpCacheWrites { get; set; }

        [Description("RLP cache hit")]
        public static long RlpCacheHit { get; set; }

        [Description("RLP cache miss")]
        public static long RlpCacheMiss { get; set; }

Yet to be tested.

## Changes

- _List the changes_

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
