### PR TITLE
Fix random trie exception after pruning

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPrunerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPrunerTests.cs
@@ -189,7 +189,7 @@ namespace Nethermind.Blockchain.Test.FullPruning
                     Block head = Build.A.Block.WithStateRoot(_stateRoot).WithNumber(number).TestObject;
                     BlockTree.Head.Returns(head);
                     BlockTree.FindHeader(number).Returns(head.Header);
-                    BlockTree.OnUpdateMainChain += Raise.EventWith(new OnUpdateMainChainArgs(new List<Block>() {head}, true));
+                    BlockTree.OnUpdateMainChain += Raise.EventWith(new OnUpdateMainChainArgs(new List<Block>() { head }, true));
                 }
             }
         }

--- a/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPrunerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPrunerTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -136,7 +137,7 @@ namespace Nethermind.Blockchain.Test.FullPruning
 
             public TestContext(bool successfulPruning, bool clearPrunedDb = false)
             {
-                BlockTree.NewHeadBlock += (_, e) => _head = e.Block.Number;
+                BlockTree.OnUpdateMainChain += (_, e) => _head = e.Blocks[^1].Number;
                 _clearPrunedDb = clearPrunedDb;
                 TrieDb = new MemDb();
                 CopyDb = new MemDb();
@@ -188,7 +189,7 @@ namespace Nethermind.Blockchain.Test.FullPruning
                     Block head = Build.A.Block.WithStateRoot(_stateRoot).WithNumber(number).TestObject;
                     BlockTree.Head.Returns(head);
                     BlockTree.FindHeader(number).Returns(head.Header);
-                    BlockTree.NewHeadBlock += Raise.EventWith(new BlockEventArgs(head));
+                    BlockTree.OnUpdateMainChain += Raise.EventWith(new OnUpdateMainChainArgs(new List<Block>() {head}, true));
                 }
             }
         }

--- a/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPruningDiskTest.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPruningDiskTest.cs
@@ -144,6 +144,8 @@ namespace Nethermind.Blockchain.Test.FullPruning
                 currentItems.IsSubsetOf(allItems).Should().BeTrue();
                 currentItems.Count.Should().BeGreaterThan(0);
             }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
         }
 
         private static async Task WriteFileStructure(PruningTestBlockchain chain)

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -1357,6 +1357,8 @@ namespace Nethermind.Blockchain
                 bool lastProcessedBlock = i == blocks.Count - 1;
                 MoveToMain(blocks[i], batch, wereProcessed, forceUpdateHeadBlock && lastProcessedBlock);
             }
+
+            OnUpdateMainChain?.Invoke(this, new OnUpdateMainChainArgs(blocks, wereProcessed));
         }
 
         public void UpdateBeaconMainChain(BlockInfo[]? blockInfos, long clearBeaconMainChainStartPoint)
@@ -1939,6 +1941,8 @@ namespace Nethermind.Blockchain
         }
 
         public event EventHandler<BlockReplacementEventArgs>? BlockAddedToMain;
+
+        public event EventHandler<OnUpdateMainChainArgs>? OnUpdateMainChain;
 
         public event EventHandler<BlockEventArgs>? NewBestSuggestedBlock;
 

--- a/src/Nethermind/Nethermind.Blockchain/IBlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/IBlockTree.cs
@@ -165,8 +165,21 @@ namespace Nethermind.Blockchain
 
         event EventHandler<BlockEventArgs> NewBestSuggestedBlock;
         event EventHandler<BlockEventArgs> NewSuggestedBlock;
+
+        /// <summary>
+        /// A block is marked as canon
+        /// </summary>
         event EventHandler<BlockReplacementEventArgs> BlockAddedToMain;
+
+        /// <summary>
+        /// A block is now set as head
+        /// </summary>
         event EventHandler<BlockEventArgs> NewHeadBlock;
+
+        /// <summary>
+        /// A branch is now set as canon. This is different from `BlockAddedToMain` as it is fired only once for the
+        /// the whole branch.
+        /// </summary>
         event EventHandler<OnUpdateMainChainArgs> OnUpdateMainChain;
 
         int DeleteChainSlice(in long startNumber, long? endNumber = null);

--- a/src/Nethermind/Nethermind.Blockchain/IBlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/IBlockTree.cs
@@ -167,6 +167,7 @@ namespace Nethermind.Blockchain
         event EventHandler<BlockEventArgs> NewSuggestedBlock;
         event EventHandler<BlockReplacementEventArgs> BlockAddedToMain;
         event EventHandler<BlockEventArgs> NewHeadBlock;
+        event EventHandler<OnUpdateMainChainArgs> OnUpdateMainChain;
 
         int DeleteChainSlice(in long startNumber, long? endNumber = null);
 

--- a/src/Nethermind/Nethermind.Blockchain/OnUpdateMainChainArgs.cs
+++ b/src/Nethermind/Nethermind.Blockchain/OnUpdateMainChainArgs.cs
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using Nethermind.Core;
+
+namespace Nethermind.Blockchain;
+
+public class OnUpdateMainChainArgs: EventArgs
+{
+    public IReadOnlyList<Block> Blocks { get; }
+
+    public bool WereProcessed { get; }
+
+    public OnUpdateMainChainArgs(IReadOnlyList<Block> blocks, bool wereProcessed)
+    {
+        Blocks = blocks;
+        WereProcessed = wereProcessed;
+    }
+}

--- a/src/Nethermind/Nethermind.Blockchain/OnUpdateMainChainArgs.cs
+++ b/src/Nethermind/Nethermind.Blockchain/OnUpdateMainChainArgs.cs
@@ -7,7 +7,7 @@ using Nethermind.Core;
 
 namespace Nethermind.Blockchain;
 
-public class OnUpdateMainChainArgs: EventArgs
+public class OnUpdateMainChainArgs : EventArgs
 {
     public IReadOnlyList<Block> Blocks { get; }
 

--- a/src/Nethermind/Nethermind.Blockchain/ReadOnlyBlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/ReadOnlyBlockTree.cs
@@ -148,6 +148,12 @@ namespace Nethermind.Blockchain
             remove { }
         }
 
+        public event EventHandler<OnUpdateMainChainArgs>? OnUpdateMainChain
+        {
+            add { }
+            remove { }
+        }
+
         public int DeleteChainSlice(in long startNumber, long? endNumber = null)
         {
             var bestKnownNumber = BestKnownNumber;


### PR DESCRIPTION
- If full pruning is started after new head event which is triggered by blockchainproccessor where the branch have more than one block, some of the block state will be missed causing trie exception after pruning complete.
- This is because blockchainprocessor will process the branch first before triggered new head event multiple time. Full pruning will start switching duplicating writes after the first event, and assume the writes for the other blocks will start after that, but that does not happen as it was already processed.
- This PR add another event `OnUpdateMainChain` which would get triggered per processing branch instead of multiple time. Ideally the event should be in BlockchainProcessor, but turns out there is a dependency issue so it can't refer to it without a bigger refactor.

```
2023-03-21 17:52:14.4630|WARN|46|Process done 8692501 
2023-03-21 17:52:14.4670|WARN|46|Processing 8692502 
2023-03-21 17:52:14.5831|WARN|46|Process done 8692502 
2023-03-21 17:52:14.5879|WARN|46|New head block 8692501 
2023-03-21 17:52:14.5899|WARN|46|Buffer size for State1 20899225 8 3028682281 
2023-03-21 17:52:14.5924|INFO|46|Full Pruning Ready to start: waiting for state 8692501 to be ready. 
2023-03-21 17:52:14.5924|WARN|46|New head block 8692502 
2023-03-21 17:52:14.5924|INFO|46|Full Pruning Waiting for block: 8692511 in order to support reorganizations. 
2023-03-21 17:52:14.5924|INFO|46|Processed    8692502 |      292ms of 802,469ms, mgasps   44.41 total   44.41, tps  396.92 total  396.92, bps    0.00 total    0.00, recv queue 0, proc queue 32 
2023-03-21 17:52:14.5924|WARN|46|Processing 8692503 
```

## Changes

- Use `OnUpdateMainChain` event instead.
- Updated unit tests to reflect.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes: well I updated the old tests.
- [ ] No

#### Notes on testing

- 6 consecutive goerli full pruning so far...
