### PR TITLE
Rename WriteBytesPerSec to BytesPerSec and add direct io flag.

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
@@ -19,7 +19,10 @@ public class DbConfig : IDbConfig
     public bool CacheIndexAndFilterBlocks { get; set; } = false;
     public int? MaxOpenFiles { get; set; }
     public long? MaxBytesPerSec { get; set; }
+    public long? MaxWriteBytesPerSec { get; set; }
     public int? BlockSize { get; set; } = 16 * 1024;
+    public bool? UseDirectReads { get; set; } = false;
+    public bool? UseDirectIoForFlushAndCompactions { get; set; } = false;
     public IDictionary<string, string>? AdditionalRocksDbOptions { get; set; }
 
     public ulong ReceiptsDbWriteBufferSize { get; set; } = (ulong)8.MiB();
@@ -27,8 +30,11 @@ public class DbConfig : IDbConfig
     public ulong ReceiptsDbBlockCacheSize { get; set; } = 0;
     public bool ReceiptsDbCacheIndexAndFilterBlocks { get; set; } = false;
     public int? ReceiptsDbMaxOpenFiles { get; set; }
+    public long? ReceiptsDbMaxWriteBytesPerSec { get; set; }
     public long? ReceiptsDbMaxBytesPerSec { get; set; }
     public int? ReceiptsBlockSize { get; set; }
+    public bool? ReceiptsUseDirectReads { get; set; } = false;
+    public bool? ReceiptsUseDirectIoForFlushAndCompactions { get; set; } = false;
     public IDictionary<string, string>? ReceiptsDbAdditionalRocksDbOptions { get; set; }
 
     public ulong BlocksDbWriteBufferSize { get; set; } = (ulong)8.MiB();
@@ -36,8 +42,11 @@ public class DbConfig : IDbConfig
     public ulong BlocksDbBlockCacheSize { get; set; } = 0;
     public bool BlocksDbCacheIndexAndFilterBlocks { get; set; } = false;
     public int? BlocksDbMaxOpenFiles { get; set; }
+    public long? BlocksDbMaxWriteBytesPerSec { get; set; }
     public long? BlocksDbMaxBytesPerSec { get; set; }
     public int? BlocksBlockSize { get; set; }
+    public bool? BlocksUseDirectReads { get; set; } = false;
+    public bool? BlocksUseDirectIoForFlushAndCompactions { get; set; } = false;
     public IDictionary<string, string>? BlocksDbAdditionalRocksDbOptions { get; set; }
 
     public ulong HeadersDbWriteBufferSize { get; set; } = (ulong)8.MiB();
@@ -45,8 +54,11 @@ public class DbConfig : IDbConfig
     public ulong HeadersDbBlockCacheSize { get; set; } = 0;
     public bool HeadersDbCacheIndexAndFilterBlocks { get; set; } = false;
     public int? HeadersDbMaxOpenFiles { get; set; }
+    public long? HeadersDbMaxWriteBytesPerSec { get; set; }
     public long? HeadersDbMaxBytesPerSec { get; set; }
     public int? HeadersBlockSize { get; set; } = 4 * 1024;
+    public bool? HeadersUseDirectReads { get; set; } = false;
+    public bool? HeadersUseDirectIoForFlushAndCompactions { get; set; } = false;
     public IDictionary<string, string>? HeadersDbAdditionalRocksDbOptions { get; set; }
 
     public ulong BlockInfosDbWriteBufferSize { get; set; } = (ulong)8.MiB();
@@ -54,8 +66,11 @@ public class DbConfig : IDbConfig
     public ulong BlockInfosDbBlockCacheSize { get; set; } = 0;
     public bool BlockInfosDbCacheIndexAndFilterBlocks { get; set; } = false;
     public int? BlockInfosDbMaxOpenFiles { get; set; }
+    public long? BlockInfosDbMaxWriteBytesPerSec { get; set; }
     public long? BlockInfosDbMaxBytesPerSec { get; set; }
     public int? BlockInfosBlockSize { get; set; }
+    public bool? BlockInfosUseDirectReads { get; set; } = false;
+    public bool? BlockInfosUseDirectIoForFlushAndCompactions { get; set; } = false;
     public IDictionary<string, string>? BlockInfosDbAdditionalRocksDbOptions { get; set; }
 
     public ulong PendingTxsDbWriteBufferSize { get; set; } = (ulong)4.MiB();
@@ -63,8 +78,11 @@ public class DbConfig : IDbConfig
     public ulong PendingTxsDbBlockCacheSize { get; set; } = 0;
     public bool PendingTxsDbCacheIndexAndFilterBlocks { get; set; } = false;
     public int? PendingTxsDbMaxOpenFiles { get; set; }
+    public long? PendingTxsDbMaxWriteBytesPerSec { get; set; }
     public long? PendingTxsDbMaxBytesPerSec { get; set; }
     public int? PendingTxsBlockSize { get; set; }
+    public bool? PendingTxsUseDirectReads { get; set; } = false;
+    public bool? PendingTxsUseDirectIoForFlushAndCompactions { get; set; } = false;
     public IDictionary<string, string>? PendingTxsDbAdditionalRocksDbOptions { get; set; }
 
     public ulong CodeDbWriteBufferSize { get; set; } = (ulong)2.MiB();
@@ -72,8 +90,11 @@ public class DbConfig : IDbConfig
     public ulong CodeDbBlockCacheSize { get; set; } = 0;
     public bool CodeDbCacheIndexAndFilterBlocks { get; set; } = false;
     public int? CodeDbMaxOpenFiles { get; set; }
+    public long? CodeDbMaxWriteBytesPerSec { get; set; }
     public long? CodeDbMaxBytesPerSec { get; set; }
     public int? CodeBlockSize { get; set; }
+    public bool? CodeUseDirectReads { get; set; } = false;
+    public bool? CodeUseDirectIoForFlushAndCompactions { get; set; } = false;
     public IDictionary<string, string>? CodeDbAdditionalRocksDbOptions { get; set; }
 
     public ulong BloomDbWriteBufferSize { get; set; } = (ulong)1.KiB();
@@ -81,6 +102,7 @@ public class DbConfig : IDbConfig
     public ulong BloomDbBlockCacheSize { get; set; } = 0;
     public bool BloomDbCacheIndexAndFilterBlocks { get; set; } = false;
     public int? BloomDbMaxOpenFiles { get; set; }
+    public long? BloomDbMaxWriteBytesPerSec { get; set; }
     public long? BloomDbMaxBytesPerSec { get; set; }
     public IDictionary<string, string>? BloomDbAdditionalRocksDbOptions { get; set; }
 
@@ -89,8 +111,11 @@ public class DbConfig : IDbConfig
     public ulong WitnessDbBlockCacheSize { get; set; } = 0;
     public bool WitnessDbCacheIndexAndFilterBlocks { get; set; } = false;
     public int? WitnessDbMaxOpenFiles { get; set; }
+    public long? WitnessDbMaxWriteBytesPerSec { get; set; }
     public long? WitnessDbMaxBytesPerSec { get; set; }
     public int? WitnessBlockSize { get; set; }
+    public bool? WitnessUseDirectReads { get; set; } = false;
+    public bool? WitnessUseDirectIoForFlushAndCompactions { get; set; } = false;
     public IDictionary<string, string>? WitnessDbAdditionalRocksDbOptions { get; set; }
 
     // TODO - profile and customize
@@ -99,8 +124,11 @@ public class DbConfig : IDbConfig
     public ulong CanonicalHashTrieDbBlockCacheSize { get; set; } = 0;
     public bool CanonicalHashTrieDbCacheIndexAndFilterBlocks { get; set; } = false;
     public int? CanonicalHashTrieDbMaxOpenFiles { get; set; }
+    public long? CanonicalHashTrieDbMaxWriteBytesPerSec { get; set; }
     public long? CanonicalHashTrieDbMaxBytesPerSec { get; set; }
     public int? CanonicalHashTrieBlockSize { get; set; }
+    public bool? CanonicalHashTrieUseDirectReads { get; set; } = false;
+    public bool? CanonicalHashTrieUseDirectIoForFlushAndCompactions { get; set; } = false;
     public IDictionary<string, string>? CanonicalHashTrieDbAdditionalRocksDbOptions { get; set; }
 
     public ulong MetadataDbWriteBufferSize { get; set; } = (ulong)1.KiB();
@@ -108,8 +136,11 @@ public class DbConfig : IDbConfig
     public ulong MetadataDbBlockCacheSize { get; set; } = 0;
     public bool MetadataDbCacheIndexAndFilterBlocks { get; set; } = false;
     public int? MetadataDbMaxOpenFiles { get; set; }
+    public long? MetadataDbMaxWriteBytesPerSec { get; set; }
     public long? MetadataDbMaxBytesPerSec { get; set; }
     public int? MetadataBlockSize { get; set; }
+    public bool? MetadataUseDirectReads { get; set; } = false;
+    public bool? MetadataUseDirectIoForFlushAndCompactions { get; set; } = false;
     public IDictionary<string, string>? MetadataDbAdditionalRocksDbOptions { get; set; }
 
     public ulong StateDbWriteBufferSize { get; set; }
@@ -117,8 +148,11 @@ public class DbConfig : IDbConfig
     public ulong StateDbBlockCacheSize { get; set; }
     public bool StateDbCacheIndexAndFilterBlocks { get; set; }
     public int? StateDbMaxOpenFiles { get; set; }
+    public long? StateDbMaxWriteBytesPerSec { get; set; }
     public long? StateDbMaxBytesPerSec { get; set; }
     public int? StateDbBlockSize { get; set; } = 4 * 1024;
+    public bool? StateDbUseDirectReads { get; set; } = false;
+    public bool? StateDbUseDirectIoForFlushAndCompactions { get; set; } = false;
     public IDictionary<string, string>? StateDbAdditionalRocksDbOptions { get; set; }
 
     public uint RecycleLogFileNum { get; set; } = 0;

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
@@ -18,7 +18,7 @@ public class DbConfig : IDbConfig
     public ulong BlockCacheSize { get; set; } = 0;
     public bool CacheIndexAndFilterBlocks { get; set; } = false;
     public int? MaxOpenFiles { get; set; }
-    public long? MaxWriteBytesPerSec { get; set; }
+    public long? MaxBytesPerSec { get; set; }
     public int? BlockSize { get; set; } = 16 * 1024;
     public IDictionary<string, string>? AdditionalRocksDbOptions { get; set; }
 
@@ -27,7 +27,7 @@ public class DbConfig : IDbConfig
     public ulong ReceiptsDbBlockCacheSize { get; set; } = 0;
     public bool ReceiptsDbCacheIndexAndFilterBlocks { get; set; } = false;
     public int? ReceiptsDbMaxOpenFiles { get; set; }
-    public long? ReceiptsDbMaxWriteBytesPerSec { get; set; }
+    public long? ReceiptsDbMaxBytesPerSec { get; set; }
     public int? ReceiptsBlockSize { get; set; }
     public IDictionary<string, string>? ReceiptsDbAdditionalRocksDbOptions { get; set; }
 
@@ -36,7 +36,7 @@ public class DbConfig : IDbConfig
     public ulong BlocksDbBlockCacheSize { get; set; } = 0;
     public bool BlocksDbCacheIndexAndFilterBlocks { get; set; } = false;
     public int? BlocksDbMaxOpenFiles { get; set; }
-    public long? BlocksDbMaxWriteBytesPerSec { get; set; }
+    public long? BlocksDbMaxBytesPerSec { get; set; }
     public int? BlocksBlockSize { get; set; }
     public IDictionary<string, string>? BlocksDbAdditionalRocksDbOptions { get; set; }
 
@@ -45,7 +45,7 @@ public class DbConfig : IDbConfig
     public ulong HeadersDbBlockCacheSize { get; set; } = 0;
     public bool HeadersDbCacheIndexAndFilterBlocks { get; set; } = false;
     public int? HeadersDbMaxOpenFiles { get; set; }
-    public long? HeadersDbMaxWriteBytesPerSec { get; set; }
+    public long? HeadersDbMaxBytesPerSec { get; set; }
     public int? HeadersBlockSize { get; set; } = 4 * 1024;
     public IDictionary<string, string>? HeadersDbAdditionalRocksDbOptions { get; set; }
 
@@ -54,7 +54,7 @@ public class DbConfig : IDbConfig
     public ulong BlockInfosDbBlockCacheSize { get; set; } = 0;
     public bool BlockInfosDbCacheIndexAndFilterBlocks { get; set; } = false;
     public int? BlockInfosDbMaxOpenFiles { get; set; }
-    public long? BlockInfosDbMaxWriteBytesPerSec { get; set; }
+    public long? BlockInfosDbMaxBytesPerSec { get; set; }
     public int? BlockInfosBlockSize { get; set; }
     public IDictionary<string, string>? BlockInfosDbAdditionalRocksDbOptions { get; set; }
 
@@ -63,7 +63,7 @@ public class DbConfig : IDbConfig
     public ulong PendingTxsDbBlockCacheSize { get; set; } = 0;
     public bool PendingTxsDbCacheIndexAndFilterBlocks { get; set; } = false;
     public int? PendingTxsDbMaxOpenFiles { get; set; }
-    public long? PendingTxsDbMaxWriteBytesPerSec { get; set; }
+    public long? PendingTxsDbMaxBytesPerSec { get; set; }
     public int? PendingTxsBlockSize { get; set; }
     public IDictionary<string, string>? PendingTxsDbAdditionalRocksDbOptions { get; set; }
 
@@ -72,7 +72,7 @@ public class DbConfig : IDbConfig
     public ulong CodeDbBlockCacheSize { get; set; } = 0;
     public bool CodeDbCacheIndexAndFilterBlocks { get; set; } = false;
     public int? CodeDbMaxOpenFiles { get; set; }
-    public long? CodeDbMaxWriteBytesPerSec { get; set; }
+    public long? CodeDbMaxBytesPerSec { get; set; }
     public int? CodeBlockSize { get; set; }
     public IDictionary<string, string>? CodeDbAdditionalRocksDbOptions { get; set; }
 
@@ -81,7 +81,7 @@ public class DbConfig : IDbConfig
     public ulong BloomDbBlockCacheSize { get; set; } = 0;
     public bool BloomDbCacheIndexAndFilterBlocks { get; set; } = false;
     public int? BloomDbMaxOpenFiles { get; set; }
-    public long? BloomDbMaxWriteBytesPerSec { get; set; }
+    public long? BloomDbMaxBytesPerSec { get; set; }
     public IDictionary<string, string>? BloomDbAdditionalRocksDbOptions { get; set; }
 
     public ulong WitnessDbWriteBufferSize { get; set; } = (ulong)1.KiB();
@@ -89,7 +89,7 @@ public class DbConfig : IDbConfig
     public ulong WitnessDbBlockCacheSize { get; set; } = 0;
     public bool WitnessDbCacheIndexAndFilterBlocks { get; set; } = false;
     public int? WitnessDbMaxOpenFiles { get; set; }
-    public long? WitnessDbMaxWriteBytesPerSec { get; set; }
+    public long? WitnessDbMaxBytesPerSec { get; set; }
     public int? WitnessBlockSize { get; set; }
     public IDictionary<string, string>? WitnessDbAdditionalRocksDbOptions { get; set; }
 
@@ -99,7 +99,7 @@ public class DbConfig : IDbConfig
     public ulong CanonicalHashTrieDbBlockCacheSize { get; set; } = 0;
     public bool CanonicalHashTrieDbCacheIndexAndFilterBlocks { get; set; } = false;
     public int? CanonicalHashTrieDbMaxOpenFiles { get; set; }
-    public long? CanonicalHashTrieDbMaxWriteBytesPerSec { get; set; }
+    public long? CanonicalHashTrieDbMaxBytesPerSec { get; set; }
     public int? CanonicalHashTrieBlockSize { get; set; }
     public IDictionary<string, string>? CanonicalHashTrieDbAdditionalRocksDbOptions { get; set; }
 
@@ -108,7 +108,7 @@ public class DbConfig : IDbConfig
     public ulong MetadataDbBlockCacheSize { get; set; } = 0;
     public bool MetadataDbCacheIndexAndFilterBlocks { get; set; } = false;
     public int? MetadataDbMaxOpenFiles { get; set; }
-    public long? MetadataDbMaxWriteBytesPerSec { get; set; }
+    public long? MetadataDbMaxBytesPerSec { get; set; }
     public int? MetadataBlockSize { get; set; }
     public IDictionary<string, string>? MetadataDbAdditionalRocksDbOptions { get; set; }
 
@@ -117,7 +117,7 @@ public class DbConfig : IDbConfig
     public ulong StateDbBlockCacheSize { get; set; }
     public bool StateDbCacheIndexAndFilterBlocks { get; set; }
     public int? StateDbMaxOpenFiles { get; set; }
-    public long? StateDbMaxWriteBytesPerSec { get; set; }
+    public long? StateDbMaxBytesPerSec { get; set; }
     public int? StateDbBlockSize { get; set; } = 4 * 1024;
     public IDictionary<string, string>? StateDbAdditionalRocksDbOptions { get; set; }
 

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/IDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/IDbConfig.cs
@@ -19,8 +19,10 @@ public interface IDbConfig : IConfig
     int? MaxOpenFiles { get; set; }
     uint RecycleLogFileNum { get; set; }
     bool WriteAheadLogSync { get; set; }
-    long? MaxWriteBytesPerSec { get; set; }
+    long? MaxBytesPerSec { get; set; }
     int? BlockSize { get; set; }
+    bool? UseDirectReads { get; set; }
+    bool? UseDirectIoForFlushAndCompactions { get; set; }
     IDictionary<string, string>? AdditionalRocksDbOptions { get; set; }
 
     ulong ReceiptsDbWriteBufferSize { get; set; }
@@ -28,8 +30,10 @@ public interface IDbConfig : IConfig
     ulong ReceiptsDbBlockCacheSize { get; set; }
     bool ReceiptsDbCacheIndexAndFilterBlocks { get; set; }
     int? ReceiptsDbMaxOpenFiles { get; set; }
-    long? ReceiptsDbMaxWriteBytesPerSec { get; set; }
+    long? ReceiptsDbMaxBytesPerSec { get; set; }
     int? ReceiptsBlockSize { get; set; }
+    bool? ReceiptsUseDirectReads { get; set; }
+    bool? ReceiptsUseDirectIoForFlushAndCompactions { get; set; }
     IDictionary<string, string>? ReceiptsDbAdditionalRocksDbOptions { get; set; }
 
     ulong BlocksDbWriteBufferSize { get; set; }
@@ -37,8 +41,10 @@ public interface IDbConfig : IConfig
     ulong BlocksDbBlockCacheSize { get; set; }
     bool BlocksDbCacheIndexAndFilterBlocks { get; set; }
     int? BlocksDbMaxOpenFiles { get; set; }
-    long? BlocksDbMaxWriteBytesPerSec { get; set; }
+    long? BlocksDbMaxBytesPerSec { get; set; }
     int? BlocksBlockSize { get; set; }
+    bool? BlocksUseDirectReads { get; set; }
+    bool? BlocksUseDirectIoForFlushAndCompactions { get; set; }
     IDictionary<string, string>? BlocksDbAdditionalRocksDbOptions { get; set; }
 
     ulong HeadersDbWriteBufferSize { get; set; }
@@ -46,8 +52,10 @@ public interface IDbConfig : IConfig
     ulong HeadersDbBlockCacheSize { get; set; }
     bool HeadersDbCacheIndexAndFilterBlocks { get; set; }
     int? HeadersDbMaxOpenFiles { get; set; }
-    long? HeadersDbMaxWriteBytesPerSec { get; set; }
+    long? HeadersDbMaxBytesPerSec { get; set; }
     int? HeadersBlockSize { get; set; }
+    bool? HeadersUseDirectReads { get; set; }
+    bool? HeadersUseDirectIoForFlushAndCompactions { get; set; }
     IDictionary<string, string>? HeadersDbAdditionalRocksDbOptions { get; set; }
 
     ulong BlockInfosDbWriteBufferSize { get; set; }
@@ -55,8 +63,10 @@ public interface IDbConfig : IConfig
     ulong BlockInfosDbBlockCacheSize { get; set; }
     bool BlockInfosDbCacheIndexAndFilterBlocks { get; set; }
     int? BlockInfosDbMaxOpenFiles { get; set; }
-    long? BlockInfosDbMaxWriteBytesPerSec { get; set; }
+    long? BlockInfosDbMaxBytesPerSec { get; set; }
     int? BlockInfosBlockSize { get; set; }
+    bool? BlockInfosUseDirectReads { get; set; }
+    bool? BlockInfosUseDirectIoForFlushAndCompactions { get; set; }
     IDictionary<string, string>? BlockInfosDbAdditionalRocksDbOptions { get; set; }
 
     ulong PendingTxsDbWriteBufferSize { get; set; }
@@ -64,8 +74,10 @@ public interface IDbConfig : IConfig
     ulong PendingTxsDbBlockCacheSize { get; set; }
     bool PendingTxsDbCacheIndexAndFilterBlocks { get; set; }
     int? PendingTxsDbMaxOpenFiles { get; set; }
-    long? PendingTxsDbMaxWriteBytesPerSec { get; set; }
+    long? PendingTxsDbMaxBytesPerSec { get; set; }
     int? PendingTxsBlockSize { get; set; }
+    bool? PendingTxsUseDirectReads { get; set; }
+    bool? PendingTxsUseDirectIoForFlushAndCompactions { get; set; }
     IDictionary<string, string>? PendingTxsDbAdditionalRocksDbOptions { get; set; }
 
     ulong CodeDbWriteBufferSize { get; set; }
@@ -73,8 +85,10 @@ public interface IDbConfig : IConfig
     ulong CodeDbBlockCacheSize { get; set; }
     bool CodeDbCacheIndexAndFilterBlocks { get; set; }
     int? CodeDbMaxOpenFiles { get; set; }
-    long? CodeDbMaxWriteBytesPerSec { get; set; }
+    long? CodeDbMaxBytesPerSec { get; set; }
     int? CodeBlockSize { get; set; }
+    bool? CodeUseDirectReads { get; set; }
+    bool? CodeUseDirectIoForFlushAndCompactions { get; set; }
     IDictionary<string, string>? CodeDbAdditionalRocksDbOptions { get; set; }
 
     ulong BloomDbWriteBufferSize { get; set; }
@@ -82,7 +96,7 @@ public interface IDbConfig : IConfig
     ulong BloomDbBlockCacheSize { get; set; }
     bool BloomDbCacheIndexAndFilterBlocks { get; set; }
     int? BloomDbMaxOpenFiles { get; set; }
-    long? BloomDbMaxWriteBytesPerSec { get; set; }
+    long? BloomDbMaxBytesPerSec { get; set; }
     IDictionary<string, string>? BloomDbAdditionalRocksDbOptions { get; set; }
 
     ulong WitnessDbWriteBufferSize { get; set; }
@@ -90,8 +104,10 @@ public interface IDbConfig : IConfig
     ulong WitnessDbBlockCacheSize { get; set; }
     bool WitnessDbCacheIndexAndFilterBlocks { get; set; }
     int? WitnessDbMaxOpenFiles { get; set; }
-    long? WitnessDbMaxWriteBytesPerSec { get; set; }
+    long? WitnessDbMaxBytesPerSec { get; set; }
     int? WitnessBlockSize { get; set; }
+    bool? WitnessUseDirectReads { get; set; }
+    bool? WitnessUseDirectIoForFlushAndCompactions { get; set; }
     IDictionary<string, string>? WitnessDbAdditionalRocksDbOptions { get; set; }
 
     ulong CanonicalHashTrieDbWriteBufferSize { get; set; }
@@ -99,8 +115,10 @@ public interface IDbConfig : IConfig
     ulong CanonicalHashTrieDbBlockCacheSize { get; set; }
     bool CanonicalHashTrieDbCacheIndexAndFilterBlocks { get; set; }
     int? CanonicalHashTrieDbMaxOpenFiles { get; set; }
-    long? CanonicalHashTrieDbMaxWriteBytesPerSec { get; set; }
+    long? CanonicalHashTrieDbMaxBytesPerSec { get; set; }
     int? CanonicalHashTrieBlockSize { get; set; }
+    bool? CanonicalHashTrieUseDirectReads { get; set; }
+    bool? CanonicalHashTrieUseDirectIoForFlushAndCompactions { get; set; }
     IDictionary<string, string>? CanonicalHashTrieDbAdditionalRocksDbOptions { get; set; }
 
     ulong MetadataDbWriteBufferSize { get; set; }
@@ -108,8 +126,10 @@ public interface IDbConfig : IConfig
     ulong MetadataDbBlockCacheSize { get; set; }
     bool MetadataDbCacheIndexAndFilterBlocks { get; set; }
     int? MetadataDbMaxOpenFiles { get; set; }
-    long? MetadataDbMaxWriteBytesPerSec { get; set; }
+    long? MetadataDbMaxBytesPerSec { get; set; }
     int? MetadataBlockSize { get; set; }
+    bool? MetadataUseDirectReads { get; set; }
+    bool? MetadataUseDirectIoForFlushAndCompactions { get; set; }
     IDictionary<string, string>? MetadataDbAdditionalRocksDbOptions { get; set; }
 
     ulong StateDbWriteBufferSize { get; set; }
@@ -117,8 +137,10 @@ public interface IDbConfig : IConfig
     ulong StateDbBlockCacheSize { get; set; }
     bool StateDbCacheIndexAndFilterBlocks { get; set; }
     int? StateDbMaxOpenFiles { get; set; }
-    long? StateDbMaxWriteBytesPerSec { get; set; }
+    long? StateDbMaxBytesPerSec { get; set; }
     int? StateDbBlockSize { get; set; }
+    bool? StateDbUseDirectReads { get; set; }
+    bool? StateDbUseDirectIoForFlushAndCompactions { get; set; }
     IDictionary<string, string>? StateDbAdditionalRocksDbOptions { get; set; }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/PerTableDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/PerTableDbConfig.cs
@@ -37,7 +37,7 @@ public class PerTableDbConfig
     public IDictionary<string, string>? AdditionalRocksDbOptions => ReadConfig<IDictionary<string, string>?>(nameof(AdditionalRocksDbOptions));
 
     public int? MaxOpenFiles => ReadConfig<int?>(nameof(MaxOpenFiles));
-    public long? MaxWriteBytesPerSec => ReadConfig<long?>(nameof(MaxWriteBytesPerSec));
+    public long? MaxBytesPerSec => ReadConfig<long?>(nameof(MaxBytesPerSec));
     public uint RecycleLogFileNum => ReadConfig<uint>(nameof(RecycleLogFileNum));
     public bool WriteAheadLogSync => ReadConfig<bool>(nameof(WriteAheadLogSync));
     public int? BlockSize => ReadConfig<int?>(nameof(BlockSize));

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/PerTableDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/PerTableDbConfig.cs
@@ -41,7 +41,7 @@ public class PerTableDbConfig
     public uint RecycleLogFileNum => ReadConfig<uint>(nameof(RecycleLogFileNum));
     public bool WriteAheadLogSync => ReadConfig<bool>(nameof(WriteAheadLogSync));
     public bool UseDirectReads => ReadConfig<bool>(nameof(UseDirectReads));
-    public bool UseDirectIoForFlushAndCompactions => ReadConfig<bool>(nameof(UseDirectIoForFlushAndCompactions ));
+    public bool UseDirectIoForFlushAndCompactions => ReadConfig<bool>(nameof(UseDirectIoForFlushAndCompactions));
     public int? BlockSize => ReadConfig<int?>(nameof(BlockSize));
     public bool EnableDbStatistics => _dbConfig.EnableDbStatistics;
     public uint StatsDumpPeriodSec => _dbConfig.StatsDumpPeriodSec;

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/PerTableDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/PerTableDbConfig.cs
@@ -40,6 +40,8 @@ public class PerTableDbConfig
     public long? MaxBytesPerSec => ReadConfig<long?>(nameof(MaxBytesPerSec));
     public uint RecycleLogFileNum => ReadConfig<uint>(nameof(RecycleLogFileNum));
     public bool WriteAheadLogSync => ReadConfig<bool>(nameof(WriteAheadLogSync));
+    public bool UseDirectReads => ReadConfig<bool>(nameof(UseDirectReads));
+    public bool UseDirectIoForFlushAndCompactions => ReadConfig<bool>(nameof(UseDirectIoForFlushAndCompactions ));
     public int? BlockSize => ReadConfig<int?>(nameof(BlockSize));
     public bool EnableDbStatistics => _dbConfig.EnableDbStatistics;
     public uint StatsDumpPeriodSec => _dbConfig.StatsDumpPeriodSec;

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -350,10 +350,10 @@ public class DbOnTheRocks : IDbWithSpan, ITunableDb
             options.SetMaxOpenFiles(dbConfig.MaxOpenFiles.Value);
         }
 
-        if (dbConfig.MaxWriteBytesPerSec.HasValue)
+        if (dbConfig.MaxBytesPerSec.HasValue)
         {
             _rateLimiter =
-                _rocksDbNative.rocksdb_ratelimiter_create(dbConfig.MaxWriteBytesPerSec.Value, 1000, 10);
+                _rocksDbNative.rocksdb_ratelimiter_create(dbConfig.MaxBytesPerSec.Value, 1000, 10);
             _rocksDbNative.rocksdb_options_set_ratelimiter(options.Handle, _rateLimiter.Value);
         }
 

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -381,6 +381,9 @@ public class DbOnTheRocks : IDbWithSpan, ITunableDb
         options.SetRecycleLogFileNum(dbConfig
             .RecycleLogFileNum); // potential optimization for reusing allocated log files
 
+        options.SetUseDirectReads(dbConfig.UseDirectReads);
+        options.SetUseDirectIoForFlushAndCompaction(dbConfig.UseDirectIoForFlushAndCompactions);
+
         // VERY important to reduce stalls. Allow L0->L1 compaction to happen with multiple thread.
         _rocksDbNative.rocksdb_options_set_max_subcompactions(options.Handle, (uint)Environment.ProcessorCount);
 


### PR DESCRIPTION
- Ratelimiter is also used for compaction reads and reads with custom priority. So write bytes per sec is actually wrong.
- Add direct io flags. Direct io bypass the OS's block cache. Tend to help with memory pressure, althought its unclear if its because its slower.

## Changes

- Rename param.

## Types of changes

#### What types of changes does your code introduce?

- [X] Refactoring

## Testing

#### Requires testing

- [ ] Yes
- [X] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No
