### PR TITLE
Use Environment.TickCount64 rather than StopWatch.GetTimestamp

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin/GC/GCKeeper.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/GC/GCKeeper.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Diagnostics;
 using System.Runtime;
 using System.Threading;
 using System.Threading.Tasks;
@@ -125,7 +124,7 @@ public class GCKeeper
         }
     }
 
-    private static long _lastGcTimeStamp;
+    private static long _lastGcTimeMs;
 
     private void ScheduleGC()
     {
@@ -133,13 +132,13 @@ public class GCKeeper
         {
             lock (_gcStrategy)
             {
-                long timeStamp = Stopwatch.GetTimestamp();
-                if (TimeSpan.FromTicks(timeStamp - _lastGcTimeStamp).TotalSeconds <= 3)
+                long timeStamp = Environment.TickCount64;
+                if (TimeSpan.FromMilliseconds(timeStamp - _lastGcTimeMs).TotalSeconds <= 3)
                 {
                     return;
                 }
 
-                _lastGcTimeStamp = timeStamp;
+                _lastGcTimeMs = timeStamp;
 
                 if (_gcScheduleTask.IsCompleted)
                 {


### PR DESCRIPTION
## Changes

- `Environment.TickCount64` is already in milliseconds whereas `StopWatch.GetTimestamp` needs conversion based on `StopWatch.Frequency` (isn't the same Ticks as DateTime Ticks)

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No