### PR TITLE
In FastHeadersSyncFeed change ConcurrentDictionary to ConcurrentHashSet

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization/Nethermind.Synchronization.csproj
+++ b/src/Nethermind/Nethermind.Synchronization/Nethermind.Synchronization.csproj
@@ -15,4 +15,8 @@
     <ProjectReference Include="..\Nethermind.Trie\Nethermind.Trie.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="ConcurrentHashSet" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Changes

- Change `ConcurrentDictionary` to `ConcurrentHashSet`
- Managed to get an increase of total 8464.70bps -> total 8756.95bps
- Could be incidental, need more tests
- Allocates a bit less

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Sync faster on my test