### PR TITLE
Add tags to every metric

### DIFF
--- a/.github/workflows/nethermind-tests.yml
+++ b/.github/workflows/nethermind-tests.yml
@@ -436,10 +436,6 @@ jobs:
       run: dotnet test src/Nethermind/Ethereum.Trie.Test -c ${{ env.BUILD_CONFIG }}
     - name: Ethereum.VM.Test
       run: dotnet test src/Nethermind/Ethereum.VM.Test -c ${{ env.BUILD_CONFIG }}
-    - name: Ethereum.Blockchain.Block.Legacy.Test
-      run: dotnet test src/Nethermind/Ethereum.Block.Legacy.Test -c ${{ env.BUILD_CONFIG }}
-    - name: Ethereum.Blockchain.Legacy.Test
-      run: dotnet test src/Nethermind/Ethereum.Legacy.Test -c ${{ env.BUILD_CONFIG }}
 
   eth-tests3:
     name: 'Run Ethereum tests #3'

--- a/.github/workflows/nethermind-tests.yml
+++ b/.github/workflows/nethermind-tests.yml
@@ -436,6 +436,10 @@ jobs:
       run: dotnet test src/Nethermind/Ethereum.Trie.Test -c ${{ env.BUILD_CONFIG }}
     - name: Ethereum.VM.Test
       run: dotnet test src/Nethermind/Ethereum.VM.Test -c ${{ env.BUILD_CONFIG }}
+    - name: Ethereum.Blockchain.Block.Legacy.Test
+      run: dotnet test src/Nethermind/Ethereum.Block.Legacy.Test -c ${{ env.BUILD_CONFIG }}
+    - name: Ethereum.Blockchain.Legacy.Test
+      run: dotnet test src/Nethermind/Ethereum.Legacy.Test -c ${{ env.BUILD_CONFIG }}
 
   eth-tests3:
     name: 'Run Ethereum tests #3'

--- a/src/Nethermind/Nethermind.Init/Metrics.cs
+++ b/src/Nethermind/Nethermind.Init/Metrics.cs
@@ -11,7 +11,6 @@ namespace Nethermind.Init
     public static class Metrics
     {
         [Description("Version number")]
-        [MetricsStaticDescriptionTag(nameof(ProductInfo.BuildTimestamp), typeof(ProductInfo))]
         public static long Version { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.Init/Metrics.cs
+++ b/src/Nethermind/Nethermind.Init/Metrics.cs
@@ -11,14 +11,7 @@ namespace Nethermind.Init
     public static class Metrics
     {
         [Description("Version number")]
-        [MetricsStaticDescriptionTag(nameof(ProductInfo.Version), typeof(ProductInfo))]
-        [MetricsStaticDescriptionTag(nameof(ProductInfo.Commit), typeof(ProductInfo))]
-        [MetricsStaticDescriptionTag(nameof(ProductInfo.Runtime), typeof(ProductInfo))]
         [MetricsStaticDescriptionTag(nameof(ProductInfo.BuildTimestamp), typeof(ProductInfo))]
-        [MetricsStaticDescriptionTag(nameof(ProductInfo.Instance), typeof(ProductInfo))]
-        [MetricsStaticDescriptionTag(nameof(ProductInfo.Network), typeof(ProductInfo))]
-        [MetricsStaticDescriptionTag(nameof(ProductInfo.SyncType), typeof(ProductInfo))]
-        [MetricsStaticDescriptionTag(nameof(ProductInfo.PruningMode), typeof(ProductInfo))]
         public static long Version { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.Monitoring/Metrics/MetricsController.cs
+++ b/src/Nethermind/Nethermind.Monitoring/Metrics/MetricsController.cs
@@ -76,6 +76,7 @@ namespace Nethermind.Monitoring.Metrics
             tags.Add(nameof(ProductInfo.Version), ProductInfo.Version);
             tags.Add(nameof(ProductInfo.Commit), ProductInfo.Commit);
             tags.Add(nameof(ProductInfo.Runtime), ProductInfo.Runtime);
+            tags.Add(nameof(ProductInfo.BuildTimestamp), ProductInfo.BuildTimestamp.ToUnixTimeSeconds().ToString());
             return tags;
         }
 


### PR DESCRIPTION
Fixes Closes Resolves #
To make requests like `avg(state_db_size{Network="Gnosis",Version=~"1.18.0.*"}` possible we have to add tags to every metric 

## Changes

- Adds tag to every metric
- Changes BuildTimestamp to unix seconds

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

