### PR TITLE
Remove PoaCore from config update

### DIFF
--- a/scripts/syncSettings.py
+++ b/scripts/syncSettings.py
@@ -29,11 +29,6 @@ configs = {
         "blockReduced": 8192,
         "multiplierRequirement": 30000
     },
-    "poacore": {
-        "url": "https://core.poa.network",
-        "blockReduced": 8192,
-        "multiplierRequirement": 10000
-    },
     "gnosis": {
         "url": "https://rpc.gnosischain.com",
         "blockReduced": 8192,


### PR DESCRIPTION
## Changes

We cannot update configs because of PoaCore Section. Is this network still supported?

![image](https://user-images.githubusercontent.com/9356351/223104030-00c85d2a-ab1b-4bd9-89e9-0bde7f252769.png)


#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No
