### PR TITLE
fix missing jwt warning

### DIFF
--- a/src/Nethermind/Nethermind.Core/Authentication/JwtAuthentication.cs
+++ b/src/Nethermind/Nethermind.Core/Authentication/JwtAuthentication.cs
@@ -64,7 +64,7 @@ public partial class JwtAuthentication : IRpcAuthentication
                 throw;
             }
 
-            if (logger.IsInfo) logger.Info($"Authentication secret has been written to '{fileInfo.FullName}'.");
+            if (logger.IsWarn) logger.Warn($"The authentication secret hasn't been found in '{fileInfo.FullName}'so it has been automatically created.");
 
             return new(secret, timestamper, logger);
         }


### PR DESCRIPTION
Fixes #4611 

## Changes

When a user provides a config value for `JwtSecretFile` and the file is not found, the node will create a secret by itself. 
This add a warning `"The authentication secret hasn't been found in <configured path> so it has been automatically created."` instead of a simple info log.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No
