### PR TITLE
Small improvement in startup logs

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -263,8 +263,6 @@ namespace Nethermind.Blockchain
                     .AsRlpStream().DecodeKeccak();
                 _lowestInsertedBeaconHeader = FindHeader(lowestBeaconHeaderHash, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
             }
-
-            if (_logger.IsInfo) _logger.Info($"Loaded LowestInsertedBeaconHeader: {LowestInsertedBeaconHeader}");
         }
 
         private void LoadLowestInsertedHeader()
@@ -1559,7 +1557,7 @@ namespace Nethermind.Blockchain
                 if (data is not null)
                 {
                     startBlock = FindBlock(new Keccak(data), BlockTreeLookupOptions.None);
-                    _logger.Warn($"Start block loaded from HEAD - {startBlock?.ToString(Block.Format.Short)}");
+                    if (_logger.IsInfo) _logger.Info($"Start block loaded from HEAD - {startBlock?.ToString(Block.Format.Short)}");
                 }
             }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconPivot.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconPivot.cs
@@ -144,7 +144,10 @@ namespace Nethermind.Merge.Plugin.Synchronization
                 }
             }
 
-            if (_logger.IsInfo) _logger.Info($"Loaded Beacon Pivot: {CurrentBeaconPivot?.ToString(BlockHeader.Format.FullHashAndNumber)}");
+            if (CurrentBeaconPivot != null)
+            {
+                if (_logger.IsInfo) _logger.Info($"Loaded Beacon Pivot: {CurrentBeaconPivot?.ToString(BlockHeader.Format.FullHashAndNumber)}");
+            }
         }
     }
 


### PR DESCRIPTION
## Changes
- Removed the ugly log ⬇️ 
![LoadLoawestInsertedBeaconHeader](https://user-images.githubusercontent.com/9356351/227230016-3729db16-1693-409d-aad7-3a317aa66905.jpg)
It was duplicated with https://github.com/NethermindEth/nethermind/blob/master/src/Nethermind/Nethermind.Blockchain/BlockTree.cs#L216
- Don't print BeaconPivot when it is null
- Changed one Warn to Info

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: logs-related changes

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

I've run unsynced/synced nodes a few times. Of course, there is no need to sync the node to test it.
