### PR TITLE
Fix column families does not use the same config as default column

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnsDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnsDb.cs
@@ -36,7 +36,7 @@ public class ColumnsDb<T> : DbOnTheRocks, IColumnsDb<T> where T : struct, Enum
         return keys;
     }
 
-    protected override void BuildOptions<O>(IDbConfig dbConfig, Options<O> options)
+    protected override void BuildOptions<O>(PerTableDbConfig dbConfig, Options<O> options)
     {
         base.BuildOptions(dbConfig, options);
         options.SetCreateMissingColumnFamilies();

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/PerTableDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/PerTableDbConfig.cs
@@ -38,7 +38,7 @@ public class PerTableDbConfig
 
     public int? MaxOpenFiles => ReadConfig<int?>(nameof(MaxOpenFiles));
     public long? MaxWriteBytesPerSec => ReadConfig<long?>(nameof(MaxWriteBytesPerSec));
-    public ulong RecycleLogFileNum => ReadConfig<ulong>(nameof(RecycleLogFileNum));
+    public uint RecycleLogFileNum => ReadConfig<uint>(nameof(RecycleLogFileNum));
     public bool WriteAheadLogSync => ReadConfig<bool>(nameof(WriteAheadLogSync));
     public bool EnableDbStatistics => _dbConfig.EnableDbStatistics;
     public uint StatsDumpPeriodSec => _dbConfig.StatsDumpPeriodSec;

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/PerTableDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/PerTableDbConfig.cs
@@ -15,11 +15,15 @@ public class PerTableDbConfig
     private readonly IDbConfig _dbConfig;
     private readonly RocksDbSettings _settings;
 
-    public PerTableDbConfig(IDbConfig dbConfig, RocksDbSettings rocksDbSettings)
+    public PerTableDbConfig(IDbConfig dbConfig, RocksDbSettings rocksDbSettings, string? columnName = null)
     {
         _dbConfig = dbConfig;
         _settings = rocksDbSettings;
         _tableName = _settings.DbName;
+        if (columnName != null)
+        {
+            _tableName += columnName;
+        }
     }
 
     public bool CacheIndexAndFilterBlocks => _settings.CacheIndexAndFilterBlocks ?? ReadConfig<bool>(nameof(CacheIndexAndFilterBlocks));
@@ -34,16 +38,25 @@ public class PerTableDbConfig
 
     public int? MaxOpenFiles => ReadConfig<int?>(nameof(MaxOpenFiles));
     public long? MaxWriteBytesPerSec => ReadConfig<long?>(nameof(MaxWriteBytesPerSec));
+    public ulong RecycleLogFileNum => ReadConfig<ulong>(nameof(RecycleLogFileNum));
+    public bool WriteAheadLogSync => ReadConfig<bool>(nameof(WriteAheadLogSync));
+    public bool EnableDbStatistics => _dbConfig.EnableDbStatistics;
+    public uint StatsDumpPeriodSec => _dbConfig.StatsDumpPeriodSec;
 
     private T? ReadConfig<T>(string propertyName)
     {
-        return ReadConfig<T>(_dbConfig, propertyName, _tableName);
+        return ReadConfig<T>(_dbConfig, propertyName, GetPrefix());
     }
 
-    private static T? ReadConfig<T>(IDbConfig dbConfig, string propertyName, string tableName)
+    private string GetPrefix()
     {
-        string prefixed = string.Concat(tableName.StartsWith("State") ? string.Empty : string.Concat(tableName, "Db"),
-            propertyName);
+        return _tableName.StartsWith("State") ? "State" : string.Concat(_tableName, "Db");
+    }
+
+    private static T? ReadConfig<T>(IDbConfig dbConfig, string propertyName, string prefix)
+    {
+        string prefixed = string.Concat(prefix, propertyName);
+
         try
         {
             Type type = dbConfig.GetType();

--- a/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
@@ -217,7 +217,7 @@ namespace Nethermind.Db.Test
             RocksDbSettings rocksDbSettings,
             IDbConfig dbConfig,
             ILogManager logManager,
-            ColumnFamilies? columnFamilies = null,
+            IList<string>? columnFamilies = null,
             RocksDbSharp.Native? rocksDbNative = null,
             IFileSystem? fileSystem = null
         ) : base(basePath, rocksDbSettings, dbConfig, logManager, columnFamilies, rocksDbNative, fileSystem)

--- a/tools/HiveConsensusWorkflowGenerator/Program.cs
+++ b/tools/HiveConsensusWorkflowGenerator/Program.cs
@@ -127,7 +127,7 @@ public static class Program
 
             if (directory.Value > TargetSize)
             {
-                yield return new List<string>(){ dirName };
+                yield return new List<string>() { dirName };
                 continue;
             }
 


### PR DESCRIPTION
- Consolidate column family and default column family options into one. 
- Makes testing config way easier. Also make sure db config is applied to column family.

## Changes

- Use the same function to declare main config and column family config.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)
- [X] Refactoring
- [ ] Other: _Description_

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

- Does not seems to affect receipts db size.
