### PR TITLE
Bugfix/autorepair fix invalid best state calculation

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -239,7 +239,7 @@ namespace Nethermind.Blockchain
             }
         }
 
-        private void RecalculateTreeLevels()
+        public void RecalculateTreeLevels()
         {
             LoadLowestInsertedBodyNumber();
             LoadLowestInsertedHeader();

--- a/src/Nethermind/Nethermind.Blockchain/IBlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/IBlockTree.cs
@@ -187,5 +187,7 @@ namespace Nethermind.Blockchain
         bool IsBetterThanHead(BlockHeader? header);
 
         void UpdateBeaconMainChain(BlockInfo[]? blockInfos, long clearBeaconMainChainStartPoint);
+
+        void RecalculateTreeLevels();
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/ReadOnlyBlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/ReadOnlyBlockTree.cs
@@ -194,6 +194,7 @@ namespace Nethermind.Blockchain
 
         public bool IsBetterThanHead(BlockHeader? header) => _wrapped.IsBetterThanHead(header);
         public void UpdateBeaconMainChain(BlockInfo[]? blockInfos, long clearBeaconMainChainStartPoint) => throw new InvalidOperationException($"{nameof(ReadOnlyBlockTree)} does not expect {nameof(UpdateBeaconMainChain)} calls");
+        public void RecalculateTreeLevels() => throw new InvalidOperationException($"{nameof(ReadOnlyBlockTree)} does not expect {nameof(RecalculateTreeLevels)} calls");
 
         public void UpdateMainChain(IReadOnlyList<Block> blocks, bool wereProcessed, bool forceHeadBlock = false) => throw new InvalidOperationException($"{nameof(ReadOnlyBlockTree)} does not expect {nameof(UpdateMainChain)} calls");
 

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Synchronization.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Synchronization.cs
@@ -824,7 +824,7 @@ public partial class EngineModuleTests
         chain.BlockTree.RecalculateTreeLevels();
 
         Assert.True(chain.BlockTree.BestSuggestedBody!.Number >= chain.BlockTree.Head!.Number);
-        Assert.True(chain.BlockTree.BestSuggestedHeader!.Number < chain.BlockTree.Head!.Number);
+        Assert.True(chain.BlockTree.BestSuggestedHeader!.Number >= chain.BlockTree.Head!.Number);
     }
 
     private void AssertBlockTreePointers(

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Synchronization.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Synchronization.cs
@@ -866,7 +866,7 @@ public partial class EngineModuleTests
         Assert.True(chain.BlockTree.BestSuggestedBody!.Number < chain.BlockTree.Head!.Number);
         Assert.True(chain.BlockTree.BestSuggestedHeader!.Number < chain.BlockTree.Head!.Number);
 
-        MultiSyncModeSelector multiSyncModeSelector =  CreateMultiSyncModeSelector(chain);
+        MultiSyncModeSelector multiSyncModeSelector = CreateMultiSyncModeSelector(chain);
         multiSyncModeSelector.Update();
 
         Assert.True(chain.BlockTree.BestSuggestedBody!.Number >= chain.BlockTree.Head!.Number);

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Synchronization.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Synchronization.cs
@@ -11,12 +11,21 @@ using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Timers;
 using Nethermind.Crypto;
 using Nethermind.Int256;
 using Nethermind.JsonRpc;
+using Nethermind.Logging;
 using Nethermind.Merge.Plugin.Data;
 using Nethermind.Merge.Plugin.Synchronization;
+using Nethermind.Stats;
+using Nethermind.Synchronization;
+using Nethermind.Synchronization.ParallelSync;
+using Nethermind.Synchronization.Peers;
+using Nethermind.Synchronization.SnapSync;
+using NSubstitute;
 using NUnit.Framework;
+using No = Nethermind.Synchronization.No;
 
 namespace Nethermind.Merge.Plugin.Test;
 
@@ -825,6 +834,62 @@ public partial class EngineModuleTests
 
         Assert.True(chain.BlockTree.BestSuggestedBody!.Number >= chain.BlockTree.Head!.Number);
         Assert.True(chain.BlockTree.BestSuggestedHeader!.Number >= chain.BlockTree.Head!.Number);
+    }
+
+    [Test]
+    public async Task MultiSyncModeSelector_should_fix_block_tree_levels_if_needed()
+    {
+        using MergeTestBlockchain chain = await CreateBlockChain();
+        IEngineRpcModule rpc = CreateEngineModule(chain);
+        Keccak lastHash = (await ProduceBranchV1(rpc, chain, 30, CreateParentBlockRequestOnHead(chain.BlockTree), true))
+            .LastOrDefault()?.BlockHash ?? Keccak.Zero;
+        chain.BlockTree.HeadHash.Should().Be(lastHash);
+
+        // send newPayload
+        ExecutionPayload validBlockOnTopOfHead = CreateBlockRequest(CreateParentBlockRequestOnHead(chain.BlockTree), TestItem.AddressD);
+        PayloadStatusV1 payloadStatusResponse = (await rpc.engine_newPayloadV1(validBlockOnTopOfHead)).Data;
+        payloadStatusResponse.Status.Should().Be(PayloadStatus.Valid);
+
+        // send block with invalid state root
+        ExecutionPayload blockWithInvalidStateRoot = CreateBlockRequest(validBlockOnTopOfHead, TestItem.AddressA);
+        blockWithInvalidStateRoot.StateRoot = TestItem.KeccakB;
+        TryCalculateHash(blockWithInvalidStateRoot, out Keccak? hash);
+        blockWithInvalidStateRoot.BlockHash = hash;
+        PayloadStatusV1 invalidStateRootNewPayloadResponse = (await rpc.engine_newPayloadV1(blockWithInvalidStateRoot)).Data;
+        invalidStateRootNewPayloadResponse.Status.Should().Be(PayloadStatus.Invalid);
+
+        // send fcU to last new payload
+        ForkchoiceUpdatedV1Result response = (await rpc.engine_forkchoiceUpdatedV1(new ForkchoiceStateV1(validBlockOnTopOfHead.BlockHash, validBlockOnTopOfHead.BlockHash, validBlockOnTopOfHead.BlockHash))).Data;
+        response.PayloadStatus.Status.Should().Be(PayloadStatus.Valid);
+
+        // invalid best state calculation
+        Assert.True(chain.BlockTree.BestSuggestedBody!.Number < chain.BlockTree.Head!.Number);
+        Assert.True(chain.BlockTree.BestSuggestedHeader!.Number < chain.BlockTree.Head!.Number);
+
+        MultiSyncModeSelector multiSyncModeSelector =  CreateMultiSyncModeSelector(chain);
+        multiSyncModeSelector.Update();
+
+        Assert.True(chain.BlockTree.BestSuggestedBody!.Number >= chain.BlockTree.Head!.Number);
+        Assert.True(chain.BlockTree.BestSuggestedHeader!.Number >= chain.BlockTree.Head!.Number);
+    }
+
+    private MultiSyncModeSelector CreateMultiSyncModeSelector(MergeTestBlockchain chain)
+    {
+        SyncProgressResolver syncProgressResolver = new(chain.BlockTree, chain.ReceiptStorage, chain.DbProvider.StateDb, chain.TrieStore, new ProgressTracker(chain.BlockTree, chain.StateDb, LimboLogs.Instance), new SyncConfig(), LimboLogs.Instance);
+        BlockHeader peerHeader = chain.BlockTree.Head!.Header;
+        ISyncPeer syncPeer = Substitute.For<ISyncPeer>();
+        syncPeer.HeadHash.Returns(peerHeader.Hash);
+        syncPeer.HeadNumber.Returns(peerHeader.Number);
+        syncPeer.TotalDifficulty.Returns(peerHeader.TotalDifficulty ?? 0);
+        syncPeer.IsInitialized.Returns(true);
+        ISyncPeerPool? syncPeerPool = Substitute.For<ISyncPeerPool>();
+        List<PeerInfo> peerInfos = new() { new(syncPeer) };
+        syncPeerPool.InitializedPeers.Returns(peerInfos);
+        MultiSyncModeSelector multiSyncModeSelector = new(syncProgressResolver,
+            syncPeerPool, new SyncConfig(), No.BeaconSync,
+            new TotalDifficultyBetterPeerStrategy(LimboLogs.Instance), LimboLogs.Instance);
+        multiSyncModeSelector.Update();
+        return multiSyncModeSelector;
     }
 
     private void AssertBlockTreePointers(

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/ISyncProgressResolver.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/ISyncProgressResolver.cs
@@ -32,5 +32,7 @@ namespace Nethermind.Synchronization.ParallelSync
         UInt256 ChainDifficulty { get; }
 
         UInt256? GetTotalDifficulty(Keccak blockHash);
+
+        void RecalculateProgressPointers();
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
@@ -158,7 +158,7 @@ namespace Nethermind.Synchronization.ParallelSync
                 // to avoid expensive checks we make this simple check at the beginning
                 else
                 {
-                    Snapshot best = TakeSnapshot(peerDifficulty.Value, peerBlock.Value, inBeaconControl);
+                    Snapshot best = EnsureSnapshot(peerDifficulty.Value, peerBlock.Value, inBeaconControl);
                     best.IsInBeaconHeaders = _beaconSyncStrategy.ShouldBeInBeaconHeaders();
 
                     if (!FastSyncEnabled)
@@ -641,6 +641,30 @@ namespace Nethermind.Synchronization.ParallelSync
 
         public void Dispose() => _cancellation.Dispose();
 
+        private Snapshot EnsureSnapshot(in UInt256 peerDifficulty, long peerBlock, bool inBeaconControl)
+        {
+            // need to find them in the reversed order otherwise we may fall behind the processing
+            // and think that we have an invalid snapshot
+            Snapshot best = TakeSnapshot(peerDifficulty, peerBlock, inBeaconControl);
+
+            if (IsSnapshotInvalid(best))
+            {
+                string stateString = BuildStateString(best);
+                if (_logger.IsWarn) _logger.Warn($"Invalid snapshot calculation: {stateString}. Recalculating progress pointers...");
+                _syncProgressResolver.RecalculateProgressPointers();
+                best = TakeSnapshot(peerDifficulty, peerBlock, inBeaconControl);
+                if (IsSnapshotInvalid(best))
+                {
+                    string recalculatedSnapshot = BuildStateString(best);
+                    string errorMessage = $"Cannot recalculate snapshot progress. Invalid snapshot calculation: {recalculatedSnapshot}";
+                    if (_logger.IsError) _logger.Error(errorMessage);
+                    throw new InvalidAsynchronousStateException(errorMessage);
+                }
+            }
+
+            return best;
+        }
+
         private Snapshot TakeSnapshot(in UInt256 peerDifficulty, long peerBlock, bool inBeaconControl)
         {
             // need to find them in the reversed order otherwise we may fall behind the processing
@@ -652,14 +676,12 @@ namespace Nethermind.Synchronization.ParallelSync
             long targetBlock = _beaconSyncStrategy.GetTargetBlockHeight() ?? peerBlock;
             UInt256 chainDifficulty = _syncProgressResolver.ChainDifficulty;
 
-            Snapshot best = new(processed, state, block, header, chainDifficulty, peerBlock, peerDifficulty, inBeaconControl, targetBlock);
-            VerifySnapshot(best);
-            return best;
+            return new(processed, state, block, header, chainDifficulty, Math.Max(peerBlock, 0), peerDifficulty, inBeaconControl, targetBlock);
         }
 
-        private void VerifySnapshot(Snapshot best)
+        private bool IsSnapshotInvalid(Snapshot best)
         {
-            if ( // none of these values should ever be negative
+            return // none of these values should ever be negative
                 best.Block < 0
                 || best.Header < 0
                 || best.State < 0
@@ -671,17 +693,9 @@ namespace Nethermind.Synchronization.ParallelSync
                 // we cannot download state for an unknown header
                 || best.State > best.Header
                 // we can only process blocks for which we have full body
-                || best.Processed > best.Block
+                || best.Processed > best.Block;
             // for any processed block we should have its full state
-            // || (best.Processed > best.State && best.Processed > best.BeamState))
-            // but we only do limited lookups for state so we need to instead fast sync to now
-            )
-            {
-                string stateString = BuildStateString(best);
-                string errorMessage = $"Invalid best state calculation: {stateString}";
-                if (_logger.IsError) _logger.Error(errorMessage);
-                throw new InvalidAsynchronousStateException(errorMessage);
-            }
+            // but we only do limited lookups for state so we need to instead fast sync to now;
         }
 
         private void LogDetailedSyncModeChecks(string syncType, params (string Name, bool IsSatisfied)[] checks)

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncModeChangedEventArgs.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncModeChangedEventArgs.cs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using Nethermind.Core;
-using Nethermind.State;
 
 namespace Nethermind.Synchronization.ParallelSync
 {

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncProgressResolver.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncProgressResolver.cs
@@ -173,6 +173,8 @@ namespace Nethermind.Synchronization.ParallelSync
 
         public bool IsSnapGetRangesFinished() => _progressTracker.IsSnapGetRangesFinished();
 
+        public void RecalculateProgressPointers() => _blockTree.RecalculateTreeLevels();
+
         private bool IsFastBlocks()
         {
             bool isFastBlocks = _syncConfig.FastBlocks;

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncProgressResolver.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncProgressResolver.cs
@@ -10,7 +10,6 @@ using Nethermind.Core.Crypto;
 using Nethermind.Db;
 using Nethermind.Int256;
 using Nethermind.Logging;
-using Nethermind.State.Snap;
 using Nethermind.Synchronization.SnapSync;
 using Nethermind.Trie;
 using Nethermind.Trie.Pruning;


### PR DESCRIPTION
## Changes

Possible fix of Invalid Best State Calculation observed on syncing some archive nodes. This is automatic repair after the issue happened. Normally, a restart of the node will fix the issue. The root cause: once we have an invalid block during the sync, we 
changed best blocks: https://github.com/NethermindEth/nethermind/blob/master/src/Nethermind/Nethermind.Blockchain/BlockTree.cs#L1111
but we can have more blocks that have been already suggested and because of that Invalid Best State Calculation is broken: https://github.com/NethermindEth/nethermind/blob/master/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs#L674

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

I haven't done testing yet, which is why it is still a draft. It takes a lot of time to sync archive nodes, I will start with this fix and will work on tests in the meantime. For now, I want to check if the fix is working

