### PR TITLE
Fix posdao tests - disable filters only if there is priority contract

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/InitializeBlockchainAuRa.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/InitializeBlockchainAuRa.cs
@@ -278,7 +278,8 @@ namespace Nethermind.Consensus.AuRa.InitializationSteps
                 _api.TxValidator,
                 _api.LogManager,
                 CreateTxPoolTxComparer(txPriorityContract, localDataSource),
-                new TxFilterAdapter(_api.BlockTree, txPoolFilter, _api.LogManager));
+                new TxFilterAdapter(_api.BlockTree, txPoolFilter, _api.LogManager),
+                txPriorityContract is not null);
         }
 
         private void ReportTxPriorityRules(TxPriorityContract? txPriorityContract, TxPriorityContract.LocalDataSource? localDataSource)

--- a/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/InitializeBlockchainAuRa.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/InitializeBlockchainAuRa.cs
@@ -279,7 +279,7 @@ namespace Nethermind.Consensus.AuRa.InitializationSteps
                 _api.LogManager,
                 CreateTxPoolTxComparer(txPriorityContract, localDataSource),
                 new TxFilterAdapter(_api.BlockTree, txPoolFilter, _api.LogManager),
-                txPriorityContract is not null);
+                txPriorityContract is not null || localDataSource is not null);
         }
 
         private void ReportTxPriorityRules(TxPriorityContract? txPriorityContract, TxPriorityContract.LocalDataSource? localDataSource)

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -1447,6 +1447,38 @@ namespace Nethermind.TxPool.Test
             _txPool.SubmitTx(txA, TxHandlingOptions.None).Should().Be(AcceptTxResult.Accepted);
         }
 
+        [TestCase(true, 1, 1, true)]
+        [TestCase(true, 1, 0, true)]
+        [TestCase(true, 0, 0, true)]
+        [TestCase(false, 1, 1, true)]
+        [TestCase(false, 1, 0, false)]
+        [TestCase(false, 0, 0, false)]
+        public void Should_filter_txs_depends_on_priority_contract(bool thereIsPriorityContract, int balance, int fee, bool shouldBeAccepted)
+        {
+            ISpecProvider specProvider = GetLondonSpecProvider();
+            _txPool = CreatePool(specProvider: specProvider, thereIsPriorityContract: thereIsPriorityContract);
+            EnsureSenderBalance(TestItem.AddressF, (UInt256)balance * GasCostOf.Transaction);
+
+            Transaction zeroCostTx = Build.A.Transaction
+                .WithNonce(0)
+                .WithValue(0)
+                .WithType(TxType.EIP1559)
+                .WithMaxFeePerGas((UInt256)fee)
+                .WithMaxPriorityFeePerGas((UInt256)fee)
+                .WithTo(TestItem.AddressB)
+                .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyF).TestObject;
+
+            AcceptTxResult result = _txPool.SubmitTx(zeroCostTx, TxHandlingOptions.None);
+            if (shouldBeAccepted)
+            {
+                result.Should().Be(AcceptTxResult.Accepted);
+            }
+            else
+            {
+                result.Should().NotBe(AcceptTxResult.Accepted);
+            }
+        }
+
         private IDictionary<ITxPoolPeer, PrivateKey> GetPeers(int limit = 100)
         {
             var peers = new Dictionary<ITxPoolPeer, PrivateKey>();
@@ -1465,7 +1497,8 @@ namespace Nethermind.TxPool.Test
             ITxPoolConfig config = null,
             ISpecProvider specProvider = null,
             ChainHeadInfoProvider chainHeadInfoProvider = null,
-            IIncomingTxFilter incomingTxFilter = null)
+            IIncomingTxFilter incomingTxFilter = null,
+            bool thereIsPriorityContract = false)
         {
             specProvider ??= RopstenSpecProvider.Instance;
             ITransactionComparerProvider transactionComparerProvider =
@@ -1484,7 +1517,8 @@ namespace Nethermind.TxPool.Test
                 new TxValidator(_specProvider.ChainId),
                 _logManager,
                 transactionComparerProvider.GetDefaultComparer(),
-                incomingTxFilter);
+                incomingTxFilter,
+                thereIsPriorityContract);
         }
 
         private ITxPoolPeer GetPeer(PublicKey publicKey)

--- a/src/Nethermind/Nethermind.TxPool/Filters/BalanceZeroFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/BalanceZeroFilter.cs
@@ -12,10 +12,12 @@ namespace Nethermind.TxPool.Filters
     /// </summary>
     internal sealed class BalanceZeroFilter : IIncomingTxFilter
     {
+        private readonly bool _thereIsPriorityContract;
         private readonly ILogger _logger;
 
-        public BalanceZeroFilter(ILogger logger)
+        public BalanceZeroFilter(bool thereIsPriorityContract, ILogger logger)
         {
+            _thereIsPriorityContract = thereIsPriorityContract;
             _logger = logger;
         }
 
@@ -25,7 +27,7 @@ namespace Nethermind.TxPool.Filters
             UInt256 balance = account.Balance;
 
             bool isNotLocal = (handlingOptions & TxHandlingOptions.PersistentBroadcast) == 0;
-            if (!tx.IsFree() && balance.IsZero)
+            if (!_thereIsPriorityContract && !tx.IsFree() && balance.IsZero)
             {
                 Metrics.PendingTransactionsZeroBalance++;
                 return isNotLocal ?

--- a/src/Nethermind/Nethermind.TxPool/Filters/FeeTooLowFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/FeeTooLowFilter.cs
@@ -42,7 +42,7 @@ namespace Nethermind.TxPool.Filters
             bool isEip1559Enabled = spec.IsEip1559Enabled;
             UInt256 affordableGasPrice = tx.CalculateGasPrice(isEip1559Enabled, _headInfo.CurrentBaseFee);
             // Don't accept zero fee txns even if pool is empty as will never run
-            if (!_thereIsPriorityContract && !tx.IsFree() && affordableGasPrice.IsZero)
+            if (isEip1559Enabled && !_thereIsPriorityContract && !tx.IsFree() && affordableGasPrice.IsZero)
             {
                 Metrics.PendingTransactionsTooLowFee++;
                 if (_logger.IsTrace) _logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, too low payable gas price with options {handlingOptions} from {new StackTrace()}");


### PR DESCRIPTION
Another approach for https://github.com/NethermindEth/nethermind/pull/5409

I don't really like passing bool flag to TxPool, but don't have better idea. Open for suggestions.

## Changes

If there is priority contract:
- change `BalanceZeroFilter` to not filter out any transactions because of zero balance of sender account
- remove zero fee check

Tests are passing from this branch:
https://github.com/NethermindEth/nethermind/actions/runs/4377073528/jobs/7660066366

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No