### PR TITLE
Improve Bloom performance

### DIFF
--- a/src/Nethermind/Nethermind.Benchmark/Core/BloomBenchmark.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Core/BloomBenchmark.cs
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+
+using BenchmarkDotNet.Attributes;
+
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Test.Builders;
+
+using NUnit.Framework;
+
+namespace Nethermind.Benchmarks.Core;
+
+public class BloomBenchmark
+{
+    private LogEntry[] LogEntries = CreateLogs();
+
+    public static LogEntry[] CreateLogs()
+    {
+        var topics = new Keccak[]
+        {
+            Keccak.Zero,
+            Keccak.EmptyTreeHash,
+            Keccak.OfAnEmptySequenceRlp,
+            Keccak.OfAnEmptyString
+        };
+
+        var logs = new LogEntry[512];
+        for (int i = 0; i < logs.Length; i++)
+        {
+            logs[i] = new LogEntry
+            (
+                Address.Zero,
+                Array.Empty<byte>(),
+                topics
+            );
+        }
+
+        return logs;
+    }
+
+    [Benchmark]
+    public Bloom ReconstructFromLogs()
+    {
+        return new Bloom(LogEntries);
+    }
+}
+

--- a/src/Nethermind/Nethermind.Core.Test/BloomTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/BloomTests.cs
@@ -18,7 +18,7 @@ namespace Nethermind.Core.Test
         {
             Bloom bloom = new();
             bloom.Set(Keccak.OfAnEmptyString.Bytes);
-            byte[] bytes = bloom.Bytes;
+            ReadOnlySpan<byte> bytes = bloom.Bytes;
             Bloom bloom2 = new(bytes);
             Assert.AreEqual(bloom.ToString(), bloom2.ToString());
         }

--- a/src/Nethermind/Nethermind.Core.Test/Json/BloomConverterTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Json/BloomConverterTests.cs
@@ -26,7 +26,7 @@ namespace Nethermind.Core.Test.Json
         public void Full_bloom()
         {
             TestConverter(
-                new Bloom(Enumerable.Range(0, 255).Select(i => (byte)i).ToArray()),
+                new Bloom(Enumerable.Range(0, 256).Select(i => (byte)i).ToArray()),
                 (bloom, bloom1) => bloom.Equals(bloom1), new BloomConverter());
         }
     }

--- a/src/Nethermind/Nethermind.Core/Bloom.cs
+++ b/src/Nethermind/Nethermind.Core/Bloom.cs
@@ -134,19 +134,27 @@ namespace Nethermind.Core
 
         public void Add(LogEntry[] logEntries, Bloom? blockBloom = null)
         {
-            for (int entryIndex = 0; entryIndex < logEntries.Length; entryIndex++)
+            for (int i = 0; i < logEntries.Length; i++)
             {
-                LogEntry logEntry = logEntries[entryIndex];
+                LogEntry logEntry = logEntries[i];
                 byte[] addressBytes = logEntry.LoggersAddress.Bytes;
 
                 Set(addressBytes, blockBloom);
 
                 Keccak[] topics = logEntry.Topics;
-                for (int topicIndex = 0; topicIndex < topics.Length; topicIndex++)
+                if (topics.Length > 0)
                 {
-                    Keccak topic = topics[topicIndex];
-                    Set(topic.Bytes, blockBloom);
+                    AddTopics(blockBloom, topics);
                 }
+            }
+        }
+
+        private void AddTopics(Bloom? blockBloom, Keccak[] topics)
+        {
+            for (int i = 0; i < topics.Length; i++)
+            {
+                Keccak topic = topics[i];
+                Set(topic.Bytes, blockBloom);
             }
         }
 
@@ -318,24 +326,6 @@ NotFound:
         public override int GetHashCode()
         {
             return Core.Extensions.Bytes.GetSimplifiedHashCode(Bytes);
-        }
-
-        public void Add(LogEntry[] logEntries, Bloom? blockBloom)
-        {
-            for (int i = 0; i < logEntries.Length; i++)
-            {
-                LogEntry logEntry = logEntries[i];
-                byte[] addressBytes = logEntry.LoggersAddress.Bytes;
-
-                Set(addressBytes, blockBloom);
-
-                var topics = logEntry.Topics;
-                for (int topicIndex = 0; topicIndex < topics.Length; topicIndex++)
-                {
-                    Keccak topic = topics[topicIndex];
-                    Set(topic.Bytes, blockBloom);
-                }
-            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.cs
@@ -441,7 +441,7 @@ namespace Nethermind.Core.Crypto
             MemoryMarshal.AsBytes(state[..(size / sizeof(ulong))]).CopyTo(output);
         }
 
-        public void Update(Span<byte> input)
+        public void Update(ReadOnlySpan<byte> input)
         {
             if (_hash is not null)
             {
@@ -465,7 +465,7 @@ namespace Nethermind.Core.Crypto
             if (_remainderLength != 0)
             {
                 // Copy data to our remainder
-                Span<byte> remainderAdditive = input[..Math.Min(input.Length, _roundSize - _remainderLength)];
+                ReadOnlySpan<byte> remainderAdditive = input[..Math.Min(input.Length, _roundSize - _remainderLength)];
                 remainderAdditive.CopyTo(_remainderBuffer.AsSpan(_remainderLength));
 
                 // Increment the length
@@ -501,7 +501,7 @@ namespace Nethermind.Core.Crypto
             while (input.Length >= _roundSize)
             {
                 // Cast our input to ulongs.
-                Span<ulong> input64 = MemoryMarshal.Cast<byte, ulong>(input[.._roundSize]);
+                ReadOnlySpan<ulong> input64 = MemoryMarshal.Cast<byte, ulong>(input[.._roundSize]);
 
                 // Eliminate bounds check for state for the loop
                 _ = state[input64.Length];

--- a/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
@@ -120,17 +120,16 @@ namespace Nethermind.Core.Extensions
 
         public static readonly byte[] Empty = new byte[0];
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+
         public static bool GetBit(this byte b, int bitNumber)
         {
             return (b & (1 << (7 - bitNumber))) != 0;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void SetBit(this ref byte b, int bitNumber)
         {
             byte mask = (byte)(1 << (7 - bitNumber));
-            b = b |= mask;
+            b |= mask;
         }
 
         public static int GetHighestSetBitIndex(this byte b)

--- a/src/Nethermind/Nethermind.Crypto/KeccakRlpStream.cs
+++ b/src/Nethermind/Nethermind.Crypto/KeccakRlpStream.cs
@@ -25,7 +25,7 @@ namespace Nethermind.Crypto
             _keccakHash = keccakHash;
         }
 
-        public override void Write(Span<byte> bytesToWrite)
+        public override void Write(ReadOnlySpan<byte> bytesToWrite)
         {
             _keccakHash.Update(bytesToWrite);
         }

--- a/src/Nethermind/Nethermind.Db/Blooms/BloomStorage.cs
+++ b/src/Nethermind/Nethermind.Db/Blooms/BloomStorage.cs
@@ -283,7 +283,7 @@ namespace Nethermind.Db.Blooms
                 }
             }
 
-            private static uint CountBits(Bloom bloom) => bloom.Bytes.AsSpan().CountBits();
+            private static uint CountBits(Bloom bloom) => bloom.Bytes.CountBits();
 
             public long GetBucket(long blockNumber) => blockNumber / LevelElementSize;
 

--- a/src/Nethermind/Nethermind.Facade/Filters/AddressFilter.cs
+++ b/src/Nethermind/Nethermind.Facade/Filters/AddressFilter.cs
@@ -54,7 +54,7 @@ namespace Nethermind.Blockchain.Filters
             return Address is null || Address == address;
         }
 
-        public bool Matches(Core.Bloom bloom)
+        public bool Matches(Bloom bloom)
         {
             if (Addresses is not null)
             {
@@ -62,8 +62,8 @@ namespace Nethermind.Blockchain.Filters
                 var indexes = AddressesBloomExtracts;
                 for (var i = 0; i < indexes.Length; i++)
                 {
-                    var index = indexes[i];
-                    result = bloom.Matches(ref index);
+                    ref readonly var index = ref indexes[i];
+                    result = bloom.Matches(in index);
                     if (result)
                     {
                         break;
@@ -90,8 +90,8 @@ namespace Nethermind.Blockchain.Filters
                 var indexes = AddressesBloomExtracts;
                 for (var i = 0; i < indexes.Length; i++)
                 {
-                    var index = indexes[i];
-                    result = bloom.Matches(ref index);
+                    ref readonly var index = ref indexes[i];
+                    result = bloom.Matches(in index);
                     if (result)
                     {
                         break;

--- a/src/Nethermind/Nethermind.Serialization.Json/BloomConverter.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/BloomConverter.cs
@@ -12,7 +12,7 @@ namespace Nethermind.Serialization.Json
     {
         public override void WriteJson(JsonWriter writer, Bloom value, JsonSerializer serializer)
         {
-            writer.WriteValue(Bytes.ByteArrayToHexViaLookup32Safe(value.Bytes, true));
+            writer.WriteValue(value.Bytes.ToHexString(withZeroX: true));
         }
 
         public override Bloom ReadJson(JsonReader reader, Type objectType, Bloom existingValue, bool hasExistingValue, JsonSerializer serializer)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/NettyRlpStream.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/NettyRlpStream.cs
@@ -20,7 +20,7 @@ namespace Nethermind.Serialization.Rlp
             _initialPosition = buffer.ReaderIndex;
         }
 
-        public override void Write(Span<byte> bytesToWrite)
+        public override void Write(ReadOnlySpan<byte> bytesToWrite)
         {
             _buffer.EnsureWritable(bytesToWrite.Length, true);
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -38,7 +38,7 @@ namespace Nethermind.Serialization.Rlp
 
         internal static readonly Rlp OfEmptyStringHash = Encode(Keccak.OfAnEmptyString.Bytes); // use bytes to avoid stack overflow
 
-        internal static readonly Rlp EmptyBloom = Encode(Bloom.Empty.Bytes); // use bytes to avoid stack overflow
+        internal static readonly Rlp EmptyBloom = Encode(new byte[Bloom.ByteLength]); // use bytes to avoid stack overflow
 
         static Rlp()
         {
@@ -535,7 +535,7 @@ namespace Nethermind.Serialization.Rlp
             result[0] = 185;
             result[1] = 1;
             result[2] = 0;
-            Buffer.BlockCopy(bloom.Bytes, 0, result, 3, 256);
+            bloom.Bytes.CopyTo(result.AsSpan(3, 256));
             return new Rlp(result);
         }
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpStream.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpStream.cs
@@ -155,7 +155,12 @@ namespace Nethermind.Serialization.Rlp
             Write(bytesToWrite.AsSpan());
         }
 
-        public virtual void Write(Span<byte> bytesToWrite)
+        public void Write(Span<byte> bytesToWrite)
+        {
+            Write((ReadOnlySpan<byte>)bytesToWrite);
+        }
+
+        public virtual void Write(ReadOnlySpan<byte> bytesToWrite)
         {
             bytesToWrite.CopyTo(Data.AsSpan(Position, bytesToWrite.Length));
             Position += bytesToWrite.Length;


### PR DESCRIPTION
## Changes

- Represent internal buffer as fixed size buffer rather than array
- Vectorise `Accumulate` directly over the fixed size buffer
- Improve asm produced for `Set`/`Get`/`GetExtract`
- Change `BloomExtract` to a `readonly struct` and pass via `in`

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No