### PR TITLE
Zero total difficulty in FindBlock

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
@@ -1309,6 +1309,34 @@ namespace Nethermind.Blockchain.Test
         }
 
         [Test, Timeout(Timeout.MaxTestTime)]
+        public void Should_set_zero_total_difficulty()
+        {
+            MemDb blocksDb = new();
+            MemDb blockInfosDb = new();
+            MemDb headersDb = new();
+            MemDb metadataDb = new();
+
+            long pivotNumber = 0L;
+
+            SyncConfig syncConfig = new();
+            syncConfig.PivotNumber = pivotNumber.ToString();
+
+            CustomSpecProvider specProvider = new(((ForkActivation)0, London.Instance));
+            specProvider.UpdateMergeTransitionInfo(null, 0);
+
+            BlockTree tree = new(blocksDb, headersDb, blockInfosDb, metadataDb,
+                new ChainLevelInfoRepository(blockInfosDb), specProvider,
+                NullBloomStorage.Instance, syncConfig, LimboLogs.Instance);
+            Block genesis = Build.A.Block.WithDifficulty(0).TestObject;
+            tree.SuggestBlock(genesis).Should().Be(AddBlockResult.Added);
+            tree.FindBlock(genesis.Hash, BlockTreeLookupOptions.None)!.TotalDifficulty.Should().Be(UInt256.Zero);
+
+            Block A = Build.A.Block.WithParent(genesis).WithDifficulty(0).TestObject;
+            tree.SuggestBlock(A).Should().Be(AddBlockResult.Added);
+            tree.FindBlock(A.Hash, BlockTreeLookupOptions.None)!.TotalDifficulty.Should().Be(UInt256.Zero);
+        }
+
+        [Test, Timeout(Timeout.MaxTestTime)]
         public void Can_batch_insert_blocks()
         {
             MemDb blocksDb = new();

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -886,8 +886,7 @@ namespace Nethermind.Blockchain
                 }
                 else
                 {
-                    if (blockInfo.TotalDifficulty != UInt256.Zero || header.IsGenesis)
-                        header.TotalDifficulty = blockInfo.TotalDifficulty;
+                    SetTotalDifficultyFromBlockInfo(header, blockInfo);
                 }
 
                 if (requiresCanonical)
@@ -1834,8 +1833,7 @@ namespace Nethermind.Blockchain
                 }
                 else
                 {
-                    if (blockInfo.TotalDifficulty != UInt256.Zero || block.IsGenesis)
-                        block.Header.TotalDifficulty = blockInfo.TotalDifficulty;
+                    SetTotalDifficultyFromBlockInfo(block.Header, blockInfo);
                 }
 
                 if (requiresCanonical)
@@ -1854,6 +1852,31 @@ namespace Nethermind.Blockchain
             return block;
         }
 
+        private bool IsTotalDifficultyAlwaysZero()
+        {
+            // In some Ethereum tests and possible testnets difficulty of all blocks might be zero
+            // We also checking TTD is zero to ensure that block after genesis have zero difficulty
+            return Genesis!.Difficulty == 0 && _specProvider.TerminalTotalDifficulty == 0;
+        }
+
+        private void SetTotalDifficultyFromBlockInfo(BlockHeader header, BlockInfo blockInfo)
+        {
+            if (header.IsGenesis)
+            {
+                header.TotalDifficulty = header.Difficulty;
+                return;
+            }
+
+            if (IsTotalDifficultyAlwaysZero())
+            {
+                header.TotalDifficulty = 0;
+                return;
+            }
+
+            if (blockInfo.TotalDifficulty != UInt256.Zero)
+                header.TotalDifficulty = blockInfo.TotalDifficulty;
+        }
+
         private void SetTotalDifficulty(BlockHeader header)
         {
             if (header.IsGenesis)
@@ -1863,9 +1886,7 @@ namespace Nethermind.Blockchain
                 return;
             }
 
-            // In some Ethereum tests and possible testnets difficulty of all blocks might be zero
-            // We also checking TTD is zero to ensure that block after genesis have zero difficulty
-            if (Genesis!.Difficulty == 0 && _specProvider.TerminalTotalDifficulty == 0)
+            if (IsTotalDifficultyAlwaysZero())
             {
                 header.TotalDifficulty = 0;
                 if (_logger.IsTrace) _logger.Trace($"Block {header} has zero total difficulty");

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -1856,7 +1856,7 @@ namespace Nethermind.Blockchain
         {
             // In some Ethereum tests and possible testnets difficulty of all blocks might be zero
             // We also checking TTD is zero to ensure that block after genesis have zero difficulty
-            return Genesis!.Difficulty == 0 && _specProvider.TerminalTotalDifficulty == 0;
+            return Genesis?.Difficulty == 0 && _specProvider.TerminalTotalDifficulty == 0;
         }
 
         private void SetTotalDifficultyFromBlockInfo(BlockHeader header, BlockInfo blockInfo)
@@ -1867,14 +1867,16 @@ namespace Nethermind.Blockchain
                 return;
             }
 
-            if (IsTotalDifficultyAlwaysZero())
+            if (blockInfo.TotalDifficulty != UInt256.Zero)
             {
-                header.TotalDifficulty = 0;
+                header.TotalDifficulty = blockInfo.TotalDifficulty;
                 return;
             }
 
-            if (blockInfo.TotalDifficulty != UInt256.Zero)
-                header.TotalDifficulty = blockInfo.TotalDifficulty;
+            if (IsTotalDifficultyAlwaysZero())
+            {
+                header.TotalDifficulty = 0;
+            }
         }
 
         private void SetTotalDifficulty(BlockHeader header)


### PR DESCRIPTION
Fixes Closes Resolves #
#5519 

## Changes

- If td for given block inside blockInfos db is zero we will set td to null even if it should be zero. This pr checks genesis difficulty and ttd to set td of this block. 

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No
