### PR TITLE
LruCache faster snapshot

### DIFF
--- a/src/Nethermind/Nethermind.Core/Caching/LruCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/LruCache.cs
@@ -123,7 +123,17 @@ namespace Nethermind.Core.Caching
         public bool Contains(TKey key) => _cacheMap.ContainsKey(key);
 
         [MethodImpl(MethodImplOptions.Synchronized)]
-        public IDictionary<TKey, TValue> Clone() => _cacheMap.ToDictionary(i => i.Key, i => i.Value.Value.Value);
+        public KeyValuePair<TKey, TValue>[] ToArray()
+        {
+            int i = 0;
+            KeyValuePair<TKey, TValue>[] array = new KeyValuePair<TKey, TValue>[_cacheMap.Count];
+            foreach (KeyValuePair<TKey, LinkedListNode<LruCacheItem>> kvp in _cacheMap)
+            {
+                array[i++] = new KeyValuePair<TKey, TValue>(kvp.Key, kvp.Value.Value.Value);
+            }
+
+            return array;
+        }
 
         private void Replace(TKey key, TValue value)
         {

--- a/src/Nethermind/Nethermind.Trie/CachingStore.cs
+++ b/src/Nethermind/Nethermind.Trie/CachingStore.cs
@@ -57,7 +57,7 @@ namespace Nethermind.Trie
 
         public void PersistCache(IKeyValueStore pruningContext)
         {
-            IDictionary<byte[], byte[]> clone = _cache.Clone();
+            KeyValuePair<byte[], byte[]>[] clone = _cache.ToArray();
             Task.Run(() =>
             {
                 foreach (KeyValuePair<byte[], byte[]> kvp in clone)


### PR DESCRIPTION
This PR changes LruCache snapshot into an array. As the snapshot is used only in pruning and requires no Dictionary interface, it can be provided with an array that saves on comparisons, hashing and more.

## Changes

- `LruCache.Clone` is array returning

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes - running a pruning would not hurt a lot
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No
