### PR TITLE
Fix processing speed is -1.

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
@@ -12,6 +12,7 @@ using Nethermind.Blockchain.Find;
 using Nethermind.Core;
 using Nethermind.Core.Attributes;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
 using Nethermind.Evm.Tracing;
 using Nethermind.Evm.Tracing.GethStyle;
 using Nethermind.Evm.Tracing.ParityStyle;
@@ -384,7 +385,7 @@ namespace Nethermind.Consensus.Processing
 
             if (!readonlyChain)
             {
-                _stats.UpdateStats(lastProcessed, _blockTree, _recoveryQueue.Count, _blockQueue.Count, blockProcessingTimeInMs);
+                _stats.UpdateStats(lastProcessed, _blockTree, _recoveryQueue.Count, _blockQueue.Count, _stopwatch.ElapsedMicroseconds());
             }
 
             return lastProcessed;

--- a/src/Nethermind/Nethermind.Consensus/Processing/ProcessingStats.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ProcessingStats.cs
@@ -32,7 +32,7 @@ namespace Nethermind.Consensus.Processing
         private long _maxMemory;
         private long _totalBlocks;
         private bool _isDebugMode = false;
-        private decimal _processingTimeInMs;
+        private decimal _processingTimeInMicros;
 
         public ProcessingStats(ILogger logger)
         {
@@ -45,7 +45,7 @@ namespace Nethermind.Consensus.Processing
 #endif
         }
 
-        public void UpdateStats(Block? block, IBlockTree blockTreeCtx, int recoveryQueueSize, int blockQueueSize, long lastBlockProcessingTimeInMs)
+        public void UpdateStats(Block? block, IBlockTree blockTreeCtx, int recoveryQueueSize, int blockQueueSize, long lastBlockProcessingTimeInMicros)
         {
             if (block is null)
             {
@@ -59,7 +59,7 @@ namespace Nethermind.Consensus.Processing
                 _lastBlockNumber = block.Number;
             }
 
-            _processingTimeInMs += lastBlockProcessingTimeInMs;
+            _processingTimeInMicros += lastBlockProcessingTimeInMicros;
 
             Metrics.Mgas += block.GasUsed / 1_000_000m;
             Metrics.Transactions += block.Transactions.Length;
@@ -80,7 +80,7 @@ namespace Nethermind.Consensus.Processing
 
             if (runMicroseconds > 1 * 1000 * 1000)
             {
-                decimal chunkMilliseconds = _processingTimeInMs;
+                decimal chunkMicroseconds = _processingTimeInMicros;
                 decimal totalMicroseconds = currentTicks * (1_000_000m / Stopwatch.Frequency);
                 long currentStateDbReads = Db.Metrics.StateDbReads;
                 long currentStateDbWrites = Db.Metrics.StateDbWrites;
@@ -93,14 +93,14 @@ namespace Nethermind.Consensus.Processing
 
                 _totalBlocks += chunkBlocks;
 
-                decimal mgasPerSecond = chunkMilliseconds == 0 ? -1 : chunkMGas / chunkMilliseconds * 1000;
+                decimal mgasPerSecond = chunkMicroseconds == 0 ? -1 : chunkMGas / chunkMicroseconds * 1000 * 1000;
                 decimal totalMgasPerSecond = totalMicroseconds == 0 ? -1 : Metrics.Mgas / totalMicroseconds * 1000 * 1000;
                 decimal totalTxPerSecond = totalMicroseconds == 0 ? -1 : Metrics.Transactions / totalMicroseconds * 1000 * 1000;
                 decimal totalBlocksPerSecond = totalMicroseconds == 0 ? -1 : _totalBlocks / totalMicroseconds * 1000 * 1000;
-                decimal txps = chunkMilliseconds == 0 ? -1 : chunkTx / chunkMilliseconds * 1000m;
-                decimal bps = chunkMilliseconds == 0 ? -1 : chunkBlocks / chunkMilliseconds * 1000m;
+                decimal txps = chunkMicroseconds == 0 ? -1 : chunkTx / chunkMicroseconds * 1000 * 1000;
+                decimal bps = chunkMicroseconds == 0 ? -1 : chunkBlocks / chunkMicroseconds * 1000 * 1000;
 
-                if (_logger.IsInfo) _logger.Info($"Processed  {block.Number,9} |  {(chunkMilliseconds == 0 ? -1 : chunkMilliseconds),7:N0}ms of {(runMicroseconds == 0 ? -1 : runMicroseconds / 1000),7:N0}ms, mgasps {mgasPerSecond,7:F2} total {totalMgasPerSecond,7:F2}, tps {txps,7:F2} total {totalTxPerSecond,7:F2}, bps {bps,7:F2} total {totalBlocksPerSecond,7:F2}, recv queue {recoveryQueueSize}, proc queue {blockQueueSize}");
+                if (_logger.IsInfo) _logger.Info($"Processed  {block.Number,9} |  {(chunkMicroseconds == 0 ? -1 : chunkMicroseconds / 1000),7:N0}ms of {(runMicroseconds == 0 ? -1 : runMicroseconds / 1000),7:N0}ms, mgasps {mgasPerSecond,7:F2} total {totalMgasPerSecond,7:F2}, tps {txps,7:F2} total {totalTxPerSecond,7:F2}, bps {bps,7:F2} total {totalBlocksPerSecond,7:F2}, recv queue {recoveryQueueSize}, proc queue {blockQueueSize}");
                 if (_logger.IsTrace)
                 {
                     long currentGen0 = GC.CollectionCount(0);
@@ -124,7 +124,7 @@ namespace Nethermind.Consensus.Processing
                 _lastTreeNodeRlp = currentTreeNodeRlp;
                 _lastEvmExceptions = evmExceptions;
                 _lastSelfDestructs = currentSelfDestructs;
-                _processingTimeInMs = 0;
+                _processingTimeInMicros = 0;
             }
         }
 


### PR DESCRIPTION
Fix #5522

- On early full sync, the time within block precessing is less than 1ms, so the report shows -1.

## Changes

- Change passed in time from millisecond to microsecond.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

- Tested to work manually.