### PR TITLE
Fix fast header disconnecting peers sometimes

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/FastHeadersSyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/FastHeadersSyncTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Antlr4.Runtime.Misc;
 using FluentAssertions;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Synchronization;

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/FastHeadersSyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/FastHeadersSyncTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Antlr4.Runtime.Misc;
 using FluentAssertions;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Synchronization;
@@ -16,6 +17,7 @@ using Nethermind.Db.Blooms;
 using Nethermind.Logging;
 using Nethermind.Specs;
 using Nethermind.State.Repositories;
+using Nethermind.Stats.Model;
 using Nethermind.Synchronization.FastBlocks;
 using Nethermind.Synchronization.ParallelSync;
 using Nethermind.Synchronization.Peers;
@@ -47,6 +49,77 @@ namespace Nethermind.Synchronization.Test.FastBlocks
             HeadersSyncBatch? batch1 = await feed.PrepareRequest();
             HeadersSyncBatch? batch2 = await feed.PrepareRequest();
             HeadersSyncBatch? batch3 = await feed.PrepareRequest();
+        }
+
+        [Test]
+        public async Task When_next_header_hash_update_is_delayed_do_not_drop_peer()
+        {
+            IDbProvider memDbProvider = await TestMemDbProvider.InitAsync();
+            BlockTree remoteBlockTree = Build.A.BlockTree().OfHeadersOnly.OfChainLength(1001).TestObject;
+
+            BlockTree blockTree = new(memDbProvider.BlocksDb, memDbProvider.HeadersDb, memDbProvider.BlockInfosDb, new ChainLevelInfoRepository(memDbProvider.BlockInfosDb), MainnetSpecProvider.Instance, NullBloomStorage.Instance, LimboLogs.Instance);
+
+            ISyncReport syncReport = Substitute.For<ISyncReport>();
+            syncReport.FastBlocksHeaders.Returns(new MeasuredProgress());
+            syncReport.HeadersInQueue.Returns(new MeasuredProgress());
+
+            ISyncPeerPool syncPeerPool = Substitute.For<ISyncPeerPool>();
+            PeerInfo peerInfo = new PeerInfo(Substitute.For<ISyncPeer>());
+
+            ManualResetEventSlim hangLatch = new(false);
+            BlockHeader pivot = remoteBlockTree.FindHeader(1000, BlockTreeLookupOptions.None)!;
+            ResettableHeaderSyncFeed feed = new(
+                Substitute.For<ISyncModeSelector>(),
+                blockTree,
+                syncPeerPool,
+                new SyncConfig
+                {
+                    FastSync = true,
+                    FastBlocks = true,
+                    PivotNumber = "1000",
+                    PivotHash = pivot.Hash.Bytes.ToHexString(),
+                    PivotTotalDifficulty = pivot.TotalDifficulty!.ToString()
+                },
+                syncReport,
+                LimboLogs.Instance,
+                hangOnBlockNumberAfterInsert: 425,
+                hangLatch: hangLatch
+            );
+
+            feed.InitializeFeed();
+
+            void FulfillBatch(HeadersSyncBatch batch)
+            {
+                batch.Response = remoteBlockTree.FindHeaders(
+                    remoteBlockTree.FindHeader(batch.StartNumber, BlockTreeLookupOptions.None)!.Hash, batch.RequestSize, 0,
+                    false);
+                batch.ResponseSourcePeer = peerInfo;
+            }
+
+            HeadersSyncBatch? batch1 = await feed.PrepareRequest();
+            HeadersSyncBatch? batch2 = await feed.PrepareRequest();
+            HeadersSyncBatch? batch3 = await feed.PrepareRequest();
+            HeadersSyncBatch? batch4 = await feed.PrepareRequest();
+
+            FulfillBatch(batch1);
+            FulfillBatch(batch2);
+            FulfillBatch(batch3);
+            FulfillBatch(batch4);
+
+            // Need to be triggered via `HandleDependencies` as there is a lock for `HandleResponse` that prevent this.
+            feed.HandleResponse(batch1);
+            feed.HandleResponse(batch3);
+            feed.HandleResponse(batch2);
+            Task.Factory.StartNew(() =>
+            {
+                feed.PrepareRequest();
+            }, TaskCreationOptions.LongRunning);
+
+            await Task.Delay(TimeSpan.FromMilliseconds(100));
+
+            feed.HandleResponse(batch4);
+
+            syncPeerPool.DidNotReceive().ReportBreachOfProtocol(peerInfo, Arg.Any<InitiateDisconnectReason>(), Arg.Any<string>());
         }
 
         [Test]
@@ -201,7 +274,8 @@ namespace Nethermind.Synchronization.Test.FastBlocks
         private class ResettableHeaderSyncFeed : HeadersSyncFeed
         {
             private ManualResetEventSlim? _hangLatch;
-            private long? _hangOnBlockNumber;
+            private readonly long? _hangOnBlockNumber;
+            private readonly long? _hangOnBlockNumberAfterInsert;
 
             public ResettableHeaderSyncFeed(
                 ISyncModeSelector syncModeSelector,
@@ -211,11 +285,13 @@ namespace Nethermind.Synchronization.Test.FastBlocks
                 ISyncReport? syncReport,
                 ILogManager? logManager,
                 long? hangOnBlockNumber = null,
+                long? hangOnBlockNumberAfterInsert = null,
                 ManualResetEventSlim? hangLatch = null,
                 bool alwaysStartHeaderSync = false
             ) : base(syncModeSelector, blockTree, syncPeerPool, syncConfig, syncReport, logManager, alwaysStartHeaderSync)
             {
                 _hangOnBlockNumber = hangOnBlockNumber;
+                _hangOnBlockNumberAfterInsert = hangOnBlockNumberAfterInsert;
                 _hangLatch = hangLatch;
             }
 
@@ -231,7 +307,18 @@ namespace Nethermind.Synchronization.Test.FastBlocks
                 {
                     _hangLatch.Wait();
                 }
-                return base.InsertToBlockTree(header);
+
+                AddBlockResult insertOutcome = _blockTree.Insert(header);
+                if (header.Number == _hangOnBlockNumberAfterInsert)
+                {
+                    _hangLatch.Wait();
+                }
+                if (insertOutcome == AddBlockResult.Added || insertOutcome == AddBlockResult.AlreadyKnown)
+                {
+                    SetExpectedNextHeaderToParent(header);
+                }
+
+                return insertOutcome;
             }
         }
 

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
@@ -709,7 +709,6 @@ namespace Nethermind.Synchronization.FastBlocks
             {
                 _nextHeaderDiff = (header.TotalDifficulty ?? 0) - header.Difficulty;
             }
-            _nextHeaderHashUpdate.Set();
         }
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
@@ -521,7 +521,11 @@ namespace Nethermind.Synchronization.FastBlocks
                     // response needs to be cached until predecessors arrive
                     if (header.Hash != _nextHeaderHash)
                     {
-                        if (header.Number == (LowestInsertedBlockHeader?.Number ?? _pivotNumber + 1) - 1)
+                        // If the header is at the exact block number, but the hash does not match, then its a different branch.
+                        // However, if the header hash does match the parent of the LowestInsertedBlockHeader, then its just
+                        // `_nextHeaderHash` not updated as the `BlockTree.Insert` has not returned yet.
+                        // We just let it go to the dependency graph.
+                        if (header.Number == (LowestInsertedBlockHeader?.Number ?? _pivotNumber + 1) - 1 && header.Hash != LowestInsertedBlockHeader?.ParentHash)
                         {
                             if (_logger.IsDebug) _logger.Debug($"{batch} - ended up IGNORED - different branch - number {header.Number} was {header.Hash} while expected {_nextHeaderHash}");
                             if (batch.ResponseSourcePeer is not null)
@@ -693,7 +697,7 @@ namespace Nethermind.Synchronization.FastBlocks
             return insertOutcome;
         }
 
-        private void SetExpectedNextHeaderToParent(BlockHeader header)
+        protected void SetExpectedNextHeaderToParent(BlockHeader header)
         {
             ulong nextHeaderDiff = 0;
             _nextHeaderHash = header.ParentHash!;
@@ -705,6 +709,7 @@ namespace Nethermind.Synchronization.FastBlocks
             {
                 _nextHeaderDiff = (header.TotalDifficulty ?? 0) - header.Difficulty;
             }
+            _nextHeaderHashUpdate.Set();
         }
     }
 }


### PR DESCRIPTION
- Fix fast header disconnecting peers due to some IO causing a race issue.

![Screenshot from 2023-03-15 12-40-35](https://user-images.githubusercontent.com/1841324/225208477-3533dc92-e317-4280-8fe5-c1197a247dfe.png)

## Changes

- Dont disonnect peer when a batch does not match next expected batch but match parent of lowest inserted header.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Seems to work.
