### PR TITLE
Only clear NetworkNode cache on changes

### DIFF
--- a/src/Nethermind/Nethermind.Network/NetworkStorage.cs
+++ b/src/Nethermind/Nethermind.Network/NetworkStorage.cs
@@ -52,14 +52,13 @@ namespace Nethermind.Network
                 if (nodes is not null)
                 {
                     // Already updated
-                    goto ReturnValue;
+                    return nodes;
                 }
 
                 List<NetworkNode> nodeList = _nodesList;
                 if (nodeList.Count > 0)
                 {
-                    nodes = _nodes = nodeList.ToArray();
-                    goto ReturnValue;
+                    return (_nodes = nodeList.ToArray());
                 }
 
                 foreach (byte[]? nodeRlp in _fullDb.Values)
@@ -83,15 +82,13 @@ namespace Nethermind.Network
 
                 if (nodeList.Count == 0)
                 {
-                    nodes = Array.Empty<NetworkNode>();
+                    return Array.Empty<NetworkNode>();
                 }
                 else
                 {
-                    nodes = _nodes = nodeList.ToArray();
+                    return (_nodes = nodeList.ToArray());
                 }
             }
-ReturnValue:
-            return nodes;
         }
 
         public void UpdateNode(NetworkNode node)


### PR DESCRIPTION
Change https://github.com/NethermindEth/nethermind/pull/5294 over regenerated the `NetworkNode[]` as it regenerated it on every change.

This change massively reduces the allocations by waiting for a request for the array to regenerate it rather than doing it on each change.

## Changes

- Wait till request for `NetworkNode[]` to regenerate

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No