### PR TITLE
Fix missing db statistics for column family

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -126,7 +126,17 @@ public class DbOnTheRocks : IDbWithSpan
 
             if (dbConfig.EnableMetricsUpdater)
             {
-                new DbMetricsUpdater(Name, DbOptions, db, dbConfig, _logger).StartUpdating();
+                new DbMetricsUpdater(Name, DbOptions, db, null, dbConfig, _logger).StartUpdating();
+                if (columnFamilies != null)
+                {
+                    foreach (ColumnFamilies.Descriptor columnFamily in columnFamilies)
+                    {
+                        if (db.TryGetColumnFamily(columnFamily.Name, out ColumnFamilyHandle handle))
+                        {
+                            new DbMetricsUpdater(Name + "_" + columnFamily.Name, DbOptions, db, handle, dbConfig, _logger).StartUpdating();
+                        }
+                    }
+                }
             }
 
             return db;

--- a/src/Nethermind/Nethermind.Db.Test/DbMetricsUpdaterTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/DbMetricsUpdaterTests.cs
@@ -26,7 +26,7 @@ namespace Nethermind.Db.Test
             ILogger logger = Substitute.For<ILogger>();
 
             string testDump = File.ReadAllText(@"InputFiles/CompactionStatsExample_AllData.txt");
-            new DbMetricsUpdater("Test", null, null, null, logger).ProcessCompactionStats(testDump);
+            new DbMetricsUpdater("Test", null, null, null, null, logger).ProcessCompactionStats(testDump);
 
             Assert.AreEqual(11, Metrics.DbStats.Count);
             Assert.AreEqual(2, Metrics.DbStats["TestDbLevel0Files"]);
@@ -48,7 +48,7 @@ namespace Nethermind.Db.Test
             ILogger logger = Substitute.For<ILogger>();
 
             string testDump = File.ReadAllText(@"InputFiles/CompactionStatsExample_MissingLevels.txt");
-            new DbMetricsUpdater("Test", null, null, null, logger).ProcessCompactionStats(testDump);
+            new DbMetricsUpdater("Test", null, null, null, null, logger).ProcessCompactionStats(testDump);
 
             Assert.AreEqual(5, Metrics.DbStats.Count);
             Assert.AreEqual(10, Metrics.DbStats["TestDbIntervalCompactionGBWrite"]);
@@ -64,7 +64,7 @@ namespace Nethermind.Db.Test
             ILogger logger = Substitute.For<ILogger>();
 
             string testDump = File.ReadAllText(@"InputFiles/CompactionStatsExample_MissingIntervalCompaction.txt");
-            new DbMetricsUpdater("Test", null, null, null, logger).ProcessCompactionStats(testDump);
+            new DbMetricsUpdater("Test", null, null, null, null, logger).ProcessCompactionStats(testDump);
 
             Assert.AreEqual(6, Metrics.DbStats.Count);
             Assert.AreEqual(2, Metrics.DbStats["TestDbLevel0Files"]);
@@ -83,7 +83,7 @@ namespace Nethermind.Db.Test
             ILogger logger = Substitute.For<ILogger>();
 
             string testDump = string.Empty;
-            new DbMetricsUpdater("Test", null, null, null, logger).ProcessCompactionStats(testDump);
+            new DbMetricsUpdater("Test", null, null, null, null, logger).ProcessCompactionStats(testDump);
 
             Assert.AreEqual(0, Metrics.DbStats.Count);
 
@@ -96,7 +96,7 @@ namespace Nethermind.Db.Test
             ILogger logger = Substitute.For<ILogger>();
 
             string testDump = null;
-            new DbMetricsUpdater("Test", null, null, null, logger).ProcessCompactionStats(testDump);
+            new DbMetricsUpdater("Test", null, null, null, null, logger).ProcessCompactionStats(testDump);
 
             Assert.AreEqual(0, Metrics.DbStats.Count);
 


### PR DESCRIPTION
- Fix rocksdb statistics not showing up for column family.

## Changes

- Add db statistics for column family.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

Confirmed metrics show up on prometheus endpoint.

```
# HELP nethermind_receipts_transactions_db_interval_compaction_seconds 
# TYPE nethermind_receipts_transactions_db_interval_compaction_seconds gauge
nethermind_receipts_transactions_db_interval_compaction_seconds 0
```