### PR TITLE
Add direct io and blob files flags

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/Config/IDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/IDbConfig.cs
@@ -15,77 +15,110 @@ public interface IDbConfig : IConfig
     int? MaxOpenFiles { get; set; }
     uint RecycleLogFileNum { get; set; }
     bool WriteAheadLogSync { get; set; }
-    long? MaxWriteBytesPerSec { get; set; }
+    long? RateLimiterBytesPerSec { get; set; }
+    bool? UseDirectReads { get; set; }
+    bool? UseDirectIOForFlushAndCompaction  { get; set; }
+    bool? EnableBlobFiles  { get; set; }
 
     ulong ReceiptsDbWriteBufferSize { get; set; }
     uint ReceiptsDbWriteBufferNumber { get; set; }
     ulong ReceiptsDbBlockCacheSize { get; set; }
     bool ReceiptsDbCacheIndexAndFilterBlocks { get; set; }
     int? ReceiptsDbMaxOpenFiles { get; set; }
-    long? ReceiptsDbMaxWriteBytesPerSec { get; set; }
+    long? ReceiptsDbRateLimiterBytesPerSec { get; set; }
+    bool? ReceiptsDbUseDirectReads { get; set; }
+    bool? ReceiptsDbUseDirectIOForFlushAndCompaction  { get; set; }
+    bool? ReceiptsDbEnableBlobFiles  { get; set; }
 
     ulong BlocksDbWriteBufferSize { get; set; }
     uint BlocksDbWriteBufferNumber { get; set; }
     ulong BlocksDbBlockCacheSize { get; set; }
     bool BlocksDbCacheIndexAndFilterBlocks { get; set; }
     int? BlocksDbMaxOpenFiles { get; set; }
-    long? BlocksDbMaxWriteBytesPerSec { get; set; }
+    long? BlocksDbRateLimiterBytesPerSec { get; set; }
+    bool? BlocksDbUseDirectReads { get; set; }
+    bool? BlocksDbUseDirectIOForFlushAndCompaction  { get; set; }
+    bool? BlocksDbEnableBlobFiles  { get; set; }
 
     ulong HeadersDbWriteBufferSize { get; set; }
     uint HeadersDbWriteBufferNumber { get; set; }
     ulong HeadersDbBlockCacheSize { get; set; }
     bool HeadersDbCacheIndexAndFilterBlocks { get; set; }
     int? HeadersDbMaxOpenFiles { get; set; }
-    long? HeadersDbMaxWriteBytesPerSec { get; set; }
+    long? HeadersDbRateLimiterBytesPerSec { get; set; }
+    bool? HeadersDbUseDirectReads { get; set; }
+    bool? HeadersDbUseDirectIOForFlushAndCompaction  { get; set; }
+    bool? HeadersDbEnableBlobFiles  { get; set; }
 
     ulong BlockInfosDbWriteBufferSize { get; set; }
     uint BlockInfosDbWriteBufferNumber { get; set; }
     ulong BlockInfosDbBlockCacheSize { get; set; }
     bool BlockInfosDbCacheIndexAndFilterBlocks { get; set; }
     int? BlockInfosDbMaxOpenFiles { get; set; }
-    long? BlockInfosDbMaxWriteBytesPerSec { get; set; }
+    long? BlockInfosDbRateLimiterBytesPerSec { get; set; }
+    bool? BlockInfoUseDirectReads { get; set; }
+    bool? BlockInfoUseDirectIOForFlushAndCompaction  { get; set; }
+    bool? BlockInfoEnableBlobFiles  { get; set; }
 
     ulong PendingTxsDbWriteBufferSize { get; set; }
     uint PendingTxsDbWriteBufferNumber { get; set; }
     ulong PendingTxsDbBlockCacheSize { get; set; }
     bool PendingTxsDbCacheIndexAndFilterBlocks { get; set; }
     int? PendingTxsDbMaxOpenFiles { get; set; }
-    long? PendingTxsDbMaxWriteBytesPerSec { get; set; }
+    long? PendingTxsDbRateLimiterBytesPerSec { get; set; }
+    bool? PendingTxsUseDirectReads { get; set; }
+    bool? PendingTxsUseDirectIOForFlushAndCompaction  { get; set; }
+    bool? PendingTxsEnableBlobFiles  { get; set; }
 
     ulong CodeDbWriteBufferSize { get; set; }
     uint CodeDbWriteBufferNumber { get; set; }
     ulong CodeDbBlockCacheSize { get; set; }
     bool CodeDbCacheIndexAndFilterBlocks { get; set; }
     int? CodeDbMaxOpenFiles { get; set; }
-    long? CodeDbMaxWriteBytesPerSec { get; set; }
+    long? CodeDbRateLimiterBytesPerSec { get; set; }
+    bool? CodeDbUseDirectReads { get; set; }
+    bool? CodeDbUseDirectIOForFlushAndCompaction  { get; set; }
+    bool? CodeDbEnableBlobFiles  { get; set; }
 
     ulong BloomDbWriteBufferSize { get; set; }
     uint BloomDbWriteBufferNumber { get; set; }
     ulong BloomDbBlockCacheSize { get; set; }
     bool BloomDbCacheIndexAndFilterBlocks { get; set; }
     int? BloomDbMaxOpenFiles { get; set; }
-    long? BloomDbMaxWriteBytesPerSec { get; set; }
+    long? BloomDbRateLimiterBytesPerSec { get; set; }
+    bool? BloomDbUseDirectReads { get; set; }
+    bool? BloomDbUseDirectIOForFlushAndCompaction  { get; set; }
+    bool? BloomDbEnableBlobFiles  { get; set; }
 
     ulong WitnessDbWriteBufferSize { get; set; }
     uint WitnessDbWriteBufferNumber { get; set; }
     ulong WitnessDbBlockCacheSize { get; set; }
     bool WitnessDbCacheIndexAndFilterBlocks { get; set; }
     int? WitnessDbMaxOpenFiles { get; set; }
-    long? WitnessDbMaxWriteBytesPerSec { get; set; }
+    long? WitnessDbRateLimiterBytesPerSec { get; set; }
+    bool? WitnessDbUseDirectReads { get; set; }
+    bool? WitnessDbUseDirectIOForFlushAndCompaction  { get; set; }
+    bool? WitnessDbEnableBlobFiles  { get; set; }
 
     ulong CanonicalHashTrieDbWriteBufferSize { get; set; }
     uint CanonicalHashTrieDbWriteBufferNumber { get; set; }
     ulong CanonicalHashTrieDbBlockCacheSize { get; set; }
     bool CanonicalHashTrieDbCacheIndexAndFilterBlocks { get; set; }
     int? CanonicalHashTrieDbMaxOpenFiles { get; set; }
-    long? CanonicalHashTrieDbMaxWriteBytesPerSec { get; set; }
+    long? CanonicalHashTrieDbRateLimiterBytesPerSec { get; set; }
+    bool? CanonicalHashTrieDbUseDirectReads { get; set; }
+    bool? CanonicalHashTrieDbUseDirectIOForFlushAndCompaction  { get; set; }
+    bool? CanonicalHashTrieDbEnableBlobFiles  { get; set; }
 
     ulong MetadataDbWriteBufferSize { get; set; }
     uint MetadataDbWriteBufferNumber { get; set; }
     ulong MetadataDbBlockCacheSize { get; set; }
     bool MetadataDbCacheIndexAndFilterBlocks { get; set; }
     int? MetadataDbMaxOpenFiles { get; set; }
-    long? MetadataDbMaxWriteBytesPerSec { get; set; }
+    long? MetadataDbRateLimiterBytesPerSec { get; set; }
+    bool? MetadataDbUseDirectReads { get; set; }
+    bool? MetadataDbUseDirectIOForFlushAndCompaction  { get; set; }
+    bool? MetadataDbEnableBlobFiles  { get; set; }
 
     /// <summary>
     /// Enables DB Statistics - https://github.com/facebook/rocksdb/wiki/Statistics

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/PerTableDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/PerTableDbConfig.cs
@@ -22,15 +22,14 @@ public class PerTableDbConfig
     }
 
     public bool CacheIndexAndFilterBlocks => _settings.CacheIndexAndFilterBlocks ?? ReadConfig<bool>(nameof(CacheIndexAndFilterBlocks));
-
     public ulong BlockCacheSize => _settings.BlockCacheSize ?? ReadConfig<ulong>(nameof(BlockCacheSize));
-
     public ulong WriteBufferSize => _settings.WriteBufferSize ?? ReadConfig<ulong>(nameof(WriteBufferSize));
-
     public ulong WriteBufferNumber => _settings.WriteBufferNumber ?? ReadConfig<uint>(nameof(WriteBufferNumber));
-
     public int? MaxOpenFiles => ReadConfig<int?>(nameof(MaxOpenFiles));
-    public long? MaxWriteBytesPerSec => ReadConfig<long?>(nameof(MaxWriteBytesPerSec));
+    public long? RateLimiterBytesPerSec => ReadConfig<long?>(nameof(RateLimiterBytesPerSec));
+    public bool? UseDirectReads => ReadConfig<bool?>(nameof(UseDirectReads));
+    public bool? UseDirectIOForFlushAndCompaction => ReadConfig<bool?>(nameof(UseDirectIOForFlushAndCompaction));
+    public bool? EnableBlobFiles => ReadConfig<bool?>(nameof(EnableBlobFiles));
 
     private T? ReadConfig<T>(string propertyName)
     {

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -252,10 +252,10 @@ public class DbOnTheRocks : IDbWithSpan, ITunableDb
             options.SetMaxOpenFiles(_perTableDbConfig.MaxOpenFiles.Value);
         }
 
-        if (_perTableDbConfig.MaxWriteBytesPerSec.HasValue)
+        if (_perTableDbConfig.RateLimiterBytesPerSec.HasValue)
         {
             _rateLimiter =
-                _rocksDbNative.rocksdb_ratelimiter_create(_perTableDbConfig.MaxWriteBytesPerSec.Value, 1000, 10);
+                _rocksDbNative.rocksdb_ratelimiter_create(_perTableDbConfig.RateLimiterBytesPerSec.Value, 1000, 10);
             _rocksDbNative.rocksdb_options_set_ratelimiter(options.Handle, _rateLimiter.Value);
         }
 
@@ -264,6 +264,10 @@ public class DbOnTheRocks : IDbWithSpan, ITunableDb
         int writeBufferNumber = (int)_perTableDbConfig.WriteBufferNumber;
         options.SetMaxWriteBufferNumber(writeBufferNumber);
         options.SetMinWriteBufferNumberToMerge(2);
+
+        if (_perTableDbConfig.UseDirectReads != null) options.SetUseDirectReads(_perTableDbConfig.UseDirectReads.Value);
+        if (_perTableDbConfig.UseDirectIOForFlushAndCompaction != null) options.SetUseDirectReads(_perTableDbConfig.UseDirectIOForFlushAndCompaction.Value);
+        if (_perTableDbConfig.EnableBlobFiles != null) _rocksDbNative.rocksdb_options_set_enable_blob_files(options.Handle, true);
 
         lock (_dbsByPath)
         {


### PR DESCRIPTION
- Add flags to enables direct io and blob files.
- Rename write rates limit to ratelimiter as its not actually used just for write. You can actually specify read priority which also charge to the same rate limiter actually, not sure if we have access to it.

## Types of changes

#### What types of changes does your code introduce?

- [X] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No: Config change

#### Notes on testing

- Have not tested the effect yet....