### PR TITLE
Use explicit memory handling for db and always free

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -372,7 +372,24 @@ public class DbOnTheRocks : IDbWithSpan, ITunableDb
 
         try
         {
-            return _db.Get(key);
+            Span<byte> data = _db.GetSpan(key);
+            if (data.IsNull())
+            {
+                return null;
+            }
+            try
+            {
+                if (data.Length == 0)
+                {
+                    return null;
+                }
+
+                return data.ToArray();
+            }
+            finally
+            {
+                _db.DangerousReleaseMemory(data);
+            }
         }
         catch (RocksDbSharpException e)
         {


### PR DESCRIPTION
## Changes

- Always use the span overloads for RocksDb Get and explicitly free rather than using underlying lib's handling

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No