### PR TITLE
When required, re-run as child process with env var set.

### DIFF
--- a/src/Nethermind/Nethermind.Init/Cpu/ConsoleExitHandler.cs
+++ b/src/Nethermind/Nethermind.Init/Cpu/ConsoleExitHandler.cs
@@ -9,11 +9,11 @@ using System.Diagnostics;
 
 namespace Nethermind.Init.Cpu;
 
-internal class ConsoleExitHandler : IDisposable
+public class ConsoleExitHandler : IDisposable
 {
     private readonly Process process;
 
-    internal ConsoleExitHandler(Process process)
+    public ConsoleExitHandler(Process process)
     {
         this.process = process;
 

--- a/src/Nethermind/Nethermind.Runner/IRunnerConfig.cs
+++ b/src/Nethermind/Nethermind.Runner/IRunnerConfig.cs
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Config;
+
+namespace Nethermind.Runner;
+
+public interface IRunnerConfig: IConfig
+{
+    [ConfigItem(Description = "Set max heap size", DefaultValue = "0")]
+    long? MaxHeapMb { get; set; }
+
+    bool ShouldWrapInRunner => MaxHeapMb != null;
+}

--- a/src/Nethermind/Nethermind.Runner/IRunnerConfig.cs
+++ b/src/Nethermind/Nethermind.Runner/IRunnerConfig.cs
@@ -5,10 +5,11 @@ using Nethermind.Config;
 
 namespace Nethermind.Runner;
 
-public interface IRunnerConfig: IConfig
+public interface IRunnerConfig : IConfig
 {
-    [ConfigItem(Description = "Set max heap size", DefaultValue = "0")]
+    [ConfigItem(Description = "Set max heap size", DefaultValue = "null")]
     long? MaxHeapMb { get; set; }
 
+    [ConfigItem(Description = "", DefaultValue = "false", HiddenFromDocs = true)]
     bool ShouldWrapInRunner => MaxHeapMb != null;
 }

--- a/src/Nethermind/Nethermind.Runner/NLog.config
+++ b/src/Nethermind/Nethermind.Runner/NLog.config
@@ -23,6 +23,7 @@
     <target xsi:type="ColoredConsole"
             autoFlush="true"
             name="auto-colored-console-async"
+            enableAnsiOutput="true"
             useDefaultRowHighlightingRules="false"
             layout="${longdate}|${message} ${exception:format=toString}">
       <!-- layout="${longdate}|${threadid}|${message} ${exception:format=toString}"> -->

--- a/src/Nethermind/Nethermind.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Runner/Program.cs
@@ -282,7 +282,7 @@ namespace Nethermind.Runner
 
             foreach (string arg in args)
             {
-                 processStartInfo.ArgumentList.Add(arg);
+                processStartInfo.ArgumentList.Add(arg);
             }
 
             using Process? process = new Process { StartInfo = processStartInfo };

--- a/src/Nethermind/Nethermind.Runner/RunnerConfig.cs
+++ b/src/Nethermind/Nethermind.Runner/RunnerConfig.cs
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.Runner;
+
+public class RunnerConfig: IRunnerConfig
+{
+    public long? MaxHeapMb { get; set; } = null;
+}

--- a/src/Nethermind/Nethermind.Runner/RunnerConfig.cs
+++ b/src/Nethermind/Nethermind.Runner/RunnerConfig.cs
@@ -3,7 +3,7 @@
 
 namespace Nethermind.Runner;
 
-public class RunnerConfig: IRunnerConfig
+public class RunnerConfig : IRunnerConfig
 {
     public long? MaxHeapMb { get; set; } = null;
 }


### PR DESCRIPTION
- Re-run as child process if needed, eg setting env var.
- Pipe the stdout and stderr, making it appear as if it is the main process.
- Forward close signal.
- Add flag to limit max heap.

## Changes

- Add a way to re-run as child process if need.

## Types of changes

#### What types of changes does your code introduce?

- [X] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

- On linux setting, `--Runner.MaxHeapMb 1` crash as expected.
- Not tested on windows or max.
