### PR TITLE
Optimize RlpStream.DeserializeLength

### DIFF
--- a/src/Nethermind/Nethermind.Serialization.Rlp/NettyRlpStream.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/NettyRlpStream.cs
@@ -8,7 +8,7 @@ using DotNetty.Common.Utilities;
 
 namespace Nethermind.Serialization.Rlp
 {
-    public class NettyRlpStream : RlpStream, IDisposable
+    public sealed class NettyRlpStream : RlpStream, IDisposable
     {
         private readonly IByteBuffer _buffer;
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpStream.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpStream.cs
@@ -713,9 +713,16 @@ namespace Nethermind.Serialization.Rlp
             }
             else if (lengthOfLength == 3)
             {
-                result = Unsafe.ReadUnaligned<byte>(ref Unsafe.Add(ref firstElement, 2)) |
-                        (Unsafe.ReadUnaligned<byte>(ref Unsafe.Add(ref firstElement, 1)) << 8) |
-                        (Unsafe.ReadUnaligned<byte>(ref firstElement) << 16);
+                if (BitConverter.IsLittleEndian)
+                {
+                    result = BinaryPrimitives.ReverseEndianness(Unsafe.ReadUnaligned<ushort>(ref Unsafe.Add(ref firstElement, 1)))
+                        | (result << 16);
+                }
+                else
+                {
+                    result = Unsafe.ReadUnaligned<ushort>(ref Unsafe.Add(ref firstElement, 1))
+                        | (result << 16);
+                }
             }
             else
             {

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpStream.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpStream.cs
@@ -2,9 +2,12 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
@@ -676,37 +679,69 @@ namespace Nethermind.Serialization.Rlp
 
         private int DeserializeLength(int lengthOfLength)
         {
-            int result;
-            if (PeekByte() == 0)
+            if (lengthOfLength == 0 || (uint)lengthOfLength > 4)
             {
-                throw new RlpException("Length starts with 0");
+                ThrowArgumentOutOfRangeException(lengthOfLength);
+            }
+
+            // Will use Unsafe.ReadUnaligned as we know the length of the span is same
+            // as what we asked for and then explicitly check lengths, so can skip the
+            // additional bounds checking from BinaryPrimitives.ReadUInt16BigEndian etc
+            ref byte firstElement = ref MemoryMarshal.GetReference(Read(lengthOfLength));
+
+            int result = firstElement;
+            if (result == 0)
+            {
+                ThrowInvalidData();
             }
 
             if (lengthOfLength == 1)
             {
-                result = PeekByte();
+                // Already read above
+                // result = span[0];
             }
             else if (lengthOfLength == 2)
             {
-                result = PeekByte(1) | (PeekByte() << 8);
+                if (BitConverter.IsLittleEndian)
+                {
+                    result = BinaryPrimitives.ReverseEndianness(Unsafe.ReadUnaligned<ushort>(ref firstElement));
+                }
+                else
+                {
+                    result = Unsafe.ReadUnaligned<ushort>(ref firstElement);
+                }
             }
             else if (lengthOfLength == 3)
             {
-                result = PeekByte(2) | (PeekByte(1) << 8) | (PeekByte() << 16);
-            }
-            else if (lengthOfLength == 4)
-            {
-                result = PeekByte(3) | (PeekByte(2) << 8) | (PeekByte(1) << 16) |
-                         (PeekByte() << 24);
+                result = Unsafe.ReadUnaligned<byte>(ref Unsafe.Add(ref firstElement, 2)) |
+                        (Unsafe.ReadUnaligned<byte>(ref Unsafe.Add(ref firstElement, 1)) << 8) |
+                        (Unsafe.ReadUnaligned<byte>(ref firstElement) << 16);
             }
             else
             {
-                // strange but needed to pass tests - seems that spec gives int64 length and tests int32 length
-                throw new InvalidOperationException($"Invalid length of length = {lengthOfLength}");
+                if (BitConverter.IsLittleEndian)
+                {
+                    result = BinaryPrimitives.ReverseEndianness(Unsafe.ReadUnaligned<int>(ref firstElement));
+                }
+                else
+                {
+                    result = Unsafe.ReadUnaligned<int>(ref firstElement);
+                }
             }
 
-            SkipBytes(lengthOfLength);
             return result;
+
+            [DoesNotReturn]
+            static void ThrowInvalidData()
+            {
+                throw new RlpException("Length starts with 0");
+            }
+
+            [DoesNotReturn]
+            static void ThrowArgumentOutOfRangeException(int lengthOfLength)
+            {
+                throw new InvalidOperationException($"Invalid length of length = {lengthOfLength}");
+            }
         }
 
         public virtual byte ReadByte()


### PR DESCRIPTION
## Changes

- Reduce multiple virtual calls to single one
- Use single reverse endienness intrinsic rather than multiple ors and shifts
- Move exceptions out of flow
  - Reduce stack zeroing 320 bytes -> 128 bytes
  - Reduce asm size 441 bytes -> 132 bytes
  - Remove 256 bytes of preamble push + pop

## Types of changes

It gets called quite a lot: 

![image](https://user-images.githubusercontent.com/1142958/222919443-f239542a-24ac-4bfb-9084-e514a9a9971b.png)

```diff
; Method Nethermind.Serialization.Rlp.RlpStream:DeserializeLength(int):int:this
G_M000_IG01:
<       push     r14
<       push     rdi
<       push     rsi
<       push     rbp
<       push     rbx                         ; five pushes (reg -> memory)
<       sub      rsp, 80
<       xor      eax, eax
<       mov      qword ptr [rsp+28H], rax     ; zero 64 bits of stack
<       vxorps   xmm4, xmm4
<       vmovdqa  xmmword ptr [rsp+30H], xmm4     ; zero 128 bits of stack
<       vmovdqa  xmmword ptr [rsp+40H], xmm4     ; zero 128 bits of stack
<       mov      rsi, rcx
<       mov      edi, edx
>       push     rsi                         ; one push (reg -> memory)
>       sub      rsp, 48
>       xor      eax, eax
>       mov      qword ptr [rsp+20H], rax     ; zero 64 bits of stack
>       mov      qword ptr [rsp+28H], rax     ; zero 64 bits of stack
>       mov      esi, edx
G_M000_IG02:
...
<       mov      rcx, rsi
<       mov      edx, 3
<       call     [rbp+38H]Nethermind.Serialization.Rlp.RlpStream:PeekByte(int):ubyte:this
<       mov      r14d, eax
<       mov      rcx, rsi
<       mov      edx, 2
<       call     [rbp+38H]Nethermind.Serialization.Rlp.RlpStream:PeekByte(int):ubyte:this
<       shl      eax, 8
<       or       r14d, eax
<       mov      rcx, rsi
<       mov      edx, 1
<       call     [rbp+38H]Nethermind.Serialization.Rlp.RlpStream:PeekByte(int):ubyte:this
<       shl      eax, 16
<       or       r14d, eax
<       mov      rcx, rsi
<       call     [rbp+30H]Nethermind.Serialization.Rlp.RlpStream:PeekByte():ubyte:this
<       shl      eax, 24
<       or       r14d, eax
>       movbe    ecx, dword ptr [rax]     ; above converted to single instruction
...

< ; Total bytes of code: 441
> ; Total bytes of code: 132
```

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No