### PR TITLE
Change pointlookup to MB

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -250,8 +250,9 @@ public class DbOnTheRocks : IDbWithSpan, ITunableDb
 
         options.SetCreateIfMissing();
         options.SetAdviseRandomOnOpen(true);
+        // Point lookup is in MB and block cache is in bytes
         options.OptimizeForPointLookup(
-            blockCacheSize); // I guess this should be the one option controlled by the DB size property - bind it to LRU cache size
+            blockCacheSizeMb: blockCacheSize / (ulong)1.MB()); // I guess this should be the one option controlled by the DB size property - bind it to LRU cache size
         //options.SetCompression(CompressionTypeEnum.rocksdb_snappy_compression);
         //options.SetLevelCompactionDynamicLevelBytes(true);
 


### PR DESCRIPTION
## Changes

- `BlockCacheSize` is in bytes (defaulting to 64MB) so `blockCacheSizeMb` should be divided by 1MB

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No