### PR TITLE
Receipt key with block number

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Receipts/PersistentReceiptStorageTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Receipts/PersistentReceiptStorageTests.cs
@@ -197,14 +197,14 @@ namespace Nethermind.Blockchain.Test.Receipts
         [Test, Timeout(Timeout.MaxTestTime)]
         public void HasBlock_should_returnFalseForMissingHash()
         {
-            _storage.HasBlock(Keccak.Compute("missing-value")).Should().BeFalse();
+            _storage.HasBlock(0, Keccak.Compute("missing-value")).Should().BeFalse();
         }
 
         [Test, Timeout(Timeout.MaxTestTime)]
         public void HasBlock_should_returnTrueForKnownHash()
         {
             var (block, _) = InsertBlock();
-            _storage.HasBlock(block.Hash!).Should().BeTrue();
+            _storage.HasBlock(block.Number, block.Hash!).Should().BeTrue();
         }
 
         [Test, Timeout(Timeout.MaxTestTime)]

--- a/src/Nethermind/Nethermind.Blockchain.Test/Receipts/PersistentReceiptStorageTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Receipts/PersistentReceiptStorageTests.cs
@@ -131,7 +131,7 @@ namespace Nethermind.Blockchain.Test.Receipts
             block.Number.ToBigEndianByteArray().CopyTo(blockNumPrefixed); // TODO: We don't need to create an array here...
             block.Hash!.Bytes.CopyTo(blockNumPrefixed[8..]);
 
-            TestMemDb blocksDb = (TestMemDb) _receiptsDb.GetColumnDb(ReceiptsColumns.Blocks);
+            TestMemDb blocksDb = (TestMemDb)_receiptsDb.GetColumnDb(ReceiptsColumns.Blocks);
             blocksDb.KeyWasRead(blockNumPrefixed.ToArray(), 0);
             blocksDb.KeyWasRead(block.Hash.Bytes, 1);
         }

--- a/src/Nethermind/Nethermind.Blockchain/Nethermind.Blockchain.csproj
+++ b/src/Nethermind/Nethermind.Blockchain/Nethermind.Blockchain.csproj
@@ -5,6 +5,7 @@
     <LangVersion>latest</LangVersion>
     <Nullable>annotations</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/IReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/IReceiptStorage.cs
@@ -13,7 +13,7 @@ namespace Nethermind.Blockchain.Receipts
         void Insert(Block block, TxReceipt[]? txReceipts, bool ensureCanonical);
         long? LowestInsertedReceiptBlockNumber { get; set; }
         long MigratedBlockNumber { get; set; }
-        bool HasBlock(Keccak hash);
+        bool HasBlock(long blockNumber, Keccak hash);
         void EnsureCanonical(Block block);
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/InMemoryReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/InMemoryReceiptStorage.cs
@@ -68,7 +68,7 @@ namespace Nethermind.Blockchain.Receipts
             }
         }
 
-        public bool HasBlock(Keccak hash)
+        public bool HasBlock(long blockNumber, Keccak hash)
         {
             return _receipts.ContainsKey(hash);
         }

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/NullReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/NullReceiptStorage.cs
@@ -43,7 +43,7 @@ namespace Nethermind.Blockchain.Receipts
             remove { }
         }
 
-        public bool HasBlock(Keccak hash)
+        public bool HasBlock(long blockNumber, Keccak hash)
         {
             return false;
         }

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
@@ -60,7 +60,7 @@ namespace Nethermind.Blockchain.Receipts
             _migratedBlockNumber = Get(MigrationBlockNumberKey, long.MaxValue);
 
             KeyValuePair<byte[], byte[]>? firstValue = _blocksDb.GetAll().FirstOrDefault();
-            _legacyHashKey = firstValue != null && firstValue.Value.Key.Length == Keccak.Size;
+            _legacyHashKey = firstValue.HasValue && firstValue.Value.Key != null && firstValue.Value.Key.Length == Keccak.Size;
 
             _blockTree.BlockAddedToMain += BlockTreeOnBlockAddedToMain;
         }

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
@@ -289,9 +289,14 @@ namespace Nethermind.Blockchain.Receipts
             _receiptsCache.Clear();
         }
 
-        public bool HasBlock(Keccak hash)
+        public bool HasBlock(long blockNumber, Keccak blockHash)
         {
-            return _receiptsCache.Contains(hash) || _blocksDb.KeyExists(hash);
+            if (_receiptsCache.Contains(blockHash)) return true;
+
+            Span<byte> blockNumPrefixed = stackalloc byte[40];
+            GetBlockNumPrefixedKey(blockNumber, blockHash, blockNumPrefixed);
+
+            return _blocksDb.KeyExists(blockNumPrefixed) || _blocksDb.KeyExists(blockHash);
         }
 
         public void EnsureCanonical(Block block)

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
@@ -181,7 +181,7 @@ namespace Nethermind.Blockchain.Receipts
 
         private static void GetBlockNumPrefixedKey(long blockNumber, Keccak blockHash, Span<byte> output)
         {
-            blockNumber.ToBigEndianByteArray().CopyTo(output); // TODO: We don't need to create an array here...
+            blockNumber.WriteBigEndian(output);
             blockHash!.Bytes.CopyTo(output[8..]);
         }
 

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
@@ -199,9 +199,9 @@ namespace Nethermind.Blockchain.Receipts
                     receiptsData = _blocksDb.GetSpan(blockHash);
                 }
 
-    #pragma warning disable CS9080
+#pragma warning disable CS9080
                 return receiptsData;
-    #pragma warning restore CS9080
+#pragma warning restore CS9080
             }
         }
 

--- a/src/Nethermind/Nethermind.Core.Test/TestMemColumnDb.cs
+++ b/src/Nethermind/Nethermind.Core.Test/TestMemColumnDb.cs
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Generic;
+using Nethermind.Db;
+
+namespace Nethermind.Core.Test;
+
+public class TestMemColumnsDb<TKey> : TestMemDb, IColumnsDb<TKey>
+{
+    private readonly IDictionary<TKey, IDbWithSpan> _columnDbs = new Dictionary<TKey, IDbWithSpan>();
+
+    public TestMemColumnsDb()
+    {
+    }
+
+    public TestMemColumnsDb(params TKey[] keys)
+    {
+        foreach (var key in keys)
+        {
+            GetColumnDb(key);
+        }
+    }
+
+    public IDbWithSpan GetColumnDb(TKey key) => !_columnDbs.TryGetValue(key, out var db) ? _columnDbs[key] = new TestMemDb() : db;
+    public IEnumerable<TKey> ColumnKeys => _columnDbs.Keys;
+
+    public IReadOnlyDb CreateReadOnly(bool createInMemWriteStore)
+    {
+        return new ReadOnlyColumnsDb<TKey>(this, createInMemWriteStore);
+    }
+}

--- a/src/Nethermind/Nethermind.Core/Extensions/Int64Extensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/Int64Extensions.cs
@@ -126,6 +126,11 @@ namespace Nethermind.Core.Extensions
             return bytes;
         }
 
+        public static void WriteBigEndian(this long value, Span<byte> output)
+        {
+            BinaryPrimitives.WriteInt64BigEndian(output, value);
+        }
+
         [ThreadStatic]
         private static byte[]? t_byteBuffer64;
         private static byte[] GetByteBuffer64() => t_byteBuffer64 ??= new byte[8];

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -51,7 +51,7 @@ public class ColumnDb : IDbWithSpan
 
     public IEnumerable<KeyValuePair<byte[], byte[]>> GetAll(bool ordered = false)
     {
-        using Iterator iterator = _mainDb.CreateIterator(ordered, _columnFamily);
+        Iterator iterator = _mainDb.CreateIterator(ordered, _columnFamily);
         return _mainDb.GetAllCore(iterator);
     }
 

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -593,79 +593,89 @@ public class DbOnTheRocks : IDbWithSpan, ITunableDb
     {
         try
         {
-            iterator.SeekToFirst();
-        }
-        catch (RocksDbSharpException e)
-        {
-            CreateMarkerIfCorrupt(e);
-            throw;
-        }
-
-        while (iterator.Valid())
-        {
-            yield return iterator.Value();
             try
             {
-                iterator.Next();
+                iterator.SeekToFirst();
             }
             catch (RocksDbSharpException e)
             {
                 CreateMarkerIfCorrupt(e);
                 throw;
             }
-        }
 
-        try
-        {
-            iterator.Dispose();
+            while (iterator.Valid())
+            {
+                yield return iterator.Value();
+                try
+                {
+                    iterator.Next();
+                }
+                catch (RocksDbSharpException e)
+                {
+                    CreateMarkerIfCorrupt(e);
+                    throw;
+                }
+            }
         }
-        catch (RocksDbSharpException e)
+        finally
         {
-            CreateMarkerIfCorrupt(e);
-            throw;
+            try
+            {
+                iterator.Dispose();
+            }
+            catch (RocksDbSharpException e)
+            {
+                CreateMarkerIfCorrupt(e);
+                throw;
+            }
         }
     }
 
     public IEnumerable<KeyValuePair<byte[], byte[]>> GetAllCore(Iterator iterator)
     {
-        if (_isDisposing)
-        {
-            throw new ObjectDisposedException($"Attempted to read form a disposed database {Name}");
-        }
-
         try
         {
-            iterator.SeekToFirst();
-        }
-        catch (RocksDbSharpException e)
-        {
-            CreateMarkerIfCorrupt(e);
-            throw;
-        }
-
-        while (iterator.Valid())
-        {
-            yield return new KeyValuePair<byte[], byte[]>(iterator.Key(), iterator.Value());
+            if (_isDisposing)
+            {
+                throw new ObjectDisposedException($"Attempted to read form a disposed database {Name}");
+            }
 
             try
             {
-                iterator.Next();
+                iterator.SeekToFirst();
             }
             catch (RocksDbSharpException e)
             {
                 CreateMarkerIfCorrupt(e);
                 throw;
             }
-        }
 
-        try
-        {
-            iterator.Dispose();
+            while (iterator.Valid())
+            {
+                yield return new KeyValuePair<byte[], byte[]>(iterator.Key(), iterator.Value());
+
+                try
+                {
+                    iterator.Next();
+                }
+                catch (RocksDbSharpException e)
+                {
+                    CreateMarkerIfCorrupt(e);
+                    throw;
+                }
+            }
         }
-        catch (RocksDbSharpException e)
+        finally
         {
-            CreateMarkerIfCorrupt(e);
-            throw;
+            try
+            {
+                iterator.Dispose();
+            }
+            catch (RocksDbSharpException e)
+            {
+                CreateMarkerIfCorrupt(e);
+                throw;
+            }
         }
     }
 

--- a/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
@@ -25,11 +25,25 @@ namespace Nethermind.Db.Test
     [Parallelizable(ParallelScope.None)]
     public class DbOnTheRocksTests
     {
+        private const string DbPath = "blocks";
+
+        [SetUp]
+        public void Setup()
+        {
+            Directory.CreateDirectory(DbPath);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Directory.Delete(DbPath, true);
+        }
+
         [Test]
         public void Smoke_test()
         {
             IDbConfig config = new DbConfig();
-            DbOnTheRocks db = new("blocks", GetRocksDbSettings("blocks", "Blocks"), config, LimboLogs.Instance);
+            DbOnTheRocks db = new(DbPath, GetRocksDbSettings(DbPath, "Blocks"), config, LimboLogs.Instance);
             db[new byte[] { 1, 2, 3 }] = new byte[] { 4, 5, 6 };
             Assert.That(db[new byte[] { 1, 2, 3 }], Is.EqualTo(new byte[] { 4, 5, 6 }));
 
@@ -44,7 +58,7 @@ namespace Nethermind.Db.Test
         public void Smoke_test_span()
         {
             IDbConfig config = new DbConfig();
-            DbOnTheRocks db = new("blocks", GetRocksDbSettings("blocks", "Blocks"), config, LimboLogs.Instance);
+            DbOnTheRocks db = new(DbPath, GetRocksDbSettings(DbPath, "Blocks"), config, LimboLogs.Instance);
             byte[] key = new byte[] { 1, 2, 3 };
             byte[] value = new byte[] { 4, 5, 6 };
             db.PutSpan(key, value);
@@ -68,6 +82,32 @@ namespace Nethermind.Db.Test
                 db.Clear();
                 db.Dispose();
             }
+        }
+
+        [Test]
+        public void Smoke_test_iterator()
+        {
+            IDbConfig config = new DbConfig();
+            DbOnTheRocks db = new(DbPath, GetRocksDbSettings(DbPath, "Blocks"), config, LimboLogs.Instance);
+            db[new byte[] { 1, 2, 3 }] = new byte[] { 4, 5, 6 };
+
+            KeyValuePair<byte[], byte[]>[] allValues = db.GetAll().ToArray()!;
+            allValues[0].Key.Should().BeEquivalentTo(new byte[] { 1, 2, 3 });
+            allValues[0].Value.Should().BeEquivalentTo(new byte[] { 4, 5, 6 });
+        }
+
+        [Test]
+        public void Columns_db_smoke_test_iterator()
+        {
+            IDbConfig config = new DbConfig();
+            using ColumnsDb<ReceiptsColumns> columnsDb = new(DbPath, GetRocksDbSettings(DbPath, "Blocks"), config,
+                LimboLogs.Instance, new List<ReceiptsColumns>() { ReceiptsColumns.Blocks });
+            IDbWithSpan? db = columnsDb.GetColumnDb(ReceiptsColumns.Blocks);
+            db[new byte[] { 1, 2, 3 }] = new byte[] { 4, 5, 6 };
+
+            KeyValuePair<byte[], byte[]>[] allValues = db.GetAll().ToArray()!;
+            allValues[0].Key.Should().BeEquivalentTo(new byte[] { 1, 2, 3 });
+            allValues[0].Value.Should().BeEquivalentTo(new byte[] { 4, 5, 6 });
         }
 
         [Test]
@@ -194,7 +234,7 @@ namespace Nethermind.Db.Test
             try
             {
                 IDbConfig config = new DbConfig();
-                using ColumnsDb<ReceiptsColumns> columnDb = new(path, GetRocksDbSettings("blocks", "Blocks"), config,
+                using ColumnsDb<ReceiptsColumns> columnDb = new(path, GetRocksDbSettings(DbPath, "Blocks"), config,
                     LimboLogs.Instance, new List<ReceiptsColumns>() { ReceiptsColumns.Blocks });
 
                 using IDbWithSpan db = columnDb.GetColumnDb(ReceiptsColumns.Blocks);

--- a/src/Nethermind/Nethermind.Db/DbExtensions.cs
+++ b/src/Nethermind/Nethermind.Db/DbExtensions.cs
@@ -48,6 +48,18 @@ namespace Nethermind.Db
             }
         }
 
+        public static void Set(this IDb db, ReadOnlySpan<byte> key, ReadOnlySpan<byte> value)
+        {
+            if (db is IDbWithSpan dbWithSpan)
+            {
+                dbWithSpan.PutSpan(key, value);
+            }
+            else
+            {
+                db[key] = value.ToArray();
+            }
+        }
+
         public static KeyValuePair<byte[], byte[]>[] MultiGet(this IDb db, IEnumerable<KeccakKey> keys)
         {
             var k = keys.Select(k => k.Bytes).ToArray();

--- a/src/Nethermind/Nethermind.Facade/Filters/LogFinder.cs
+++ b/src/Nethermind/Nethermind.Facade/Filters/LogFinder.cs
@@ -64,13 +64,13 @@ namespace Nethermind.Blockchain.Find
             }
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (fromBlock.Number != 0 && fromBlock.ReceiptsRoot != Keccak.EmptyTreeHash && !_receiptStorage.HasBlock(fromBlock.Hash!))
+            if (fromBlock.Number != 0 && fromBlock.ReceiptsRoot != Keccak.EmptyTreeHash && !_receiptStorage.HasBlock(fromBlock.Number, fromBlock.Hash!))
             {
                 throw new ResourceNotFoundException($"Receipt not available for 'From' block '{fromBlock.Number}'.");
             }
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (toBlock.Number != 0 && toBlock.ReceiptsRoot != Keccak.EmptyTreeHash && !_receiptStorage.HasBlock(toBlock.Hash!))
+            if (toBlock.Number != 0 && toBlock.ReceiptsRoot != Keccak.EmptyTreeHash && !_receiptStorage.HasBlock(toBlock.Number, toBlock.Hash!))
             {
                 throw new ResourceNotFoundException($"Receipt not available for 'To' block '{toBlock.Number}'.");
             }

--- a/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/Migrations/ReceiptMigrationTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/Migrations/ReceiptMigrationTests.cs
@@ -121,9 +121,9 @@ namespace Nethermind.Runner.Test.Ethereum.Steps.Migrations
                 set => _outStorage.MigratedBlockNumber = value;
             }
 
-            public bool HasBlock(Keccak hash)
+            public bool HasBlock(long blockNumber, Keccak hash)
             {
-                return _outStorage.HasBlock(hash);
+                return _outStorage.HasBlock(blockNumber, hash);
             }
 
             public void EnsureCanonical(Block block)


### PR DESCRIPTION
- Prefix receipt's data key with block number like erigon. 
- Reduced write amplification during sync. Total write goes down from 5TB to 2.65TB.
- Does not noticably increase disk space use (in my run the one without blocknumber is actually slighly higher). This is likely because rocksdb have delta compression turned on by default for keys, so multiple keys with same prefix got compressed really well.
- Unexpectedly did not improve RPC performance, nor does it reduce iops. I guess on SSDs at least, it just reduce write amplification. ~~Maybe with readahead flag it'll do something.~~ not even with readahead. I guess 50iops per receipts means something else is using it...
- Tested on non-compact receipts as compact receipts still need to load blocks.

![Screenshot from 2023-05-04 17-05-25](https://user-images.githubusercontent.com/1841324/236169477-c746005b-d491-4b09-b9d1-7192c37fd229.png)

## Changes

- Address receipts by blocknum+hash.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [X] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Scanned log with CL filter with archive node. Log matches. 