### PR TITLE
Fix memory hint not applied to database sometimes

### DIFF
--- a/src/Nethermind/Nethermind.Init/Steps/InitDatabase.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitDatabase.cs
@@ -18,6 +18,7 @@ using Nethermind.Synchronization.ParallelSync;
 
 namespace Nethermind.Init.Steps
 {
+    [RunnerStepDependencies(typeof(ApplyMemoryHint))]
     public class InitDatabase : IStep
     {
         private readonly IBasicApi _api;


### PR DESCRIPTION
- Seems that database may be initialized without memory hint being applied.
- This is important because writebuffersize which effect l0 file size depends on memory hint.
- Can be confirmed by adding a `Thread.Sleep` in `MemoryHintMan`. 

## Changes

- Make sure to apply memory hint before database starts.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

- Tested manually. The write/read amplification during sync is actually similar, with or without the memory setup properly.
