### PR TITLE
Return a couple additional ArrayPoolLists

### DIFF
--- a/src/Nethermind/Nethermind.Abi.Test/AbiTests.cs
+++ b/src/Nethermind/Nethermind.Abi.Test/AbiTests.cs
@@ -551,7 +551,7 @@ public class AbiTests
         var abi = new AbiArray(AbiType.UInt256);
         var array = new UInt256[] { 1, 2, 3, UInt256.MaxValue };
         var list = new List<UInt256>() { 1, 2, 3, UInt256.MaxValue };
-        var pool = new ArrayPoolList<UInt256>(4);
+        using var pool = new ArrayPoolList<UInt256>(4);
 
         pool.AddRange(array);
 

--- a/src/Nethermind/Nethermind.Core/Collections/ArrayPoolList.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/ArrayPoolList.cs
@@ -266,6 +266,7 @@ public sealed class ArrayPoolList<T> : IList<T>, IList, IReadOnlyList<T>, IDispo
         if (!_disposed)
         {
             _arrayPool.Return(_array);
+            _array = null!;
             _disposed = true;
         }
     }

--- a/src/Nethermind/Nethermind.Core/Resettables/Resettable.cs
+++ b/src/Nethermind/Nethermind.Core/Resettables/Resettable.cs
@@ -18,8 +18,6 @@ namespace Nethermind.Core.Resettables
         private const int ResetRatio = Resettable.ResetRatio;
         private const int StartCapacity = Resettable.StartCapacity;
 
-        private static ArrayPool<T> _arrayPool = ArrayPool<T>.Shared;
-
         public static void IncrementPosition(ref T[] array, ref int currentCapacity, ref int currentPosition)
         {
             currentPosition++;
@@ -31,10 +29,10 @@ namespace Nethermind.Core.Resettables
             if (currentCapacity > array.Length)
             {
                 T[] oldArray = array;
-                array = _arrayPool.Rent(currentCapacity);
+                array = ArrayPool<T>.Shared.Rent(currentCapacity);
                 Array.Copy(oldArray, array, oldArray.Length);
                 oldArray.AsSpan().Clear();
-                _arrayPool.Return(oldArray);
+                ArrayPool<T>.Shared.Return(oldArray);
             }
         }
 
@@ -43,9 +41,9 @@ namespace Nethermind.Core.Resettables
             array.AsSpan().Clear();
             if (currentPosition < currentCapacity / ResetRatio && currentCapacity > startCapacity)
             {
-                _arrayPool.Return(array);
+                ArrayPool<T>.Shared.Return(array);
                 currentCapacity = Math.Max(startCapacity, currentCapacity / ResetRatio);
-                array = _arrayPool.Rent(currentCapacity);
+                array = ArrayPool<T>.Shared.Rent(currentCapacity);
             }
 
             currentPosition = Resettable.EmptyPosition;


### PR DESCRIPTION
Very minor

## Changes

- Dispose two additional ArrayPoolLists
- Refactor existing ones to use `using`
- Use `ArrayPool<T>.Shared` directly rather than storing in field (Jit can then devirtualise)

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No