### PR TITLE
Make sure compact receipt does not get registered as global receipt decoder.

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Encoding/ReceiptMessageDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/ReceiptMessageDecoderTests.cs
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Serialization.Rlp;
+using NUnit.Framework;
+
+namespace Nethermind.Core.Test.Encoding;
+
+public class ReceiptMessageDecoderTests
+{
+    [Test]
+    public void TestGlobalReceiptEncoderMustBeReceiptMessageDecoder()
+    {
+        Rlp.Decoders[typeof(TxReceipt)].Equals(typeof(ReceiptMessageDecoder));
+        Rlp.Decoders[typeof(LogEntry)].Equals(typeof(LogEntryDecoder));
+    }
+}

--- a/src/Nethermind/Nethermind.Serialization.Rlp/CompactLogEntryDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/CompactLogEntryDecoder.cs
@@ -12,7 +12,7 @@ using Nethermind.Core.Extensions;
 namespace Nethermind.Serialization.Rlp
 {
     [Rlp.SkipGlobalRegistration]
-    public class CompactLogEntryDecoder: IRlpDecoder<LogEntry>
+    public class CompactLogEntryDecoder : IRlpDecoder<LogEntry>
     {
         public static CompactLogEntryDecoder Instance { get; } = new();
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/CompactLogEntryDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/CompactLogEntryDecoder.cs
@@ -11,7 +11,8 @@ using Nethermind.Core.Extensions;
 
 namespace Nethermind.Serialization.Rlp
 {
-    public class CompactLogEntryDecoder
+    [Rlp.SkipGlobalRegistration]
+    public class CompactLogEntryDecoder: IRlpDecoder<LogEntry>
     {
         public static CompactLogEntryDecoder Instance { get; } = new();
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/CompactReceiptStorageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/CompactReceiptStorageDecoder.cs
@@ -12,6 +12,8 @@ using Nethermind.Core.Crypto;
 
 namespace Nethermind.Serialization.Rlp
 {
+
+    [Rlp.SkipGlobalRegistration]
     public class CompactReceiptStorageDecoder : IRlpStreamDecoder<TxReceipt>, IRlpValueDecoder<TxReceipt>, IRlpObjectDecoder<TxReceipt>
     {
         public static readonly CompactReceiptStorageDecoder Instance = new();

--- a/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptArrayStorageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptArrayStorageDecoder.cs
@@ -7,6 +7,7 @@ using Nethermind.Core.Crypto;
 
 namespace Nethermind.Serialization.Rlp;
 
+[Rlp.SkipGlobalRegistration]
 public class ReceiptArrayStorageDecoder : IRlpStreamDecoder<TxReceipt[]>
 {
     public static readonly ReceiptArrayStorageDecoder Instance = new();

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -79,6 +79,11 @@ namespace Nethermind.Serialization.Rlp
                     continue;
                 }
 
+                if (type.GetCustomAttribute(typeof(SkipGlobalRegistration)) is not null)
+                {
+                    continue;
+                }
+
                 Type[]? implementedInterfaces = type.GetInterfaces();
                 foreach (Type? implementedInterface in implementedInterfaces)
                 {
@@ -1445,5 +1450,8 @@ namespace Nethermind.Serialization.Rlp
             return rlpDecoder?.GetLength(item, RlpBehaviors.None) ?? throw new RlpException($"{nameof(Rlp)} does not support length of {nameof(BlockInfo)}");
         }
 
+        public class SkipGlobalRegistration : Attribute
+        {
+        }
     }
 }


### PR DESCRIPTION
- After logging in RLP code, these show up.
```
The type is Nethermind.Serialization.Rlp.AccountDecoder Nethermind.Serialization.Rlp.IRlpDecoder`1[Nethermind.Core.Account]
The type is Nethermind.Serialization.Rlp.ByteStreamDecoder Nethermind.Serialization.Rlp.IRlpDecoder`1[System.Byte]
The type is Nethermind.Serialization.Rlp.ShortStreamDecoder Nethermind.Serialization.Rlp.IRlpDecoder`1[System.Int16]
The type is Nethermind.Serialization.Rlp.UShortStreamDecoder Nethermind.Serialization.Rlp.IRlpDecoder`1[System.UInt16]
The type is Nethermind.Serialization.Rlp.IntStreamDecoder Nethermind.Serialization.Rlp.IRlpDecoder`1[System.Int32]
The type is Nethermind.Serialization.Rlp.UIntStreamDecoder Nethermind.Serialization.Rlp.IRlpDecoder`1[System.UInt32]
The type is Nethermind.Serialization.Rlp.ULongStreamDecoder Nethermind.Serialization.Rlp.IRlpDecoder`1[System.UInt64]
The type is Nethermind.Serialization.Rlp.BlockDecoder Nethermind.Serialization.Rlp.IRlpDecoder`1[Nethermind.Core.Block]
The type is Nethermind.Serialization.Rlp.BlockInfoDecoder Nethermind.Serialization.Rlp.IRlpDecoder`1[Nethermind.Core.BlockInfo]
The type is Nethermind.Serialization.Rlp.ChainLevelDecoder Nethermind.Serialization.Rlp.IRlpDecoder`1[Nethermind.Core.ChainLevelInfo]
The type is Nethermind.Serialization.Rlp.CompactLogEntryDecoder Nethermind.Serialization.Rlp.IRlpDecoder`1[Nethermind.Core.LogEntry]
The type is Nethermind.Serialization.Rlp.CompactReceiptStorageDecoder Nethermind.Serialization.Rlp.IRlpDecoder`1[Nethermind.Core.TxReceipt]
The type is Nethermind.Serialization.Rlp.HeaderDecoder Nethermind.Serialization.Rlp.IRlpDecoder`1[Nethermind.Core.BlockHeader]
The type is Nethermind.Serialization.Rlp.KeccakDecoder Nethermind.Serialization.Rlp.IRlpDecoder`1[Nethermind.Core.Crypto.Keccak]
The type is Nethermind.Serialization.Rlp.LogEntryDecoder Nethermind.Serialization.Rlp.IRlpDecoder`1[Nethermind.Core.LogEntry]
The type is Nethermind.Serialization.Rlp.ReceiptMessageDecoder Nethermind.Serialization.Rlp.IRlpDecoder`1[Nethermind.Core.TxReceipt]
The type is Nethermind.Serialization.Rlp.TxDecoder Nethermind.Serialization.Rlp.IRlpDecoder`1[Nethermind.Core.Transaction]
The type is Nethermind.Serialization.Rlp.SystemTxDecoder Nethermind.Serialization.Rlp.IRlpDecoder`1[Nethermind.Core.SystemTransaction]
The type is Nethermind.Serialization.Rlp.GeneratedTxDecoder Nethermind.Serialization.Rlp.IRlpDecoder`1[Nethermind.Core.GeneratedTransaction]
The type is Nethermind.Serialization.Rlp.WithdrawalDecoder Nethermind.Serialization.Rlp.IRlpDecoder`1[Nethermind.Core.Withdrawal]
The type is Nethermind.Serialization.Rlp.Eip2930.AccessListDecoder Nethermind.Serialization.Rlp.IRlpDecoder`1[Nethermind.Core.Eip2930.AccessList]
The type is Nethermind.Network.NetworkNodeDecoder Nethermind.Serialization.Rlp.IRlpDecoder`1[Nethermind.Config.NetworkNode]
```
- The correct decoder is replaced later, but it could happen that this would randomly crash on other system.

After:
```
The type is Nethermind.Serialization.Rlp.AccountDecoder Nethermind.Serialization.Rlp.IRlpDecoder`1[Nethermind.Core.Account]
The type is Nethermind.Serialization.Rlp.ByteStreamDecoder Nethermind.Serialization.Rlp.IRlpDecoder`1[System.Byte]
The type is Nethermind.Serialization.Rlp.ShortStreamDecoder Nethermind.Serialization.Rlp.IRlpDecoder`1[System.Int16]
The type is Nethermind.Serialization.Rlp.UShortStreamDecoder Nethermind.Serialization.Rlp.IRlpDecoder`1[System.UInt16]
The type is Nethermind.Serialization.Rlp.IntStreamDecoder Nethermind.Serialization.Rlp.IRlpDecoder`1[System.Int32]
The type is Nethermind.Serialization.Rlp.UIntStreamDecoder Nethermind.Serialization.Rlp.IRlpDecoder`1[System.UInt32]
The type is Nethermind.Serialization.Rlp.ULongStreamDecoder Nethermind.Serialization.Rlp.IRlpDecoder`1[System.UInt64]
The type is Nethermind.Serialization.Rlp.BlockDecoder Nethermind.Serialization.Rlp.IRlpDecoder`1[Nethermind.Core.Block]
The type is Nethermind.Serialization.Rlp.BlockInfoDecoder Nethermind.Serialization.Rlp.IRlpDecoder`1[Nethermind.Core.BlockInfo]
The type is Nethermind.Serialization.Rlp.ChainLevelDecoder Nethermind.Serialization.Rlp.IRlpDecoder`1[Nethermind.Core.ChainLevelInfo]
The type is Nethermind.Serialization.Rlp.HeaderDecoder Nethermind.Serialization.Rlp.IRlpDecoder`1[Nethermind.Core.BlockHeader]
The type is Nethermind.Serialization.Rlp.KeccakDecoder Nethermind.Serialization.Rlp.IRlpDecoder`1[Nethermind.Core.Crypto.Keccak]
The type is Nethermind.Serialization.Rlp.LogEntryDecoder Nethermind.Serialization.Rlp.IRlpDecoder`1[Nethermind.Core.LogEntry]
The type is Nethermind.Serialization.Rlp.ReceiptMessageDecoder Nethermind.Serialization.Rlp.IRlpDecoder`1[Nethermind.Core.TxReceipt]
The type is Nethermind.Serialization.Rlp.TxDecoder Nethermind.Serialization.Rlp.IRlpDecoder`1[Nethermind.Core.Transaction]
The type is Nethermind.Serialization.Rlp.SystemTxDecoder Nethermind.Serialization.Rlp.IRlpDecoder`1[Nethermind.Core.SystemTransaction]
The type is Nethermind.Serialization.Rlp.GeneratedTxDecoder Nethermind.Serialization.Rlp.IRlpDecoder`1[Nethermind.Core.GeneratedTransaction]
The type is Nethermind.Serialization.Rlp.WithdrawalDecoder Nethermind.Serialization.Rlp.IRlpDecoder`1[Nethermind.Core.Withdrawal]
The type is Nethermind.Serialization.Rlp.Eip2930.AccessListDecoder Nethermind.Serialization.Rlp.IRlpDecoder`1[Nethermind.Core.Eip2930.AccessList]
The type is Nethermind.Network.NetworkNodeDecoder Nethermind.Serialization.Rlp.IRlpDecoder`1[Nethermind.Config.NetworkNode]
```

## Changes

- Add an attribute to skip registration of compact receipt decoder.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

