### PR TITLE
Fix Overseer path for .NET version update and config state

### DIFF
--- a/src/Nethermind/Nethermind.Overseer.Test/Framework/TestBuilder.cs
+++ b/src/Nethermind/Nethermind.Overseer.Test/Framework/TestBuilder.cs
@@ -271,9 +271,15 @@ namespace Nethermind.Overseer.Test.Framework
             return this;
         }
 
+#if DEBUG
+        const string buildConfiguration = "Debug";
+#else
+        const string buildConfiguration = "Release";
+#endif
+
         private void CopyRunnerFiles(string targetDirectory)
         {
-            string sourceDirectory = Path.Combine(Directory.GetCurrentDirectory(), "../../../../Nethermind.Runner/bin/Debug/net6.0/");
+            string sourceDirectory = Path.Combine(Directory.GetCurrentDirectory(), $"../../../../Nethermind.Runner/bin/{buildConfiguration}/net7.0/");
             if (!Directory.Exists(sourceDirectory))
             {
                 throw new IOException($"Runner not found at {sourceDirectory}");


### PR DESCRIPTION
## Changes

- Fix path from `net6.0` to `net7.0` and change mode from `Debug` to `Release` depending on build

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No