### PR TITLE
Migrate To use BitOperation Class for BinaryOperations

### DIFF
--- a/src/Nethermind/Nethermind.Merkleization/Merkle.cs
+++ b/src/Nethermind/Nethermind.Merkleization/Merkle.cs
@@ -1,9 +1,9 @@
-// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Numerics;
 using System.Runtime.InteropServices;
-using System.Runtime.Intrinsics.X86;
 using System.Security.Cryptography;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
@@ -34,79 +34,28 @@ public static partial class Merkle
         RootOfNull = new UInt256(new Root(SHA256.HashData(Array.Empty<byte>())).AsSpan().ToArray());
     }
 
-    public static uint NextPowerOfTwo(uint v)
+    public static ulong NextPowerOfTwo(uint v)
     {
-        if (Lzcnt.IsSupported)
-        {
-            return (uint)1 << (int)(32 - Lzcnt.LeadingZeroCount(--v));
-        }
-
-        if (v != 0U) v--;
-        v |= v >> 1;
-        v |= v >> 2;
-        v |= v >> 4;
-        v |= v >> 8;
-        v |= v >> 16;
-        v++;
-
-        return v;
+        if (v == 0) return 1;
+        return BitOperations.RoundUpToPowerOf2(v);
+    }
+    public static ulong NextPowerOfTwo(ulong v)
+    {
+        if (v == 0) return 1;
+        return BitOperations.RoundUpToPowerOf2(v);
     }
 
     public static int NextPowerOfTwoExponent(ulong v)
     {
-        if (v == 0)
-        {
-            return 0;
-        }
-
-        int leadingZeros = 0;
-        if (Lzcnt.IsSupported)
-        {
-            leadingZeros = (int)Lzcnt.X64.LeadingZeroCount(--v);
-        }
-        else
-        {
-            leadingZeros = CountLeadingZeros(v);
-        }
-
-        return 64 - leadingZeros;
+        return BitOperations.Log2(BitOperations.RoundUpToPowerOf2(v));
     }
 
-    private static int CountLeadingZeros(ulong x)
+    public static int CountLeadingZeros(ulong x)
     {
-        x--;
+        if (x == 0) return 0;
+        if (x == 1) return 64;
 
-        int count = 0;
-        for (int i = 63; i >= 0; i--)
-        {
-            if (x / (1UL << i) == 1)
-            {
-                break;
-            }
-
-            count++;
-        }
-
-        return count;
-    }
-
-    public static ulong NextPowerOfTwo(ulong v)
-    {
-        if (Lzcnt.IsSupported)
-        {
-            return (ulong)1 << (int)(64 - Lzcnt.X64.LeadingZeroCount(--v));
-        }
-
-        if (v != 0UL) v--;
-        v |= v >> 1;
-        v |= v >> 2;
-        v |= v >> 4;
-        v |= v >> 8;
-        v |= v >> 16;
-        v |= v >> 32;
-        v++;
-
-        return v;
+        return BitOperations.LeadingZeroCount(x) + (BitOperations.IsPow2(x) ? 1 : 0);
     }
 
     private static UInt256 Compute(Span<UInt256> span)


### PR DESCRIPTION
## Changes

- Move from using hand written Bit manipulation based operation in Merke class to using Builtin methods in the BitOperations class
- 
## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

## Remarks

BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.22621.1265/22H2/2022Update/SunValley2)
Intel Core i5-8265U CPU 1.60GHz (Whiskey Lake), 1 CPU, 8 logical and 4 physical cores
.NET SDK=7.0.100
  [Host]     : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
  DefaultJob : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2


|                    Method |             Argument |       Mean |     Error |    StdDev |     Median | Allocated |
|-------------------------- |--------------------- |-----------:|----------:|----------:|-----------:|----------:|
|         NextPowerOfTwoOld |                    0 |  1.7146 ns | 0.1994 ns | 0.5818 ns |  1.6501 ns |         - |
|         NextPowerOfTwoNew |                    0 |  0.0000 ns | 0.0000 ns | 0.0000 ns |  0.0000 ns |         - |
| NextPowerOfTwoExponentOld |                    0 |  0.0290 ns | 0.0267 ns | 0.0356 ns |  0.0126 ns |         - |
| NextPowerOfTwoExponentNew |                    0 |  0.2593 ns | 0.0706 ns | 0.2002 ns |  0.2189 ns |         - |
|      CountLeadingZerosOld |                    0 |  8.7962 ns | 0.4103 ns | 1.2034 ns |  9.0864 ns |         - |
|      CountLeadingZerosNew |                    0 |  0.1692 ns | 0.0402 ns | 0.1133 ns |  0.1747 ns |         - |
|         NextPowerOfTwoOld | 18446744073709551615 |  1.2856 ns | 0.0647 ns | 0.0540 ns |  1.2866 ns |         - |
|         NextPowerOfTwoNew | 18446744073709551615 |  0.3311 ns | 0.1741 ns | 0.5052 ns |  0.0006 ns |         - |
| NextPowerOfTwoExponentOld | 18446744073709551615 |  0.3359 ns | 0.0957 ns | 0.2762 ns |  0.2573 ns |         - |
| NextPowerOfTwoExponentNew | 18446744073709551615 |  0.0861 ns | 0.0442 ns | 0.1262 ns |  0.0061 ns |         - |
|      CountLeadingZerosOld | 18446744073709551615 |  9.2383 ns | 0.4208 ns | 1.2142 ns |  8.9365 ns |         - |
|      CountLeadingZerosNew | 18446744073709551615 |  0.0144 ns | 0.0159 ns | 0.0432 ns |  0.0000 ns |         - |
|         NextPowerOfTwoOld |  2305843009213693951 |  1.5685 ns | 0.0888 ns | 0.2519 ns |  1.5497 ns |         - |
|         NextPowerOfTwoNew |  2305843009213693951 |  0.1133 ns | 0.0544 ns | 0.1561 ns |  0.0551 ns |         - |
| NextPowerOfTwoExponentOld |  2305843009213693951 |  0.0288 ns | 0.0276 ns | 0.0801 ns |  0.0000 ns |         - |
| NextPowerOfTwoExponentNew |  2305843009213693951 |  0.0594 ns | 0.0315 ns | 0.0909 ns |  0.0000 ns |         - |
|      CountLeadingZerosOld |  2305843009213693951 | 29.0039 ns | 0.7337 ns | 2.1285 ns | 28.8054 ns |         - |
|      CountLeadingZerosNew |  2305843009213693951 |  0.0238 ns | 0.0182 ns | 0.0536 ns |  0.0000 ns |         - |
|         NextPowerOfTwoOld |  4611686018427387903 |  1.3297 ns | 0.0806 ns | 0.2377 ns |  1.2400 ns |         - |
|         NextPowerOfTwoNew |  4611686018427387903 |  0.0000 ns | 0.0000 ns | 0.0000 ns |  0.0000 ns |         - |
| NextPowerOfTwoExponentOld |  4611686018427387903 |  0.0074 ns | 0.0154 ns | 0.0136 ns |  0.0000 ns |         - |
| NextPowerOfTwoExponentNew |  4611686018427387903 |  0.0000 ns | 0.0000 ns | 0.0000 ns |  0.0000 ns |         - |
|      CountLeadingZerosOld |  4611686018427387903 | 24.7990 ns | 1.5581 ns | 4.5451 ns | 23.1529 ns |         - |
|      CountLeadingZerosNew |  4611686018427387903 |  0.0100 ns | 0.0171 ns | 0.0152 ns |  0.0017 ns |         - |
|         NextPowerOfTwoOld |  9223372036854775807 |  1.4212 ns | 0.0665 ns | 0.1417 ns |  1.4013 ns |         - |
|         NextPowerOfTwoNew |  9223372036854775807 |  0.2799 ns | 0.1190 ns | 0.3298 ns |  0.1558 ns |         - |
| NextPowerOfTwoExponentOld |  9223372036854775807 |  0.0029 ns | 0.0071 ns | 0.0148 ns |  0.0000 ns |         - |
| NextPowerOfTwoExponentNew |  9223372036854775807 |  0.0070 ns | 0.0150 ns | 0.0166 ns |  0.0000 ns |         - |
|      CountLeadingZerosOld |  9223372036854775807 | 14.3013 ns | 0.2365 ns | 0.2096 ns | 14.2239 ns |         - |
|      CountLeadingZerosNew |  9223372036854775807 |  0.0008 ns | 0.0035 ns | 0.0027 ns |  0.0000 ns |         - |