### PR TITLE
Feature/low priority write

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/CopyTreeVisitorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/CopyTreeVisitorTests.cs
@@ -1,10 +1,14 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Nethermind.Blockchain.FullPruning;
+using Nethermind.Core;
 using Nethermind.Core.Extensions;
+using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
 using Nethermind.Db.FullPruning;
@@ -27,8 +31,8 @@ namespace Nethermind.Blockchain.Test.FullPruning
         [Timeout(Timeout.MaxTestTime)]
         public void copies_state_between_dbs(int fullPruningMemoryBudgetMb, int maxDegreeOfParallelism)
         {
-            MemDb trieDb = new();
-            MemDb clonedDb = new();
+            TestMemDb trieDb = new();
+            TestMemDb clonedDb = new();
 
             VisitingOptions visitingOptions = new()
             {
@@ -36,11 +40,19 @@ namespace Nethermind.Blockchain.Test.FullPruning
                 FullScanMemoryBudget = fullPruningMemoryBudgetMb.MiB(),
             };
 
-            CopyDb(StartPruning(trieDb, clonedDb), trieDb, clonedDb, visitingOptions);
+            IPruningContext ctx = StartPruning(trieDb, clonedDb);
+            CopyDb(ctx, trieDb, clonedDb, visitingOptions);
+
+            List<byte[]> keys = trieDb.Keys.ToList();
+            List<byte[]> values = trieDb.Values.ToList();
+
+            ctx.Commit();
 
             clonedDb.Count.Should().Be(132);
-            clonedDb.Keys.Should().BeEquivalentTo(trieDb.Keys);
-            clonedDb.Values.Should().BeEquivalentTo(trieDb.Values);
+            clonedDb.Keys.Should().BeEquivalentTo(keys);
+            clonedDb.Values.Should().BeEquivalentTo(values);
+
+            clonedDb.KeyWasWrittenWithFlags(keys[0], WriteFlags.LowPriority);
         }
 
         [Test, Timeout(Timeout.MaxTestTime)]

--- a/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPrunerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPrunerTests.cs
@@ -285,6 +285,16 @@ namespace Nethermind.Blockchain.Test.FullPruning
                     set => _context[key] = value;
                 }
 
+                public void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None)
+                {
+                    _context.Set(key, value, flags);
+                }
+
+                public byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)
+                {
+                    return _context.Get(key, flags);
+                }
+
                 public void Commit()
                 {
                     WaitForFinish.Set();

--- a/src/Nethermind/Nethermind.Blockchain/FullPruning/CopyTreeVisitor.cs
+++ b/src/Nethermind/Nethermind.Blockchain/FullPruning/CopyTreeVisitor.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.Threading;
+using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Db.FullPruning;
 using Nethermind.Logging;
@@ -70,7 +71,7 @@ namespace Nethermind.Blockchain.FullPruning
             if (node.Keccak is not null)
             {
                 // simple copy of nodes RLP
-                _pruningContext[node.Keccak.Bytes] = node.FullRlp;
+                _pruningContext.Set(node.Keccak.Bytes, node.FullRlp, WriteFlags.LowPriority);
                 Interlocked.Increment(ref _persistedNodes);
 
                 // log message every 1 mln nodes

--- a/src/Nethermind/Nethermind.Core.Test/InMemoryBatch.cs
+++ b/src/Nethermind/Nethermind.Core.Test/InMemoryBatch.cs
@@ -27,13 +27,14 @@ namespace Nethermind.Core
             GC.SuppressFinalize(this);
         }
 
-        public byte[]? this[ReadOnlySpan<byte> key]
+        public void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None)
         {
-            get => _store[key];
-            set
-            {
-                _currentItems[key.ToArray()] = value;
-            }
+            _currentItems[key.ToArray()] = value;
+        }
+
+        public byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)
+        {
+            return _store.Get(key, flags);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Core.Test/InMemoryBatch.cs
+++ b/src/Nethermind/Nethermind.Core.Test/InMemoryBatch.cs
@@ -11,6 +11,7 @@ namespace Nethermind.Core
     {
         private readonly IKeyValueStore _store;
         private readonly ConcurrentDictionary<byte[], byte[]?> _currentItems = new();
+        private WriteFlags _writeFlags = WriteFlags.None;
 
         public InMemoryBatch(IKeyValueStore storeWithNoBatchSupport)
         {
@@ -21,7 +22,7 @@ namespace Nethermind.Core
         {
             foreach (KeyValuePair<byte[], byte[]?> keyValuePair in _currentItems)
             {
-                _store[keyValuePair.Key] = keyValuePair.Value;
+                _store.Set(keyValuePair.Key, keyValuePair.Value, _writeFlags) ;
             }
 
             GC.SuppressFinalize(this);
@@ -30,6 +31,7 @@ namespace Nethermind.Core
         public void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None)
         {
             _currentItems[key.ToArray()] = value;
+            _writeFlags = flags;
         }
 
         public byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)

--- a/src/Nethermind/Nethermind.Core.Test/InMemoryBatch.cs
+++ b/src/Nethermind/Nethermind.Core.Test/InMemoryBatch.cs
@@ -22,7 +22,7 @@ namespace Nethermind.Core
         {
             foreach (KeyValuePair<byte[], byte[]?> keyValuePair in _currentItems)
             {
-                _store.Set(keyValuePair.Key, keyValuePair.Value, _writeFlags) ;
+                _store.Set(keyValuePair.Key, keyValuePair.Value, _writeFlags);
             }
 
             GC.SuppressFinalize(this);

--- a/src/Nethermind/Nethermind.Core.Test/TestMemDb.cs
+++ b/src/Nethermind/Nethermind.Core.Test/TestMemDb.cs
@@ -22,19 +22,6 @@ public class TestMemDb : MemDb
     public Func<byte[], byte[]>? ReadFunc { get; set; }
     public Action<byte[]>? RemoveFunc { get; set; }
 
-    public override byte[]? this[ReadOnlySpan<byte> key]
-    {
-        get
-        {
-            return Get(key);
-        }
-        set
-        {
-            _writeKeys.Add(key.ToArray());
-            base[key] = value;
-        }
-    }
-
     public override byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)
     {
         _readKeys.Add((key.ToArray(), flags));
@@ -43,9 +30,15 @@ public class TestMemDb : MemDb
         return base.Get(key, flags);
     }
 
+    public virtual void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None)
+    {
+        _writeKeys.Add(key.ToArray());
+        base.Set(key, value, flags);
+    }
+
     public override Span<byte> GetSpan(ReadOnlySpan<byte> key)
     {
-        return this[key];
+        return Get(key);
     }
 
     public override void Remove(ReadOnlySpan<byte> key)

--- a/src/Nethermind/Nethermind.Core/FakeBatch.cs
+++ b/src/Nethermind/Nethermind.Core/FakeBatch.cs
@@ -27,10 +27,14 @@ namespace Nethermind.Core
             _onDispose?.Invoke();
         }
 
-        public byte[]? this[ReadOnlySpan<byte> key]
+        public byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)
         {
-            get => _storePretendingToSupportBatches[key];
-            set => _storePretendingToSupportBatches[key] = value;
+            return _storePretendingToSupportBatches.Get(key, flags);
+        }
+
+        public void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None)
+        {
+            _storePretendingToSupportBatches.Set(key, value, flags);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Core/IKeyValueStore.cs
+++ b/src/Nethermind/Nethermind.Core/IKeyValueStore.cs
@@ -7,17 +7,20 @@ namespace Nethermind.Core
 {
     public interface IKeyValueStore : IReadOnlyKeyValueStore
     {
-        new byte[]? this[ReadOnlySpan<byte> key] { get; set; }
+        new byte[]? this[ReadOnlySpan<byte> key]
+        {
+            get => Get(key, ReadFlags.None);
+            set => Set(key, value, WriteFlags.None);
+        }
+
+        void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None);
     }
 
     public interface IReadOnlyKeyValueStore
     {
-        byte[]? this[ReadOnlySpan<byte> key] { get; }
+        byte[]? this[ReadOnlySpan<byte> key] => Get(key, ReadFlags.None);
 
-        byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)
-        {
-            return this[key];
-        }
+        byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None);
     }
 
     public enum ReadFlags
@@ -27,5 +30,13 @@ namespace Nethermind.Core
         // Hint that the workload is likely to not going to benefit from caching and should skip any cache handling
         // to reduce CPU usage
         HintCacheMiss,
+    }
+
+    public enum WriteFlags
+    {
+        None,
+
+        // Hint that this is a low priority write
+        LowPriority,
     }
 }

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -38,11 +38,11 @@ public class ColumnDb : IDbWithSpan
         UpdateWriteMetrics();
         if (value is null)
         {
-            _rocksDb.Remove(key, _columnFamily, _mainDb.WriteOptions);
+            _rocksDb.Remove(key, _columnFamily, _mainDb.WriteFlagsToWriteOptions(flags));
         }
         else
         {
-            _rocksDb.Put(key, value, _columnFamily, _mainDb.WriteOptions);
+            _rocksDb.Put(key, value, _columnFamily, _mainDb.WriteFlagsToWriteOptions(flags));
         }
     }
 

--- a/src/Nethermind/Nethermind.Db.Rpc/RpcDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rpc/RpcDb.cs
@@ -40,8 +40,18 @@ namespace Nethermind.Db.Rpc
 
         public byte[] this[ReadOnlySpan<byte> key]
         {
-            get => GetThroughRpc(key);
-            set => throw new InvalidOperationException("RPC DB does not support writes");
+            get => Get(key);
+            set => Set(key, value);
+        }
+
+        public void Set(ReadOnlySpan<byte> key, byte[] value, WriteFlags flags = WriteFlags.None)
+        {
+            throw new InvalidOperationException("RPC DB does not support writes");
+        }
+
+        public byte[] Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)
+        {
+            return GetThroughRpc(key);
         }
 
         public KeyValuePair<byte[], byte[]>[] this[byte[][] keys] => keys.Select(k => new KeyValuePair<byte[], byte[]>(k, GetThroughRpc(k))).ToArray();

--- a/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
@@ -32,6 +32,12 @@ namespace Nethermind.Db.Test
             DbOnTheRocks db = new("blocks", GetRocksDbSettings("blocks", "Blocks"), config, LimboLogs.Instance);
             db[new byte[] { 1, 2, 3 }] = new byte[] { 4, 5, 6 };
             Assert.AreEqual(new byte[] { 4, 5, 6 }, db[new byte[] { 1, 2, 3 }]);
+
+            WriteOptions? options = db.WriteFlagsToWriteOptions(WriteFlags.LowPriority);
+            RocksDbSharp.Native.Instance.rocksdb_writeoptions_get_low_pri(options.Handle).Should().BeTrue();
+
+            db.Set(new byte[] { 2, 3, 4 }, new byte[] { 5, 6, 7 }, WriteFlags.LowPriority);
+            Assert.AreEqual(new byte[] { 5, 6, 7 }, db[new byte[] { 2, 3, 4 }]);
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Db/FullPruning/FullPruningDb.cs
+++ b/src/Nethermind/Nethermind.Db/FullPruning/FullPruningDb.cs
@@ -46,25 +46,8 @@ namespace Nethermind.Db.FullPruning
 
         public byte[]? this[ReadOnlySpan<byte> key]
         {
-            get
-            {
-                byte[]? value = _currentDb[key]; // we are reading from the main DB
-                if (_pruningContext?.DuplicateReads == true)
-                {
-                    Duplicate(_pruningContext.CloningDb, key, value);
-                }
-
-                return value;
-            }
-            set
-            {
-                _currentDb[key] = value; // we are writing to the main DB
-                IDb? cloningDb = _pruningContext?.CloningDb;
-                if (cloningDb is not null) // if pruning is in progress we are also writing to the secondary, copied DB
-                {
-                    Duplicate(cloningDb, key, value);
-                }
-            }
+            get => Get(key, ReadFlags.None);
+            set => Set(key, value, WriteFlags.None);
         }
 
         public byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)
@@ -72,15 +55,25 @@ namespace Nethermind.Db.FullPruning
             byte[]? value = _currentDb.Get(key, flags); // we are reading from the main DB
             if (_pruningContext?.DuplicateReads == true)
             {
-                Duplicate(_pruningContext.CloningDb, key, value);
+                Duplicate(_pruningContext.CloningDb, key, value, WriteFlags.None);
             }
 
             return value;
         }
 
-        private void Duplicate(IKeyValueStore db, ReadOnlySpan<byte> key, byte[]? value)
+        public void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None)
         {
-            db[key] = value;
+            _currentDb.Set(key, value, flags); // we are writing to the main DB
+            IDb? cloningDb = _pruningContext?.CloningDb;
+            if (cloningDb is not null) // if pruning is in progress we are also writing to the secondary, copied DB
+            {
+                Duplicate(cloningDb, key, value, flags);
+            }
+        }
+
+        private void Duplicate(IKeyValueStore db, ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags)
+        {
+            db.Set(key, value, flags);
             _updateDuplicateWriteMetrics?.Invoke();
         }
 
@@ -208,28 +201,28 @@ namespace Nethermind.Db.FullPruning
                 _db = db;
             }
 
-            /// <inheritdoc />
-            public byte[]? this[ReadOnlySpan<byte> key]
+            public void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None)
             {
-                get => CloningDb[key];
-                set
+                if (!_batches.TryDequeue(out IBatch currentBatch))
                 {
-                    if (!_batches.TryDequeue(out IBatch currentBatch))
-                    {
-                        currentBatch = CloningDb.StartBatch();
-                    }
-
-                    _db.Duplicate(currentBatch, key, value);
-                    long val = Interlocked.Increment(ref _counter);
-                    if (val % 10000 == 0)
-                    {
-                        currentBatch.Dispose();
-                    }
-                    else
-                    {
-                        _batches.Enqueue(currentBatch);
-                    }
+                    currentBatch = CloningDb.StartBatch();
                 }
+
+                _db.Duplicate(currentBatch, key, value, flags);
+                long val = Interlocked.Increment(ref _counter);
+                if (val % 10000 == 0)
+                {
+                    currentBatch.Dispose();
+                }
+                else
+                {
+                    _batches.Enqueue(currentBatch);
+                }
+            }
+
+            public byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)
+            {
+                return CloningDb.Get(key, flags);
             }
 
             /// <inheritdoc />
@@ -296,14 +289,15 @@ namespace Nethermind.Db.FullPruning
                 _clonedBatch.Dispose();
             }
 
-            public byte[]? this[ReadOnlySpan<byte> key]
+            public byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)
             {
-                get => _batch[key];
-                set
-                {
-                    _batch[key] = value;
-                    _db.Duplicate(_clonedBatch, key, value);
-                }
+                return _batch.Get(key, flags);
+            }
+
+            public void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None)
+            {
+                _batch.Set(key, value, flags);
+                _db.Duplicate(_clonedBatch, key, value, flags);
             }
         }
 

--- a/src/Nethermind/Nethermind.Db/MemDb.cs
+++ b/src/Nethermind/Nethermind.Db/MemDb.cs
@@ -48,13 +48,7 @@ namespace Nethermind.Db
             }
             set
             {
-                if (_writeDelay > 0)
-                {
-                    Thread.Sleep(_writeDelay);
-                }
-
-                WritesCount++;
-                _db[key] = value;
+                Set(key, value);
             }
         }
 
@@ -113,12 +107,12 @@ namespace Nethermind.Db
 
         public virtual Span<byte> GetSpan(ReadOnlySpan<byte> key)
         {
-            return this[key].AsSpan();
+            return Get(key).AsSpan();
         }
 
         public void PutSpan(ReadOnlySpan<byte> key, ReadOnlySpan<byte> value)
         {
-            this[key] = value.ToArray();
+            Set(key, value.ToArray());
         }
 
         public void DangerousReleaseMemory(in Span<byte> span)
@@ -134,6 +128,17 @@ namespace Nethermind.Db
 
             ReadsCount++;
             return _db.TryGetValue(key, out byte[] value) ? value : null;
+        }
+
+        public virtual void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None)
+        {
+            if (_writeDelay > 0)
+            {
+                Thread.Sleep(_writeDelay);
+            }
+
+            WritesCount++;
+            _db[key] = value;
         }
     }
 }

--- a/src/Nethermind/Nethermind.Db/NullDb.cs
+++ b/src/Nethermind/Nethermind.Db/NullDb.cs
@@ -21,10 +21,14 @@ namespace Nethermind.Db
 
         public string Name { get; } = "NullDb";
 
-        public byte[]? this[ReadOnlySpan<byte> key]
+        public byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)
         {
-            get => null;
-            set => throw new NotSupportedException();
+            return null;
+        }
+
+        public void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None)
+        {
+            throw new NotSupportedException();
         }
 
         public KeyValuePair<byte[], byte[]>[] this[byte[][] keys] => keys.Select(k => new KeyValuePair<byte[], byte[]>(k, null)).ToArray();

--- a/src/Nethermind/Nethermind.Db/ReadOnlyDb.cs
+++ b/src/Nethermind/Nethermind.Db/ReadOnlyDb.cs
@@ -27,18 +27,19 @@ namespace Nethermind.Db
 
         public string Name { get; } = "ReadOnlyDb";
 
-        public byte[]? this[ReadOnlySpan<byte> key]
+        public byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)
         {
-            get => _memDb[key] ?? _wrappedDb[key];
-            set
-            {
-                if (!_createInMemWriteStore)
-                {
-                    throw new InvalidOperationException($"This {nameof(ReadOnlyDb)} did not expect any writes.");
-                }
+            return _memDb.Get(key, flags) ?? _wrappedDb.Get(key, flags);
+        }
 
-                _memDb[key] = value;
+        public void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None)
+        {
+            if (!_createInMemWriteStore)
+            {
+                throw new InvalidOperationException($"This {nameof(ReadOnlyDb)} did not expect any writes.");
             }
+
+            _memDb.Set(key, value, flags);
         }
 
         public KeyValuePair<byte[], byte[]>[] this[byte[][] keys]
@@ -89,7 +90,7 @@ namespace Nethermind.Db
             _memDb.Clear();
         }
 
-        public Span<byte> GetSpan(ReadOnlySpan<byte> key) => this[key].AsSpan();
+        public Span<byte> GetSpan(ReadOnlySpan<byte> key) => _memDb.Get(key).AsSpan();
         public void PutSpan(ReadOnlySpan<byte> keyBytes, ReadOnlySpan<byte> value)
         {
             if (!_createInMemWriteStore)
@@ -97,7 +98,7 @@ namespace Nethermind.Db
                 throw new InvalidOperationException($"This {nameof(ReadOnlyDb)} did not expect any writes.");
             }
 
-            _memDb[keyBytes] = value.ToArray();
+            _memDb.Set(keyBytes, value.ToArray());
         }
 
         public void DangerousReleaseMemory(in Span<byte> span) { }

--- a/src/Nethermind/Nethermind.Db/SimpleFilePublicKeyDb.cs
+++ b/src/Nethermind/Nethermind.Db/SimpleFilePublicKeyDb.cs
@@ -50,19 +50,26 @@ namespace Nethermind.Db
             LoadData();
         }
 
-        public byte[] this[ReadOnlySpan<byte> key]
+        public byte[]? this[ReadOnlySpan<byte> key]
         {
-            get => _cache[key];
-            set
+            get => Get(key, ReadFlags.None);
+            set => Set(key, value, WriteFlags.None);
+        }
+
+        public byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)
+        {
+            return _cache[key];
+        }
+
+        public void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None)
+        {
+            if (value is null)
             {
-                if (value is null)
-                {
-                    _cache.TryRemove(key, out _);
-                }
-                else
-                {
-                    _cache.AddOrUpdate(key.ToArray(), newValue => Add(value), (x, oldValue) => Update(oldValue, value));
-                }
+                _cache.TryRemove(key, out _);
+            }
+            else
+            {
+                _cache.AddOrUpdate(key.ToArray(), newValue => Add(value), (x, oldValue) => Update(oldValue, value));
             }
         }
 

--- a/src/Nethermind/Nethermind.State/Witnesses/WitnessingStore.cs
+++ b/src/Nethermind/Nethermind.State/Witnesses/WitnessingStore.cs
@@ -32,17 +32,24 @@ namespace Nethermind.State.Witnesses
 
         public byte[]? this[ReadOnlySpan<byte> key]
         {
-            get
-            {
-                if (key.Length != 32)
-                {
-                    throw new NotSupportedException($"{nameof(WitnessingStore)} requires 32 bytes long keys.");
-                }
+            get => Get(key);
+            set => Set(key, value);
+        }
 
-                Touch(key);
-                return _wrapped[key];
+        public byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)
+        {
+            if (key.Length != 32)
+            {
+                throw new NotSupportedException($"{nameof(WitnessingStore)} requires 32 bytes long keys.");
             }
-            set => _wrapped[key] = value;
+
+            Touch(key);
+            return _wrapped.Get(key, flags);
+        }
+
+        public void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None)
+        {
+            _wrapped.Set(key, value, flags);
         }
 
         public IBatch StartBatch()

--- a/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
@@ -384,8 +384,18 @@ namespace Nethermind.Trie.Test.Pruning
 
             public byte[]? this[ReadOnlySpan<byte> key]
             {
-                get => _db[key.ToArray()];
-                set => _db[key.ToArray()] = value;
+                get => Get(key);
+                set => Set(key, value);
+            }
+
+            public void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None)
+            {
+                _db[key.ToArray()] = value;
+            }
+
+            public byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)
+            {
+                return _db[key.ToArray()];
             }
 
             public IBatch StartBatch()
@@ -403,8 +413,18 @@ namespace Nethermind.Trie.Test.Pruning
 
                 public byte[]? this[ReadOnlySpan<byte> key]
                 {
-                    get => _inBatched[key.ToArray()];
-                    set => _inBatched[key.ToArray()] = value;
+                    get => Get(key);
+                    set => Set(key, value);
+                }
+
+                public void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None)
+                {
+                    _inBatched[key.ToArray()] = value;
+                }
+
+                public byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)
+                {
+                    return _inBatched[key.ToArray()];
                 }
             }
         }

--- a/src/Nethermind/Nethermind.Trie/CachingStore.cs
+++ b/src/Nethermind/Nethermind.Trie/CachingStore.cs
@@ -40,8 +40,7 @@ namespace Nethermind.Trie
             }
             set
             {
-                _cache.Set(key, value);
-                _wrappedStore[key] = value;
+                Set(key, value);
             }
         }
 
@@ -65,6 +64,13 @@ namespace Nethermind.Trie
 
             return value;
         }
+
+        public void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None)
+        {
+            _cache.Set(key, value);
+            _wrappedStore.Set(key, value, flags);
+        }
+
 
         public IBatch StartBatch() => _wrappedStore.StartBatch();
 

--- a/src/Nethermind/Nethermind.Trie/NullKeyValueStore.cs
+++ b/src/Nethermind/Nethermind.Trie/NullKeyValueStore.cs
@@ -16,10 +16,14 @@ namespace Nethermind.Trie
         private static NullKeyValueStore _instance;
         public static NullKeyValueStore Instance => LazyInitializer.EnsureInitialized(ref _instance, () => new NullKeyValueStore());
 
-        public byte[] this[ReadOnlySpan<byte> key]
+        public byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)
         {
-            get => null;
-            set => throw new NotSupportedException();
+            return null;
+        }
+
+        public void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None)
+        {
+            throw new NotSupportedException();
         }
     }
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/NullTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/NullTrieStore.cs
@@ -44,6 +44,9 @@ namespace Nethermind.Trie.Pruning
 
         public void Dispose() { }
 
-        public byte[]? this[ReadOnlySpan<byte> key] => null;
+        public byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)
+        {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
- When full pruning runs too fast, it will cause some write stalls which will essentially stalls block processing.
- This add a low priority write flag so that full pruning writes will be of low priority so that other writes is not blocked.

## Changes

- Add low priority write flags.
- Minor refactor to make read and write with flags consistent.
- Integrate with rocksdb and copy tree visitor.

## Types of changes

#### What types of changes does your code introduce?

- [X] New feature (a non-breaking change that adds functionality)
- [X] Optimization
- [X] Refactoring

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

Node write rate limited to 100MBps via cgroup. Seems to work.
Graph is (after, before, after)
![Screenshot from 2023-04-20 02-16-19](https://user-images.githubusercontent.com/1841324/233164827-440e987c-df1b-497c-b1ca-268110320853.png)

