### PR TITLE
Fix `BlockInfoDecoder`

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Encoding/BlockInfoDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/BlockInfoDecoderTests.cs
@@ -40,7 +40,6 @@ namespace Nethermind.Core.Test.Encoding
             rlp.Length.Should().Be(1);
 
             BlockInfo decoded = Rlp.Decode<BlockInfo>(rlp);
-            Assert.Null(decoded);
             decoded.Should().BeNull();
         }
 

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/BlockInfoDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/BlockInfoDecoderTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using FluentAssertions;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Int256;
 using Nethermind.Serialization.Rlp;
@@ -36,8 +37,11 @@ namespace Nethermind.Core.Test.Encoding
         public void Can_handle_nulls()
         {
             Rlp rlp = Rlp.Encode((BlockInfo)null!);
+            rlp.Length.Should().Be(1);
+
             BlockInfo decoded = Rlp.Decode<BlockInfo>(rlp);
             Assert.Null(decoded);
+            decoded.Should().BeNull();
         }
 
         private static void Roundtrip(bool valueDecode)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/BlockInfoDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/BlockInfoDecoder.cs
@@ -72,13 +72,8 @@ namespace Nethermind.Serialization.Rlp
             }
         }
 
-        private int GetContentLength(BlockInfo? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+        private int GetContentLength(BlockInfo item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
         {
-            if (item == null)
-            {
-                return Rlp.OfEmptySequence.Length;
-            }
-
             bool hasMetadata = item.Metadata != BlockMetadata.None;
             int contentLength = 0;
             contentLength += Rlp.LengthOf(item.BlockHash);
@@ -95,7 +90,7 @@ namespace Nethermind.Serialization.Rlp
 
         public int GetLength(BlockInfo? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
         {
-            return Rlp.LengthOfSequence(GetContentLength(item, rlpBehaviors));
+            return item == null ? Rlp.OfEmptySequence.Length : Rlp.LengthOfSequence(GetContentLength(item, rlpBehaviors));
         }
 
         public BlockInfo? Decode(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)


### PR DESCRIPTION
## Changes

- fix calculating content length of empty sequence
in `GetLength` return `Rlp.OfEmptySequence.Length` instead of `Rlp.LengthOfSequence(Rlp.OfEmptySequence.Length)` (1 instead of 2)

It's a fix for changes merged 2 weeks ago in https://github.com/NethermindEth/nethermind/pull/5114

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes - adjusted existing one
- [ ] No