### PR TITLE
Revert "Reduce TrieNode allocations (#5457)"

### DIFF
--- a/src/Nethermind/Nethermind.Benchmark/Store/PatriciaTreeBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Store/PatriciaTreeBenchmarks.cs
@@ -12,7 +12,6 @@ using Nethermind.Db.Blooms;
 
 namespace Nethermind.Benchmarks.Store
 {
-    [MemoryDiagnoser]
     public class PatriciaTreeBenchmarks
     {
         private static readonly Account _empty = Build.An.Account.WithBalance(0).TestObject;
@@ -21,26 +20,10 @@ namespace Nethermind.Benchmarks.Store
         private static readonly Account _account2 = Build.An.Account.WithBalance(3).TestObject;
         private static readonly Account _account3 = Build.An.Account.WithBalance(4).TestObject;
 
-        private static readonly Keccak _keccak1 = new("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb00000000");
-        private static readonly Keccak _keccak2 = new("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb1eeeeeb0");
-        private static readonly Keccak _keccak3 = new("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb1eeeeeb1");
-        private static readonly Keccak _keccak4 = new("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb11111111");
-        private static readonly Keccak _keccak5 = new("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeedddddddddddddddddddddddd");
-        private static readonly Keccak _keccak6 = new("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeddddddddddddddddddddddddd");
-        private static readonly Keccak _keccak7 = new("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeaaaaaaaaaaaaaaaab00000000");
-        private static readonly Keccak _keccak8 = new("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeaaaaaaaaaaaaaaaab11111111");
-        private static readonly Keccak _keccak9 = new("1111111111111111111111111111111111111111111111111111111111111111");
-        private static readonly Keccak _keccak10 = new("1111111111111111111111111111111ddddddddddddddddddddddddddddddddd");
-        private static readonly Keccak _keccak11 = new("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb11111111111111111111111111111111");
-        private static readonly Keccak _keccak12 = new("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb00000000000000000000000000000000");
-        private static readonly Keccak _keccak13 = new("111111111111111111111111111111111111111111111111111111111ddddddd");
-        private static readonly Keccak _keccak14 = new("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb00000");
-        private static readonly Keccak _keccak15 = new("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb11111");
-        private static readonly Keccak _keccak16 = new("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb22222");
-
         private StateTree _tree;
 
-        private readonly (string Name, Action<StateTree> Action)[] _scenarios = {
+        private (string Name, Action<StateTree> Action)[] _scenarios = new (string, Action<StateTree>)[]
+        {
             ("set_3_via_address", tree =>
             {
                 tree.Set(TestItem.AddressA, _account0);
@@ -50,163 +33,163 @@ namespace Nethermind.Benchmarks.Store
             }),
             ("set_3_via_hash", tree =>
             {
-                tree.Set(_keccak1, _account0);
-                tree.Set(_keccak2, _account0);
-                tree.Set(_keccak3, _account0);
+                tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb00000000"), _account0);
+                tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb1eeeeeb0"), _account0);
+                tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb1eeeeeb1"), _account0);
                 tree.Commit(1);
             }),
             ("set_3_delete_1", tree =>
             {
-                tree.Set(_keccak1, _account0);
-                tree.Set(_keccak2, _account0);
-                tree.Set(_keccak3, _account0);
-                tree.Set(_keccak3, null);
+                tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb00000000"), _account0);
+                tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb1eeeeeb0"), _account0);
+                tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb1eeeeeb1"), _account0);
+                tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb1eeeeeb1"), null);
                 tree.Commit(1);
             }),
             ("set_3_delete_2", tree =>
             {
-                tree.Set(_keccak1, _account0);
-                tree.Set(_keccak2, _account0);
-                tree.Set(_keccak3, _account0);
-                tree.Set(_keccak2, null);
-                tree.Set(_keccak3, null);
+                tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb00000000"), _account0);
+                tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb1eeeeeb0"), _account0);
+                tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb1eeeeeb1"), _account0);
+                tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb1eeeeeb0"), null);
+                tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb1eeeeeb1"), null);
                 tree.Commit(1);
             }),
             ("set_3_delete_all", tree =>
             {
-                tree.Set(_keccak1, _account0);
-                tree.Set(_keccak2, _account0);
-                tree.Set(_keccak3, _account0);
-                tree.Set(_keccak2, null);
-                tree.Set(_keccak3, null);
-                tree.Set(_keccak1, null);
+                tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb00000000"), _account0);
+                tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb1eeeeeb0"), _account0);
+                tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb1eeeeeb1"), _account0);
+                tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb1eeeeeb0"), null);
+                tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb1eeeeeb1"), null);
+                tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb00000000"), null);
                 tree.Commit(1);
             }),
             ("extension_read_full_match", tree =>
             {
-                tree.Set(_keccak1, _account0);
-                tree.Set(_keccak4, _account1);
-                Account account = tree.Get(_keccak4);
+                tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb00000000"), _account0);
+                tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb11111111"), _account1);
+                Account account = tree.Get(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb11111111"));
                 tree.UpdateRootHash();
                 Keccak rootHash = tree.RootHash;
                 tree.Commit(1);
             }),
             ("extension_read_missing", tree =>
             {
-                tree.Set(_keccak1, _account0);
-                tree.Set(_keccak4, _account1);
-                Account account = tree.Get(_keccak5);
+                tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb00000000"), _account0);
+                tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb11111111"), _account1);
+                Account account = tree.Get(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeedddddddddddddddddddddddd"));
                 tree.UpdateRootHash();
                 Keccak rootHash = tree.RootHash;
                 tree.Commit(1);
             }),
             ("extension_new_branch", tree =>
             {
-                tree.Set(_keccak1, _account0);
-                tree.Set(_keccak4, _account1);
-                tree.Set(_keccak5, _account2);
+                tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb00000000"), _account0);
+                tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb11111111"), _account1);
+                tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeedddddddddddddddddddddddd"), _account2);
                 tree.UpdateRootHash();
                 Keccak rootHash = tree.RootHash;
                 tree.Commit(1);
             }),
             ("extension_delete_missing", tree =>
             {
-                tree.Set(_keccak1, _account0);
-                tree.Set(_keccak4, _account1);
-                tree.Set(_keccak6, null);
+                tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb00000000"), _account0);
+                tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb11111111"), _account1);
+                tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeddddddddddddddddddddddddd"), null);
                 tree.UpdateRootHash();
                 Keccak rootHash = tree.RootHash;
                 tree.Commit(1);
             }),
             ("extenson_create_new_extension", tree =>
             {
-                tree.Set(_keccak1, _account0);
-                tree.Set(_keccak4, _account1);
-                tree.Set(_keccak7, _account2);
-                tree.Set(_keccak8, _account3);
+                tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb00000000"), _account0);
+                tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb11111111"), _account1);
+                tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeaaaaaaaaaaaaaaaab00000000"), _account2);
+                tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeaaaaaaaaaaaaaaaab11111111"), _account3);
                 tree.UpdateRootHash();
                 Keccak rootHash = tree.RootHash;
                 tree.Commit(1);
             }),
             ("leaf_new_value", tree =>
             {
-                tree.Set(_keccak9, _account0);
-                tree.Set(_keccak9, _account1);
+                tree.Set(new Keccak("1111111111111111111111111111111111111111111111111111111111111111"), _account0);
+                tree.Set(new Keccak("1111111111111111111111111111111111111111111111111111111111111111"), _account1);
                 tree.UpdateRootHash();
                 Keccak rootHash = tree.RootHash;
                 tree.Commit(1);
             }),
             ("leaf_no_change", tree =>
             {
-                tree.Set(_keccak9, _account0);
-                tree.Set(_keccak9, _account0);
+                tree.Set(new Keccak("1111111111111111111111111111111111111111111111111111111111111111"), _account0);
+                tree.Set(new Keccak("1111111111111111111111111111111111111111111111111111111111111111"), _account0);
                 tree.UpdateRootHash();
                 Keccak rootHash = tree.RootHash;
                 tree.Commit(1);
             }),
             ("leaf_delete", tree =>
             {
-                tree.Set(_keccak9, _account0);
-                tree.Set(_keccak9, null);
+                tree.Set(new Keccak("1111111111111111111111111111111111111111111111111111111111111111"), _account0);
+                tree.Set(new Keccak("1111111111111111111111111111111111111111111111111111111111111111"), null);
                 tree.UpdateRootHash();
                 Keccak rootHash = tree.RootHash;
                 tree.Commit(1);
             }),
             ("leaf_delete_missing", tree =>
             {
-                tree.Set(_keccak9, _account0);
-                tree.Set(_keccak10, null);
+                tree.Set(new Keccak("1111111111111111111111111111111111111111111111111111111111111111"), _account0);
+                tree.Set(new Keccak("1111111111111111111111111111111ddddddddddddddddddddddddddddddddd"), null);
                 tree.UpdateRootHash();
                 Keccak rootHash = tree.RootHash;
                 tree.Commit(1);
             }),
             ("leaf_update_extension", tree =>
             {
-                tree.Set(_keccak11, _account0);
-                tree.Set(_keccak12, _account1);
+                tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb11111111111111111111111111111111"), _account0);
+                tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb00000000000000000000000000000000"), _account1);
                 tree.UpdateRootHash();
                 Keccak rootHash = tree.RootHash;
                 tree.Commit(1);
             }),
             ("leaf_read", tree =>
             {
-                tree.Set(_keccak9, _account0);
-                Account account = tree.Get(_keccak9);
+                tree.Set(new Keccak("1111111111111111111111111111111111111111111111111111111111111111"), _account0);
+                Account account = tree.Get(new Keccak("1111111111111111111111111111111111111111111111111111111111111111"));
                 tree.UpdateRootHash();
                 Keccak rootHash = tree.RootHash;
                 tree.Commit(1);
             }),
             ("leaf_update_missing", tree =>
             {
-                tree.Set(_keccak9, _account0);
-                Account account = tree.Get(_keccak13);
+                tree.Set(new Keccak("1111111111111111111111111111111111111111111111111111111111111111"), _account0);
+                Account account = tree.Get(new Keccak("111111111111111111111111111111111111111111111111111111111ddddddd"));
                 tree.UpdateRootHash();
                 Keccak rootHash = tree.RootHash;
                 tree.Commit(1);
             }),
             ("branch_update_missing", tree =>
             {
-                tree.Set(_keccak14, _account0);
-                tree.Set(_keccak15, _account1);
-                tree.Set(_keccak16, _account2);
+                tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb00000"), _account0);
+                tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb11111"), _account1);
+                tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb22222"), _account2);
                 tree.UpdateRootHash();
                 Keccak rootHash = tree.RootHash;
                 tree.Commit(1);
             }),
             ("branch_read_missing", tree =>
             {
-                tree.Set(_keccak14, _account0);
-                tree.Set(_keccak15, _account1);
-                Account account = tree.Get(_keccak16);
+                tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb00000"), _account0);
+                tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb11111"), _account1);
+                Account account = tree.Get(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb22222"));
                 tree.UpdateRootHash();
                 Keccak rootHash = tree.RootHash;
                 tree.Commit(1);
             }),
             ("branch_delete_missing", tree =>
             {
-                tree.Set(_keccak14, _account0);
-                tree.Set(_keccak15, _account1);
-                tree.Set(_keccak16, null);
+                tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb00000"), _account0);
+                tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb11111"), _account1);
+                tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb22222"), null);
                 tree.UpdateRootHash();
                 Keccak rootHash = tree.RootHash;
                 tree.Commit(1);
@@ -217,6 +200,15 @@ namespace Nethermind.Benchmarks.Store
         public void Setup()
         {
             _tree = new StateTree();
+        }
+
+        [Benchmark]
+        public void Improved()
+        {
+            for (int i = 0; i < 19; i++)
+            {
+                _scenarios[i].Action(_tree);
+            }
         }
 
         [Benchmark]

--- a/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
@@ -532,8 +532,8 @@ namespace Nethermind.Trie.Test
                 node.SetChild(i, ctx.AccountLeaf);
             }
 
-            Assert.AreEqual(3656, node.GetMemorySize(true));
-            Assert.AreEqual(200, node.GetMemorySize(false));
+            Assert.AreEqual(3664, node.GetMemorySize(true));
+            Assert.AreEqual(208, node.GetMemorySize(false));
         }
 
         [Test]
@@ -544,7 +544,7 @@ namespace Nethermind.Trie.Test
             trieNode.Key = new byte[] { 1 };
             trieNode.SetChild(0, ctx.TiniestLeaf);
 
-            Assert.AreEqual(112, trieNode.GetMemorySize(false));
+            Assert.AreEqual(120, trieNode.GetMemorySize(false));
         }
 
         [Test]
@@ -555,22 +555,22 @@ namespace Nethermind.Trie.Test
             trieNode.Key = new byte[] { 1 };
             trieNode.SetChild(0, ctx.TiniestLeaf);
 
-            Assert.AreEqual(256, trieNode.GetMemorySize(true));
-            Assert.AreEqual(112, trieNode.GetMemorySize(false));
+            Assert.AreEqual(264, trieNode.GetMemorySize(true));
+            Assert.AreEqual(120, trieNode.GetMemorySize(false));
         }
 
         [Test]
         public void Size_of_an_unknown_empty_node_is_correct()
         {
             TrieNode trieNode = new(NodeType.Unknown);
-            trieNode.GetMemorySize(false).Should().Be(48);
+            trieNode.GetMemorySize(false).Should().Be(56);
         }
 
         [Test]
         public void Size_of_an_unknown_node_with_keccak_is_correct()
         {
             TrieNode trieNode = new(NodeType.Unknown, Keccak.Zero);
-            trieNode.GetMemorySize(false).Should().Be(128);
+            trieNode.GetMemorySize(false).Should().Be(136);
         }
 
         [Test]
@@ -578,7 +578,7 @@ namespace Nethermind.Trie.Test
         {
             TrieNode trieNode = new(NodeType.Extension);
             trieNode.SetChild(0, null);
-            trieNode.GetMemorySize(false).Should().Be(88);
+            trieNode.GetMemorySize(false).Should().Be(96);
         }
 
         [Test]
@@ -586,7 +586,7 @@ namespace Nethermind.Trie.Test
         {
             TrieNode trieNode = new(NodeType.Branch);
             trieNode.SetChild(0, null);
-            trieNode.GetMemorySize(false).Should().Be(200);
+            trieNode.GetMemorySize(false).Should().Be(208);
         }
 
         [Test]
@@ -601,7 +601,7 @@ namespace Nethermind.Trie.Test
         public void Size_of_an_unknown_node_with_full_rlp_is_correct()
         {
             TrieNode trieNode = new(NodeType.Unknown, new byte[7]);
-            trieNode.GetMemorySize(false).Should().Be(80);
+            trieNode.GetMemorySize(false).Should().Be(120);
         }
 
         [Test]
@@ -699,7 +699,7 @@ namespace Nethermind.Trie.Test
             trieNode.SetChild(0, child);
 
             trieNode.PrunePersistedRecursively(1);
-            trieNode.GetMemorySize(false).Should().Be(168);
+            trieNode.GetMemorySize(false).Should().Be(176);
         }
 
         [Test]
@@ -712,7 +712,7 @@ namespace Nethermind.Trie.Test
             trieNode.PrunePersistedRecursively(1);
             TrieNode cloned = trieNode.Clone();
 
-            cloned.GetMemorySize(false).Should().Be(168);
+            cloned.GetMemorySize(false).Should().Be(176);
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Trie/TrieNode.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using Nethermind.Core;
@@ -26,18 +27,13 @@ namespace Nethermind.Trie
 #endif
         public bool IsBoundaryProofNode { get; set; }
 
+        private TrieNode? _storageRoot;
         private static object _nullNode = new();
         private static TrieNodeDecoder _nodeDecoder = new();
         private static AccountDecoder _accountDecoder = new();
         private static Action<TrieNode> _markPersisted => tn => tn.IsPersisted = true;
+        private RlpStream? _rlpStream;
         private object?[]? _data;
-
-        private const int DataStorageRootIndex = 2;
-        private TrieNode? StorageRoot
-        {
-            set => _data![DataStorageRootIndex] = value;
-            get => _data?[DataStorageRootIndex] as TrieNode;
-        }
 
         /// <summary>
         /// Ethereum Patricia Trie specification allows for branch values,
@@ -107,15 +103,14 @@ namespace Nethermind.Trie
 
                 if (_data![BranchesCount] is null)
                 {
-                    if (FullRlp is null)
+                    if (_rlpStream is null)
                     {
                         _data[BranchesCount] = Array.Empty<byte>();
                     }
                     else
                     {
-                        Rlp.ValueDecoderContext reader = new(FullRlp);
-                        SeekChild(ref reader, BranchesCount);
-                        _data![BranchesCount] = reader.DecodeByteArray();
+                        SeekChild(BranchesCount);
+                        _data![BranchesCount] = _rlpStream!.DecodeByteArray();
                     }
                 }
 
@@ -190,6 +185,8 @@ namespace Nethermind.Trie
             NodeType = nodeType;
             FullRlp = rlp;
             IsDirty = isDirty;
+
+            _rlpStream = rlp.AsRlpStream();
         }
 
         public TrieNode(NodeType nodeType, Keccak keccak, byte[] rlp)
@@ -256,13 +253,17 @@ namespace Nethermind.Trie
                     return;
                 }
 
-                Rlp.ValueDecoderContext reader = new(FullRlp);
+                _rlpStream = FullRlp.AsRlpStream();
+                if (_rlpStream is null)
+                {
+                    throw new InvalidAsynchronousStateException($"{nameof(_rlpStream)} is null when {nameof(NodeType)} is {NodeType}");
+                }
 
                 Metrics.TreeNodeRlpDecodings++;
-                reader.ReadSequenceLength();
+                _rlpStream.ReadSequenceLength();
 
                 // micro optimization to prevent searches beyond 3 items for branches (search up to three)
-                int numberOfItems = reader.PeekNumberOfItemsRemaining(null, 3);
+                int numberOfItems = _rlpStream.PeekNumberOfItemsRemaining(null, 3);
 
                 if (numberOfItems > 2)
                 {
@@ -270,7 +271,7 @@ namespace Nethermind.Trie
                 }
                 else if (numberOfItems == 2)
                 {
-                    (byte[] key, bool isLeaf) = HexPrefix.FromBytes(reader.DecodeByteArraySpan());
+                    (byte[] key, bool isLeaf) = HexPrefix.FromBytes(_rlpStream.DecodeByteArraySpan());
 
                     // a hack to set internally and still verify attempts from the outside
                     // after the code is ready we should just add proper access control for methods from the outside and inside
@@ -281,7 +282,7 @@ namespace Nethermind.Trie
                     {
                         NodeType = NodeType.Leaf;
                         Key = key;
-                        Value = reader.DecodeByteArray();
+                        Value = _rlpStream.DecodeByteArray();
                     }
                     else
                     {
@@ -314,6 +315,7 @@ namespace Nethermind.Trie
             if (FullRlp is null || IsDirty)
             {
                 FullRlp = RlpEncode(tree);
+                _rlpStream = FullRlp.AsRlpStream();
             }
 
             /* nodes that are descendants of other nodes are stored inline
@@ -374,16 +376,14 @@ namespace Nethermind.Trie
 
         public Keccak? GetChildHash(int i)
         {
-            if (FullRlp is null)
+            if (_rlpStream is null)
             {
                 return null;
             }
 
-            Rlp.ValueDecoderContext reader = new(FullRlp);
-            SeekChild(ref reader, i);
-
-            (int _, int length) = reader.PeekPrefixAndContentLength();
-            return length == 32 ? reader.DecodeKeccak() : null;
+            SeekChild(i);
+            (int _, int length) = _rlpStream!.PeekPrefixAndContentLength();
+            return length == 32 ? _rlpStream.DecodeKeccak() : null;
         }
 
         public bool IsChildNull(int i)
@@ -394,11 +394,10 @@ namespace Nethermind.Trie
                     "An attempt was made to ask about whether a child is null on a non-branch node.");
             }
 
-            if (FullRlp is not null && _data?[i] is null)
+            if (_rlpStream is not null && _data?[i] is null)
             {
-                Rlp.ValueDecoderContext reader = new(FullRlp);
-                SeekChild(ref reader, i);
-                return reader!.PeekNextRlpLength() == 1;
+                SeekChild(i);
+                return _rlpStream!.PeekNextRlpLength() == 1;
             }
 
             return _data?[i] is null || ReferenceEquals(_data[i], _nullNode);
@@ -509,6 +508,9 @@ namespace Nethermind.Trie
             long fullRlpSize =
                 MemorySizes.RefSize +
                 (FullRlp is null ? 0 : MemorySizes.Align(FullRlp.Length + MemorySizes.ArrayOverhead));
+            long rlpStreamSize =
+                MemorySizes.RefSize + (_rlpStream?.MemorySize ?? 0)
+                - (FullRlp is null ? 0 : MemorySizes.Align(FullRlp.Length + MemorySizes.ArrayOverhead));
             long dataSize =
                 MemorySizes.RefSize +
                 (_data is null
@@ -547,6 +549,7 @@ namespace Nethermind.Trie
 
             long unaligned = keccakSize +
                              fullRlpSize +
+                             rlpStreamSize +
                              dataSize +
                              isDirtySize +
                              nodeTypeSize +
@@ -577,6 +580,7 @@ namespace Nethermind.Trie
             if (FullRlp is not null)
             {
                 trieNode.FullRlp = FullRlp;
+                trieNode._rlpStream = FullRlp.AsRlpStream();
             }
 
             return trieNode;
@@ -645,10 +649,10 @@ namespace Nethermind.Trie
             }
             else
             {
-                TrieNode? storageRoot = StorageRoot;
+                TrieNode? storageRoot = _storageRoot;
                 if (storageRoot is not null || (resolveStorageRoot && TryResolveStorageRoot(resolver, out storageRoot)))
                 {
-                    if (logger.IsTrace) logger.Trace($"Persist recursively on storage root {StorageRoot} of {this}");
+                    if (logger.IsTrace) logger.Trace($"Persist recursively on storage root {_storageRoot} of {this}");
                     storageRoot!.CallRecursively(action, resolver, skipPersisted, logger);
                 }
             }
@@ -696,9 +700,9 @@ namespace Nethermind.Trie
                     }
                 }
             }
-            else if (StorageRoot?.IsPersisted == true)
+            else if (_storageRoot?.IsPersisted == true)
             {
-                StorageRoot = null;
+                _storageRoot = null;
             }
 
             // else
@@ -714,7 +718,7 @@ namespace Nethermind.Trie
         private bool TryResolveStorageRoot(ITrieNodeResolver resolver, out TrieNode? storageRoot)
         {
             bool hasStorage = false;
-            storageRoot = StorageRoot;
+            storageRoot = _storageRoot;
 
             if (IsLeaf)
             {
@@ -728,7 +732,7 @@ namespace Nethermind.Trie
                     if (storageRootKey != Keccak.EmptyTreeHash)
                     {
                         hasStorage = true;
-                        StorageRoot = storageRoot = resolver.FindCachedOrUnknown(storageRootKey);
+                        _storageRoot = storageRoot = resolver.FindCachedOrUnknown(storageRootKey);
                     }
                 }
             }
@@ -748,10 +752,6 @@ namespace Nethermind.Trie
                     case NodeType.Branch:
                         _data = new object[AllowBranchValues ? BranchesCount + 1 : BranchesCount];
                         break;
-                    case NodeType.Leaf:
-                        // takes storage root into consideration
-                        _data = new object[DataStorageRootIndex + 1];
-                        break;
                     default:
                         _data = new object[2];
                         break;
@@ -759,32 +759,36 @@ namespace Nethermind.Trie
             }
         }
 
-        private void SeekChild(ref Rlp.ValueDecoderContext context, int itemToSetOn)
+        private void SeekChild(int itemToSetOn)
         {
-            if (context.IsEmpty)
+            if (_rlpStream is null)
             {
                 return;
             }
 
-            context.Reset();
-            context.SkipLength();
+            SeekChild(_rlpStream, itemToSetOn);
+        }
 
+        private void SeekChild(RlpStream rlpStream, int itemToSetOn)
+        {
+            rlpStream.Reset();
+            rlpStream.SkipLength();
             if (IsExtension)
             {
-                context.SkipItem();
+                rlpStream.SkipItem();
                 itemToSetOn--;
             }
 
             for (int i = 0; i < itemToSetOn; i++)
             {
-                context.SkipItem();
+                rlpStream.SkipItem();
             }
         }
 
         private object? ResolveChild(ITrieNodeResolver tree, int i)
         {
             object? childOrRef;
-            if (FullRlp is null)
+            if (_rlpStream is null)
             {
                 childOrRef = _data?[i];
             }
@@ -794,10 +798,9 @@ namespace Nethermind.Trie
                 if (_data![i] is null)
                 {
                     // Allows to load children in parallel
-                    Rlp.ValueDecoderContext reader = new(FullRlp);
-                    SeekChild(ref reader, i);
-
-                    int prefix = reader.ReadByte();
+                    RlpStream rlpStream = new(_rlpStream!.Data!);
+                    SeekChild(rlpStream, i);
+                    int prefix = rlpStream!.ReadByte();
 
                     switch (prefix)
                     {
@@ -809,8 +812,8 @@ namespace Nethermind.Trie
                             }
                         case 160:
                             {
-                                reader.Position--;
-                                Keccak keccak = reader.DecodeKeccak();
+                                rlpStream.Position--;
+                                Keccak keccak = rlpStream.DecodeKeccak();
                                 TrieNode child = tree.FindCachedOrUnknown(keccak);
                                 _data![i] = childOrRef = child;
 
@@ -823,8 +826,8 @@ namespace Nethermind.Trie
                             }
                         default:
                             {
-                                reader.Position--;
-                                Span<byte> fullRlp = reader.PeekNextItem();
+                                rlpStream.Position--;
+                                Span<byte> fullRlp = rlpStream.PeekNextItem();
                                 TrieNode child = new(NodeType.Unknown, fullRlp.ToArray());
                                 _data![i] = childOrRef = child;
                                 break;


### PR DESCRIPTION
This reverts commit 5488e31b2c0ef18f37e3f5900e92ea07c7752ffb.

Reverted this PR, because after investigation i've find out that this one causes Full Node not being able to sync properly.
On goerli node after around 500k blocks processed there was a TrieException.
Confirmed that 3 times (branch with this change vs without).

How to reproduce:
Nethermind.Runner.exe --config goerli_archive --Pruning.Mode=Hybrid

Wait for ~520k of blocks to be processed.

**OBSERVATION**
I've notice that if I'll run a branch WITHOUT this PR to about 400k blocks processed, stop gracefully node, switch to branch WITH this PR and wait for this 520k barrier, it will progress fine (may fail later in the process).
Because of that I assume, that this corrupts database earlier but it is being visible on 520 BUT node needs to be synced from scratch with this PR included.

## Changes

- _Revert of #5457_

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No