### PR TITLE
Reduce SyncStatusList lock contention

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastBlockStatusList.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastBlockStatusList.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using System.Threading;
 
 [assembly: InternalsVisibleTo("Nethermind.Synchronization.Test")]
 namespace Nethermind.Synchronization.FastBlocks;
@@ -36,7 +37,7 @@ internal class FastBlockStatusList
 
             (long q, long r) = Math.DivRem(index, 4);
 
-            byte status = _statuses[q];
+            byte status = Volatile.Read(ref _statuses[q]);
             return (FastBlockStatus)((status >> (int)(r * 2)) & 0b11);
         }
         set


### PR DESCRIPTION
Less exciting change than  #5339

## Changes

- Shrink the lock to remove `_blockTree.FindCanonicalBlockInfo(currentNumber)` out of the lock

## Types of changes

`MarkInserted` gets set to sleep due to lock contention, shrink the lock to reduce the contention and that thread inserting can make forward progress

![image](https://user-images.githubusercontent.com/1142958/221367308-ab7f9935-c456-49ca-87b4-7a59d6980185.png)


#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No
