### PR TITLE
Reduce state access for TxPool

### DIFF
--- a/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -411,10 +412,9 @@ namespace Nethermind.TxPool.Collections
         {
             foreach ((TGroupKey groupKey, EnhancedSortedSet<TValue> bucket) in _buckets)
             {
-                if (bucket.Count > 0)
-                {
-                    UpdateGroup(groupKey, bucket, changingElements);
-                }
+                Debug.Assert(bucket.Count > 0);
+
+                UpdateGroup(groupKey, bucket, changingElements);
             }
         }
 
@@ -424,10 +424,9 @@ namespace Nethermind.TxPool.Collections
             if (groupKey is null) throw new ArgumentNullException(nameof(groupKey));
             if (_buckets.TryGetValue(groupKey, out EnhancedSortedSet<TValue>? bucket))
             {
-                if (bucket.Count > 0)
-                {
-                    UpdateGroup(groupKey, bucket, changingElements);
-                }
+                Debug.Assert(bucket.Count > 0);
+
+                UpdateGroup(groupKey, bucket, changingElements);
             }
         }
 

--- a/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
@@ -26,9 +26,9 @@ namespace Nethermind.TxPool.Collections
         private readonly IComparer<TValue> _groupComparer;
 
         // group buckets, keep the items grouped by group key and sorted in group
-        private readonly IDictionary<TGroupKey, EnhancedSortedSet<TValue>> _buckets;
+        protected readonly Dictionary<TGroupKey, EnhancedSortedSet<TValue>> _buckets;
 
-        private readonly IDictionary<TKey, TValue> _cacheMap;
+        private readonly Dictionary<TKey, TValue> _cacheMap;
         private bool _isFull = false;
 
         // comparer for worst elements in buckets
@@ -411,8 +411,10 @@ namespace Nethermind.TxPool.Collections
         {
             foreach ((TGroupKey groupKey, EnhancedSortedSet<TValue> bucket) in _buckets)
             {
-                changingElements(groupKey, bucket);
-                UpdateGroup(groupKey, bucket, changingElements);
+                if (bucket.Count > 0)
+                {
+                    UpdateGroup(groupKey, bucket, changingElements);
+                }
             }
         }
 
@@ -422,7 +424,10 @@ namespace Nethermind.TxPool.Collections
             if (groupKey is null) throw new ArgumentNullException(nameof(groupKey));
             if (_buckets.TryGetValue(groupKey, out EnhancedSortedSet<TValue>? bucket))
             {
-                UpdateGroup(groupKey, bucket, changingElements);
+                if (bucket.Count > 0)
+                {
+                    UpdateGroup(groupKey, bucket, changingElements);
+                }
             }
         }
 

--- a/src/Nethermind/Nethermind.TxPool/Collections/TxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/TxDistinctSortedPool.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -70,11 +71,10 @@ namespace Nethermind.TxPool.Collections
         {
             foreach ((Address address, EnhancedSortedSet<Transaction> bucket) in _buckets)
             {
-                if (bucket.Count > 0)
-                {
-                    Account? account = accounts.GetAccount(address);
-                    UpdateGroup(address, account, bucket, changingElements);
-                }
+                Debug.Assert(bucket.Count > 0);
+
+                Account? account = accounts.GetAccount(address);
+                UpdateGroup(address, account, bucket, changingElements);
             }
         }
 
@@ -119,10 +119,9 @@ namespace Nethermind.TxPool.Collections
             if (groupKey is null) throw new ArgumentNullException(nameof(groupKey));
             if (_buckets.TryGetValue(groupKey, out EnhancedSortedSet<Transaction>? bucket))
             {
-                if (bucket.Count > 0)
-                {
-                    UpdateGroup(groupKey, groupValue, bucket, changingElements);
-                }
+                Debug.Assert(bucket.Count > 0);
+
+                UpdateGroup(groupKey, groupValue, bucket, changingElements);
             }
         }
     }

--- a/src/Nethermind/Nethermind.TxPool/Filters/DeployedCodeFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/DeployedCodeFilter.cs
@@ -12,16 +12,16 @@ namespace Nethermind.TxPool.Filters
     internal sealed class DeployedCodeFilter : IIncomingTxFilter
     {
         private readonly IChainHeadSpecProvider _specProvider;
-        private readonly IAccountStateProvider _stateProvider;
 
-        public DeployedCodeFilter(IChainHeadSpecProvider specProvider, IAccountStateProvider stateProvider)
+        public DeployedCodeFilter(IChainHeadSpecProvider specProvider)
         {
             _specProvider = specProvider;
-            _stateProvider = stateProvider;
         }
-        public AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions txHandlingOptions) =>
-            _stateProvider.IsInvalidContractSender(_specProvider.GetCurrentHeadSpec(), tx.SenderAddress!)
+        public AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions txHandlingOptions)
+        {
+            return _specProvider.GetCurrentHeadSpec().IsEip3607Enabled && state.SenderAccount.HasCode
                 ? AcceptTxResult.SenderIsContract
                 : AcceptTxResult.Accepted;
+        }
     }
 }

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -3,13 +3,13 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using Nethermind.Core;
 using Nethermind.Core.Caching;
+using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Timers;
@@ -50,6 +50,8 @@ namespace Nethermind.TxPool
         private readonly ILogger _logger;
 
         private readonly Channel<BlockReplacementEventArgs> _headBlocksChannel = Channel.CreateUnbounded<BlockReplacementEventArgs>(new UnboundedChannelOptions() { SingleReader = true, SingleWriter = true });
+
+        private readonly Func<Address, Account, EnhancedSortedSet<Transaction>, IEnumerable<(Transaction Tx, UInt256? changedGasBottleneck)>> _updateBucket;
 
         /// <summary>
         /// Indexes transactions
@@ -121,6 +123,9 @@ namespace Nethermind.TxPool
             postHashFilters.Add(new DeployedCodeFilter(_specProvider, _accounts));
 
             _postHashFilters = postHashFilters.ToArray();
+
+            // Capture closures once rather than per invocation
+            _updateBucket = UpdateBucket;
 
             int? reportMinutes = txPoolConfig.ReportMinutes;
             if (_logger.IsInfo && reportMinutes.HasValue)
@@ -208,33 +213,34 @@ namespace Nethermind.TxPool
             }
         }
 
-        private void RemoveProcessedTransactions(IReadOnlyList<Transaction> blockTransactions)
+        private void RemoveProcessedTransactions(Transaction[] blockTransactions)
         {
-            long transactionsInBlock = blockTransactions.Count;
             long discoveredForPendingTxs = 0;
             long discoveredForHashCache = 0;
             long eip1559Txs = 0;
 
-            for (int i = 0; i < transactionsInBlock; i++)
+            for (int i = 0; i < blockTransactions.Length; i++)
             {
-                Keccak txHash = blockTransactions[i].Hash ?? throw new ArgumentException("Hash was unexpectedly null!");
+                Transaction transaction = blockTransactions[i];
+                Keccak txHash = transaction.Hash ?? throw new ArgumentException("Hash was unexpectedly null!");
 
-                if (!IsKnown(txHash!))
+                if (!IsKnown(txHash))
                 {
                     discoveredForHashCache++;
                 }
 
-                if (!RemoveIncludedTransaction(blockTransactions[i]))
+                if (!RemoveIncludedTransaction(transaction))
                 {
                     discoveredForPendingTxs++;
                 }
 
-                if (blockTransactions[i].IsEip1559)
+                if (transaction.IsEip1559)
                 {
                     eip1559Txs++;
                 }
             }
 
+            long transactionsInBlock = blockTransactions.Length;
             if (transactionsInBlock != 0)
             {
                 Metrics.DarkPoolRatioLevel1 = (float)discoveredForHashCache / transactionsInBlock;
@@ -297,7 +303,7 @@ namespace Nethermind.TxPool
                 return accepted;
             }
 
-            return AddCore(tx, startBroadcast);
+            return AddCore(tx, state, startBroadcast);
         }
 
         private AcceptTxResult FilterTransactions(Transaction tx, TxHandlingOptions handlingOptions, TxFilteringState state)
@@ -325,7 +331,7 @@ namespace Nethermind.TxPool
             return AcceptTxResult.Accepted;
         }
 
-        private AcceptTxResult AddCore(Transaction tx, bool isPersistentBroadcast)
+        private AcceptTxResult AddCore(Transaction tx, TxFilteringState state, bool isPersistentBroadcast)
         {
             lock (_locker)
             {
@@ -335,7 +341,7 @@ namespace Nethermind.TxPool
                 bool inserted = _transactions.TryInsert(tx.Hash!, tx, out Transaction? removed);
                 if (inserted)
                 {
-                    _transactions.UpdateGroup(tx.SenderAddress!, UpdateBucketWithAddedTransaction);
+                    _transactions.UpdateGroup(tx.SenderAddress!, state.SenderAccount, UpdateBucketWithAddedTransaction);
                     Metrics.PendingTransactionsAdded++;
                     if (tx.IsEip1559) { Metrics.Pending1559TransactionsAdded++; }
 
@@ -364,12 +370,11 @@ namespace Nethermind.TxPool
             return AcceptTxResult.Accepted;
         }
 
-        private IEnumerable<(Transaction Tx, Action<Transaction>? Change)> UpdateBucketWithAddedTransaction(
-            Address address, IReadOnlyCollection<Transaction> transactions)
+        private IEnumerable<(Transaction Tx, UInt256? changedGasBottleneck)> UpdateBucketWithAddedTransaction(
+            Address address, Account account, EnhancedSortedSet<Transaction> transactions)
         {
             if (transactions.Count != 0)
             {
-                Account account = _accounts.GetAccount(address);
                 UInt256 balance = account.Balance;
                 long currentNonce = (long)(account.Nonce);
 
@@ -380,8 +385,8 @@ namespace Nethermind.TxPool
             }
         }
 
-        private IEnumerable<(Transaction Tx, Action<Transaction>? Change)> UpdateGasBottleneck(
-            IReadOnlyCollection<Transaction> transactions, long currentNonce, UInt256 balance)
+        private IEnumerable<(Transaction Tx, UInt256? changedGasBottleneck)> UpdateGasBottleneck(
+            EnhancedSortedSet<Transaction> transactions, long currentNonce, UInt256 balance)
         {
             UInt256? previousTxBottleneck = null;
             int i = 0;
@@ -413,18 +418,13 @@ namespace Nethermind.TxPool
 
                     if (tx.GasBottleneck != gasBottleneck)
                     {
-                        yield return (tx, SetGasBottleneckChange(gasBottleneck));
+                        yield return (tx, gasBottleneck);
                     }
 
                     previousTxBottleneck = gasBottleneck;
                     i++;
                 }
             }
-        }
-
-        private static Action<Transaction> SetGasBottleneckChange(UInt256 gasBottleneck)
-        {
-            return t => t.GasBottleneck = gasBottleneck;
         }
 
         private void UpdateBuckets()
@@ -434,18 +434,26 @@ namespace Nethermind.TxPool
                 // ensure the capacity of the pool
                 if (_transactions.Count > _txPoolConfig.Size)
                     if (_logger.IsWarn) _logger.Warn($"TxPool exceeds the config size {_transactions.Count}/{_txPoolConfig.Size}");
-                _transactions.UpdatePool(UpdateBucket);
+                _transactions.UpdatePool(_accounts, _updateBucket);
             }
         }
 
-        private IEnumerable<(Transaction Tx, Action<Transaction>? Change)> UpdateBucket(Address address, IReadOnlyCollection<Transaction> transactions)
+        private IEnumerable<(Transaction Tx, UInt256? changedGasBottleneck)> UpdateBucket(Address address, Account account, EnhancedSortedSet<Transaction> transactions)
         {
             if (transactions.Count != 0)
             {
-                Account? account = _accounts.GetAccount(address);
                 UInt256 balance = account.Balance;
                 long currentNonce = (long)(account.Nonce);
-                Transaction? tx = transactions.FirstOrDefault(t => t.Nonce == currentNonce);
+                Transaction? tx = null;
+                foreach (Transaction txn in transactions)
+                {
+                    if (txn.Nonce == currentNonce)
+                    {
+                        tx = txn;
+                        break;
+                    }
+                }
+
                 bool shouldBeDumped = false;
 
                 if (tx is null)
@@ -597,12 +605,12 @@ namespace Nethermind.TxPool
 
         private void TimerOnElapsed(object? sender, EventArgs e)
         {
-            WriteTxnPoolReport(_logger);
+            WriteTxPoolReport(_logger);
 
             _timer!.Enabled = true;
         }
 
-        private static void WriteTxnPoolReport(ILogger logger)
+        private static void WriteTxPoolReport(ILogger logger)
         {
             if (!logger.IsInfo)
             {

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -120,7 +120,7 @@ namespace Nethermind.TxPool
                 postHashFilters.Add(incomingTxFilter);
             }
 
-            postHashFilters.Add(new DeployedCodeFilter(_specProvider, _accounts));
+            postHashFilters.Add(new DeployedCodeFilter(_specProvider));
 
             _postHashFilters = postHashFilters.ToArray();
 


### PR DESCRIPTION
Removes 3 state lookups per txn add

## Changes

- Pass `Account` to `AddCore` to avoid ***2 additional lookups*** of account
- `DeployedCodeFilter` doesn't need to look up account removing an ***additional lookup of account***
- Capture closure in constructor to avoid `Func` allocation per call in `UpdateBuckets()`
- Use concrete types to avoid enumerator allocations via interface
- ~~Use an intra-block Address -> Account cache~~
- Reuse a `ThreadStatic` `TxFilteringState` rather than allocating each txn
- Drop Linq use in TxPool
- Return `UInt256?` `GasBottleneck` change rather than `Action` to change gas to avoid allocating an `Action` per gas change
- Only resnapshot on change

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No