### PR TITLE
Perf/get with options

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/FullPruning/FullPruner.cs
+++ b/src/Nethermind/Nethermind.Blockchain/FullPruning/FullPruner.cs
@@ -169,7 +169,11 @@ namespace Nethermind.Blockchain.FullPruning
             {
                 pruning.MarkStart();
                 using CopyTreeVisitor copyTreeVisitor = new(pruning, _logManager);
-                VisitingOptions visitingOptions = new() { MaxDegreeOfParallelism = _pruningConfig.FullPruningMaxDegreeOfParallelism };
+                VisitingOptions visitingOptions = new()
+                {
+                    MaxDegreeOfParallelism = _pruningConfig.FullPruningMaxDegreeOfParallelism,
+                    FullDbScan = true,
+                };
                 _stateReader.RunTreeVisitor(copyTreeVisitor, statRoot, visitingOptions);
 
                 if (!pruning.CancellationTokenSource.IsCancellationRequested)

--- a/src/Nethermind/Nethermind.Core/IKeyValueStore.cs
+++ b/src/Nethermind/Nethermind.Core/IKeyValueStore.cs
@@ -24,7 +24,8 @@ namespace Nethermind.Core
     {
         None,
 
-        // Hint that the workload is likely to not going to benefit from caching and should skip any cache handling.
+        // Hint that the workload is likely to not going to benefit from caching and should skip any cache handling
+        // to reduce CPU usage
         HintCacheMiss,
     }
 }

--- a/src/Nethermind/Nethermind.Core/IKeyValueStore.cs
+++ b/src/Nethermind/Nethermind.Core/IKeyValueStore.cs
@@ -13,5 +13,18 @@ namespace Nethermind.Core
     public interface IReadOnlyKeyValueStore
     {
         byte[]? this[ReadOnlySpan<byte> key] { get; }
+
+        byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)
+        {
+            return this[key];
+        }
+    }
+
+    public enum ReadFlags
+    {
+        None,
+
+        // Hint that the workload is likely to not going to benefit from caching and should skip any cache handling.
+        HintCacheMiss,
     }
 }

--- a/src/Nethermind/Nethermind.Db/FullPruning/FullPruningDb.cs
+++ b/src/Nethermind/Nethermind.Db/FullPruning/FullPruningDb.cs
@@ -67,6 +67,17 @@ namespace Nethermind.Db.FullPruning
             }
         }
 
+        public byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)
+        {
+            byte[]? value = _currentDb.Get(key, flags); // we are reading from the main DB
+            if (_pruningContext?.DuplicateReads == true)
+            {
+                Duplicate(_pruningContext.CloningDb, key, value);
+            }
+
+            return value;
+        }
+
         private void Duplicate(IKeyValueStore db, ReadOnlySpan<byte> key, byte[]? value)
         {
             db[key] = value;

--- a/src/Nethermind/Nethermind.Db/MemDb.cs
+++ b/src/Nethermind/Nethermind.Db/MemDb.cs
@@ -44,13 +44,7 @@ namespace Nethermind.Db
         {
             get
             {
-                if (_readDelay > 0)
-                {
-                    Thread.Sleep(_readDelay);
-                }
-
-                ReadsCount++;
-                return _db.TryGetValue(key, out byte[] value) ? value : null;
+                return Get(key);
             }
             set
             {
@@ -129,6 +123,17 @@ namespace Nethermind.Db
 
         public void DangerousReleaseMemory(in Span<byte> span)
         {
+        }
+
+        public virtual byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)
+        {
+            if (_readDelay > 0)
+            {
+                Thread.Sleep(_readDelay);
+            }
+
+            ReadsCount++;
+            return _db.TryGetValue(key, out byte[] value) ? value : null;
         }
     }
 }

--- a/src/Nethermind/Nethermind.State/IStateProviderExtensions.cs
+++ b/src/Nethermind/Nethermind.State/IStateProviderExtensions.cs
@@ -26,7 +26,11 @@ namespace Nethermind.State
         public static TrieStats CollectStats(this IStateProvider stateProvider, IKeyValueStore codeStorage, ILogManager logManager)
         {
             TrieStatsCollector collector = new(codeStorage, logManager);
-            stateProvider.Accept(collector, stateProvider.StateRoot, new VisitingOptions { MaxDegreeOfParallelism = Environment.ProcessorCount });
+            stateProvider.Accept(collector, stateProvider.StateRoot, new VisitingOptions
+            {
+                MaxDegreeOfParallelism = Environment.ProcessorCount,
+                FullDbScan = true,
+            });
             return collector.Stats;
         }
     }

--- a/src/Nethermind/Nethermind.Trie.Test/TrieNodeResolverWithReadFlagsTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieNodeResolverWithReadFlagsTests.cs
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Test;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Logging;
+using Nethermind.Trie.Pruning;
+using NUnit.Framework;
+
+namespace Nethermind.Trie.Test;
+
+public class TrieNodeResolverWithReadFlagsTests
+{
+    [Test]
+    public void LoadRlp_shouldPassTheFlag()
+    {
+        ReadFlags theFlags = ReadFlags.HintCacheMiss;
+        TestMemDb memDb = new();
+        ITrieStore trieStore = new TrieStore(memDb, LimboLogs.Instance);
+        TrieNodeResolverWithReadFlags resolver = new(trieStore, theFlags);
+
+        Keccak theKeccak = TestItem.KeccakA;
+        resolver.LoadRlp(theKeccak);
+
+        memDb.KeyWasReadWithFlags(theKeccak.Bytes, theFlags);
+    }
+}

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -909,7 +909,7 @@ namespace Nethermind.Trie
         private byte[] TraverseNext(in TraverseContext traverseContext, int extensionLength, TrieNode next)
         {
             // Move large struct creation out of flow so doesn't force additional stack space
-            // in calling method even if not used 
+            // in calling method even if not used
             TraverseContext newContext = traverseContext.WithNewIndex(traverseContext.CurrentIndex + extensionLength);
             return TraverseNode(next, in newContext);
         }
@@ -1025,7 +1025,14 @@ namespace Nethermind.Trie
             }
 
             visitor.VisitTree(rootHash, trieVisitContext);
-            rootRef?.Accept(visitor, TrieStore, trieVisitContext);
+
+            ITrieNodeResolver resolver = TrieStore;
+            if (visitingOptions.FullDbScan)
+            {
+                resolver = new TrieNodeResolverWithReadFlags(TrieStore, ReadFlags.HintCacheMiss);
+            }
+
+            rootRef?.Accept(visitor, resolver, trieVisitContext);
         }
 
         [DoesNotReturn]

--- a/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStore.cs
@@ -48,5 +48,7 @@ namespace Nethermind.Trie.Pruning
         public void Dispose() { }
 
         public byte[]? this[ReadOnlySpan<byte> key] => _trieStore[key];
+
+        public byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags) => _trieStore.Get(key, flags);
     }
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -823,13 +823,18 @@ namespace Nethermind.Trie.Pruning
 
         public byte[]? this[ReadOnlySpan<byte> key]
         {
-            get => _pruningStrategy.PruningEnabled
+            get => Get(key);
+        }
+
+        public byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.HintCacheMiss)
+        {
+            return _pruningStrategy.PruningEnabled
                    && _dirtyNodes.AllNodes.TryGetValue(new Keccak(key.ToArray()), out TrieNode? trieNode)
                    && trieNode is not null
                    && trieNode.NodeType != NodeType.Unknown
                    && trieNode.FullRlp is not null
                 ? trieNode.FullRlp
-                : _currentBatch?[key] ?? _keyValueStore[key];
+                : _currentBatch?.Get(key, flags) ?? _keyValueStore.Get(key, flags);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -826,7 +826,7 @@ namespace Nethermind.Trie.Pruning
             get => Get(key);
         }
 
-        public byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.HintCacheMiss)
+        public byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)
         {
             return _pruningStrategy.PruningEnabled
                    && _dirtyNodes.AllNodes.TryGetValue(new Keccak(key.ToArray()), out TrieNode? trieNode)

--- a/src/Nethermind/Nethermind.Trie/TrieNodeResolverWithReadFlags.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNodeResolverWithReadFlags.cs
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Trie.Pruning;
+
+namespace Nethermind.Trie;
+
+public class TrieNodeResolverWithReadFlags: ITrieNodeResolver
+{
+    private ITrieStore _baseResolver;
+    private ReadFlags _flags;
+
+    public TrieNodeResolverWithReadFlags(ITrieStore baseResolver, ReadFlags flags)
+    {
+        _baseResolver = baseResolver;
+        _flags = flags;
+    }
+
+    public TrieNode FindCachedOrUnknown(Keccak hash)
+    {
+        return _baseResolver.FindCachedOrUnknown(hash);
+    }
+
+    public byte[]? LoadRlp(Keccak hash)
+    {
+        return _baseResolver.Get(hash.Bytes, _flags);
+    }
+}

--- a/src/Nethermind/Nethermind.Trie/VisitingOptions.cs
+++ b/src/Nethermind/Nethermind.Trie/VisitingOptions.cs
@@ -21,5 +21,7 @@ namespace Nethermind.Trie
         /// Maximum number of threads that will be used to visit the trie.
         /// </summary>
         public int MaxDegreeOfParallelism { get; init; } = 1;
+
+        public bool FullDbScan { get; set; }
     }
 }


### PR DESCRIPTION
- Add a read flag to get method to be able to skip caching db.
- Once read iops goes down (some other PR), the CPU is the bottleneck and this will be important.
- Improve full pruning time by about 20 to 25%.

## Types of changes

#### What types of changes does your code introduce?

- [X] Optimization

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- still testing.