### PR TITLE
Add Nethermind.ReferenceAssemblies package

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -1,0 +1,46 @@
+name: Publish NuGet packages
+
+on:
+  release:
+    types: [published]
+  
+env:
+  RELEASE_URL: https://api.github.com/repos/nethermindeth/nethermind/releases/latest
+  
+jobs:
+  get-release:
+    name: Get latest release
+    runs-on: ubuntu-latest
+    outputs:
+      COMMIT: ${{ steps.release.outputs.COMMIT }}
+      PRERELEASE: ${{ steps.release.outputs.PRERELEASE }}
+      URL: ${{ steps.release.outputs.URL }}
+      VERSION: ${{ steps.release.outputs.VERSION }}
+    steps:
+    - name: Get release metadata
+      id: release
+      run: |
+        read tag_name prerelease url < <(echo $(curl -s ${{ env.RELEASE_URL }} | jq -r '.tag_name, .prerelease, (.assets[].browser_download_url | select(contains("plugin-sdk")))'))
+        echo "PRERELEASE=$prerelease" >> $GITHUB_OUTPUT
+        echo "URL=$url" >> $GITHUB_OUTPUT
+        echo "VERSION=$tag_name" >> $GITHUB_OUTPUT
+
+  publish-ref-assemblies:
+    name: Publish Nethermind.ReferenceAssemblies
+    runs-on: ubuntu-latest
+    needs: get-release
+    if: needs.get-release.outputs.PRERELEASE == 'false'
+    steps:
+    - name: Check out Nethermind repository
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ needs.get-release.outputs.VERSION }}
+    - name: Download Nethermind reference assemblies
+      run: |
+        curl -sL ${{ needs.get-release.outputs.URL }} -o refasm.zip
+        unzip refasm.zip -d src/Nethermind/Nethermind.ReferenceAssemblies/ref
+    - name: Submit package
+      working-directory: src/Nethermind/Nethermind.ReferenceAssemblies
+      run: | 
+        dotnet pack -c release
+        dotnet nuget push bin/release/*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -18,8 +18,8 @@ jobs:
     - name: Get release metadata
       id: release
       run: |
-        read tag_name prerelase < <(echo $(curl -s ${{ env.RELEASE_URL }} | jq -r '.tag_name, .prerelease'))
-        echo "PRERELEASE=$prerelase" >> $GITHUB_OUTPUT
+        read tag_name prerelease < <(echo $(curl -s ${{ env.RELEASE_URL }} | jq -r '.tag_name, .prerelease'))
+        echo "PRERELEASE=$prerelease" >> $GITHUB_OUTPUT
         echo "VERSION=$tag_name" >> $GITHUB_OUTPUT
 
   publish-ppa:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ permissions:
 
 env:
   PACKAGE_DIR: pkg
-  PACKAGE_RETENTION: 2
+  PACKAGE_RETENTION: 7
   PUB_DIR: pub
   SCRIPTS_PATH: ${{ github.workspace }}/nethermind/scripts/deployment
 
@@ -116,6 +116,12 @@ jobs:
       with:
         name: ${{ steps.archive.outputs.PACKAGE_PREFIX }}-macos-arm64-package
         path: ${{ github.workspace }}/${{ env.PACKAGE_DIR }}/*macos-arm64*
+        retention-days: ${{ env.PACKAGE_RETENTION }}
+    - name: Upload Nethermind reference assemblies
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ steps.archive.outputs.PACKAGE_PREFIX }}-plugin-sdk-package
+        path: ${{ github.workspace }}/${{ env.PACKAGE_DIR }}/*plugin-sdk*
         retention-days: ${{ env.PACKAGE_RETENTION }}
         
   approval:

--- a/scripts/deployment/archive-packages.sh
+++ b/scripts/deployment/archive-packages.sh
@@ -15,5 +15,6 @@ cd linux-arm64 && zip -r $GITHUB_WORKSPACE/$PACKAGE_DIR/$PACKAGE_PREFIX-linux-ar
 cd win-x64 && zip -r $GITHUB_WORKSPACE/$PACKAGE_DIR/$PACKAGE_PREFIX-windows-x64.zip . && cd ..
 cd osx-x64 && zip -r $GITHUB_WORKSPACE/$PACKAGE_DIR/$PACKAGE_PREFIX-macos-x64.zip . && cd ..
 cd osx-arm64 && zip -r $GITHUB_WORKSPACE/$PACKAGE_DIR/$PACKAGE_PREFIX-macos-arm64.zip . && cd ..
+cd ref && zip -r $GITHUB_WORKSPACE/$PACKAGE_DIR/$PACKAGE_PREFIX-plugin-sdk.zip . && cd ..
 
 echo "Archiving completed"

--- a/scripts/deployment/build-runner.sh
+++ b/scripts/deployment/build-runner.sh
@@ -15,7 +15,13 @@ for rid in "linux-x64" "linux-arm64" "win-x64" "osx-x64" "osx-arm64"
 do
   echo "  Publishing for $rid"
 
-  dotnet publish -c release -r $rid -o $OUTPUT_PATH/$rid --sc true -p:Commit=$2 -p:BuildTimestamp=$3 -p:PublishSingleFile=true -p:IncludeAllContentForSelfExtract=true
+  dotnet publish -c release -r $rid -o $OUTPUT_PATH/$rid --sc true \
+    -p:BuildTimestamp=$3 \
+    -p:Commit=$2 \
+    -p:Deterministic=true \
+    -p:IncludeAllContentForSelfExtract=true \
+    -p:ProduceReferenceAssembly=true \
+    -p:PublishSingleFile=true
 
   rm -rf $OUTPUT_PATH/$rid/*.pdb
   rm -rf $OUTPUT_PATH/$rid/Data/*
@@ -24,5 +30,9 @@ do
   cp Data/static-nodes.json $OUTPUT_PATH/$rid/Data
   mkdir $OUTPUT_PATH/$rid/keystore
 done
+
+cd ..
+mkdir $OUTPUT_PATH/ref
+cp **/obj/release/**/ref/*.dll $OUTPUT_PATH/ref
 
 echo "Build completed"

--- a/scripts/deployment/publish-github.sh
+++ b/scripts/deployment/publish-github.sh
@@ -42,7 +42,7 @@ fi
 
 cd $PACKAGE_PATH
 
-for rid in "linux-x64" "linux-arm64" "windows-x64" "macos-x64" "macos-arm64"
+for rid in "linux-x64" "linux-arm64" "windows-x64" "macos-x64" "macos-arm64" "plugin-sdk"
 do
   FILE_NAME=$(basename *$rid*)
 

--- a/src/Nethermind/Nethermind.Abi/Nethermind.Abi.csproj
+++ b/src/Nethermind/Nethermind.Abi/Nethermind.Abi.csproj
@@ -4,8 +4,6 @@
     <TargetFramework>net7.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
-    <Deterministic>true</Deterministic>
-    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/src/Nethermind/Nethermind.Blockchain/Nethermind.Blockchain.csproj
+++ b/src/Nethermind/Nethermind.Blockchain/Nethermind.Blockchain.csproj
@@ -3,8 +3,6 @@
     <TargetFramework>net7.0</TargetFramework>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <LangVersion>latest</LangVersion>
-    <Deterministic>true</Deterministic>
-    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <Nullable>annotations</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/src/Nethermind/Nethermind.Config/Nethermind.Config.csproj
+++ b/src/Nethermind/Nethermind.Config/Nethermind.Config.csproj
@@ -2,8 +2,6 @@
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
     <LangVersion>latest</LangVersion>
-    <Deterministic>true</Deterministic>
-    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Nethermind/Nethermind.Consensus/Nethermind.Consensus.csproj
+++ b/src/Nethermind/Nethermind.Consensus/Nethermind.Consensus.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
-    <Deterministic>true</Deterministic>
-    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <Nullable>annotations</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/src/Nethermind/Nethermind.Core/Nethermind.Core.csproj
+++ b/src/Nethermind/Nethermind.Core/Nethermind.Core.csproj
@@ -4,8 +4,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
-    <Deterministic>true</Deterministic>
-    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/Nethermind/Nethermind.Crypto/Nethermind.Crypto.csproj
+++ b/src/Nethermind/Nethermind.Crypto/Nethermind.Crypto.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Deterministic>true</Deterministic>
-    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <Nullable>annotations</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/src/Nethermind/Nethermind.Db/Nethermind.Db.csproj
+++ b/src/Nethermind/Nethermind.Db/Nethermind.Db.csproj
@@ -2,8 +2,6 @@
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
     <LangVersion>latest</LangVersion>
-    <Deterministic>true</Deterministic>
-    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <Nullable>annotations</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/src/Nethermind/Nethermind.Evm/Nethermind.Evm.csproj
+++ b/src/Nethermind/Nethermind.Evm/Nethermind.Evm.csproj
@@ -3,8 +3,6 @@
     <TargetFramework>net7.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Deterministic>true</Deterministic>
-    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <Nullable>annotations</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/src/Nethermind/Nethermind.Facade/Nethermind.Facade.csproj
+++ b/src/Nethermind/Nethermind.Facade/Nethermind.Facade.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
     <LangVersion>latest</LangVersion>
-    <Deterministic>true</Deterministic>
-    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <Nullable>annotations</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/src/Nethermind/Nethermind.Grpc/Nethermind.Grpc.csproj
+++ b/src/Nethermind/Nethermind.Grpc/Nethermind.Grpc.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
     <LangVersion>latest</LangVersion>
-    <Deterministic>true</Deterministic>
-    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+    
+    
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/src/Nethermind/Nethermind.JsonRpc/Nethermind.JsonRpc.csproj
+++ b/src/Nethermind/Nethermind.JsonRpc/Nethermind.JsonRpc.csproj
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
     <LangVersion>latest</LangVersion>
-    <Deterministic>true</Deterministic>
-    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+    
+    
     <Nullable>annotations</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/src/Nethermind/Nethermind.KeyStore/Nethermind.KeyStore.csproj
+++ b/src/Nethermind/Nethermind.KeyStore/Nethermind.KeyStore.csproj
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
     <LangVersion>latest</LangVersion>
-    <Deterministic>true</Deterministic>
-    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+    
+    
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/Nethermind/Nethermind.Logging/Nethermind.Logging.csproj
+++ b/src/Nethermind/Nethermind.Logging/Nethermind.Logging.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
     <LangVersion>latest</LangVersion>
-    <Deterministic>true</Deterministic>
-    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/src/Nethermind/Nethermind.Mev/Nethermind.Mev.csproj
+++ b/src/Nethermind/Nethermind.Mev/Nethermind.Mev.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <Deterministic>true</Deterministic>
-    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/src/Nethermind/Nethermind.Monitoring/Nethermind.Monitoring.csproj
+++ b/src/Nethermind/Nethermind.Monitoring/Nethermind.Monitoring.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
     <LangVersion>latest</LangVersion>
-    <Deterministic>true</Deterministic>
-    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/src/Nethermind/Nethermind.Network.Contract/Nethermind.Network.Contract.csproj
+++ b/src/Nethermind/Nethermind.Network.Contract/Nethermind.Network.Contract.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
     <LangVersion>latest</LangVersion>
-    <Deterministic>true</Deterministic>
-    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <Nullable>annotations</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/src/Nethermind/Nethermind.Network.Stats/Nethermind.Network.Stats.csproj
+++ b/src/Nethermind/Nethermind.Network.Stats/Nethermind.Network.Stats.csproj
@@ -4,8 +4,6 @@
     <TargetFramework>net7.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <RootNamespace>Nethermind.Stats</RootNamespace>
-    <Deterministic>true</Deterministic>
-    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/src/Nethermind/Nethermind.Network/Nethermind.Network.csproj
+++ b/src/Nethermind/Nethermind.Network/Nethermind.Network.csproj
@@ -2,8 +2,6 @@
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
     <LangVersion>latest</LangVersion>
-    <Deterministic>true</Deterministic>
-    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <Nullable>annotations</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/src/Nethermind/Nethermind.ReferenceAssemblies/Nethermind.ReferenceAssemblies.csproj
+++ b/src/Nethermind/Nethermind.ReferenceAssemblies/Nethermind.ReferenceAssemblies.csproj
@@ -1,29 +1,29 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
-		<IncludeBuildOutput>false</IncludeBuildOutput>
-		<NoBuild>true</NoBuild>
-		<NoWarn>$(NoWarn);NU5131;NU5017</NoWarn>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <NoBuild>true</NoBuild>
+    <NoWarn>$(NoWarn);NU5131;NU5017</NoWarn>
+  </PropertyGroup>
 
-	<PropertyGroup>
-		<Authors>Nethermind</Authors>
-		<Description>The reference assemblies of the Nethermind execution client</Description>
-		<EmbedUntrackedSources>false</EmbedUntrackedSources>
-		<IncludeSymbols>false</IncludeSymbols>
-		<PackageId>Nethermind.ReferenceAssemblies</PackageId>
-		<PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
-		<PackageProjectUrl>https://nethermind.io/nethermind-client</PackageProjectUrl>
-		<PackageTags>nethermind</PackageTags>
-		<RepositoryType>git</RepositoryType>
-		<RepositoryUrl>https://github.com/nethermindeth/nethermind</RepositoryUrl>
-	</PropertyGroup>
+  <PropertyGroup>
+    <Authors>Nethermind</Authors>
+    <Description>The reference assemblies of the Nethermind Ethereum execution client</Description>
+    <EmbedUntrackedSources>false</EmbedUntrackedSources>
+    <IncludeSymbols>false</IncludeSymbols>
+    <PackageId>Nethermind.ReferenceAssemblies</PackageId>
+    <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
+    <PackageProjectUrl>https://nethermind.io/nethermind-client</PackageProjectUrl>
+    <PackageTags>nethermind</PackageTags>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/nethermindeth/nethermind</RepositoryUrl>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<Content Include="ref/**/*.dll" Pack="true" PackagePath="ref/net7.0">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</Content>
-	</ItemGroup>
+  <ItemGroup>
+    <Content Include="ref/**/*.dll" Pack="true" PackagePath="ref/net7.0">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 
 </Project>

--- a/src/Nethermind/Nethermind.ReferenceAssemblies/Nethermind.ReferenceAssemblies.csproj
+++ b/src/Nethermind/Nethermind.ReferenceAssemblies/Nethermind.ReferenceAssemblies.csproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net7.0</TargetFramework>
+		<IncludeBuildOutput>false</IncludeBuildOutput>
+		<NoBuild>true</NoBuild>
+		<NoWarn>$(NoWarn);NU5131;NU5017</NoWarn>
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<Authors>Nethermind</Authors>
+		<Description>The reference assemblies of the Nethermind execution client</Description>
+		<EmbedUntrackedSources>false</EmbedUntrackedSources>
+		<IncludeSymbols>false</IncludeSymbols>
+		<PackageId>Nethermind.ReferenceAssemblies</PackageId>
+		<PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
+		<PackageProjectUrl>https://nethermind.io/nethermind-client</PackageProjectUrl>
+		<PackageTags>nethermind</PackageTags>
+		<RepositoryType>git</RepositoryType>
+		<RepositoryUrl>https://github.com/nethermindeth/nethermind</RepositoryUrl>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<Content Include="ref/**/*.dll" Pack="true" PackagePath="ref/net7.0">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+	</ItemGroup>
+
+</Project>

--- a/src/Nethermind/Nethermind.Serialization.Json/Nethermind.Serialization.Json.csproj
+++ b/src/Nethermind/Nethermind.Serialization.Json/Nethermind.Serialization.Json.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
-    <Deterministic>true</Deterministic>
-    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+    
+    
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/src/Nethermind/Nethermind.Sockets/Nethermind.Sockets.csproj
+++ b/src/Nethermind/Nethermind.Sockets/Nethermind.Sockets.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
     <LangVersion>latest</LangVersion>
-    <Deterministic>true</Deterministic>
-    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+    
+    
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/src/Nethermind/Nethermind.Specs/Nethermind.Specs.csproj
+++ b/src/Nethermind/Nethermind.Specs/Nethermind.Specs.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
-    <Deterministic>true</Deterministic>
-    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+    
+    
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/src/Nethermind/Nethermind.State/Nethermind.State.csproj
+++ b/src/Nethermind/Nethermind.State/Nethermind.State.csproj
@@ -3,8 +3,8 @@
     <TargetFramework>net7.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>annotations</Nullable>
-    <Deterministic>true</Deterministic>
-    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+    
+    
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/Nethermind/Nethermind.Synchronization/Nethermind.Synchronization.csproj
+++ b/src/Nethermind/Nethermind.Synchronization/Nethermind.Synchronization.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
     <Nullable>annotations</Nullable>
-    <Deterministic>true</Deterministic>
-    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+    
+    
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/src/Nethermind/Nethermind.Trie/Nethermind.Trie.csproj
+++ b/src/Nethermind/Nethermind.Trie/Nethermind.Trie.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
     <Nullable>annotations</Nullable>
-    <Deterministic>true</Deterministic>
-    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+    
+    
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/Nethermind/Nethermind.TxPool/Nethermind.TxPool.csproj
+++ b/src/Nethermind/Nethermind.TxPool/Nethermind.TxPool.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
-    <Deterministic>true</Deterministic>
-    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+    
+    
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/src/Nethermind/Nethermind.Wallet/Nethermind.Wallet.csproj
+++ b/src/Nethermind/Nethermind.Wallet/Nethermind.Wallet.csproj
@@ -2,8 +2,6 @@
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
     <LangVersion>latest</LangVersion>
-    <Deterministic>true</Deterministic>
-    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
## Changes

- The build workflow has been modified to publish `Nethermind.ReferenceAssemblies` NuGet package on every Nethermind release
- As a side effect, a new archive with reference assemblies is also published to GitHub Releases
- Replaced `Deterministic` and `ProduceReferenceAssembly` properties in the project files with CLI options in the build script

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [x] Other: New package

## Testing

#### Requires testing

- [ ] Yes
- [x] No
