### PR TITLE
Snapsync boundary status removed from TrieNode

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedHealingTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedHealingTests.cs
@@ -13,6 +13,7 @@ using Nethermind.State.Proofs;
 using Nethermind.State.Snap;
 using Nethermind.Synchronization.FastSync;
 using Nethermind.Synchronization.SnapSync;
+using Nethermind.Trie;
 using NUnit.Framework;
 
 namespace Nethermind.Synchronization.Test.FastSync
@@ -164,7 +165,7 @@ namespace Nethermind.Synchronization.Test.FastSync
             remoteStateTree.Accept(accountProofCollector, remoteStateTree.RootHash);
             byte[][] lastProof = accountProofCollector.BuildResult().Proof;
 
-            (_, _, _, _) = SnapProviderHelper.AddAccountRange(localStateTree, blockNumber, rootHash, startingHash, limitHash, accounts, firstProof!.Concat(lastProof!).ToArray());
+            (_, _, _, _) = SnapProviderHelper.AddAccountRange(localStateTree, blockNumber, rootHash, startingHash, limitHash, accounts, new HashSet<TrieNode>(), firstProof!.Concat(lastProof!).ToArray());
         }
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/RecreateStateFromAccountRangesTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/RecreateStateFromAccountRangesTests.cs
@@ -332,10 +332,12 @@ namespace Nethermind.Synchronization.Test.SnapSync
 
             PathWithAccount[] receiptAccounts = TestItem.Tree.AccountsWithPaths[0..2];
 
+            HashSet<TrieNode> boundaryProofNodes = new();
+
             bool HasMoreChildren(Keccak limitHash)
             {
                 (AddRangeResult _, bool moreChildrenToRight, IList<PathWithAccount> _, IList<Keccak> _) =
-                    SnapProviderHelper.AddAccountRange(newTree, 0, rootHash, Keccak.Zero, limitHash, receiptAccounts, proofs);
+                    SnapProviderHelper.AddAccountRange(newTree, 0, rootHash, Keccak.Zero, limitHash, receiptAccounts, boundaryProofNodes, proofs);
                 return moreChildrenToRight;
             }
 
@@ -386,10 +388,11 @@ namespace Nethermind.Synchronization.Test.SnapSync
 
             PathWithAccount[] receiptAccounts = { ac1, ac2 };
 
+            HashSet<TrieNode> boundaryProofNodes = new();
             bool HasMoreChildren(Keccak limitHash)
             {
                 (AddRangeResult _, bool moreChildrenToRight, IList<PathWithAccount> _, IList<Keccak> _) =
-                    SnapProviderHelper.AddAccountRange(newTree, 0, rootHash, Keccak.Zero, limitHash, receiptAccounts, proofs);
+                    SnapProviderHelper.AddAccountRange(newTree, 0, rootHash, Keccak.Zero, limitHash, receiptAccounts, boundaryProofNodes, proofs);
                 return moreChildrenToRight;
             }
 

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProviderHelper.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProviderHelper.cs
@@ -315,24 +315,13 @@ namespace Nethermind.Synchronization.SnapSync
 
                     if (node.IsBranch)
                     {
-                        bool isBoundaryProofNode = false;
                         for (int ci = 0; ci <= 15; ci++)
                         {
                             if (!IsChildPersisted(node, ci, store, boundaryProofNodes))
                             {
                                 boundaryProofNodes.Add(node);
-                                isBoundaryProofNode = true;
                                 break;
                             }
-                        }
-
-                        if (isBoundaryProofNode)
-                        {
-                            boundaryProofNodes.Add(node);
-                        }
-                        else
-                        {
-                            boundaryProofNodes.Remove(node);
                         }
                     }
                 }

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProviderHelper.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProviderHelper.cs
@@ -315,13 +315,20 @@ namespace Nethermind.Synchronization.SnapSync
 
                     if (node.IsBranch)
                     {
+                        bool isBoundaryProofNode = false;
                         for (int ci = 0; ci <= 15; ci++)
                         {
                             if (!IsChildPersisted(node, ci, store, boundaryProofNodes))
                             {
+                                isBoundaryProofNode = true;
                                 boundaryProofNodes.Add(node);
                                 break;
                             }
+                        }
+
+                        if (isBoundaryProofNode == false)
+                        {
+                            boundaryProofNodes.Remove(node);
                         }
                     }
                 }

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -144,7 +144,7 @@ namespace Nethermind.Trie
                 {
                     if (_logger.IsTrace) _logger.Trace($"Committing {node} in {blockNumber}");
 
-                    if (nodesToSkip != null && !nodesToSkip.Contains(node.Node))
+                    if (nodesToSkip == null || !nodesToSkip.Contains(node.Node))
                     {
                         TrieStore.CommitNode(blockNumber, node);
                     }

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -124,7 +124,7 @@ namespace Nethermind.Trie
             }
         }
 
-        public void Commit(long blockNumber, bool skipRoot = false)
+        public void Commit(long blockNumber, bool skipRoot = false, IReadOnlySet<TrieNode>? nodesToSkip = default)
         {
             if (_currentCommit is null)
             {
@@ -143,7 +143,11 @@ namespace Nethermind.Trie
                 while (_currentCommit.TryDequeue(out NodeCommitInfo node))
                 {
                     if (_logger.IsTrace) _logger.Trace($"Committing {node} in {blockNumber}");
-                    TrieStore.CommitNode(blockNumber, node);
+
+                    if (nodesToSkip != null && !nodesToSkip.Contains(node.Node))
+                    {
+                        TrieStore.CommitNode(blockNumber, node);
+                    }
                 }
 
                 // reset objects
@@ -909,7 +913,7 @@ namespace Nethermind.Trie
         private byte[] TraverseNext(in TraverseContext traverseContext, int extensionLength, TrieNode next)
         {
             // Move large struct creation out of flow so doesn't force additional stack space
-            // in calling method even if not used 
+            // in calling method even if not used
             TraverseContext newContext = traverseContext.WithNewIndex(traverseContext.CurrentIndex + extensionLength);
             return TraverseNode(next, in newContext);
         }

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -210,7 +210,7 @@ namespace Nethermind.Trie.Pruning
             EnsureCommitSetExistsForBlock(blockNumber);
 
             if (_logger.IsTrace) _logger.Trace($"Committing {nodeCommitInfo} at {blockNumber}");
-            if (!nodeCommitInfo.IsEmptyBlockMarker && !nodeCommitInfo.Node.IsBoundaryProofNode)
+            if (!nodeCommitInfo.IsEmptyBlockMarker)
             {
                 TrieNode node = nodeCommitInfo.Node!;
 

--- a/src/Nethermind/Nethermind.Trie/TrieNode.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.cs
@@ -25,8 +25,6 @@ namespace Nethermind.Trie
 
         public int Id = Interlocked.Increment(ref _idCounter);
 #endif
-        public bool IsBoundaryProofNode { get; set; }
-
         private TrieNode? _storageRoot;
         private static object _nullNode = new();
         private static TrieNodeDecoder _nodeDecoder = new();


### PR DESCRIPTION
This PR removes the flag `IsBoundaryProofNode` from the `TrieNode` and moves this responsibility to a `HashSet` of nodes that is used solely in the Snapsync. The reason for this is to prepare `TrieNode` to me mostly readonly and separate it from cross-cutting, potentially multi-threaded access.

## Changes

- `TrieNode.IsBoundaryProofNode` removed
- `HashSet<TrieNode>` passing introduced in the snapsync

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

- [x] built to this [image](https://github.com/NethermindEth/nethermind/actions/runs/4383983577)
- [x] deployed to a 'Nethermind-mainnet-prysm'
- [ ] getting synced
- [ ] confirmed synced properly

#### Requires testing

- [ ] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

