### PR TITLE
Update ethereum tests, add `Eip4895WithdrawalsTests`

### DIFF
--- a/src/Nethermind/Ethereum.Blockchain.Block.Test/Eip4895WithdrawalsTests.cs
+++ b/src/Nethermind/Ethereum.Blockchain.Block.Test/Eip4895WithdrawalsTests.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Collections.Generic;

--- a/src/Nethermind/Ethereum.Blockchain.Block.Test/Eip4895WithdrawalsTests.cs
+++ b/src/Nethermind/Ethereum.Blockchain.Block.Test/Eip4895WithdrawalsTests.cs
@@ -1,0 +1,26 @@
+﻿// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Ethereum.Test.Base;
+using NUnit.Framework;
+
+namespace Ethereum.Blockchain.Block.Test;
+
+[TestFixture]
+[Parallelizable(ParallelScope.All)]
+public class Eip4895WithdrawalsTests : BlockchainTestBase
+{
+    [TestCaseSource(nameof(LoadTests))]
+    public async Task Test(BlockchainTest test)
+    {
+        await RunTest(test);
+    }
+
+    public static IEnumerable<BlockchainTest> LoadTests()
+    {
+        var loader = new TestsSourceLoader(new LoadBlockchainTestsStrategy(), "bc4895-withdrawals");
+        return (IEnumerable<BlockchainTest>)loader.LoadTests();
+    }
+}

--- a/src/Nethermind/Ethereum.Blockchain.Block.Test/MetaTests.cs
+++ b/src/Nethermind/Ethereum.Blockchain.Block.Test/MetaTests.cs
@@ -62,7 +62,12 @@ namespace Ethereum.Blockchain.Block.Test
                 }
             }
 
-            return prefix + expectedTypeName;
+            if (char.IsDigit(expectedTypeName.FirstOrDefault()))
+            {
+                prefix += "eip";
+            }
+
+            return prefix + expectedTypeName.Replace("-", "");
         }
     }
 }


### PR DESCRIPTION
## Changes

- standard update of ethereum tests
- added class `Eip4895WithdrawalsTests`
- adjusted `MetaTest` to work fine with `4895-withdrawals` (starting with digit and `-` inside)

## Types of changes

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: standard update of ethereum tests

## Testing

#### Requires testing

- [ ] Yes
- [x] No
