### PR TITLE
Use LibraryImport rather than DllImport

### DIFF
--- a/src/Nethermind/Nethermind.Crypto/ShamatarLib.cs
+++ b/src/Nethermind/Nethermind.Crypto/ShamatarLib.cs
@@ -7,15 +7,15 @@ using System.Runtime.InteropServices;
 
 namespace Nethermind.Crypto.Bls
 {
-    public static class ShamatarLib
+    public static partial class ShamatarLib
     {
         static ShamatarLib()
         {
             LibResolver.Setup();
         }
 
-        [DllImport("shamatar")]
-        private static extern unsafe uint eip196_perform_operation(
+        [LibraryImport("shamatar")]
+        private static unsafe partial uint eip196_perform_operation(
             byte operation,
             byte* input,
             int inputLength,
@@ -24,8 +24,8 @@ namespace Nethermind.Crypto.Bls
             byte* error,
             ref int errorLength);
 
-        [DllImport("shamatar")]
-        private static extern unsafe uint eip2537_perform_operation(
+        [LibraryImport("shamatar")]
+        private static unsafe partial uint eip2537_perform_operation(
             byte operation,
             byte* input,
             int inputLength,

--- a/src/Nethermind/Nethermind.Secp256k1/Proxy.cs
+++ b/src/Nethermind/Nethermind.Secp256k1/Proxy.cs
@@ -8,6 +8,7 @@ using System.Runtime.InteropServices;
 using System.Security;
 using Nethermind.Native;
 
+
 namespace Nethermind.Secp256k1
 {
     public static partial class Proxy

--- a/src/Nethermind/Nethermind.Secp256k1/Proxy.cs
+++ b/src/Nethermind/Nethermind.Secp256k1/Proxy.cs
@@ -10,7 +10,7 @@ using Nethermind.Native;
 
 namespace Nethermind.Secp256k1
 {
-    public static class Proxy
+    public static partial class Proxy
     {
         private const string Secp256k1 = "secp256k1";
 
@@ -25,48 +25,56 @@ namespace Nethermind.Secp256k1
         /*****************************************************************************************/
 
         [SuppressUnmanagedCodeSecurity]
-        [DllImport(Secp256k1)]
-        public static extern /* secp256k1_context */ IntPtr secp256k1_context_create(uint flags);
+        [LibraryImport(Secp256k1)]
+        public static partial IntPtr secp256k1_context_create(uint flags);
 
         [SuppressUnmanagedCodeSecurity]
-        [DllImport(Secp256k1)]
-        public static extern /* void */ IntPtr secp256k1_context_destroy(IntPtr context);
+        [LibraryImport(Secp256k1)]
+        public static partial IntPtr secp256k1_context_destroy(IntPtr context);
 
         [SuppressUnmanagedCodeSecurity]
-        [DllImport(Secp256k1)]
-        public static extern bool secp256k1_ec_seckey_verify( /* secp256k1_context */ IntPtr context, byte[] seckey);
+        [LibraryImport(Secp256k1)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static partial bool secp256k1_ec_seckey_verify( /* secp256k1_context */ IntPtr context, byte[] seckey);
 
         [SuppressUnmanagedCodeSecurity]
-        [DllImport(Secp256k1)]
-        public static extern unsafe bool secp256k1_ec_pubkey_create( /* secp256k1_context */ IntPtr context, void* pubkey, byte[] seckey);
+        [LibraryImport(Secp256k1)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static unsafe partial bool secp256k1_ec_pubkey_create( /* secp256k1_context */ IntPtr context, void* pubkey, byte[] seckey);
 
         [SuppressUnmanagedCodeSecurity]
-        [DllImport(Secp256k1)]
-        public static extern unsafe bool secp256k1_ec_pubkey_serialize( /* secp256k1_context */ IntPtr context, void* serializedPublicKey, ref uint outputSize, void* publicKey, uint flags);
+        [LibraryImport(Secp256k1)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static unsafe partial bool secp256k1_ec_pubkey_serialize( /* secp256k1_context */ IntPtr context, void* serializedPublicKey, ref uint outputSize, void* publicKey, uint flags);
 
         [SuppressUnmanagedCodeSecurity]
-        [DllImport(Secp256k1)]
-        public static extern bool secp256k1_ecdsa_sign_recoverable( /* secp256k1_context */ IntPtr context, byte[] signature, byte[] messageHash, byte[] privateKey, IntPtr nonceFunction, IntPtr nonceData);
+        [LibraryImport(Secp256k1)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static partial bool secp256k1_ecdsa_sign_recoverable( /* secp256k1_context */ IntPtr context, byte[] signature, byte[] messageHash, byte[] privateKey, IntPtr nonceFunction, IntPtr nonceData);
 
         [SuppressUnmanagedCodeSecurity]
-        [DllImport(Secp256k1)]
-        public static extern bool secp256k1_ecdsa_recoverable_signature_serialize_compact( /* secp256k1_context */ IntPtr context, byte[] compactSignature, out int recoveryId, byte[] signature);
+        [LibraryImport(Secp256k1)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static partial bool secp256k1_ecdsa_recoverable_signature_serialize_compact( /* secp256k1_context */ IntPtr context, byte[] compactSignature, out int recoveryId, byte[] signature);
 
         [SuppressUnmanagedCodeSecurity]
-        [DllImport(Secp256k1)]
-        public static extern unsafe bool secp256k1_ecdsa_recoverable_signature_parse_compact( /* secp256k1_context */ IntPtr context, void* signature, void* compactSignature, int recoveryId);
+        [LibraryImport(Secp256k1)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static unsafe partial bool secp256k1_ecdsa_recoverable_signature_parse_compact( /* secp256k1_context */ IntPtr context, void* signature, void* compactSignature, int recoveryId);
 
         [SuppressUnmanagedCodeSecurity]
-        [DllImport(Secp256k1)]
-        public static extern unsafe bool secp256k1_ecdsa_recover( /* secp256k1_context */ IntPtr context, void* publicKey, void* signature, byte[] message);
+        [LibraryImport(Secp256k1)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static unsafe partial bool secp256k1_ecdsa_recover( /* secp256k1_context */ IntPtr context, void* publicKey, void* signature, byte[] message);
 
         [SuppressUnmanagedCodeSecurity]
-        [DllImport(Secp256k1)]
-        public static extern bool secp256k1_ecdh( /* secp256k1_context */ IntPtr context, byte[] output, byte[] publicKey, byte[] privateKey, IntPtr hashFunctionPointer, IntPtr data);
+        [LibraryImport(Secp256k1)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static partial bool secp256k1_ecdh( /* secp256k1_context */ IntPtr context, byte[] output, byte[] publicKey, byte[] privateKey, IntPtr hashFunctionPointer, IntPtr data);
 
         [SuppressUnmanagedCodeSecurity]
-        [DllImport(Secp256k1)]
-        public static extern unsafe int secp256k1_ec_pubkey_parse(IntPtr ctx, void* pubkey, void* input, uint inputlen);
+        [LibraryImport(Secp256k1)]
+        public static unsafe partial int secp256k1_ec_pubkey_parse(IntPtr ctx, void* pubkey, void* input, uint inputlen);
 
 
         /*****************************************************************************************/


### PR DESCRIPTION
[LibraryImport](https://learn.microsoft.com/en-us/dotnet/standard/native-interop/pinvoke-source-generation) source generates the calling stubs decreasing the Jit work and also allowing them to be inlined and AoT complied vs DllImport

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or a feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional or API changes)
- [ ] Build-related changes
- [ ] Other: _description_ 

## Testing

#### Requires testing

- [ ] Yes
- [x] No