### PR TITLE
Account Optimisations

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/SpecificBlockReadOnlyStateProvider.cs
+++ b/src/Nethermind/Nethermind.Blockchain/SpecificBlockReadOnlyStateProvider.cs
@@ -49,6 +49,17 @@ namespace Nethermind.Blockchain
 
         public bool IsEmptyAccount(Address address) => GetAccount(address).IsEmpty;
 
+        public bool IsContract(Address address)
+        {
+            Account? account = GetAccount(address);
+            if (account is null)
+            {
+                return false;
+            }
+
+            return account.IsContract;
+        }
+
         public bool IsDeadAccount(Address address)
         {
             Account account = GetAccount(address);

--- a/src/Nethermind/Nethermind.Core.Test/Builders/TestItem.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Builders/TestItem.cs
@@ -137,9 +137,7 @@ namespace Nethermind.Core.Test.Builders
 
             Account account = new(
                 (UInt256)random.Next(1000),
-                (UInt256)random.Next(1000),
-                Keccak.EmptyTreeHash,
-                Keccak.OfAnEmptyString);
+                (UInt256)random.Next(1000));
 
             return account;
         }
@@ -156,9 +154,7 @@ namespace Nethermind.Core.Test.Builders
         {
             Account account = new(
                 (UInt256)index,
-                (UInt256)index,
-                Keccak.EmptyTreeHash,
-                Keccak.OfAnEmptyString);
+                (UInt256)index);
 
             return account;
         }

--- a/src/Nethermind/Nethermind.Core.Test/Builders/TrieBuilder.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Builders/TrieBuilder.cs
@@ -46,9 +46,7 @@ namespace Nethermind.Core.Test.Builders
         {
             Account account = new(
                 (UInt256)index,
-                (UInt256)index,
-                Keccak.EmptyTreeHash,
-                Keccak.OfAnEmptyString);
+                (UInt256)index);
 
             return account;
         }

--- a/src/Nethermind/Nethermind.Core/Account.cs
+++ b/src/Nethermind/Nethermind.Core/Account.cs
@@ -8,92 +8,159 @@ namespace Nethermind.Core
 {
     public class Account
     {
-        public static Account TotallyEmpty = new();
-
-        private static UInt256 _accountStartNonce = UInt256.Zero;
-
-        /// <summary>
-        /// This is a special field that was used by some of the testnets (namely - Morden and Mordor).
-        /// It makes all the account nonces start from a different number then zero,
-        /// hence preventing potential signature reuse.
-        /// It is no longer needed since the replay attack protection on chain ID is used now.
-        /// We can remove it now but then we also need to remove any historical Mordor / Morden tests.
-        /// </summary>
-        public static UInt256 AccountStartNonce
-        {
-            set
-            {
-                _accountStartNonce = value;
-                TotallyEmpty = new Account();
-            }
-        }
-
-        public Account(UInt256 balance)
-        {
-            Balance = balance;
-            Nonce = _accountStartNonce;
-            CodeHash = Keccak.OfAnEmptyString;
-            StorageRoot = Keccak.EmptyTreeHash;
-            IsTotallyEmpty = Balance.IsZero;
-        }
+        public readonly static Account TotallyEmpty = new();
 
         private Account()
         {
-            Balance = UInt256.Zero;
-            Nonce = _accountStartNonce;
-            CodeHash = Keccak.OfAnEmptyString;
-            StorageRoot = Keccak.EmptyTreeHash;
-            IsTotallyEmpty = true;
+            _nonce = default;
+            _balance = default;
         }
 
-        public Account(in UInt256 nonce, in UInt256 balance, Keccak storageRoot, Keccak codeHash)
+        public Account(in UInt256 balance)
         {
-            Nonce = nonce;
-            Balance = balance;
-            StorageRoot = storageRoot;
-            CodeHash = codeHash;
-            IsTotallyEmpty = Balance.IsZero && Nonce == _accountStartNonce && CodeHash == Keccak.OfAnEmptyString && StorageRoot == Keccak.EmptyTreeHash;
+            _nonce = default;
+            _balance = balance;
         }
 
-        private Account(in UInt256 nonce, in UInt256 balance, Keccak storageRoot, Keccak codeHash, bool isTotallyEmpty)
+        public Account(in UInt256 nonce, in UInt256 balance)
         {
-            Nonce = nonce;
-            Balance = balance;
-            StorageRoot = storageRoot;
-            CodeHash = codeHash;
-            IsTotallyEmpty = isTotallyEmpty;
+            _nonce = nonce;
+            _balance = balance;
         }
 
-        public bool HasCode => !CodeHash.Equals(Keccak.OfAnEmptyString);
+        protected readonly UInt256 _nonce;
+        public UInt256 Nonce => _nonce;
+        protected readonly UInt256 _balance;
+        public UInt256 Balance => _balance;
 
-        public bool HasStorage => !StorageRoot.Equals(Keccak.EmptyTreeHash);
+        public virtual bool HasCode => false;
+        public virtual bool HasStorage => false;
+        public virtual Keccak StorageRoot => Keccak.EmptyTreeHash;
+        public virtual Keccak CodeHash => Keccak.OfAnEmptyString;
+        public virtual bool IsTotallyEmpty => IsEmpty;
+        public virtual bool IsEmpty => Balance.IsZero && Nonce.IsZero;
+        public virtual bool IsContract => false;
 
-        public UInt256 Nonce { get; }
-        public UInt256 Balance { get; }
-        public Keccak StorageRoot { get; }
-        public Keccak CodeHash { get; }
-        public bool IsTotallyEmpty { get; }
-        public bool IsEmpty => IsTotallyEmpty || (Balance.IsZero && Nonce == _accountStartNonce && CodeHash == Keccak.OfAnEmptyString);
-        public bool IsContract => CodeHash != Keccak.OfAnEmptyString;
-
-        public Account WithChangedBalance(in UInt256 newBalance)
+        public static Account CreateAccount(in UInt256 nonce, in UInt256 balance, Keccak storageRoot, Keccak codeHash)
         {
-            return new(Nonce, newBalance, StorageRoot, CodeHash, IsTotallyEmpty && newBalance.IsZero);
+            if (storageRoot == Keccak.EmptyTreeHash)
+            {
+                if (codeHash == Keccak.OfAnEmptyString)
+                {
+                    return new Account(in nonce, in balance);
+                }
+
+                return new ContractAccount(in nonce, in balance, codeHash: codeHash);
+            }
+
+            if (codeHash == Keccak.OfAnEmptyString)
+            {
+                return new ContractAccount(storageRoot: storageRoot, in nonce, in balance);
+            }
+
+            return new ContractAccount(in nonce, in balance, storageRoot, codeHash);
         }
 
-        public Account WithChangedNonce(in UInt256 newNonce)
+        public virtual Account WithChangedBalance(in UInt256 newBalance)
         {
-            return new(newNonce, Balance, StorageRoot, CodeHash, IsTotallyEmpty && newNonce == _accountStartNonce);
+            return new(in _nonce, in newBalance);
         }
 
-        public Account WithChangedStorageRoot(Keccak newStorageRoot)
+        public virtual Account WithChangedNonce(in UInt256 newNonce)
         {
-            return new(Nonce, Balance, newStorageRoot, CodeHash, IsTotallyEmpty && newStorageRoot == Keccak.EmptyTreeHash);
+            return new(in newNonce, in _balance);
         }
 
-        public Account WithChangedCodeHash(Keccak newCodeHash)
+        public virtual Account WithChangedStorageRoot(Keccak newStorageRoot)
         {
-            return new(Nonce, Balance, StorageRoot, newCodeHash, IsTotallyEmpty && newCodeHash == Keccak.OfAnEmptyString);
+            if (newStorageRoot == Keccak.EmptyTreeHash)
+            {
+                return this;
+            }
+            else
+            {
+                return new ContractAccount(storageRoot: newStorageRoot, in _nonce, in _balance);
+            }
+        }
+
+        public virtual Account WithChangedCodeHash(Keccak newCodeHash)
+        {
+            if (newCodeHash == Keccak.OfAnEmptyString)
+            {
+                return this;
+            }
+            else
+            {
+                return new ContractAccount(_nonce, _balance, codeHash: newCodeHash);
+            }
+        }
+    }
+
+    public sealed class ContractAccount : Account
+    {
+        public ContractAccount(in UInt256 nonce, in UInt256 balance, Keccak storageRoot, Keccak codeHash)
+            : base(in nonce, in balance)
+        {
+            _storageRoot = storageRoot;
+            _codeHash = codeHash;
+        }
+
+        public ContractAccount(Keccak storageRoot, in UInt256 nonce, in UInt256 balance)
+            : base(in nonce, in balance)
+        {
+            _storageRoot = storageRoot;
+            _codeHash = Keccak.OfAnEmptyString;
+        }
+
+        public ContractAccount(in UInt256 nonce, in UInt256 balance, Keccak codeHash)
+            : base(in nonce, in balance)
+        {
+            _storageRoot = Keccak.EmptyTreeHash;
+            _codeHash = codeHash;
+        }
+
+        private readonly Keccak _storageRoot;
+        public override Keccak StorageRoot => _storageRoot;
+
+        private readonly Keccak _codeHash;
+        public override Keccak CodeHash => _codeHash;
+
+        public override bool HasCode => !ReferenceEquals(_codeHash, Keccak.OfAnEmptyString);
+        public override bool HasStorage => !ReferenceEquals(_storageRoot, Keccak.EmptyTreeHash);
+        public override bool IsEmpty => !HasCode && base.IsEmpty;
+        public override bool IsTotallyEmpty => false;
+        public override bool IsContract => HasCode;
+
+        public override ContractAccount WithChangedBalance(in UInt256 newBalance)
+        {
+            return new ContractAccount(in _nonce, in newBalance, _storageRoot, _codeHash);
+        }
+
+        public override ContractAccount WithChangedNonce(in UInt256 newNonce)
+        {
+            return new ContractAccount(in newNonce, in _balance, _storageRoot, _codeHash);
+        }
+
+        public override ContractAccount WithChangedStorageRoot(Keccak newStorageRoot)
+        {
+            if (!ReferenceEquals(newStorageRoot, Keccak.EmptyTreeHash)
+                && newStorageRoot == Keccak.EmptyTreeHash)
+            {
+                newStorageRoot = Keccak.EmptyTreeHash;
+            }
+
+            return new ContractAccount(in _nonce, in _balance, newStorageRoot, _codeHash);
+        }
+
+        public override ContractAccount WithChangedCodeHash(Keccak newCodeHash)
+        {
+            if (!ReferenceEquals(newCodeHash, Keccak.OfAnEmptyString)
+                && newCodeHash == Keccak.OfAnEmptyString)
+            {
+                newCodeHash = Keccak.OfAnEmptyString;
+            }
+
+            return new ContractAccount(in _nonce, in _balance, _storageRoot, newCodeHash);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.cs
@@ -443,6 +443,11 @@ namespace Nethermind.Core.Crypto
 
         public void Update(Span<byte> input)
         {
+            Update((ReadOnlySpan<byte>)input);
+        }
+
+        public void Update(ReadOnlySpan<byte> input)
+        {
             if (_hash is not null)
             {
                 ThrowHashingComplete();
@@ -465,7 +470,7 @@ namespace Nethermind.Core.Crypto
             if (_remainderLength != 0)
             {
                 // Copy data to our remainder
-                Span<byte> remainderAdditive = input[..Math.Min(input.Length, _roundSize - _remainderLength)];
+                ReadOnlySpan<byte> remainderAdditive = input[..Math.Min(input.Length, _roundSize - _remainderLength)];
                 remainderAdditive.CopyTo(_remainderBuffer.AsSpan(_remainderLength));
 
                 // Increment the length
@@ -501,7 +506,7 @@ namespace Nethermind.Core.Crypto
             while (input.Length >= _roundSize)
             {
                 // Cast our input to ulongs.
-                Span<ulong> input64 = MemoryMarshal.Cast<byte, ulong>(input[.._roundSize]);
+                ReadOnlySpan<ulong> input64 = MemoryMarshal.Cast<byte, ulong>(input[.._roundSize]);
 
                 // Eliminate bounds check for state for the loop
                 _ = state[input64.Length];

--- a/src/Nethermind/Nethermind.Crypto/KeccakRlpStream.cs
+++ b/src/Nethermind/Nethermind.Crypto/KeccakRlpStream.cs
@@ -25,7 +25,7 @@ namespace Nethermind.Crypto
             _keccakHash = keccakHash;
         }
 
-        public override void Write(Span<byte> bytesToWrite)
+        public override void Write(ReadOnlySpan<byte> bytesToWrite)
         {
             _keccakHash.Update(bytesToWrite);
         }

--- a/src/Nethermind/Nethermind.Evm/EvmStack.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmStack.cs
@@ -267,6 +267,18 @@ namespace Nethermind.Evm
             result = new UInt256(u0, u1, u2, u3);
         }
 
+        public bool PeekUInt256IsZero()
+        {
+            int head = Head - 1;
+            if (head <= 0)
+            {
+                return false;
+            }
+
+            ref byte bytes = ref _bytes[head * 32];
+            return Unsafe.ReadUnaligned<UInt256>(ref bytes).IsZero;
+        }
+
         public Address PopAddress()
         {
             if (Head-- == 0)

--- a/src/Nethermind/Nethermind.Evm/Metrics.cs
+++ b/src/Nethermind/Nethermind.Evm/Metrics.cs
@@ -8,6 +8,16 @@ namespace Nethermind.Evm
 {
     public class Metrics
     {
+        [Description("Number of EXTCODESIZE opcodes executed.")]
+        public static long ExtCodeSizeOpcode;
+
+        [Description("Number of EXTCODESIZE ISZERO optimizations.")]
+        public static long ExtCodeSizeOptimizedIsZero;
+        [Description("Number of EXTCODESIZE GT optimizations.")]
+        public static long ExtCodeSizeOptimizedGT;
+        [Description("Number of EXTCODESIZE EQ optimizations.")]
+        public static long ExtCodeSizeOptimizedEQ;
+
         [CounterMetric]
         [Description("Number of EVM exceptions thrown by contracts.")]
         public static long EvmExceptions { get; set; }

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -1286,8 +1286,8 @@ namespace Nethermind.Evm
                                     // to reduce storage access from trying to load the code
                                     if (traceOpcodes)
                                     {
-                                        EndInstructionTrace();
-                                        StartInstructionTrace(Instruction.ISZERO, stack);
+                                        EndInstructionTrace(gasAvailable, vmState.Memory?.Size ?? 0);
+                                        StartInstructionTrace(Instruction.ISZERO, vmState, gasAvailable, programCounter, in stack);
                                     }
 
                                     programCounter++;

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeBlockchain.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeBlockchain.cs
@@ -86,8 +86,6 @@ namespace Nethermind.Init.Steps
                 syncConfig.DownloadBodiesInFastSync = true;
             }
 
-            Account.AccountStartNonce = getApi.ChainSpec.Parameters.AccountStartNonce;
-
             IWitnessCollector witnessCollector;
             if (syncConfig.WitnessProtocolEnabled)
             {
@@ -161,7 +159,6 @@ namespace Nethermind.Init.Steps
 
             setApi.TransactionComparerProvider = new TransactionComparerProvider(getApi.SpecProvider!, getApi.BlockTree.AsReadOnly());
             setApi.ChainHeadStateProvider = new ChainHeadReadOnlyStateProvider(getApi.BlockTree, stateReader);
-            Account.AccountStartNonce = getApi.ChainSpec.Parameters.AccountStartNonce;
 
             stateProvider.StateRoot = getApi.BlockTree!.Head?.StateRoot ?? Keccak.EmptyTreeHash;
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/NettyRlpStream.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/NettyRlpStream.cs
@@ -20,7 +20,7 @@ namespace Nethermind.Serialization.Rlp
             _initialPosition = buffer.ReaderIndex;
         }
 
-        public override void Write(Span<byte> bytesToWrite)
+        public override void Write(ReadOnlySpan<byte> bytesToWrite)
         {
             _buffer.EnsureWritable(bytesToWrite.Length, true);
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpStream.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpStream.cs
@@ -155,10 +155,15 @@ namespace Nethermind.Serialization.Rlp
             Write(bytesToWrite.AsSpan());
         }
 
-        public virtual void Write(Span<byte> bytesToWrite)
+        public virtual void Write(ReadOnlySpan<byte> bytesToWrite)
         {
             bytesToWrite.CopyTo(Data.AsSpan(Position, bytesToWrite.Length));
             Position += bytesToWrite.Length;
+        }
+
+        public void Write(Span<byte> bytesToWrite)
+        {
+            Write((ReadOnlySpan<byte>)bytesToWrite);
         }
 
         public virtual void Write(IReadOnlyList<byte> bytesToWrite)

--- a/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecLoaderTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecLoaderTests.cs
@@ -112,8 +112,6 @@ namespace Nethermind.Specs.Test.ChainSpecStyle
 
             Assert.AreEqual((long)32, chainSpec.Parameters.MaximumExtraDataSize, "extra data");
             Assert.AreEqual((long)0x0400, chainSpec.Parameters.GasLimitBoundDivisor, "gas limit bound divisor");
-            Assert.AreEqual((UInt256)0x0, chainSpec.Parameters.AccountStartNonce, "account start nonce");
-
         }
 
         private static ChainSpec LoadChainSpec(string path)

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
@@ -14,7 +14,6 @@ namespace Nethermind.Specs.ChainSpecStyle
         public ulong? MaxCodeSizeTransitionTimestamp { get; set; }
         public long GasLimitBoundDivisor { get; set; }
         public Address Registrar { get; set; }
-        public UInt256 AccountStartNonce { get; set; }
         public long MaximumExtraDataSize { get; set; }
         public long MinGasLimit { get; set; }
         public Keccak ForkCanonHash { get; set; }

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
@@ -91,7 +91,6 @@ namespace Nethermind.Specs.ChainSpecStyle
 
             chainSpec.Parameters = new ChainParameters
             {
-                AccountStartNonce = chainSpecJson.Params.AccountStartNonce ?? UInt256.Zero,
                 GasLimitBoundDivisor = chainSpecJson.Params.GasLimitBoundDivisor ?? 0x0400,
                 MaximumExtraDataSize = chainSpecJson.Params.MaximumExtraDataSize ?? 32,
                 MinGasLimit = chainSpecJson.Params.MinGasLimit ?? 5000,

--- a/src/Nethermind/Nethermind.State/IReadOnlyStateProvider.cs
+++ b/src/Nethermind/Nethermind.State/IReadOnlyStateProvider.cs
@@ -24,7 +24,7 @@ namespace Nethermind.State
 
         Keccak GetCodeHash(Address address);
 
-        public bool IsContract(Address address) => GetCodeHash(address) != Keccak.OfAnEmptyString;
+        public bool IsContract(Address address);
 
         /// <summary>
         /// Runs a visitor over trie.

--- a/src/Nethermind/Nethermind.State/StateProvider.cs
+++ b/src/Nethermind/Nethermind.State/StateProvider.cs
@@ -77,6 +77,17 @@ namespace Nethermind.State
 
         private readonly StateTree _tree;
 
+        public bool IsContract(Address address)
+        {
+            Account account = GetThroughCache(address);
+            if (account is null)
+            {
+                return false;
+            }
+
+            return account.IsContract;
+        }
+
         public bool AccountExists(Address address)
         {
             if (_intraBlockCache.TryGetValue(address, out Stack<int> value))
@@ -398,7 +409,7 @@ namespace Nethermind.State
         {
             _needsStateRootUpdate = true;
             if (_logger.IsTrace) _logger.Trace($"Creating account: {address} with balance {balance} and nonce {nonce}");
-            Account account = (balance.IsZero && nonce.IsZero) ? Account.TotallyEmpty : new Account(nonce, balance, Keccak.EmptyTreeHash, Keccak.OfAnEmptyString);
+            Account account = (balance.IsZero && nonce.IsZero) ? Account.TotallyEmpty : new Account(nonce, balance);
             PushNew(address, account);
         }
 

--- a/src/Nethermind/Nethermind.State/StateReader.cs
+++ b/src/Nethermind/Nethermind.State/StateReader.cs
@@ -35,7 +35,8 @@ namespace Nethermind.State
 
         public byte[] GetStorage(Keccak storageRoot, in UInt256 index)
         {
-            if (storageRoot == Keccak.EmptyTreeHash)
+            if (ReferenceEquals(storageRoot, Keccak.EmptyTreeHash)
+                || storageRoot == Keccak.EmptyTreeHash)
             {
                 return new byte[] { 0 };
             }
@@ -51,7 +52,8 @@ namespace Nethermind.State
 
         public byte[]? GetCode(Keccak codeHash)
         {
-            if (codeHash == Keccak.OfAnEmptyString)
+            if (ReferenceEquals(codeHash, Keccak.OfAnEmptyString)
+                || codeHash == Keccak.OfAnEmptyString)
             {
                 return Array.Empty<byte>();
             }
@@ -72,7 +74,8 @@ namespace Nethermind.State
 
         private Account? GetState(Keccak stateRoot, Address address)
         {
-            if (stateRoot == Keccak.EmptyTreeHash)
+            if (ReferenceEquals(stateRoot, Keccak.EmptyTreeHash)
+                || stateRoot == Keccak.EmptyTreeHash)
             {
                 return null;
             }

--- a/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
@@ -8,7 +8,6 @@ using FluentAssertions;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
-using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
 using Nethermind.Logging;
@@ -428,7 +427,7 @@ namespace Nethermind.Trie.Test.Pruning
             storage1.ResolveKey(NullTrieNodeResolver.Instance, true);
 
             TrieNode a = new(NodeType.Leaf);
-            Account account = new(1, 1, storage1.Keccak, Keccak.OfAnEmptyString);
+            Account account = Account.CreateAccount(1, 1, storage1.Keccak, Keccak.OfAnEmptyString);
             a.Value = _accountDecoder.Encode(account).Bytes;
             a.Key = Bytes.FromHexString("abc");
             a.ResolveKey(NullTrieNodeResolver.Instance, true);
@@ -462,7 +461,7 @@ namespace Nethermind.Trie.Test.Pruning
             storage1.ResolveKey(NullTrieNodeResolver.Instance, true);
 
             TrieNode a = new(NodeType.Leaf);
-            Account account = new(1, 1, storage1.Keccak, Keccak.OfAnEmptyString);
+            Account account = Account.CreateAccount(1, 1, storage1.Keccak, Keccak.OfAnEmptyString);
             a.Value = _accountDecoder.Encode(account).Bytes;
             a.Key = Bytes.FromHexString("abc");
             a.ResolveKey(NullTrieNodeResolver.Instance, true);
@@ -501,7 +500,7 @@ namespace Nethermind.Trie.Test.Pruning
             storage1.ResolveKey(NullTrieNodeResolver.Instance, true);
 
             TrieNode a = new(NodeType.Leaf);
-            Account account = new(1, 1, storage1.Keccak, Keccak.OfAnEmptyString);
+            Account account = Account.CreateAccount(1, 1, storage1.Keccak, Keccak.OfAnEmptyString);
             a.Value = _accountDecoder.Encode(account).Bytes;
             a.Key = Bytes.FromHexString("abc");
             a.ResolveKey(NullTrieNodeResolver.Instance, true);
@@ -510,7 +509,7 @@ namespace Nethermind.Trie.Test.Pruning
             storage2.ResolveKey(NullTrieNodeResolver.Instance, true);
 
             TrieNode b = new(NodeType.Leaf);
-            Account accountB = new(2, 1, storage2.Keccak, Keccak.OfAnEmptyString);
+            Account accountB = Account.CreateAccount(2, 1, storage2.Keccak, Keccak.OfAnEmptyString);
             b.Value = _accountDecoder.Encode(accountB).Bytes;
             b.Key = Bytes.FromHexString("abcd");
             b.ResolveKey(NullTrieNodeResolver.Instance, true);
@@ -551,7 +550,7 @@ namespace Nethermind.Trie.Test.Pruning
         public void ReadOnly_store_doesnt_change_witness()
         {
             TrieNode node = new(NodeType.Leaf);
-            Account account = new(1, 1, TestItem.KeccakA, Keccak.OfAnEmptyString);
+            Account account = Account.CreateAccount(1, 1, TestItem.KeccakA, Keccak.OfAnEmptyString);
             node.Value = _accountDecoder.Encode(account).Bytes;
             node.Key = Bytes.FromHexString("abc");
             node.ResolveKey(NullTrieNodeResolver.Instance, true);
@@ -630,7 +629,7 @@ namespace Nethermind.Trie.Test.Pruning
         public void ReadOnly_store_returns_copies(bool pruning)
         {
             TrieNode node = new(NodeType.Leaf);
-            Account account = new(1, 1, TestItem.KeccakA, Keccak.OfAnEmptyString);
+            Account account = Account.CreateAccount(1, 1, TestItem.KeccakA, Keccak.OfAnEmptyString);
             node.Value = _accountDecoder.Encode(account).Bytes;
             node.Key = Bytes.FromHexString("abc");
             node.ResolveKey(NullTrieNodeResolver.Instance, true);

--- a/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
@@ -339,7 +339,7 @@ namespace Nethermind.Trie.Test
         {
             ITreeVisitor visitor = Substitute.For<ITreeVisitor>();
             TrieVisitContext context = new();
-            Account account = new(1, 100, Keccak.EmptyTreeHash, Keccak.OfAnEmptyString);
+            Account account = new(1, 100);
             AccountDecoder decoder = new();
             TrieNode node = TrieNodeFactory.CreateLeaf(Bytes.FromHexString("aa"), decoder.Encode(account).Bytes);
 
@@ -355,7 +355,7 @@ namespace Nethermind.Trie.Test
             visitor.ShouldVisit(Arg.Any<Keccak>()).Returns(true);
 
             TrieVisitContext context = new();
-            Account account = new(1, 100, Keccak.EmptyTreeHash, Keccak.Zero);
+            Account account = Account.CreateAccount(1, 100, Keccak.EmptyTreeHash, Keccak.Zero);
             AccountDecoder decoder = new();
             TrieNode node = TrieNodeFactory.CreateLeaf(Bytes.FromHexString("aa"), decoder.Encode(account).Bytes);
 
@@ -371,7 +371,7 @@ namespace Nethermind.Trie.Test
             visitor.ShouldVisit(Arg.Any<Keccak>()).Returns(true);
 
             TrieVisitContext context = new();
-            Account account = new(1, 100, Keccak.Zero, Keccak.OfAnEmptyString);
+            Account account = Account.CreateAccount(1, 100, Keccak.Zero, Keccak.OfAnEmptyString);
             AccountDecoder decoder = new();
             TrieNode node = TrieNodeFactory.CreateLeaf(Bytes.FromHexString("aa"), decoder.Encode(account).Bytes);
 


### PR DESCRIPTION
## Changes

- Peephole optimization for IsContract type checks via `EXTCODESIZE` + `ISZERO`/`GT`/`EQ` by skipping to code lookup [required pattern for ERC721, ERC777 and ERC1155 transfers; as well as ERC1967, Upgradeable proxies (UUPS, Beacon), etc] with [154k Solidity code references in GitHub](https://github.com/search?q=%22account.code.length%22+language%3A%22Gerber+Image%22&type=code&p=2&l=Gerber+Image)
    - Hit rates (94.1% reduction in code lookup)
    - 53584 EXTCODESIZE
    - 48521 EXTCODESIZE + ISZERO (90.6%)
    - 1895 ZERO EXTCODESIZE GT (3.5%)
    - 43 ZERO EXTCODESIZE EQ (0.08%)
    - Remaining requiring storage access to code: 5.8%
- Faster Account `IsContract` checks - used by above and every txPool queue
- Removes the `bool` field `IsTotallyEmpty` as is fast via other checks.

This saves 8 bytes per instantiation

Before 88 bytes, 7 bytes wasted
```
Type layout for 'Account'
Size: 88 bytes. Paddings: 7 bytes (%7 of empty space)
``` 

After 64 bytes for EOA
```
Type layout for 'Account'
Size: 64 bytes. Paddings: 0 bytes (%0 of empty space)
```
And 80 bytes for Contracts
```
Type layout for 'ContractAccount'
Size: 80 bytes. Paddings: 0 bytes (%0 of empty space)
```

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No