### PR TITLE
Vectorize HexConverter.TryDecodeFromUtf16

### DIFF
--- a/src/Nethermind/Nethermind.Benchmark/Core/FromHexBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Core/FromHexBenchmarks.cs
@@ -32,7 +32,7 @@ namespace Nethermind.Benchmarks.Core
         [Benchmark(Baseline = true)]
         public byte[] Current()
         {
-            return Bytes.FromHexStringOld(hex);
+            return Bytes.FromHexString(hex);
         }
 
         [Benchmark]

--- a/src/Nethermind/Nethermind.Core/Collections/ThrowHelper.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/ThrowHelper.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace Nethermind.Core.Collections;
@@ -16,6 +18,22 @@ public class ThrowHelper
     {
         // Note that default(T) is not equal to null for value types except when T is Nullable<U>.
         if (default(T) is not null && value is null)
-            throw new ArgumentNullException(argName);
+        {
+            ThrowArgumentNullException(argName);
+        }
+    }
+
+    [DoesNotReturn]
+    [StackTraceHidden]
+    private static void ThrowArgumentNullException(string argName)
+    {
+        throw new ArgumentNullException(argName);
+    }
+
+    [DoesNotReturn]
+    [StackTraceHidden]
+    internal static void ThrowNotSupportedException()
+    {
+        throw new NotImplementedException();
     }
 }

--- a/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
@@ -669,7 +669,7 @@ namespace Nethermind.Core.Extensions
                         }
                         else if (!AdvSimd.Arm64.IsSupported)
                         {
-                            ThrowNotSupportedException();
+                            ThrowHelper.ThrowNotSupportedException();
                         }
                         return AdvSimd.Arm64.VectorTableLookup(value, mask);
                     }
@@ -739,12 +739,6 @@ namespace Nethermind.Core.Extensions
 
                     toProcess -= 1;
                 }
-            }
-
-            [DoesNotReturn]
-            static void ThrowNotSupportedException()
-            {
-                throw new NotSupportedException();
             }
         }
 
@@ -847,7 +841,7 @@ namespace Nethermind.Core.Extensions
         {
             if (hexString is null)
             {
-                throw new ArgumentNullException($"{nameof(hexString)}");
+                throw new ArgumentNullException(nameof(hexString));
             }
 
             int start = hexString is ['0', 'x', ..] ? 2 : 0;
@@ -860,71 +854,21 @@ namespace Nethermind.Core.Extensions
 
             int oddMod = hexString.Length % 2;
             byte[] result = GC.AllocateUninitializedArray<byte>((chars.Length >> 1) + oddMod);
-            return HexConverter.TryDecodeFromUtf16(chars, result, oddMod == 1) ? result : throw new FormatException("Incorrect hex string");
-        }
 
-        [DebuggerStepThrough]
-        public static byte[] FromHexStringOld(string hexString)
-        {
-            if (hexString is null)
+            bool isSuccess;
+            if (oddMod == 0 &&
+                BitConverter.IsLittleEndian && (Ssse3.IsSupported || AdvSimd.Arm64.IsSupported) &&
+                chars.Length >= Vector128<ushort>.Count * 2)
             {
-                throw new ArgumentNullException($"{nameof(hexString)}");
+                isSuccess = HexConverter.TryDecodeFromUtf16_Vector128(chars, result);
+            }
+            else
+            {
+                isSuccess = HexConverter.TryDecodeFromUtf16(chars, result, oddMod == 1);
             }
 
-            int startIndex = hexString.StartsWith("0x") ? 2 : 0;
-            bool odd = hexString.Length % 2 == 1;
-            int numberChars = hexString.Length - startIndex + (odd ? 1 : 0);
-            byte[] bytes = new byte[numberChars / 2];
-            for (int i = 0; i < numberChars; i += 2)
-            {
-                if (odd && i == 0)
-                {
-                    bytes[0] += FromHexNibble2Table[(byte)hexString[startIndex]];
-                }
-                else if (odd)
-                {
-                    bytes[i / 2] += FromHexNibble1Table[(byte)hexString[i + startIndex - 1]];
-                    bytes[i / 2] += FromHexNibble2Table[(byte)hexString[i + startIndex]];
-                }
-                else
-                {
-                    bytes[i / 2] += FromHexNibble1Table[(byte)hexString[i + startIndex]];
-                    bytes[i / 2] += FromHexNibble2Table[(byte)hexString[i + startIndex + 1]];
-                }
-            }
-
-            return bytes;
+            return isSuccess ? result : throw new FormatException("Incorrect hex string");
         }
-
-        private static byte[] FromHexNibble1Table =
-        {
-            255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
-            255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
-            255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
-            255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
-            255, 255, 255, 255, 255, 255, 255, 255, 0, 16,
-            32, 48, 64, 80, 96, 112, 128, 144, 255, 255,
-            255, 255, 255, 255, 255, 160, 176, 192, 208, 224,
-            240, 255, 255, 255, 255, 255, 255, 255, 255, 255,
-            255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
-            255, 255, 255, 255, 255, 255, 255, 160, 176, 192,
-            208, 224, 240
-        };
-
-        private static byte[] FromHexNibble2Table =
-        {
-            255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
-            255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
-            255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
-            255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
-            255, 255, 255, 255, 255, 255, 255, 255, 0, 1,
-            2, 3, 4, 5, 6, 7, 8, 9, 255, 255,
-            255, 255, 255, 255, 255, 10, 11, 12, 13, 14,
-            15, 255, 255, 255, 255, 255, 255, 255, 255, 255,
-            255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
-            255, 255, 255, 255, 255, 255, 255, 10, 11, 12,
-            13, 14, 15
-        };
 
         [SuppressMessage("ReSharper", "NonReadonlyMemberInGetHashCode")]
         public static int GetSimplifiedHashCode(this byte[] bytes)

--- a/src/Nethermind/Nethermind.Core/Extensions/HexConverter.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/HexConverter.cs
@@ -9,6 +9,8 @@ using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.Arm;
 using System.Runtime.Intrinsics.X86;
 
+using Nethermind.Core.Collections;
+
 namespace Nethermind.Core.Extensions
 {
     // copied and bit modified from: https://github.com/dotnet/runtime/blob/main/src/libraries/Common/src/System/HexConverter.cs
@@ -256,10 +258,125 @@ namespace Nethermind.Core.Extensions
                 i += 2;
             }
 
-            if (byteLo == 0xFF)
-                i++;
-
             return (byteLo | byteHi) != 0xFF;
+        }
+
+        public static bool TryDecodeFromUtf16_Vector128(ReadOnlySpan<char> chars, Span<byte> bytes)
+        {
+            Debug.Assert(Ssse3.IsSupported || AdvSimd.Arm64.IsSupported);
+            Debug.Assert(chars.Length <= bytes.Length * 2);
+            Debug.Assert(chars.Length % 2 == 0);
+            Debug.Assert(chars.Length >= Vector128<ushort>.Count * 2);
+
+            nuint offset = 0;
+            nuint lengthSubTwoVector128 = (nuint)chars.Length - ((nuint)Vector128<ushort>.Count * 2);
+
+            ref ushort srcRef = ref Unsafe.As<char, ushort>(ref MemoryMarshal.GetReference(chars));
+            ref byte destRef = ref MemoryMarshal.GetReference(bytes);
+
+            do
+            {
+                // The algorithm is UTF8 so we'll be loading two UTF-16 vectors to narrow them into a
+                // single UTF8 ASCII vector - the implementation can be shared with UTF8 paths.
+                Vector128<ushort> vec1 = Vector128.LoadUnsafe(ref srcRef, offset);
+                Vector128<ushort> vec2 = Vector128.LoadUnsafe(ref srcRef, offset + (nuint)Vector128<ushort>.Count);
+                Vector128<byte> vec = Vector128.Narrow(vec1, vec2);
+
+                // Based on "Algorithm #3" https://github.com/WojciechMula/toys/blob/master/simd-parse-hex/geoff_algorithm.cpp
+                // by Geoff Langdale and Wojciech Mula
+                // Move digits '0'..'9' into range 0xf6..0xff.
+                Vector128<byte> t1 = vec + Vector128.Create((byte)(0xFF - '9'));
+                // And then correct the range to 0xf0..0xf9.
+                // All other bytes become less than 0xf0.
+                Vector128<byte> t2 = SubtractSaturate(t1, Vector128.Create((byte)6));
+                // Convert into uppercase 'a'..'f' => 'A'..'F' and
+                // move hex letter 'A'..'F' into range 0..5.
+                Vector128<byte> t3 = (vec & Vector128.Create((byte)0xDF)) - Vector128.Create((byte)'A');
+                // And correct the range into 10..15.
+                // The non-hex letters bytes become greater than 0x0f.
+                Vector128<byte> t4 = AddSaturate(t3, Vector128.Create((byte)10));
+                // Convert '0'..'9' into nibbles 0..9. Non-digit bytes become
+                // greater than 0x0f. Finally choose the result: either valid nibble (0..9/10..15)
+                // or some byte greater than 0x0f.
+                Vector128<byte> nibbles = Vector128.Min(t2 - Vector128.Create((byte)0xF0), t4);
+                // Any high bit is a sign that input is not a valid hex data
+                if (!AllCharsInVector128AreAscii(vec1 | vec2) ||
+                    AddSaturate(nibbles, Vector128.Create((byte)(127 - 15))).ExtractMostSignificantBits() != 0)
+                {
+                    // Input is either non-ASCII or invalid hex data
+                    break;
+                }
+                Vector128<byte> output;
+                if (Ssse3.IsSupported)
+                {
+                    output = Ssse3.MultiplyAddAdjacent(nibbles,
+                        Vector128.Create((short)0x0110).AsSByte()).AsByte();
+                }
+                else
+                {
+                    // Workaround for missing MultiplyAddAdjacent on ARM
+                    Vector128<short> even = AdvSimd.Arm64.TransposeEven(nibbles, Vector128<byte>.Zero).AsInt16();
+                    Vector128<short> odd = AdvSimd.Arm64.TransposeOdd(nibbles, Vector128<byte>.Zero).AsInt16();
+                    even = AdvSimd.ShiftLeftLogical(even, 4).AsInt16();
+                    output = AdvSimd.AddSaturate(even, odd).AsByte();
+                }
+                // Accumulate output in lower INT64 half and take care about endianness
+                output = Vector128.Shuffle(output, Vector128.Create((byte)0, 2, 4, 6, 8, 10, 12, 14, 0, 0, 0, 0, 0, 0, 0, 0));
+                // Store 8 bytes in dest by given offset
+                Unsafe.WriteUnaligned(ref Unsafe.Add(ref destRef, offset / 2), output.AsUInt64().ToScalar());
+
+                offset += (nuint)Vector128<ushort>.Count * 2;
+                if (offset == (nuint)chars.Length)
+                {
+                    return true;
+                }
+                // Overlap with the current chunk for trailing elements
+                if (offset > lengthSubTwoVector128)
+                {
+                    offset = lengthSubTwoVector128;
+                }
+            }
+            while (true);
+
+            // Fall back to the scalar routine in case of invalid input.
+            return TryDecodeFromUtf16(chars.Slice((int)offset), bytes.Slice((int)(offset / 2)), isOdd: false);
+        }
+
+        /// <summary>
+        /// Returns true iff the Vector128 represents 8 ASCII UTF-16 characters in machine endianness.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool AllCharsInVector128AreAscii(Vector128<ushort> vec)
+        {
+            return (vec & Vector128.Create(unchecked((ushort)~0x007F))) == Vector128<ushort>.Zero;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static Vector128<byte> AddSaturate(Vector128<byte> left, Vector128<byte> right)
+        {
+            if (Sse2.IsSupported)
+            {
+                return Sse2.AddSaturate(left, right);
+            }
+            else if (!AdvSimd.Arm64.IsSupported)
+            {
+                ThrowHelper.ThrowNotSupportedException();
+            }
+            return AdvSimd.AddSaturate(left, right);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static Vector128<byte> SubtractSaturate(Vector128<byte> left, Vector128<byte> right)
+        {
+            if (Sse2.IsSupported)
+            {
+                return Sse2.SubtractSaturate(left, right);
+            }
+            else if (!AdvSimd.Arm64.IsSupported)
+            {
+                ThrowHelper.ThrowNotSupportedException();
+            }
+            return AdvSimd.SubtractSaturate(left, right);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -291,9 +408,6 @@ namespace Nethermind.Core.Extensions
                 bytes[j++] = (byte)((byteHi << 4) | byteLo);
                 i += 2;
             }
-
-            if (byteLo == 0xFF)
-                i++;
 
             return (byteLo | byteHi) != 0xFF;
         }


### PR DESCRIPTION
## Changes

- Vectorize `HexConverter.TryDecodeFromUtf16` for x64 and Arm as per https://github.com/dotnet/runtime/pull/82521

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No