### PR TITLE
Fix posdao tests

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
@@ -1074,7 +1074,7 @@ public partial class EthRpcModuleTests
 
         string serialized = ctx.Test.TestEthRpc("eth_sendTransaction", new EthereumJsonSerializer().Serialize(txForRpc));
 
-        Assert.AreEqual("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32010,\"message\":\"InsufficientFunds, Balance is zero, cannot pay gas\"},\"id\":67}", serialized);
+        Assert.AreEqual("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32010,\"message\":\"InsufficientFunds, Balance is 0 - less than sending value 10000\"},\"id\":67}", serialized);
     }
 
     public enum AccessListProvided

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
@@ -1077,6 +1077,18 @@ public partial class EthRpcModuleTests
         Assert.AreEqual("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32010,\"message\":\"InsufficientFunds, Balance is 0 - less than sending value 10000\"},\"id\":67}", serialized);
     }
 
+    [Test]
+    public async Task Send_transaction_should_not_return_ErrorCode_if_sender_balance_is_zero_but_tx_cost_is_zero_too()
+    {
+        using Context ctx = await Context.Create();
+        Transaction tx = Build.A.Transaction.WithValue(0).WithGasPrice(0).SignedAndResolved(new PrivateKey("0x0000000000000000000000000000000000000000000000000000000000000001")).WithNonce(0).TestObject;
+        TransactionForRpc txForRpc = new(tx);
+
+        string serialized = ctx.Test.TestEthRpc("eth_sendTransaction", new EthereumJsonSerializer().Serialize(txForRpc));
+
+        Assert.AreEqual("{\"jsonrpc\":\"2.0\",\"result\":\"0x432300203475b2268c4b86252f14cc26ad2b1d1fc05d7cb635d4875f18d1b407\",\"id\":67}", serialized);
+    }
+
     public enum AccessListProvided
     {
         None,

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -1334,7 +1334,7 @@ namespace Nethermind.TxPool.Test
                 .WithTo(TestItem.AddressB)
                 .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyF).TestObject;
 
-            _txPool.SubmitTx(zeroCostTx, TxHandlingOptions.PersistentBroadcast).Should().Be(AcceptTxResult.Accepted);
+            _txPool.SubmitTx(zeroCostTx, TxHandlingOptions.None).Should().Be(AcceptTxResult.Accepted);
 
             // Cumulative cost should be 1
             Transaction expensiveTx = Build.A.Transaction
@@ -1345,7 +1345,7 @@ namespace Nethermind.TxPool.Test
                 .WithMaxPriorityFeePerGas(0)
                 .WithTo(TestItem.AddressB)
                 .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyF).TestObject;
-            _txPool.SubmitTx(expensiveTx, TxHandlingOptions.PersistentBroadcast).Should().Be(AcceptTxResult.Accepted);
+            _txPool.SubmitTx(expensiveTx, TxHandlingOptions.None).Should().Be(AcceptTxResult.Accepted);
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.TxPool/Filters/BalanceBelowValueFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/BalanceBelowValueFilter.cs
@@ -10,11 +10,11 @@ namespace Nethermind.TxPool.Filters
     /// <summary>
     /// Filters out transactions which gas payments overflow uint256 or simply exceed sender balance
     /// </summary>
-    internal sealed class BalanceZeroFilter : IIncomingTxFilter
+    internal sealed class BalanceBelowValueFilter : IIncomingTxFilter
     {
         private readonly ILogger _logger;
 
-        public BalanceZeroFilter(ILogger logger)
+        public BalanceBelowValueFilter(ILogger logger)
         {
             _logger = logger;
         }

--- a/src/Nethermind/Nethermind.TxPool/Filters/BalanceZeroFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/BalanceZeroFilter.cs
@@ -25,19 +25,17 @@ namespace Nethermind.TxPool.Filters
             UInt256 balance = account.Balance;
 
             bool isNotLocal = (handlingOptions & TxHandlingOptions.PersistentBroadcast) == 0;
-            if (!tx.IsFree() && balance.IsZero)
+            if (isNotLocal && !tx.IsFree() && balance.IsZero)
             {
                 Metrics.PendingTransactionsZeroBalance++;
-                return isNotLocal ?
-                    AcceptTxResult.InsufficientFunds :
-                    AcceptTxResult.InsufficientFunds.WithMessage("Balance is zero, cannot pay gas");
+                return AcceptTxResult.InsufficientFunds;
             }
             if (balance < tx.Value)
             {
                 Metrics.PendingTransactionsBalanceBelowValue++;
                 return isNotLocal ?
                     AcceptTxResult.InsufficientFunds :
-                    AcceptTxResult.InsufficientFunds.WithMessage($"Balance is {balance} less than sending value {tx.Value}");
+                    AcceptTxResult.InsufficientFunds.WithMessage($"Balance is {balance} - less than sending value {tx.Value}");
             }
 
             return AcceptTxResult.Accepted;

--- a/src/Nethermind/Nethermind.TxPool/Filters/BalanceZeroFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/BalanceZeroFilter.cs
@@ -25,11 +25,6 @@ namespace Nethermind.TxPool.Filters
             UInt256 balance = account.Balance;
 
             bool isNotLocal = (handlingOptions & TxHandlingOptions.PersistentBroadcast) == 0;
-            if (isNotLocal && !tx.IsFree() && balance.IsZero)
-            {
-                Metrics.PendingTransactionsZeroBalance++;
-                return AcceptTxResult.InsufficientFunds;
-            }
             if (balance < tx.Value)
             {
                 Metrics.PendingTransactionsBalanceBelowValue++;

--- a/src/Nethermind/Nethermind.TxPool/Filters/FeeTooLowFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/FeeTooLowFilter.cs
@@ -39,15 +39,6 @@ namespace Nethermind.TxPool.Filters
             IReleaseSpec spec = _specProvider.GetCurrentHeadSpec();
             bool isEip1559Enabled = spec.IsEip1559Enabled;
             UInt256 affordableGasPrice = tx.CalculateGasPrice(isEip1559Enabled, _headInfo.CurrentBaseFee);
-            // Don't accept zero fee txns even if pool is empty as will never run
-            if (isEip1559Enabled && !tx.IsFree() && affordableGasPrice.IsZero)
-            {
-                Metrics.PendingTransactionsTooLowFee++;
-                if (_logger.IsTrace) _logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, too low payable gas price with options {handlingOptions} from {new StackTrace()}");
-                return !isLocal ?
-                    AcceptTxResult.FeeTooLow :
-                    AcceptTxResult.FeeTooLow.WithMessage("Affordable gas price is 0");
-            }
 
             if (_txs.IsFull() && _txs.TryGetLast(out Transaction? lastTx)
                 && affordableGasPrice <= lastTx?.GasBottleneck)

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -105,7 +105,7 @@ namespace Nethermind.TxPool
                 new NullHashTxFilter(), // needs to be first as it assigns the hash
                 new AlreadyKnownTxFilter(_hashCache, _logger),
                 new UnknownSenderFilter(ecdsa, _logger),
-                new BalanceZeroFilter(_logger),
+                new BalanceBelowValueFilter(_logger),
                 new BalanceTooLowFilter(_transactions, _logger),
                 new LowNonceFilter(_logger), // has to be after UnknownSenderFilter as it uses sender
                 new GapNonceFilter(_transactions, _logger),
@@ -623,7 +623,7 @@ Sent
 ------------------------------------------------
 Total Received:         {Metrics.PendingTransactionsReceived,24:N0}
 ------------------------------------------------
-Discarded at Filter Stage:        
+Discarded at Filter Stage:
 1.  GasLimitTooHigh:    {Metrics.PendingTransactionsGasLimitTooHigh,24:N0}
 2.  Too Low Fee:        {Metrics.PendingTransactionsTooLowFee,24:N0}
 3.  Malformed           {Metrics.PendingTransactionsMalformed,24:N0}


### PR DESCRIPTION
## Changes

- change `BalanceZeroFilter` to not filter out ANY transactions because of zero balance of sender account
- remove zero fee check

We started failing POSDAO master tests after commit https://github.com/NethermindEth/nethermind/pull/5290

posdao run: https://github.com/NethermindEth/nethermind/actions/runs/4363851628/jobs/7630451828
(lines 931-942)
```
Error: JSON RPC result is undefined. Response text: {"jsonrpc":"2.0","error":{"code":-32010,"message":"InsufficientFunds, Balance is zero, cannot pay gas"},"id":1}
    at /home/runner/work/nethermind/nethermind/posdao-test-setup/utils/sendRequest.js:17:16
    at ChildProcess.exithandler (child_process.js:299:7)
    at ChildProcess.emit (events.js:314:20)
    at maybeClose (internal/child_process.js:1022:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:287:5)
```
After reverting commit https://github.com/NethermindEth/nethermind/pull/5290 tests are passing:
https://github.com/NethermindEth/nethermind/actions/runs/4372125278

Tests expect us to accept transactions with zero balance if they are local.

In this PR I changed `BalanceZeroFilter` to not filter out local transactions because of zero balance of sender account.

After this change POSDAO master tests are still failing, but for different reason, on later stage:
```
  1) Check log of random seeds to find incorrect seed values
       file /home/runner/work/nethermind/nethermind/posdao-test-setup/data/node1/checkRandomSeed.log should be empty:

      There were errors in seed calculation, check checkRandomSeed.log for logs
      + expected - actual

      -false
      +true
      
      at Context.<anonymous> (test/04_random_seed.js:15:127)
      at processImmediate (internal/timers.js:461:21)
```


It was because of zero fee check. Removed it. Tests are passing now:
https://github.com/NethermindEth/nethermind/actions/runs/4375138762/jobs/7655463220

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No