### PR TITLE
Reduce VirtualMachine.Execute call stack

### DIFF
--- a/src/Nethermind/Nethermind.Core/LogEntry.cs
+++ b/src/Nethermind/Nethermind.Core/LogEntry.cs
@@ -37,7 +37,7 @@ namespace Nethermind.Core
             LoggersAddress = logEntry.LoggersAddress.ToStructRef();
             Data = logEntry.Data;
             Topics = logEntry.Topics;
-            TopicsRlp = Span<byte>.Empty;
+            TopicsRlp = default;
         }
 
         public Keccak[]? Topics { get; }

--- a/src/Nethermind/Nethermind.Core/TransactionReceipt.cs
+++ b/src/Nethermind/Nethermind.Core/TransactionReceipt.cs
@@ -103,7 +103,7 @@ namespace Nethermind.Core
             PostTransactionState = (receipt.PostTransactionState ?? Keccak.Zero).ToStructRef();
             Bloom = (receipt.Bloom ?? Core.Bloom.Empty).ToStructRef();
             Logs = receipt.Logs;
-            LogsRlp = Span<byte>.Empty;
+            LogsRlp = default;
             Error = receipt.Error;
         }
     }

--- a/src/Nethermind/Nethermind.Evm.Benchmark/EvmBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/EvmBenchmarks.cs
@@ -54,15 +54,16 @@ namespace Nethermind.Evm.Benchmark
             _virtualMachine = new VirtualMachine(_blockhashProvider, MainnetSpecProvider.Instance, LimboLogs.Instance);
 
             _environment = new ExecutionEnvironment
-            {
-                ExecutingAccount = Address.Zero,
-                CodeSource = Address.Zero,
-                Caller = Address.Zero,
-                CodeInfo = new CodeInfo(ByteCode),
-                Value = 0,
-                TransferValue = 0,
-                TxExecutionContext = new TxExecutionContext(_header, Address.Zero, 0, null)
-            };
+            (
+                executingAccount: Address.Zero,
+                codeSource: Address.Zero,
+                caller: Address.Zero,
+                codeInfo: new CodeInfo(ByteCode),
+                value: 0,
+                transferValue: 0,
+                txExecutionContext: new TxExecutionContext(_header, Address.Zero, 0, null),
+                inputData: default
+            );
 
             _evmState = new EvmState(long.MaxValue, _environment, ExecutionType.Transaction, true, _worldState.TakeSnapshot(), false);
         }

--- a/src/Nethermind/Nethermind.Evm.Benchmark/MultipleUnsignedOperations.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/MultipleUnsignedOperations.cs
@@ -84,15 +84,16 @@ public class MultipleUnsignedOperations
         _virtualMachine = new VirtualMachine(_blockhashProvider, MainnetSpecProvider.Instance, new OneLoggerLogManager(NullLogger.Instance));
 
         _environment = new ExecutionEnvironment
-        {
-            ExecutingAccount = Address.Zero,
-            CodeSource = Address.Zero,
-            Caller = Address.Zero,
-            CodeInfo = new CodeInfo(_bytecode.Concat(_bytecode).Concat(_bytecode).Concat(_bytecode).ToArray()),
-            Value = 0,
-            TransferValue = 0,
-            TxExecutionContext = new TxExecutionContext(_header, Address.Zero, 0, null)
-        };
+        (
+            executingAccount: Address.Zero,
+            codeSource: Address.Zero,
+            caller: Address.Zero,
+            codeInfo: new CodeInfo(_bytecode.Concat(_bytecode).Concat(_bytecode).Concat(_bytecode).ToArray()),
+            value: 0,
+            transferValue: 0,
+            txExecutionContext: new TxExecutionContext(_header, Address.Zero, 0, null),
+            inputData: default
+        );
 
         _evmState = new EvmState(100_000_000L, _environment, ExecutionType.Transaction, true, _worldState.TakeSnapshot(), false);
     }

--- a/src/Nethermind/Nethermind.Evm.Benchmark/StaticCallBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/StaticCallBenchmarks.cs
@@ -95,15 +95,16 @@ namespace Nethermind.Evm.Benchmark
             _virtualMachine = new VirtualMachine(_blockhashProvider, MainnetSpecProvider.Instance, new OneLoggerLogManager(NullLogger.Instance));
 
             _environment = new ExecutionEnvironment
-            {
-                ExecutingAccount = Address.Zero,
-                CodeSource = Address.Zero,
-                Caller = Address.Zero,
-                CodeInfo = new CodeInfo(Bytecode),
-                Value = 0,
-                TransferValue = 0,
-                TxExecutionContext = new TxExecutionContext(_header, Address.Zero, 0, null)
-            };
+            (
+                executingAccount: Address.Zero,
+                codeSource: Address.Zero,
+                caller: Address.Zero,
+                codeInfo: new CodeInfo(Bytecode),
+                value: 0,
+                transferValue: 0,
+                txExecutionContext: new TxExecutionContext(_header, Address.Zero, 0, null),
+                inputData: default
+            );
 
             _evmState = new EvmState(100_000_000L, _environment, ExecutionType.Transaction, true, _worldState.TakeSnapshot(), false);
         }

--- a/src/Nethermind/Nethermind.Evm/ByteArrayExtensions.cs
+++ b/src/Nethermind/Nethermind.Evm/ByteArrayExtensions.cs
@@ -12,7 +12,7 @@ namespace Nethermind.Evm
         {
             if (startIndex >= span.Length)
             {
-                return new ZeroPaddedSpan(Span<byte>.Empty, length, padDirection);
+                return new ZeroPaddedSpan(default, length, padDirection);
             }
 
             if (length == 1)
@@ -20,8 +20,8 @@ namespace Nethermind.Evm
                 // why do we return zero length here?
                 // it was passing all the tests like this...
                 // return bytes.Length == 0 ? new byte[0] : new[] {bytes[startIndex]};
-                return span.Length == 0 ? new ZeroPaddedSpan(Span<byte>.Empty, 0, padDirection) : new ZeroPaddedSpan(span.Slice(startIndex, 1), 0, padDirection);
-                // return bytes.Length == 0 ? new ZeroPaddedSpan(Span<byte>.Empty, 1) : new ZeroPaddedSpan(bytes.Slice(startIndex, 1), 0);
+                return span.Length == 0 ? new ZeroPaddedSpan(default, 0, padDirection) : new ZeroPaddedSpan(span.Slice(startIndex, 1), 0, padDirection);
+                // return bytes.Length == 0 ? new ZeroPaddedSpan(default, 1) : new ZeroPaddedSpan(bytes.Slice(startIndex, 1), 0);
             }
 
             int copiedLength = Math.Min(span.Length - startIndex, length);
@@ -32,7 +32,7 @@ namespace Nethermind.Evm
         {
             if (startIndex >= memory.Length)
             {
-                return new ZeroPaddedMemory(ReadOnlyMemory<byte>.Empty, length, padDirection);
+                return new ZeroPaddedMemory(default, length, padDirection);
             }
 
             if (length == 1)
@@ -40,8 +40,8 @@ namespace Nethermind.Evm
                 // why do we return zero length here?
                 // it was passing all the tests like this...
                 // return bytes.Length == 0 ? new byte[0] : new[] {bytes[startIndex]};
-                return memory.Length == 0 ? new ZeroPaddedMemory(ReadOnlyMemory<byte>.Empty, 0, padDirection) : new ZeroPaddedMemory(memory.Slice(startIndex, 1), 0, padDirection);
-                // return bytes.Length == 0 ? new ZeroPaddedSpan(Span<byte>.Empty, 1) : new ZeroPaddedSpan(bytes.Slice(startIndex, 1), 0);
+                return memory.Length == 0 ? new ZeroPaddedMemory(default, 0, padDirection) : new ZeroPaddedMemory(memory.Slice(startIndex, 1), 0, padDirection);
+                // return bytes.Length == 0 ? new ZeroPaddedSpan(default, 1) : new ZeroPaddedSpan(bytes.Slice(startIndex, 1), 0);
             }
 
             int copiedLength = Math.Min(memory.Length - startIndex, length);
@@ -52,7 +52,7 @@ namespace Nethermind.Evm
         {
             if (startIndex >= span.Length || startIndex > int.MaxValue)
             {
-                return new ZeroPaddedSpan(Span<byte>.Empty, length, PadDirection.Right);
+                return new ZeroPaddedSpan(default, length, PadDirection.Right);
             }
 
             return SliceWithZeroPadding(span, (int)startIndex, length, padDirection);
@@ -62,7 +62,7 @@ namespace Nethermind.Evm
         {
             if (startIndex >= bytes.Length || startIndex > int.MaxValue)
             {
-                return new ZeroPaddedMemory(ReadOnlyMemory<byte>.Empty, length, PadDirection.Right);
+                return new ZeroPaddedMemory(default, length, PadDirection.Right);
             }
 
             return MemoryWithZeroPadding(bytes, (int)startIndex, length, padDirection);

--- a/src/Nethermind/Nethermind.Evm/EvmPooledMemory.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmPooledMemory.cs
@@ -134,7 +134,7 @@ namespace Nethermind.Evm
         {
             if (length.IsZero)
             {
-                return ReadOnlyMemory<byte>.Empty;
+                return default;
             }
 
             if (location > int.MaxValue)
@@ -151,7 +151,7 @@ namespace Nethermind.Evm
         {
             if (length.IsZero)
             {
-                return ReadOnlyMemory<byte>.Empty;
+                return default;
             }
 
             if (location > int.MaxValue)
@@ -161,7 +161,7 @@ namespace Nethermind.Evm
 
             if (_memory is null || location + length > _memory.Length)
             {
-                return ReadOnlyMemory<byte>.Empty;
+                return default;
             }
 
             return _memory.AsMemory((int)location, (int)length);

--- a/src/Nethermind/Nethermind.Evm/EvmState.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmState.cs
@@ -223,7 +223,7 @@ namespace Nethermind.Evm
 
         public Address To => Env.CodeSource;
         internal bool IsPrecompile => Env.CodeInfo.IsPrecompile;
-        public ExecutionEnvironment Env { get; }
+        public readonly ExecutionEnvironment Env;
 
         internal ExecutionType ExecutionType { get; } // TODO: move to CallEnv
         public bool IsTopLevel { get; } // TODO: move to CallEnv

--- a/src/Nethermind/Nethermind.Evm/ExecutionEnvironment.cs
+++ b/src/Nethermind/Nethermind.Evm/ExecutionEnvironment.cs
@@ -8,51 +8,74 @@ using Nethermind.Int256;
 
 namespace Nethermind.Evm
 {
-    public struct ExecutionEnvironment
+    public readonly struct ExecutionEnvironment
     {
+        public ExecutionEnvironment
+        (
+            CodeInfo codeInfo,
+            Address executingAccount,
+            Address caller,
+            Address? codeSource,
+            ReadOnlyMemory<byte> inputData,
+            TxExecutionContext txExecutionContext,
+            UInt256 transferValue,
+            UInt256 value,
+            int callDepth = 0)
+        {
+            CodeInfo = codeInfo;
+            ExecutingAccount = executingAccount;
+            Caller = caller;
+            CodeSource = codeSource;
+            InputData = inputData;
+            TxExecutionContext = txExecutionContext;
+            TransferValue = transferValue;
+            Value = value;
+            CallDepth = callDepth;
+        }
+
         /// <summary>
-        /// Transaction originator
+        /// Parsed bytecode for the current call.
         /// </summary>
-        public TxExecutionContext TxExecutionContext { get; set; }
+        public readonly CodeInfo CodeInfo;
 
         /// <summary>
         /// Currently executing account (in DELEGATECALL this will be equal to caller).
         /// </summary>
-        public Address ExecutingAccount { get; set; }
+        public readonly Address ExecutingAccount;
 
         /// <summary>
         /// Caller
         /// </summary>
-        public Address Caller { get; set; }
+        public readonly Address Caller;
 
         /// <summary>
         /// Bytecode source (account address).
         /// </summary>
-        public Address? CodeSource { get; set; }
+        public readonly Address? CodeSource;
 
         /// <summary>
         /// Parameters / arguments of the current call.
         /// </summary>
-        public ReadOnlyMemory<byte> InputData { get; set; }
+        public readonly ReadOnlyMemory<byte> InputData;
+
+        /// <summary>
+        /// Transaction originator
+        /// </summary>
+        public readonly TxExecutionContext TxExecutionContext;
 
         /// <summary>
         /// ETH value transferred in this call.
         /// </summary>
-        public UInt256 TransferValue { get; set; }
+        public readonly UInt256 TransferValue;
 
         /// <summary>
         /// Value information passed (it is different from transfer value in DELEGATECALL.
         /// DELEGATECALL behaves like a library call and it uses the value information from the caller even
         /// as no transfer happens.
         /// </summary>
-        public UInt256 Value { get; set; }
-
-        /// <summary>
-        /// Parsed bytecode for the current call.
-        /// </summary>
-        public CodeInfo CodeInfo { get; set; }
+        public readonly UInt256 Value;
 
         /// <example>If we call TX -> DELEGATECALL -> CALL -> STATICCALL then the call depth would be 3.</example>
-        public int CallDepth { get; set; }
+        public readonly int CallDepth;
     }
 }

--- a/src/Nethermind/Nethermind.Evm/Precompiles/PointEvaluationPrecompile.cs
+++ b/src/Nethermind/Nethermind.Evm/Precompiles/PointEvaluationPrecompile.cs
@@ -51,6 +51,6 @@ public class PointEvaluationPrecompile : IPrecompile
         Metrics.PointEvaluationPrecompile++;
         return IsValid(inputData)
             ? (PointEvaluationSuccessfulResponse, true)
-            : (ReadOnlyMemory<byte>.Empty, false);
+            : (default, false);
     }
 }

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -320,18 +320,19 @@ namespace Nethermind.Evm.TransactionProcessing
 
                 recipientOrNull = recipient;
 
-                ExecutionEnvironment env = new();
-                env.TxExecutionContext = new TxExecutionContext(block, caller, effectiveGasPrice, transaction.BlobVersionedHashes);
-                env.Value = value;
-                env.TransferValue = value;
-                env.Caller = caller;
-                env.CodeSource = recipient;
-                env.ExecutingAccount = recipient;
-                env.InputData = data ?? Array.Empty<byte>();
-                env.CodeInfo = machineCode is null
-                    ? _virtualMachine.GetCachedCodeInfo(_worldState, recipient, spec)
-                    : new CodeInfo(machineCode);
-
+                ExecutionEnvironment env = new
+                (
+                    txExecutionContext: new TxExecutionContext(block, caller, effectiveGasPrice, transaction.BlobVersionedHashes),
+                    value: value,
+                    transferValue: value,
+                    caller: caller,
+                    codeSource: recipient,
+                    executingAccount: recipient,
+                    inputData: data ?? Array.Empty<byte>(),
+                    codeInfo: machineCode is null
+                        ? _virtualMachine.GetCachedCodeInfo(_worldState, recipient, spec)
+                        : new CodeInfo(machineCode)
+                );
                 ExecutionType executionType =
                     transaction.IsContractCreation ? ExecutionType.Create : ExecutionType.Transaction;
                 using (EvmState state =

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -2026,7 +2026,7 @@ namespace Nethermind.Evm
                                 executingAccount: contractAddress,
                                 codeSource: null,
                                 codeInfo: new CodeInfo(initCode.ToArray()),
-                                inputData: ReadOnlyMemory<byte>.Empty,
+                                inputData: default,
                                 transferValue: value,
                                 value: value
                             );

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -1227,7 +1227,7 @@ namespace Nethermind.Evm
 
                             if (length > UInt256.Zero)
                             {
-                                if(!UpdateMemoryCost(vmState, ref gasAvailable, in dest, length)) goto OutOfGas;
+                                if (!UpdateMemoryCost(vmState, ref gasAvailable, in dest, length)) goto OutOfGas;
 
                                 ZeroPaddedSpan codeSlice = code.SliceWithZeroPadding(src, (int)length);
                                 vmState.Memory.Save(in dest, codeSlice);
@@ -2119,7 +2119,7 @@ namespace Nethermind.Evm
                             }
 
                             if (!UpdateGas(spec.GetCallCost(), ref gasAvailable) ||
-                                !UpdateMemoryCost(vmState, ref gasAvailable, in dataOffset, dataLength) || 
+                                !UpdateMemoryCost(vmState, ref gasAvailable, in dataOffset, dataLength) ||
                                 !UpdateMemoryCost(vmState, ref gasAvailable, in outputOffset, outputLength) ||
                                 !UpdateGas(gasExtra, ref gasAvailable)) goto OutOfGas;
 

--- a/src/Nethermind/Nethermind.Evm/ZeroPaddedSpan.cs
+++ b/src/Nethermind/Nethermind.Evm/ZeroPaddedSpan.cs
@@ -7,7 +7,7 @@ namespace Nethermind.Evm
 {
     public readonly ref struct ZeroPaddedSpan
     {
-        public static ZeroPaddedSpan Empty => new(Span<byte>.Empty, 0, PadDirection.Right);
+        public static ZeroPaddedSpan Empty => new(default, 0, PadDirection.Right);
 
         public ZeroPaddedSpan(ReadOnlySpan<byte> span, int paddingLength, PadDirection padDirection)
         {

--- a/src/Nethermind/Nethermind.Merkleization/Merkle.cs
+++ b/src/Nethermind/Nethermind.Merkleization/Merkle.cs
@@ -280,7 +280,7 @@ public static partial class Merkle
         }
         else
         {
-            Ize(out root, MemoryMarshal.Cast<byte, UInt256>(value), Span<UInt256>.Empty, limit);
+            Ize(out root, MemoryMarshal.Cast<byte, UInt256>(value), default, limit);
         }
 
         MixIn(ref root, length);


### PR DESCRIPTION
Less extreme approach than https://github.com/NethermindEth/nethermind/pull/5367 for some quick wins

## Changes

- Don't use local functions that take hidden copies of very large structs (e.g. `ExecutionEnvironment`)
- Change `ExecutionEnvironment` `readonly struct` and use `ref readonly` to refer to it rather than take copy
- `ref readonly` to refer to `TxExecutionContext` rather than take copy
- Move all the `CallResult` struct returns out of the loop, and use goto error pattern (both reduces code duplication and stack space)
- ReadOnlyMemory<byte>.Empty -> default (Jit does less work and doesn't think it needs to save space for a variable)

## Types of changes

- Reduce stack clearance (Method stack clearance 8928 bytes -> 8304 bytes, -624 bytes)
- Reduce method size (Method asm 33454 bytes -> 27349 bytes, -6105 bytes)
- Reduce code duplication
- Reduce code size in hot loop
- Move more errors to returns rather than exceptions e.g. `UpdateMemoryCost`

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Needs Hive tests run