### PR TITLE
Stronger guarantees of state return during failures

### DIFF
--- a/src/Nethermind/Nethermind.Evm/EvmStack.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmStack.cs
@@ -12,6 +12,7 @@ using Nethermind.Int256;
 using Nethermind.Evm.Tracing;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Intrinsics;
+using System.Diagnostics;
 
 namespace Nethermind.Evm
 {
@@ -399,14 +400,16 @@ namespace Nethermind.Evm
             return stackTrace;
         }
 
+        [StackTraceHidden]
         [DoesNotReturn]
         private static void ThrowEvmStackUnderflowException()
         {
             throw new EvmStackUnderflowException();
         }
 
+        [StackTraceHidden]
         [DoesNotReturn]
-        private static void ThrowEvmStackOverflowException()
+        internal static void ThrowEvmStackOverflowException()
         {
             throw new EvmStackOverflowException();
         }

--- a/src/Nethermind/Nethermind.Evm/EvmState.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmState.cs
@@ -243,10 +243,10 @@ namespace Nethermind.Evm
                 _stackPool.Value.ReturnStacks(DataStack, ReturnStack!);
                 DataStack = null;
                 ReturnStack = null;
-                Restore(); // we are trying to restore when disposing
-                Memory?.Dispose();
-                Memory = null;
             }
+            Restore(); // we are trying to restore when disposing
+            Memory?.Dispose();
+            Memory = null;
         }
 
         public void InitStacks()

--- a/src/Nethermind/Nethermind.Evm/EvmState.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmState.cs
@@ -58,7 +58,7 @@ namespace Nethermind.Evm
                 Interlocked.Increment(ref _dataStackPoolDepth);
                 if (_dataStackPoolDepth > _maxCallStackDepth)
                 {
-                    throw new Exception();
+                    EvmStack.ThrowEvmStackOverflowException();
                 }
 
                 return new byte[(EvmStack.MaxStackSize + EvmStack.RegisterLength) * 32];
@@ -74,7 +74,7 @@ namespace Nethermind.Evm
                 Interlocked.Increment(ref _returnStackPoolDepth);
                 if (_returnStackPoolDepth > _maxCallStackDepth)
                 {
-                    throw new Exception();
+                    EvmStack.ThrowEvmStackOverflowException();
                 }
 
                 return new int[EvmStack.ReturnStackSize];
@@ -237,9 +237,16 @@ namespace Nethermind.Evm
 
         public void Dispose()
         {
-            if (DataStack is not null) _stackPool.Value.ReturnStacks(DataStack, ReturnStack!);
-            Restore(); // we are trying to restore when disposing
-            Memory?.Dispose();
+            if (DataStack is not null) 
+            {
+                // Only Dispose once
+                _stackPool.Value.ReturnStacks(DataStack, ReturnStack!);
+                DataStack = null;
+                ReturnStack = null;
+                Restore(); // we are trying to restore when disposing
+                Memory?.Dispose();
+                Memory = null;
+            }
         }
 
         public void InitStacks()

--- a/src/Nethermind/Nethermind.Evm/EvmState.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmState.cs
@@ -237,7 +237,7 @@ namespace Nethermind.Evm
 
         public void Dispose()
         {
-            if (DataStack is not null) 
+            if (DataStack is not null)
             {
                 // Only Dispose once
                 _stackPool.Value.ReturnStacks(DataStack, ReturnStack!);

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -230,7 +230,7 @@ namespace Nethermind.Evm
                     }
 
                     Address callCodeOwner = currentState.Env.ExecutingAccount;
-                    EvmState previousState = currentState;
+                    using EvmState previousState = currentState;
                     currentState = _stateStack.Pop();
                     currentState.IsContinuation = true;
                     currentState.GasAvailable += previousState.GasAvailable;
@@ -321,8 +321,6 @@ namespace Nethermind.Evm
                             _txTracer.ReportActionError(EvmExceptionType.Revert, previousState.GasAvailable);
                         }
                     }
-
-                    previousState.Dispose();
                 }
                 catch (Exception ex) when (ex is EvmException or OverflowException)
                 {


### PR DESCRIPTION
Since in same scenario with https://github.com/NethermindEth/nethermind/issues/5386

Ran out of stacks

![image](https://user-images.githubusercontent.com/1142958/223414536-7fab6575-ee0e-4eb8-bfb6-7aa7341c082f.png)

## Changes

- Dispose `previousState` even when exception 

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No