### PR TITLE
Fix crash after full pruning complete when db metrics is enabled

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/Statistics/DbMetricsUpdater.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Statistics/DbMetricsUpdater.cs
@@ -153,4 +153,9 @@ public partial class DbMetricsUpdater
 
     [GeneratedRegex("^Interval compaction: (\\d+)\\.\\d+.*GB write.*\\s+(\\d+)\\.\\d+.*MB\\/s write.*\\s+(\\d+)\\.\\d+.*GB read.*\\s+(\\d+)\\.\\d+.*MB\\/s read.*\\s+(\\d+)\\.\\d+.*seconds.*$", RegexOptions.Multiline)]
     private static partial Regex ExtractIntervalRegex();
+
+    public void Dispose()
+    {
+        _timer?.Dispose();
+    }
 }


### PR DESCRIPTION
- Turns out the crash that I keep encountering after full pruning is the db metrics updater trying to get metrics from a disposed rocksdb.

## Changes

- Stop metrics updater on dispose.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

- Tested to reliably no longer crash.

## Remarks

_Optional. Remove if not applicable._
