### PR TITLE
Switch off DotNetty ResourceLeakDetector

### DIFF
--- a/src/Nethermind/Nethermind.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Runner/Program.cs
@@ -13,6 +13,9 @@ using System.Runtime.Loader;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+
+using DotNetty.Common;
+
 using Microsoft.Extensions.CommandLineUtils;
 using Nethermind.Api;
 using Nethermind.Api.Extensions;
@@ -55,6 +58,8 @@ namespace Nethermind.Runner
 
         public static void Main(string[] args)
         {
+            ResourceLeakDetector.Level = ResourceLeakDetector.DetectionLevel.Disabled;
+
             AppDomain.CurrentDomain.UnhandledException += (sender, eventArgs) =>
             {
                 ILogger logger = GetCriticalLogger();


### PR DESCRIPTION
## Changes

- Switch off DotNetty's Resource Leak Detector as it is the largest single allocator; and isn't adding high value as there are currently no leak errors being reported

![image](https://user-images.githubusercontent.com/1142958/224517824-148279f6-5e39-44e4-904f-1bc41304d831.png)

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No