### PR TITLE
Fix `SendNewTransactions`

### DIFF
--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
@@ -186,7 +186,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
             SendMessage(new[] { tx });
         }
 
-        public void SendNewTransactions(IEnumerable<Transaction> txs, bool sendFullTx = false)
+        public virtual void SendNewTransactions(IEnumerable<Transaction> txs, bool sendFullTx = false)
         {
             SendNewTransactionsCore(TxsToSendAndMarkAsNotified(txs, sendFullTx), sendFullTx);
         }
@@ -202,7 +202,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
             }
         }
 
-        protected virtual void SendNewTransactionsCore(IEnumerable<Transaction> txs, bool sendFullTx)
+        private void SendNewTransactionsCore(IEnumerable<Transaction> txs, bool sendFullTx)
         {
             int packetSizeLeft = TransactionsMessage.MaxPacketSize;
             using ArrayPoolList<Transaction> txsToSend = new(1024);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandler.cs
@@ -155,7 +155,6 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V65
                 if (tx.Hash is not null)
                 {
                     hashes.Add(tx.Hash);
-                    NotifiedTransactions.Set(tx.Hash);
                     TxPool.Metrics.PendingTransactionsHashesSent++;
                 }
             }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandler.cs
@@ -134,11 +134,11 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V65
             return new PooledTransactionsMessage(txsToSend);
         }
 
-        protected override void SendNewTransactionsCore(IEnumerable<Transaction> txs, bool sendFullTx)
+        public override void SendNewTransactions(IEnumerable<Transaction> txs, bool sendFullTx)
         {
             if (sendFullTx)
             {
-                base.SendNewTransactionsCore(txs, true);
+                base.SendNewTransactions(txs, true);
                 return;
             }
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandler.cs
@@ -155,6 +155,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V65
                 if (tx.Hash is not null)
                 {
                     hashes.Add(tx.Hash);
+                    NotifiedTransactions.Set(tx.Hash);
                     TxPool.Metrics.PendingTransactionsHashesSent++;
                 }
             }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
@@ -120,6 +120,7 @@ public class Eth68ProtocolHandler : Eth67ProtocolHandler
                 sizes.Add(tx.GetLength(_txDecoder));
                 hashes.Add(tx.Hash);
                 NotifiedTransactions.Set(tx.Hash);
+                TxPool.Metrics.PendingTransactionsHashesSent++;
             }
         }
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
@@ -119,6 +119,7 @@ public class Eth68ProtocolHandler : Eth67ProtocolHandler
                 types.Add((byte)tx.Type);
                 sizes.Add(tx.GetLength(_txDecoder));
                 hashes.Add(tx.Hash);
+                NotifiedTransactions.Set(tx.Hash);
             }
         }
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
@@ -119,7 +119,6 @@ public class Eth68ProtocolHandler : Eth67ProtocolHandler
                 types.Add((byte)tx.Type);
                 sizes.Add(tx.GetLength(_txDecoder));
                 hashes.Add(tx.Hash);
-                NotifiedTransactions.Set(tx.Hash);
                 TxPool.Metrics.PendingTransactionsHashesSent++;
             }
         }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
@@ -92,11 +92,11 @@ public class Eth68ProtocolHandler : Eth67ProtocolHandler
         if (isTrace) Logger.Trace($"OUT {Counter:D5} {nameof(NewPooledTransactionHashesMessage68)} to {Node:c} in {stopwatch.Elapsed.TotalMilliseconds}ms");
     }
 
-    protected override void SendNewTransactionsCore(IEnumerable<Transaction> txs, bool sendFullTx)
+    public override void SendNewTransactions(IEnumerable<Transaction> txs, bool sendFullTx)
     {
         if (sendFullTx)
         {
-            base.SendNewTransactionsCore(txs, sendFullTx);
+            base.SendNewTransactions(txs, sendFullTx);
             return;
         }
 


### PR DESCRIPTION
## Changes

- after changes from https://github.com/NethermindEth/nethermind/pull/5449 `SendNewTransactions` from `ITxPoolPeer` is pointing directly to `SyncPeerProtocolHandlerBase` which is not correct. Name of this method in `Eth68ProtocolHandler` and `Eth65ProtocolHandler` was changed to `SendNewTransactionsCore` and now is not overriding `SendNewTransactions` as expected. `TxBroadcaster` is calling `SyncPeerProtocolHandlerBase` instead of newest version of eth protocol. This PR is fixing it.
Tests didn't catch it - `Eth68ProtocolHandlerTests` are testing only eth68 handler and `TxBroadcasterTests` are testing only correctness of call to `ITxPoolPeer`.
I'm open for an idea how to write regression test to avoid that bug in the future - I haven't figure it out yet.
- added `TxPool.Metrics.PendingTransactionsHashesSent++` in missing place (`SendNewTransactions` in `Eth68ProtocolHandler`)

## Types of changes=

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No