### PR TITLE
Add JSON-RPC endpoints for EIP-4844

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Validators/BlockValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/BlockValidator.cs
@@ -197,7 +197,7 @@ public class BlockValidator : IBlockValidator
     {
         if (spec.IsEip4844Enabled ^ block.ExcessDataGas is not null)
         {
-            error = $"ExcessDataGas cannot be null in block {block.Hash} when EIP-4844 activated.";
+            error = "ExcessDataGas field is incorrect.";
             if (_logger.IsWarn) _logger.Warn(error);
             return false;
         }

--- a/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
@@ -146,7 +146,7 @@ namespace Nethermind.Consensus.Validators
                      i < transaction.BlobVersionedHashes!.Length;
                      i++, n += Ckzg.Ckzg.BytesPerCommitment)
                 {
-                    if (!KzgPolynomialCommitments.TryComputeCommitmentV1(
+                    if (!KzgPolynomialCommitments.TryComputeCommitmentHashV1(
                             commitements[n..(n + Ckzg.Ckzg.BytesPerCommitment)], hash) ||
                         !hash.SequenceEqual(transaction.BlobVersionedHashes![i]))
                     {

--- a/src/Nethermind/Nethermind.Core.Test/Builders/TransactionBuilder.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Builders/TransactionBuilder.cs
@@ -166,6 +166,33 @@ namespace Nethermind.Core.Test.Builders
 
             return this;
         }
+
+        public TransactionBuilder<T> WithShardBlobTxFields(int blobCount)
+        {
+            if (blobCount is 0)
+            {
+                return this;
+            }
+
+            TestObjectInternal.Blobs = new byte[Ckzg.Ckzg.BytesPerBlob * blobCount];
+            TestObjectInternal.BlobKzgs = new byte[Ckzg.Ckzg.BytesPerCommitment * blobCount];
+            TestObjectInternal.BlobProofs = new byte[Ckzg.Ckzg.BytesPerProof * blobCount];
+            TestObjectInternal.BlobVersionedHashes = new byte[blobCount][];
+            for (int i = 0; i < blobCount; i++)
+            {
+                TestObjectInternal.BlobVersionedHashes[i] = new byte[32];
+                TestObjectInternal.BlobVersionedHashes[i]![0] = KzgPolynomialCommitments.KzgBlobHashVersionV1;
+                TestObjectInternal.Blobs[Ckzg.Ckzg.BytesPerBlob * i] = 1;
+                KzgPolynomialCommitments.KzgifyBlob(
+                    TestObjectInternal.Blobs.AsSpan(Ckzg.Ckzg.BytesPerBlob * i,Ckzg.Ckzg.BytesPerBlob * (i+1)),
+                    TestObjectInternal.BlobKzgs.AsSpan(Ckzg.Ckzg.BytesPerCommitment * i,Ckzg.Ckzg.BytesPerCommitment * (i+1)),
+                    TestObjectInternal.BlobProofs.AsSpan(Ckzg.Ckzg.BytesPerProof * i,Ckzg.Ckzg.BytesPerProof * (i+1)),
+                    TestObjectInternal.BlobVersionedHashes[i].AsSpan());
+            }
+
+            return this;
+        }
+
         public TransactionBuilder<T> WithBlobKzgs(byte[] blobKzgs)
         {
             TestObjectInternal.BlobKzgs = blobKzgs;

--- a/src/Nethermind/Nethermind.Crypto/KzgPolynomialCommitments.cs
+++ b/src/Nethermind/Nethermind.Crypto/KzgPolynomialCommitments.cs
@@ -27,7 +27,7 @@ public static class KzgPolynomialCommitments
 
     private static Task? _initializeTask;
 
-    public static Task Initialize(ILogger? logger = null) => _initializeTask ??= Task.Run(() =>
+    public static Task InitializeAsync(ILogger? logger = null) => _initializeTask ??= Task.Run(() =>
     {
         if (_ckzgSetup != IntPtr.Zero) return;
 
@@ -52,7 +52,7 @@ public static class KzgPolynomialCommitments
     /// <param name="hashBuffer">Holds the output, can safely contain any data before the call.</param>
     /// <returns>Result of the attempt</returns>
     /// <exception cref="ArgumentException"></exception>
-    public static bool TryComputeCommitmentV1(ReadOnlySpan<byte> commitment, Span<byte> hashBuffer)
+    public static bool TryComputeCommitmentHashV1(ReadOnlySpan<byte> commitment, Span<byte> hashBuffer)
     {
         if (commitment.Length != Ckzg.Ckzg.BytesPerCommitment)
         {
@@ -97,5 +97,14 @@ public static class KzgPolynomialCommitments
         {
             return false;
         }
+    }
+
+    /// <summary>
+    /// Method to genereate correct data for tests only, not safe
+    /// </summary>
+    public static void KzgifyBlob(Span<byte> blob, Span<byte> commitment, Span<byte> proof, Span<byte> hashV1)
+    {
+        Ckzg.Ckzg.ComputeBlobKzgProof(blob, commitment,  proof, _ckzgSetup);
+        TryComputeCommitmentHashV1(commitment, hashV1);
     }
 }

--- a/src/Nethermind/Nethermind.Evm.Test/PointEvaluationPrecompileTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/PointEvaluationPrecompileTests.cs
@@ -24,7 +24,7 @@ public class PointEvaluationPrecompileTests
     private static readonly byte[] _predefinedFailureAnswer = Array.Empty<byte>();
 
     [OneTimeSetUp]
-    public Task OneTimeSetUp() => KzgPolynomialCommitments.Initialize();
+    public Task OneTimeSetUp() => KzgPolynomialCommitments.InitializeAsync();
 
     [TestCaseSource(nameof(OutputTests))]
     public bool Test_PointEvaluationPrecompile_Produces_Correct_Outputs(byte[] input)

--- a/src/Nethermind/Nethermind.Evm/Precompiles/PointEvaluationPrecompile.cs
+++ b/src/Nethermind/Nethermind.Evm/Precompiles/PointEvaluationPrecompile.cs
@@ -43,7 +43,7 @@ public class PointEvaluationPrecompile : IPrecompile
             ReadOnlySpan<byte> proof = inputDataSpan[144..192];
             Span<byte> hash = stackalloc byte[32];
 
-            return KzgPolynomialCommitments.TryComputeCommitmentV1(commitment, hash)
+            return KzgPolynomialCommitments.TryComputeCommitmentHashV1(commitment, hash)
                    && hash.SequenceEqual(versionedHash)
                    && KzgPolynomialCommitments.VerifyProof(commitment, z, y, proof);
         }

--- a/src/Nethermind/Nethermind.Init/Steps/InitializePrecompiles.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializePrecompiles.cs
@@ -27,7 +27,7 @@ public class InitializePrecompiles : IStep
 
             try
             {
-                await KzgPolynomialCommitments.Initialize(logger);
+                await KzgPolynomialCommitments.InitializeAsync(logger);
             }
             catch (Exception e)
             {

--- a/src/Nethermind/Nethermind.JsonRpc/IJsonRpcConfig.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/IJsonRpcConfig.cs
@@ -108,7 +108,7 @@ namespace Nethermind.JsonRpc
 
         [ConfigItem(
             Description = "Defines method names of Json RPC service requests to NOT log. Example: {\"eth_blockNumber\"} will not log \"eth_blockNumber\" requests.",
-            DefaultValue = "[engine_newPayloadV1, engine_newPayloadV2, engine_forkchoiceUpdatedV1, engine_forkchoiceUpdatedV2]")]
+            DefaultValue = "[engine_newPayloadV1, engine_newPayloadV2, engine_newPayloadV3, engine_forkchoiceUpdatedV1, engine_forkchoiceUpdatedV2]")]
         public string[]? MethodsLoggingFiltering { get; set; }
 
         [ConfigItem(

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcConfig.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcConfig.cs
@@ -44,6 +44,7 @@ namespace Nethermind.JsonRpc
         {
             "engine_newPayloadV1",
             "engine_newPayloadV2",
+            "engine_newPayloadV3",
             "engine_forkchoiceUpdatedV1",
             "engine_forkchoiceUpdatedV2"
         };

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V2.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V2.cs
@@ -35,9 +35,11 @@ public partial class EngineModuleTests
         "0x6d8a107ccab7a785de89f58db49064ee091df5d2b6306fe55db666e75a0e9f68",
         "0x03e662d795ee2234c492ca4a08de03b1d7e3e0297af81a76582e16de75cdfc51",
         "0x6454408c425ddd96")]
-    public virtual async Task Should_process_block_as_expected_V2(string latestValidHash, string blockHash, string stateRoot, string payloadId)
+    public virtual async Task Should_process_block_as_expected_V2(string latestValidHash, string blockHash,
+        string stateRoot, string payloadId)
     {
-        using MergeTestBlockchain chain = await CreateShanghaiBlockChain(new MergeConfig { TerminalTotalDifficulty = "0" });
+        using MergeTestBlockchain chain =
+            await CreateShanghaiBlockChain(new MergeConfig { TerminalTotalDifficulty = "0" });
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak startingHead = chain.BlockTree.HeadHash;
         Keccak prevRandao = Keccak.Zero;
@@ -62,8 +64,7 @@ public partial class EngineModuleTests
         };
         string?[] @params = new string?[]
         {
-            chain.JsonSerializer.Serialize(fcuState),
-            chain.JsonSerializer.Serialize(payloadAttrs)
+            chain.JsonSerializer.Serialize(fcuState), chain.JsonSerializer.Serialize(payloadAttrs)
         };
         string expectedPayloadId = payloadId;
 
@@ -97,7 +98,7 @@ public partial class EngineModuleTests
                 chain.BlockTree.Head!.GasLimit,
                 timestamp,
                 Bytes.FromHexString("0x4e65746865726d696e64") // Nethermind
-                )
+            )
             {
                 BaseFeePerGas = 0,
                 Bloom = Bloom.Empty,
@@ -119,8 +120,7 @@ public partial class EngineModuleTests
         successResponse.Should().NotBeNull();
         response.Should().Be(chain.JsonSerializer.Serialize(new JsonRpcSuccessResponse
         {
-            Id = successResponse.Id,
-            Result = expectedPayload
+            Id = successResponse.Id, Result = expectedPayload
         }));
 
         response = RpcTest.TestSerializedRequest(rpc, "engine_newPayloadV2",
@@ -133,9 +133,7 @@ public partial class EngineModuleTests
             Id = successResponse.Id,
             Result = new PayloadStatusV1
             {
-                LatestValidHash = expectedBlockHash,
-                Status = PayloadStatus.Valid,
-                ValidationError = null
+                LatestValidHash = expectedBlockHash, Status = PayloadStatus.Valid, ValidationError = null
             }
         }));
 
@@ -145,11 +143,7 @@ public partial class EngineModuleTests
             safeBlockHash = expectedBlockHash.ToString(true),
             finalizedBlockHash = startingHead.ToString(true)
         };
-        @params = new[]
-        {
-            chain.JsonSerializer.Serialize(fcuState),
-            null
-        };
+        @params = new[] { chain.JsonSerializer.Serialize(fcuState), null };
 
         response = RpcTest.TestSerializedRequest(rpc, "engine_forkchoiceUpdatedV2", @params!);
         successResponse = chain.JsonSerializer.Deserialize<JsonRpcSuccessResponse>(response);
@@ -191,8 +185,7 @@ public partial class EngineModuleTests
         };
         string[] @params = new[]
         {
-            chain.JsonSerializer.Serialize(fcuState),
-            chain.JsonSerializer.Serialize(payloadAttrs)
+            chain.JsonSerializer.Serialize(fcuState), chain.JsonSerializer.Serialize(payloadAttrs)
         };
 
         string response = RpcTest.TestSerializedRequest(rpcModule, "engine_forkchoiceUpdatedV1", @params);
@@ -229,8 +222,7 @@ public partial class EngineModuleTests
         };
         string[] @params = new[]
         {
-            chain.JsonSerializer.Serialize(fcuState),
-            chain.JsonSerializer.Serialize(payloadAttrs)
+            chain.JsonSerializer.Serialize(fcuState), chain.JsonSerializer.Serialize(payloadAttrs)
         };
 
         string response = RpcTest.TestSerializedRequest(rpcModule, "engine_forkchoiceUpdatedV2", @params);
@@ -251,8 +243,12 @@ public partial class EngineModuleTests
         Keccak startingHead = chain.BlockTree.HeadHash;
 
         ForkchoiceStateV1 forkchoiceState = new(startingHead, Keccak.Zero, startingHead);
-        PayloadAttributes payload = new() { Timestamp = Timestamper.UnixTime.Seconds, SuggestedFeeRecipient = Address.Zero, PrevRandao = Keccak.Zero };
-        Task<ResultWrapper<ForkchoiceUpdatedV1Result>> forkchoiceResponse = rpc.engine_forkchoiceUpdatedV1(forkchoiceState, payload);
+        PayloadAttributes payload = new()
+        {
+            Timestamp = Timestamper.UnixTime.Seconds, SuggestedFeeRecipient = Address.Zero, PrevRandao = Keccak.Zero
+        };
+        Task<ResultWrapper<ForkchoiceUpdatedV1Result>> forkchoiceResponse =
+            rpc.engine_forkchoiceUpdatedV1(forkchoiceState, payload);
 
         byte[] payloadId = Bytes.FromHexString(forkchoiceResponse.Result.Data.PayloadId!);
         ResultWrapper<GetPayloadV2Result?> responseFirst = await rpc.engine_getPayloadV2(payloadId);
@@ -275,14 +271,18 @@ public partial class EngineModuleTests
         int value = 10;
 
         PrivateKey sender = TestItem.PrivateKeyB;
-        Transaction[] transactions = BuildTransactions(chain, startingHead, sender, Address.Zero, count, value, out _, out _);
+        Transaction[] transactions =
+            BuildTransactions(chain, startingHead, sender, Address.Zero, count, value, out _, out _);
 
         chain.AddTransactions(transactions);
         chain.PayloadPreparationService!.BlockImproved += (_, _) => { blockImprovementLock.Release(1); };
 
         string? payloadId = rpc.engine_forkchoiceUpdatedV1(
                 new ForkchoiceStateV1(startingHead, Keccak.Zero, startingHead),
-                new PayloadAttributes() { Timestamp = 100, PrevRandao = TestItem.KeccakA, SuggestedFeeRecipient = feeRecipient })
+                new PayloadAttributes()
+                {
+                    Timestamp = 100, PrevRandao = TestItem.KeccakA, SuggestedFeeRecipient = feeRecipient
+                })
             .Result.Data.PayloadId!;
 
         UInt256 startingBalance = chain.StateReader.GetBalance(chain.State.StateRoot, feeRecipient);
@@ -290,7 +290,8 @@ public partial class EngineModuleTests
         await blockImprovementLock.WaitAsync(10000);
         GetPayloadV2Result getPayloadResult = (await rpc.engine_getPayloadV2(Bytes.FromHexString(payloadId))).Data!;
 
-        ResultWrapper<PayloadStatusV1> executePayloadResult = await rpc.engine_newPayloadV1(getPayloadResult.ExecutionPayload);
+        ResultWrapper<PayloadStatusV1> executePayloadResult =
+            await rpc.engine_newPayloadV1(getPayloadResult.ExecutionPayload);
         executePayloadResult.Data.Status.Should().Be(PayloadStatus.Valid);
 
         UInt256 finalBalance = chain.StateReader.GetBalance(getPayloadResult.ExecutionPayload.StateRoot, feeRecipient);
@@ -313,57 +314,55 @@ public partial class EngineModuleTests
     }
 
     [TestCaseSource(nameof(GetPayloadWithdrawalsTestCases))]
-    public virtual async Task getPayloadBodiesByHashV1_should_return_payload_bodies_in_order_of_request_block_hashes_and_null_for_unknown_hashes(
-        IList<Withdrawal> withdrawals)
+    public virtual async Task
+        getPayloadBodiesByHashV1_should_return_payload_bodies_in_order_of_request_block_hashes_and_null_for_unknown_hashes(
+            IList<Withdrawal> withdrawals)
     {
-        using var chain = await CreateShanghaiBlockChain();
-        var rpc = CreateEngineModule(chain);
-        var executionPayload1 = await SendNewBlockV2(rpc, chain, withdrawals);
-        var txs = BuildTransactions(
+        using MergeTestBlockchain chain = await CreateShanghaiBlockChain();
+        IEngineRpcModule rpc = CreateEngineModule(chain);
+        ExecutionPayload executionPayload1 = await SendNewBlockV2(rpc, chain, withdrawals);
+        Transaction[] txs = BuildTransactions(
             chain, executionPayload1.BlockHash, TestItem.PrivateKeyA, TestItem.AddressB, 3, 0, out _, out _);
 
         chain.AddTransactions(txs);
 
-        var executionPayload2 = await BuildAndSendNewBlockV2(rpc, chain, true, withdrawals);
-        var blockHashes = new Keccak[]
+        ExecutionPayload executionPayload2 = await BuildAndSendNewBlockV2(rpc, chain, true, withdrawals);
+        Keccak[] blockHashes = new Keccak[]
         {
-            executionPayload1.BlockHash, TestItem.KeccakA,
-            executionPayload2.BlockHash
+            executionPayload1.BlockHash, TestItem.KeccakA, executionPayload2.BlockHash
         };
-        var payloadBodies = rpc.engine_getPayloadBodiesByHashV1(blockHashes).Result.Data;
-        var expected = new ExecutionPayloadBodyV1Result?[]
+        IEnumerable<ExecutionPayloadBodyV1Result?> payloadBodies =
+            rpc.engine_getPayloadBodiesByHashV1(blockHashes).Result.Data;
+        ExecutionPayloadBodyV1Result[] expected = new ExecutionPayloadBodyV1Result?[]
         {
-            new(Array.Empty<Transaction>(), withdrawals),
-            null,
-            new(txs, withdrawals)
+            new(Array.Empty<Transaction>(), withdrawals), null, new(txs, withdrawals)
         };
 
         payloadBodies.Should().BeEquivalentTo(expected, o => o.WithStrictOrdering());
     }
 
     [TestCaseSource(nameof(GetPayloadWithdrawalsTestCases))]
-    public virtual async Task getPayloadBodiesByRangeV1_should_return_payload_bodies_in_order_of_request_range_and_null_for_unknown_indexes(
-        IList<Withdrawal> withdrawals)
+    public virtual async Task
+        getPayloadBodiesByRangeV1_should_return_payload_bodies_in_order_of_request_range_and_null_for_unknown_indexes(
+            IList<Withdrawal> withdrawals)
     {
-        using var chain = await CreateShanghaiBlockChain();
-        var rpc = CreateEngineModule(chain);
-        var executionPayload1 = await SendNewBlockV2(rpc, chain, withdrawals);
-        var txs = BuildTransactions(
+        using MergeTestBlockchain chain = await CreateShanghaiBlockChain();
+        IEngineRpcModule rpc = CreateEngineModule(chain);
+        ExecutionPayload executionPayload1 = await SendNewBlockV2(rpc, chain, withdrawals);
+        Transaction[] txs = BuildTransactions(
             chain, executionPayload1.BlockHash, TestItem.PrivateKeyA, TestItem.AddressB, 3, 0, out _, out _);
 
         chain.AddTransactions(txs);
 
         await BuildAndSendNewBlockV2(rpc, chain, true, withdrawals);
-        var executionPayload2 = await BuildAndSendNewBlockV2(rpc, chain, true, withdrawals);
+        ExecutionPayload executionPayload2 = await BuildAndSendNewBlockV2(rpc, chain, true, withdrawals);
 
         await rpc.engine_forkchoiceUpdatedV2(new ForkchoiceStateV1(executionPayload2.BlockHash!,
             executionPayload2.BlockHash!, executionPayload2.BlockHash!));
 
-        var payloadBodies = rpc.engine_getPayloadBodiesByRangeV1(1, 3).Result.Data;
-        var expected = new ExecutionPayloadBodyV1Result?[]
-        {
-            new(txs, withdrawals)
-        };
+        IEnumerable<ExecutionPayloadBodyV1Result?> payloadBodies =
+            rpc.engine_getPayloadBodiesByRangeV1(1, 3).Result.Data;
+        ExecutionPayloadBodyV1Result[] expected = new ExecutionPayloadBodyV1Result?[] { new(txs, withdrawals) };
 
         payloadBodies.Should().BeEquivalentTo(expected, o => o.WithStrictOrdering());
     }
@@ -371,10 +370,11 @@ public partial class EngineModuleTests
     [Test]
     public async Task getPayloadBodiesByRangeV1_empty_response()
     {
-        using var chain = await CreateBlockChain();
-        var rpc = CreateEngineModule(chain);
-        var payloadBodies = rpc.engine_getPayloadBodiesByRangeV1(1, 1).Result.Data;
-        var expected = Array.Empty<ExecutionPayloadBodyV1Result?>();
+        using MergeTestBlockchain chain = await CreateBlockChain();
+        IEngineRpcModule rpc = CreateEngineModule(chain);
+        IEnumerable<ExecutionPayloadBodyV1Result?> payloadBodies =
+            rpc.engine_getPayloadBodiesByRangeV1(1, 1).Result.Data;
+        ExecutionPayloadBodyV1Result[] expected = Array.Empty<ExecutionPayloadBodyV1Result?>();
 
         payloadBodies.Should().BeEquivalentTo(expected);
     }
@@ -382,9 +382,10 @@ public partial class EngineModuleTests
     [Test]
     public async Task getPayloadBodiesByRangeV1_should_fail_when_too_many_payloads_requested()
     {
-        using var chain = await CreateBlockChain();
-        var rpc = CreateEngineModule(chain);
-        var result = rpc.engine_getPayloadBodiesByRangeV1(1, 1025);
+        using MergeTestBlockchain chain = await CreateBlockChain();
+        IEngineRpcModule rpc = CreateEngineModule(chain);
+        Task<ResultWrapper<IEnumerable<ExecutionPayloadBodyV1Result?>>> result =
+            rpc.engine_getPayloadBodiesByRangeV1(1, 1025);
 
         result.Result.ErrorCode.Should().Be(MergeErrorCodes.TooLargeRequest);
     }
@@ -392,10 +393,11 @@ public partial class EngineModuleTests
     [Test]
     public async Task getPayloadBodiesByHashV1_should_fail_when_too_many_payloads_requested()
     {
-        using var chain = await CreateBlockChain();
-        var rpc = CreateEngineModule(chain);
-        var hashes = Enumerable.Repeat(TestItem.KeccakA, 1025).ToArray();
-        var result = rpc.engine_getPayloadBodiesByHashV1(hashes);
+        using MergeTestBlockchain chain = await CreateBlockChain();
+        IEngineRpcModule rpc = CreateEngineModule(chain);
+        Keccak[] hashes = Enumerable.Repeat(TestItem.KeccakA, 1025).ToArray();
+        Task<ResultWrapper<IEnumerable<ExecutionPayloadBodyV1Result?>>> result =
+            rpc.engine_getPayloadBodiesByHashV1(hashes);
 
         result.Result.ErrorCode.Should().Be(MergeErrorCodes.TooLargeRequest);
     }
@@ -403,9 +405,10 @@ public partial class EngineModuleTests
     [Test]
     public async Task getPayloadBodiesByRangeV1_should_fail_when_params_below_1()
     {
-        using var chain = await CreateBlockChain();
-        var rpc = CreateEngineModule(chain);
-        var result = rpc.engine_getPayloadBodiesByRangeV1(0, 1);
+        using MergeTestBlockchain chain = await CreateBlockChain();
+        IEngineRpcModule rpc = CreateEngineModule(chain);
+        Task<ResultWrapper<IEnumerable<ExecutionPayloadBodyV1Result?>>> result =
+            rpc.engine_getPayloadBodiesByRangeV1(0, 1);
 
         result.Result.ErrorCode.Should().Be(ErrorCodes.InvalidParams);
 
@@ -417,38 +420,38 @@ public partial class EngineModuleTests
     [TestCaseSource(nameof(GetPayloadWithdrawalsTestCases))]
     public virtual async Task getPayloadBodiesByRangeV1_should_return_canonical(IList<Withdrawal> withdrawals)
     {
-        using var chain = await CreateShanghaiBlockChain();
-        var rpc = CreateEngineModule(chain);
-        var executionPayload1 = await SendNewBlockV2(rpc, chain, withdrawals);
+        using MergeTestBlockchain chain = await CreateShanghaiBlockChain();
+        IEngineRpcModule rpc = CreateEngineModule(chain);
+        ExecutionPayload executionPayload1 = await SendNewBlockV2(rpc, chain, withdrawals);
 
         await rpc.engine_forkchoiceUpdatedV2(new ForkchoiceStateV1(executionPayload1.BlockHash!,
             executionPayload1.BlockHash!, executionPayload1.BlockHash!));
 
-        var head = chain.BlockTree.Head!;
+        Block head = chain.BlockTree.Head!;
 
         // First branch
         {
-            var txsA = BuildTransactions(
+            Transaction[] txsA = BuildTransactions(
                 chain, executionPayload1.BlockHash!, TestItem.PrivateKeyA, TestItem.AddressA, 1, 0, out _, out _);
 
             chain.AddTransactions(txsA);
 
-            var executionPayload2 = await BuildAndGetPayloadResultV2(
+            ExecutionPayload executionPayload2 = await BuildAndGetPayloadResultV2(
                 rpc, chain, head.Hash!, head.Hash!, head.Hash!, 1001, Keccak.Zero, Address.Zero, withdrawals);
-            var execResult = await rpc.engine_newPayloadV2(executionPayload2);
+            ResultWrapper<PayloadStatusV1> execResult = await rpc.engine_newPayloadV2(executionPayload2);
 
             execResult.Data.Status.Should().Be(PayloadStatus.Valid);
 
-            var fcuResult = await rpc.engine_forkchoiceUpdatedV2(
+            ResultWrapper<ForkchoiceUpdatedV1Result> fcuResult = await rpc.engine_forkchoiceUpdatedV2(
                 new ForkchoiceStateV1(executionPayload2.BlockHash!, head.Hash!, head.Hash!));
 
             fcuResult.Data.PayloadStatus.Status.Should().Be(PayloadStatus.Valid);
 
-            var payloadBodies = rpc.engine_getPayloadBodiesByRangeV1(1, 3).Result.Data;
-            var expected = new ExecutionPayloadBodyV1Result?[]
+            IEnumerable<ExecutionPayloadBodyV1Result?> payloadBodies =
+                rpc.engine_getPayloadBodiesByRangeV1(1, 3).Result.Data;
+            ExecutionPayloadBodyV1Result[] expected =
             {
-                new(Array.Empty<Transaction>(), withdrawals),
-                new(txsA, withdrawals)
+                new(Array.Empty<Transaction>(), withdrawals), new(txsA, withdrawals)
             };
 
             payloadBodies.Should().BeEquivalentTo(expected, o => o.WithStrictOrdering());
@@ -456,7 +459,7 @@ public partial class EngineModuleTests
 
         // Second branch
         {
-            var newBlock = Build.A.Block
+            Block newBlock = Build.A.Block
                 .WithNumber(head.Number + 1)
                 .WithParent(head)
                 .WithNonce(0)
@@ -466,18 +469,18 @@ public partial class EngineModuleTests
                 .WithWithdrawals(withdrawals.ToArray())
                 .TestObject;
 
-            var fcuResult = await rpc.engine_newPayloadV2(new ExecutionPayload(newBlock));
+            ResultWrapper<PayloadStatusV1> fcuResult = await rpc.engine_newPayloadV2(new ExecutionPayload(newBlock));
 
             fcuResult.Data.Status.Should().Be(PayloadStatus.Valid);
 
             await rpc.engine_forkchoiceUpdatedV2(
                 new ForkchoiceStateV1(newBlock.Hash!, newBlock.Hash!, newBlock.Hash!));
 
-            var payloadBodies = rpc.engine_getPayloadBodiesByRangeV1(1, 3).Result.Data;
-            var expected = new ExecutionPayloadBodyV1Result?[]
+            IEnumerable<ExecutionPayloadBodyV1Result?> payloadBodies =
+                rpc.engine_getPayloadBodiesByRangeV1(1, 3).Result.Data;
+            ExecutionPayloadBodyV1Result[] expected =
             {
-                new(Array.Empty<Transaction>(), withdrawals),
-                new(Array.Empty<Transaction>(), withdrawals)
+                new(Array.Empty<Transaction>(), withdrawals), new(Array.Empty<Transaction>(), withdrawals)
             };
 
             payloadBodies.Should().BeEquivalentTo(expected, o => o.WithStrictOrdering());
@@ -487,18 +490,19 @@ public partial class EngineModuleTests
     [TestCaseSource(nameof(PayloadBodiesByRangeNullTrimTestCases))]
     public async Task getPayloadBodiesByRangeV1_should_trim_trailing_null_bodies(
         (Func<CallInfo, Block?> Impl,
-        IEnumerable<ExecutionPayloadBodyV1Result?> Outcome) input)
+            IEnumerable<ExecutionPayloadBodyV1Result?> Outcome) input)
     {
-        var blockTree = Substitute.For<IBlockTree>();
+        IBlockTree? blockTree = Substitute.For<IBlockTree>();
 
         blockTree.Head.Returns(Build.A.Block.WithNumber(5).TestObject);
         blockTree.FindBlock(Arg.Any<long>()).Returns(input.Impl);
 
-        using var chain = await CreateShanghaiBlockChain();
+        using MergeTestBlockchain chain = await CreateShanghaiBlockChain();
         chain.BlockTree = blockTree;
 
-        var rpc = CreateEngineModule(chain);
-        var payloadBodies = rpc.engine_getPayloadBodiesByRangeV1(1, 5).Result.Data;
+        IEngineRpcModule rpc = CreateEngineModule(chain);
+        IEnumerable<ExecutionPayloadBodyV1Result?> payloadBodies =
+            rpc.engine_getPayloadBodiesByRangeV1(1, 5).Result.Data;
 
         payloadBodies.Should().BeEquivalentTo(input.Outcome);
     }
@@ -506,17 +510,18 @@ public partial class EngineModuleTests
     [Test]
     public async Task getPayloadBodiesByRangeV1_should_return_up_to_best_body_number()
     {
-        var blockTree = Substitute.For<IBlockTree>();
+        IBlockTree? blockTree = Substitute.For<IBlockTree>();
 
         blockTree.FindBlock(Arg.Any<long>())
             .Returns(i => Build.A.Block.WithNumber(i.ArgAt<long>(0)).TestObject);
         blockTree.Head.Returns(Build.A.Block.WithNumber(5).TestObject);
 
-        using var chain = await CreateShanghaiBlockChain();
+        using MergeTestBlockchain chain = await CreateShanghaiBlockChain();
         chain.BlockTree = blockTree;
 
-        var rpc = CreateEngineModule(chain);
-        var payloadBodies = rpc.engine_getPayloadBodiesByRangeV1(1, 7).Result.Data;
+        IEngineRpcModule rpc = CreateEngineModule(chain);
+        IEnumerable<ExecutionPayloadBodyV1Result?> payloadBodies =
+            rpc.engine_getPayloadBodiesByRangeV1(1, 7).Result.Data;
 
         payloadBodies.Count().Should().Be(5);
     }
@@ -626,7 +631,8 @@ public partial class EngineModuleTests
     {
         using MergeTestBlockchain chain = await CreateBlockChain(null, null, input.ReleaseSpec);
         IEngineRpcModule rpc = CreateEngineModule(chain);
-        ExecutionPayload executionPayload = CreateBlockRequest(CreateParentBlockRequestOnHead(chain.BlockTree), TestItem.AddressD, input.Withdrawals);
+        ExecutionPayload executionPayload = CreateBlockRequest(CreateParentBlockRequestOnHead(chain.BlockTree),
+            TestItem.AddressD, input.Withdrawals);
         ResultWrapper<PayloadStatusV1> resultWrapper = await rpc.engine_newPayloadV2(executionPayload);
 
         if (input.IsValid)
@@ -636,7 +642,8 @@ public partial class EngineModuleTests
     }
 
     [TestCaseSource(nameof(WithdrawalsTestCases))]
-    public virtual async Task Can_apply_withdrawals_correctly((Withdrawal[][] Withdrawals, (Address Account, UInt256 BalanceIncrease)[] ExpectedAccountIncrease) input)
+    public virtual async Task Can_apply_withdrawals_correctly(
+        (Withdrawal[][] Withdrawals, (Address Account, UInt256 BalanceIncrease)[] ExpectedAccountIncrease) input)
     {
         using MergeTestBlockchain chain = await CreateShanghaiBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
@@ -645,14 +652,22 @@ public partial class EngineModuleTests
         List<UInt256> initialBalances = new();
         foreach ((Address Account, UInt256 BalanceIncrease) accountIncrease in input.ExpectedAccountIncrease)
         {
-            UInt256 initialBalance = chain.StateReader.GetBalance(chain.BlockTree.Head!.StateRoot!, accountIncrease.Account);
+            UInt256 initialBalance =
+                chain.StateReader.GetBalance(chain.BlockTree.Head!.StateRoot!, accountIncrease.Account);
             initialBalances.Add(initialBalance);
         }
 
         foreach (Withdrawal[] withdrawal in input.Withdrawals)
         {
-            PayloadAttributes payloadAttributes = new() { Timestamp = chain.BlockTree.Head!.Timestamp + 1, PrevRandao = TestItem.KeccakH, SuggestedFeeRecipient = TestItem.AddressF, Withdrawals = withdrawal };
-            ExecutionPayload payload = (await BuildAndGetPayloadResultV2(rpc, chain, payloadAttributes))?.ExecutionPayload!;
+            PayloadAttributes payloadAttributes = new()
+            {
+                Timestamp = chain.BlockTree.Head!.Timestamp + 1,
+                PrevRandao = TestItem.KeccakH,
+                SuggestedFeeRecipient = TestItem.AddressF,
+                Withdrawals = withdrawal
+            };
+            ExecutionPayload payload =
+                (await BuildAndGetPayloadResultV2(rpc, chain, payloadAttributes))?.ExecutionPayload!;
             ResultWrapper<PayloadStatusV1> resultWrapper = await rpc.engine_newPayloadV2(payload!);
             resultWrapper.Data.Status.Should().Be(PayloadStatus.Valid);
             ResultWrapper<ForkchoiceUpdatedV1Result> resultFcu = await rpc.engine_forkchoiceUpdatedV2(
@@ -664,7 +679,8 @@ public partial class EngineModuleTests
         for (int index = 0; index < input.ExpectedAccountIncrease.Length; index++)
         {
             (Address Account, UInt256 BalanceIncrease) accountIncrease = input.ExpectedAccountIncrease[index];
-            UInt256 currentBalance = chain.StateReader.GetBalance(chain.BlockTree.Head!.StateRoot!, accountIncrease.Account);
+            UInt256 currentBalance =
+                chain.StateReader.GetBalance(chain.BlockTree.Head!.StateRoot!, accountIncrease.Account);
             currentBalance.Should().Be(accountIncrease.BalanceIncrease + initialBalances[index]);
         }
     }
@@ -676,14 +692,15 @@ public partial class EngineModuleTests
         CustomSpecProvider specProvider = new(
             (new ForkActivation(0, null), ArrowGlacier.Instance),
             (new ForkActivation(0, 3), Shanghai.Instance)
-            );
+        );
 
         // Genesis, Timestamp = 1
         using MergeTestBlockchain chain = await CreateBlockChain(specProvider);
         IEngineRpcModule rpc = CreateEngineModule(chain);
 
         // Block without withdrawals, Timestamp = 2
-        ExecutionPayload executionPayload = CreateBlockRequest(CreateParentBlockRequestOnHead(chain.BlockTree), TestItem.AddressD);
+        ExecutionPayload executionPayload =
+            CreateBlockRequest(CreateParentBlockRequestOnHead(chain.BlockTree), TestItem.AddressD);
         ResultWrapper<PayloadStatusV1> resultWrapper = await rpc.engine_newPayloadV2(executionPayload);
         resultWrapper.Data.Status.Should().Be(PayloadStatus.Valid);
 
@@ -695,7 +712,8 @@ public partial class EngineModuleTests
             SuggestedFeeRecipient = TestItem.AddressF,
             Withdrawals = new[] { TestItem.WithdrawalA_1Eth }
         };
-        ExecutionPayload payloadWithWithdrawals = (await BuildAndGetPayloadResultV2(rpc, chain, payloadAttributes))?.ExecutionPayload!;
+        ExecutionPayload payloadWithWithdrawals =
+            (await BuildAndGetPayloadResultV2(rpc, chain, payloadAttributes))?.ExecutionPayload!;
         ResultWrapper<PayloadStatusV1> resultWithWithdrawals = await rpc.engine_newPayloadV2(payloadWithWithdrawals!);
 
         resultWithWithdrawals.Data.Status.Should().Be(PayloadStatus.Valid);
@@ -737,25 +755,35 @@ public partial class EngineModuleTests
         (Address, UInt256)[] expectedAccountIncrease)> WithdrawalsTestCases()
     {
         yield return (new[] { Array.Empty<Withdrawal>() }, Array.Empty<(Address, UInt256)>());
-        yield return (new[] { new[] { TestItem.WithdrawalA_1Eth, TestItem.WithdrawalB_2Eth } }, new[] { (TestItem.AddressA, 1.Ether()), (TestItem.AddressB, 2.Ether()) });
-        yield return (new[] { new[] { TestItem.WithdrawalA_1Eth, TestItem.WithdrawalA_1Eth } }, new[] { (TestItem.AddressA, 2.Ether()), (TestItem.AddressB, 0.Ether()) });
-        yield return (new[] { new[] { TestItem.WithdrawalA_1Eth, TestItem.WithdrawalA_1Eth }, new[] { TestItem.WithdrawalA_1Eth } }, new[] { (TestItem.AddressA, 3.Ether()), (TestItem.AddressB, 0.Ether()) });
+        yield return (new[] { new[] { TestItem.WithdrawalA_1Eth, TestItem.WithdrawalB_2Eth } },
+            new[] { (TestItem.AddressA, 1.Ether()), (TestItem.AddressB, 2.Ether()) });
+        yield return (new[] { new[] { TestItem.WithdrawalA_1Eth, TestItem.WithdrawalA_1Eth } },
+            new[] { (TestItem.AddressA, 2.Ether()), (TestItem.AddressB, 0.Ether()) });
+        yield return (
+            new[]
+            {
+                new[] { TestItem.WithdrawalA_1Eth, TestItem.WithdrawalA_1Eth }, new[] { TestItem.WithdrawalA_1Eth }
+            }, new[] { (TestItem.AddressA, 3.Ether()), (TestItem.AddressB, 0.Ether()) });
         yield return (new[]
-        {
-            new[] { TestItem.WithdrawalA_1Eth, TestItem.WithdrawalA_1Eth }, // 1st payload
-            new[] { TestItem.WithdrawalA_1Eth }, // 2nd payload
-            Array.Empty<Withdrawal>(), // 3rd payload
-            new[] { TestItem.WithdrawalA_1Eth, TestItem.WithdrawalC_3Eth }, // 4th payload
-            new[] { TestItem.WithdrawalB_2Eth, TestItem.WithdrawalF_6Eth }, // 5th payload
-        }, new[] { (TestItem.AddressA, 4.Ether()), (TestItem.AddressB, 2.Ether()), (TestItem.AddressC, 3.Ether()), (TestItem.AddressF, 6.Ether()) });
+            {
+                new[] { TestItem.WithdrawalA_1Eth, TestItem.WithdrawalA_1Eth }, // 1st payload
+                new[] { TestItem.WithdrawalA_1Eth }, // 2nd payload
+                Array.Empty<Withdrawal>(), // 3rd payload
+                new[] { TestItem.WithdrawalA_1Eth, TestItem.WithdrawalC_3Eth }, // 4th payload
+                new[] { TestItem.WithdrawalB_2Eth, TestItem.WithdrawalF_6Eth }, // 5th payload
+            },
+            new[]
+            {
+                (TestItem.AddressA, 4.Ether()), (TestItem.AddressB, 2.Ether()), (TestItem.AddressC, 3.Ether()),
+                (TestItem.AddressF, 6.Ether())
+            });
     }
 
     protected static IEnumerable<IList<Withdrawal>> GetPayloadWithdrawalsTestCases()
     {
         yield return new[]
         {
-            new Withdrawal { Index = 1, ValidatorIndex = 1 },
-            new Withdrawal { Index = 2, ValidatorIndex = 2 }
+            new Withdrawal { Index = 1, ValidatorIndex = 1 }, new Withdrawal { Index = 2, ValidatorIndex = 2 }
         };
     }
 
@@ -771,7 +799,7 @@ public partial class EngineModuleTests
         IList<Withdrawal>? withdrawals,
         bool waitForBlockImprovement = true)
     {
-        using var blockImprovementLock = new SemaphoreSlim(0);
+        using SemaphoreSlim blockImprovementLock = new SemaphoreSlim(0);
 
         if (waitForBlockImprovement)
         {
@@ -781,20 +809,21 @@ public partial class EngineModuleTests
             };
         }
 
-        var forkchoiceState = new ForkchoiceStateV1(headBlockHash, finalizedBlockHash, safeBlockHash);
-        var payloadAttributes = new PayloadAttributes
+        ForkchoiceStateV1 forkchoiceState = new ForkchoiceStateV1(headBlockHash, finalizedBlockHash, safeBlockHash);
+        PayloadAttributes payloadAttributes = new PayloadAttributes
         {
             Timestamp = timestamp,
             PrevRandao = random,
             SuggestedFeeRecipient = feeRecipient,
             Withdrawals = withdrawals
         };
-        var payloadId = rpc.engine_forkchoiceUpdatedV2(forkchoiceState, payloadAttributes).Result.Data.PayloadId;
+        string? payloadId = rpc.engine_forkchoiceUpdatedV2(forkchoiceState, payloadAttributes).Result.Data.PayloadId;
 
         if (waitForBlockImprovement)
             await blockImprovementLock.WaitAsync(10000);
 
-        var getPayloadResult = await rpc.engine_getPayloadV1(Bytes.FromHexString(payloadId!));
+        ResultWrapper<ExecutionPayload?> getPayloadResult =
+            await rpc.engine_getPayloadV1(Bytes.FromHexString(payloadId!));
 
         return getPayloadResult.Data!;
     }
@@ -817,11 +846,12 @@ public partial class EngineModuleTests
         return executionPayload;
     }
 
-    private async Task<ExecutionPayload> SendNewBlockV2(IEngineRpcModule rpc, MergeTestBlockchain chain, IList<Withdrawal>? withdrawals)
+    private async Task<ExecutionPayload> SendNewBlockV2(IEngineRpcModule rpc, MergeTestBlockchain chain,
+        IList<Withdrawal>? withdrawals)
     {
-        var executionPayload = CreateBlockRequest(
+        ExecutionPayload executionPayload = CreateBlockRequest(
             CreateParentBlockRequestOnHead(chain.BlockTree), TestItem.AddressD, withdrawals);
-        var executePayloadResult = await rpc.engine_newPayloadV2(executionPayload);
+        ResultWrapper<PayloadStatusV1> executePayloadResult = await rpc.engine_newPayloadV2(executionPayload);
 
         executePayloadResult.Data.Status.Should().Be(PayloadStatus.Valid);
 
@@ -846,8 +876,8 @@ public partial class EngineModuleTests
         IEnumerable<ExecutionPayloadBodyV1Result?>
         )> PayloadBodiesByRangeNullTrimTestCases()
     {
-        var block = Build.A.Block.TestObject;
-        var result = new ExecutionPayloadBodyV1Result(Array.Empty<Transaction>(), null);
+        Block block = Build.A.Block.TestObject;
+        ExecutionPayloadBodyV1Result result = new ExecutionPayloadBodyV1Result(Array.Empty<Transaction>(), null);
 
         yield return (
             new Func<CallInfo, Block?>(i => null),

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V3.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V3.cs
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Nethermind.Consensus.Producers;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Specs;
+using Nethermind.Core.Test.Builders;
+using Nethermind.JsonRpc;
+using Nethermind.Merge.Plugin.Data;
+using Nethermind.Specs.Forks;
+using NUnit.Framework;
+using Transaction = Nethermind.Core.Transaction;
+
+namespace Nethermind.Merge.Plugin.Test;
+
+public partial class EngineModuleTests
+{
+    [TestCaseSource(nameof(ExcessDataGasInGetPayloadV3ForDifferentSpecTestSource))]
+    public async Task ExccessDataGas_should_present_in_cancun_only((IReleaseSpec Spec, bool IsExcessDataGasSet) input)
+    {
+        (IEngineRpcModule rpcModule, string payloadId) = await BuildAndGetPayloadV3Result(input.Spec);
+        ResultWrapper<GetPayloadV2Result?> getPayloadResult =
+            await rpcModule.engine_getPayloadV3(Bytes.FromHexString(payloadId));
+        Assert.That(getPayloadResult.Data!.ExecutionPayload.ExcessDataGas.HasValue,
+            Is.EqualTo(input.IsExcessDataGasSet));
+    }
+
+    [Test]
+    public async Task GetPayloadV3_should_fail_on_unknown_payload()
+    {
+        using SemaphoreSlim blockImprovementLock = new(0);
+        using MergeTestBlockchain chain = await CreateBlockChain();
+        IEngineRpcModule rpc = CreateEngineModule(chain);
+
+        byte[] payloadId = Bytes.FromHexString("0x0");
+        ResultWrapper<GetPayloadV2Result?> responseFirst = await rpc.engine_getPayloadV3(payloadId);
+        responseFirst.Should().NotBeNull();
+        responseFirst.Result.ResultType.Should().Be(ResultType.Failure);
+        responseFirst.ErrorCode.Should().Be(MergeErrorCodes.UnknownPayload);
+    }
+
+    [TestCase(1)]
+    [TestCase(2)]
+    [TestCase(3)]
+    [TestCase(4)]
+    public async Task BlobsBundleV1_should_return_blobs_and_kzgs(int blobTxCount)
+    {
+        (IEngineRpcModule rpcModule, string payloadId) = await BuildAndGetPayloadV3Result(Cancun.Instance, blobTxCount);
+        BlobsBundleV1 getPayloadResultData =
+            (await rpcModule.engine_getBlobsBundleV1(Bytes.FromHexString(payloadId))).Data!;
+        Assert.That(getPayloadResultData.Blobs.Length, Is.EqualTo(blobTxCount));
+        Assert.That(getPayloadResultData.Kzgs.Length, Is.EqualTo(blobTxCount));
+    }
+
+    private async Task<ExecutionPayload> SendNewBlockV3(IEngineRpcModule rpc, MergeTestBlockchain chain, IList<Withdrawal>? withdrawals)
+    {
+        ExecutionPayload executionPayload = CreateBlockRequest(
+            CreateParentBlockRequestOnHead(chain.BlockTree), TestItem.AddressD, withdrawals, 0);
+        ResultWrapper<PayloadStatusV1> executePayloadResult = await rpc.engine_newPayloadV3(executionPayload);
+
+        executePayloadResult.Data.Status.Should().Be(PayloadStatus.Valid);
+
+        return executionPayload;
+    }
+
+    private async Task<(IEngineRpcModule, string)> BuildAndGetPayloadV3Result(
+        IReleaseSpec spec, int transactionCount = 0)
+    {
+        MergeTestBlockchain chain = await CreateBlockChain(releaseSpec: spec);
+        IEngineRpcModule rpcModule = CreateEngineModule(chain);
+        if (transactionCount is not 0)
+        {
+            using SemaphoreSlim blockImprovementLock = new(0);
+
+            ExecutionPayload executionPayload1 = await SendNewBlockV3(rpcModule, chain, new List<Withdrawal>());
+            Transaction[] txs = BuildTransactions(
+                chain, executionPayload1.BlockHash, TestItem.PrivateKeyA, TestItem.AddressB, (uint)transactionCount, 0, out _, out _, 1);
+            foreach (Transaction tx in txs)
+            {
+                tx.Type = TxType.Blob;
+                tx.MaxFeePerDataGas = 1;
+            }
+            chain.AddTransactions(txs);
+
+            EventHandler<BlockEventArgs> onBlockImprovedHandler = (_, _) => blockImprovementLock.Release(1);
+
+            chain.PayloadPreparationService!.BlockImproved += onBlockImprovedHandler;
+            await blockImprovementLock.WaitAsync(10000);
+            chain.PayloadPreparationService!.BlockImproved -= onBlockImprovedHandler;
+        }
+
+        PayloadAttributes payloadAttributes = new()
+        {
+            Timestamp = chain.BlockTree.Head!.Timestamp + 1,
+            PrevRandao = TestItem.KeccakH,
+            SuggestedFeeRecipient = TestItem.AddressF,
+            Withdrawals = new List<Withdrawal> { TestItem.WithdrawalA_1Eth }
+        };
+        Keccak currentHeadHash = chain.BlockTree.HeadHash;
+        ForkchoiceStateV1 forkchoiceState = new(currentHeadHash, currentHeadHash, currentHeadHash);
+        string payloadId = rpcModule.engine_forkchoiceUpdatedV2(forkchoiceState, payloadAttributes).Result.Data
+            .PayloadId!;
+        return (rpcModule, payloadId);
+    }
+
+    protected static IEnumerable<(IReleaseSpec Spec, bool IsExcessDataGasSet)> ExcessDataGasInGetPayloadV3ForDifferentSpecTestSource()
+    {
+        yield return (Shanghai.Instance, false);
+        yield return (Cancun.Instance, true);
+    }
+}

--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/BlobsBundleV1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/BlobsBundleV1.cs
@@ -1,0 +1,69 @@
+//  Copyright (c) 2021 Demerzel Solutions Limited
+//  This file is part of the Nethermind library.
+//
+//  The Nethermind library is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  The Nethermind library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with the Nethermind. If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+using System.Collections.Generic;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Newtonsoft.Json;
+
+namespace Nethermind.Merge.Plugin.Data
+{
+    /// <summary>
+    /// A data object representing a block as being sent from the execution layer to the consensus layer.
+    ///
+    /// See <a href="https://github.com/ethereum/execution-apis/blob/main/src/engine/experimental/blob-extension.md#blobsbundlev1">BlobsBundleV1</a>
+    /// </summary>
+    public class BlobsBundleV1
+    {
+        public BlobsBundleV1()
+        {
+            BlockHash = Keccak.Zero;
+        }
+
+        public BlobsBundleV1(Block block)
+        {
+            BlockHash = block.Hash!;
+            List<Memory<byte>> kzgs = new();
+            List<Memory<byte>> blobs = new();
+            foreach (Transaction? tx in block.Transactions)
+            {
+                if (tx.Type is not TxType.Blob || tx.BlobKzgs is null || tx.Blobs is null)
+                {
+                    continue;
+                }
+
+                for (int cc = 0, bc = 0;
+                     cc < tx.BlobKzgs.Length;
+                     cc += Ckzg.Ckzg.BytesPerCommitment, bc += Ckzg.Ckzg.BytesPerBlob)
+                {
+                    kzgs.Add(tx.BlobKzgs.AsMemory(cc, cc + Ckzg.Ckzg.BytesPerCommitment));
+                    blobs.Add(tx.Blobs.AsMemory(bc, bc + Ckzg.Ckzg.BytesPerBlob));
+                }
+            }
+
+            Kzgs = kzgs.ToArray();
+            Blobs = blobs.ToArray();
+        }
+
+        public Memory<byte>[] Kzgs { get; set; } = Array.Empty<Memory<byte>>();
+        public Memory<byte>[] Blobs { get; set; } = Array.Empty<Memory<byte>>();
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Include)]
+        public Keccak? BlockHash { get; set; } = null!;
+    }
+}

--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayload.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayload.cs
@@ -83,7 +83,7 @@ public class ExecutionPayload
     /// </summary>
     public IEnumerable<Withdrawal>? Withdrawals { get; set; }
 
-    [JsonConverter(typeof(NullableUInt256Converter))]
+    [JsonProperty(ItemConverterType = typeof(NullableUInt256Converter), NullValueHandling = NullValueHandling.Ignore)]
     public UInt256? ExcessDataGas { get; set; }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.Cancun.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.Cancun.cs
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Threading.Tasks;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Specs;
+using Nethermind.JsonRpc;
+using Nethermind.Logging;
+using Nethermind.Merge.Plugin.Data;
+using Nethermind.Merge.Plugin.Handlers;
+
+namespace Nethermind.Merge.Plugin;
+
+public partial class EngineRpcModule : IEngineRpcModule
+{
+    private readonly IAsyncHandler<byte[], GetPayloadV2Result?> _getPayloadHandlerV3;
+    private readonly IAsyncHandler<byte[], BlobsBundleV1?> _getBlobsBundleV1Handler;
+
+    public Task<ResultWrapper<PayloadStatusV1>> engine_newPayloadV3(ExecutionPayload executionPayload) =>
+        NewPayload(executionPayload, 3);
+
+    public async Task<ResultWrapper<GetPayloadV2Result?>> engine_getPayloadV3(byte[] payloadId) =>
+        await _getPayloadHandlerV3.HandleAsync(payloadId);
+
+    public async Task<ResultWrapper<BlobsBundleV1?>> engine_getBlobsBundleV1(byte[] payloadId) =>
+        await (_getBlobsBundleV1Handler.HandleAsync(payloadId));
+}

--- a/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.cs
@@ -23,6 +23,8 @@ public partial class EngineRpcModule : IEngineRpcModule
     public EngineRpcModule(
         IAsyncHandler<byte[], ExecutionPayload?> getPayloadHandlerV1,
         IAsyncHandler<byte[], GetPayloadV2Result?> getPayloadHandlerV2,
+        IAsyncHandler<byte[], GetPayloadV2Result?> getPayloadHandlerV3,
+        IAsyncHandler<byte[], BlobsBundleV1?> getBlobsBundleV1Handler,
         IAsyncHandler<ExecutionPayload, PayloadStatusV1> newPayloadV1Handler,
         IForkchoiceUpdatedHandler forkchoiceUpdatedV1Handler,
         IAsyncHandler<IList<Keccak>, IEnumerable<ExecutionPayloadBodyV1Result?>> executionGetPayloadBodiesByHashV1Handler,
@@ -36,6 +38,8 @@ public partial class EngineRpcModule : IEngineRpcModule
         _capabilitiesHandler = capabilitiesHandler ?? throw new ArgumentNullException(nameof(capabilitiesHandler));
         _getPayloadHandlerV1 = getPayloadHandlerV1;
         _getPayloadHandlerV2 = getPayloadHandlerV2;
+        _getPayloadHandlerV3 = getPayloadHandlerV3;
+        _getBlobsBundleV1Handler = getBlobsBundleV1Handler;
         _newPayloadV1Handler = newPayloadV1Handler;
         _forkchoiceUpdatedV1Handler = forkchoiceUpdatedV1Handler;
         _executionGetPayloadBodiesByHashV1Handler = executionGetPayloadBodiesByHashV1Handler;

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/EngineRpcCapabilitiesProvider.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/EngineRpcCapabilitiesProvider.cs
@@ -39,6 +39,12 @@ public class EngineRpcCapabilitiesProvider : IRpcCapabilitiesProvider
             _capabilities[nameof(IEngineRpcModule.engine_getPayloadV2)] = spec.WithdrawalsEnabled;
             _capabilities[nameof(IEngineRpcModule.engine_newPayloadV2)] = spec.WithdrawalsEnabled;
             #endregion
+
+            #region Cancun
+            _capabilities[nameof(IEngineRpcModule.engine_getBlobsBundleV1)] = spec.IsEip4844Enabled;
+            _capabilities[nameof(IEngineRpcModule.engine_getPayloadV3)] = spec.IsEip4844Enabled;
+            _capabilities[nameof(IEngineRpcModule.engine_newPayloadV3)] = spec.IsEip4844Enabled;
+            #endregion
         }
 
         return _capabilities;

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetBlobsBundleV1Handler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetBlobsBundleV1Handler.cs
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Threading.Tasks;
+using Nethermind.Core;
+using Nethermind.Core.Extensions;
+using Nethermind.JsonRpc;
+using Nethermind.Logging;
+using Nethermind.Merge.Plugin.BlockProduction;
+using Nethermind.Merge.Plugin.Data;
+
+namespace Nethermind.Merge.Plugin.Handlers;
+
+/// <summary>
+/// engine_getBlobsBundleV1
+///
+/// Given a 8 byte payload_id, it returns blobs and kzgs of the most recent version of an execution payload
+/// that is available by the time of the call or responds with an error.
+/// See <a href="https://github.com/ethereum/execution-apis/blob/main/src/engine/experimental/blob-extension.md#engine_getblobsbundlev1">engine_getblobsbundlev1</a>
+/// </summary>
+public class GetBlobsBundleV1Handler : IAsyncHandler<byte[], BlobsBundleV1?>
+{
+    private readonly IPayloadPreparationService _payloadPreparationService;
+    private readonly ILogger _logger;
+
+    public GetBlobsBundleV1Handler(IPayloadPreparationService payloadPreparationService, ILogManager logManager)
+    {
+        _payloadPreparationService = payloadPreparationService;
+        _logger = logManager.GetClassLogger();
+    }
+
+    public async Task<ResultWrapper<BlobsBundleV1?>> HandleAsync(byte[] payloadId)
+    {
+        string payloadStr = payloadId.ToHexString(true);
+        Block? block = (await _payloadPreparationService.GetPayload(payloadStr))?.CurrentBestBlock;
+
+        if (block is null)
+        {
+            // The call MUST return -38001: Unknown payload error if the build process identified by the payloadId does not exist.
+            if (_logger.IsWarn)
+                _logger.Warn(
+                    $"Block production for payload with id={payloadId.ToHexString()} failed - unknown payload.");
+            return ResultWrapper<BlobsBundleV1?>.Fail("unknown payload", MergeErrorCodes.UnknownPayload);
+        }
+
+        BlobsBundleV1 blobsBundle = new(block);
+        if (_logger.IsInfo)
+            _logger.Info(
+                $"GetBlobsBundleV1 result: {blobsBundle.Kzgs.Length} kzgs and blobs.");
+
+        Metrics.GetBlobsBundleRequests++;
+        Metrics.NumberOfTransactionsInGetBlobsBundle = block.Transactions.Length;
+        return ResultWrapper<BlobsBundleV1?>.Success(blobsBundle);
+    }
+}

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetPayloadV3Handler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetPayloadV3Handler.cs
@@ -12,14 +12,14 @@ using Nethermind.Merge.Plugin.Data;
 namespace Nethermind.Merge.Plugin.Handlers
 {
     /// <summary>
-    /// <see href="https://github.com/ethereum/execution-apis/blob/main/src/engine/shanghai.md#engine_getpayloadv2">engine_getpayloadv2</see>.
+    /// https://github.com/ethereum/execution-apis/blob/main/src/engine/experimental/blob-extension.md#engine_getpayloadv3
     /// </summary>
-    public class GetPayloadV2Handler : IAsyncHandler<byte[], GetPayloadV2Result?>
+    public class GetPayloadV3Handler : IAsyncHandler<byte[], GetPayloadV2Result?>
     {
         private readonly IPayloadPreparationService _payloadPreparationService;
         private readonly ILogger _logger;
 
-        public GetPayloadV2Handler(IPayloadPreparationService payloadPreparationService, ILogManager logManager)
+        public GetPayloadV3Handler(IPayloadPreparationService payloadPreparationService, ILogManager logManager)
         {
             _payloadPreparationService = payloadPreparationService;
             _logger = logManager.GetClassLogger();
@@ -38,7 +38,7 @@ namespace Nethermind.Merge.Plugin.Handlers
                 return ResultWrapper<GetPayloadV2Result?>.Fail("unknown payload", MergeErrorCodes.UnknownPayload);
             }
 
-            if (_logger.IsInfo) _logger.Info($"GetPayloadV2 result: {block.Header.ToString(BlockHeader.Format.Full)}.");
+            if (_logger.IsInfo) _logger.Info($"GetPayloadV3 result: {block.Header.ToString(BlockHeader.Format.Full)}.");
 
             Metrics.GetPayloadRequests++;
             Metrics.NumberOfTransactionsInGetPayload = block.Transactions.Length;

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/NewPayloadHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/NewPayloadHandler.cs
@@ -26,8 +26,8 @@ namespace Nethermind.Merge.Plugin.Handlers;
 
 /// <summary>
 /// Provides an execution payload handler as defined in Engine API
-/// <see href="https://github.com/ethereum/execution-apis/blob/main/src/engine/shanghai.md#engine_newpayloadv2">
-/// Shanghai</see> specification.
+/// <a href="https://github.com/ethereum/execution-apis/blob/main/src/engine/shanghai.md#engine_newpayloadv2">
+/// Shanghai</a> specification.
 /// </summary>
 public class NewPayloadHandler : IAsyncHandler<ExecutionPayload, PayloadStatusV1>
 {

--- a/src/Nethermind/Nethermind.Merge.Plugin/IEngineRpcModule.Cancun.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/IEngineRpcModule.Cancun.cs
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Nethermind.JsonRpc;
+using Nethermind.JsonRpc.Modules;
+using Nethermind.Merge.Plugin.Data;
+
+namespace Nethermind.Merge.Plugin;
+
+public partial interface IEngineRpcModule : IRpcModule
+{
+    [JsonRpcMethod(
+        Description = "Verifies the payload according to the execution environment rules and returns the verification status and hash of the last valid block.",
+        IsSharable = true,
+        IsImplemented = true)]
+    Task<ResultWrapper<PayloadStatusV1>> engine_newPayloadV3(ExecutionPayload executionPayload);
+
+    [JsonRpcMethod(
+        Description = "Returns blob data of an execution payload with respect to the transaction set contained by the mempool.",
+        IsSharable = true,
+        IsImplemented = true)]
+    Task<ResultWrapper<BlobsBundleV1?>> engine_getBlobsBundleV1(byte[] payloadId);
+
+    [JsonRpcMethod(
+        Description = "Returns the most recent version of an execution payload and fees with respect to the transaction set contained by the mempool.",
+        IsSharable = true,
+        IsImplemented = true)]
+    public Task<ResultWrapper<GetPayloadV2Result?>> engine_getPayloadV3(byte[] payloadId);
+}

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
@@ -309,6 +309,8 @@ public partial class MergePlugin : IConsensusWrapperPlugin, ISynchronizationPlug
             IEngineRpcModule engineRpcModule = new EngineRpcModule(
                 new GetPayloadV1Handler(payloadPreparationService, _api.LogManager),
                 new GetPayloadV2Handler(payloadPreparationService, _api.LogManager),
+                new GetPayloadV3Handler(payloadPreparationService, _api.LogManager),
+                new GetBlobsBundleV1Handler(payloadPreparationService, _api.LogManager),
                 new NewPayloadHandler(
                     _api.BlockValidator,
                     _api.BlockTree,

--- a/src/Nethermind/Nethermind.Merge.Plugin/Metrics.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Metrics.cs
@@ -29,5 +29,10 @@ namespace Nethermind.Merge.Plugin
         [Description("Number of Transactions included in the Last GetPayload Request")]
         public static int NumberOfTransactionsInGetPayload { get; set; }
 
+        [Description("Number of GetBlobsBundle Requests")]
+        public static long GetBlobsBundleRequests { get; set; }
+
+        [Description("Number of Transactions included in the Last GetBlobsBundle Request")]
+        public static int NumberOfTransactionsInGetBlobsBundle { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.Serialization.Json/EthereumJsonSerializer.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/EthereumJsonSerializer.cs
@@ -46,7 +46,8 @@ namespace Nethermind.Serialization.Json
                 new BigIntegerConverter(),
                 new NullableBigIntegerConverter(),
                 new PublicKeyConverter(),
-                new TxTypeConverter()
+                new TxTypeConverter(),
+                new MemoryByteConverter()
             });
 
         public IList<JsonConverter> BasicConverters { get; } = CommonConverters.ToList();
@@ -66,7 +67,8 @@ namespace Nethermind.Serialization.Json
             new BigIntegerConverter(NumberConversion.Decimal),
             new NullableBigIntegerConverter(NumberConversion.Decimal),
             new PublicKeyConverter(),
-            new TxTypeConverter()
+            new TxTypeConverter(),
+            new MemoryByteConverter(),
         };
 
         public T Deserialize<T>(Stream stream)

--- a/src/Nethermind/Nethermind.Serialization.Json/MemoryByteConverter.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/MemoryByteConverter.cs
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Core.Extensions;
+using Newtonsoft.Json;
+
+namespace Nethermind.Serialization.Json
+{
+    public class MemoryByteConverter : JsonConverter<Memory<byte>>
+    {
+        public override void WriteJson(JsonWriter writer, Memory<byte> value, JsonSerializer serializer)
+        {
+            if (value.IsEmpty)
+            {
+                writer.WriteNull();
+            }
+            else
+            {
+                writer.WriteValue(Bytes.ByteArrayToHexViaLookup32Safe(value, true));
+            }
+        }
+
+        public override Memory<byte> ReadJson(JsonReader reader, Type objectType, Memory<byte> existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null)
+            {
+                return null;
+            }
+
+            string s = (string)reader.Value;
+            return Bytes.FromHexString(s);
+        }
+    }
+}


### PR DESCRIPTION
Adds [JSONRPC stuff for EIP-4844](https://github.com/ethereum/execution-apis/blob/main/src/engine/experimental/blob-extension.md)
There is a chance `engine_getBlobsBundleV1` may become a part of `engine_getPayloadV3`

## Changes

Add new JSONRPC end-points to support shard blob txs:
- engine_newPayloadV3
- engine_getPayloadV3
- engine_getBlobsBundleV1
Add Memory<byte> JSON serializer

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

Requires Cancun to be activated
