### PR TITLE
VirtualMachine.ExecuteCall

### DIFF
--- a/src/Nethermind/Nethermind.Core/BlockHeader.cs
+++ b/src/Nethermind/Nethermind.Core/BlockHeader.cs
@@ -49,7 +49,7 @@ public class BlockHeader
     public Keccak? TxRoot { get; set; }
     public Keccak? ReceiptsRoot { get; set; }
     public Bloom? Bloom { get; set; }
-    public UInt256 Difficulty { get; set; }
+    public UInt256 Difficulty;
     public long Number { get; set; }
     public long GasUsed { get; set; }
     public long GasLimit { get; set; }

--- a/src/Nethermind/Nethermind.Core/BlockHeader.cs
+++ b/src/Nethermind/Nethermind.Core/BlockHeader.cs
@@ -63,7 +63,7 @@ public class BlockHeader
     public UInt256? TotalDifficulty { get; set; }
     public byte[]? AuRaSignature { get; set; }
     public long? AuRaStep { get; set; }
-    public UInt256 BaseFeePerGas { get; set; }
+    public UInt256 BaseFeePerGas;
     public Keccak? WithdrawalsRoot { get; set; }
     public UInt256? ExcessDataGas { get; set; }
 

--- a/src/Nethermind/Nethermind.Evm.Benchmark/EvmBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/EvmBenchmarks.cs
@@ -54,15 +54,17 @@ namespace Nethermind.Evm.Benchmark
             _virtualMachine = new VirtualMachine(_blockhashProvider, MainnetSpecProvider.Instance, LimboLogs.Instance);
 
             _environment = new ExecutionEnvironment
-            {
-                ExecutingAccount = Address.Zero,
-                CodeSource = Address.Zero,
-                Caller = Address.Zero,
-                CodeInfo = new CodeInfo(ByteCode),
-                Value = 0,
-                TransferValue = 0,
-                TxExecutionContext = new TxExecutionContext(_header, Address.Zero, 0, null)
-            };
+            (
+                executingAccount: Address.Zero,
+                codeSource: Address.Zero,
+                caller: Address.Zero,
+                codeInfo: new CodeInfo(ByteCode),
+                value: 0,
+                transferValue: 0,
+                txExecutionContext: new TxExecutionContext(_header, Address.Zero, null, 0),
+                callDepth: 0,
+                inputData: default
+            );
 
             _evmState = new EvmState(long.MaxValue, _environment, ExecutionType.Transaction, true, _worldState.TakeSnapshot(), false);
         }

--- a/src/Nethermind/Nethermind.Evm.Benchmark/MultipleUnsignedOperations.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/MultipleUnsignedOperations.cs
@@ -92,7 +92,7 @@ public class MultipleUnsignedOperations
             value: 0,
             transferValue: 0,
             txExecutionContext: new TxExecutionContext(_header, Address.Zero, null, 0),
-            callDepth:0,
+            callDepth: 0,
             inputData: default
         );
 

--- a/src/Nethermind/Nethermind.Evm.Benchmark/MultipleUnsignedOperations.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/MultipleUnsignedOperations.cs
@@ -84,15 +84,17 @@ public class MultipleUnsignedOperations
         _virtualMachine = new VirtualMachine(_blockhashProvider, MainnetSpecProvider.Instance, new OneLoggerLogManager(NullLogger.Instance));
 
         _environment = new ExecutionEnvironment
-        {
-            ExecutingAccount = Address.Zero,
-            CodeSource = Address.Zero,
-            Caller = Address.Zero,
-            CodeInfo = new CodeInfo(_bytecode.Concat(_bytecode).Concat(_bytecode).Concat(_bytecode).ToArray()),
-            Value = 0,
-            TransferValue = 0,
-            TxExecutionContext = new TxExecutionContext(_header, Address.Zero, 0, null)
-        };
+        (
+            executingAccount: Address.Zero,
+            codeSource: Address.Zero,
+            caller: Address.Zero,
+            codeInfo: new CodeInfo(_bytecode.Concat(_bytecode).Concat(_bytecode).Concat(_bytecode).ToArray()),
+            value: 0,
+            transferValue: 0,
+            txExecutionContext: new TxExecutionContext(_header, Address.Zero, null, 0),
+            callDepth:0,
+            inputData: default
+        );
 
         _evmState = new EvmState(100_000_000L, _environment, ExecutionType.Transaction, true, _worldState.TakeSnapshot(), false);
     }

--- a/src/Nethermind/Nethermind.Evm.Benchmark/StaticCallBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/StaticCallBenchmarks.cs
@@ -95,15 +95,17 @@ namespace Nethermind.Evm.Benchmark
             _virtualMachine = new VirtualMachine(_blockhashProvider, MainnetSpecProvider.Instance, new OneLoggerLogManager(NullLogger.Instance));
 
             _environment = new ExecutionEnvironment
-            {
-                ExecutingAccount = Address.Zero,
-                CodeSource = Address.Zero,
-                Caller = Address.Zero,
-                CodeInfo = new CodeInfo(Bytecode),
-                Value = 0,
-                TransferValue = 0,
-                TxExecutionContext = new TxExecutionContext(_header, Address.Zero, 0, null)
-            };
+            (
+                executingAccount: Address.Zero,
+                codeSource: Address.Zero,
+                caller: Address.Zero,
+                codeInfo: new CodeInfo(Bytecode),
+                value: 0,
+                transferValue: 0,
+                txExecutionContext: new TxExecutionContext(_header, Address.Zero, null, 0),
+                callDepth: 0,
+                inputData: default
+            );
 
             _evmState = new EvmState(100_000_000L, _environment, ExecutionType.Transaction, true, _worldState.TakeSnapshot(), false);
         }

--- a/src/Nethermind/Nethermind.Evm.Test/CmpTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/CmpTests.cs
@@ -9,12 +9,10 @@ using NUnit.Framework;
 
 namespace Nethermind.Evm.Test
 {
-    [TestFixture(true)]
-    [TestFixture(false)]
+    [TestFixture]
     [Parallelizable(ParallelScope.Self)]
     public class CmpTests : VirtualMachineTestsBase
     {
-        private readonly bool _simdDisabled;
         protected override long BlockNumber => MainnetSpecProvider.ConstantinopleFixBlockNumber;
 
         private void AssertEip1014(Address address, byte[] code)
@@ -22,19 +20,9 @@ namespace Nethermind.Evm.Test
             AssertCodeHash(address, Keccak.Compute(code));
         }
 
-        public CmpTests(bool simdDisabled)
-        {
-            _simdDisabled = simdDisabled;
-        }
-
         [Test]
         public void Gt()
         {
-            if (_simdDisabled)
-            {
-                Machine.DisableSimdInstructions();
-            }
-
             byte[] a = Bytes.FromHexString("0xf0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0ff");
             byte[] b = Bytes.FromHexString("0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f");
             byte[] result = Bytes.FromHexString("0x0000000000000000000000000000000000000000000000000000000000000000");
@@ -54,11 +42,6 @@ namespace Nethermind.Evm.Test
         [Test]
         public void Lt()
         {
-            if (_simdDisabled)
-            {
-                Machine.DisableSimdInstructions();
-            }
-
             byte[] a = Bytes.FromHexString("0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f");
             byte[] b = Bytes.FromHexString("0xf0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0");
             byte[] result = Bytes.FromHexString("0x0000000000000000000000000000000000000000000000000000000000000000");
@@ -78,11 +61,6 @@ namespace Nethermind.Evm.Test
         [Test]
         public void Eq()
         {
-            if (_simdDisabled)
-            {
-                Machine.DisableSimdInstructions();
-            }
-
             byte[] a = Bytes.FromHexString("0xf0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0");
             byte[] b = Bytes.FromHexString("0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f");
             byte[] result = Bytes.FromHexString("0x0000000000000000000000000000000000000000000000000000000000000000");

--- a/src/Nethermind/Nethermind.Evm.Test/SimdTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/SimdTests.cs
@@ -10,12 +10,10 @@ using NUnit.Framework;
 
 namespace Nethermind.Evm.Test
 {
-    [TestFixture(true)]
-    [TestFixture(false)]
+    [TestFixture]
     [Parallelizable(ParallelScope.Self)]
     public class SimdTests : VirtualMachineTestsBase
     {
-        private readonly bool _simdDisabled;
         protected override long BlockNumber => MainnetSpecProvider.ConstantinopleFixBlockNumber;
 
         private void AssertEip1014(Address address, byte[] code)
@@ -23,19 +21,9 @@ namespace Nethermind.Evm.Test
             AssertCodeHash(address, Keccak.Compute(code));
         }
 
-        public SimdTests(bool simdDisabled)
-        {
-            _simdDisabled = simdDisabled;
-        }
-
         [Test]
         public void And()
         {
-            if (_simdDisabled)
-            {
-                Machine.DisableSimdInstructions();
-            }
-
             byte[] a = Bytes.FromHexString("0xf0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0ff");
             byte[] b = Bytes.FromHexString("0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f");
             byte[] result = Bytes.FromHexString("0x000000000000000000000000000000000000000000000000000000000000000f");
@@ -55,11 +43,6 @@ namespace Nethermind.Evm.Test
         [Test]
         public void Or()
         {
-            if (_simdDisabled)
-            {
-                Machine.DisableSimdInstructions();
-            }
-
             byte[] a = Bytes.FromHexString("0xf0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0");
             byte[] b = Bytes.FromHexString("0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f");
             byte[] result = Bytes.FromHexString("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
@@ -79,11 +62,6 @@ namespace Nethermind.Evm.Test
         [Test]
         public void Xor()
         {
-            if (_simdDisabled)
-            {
-                Machine.DisableSimdInstructions();
-            }
-
             byte[] a = Bytes.FromHexString("0xf0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0");
             byte[] b = Bytes.FromHexString("0xff0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f");
             byte[] result = Bytes.FromHexString("0x0fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
@@ -103,11 +81,6 @@ namespace Nethermind.Evm.Test
         [Test]
         public void Not()
         {
-            if (_simdDisabled)
-            {
-                Machine.DisableSimdInstructions();
-            }
-
             byte[] a = Bytes.FromHexString("0xf0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0");
             byte[] result = Bytes.FromHexString("0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f");
 

--- a/src/Nethermind/Nethermind.Evm/ByteArrayExtensions.cs
+++ b/src/Nethermind/Nethermind.Evm/ByteArrayExtensions.cs
@@ -12,7 +12,7 @@ namespace Nethermind.Evm
         {
             if (startIndex >= span.Length)
             {
-                return new ZeroPaddedSpan(Span<byte>.Empty, length, padDirection);
+                return new ZeroPaddedSpan(default, length, padDirection);
             }
 
             if (length == 1)
@@ -20,8 +20,8 @@ namespace Nethermind.Evm
                 // why do we return zero length here?
                 // it was passing all the tests like this...
                 // return bytes.Length == 0 ? new byte[0] : new[] {bytes[startIndex]};
-                return span.Length == 0 ? new ZeroPaddedSpan(Span<byte>.Empty, 0, padDirection) : new ZeroPaddedSpan(span.Slice(startIndex, 1), 0, padDirection);
-                // return bytes.Length == 0 ? new ZeroPaddedSpan(Span<byte>.Empty, 1) : new ZeroPaddedSpan(bytes.Slice(startIndex, 1), 0);
+                return span.Length == 0 ? new ZeroPaddedSpan(default, 0, padDirection) : new ZeroPaddedSpan(span.Slice(startIndex, 1), 0, padDirection);
+                // return bytes.Length == 0 ? new ZeroPaddedSpan(default, 1) : new ZeroPaddedSpan(bytes.Slice(startIndex, 1), 0);
             }
 
             int copiedLength = Math.Min(span.Length - startIndex, length);
@@ -32,7 +32,7 @@ namespace Nethermind.Evm
         {
             if (startIndex >= memory.Length)
             {
-                return new ZeroPaddedMemory(ReadOnlyMemory<byte>.Empty, length, padDirection);
+                return new ZeroPaddedMemory(default, length, padDirection);
             }
 
             if (length == 1)
@@ -40,8 +40,8 @@ namespace Nethermind.Evm
                 // why do we return zero length here?
                 // it was passing all the tests like this...
                 // return bytes.Length == 0 ? new byte[0] : new[] {bytes[startIndex]};
-                return memory.Length == 0 ? new ZeroPaddedMemory(ReadOnlyMemory<byte>.Empty, 0, padDirection) : new ZeroPaddedMemory(memory.Slice(startIndex, 1), 0, padDirection);
-                // return bytes.Length == 0 ? new ZeroPaddedSpan(Span<byte>.Empty, 1) : new ZeroPaddedSpan(bytes.Slice(startIndex, 1), 0);
+                return memory.Length == 0 ? new ZeroPaddedMemory(default, 0, padDirection) : new ZeroPaddedMemory(memory.Slice(startIndex, 1), 0, padDirection);
+                // return bytes.Length == 0 ? new ZeroPaddedSpan(default, 1) : new ZeroPaddedSpan(bytes.Slice(startIndex, 1), 0);
             }
 
             int copiedLength = Math.Min(memory.Length - startIndex, length);
@@ -52,7 +52,7 @@ namespace Nethermind.Evm
         {
             if (startIndex >= span.Length || startIndex > int.MaxValue)
             {
-                return new ZeroPaddedSpan(Span<byte>.Empty, length, PadDirection.Right);
+                return new ZeroPaddedSpan(default, length, PadDirection.Right);
             }
 
             return SliceWithZeroPadding(span, (int)startIndex, length, padDirection);
@@ -62,7 +62,7 @@ namespace Nethermind.Evm
         {
             if (startIndex >= bytes.Length || startIndex > int.MaxValue)
             {
-                return new ZeroPaddedMemory(ReadOnlyMemory<byte>.Empty, length, PadDirection.Right);
+                return new ZeroPaddedMemory(default, length, PadDirection.Right);
             }
 
             return MemoryWithZeroPadding(bytes, (int)startIndex, length, padDirection);

--- a/src/Nethermind/Nethermind.Evm/EvmStack.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmStack.cs
@@ -124,6 +124,7 @@ namespace Nethermind.Evm
 
         private static readonly byte[] OneStackItem = { 1 };
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public void PushOne()
         {
             if (_tracer.IsTracingInstructions) _tracer.ReportStackPush(OneStackItem);
@@ -142,6 +143,7 @@ namespace Nethermind.Evm
 
         private static readonly byte[] ZeroStackItem = { 0 };
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public void PushZero()
         {
             if (_tracer.IsTracingInstructions)
@@ -175,6 +177,14 @@ namespace Nethermind.Evm
             }
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal void PushUInt256(ulong value)
+        {
+            UInt256 uint256 = value;
+            PushUInt256(in uint256);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
         internal void PushUInt256(long value)
         {
             UInt256 uint256 = (UInt256)value;

--- a/src/Nethermind/Nethermind.Evm/EvmStack.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmStack.cs
@@ -124,7 +124,6 @@ namespace Nethermind.Evm
 
         private static readonly byte[] OneStackItem = { 1 };
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public void PushOne()
         {
             if (_tracer.IsTracingInstructions) _tracer.ReportStackPush(OneStackItem);
@@ -143,7 +142,6 @@ namespace Nethermind.Evm
 
         private static readonly byte[] ZeroStackItem = { 0 };
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public void PushZero()
         {
             if (_tracer.IsTracingInstructions)

--- a/src/Nethermind/Nethermind.Evm/EvmStack.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmStack.cs
@@ -405,7 +405,7 @@ namespace Nethermind.Evm
             }
         }
 
-        public List<string> GetStackTrace()
+        public readonly List<string> GetStackTrace()
         {
             List<string> stackTrace = new();
             for (int i = 0; i < Head; i++)

--- a/src/Nethermind/Nethermind.Evm/EvmStack.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmStack.cs
@@ -41,6 +41,9 @@ namespace Nethermind.Evm
 
         private ITxTracer _tracer;
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void PushBytes(byte[] value) => PushBytes(new Span<byte>(value));
+
         public void PushBytes(scoped in Span<byte> value)
         {
             if (_tracer.IsTracingInstructions) _tracer.ReportStackPush(value);

--- a/src/Nethermind/Nethermind.Evm/EvmStack.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmStack.cs
@@ -175,6 +175,12 @@ namespace Nethermind.Evm
             }
         }
 
+        internal void PushUInt256(long value)
+        {
+            UInt256 uint256 = (UInt256)value;
+            PushUInt256(in uint256);
+        }
+
         /// <summary>
         /// Pushes an Uint256 written in big endian.
         /// </summary>

--- a/src/Nethermind/Nethermind.Evm/EvmState.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmState.cs
@@ -223,7 +223,7 @@ namespace Nethermind.Evm
 
         public Address To => Env.CodeSource;
         internal bool IsPrecompile => Env.CodeInfo.IsPrecompile;
-        public ExecutionEnvironment Env { get; }
+        public readonly ExecutionEnvironment Env;
 
         internal ExecutionType ExecutionType { get; } // TODO: move to CallEnv
         public bool IsTopLevel { get; } // TODO: move to CallEnv

--- a/src/Nethermind/Nethermind.Evm/ExecutionEnvironment.cs
+++ b/src/Nethermind/Nethermind.Evm/ExecutionEnvironment.cs
@@ -8,51 +8,74 @@ using Nethermind.Int256;
 
 namespace Nethermind.Evm
 {
-    public struct ExecutionEnvironment
+    public readonly struct ExecutionEnvironment
     {
+        public ExecutionEnvironment
+        (
+            CodeInfo codeInfo,
+            Address executingAccount,
+            Address caller,
+            Address? codeSource,
+            ReadOnlyMemory<byte> inputData,
+            TxExecutionContext txExecutionContext,
+            UInt256 transferValue,
+            UInt256 value,
+            int callDepth)
+        {
+            CodeInfo = codeInfo;
+            ExecutingAccount = executingAccount;
+            Caller = caller;
+            CodeSource = codeSource;
+            InputData = inputData;
+            TxExecutionContext = txExecutionContext;
+            TransferValue = transferValue;
+            Value = value;
+            CallDepth = callDepth;
+        }
+
         /// <summary>
-        /// Transaction originator
+        /// Parsed bytecode for the current call.
         /// </summary>
-        public TxExecutionContext TxExecutionContext { get; set; }
+        public readonly CodeInfo CodeInfo;
 
         /// <summary>
         /// Currently executing account (in DELEGATECALL this will be equal to caller).
         /// </summary>
-        public Address ExecutingAccount { get; set; }
+        public readonly Address ExecutingAccount;
 
         /// <summary>
         /// Caller
         /// </summary>
-        public Address Caller { get; set; }
+        public readonly Address Caller;
 
         /// <summary>
         /// Bytecode source (account address).
         /// </summary>
-        public Address? CodeSource { get; set; }
+        public readonly Address? CodeSource;
 
         /// <summary>
         /// Parameters / arguments of the current call.
         /// </summary>
-        public ReadOnlyMemory<byte> InputData;
+        public readonly ReadOnlyMemory<byte> InputData;
+
+        /// <summary>
+        /// Transaction originator
+        /// </summary>
+        public readonly TxExecutionContext TxExecutionContext;
 
         /// <summary>
         /// ETH value transferred in this call.
         /// </summary>
-        public UInt256 TransferValue { get; set; }
+        public readonly UInt256 TransferValue;
 
         /// <summary>
         /// Value information passed (it is different from transfer value in DELEGATECALL.
         /// DELEGATECALL behaves like a library call and it uses the value information from the caller even
         /// as no transfer happens.
         /// </summary>
-        public UInt256 Value;
-
-        /// <summary>
-        /// Parsed bytecode for the current call.
-        /// </summary>
-        public CodeInfo CodeInfo { get; set; }
+        public readonly UInt256 Value;
 
         /// <example>If we call TX -> DELEGATECALL -> CALL -> STATICCALL then the call depth would be 3.</example>
-        public int CallDepth { get; set; }
+        public readonly int CallDepth;
     }
 }

--- a/src/Nethermind/Nethermind.Evm/ExecutionEnvironment.cs
+++ b/src/Nethermind/Nethermind.Evm/ExecutionEnvironment.cs
@@ -33,7 +33,7 @@ namespace Nethermind.Evm
         /// <summary>
         /// Parameters / arguments of the current call.
         /// </summary>
-        public ReadOnlyMemory<byte> InputData { get; set; }
+        public ReadOnlyMemory<byte> InputData;
 
         /// <summary>
         /// ETH value transferred in this call.
@@ -45,7 +45,7 @@ namespace Nethermind.Evm
         /// DELEGATECALL behaves like a library call and it uses the value information from the caller even
         /// as no transfer happens.
         /// </summary>
-        public UInt256 Value { get; set; }
+        public UInt256 Value;
 
         /// <summary>
         /// Parsed bytecode for the current call.

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -320,18 +320,11 @@ namespace Nethermind.Evm.TransactionProcessing
 
                 recipientOrNull = recipient;
 
-                ExecutionEnvironment env = new();
-                env.TxExecutionContext = new TxExecutionContext(block, caller, effectiveGasPrice, transaction.BlobVersionedHashes);
-                env.Value = value;
-                env.TransferValue = value;
-                env.Caller = caller;
-                env.CodeSource = recipient;
-                env.ExecutingAccount = recipient;
-                env.InputData = data ?? Array.Empty<byte>();
-                env.CodeInfo = machineCode is null
-                    ? _virtualMachine.GetCachedCodeInfo(_worldState, recipient, spec)
-                    : new CodeInfo(machineCode);
-
+                ExecutionEnvironment env = new
+                (codeInfo: machineCode is null
+                        ? _virtualMachine.GetCachedCodeInfo(_worldState, recipient, spec)
+                        : new CodeInfo(machineCode),
+                    executingAccount: recipient, caller: caller, codeSource: recipient, inputData: data ?? Array.Empty<byte>(), txExecutionContext: new TxExecutionContext(block, caller, transaction.BlobVersionedHashes, effectiveGasPrice), transferValue: value, value: value, callDepth: 0);
                 ExecutionType executionType =
                     transaction.IsContractCreation ? ExecutionType.Create : ExecutionType.Transaction;
                 using (EvmState state =

--- a/src/Nethermind/Nethermind.Evm/TxExecutionContext.cs
+++ b/src/Nethermind/Nethermind.Evm/TxExecutionContext.cs
@@ -10,15 +10,15 @@ namespace Nethermind.Evm
     {
         public BlockHeader Header { get; }
         public Address Origin { get; }
-        public readonly UInt256 GasPrice;
         public byte[][]? BlobVersionedHashes { get; }
+        public readonly UInt256 GasPrice;
 
-        public TxExecutionContext(BlockHeader blockHeader, Address origin, in UInt256 gasPrice, byte[][] blobVersionedHashes)
+        public TxExecutionContext(BlockHeader blockHeader, Address origin, byte[][] blobVersionedHashes, in UInt256 gasPrice)
         {
             Header = blockHeader;
             Origin = origin;
-            GasPrice = gasPrice;
             BlobVersionedHashes = blobVersionedHashes;
+            GasPrice = gasPrice;
         }
     }
 }

--- a/src/Nethermind/Nethermind.Evm/TxExecutionContext.cs
+++ b/src/Nethermind/Nethermind.Evm/TxExecutionContext.cs
@@ -10,7 +10,7 @@ namespace Nethermind.Evm
     {
         public BlockHeader Header { get; }
         public Address Origin { get; }
-        public UInt256 GasPrice { get; }
+        public readonly UInt256 GasPrice;
         public byte[][]? BlobVersionedHashes { get; }
 
         public TxExecutionContext(BlockHeader blockHeader, Address origin, in UInt256 gasPrice, byte[][] blobVersionedHashes)

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.Instructions.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.Instructions.cs
@@ -31,6 +31,7 @@ public partial class VirtualMachine
         AccessViolation
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private bool InstructionEXTCODEHASH(ref EvmStack stack, ref long gasAvailable, EvmState vmState, IReleaseSpec spec)
     {
         if (!UpdateGas(spec.GetExtCodeHashCost(), ref gasAvailable)) return false;
@@ -50,6 +51,7 @@ public partial class VirtualMachine
         return true;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private bool InstructionSELFDESTRUCT(ref EvmStack stack, ref long gasAvailable, EvmState vmState, Address executingAccount, IReleaseSpec spec)
     {
         Metrics.SelfDestructs++;
@@ -88,6 +90,7 @@ public partial class VirtualMachine
         return true;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private static bool InstructionSHL(ref EvmStack stack, ref long gasAvailable)
     {
         if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) return false;
@@ -108,6 +111,7 @@ public partial class VirtualMachine
         return true;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private static bool InstructionSHR(ref EvmStack stack, ref long gasAvailable)
     {
         if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) return false;
@@ -128,6 +132,7 @@ public partial class VirtualMachine
         return true;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private static bool InstructionSAR(ref EvmStack stack, ref long gasAvailable)
     {
         if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) return false;
@@ -155,6 +160,7 @@ public partial class VirtualMachine
         return true;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private (InstructionReturn result, EvmState? callState) InstructionCREATE(Instruction instruction, ref EvmStack stack, ref long gasAvailable, ref ExecutionEnvironment env, EvmState vmState, IReleaseSpec spec)
     {
         // TODO: happens in CREATE_empty000CreateInitCode_Transaction but probably has to be handled differently
@@ -236,7 +242,7 @@ public partial class VirtualMachine
         bool accountExists = _state.AccountExists(contractAddress);
         if (accountExists && (GetCachedCodeInfo(_worldState, contractAddress, spec).MachineCode.Length != 0 || _state.GetNonce(contractAddress) != 0))
         {
-/* we get the snapshot before this as there is a possibility with that we will touch an empty account and remove it even if the REVERT operation follows */
+            /* we get the snapshot before this as there is a possibility with that we will touch an empty account and remove it even if the REVERT operation follows */
             if (_logger.IsTrace) _logger.Trace($"Contract collision at {contractAddress}");
             _returnDataBuffer = Array.Empty<byte>();
             stack.PushZero();
@@ -279,7 +285,8 @@ public partial class VirtualMachine
 
         return (InstructionReturn.Success, callState);
     }
-    
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private bool InstructionSSTORE(ref EvmStack stack, ref long gasAvailable, Address executingAccount, EvmState vmState, IReleaseSpec spec)
     {
         stack.PopUInt256(out UInt256 storageIndex);
@@ -416,7 +423,8 @@ public partial class VirtualMachine
 
         return true;
     }
-    
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private bool InstructionBLOCKHASH(ref EvmStack stack, ref long gasAvailable, BlockHeader header)
     {
         Metrics.BlockhashOpcode++;
@@ -439,6 +447,7 @@ public partial class VirtualMachine
         return true;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private InstructionReturn InstructionRETURNDATACOPY(ref EvmStack stack, ref long gasAvailable, EvmPooledMemory? memory)
     {
         stack.PopUInt256(out UInt256 dest);
@@ -466,12 +475,14 @@ public partial class VirtualMachine
         return InstructionReturn.Success;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private void InstructionRETURNDATASIZE(ref EvmStack stack)
     {
         UInt256 res = (UInt256)_returnDataBuffer.Length;
         stack.PushUInt256(in res);
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private bool InstructionEXTCODECOPY(ref EvmStack stack, ref long gasAvailable, EvmState vmState, IReleaseSpec spec)
     {
         Address address = stack.PopAddress();
@@ -500,6 +511,7 @@ public partial class VirtualMachine
         return true;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private bool InstructionEXTCODESIZE(ref EvmStack stack, ref long gasAvailable, EvmState vmState, IReleaseSpec spec)
     {
         if (!UpdateGas(spec.GetExtCodeCost(), ref gasAvailable)) return false;
@@ -514,6 +526,7 @@ public partial class VirtualMachine
         return true;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private bool InstructionCODECOPY(ref EvmStack stack, ref long gasAvailable, EvmPooledMemory? memory, in Span<byte> code)
     {
         stack.PopUInt256(out UInt256 dest);
@@ -533,6 +546,7 @@ public partial class VirtualMachine
         return true;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private static bool InstructionCODESIZE(ref EvmStack stack, ref long gasAvailable, int codeLength)
     {
         if (!UpdateGas(GasCostOf.Base, ref gasAvailable)) return false;
@@ -543,6 +557,7 @@ public partial class VirtualMachine
         return true;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private bool InstructionCALLDATACOPY(ref EvmStack stack, ref long gasAvailable, EvmPooledMemory? memory, in ReadOnlyMemory<byte> inputData)
     {
         stack.PopUInt256(out UInt256 dest);
@@ -566,6 +581,7 @@ public partial class VirtualMachine
         return true;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private static bool InstructionCALLDATASIZE(ref EvmStack stack, ref long gasAvailable, in ReadOnlyMemory<byte> inputData)
     {
         if (!UpdateGas(GasCostOf.Base, ref gasAvailable)) return false;
@@ -576,6 +592,7 @@ public partial class VirtualMachine
         return true;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private static bool InstructionCALLDATALOAD(ref EvmStack stack, ref long gasAvailable, in ReadOnlyMemory<byte> inputData)
     {
         if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) return false;
@@ -586,6 +603,7 @@ public partial class VirtualMachine
         return true;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private bool InstructionBALANCE(ref EvmStack stack, ref long gasAvailable, EvmState vmState, IReleaseSpec spec)
     {
         long gasCost = spec.GetBalanceCost();
@@ -599,6 +617,8 @@ public partial class VirtualMachine
 
         return true;
     }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private static bool InstructionSHA3(ref EvmStack stack, ref long gasAvailable, EvmPooledMemory memory)
     {
         stack.PopUInt256(out UInt256 memSrc);
@@ -615,6 +635,7 @@ public partial class VirtualMachine
         return true;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private static bool InstructionBYTE(ref EvmStack stack, ref long gasAvailable)
     {
         if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) return false;
@@ -641,6 +662,7 @@ public partial class VirtualMachine
         return true;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private static bool InstructionNOT(ref EvmStack stack, ref long gasAvailable)
     {
         if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) return false;
@@ -655,6 +677,7 @@ public partial class VirtualMachine
         return true;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private static bool InstructionXOR(ref EvmStack stack, ref long gasAvailable)
     {
         if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) return false;
@@ -671,6 +694,7 @@ public partial class VirtualMachine
         return true;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private static bool InstructionOR(ref EvmStack stack, ref long gasAvailable)
     {
         if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) return false;
@@ -687,6 +711,7 @@ public partial class VirtualMachine
         return true;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private static bool InstructionAND(ref EvmStack stack, ref long gasAvailable)
     {
         if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) return false;
@@ -703,6 +728,7 @@ public partial class VirtualMachine
         return true;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private static bool InstructionISZERO(ref EvmStack stack, ref long gasAvailable)
     {
         if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) return false;
@@ -720,6 +746,7 @@ public partial class VirtualMachine
         return true;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private static bool InstructionEQ(ref EvmStack stack, ref long gasAvailable)
     {
         if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) return false;
@@ -738,6 +765,7 @@ public partial class VirtualMachine
         return true;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private static bool InstructionSGT(ref EvmStack stack, ref long gasAvailable)
     {
         if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) return false;
@@ -756,6 +784,7 @@ public partial class VirtualMachine
         return true;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private static bool InstructionSLT(ref EvmStack stack, ref long gasAvailable)
     {
         if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) return false;
@@ -775,6 +804,7 @@ public partial class VirtualMachine
         return true;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private static bool InstructionGT(ref EvmStack stack, ref long gasAvailable)
     {
         if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) return false;
@@ -793,6 +823,7 @@ public partial class VirtualMachine
         return true;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private static bool InstructionLT(ref EvmStack stack, ref long gasAvailable)
     {
         if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) return false;
@@ -811,6 +842,7 @@ public partial class VirtualMachine
         return true;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private static bool InstructionSIGNEXTEND(ref EvmStack stack, ref long gasAvailable)
     {
         if (!UpdateGas(GasCostOf.Low, ref gasAvailable)) return false;
@@ -840,10 +872,11 @@ public partial class VirtualMachine
         return true;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private static bool InstructionEXP(ref EvmStack stack, ref long gasAvailable, IReleaseSpec spec)
     {
         Metrics.ModExpOpcode++;
-        
+
         if (!UpdateGas(GasCostOf.Exp, ref gasAvailable)) return false;
 
         stack.PopUInt256(out UInt256 baseInt);
@@ -878,6 +911,7 @@ public partial class VirtualMachine
         return true;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private static bool InstructionMULMOD(ref EvmStack stack, ref long gasAvailable)
     {
         if (!UpdateGas(GasCostOf.Mid, ref gasAvailable)) return false;
@@ -899,6 +933,7 @@ public partial class VirtualMachine
         return true;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private static bool InstructionADDMOD(ref EvmStack stack, ref long gasAvailable)
     {
         if (!UpdateGas(GasCostOf.Mid, ref gasAvailable)) return false;
@@ -920,6 +955,7 @@ public partial class VirtualMachine
         return true;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private static bool InstructionSMOD(ref EvmStack stack, ref long gasAvailable)
     {
         if (!UpdateGas(GasCostOf.Low, ref gasAvailable)) return false;
@@ -939,6 +975,7 @@ public partial class VirtualMachine
         return true;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private static bool InstructionMOD(ref EvmStack stack, ref long gasAvailable)
     {
         if (!UpdateGas(GasCostOf.Low, ref gasAvailable)) return false;
@@ -951,6 +988,7 @@ public partial class VirtualMachine
         return true;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private static bool InstructionDIV(ref EvmStack stack, ref long gasAvailable)
     {
         if (!UpdateGas(GasCostOf.Low, ref gasAvailable)) return false;
@@ -970,6 +1008,7 @@ public partial class VirtualMachine
         return true;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private static bool InstructionSDIV(ref EvmStack stack, ref long gasAvailable)
     {
         if (!UpdateGas(GasCostOf.Low, ref gasAvailable)) return false;
@@ -995,6 +1034,7 @@ public partial class VirtualMachine
         return true;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private static bool InstructionSUB(ref EvmStack stack, ref long gasAvailable)
     {
         if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) return false;
@@ -1008,6 +1048,7 @@ public partial class VirtualMachine
         return true;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private static bool InstructionMUL(ref EvmStack stack, ref long gasAvailable)
     {
         if (!UpdateGas(GasCostOf.Low, ref gasAvailable)) return false;
@@ -1020,6 +1061,7 @@ public partial class VirtualMachine
         return true;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private static bool InstructionADD(ref EvmStack stack, ref long gasAvailable)
     {
         if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) return false;

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.Instructions.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.Instructions.cs
@@ -1401,4 +1401,70 @@ public partial class VirtualMachine
 
         return true;
     }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool InstructionPUSH0(ref EvmStack stack, ref long gasAvailable)
+    {
+        if (!UpdateGas(GasCostOf.Base, ref gasAvailable)) return false;
+
+        stack.PushZero();
+
+        return true;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool InstructionPUSH1(ref EvmStack stack, ref long gasAvailable, ref int programCounter, in Span<byte> code)
+    {
+        if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) return false;
+
+        int programCounterInt = programCounter;
+        if (programCounterInt >= code.Length)
+        {
+            stack.PushZero();
+        }
+        else
+        {
+            stack.PushByte(code[programCounterInt]);
+        }
+
+        programCounter = programCounterInt + 1;
+
+        return true;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool InstructionPUSH(Instruction instruction, ref EvmStack stack, ref long gasAvailable, ref int programCounter, in Span<byte> code)
+    {
+        if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) return false;
+
+        int length = instruction - Instruction.PUSH1 + 1;
+        int programCounterInt = programCounter;
+        int usedFromCode = Math.Min(code.Length - programCounterInt, length);
+
+        stack.PushLeftPaddedBytes(code.Slice(programCounterInt, usedFromCode), length);
+
+        programCounter = programCounterInt + length;
+
+        return true;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool InstructionDUP(Instruction instruction, ref EvmStack stack, ref long gasAvailable)
+    {
+        if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) return false;
+
+        stack.Dup(instruction - Instruction.DUP1 + 1);
+
+        return true;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool InstructionSWAP(Instruction instruction, ref EvmStack stack, ref long gasAvailable)
+    {
+        if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) return false;
+
+        stack.Swap(instruction - Instruction.SWAP1 + 2);
+
+        return true;
+    }
 }

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.Instructions.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.Instructions.cs
@@ -764,7 +764,7 @@ public partial class VirtualMachine
         Keccak blockHash = _blockhashProvider.GetBlockhash(header, number);
         stack.PushBytes(blockHash?.Bytes ?? BytesZero32);
 
-        if (_txTracer.IsTracingInstructions)
+        if (_logger.IsTrace)
         {
             if (_txTracer.IsTracingBlockHash && blockHash is not null)
             {

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.Instructions.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.Instructions.cs
@@ -1062,7 +1062,7 @@ public partial class VirtualMachine
         if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) return false;
 
         Span<byte> a = stack.PopBytes();
-        if (a.SequenceEqual(BytesZero32))
+        if (a.IsZero())
         {
             stack.PushOne();
         }

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.Instructions.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.Instructions.cs
@@ -16,6 +16,8 @@ using System.Runtime.Intrinsics;
 namespace Nethermind.Evm;
 public partial class VirtualMachine
 {
+    private static readonly UInt256 UInt256ThirtyTwo = 32;
+
     private enum InstructionReturn
     {
         Success,
@@ -207,7 +209,7 @@ public partial class VirtualMachine
             if (traceOpcodes)
             {
                 // very specific for Parity trace, need to find generalization - very peculiar 32 length...
-                ReadOnlyMemory<byte> memoryTrace = vmState.Memory.Inspect(in dataOffset, 32);
+                ReadOnlyMemory<byte> memoryTrace = vmState.Memory.Inspect(in dataOffset, in UInt256ThirtyTwo);
                 _txTracer.ReportMemoryChange(dataOffset, memoryTrace.Span);
             }
 
@@ -379,7 +381,7 @@ public partial class VirtualMachine
 
         Span<byte> data = stack.PopBytes();
 
-        if (!UpdateMemoryCost(vmState.Memory, ref gasAvailable, in memPosition, 32)) return false;
+        if (!UpdateMemoryCost(vmState.Memory, ref gasAvailable, in memPosition, in UInt256ThirtyTwo)) return false;
 
         vmState.Memory.SaveWord(in memPosition, data);
         if (_txTracer.IsTracingInstructions) _txTracer.ReportMemoryChange((long)memPosition, data.SliceWithZeroPadding(0, 32, PadDirection.Left));
@@ -394,7 +396,7 @@ public partial class VirtualMachine
 
         stack.PopUInt256(out UInt256 memPosition);
 
-        if (!UpdateMemoryCost(vmState.Memory, ref gasAvailable, in memPosition, 32)) return false;
+        if (!UpdateMemoryCost(vmState.Memory, ref gasAvailable, in memPosition, in UInt256ThirtyTwo)) return false;
 
         Span<byte> memData = vmState.Memory.LoadSpan(in memPosition);
         if (_txTracer.IsTracingInstructions) _txTracer.ReportMemoryChange(memPosition, memData);

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.Instructions.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.Instructions.cs
@@ -799,10 +799,14 @@ public partial class VirtualMachine
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private void InstructionRETURNDATASIZE(ref EvmStack stack)
+    private bool InstructionRETURNDATASIZE(ref EvmStack stack, ref long gasAvailable)
     {
+        if (!UpdateGas(GasCostOf.Base, ref gasAvailable)) return false;
+
         UInt256 res = (UInt256)_returnDataBuffer.Length;
         stack.PushUInt256(in res);
+
+        return true;
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.Instructions.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.Instructions.cs
@@ -1,0 +1,363 @@
+// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Nethermind.Core;
+using Nethermind.Core.Caching;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Specs;
+using Nethermind.Evm.CodeAnalysis;
+using Nethermind.Int256;
+using Nethermind.Evm.Precompiles;
+using Nethermind.Evm.Precompiles.Bls.Shamatar;
+using Nethermind.Evm.Precompiles.Snarks.Shamatar;
+using Nethermind.Evm.Tracing;
+using Nethermind.Logging;
+using Nethermind.State;
+using System.Runtime.Intrinsics;
+
+namespace Nethermind.Evm;
+public partial class VirtualMachine
+{
+    private static void InstructionSHA3(ref EvmStack stack, EvmState vmState, in UInt256 memSrc, in UInt256 memLength)
+    {
+        Span<byte> memData = vmState.Memory.LoadSpan(in memSrc, memLength);
+        stack.PushBytes(ValueKeccak.Compute(memData).BytesAsSpan);
+    }
+
+    private static void InstructionBYTE(ref EvmStack stack)
+    {
+        stack.PopUInt256(out UInt256 position);
+        Span<byte> bytes = stack.PopBytes();
+
+        if (position >= BigInt32)
+        {
+            stack.PushZero();
+            return;
+        }
+
+        int adjustedPosition = bytes.Length - 32 + (int)position;
+        if (adjustedPosition < 0)
+        {
+            stack.PushZero();
+        }
+        else
+        {
+            stack.PushByte(bytes[adjustedPosition]);
+        }
+    }
+
+    private static void InstructionNOT(ref EvmStack stack)
+    {
+        Span<byte> a = stack.PopBytes();
+
+        Vector256<byte> aVec = MemoryMarshal.Read<Vector256<byte>>(a);
+        MemoryMarshal.AsRef<Vector256<byte>>(stack.Register) = ~aVec;
+
+        stack.PushBytes(stack.Register);
+    }
+
+    private static void InstructionXOR(ref EvmStack stack)
+    {
+        Span<byte> a = stack.PopBytes();
+        Span<byte> b = stack.PopBytes();
+
+        Vector256<byte> aVec = MemoryMarshal.Read<Vector256<byte>>(a);
+        Vector256<byte> bVec = MemoryMarshal.Read<Vector256<byte>>(b);
+        MemoryMarshal.AsRef<Vector256<byte>>(stack.Register) = aVec ^ bVec;
+
+        stack.PushBytes(stack.Register);
+    }
+
+    private static void InstructionOR(ref EvmStack stack)
+    {
+        Span<byte> a = stack.PopBytes();
+        Span<byte> b = stack.PopBytes();
+
+        Vector256<byte> aVec = MemoryMarshal.Read<Vector256<byte>>(a);
+        Vector256<byte> bVec = MemoryMarshal.Read<Vector256<byte>>(b);
+        MemoryMarshal.AsRef<Vector256<byte>>(stack.Register) = aVec | bVec;
+
+        stack.PushBytes(stack.Register);
+    }
+
+    private static void InstructionAND(ref EvmStack stack)
+    {
+        Span<byte> a = stack.PopBytes();
+        Span<byte> b = stack.PopBytes();
+
+        Vector256<byte> aVec = MemoryMarshal.Read<Vector256<byte>>(a);
+        Vector256<byte> bVec = MemoryMarshal.Read<Vector256<byte>>(b);
+        MemoryMarshal.AsRef<Vector256<byte>>(stack.Register) = aVec & bVec;
+
+        stack.PushBytes(stack.Register);
+    }
+
+    private static void InstructionISZERO(ref EvmStack stack)
+    {
+        Span<byte> a = stack.PopBytes();
+        if (a.SequenceEqual(BytesZero32))
+        {
+            stack.PushOne();
+        }
+        else
+        {
+            stack.PushZero();
+        }
+    }
+
+    private static void InstructionEQ(ref EvmStack stack)
+    {
+        Span<byte> a = stack.PopBytes();
+        Span<byte> b = stack.PopBytes();
+        if (a.SequenceEqual(b))
+        {
+            stack.PushOne();
+        }
+        else
+        {
+            stack.PushZero();
+        }
+    }
+
+    private static void InstructionSGT(ref EvmStack stack)
+    {
+        stack.PopSignedInt256(out Int256.Int256 a);
+        stack.PopSignedInt256(out Int256.Int256 b);
+        if (a.CompareTo(b) > 0)
+        {
+            stack.PushOne();
+        }
+        else
+        {
+            stack.PushZero();
+        }
+    }
+
+    private static void InstructionSLT(ref EvmStack stack)
+    {
+        stack.PopSignedInt256(out Int256.Int256 a);
+        stack.PopSignedInt256(out Int256.Int256 b);
+
+        if (a.CompareTo(b) < 0)
+        {
+            stack.PushOne();
+        }
+        else
+        {
+            stack.PushZero();
+        }
+    }
+
+    private static void InstructionGT(ref EvmStack stack)
+    {
+        stack.PopUInt256(out UInt256 a);
+        stack.PopUInt256(out UInt256 b);
+        if (a > b)
+        {
+            stack.PushOne();
+        }
+        else
+        {
+            stack.PushZero();
+        }
+    }
+
+    private static void InstructionLT(ref EvmStack stack)
+    {
+        stack.PopUInt256(out UInt256 a);
+        stack.PopUInt256(out UInt256 b);
+        if (a < b)
+        {
+            stack.PushOne();
+        }
+        else
+        {
+            stack.PushZero();
+        }
+    }
+
+    private static void InstructionSIGNEXTEND(ref EvmStack stack)
+    {
+        stack.PopUInt256(out UInt256 a);
+        if (a >= BigInt32)
+        {
+            stack.EnsureDepth(1);
+            return;
+        }
+        int position = 31 - (int)a;
+
+        Span<byte> b = stack.PopBytes();
+        sbyte sign = (sbyte)b[position];
+
+        if (sign >= 0)
+        {
+            b[..position].Clear();
+        }
+        else
+        {
+            b[..position].Fill(byte.MaxValue);
+        }
+
+        stack.PushBytes(b);
+    }
+
+    private static bool InstructionEXP(ref EvmStack stack, ref long gasAvailable, IReleaseSpec spec)
+    {
+        Metrics.ModExpOpcode++;
+
+        stack.PopUInt256(out UInt256 baseInt);
+        Span<byte> exp = stack.PopBytes();
+
+        int leadingZeros = exp.LeadingZerosCount();
+        if (leadingZeros != 32)
+        {
+            int expSize = 32 - leadingZeros;
+            if (!UpdateGas(spec.GetExpByteCost() * expSize, ref gasAvailable)) return false;
+        }
+        else
+        {
+            stack.PushOne();
+            return true;
+        }
+
+        if (baseInt.IsZero)
+        {
+            stack.PushZero();
+        }
+        else if (baseInt.IsOne)
+        {
+            stack.PushOne();
+        }
+        else
+        {
+            UInt256.Exp(baseInt, new UInt256(exp, true), out UInt256 res);
+            stack.PushUInt256(in res);
+        }
+
+        return true;
+    }
+
+    private static void InstructionMULMOD(ref EvmStack stack)
+    {
+        stack.PopUInt256(out UInt256 a);
+        stack.PopUInt256(out UInt256 b);
+        stack.PopUInt256(out UInt256 mod);
+
+        if (mod.IsZero)
+        {
+            stack.PushZero();
+        }
+        else
+        {
+            UInt256.MultiplyMod(in a, in b, in mod, out UInt256 res);
+            stack.PushUInt256(in res);
+        }
+    }
+
+    private static void InstructionADDMOD(ref EvmStack stack)
+    {
+        stack.PopUInt256(out UInt256 a);
+        stack.PopUInt256(out UInt256 b);
+        stack.PopUInt256(out UInt256 mod);
+
+        if (mod.IsZero)
+        {
+            stack.PushZero();
+        }
+        else
+        {
+            UInt256.AddMod(a, b, mod, out UInt256 res);
+            stack.PushUInt256(in res);
+        }
+    }
+
+    private static void InstructionSMOD(ref EvmStack stack)
+    {
+        stack.PopSignedInt256(out Int256.Int256 a);
+        stack.PopSignedInt256(out Int256.Int256 b);
+        if (b.IsZero || b.IsOne)
+        {
+            stack.PushZero();
+        }
+        else
+        {
+            a.Mod(in b, out Int256.Int256 mod);
+            stack.PushSignedInt256(in mod);
+        }
+    }
+
+    private static void InstructionMOD(ref EvmStack stack)
+    {
+        stack.PopUInt256(out UInt256 a);
+        stack.PopUInt256(out UInt256 b);
+        UInt256.Mod(in a, in b, out UInt256 result);
+        stack.PushUInt256(in result);
+    }
+
+    private static void InstructionDIV(ref EvmStack stack)
+    {
+        stack.PopUInt256(out UInt256 a);
+        stack.PopUInt256(out UInt256 b);
+        if (b.IsZero)
+        {
+            stack.PushZero();
+        }
+        else
+        {
+            UInt256.Divide(in a, in b, out UInt256 res);
+            stack.PushUInt256(in res);
+        }
+    }
+
+    private static void InstructionSDIV(ref EvmStack stack)
+    {
+        stack.PopUInt256(out UInt256 a);
+        stack.PopSignedInt256(out Int256.Int256 b);
+        if (b.IsZero)
+        {
+            stack.PushZero();
+        }
+        else if (b == Int256.Int256.MinusOne && a == P255)
+        {
+            UInt256 res = P255;
+            stack.PushUInt256(in res);
+        }
+        else
+        {
+            Int256.Int256 signedA = new(a);
+            Int256.Int256.Divide(in signedA, in b, out Int256.Int256 res);
+            stack.PushSignedInt256(in res);
+        }
+    }
+
+    private static void InstructionSUB(ref EvmStack stack)
+    {
+        stack.PopUInt256(out UInt256 a);
+        stack.PopUInt256(out UInt256 b);
+        UInt256.Subtract(in a, in b, out UInt256 result);
+
+        stack.PushUInt256(in result);
+    }
+
+    private static void InstructionMUL(ref EvmStack stack)
+    {
+        stack.PopUInt256(out UInt256 a);
+        stack.PopUInt256(out UInt256 b);
+        UInt256.Multiply(in a, in b, out UInt256 res);
+        stack.PushUInt256(in res);
+    }
+
+    private static void InstructionADD(ref EvmStack stack)
+    {
+        stack.PopUInt256(out UInt256 b);
+        stack.PopUInt256(out UInt256 a);
+        UInt256.Add(in a, in b, out UInt256 c);
+        stack.PushUInt256(c);
+    }
+}

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.Instructions.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.Instructions.cs
@@ -946,11 +946,11 @@ public partial class VirtualMachine
         stack.PopUInt256(out UInt256 src);
         stack.PopUInt256(out UInt256 length);
         if (!UpdateGas(GasCostOf.VeryLow + GasCostOf.Memory * EvmPooledMemory.Div32Ceiling(length),
-            ref gasAvailable)) return true;
+            ref gasAvailable)) return false;
 
         if (!length.IsZero)
         {
-            if (!UpdateMemoryCost(memory, ref gasAvailable, in dest, length)) return true;
+            if (!UpdateMemoryCost(memory, ref gasAvailable, in dest, length)) return false;
 
             ZeroPaddedMemory callDataSlice = inputData.SliceWithZeroPadding(src, (int)length);
             memory.Save(in dest, callDataSlice);

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -803,7 +803,11 @@ namespace Nethermind.Evm
                             break;
                         }
                     case Instruction.EXTCODESIZE:
-                        if (!InstructionEXTCODESIZE(ref stack, ref gasAvailable, vmState, spec)) goto OutOfGas;
+                        if (programCounter < code.Length && (Instruction)code[programCounter] == Instruction.ISZERO)
+                        {
+                            if (!InstructionIsContract(ref stack, ref gasAvailable, ref programCounter, vmState, spec)) goto OutOfGas;
+                        }
+                        else if (!InstructionEXTCODESIZE(ref stack, ref gasAvailable, vmState, spec)) goto OutOfGas;
                         break;
                     case Instruction.EXTCODECOPY:
                         if (!InstructionEXTCODECOPY(ref stack, ref gasAvailable, vmState, spec)) goto OutOfGas;

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -455,6 +455,7 @@ namespace Nethermind.Evm
 
             return result;
 
+            [StackTraceHidden]
             [DoesNotReturn]
             static void ThrowInvalidOperationException()
             {

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -445,7 +445,6 @@ namespace Nethermind.Evm
 
         private static bool UpdateGas(long gasCost, ref long gasAvailable)
         {
-            // Console.WriteLine($"{gasCost}");
             if (gasAvailable < gasCost)
             {
                 return false;
@@ -561,7 +560,6 @@ namespace Nethermind.Evm
                 _parityTouchBugAccount.ShouldDelete = true;
             }
 
-            //if(!UpdateGas(dataGasCost, ref gasAvailable)) return CallResult.Exception;
             if (!UpdateGas(baseGasCost, ref gasAvailable))
             {
                 Metrics.EvmExceptions++;
@@ -648,34 +646,12 @@ namespace Nethermind.Evm
                 }
             }
 
-            void EndInstructionTrace()
-            {
-                if (traceOpcodes)
-                {
-                    if (_txTracer.IsTracingMemory)
-                    {
-                        _txTracer.SetOperationMemorySize(vmState.Memory?.Size ?? 0);
-                    }
-
-                    _txTracer.ReportOperationRemainingGas(gasAvailable);
-                }
-            }
-
-            void EndInstructionTraceError(EvmExceptionType evmExceptionType)
-            {
-                if (traceOpcodes)
-                {
-                    _txTracer.ReportOperationError(evmExceptionType);
-                    _txTracer.ReportOperationRemainingGas(gasAvailable);
-                }
-            }
-
             void Jump(in UInt256 jumpDest, bool isSubroutine = false)
             {
                 if (jumpDest > int.MaxValue)
                 {
                     Metrics.EvmExceptions++;
-                    EndInstructionTraceError(EvmExceptionType.InvalidJumpDestination);
+                    if (traceOpcodes) EndInstructionTraceError(gasAvailable, EvmExceptionType.InvalidJumpDestination);
                     // https://github.com/NethermindEth/nethermind/issues/140
                     throw new InvalidJumpDestinationException();
                     //                                return CallResult.InvalidJumpDestination; // TODO: add a test, validating inside the condition was not covered by existing tests and fails on 0xf435a354924097686ea88dab3aac1dd464e6a3b387c77aeee94145b0fa5a63d2 mainnet
@@ -685,7 +661,7 @@ namespace Nethermind.Evm
 
                 if (!env.CodeInfo.ValidateJump(jumpDestInt, isSubroutine))
                 {
-                    EndInstructionTraceError(EvmExceptionType.InvalidJumpDestination);
+                    if (traceOpcodes) EndInstructionTraceError(gasAvailable, EvmExceptionType.InvalidJumpDestination);
                     // https://github.com/NethermindEth/nethermind/issues/140
                     throw new InvalidJumpDestinationException();
                     //                                return CallResult.InvalidJumpDestination; // TODO: add a test, validating inside the condition was not covered by existing tests and fails on 61363 Ropsten
@@ -707,7 +683,6 @@ namespace Nethermind.Evm
                     if (!UpdateGas(memoryCost, ref gasAvailable))
                     {
                         Metrics.EvmExceptions++;
-                        EndInstructionTraceError(EvmExceptionType.OutOfGas);
                         throw new OutOfGasException();
                     }
                 }
@@ -748,16 +723,12 @@ namespace Nethermind.Evm
                     case Instruction.STOP:
                         {
                             UpdateCurrentState(vmState, programCounter, gasAvailable, stack.Head);
-                            EndInstructionTrace();
+                            if (traceOpcodes) EndInstructionTrace(gasAvailable, vmState.Memory?.Size ?? 0);
                             return CallResult.Empty;
                         }
                     case Instruction.ADD:
                         {
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
 
                             stack.PopUInt256(out UInt256 b);
                             stack.PopUInt256(out UInt256 a);
@@ -768,11 +739,7 @@ namespace Nethermind.Evm
                         }
                     case Instruction.MUL:
                         {
-                            if (!UpdateGas(GasCostOf.Low, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.Low, ref gasAvailable)) goto OutOfGas;
 
                             stack.PopUInt256(out UInt256 a);
                             stack.PopUInt256(out UInt256 b);
@@ -782,11 +749,7 @@ namespace Nethermind.Evm
                         }
                     case Instruction.SUB:
                         {
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
 
                             stack.PopUInt256(out UInt256 a);
                             stack.PopUInt256(out UInt256 b);
@@ -797,11 +760,7 @@ namespace Nethermind.Evm
                         }
                     case Instruction.DIV:
                         {
-                            if (!UpdateGas(GasCostOf.Low, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.Low, ref gasAvailable)) goto OutOfGas;
 
                             stack.PopUInt256(out UInt256 a);
                             stack.PopUInt256(out UInt256 b);
@@ -819,11 +778,7 @@ namespace Nethermind.Evm
                         }
                     case Instruction.SDIV:
                         {
-                            if (!UpdateGas(GasCostOf.Low, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.Low, ref gasAvailable)) goto OutOfGas;
 
                             stack.PopUInt256(out UInt256 a);
                             stack.PopSignedInt256(out Int256.Int256 b);
@@ -847,11 +802,7 @@ namespace Nethermind.Evm
                         }
                     case Instruction.MOD:
                         {
-                            if (!UpdateGas(GasCostOf.Low, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.Low, ref gasAvailable)) goto OutOfGas;
 
                             stack.PopUInt256(out UInt256 a);
                             stack.PopUInt256(out UInt256 b);
@@ -861,11 +812,7 @@ namespace Nethermind.Evm
                         }
                     case Instruction.SMOD:
                         {
-                            if (!UpdateGas(GasCostOf.Low, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.Low, ref gasAvailable)) goto OutOfGas;
 
                             stack.PopSignedInt256(out Int256.Int256 a);
                             stack.PopSignedInt256(out Int256.Int256 b);
@@ -883,11 +830,7 @@ namespace Nethermind.Evm
                         }
                     case Instruction.ADDMOD:
                         {
-                            if (!UpdateGas(GasCostOf.Mid, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.Mid, ref gasAvailable)) goto OutOfGas;
 
                             stack.PopUInt256(out UInt256 a);
                             stack.PopUInt256(out UInt256 b);
@@ -907,11 +850,7 @@ namespace Nethermind.Evm
                         }
                     case Instruction.MULMOD:
                         {
-                            if (!UpdateGas(GasCostOf.Mid, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.Mid, ref gasAvailable)) goto OutOfGas;
 
                             stack.PopUInt256(out UInt256 a);
                             stack.PopUInt256(out UInt256 b);
@@ -931,11 +870,7 @@ namespace Nethermind.Evm
                         }
                     case Instruction.EXP:
                         {
-                            if (!UpdateGas(GasCostOf.Exp, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.Exp, ref gasAvailable)) goto OutOfGas;
 
                             Metrics.ModExpOpcode++;
 
@@ -946,11 +881,7 @@ namespace Nethermind.Evm
                             if (leadingZeros != 32)
                             {
                                 int expSize = 32 - leadingZeros;
-                                if (!UpdateGas(spec.GetExpByteCost() * expSize, ref gasAvailable))
-                                {
-                                    EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                    return CallResult.OutOfGasException;
-                                }
+                                if (!UpdateGas(spec.GetExpByteCost() * expSize, ref gasAvailable)) goto OutOfGas;
                             }
                             else
                             {
@@ -976,11 +907,7 @@ namespace Nethermind.Evm
                         }
                     case Instruction.SIGNEXTEND:
                         {
-                            if (!UpdateGas(GasCostOf.Low, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.Low, ref gasAvailable)) goto OutOfGas;
 
                             stack.PopUInt256(out UInt256 a);
                             if (a >= BigInt32)
@@ -1008,11 +935,7 @@ namespace Nethermind.Evm
                         }
                     case Instruction.LT:
                         {
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
 
                             stack.PopUInt256(out UInt256 a);
                             stack.PopUInt256(out UInt256 b);
@@ -1029,11 +952,7 @@ namespace Nethermind.Evm
                         }
                     case Instruction.GT:
                         {
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
 
                             stack.PopUInt256(out UInt256 a);
                             stack.PopUInt256(out UInt256 b);
@@ -1050,11 +969,7 @@ namespace Nethermind.Evm
                         }
                     case Instruction.SLT:
                         {
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
 
                             stack.PopSignedInt256(out Int256.Int256 a);
                             stack.PopSignedInt256(out Int256.Int256 b);
@@ -1072,11 +987,7 @@ namespace Nethermind.Evm
                         }
                     case Instruction.SGT:
                         {
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
 
                             stack.PopSignedInt256(out Int256.Int256 a);
                             stack.PopSignedInt256(out Int256.Int256 b);
@@ -1093,11 +1004,7 @@ namespace Nethermind.Evm
                         }
                     case Instruction.EQ:
                         {
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
 
                             Span<byte> a = stack.PopBytes();
                             Span<byte> b = stack.PopBytes();
@@ -1114,11 +1021,7 @@ namespace Nethermind.Evm
                         }
                     case Instruction.ISZERO:
                         {
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
 
                             Span<byte> a = stack.PopBytes();
                             if (a.SequenceEqual(BytesZero32))
@@ -1134,11 +1037,7 @@ namespace Nethermind.Evm
                         }
                     case Instruction.AND:
                         {
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
 
                             Span<byte> a = stack.PopBytes();
                             Span<byte> b = stack.PopBytes();
@@ -1167,11 +1066,7 @@ namespace Nethermind.Evm
                         }
                     case Instruction.OR:
                         {
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
 
                             Span<byte> a = stack.PopBytes();
                             Span<byte> b = stack.PopBytes();
@@ -1200,11 +1095,7 @@ namespace Nethermind.Evm
                         }
                     case Instruction.XOR:
                         {
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
 
                             Span<byte> a = stack.PopBytes();
                             Span<byte> b = stack.PopBytes();
@@ -1233,11 +1124,7 @@ namespace Nethermind.Evm
                         }
                     case Instruction.NOT:
                         {
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
 
                             Span<byte> a = stack.PopBytes();
 
@@ -1264,11 +1151,7 @@ namespace Nethermind.Evm
                         }
                     case Instruction.BYTE:
                         {
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
 
                             stack.PopUInt256(out UInt256 position);
                             Span<byte> bytes = stack.PopBytes();
@@ -1296,11 +1179,7 @@ namespace Nethermind.Evm
                             stack.PopUInt256(out UInt256 memSrc);
                             stack.PopUInt256(out UInt256 memLength);
                             if (!UpdateGas(GasCostOf.Sha3 + GasCostOf.Sha3Word * EvmPooledMemory.Div32Ceiling(memLength),
-                                ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                                ref gasAvailable)) goto OutOfGas;
 
                             UpdateMemoryCost(in memSrc, memLength);
 
@@ -1310,11 +1189,7 @@ namespace Nethermind.Evm
                         }
                     case Instruction.ADDRESS:
                         {
-                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable)) goto OutOfGas;
 
                             stack.PushBytes(env.ExecutingAccount.Bytes);
                             break;
@@ -1322,18 +1197,10 @@ namespace Nethermind.Evm
                     case Instruction.BALANCE:
                         {
                             long gasCost = spec.GetBalanceCost();
-                            if (gasCost != 0 && !UpdateGas(gasCost, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (gasCost != 0 && !UpdateGas(gasCost, ref gasAvailable)) goto OutOfGas;
 
                             Address address = stack.PopAddress();
-                            if (!ChargeAccountAccessGas(ref gasAvailable, vmState, address, spec))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!ChargeAccountAccessGas(ref gasAvailable, vmState, address, spec)) goto OutOfGas;
 
                             UInt256 balance = _state.GetBalance(address);
                             stack.PushUInt256(in balance);
@@ -1341,22 +1208,14 @@ namespace Nethermind.Evm
                         }
                     case Instruction.CALLER:
                         {
-                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable)) goto OutOfGas;
 
                             stack.PushBytes(env.Caller.Bytes);
                             break;
                         }
                     case Instruction.CALLVALUE:
                         {
-                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable)) goto OutOfGas;
 
                             UInt256 callValue = env.Value;
                             stack.PushUInt256(in callValue);
@@ -1364,22 +1223,14 @@ namespace Nethermind.Evm
                         }
                     case Instruction.ORIGIN:
                         {
-                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable)) goto OutOfGas;
 
                             stack.PushBytes(txCtx.Origin.Bytes);
                             break;
                         }
                     case Instruction.CALLDATALOAD:
                         {
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
 
                             stack.PopUInt256(out UInt256 src);
                             stack.PushBytes(env.InputData.SliceWithZeroPadding(src, 32));
@@ -1387,11 +1238,7 @@ namespace Nethermind.Evm
                         }
                     case Instruction.CALLDATASIZE:
                         {
-                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable)) goto OutOfGas;
 
                             UInt256 callDataSize = (UInt256)env.InputData.Length;
                             stack.PushUInt256(in callDataSize);
@@ -1403,11 +1250,7 @@ namespace Nethermind.Evm
                             stack.PopUInt256(out UInt256 src);
                             stack.PopUInt256(out UInt256 length);
                             if (!UpdateGas(GasCostOf.VeryLow + GasCostOf.Memory * EvmPooledMemory.Div32Ceiling(length),
-                                ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                                ref gasAvailable)) goto OutOfGas;
 
                             if (length > UInt256.Zero)
                             {
@@ -1425,11 +1268,7 @@ namespace Nethermind.Evm
                         }
                     case Instruction.CODESIZE:
                         {
-                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable)) goto OutOfGas;
 
                             UInt256 codeLength = (UInt256)code.Length;
                             stack.PushUInt256(in codeLength);
@@ -1440,11 +1279,7 @@ namespace Nethermind.Evm
                             stack.PopUInt256(out UInt256 dest);
                             stack.PopUInt256(out UInt256 src);
                             stack.PopUInt256(out UInt256 length);
-                            if (!UpdateGas(GasCostOf.VeryLow + GasCostOf.Memory * EvmPooledMemory.Div32Ceiling(length), ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.VeryLow + GasCostOf.Memory * EvmPooledMemory.Div32Ceiling(length), ref gasAvailable)) goto OutOfGas;
 
                             if (length > UInt256.Zero)
                             {
@@ -1459,11 +1294,7 @@ namespace Nethermind.Evm
                         }
                     case Instruction.GASPRICE:
                         {
-                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable)) goto OutOfGas;
 
                             UInt256 gasPrice = txCtx.GasPrice;
                             stack.PushUInt256(in gasPrice);
@@ -1471,19 +1302,10 @@ namespace Nethermind.Evm
                         }
                     case Instruction.EXTCODESIZE:
                         {
-                            long gasCost = spec.GetExtCodeCost();
-                            if (!UpdateGas(gasCost, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(spec.GetExtCodeCost(), ref gasAvailable)) goto OutOfGas;
 
                             Address address = stack.PopAddress();
-                            if (!ChargeAccountAccessGas(ref gasAvailable, vmState, address, spec))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!ChargeAccountAccessGas(ref gasAvailable, vmState, address, spec)) goto OutOfGas;
 
                             byte[] accountCode = GetCachedCodeInfo(_worldState, address, spec).MachineCode;
                             UInt256 codeSize = (UInt256)accountCode.Length;
@@ -1499,17 +1321,8 @@ namespace Nethermind.Evm
 
                             long gasCost = spec.GetExtCodeCost();
                             if (!UpdateGas(gasCost + GasCostOf.Memory * EvmPooledMemory.Div32Ceiling(length),
-                                ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
-
-                            if (!ChargeAccountAccessGas(ref gasAvailable, vmState, address, spec))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                                ref gasAvailable)) goto OutOfGas;
+                            if (!ChargeAccountAccessGas(ref gasAvailable, vmState, address, spec)) goto OutOfGas;
 
                             if (length > UInt256.Zero)
                             {
@@ -1528,17 +1341,8 @@ namespace Nethermind.Evm
                         }
                     case Instruction.RETURNDATASIZE:
                         {
-                            if (!spec.ReturnDataOpcodesEnabled)
-                            {
-                                EndInstructionTraceError(EvmExceptionType.BadInstruction);
-                                return CallResult.InvalidInstructionException;
-                            }
-
-                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!spec.ReturnDataOpcodesEnabled) goto InvalidInstruction;
+                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable)) goto OutOfGas;
 
                             UInt256 res = (UInt256)_returnDataBuffer.Length;
                             stack.PushUInt256(in res);
@@ -1546,20 +1350,12 @@ namespace Nethermind.Evm
                         }
                     case Instruction.RETURNDATACOPY:
                         {
-                            if (!spec.ReturnDataOpcodesEnabled)
-                            {
-                                EndInstructionTraceError(EvmExceptionType.BadInstruction);
-                                return CallResult.InvalidInstructionException;
-                            }
+                            if (!spec.ReturnDataOpcodesEnabled) goto InvalidInstruction;
 
                             stack.PopUInt256(out UInt256 dest);
                             stack.PopUInt256(out UInt256 src);
                             stack.PopUInt256(out UInt256 length);
-                            if (!UpdateGas(GasCostOf.VeryLow + GasCostOf.Memory * EvmPooledMemory.Div32Ceiling(length), ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.VeryLow + GasCostOf.Memory * EvmPooledMemory.Div32Ceiling(length), ref gasAvailable)) goto OutOfGas;
 
                             if (UInt256.AddOverflow(length, src, out UInt256 newLength) || newLength > _returnDataBuffer.Length)
                             {
@@ -1584,11 +1380,7 @@ namespace Nethermind.Evm
                         {
                             Metrics.BlockhashOpcode++;
 
-                            if (!UpdateGas(GasCostOf.BlockHash, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.BlockHash, ref gasAvailable)) goto OutOfGas;
 
                             stack.PopUInt256(out UInt256 a);
                             long number = a > long.MaxValue ? long.MaxValue : (long)a;
@@ -1607,22 +1399,14 @@ namespace Nethermind.Evm
                         }
                     case Instruction.COINBASE:
                         {
-                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable)) goto OutOfGas;
 
                             stack.PushBytes(txCtx.Header.GasBeneficiary.Bytes);
                             break;
                         }
                     case Instruction.PREVRANDAO:
                         {
-                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable)) goto OutOfGas;
 
                             if (txCtx.Header.IsPostMerge)
                             {
@@ -1638,11 +1422,7 @@ namespace Nethermind.Evm
                         }
                     case Instruction.TIMESTAMP:
                         {
-                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable)) goto OutOfGas;
 
                             UInt256 timestamp = txCtx.Header.Timestamp;
                             stack.PushUInt256(in timestamp);
@@ -1650,11 +1430,7 @@ namespace Nethermind.Evm
                         }
                     case Instruction.NUMBER:
                         {
-                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable)) goto OutOfGas;
 
                             UInt256 blockNumber = (UInt256)txCtx.Header.Number;
                             stack.PushUInt256(in blockNumber);
@@ -1662,11 +1438,7 @@ namespace Nethermind.Evm
                         }
                     case Instruction.GASLIMIT:
                         {
-                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable)) goto OutOfGas;
 
                             UInt256 gasLimit = (UInt256)txCtx.Header.GasLimit;
                             stack.PushUInt256(in gasLimit);
@@ -1674,34 +1446,16 @@ namespace Nethermind.Evm
                         }
                     case Instruction.CHAINID:
                         {
-                            if (!spec.ChainIdOpcodeEnabled)
-                            {
-                                EndInstructionTraceError(EvmExceptionType.BadInstruction);
-                                return CallResult.InvalidInstructionException;
-                            }
-
-                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!spec.ChainIdOpcodeEnabled) goto InvalidInstruction;
+                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable)) goto OutOfGas;
 
                             stack.PushBytes(_chainId);
                             break;
                         }
                     case Instruction.SELFBALANCE:
                         {
-                            if (!spec.SelfBalanceOpcodeEnabled)
-                            {
-                                EndInstructionTraceError(EvmExceptionType.BadInstruction);
-                                return CallResult.InvalidInstructionException;
-                            }
-
-                            if (!UpdateGas(GasCostOf.SelfBalance, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!spec.SelfBalanceOpcodeEnabled) goto InvalidInstruction;
+                            if (!UpdateGas(GasCostOf.SelfBalance, ref gasAvailable)) goto OutOfGas;
 
                             UInt256 balance = _state.GetBalance(env.ExecutingAccount);
                             stack.PushUInt256(in balance);
@@ -1709,17 +1463,8 @@ namespace Nethermind.Evm
                         }
                     case Instruction.BASEFEE:
                         {
-                            if (!spec.BaseFeeEnabled)
-                            {
-                                EndInstructionTraceError(EvmExceptionType.BadInstruction);
-                                return CallResult.InvalidInstructionException;
-                            }
-
-                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!spec.BaseFeeEnabled) goto InvalidInstruction;
+                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable)) goto OutOfGas;
 
                             UInt256 baseFee = txCtx.Header.BaseFeePerGas;
                             stack.PushUInt256(in baseFee);
@@ -1727,17 +1472,8 @@ namespace Nethermind.Evm
                         }
                     case Instruction.DATAHASH:
                         {
-                            if (!spec.IsEip4844Enabled)
-                            {
-                                EndInstructionTraceError(EvmExceptionType.BadInstruction);
-                                return CallResult.InvalidInstructionException;
-                            }
-
-                            if (!UpdateGas(GasCostOf.DataHash, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!spec.IsEip4844Enabled) goto InvalidInstruction;
+                            if (!UpdateGas(GasCostOf.DataHash, ref gasAvailable)) goto OutOfGas;
 
                             stack.PopUInt256(out UInt256 blobIndex);
 
@@ -1753,22 +1489,14 @@ namespace Nethermind.Evm
                         }
                     case Instruction.POP:
                         {
-                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable)) goto OutOfGas;
 
                             stack.PopLimbo();
                             break;
                         }
                     case Instruction.MLOAD:
                         {
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
 
                             stack.PopUInt256(out UInt256 memPosition);
                             UpdateMemoryCost(in memPosition, 32);
@@ -1780,11 +1508,7 @@ namespace Nethermind.Evm
                         }
                     case Instruction.MSTORE:
                         {
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
 
                             stack.PopUInt256(out UInt256 memPosition);
 
@@ -1797,11 +1521,7 @@ namespace Nethermind.Evm
                         }
                     case Instruction.MSTORE8:
                         {
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
 
                             stack.PopUInt256(out UInt256 memPosition);
                             byte data = stack.PopByte();
@@ -1814,13 +1534,7 @@ namespace Nethermind.Evm
                     case Instruction.SLOAD:
                         {
                             Metrics.SloadOpcode++;
-                            var gasCost = spec.GetSLoadCost();
-
-                            if (!UpdateGas(gasCost, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(spec.GetSLoadCost(), ref gasAvailable)) goto OutOfGas;
 
                             stack.PopUInt256(out UInt256 storageIndex);
                             StorageCell storageCell = new(env.ExecutingAccount, storageIndex);
@@ -1829,11 +1543,7 @@ namespace Nethermind.Evm
                                 vmState,
                                 storageCell,
                                 StorageAccessType.SLOAD,
-                                spec))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                                spec)) goto OutOfGas;
 
                             byte[] value = _storage.Get(storageCell);
                             stack.PushBytes(value);
@@ -1849,27 +1559,13 @@ namespace Nethermind.Evm
                         {
                             Metrics.SstoreOpcode++;
 
-                            if (vmState.IsStatic)
-                            {
-                                EndInstructionTraceError(EvmExceptionType.StaticCallViolation);
-                                return CallResult.StaticCallViolationException;
-                            }
-
+                            if (vmState.IsStatic) goto StaticCallViolation;
                             // fail fast before the first storage read if gas is not enough even for reset
-                            if (!spec.UseNetGasMetering && !UpdateGas(spec.GetSStoreResetCost(), ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
-
+                            if (!spec.UseNetGasMetering && !UpdateGas(spec.GetSStoreResetCost(), ref gasAvailable)) goto OutOfGas;
                             if (spec.UseNetGasMeteringWithAStipendFix)
                             {
                                 if (_txTracer.IsTracingRefunds) _txTracer.ReportExtraGasPressure(GasCostOf.CallStipend - spec.GetNetMeteredSStoreCost() + 1);
-                                if (gasAvailable <= GasCostOf.CallStipend)
-                                {
-                                    EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                    return CallResult.OutOfGasException;
-                                }
+                                if (gasAvailable <= GasCostOf.CallStipend) goto OutOfGas;
                             }
 
                             stack.PopUInt256(out UInt256 storageIndex);
@@ -1891,11 +1587,7 @@ namespace Nethermind.Evm
                                 vmState,
                                 storageCell,
                                 StorageAccessType.SSTORE,
-                                spec))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                                spec)) goto OutOfGas;
 
                             Span<byte> currentValue = _storage.Get(storageCell);
                             // Console.WriteLine($"current: {currentValue.ToHexString()} newValue {newValue.ToHexString()}");
@@ -1916,22 +1608,14 @@ namespace Nethermind.Evm
                                 }
                                 else if (currentIsZero)
                                 {
-                                    if (!UpdateGas(GasCostOf.SSet - GasCostOf.SReset, ref gasAvailable))
-                                    {
-                                        EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                        return CallResult.OutOfGasException;
-                                    }
+                                    if (!UpdateGas(GasCostOf.SSet - GasCostOf.SReset, ref gasAvailable)) goto OutOfGas;
                                 }
                             }
                             else // net metered
                             {
                                 if (newSameAsCurrent)
                                 {
-                                    if (!UpdateGas(spec.GetNetMeteredSStoreCost(), ref gasAvailable))
-                                    {
-                                        EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                        return CallResult.OutOfGasException;
-                                    }
+                                    if (!UpdateGas(spec.GetNetMeteredSStoreCost(), ref gasAvailable)) goto OutOfGas;
                                 }
                                 else // net metered, C != N
                                 {
@@ -1943,19 +1627,11 @@ namespace Nethermind.Evm
                                     {
                                         if (currentIsZero)
                                         {
-                                            if (!UpdateGas(GasCostOf.SSet, ref gasAvailable))
-                                            {
-                                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                                return CallResult.OutOfGasException;
-                                            }
+                                            if (!UpdateGas(GasCostOf.SSet, ref gasAvailable)) goto OutOfGas;
                                         }
                                         else // net metered, current == original != new, !currentIsZero
                                         {
-                                            if (!UpdateGas(spec.GetSStoreResetCost(), ref gasAvailable))
-                                            {
-                                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                                return CallResult.OutOfGasException;
-                                            }
+                                            if (!UpdateGas(spec.GetSStoreResetCost(), ref gasAvailable)) goto OutOfGas;
 
                                             if (newIsZero)
                                             {
@@ -1967,11 +1643,7 @@ namespace Nethermind.Evm
                                     else // net metered, new != current != original
                                     {
                                         long netMeteredStoreCost = spec.GetNetMeteredSStoreCost();
-                                        if (!UpdateGas(netMeteredStoreCost, ref gasAvailable))
-                                        {
-                                            EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                            return CallResult.OutOfGasException;
-                                        }
+                                        if (!UpdateGas(netMeteredStoreCost, ref gasAvailable)) goto OutOfGas;
 
                                         if (!originalIsZero) // net metered, new != current != original != 0
                                         {
@@ -2032,18 +1704,8 @@ namespace Nethermind.Evm
                     case Instruction.TLOAD:
                         {
                             Metrics.TloadOpcode++;
-                            if (!spec.TransientStorageEnabled)
-                            {
-                                EndInstructionTraceError(EvmExceptionType.BadInstruction);
-                                return CallResult.InvalidInstructionException;
-                            }
-                            var gasCost = GasCostOf.TLoad;
-
-                            if (!UpdateGas(gasCost, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!spec.TransientStorageEnabled) goto InvalidInstruction;
+                            if (!UpdateGas(GasCostOf.TLoad, ref gasAvailable)) goto OutOfGas;
 
                             stack.PopUInt256(out UInt256 storageIndex);
                             StorageCell storageCell = new(env.ExecutingAccount, storageIndex);
@@ -2061,24 +1723,9 @@ namespace Nethermind.Evm
                     case Instruction.TSTORE:
                         {
                             Metrics.TstoreOpcode++;
-                            if (!spec.TransientStorageEnabled)
-                            {
-                                EndInstructionTraceError(EvmExceptionType.BadInstruction);
-                                return CallResult.InvalidInstructionException;
-                            }
-
-                            if (vmState.IsStatic)
-                            {
-                                EndInstructionTraceError(EvmExceptionType.StaticCallViolation);
-                                return CallResult.StaticCallViolationException;
-                            }
-
-                            long gasCost = GasCostOf.TStore;
-                            if (!UpdateGas(gasCost, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!spec.TransientStorageEnabled) goto InvalidInstruction;
+                            if (vmState.IsStatic) goto StaticCallViolation;
+                            if (!UpdateGas(GasCostOf.TStore, ref gasAvailable)) goto OutOfGas;
 
                             stack.PopUInt256(out UInt256 storageIndex);
                             Span<byte> newValue = stack.PopBytes();
@@ -2105,11 +1752,7 @@ namespace Nethermind.Evm
                         }
                     case Instruction.JUMP:
                         {
-                            if (!UpdateGas(GasCostOf.Mid, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.Mid, ref gasAvailable)) goto OutOfGas;
 
                             stack.PopUInt256(out UInt256 jumpDest);
                             Jump(jumpDest);
@@ -2117,11 +1760,7 @@ namespace Nethermind.Evm
                         }
                     case Instruction.JUMPI:
                         {
-                            if (!UpdateGas(GasCostOf.High, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.High, ref gasAvailable)) goto OutOfGas;
 
                             stack.PopUInt256(out UInt256 jumpDest);
                             Span<byte> condition = stack.PopBytes();
@@ -2134,22 +1773,14 @@ namespace Nethermind.Evm
                         }
                     case Instruction.PC:
                         {
-                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable)) goto OutOfGas;
 
                             stack.PushUInt32(programCounter - 1);
                             break;
                         }
                     case Instruction.MSIZE:
                         {
-                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable)) goto OutOfGas;
 
                             UInt256 size = vmState.Memory.Size;
                             stack.PushUInt256(in size);
@@ -2157,11 +1788,7 @@ namespace Nethermind.Evm
                         }
                     case Instruction.GAS:
                         {
-                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable)) goto OutOfGas;
 
                             UInt256 gas = (UInt256)gasAvailable;
                             stack.PushUInt256(in gas);
@@ -2169,40 +1796,22 @@ namespace Nethermind.Evm
                         }
                     case Instruction.JUMPDEST:
                         {
-                            if (!UpdateGas(GasCostOf.JumpDest, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.JumpDest, ref gasAvailable)) goto OutOfGas;
 
                             break;
                         }
                     case Instruction.PUSH0:
                         {
-                            if (spec.IncludePush0Instruction)
-                            {
-                                if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
-                                {
-                                    EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                    return CallResult.OutOfGasException;
-                                }
+                            if (!spec.IncludePush0Instruction) goto InvalidInstruction;
+                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable)) goto OutOfGas;
 
-                                stack.PushZero();
-                            }
-                            else
-                            {
-                                EndInstructionTraceError(EvmExceptionType.BadInstruction);
-                                return CallResult.InvalidInstructionException;
-                            }
+                            stack.PushZero();
+
                             break;
                         }
                     case Instruction.PUSH1:
                         {
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
 
                             int programCounterInt = programCounter;
                             if (programCounterInt >= code.Length)
@@ -2249,11 +1858,7 @@ namespace Nethermind.Evm
                     case Instruction.PUSH31:
                     case Instruction.PUSH32:
                         {
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
 
                             int length = instruction - Instruction.PUSH1 + 1;
                             int programCounterInt = programCounter;
@@ -2281,11 +1886,7 @@ namespace Nethermind.Evm
                     case Instruction.DUP15:
                     case Instruction.DUP16:
                         {
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
 
                             stack.Dup(instruction - Instruction.DUP1 + 1);
                             break;
@@ -2307,11 +1908,7 @@ namespace Nethermind.Evm
                     case Instruction.SWAP15:
                     case Instruction.SWAP16:
                         {
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
 
                             stack.Swap(instruction - Instruction.SWAP1 + 2);
                             break;
@@ -2322,11 +1919,7 @@ namespace Nethermind.Evm
                     case Instruction.LOG3:
                     case Instruction.LOG4:
                         {
-                            if (vmState.IsStatic)
-                            {
-                                EndInstructionTraceError(EvmExceptionType.StaticCallViolation);
-                                return CallResult.StaticCallViolationException;
-                            }
+                            if (vmState.IsStatic) goto StaticCallViolation;
 
                             stack.PopUInt256(out UInt256 memoryPos);
                             stack.PopUInt256(out UInt256 length);
@@ -2334,11 +1927,7 @@ namespace Nethermind.Evm
                             UpdateMemoryCost(in memoryPos, length);
                             if (!UpdateGas(
                                 GasCostOf.Log + topicsCount * GasCostOf.LogTopic +
-                                (long)length * GasCostOf.LogData, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                                (long)length * GasCostOf.LogData, ref gasAvailable)) goto OutOfGas;
 
                             ReadOnlyMemory<byte> data = vmState.Memory.Load(in memoryPos, length);
                             Keccak[] topics = new Keccak[topicsCount];
@@ -2357,17 +1946,9 @@ namespace Nethermind.Evm
                     case Instruction.CREATE:
                     case Instruction.CREATE2:
                         {
-                            if (!spec.Create2OpcodeEnabled && instruction == Instruction.CREATE2)
-                            {
-                                EndInstructionTraceError(EvmExceptionType.BadInstruction);
-                                return CallResult.InvalidInstructionException;
-                            }
+                            if (!spec.Create2OpcodeEnabled && instruction == Instruction.CREATE2) goto InvalidInstruction;
 
-                            if (vmState.IsStatic)
-                            {
-                                EndInstructionTraceError(EvmExceptionType.StaticCallViolation);
-                                return CallResult.StaticCallViolationException;
-                            }
+                            if (vmState.IsStatic) goto StaticCallViolation;
 
                             // TODO: happens in CREATE_empty000CreateInitCode_Transaction but probably has to be handled differently
                             if (!_state.AccountExists(env.ExecutingAccount))
@@ -2387,22 +1968,14 @@ namespace Nethermind.Evm
                             //EIP-3860
                             if (spec.IsEip3860Enabled)
                             {
-                                if (initCodeLength > spec.MaxInitCodeSize)
-                                {
-                                    EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                    return CallResult.OutOfGasException;
-                                }
+                                if (initCodeLength > spec.MaxInitCodeSize) goto OutOfGas;
                             }
 
                             long gasCost = GasCostOf.Create +
                                 (spec.IsEip3860Enabled ? GasCostOf.InitCodeWord * EvmPooledMemory.Div32Ceiling(initCodeLength) : 0) +
                                 (instruction == Instruction.CREATE2 ? GasCostOf.Sha3Word * EvmPooledMemory.Div32Ceiling(initCodeLength) : 0);
 
-                            if (!UpdateGas(gasCost, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(gasCost, ref gasAvailable)) goto OutOfGas;
 
                             UpdateMemoryCost(in memoryPositionOfInitCode, initCodeLength);
 
@@ -2434,15 +2007,11 @@ namespace Nethermind.Evm
                                 break;
                             }
 
-                            EndInstructionTrace();
+                            if (traceOpcodes) EndInstructionTrace(gasAvailable, vmState.Memory?.Size ?? 0);
                             // todo: === below is a new call - refactor / move
 
                             long callGas = spec.Use63Over64Rule ? gasAvailable - gasAvailable / 64L : gasAvailable;
-                            if (!UpdateGas(callGas, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(callGas, ref gasAvailable)) goto OutOfGas;
 
                             Address contractAddress = instruction == Instruction.CREATE
                                 ? ContractAddress.From(env.ExecutingAccount, _state.GetNonce(env.ExecutingAccount))
@@ -2514,7 +2083,7 @@ namespace Nethermind.Evm
                             ReadOnlyMemory<byte> returnData = vmState.Memory.Load(in memoryPos, length);
 
                             UpdateCurrentState(vmState, programCounter, gasAvailable, stack.Head);
-                            EndInstructionTrace();
+                            if (traceOpcodes) EndInstructionTrace(gasAvailable, vmState.Memory?.Size ?? 0);
                             return new CallResult(returnData.ToArray(), null);
                         }
                     case Instruction.CALL:
@@ -2525,21 +2094,13 @@ namespace Nethermind.Evm
                             Metrics.Calls++;
 
                             if (instruction == Instruction.DELEGATECALL && !spec.DelegateCallEnabled ||
-                                instruction == Instruction.STATICCALL && !spec.StaticCallEnabled)
-                            {
-                                EndInstructionTraceError(EvmExceptionType.BadInstruction);
-                                return CallResult.InvalidInstructionException;
-                            }
+                                instruction == Instruction.STATICCALL && !spec.StaticCallEnabled) goto InvalidInstruction;
 
                             stack.PopUInt256(out UInt256 gasLimit);
                             Address codeSource = stack.PopAddress();
 
                             // Console.WriteLine($"CALLIN {codeSource}");
-                            if (!ChargeAccountAccessGas(ref gasAvailable, vmState, codeSource, spec))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!ChargeAccountAccessGas(ref gasAvailable, vmState, codeSource, spec)) goto OutOfGas;
 
                             UInt256 callValue;
                             switch (instruction)
@@ -2561,11 +2122,7 @@ namespace Nethermind.Evm
                             stack.PopUInt256(out UInt256 outputOffset);
                             stack.PopUInt256(out UInt256 outputLength);
 
-                            if (vmState.IsStatic && !transferValue.IsZero && instruction != Instruction.CALLCODE)
-                            {
-                                EndInstructionTraceError(EvmExceptionType.StaticCallViolation);
-                                return CallResult.StaticCallViolationException;
-                            }
+                            if (vmState.IsStatic && !transferValue.IsZero && instruction != Instruction.CALLCODE) goto StaticCallViolation;
 
                             Address caller = instruction == Instruction.DELEGATECALL ? env.Caller : env.ExecutingAccount;
                             Address target = instruction == Instruction.CALL || instruction == Instruction.STATICCALL ? codeSource : env.ExecutingAccount;
@@ -2595,37 +2152,21 @@ namespace Nethermind.Evm
                                 gasExtra += GasCostOf.NewAccount;
                             }
 
-                            if (!UpdateGas(spec.GetCallCost(), ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(spec.GetCallCost(), ref gasAvailable)) goto OutOfGas;
 
                             UpdateMemoryCost(in dataOffset, dataLength);
                             UpdateMemoryCost(in outputOffset, outputLength);
-                            if (!UpdateGas(gasExtra, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(gasExtra, ref gasAvailable)) goto OutOfGas;
 
                             if (spec.Use63Over64Rule)
                             {
                                 gasLimit = UInt256.Min((UInt256)(gasAvailable - gasAvailable / 64), gasLimit);
                             }
 
-                            if (gasLimit >= long.MaxValue)
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (gasLimit >= long.MaxValue) goto OutOfGas;
 
                             long gasLimitUl = (long)gasLimit;
-                            if (!UpdateGas(gasLimitUl, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(gasLimitUl, ref gasAvailable)) goto OutOfGas;
 
                             if (!transferValue.IsZero)
                             {
@@ -2693,16 +2234,12 @@ namespace Nethermind.Evm
                                 false);
 
                             UpdateCurrentState(vmState, programCounter, gasAvailable, stack.Head);
-                            EndInstructionTrace();
+                            if (traceOpcodes) EndInstructionTrace(gasAvailable, vmState.Memory?.Size ?? 0);
                             return new CallResult(callState);
                         }
                     case Instruction.REVERT:
                         {
-                            if (!spec.RevertOpcodeEnabled)
-                            {
-                                EndInstructionTraceError(EvmExceptionType.BadInstruction);
-                                return CallResult.InvalidInstructionException;
-                            }
+                            if (!spec.RevertOpcodeEnabled) goto InvalidInstruction;
 
                             stack.PopUInt256(out UInt256 memoryPos);
                             stack.PopUInt256(out UInt256 length);
@@ -2711,42 +2248,24 @@ namespace Nethermind.Evm
                             ReadOnlyMemory<byte> errorDetails = vmState.Memory.Load(in memoryPos, length);
 
                             UpdateCurrentState(vmState, programCounter, gasAvailable, stack.Head);
-                            EndInstructionTrace();
+                            if (traceOpcodes) EndInstructionTrace(gasAvailable, vmState.Memory?.Size ?? 0);
                             return new CallResult(errorDetails.ToArray(), null, true);
                         }
                     case Instruction.INVALID:
                         {
-                            if (!UpdateGas(GasCostOf.High, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!UpdateGas(GasCostOf.High, ref gasAvailable)) goto OutOfGas;
 
-                            EndInstructionTraceError(EvmExceptionType.BadInstruction);
-                            return CallResult.InvalidInstructionException;
+                            goto InvalidInstruction;
                         }
                     case Instruction.SELFDESTRUCT:
                         {
-                            if (vmState.IsStatic)
-                            {
-                                EndInstructionTraceError(EvmExceptionType.StaticCallViolation);
-                                return CallResult.StaticCallViolationException;
-                            }
-
-                            if (spec.UseShanghaiDDosProtection && !UpdateGas(GasCostOf.SelfDestructEip150, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (vmState.IsStatic) goto StaticCallViolation;
+                            if (spec.UseShanghaiDDosProtection && !UpdateGas(GasCostOf.SelfDestructEip150, ref gasAvailable)) goto OutOfGas;
 
                             Metrics.SelfDestructs++;
 
                             Address inheritor = stack.PopAddress();
-                            if (!ChargeAccountAccessGas(ref gasAvailable, vmState, inheritor, spec, false))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!ChargeAccountAccessGas(ref gasAvailable, vmState, inheritor, spec, false)) goto OutOfGas;
 
                             vmState.DestroyList.Add(env.ExecutingAccount);
 
@@ -2754,21 +2273,13 @@ namespace Nethermind.Evm
                             if (_txTracer.IsTracingActions) _txTracer.ReportSelfDestruct(env.ExecutingAccount, ownerBalance, inheritor);
                             if (spec.ClearEmptyAccountWhenTouched && ownerBalance != 0 && _state.IsDeadAccount(inheritor))
                             {
-                                if (!UpdateGas(GasCostOf.NewAccount, ref gasAvailable))
-                                {
-                                    EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                    return CallResult.OutOfGasException;
-                                }
+                                if (!UpdateGas(GasCostOf.NewAccount, ref gasAvailable)) goto OutOfGas;
                             }
 
                             bool inheritorAccountExists = _state.AccountExists(inheritor);
                             if (!spec.ClearEmptyAccountWhenTouched && !inheritorAccountExists && spec.UseShanghaiDDosProtection)
                             {
-                                if (!UpdateGas(GasCostOf.NewAccount, ref gasAvailable))
-                                {
-                                    EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                    return CallResult.OutOfGasException;
-                                }
+                                if (!UpdateGas(GasCostOf.NewAccount, ref gasAvailable)) goto OutOfGas;
                             }
 
                             if (!inheritorAccountExists)
@@ -2783,22 +2294,13 @@ namespace Nethermind.Evm
                             _state.SubtractFromBalance(env.ExecutingAccount, ownerBalance, spec);
 
                             UpdateCurrentState(vmState, programCounter, gasAvailable, stack.Head);
-                            EndInstructionTrace();
+                            if (traceOpcodes) EndInstructionTrace(gasAvailable, vmState.Memory?.Size ?? 0);
                             return CallResult.Empty;
                         }
                     case Instruction.SHL:
                         {
-                            if (!spec.ShiftOpcodesEnabled)
-                            {
-                                EndInstructionTraceError(EvmExceptionType.BadInstruction);
-                                return CallResult.InvalidInstructionException;
-                            }
-
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!spec.ShiftOpcodesEnabled) goto InvalidInstruction;
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
 
                             stack.PopUInt256(out UInt256 a);
                             if (a >= 256UL)
@@ -2817,17 +2319,8 @@ namespace Nethermind.Evm
                         }
                     case Instruction.SHR:
                         {
-                            if (!spec.ShiftOpcodesEnabled)
-                            {
-                                EndInstructionTraceError(EvmExceptionType.BadInstruction);
-                                return CallResult.InvalidInstructionException;
-                            }
-
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!spec.ShiftOpcodesEnabled) goto InvalidInstruction;
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
 
                             stack.PopUInt256(out UInt256 a);
                             if (a >= 256)
@@ -2846,17 +2339,8 @@ namespace Nethermind.Evm
                         }
                     case Instruction.SAR:
                         {
-                            if (!spec.ShiftOpcodesEnabled)
-                            {
-                                EndInstructionTraceError(EvmExceptionType.BadInstruction);
-                                return CallResult.InvalidInstructionException;
-                            }
-
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!spec.ShiftOpcodesEnabled) goto InvalidInstruction;
+                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
 
                             stack.PopUInt256(out UInt256 a);
                             stack.PopSignedInt256(out Int256.Int256 b);
@@ -2882,25 +2366,11 @@ namespace Nethermind.Evm
                         }
                     case Instruction.EXTCODEHASH:
                         {
-                            if (!spec.ExtCodeHashOpcodeEnabled)
-                            {
-                                EndInstructionTraceError(EvmExceptionType.BadInstruction);
-                                return CallResult.InvalidInstructionException;
-                            }
-
-                            var gasCost = spec.GetExtCodeHashCost();
-                            if (!UpdateGas(gasCost, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!spec.ExtCodeHashOpcodeEnabled) goto InvalidInstruction;
+                            if (!UpdateGas(spec.GetExtCodeHashCost(), ref gasAvailable)) goto OutOfGas;
 
                             Address address = stack.PopAddress();
-                            if (!ChargeAccountAccessGas(ref gasAvailable, vmState, address, spec))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!ChargeAccountAccessGas(ref gasAvailable, vmState, address, spec)) goto OutOfGas;
 
                             if (!_state.AccountExists(address) || _state.IsDeadAccount(address))
                             {
@@ -2915,39 +2385,20 @@ namespace Nethermind.Evm
                         }
                     case Instruction.BEGINSUB:
                         {
-                            if (!spec.SubroutinesEnabled)
-                            {
-                                EndInstructionTraceError(EvmExceptionType.BadInstruction);
-                                return CallResult.InvalidInstructionException;
-                            }
+                            if (!spec.SubroutinesEnabled) goto InvalidInstruction;
+                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable)) goto OutOfGas;
 
-                            // why do we even need the cost of it?
-                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
-
-                            EndInstructionTraceError(EvmExceptionType.InvalidSubroutineEntry);
+                            if (traceOpcodes) EndInstructionTraceError(gasAvailable, EvmExceptionType.InvalidSubroutineEntry);
                             return CallResult.InvalidSubroutineEntry;
                         }
                     case Instruction.RETURNSUB:
                         {
-                            if (!spec.SubroutinesEnabled)
-                            {
-                                EndInstructionTraceError(EvmExceptionType.BadInstruction);
-                                return CallResult.InvalidInstructionException;
-                            }
-
-                            if (!UpdateGas(GasCostOf.Low, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!spec.SubroutinesEnabled) goto InvalidInstruction;
+                            if (!UpdateGas(GasCostOf.Low, ref gasAvailable)) goto OutOfGas;
 
                             if (vmState.ReturnStackHead == 0)
                             {
-                                EndInstructionTraceError(EvmExceptionType.InvalidSubroutineReturn);
+                                if (traceOpcodes) EndInstructionTraceError(gasAvailable, EvmExceptionType.InvalidSubroutineReturn);
                                 return CallResult.InvalidSubroutineReturn;
                             }
 
@@ -2956,21 +2407,12 @@ namespace Nethermind.Evm
                         }
                     case Instruction.JUMPSUB:
                         {
-                            if (!spec.SubroutinesEnabled)
-                            {
-                                EndInstructionTraceError(EvmExceptionType.BadInstruction);
-                                return CallResult.InvalidInstructionException;
-                            }
-
-                            if (!UpdateGas(GasCostOf.High, ref gasAvailable))
-                            {
-                                EndInstructionTraceError(EvmExceptionType.OutOfGas);
-                                return CallResult.OutOfGasException;
-                            }
+                            if (!spec.SubroutinesEnabled) goto InvalidInstruction;
+                            if (!UpdateGas(GasCostOf.High, ref gasAvailable)) goto OutOfGas;
 
                             if (vmState.ReturnStackHead == EvmStack.ReturnStackSize)
                             {
-                                EndInstructionTraceError(EvmExceptionType.StackOverflow);
+                                if (traceOpcodes) EndInstructionTraceError(gasAvailable, EvmExceptionType.StackOverflow);
                                 return CallResult.StackOverflowException;
                             }
 
@@ -2984,16 +2426,42 @@ namespace Nethermind.Evm
                         }
                     default:
                         {
-                            EndInstructionTraceError(EvmExceptionType.BadInstruction);
-                            return CallResult.InvalidInstructionException;
+                            goto InvalidInstruction;
                         }
                 }
 
-                EndInstructionTrace();
+                if (traceOpcodes) EndInstructionTrace(gasAvailable, vmState.Memory?.Size ?? 0);
             }
 
             UpdateCurrentState(vmState, programCounter, gasAvailable, stack.Head);
             return CallResult.Empty;
+
+// Common exit errors, goto labels to reduce in loop code duplication
+OutOfGas:
+            if (traceOpcodes) EndInstructionTraceError(gasAvailable, EvmExceptionType.OutOfGas);
+            return CallResult.OutOfGasException;
+InvalidInstruction:
+            if (traceOpcodes) EndInstructionTraceError(gasAvailable, EvmExceptionType.BadInstruction);
+            return CallResult.InvalidInstructionException;
+StaticCallViolation:
+            if (traceOpcodes) EndInstructionTraceError(gasAvailable, EvmExceptionType.StaticCallViolation);
+            return CallResult.StaticCallViolationException;
+        }
+
+        private void EndInstructionTrace(long gasAvailable, ulong memorySize)
+        {
+            if (_txTracer.IsTracingMemory)
+            {
+                _txTracer.SetOperationMemorySize(memorySize);
+            }
+
+            _txTracer.ReportOperationRemainingGas(gasAvailable);
+        }
+
+        private void EndInstructionTraceError(long gasAvailable, EvmExceptionType evmExceptionType)
+        {
+            _txTracer.ReportOperationError(evmExceptionType);
+            _txTracer.ReportOperationRemainingGas(gasAvailable);
         }
 
         private static ExecutionType GetCallExecutionType(Instruction instruction, bool isPostMerge = false)

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -643,7 +643,7 @@ namespace Nethermind.Evm
             int programCounter = vmState.ProgramCounter;
             Span<byte> code = env.CodeInfo.MachineCode.AsSpan();
 
-
+            [MethodImpl(MethodImplOptions.NoInlining)]
             static void UpdateCurrentState(EvmState state, in int pc, in long gas, in int stackHead)
             {
                 state.ProgramCounter = pc;
@@ -651,6 +651,7 @@ namespace Nethermind.Evm
                 state.DataStackHead = stackHead;
             }
 
+            [MethodImpl(MethodImplOptions.NoInlining)]
             void StartInstructionTrace(Instruction instruction, EvmStack stackValue)
             {
                 _txTracer.StartOperation(env.CallDepth + 1, gasAvailable, instruction, programCounter, txCtx.Header.IsPostMerge);
@@ -665,6 +666,7 @@ namespace Nethermind.Evm
                 }
             }
 
+            [MethodImpl(MethodImplOptions.NoInlining)]
             void Jump(in UInt256 jumpDest, bool isSubroutine = false)
             {
                 if (jumpDest > int.MaxValue)
@@ -1561,7 +1563,7 @@ namespace Nethermind.Evm
             }
 
             UpdateCurrentState(vmState, programCounter, gasAvailable, stack.Head);
-            // Fall through to Empty: label
+// Fall through to Empty: label
 
 // Common exit errors, goto labels to reduce in loop code duplication
 Empty:
@@ -1577,6 +1579,7 @@ StaticCallViolation:
             return CallResult.StaticCallViolationException;
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private void EndInstructionTrace(long gasAvailable, ulong memorySize)
         {
             if (_txTracer.IsTracingMemory)
@@ -1587,6 +1590,7 @@ StaticCallViolation:
             _txTracer.ReportOperationRemainingGas(gasAvailable);
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private void EndInstructionTraceError(long gasAvailable, EvmExceptionType evmExceptionType)
         {
             _txTracer.ReportOperationError(evmExceptionType);

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -1211,7 +1211,6 @@ namespace Nethermind.Evm
                             {
                                 Debug.Assert(callState is not null);
                                 UpdateCurrentState(vmState, programCounter, gasAvailable, stack.Head);
-                                if (traceOpcodes) EndInstructionTrace(gasAvailable, vmState.Memory?.Size ?? 0);
                                 return new CallResult(callState);
                             }
                             Debug.Assert(result == InstructionReturn.Continue);
@@ -1221,16 +1220,12 @@ namespace Nethermind.Evm
                         {
                             if (!spec.RevertOpcodeEnabled) goto InvalidInstruction;
 
-                            stack.PopUInt256(out UInt256 memoryPos);
-                            stack.PopUInt256(out UInt256 length);
+                            (InstructionReturn result, byte[]? message) = InstructionREVERT(ref stack, ref gasAvailable, vmState);
+                            if (result == InstructionReturn.OutOfGas) goto OutOfGas;
 
-                            if (!UpdateMemoryCost(vmState.Memory, ref gasAvailable, in memoryPos, length)) goto OutOfGas;
-
-                            ReadOnlyMemory<byte> errorDetails = vmState.Memory.Load(in memoryPos, length);
-
+                            Debug.Assert(result == InstructionReturn.Success);
                             UpdateCurrentState(vmState, programCounter, gasAvailable, stack.Head);
-                            if (traceOpcodes) EndInstructionTrace(gasAvailable, vmState.Memory?.Size ?? 0);
-                            return new CallResult(errorDetails.ToArray(), null, true);
+                            return new CallResult(message, null, true);
                         }
                     case Instruction.INVALID:
                         {
@@ -1269,8 +1264,7 @@ namespace Nethermind.Evm
                             if (!spec.SubroutinesEnabled) goto InvalidInstruction;
                             if (!UpdateGas(GasCostOf.Base, ref gasAvailable)) goto OutOfGas;
 
-                            if (traceOpcodes) EndInstructionTraceError(gasAvailable, EvmExceptionType.InvalidSubroutineEntry);
-                            return CallResult.InvalidSubroutineEntry;
+                            goto InvalidSubroutineEntry;
                         }
                     case Instruction.RETURNSUB:
                         {
@@ -1279,8 +1273,7 @@ namespace Nethermind.Evm
 
                             if (vmState.ReturnStackHead == 0)
                             {
-                                if (traceOpcodes) EndInstructionTraceError(gasAvailable, EvmExceptionType.InvalidSubroutineReturn);
-                                return CallResult.InvalidSubroutineReturn;
+                                goto InvalidSubroutineReturn;
                             }
 
                             programCounter = vmState.ReturnStack[--vmState.ReturnStackHead];
@@ -1293,8 +1286,7 @@ namespace Nethermind.Evm
 
                             if (vmState.ReturnStackHead == EvmStack.ReturnStackSize)
                             {
-                                if (traceOpcodes) EndInstructionTraceError(gasAvailable, EvmExceptionType.StackOverflow);
-                                return CallResult.StackOverflowException;
+                                goto StackOverflowException;
                             }
 
                             vmState.ReturnStack[vmState.ReturnStackHead++] = programCounter;
@@ -1317,7 +1309,7 @@ namespace Nethermind.Evm
             UpdateCurrentState(vmState, programCounter, gasAvailable, stack.Head);
 // Fall through to Empty: label
 
-// Common exit errors, goto labels to reduce in loop code duplication
+// Common exit errors, goto labels to reduce in loop code duplication and to keep loop body smaller
 Empty:
             return CallResult.Empty;
 OutOfGas:
@@ -1329,6 +1321,15 @@ InvalidInstruction:
 StaticCallViolation:
             if (traceOpcodes) EndInstructionTraceError(gasAvailable, EvmExceptionType.StaticCallViolation);
             return CallResult.StaticCallViolationException;
+InvalidSubroutineEntry:
+            if (traceOpcodes) EndInstructionTraceError(gasAvailable, EvmExceptionType.InvalidSubroutineEntry);
+            return CallResult.InvalidSubroutineEntry;
+InvalidSubroutineReturn:
+            if (traceOpcodes) EndInstructionTraceError(gasAvailable, EvmExceptionType.InvalidSubroutineReturn);
+            return CallResult.InvalidSubroutineReturn;
+StackOverflowException:
+            if (traceOpcodes) EndInstructionTraceError(gasAvailable, EvmExceptionType.StackOverflow);
+            return CallResult.StackOverflowException;
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -882,14 +882,7 @@ namespace Nethermind.Evm
                         }
                     case Instruction.SHA3:
                         {
-                            stack.PopUInt256(out UInt256 memSrc);
-                            stack.PopUInt256(out UInt256 memLength);
-                            if (!UpdateGas(GasCostOf.Sha3 + GasCostOf.Sha3Word * EvmPooledMemory.Div32Ceiling(memLength),
-                                ref gasAvailable)) goto OutOfGas;
-
-                            if (!UpdateMemoryCost(vmState.Memory, ref gasAvailable, in memSrc, memLength)) goto OutOfGas;
-
-                            InstructionSHA3(ref stack, vmState, in memSrc, in memLength);
+                            if (!InstructionSHA3(ref stack, ref gasAvailable, vmState.Memory)) goto OutOfGas;
                             break;
                         }
                     case Instruction.ADDRESS:

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -3,9 +3,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using Nethermind.Core;
 using Nethermind.Core.Caching;
 using Nethermind.Core.Crypto;
@@ -19,9 +20,6 @@ using Nethermind.Evm.Precompiles.Snarks.Shamatar;
 using Nethermind.Evm.Tracing;
 using Nethermind.Logging;
 using Nethermind.State;
-using System.Runtime.Intrinsics;
-using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics;
 
 [assembly: InternalsVisibleTo("Nethermind.Evm.Test")]
 
@@ -636,7 +634,7 @@ namespace Nethermind.Evm
 
             if (vmState.Env.CodeInfo.MachineCode.Length == 0)
             {
-                return CallResult.Empty;
+                goto Empty;
             }
 
             vmState.InitStacks();
@@ -699,13 +697,12 @@ namespace Nethermind.Evm
 
             if (previousCallOutput.Length > 0)
             {
-                UInt256 localPreviousDest = previousCallOutputDestination;
-                if (!UpdateMemoryCost(vmState.Memory, ref gasAvailable, in localPreviousDest, (ulong)previousCallOutput.Length))
+                if (!UpdateMemoryCost(vmState.Memory, ref gasAvailable, in previousCallOutputDestination, (ulong)previousCallOutput.Length))
                 {
                     goto OutOfGas;
                 }
 
-                vmState.Memory.Save(in localPreviousDest, previousCallOutput);
+                vmState.Memory.Save(in previousCallOutputDestination, previousCallOutput);
                 //                if(traceOpcodes) _txTracer.ReportMemoryChange((long)localPreviousDest, previousCallOutput);
             }
 
@@ -725,7 +722,7 @@ namespace Nethermind.Evm
                         {
                             UpdateCurrentState(vmState, programCounter, gasAvailable, stack.Head);
                             if (traceOpcodes) EndInstructionTrace(gasAvailable, vmState.Memory?.Size ?? 0);
-                            return CallResult.Empty;
+                            goto Empty;
                         }
                     case Instruction.ADD:
                         {
@@ -1614,59 +1611,17 @@ namespace Nethermind.Evm
                             if (vmState.IsStatic) goto StaticCallViolation;
                             if (spec.UseShanghaiDDosProtection && !UpdateGas(GasCostOf.SelfDestructEip150, ref gasAvailable)) goto OutOfGas;
 
-                            Metrics.SelfDestructs++;
-
-                            Address inheritor = stack.PopAddress();
-                            if (!ChargeAccountAccessGas(ref gasAvailable, vmState, inheritor, spec, false)) goto OutOfGas;
-
-                            vmState.DestroyList.Add(env.ExecutingAccount);
-
-                            UInt256 ownerBalance = _state.GetBalance(env.ExecutingAccount);
-                            if (_txTracer.IsTracingActions) _txTracer.ReportSelfDestruct(env.ExecutingAccount, ownerBalance, inheritor);
-                            if (spec.ClearEmptyAccountWhenTouched && ownerBalance != 0 && _state.IsDeadAccount(inheritor))
-                            {
-                                if (!UpdateGas(GasCostOf.NewAccount, ref gasAvailable)) goto OutOfGas;
-                            }
-
-                            bool inheritorAccountExists = _state.AccountExists(inheritor);
-                            if (!spec.ClearEmptyAccountWhenTouched && !inheritorAccountExists && spec.UseShanghaiDDosProtection)
-                            {
-                                if (!UpdateGas(GasCostOf.NewAccount, ref gasAvailable)) goto OutOfGas;
-                            }
-
-                            if (!inheritorAccountExists)
-                            {
-                                _state.CreateAccount(inheritor, ownerBalance);
-                            }
-                            else if (!inheritor.Equals(env.ExecutingAccount))
-                            {
-                                _state.AddToBalance(inheritor, ownerBalance, spec);
-                            }
-
-                            _state.SubtractFromBalance(env.ExecutingAccount, ownerBalance, spec);
+                            if (!InstructionSELFDESTRUCT(ref stack, ref gasAvailable, vmState, env.ExecutingAccount, spec)) goto OutOfGas;
 
                             UpdateCurrentState(vmState, programCounter, gasAvailable, stack.Head);
-                            if (traceOpcodes) EndInstructionTrace(gasAvailable, vmState.Memory?.Size ?? 0);
-                            return CallResult.Empty;
+                            goto Empty;
                         }
                     case Instruction.SHL:
                         {
                             if (!spec.ShiftOpcodesEnabled) goto InvalidInstruction;
                             if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
 
-                            stack.PopUInt256(out UInt256 a);
-                            if (a >= 256UL)
-                            {
-                                stack.PopLimbo();
-                                stack.PushZero();
-                            }
-                            else
-                            {
-                                stack.PopUInt256(out UInt256 b);
-                                UInt256 res = b << (int)a.u0;
-                                stack.PushUInt256(in res);
-                            }
-
+                            InstructionSHL(ref stack);
                             break;
                         }
                     case Instruction.SHR:
@@ -1674,19 +1629,7 @@ namespace Nethermind.Evm
                             if (!spec.ShiftOpcodesEnabled) goto InvalidInstruction;
                             if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
 
-                            stack.PopUInt256(out UInt256 a);
-                            if (a >= 256)
-                            {
-                                stack.PopLimbo();
-                                stack.PushZero();
-                            }
-                            else
-                            {
-                                stack.PopUInt256(out UInt256 b);
-                                UInt256 res = b >> (int)a.u0;
-                                stack.PushUInt256(in res);
-                            }
-
+                            InstructionSHR(ref stack);
                             break;
                         }
                     case Instruction.SAR:
@@ -1694,26 +1637,7 @@ namespace Nethermind.Evm
                             if (!spec.ShiftOpcodesEnabled) goto InvalidInstruction;
                             if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
 
-                            stack.PopUInt256(out UInt256 a);
-                            stack.PopSignedInt256(out Int256.Int256 b);
-                            if (a >= BigInt256)
-                            {
-                                if (b.Sign >= 0)
-                                {
-                                    stack.PushZero();
-                                }
-                                else
-                                {
-                                    Int256.Int256 res = Int256.Int256.MinusOne;
-                                    stack.PushSignedInt256(in res);
-                                }
-                            }
-                            else
-                            {
-                                b.RightShift((int)a, out Int256.Int256 res);
-                                stack.PushSignedInt256(in res);
-                            }
-
+                            InstructionSAR(ref stack);
                             break;
                         }
                     case Instruction.EXTCODEHASH:
@@ -1721,18 +1645,7 @@ namespace Nethermind.Evm
                             if (!spec.ExtCodeHashOpcodeEnabled) goto InvalidInstruction;
                             if (!UpdateGas(spec.GetExtCodeHashCost(), ref gasAvailable)) goto OutOfGas;
 
-                            Address address = stack.PopAddress();
-                            if (!ChargeAccountAccessGas(ref gasAvailable, vmState, address, spec)) goto OutOfGas;
-
-                            if (!_state.AccountExists(address) || _state.IsDeadAccount(address))
-                            {
-                                stack.PushZero();
-                            }
-                            else
-                            {
-                                stack.PushBytes(_state.GetCodeHash(address).Bytes);
-                            }
-
+                            if (!InstructionEXTCODEHASH(ref stack, ref gasAvailable, vmState, spec)) goto OutOfGas;
                             break;
                         }
                     case Instruction.BEGINSUB:
@@ -1786,9 +1699,11 @@ namespace Nethermind.Evm
             }
 
             UpdateCurrentState(vmState, programCounter, gasAvailable, stack.Head);
-            return CallResult.Empty;
+            // Fall through to Empty: label
 
 // Common exit errors, goto labels to reduce in loop code duplication
+Empty:
+            return CallResult.Empty;
 OutOfGas:
             if (traceOpcodes) EndInstructionTraceError(gasAvailable, EvmExceptionType.OutOfGas);
             return CallResult.OutOfGasException;

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -725,228 +725,114 @@ namespace Nethermind.Evm
                             goto Empty;
                         }
                     case Instruction.ADD:
-                        {
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
-
-                            InstructionADD(ref stack);
-                            break;
-                        }
+                        if (!InstructionADD(ref stack, ref gasAvailable)) goto OutOfGas;
+                        break;
                     case Instruction.MUL:
-                        {
-                            if (!UpdateGas(GasCostOf.Low, ref gasAvailable)) goto OutOfGas;
-
-                            InstructionMUL(ref stack);
-                            break;
-                        }
+                        if (!InstructionMUL(ref stack, ref gasAvailable)) goto OutOfGas;
+                        break;
                     case Instruction.SUB:
-                        {
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
-
-                            InstructionSUB(ref stack);
-                            break;
-                        }
+                        if (!InstructionSUB(ref stack, ref gasAvailable)) goto OutOfGas;
+                        break;
                     case Instruction.DIV:
-                        {
-                            if (!UpdateGas(GasCostOf.Low, ref gasAvailable)) goto OutOfGas;
-
-                            InstructionDIV(ref stack);
-                            break;
-                        }
+                        if (!InstructionDIV(ref stack, ref gasAvailable)) goto OutOfGas;
+                        break;
                     case Instruction.SDIV:
-                        {
-                            if (!UpdateGas(GasCostOf.Low, ref gasAvailable)) goto OutOfGas;
-
-                            InstructionSDIV(ref stack);
-                            break;
-                        }
+                        if (!InstructionSDIV(ref stack, ref gasAvailable)) goto OutOfGas;
+                        break;
                     case Instruction.MOD:
-                        {
-                            if (!UpdateGas(GasCostOf.Low, ref gasAvailable)) goto OutOfGas;
-
-                            InstructionMOD(ref stack);
-                            break;
-                        }
+                        if (!InstructionMOD(ref stack, ref gasAvailable)) goto OutOfGas;
+                        break;
                     case Instruction.SMOD:
-                        {
-                            if (!UpdateGas(GasCostOf.Low, ref gasAvailable)) goto OutOfGas;
-
-                            InstructionSMOD(ref stack);
-                            break;
-                        }
+                        if (!InstructionSMOD(ref stack, ref gasAvailable)) goto OutOfGas;
+                        break;
                     case Instruction.ADDMOD:
-                        {
-                            if (!UpdateGas(GasCostOf.Mid, ref gasAvailable)) goto OutOfGas;
-
-                            InstructionADDMOD(ref stack);
-                            break;
-                        }
+                        if (!InstructionADDMOD(ref stack, ref gasAvailable)) goto OutOfGas;
+                        break;
                     case Instruction.MULMOD:
-                        {
-                            if (!UpdateGas(GasCostOf.Mid, ref gasAvailable)) goto OutOfGas;
-
-                            InstructionMULMOD(ref stack);
-                            break;
-                        }
+                        if (!InstructionMULMOD(ref stack, ref gasAvailable)) goto OutOfGas;
+                        break;
                     case Instruction.EXP:
-                        {
-                            if (!UpdateGas(GasCostOf.Exp, ref gasAvailable)) goto OutOfGas;
-
-                            if (!InstructionEXP(ref stack, ref gasAvailable, spec)) goto OutOfGas;
-                            break;
-                        }
+                        if (!InstructionEXP(ref stack, ref gasAvailable, spec)) goto OutOfGas;
+                        break;
                     case Instruction.SIGNEXTEND:
-                        {
-                            if (!UpdateGas(GasCostOf.Low, ref gasAvailable)) goto OutOfGas;
-
-                            InstructionSIGNEXTEND(ref stack);
-                            break;
-                        }
+                        if (!InstructionSIGNEXTEND(ref stack, ref gasAvailable)) goto OutOfGas;
+                        break;
                     case Instruction.LT:
-                        {
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
-
-                            InstructionLT(ref stack);
-                            break;
-                        }
+                        if (!InstructionLT(ref stack, ref gasAvailable)) goto OutOfGas;
+                        break;
                     case Instruction.GT:
-                        {
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
-
-                            InstructionGT(ref stack);
-                            break;
-                        }
+                        if (!InstructionGT(ref stack, ref gasAvailable)) goto OutOfGas;
+                        break;
                     case Instruction.SLT:
-                        {
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
-
-                            InstructionSLT(ref stack);
-                            break;
-                        }
+                        if (!InstructionSLT(ref stack, ref gasAvailable)) goto OutOfGas;
+                        break;
                     case Instruction.SGT:
-                        {
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
-
-                            InstructionSGT(ref stack);
-                            break;
-                        }
+                        if (!InstructionSGT(ref stack, ref gasAvailable)) goto OutOfGas;
+                        break;
                     case Instruction.EQ:
-                        {
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
-
-                            InstructionEQ(ref stack);
-                            break;
-                        }
+                        if (!InstructionEQ(ref stack, ref gasAvailable)) goto OutOfGas;
+                        break;
                     case Instruction.ISZERO:
-                        {
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
-
-                            InstructionISZERO(ref stack);
-                            break;
-                        }
+                        if (!InstructionISZERO(ref stack, ref gasAvailable)) goto OutOfGas;
+                        break;
                     case Instruction.AND:
-                        {
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
-
-                            InstructionAND(ref stack);
-                            break;
-                        }
+                        if (!InstructionAND(ref stack, ref gasAvailable)) goto OutOfGas;
+                        break;
                     case Instruction.OR:
-                        {
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
-
-                            InstructionOR(ref stack);
-                            break;
-                        }
+                        if (!InstructionOR(ref stack, ref gasAvailable)) goto OutOfGas;
+                        break;
                     case Instruction.XOR:
-                        {
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
-
-                            InstructionXOR(ref stack);
-                            break;
-                        }
+                        if (!InstructionXOR(ref stack, ref gasAvailable)) goto OutOfGas;
+                        break;
                     case Instruction.NOT:
-                        {
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
-
-                            InstructionNOT(ref stack);
-                            break;
-                        }
+                        if (!InstructionNOT(ref stack, ref gasAvailable)) goto OutOfGas;
+                        break;
                     case Instruction.BYTE:
-                        {
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
-
-                            InstructionBYTE(ref stack);
-                            break;
-                        }
+                        if (!InstructionBYTE(ref stack, ref gasAvailable)) goto OutOfGas;
+                        break;
                     case Instruction.SHA3:
-                        {
-                            if (!InstructionSHA3(ref stack, ref gasAvailable, vmState.Memory)) goto OutOfGas;
-                            break;
-                        }
+                        if (!InstructionSHA3(ref stack, ref gasAvailable, vmState.Memory)) goto OutOfGas;
+                        break;
                     case Instruction.ADDRESS:
                         {
                             if (!UpdateGas(GasCostOf.Base, ref gasAvailable)) goto OutOfGas;
-
                             stack.PushBytes(env.ExecutingAccount.Bytes);
-                            break;
                         }
+                        break;
                     case Instruction.BALANCE:
-                        {
-                            if (!InstructionBALANCE(ref stack, ref gasAvailable, vmState, spec)) goto OutOfGas;
-                            break;
-                        }
+                        if (!InstructionBALANCE(ref stack, ref gasAvailable, vmState, spec)) goto OutOfGas;
+                        break;
                     case Instruction.CALLER:
                         {
                             if (!UpdateGas(GasCostOf.Base, ref gasAvailable)) goto OutOfGas;
-
                             stack.PushBytes(env.Caller.Bytes);
-                            break;
                         }
+                        break;
                     case Instruction.CALLVALUE:
                         {
                             if (!UpdateGas(GasCostOf.Base, ref gasAvailable)) goto OutOfGas;
-
                             stack.PushUInt256(in env.Value);
-                            break;
                         }
+                        break;
                     case Instruction.ORIGIN:
-                        {
-                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable)) goto OutOfGas;
-
-                            stack.PushBytes(txCtx.Origin.Bytes);
-                            break;
-                        }
+                        if (!UpdateGas(GasCostOf.Base, ref gasAvailable)) goto OutOfGas;
+                        stack.PushBytes(txCtx.Origin.Bytes);
+                        break;
                     case Instruction.CALLDATALOAD:
-                        {
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
-
-                            InstructionCALLDATALOAD(ref stack, in env.InputData);
-                            break;
-                        }
+                        if (!InstructionCALLDATALOAD(ref stack, ref gasAvailable, in env.InputData)) goto OutOfGas;
+                        break;
                     case Instruction.CALLDATASIZE:
-                        {
-                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable)) goto OutOfGas;
-
-                            InstructionCALLDATASIZE(ref stack, in env.InputData);
-                            break;
-                        }
+                        if (!InstructionCALLDATASIZE(ref stack, ref gasAvailable, in env.InputData)) goto OutOfGas;
+                        break;
                     case Instruction.CALLDATACOPY:
-                        {
-                            if (!InstructionCALLDATACOPY(ref stack, ref gasAvailable, vmState.Memory, in env.InputData)) goto OutOfGas;
-                            break;
-                        }
+                        if (!InstructionCALLDATACOPY(ref stack, ref gasAvailable, vmState.Memory, in env.InputData)) goto OutOfGas;
+                        break;
                     case Instruction.CODESIZE:
-                        {
-                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable)) goto OutOfGas;
-
-                            InstructionCODESIZE(ref stack, code.Length);
-                            break;
-                        }
+                        if (!InstructionCODESIZE(ref stack, ref gasAvailable, code.Length)) goto OutOfGas;
+                        break;
                     case Instruction.CODECOPY:
-                        {
-                            if (!InstructionCODECOPY(ref stack, ref gasAvailable, vmState.Memory, in code)) goto OutOfGas;
-                            break;
-                        }
+                        if (!InstructionCODECOPY(ref stack, ref gasAvailable, vmState.Memory, in code)) goto OutOfGas;
+                        break;
                     case Instruction.GASPRICE:
                         {
                             if (!UpdateGas(GasCostOf.Base, ref gasAvailable)) goto OutOfGas;
@@ -955,15 +841,11 @@ namespace Nethermind.Evm
                             break;
                         }
                     case Instruction.EXTCODESIZE:
-                        {
-                            if (!InstructionEXTCODESIZE(ref stack, ref gasAvailable, vmState, spec)) goto OutOfGas;
-                            break;
-                        }
+                        if (!InstructionEXTCODESIZE(ref stack, ref gasAvailable, vmState, spec)) goto OutOfGas;
+                        break;
                     case Instruction.EXTCODECOPY:
-                        {
-                            if (!InstructionEXTCODECOPY(ref stack, ref gasAvailable, vmState, spec)) goto OutOfGas;
-                            break;
-                        }
+                        if (!InstructionEXTCODECOPY(ref stack, ref gasAvailable, vmState, spec)) goto OutOfGas;
+                        break;
                     case Instruction.RETURNDATASIZE:
                         {
                             if (!spec.ReturnDataOpcodesEnabled) goto InvalidInstruction;
@@ -982,10 +864,8 @@ namespace Nethermind.Evm
                             break;
                         }
                     case Instruction.BLOCKHASH:
-                        {
-                            if (!InstructionBLOCKHASH(ref stack, ref gasAvailable, txCtx.Header)) goto OutOfGas;
-                            break;
-                        }
+                        if (!InstructionBLOCKHASH(ref stack, ref gasAvailable, txCtx.Header)) goto OutOfGas;
+                        break;
                     case Instruction.COINBASE:
                         {
                             if (!UpdateGas(GasCostOf.Base, ref gasAvailable)) goto OutOfGas;
@@ -1249,8 +1129,7 @@ namespace Nethermind.Evm
                         {
                             if (!UpdateGas(GasCostOf.Base, ref gasAvailable)) goto OutOfGas;
 
-                            UInt256 gas = (UInt256)gasAvailable;
-                            stack.PushUInt256(in gas);
+                            stack.PushUInt256(gasAvailable);
                             break;
                         }
                     case Instruction.JUMPDEST:
@@ -1406,7 +1285,6 @@ namespace Nethermind.Evm
                     case Instruction.CREATE2:
                         {
                             if (!spec.Create2OpcodeEnabled && instruction == Instruction.CREATE2) goto InvalidInstruction;
-
                             if (vmState.IsStatic) goto StaticCallViolation;
 
                             (InstructionReturn result, EvmState? callState) = InstructionCREATE(instruction, ref stack, ref gasAvailable, ref env, vmState, spec);
@@ -1617,37 +1495,21 @@ namespace Nethermind.Evm
                             goto Empty;
                         }
                     case Instruction.SHL:
-                        {
-                            if (!spec.ShiftOpcodesEnabled) goto InvalidInstruction;
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
-
-                            InstructionSHL(ref stack);
-                            break;
-                        }
+                        if (!spec.ShiftOpcodesEnabled) goto InvalidInstruction;
+                        if (!InstructionSHL(ref stack, ref gasAvailable)) goto OutOfGas;
+                        break;
                     case Instruction.SHR:
-                        {
-                            if (!spec.ShiftOpcodesEnabled) goto InvalidInstruction;
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
-
-                            InstructionSHR(ref stack);
-                            break;
-                        }
+                        if (!spec.ShiftOpcodesEnabled) goto InvalidInstruction;
+                        if (!InstructionSHR(ref stack, ref gasAvailable)) goto OutOfGas;
+                        break;
                     case Instruction.SAR:
-                        {
-                            if (!spec.ShiftOpcodesEnabled) goto InvalidInstruction;
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
-
-                            InstructionSAR(ref stack);
-                            break;
-                        }
+                        if (!spec.ShiftOpcodesEnabled) goto InvalidInstruction;
+                        if (!InstructionSAR(ref stack, ref gasAvailable)) goto OutOfGas;
+                        break;
                     case Instruction.EXTCODEHASH:
-                        {
-                            if (!spec.ExtCodeHashOpcodeEnabled) goto InvalidInstruction;
-                            if (!UpdateGas(spec.GetExtCodeHashCost(), ref gasAvailable)) goto OutOfGas;
-
-                            if (!InstructionEXTCODEHASH(ref stack, ref gasAvailable, vmState, spec)) goto OutOfGas;
-                            break;
-                        }
+                        if (!spec.ExtCodeHashOpcodeEnabled) goto InvalidInstruction;
+                        if (!InstructionEXTCODEHASH(ref stack, ref gasAvailable, vmState, spec)) goto OutOfGas;
+                        break;
                     case Instruction.BEGINSUB:
                         {
                             if (!spec.SubroutinesEnabled) goto InvalidInstruction;

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -1044,31 +1044,12 @@ namespace Nethermind.Evm
                             break;
                         }
                     case Instruction.PUSH0:
-                        {
-                            if (!spec.IncludePush0Instruction) goto InvalidInstruction;
-                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable)) goto OutOfGas;
-
-                            stack.PushZero();
-
-                            break;
-                        }
+                        if (!spec.IncludePush0Instruction) goto InvalidInstruction;
+                        if (!InstructionPUSH0(ref stack, ref gasAvailable)) goto OutOfGas;
+                        break;
                     case Instruction.PUSH1:
-                        {
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
-
-                            int programCounterInt = programCounter;
-                            if (programCounterInt >= code.Length)
-                            {
-                                stack.PushZero();
-                            }
-                            else
-                            {
-                                stack.PushByte(code[programCounterInt]);
-                            }
-
-                            programCounter++;
-                            break;
-                        }
+                        if (!InstructionPUSH1(ref stack, ref gasAvailable, ref programCounter, in code)) goto OutOfGas;
+                        break;
                     case Instruction.PUSH2:
                     case Instruction.PUSH3:
                     case Instruction.PUSH4:
@@ -1100,18 +1081,8 @@ namespace Nethermind.Evm
                     case Instruction.PUSH30:
                     case Instruction.PUSH31:
                     case Instruction.PUSH32:
-                        {
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
-
-                            int length = instruction - Instruction.PUSH1 + 1;
-                            int programCounterInt = programCounter;
-                            int usedFromCode = Math.Min(code.Length - programCounterInt, length);
-
-                            stack.PushLeftPaddedBytes(code.Slice(programCounterInt, usedFromCode), length);
-
-                            programCounter += length;
-                            break;
-                        }
+                        if (!InstructionPUSH(instruction, ref stack, ref gasAvailable, ref programCounter, in code)) goto OutOfGas;
+                        break;
                     case Instruction.DUP1:
                     case Instruction.DUP2:
                     case Instruction.DUP3:
@@ -1128,12 +1099,8 @@ namespace Nethermind.Evm
                     case Instruction.DUP14:
                     case Instruction.DUP15:
                     case Instruction.DUP16:
-                        {
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
-
-                            stack.Dup(instruction - Instruction.DUP1 + 1);
-                            break;
-                        }
+                        if (!InstructionDUP(instruction, ref stack, ref gasAvailable)) goto OutOfGas;
+                        break;
                     case Instruction.SWAP1:
                     case Instruction.SWAP2:
                     case Instruction.SWAP3:
@@ -1150,12 +1117,8 @@ namespace Nethermind.Evm
                     case Instruction.SWAP14:
                     case Instruction.SWAP15:
                     case Instruction.SWAP16:
-                        {
-                            if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
-
-                            stack.Swap(instruction - Instruction.SWAP1 + 2);
-                            break;
-                        }
+                        if (!InstructionSWAP(instruction, ref stack, ref gasAvailable)) goto OutOfGas;
+                        break;
                     case Instruction.LOG0:
                     case Instruction.LOG1:
                     case Instruction.LOG2:

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -850,9 +850,7 @@ namespace Nethermind.Evm
                     case Instruction.RETURNDATASIZE:
                         {
                             if (!spec.ReturnDataOpcodesEnabled) goto InvalidInstruction;
-                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable)) goto OutOfGas;
-
-                            InstructionRETURNDATASIZE(ref stack);
+                            if (!InstructionRETURNDATASIZE(ref stack, ref gasAvailable)) goto OutOfGas;
                             break;
                         }
                     case Instruction.RETURNDATACOPY:

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -893,8 +893,7 @@ namespace Nethermind.Evm
                         {
                             if (!UpdateGas(GasCostOf.Base, ref gasAvailable)) goto OutOfGas;
 
-                            UInt256 timestamp = txCtx.Header.Timestamp;
-                            stack.PushUInt256(in timestamp);
+                            stack.PushUInt256(txCtx.Header.Timestamp);
                             break;
                         }
                     case Instruction.NUMBER:
@@ -933,8 +932,7 @@ namespace Nethermind.Evm
                             if (!spec.BaseFeeEnabled) goto InvalidInstruction;
                             if (!UpdateGas(GasCostOf.Base, ref gasAvailable)) goto OutOfGas;
 
-                            UInt256 baseFee = txCtx.Header.BaseFeePerGas;
-                            stack.PushUInt256(in baseFee);
+                            stack.PushUInt256(in txCtx.Header.BaseFeePerGas);
                             break;
                         }
                     case Instruction.DATAHASH:
@@ -1011,8 +1009,7 @@ namespace Nethermind.Evm
                             if (!UpdateGas(GasCostOf.High, ref gasAvailable)) goto OutOfGas;
 
                             stack.PopUInt256(out UInt256 jumpDest);
-                            Span<byte> condition = stack.PopBytes();
-                            if (!condition.SequenceEqual(BytesZero32))
+                            if (!stack.PopBytes().IsZero())
                             {
                                 Jump(jumpDest);
                             }
@@ -1030,8 +1027,7 @@ namespace Nethermind.Evm
                         {
                             if (!UpdateGas(GasCostOf.Base, ref gasAvailable)) goto OutOfGas;
 
-                            UInt256 size = vmState.Memory.Size;
-                            stack.PushUInt256(in size);
+                            stack.PushUInt256(vmState.Memory.Size);
                             break;
                         }
                     case Instruction.GAS:


### PR DESCRIPTION
Experiment into shrinking the size of the `ExecuteCall` hot loop and reducing the amount of stack that needs to be cleared at the start of the method

Amount of stack cleared from 9472 bytes -> 624 bytes (93% removed)
Amount of asm in main method (hot loop) 33310 bytes -> 6553 bytes (80% removed)

The current size of the loop is problematic as its larger than the L1 instruction cache so to loop once its having to load from the L2 cache.

However looking at the performance with these changes; 85% of the time is in `SLOAD`, so 🤷‍♂️ storage performance is a more important thing to resolve

<img width="599" alt="image" src="https://user-images.githubusercontent.com/1142958/223085483-1239ad6d-90cc-45dc-8174-185dcc9e4674.png">

## Changes

- Can follow up later

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No
