### PR TITLE
Feature/sync db tuner

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
@@ -87,5 +87,11 @@ namespace Nethermind.Blockchain.Synchronization
 
         [ConfigItem(Description = "[EXPERIMENTAL] Only for non validator nodes! If set to true, DownloadReceiptsInFastSync and/or DownloadBodiesInFastSync can be set to false.", DefaultValue = "false")]
         public bool NonValidatorNode { get; set; }
+
+        [ConfigItem(Description = "[EXPERIMENTAL] Optimize db for write during sync. Significantly reduce total writes written and some sync time if you are not network limited.", DefaultValue = "false")]
+        public bool EnableDbOptimizer { get; set; }
+
+        [ConfigItem(Description = "[EXPERIMENTAL] Optimize for total writes written even further, resulting in minimum writes written and final db size, but triggers a very long rocksdb compaction. This can increase overall sync time.", DefaultValue = "false")]
+        public bool OptimizeDbForWriteAmplification { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
@@ -5,6 +5,7 @@ using System;
 using Nethermind.Config;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
+using Nethermind.Db;
 using Nethermind.Int256;
 using Nethermind.Serialization.Json;
 
@@ -88,10 +89,7 @@ namespace Nethermind.Blockchain.Synchronization
         [ConfigItem(Description = "[EXPERIMENTAL] Only for non validator nodes! If set to true, DownloadReceiptsInFastSync and/or DownloadBodiesInFastSync can be set to false.", DefaultValue = "false")]
         public bool NonValidatorNode { get; set; }
 
-        [ConfigItem(Description = "[EXPERIMENTAL] Optimize db for write during sync. Significantly reduce total writes written and some sync time if you are not network limited.", DefaultValue = "false")]
-        public bool EnableDbOptimizer { get; set; }
-
-        [ConfigItem(Description = "[EXPERIMENTAL] Optimize for total writes written even further, resulting in minimum writes written and final db size, but triggers a very long rocksdb compaction. This can increase overall sync time.", DefaultValue = "false")]
-        public bool OptimizeDbForWriteAmplification { get; set; }
+        [ConfigItem(Description = "[EXPERIMENTAL] Optimize db for write during sync. Significantly reduce total writes written and some sync time if you are not network limited.", DefaultValue = "Default")]
+        public ITunableDb.TuneType TuneDbMode { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
@@ -5,6 +5,7 @@ using System;
 using System.Text;
 using Nethermind.Config;
 using Nethermind.Core;
+using Nethermind.Db;
 
 namespace Nethermind.Blockchain.Synchronization
 {
@@ -44,10 +45,9 @@ namespace Nethermind.Blockchain.Synchronization
         public bool SnapSync { get; set; } = false;
         public bool FixReceipts { get; set; } = false;
         public bool StrictMode { get; set; } = false;
-        public bool EnableDbOptimizer { get; set; } = false;
-        public bool OptimizeDbForWriteAmplification { get; set; } = false;
         public bool BlockGossipEnabled { get; set; } = true;
         public bool NonValidatorNode { get; set; } = false;
+        public ITunableDb.TuneType TuneDbMode { get; set; } = ITunableDb.TuneType.Default;
 
         public override string ToString()
         {

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
@@ -44,6 +44,8 @@ namespace Nethermind.Blockchain.Synchronization
         public bool SnapSync { get; set; } = false;
         public bool FixReceipts { get; set; } = false;
         public bool StrictMode { get; set; } = false;
+        public bool EnableDbOptimizer { get; set; } = false;
+        public bool OptimizeDbForWriteAmplification { get; set; } = false;
         public bool BlockGossipEnabled { get; set; } = true;
         public bool NonValidatorNode { get; set; } = false;
 

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -13,7 +13,7 @@ public class ColumnDb : IDbWithSpan
 {
     private readonly RocksDb _rocksDb;
     private readonly DbOnTheRocks _mainDb;
-    private readonly ColumnFamilyHandle _columnFamily;
+    internal readonly ColumnFamilyHandle _columnFamily;
 
     public ColumnDb(RocksDb rocksDb, DbOnTheRocks mainDb, string name)
     {

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -763,7 +763,7 @@ public class DbOnTheRocks : IDbWithSpan, ITunableDb
             // machine. Specifying a rate limit smoothens this spike somewhat by not blocking writes while allowing
             // compaction to happen in background at 1/10th the specified speed (if rate limited).
             //
-            // Read and writes written on different tune during sync in TB. StateSync omitted but included in total:
+            // Read and writes written on different tune during mainnet sync in TB. StateSync omitted but included in total:
             // +-----------------------------+--------------+--------------+--------------+--------------+
             // | L0FileNumTarget             |  Total (R/W) |     SnapSync |    OldBodies |  OldReceipts |
             // +-----------------------------+--------------+--------------+--------------+--------------+

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -763,19 +763,20 @@ public class DbOnTheRocks : IDbWithSpan, ITunableDb
             // machine. Specifying a rate limit smoothens this spike somewhat by not blocking writes while allowing
             // compaction to happen in background at 1/10th the specified speed (if rate limited).
             //
-            // Read and writes written on different tune during sync:
+            // Read and writes written on different tune during sync in TB. StateSync omitted but included in total:
             // +---------------------------+---------+----------+-----------+-------------+
-            // | Tune                      | Total   | SnapSync | OldBodies | OldReceipts |
+            // | Tune                      | Total (R/W) |     SnapSync |   OldBodies | OldReceipts |
             // +---------------------------+---------+----------+-----------+-------------+
-            // | Default                   | 12.5 |  3.20 TB |   ?.?0 TB |             |
-            // | WriteBias                 | 10.B |  5.68 TB / 2.60 TB |   4.00 TB |     4.00 TB |
-            // | HeavyWrite                |  24.2 / 8.4 |  8.7 / 1.85 TB |   5.95 / 3.12 | 5.9 / 3.4 TB |
-            // | AggressiveHeavyWrite      |  6.0 |  1.20 TB |   2.50 TB |     2.25 TB |
-            // | VeryAggressiveHeavyWrite  |  ?.? |  ?.?? TB |           |             |
-            // | DisableCompaction         |  2.9 |  0.67 TB |           |             |
+            // | Default                   |        12.5 |      3.20 TB |     ?.?0 TB |             |
+            // | WriteBias                 |        10.B |  5.68 / 2.60 | 6.90 / 3.80 |       4.00  |
+            // | HeavyWrite                |  24.2 / 8.4 |   8.7 / 1.85 | 5.95 / 3.12 |   5.9 / 3.4 |
+            // | AggressiveHeavyWrite      |  32.7 / 6.0 |  15.2 / 1.20 | 7.00 / 2.50 |  6.0 / 2.30 |
+            // | VeryAggressiveHeavyWrite  |         ?.? |      ?.?? TB |             |             |
+            // | DisableCompaction         |         2.9 |      0.67 TB |             |             |
             // +---------------------------+---------+----------+-----------+-------------+
-            // Note, in practice on my system, the reads does not reach the SSD. Read measured from SSD is much lower
+            // Note, in practice on my machine, the reads does not reach the SSD. Read measured from SSD is much lower
             // than read measured from process. It is likely that most files are cached as I have 128GB of RAM.
+            // Also notice that the heavier the tune, the higher the reads.
             case ITunableDb.TuneType.WriteBias:
                 // The default l1SizeTarget is 256MB, so the compaction is fairly light. But the default options is not very
                 // efficient for write amplification to conserve memory, so the write amplification reduction is noticeable.

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -756,36 +756,53 @@ public class DbOnTheRocks : IDbWithSpan, ITunableDb
         // See https://github.com/EighteenZi/rocksdb_wiki/blob/master/RocksDB-Tuning-Guide.md
         switch (type)
         {
+            // Depending on tune type, allow num of L0 files to grow causing compaction to occur in larger size. This
+            // reduces write amplification at the expense of read response time and amplification while the tune is
+            // active. Additionally, the larger compaction causes larger spikes of IO. User may not want to enable this
+            // if they plan to run a validator node while the node is still syncing, or run another node on the same
+            // machine. Specifying a rate limit smoothens this spike somewhat by not blocking writes while allowing
+            // compaction to happen in background at 1/10th the specified speed (if rate limited).
+            //
+            // Read and writes written on different tune during sync:
+            // +---------------------------+---------+----------+-----------+-------------+
+            // | Tune                      | Total   | SnapSync | OldBodies | OldReceipts |
+            // +---------------------------+---------+----------+-----------+-------------+
+            // | Default                   | 12.5 |  3.20 TB |   ?.?0 TB |             |
+            // | WriteBias                 | 10.B |  5.68 TB / 2.60 TB |   4.00 TB |     4.00 TB |
+            // | HeavyWrite                |  24.2 / 8.4 |  8.7 / 1.85 TB |   5.95 / 3.12 | 5.9 / 3.4 TB |
+            // | AggressiveHeavyWrite      |  6.0 |  1.20 TB |   2.50 TB |     2.25 TB |
+            // | VeryAggressiveHeavyWrite  |  ?.? |  ?.?? TB |           |             |
+            // | DisableCompaction         |  2.9 |  0.67 TB |           |             |
+            // +---------------------------+---------+----------+-----------+-------------+
+            // Note, in practice on my system, the reads does not reach the SSD. Read measured from SSD is much lower
+            // than read measured from process. It is likely that most files are cached as I have 128GB of RAM.
             case ITunableDb.TuneType.WriteBias:
+                // The default l1SizeTarget is 256MB, so the compaction is fairly light. But the default options is not very
+                // efficient for write amplification to conserve memory, so the write amplification reduction is noticeable.
+                // Does not seems to impact sync performance, might improve sync time slightly if user is IO limited.
                 ApplyOptions(GetHeavyWriteOptions(64, (ulong) 1.GiB()));
                 break;
             case ITunableDb.TuneType.HeavyWrite:
+                // Compaction spikes are clear at this point. Will definitely affect attestation performance.
+                // Its unclear if it improve or slow down sync time. Seems to be the sweet spot.
                 ApplyOptions(GetHeavyWriteOptions(256, (ulong) 5.GiB()));
                 break;
             case ITunableDb.TuneType.AggressiveHeavyWrite:
-                // This still allows for concurrent compaction during write,
-                // although it happens in burst of 1 minute every 5 minute or so instead of all the time.
-                // Note, l1SizeTarget is only 8x more than default, but our write buffer is so low the number of l0
-                // file size is quite high, and normally it will trigger a lot of l0->l1 compaction, causing higher
-                // than standard write amplification
-                //
-                // On goerli, this cut down the total writes during sync from 3.5 TB to 2.4 TB.
-                // On mainnet, 12.5 TB to 7.21 TB.
-                // However, the high burst will increase block processing time during the compaction more than usual.
+                // Large, 1 minute long compaction every 7 minute or so. If you don't specify a ratelimiter, snap sync
+                // effectively hang during this 1 minute and snap pivot change every time. Likely slow down sync time.
                 ApplyOptions(GetHeavyWriteOptions(512, (ulong) 20.GiB()));
                 break;
+            case ITunableDb.TuneType.VeryAggressiveHeavyWrite:
+                ApplyOptions(GetHeavyWriteOptions(1024, (ulong) 50.GiB()));
+                break;
             case ITunableDb.TuneType.DisableCompaction:
-                // Originally, I thought of completely disabling compaction. But blocks db did not complete compaction
-                // even after 4 hours.
-                //
-                // In this config, read response time would be slow to a halt. If any peer send a GetNodeData request,
-                // that request will likely hang, blocking the single threaded network pipeline temporarily, causing
-                // peer drops. Final compaction will take about 30 minute, per stage, which tend to increase total sync
-                // time. If you don't set max open file, there is a good chance that it will crash on mainnet.
-                // However, this allow for minimum write and space amplification.
-                // On goerli, this cut down the total writes during sync from 3.5 TB to 1.4 TB
-                // On mainnet, 12.5 TB to X TB
-
+                // Completely disable compaction. On mainnet, max num of l0 files for state seems to be about 5400.
+                // Snap sync performance suffer as it does have some read during sync. If you don't specify
+                // a lower open files limit, it has a tendency to crash. Also, if a peer send a packet that causes a query
+                // to the state db during snap sync like GetNodeData or some of the tx filter querying state, It'll cause
+                // the network stack to hang and triggers a large peer drops. Also happens on lesser tune, but weaker.
+                // With all those cons, this result in the minimum write amplification possible via tweaking compaction.
+                // Not recommended for mainnet, unless you are desperate.
                 IDictionary<string, string> heavyWriteOption = GetHeavyWriteOptions(10000, (ulong) 100.GiB());
                 heavyWriteOption["disable_auto_compactions"] = "true";
                 ApplyOptions(heavyWriteOption);
@@ -815,6 +832,9 @@ public class DbOnTheRocks : IDbWithSpan, ITunableDb
 
             { "max_bytes_for_level_base", 256.MiB().ToString() },
             { "disable_auto_compactions", "false" },
+
+            { "soft_pending_compaction_bytes_limit", 64.GiB().ToString() },
+            { "hard_pending_compaction_bytes_limit", 256.GiB().ToString() },
         };
     }
 
@@ -825,15 +845,14 @@ public class DbOnTheRocks : IDbWithSpan, ITunableDb
     /// </summary>
     /// <param name="l0FileNumTarget">
     ///  This caps the maximum allowed number of l0 files, which is also the read response time amplification.
-    ///  Most of the time, the l1SizeTarget will take into effect first, but for some db, like code, this limit
-    ///  will be reached first. Fox reference, in goerli: code db reach this limit, statedb limit is 64 file when
-    ///  l1SizeTarget is 5 GB.
+    ///  Sometimes, l1SizeTarget will take into effect first, but for some db, like code, this limit
+    ///  will be reached first. It depends on the size of l0 files which seems to be its write buffer size * 2.
     /// </param>
     /// <param name="l1SizeTarget">
     ///  Specify a target size for l1. This target how much the l0->l1 will need to compact, which control
-    ///  how often and how long do each compaction take, and also effect write amplification. .
+    ///  how often and how long do each compaction take, and also effect write amplification.
     ///
-    ///  Contrary to the doc, l0->l1 compaction will still get trigger at l1 size even if l0 file num is not triggered.
+    ///  Contrary to the doc, l0->l1 compaction still seems to get triggered at l1 size even if l0 file num is not triggered.
     ///  Anyway, its recommended to set this the same size as l0 anyway.
     /// </param>
     /// <returns></returns>
@@ -841,10 +860,18 @@ public class DbOnTheRocks : IDbWithSpan, ITunableDb
     {
         return new Dictionary<string, string>()
         {
-            { "level0_file_num_compaction_trigger", l0FileNumTarget.ToString() },
-            { "level0_slowdown_writes_trigger", (l0FileNumTarget * 2).ToString() },
-            { "level0_stop_writes_trigger", (l0FileNumTarget * 2).ToString() },
             { "max_bytes_for_level_base", l1SizeTarget.ToString() },
+
+            { "level0_file_num_compaction_trigger", l0FileNumTarget.ToString() },
+
+            // Note: If ratelimiter is not specified and if delayed_write_rate is not specified, the default is 16MBps.
+            //   which basically means it'll hang.
+            { "level0_slowdown_writes_trigger", (l0FileNumTarget * 2).ToString() },
+            { "level0_stop_writes_trigger", (l0FileNumTarget * 4).ToString() },
+
+            // Very high, so slowdown is only triggered by file num. Make things easier to predict.
+            { "soft_pending_compaction_bytes_limit", 100000.GiB().ToString() },
+            { "hard_pending_compaction_bytes_limit", 100000.GiB().ToString() },
         };
     }
 }

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -814,7 +814,7 @@ public class DbOnTheRocks : IDbWithSpan, ITunableDb
 
     /// <summary>
     /// Allow num of l0 file to grow very large. This dramatically increase read response time by about
-    /// (l0FileNumTarget / (default num (4) + max level usually (4)). but it saves bandwidth as l0->l1 happens
+    /// (l0FileNumTarget / (default num (4) + max level usually (4)). but it saves write bandwidth as l0->l1 happens
     /// in larger size.
     /// </summary>
     /// <param name="l0FileNumTarget">

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -756,7 +756,13 @@ public class DbOnTheRocks : IDbWithSpan, ITunableDb
         // See https://github.com/EighteenZi/rocksdb_wiki/blob/master/RocksDB-Tuning-Guide.md
         switch (type)
         {
+            case ITunableDb.TuneType.WriteBias:
+                ApplyOptions(GetHeavyWriteOptions(64, (ulong) 1.GiB()));
+                break;
             case ITunableDb.TuneType.HeavyWrite:
+                ApplyOptions(GetHeavyWriteOptions(256, (ulong) 5.GiB()));
+                break;
+            case ITunableDb.TuneType.AggressiveHeavyWrite:
                 // This still allows for concurrent compaction during write,
                 // although it happens in burst of 1 minute every 5 minute or so instead of all the time.
                 // Note, l1SizeTarget is only 8x more than default, but our write buffer is so low the number of l0
@@ -766,9 +772,9 @@ public class DbOnTheRocks : IDbWithSpan, ITunableDb
                 // On goerli, this cut down the total writes during sync from 3.5 TB to 2.4 TB.
                 // On mainnet, 12.5 TB to 7.21 TB.
                 // However, the high burst will increase block processing time during the compaction more than usual.
-                ApplyOptions(GetHeavyWriteOptions(500, (ulong) 5.GiB()));
+                ApplyOptions(GetHeavyWriteOptions(512, (ulong) 20.GiB()));
                 break;
-            case ITunableDb.TuneType.OptimizeWriteAmplification:
+            case ITunableDb.TuneType.DisableCompaction:
                 // Originally, I thought of completely disabling compaction. But blocks db did not complete compaction
                 // even after 4 hours.
                 //

--- a/src/Nethermind/Nethermind.Db/FullPruning/FullPruningDb.cs
+++ b/src/Nethermind/Nethermind.Db/FullPruning/FullPruningDb.cs
@@ -21,7 +21,7 @@ namespace Nethermind.Db.FullPruning
     /// When <see cref="IPruningContext"/> returned in <see cref="TryStartPruning"/> is <see cref="IDisposable.Dispose"/>d it will delete the pruning DB if the pruning was not successful.
     /// It uses <see cref="IRocksDbFactory"/> to create new pruning DB's. Check <see cref="FullPruningInnerDbFactory"/> to see how inner sub DB's are organised.
     /// </remarks>
-    public class FullPruningDb : IDb, IFullPruningDb
+    public class FullPruningDb : IDb, IFullPruningDb, ITunableDb
     {
         private readonly RocksDbSettings _settings;
         private readonly IRocksDbFactory _dbFactory;
@@ -268,6 +268,14 @@ namespace Nethermind.Db.FullPruning
                     _batch[key] = value;
                     _db.Duplicate(_clonedBatch, key, value);
                 }
+            }
+        }
+
+        public void Tune(ITunableDb.TuneType type)
+        {
+            if (_currentDb is ITunableDb tunableDb)
+            {
+                tunableDb.Tune(type);
             }
         }
     }

--- a/src/Nethermind/Nethermind.Db/ITunableDb.cs
+++ b/src/Nethermind/Nethermind.Db/ITunableDb.cs
@@ -3,7 +3,7 @@
 
 namespace Nethermind.Db;
 
-public interface ITunableDb
+public interface ITunableDb: IDb
 {
     public void Tune(TuneType type);
 

--- a/src/Nethermind/Nethermind.Db/ITunableDb.cs
+++ b/src/Nethermind/Nethermind.Db/ITunableDb.cs
@@ -13,6 +13,7 @@ public interface ITunableDb
         WriteBias,
         HeavyWrite,
         AggressiveHeavyWrite,
+        VeryAggressiveHeavyWrite,
         DisableCompaction,
     }
 }

--- a/src/Nethermind/Nethermind.Db/ITunableDb.cs
+++ b/src/Nethermind/Nethermind.Db/ITunableDb.cs
@@ -9,8 +9,10 @@ public interface ITunableDb
 
     enum TuneType
     {
+        Default,
+        WriteBias,
         HeavyWrite,
-        OptimizeWriteAmplification,
-        Default
+        AggressiveHeavyWrite,
+        DisableCompaction,
     }
 }

--- a/src/Nethermind/Nethermind.Db/ITunableDb.cs
+++ b/src/Nethermind/Nethermind.Db/ITunableDb.cs
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.Db;
+
+public interface ITunableDb
+{
+    public void Tune(TuneType type);
+
+    enum TuneType
+    {
+        HeavyWrite,
+        OptimizeWriteAmplification,
+        Default
+    }
+}

--- a/src/Nethermind/Nethermind.Synchronization.Test/DbTuner/SyncDbTunerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/DbTuner/SyncDbTunerTests.cs
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Blockchain.Synchronization;
+using Nethermind.Db;
+using Nethermind.Synchronization.DbTuner;
+using Nethermind.Synchronization.FastBlocks;
+using Nethermind.Synchronization.FastSync;
+using Nethermind.Synchronization.ParallelSync;
+using Nethermind.Synchronization.SnapSync;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Synchronization.Test.DbTuner;
+
+public class SyncDbTunerTests
+{
+    private ITunableDb.TuneType _tuneType = ITunableDb.TuneType.HeavyWrite;
+    private SyncConfig _syncConfig = null!;
+    private ISyncFeed<SnapSyncBatch>? _snapSyncFeed;
+    private ISyncFeed<BodiesSyncBatch>? _bodiesSyncFeed;
+    private ISyncFeed<ReceiptsSyncBatch>? _receiptSyncFeed;
+    private ITunableDb _stateDb = null!;
+    private ITunableDb _codeDb = null!;
+    private ITunableDb _blockDb = null!;
+    private ITunableDb _receiptDb = null!;
+    private SyncDbTuner _tuner = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _tuneType = ITunableDb.TuneType.HeavyWrite;
+        _syncConfig = new SyncConfig()
+        {
+            TuneDbMode = _tuneType
+        };
+        _snapSyncFeed = Substitute.For<ISyncFeed<SnapSyncBatch>?>();
+        _bodiesSyncFeed = Substitute.For<ISyncFeed<BodiesSyncBatch>?>();
+        _receiptSyncFeed = Substitute.For<ISyncFeed<ReceiptsSyncBatch>?>();
+        _stateDb = Substitute.For<ITunableDb>();
+        _codeDb = Substitute.For<ITunableDb>();
+        _blockDb = Substitute.For<ITunableDb>();
+        _receiptDb = Substitute.For<ITunableDb>();
+
+        _tuner = new SyncDbTuner(
+            _syncConfig,
+            _snapSyncFeed,
+            _bodiesSyncFeed,
+            _receiptSyncFeed,
+            _stateDb,
+            _codeDb,
+            _blockDb,
+            _receiptDb);
+    }
+
+    [Test]
+    public void WhenSnapIsOn_TriggerStateDbTune()
+    {
+        TestFeedAndDbTune(_snapSyncFeed, _stateDb);
+    }
+
+    [Test]
+    public void WhenSnapIsOn_TriggerCodeDbTune()
+    {
+        TestFeedAndDbTune(_snapSyncFeed, _codeDb);
+    }
+
+    [Test]
+    public void WhenBodiesIsOn_TriggerBlocksDbTune()
+    {
+        TestFeedAndDbTune(_bodiesSyncFeed, _blockDb);
+    }
+
+    [Test]
+    public void WhenReceiptsIsOn_TriggerReceiptsDbTune()
+    {
+        TestFeedAndDbTune(_bodiesSyncFeed, _blockDb);
+    }
+
+    public void TestFeedAndDbTune<T>(ISyncFeed<T> feed, ITunableDb db)
+    {
+        feed.StateChanged += Raise.EventWith(new SyncFeedStateEventArgs(SyncFeedState.Active));
+
+        db.Received().Tune(_tuneType);
+
+        feed.StateChanged += Raise.EventWith(new SyncFeedStateEventArgs(SyncFeedState.Finished));
+
+        db.Received().Tune(ITunableDb.TuneType.Default);
+    }
+}

--- a/src/Nethermind/Nethermind.Synchronization/DbOptimizer/SyncDbOptimizer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/DbOptimizer/SyncDbOptimizer.cs
@@ -52,14 +52,7 @@ public class DbSyncOptimizer
         _blockDb = blockDb;
         _receiptDb = receiptDb;
 
-        if (syncConfig.OptimizeDbForWriteAmplification)
-        {
-            _tuneType = ITunableDb.TuneType.OptimizeWriteAmplification;
-        }
-        else
-        {
-            _tuneType = ITunableDb.TuneType.HeavyWrite;
-        }
+        _tuneType = syncConfig.TuneDbMode;
     }
 
     private void SnapStateChanged(object? sender, SyncFeedStateEventArgs e)

--- a/src/Nethermind/Nethermind.Synchronization/DbOptimizer/SyncDbOptimizer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/DbOptimizer/SyncDbOptimizer.cs
@@ -1,0 +1,126 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Blockchain.Synchronization;
+using Nethermind.Db;
+using Nethermind.Synchronization.FastBlocks;
+using Nethermind.Synchronization.ParallelSync;
+using Nethermind.Synchronization.SnapSync;
+
+namespace Nethermind.Synchronization;
+
+public class DbSyncOptimizer
+{
+    private readonly IDb _stateDb;
+    private readonly IDb _codeDb;
+    private readonly IDb _blockDb;
+    private readonly IDb _receiptDb;
+
+    private ITunableDb.TuneType _tuneType;
+
+    public DbSyncOptimizer(
+        ISyncConfig syncConfig,
+        ISyncFeed<SnapSyncBatch>? snapSyncFeed,
+        ISyncFeed<BodiesSyncBatch>? bodiesSyncFeed,
+        ISyncFeed<ReceiptsSyncBatch>? receiptSyncFeed,
+        IDb stateDb,
+        IDb codeDb,
+        IDb blockDb,
+        IDb receiptDb
+    )
+    {
+        // Only these three make sense as they are write heavy
+        // Headers is used everywhere, so slowing read might slow the whole sync.
+        // Statesync is read heavy, Forward sync is just plain too slow to saturate IO.
+        if (snapSyncFeed != null)
+        {
+            snapSyncFeed.StateChanged += SnapStateChanged;
+        }
+
+        if (bodiesSyncFeed != null)
+        {
+            bodiesSyncFeed.StateChanged += BodiesStateChanged;
+        }
+
+        if (receiptSyncFeed != null)
+        {
+            receiptSyncFeed.StateChanged += ReceiptsStateChanged;
+        }
+
+        _stateDb = stateDb;
+        _codeDb = codeDb;
+        _blockDb = blockDb;
+        _receiptDb = receiptDb;
+
+        if (syncConfig.OptimizeDbForWriteAmplification)
+        {
+            _tuneType = ITunableDb.TuneType.OptimizeWriteAmplification;
+        }
+        else
+        {
+            _tuneType = ITunableDb.TuneType.HeavyWrite;
+        }
+    }
+
+    private void SnapStateChanged(object? sender, SyncFeedStateEventArgs e)
+    {
+        if (e.NewState == SyncFeedState.Active)
+        {
+            if (_stateDb is ITunableDb stateDb)
+            {
+                stateDb.Tune(_tuneType);
+            }
+            if (_codeDb is ITunableDb codeDb)
+            {
+                codeDb.Tune(_tuneType);
+            }
+        }
+        else if (e.NewState == SyncFeedState.Finished)
+        {
+            if (_stateDb is ITunableDb stateDb)
+            {
+                stateDb.Tune(ITunableDb.TuneType.Default);
+            }
+            if (_codeDb is ITunableDb codeDb)
+            {
+                codeDb.Tune(ITunableDb.TuneType.Default);
+            }
+        }
+    }
+
+    private void BodiesStateChanged(object? sender, SyncFeedStateEventArgs e)
+    {
+        if (e.NewState == SyncFeedState.Active)
+        {
+            if (_blockDb is ITunableDb blockDb)
+            {
+                blockDb.Tune(_tuneType);
+            }
+        }
+        else if (e.NewState == SyncFeedState.Finished)
+        {
+            if (_blockDb is ITunableDb blockDb)
+            {
+                blockDb.Tune(ITunableDb.TuneType.Default);
+            }
+        }
+    }
+
+    private void ReceiptsStateChanged(object? sender, SyncFeedStateEventArgs e)
+    {
+        if (e.NewState == SyncFeedState.Active)
+        {
+            if (_receiptDb is ITunableDb receiptDb)
+            {
+                receiptDb.Tune(_tuneType);
+            }
+        }
+        else if (e.NewState == SyncFeedState.Finished)
+        {
+            if (_receiptDb is ITunableDb receiptDb)
+            {
+                receiptDb.Tune(ITunableDb.TuneType.Default);
+            }
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Synchronization/DbTuner/SyncDbOptimizer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/DbTuner/SyncDbOptimizer.cs
@@ -7,9 +7,9 @@ using Nethermind.Synchronization.FastBlocks;
 using Nethermind.Synchronization.ParallelSync;
 using Nethermind.Synchronization.SnapSync;
 
-namespace Nethermind.Synchronization;
+namespace Nethermind.Synchronization.DbTuner;
 
-public class DbSyncOptimizer
+public class SyncDbTuner
 {
     private readonly IDb _stateDb;
     private readonly IDb _codeDb;
@@ -18,7 +18,7 @@ public class DbSyncOptimizer
 
     private ITunableDb.TuneType _tuneType;
 
-    public DbSyncOptimizer(
+    public SyncDbTuner(
         ISyncConfig syncConfig,
         ISyncFeed<SnapSyncBatch>? snapSyncFeed,
         ISyncFeed<BodiesSyncBatch>? bodiesSyncFeed,

--- a/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
@@ -14,6 +14,7 @@ using Nethermind.Logging;
 using Nethermind.Stats;
 using Nethermind.Stats.Model;
 using Nethermind.Synchronization.Blocks;
+using Nethermind.Synchronization.DbTuner;
 using Nethermind.Synchronization.FastBlocks;
 using Nethermind.Synchronization.FastSync;
 using Nethermind.Synchronization.ParallelSync;
@@ -122,7 +123,7 @@ namespace Nethermind.Synchronization
 
         private void SetupDbOptimizer()
         {
-            new DbSyncOptimizer(_syncConfig, _snapSyncFeed, _bodiesFeed, _receiptsFeed, _dbProvider.StateDb, _dbProvider.CodeDb,
+            new SyncDbTuner(_syncConfig, _snapSyncFeed, _bodiesFeed, _receiptsFeed, _dbProvider.StateDb, _dbProvider.CodeDb,
                 _dbProvider.BlocksDb, _dbProvider.ReceiptsDb);
         }
 

--- a/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
@@ -203,7 +203,7 @@ namespace Nethermind.Synchronization
             {
                 if (_syncConfig.DownloadBodiesInFastSync)
                 {
-                    _bodiesFeed = new BodiesSyncFeed(_syncMode, _blockTree, _syncPeerPool, _syncConfig, _syncReport, _specProvider,  _logManager);
+                    _bodiesFeed = new BodiesSyncFeed(_syncMode, _blockTree, _syncPeerPool, _syncConfig, _syncReport, _specProvider, _logManager);
                     BodiesSyncDispatcher bodiesDispatcher = new(_bodiesFeed!, _syncPeerPool, fastFactory, _logManager);
                     Task bodiesTask = bodiesDispatcher.Start(_syncCancellation.Token).ContinueWith(t =>
                     {

--- a/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
@@ -114,7 +114,7 @@ namespace Nethermind.Synchronization
                 StartStateSyncComponents();
             }
 
-            if (_syncConfig.EnableDbOptimizer)
+            if (_syncConfig.TuneDbMode != ITunableDb.TuneType.Default)
             {
                 SetupDbOptimizer();
             }

--- a/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
@@ -113,6 +113,17 @@ namespace Nethermind.Synchronization
 
                 StartStateSyncComponents();
             }
+
+            if (_syncConfig.EnableDbOptimizer)
+            {
+                SetupDbOptimizer();
+            }
+        }
+
+        private void SetupDbOptimizer()
+        {
+            new DbSyncOptimizer(_syncConfig, _snapSyncFeed, _bodiesFeed, _receiptsFeed, _dbProvider.StateDb, _dbProvider.CodeDb,
+                _dbProvider.BlocksDb, _dbProvider.ReceiptsDb);
         }
 
         private void StartFullSyncComponents()
@@ -191,7 +202,7 @@ namespace Nethermind.Synchronization
             {
                 if (_syncConfig.DownloadBodiesInFastSync)
                 {
-                    _bodiesFeed = new BodiesSyncFeed(_syncMode, _blockTree, _syncPeerPool, _syncConfig, _syncReport, _specProvider, _logManager);
+                    _bodiesFeed = new BodiesSyncFeed(_syncMode, _blockTree, _syncPeerPool, _syncConfig, _syncReport, _specProvider,  _logManager);
                     BodiesSyncDispatcher bodiesDispatcher = new(_bodiesFeed!, _syncPeerPool, fastFactory, _logManager);
                     Task bodiesTask = bodiesDispatcher.Start(_syncCancellation.Token).ContinueWith(t =>
                     {


### PR DESCRIPTION
- It turns out if you keep syncing mainnet multiple times because you know.. you wanna try something that might improve sync time, it will eat up your SSD's write endurance pretty quickly. 
- This add an option that changes some rocksdb tuning during sync to reduce write amplification, resulting in a much lower write amplification at various other expense. The tune goes back to default after the different sync stage complete.
- Depending on options, may speed up or slow down sync time, or sometimes event hang your system. But at least it saves you some SSD money.

## Changes

- Add a parameter `--Sync.TuneDbMode` with values `WriteBias`, `HeavyWrite`, `AggressiveHeavyWrite` and `DisableCompaction` which increasingly reduces write amplification at expense of read amplification and response time and some stability.

## Types of changes

#### What types of changes does your code introduce?

- [X] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Well, multiple mainnet sync. Thats how I got the numbers for the comment. Except for the `DisableCompaction` options, which have not finished yet.... 
