### PR TITLE
Fix/transactionhash not threadsafe

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Receipts/PersistentReceiptStorageTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Receipts/PersistentReceiptStorageTests.cs
@@ -2,10 +2,8 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Configuration;
 using System.Linq;
 using System.Threading;
-using DotNetty.Transport.Channels;
 using FluentAssertions;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Core;
@@ -223,7 +221,6 @@ namespace Nethermind.Blockchain.Test.Receipts
         }
 
         [Test]
-        [Ignore("Needs to be fixed, details https://github.com/NethermindEth/nethermind/pull/5621")]
         public void When_TxLookupLimitIs_NegativeOne_DoNotIndexTxHash()
         {
             _receiptConfig.TxLookupLimit = -1;
@@ -249,7 +246,6 @@ namespace Nethermind.Blockchain.Test.Receipts
         }
 
         [Test]
-        [Ignore("Needs to be fixed, details https://github.com/NethermindEth/nethermind/pull/5621")]
         public void When_HeadBlockIsFarAhead_DoNotIndexTxHash()
         {
             _receiptConfig.TxLookupLimit = 1000;
@@ -261,7 +257,6 @@ namespace Nethermind.Blockchain.Test.Receipts
         }
 
         [Test]
-        [Ignore("Needs to be fixed, details https://github.com/NethermindEth/nethermind/pull/5621")]
         public void When_NewHeadBlock_Remove_TxIndex_OfRemovedBlock()
         {
             CreateStorage();

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/IReceiptConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/IReceiptConfig.cs
@@ -13,12 +13,12 @@ public interface IReceiptConfig : IConfig
     [ConfigItem(Description = "If set to 'true' then receipts db will be migrated to new schema.", DefaultValue = "false")]
     bool ReceiptsMigration { get; set; }
 
-    [ConfigItem(Description = "If set to 'true' then reduce receipt db size at expense of rpc performance.", DefaultValue = "false", HiddenFromDocs = true)]
+    [ConfigItem(Description = "If set to 'true' then reduce receipt db size at expense of rpc performance.", DefaultValue = "true")]
     bool CompactReceiptStore { get; set; }
 
-    [ConfigItem(Description = "If set to 'true' then reduce receipt tx index db size at expense of rpc performance.", DefaultValue = "false", HiddenFromDocs = true)]
+    [ConfigItem(Description = "If set to 'true' then reduce receipt tx index db size at expense of rpc performance.", DefaultValue = "true")]
     bool CompactTxIndex { get; set; }
 
-    [ConfigItem(Description = "Number of recent blocks to maintain transaction index. 0 to never remove tx index. -1 to never index.", DefaultValue = "0", HiddenFromDocs = true)]
+    [ConfigItem(Description = "Number of recent blocks to maintain transaction index. 0 to never remove tx index. -1 to never index.", DefaultValue = "2350000")]
     long? TxLookupLimit { get; set; }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/ReceiptConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/ReceiptConfig.cs
@@ -7,7 +7,7 @@ public class ReceiptConfig : IReceiptConfig
 {
     public bool StoreReceipts { get; set; } = true;
     public bool ReceiptsMigration { get; set; } = false;
-    public bool CompactReceiptStore { get; set; } = false;
-    public bool CompactTxIndex { get; set; } = false;
-    public long? TxLookupLimit { get; set; } = 0;
+    public bool CompactReceiptStore { get; set; } = true;
+    public bool CompactTxIndex { get; set; } = true;
+    public long? TxLookupLimit { get; set; } = 2350000;
 }

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/TxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/TxDecoderTests.cs
@@ -3,7 +3,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using FluentAssertions;
+using FluentAssertions.Numeric;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Eip2930;
 using Nethermind.Core.Extensions;
@@ -60,6 +63,31 @@ namespace Nethermind.Core.Test.Encoding
                 .WithGasPrice(0)
                 .WithChainId(1559)
                 .SignedAndResolved().TestObject, "EIP 1559 second test case");
+        }
+
+        [TestCaseSource(nameof(TestCaseSource))]
+        [Repeat(10)] // Might wanna increase this to double check when changing logic as on lower value, it does not reproduce.
+        public void CanCorrectlyCalculateTxHash_when_called_concurrently((Transaction Tx, string Description) testCase)
+        {
+            Transaction tx = testCase.Tx;
+
+            TxDecoder decoder = new TxDecoder();
+            Rlp rlp = decoder.Encode(tx);
+
+            Keccak expectedHash = Keccak.Compute(rlp.Bytes);
+
+            Transaction decodedTx = decoder.Decode(new RlpStream(rlp.Bytes));
+
+            decodedTx.SetPreHash(rlp.Bytes);
+
+            IEnumerable<Task<AndConstraint<ComparableTypeAssertions<Keccak>>>> tasks = Enumerable
+                .Range(0, 32)
+                .Select((_) =>
+                    Task.Factory
+                        .StartNew(() => decodedTx.Hash.Should().Be(expectedHash),
+                            TaskCreationOptions.RunContinuationsAsynchronously));
+
+            Task.WaitAll(tasks.ToArray());
         }
 
         [TestCaseSource(nameof(TestCaseSource))]


### PR DESCRIPTION
- The invalid block issue is probably caused by some corruption in arraypool due to concurrent lazy transaction hash calculation, which causes the memory to be released and probably reused somewhere else unintentially.
- Adding logs shows that the tx hash changes within `EnsureCanonical`. 
- EnsureCanonical changed from using receipt hash to tx hash to prevent reloading the receipt. But for some reason, the tx hash is not resolved at that point. The resolving of the tx hash seems to be the problem.
- Adding some custom logic to check where the other concurrent hash calculation shows that its on `Nethermind.TxPool.TxPool.RemoveProcessedTransactions` which would get triggered on new head.
- This happens relatively easily on vps but I've not been able to reproduce it locally.
- I just add a lock around it ...  

## Changes

- Add a lock around lazy tx hash calculation.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- No invalid block so far.