### PR TITLE
Adds Deterministic and ProduceReferenceAssembly to Nethermind.Mev

### DIFF
--- a/src/Nethermind/Nethermind.Mev/Nethermind.Mev.csproj
+++ b/src/Nethermind/Nethermind.Mev/Nethermind.Mev.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <Deterministic>true</Deterministic>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 


### PR DESCRIPTION
## Changes

Adds Deterministic and `ProduceReferenceAssembly` to `Nethermind.Mev`

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [X] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [X] No

## Remarks

All projects should have this set, but this is the one that broke my plugin so it is the one I am submitting a PR for.  Ideally, anytime a new project is created this is automatically added to it.  Alternatively, perhaps there could be a linter check or something that verifies these lines get added to all projects?

It is necessary for anyone building plugins that live external to this repository/project as the reference assemblies are needed to build against.