### PR TITLE
BlockToProduce use base Transactions

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Producers/BlockToProduce.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/BlockToProduce.cs
@@ -15,19 +15,11 @@ namespace Nethermind.Consensus.Producers
 {
     internal class BlockToProduce : Block
     {
-        private IEnumerable<Transaction>? _transactions;
-
-        public new IEnumerable<Transaction> Transactions
+        // Changes visibility of Transactions property setter to public
+        public new Transaction[] Transactions
         {
-            get => _transactions ?? base.Transactions;
-            set
-            {
-                _transactions = value;
-                if (_transactions is Transaction[] transactionsArray)
-                {
-                    base.Transactions = transactionsArray;
-                }
-            }
+            get => base.Transactions;
+            set => base.Transactions = value;
         }
 
         public BlockToProduce(
@@ -37,7 +29,9 @@ namespace Nethermind.Consensus.Producers
             IEnumerable<Withdrawal>? withdrawals = null)
             : base(blockHeader, Array.Empty<Transaction>(), uncles, withdrawals)
         {
-            Transactions = transactions;
+            Transactions = transactions is Transaction[] transactionsArray
+                ? transactionsArray
+                : transactions.ToArray();
         }
     }
 }


### PR DESCRIPTION
Don't return different results based on whether derived type or base type is used and depending on initialization; i.e. don't use different backing field.

## Changes

- Remove the shadowing backing field `_transactions`

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No