### PR TITLE
Update hive consensus workflow and ethereum tests

### DIFF
--- a/.github/workflows/hive-consensus-tests.yml
+++ b/.github/workflows/hive-consensus-tests.yml
@@ -84,24 +84,12 @@ jobs:
         continue-on-error: true
         working-directory: hive
         run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /measureGas --sim.parallelism $PARALLELISM
-      - name: Run opc0CDiffPlaces
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opc0CDiffPlaces --sim.parallelism $PARALLELISM
-      - name: Run opc0DDiffPlaces
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opc0DDiffPlaces --sim.parallelism $PARALLELISM
-      - name: Run opc0EDiffPlaces
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opc0EDiffPlaces --sim.parallelism $PARALLELISM
       - name: Print results
         run: |
           chmod +x nethermind/scripts/hive-results.sh
           nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
   test_2:
-    name: 2. Combined tests (e.g. opc0FDiffPlaces)
+    name: 2. Combined tests (e.g. opc0CDiffPlaces)
     runs-on: ubuntu-latest
     steps:
       - name: Set up parameters
@@ -143,6 +131,18 @@ jobs:
         run: go build .
       - name: Load Docker image
         run: docker load --input /tmp/image.tar
+      - name: Run opc0CDiffPlaces
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opc0CDiffPlaces --sim.parallelism $PARALLELISM
+      - name: Run opc0DDiffPlaces
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opc0DDiffPlaces --sim.parallelism $PARALLELISM
+      - name: Run opc0EDiffPlaces
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opc0EDiffPlaces --sim.parallelism $PARALLELISM
       - name: Run opc0FDiffPlaces
         continue-on-error: true
         working-directory: hive
@@ -163,6 +163,53 @@ jobs:
         continue-on-error: true
         working-directory: hive
         run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opc22DiffPlaces --sim.parallelism $PARALLELISM
+      - name: Print results
+        run: |
+          chmod +x nethermind/scripts/hive-results.sh
+          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
+  test_3:
+    name: 3. Combined tests (e.g. opc23DiffPlaces)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up parameters
+        run: |
+          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
+      - name: Check out Nethermind repository
+        uses: actions/checkout@v3
+        with:
+          path: nethermind
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: nethermind
+          file: nethermind/Dockerfile
+          tags: nethermind:test-${{ github.sha }}
+          outputs: type=docker,dest=/tmp/image.tar
+      - name: Install Linux packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
+      - name: Set up Go environment
+        uses: actions/setup-go@v3.0.0
+        with:
+          go-version: '>=1.17.0'
+      - name: Check out Hive repository
+        uses: actions/checkout@v3
+        with:
+          repository: ethereum/hive
+          ref: master
+          path: hive
+      - name: Patch Hive Dockerfile
+        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
+      - name: Build Hive
+        working-directory: hive
+        run: go build .
+      - name: Load Docker image
+        run: docker load --input /tmp/image.tar
       - name: Run opc23DiffPlaces
         continue-on-error: true
         working-directory: hive
@@ -187,12 +234,20 @@ jobs:
         continue-on-error: true
         working-directory: hive
         run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opc28DiffPlaces --sim.parallelism $PARALLELISM
+      - name: Run opc29DiffPlaces
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opc29DiffPlaces --sim.parallelism $PARALLELISM
+      - name: Run opc2ADiffPlaces
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opc2ADiffPlaces --sim.parallelism $PARALLELISM
       - name: Print results
         run: |
           chmod +x nethermind/scripts/hive-results.sh
           nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_3:
-    name: 3. Combined tests (e.g. opc29DiffPlaces)
+  test_4:
+    name: 4. Combined tests (e.g. opc2BDiffPlaces)
     runs-on: ubuntu-latest
     steps:
       - name: Set up parameters
@@ -234,14 +289,6 @@ jobs:
         run: go build .
       - name: Load Docker image
         run: docker load --input /tmp/image.tar
-      - name: Run opc29DiffPlaces
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opc29DiffPlaces --sim.parallelism $PARALLELISM
-      - name: Run opc2ADiffPlaces
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opc2ADiffPlaces --sim.parallelism $PARALLELISM
       - name: Run opc2BDiffPlaces
         continue-on-error: true
         working-directory: hive
@@ -274,16 +321,12 @@ jobs:
         continue-on-error: true
         working-directory: hive
         run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opc4BDiffPlaces --sim.parallelism $PARALLELISM
-      - name: Run opc4CDiffPlaces
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opc4CDiffPlaces --sim.parallelism $PARALLELISM
       - name: Print results
         run: |
           chmod +x nethermind/scripts/hive-results.sh
           nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_4:
-    name: 4. Combined tests (e.g. opc4DDiffPlaces)
+  test_5:
+    name: 5. Combined tests (e.g. opc4CDiffPlaces)
     runs-on: ubuntu-latest
     steps:
       - name: Set up parameters
@@ -325,6 +368,10 @@ jobs:
         run: go build .
       - name: Load Docker image
         run: docker load --input /tmp/image.tar
+      - name: Run opc4CDiffPlaces
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opc4CDiffPlaces --sim.parallelism $PARALLELISM
       - name: Run opc4DDiffPlaces
         continue-on-error: true
         working-directory: hive
@@ -353,28 +400,12 @@ jobs:
         continue-on-error: true
         working-directory: hive
         run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opc5FDiffPlaces --sim.parallelism $PARALLELISM
-      - name: Run opcA5DiffPlaces
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcA5DiffPlaces --sim.parallelism $PARALLELISM
-      - name: Run opcA6DiffPlaces
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcA6DiffPlaces --sim.parallelism $PARALLELISM
-      - name: Run opcA7DiffPlaces
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcA7DiffPlaces --sim.parallelism $PARALLELISM
-      - name: Run opcA8DiffPlaces
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcA8DiffPlaces --sim.parallelism $PARALLELISM
       - name: Print results
         run: |
           chmod +x nethermind/scripts/hive-results.sh
           nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_5:
-    name: 5. Combined tests (e.g. opcA9DiffPlaces)
+  test_6:
+    name: 6. Combined tests (e.g. opcA5DiffPlaces)
     runs-on: ubuntu-latest
     steps:
       - name: Set up parameters
@@ -416,6 +447,22 @@ jobs:
         run: go build .
       - name: Load Docker image
         run: docker load --input /tmp/image.tar
+      - name: Run opcA5DiffPlaces
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcA5DiffPlaces --sim.parallelism $PARALLELISM
+      - name: Run opcA6DiffPlaces
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcA6DiffPlaces --sim.parallelism $PARALLELISM
+      - name: Run opcA7DiffPlaces
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcA7DiffPlaces --sim.parallelism $PARALLELISM
+      - name: Run opcA8DiffPlaces
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcA8DiffPlaces --sim.parallelism $PARALLELISM
       - name: Run opcA9DiffPlaces
         continue-on-error: true
         working-directory: hive
@@ -432,6 +479,53 @@ jobs:
         continue-on-error: true
         working-directory: hive
         run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcACDiffPlaces --sim.parallelism $PARALLELISM
+      - name: Print results
+        run: |
+          chmod +x nethermind/scripts/hive-results.sh
+          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
+  test_7:
+    name: 7. Combined tests (e.g. opcADDiffPlaces)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up parameters
+        run: |
+          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
+      - name: Check out Nethermind repository
+        uses: actions/checkout@v3
+        with:
+          path: nethermind
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: nethermind
+          file: nethermind/Dockerfile
+          tags: nethermind:test-${{ github.sha }}
+          outputs: type=docker,dest=/tmp/image.tar
+      - name: Install Linux packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
+      - name: Set up Go environment
+        uses: actions/setup-go@v3.0.0
+        with:
+          go-version: '>=1.17.0'
+      - name: Check out Hive repository
+        uses: actions/checkout@v3
+        with:
+          repository: ethereum/hive
+          ref: master
+          path: hive
+      - name: Patch Hive Dockerfile
+        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
+      - name: Build Hive
+        working-directory: hive
+        run: go build .
+      - name: Load Docker image
+        run: docker load --input /tmp/image.tar
       - name: Run opcADDiffPlaces
         continue-on-error: true
         working-directory: hive
@@ -460,12 +554,16 @@ jobs:
         continue-on-error: true
         working-directory: hive
         run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcB3DiffPlaces --sim.parallelism $PARALLELISM
+      - name: Run opcB4DiffPlaces
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcB4DiffPlaces --sim.parallelism $PARALLELISM
       - name: Print results
         run: |
           chmod +x nethermind/scripts/hive-results.sh
           nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_6:
-    name: 6. Combined tests (e.g. opcB4DiffPlaces)
+  test_8:
+    name: 8. Combined tests (e.g. opcB5DiffPlaces)
     runs-on: ubuntu-latest
     steps:
       - name: Set up parameters
@@ -507,10 +605,6 @@ jobs:
         run: go build .
       - name: Load Docker image
         run: docker load --input /tmp/image.tar
-      - name: Run opcB4DiffPlaces
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcB4DiffPlaces --sim.parallelism $PARALLELISM
       - name: Run opcB5DiffPlaces
         continue-on-error: true
         working-directory: hive
@@ -543,20 +637,12 @@ jobs:
         continue-on-error: true
         working-directory: hive
         run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcBCDiffPlaces --sim.parallelism $PARALLELISM
-      - name: Run opcBDDiffPlaces
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcBDDiffPlaces --sim.parallelism $PARALLELISM
-      - name: Run opcBEDiffPlaces
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcBEDiffPlaces --sim.parallelism $PARALLELISM
       - name: Print results
         run: |
           chmod +x nethermind/scripts/hive-results.sh
           nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_7:
-    name: 7. Combined tests (e.g. opcBFDiffPlaces)
+  test_9:
+    name: 9. Combined tests (e.g. opcBDDiffPlaces)
     runs-on: ubuntu-latest
     steps:
       - name: Set up parameters
@@ -598,6 +684,14 @@ jobs:
         run: go build .
       - name: Load Docker image
         run: docker load --input /tmp/image.tar
+      - name: Run opcBDDiffPlaces
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcBDDiffPlaces --sim.parallelism $PARALLELISM
+      - name: Run opcBEDiffPlaces
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcBEDiffPlaces --sim.parallelism $PARALLELISM
       - name: Run opcBFDiffPlaces
         continue-on-error: true
         working-directory: hive
@@ -622,32 +716,12 @@ jobs:
         continue-on-error: true
         working-directory: hive
         run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcC4DiffPlaces --sim.parallelism $PARALLELISM
-      - name: Run opcC5DiffPlaces
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcC5DiffPlaces --sim.parallelism $PARALLELISM
-      - name: Run opcC6DiffPlaces
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcC6DiffPlaces --sim.parallelism $PARALLELISM
-      - name: Run opcC7DiffPlaces
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcC7DiffPlaces --sim.parallelism $PARALLELISM
-      - name: Run opcC8DiffPlaces
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcC8DiffPlaces --sim.parallelism $PARALLELISM
-      - name: Run opcC9DiffPlaces
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcC9DiffPlaces --sim.parallelism $PARALLELISM
       - name: Print results
         run: |
           chmod +x nethermind/scripts/hive-results.sh
           nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_8:
-    name: 8. Combined tests (e.g. opcCADiffPlaces)
+  test_10:
+    name: 10. Combined tests (e.g. opcC5DiffPlaces)
     runs-on: ubuntu-latest
     steps:
       - name: Set up parameters
@@ -689,6 +763,26 @@ jobs:
         run: go build .
       - name: Load Docker image
         run: docker load --input /tmp/image.tar
+      - name: Run opcC5DiffPlaces
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcC5DiffPlaces --sim.parallelism $PARALLELISM
+      - name: Run opcC6DiffPlaces
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcC6DiffPlaces --sim.parallelism $PARALLELISM
+      - name: Run opcC7DiffPlaces
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcC7DiffPlaces --sim.parallelism $PARALLELISM
+      - name: Run opcC8DiffPlaces
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcC8DiffPlaces --sim.parallelism $PARALLELISM
+      - name: Run opcC9DiffPlaces
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcC9DiffPlaces --sim.parallelism $PARALLELISM
       - name: Run opcCADiffPlaces
         continue-on-error: true
         working-directory: hive
@@ -701,6 +795,53 @@ jobs:
         continue-on-error: true
         working-directory: hive
         run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcCCDiffPlaces --sim.parallelism $PARALLELISM
+      - name: Print results
+        run: |
+          chmod +x nethermind/scripts/hive-results.sh
+          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
+  test_11:
+    name: 11. Combined tests (e.g. opcCDDiffPlaces)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up parameters
+        run: |
+          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
+      - name: Check out Nethermind repository
+        uses: actions/checkout@v3
+        with:
+          path: nethermind
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: nethermind
+          file: nethermind/Dockerfile
+          tags: nethermind:test-${{ github.sha }}
+          outputs: type=docker,dest=/tmp/image.tar
+      - name: Install Linux packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
+      - name: Set up Go environment
+        uses: actions/setup-go@v3.0.0
+        with:
+          go-version: '>=1.17.0'
+      - name: Check out Hive repository
+        uses: actions/checkout@v3
+        with:
+          repository: ethereum/hive
+          ref: master
+          path: hive
+      - name: Patch Hive Dockerfile
+        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
+      - name: Build Hive
+        working-directory: hive
+        run: go build .
+      - name: Load Docker image
+        run: docker load --input /tmp/image.tar
       - name: Run opcCDDiffPlaces
         continue-on-error: true
         working-directory: hive
@@ -737,8 +878,8 @@ jobs:
         run: |
           chmod +x nethermind/scripts/hive-results.sh
           nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_9:
-    name: 9. Combined tests (e.g. opcD5DiffPlaces)
+  test_12:
+    name: 12. Combined tests (e.g. opcD5DiffPlaces)
     runs-on: ubuntu-latest
     steps:
       - name: Set up parameters
@@ -812,24 +953,12 @@ jobs:
         continue-on-error: true
         working-directory: hive
         run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcDCDiffPlaces --sim.parallelism $PARALLELISM
-      - name: Run opcDDDiffPlaces
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcDDDiffPlaces --sim.parallelism $PARALLELISM
-      - name: Run opcDEDiffPlaces
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcDEDiffPlaces --sim.parallelism $PARALLELISM
-      - name: Run opcDFDiffPlaces
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcDFDiffPlaces --sim.parallelism $PARALLELISM
       - name: Print results
         run: |
           chmod +x nethermind/scripts/hive-results.sh
           nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_10:
-    name: 10. Combined tests (e.g. opcE0DiffPlaces)
+  test_13:
+    name: 13. Combined tests (e.g. opcDDDiffPlaces)
     runs-on: ubuntu-latest
     steps:
       - name: Set up parameters
@@ -871,6 +1000,18 @@ jobs:
         run: go build .
       - name: Load Docker image
         run: docker load --input /tmp/image.tar
+      - name: Run opcDDDiffPlaces
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcDDDiffPlaces --sim.parallelism $PARALLELISM
+      - name: Run opcDEDiffPlaces
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcDEDiffPlaces --sim.parallelism $PARALLELISM
+      - name: Run opcDFDiffPlaces
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcDFDiffPlaces --sim.parallelism $PARALLELISM
       - name: Run opcE0DiffPlaces
         continue-on-error: true
         working-directory: hive
@@ -891,6 +1032,53 @@ jobs:
         continue-on-error: true
         working-directory: hive
         run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcE4DiffPlaces --sim.parallelism $PARALLELISM
+      - name: Print results
+        run: |
+          chmod +x nethermind/scripts/hive-results.sh
+          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
+  test_14:
+    name: 14. Combined tests (e.g. opcE5DiffPlaces)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up parameters
+        run: |
+          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
+      - name: Check out Nethermind repository
+        uses: actions/checkout@v3
+        with:
+          path: nethermind
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: nethermind
+          file: nethermind/Dockerfile
+          tags: nethermind:test-${{ github.sha }}
+          outputs: type=docker,dest=/tmp/image.tar
+      - name: Install Linux packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
+      - name: Set up Go environment
+        uses: actions/setup-go@v3.0.0
+        with:
+          go-version: '>=1.17.0'
+      - name: Check out Hive repository
+        uses: actions/checkout@v3
+        with:
+          repository: ethereum/hive
+          ref: master
+          path: hive
+      - name: Patch Hive Dockerfile
+        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
+      - name: Build Hive
+        working-directory: hive
+        run: go build .
+      - name: Load Docker image
+        run: docker load --input /tmp/image.tar
       - name: Run opcE5DiffPlaces
         continue-on-error: true
         working-directory: hive
@@ -915,12 +1103,20 @@ jobs:
         continue-on-error: true
         working-directory: hive
         run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcEADiffPlaces --sim.parallelism $PARALLELISM
+      - name: Run opcEBDiffPlaces
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcEBDiffPlaces --sim.parallelism $PARALLELISM
+      - name: Run opcECDiffPlaces
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcECDiffPlaces --sim.parallelism $PARALLELISM
       - name: Print results
         run: |
           chmod +x nethermind/scripts/hive-results.sh
           nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_11:
-    name: 11. Combined tests (e.g. opcEBDiffPlaces)
+  test_15:
+    name: 15. Combined tests (e.g. opcEDDiffPlaces)
     runs-on: ubuntu-latest
     steps:
       - name: Set up parameters
@@ -962,14 +1158,6 @@ jobs:
         run: go build .
       - name: Load Docker image
         run: docker load --input /tmp/image.tar
-      - name: Run opcEBDiffPlaces
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcEBDiffPlaces --sim.parallelism $PARALLELISM
-      - name: Run opcECDiffPlaces
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcECDiffPlaces --sim.parallelism $PARALLELISM
       - name: Run opcEDDiffPlaces
         continue-on-error: true
         working-directory: hive
@@ -1002,16 +1190,12 @@ jobs:
         continue-on-error: true
         working-directory: hive
         run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcFBDiffPlaces --sim.parallelism $PARALLELISM
-      - name: Run opcFCDiffPlaces
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcFCDiffPlaces --sim.parallelism $PARALLELISM
       - name: Print results
         run: |
           chmod +x nethermind/scripts/hive-results.sh
           nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_12:
-    name: 12. Combined tests (e.g. opcFEDiffPlaces)
+  test_16:
+    name: 16. Combined tests (e.g. opcFCDiffPlaces)
     runs-on: ubuntu-latest
     steps:
       - name: Set up parameters
@@ -1053,6 +1237,10 @@ jobs:
         run: go build .
       - name: Load Docker image
         run: docker load --input /tmp/image.tar
+      - name: Run opcFCDiffPlaces
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /opcFCDiffPlaces --sim.parallelism $PARALLELISM
       - name: Run opcFEDiffPlaces
         continue-on-error: true
         working-directory: hive
@@ -1085,6 +1273,53 @@ jobs:
         continue-on-error: true
         working-directory: hive
         run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /stCallDelegateCodesHomestead --sim.parallelism $PARALLELISM
+      - name: Print results
+        run: |
+          chmod +x nethermind/scripts/hive-results.sh
+          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
+  test_17:
+    name: 17. Combined tests (e.g. stChainId)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up parameters
+        run: |
+          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
+      - name: Check out Nethermind repository
+        uses: actions/checkout@v3
+        with:
+          path: nethermind
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: nethermind
+          file: nethermind/Dockerfile
+          tags: nethermind:test-${{ github.sha }}
+          outputs: type=docker,dest=/tmp/image.tar
+      - name: Install Linux packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
+      - name: Set up Go environment
+        uses: actions/setup-go@v3.0.0
+        with:
+          go-version: '>=1.17.0'
+      - name: Check out Hive repository
+        uses: actions/checkout@v3
+        with:
+          repository: ethereum/hive
+          ref: master
+          path: hive
+      - name: Patch Hive Dockerfile
+        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
+      - name: Build Hive
+        working-directory: hive
+        run: go build .
+      - name: Load Docker image
+        run: docker load --input /tmp/image.tar
       - name: Run stChainId
         continue-on-error: true
         working-directory: hive
@@ -1097,12 +1332,16 @@ jobs:
         continue-on-error: true
         working-directory: hive
         run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /stCodeSizeLimit --sim.parallelism $PARALLELISM
+      - name: Run stCreate2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /stCreate2 --sim.parallelism $PARALLELISM
       - name: Print results
         run: |
           chmod +x nethermind/scripts/hive-results.sh
           nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_13:
-    name: 13. Combined tests (e.g. stCreate2)
+  test_18:
+    name: 18. Combined tests (e.g. stCreateTest)
     runs-on: ubuntu-latest
     steps:
       - name: Set up parameters
@@ -1144,10 +1383,6 @@ jobs:
         run: go build .
       - name: Load Docker image
         run: docker load --input /tmp/image.tar
-      - name: Run stCreate2
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /stCreate2 --sim.parallelism $PARALLELISM
       - name: Run stCreateTest
         continue-on-error: true
         working-directory: hive
@@ -1160,59 +1395,8 @@ jobs:
         run: |
           chmod +x nethermind/scripts/hive-results.sh
           nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_14:
-    name: 14. stEIP1559
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up parameters
-        run: |
-          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
-      - name: Check out Nethermind repository
-        uses: actions/checkout@v3
-        with:
-          path: nethermind
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Build Docker image
-        uses: docker/build-push-action@v3
-        with:
-          context: nethermind
-          file: nethermind/Dockerfile
-          tags: nethermind:test-${{ github.sha }}
-          outputs: type=docker,dest=/tmp/image.tar
-      - name: Install Linux packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
-      - name: Set up Go environment
-        uses: actions/setup-go@v3.0.0
-        with:
-          go-version: '>=1.17.0'
-      - name: Check out Hive repository
-        uses: actions/checkout@v3
-        with:
-          repository: ethereum/hive
-          ref: master
-          path: hive
-      - name: Patch Hive Dockerfile
-        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
-      - name: Build Hive
-        working-directory: hive
-        run: go build .
-      - name: Load Docker image
-        run: docker load --input /tmp/image.tar
-      - name: Run stEIP1559
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /stEIP1559 --sim.parallelism $PARALLELISM
-      - name: Print results
-        run: |
-          chmod +x nethermind/scripts/hive-results.sh
-          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_15:
-    name: 15. Combined tests (e.g. stEIP150singleCodeGasPrices)
+  test_19:
+    name: 19. Combined tests (e.g. stEIP150singleCodeGasPrices)
     runs-on: ubuntu-latest
     steps:
       - name: Set up parameters
@@ -1262,108 +1446,156 @@ jobs:
         continue-on-error: true
         working-directory: hive
         run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /stEIP150Specific --sim.parallelism $PARALLELISM
+      - name: Print results
+        run: |
+          chmod +x nethermind/scripts/hive-results.sh
+          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
+  test_20:
+    name: 20. intrinsic
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up parameters
+        run: |
+          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
+      - name: Check out Nethermind repository
+        uses: actions/checkout@v3
+        with:
+          path: nethermind
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: nethermind
+          file: nethermind/Dockerfile
+          tags: nethermind:test-${{ github.sha }}
+          outputs: type=docker,dest=/tmp/image.tar
+      - name: Install Linux packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
+      - name: Set up Go environment
+        uses: actions/setup-go@v3.0.0
+        with:
+          go-version: '>=1.17.0'
+      - name: Check out Hive repository
+        uses: actions/checkout@v3
+        with:
+          repository: ethereum/hive
+          ref: master
+          path: hive
+      - name: Patch Hive Dockerfile
+        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
+      - name: Build Hive
+        working-directory: hive
+        run: go build .
+      - name: Load Docker image
+        run: docker load --input /tmp/image.tar
+      - name: Run intrinsic
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /intrinsic --sim.parallelism $PARALLELISM
+      - name: Print results
+        run: |
+          chmod +x nethermind/scripts/hive-results.sh
+          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
+  test_21:
+    name: 21. Combined tests (e.g. baseFeeDiffPlaces)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up parameters
+        run: |
+          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
+      - name: Check out Nethermind repository
+        uses: actions/checkout@v3
+        with:
+          path: nethermind
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: nethermind
+          file: nethermind/Dockerfile
+          tags: nethermind:test-${{ github.sha }}
+          outputs: type=docker,dest=/tmp/image.tar
+      - name: Install Linux packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
+      - name: Set up Go environment
+        uses: actions/setup-go@v3.0.0
+        with:
+          go-version: '>=1.17.0'
+      - name: Check out Hive repository
+        uses: actions/checkout@v3
+        with:
+          repository: ethereum/hive
+          ref: master
+          path: hive
+      - name: Patch Hive Dockerfile
+        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
+      - name: Build Hive
+        working-directory: hive
+        run: go build .
+      - name: Load Docker image
+        run: docker load --input /tmp/image.tar
+      - name: Run baseFeeDiffPlaces
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /baseFeeDiffPlaces --sim.parallelism $PARALLELISM
+      - name: Run gasPriceDiffPlaces
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /gasPriceDiffPlaces --sim.parallelism $PARALLELISM
+      - name: Run lowFeeCap
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /lowFeeCap --sim.parallelism $PARALLELISM
+      - name: Run lowGasLimit
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /lowGasLimit --sim.parallelism $PARALLELISM
+      - name: Run lowGasPriceOldTypes
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /lowGasPriceOldTypes --sim.parallelism $PARALLELISM
+      - name: Run outOfFunds
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /outOfFunds --sim.parallelism $PARALLELISM
+      - name: Run outOfFundsOldTypes
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /outOfFundsOldTypes --sim.parallelism $PARALLELISM
+      - name: Run senderBalance
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /senderBalance --sim.parallelism $PARALLELISM
+      - name: Run tipTooHigh
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /tipTooHigh --sim.parallelism $PARALLELISM
+      - name: Run transactionIntinsicBug
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /transactionIntinsicBug --sim.parallelism $PARALLELISM
+      - name: Run typeTwoBerlin
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /typeTwoBerlin --sim.parallelism $PARALLELISM
+      - name: Run valCausesOOF
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /valCausesOOF --sim.parallelism $PARALLELISM
       - name: Run stEIP158Specific
         continue-on-error: true
         working-directory: hive
         run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /stEIP158Specific --sim.parallelism $PARALLELISM
-      - name: Print results
-        run: |
-          chmod +x nethermind/scripts/hive-results.sh
-          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_16:
-    name: 16. stMemoryTest
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up parameters
-        run: |
-          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
-      - name: Check out Nethermind repository
-        uses: actions/checkout@v3
-        with:
-          path: nethermind
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Build Docker image
-        uses: docker/build-push-action@v3
-        with:
-          context: nethermind
-          file: nethermind/Dockerfile
-          tags: nethermind:test-${{ github.sha }}
-          outputs: type=docker,dest=/tmp/image.tar
-      - name: Install Linux packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
-      - name: Set up Go environment
-        uses: actions/setup-go@v3.0.0
-        with:
-          go-version: '>=1.17.0'
-      - name: Check out Hive repository
-        uses: actions/checkout@v3
-        with:
-          repository: ethereum/hive
-          ref: master
-          path: hive
-      - name: Patch Hive Dockerfile
-        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
-      - name: Build Hive
-        working-directory: hive
-        run: go build .
-      - name: Load Docker image
-        run: docker load --input /tmp/image.tar
-      - name: Run stMemoryTest
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /stMemoryTest --sim.parallelism $PARALLELISM
-      - name: Print results
-        run: |
-          chmod +x nethermind/scripts/hive-results.sh
-          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_17:
-    name: 17. Combined tests (e.g. stEIP2930)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up parameters
-        run: |
-          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
-      - name: Check out Nethermind repository
-        uses: actions/checkout@v3
-        with:
-          path: nethermind
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Build Docker image
-        uses: docker/build-push-action@v3
-        with:
-          context: nethermind
-          file: nethermind/Dockerfile
-          tags: nethermind:test-${{ github.sha }}
-          outputs: type=docker,dest=/tmp/image.tar
-      - name: Install Linux packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
-      - name: Set up Go environment
-        uses: actions/setup-go@v3.0.0
-        with:
-          go-version: '>=1.17.0'
-      - name: Check out Hive repository
-        uses: actions/checkout@v3
-        with:
-          repository: ethereum/hive
-          ref: master
-          path: hive
-      - name: Patch Hive Dockerfile
-        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
-      - name: Build Hive
-        working-directory: hive
-        run: go build .
-      - name: Load Docker image
-        run: docker load --input /tmp/image.tar
       - name: Run stEIP2930
         continue-on-error: true
         working-directory: hive
@@ -1376,6 +1608,104 @@ jobs:
         continue-on-error: true
         working-directory: hive
         run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /stExample --sim.parallelism $PARALLELISM
+      - name: Print results
+        run: |
+          chmod +x nethermind/scripts/hive-results.sh
+          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
+  test_22:
+    name: 22. buffer
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up parameters
+        run: |
+          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
+      - name: Check out Nethermind repository
+        uses: actions/checkout@v3
+        with:
+          path: nethermind
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: nethermind
+          file: nethermind/Dockerfile
+          tags: nethermind:test-${{ github.sha }}
+          outputs: type=docker,dest=/tmp/image.tar
+      - name: Install Linux packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
+      - name: Set up Go environment
+        uses: actions/setup-go@v3.0.0
+        with:
+          go-version: '>=1.17.0'
+      - name: Check out Hive repository
+        uses: actions/checkout@v3
+        with:
+          repository: ethereum/hive
+          ref: master
+          path: hive
+      - name: Patch Hive Dockerfile
+        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
+      - name: Build Hive
+        working-directory: hive
+        run: go build .
+      - name: Load Docker image
+        run: docker load --input /tmp/image.tar
+      - name: Run buffer
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /buffer --sim.parallelism $PARALLELISM
+      - name: Print results
+        run: |
+          chmod +x nethermind/scripts/hive-results.sh
+          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
+  test_23:
+    name: 23. Combined tests (e.g. stExtCodeHash)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up parameters
+        run: |
+          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
+      - name: Check out Nethermind repository
+        uses: actions/checkout@v3
+        with:
+          path: nethermind
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: nethermind
+          file: nethermind/Dockerfile
+          tags: nethermind:test-${{ github.sha }}
+          outputs: type=docker,dest=/tmp/image.tar
+      - name: Install Linux packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
+      - name: Set up Go environment
+        uses: actions/setup-go@v3.0.0
+        with:
+          go-version: '>=1.17.0'
+      - name: Check out Hive repository
+        uses: actions/checkout@v3
+        with:
+          repository: ethereum/hive
+          ref: master
+          path: hive
+      - name: Patch Hive Dockerfile
+        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
+      - name: Build Hive
+        working-directory: hive
+        run: go build .
+      - name: Load Docker image
+        run: docker load --input /tmp/image.tar
       - name: Run stExtCodeHash
         continue-on-error: true
         working-directory: hive
@@ -1400,16 +1730,28 @@ jobs:
         continue-on-error: true
         working-directory: hive
         run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /stMemoryStressTest --sim.parallelism $PARALLELISM
-      - name: Run stNonZeroCallsTest
+      - name: Run bufferSrcOffset
         continue-on-error: true
         working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /stNonZeroCallsTest --sim.parallelism $PARALLELISM
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /bufferSrcOffset --sim.parallelism $PARALLELISM
+      - name: Run callDataCopyOffset
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /callDataCopyOffset --sim.parallelism $PARALLELISM
+      - name: Run calldatacopy_dejavu
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /calldatacopy_dejavu --sim.parallelism $PARALLELISM
+      - name: Run calldatacopy_dejavu2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /calldatacopy_dejavu2 --sim.parallelism $PARALLELISM
       - name: Print results
         run: |
           chmod +x nethermind/scripts/hive-results.sh
           nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_18:
-    name: 18. Combined tests (e.g. blake2B)
+  test_24:
+    name: 24. Combined tests (e.g. codeCopyOffset)
     runs-on: ubuntu-latest
     steps:
       - name: Set up parameters
@@ -1451,6 +1793,321 @@ jobs:
         run: go build .
       - name: Load Docker image
         run: docker load --input /tmp/image.tar
+      - name: Run codeCopyOffset
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /codeCopyOffset --sim.parallelism $PARALLELISM
+      - name: Run codecopy_dejavu
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /codecopy_dejavu --sim.parallelism $PARALLELISM
+      - name: Run codecopy_dejavu2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /codecopy_dejavu2 --sim.parallelism $PARALLELISM
+      - name: Run extcodecopy_dejavu
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /extcodecopy_dejavu --sim.parallelism $PARALLELISM
+      - name: Run log1_dejavu
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /log1_dejavu --sim.parallelism $PARALLELISM
+      - name: Run log2_dejavu
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /log2_dejavu --sim.parallelism $PARALLELISM
+      - name: Run log3_dejavu
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /log3_dejavu --sim.parallelism $PARALLELISM
+      - name: Run log4_dejavu
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /log4_dejavu --sim.parallelism $PARALLELISM
+      - name: Run mem0b_singleByte
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mem0b_singleByte --sim.parallelism $PARALLELISM
+      - name: Run mem31b_singleByte
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mem31b_singleByte --sim.parallelism $PARALLELISM
+      - name: Run mem32b_singleByte
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mem32b_singleByte --sim.parallelism $PARALLELISM
+      - name: Run mem32kb+1
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mem32kb+1 --sim.parallelism $PARALLELISM
+      - name: Run mem32kb+31
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mem32kb+31 --sim.parallelism $PARALLELISM
+      - name: Run mem32kb+32
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mem32kb+32 --sim.parallelism $PARALLELISM
+      - name: Run mem32kb+33
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mem32kb+33 --sim.parallelism $PARALLELISM
+      - name: Run mem32kb-1
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mem32kb-1 --sim.parallelism $PARALLELISM
+      - name: Run mem32kb-31
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mem32kb-31 --sim.parallelism $PARALLELISM
+      - name: Run mem32kb-32
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mem32kb-32 --sim.parallelism $PARALLELISM
+      - name: Run mem32kb-33
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mem32kb-33 --sim.parallelism $PARALLELISM
+      - name: Run mem32kb
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mem32kb --sim.parallelism $PARALLELISM
+      - name: Run mem32kb_singleByte+1
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mem32kb_singleByte+1 --sim.parallelism $PARALLELISM
+      - name: Run mem32kb_singleByte+31
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mem32kb_singleByte+31 --sim.parallelism $PARALLELISM
+      - name: Run mem32kb_singleByte+32
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mem32kb_singleByte+32 --sim.parallelism $PARALLELISM
+      - name: Run mem32kb_singleByte+33
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mem32kb_singleByte+33 --sim.parallelism $PARALLELISM
+      - name: Run mem32kb_singleByte-1
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mem32kb_singleByte-1 --sim.parallelism $PARALLELISM
+      - name: Run mem32kb_singleByte-31
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mem32kb_singleByte-31 --sim.parallelism $PARALLELISM
+      - name: Run mem32kb_singleByte-32
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mem32kb_singleByte-32 --sim.parallelism $PARALLELISM
+      - name: Run mem32kb_singleByte-33
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mem32kb_singleByte-33 --sim.parallelism $PARALLELISM
+      - name: Run mem32kb_singleByte
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mem32kb_singleByte --sim.parallelism $PARALLELISM
+      - name: Run mem33b_singleByte
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mem33b_singleByte --sim.parallelism $PARALLELISM
+      - name: Run mem64kb+1
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mem64kb+1 --sim.parallelism $PARALLELISM
+      - name: Run mem64kb+31
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mem64kb+31 --sim.parallelism $PARALLELISM
+      - name: Run mem64kb+32
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mem64kb+32 --sim.parallelism $PARALLELISM
+      - name: Run mem64kb+33
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mem64kb+33 --sim.parallelism $PARALLELISM
+      - name: Run mem64kb-1
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mem64kb-1 --sim.parallelism $PARALLELISM
+      - name: Run mem64kb-31
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mem64kb-31 --sim.parallelism $PARALLELISM
+      - name: Run mem64kb-32
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mem64kb-32 --sim.parallelism $PARALLELISM
+      - name: Run mem64kb-33
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mem64kb-33 --sim.parallelism $PARALLELISM
+      - name: Run mem64kb
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mem64kb --sim.parallelism $PARALLELISM
+      - name: Run mem64kb_singleByte+1
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mem64kb_singleByte+1 --sim.parallelism $PARALLELISM
+      - name: Run mem64kb_singleByte+31
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mem64kb_singleByte+31 --sim.parallelism $PARALLELISM
+      - name: Run mem64kb_singleByte+32
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mem64kb_singleByte+32 --sim.parallelism $PARALLELISM
+      - name: Run mem64kb_singleByte+33
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mem64kb_singleByte+33 --sim.parallelism $PARALLELISM
+      - name: Run mem64kb_singleByte-1
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mem64kb_singleByte-1 --sim.parallelism $PARALLELISM
+      - name: Run mem64kb_singleByte-31
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mem64kb_singleByte-31 --sim.parallelism $PARALLELISM
+      - name: Run mem64kb_singleByte-32
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mem64kb_singleByte-32 --sim.parallelism $PARALLELISM
+      - name: Run mem64kb_singleByte-33
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mem64kb_singleByte-33 --sim.parallelism $PARALLELISM
+      - name: Run mem64kb_singleByte
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mem64kb_singleByte --sim.parallelism $PARALLELISM
+      - name: Run memCopySelf
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /memCopySelf --sim.parallelism $PARALLELISM
+      - name: Run memReturn
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /memReturn --sim.parallelism $PARALLELISM
+      - name: Run mload16bitBound
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mload16bitBound --sim.parallelism $PARALLELISM
+      - name: Run mload8bitBound
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mload8bitBound --sim.parallelism $PARALLELISM
+      - name: Run mload_dejavu
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mload_dejavu --sim.parallelism $PARALLELISM
+      - name: Run mstore_dejavu
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mstore_dejavu --sim.parallelism $PARALLELISM
+      - name: Run mstroe8_dejavu
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /mstroe8_dejavu --sim.parallelism $PARALLELISM
+      - name: Run oog
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /oog --sim.parallelism $PARALLELISM
+      - name: Run sha3_dejavu
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /sha3_dejavu --sim.parallelism $PARALLELISM
+      - name: Print results
+        run: |
+          chmod +x nethermind/scripts/hive-results.sh
+          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
+  test_25:
+    name: 25. Combined tests (e.g. stackLimitGas_1023)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up parameters
+        run: |
+          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
+      - name: Check out Nethermind repository
+        uses: actions/checkout@v3
+        with:
+          path: nethermind
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: nethermind
+          file: nethermind/Dockerfile
+          tags: nethermind:test-${{ github.sha }}
+          outputs: type=docker,dest=/tmp/image.tar
+      - name: Install Linux packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
+      - name: Set up Go environment
+        uses: actions/setup-go@v3.0.0
+        with:
+          go-version: '>=1.17.0'
+      - name: Check out Hive repository
+        uses: actions/checkout@v3
+        with:
+          repository: ethereum/hive
+          ref: master
+          path: hive
+      - name: Patch Hive Dockerfile
+        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
+      - name: Build Hive
+        working-directory: hive
+        run: go build .
+      - name: Load Docker image
+        run: docker load --input /tmp/image.tar
+      - name: Run stackLimitGas_1023
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /stackLimitGas_1023 --sim.parallelism $PARALLELISM
+      - name: Run stackLimitGas_1024
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /stackLimitGas_1024 --sim.parallelism $PARALLELISM
+      - name: Run stackLimitGas_1025
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /stackLimitGas_1025 --sim.parallelism $PARALLELISM
+      - name: Run stackLimitPush31_1023
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /stackLimitPush31_1023 --sim.parallelism $PARALLELISM
+      - name: Run stackLimitPush31_1024
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /stackLimitPush31_1024 --sim.parallelism $PARALLELISM
+      - name: Run stackLimitPush31_1025
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /stackLimitPush31_1025 --sim.parallelism $PARALLELISM
+      - name: Run stackLimitPush32_1023
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /stackLimitPush32_1023 --sim.parallelism $PARALLELISM
+      - name: Run stackLimitPush32_1024
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /stackLimitPush32_1024 --sim.parallelism $PARALLELISM
+      - name: Run stackLimitPush32_1025
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /stackLimitPush32_1025 --sim.parallelism $PARALLELISM
+      - name: Run stNonZeroCallsTest
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /stNonZeroCallsTest --sim.parallelism $PARALLELISM
       - name: Run blake2B
         continue-on-error: true
         working-directory: hive
@@ -1471,20 +2128,12 @@ jobs:
         continue-on-error: true
         working-directory: hive
         run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /idPrecomps --sim.parallelism $PARALLELISM
-      - name: Run modexp
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /modexp --sim.parallelism $PARALLELISM
-      - name: Run modexpTests
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /modexpTests --sim.parallelism $PARALLELISM
       - name: Print results
         run: |
           chmod +x nethermind/scripts/hive-results.sh
           nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_19:
-    name: 19. Combined tests (e.g. precompsEIP2929)
+  test_26:
+    name: 26. precompsEIP2929
     runs-on: ubuntu-latest
     steps:
       - name: Set up parameters
@@ -1530,6 +2179,61 @@ jobs:
         continue-on-error: true
         working-directory: hive
         run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /precompsEIP2929 --sim.parallelism $PARALLELISM
+      - name: Print results
+        run: |
+          chmod +x nethermind/scripts/hive-results.sh
+          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
+  test_27:
+    name: 27. Combined tests (e.g. modexp)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up parameters
+        run: |
+          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
+      - name: Check out Nethermind repository
+        uses: actions/checkout@v3
+        with:
+          path: nethermind
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: nethermind
+          file: nethermind/Dockerfile
+          tags: nethermind:test-${{ github.sha }}
+          outputs: type=docker,dest=/tmp/image.tar
+      - name: Install Linux packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
+      - name: Set up Go environment
+        uses: actions/setup-go@v3.0.0
+        with:
+          go-version: '>=1.17.0'
+      - name: Check out Hive repository
+        uses: actions/checkout@v3
+        with:
+          repository: ethereum/hive
+          ref: master
+          path: hive
+      - name: Patch Hive Dockerfile
+        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
+      - name: Build Hive
+        working-directory: hive
+        run: go build .
+      - name: Load Docker image
+        run: docker load --input /tmp/image.tar
+      - name: Run modexp
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /modexp --sim.parallelism $PARALLELISM
+      - name: Run modexpTests
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /modexpTests --sim.parallelism $PARALLELISM
       - name: Run sec80
         continue-on-error: true
         working-directory: hive
@@ -1538,8 +2242,8 @@ jobs:
         run: |
           chmod +x nethermind/scripts/hive-results.sh
           nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_20:
-    name: 20. Combined tests (e.g. stPreCompiledContracts2)
+  test_28:
+    name: 28. Combined tests (e.g. stPreCompiledContracts2)
     runs-on: ubuntu-latest
     steps:
       - name: Set up parameters
@@ -1593,8 +2297,8 @@ jobs:
         run: |
           chmod +x nethermind/scripts/hive-results.sh
           nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_21:
-    name: 21. stRandom
+  test_29:
+    name: 29. stRandom
     runs-on: ubuntu-latest
     steps:
       - name: Set up parameters
@@ -1644,8 +2348,8 @@ jobs:
         run: |
           chmod +x nethermind/scripts/hive-results.sh
           nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_22:
-    name: 22. Combined tests (e.g. stRandom2)
+  test_30:
+    name: 30. Combined tests (e.g. stRandom2)
     runs-on: ubuntu-latest
     steps:
       - name: Set up parameters
@@ -1699,6 +2403,53 @@ jobs:
         continue-on-error: true
         working-directory: hive
         run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /stRefundTest --sim.parallelism $PARALLELISM
+      - name: Print results
+        run: |
+          chmod +x nethermind/scripts/hive-results.sh
+          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
+  test_31:
+    name: 31. stReturnDataTest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up parameters
+        run: |
+          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
+      - name: Check out Nethermind repository
+        uses: actions/checkout@v3
+        with:
+          path: nethermind
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: nethermind
+          file: nethermind/Dockerfile
+          tags: nethermind:test-${{ github.sha }}
+          outputs: type=docker,dest=/tmp/image.tar
+      - name: Install Linux packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
+      - name: Set up Go environment
+        uses: actions/setup-go@v3.0.0
+        with:
+          go-version: '>=1.17.0'
+      - name: Check out Hive repository
+        uses: actions/checkout@v3
+        with:
+          repository: ethereum/hive
+          ref: master
+          path: hive
+      - name: Patch Hive Dockerfile
+        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
+      - name: Build Hive
+        working-directory: hive
+        run: go build .
+      - name: Load Docker image
+        run: docker load --input /tmp/image.tar
       - name: Run stReturnDataTest
         continue-on-error: true
         working-directory: hive
@@ -1707,8 +2458,8 @@ jobs:
         run: |
           chmod +x nethermind/scripts/hive-results.sh
           nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_23:
-    name: 23. Combined tests (e.g. stRevertTest)
+  test_32:
+    name: 32. Combined tests (e.g. stRevertTest)
     runs-on: ubuntu-latest
     steps:
       - name: Set up parameters
@@ -1758,6 +2509,104 @@ jobs:
         continue-on-error: true
         working-directory: hive
         run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /stSelfBalance --sim.parallelism $PARALLELISM
+      - name: Print results
+        run: |
+          chmod +x nethermind/scripts/hive-results.sh
+          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
+  test_33:
+    name: 33. stSStoreTest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up parameters
+        run: |
+          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
+      - name: Check out Nethermind repository
+        uses: actions/checkout@v3
+        with:
+          path: nethermind
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: nethermind
+          file: nethermind/Dockerfile
+          tags: nethermind:test-${{ github.sha }}
+          outputs: type=docker,dest=/tmp/image.tar
+      - name: Install Linux packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
+      - name: Set up Go environment
+        uses: actions/setup-go@v3.0.0
+        with:
+          go-version: '>=1.17.0'
+      - name: Check out Hive repository
+        uses: actions/checkout@v3
+        with:
+          repository: ethereum/hive
+          ref: master
+          path: hive
+      - name: Patch Hive Dockerfile
+        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
+      - name: Build Hive
+        working-directory: hive
+        run: go build .
+      - name: Load Docker image
+        run: docker load --input /tmp/image.tar
+      - name: Run stSStoreTest
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /stSStoreTest --sim.parallelism $PARALLELISM
+      - name: Print results
+        run: |
+          chmod +x nethermind/scripts/hive-results.sh
+          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
+  test_34:
+    name: 34. Combined tests (e.g. stShift)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up parameters
+        run: |
+          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
+      - name: Check out Nethermind repository
+        uses: actions/checkout@v3
+        with:
+          path: nethermind
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: nethermind
+          file: nethermind/Dockerfile
+          tags: nethermind:test-${{ github.sha }}
+          outputs: type=docker,dest=/tmp/image.tar
+      - name: Install Linux packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
+      - name: Set up Go environment
+        uses: actions/setup-go@v3.0.0
+        with:
+          go-version: '>=1.17.0'
+      - name: Check out Hive repository
+        uses: actions/checkout@v3
+        with:
+          repository: ethereum/hive
+          ref: master
+          path: hive
+      - name: Patch Hive Dockerfile
+        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
+      - name: Build Hive
+        working-directory: hive
+        run: go build .
+      - name: Load Docker image
+        run: docker load --input /tmp/image.tar
       - name: Run stShift
         continue-on-error: true
         working-directory: hive
@@ -1770,108 +2619,10 @@ jobs:
         continue-on-error: true
         working-directory: hive
         run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /stSolidityTest --sim.parallelism $PARALLELISM
-      - name: Print results
-        run: |
-          chmod +x nethermind/scripts/hive-results.sh
-          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_24:
-    name: 24. Combined tests (e.g. stSpecialTest)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up parameters
-        run: |
-          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
-      - name: Check out Nethermind repository
-        uses: actions/checkout@v3
-        with:
-          path: nethermind
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Build Docker image
-        uses: docker/build-push-action@v3
-        with:
-          context: nethermind
-          file: nethermind/Dockerfile
-          tags: nethermind:test-${{ github.sha }}
-          outputs: type=docker,dest=/tmp/image.tar
-      - name: Install Linux packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
-      - name: Set up Go environment
-        uses: actions/setup-go@v3.0.0
-        with:
-          go-version: '>=1.17.0'
-      - name: Check out Hive repository
-        uses: actions/checkout@v3
-        with:
-          repository: ethereum/hive
-          ref: master
-          path: hive
-      - name: Patch Hive Dockerfile
-        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
-      - name: Build Hive
-        working-directory: hive
-        run: go build .
-      - name: Load Docker image
-        run: docker load --input /tmp/image.tar
       - name: Run stSpecialTest
         continue-on-error: true
         working-directory: hive
         run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /stSpecialTest --sim.parallelism $PARALLELISM
-      - name: Run stSStoreTest
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /stSStoreTest --sim.parallelism $PARALLELISM
-      - name: Print results
-        run: |
-          chmod +x nethermind/scripts/hive-results.sh
-          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_25:
-    name: 25. Combined tests (e.g. shallowStack)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up parameters
-        run: |
-          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
-      - name: Check out Nethermind repository
-        uses: actions/checkout@v3
-        with:
-          path: nethermind
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Build Docker image
-        uses: docker/build-push-action@v3
-        with:
-          context: nethermind
-          file: nethermind/Dockerfile
-          tags: nethermind:test-${{ github.sha }}
-          outputs: type=docker,dest=/tmp/image.tar
-      - name: Install Linux packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
-      - name: Set up Go environment
-        uses: actions/setup-go@v3.0.0
-        with:
-          go-version: '>=1.17.0'
-      - name: Check out Hive repository
-        uses: actions/checkout@v3
-        with:
-          repository: ethereum/hive
-          ref: master
-          path: hive
-      - name: Patch Hive Dockerfile
-        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
-      - name: Build Hive
-        working-directory: hive
-        run: go build .
-      - name: Load Docker image
-        run: docker load --input /tmp/image.tar
       - name: Run shallowStack
         continue-on-error: true
         working-directory: hive
@@ -1892,6 +2643,53 @@ jobs:
         continue-on-error: true
         working-directory: hive
         run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /stackOverflowM1DUP --sim.parallelism $PARALLELISM
+      - name: Print results
+        run: |
+          chmod +x nethermind/scripts/hive-results.sh
+          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
+  test_35:
+    name: 35. stackOverflowM1PUSH
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up parameters
+        run: |
+          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
+      - name: Check out Nethermind repository
+        uses: actions/checkout@v3
+        with:
+          path: nethermind
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: nethermind
+          file: nethermind/Dockerfile
+          tags: nethermind:test-${{ github.sha }}
+          outputs: type=docker,dest=/tmp/image.tar
+      - name: Install Linux packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
+      - name: Set up Go environment
+        uses: actions/setup-go@v3.0.0
+        with:
+          go-version: '>=1.17.0'
+      - name: Check out Hive repository
+        uses: actions/checkout@v3
+        with:
+          repository: ethereum/hive
+          ref: master
+          path: hive
+      - name: Patch Hive Dockerfile
+        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
+      - name: Build Hive
+        working-directory: hive
+        run: go build .
+      - name: Load Docker image
+        run: docker load --input /tmp/image.tar
       - name: Run stackOverflowM1PUSH
         continue-on-error: true
         working-directory: hive
@@ -1900,8 +2698,8 @@ jobs:
         run: |
           chmod +x nethermind/scripts/hive-results.sh
           nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_26:
-    name: 26. underflowTest
+  test_36:
+    name: 36. underflowTest
     runs-on: ubuntu-latest
     steps:
       - name: Set up parameters
@@ -1951,671 +2749,8 @@ jobs:
         run: |
           chmod +x nethermind/scripts/hive-results.sh
           nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_27:
-    name: 27. stStaticCall
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up parameters
-        run: |
-          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
-      - name: Check out Nethermind repository
-        uses: actions/checkout@v3
-        with:
-          path: nethermind
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Build Docker image
-        uses: docker/build-push-action@v3
-        with:
-          context: nethermind
-          file: nethermind/Dockerfile
-          tags: nethermind:test-${{ github.sha }}
-          outputs: type=docker,dest=/tmp/image.tar
-      - name: Install Linux packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
-      - name: Set up Go environment
-        uses: actions/setup-go@v3.0.0
-        with:
-          go-version: '>=1.17.0'
-      - name: Check out Hive repository
-        uses: actions/checkout@v3
-        with:
-          repository: ethereum/hive
-          ref: master
-          path: hive
-      - name: Patch Hive Dockerfile
-        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
-      - name: Build Hive
-        working-directory: hive
-        run: go build .
-      - name: Load Docker image
-        run: docker load --input /tmp/image.tar
-      - name: Run stStaticCall
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /stStaticCall --sim.parallelism $PARALLELISM
-      - name: Print results
-        run: |
-          chmod +x nethermind/scripts/hive-results.sh
-          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_28:
-    name: 28. sstore_combinations_initial00
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up parameters
-        run: |
-          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
-      - name: Check out Nethermind repository
-        uses: actions/checkout@v3
-        with:
-          path: nethermind
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Build Docker image
-        uses: docker/build-push-action@v3
-        with:
-          context: nethermind
-          file: nethermind/Dockerfile
-          tags: nethermind:test-${{ github.sha }}
-          outputs: type=docker,dest=/tmp/image.tar
-      - name: Install Linux packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
-      - name: Set up Go environment
-        uses: actions/setup-go@v3.0.0
-        with:
-          go-version: '>=1.17.0'
-      - name: Check out Hive repository
-        uses: actions/checkout@v3
-        with:
-          repository: ethereum/hive
-          ref: master
-          path: hive
-      - name: Patch Hive Dockerfile
-        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
-      - name: Build Hive
-        working-directory: hive
-        run: go build .
-      - name: Load Docker image
-        run: docker load --input /tmp/image.tar
-      - name: Run sstore_combinations_initial00
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /sstore_combinations_initial00 --sim.parallelism $PARALLELISM
-      - name: Print results
-        run: |
-          chmod +x nethermind/scripts/hive-results.sh
-          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_29:
-    name: 29. sstore_combinations_initial00_2
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up parameters
-        run: |
-          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
-      - name: Check out Nethermind repository
-        uses: actions/checkout@v3
-        with:
-          path: nethermind
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Build Docker image
-        uses: docker/build-push-action@v3
-        with:
-          context: nethermind
-          file: nethermind/Dockerfile
-          tags: nethermind:test-${{ github.sha }}
-          outputs: type=docker,dest=/tmp/image.tar
-      - name: Install Linux packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
-      - name: Set up Go environment
-        uses: actions/setup-go@v3.0.0
-        with:
-          go-version: '>=1.17.0'
-      - name: Check out Hive repository
-        uses: actions/checkout@v3
-        with:
-          repository: ethereum/hive
-          ref: master
-          path: hive
-      - name: Patch Hive Dockerfile
-        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
-      - name: Build Hive
-        working-directory: hive
-        run: go build .
-      - name: Load Docker image
-        run: docker load --input /tmp/image.tar
-      - name: Run sstore_combinations_initial00_2
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /sstore_combinations_initial00_2 --sim.parallelism $PARALLELISM
-      - name: Print results
-        run: |
-          chmod +x nethermind/scripts/hive-results.sh
-          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_30:
-    name: 30. sstore_combinations_initial01
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up parameters
-        run: |
-          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
-      - name: Check out Nethermind repository
-        uses: actions/checkout@v3
-        with:
-          path: nethermind
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Build Docker image
-        uses: docker/build-push-action@v3
-        with:
-          context: nethermind
-          file: nethermind/Dockerfile
-          tags: nethermind:test-${{ github.sha }}
-          outputs: type=docker,dest=/tmp/image.tar
-      - name: Install Linux packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
-      - name: Set up Go environment
-        uses: actions/setup-go@v3.0.0
-        with:
-          go-version: '>=1.17.0'
-      - name: Check out Hive repository
-        uses: actions/checkout@v3
-        with:
-          repository: ethereum/hive
-          ref: master
-          path: hive
-      - name: Patch Hive Dockerfile
-        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
-      - name: Build Hive
-        working-directory: hive
-        run: go build .
-      - name: Load Docker image
-        run: docker load --input /tmp/image.tar
-      - name: Run sstore_combinations_initial01
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /sstore_combinations_initial01 --sim.parallelism $PARALLELISM
-      - name: Print results
-        run: |
-          chmod +x nethermind/scripts/hive-results.sh
-          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_31:
-    name: 31. sstore_combinations_initial01_2
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up parameters
-        run: |
-          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
-      - name: Check out Nethermind repository
-        uses: actions/checkout@v3
-        with:
-          path: nethermind
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Build Docker image
-        uses: docker/build-push-action@v3
-        with:
-          context: nethermind
-          file: nethermind/Dockerfile
-          tags: nethermind:test-${{ github.sha }}
-          outputs: type=docker,dest=/tmp/image.tar
-      - name: Install Linux packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
-      - name: Set up Go environment
-        uses: actions/setup-go@v3.0.0
-        with:
-          go-version: '>=1.17.0'
-      - name: Check out Hive repository
-        uses: actions/checkout@v3
-        with:
-          repository: ethereum/hive
-          ref: master
-          path: hive
-      - name: Patch Hive Dockerfile
-        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
-      - name: Build Hive
-        working-directory: hive
-        run: go build .
-      - name: Load Docker image
-        run: docker load --input /tmp/image.tar
-      - name: Run sstore_combinations_initial01_2
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /sstore_combinations_initial01_2 --sim.parallelism $PARALLELISM
-      - name: Print results
-        run: |
-          chmod +x nethermind/scripts/hive-results.sh
-          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_32:
-    name: 32. sstore_combinations_initial10
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up parameters
-        run: |
-          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
-      - name: Check out Nethermind repository
-        uses: actions/checkout@v3
-        with:
-          path: nethermind
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Build Docker image
-        uses: docker/build-push-action@v3
-        with:
-          context: nethermind
-          file: nethermind/Dockerfile
-          tags: nethermind:test-${{ github.sha }}
-          outputs: type=docker,dest=/tmp/image.tar
-      - name: Install Linux packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
-      - name: Set up Go environment
-        uses: actions/setup-go@v3.0.0
-        with:
-          go-version: '>=1.17.0'
-      - name: Check out Hive repository
-        uses: actions/checkout@v3
-        with:
-          repository: ethereum/hive
-          ref: master
-          path: hive
-      - name: Patch Hive Dockerfile
-        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
-      - name: Build Hive
-        working-directory: hive
-        run: go build .
-      - name: Load Docker image
-        run: docker load --input /tmp/image.tar
-      - name: Run sstore_combinations_initial10
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /sstore_combinations_initial10 --sim.parallelism $PARALLELISM
-      - name: Print results
-        run: |
-          chmod +x nethermind/scripts/hive-results.sh
-          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_33:
-    name: 33. sstore_combinations_initial10_2
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up parameters
-        run: |
-          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
-      - name: Check out Nethermind repository
-        uses: actions/checkout@v3
-        with:
-          path: nethermind
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Build Docker image
-        uses: docker/build-push-action@v3
-        with:
-          context: nethermind
-          file: nethermind/Dockerfile
-          tags: nethermind:test-${{ github.sha }}
-          outputs: type=docker,dest=/tmp/image.tar
-      - name: Install Linux packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
-      - name: Set up Go environment
-        uses: actions/setup-go@v3.0.0
-        with:
-          go-version: '>=1.17.0'
-      - name: Check out Hive repository
-        uses: actions/checkout@v3
-        with:
-          repository: ethereum/hive
-          ref: master
-          path: hive
-      - name: Patch Hive Dockerfile
-        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
-      - name: Build Hive
-        working-directory: hive
-        run: go build .
-      - name: Load Docker image
-        run: docker load --input /tmp/image.tar
-      - name: Run sstore_combinations_initial10_2
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /sstore_combinations_initial10_2 --sim.parallelism $PARALLELISM
-      - name: Print results
-        run: |
-          chmod +x nethermind/scripts/hive-results.sh
-          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_34:
-    name: 34. sstore_combinations_initial11
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up parameters
-        run: |
-          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
-      - name: Check out Nethermind repository
-        uses: actions/checkout@v3
-        with:
-          path: nethermind
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Build Docker image
-        uses: docker/build-push-action@v3
-        with:
-          context: nethermind
-          file: nethermind/Dockerfile
-          tags: nethermind:test-${{ github.sha }}
-          outputs: type=docker,dest=/tmp/image.tar
-      - name: Install Linux packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
-      - name: Set up Go environment
-        uses: actions/setup-go@v3.0.0
-        with:
-          go-version: '>=1.17.0'
-      - name: Check out Hive repository
-        uses: actions/checkout@v3
-        with:
-          repository: ethereum/hive
-          ref: master
-          path: hive
-      - name: Patch Hive Dockerfile
-        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
-      - name: Build Hive
-        working-directory: hive
-        run: go build .
-      - name: Load Docker image
-        run: docker load --input /tmp/image.tar
-      - name: Run sstore_combinations_initial11
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /sstore_combinations_initial11 --sim.parallelism $PARALLELISM
-      - name: Print results
-        run: |
-          chmod +x nethermind/scripts/hive-results.sh
-          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_35:
-    name: 35. sstore_combinations_initial11_2
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up parameters
-        run: |
-          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
-      - name: Check out Nethermind repository
-        uses: actions/checkout@v3
-        with:
-          path: nethermind
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Build Docker image
-        uses: docker/build-push-action@v3
-        with:
-          context: nethermind
-          file: nethermind/Dockerfile
-          tags: nethermind:test-${{ github.sha }}
-          outputs: type=docker,dest=/tmp/image.tar
-      - name: Install Linux packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
-      - name: Set up Go environment
-        uses: actions/setup-go@v3.0.0
-        with:
-          go-version: '>=1.17.0'
-      - name: Check out Hive repository
-        uses: actions/checkout@v3
-        with:
-          repository: ethereum/hive
-          ref: master
-          path: hive
-      - name: Patch Hive Dockerfile
-        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
-      - name: Build Hive
-        working-directory: hive
-        run: go build .
-      - name: Load Docker image
-        run: docker load --input /tmp/image.tar
-      - name: Run sstore_combinations_initial11_2
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /sstore_combinations_initial11_2 --sim.parallelism $PARALLELISM
-      - name: Print results
-        run: |
-          chmod +x nethermind/scripts/hive-results.sh
-          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_36:
-    name: 36. sstore_combinations_initial20
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up parameters
-        run: |
-          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
-      - name: Check out Nethermind repository
-        uses: actions/checkout@v3
-        with:
-          path: nethermind
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Build Docker image
-        uses: docker/build-push-action@v3
-        with:
-          context: nethermind
-          file: nethermind/Dockerfile
-          tags: nethermind:test-${{ github.sha }}
-          outputs: type=docker,dest=/tmp/image.tar
-      - name: Install Linux packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
-      - name: Set up Go environment
-        uses: actions/setup-go@v3.0.0
-        with:
-          go-version: '>=1.17.0'
-      - name: Check out Hive repository
-        uses: actions/checkout@v3
-        with:
-          repository: ethereum/hive
-          ref: master
-          path: hive
-      - name: Patch Hive Dockerfile
-        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
-      - name: Build Hive
-        working-directory: hive
-        run: go build .
-      - name: Load Docker image
-        run: docker load --input /tmp/image.tar
-      - name: Run sstore_combinations_initial20
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /sstore_combinations_initial20 --sim.parallelism $PARALLELISM
-      - name: Print results
-        run: |
-          chmod +x nethermind/scripts/hive-results.sh
-          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
   test_37:
-    name: 37. sstore_combinations_initial20_2
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up parameters
-        run: |
-          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
-      - name: Check out Nethermind repository
-        uses: actions/checkout@v3
-        with:
-          path: nethermind
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Build Docker image
-        uses: docker/build-push-action@v3
-        with:
-          context: nethermind
-          file: nethermind/Dockerfile
-          tags: nethermind:test-${{ github.sha }}
-          outputs: type=docker,dest=/tmp/image.tar
-      - name: Install Linux packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
-      - name: Set up Go environment
-        uses: actions/setup-go@v3.0.0
-        with:
-          go-version: '>=1.17.0'
-      - name: Check out Hive repository
-        uses: actions/checkout@v3
-        with:
-          repository: ethereum/hive
-          ref: master
-          path: hive
-      - name: Patch Hive Dockerfile
-        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
-      - name: Build Hive
-        working-directory: hive
-        run: go build .
-      - name: Load Docker image
-        run: docker load --input /tmp/image.tar
-      - name: Run sstore_combinations_initial20_2
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /sstore_combinations_initial20_2 --sim.parallelism $PARALLELISM
-      - name: Print results
-        run: |
-          chmod +x nethermind/scripts/hive-results.sh
-          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_38:
-    name: 38. sstore_combinations_initial21
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up parameters
-        run: |
-          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
-      - name: Check out Nethermind repository
-        uses: actions/checkout@v3
-        with:
-          path: nethermind
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Build Docker image
-        uses: docker/build-push-action@v3
-        with:
-          context: nethermind
-          file: nethermind/Dockerfile
-          tags: nethermind:test-${{ github.sha }}
-          outputs: type=docker,dest=/tmp/image.tar
-      - name: Install Linux packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
-      - name: Set up Go environment
-        uses: actions/setup-go@v3.0.0
-        with:
-          go-version: '>=1.17.0'
-      - name: Check out Hive repository
-        uses: actions/checkout@v3
-        with:
-          repository: ethereum/hive
-          ref: master
-          path: hive
-      - name: Patch Hive Dockerfile
-        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
-      - name: Build Hive
-        working-directory: hive
-        run: go build .
-      - name: Load Docker image
-        run: docker load --input /tmp/image.tar
-      - name: Run sstore_combinations_initial21
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /sstore_combinations_initial21 --sim.parallelism $PARALLELISM
-      - name: Print results
-        run: |
-          chmod +x nethermind/scripts/hive-results.sh
-          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_39:
-    name: 39. sstore_combinations_initial21_2
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up parameters
-        run: |
-          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
-      - name: Check out Nethermind repository
-        uses: actions/checkout@v3
-        with:
-          path: nethermind
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Build Docker image
-        uses: docker/build-push-action@v3
-        with:
-          context: nethermind
-          file: nethermind/Dockerfile
-          tags: nethermind:test-${{ github.sha }}
-          outputs: type=docker,dest=/tmp/image.tar
-      - name: Install Linux packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
-      - name: Set up Go environment
-        uses: actions/setup-go@v3.0.0
-        with:
-          go-version: '>=1.17.0'
-      - name: Check out Hive repository
-        uses: actions/checkout@v3
-        with:
-          repository: ethereum/hive
-          ref: master
-          path: hive
-      - name: Patch Hive Dockerfile
-        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
-      - name: Build Hive
-        working-directory: hive
-        run: go build .
-      - name: Load Docker image
-        run: docker load --input /tmp/image.tar
-      - name: Run sstore_combinations_initial21_2
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /sstore_combinations_initial21_2 --sim.parallelism $PARALLELISM
-      - name: Print results
-        run: |
-          chmod +x nethermind/scripts/hive-results.sh
-          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_40:
-    name: 40. Combined tests (e.g. stackOverflowPUSH)
+    name: 37. Combined tests (e.g. stackOverflowPUSH)
     runs-on: ubuntu-latest
     steps:
       - name: Set up parameters
@@ -2669,28 +2804,84 @@ jobs:
         continue-on-error: true
         working-directory: hive
         run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /stacksanitySWAP --sim.parallelism $PARALLELISM
-      - name: Run stStaticFlagEnabled
+      - name: Run StaticcallToPrecompileFromCalledContract
         continue-on-error: true
         working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /stStaticFlagEnabled --sim.parallelism $PARALLELISM
-      - name: Run stSystemOperationsTest
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /StaticcallToPrecompileFromCalledContract --sim.parallelism $PARALLELISM
+      - name: Run StaticcallToPrecompileFromContractInitialization
         continue-on-error: true
         working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /stSystemOperationsTest --sim.parallelism $PARALLELISM
-      - name: Run CALLBlake2f_MaxRounds
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /StaticcallToPrecompileFromContractInitialization --sim.parallelism $PARALLELISM
+      - name: Run StaticcallToPrecompileFromTransaction
         continue-on-error: true
         working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /CALLBlake2f_MaxRounds --sim.parallelism $PARALLELISM
-      - name: Run static_Call50000_sha256
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /StaticcallToPrecompileFromTransaction --sim.parallelism $PARALLELISM
+      - name: Run static_ABAcalls0
         continue-on-error: true
         working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_Call50000_sha256 --sim.parallelism $PARALLELISM
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_ABAcalls0 --sim.parallelism $PARALLELISM
+      - name: Run static_ABAcalls1
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_ABAcalls1 --sim.parallelism $PARALLELISM
+      - name: Run static_ABAcalls2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_ABAcalls2 --sim.parallelism $PARALLELISM
+      - name: Run static_ABAcalls3
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_ABAcalls3 --sim.parallelism $PARALLELISM
+      - name: Run static_ABAcallsSuicide0
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_ABAcallsSuicide0 --sim.parallelism $PARALLELISM
+      - name: Run static_ABAcallsSuicide1
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_ABAcallsSuicide1 --sim.parallelism $PARALLELISM
+      - name: Run static_Call10
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_Call10 --sim.parallelism $PARALLELISM
+      - name: Run static_Call1024BalanceTooLow
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_Call1024BalanceTooLow --sim.parallelism $PARALLELISM
+      - name: Run static_Call1024BalanceTooLow2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_Call1024BalanceTooLow2 --sim.parallelism $PARALLELISM
+      - name: Run static_Call1024OOG
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_Call1024OOG --sim.parallelism $PARALLELISM
+      - name: Run static_Call1024PreCalls
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_Call1024PreCalls --sim.parallelism $PARALLELISM
+      - name: Run static_Call1024PreCalls2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_Call1024PreCalls2 --sim.parallelism $PARALLELISM
+      - name: Run static_Call1024PreCalls3
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_Call1024PreCalls3 --sim.parallelism $PARALLELISM
+      - name: Run static_Call1MB1024Calldepth
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_Call1MB1024Calldepth --sim.parallelism $PARALLELISM
+      - name: Run static_Call50000
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_Call50000 --sim.parallelism $PARALLELISM
       - name: Print results
         run: |
           chmod +x nethermind/scripts/hive-results.sh
           nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_41:
-    name: 41. Combined tests (e.g. stTransactionTest)
+  test_38:
+    name: 38. Combined tests (e.g. static_Call50000bytesContract50_1)
     runs-on: ubuntu-latest
     steps:
       - name: Set up parameters
@@ -2732,6 +2923,1941 @@ jobs:
         run: go build .
       - name: Load Docker image
         run: docker load --input /tmp/image.tar
+      - name: Run static_Call50000bytesContract50_1
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_Call50000bytesContract50_1 --sim.parallelism $PARALLELISM
+      - name: Run static_Call50000bytesContract50_2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_Call50000bytesContract50_2 --sim.parallelism $PARALLELISM
+      - name: Run static_Call50000bytesContract50_3
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_Call50000bytesContract50_3 --sim.parallelism $PARALLELISM
+      - name: Run static_Call50000_ecrec
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_Call50000_ecrec --sim.parallelism $PARALLELISM
+      - name: Run static_Call50000_identity
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_Call50000_identity --sim.parallelism $PARALLELISM
+      - name: Run static_Call50000_identity2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_Call50000_identity2 --sim.parallelism $PARALLELISM
+      - name: Run static_Call50000_rip160
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_Call50000_rip160 --sim.parallelism $PARALLELISM
+      - name: Run static_CallAndCallcodeConsumeMoreGasThenTransactionHas
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallAndCallcodeConsumeMoreGasThenTransactionHas --sim.parallelism $PARALLELISM
+      - name: Run static_CallAskMoreGasOnDepth2ThenTransactionHas
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallAskMoreGasOnDepth2ThenTransactionHas --sim.parallelism $PARALLELISM
+      - name: Run static_callBasic
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callBasic --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcallcode_001
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcallcode_001 --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcallcode_001_2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcallcode_001_2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcallcode_001_OOGE
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcallcode_001_OOGE --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcallcode_001_OOGE_2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcallcode_001_OOGE_2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcallcode_001_OOGMAfter
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcallcode_001_OOGMAfter --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcallcode_001_OOGMAfter2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcallcode_001_OOGMAfter2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcallcode_001_OOGMAfter_2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcallcode_001_OOGMAfter_2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcallcode_001_OOGMAfter_3
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcallcode_001_OOGMAfter_3 --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcallcode_001_OOGMBefore
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcallcode_001_OOGMBefore --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcallcode_001_OOGMBefore2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcallcode_001_OOGMBefore2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcallcode_001_SuicideEnd
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcallcode_001_SuicideEnd --sim.parallelism $PARALLELISM
+      - name: Print results
+        run: |
+          chmod +x nethermind/scripts/hive-results.sh
+          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
+  test_39:
+    name: 39. Combined tests (e.g. static_callcallcallcode_001_SuicideEnd2)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up parameters
+        run: |
+          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
+      - name: Check out Nethermind repository
+        uses: actions/checkout@v3
+        with:
+          path: nethermind
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: nethermind
+          file: nethermind/Dockerfile
+          tags: nethermind:test-${{ github.sha }}
+          outputs: type=docker,dest=/tmp/image.tar
+      - name: Install Linux packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
+      - name: Set up Go environment
+        uses: actions/setup-go@v3.0.0
+        with:
+          go-version: '>=1.17.0'
+      - name: Check out Hive repository
+        uses: actions/checkout@v3
+        with:
+          repository: ethereum/hive
+          ref: master
+          path: hive
+      - name: Patch Hive Dockerfile
+        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
+      - name: Build Hive
+        working-directory: hive
+        run: go build .
+      - name: Load Docker image
+        run: docker load --input /tmp/image.tar
+      - name: Run static_callcallcallcode_001_SuicideEnd2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcallcode_001_SuicideEnd2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcallcode_001_SuicideMiddle
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcallcode_001_SuicideMiddle --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcallcode_001_SuicideMiddle2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcallcode_001_SuicideMiddle2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcallcode_ABCB_RECURSIVE
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcallcode_ABCB_RECURSIVE --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcallcode_ABCB_RECURSIVE2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcallcode_ABCB_RECURSIVE2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcall_000
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcall_000 --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcall_000_OOGE
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcall_000_OOGE --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcall_000_OOGMAfter
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcall_000_OOGMAfter --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcall_000_OOGMAfter2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcall_000_OOGMAfter2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcall_000_OOGMBefore
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcall_000_OOGMBefore --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcall_000_SuicideEnd
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcall_000_SuicideEnd --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcall_000_SuicideMiddle
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcall_000_SuicideMiddle --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcall_ABCB_RECURSIVE
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcall_ABCB_RECURSIVE --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcodecallcode_011
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcodecallcode_011 --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcodecallcode_011_2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcodecallcode_011_2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcodecallcode_011_OOGE
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcodecallcode_011_OOGE --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcodecallcode_011_OOGE_2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcodecallcode_011_OOGE_2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcodecallcode_011_OOGMAfter
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcodecallcode_011_OOGMAfter --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcodecallcode_011_OOGMAfter2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcodecallcode_011_OOGMAfter2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcodecallcode_011_OOGMAfter_1
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcodecallcode_011_OOGMAfter_1 --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcodecallcode_011_OOGMAfter_2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcodecallcode_011_OOGMAfter_2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcodecallcode_011_OOGMBefore
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcodecallcode_011_OOGMBefore --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcodecallcode_011_OOGMBefore2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcodecallcode_011_OOGMBefore2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcodecallcode_011_SuicideEnd
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcodecallcode_011_SuicideEnd --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcodecallcode_011_SuicideEnd2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcodecallcode_011_SuicideEnd2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcodecallcode_011_SuicideMiddle
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcodecallcode_011_SuicideMiddle --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcodecallcode_011_SuicideMiddle2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcodecallcode_011_SuicideMiddle2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcodecallcode_ABCB_RECURSIVE
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcodecallcode_ABCB_RECURSIVE --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcodecallcode_ABCB_RECURSIVE2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcodecallcode_ABCB_RECURSIVE2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcodecall_010
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcodecall_010 --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcodecall_010_2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcodecall_010_2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcodecall_010_OOGE
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcodecall_010_OOGE --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcodecall_010_OOGE_2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcodecall_010_OOGE_2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcodecall_010_OOGMAfter
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcodecall_010_OOGMAfter --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcodecall_010_OOGMAfter2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcodecall_010_OOGMAfter2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcodecall_010_OOGMAfter_2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcodecall_010_OOGMAfter_2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcodecall_010_OOGMAfter_3
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcodecall_010_OOGMAfter_3 --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcodecall_010_OOGMBefore
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcodecall_010_OOGMBefore --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcodecall_010_OOGMBefore2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcodecall_010_OOGMBefore2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcodecall_010_SuicideEnd
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcodecall_010_SuicideEnd --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcodecall_010_SuicideEnd2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcodecall_010_SuicideEnd2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcodecall_010_SuicideMiddle
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcodecall_010_SuicideMiddle --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcodecall_010_SuicideMiddle2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcodecall_010_SuicideMiddle2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcodecall_ABCB_RECURSIVE
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcodecall_ABCB_RECURSIVE --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcodecall_ABCB_RECURSIVE2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcodecall_ABCB_RECURSIVE2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcode_01_2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcode_01_2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcode_01_OOGE_2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcode_01_OOGE_2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcode_01_SuicideEnd
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcode_01_SuicideEnd --sim.parallelism $PARALLELISM
+      - name: Run static_callcallcode_01_SuicideEnd2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcallcode_01_SuicideEnd2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcall_00
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcall_00 --sim.parallelism $PARALLELISM
+      - name: Run static_callcall_00_OOGE
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcall_00_OOGE --sim.parallelism $PARALLELISM
+      - name: Run static_callcall_00_OOGE_1
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcall_00_OOGE_1 --sim.parallelism $PARALLELISM
+      - name: Run static_callcall_00_OOGE_2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcall_00_OOGE_2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcall_00_SuicideEnd
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcall_00_SuicideEnd --sim.parallelism $PARALLELISM
+      - name: Run static_callChangeRevert
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callChangeRevert --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcallcode_101
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcallcode_101 --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcallcode_101_2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcallcode_101_2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcallcode_101_OOGE
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcallcode_101_OOGE --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcallcode_101_OOGE_2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcallcode_101_OOGE_2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcallcode_101_OOGMAfter
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcallcode_101_OOGMAfter --sim.parallelism $PARALLELISM
+      - name: Print results
+        run: |
+          chmod +x nethermind/scripts/hive-results.sh
+          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
+  test_40:
+    name: 40. Combined tests (e.g. static_callcodecallcallcode_101_OOGMAfter2)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up parameters
+        run: |
+          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
+      - name: Check out Nethermind repository
+        uses: actions/checkout@v3
+        with:
+          path: nethermind
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: nethermind
+          file: nethermind/Dockerfile
+          tags: nethermind:test-${{ github.sha }}
+          outputs: type=docker,dest=/tmp/image.tar
+      - name: Install Linux packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
+      - name: Set up Go environment
+        uses: actions/setup-go@v3.0.0
+        with:
+          go-version: '>=1.17.0'
+      - name: Check out Hive repository
+        uses: actions/checkout@v3
+        with:
+          repository: ethereum/hive
+          ref: master
+          path: hive
+      - name: Patch Hive Dockerfile
+        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
+      - name: Build Hive
+        working-directory: hive
+        run: go build .
+      - name: Load Docker image
+        run: docker load --input /tmp/image.tar
+      - name: Run static_callcodecallcallcode_101_OOGMAfter2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcallcode_101_OOGMAfter2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcallcode_101_OOGMAfter_1
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcallcode_101_OOGMAfter_1 --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcallcode_101_OOGMAfter_3
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcallcode_101_OOGMAfter_3 --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcallcode_101_OOGMBefore
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcallcode_101_OOGMBefore --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcallcode_101_OOGMBefore2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcallcode_101_OOGMBefore2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcallcode_101_SuicideEnd
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcallcode_101_SuicideEnd --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcallcode_101_SuicideEnd2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcallcode_101_SuicideEnd2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcallcode_101_SuicideMiddle
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcallcode_101_SuicideMiddle --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcallcode_101_SuicideMiddle2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcallcode_101_SuicideMiddle2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcallcode_ABCB_RECURSIVE
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcallcode_ABCB_RECURSIVE --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcallcode_ABCB_RECURSIVE2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcallcode_ABCB_RECURSIVE2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcall_100
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcall_100 --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcall_100_2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcall_100_2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcall_100_OOGE
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcall_100_OOGE --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcall_100_OOGE2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcall_100_OOGE2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcall_100_OOGMAfter
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcall_100_OOGMAfter --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcall_100_OOGMAfter2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcall_100_OOGMAfter2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcall_100_OOGMAfter_2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcall_100_OOGMAfter_2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcall_100_OOGMAfter_3
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcall_100_OOGMAfter_3 --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcall_100_OOGMBefore
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcall_100_OOGMBefore --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcall_100_OOGMBefore2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcall_100_OOGMBefore2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcall_100_SuicideEnd
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcall_100_SuicideEnd --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcall_100_SuicideEnd2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcall_100_SuicideEnd2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcall_100_SuicideMiddle
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcall_100_SuicideMiddle --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcall_100_SuicideMiddle2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcall_100_SuicideMiddle2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcall_ABCB_RECURSIVE
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcall_ABCB_RECURSIVE --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcall_ABCB_RECURSIVE2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcall_ABCB_RECURSIVE2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcodecallcode_111_SuicideEnd
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcodecallcode_111_SuicideEnd --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcodecall_110
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcodecall_110 --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcodecall_1102
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcodecall_1102 --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcodecall_110_2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcodecall_110_2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcodecall_110_OOGE
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcodecall_110_OOGE --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcodecall_110_OOGE2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcodecall_110_OOGE2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcodecall_110_OOGMAfter
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcodecall_110_OOGMAfter --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcodecall_110_OOGMAfter2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcodecall_110_OOGMAfter2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcodecall_110_OOGMAfter_2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcodecall_110_OOGMAfter_2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcodecall_110_OOGMAfter_3
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcodecall_110_OOGMAfter_3 --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcodecall_110_OOGMBefore
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcodecall_110_OOGMBefore --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcodecall_110_OOGMBefore2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcodecall_110_OOGMBefore2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcodecall_110_SuicideEnd
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcodecall_110_SuicideEnd --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcodecall_110_SuicideEnd2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcodecall_110_SuicideEnd2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcodecall_110_SuicideMiddle
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcodecall_110_SuicideMiddle --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcodecall_110_SuicideMiddle2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcodecall_110_SuicideMiddle2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcodecall_ABCB_RECURSIVE
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcodecall_ABCB_RECURSIVE --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecallcodecall_ABCB_RECURSIVE2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecallcodecall_ABCB_RECURSIVE2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecall_10
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecall_10 --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecall_10_2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecall_10_2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecall_10_OOGE
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecall_10_OOGE --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecall_10_OOGE_2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecall_10_OOGE_2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecall_10_SuicideEnd
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecall_10_SuicideEnd --sim.parallelism $PARALLELISM
+      - name: Run static_callcodecall_10_SuicideEnd2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcodecall_10_SuicideEnd2 --sim.parallelism $PARALLELISM
+      - name: Run static_callcode_checkPC
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callcode_checkPC --sim.parallelism $PARALLELISM
+      - name: Run static_CallContractToCreateContractAndCallItOOG
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallContractToCreateContractAndCallItOOG --sim.parallelism $PARALLELISM
+      - name: Run static_CallContractToCreateContractOOG
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallContractToCreateContractOOG --sim.parallelism $PARALLELISM
+      - name: Run static_CallContractToCreateContractOOGBonusGas
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallContractToCreateContractOOGBonusGas --sim.parallelism $PARALLELISM
+      - name: Run static_CallContractToCreateContractWhichWouldCreateContractIfCalled
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallContractToCreateContractWhichWouldCreateContractIfCalled --sim.parallelism $PARALLELISM
+      - name: Run static_callCreate
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callCreate --sim.parallelism $PARALLELISM
+      - name: Run static_callCreate2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callCreate2 --sim.parallelism $PARALLELISM
+      - name: Print results
+        run: |
+          chmod +x nethermind/scripts/hive-results.sh
+          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
+  test_41:
+    name: 41. Combined tests (e.g. static_callCreate3)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up parameters
+        run: |
+          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
+      - name: Check out Nethermind repository
+        uses: actions/checkout@v3
+        with:
+          path: nethermind
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: nethermind
+          file: nethermind/Dockerfile
+          tags: nethermind:test-${{ github.sha }}
+          outputs: type=docker,dest=/tmp/image.tar
+      - name: Install Linux packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
+      - name: Set up Go environment
+        uses: actions/setup-go@v3.0.0
+        with:
+          go-version: '>=1.17.0'
+      - name: Check out Hive repository
+        uses: actions/checkout@v3
+        with:
+          repository: ethereum/hive
+          ref: master
+          path: hive
+      - name: Patch Hive Dockerfile
+        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
+      - name: Build Hive
+        working-directory: hive
+        run: go build .
+      - name: Load Docker image
+        run: docker load --input /tmp/image.tar
+      - name: Run static_callCreate3
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callCreate3 --sim.parallelism $PARALLELISM
+      - name: Run static_calldelcode_01
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_calldelcode_01 --sim.parallelism $PARALLELISM
+      - name: Run static_calldelcode_01_OOGE
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_calldelcode_01_OOGE --sim.parallelism $PARALLELISM
+      - name: Run static_CallEcrecover0
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallEcrecover0 --sim.parallelism $PARALLELISM
+      - name: Run static_CallEcrecover0_0input
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallEcrecover0_0input --sim.parallelism $PARALLELISM
+      - name: Run static_CallEcrecover0_completeReturnValue
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallEcrecover0_completeReturnValue --sim.parallelism $PARALLELISM
+      - name: Run static_CallEcrecover0_Gas2999
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallEcrecover0_Gas2999 --sim.parallelism $PARALLELISM
+      - name: Run static_CallEcrecover0_gas3000
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallEcrecover0_gas3000 --sim.parallelism $PARALLELISM
+      - name: Run static_CallEcrecover0_NoGas
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallEcrecover0_NoGas --sim.parallelism $PARALLELISM
+      - name: Run static_CallEcrecover0_overlappingInputOutput
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallEcrecover0_overlappingInputOutput --sim.parallelism $PARALLELISM
+      - name: Run static_CallEcrecover1
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallEcrecover1 --sim.parallelism $PARALLELISM
+      - name: Run static_CallEcrecover2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallEcrecover2 --sim.parallelism $PARALLELISM
+      - name: Run static_CallEcrecover3
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallEcrecover3 --sim.parallelism $PARALLELISM
+      - name: Run static_CallEcrecover80
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallEcrecover80 --sim.parallelism $PARALLELISM
+      - name: Run static_CallEcrecoverCheckLength
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallEcrecoverCheckLength --sim.parallelism $PARALLELISM
+      - name: Run static_CallEcrecoverCheckLengthWrongV
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallEcrecoverCheckLengthWrongV --sim.parallelism $PARALLELISM
+      - name: Run static_CallEcrecoverH_prefixed0
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallEcrecoverH_prefixed0 --sim.parallelism $PARALLELISM
+      - name: Run static_CallEcrecoverR_prefixed0
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallEcrecoverR_prefixed0 --sim.parallelism $PARALLELISM
+      - name: Run static_CallEcrecoverS_prefixed0
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallEcrecoverS_prefixed0 --sim.parallelism $PARALLELISM
+      - name: Run static_CallEcrecoverV_prefixed0
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallEcrecoverV_prefixed0 --sim.parallelism $PARALLELISM
+      - name: Run static_CallGoesOOGOnSecondLevel
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallGoesOOGOnSecondLevel --sim.parallelism $PARALLELISM
+      - name: Run static_CallGoesOOGOnSecondLevel2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallGoesOOGOnSecondLevel2 --sim.parallelism $PARALLELISM
+      - name: Run static_CallIdentitiy_1
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallIdentitiy_1 --sim.parallelism $PARALLELISM
+      - name: Run static_CallIdentity_1_nonzeroValue
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallIdentity_1_nonzeroValue --sim.parallelism $PARALLELISM
+      - name: Run static_CallIdentity_2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallIdentity_2 --sim.parallelism $PARALLELISM
+      - name: Run static_CallIdentity_3
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallIdentity_3 --sim.parallelism $PARALLELISM
+      - name: Run static_CallIdentity_4
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallIdentity_4 --sim.parallelism $PARALLELISM
+      - name: Run static_CallIdentity_4_gas17
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallIdentity_4_gas17 --sim.parallelism $PARALLELISM
+      - name: Run static_CallIdentity_4_gas18
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallIdentity_4_gas18 --sim.parallelism $PARALLELISM
+      - name: Run static_CallIdentity_5
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallIdentity_5 --sim.parallelism $PARALLELISM
+      - name: Run static_CallLoseGasOOG
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallLoseGasOOG --sim.parallelism $PARALLELISM
+      - name: Run static_callOutput1
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callOutput1 --sim.parallelism $PARALLELISM
+      - name: Run static_callOutput2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callOutput2 --sim.parallelism $PARALLELISM
+      - name: Run static_callOutput3
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callOutput3 --sim.parallelism $PARALLELISM
+      - name: Run static_callOutput3Fail
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callOutput3Fail --sim.parallelism $PARALLELISM
+      - name: Run static_callOutput3partial
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callOutput3partial --sim.parallelism $PARALLELISM
+      - name: Run static_callOutput3partialFail
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callOutput3partialFail --sim.parallelism $PARALLELISM
+      - name: Run static_CallRecursiveBomb0
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallRecursiveBomb0 --sim.parallelism $PARALLELISM
+      - name: Run static_CallRecursiveBomb0_OOG_atMaxCallDepth
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallRecursiveBomb0_OOG_atMaxCallDepth --sim.parallelism $PARALLELISM
+      - name: Run static_CallRecursiveBomb1
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallRecursiveBomb1 --sim.parallelism $PARALLELISM
+      - name: Run static_CallRecursiveBomb2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallRecursiveBomb2 --sim.parallelism $PARALLELISM
+      - name: Run static_CallRecursiveBomb3
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallRecursiveBomb3 --sim.parallelism $PARALLELISM
+      - name: Run static_CallRecursiveBombLog
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallRecursiveBombLog --sim.parallelism $PARALLELISM
+      - name: Run static_CallRecursiveBombLog2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallRecursiveBombLog2 --sim.parallelism $PARALLELISM
+      - name: Run static_CallRecursiveBombPreCall
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallRecursiveBombPreCall --sim.parallelism $PARALLELISM
+      - name: Run static_CallRecursiveBombPreCall2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallRecursiveBombPreCall2 --sim.parallelism $PARALLELISM
+      - name: Run static_CallRipemd160_1
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallRipemd160_1 --sim.parallelism $PARALLELISM
+      - name: Run static_CallRipemd160_2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallRipemd160_2 --sim.parallelism $PARALLELISM
+      - name: Run static_CallRipemd160_3
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallRipemd160_3 --sim.parallelism $PARALLELISM
+      - name: Run static_CallRipemd160_3_postfixed0
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallRipemd160_3_postfixed0 --sim.parallelism $PARALLELISM
+      - name: Run static_CallRipemd160_3_prefixed0
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallRipemd160_3_prefixed0 --sim.parallelism $PARALLELISM
+      - name: Run static_CallRipemd160_4
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallRipemd160_4 --sim.parallelism $PARALLELISM
+      - name: Run static_CallRipemd160_4_gas719
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallRipemd160_4_gas719 --sim.parallelism $PARALLELISM
+      - name: Run static_CallRipemd160_5
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallRipemd160_5 --sim.parallelism $PARALLELISM
+      - name: Run static_CallSha256_1
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallSha256_1 --sim.parallelism $PARALLELISM
+      - name: Run static_CallSha256_1_nonzeroValue
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallSha256_1_nonzeroValue --sim.parallelism $PARALLELISM
+      - name: Run static_CallSha256_2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallSha256_2 --sim.parallelism $PARALLELISM
+      - name: Run static_CallSha256_3
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallSha256_3 --sim.parallelism $PARALLELISM
+      - name: Run static_CallSha256_3_postfix0
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallSha256_3_postfix0 --sim.parallelism $PARALLELISM
+      - name: Run static_CallSha256_3_prefix0
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallSha256_3_prefix0 --sim.parallelism $PARALLELISM
+      - name: Run static_CallSha256_4
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallSha256_4 --sim.parallelism $PARALLELISM
+      - name: Run static_CallSha256_4_gas99
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallSha256_4_gas99 --sim.parallelism $PARALLELISM
+      - name: Run static_CallSha256_5
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallSha256_5 --sim.parallelism $PARALLELISM
+      - name: Run static_callToCallCodeOpCodeCheck
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callToCallCodeOpCodeCheck --sim.parallelism $PARALLELISM
+      - name: Run static_callToCallOpCodeCheck
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callToCallOpCodeCheck --sim.parallelism $PARALLELISM
+      - name: Print results
+        run: |
+          chmod +x nethermind/scripts/hive-results.sh
+          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
+  test_42:
+    name: 42. Combined tests (e.g. static_callToDelCallOpCodeCheck)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up parameters
+        run: |
+          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
+      - name: Check out Nethermind repository
+        uses: actions/checkout@v3
+        with:
+          path: nethermind
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: nethermind
+          file: nethermind/Dockerfile
+          tags: nethermind:test-${{ github.sha }}
+          outputs: type=docker,dest=/tmp/image.tar
+      - name: Install Linux packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
+      - name: Set up Go environment
+        uses: actions/setup-go@v3.0.0
+        with:
+          go-version: '>=1.17.0'
+      - name: Check out Hive repository
+        uses: actions/checkout@v3
+        with:
+          repository: ethereum/hive
+          ref: master
+          path: hive
+      - name: Patch Hive Dockerfile
+        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
+      - name: Build Hive
+        working-directory: hive
+        run: go build .
+      - name: Load Docker image
+        run: docker load --input /tmp/image.tar
+      - name: Run static_callToDelCallOpCodeCheck
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callToDelCallOpCodeCheck --sim.parallelism $PARALLELISM
+      - name: Run static_CallToNameRegistrator0
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallToNameRegistrator0 --sim.parallelism $PARALLELISM
+      - name: Run static_CallToReturn1
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CallToReturn1 --sim.parallelism $PARALLELISM
+      - name: Run static_CalltoReturn2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CalltoReturn2 --sim.parallelism $PARALLELISM
+      - name: Run static_callToStaticOpCodeCheck
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callToStaticOpCodeCheck --sim.parallelism $PARALLELISM
+      - name: Run static_callWithHighValue
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callWithHighValue --sim.parallelism $PARALLELISM
+      - name: Run static_callWithHighValueAndGasOOG
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callWithHighValueAndGasOOG --sim.parallelism $PARALLELISM
+      - name: Run static_callWithHighValueAndOOGatTxLevel
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callWithHighValueAndOOGatTxLevel --sim.parallelism $PARALLELISM
+      - name: Run static_callWithHighValueOOGinCall
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_callWithHighValueOOGinCall --sim.parallelism $PARALLELISM
+      - name: Run static_CALL_OneVCallSuicide
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CALL_OneVCallSuicide --sim.parallelism $PARALLELISM
+      - name: Run static_call_OOG_additionalGasCosts1
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_call_OOG_additionalGasCosts1 --sim.parallelism $PARALLELISM
+      - name: Run static_call_OOG_additionalGasCosts2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_call_OOG_additionalGasCosts2 --sim.parallelism $PARALLELISM
+      - name: Run static_call_value_inherit
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_call_value_inherit --sim.parallelism $PARALLELISM
+      - name: Run static_call_value_inherit_from_call
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_call_value_inherit_from_call --sim.parallelism $PARALLELISM
+      - name: Run static_CALL_ZeroVCallSuicide
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CALL_ZeroVCallSuicide --sim.parallelism $PARALLELISM
+      - name: Run static_CheckCallCostOOG
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CheckCallCostOOG --sim.parallelism $PARALLELISM
+      - name: Run static_CheckOpcodes
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CheckOpcodes --sim.parallelism $PARALLELISM
+      - name: Run static_CheckOpcodes2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CheckOpcodes2 --sim.parallelism $PARALLELISM
+      - name: Run static_CheckOpcodes3
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CheckOpcodes3 --sim.parallelism $PARALLELISM
+      - name: Run static_CheckOpcodes4
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CheckOpcodes4 --sim.parallelism $PARALLELISM
+      - name: Run static_CheckOpcodes5
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CheckOpcodes5 --sim.parallelism $PARALLELISM
+      - name: Run static_contractCreationMakeCallThatAskMoreGasThenTransactionProvided
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_contractCreationMakeCallThatAskMoreGasThenTransactionProvided --sim.parallelism $PARALLELISM
+      - name: Run static_contractCreationOOGdontLeaveEmptyContractViaTransaction
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_contractCreationOOGdontLeaveEmptyContractViaTransaction --sim.parallelism $PARALLELISM
+      - name: Run static_CREATE_ContractSuicideDuringInit
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CREATE_ContractSuicideDuringInit --sim.parallelism $PARALLELISM
+      - name: Run static_CREATE_ContractSuicideDuringInit_ThenStoreThenReturn
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CREATE_ContractSuicideDuringInit_ThenStoreThenReturn --sim.parallelism $PARALLELISM
+      - name: Run static_CREATE_ContractSuicideDuringInit_WithValue
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CREATE_ContractSuicideDuringInit_WithValue --sim.parallelism $PARALLELISM
+      - name: Run static_CREATE_EmptyContractAndCallIt_0wei
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CREATE_EmptyContractAndCallIt_0wei --sim.parallelism $PARALLELISM
+      - name: Run static_CREATE_EmptyContractWithStorageAndCallIt_0wei
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_CREATE_EmptyContractWithStorageAndCallIt_0wei --sim.parallelism $PARALLELISM
+      - name: Run static_ExecuteCallThatAskForeGasThenTrabsactionHas
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_ExecuteCallThatAskForeGasThenTrabsactionHas --sim.parallelism $PARALLELISM
+      - name: Run static_InternalCallHittingGasLimit
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_InternalCallHittingGasLimit --sim.parallelism $PARALLELISM
+      - name: Run static_InternalCallHittingGasLimit2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_InternalCallHittingGasLimit2 --sim.parallelism $PARALLELISM
+      - name: Run static_InternlCallStoreClearsOOG
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_InternlCallStoreClearsOOG --sim.parallelism $PARALLELISM
+      - name: Run static_log0_emptyMem
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_log0_emptyMem --sim.parallelism $PARALLELISM
+      - name: Run static_log0_logMemsizeTooHigh
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_log0_logMemsizeTooHigh --sim.parallelism $PARALLELISM
+      - name: Run static_log0_logMemsizeZero
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_log0_logMemsizeZero --sim.parallelism $PARALLELISM
+      - name: Run static_log0_logMemStartTooHigh
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_log0_logMemStartTooHigh --sim.parallelism $PARALLELISM
+      - name: Run static_log0_nonEmptyMem
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_log0_nonEmptyMem --sim.parallelism $PARALLELISM
+      - name: Run static_log0_nonEmptyMem_logMemSize1
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_log0_nonEmptyMem_logMemSize1 --sim.parallelism $PARALLELISM
+      - name: Run static_log0_nonEmptyMem_logMemSize1_logMemStart31
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_log0_nonEmptyMem_logMemSize1_logMemStart31 --sim.parallelism $PARALLELISM
+      - name: Run static_log1_emptyMem
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_log1_emptyMem --sim.parallelism $PARALLELISM
+      - name: Run static_log1_logMemsizeTooHigh
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_log1_logMemsizeTooHigh --sim.parallelism $PARALLELISM
+      - name: Run static_log1_logMemsizeZero
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_log1_logMemsizeZero --sim.parallelism $PARALLELISM
+      - name: Run static_log1_logMemStartTooHigh
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_log1_logMemStartTooHigh --sim.parallelism $PARALLELISM
+      - name: Run static_log1_MaxTopic
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_log1_MaxTopic --sim.parallelism $PARALLELISM
+      - name: Run static_log_Caller
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_log_Caller --sim.parallelism $PARALLELISM
+      - name: Run static_LoopCallsDepthThenRevert
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_LoopCallsDepthThenRevert --sim.parallelism $PARALLELISM
+      - name: Run static_LoopCallsDepthThenRevert2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_LoopCallsDepthThenRevert2 --sim.parallelism $PARALLELISM
+      - name: Run static_LoopCallsDepthThenRevert3
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_LoopCallsDepthThenRevert3 --sim.parallelism $PARALLELISM
+      - name: Run static_LoopCallsThenRevert
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_LoopCallsThenRevert --sim.parallelism $PARALLELISM
+      - name: Run static_makeMoney
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_makeMoney --sim.parallelism $PARALLELISM
+      - name: Run static_PostToReturn1
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_PostToReturn1 --sim.parallelism $PARALLELISM
+      - name: Run static_RawCallGasAsk
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_RawCallGasAsk --sim.parallelism $PARALLELISM
+      - name: Print results
+        run: |
+          chmod +x nethermind/scripts/hive-results.sh
+          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
+  test_43:
+    name: 43. sstore_combinations_initial00
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up parameters
+        run: |
+          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
+      - name: Check out Nethermind repository
+        uses: actions/checkout@v3
+        with:
+          path: nethermind
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: nethermind
+          file: nethermind/Dockerfile
+          tags: nethermind:test-${{ github.sha }}
+          outputs: type=docker,dest=/tmp/image.tar
+      - name: Install Linux packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
+      - name: Set up Go environment
+        uses: actions/setup-go@v3.0.0
+        with:
+          go-version: '>=1.17.0'
+      - name: Check out Hive repository
+        uses: actions/checkout@v3
+        with:
+          repository: ethereum/hive
+          ref: master
+          path: hive
+      - name: Patch Hive Dockerfile
+        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
+      - name: Build Hive
+        working-directory: hive
+        run: go build .
+      - name: Load Docker image
+        run: docker load --input /tmp/image.tar
+      - name: Run sstore_combinations_initial00
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /sstore_combinations_initial00 --sim.parallelism $PARALLELISM
+      - name: Print results
+        run: |
+          chmod +x nethermind/scripts/hive-results.sh
+          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
+  test_44:
+    name: 44. sstore_combinations_initial00_2
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up parameters
+        run: |
+          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
+      - name: Check out Nethermind repository
+        uses: actions/checkout@v3
+        with:
+          path: nethermind
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: nethermind
+          file: nethermind/Dockerfile
+          tags: nethermind:test-${{ github.sha }}
+          outputs: type=docker,dest=/tmp/image.tar
+      - name: Install Linux packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
+      - name: Set up Go environment
+        uses: actions/setup-go@v3.0.0
+        with:
+          go-version: '>=1.17.0'
+      - name: Check out Hive repository
+        uses: actions/checkout@v3
+        with:
+          repository: ethereum/hive
+          ref: master
+          path: hive
+      - name: Patch Hive Dockerfile
+        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
+      - name: Build Hive
+        working-directory: hive
+        run: go build .
+      - name: Load Docker image
+        run: docker load --input /tmp/image.tar
+      - name: Run sstore_combinations_initial00_2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /sstore_combinations_initial00_2 --sim.parallelism $PARALLELISM
+      - name: Print results
+        run: |
+          chmod +x nethermind/scripts/hive-results.sh
+          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
+  test_45:
+    name: 45. sstore_combinations_initial01
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up parameters
+        run: |
+          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
+      - name: Check out Nethermind repository
+        uses: actions/checkout@v3
+        with:
+          path: nethermind
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: nethermind
+          file: nethermind/Dockerfile
+          tags: nethermind:test-${{ github.sha }}
+          outputs: type=docker,dest=/tmp/image.tar
+      - name: Install Linux packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
+      - name: Set up Go environment
+        uses: actions/setup-go@v3.0.0
+        with:
+          go-version: '>=1.17.0'
+      - name: Check out Hive repository
+        uses: actions/checkout@v3
+        with:
+          repository: ethereum/hive
+          ref: master
+          path: hive
+      - name: Patch Hive Dockerfile
+        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
+      - name: Build Hive
+        working-directory: hive
+        run: go build .
+      - name: Load Docker image
+        run: docker load --input /tmp/image.tar
+      - name: Run sstore_combinations_initial01
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /sstore_combinations_initial01 --sim.parallelism $PARALLELISM
+      - name: Print results
+        run: |
+          chmod +x nethermind/scripts/hive-results.sh
+          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
+  test_46:
+    name: 46. sstore_combinations_initial01_2
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up parameters
+        run: |
+          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
+      - name: Check out Nethermind repository
+        uses: actions/checkout@v3
+        with:
+          path: nethermind
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: nethermind
+          file: nethermind/Dockerfile
+          tags: nethermind:test-${{ github.sha }}
+          outputs: type=docker,dest=/tmp/image.tar
+      - name: Install Linux packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
+      - name: Set up Go environment
+        uses: actions/setup-go@v3.0.0
+        with:
+          go-version: '>=1.17.0'
+      - name: Check out Hive repository
+        uses: actions/checkout@v3
+        with:
+          repository: ethereum/hive
+          ref: master
+          path: hive
+      - name: Patch Hive Dockerfile
+        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
+      - name: Build Hive
+        working-directory: hive
+        run: go build .
+      - name: Load Docker image
+        run: docker load --input /tmp/image.tar
+      - name: Run sstore_combinations_initial01_2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /sstore_combinations_initial01_2 --sim.parallelism $PARALLELISM
+      - name: Print results
+        run: |
+          chmod +x nethermind/scripts/hive-results.sh
+          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
+  test_47:
+    name: 47. sstore_combinations_initial10
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up parameters
+        run: |
+          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
+      - name: Check out Nethermind repository
+        uses: actions/checkout@v3
+        with:
+          path: nethermind
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: nethermind
+          file: nethermind/Dockerfile
+          tags: nethermind:test-${{ github.sha }}
+          outputs: type=docker,dest=/tmp/image.tar
+      - name: Install Linux packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
+      - name: Set up Go environment
+        uses: actions/setup-go@v3.0.0
+        with:
+          go-version: '>=1.17.0'
+      - name: Check out Hive repository
+        uses: actions/checkout@v3
+        with:
+          repository: ethereum/hive
+          ref: master
+          path: hive
+      - name: Patch Hive Dockerfile
+        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
+      - name: Build Hive
+        working-directory: hive
+        run: go build .
+      - name: Load Docker image
+        run: docker load --input /tmp/image.tar
+      - name: Run sstore_combinations_initial10
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /sstore_combinations_initial10 --sim.parallelism $PARALLELISM
+      - name: Print results
+        run: |
+          chmod +x nethermind/scripts/hive-results.sh
+          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
+  test_48:
+    name: 48. sstore_combinations_initial10_2
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up parameters
+        run: |
+          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
+      - name: Check out Nethermind repository
+        uses: actions/checkout@v3
+        with:
+          path: nethermind
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: nethermind
+          file: nethermind/Dockerfile
+          tags: nethermind:test-${{ github.sha }}
+          outputs: type=docker,dest=/tmp/image.tar
+      - name: Install Linux packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
+      - name: Set up Go environment
+        uses: actions/setup-go@v3.0.0
+        with:
+          go-version: '>=1.17.0'
+      - name: Check out Hive repository
+        uses: actions/checkout@v3
+        with:
+          repository: ethereum/hive
+          ref: master
+          path: hive
+      - name: Patch Hive Dockerfile
+        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
+      - name: Build Hive
+        working-directory: hive
+        run: go build .
+      - name: Load Docker image
+        run: docker load --input /tmp/image.tar
+      - name: Run sstore_combinations_initial10_2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /sstore_combinations_initial10_2 --sim.parallelism $PARALLELISM
+      - name: Print results
+        run: |
+          chmod +x nethermind/scripts/hive-results.sh
+          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
+  test_49:
+    name: 49. sstore_combinations_initial11
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up parameters
+        run: |
+          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
+      - name: Check out Nethermind repository
+        uses: actions/checkout@v3
+        with:
+          path: nethermind
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: nethermind
+          file: nethermind/Dockerfile
+          tags: nethermind:test-${{ github.sha }}
+          outputs: type=docker,dest=/tmp/image.tar
+      - name: Install Linux packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
+      - name: Set up Go environment
+        uses: actions/setup-go@v3.0.0
+        with:
+          go-version: '>=1.17.0'
+      - name: Check out Hive repository
+        uses: actions/checkout@v3
+        with:
+          repository: ethereum/hive
+          ref: master
+          path: hive
+      - name: Patch Hive Dockerfile
+        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
+      - name: Build Hive
+        working-directory: hive
+        run: go build .
+      - name: Load Docker image
+        run: docker load --input /tmp/image.tar
+      - name: Run sstore_combinations_initial11
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /sstore_combinations_initial11 --sim.parallelism $PARALLELISM
+      - name: Print results
+        run: |
+          chmod +x nethermind/scripts/hive-results.sh
+          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
+  test_50:
+    name: 50. sstore_combinations_initial11_2
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up parameters
+        run: |
+          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
+      - name: Check out Nethermind repository
+        uses: actions/checkout@v3
+        with:
+          path: nethermind
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: nethermind
+          file: nethermind/Dockerfile
+          tags: nethermind:test-${{ github.sha }}
+          outputs: type=docker,dest=/tmp/image.tar
+      - name: Install Linux packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
+      - name: Set up Go environment
+        uses: actions/setup-go@v3.0.0
+        with:
+          go-version: '>=1.17.0'
+      - name: Check out Hive repository
+        uses: actions/checkout@v3
+        with:
+          repository: ethereum/hive
+          ref: master
+          path: hive
+      - name: Patch Hive Dockerfile
+        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
+      - name: Build Hive
+        working-directory: hive
+        run: go build .
+      - name: Load Docker image
+        run: docker load --input /tmp/image.tar
+      - name: Run sstore_combinations_initial11_2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /sstore_combinations_initial11_2 --sim.parallelism $PARALLELISM
+      - name: Print results
+        run: |
+          chmod +x nethermind/scripts/hive-results.sh
+          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
+  test_51:
+    name: 51. sstore_combinations_initial20
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up parameters
+        run: |
+          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
+      - name: Check out Nethermind repository
+        uses: actions/checkout@v3
+        with:
+          path: nethermind
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: nethermind
+          file: nethermind/Dockerfile
+          tags: nethermind:test-${{ github.sha }}
+          outputs: type=docker,dest=/tmp/image.tar
+      - name: Install Linux packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
+      - name: Set up Go environment
+        uses: actions/setup-go@v3.0.0
+        with:
+          go-version: '>=1.17.0'
+      - name: Check out Hive repository
+        uses: actions/checkout@v3
+        with:
+          repository: ethereum/hive
+          ref: master
+          path: hive
+      - name: Patch Hive Dockerfile
+        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
+      - name: Build Hive
+        working-directory: hive
+        run: go build .
+      - name: Load Docker image
+        run: docker load --input /tmp/image.tar
+      - name: Run sstore_combinations_initial20
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /sstore_combinations_initial20 --sim.parallelism $PARALLELISM
+      - name: Print results
+        run: |
+          chmod +x nethermind/scripts/hive-results.sh
+          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
+  test_52:
+    name: 52. sstore_combinations_initial20_2
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up parameters
+        run: |
+          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
+      - name: Check out Nethermind repository
+        uses: actions/checkout@v3
+        with:
+          path: nethermind
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: nethermind
+          file: nethermind/Dockerfile
+          tags: nethermind:test-${{ github.sha }}
+          outputs: type=docker,dest=/tmp/image.tar
+      - name: Install Linux packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
+      - name: Set up Go environment
+        uses: actions/setup-go@v3.0.0
+        with:
+          go-version: '>=1.17.0'
+      - name: Check out Hive repository
+        uses: actions/checkout@v3
+        with:
+          repository: ethereum/hive
+          ref: master
+          path: hive
+      - name: Patch Hive Dockerfile
+        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
+      - name: Build Hive
+        working-directory: hive
+        run: go build .
+      - name: Load Docker image
+        run: docker load --input /tmp/image.tar
+      - name: Run sstore_combinations_initial20_2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /sstore_combinations_initial20_2 --sim.parallelism $PARALLELISM
+      - name: Print results
+        run: |
+          chmod +x nethermind/scripts/hive-results.sh
+          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
+  test_53:
+    name: 53. sstore_combinations_initial21
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up parameters
+        run: |
+          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
+      - name: Check out Nethermind repository
+        uses: actions/checkout@v3
+        with:
+          path: nethermind
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: nethermind
+          file: nethermind/Dockerfile
+          tags: nethermind:test-${{ github.sha }}
+          outputs: type=docker,dest=/tmp/image.tar
+      - name: Install Linux packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
+      - name: Set up Go environment
+        uses: actions/setup-go@v3.0.0
+        with:
+          go-version: '>=1.17.0'
+      - name: Check out Hive repository
+        uses: actions/checkout@v3
+        with:
+          repository: ethereum/hive
+          ref: master
+          path: hive
+      - name: Patch Hive Dockerfile
+        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
+      - name: Build Hive
+        working-directory: hive
+        run: go build .
+      - name: Load Docker image
+        run: docker load --input /tmp/image.tar
+      - name: Run sstore_combinations_initial21
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /sstore_combinations_initial21 --sim.parallelism $PARALLELISM
+      - name: Print results
+        run: |
+          chmod +x nethermind/scripts/hive-results.sh
+          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
+  test_54:
+    name: 54. sstore_combinations_initial21_2
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up parameters
+        run: |
+          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
+      - name: Check out Nethermind repository
+        uses: actions/checkout@v3
+        with:
+          path: nethermind
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: nethermind
+          file: nethermind/Dockerfile
+          tags: nethermind:test-${{ github.sha }}
+          outputs: type=docker,dest=/tmp/image.tar
+      - name: Install Linux packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
+      - name: Set up Go environment
+        uses: actions/setup-go@v3.0.0
+        with:
+          go-version: '>=1.17.0'
+      - name: Check out Hive repository
+        uses: actions/checkout@v3
+        with:
+          repository: ethereum/hive
+          ref: master
+          path: hive
+      - name: Patch Hive Dockerfile
+        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
+      - name: Build Hive
+        working-directory: hive
+        run: go build .
+      - name: Load Docker image
+        run: docker load --input /tmp/image.tar
+      - name: Run sstore_combinations_initial21_2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /sstore_combinations_initial21_2 --sim.parallelism $PARALLELISM
+      - name: Print results
+        run: |
+          chmod +x nethermind/scripts/hive-results.sh
+          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
+  test_55:
+    name: 55. Combined tests (e.g. static_refund_CallA)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up parameters
+        run: |
+          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
+      - name: Check out Nethermind repository
+        uses: actions/checkout@v3
+        with:
+          path: nethermind
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: nethermind
+          file: nethermind/Dockerfile
+          tags: nethermind:test-${{ github.sha }}
+          outputs: type=docker,dest=/tmp/image.tar
+      - name: Install Linux packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
+      - name: Set up Go environment
+        uses: actions/setup-go@v3.0.0
+        with:
+          go-version: '>=1.17.0'
+      - name: Check out Hive repository
+        uses: actions/checkout@v3
+        with:
+          repository: ethereum/hive
+          ref: master
+          path: hive
+      - name: Patch Hive Dockerfile
+        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
+      - name: Build Hive
+        working-directory: hive
+        run: go build .
+      - name: Load Docker image
+        run: docker load --input /tmp/image.tar
+      - name: Run static_refund_CallA
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_refund_CallA --sim.parallelism $PARALLELISM
+      - name: Run static_refund_CallToSuicideNoStorage
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_refund_CallToSuicideNoStorage --sim.parallelism $PARALLELISM
+      - name: Run static_refund_CallToSuicideTwice
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_refund_CallToSuicideTwice --sim.parallelism $PARALLELISM
+      - name: Run static_Return50000_2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_Return50000_2 --sim.parallelism $PARALLELISM
+      - name: Run static_ReturnTest
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_ReturnTest --sim.parallelism $PARALLELISM
+      - name: Run static_ReturnTest2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_ReturnTest2 --sim.parallelism $PARALLELISM
+      - name: Run static_RETURN_Bounds
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_RETURN_Bounds --sim.parallelism $PARALLELISM
+      - name: Run static_RETURN_BoundsOOG
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_RETURN_BoundsOOG --sim.parallelism $PARALLELISM
+      - name: Run static_RevertDepth2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_RevertDepth2 --sim.parallelism $PARALLELISM
+      - name: Run static_RevertOpcodeCalls
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_RevertOpcodeCalls --sim.parallelism $PARALLELISM
+      - name: Run static_ZeroValue_CALL_OOGRevert
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_ZeroValue_CALL_OOGRevert --sim.parallelism $PARALLELISM
+      - name: Run static_ZeroValue_SUICIDE_OOGRevert
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_ZeroValue_SUICIDE_OOGRevert --sim.parallelism $PARALLELISM
+      - name: Run stStaticFlagEnabled
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /stStaticFlagEnabled --sim.parallelism $PARALLELISM
+      - name: Run stSystemOperationsTest
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /stSystemOperationsTest --sim.parallelism $PARALLELISM
+      - name: Run CALLBlake2f_MaxRounds
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /CALLBlake2f_MaxRounds --sim.parallelism $PARALLELISM
+      - name: Run static_Call50000_sha256
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /static_Call50000_sha256 --sim.parallelism $PARALLELISM
       - name: Run stTransactionTest
         continue-on-error: true
         working-directory: hive
@@ -2740,6 +4866,53 @@ jobs:
         continue-on-error: true
         working-directory: hive
         run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /stTransitionTest --sim.parallelism $PARALLELISM
+      - name: Print results
+        run: |
+          chmod +x nethermind/scripts/hive-results.sh
+          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
+  test_56:
+    name: 56. Combined tests (e.g. stWalletTest)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up parameters
+        run: |
+          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
+      - name: Check out Nethermind repository
+        uses: actions/checkout@v3
+        with:
+          path: nethermind
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: nethermind
+          file: nethermind/Dockerfile
+          tags: nethermind:test-${{ github.sha }}
+          outputs: type=docker,dest=/tmp/image.tar
+      - name: Install Linux packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
+      - name: Set up Go environment
+        uses: actions/setup-go@v3.0.0
+        with:
+          go-version: '>=1.17.0'
+      - name: Check out Hive repository
+        uses: actions/checkout@v3
+        with:
+          repository: ethereum/hive
+          ref: master
+          path: hive
+      - name: Patch Hive Dockerfile
+        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
+      - name: Build Hive
+        working-directory: hive
+        run: go build .
+      - name: Load Docker image
+        run: docker load --input /tmp/image.tar
       - name: Run stWalletTest
         continue-on-error: true
         working-directory: hive
@@ -2812,12 +4985,40 @@ jobs:
         continue-on-error: true
         working-directory: hive
         run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_1-2_5617_28000_96 --sim.parallelism $PARALLELISM
+      - name: Run ecmul_1-2_616_28000_96
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_1-2_616_28000_96 --sim.parallelism $PARALLELISM
+      - name: Run ecmul_1-2_9935_21000_128
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_1-2_9935_21000_128 --sim.parallelism $PARALLELISM
+      - name: Run ecmul_1-2_9935_21000_96
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_1-2_9935_21000_96 --sim.parallelism $PARALLELISM
+      - name: Run ecmul_1-2_9935_28000_128
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_1-2_9935_28000_128 --sim.parallelism $PARALLELISM
+      - name: Run ecmul_1-2_9935_28000_96
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_1-2_9935_28000_96 --sim.parallelism $PARALLELISM
+      - name: Run ecmul_1-2_9_21000_128
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_1-2_9_21000_128 --sim.parallelism $PARALLELISM
+      - name: Run ecmul_1-2_9_21000_96
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_1-2_9_21000_96 --sim.parallelism $PARALLELISM
       - name: Print results
         run: |
           chmod +x nethermind/scripts/hive-results.sh
           nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_42:
-    name: 42. Combined tests (e.g. ecmul_1-2_616_28000_96)
+  test_57:
+    name: 57. Combined tests (e.g. ecmul_1-2_9_28000_128)
     runs-on: ubuntu-latest
     steps:
       - name: Set up parameters
@@ -2859,34 +5060,6 @@ jobs:
         run: go build .
       - name: Load Docker image
         run: docker load --input /tmp/image.tar
-      - name: Run ecmul_1-2_616_28000_96
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_1-2_616_28000_96 --sim.parallelism $PARALLELISM
-      - name: Run ecmul_1-2_9935_21000_128
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_1-2_9935_21000_128 --sim.parallelism $PARALLELISM
-      - name: Run ecmul_1-2_9935_21000_96
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_1-2_9935_21000_96 --sim.parallelism $PARALLELISM
-      - name: Run ecmul_1-2_9935_28000_128
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_1-2_9935_28000_128 --sim.parallelism $PARALLELISM
-      - name: Run ecmul_1-2_9935_28000_96
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_1-2_9935_28000_96 --sim.parallelism $PARALLELISM
-      - name: Run ecmul_1-2_9_21000_128
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_1-2_9_21000_128 --sim.parallelism $PARALLELISM
-      - name: Run ecmul_1-2_9_21000_96
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_1-2_9_21000_96 --sim.parallelism $PARALLELISM
       - name: Run ecmul_1-2_9_28000_128
         continue-on-error: true
         working-directory: hive
@@ -3011,12 +5184,20 @@ jobs:
         continue-on-error: true
         working-directory: hive
         run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_1-3_5617_28000_128 --sim.parallelism $PARALLELISM
+      - name: Run ecmul_1-3_5617_28000_96
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_1-3_5617_28000_96 --sim.parallelism $PARALLELISM
+      - name: Run ecmul_1-3_9935_21000_128
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_1-3_9935_21000_128 --sim.parallelism $PARALLELISM
       - name: Print results
         run: |
           chmod +x nethermind/scripts/hive-results.sh
           nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_43:
-    name: 43. Combined tests (e.g. ecmul_1-3_5617_28000_96)
+  test_58:
+    name: 58. Combined tests (e.g. ecmul_1-3_9935_21000_96)
     runs-on: ubuntu-latest
     steps:
       - name: Set up parameters
@@ -3058,14 +5239,6 @@ jobs:
         run: go build .
       - name: Load Docker image
         run: docker load --input /tmp/image.tar
-      - name: Run ecmul_1-3_5617_28000_96
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_1-3_5617_28000_96 --sim.parallelism $PARALLELISM
-      - name: Run ecmul_1-3_9935_21000_128
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_1-3_9935_21000_128 --sim.parallelism $PARALLELISM
       - name: Run ecmul_1-3_9935_21000_96
         continue-on-error: true
         working-directory: hive
@@ -3198,24 +5371,12 @@ jobs:
         continue-on-error: true
         working-directory: hive
         run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_7827-6598_5616_28000_96 --sim.parallelism $PARALLELISM
-      - name: Run ecmul_7827-6598_5617_21000_128
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_7827-6598_5617_21000_128 --sim.parallelism $PARALLELISM
-      - name: Run ecmul_7827-6598_5617_21000_96
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_7827-6598_5617_21000_96 --sim.parallelism $PARALLELISM
-      - name: Run ecmul_7827-6598_5617_28000_128
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_7827-6598_5617_28000_128 --sim.parallelism $PARALLELISM
       - name: Print results
         run: |
           chmod +x nethermind/scripts/hive-results.sh
           nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_44:
-    name: 44. Combined tests (e.g. ecmul_7827-6598_5617_28000_96)
+  test_59:
+    name: 59. Combined tests (e.g. ecmul_7827-6598_5617_21000_128)
     runs-on: ubuntu-latest
     steps:
       - name: Set up parameters
@@ -3257,6 +5418,18 @@ jobs:
         run: go build .
       - name: Load Docker image
         run: docker load --input /tmp/image.tar
+      - name: Run ecmul_7827-6598_5617_21000_128
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_7827-6598_5617_21000_128 --sim.parallelism $PARALLELISM
+      - name: Run ecmul_7827-6598_5617_21000_96
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_7827-6598_5617_21000_96 --sim.parallelism $PARALLELISM
+      - name: Run ecmul_7827-6598_5617_28000_128
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_7827-6598_5617_28000_128 --sim.parallelism $PARALLELISM
       - name: Run ecmul_7827-6598_5617_28000_96
         continue-on-error: true
         working-directory: hive
@@ -3381,36 +5554,12 @@ jobs:
         continue-on-error: true
         working-directory: hive
         run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecpairing_two_point_fail_2 --sim.parallelism $PARALLELISM
-      - name: Run ecpairing_two_point_match_1
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecpairing_two_point_match_1 --sim.parallelism $PARALLELISM
-      - name: Run ecpairing_two_point_match_2
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecpairing_two_point_match_2 --sim.parallelism $PARALLELISM
-      - name: Run ecpairing_two_point_match_3
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecpairing_two_point_match_3 --sim.parallelism $PARALLELISM
-      - name: Run ecpairing_two_point_match_4
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecpairing_two_point_match_4 --sim.parallelism $PARALLELISM
-      - name: Run ecpairing_two_point_match_5
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecpairing_two_point_match_5 --sim.parallelism $PARALLELISM
-      - name: Run ecpairing_two_point_oog
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecpairing_two_point_oog --sim.parallelism $PARALLELISM
       - name: Print results
         run: |
           chmod +x nethermind/scripts/hive-results.sh
           nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_45:
-    name: 45. Combined tests (e.g. pairingTest)
+  test_60:
+    name: 60. Combined tests (e.g. ecpairing_two_point_match_1)
     runs-on: ubuntu-latest
     steps:
       - name: Set up parameters
@@ -3452,6 +5601,30 @@ jobs:
         run: go build .
       - name: Load Docker image
         run: docker load --input /tmp/image.tar
+      - name: Run ecpairing_two_point_match_1
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecpairing_two_point_match_1 --sim.parallelism $PARALLELISM
+      - name: Run ecpairing_two_point_match_2
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecpairing_two_point_match_2 --sim.parallelism $PARALLELISM
+      - name: Run ecpairing_two_point_match_3
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecpairing_two_point_match_3 --sim.parallelism $PARALLELISM
+      - name: Run ecpairing_two_point_match_4
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecpairing_two_point_match_4 --sim.parallelism $PARALLELISM
+      - name: Run ecpairing_two_point_match_5
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecpairing_two_point_match_5 --sim.parallelism $PARALLELISM
+      - name: Run ecpairing_two_point_oog
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecpairing_two_point_oog --sim.parallelism $PARALLELISM
       - name: Run pairingTest
         continue-on-error: true
         working-directory: hive
@@ -3484,6 +5657,53 @@ jobs:
         continue-on-error: true
         working-directory: hive
         run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecadd_0-0_0-0_21000_192 --sim.parallelism $PARALLELISM
+      - name: Print results
+        run: |
+          chmod +x nethermind/scripts/hive-results.sh
+          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
+  test_61:
+    name: 61. Combined tests (e.g. ecadd_0-0_0-0_21000_64)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up parameters
+        run: |
+          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
+      - name: Check out Nethermind repository
+        uses: actions/checkout@v3
+        with:
+          path: nethermind
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: nethermind
+          file: nethermind/Dockerfile
+          tags: nethermind:test-${{ github.sha }}
+          outputs: type=docker,dest=/tmp/image.tar
+      - name: Install Linux packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
+      - name: Set up Go environment
+        uses: actions/setup-go@v3.0.0
+        with:
+          go-version: '>=1.17.0'
+      - name: Check out Hive repository
+        uses: actions/checkout@v3
+        with:
+          repository: ethereum/hive
+          ref: master
+          path: hive
+      - name: Patch Hive Dockerfile
+        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
+      - name: Build Hive
+        working-directory: hive
+        run: go build .
+      - name: Load Docker image
+        run: docker load --input /tmp/image.tar
       - name: Run ecadd_0-0_0-0_21000_64
         continue-on-error: true
         working-directory: hive
@@ -3536,53 +5756,6 @@ jobs:
         continue-on-error: true
         working-directory: hive
         run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecadd_0-0_1-3_25000_128 --sim.parallelism $PARALLELISM
-      - name: Print results
-        run: |
-          chmod +x nethermind/scripts/hive-results.sh
-          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_46:
-    name: 46. Combined tests (e.g. ecadd_0-3_1-2_21000_128)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up parameters
-        run: |
-          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
-      - name: Check out Nethermind repository
-        uses: actions/checkout@v3
-        with:
-          path: nethermind
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Build Docker image
-        uses: docker/build-push-action@v3
-        with:
-          context: nethermind
-          file: nethermind/Dockerfile
-          tags: nethermind:test-${{ github.sha }}
-          outputs: type=docker,dest=/tmp/image.tar
-      - name: Install Linux packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
-      - name: Set up Go environment
-        uses: actions/setup-go@v3.0.0
-        with:
-          go-version: '>=1.17.0'
-      - name: Check out Hive repository
-        uses: actions/checkout@v3
-        with:
-          repository: ethereum/hive
-          ref: master
-          path: hive
-      - name: Patch Hive Dockerfile
-        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
-      - name: Build Hive
-        working-directory: hive
-        run: go build .
-      - name: Load Docker image
-        run: docker load --input /tmp/image.tar
       - name: Run ecadd_0-3_1-2_21000_128
         continue-on-error: true
         working-directory: hive
@@ -3663,6 +5836,53 @@ jobs:
         continue-on-error: true
         working-directory: hive
         run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecadd_6-9_19274124-124124_25000_128 --sim.parallelism $PARALLELISM
+      - name: Print results
+        run: |
+          chmod +x nethermind/scripts/hive-results.sh
+          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
+  test_62:
+    name: 62. Combined tests (e.g. ecmul_0-0_0_21000_0)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up parameters
+        run: |
+          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
+      - name: Check out Nethermind repository
+        uses: actions/checkout@v3
+        with:
+          path: nethermind
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: nethermind
+          file: nethermind/Dockerfile
+          tags: nethermind:test-${{ github.sha }}
+          outputs: type=docker,dest=/tmp/image.tar
+      - name: Install Linux packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
+      - name: Set up Go environment
+        uses: actions/setup-go@v3.0.0
+        with:
+          go-version: '>=1.17.0'
+      - name: Check out Hive repository
+        uses: actions/checkout@v3
+        with:
+          repository: ethereum/hive
+          ref: master
+          path: hive
+      - name: Patch Hive Dockerfile
+        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
+      - name: Build Hive
+        working-directory: hive
+        run: go build .
+      - name: Load Docker image
+        run: docker load --input /tmp/image.tar
       - name: Run ecmul_0-0_0_21000_0
         continue-on-error: true
         working-directory: hive
@@ -3735,53 +5955,6 @@ jobs:
         continue-on-error: true
         working-directory: hive
         run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_0-0_2_21000_96 --sim.parallelism $PARALLELISM
-      - name: Print results
-        run: |
-          chmod +x nethermind/scripts/hive-results.sh
-          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_47:
-    name: 47. Combined tests (e.g. ecmul_0-0_2_28000_128)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up parameters
-        run: |
-          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
-      - name: Check out Nethermind repository
-        uses: actions/checkout@v3
-        with:
-          path: nethermind
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Build Docker image
-        uses: docker/build-push-action@v3
-        with:
-          context: nethermind
-          file: nethermind/Dockerfile
-          tags: nethermind:test-${{ github.sha }}
-          outputs: type=docker,dest=/tmp/image.tar
-      - name: Install Linux packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
-      - name: Set up Go environment
-        uses: actions/setup-go@v3.0.0
-        with:
-          go-version: '>=1.17.0'
-      - name: Check out Hive repository
-        uses: actions/checkout@v3
-        with:
-          repository: ethereum/hive
-          ref: master
-          path: hive
-      - name: Patch Hive Dockerfile
-        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
-      - name: Build Hive
-        working-directory: hive
-        run: go build .
-      - name: Load Docker image
-        run: docker load --input /tmp/image.tar
       - name: Run ecmul_0-0_2_28000_128
         continue-on-error: true
         working-directory: hive
@@ -3842,6 +6015,53 @@ jobs:
         continue-on-error: true
         working-directory: hive
         run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_0-0_5617_28000_128 --sim.parallelism $PARALLELISM
+      - name: Print results
+        run: |
+          chmod +x nethermind/scripts/hive-results.sh
+          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
+  test_63:
+    name: 63. Combined tests (e.g. ecmul_0-0_5617_28000_96)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up parameters
+        run: |
+          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
+      - name: Check out Nethermind repository
+        uses: actions/checkout@v3
+        with:
+          path: nethermind
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: nethermind
+          file: nethermind/Dockerfile
+          tags: nethermind:test-${{ github.sha }}
+          outputs: type=docker,dest=/tmp/image.tar
+      - name: Install Linux packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
+      - name: Set up Go environment
+        uses: actions/setup-go@v3.0.0
+        with:
+          go-version: '>=1.17.0'
+      - name: Check out Hive repository
+        uses: actions/checkout@v3
+        with:
+          repository: ethereum/hive
+          ref: master
+          path: hive
+      - name: Patch Hive Dockerfile
+        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
+      - name: Build Hive
+        working-directory: hive
+        run: go build .
+      - name: Load Docker image
+        run: docker load --input /tmp/image.tar
       - name: Run ecmul_0-0_5617_28000_96
         continue-on-error: true
         working-directory: hive
@@ -3934,12 +6154,52 @@ jobs:
         continue-on-error: true
         working-directory: hive
         run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_0-3_2_21000_96 --sim.parallelism $PARALLELISM
+      - name: Run ecmul_0-3_2_28000_128
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_0-3_2_28000_128 --sim.parallelism $PARALLELISM
+      - name: Run ecmul_0-3_2_28000_96
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_0-3_2_28000_96 --sim.parallelism $PARALLELISM
+      - name: Run ecmul_0-3_340282366920938463463374607431768211456_21000_128
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_0-3_340282366920938463463374607431768211456_21000_128 --sim.parallelism $PARALLELISM
+      - name: Run ecmul_0-3_340282366920938463463374607431768211456_21000_80
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_0-3_340282366920938463463374607431768211456_21000_80 --sim.parallelism $PARALLELISM
+      - name: Run ecmul_0-3_340282366920938463463374607431768211456_21000_96
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_0-3_340282366920938463463374607431768211456_21000_96 --sim.parallelism $PARALLELISM
+      - name: Run ecmul_0-3_340282366920938463463374607431768211456_28000_128
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_0-3_340282366920938463463374607431768211456_28000_128 --sim.parallelism $PARALLELISM
+      - name: Run ecmul_0-3_340282366920938463463374607431768211456_28000_80
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_0-3_340282366920938463463374607431768211456_28000_80 --sim.parallelism $PARALLELISM
+      - name: Run ecmul_0-3_340282366920938463463374607431768211456_28000_96
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_0-3_340282366920938463463374607431768211456_28000_96 --sim.parallelism $PARALLELISM
+      - name: Run ecmul_0-3_5616_21000_128
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_0-3_5616_21000_128 --sim.parallelism $PARALLELISM
+      - name: Run ecmul_0-3_5616_21000_96
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_0-3_5616_21000_96 --sim.parallelism $PARALLELISM
       - name: Print results
         run: |
           chmod +x nethermind/scripts/hive-results.sh
           nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_48:
-    name: 48. Combined tests (e.g. ecmul_0-3_2_28000_128)
+  test_64:
+    name: 64. Combined tests (e.g. ecmul_0-3_5616_28000_128)
     runs-on: ubuntu-latest
     steps:
       - name: Set up parameters
@@ -3981,46 +6241,6 @@ jobs:
         run: go build .
       - name: Load Docker image
         run: docker load --input /tmp/image.tar
-      - name: Run ecmul_0-3_2_28000_128
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_0-3_2_28000_128 --sim.parallelism $PARALLELISM
-      - name: Run ecmul_0-3_2_28000_96
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_0-3_2_28000_96 --sim.parallelism $PARALLELISM
-      - name: Run ecmul_0-3_340282366920938463463374607431768211456_21000_128
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_0-3_340282366920938463463374607431768211456_21000_128 --sim.parallelism $PARALLELISM
-      - name: Run ecmul_0-3_340282366920938463463374607431768211456_21000_80
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_0-3_340282366920938463463374607431768211456_21000_80 --sim.parallelism $PARALLELISM
-      - name: Run ecmul_0-3_340282366920938463463374607431768211456_21000_96
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_0-3_340282366920938463463374607431768211456_21000_96 --sim.parallelism $PARALLELISM
-      - name: Run ecmul_0-3_340282366920938463463374607431768211456_28000_128
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_0-3_340282366920938463463374607431768211456_28000_128 --sim.parallelism $PARALLELISM
-      - name: Run ecmul_0-3_340282366920938463463374607431768211456_28000_80
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_0-3_340282366920938463463374607431768211456_28000_80 --sim.parallelism $PARALLELISM
-      - name: Run ecmul_0-3_340282366920938463463374607431768211456_28000_96
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_0-3_340282366920938463463374607431768211456_28000_96 --sim.parallelism $PARALLELISM
-      - name: Run ecmul_0-3_5616_21000_128
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_0-3_5616_21000_128 --sim.parallelism $PARALLELISM
-      - name: Run ecmul_0-3_5616_21000_96
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_0-3_5616_21000_96 --sim.parallelism $PARALLELISM
       - name: Run ecmul_0-3_5616_28000_128
         continue-on-error: true
         working-directory: hive
@@ -4133,116 +6353,18 @@ jobs:
         continue-on-error: true
         working-directory: hive
         run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /ecmul_1-2_2_21000_96 --sim.parallelism $PARALLELISM
-      - name: Print results
-        run: |
-          chmod +x nethermind/scripts/hive-results.sh
-          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_49:
-    name: 49. stEOF
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up parameters
-        run: |
-          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
-      - name: Check out Nethermind repository
-        uses: actions/checkout@v3
-        with:
-          path: nethermind
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Build Docker image
-        uses: docker/build-push-action@v3
-        with:
-          context: nethermind
-          file: nethermind/Dockerfile
-          tags: nethermind:test-${{ github.sha }}
-          outputs: type=docker,dest=/tmp/image.tar
-      - name: Install Linux packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
-      - name: Set up Go environment
-        uses: actions/setup-go@v3.0.0
-        with:
-          go-version: '>=1.17.0'
-      - name: Check out Hive repository
-        uses: actions/checkout@v3
-        with:
-          repository: ethereum/hive
-          ref: master
-          path: hive
-      - name: Patch Hive Dockerfile
-        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
-      - name: Build Hive
-        working-directory: hive
-        run: go build .
-      - name: Load Docker image
-        run: docker load --input /tmp/image.tar
-      - name: Run stEOF
+      - name: Run stEIP3651-warmcoinbase
         continue-on-error: true
         working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /stEOF --sim.parallelism $PARALLELISM
-      - name: Print results
-        run: |
-          chmod +x nethermind/scripts/hive-results.sh
-          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_50:
-    name: 50. Combined tests (e.g. stEIP3651)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up parameters
-        run: |
-          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
-      - name: Check out Nethermind repository
-        uses: actions/checkout@v3
-        with:
-          path: nethermind
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Build Docker image
-        uses: docker/build-push-action@v3
-        with:
-          context: nethermind
-          file: nethermind/Dockerfile
-          tags: nethermind:test-${{ github.sha }}
-          outputs: type=docker,dest=/tmp/image.tar
-      - name: Install Linux packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
-      - name: Set up Go environment
-        uses: actions/setup-go@v3.0.0
-        with:
-          go-version: '>=1.17.0'
-      - name: Check out Hive repository
-        uses: actions/checkout@v3
-        with:
-          repository: ethereum/hive
-          ref: master
-          path: hive
-      - name: Patch Hive Dockerfile
-        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
-      - name: Build Hive
-        working-directory: hive
-        run: go build .
-      - name: Load Docker image
-        run: docker load --input /tmp/image.tar
-      - name: Run stEIP3651
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /stEIP3651-warmcoinbase --sim.parallelism $PARALLELISM
+      - name: Run stEIP3855-push0
         continue-on-error: true
         working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /stEIP3651 --sim.parallelism $PARALLELISM
-      - name: Run stEIP3855
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /stEIP3855-push0 --sim.parallelism $PARALLELISM
+      - name: Run stEIP3860-limitmeterinitcode
         continue-on-error: true
         working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /stEIP3855 --sim.parallelism $PARALLELISM
-      - name: Run stEIP3860
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /stEIP3860 --sim.parallelism $PARALLELISM
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /stEIP3860-limitmeterinitcode --sim.parallelism $PARALLELISM
       - name: Run bc4895-withdrawals
         continue-on-error: true
         working-directory: hive
@@ -4255,6 +6377,53 @@ jobs:
         continue-on-error: true
         working-directory: hive
         run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /bcEIP1559 --sim.parallelism $PARALLELISM
+      - name: Print results
+        run: |
+          chmod +x nethermind/scripts/hive-results.sh
+          nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
+  test_65:
+    name: 65. Combined tests (e.g. bcEIP3675)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up parameters
+        run: |
+          echo "PARALLELISM=${{ github.event.inputs.parallelism || '3' }}" >> $GITHUB_ENV
+      - name: Check out Nethermind repository
+        uses: actions/checkout@v3
+        with:
+          path: nethermind
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: nethermind
+          file: nethermind/Dockerfile
+          tags: nethermind:test-${{ github.sha }}
+          outputs: type=docker,dest=/tmp/image.tar
+      - name: Install Linux packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsnappy-dev libc6-dev libc6 build-essential
+      - name: Set up Go environment
+        uses: actions/setup-go@v3.0.0
+        with:
+          go-version: '>=1.17.0'
+      - name: Check out Hive repository
+        uses: actions/checkout@v3
+        with:
+          repository: ethereum/hive
+          ref: master
+          path: hive
+      - name: Patch Hive Dockerfile
+        run: sed -i 's#FROM nethermindeth/hive:$branch#FROM nethermind:test-${{ github.sha }}#g' hive/clients/nethermind/Dockerfile
+      - name: Build Hive
+        working-directory: hive
+        run: go build .
+      - name: Load Docker image
+        run: docker load --input /tmp/image.tar
       - name: Run bcEIP3675
         continue-on-error: true
         working-directory: hive
@@ -4319,12 +6488,20 @@ jobs:
         continue-on-error: true
         working-directory: hive
         run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /bcBlockGasLimitTest --sim.parallelism $PARALLELISM
+      - name: Run bcEIP1559
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /bcEIP1559 --sim.parallelism $PARALLELISM
+      - name: Run bcEIP3675
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /bcEIP3675 --sim.parallelism $PARALLELISM
       - name: Print results
         run: |
           chmod +x nethermind/scripts/hive-results.sh
           nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_51:
-    name: 51. bcExploitTest
+  test_66:
+    name: 66. bcExploitTest
     runs-on: ubuntu-latest
     steps:
       - name: Set up parameters
@@ -4374,8 +6551,8 @@ jobs:
         run: |
           chmod +x nethermind/scripts/hive-results.sh
           nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_52:
-    name: 52. Combined tests (e.g. bcEIP1559)
+  test_67:
+    name: 67. Combined tests (e.g. bcExample)
     runs-on: ubuntu-latest
     steps:
       - name: Set up parameters
@@ -4417,14 +6594,6 @@ jobs:
         run: go build .
       - name: Load Docker image
         run: docker load --input /tmp/image.tar
-      - name: Run bcEIP1559
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /bcEIP1559 --sim.parallelism $PARALLELISM
-      - name: Run bcEIP3675
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /bcEIP3675 --sim.parallelism $PARALLELISM
       - name: Run bcExample
         continue-on-error: true
         working-directory: hive
@@ -4445,12 +6614,16 @@ jobs:
         continue-on-error: true
         working-directory: hive
         run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /bcRandomBlockhashTest --sim.parallelism $PARALLELISM
+      - name: Run bcStateTests
+        continue-on-error: true
+        working-directory: hive
+        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /bcStateTests --sim.parallelism $PARALLELISM
       - name: Print results
         run: |
           chmod +x nethermind/scripts/hive-results.sh
           nethermind/scripts/hive-results.sh "hive/workspace/logs/*.json"
-  test_53:
-    name: 53. Combined tests (e.g. bcStateTests)
+  test_68:
+    name: 68. Combined tests (e.g. bcTotalDifficultyTest)
     runs-on: ubuntu-latest
     steps:
       - name: Set up parameters
@@ -4492,10 +6665,6 @@ jobs:
         run: go build .
       - name: Load Docker image
         run: docker load --input /tmp/image.tar
-      - name: Run bcStateTests
-        continue-on-error: true
-        working-directory: hive
-        run: ./hive --client nethermind --sim ethereum/consensus --sim.limit /bcStateTests --sim.parallelism $PARALLELISM
       - name: Run bcTotalDifficultyTest
         continue-on-error: true
         working-directory: hive


### PR DESCRIPTION
## Changes

- update workflow of hive consensus tests.
After adding Shanghai there is 89k tests. Now there will be 68 jobs (instead of 53 before). We might have some timeouts, but we can do nothing about it, as single, indivisible tests are generating it - it was taking 4,5-5h before and after adding Shanghai is close to 6h - sometimes pass, sometimes timeout hit. Testing run: https://github.com/NethermindEth/nethermind/actions/runs/4540612392 (looks okayish after 1 rerun of failed tests)
- standard update of ethereum tests

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: updates

## Testing

#### Requires testing

- [ ] Yes
- [x] No