### PR TITLE
Use write batch for full pruning write

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPrunerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPrunerTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -9,6 +10,7 @@ using Nethermind.Blockchain.FullPruning;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
+using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
 using Nethermind.Db.FullPruning;
@@ -30,6 +32,7 @@ namespace Nethermind.Blockchain.Test.FullPruning
             TestContext test = CreateTest();
             bool contextDisposed = await test.WaitForPruning();
             contextDisposed.Should().BeTrue();
+            test.ShouldCopyAllValues();
         }
 
         [Test, Timeout(Timeout.MaxTestTime)]
@@ -138,14 +141,14 @@ namespace Nethermind.Blockchain.Test.FullPruning
             {
                 BlockTree.NewHeadBlock += (_, e) => _head = e.Block.Number;
                 _clearPrunedDb = clearPrunedDb;
-                TrieDb = new MemDb();
-                CopyDb = new MemDb();
+                TrieDb = new TestMemDb();
+                CopyDb = new TestMemDb();
                 IRocksDbFactory rocksDbFactory = Substitute.For<IRocksDbFactory>();
                 rocksDbFactory.CreateDb(Arg.Any<RocksDbSettings>()).Returns(TrieDb, CopyDb);
 
                 PatriciaTree trie = Build.A.Trie(TrieDb).WithAccountsByIndex(0, 100).TestObject;
                 _stateRoot = trie.RootHash;
-                StateReader = new StateReader(new TrieStore(TrieDb, LimboLogs.Instance), new MemDb(), LimboLogs.Instance);
+                StateReader = new StateReader(new TrieStore(TrieDb, LimboLogs.Instance), new TestMemDb(), LimboLogs.Instance);
                 FullPruningDb = new TestFullPruningDb(new RocksDbSettings("test", "test"), rocksDbFactory, successfulPruning, clearPrunedDb);
 
                 Pruner = new(FullPruningDb, PruningTrigger, new PruningConfig(), BlockTree, StateReader, LimboLogs.Instance);
@@ -189,6 +192,14 @@ namespace Nethermind.Blockchain.Test.FullPruning
                     BlockTree.Head.Returns(head);
                     BlockTree.FindHeader(number).Returns(head.Header);
                     BlockTree.NewHeadBlock += Raise.EventWith(new BlockEventArgs(head));
+                }
+            }
+
+            public void ShouldCopyAllValues()
+            {
+                foreach (KeyValuePair<byte[], byte[]?> keyValuePair in TrieDb.GetAll())
+                {
+                    CopyDb[keyValuePair.Key].Should().BeEquivalentTo(keyValuePair.Value);
                 }
             }
         }

--- a/src/Nethermind/Nethermind.Core.Test/InMemoryBatch.cs
+++ b/src/Nethermind/Nethermind.Core.Test/InMemoryBatch.cs
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+namespace Nethermind.Core
+{
+    public class InMemoryBatch : IBatch
+    {
+        private readonly IKeyValueStore _store;
+        private readonly ConcurrentDictionary<byte[], byte[]?> _currentItems = new();
+
+        public InMemoryBatch(IKeyValueStore storeWithNoBatchSupport)
+        {
+            _store = storeWithNoBatchSupport;
+        }
+
+        public void Dispose()
+        {
+            foreach (KeyValuePair<byte[], byte[]?> keyValuePair in _currentItems)
+            {
+                _store[keyValuePair.Key] = keyValuePair.Value;
+            }
+
+            GC.SuppressFinalize(this);
+        }
+
+        public byte[]? this[ReadOnlySpan<byte> key]
+        {
+            get => _store[key];
+            set
+            {
+                _currentItems[key.ToArray()] = value;
+            }
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Core.Test/TestMemDb.cs
+++ b/src/Nethermind/Nethermind.Core.Test/TestMemDb.cs
@@ -69,4 +69,9 @@ public class TestMemDb : MemDb
     {
         _removedKeys.Count(cond).Should().Be(times);
     }
+
+    public override IBatch StartBatch()
+    {
+        return new InMemoryBatch(this);
+    }
 }

--- a/src/Nethermind/Nethermind.Db/FullPruning/FullPruningDb.cs
+++ b/src/Nethermind/Nethermind.Db/FullPruning/FullPruningDb.cs
@@ -188,7 +188,7 @@ namespace Nethermind.Db.FullPruning
             private readonly FullPruningDb _db;
 
             private long _counter = 0;
-            private ConcurrentBag<IBatch> _batches = new();
+            private ConcurrentQueue<IBatch> _batches = new();
 
             public PruningContext(FullPruningDb db, IDb cloningDb, bool duplicateReads)
             {
@@ -203,7 +203,7 @@ namespace Nethermind.Db.FullPruning
                 get => CloningDb[key];
                 set
                 {
-                    if (!_batches.TryTake(out IBatch currentBatch))
+                    if (!_batches.TryDequeue(out IBatch currentBatch))
                     {
                         currentBatch = CloningDb.StartBatch();
                     }
@@ -216,7 +216,7 @@ namespace Nethermind.Db.FullPruning
                     }
                     else
                     {
-                        _batches.Add(currentBatch);
+                        _batches.Enqueue(currentBatch);
                     }
                 }
             }

--- a/src/Nethermind/Nethermind.Db/MemDb.cs
+++ b/src/Nethermind/Nethermind.Db/MemDb.cs
@@ -103,7 +103,7 @@ namespace Nethermind.Db
 
         public IEnumerable<byte[]> GetAllValues(bool ordered = false) => Values;
 
-        public IBatch StartBatch()
+        public virtual IBatch StartBatch()
         {
             return this.LikeABatch();
         }


### PR DESCRIPTION
- Use write batch for writes in full pruning that periodically write instead of writing on each node.
- Does not reduce pruning time but significantly reduce write iops and system cpu time. 

Graph is after, before, after. Third have another optimization (#5463).
![Screenshot from 2023-03-20 22-18-48](https://user-images.githubusercontent.com/1841324/226368251-af9b0b7b-e18e-482a-819c-8844b7ff8bd4.png)
Ok, it reduce it a little bit. My SSD is getting hot I suppose?

## Changes

- Use write batch for writes in full pruning.
- Modified TestMemDb to simulate batch behaviour more correctly. Confirmed without final batch dispose, tests would fail.

## Types of changes

#### What types of changes does your code introduce?

- [X] Optimization
## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Seems to work many consecutive times.