### PR TITLE
Add config for eth_getLogs max block depth

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Receipts/IReceiptConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/IReceiptConfig.cs
@@ -21,4 +21,7 @@ public interface IReceiptConfig : IConfig
 
     [ConfigItem(Description = "Number of recent blocks to maintain transaction index. 0 to never remove tx index. -1 to never index.", DefaultValue = "2350000")]
     long? TxLookupLimit { get; set; }
+
+    [ConfigItem(Description = "Max num of block per eth_getLogs request.", DefaultValue = "10000")]
+    int MaxBlockDepth { get; set; }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/ReceiptConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/ReceiptConfig.cs
@@ -10,4 +10,5 @@ public class ReceiptConfig : IReceiptConfig
     public bool CompactReceiptStore { get; set; } = true;
     public bool CompactTxIndex { get; set; } = true;
     public long? TxLookupLimit { get; set; } = 2350000;
+    public int MaxBlockDepth { get; set; } = 10000;
 }

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeBlockTree.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeBlockTree.cs
@@ -89,7 +89,7 @@ namespace Nethermind.Init.Steps
                 bloomStorage,
                 _get.LogManager,
                 new ReceiptsRecovery(_get.EthereumEcdsa, _get.SpecProvider),
-                1024);
+                receiptConfig.MaxBlockDepth);
 
             _set.LogFinder = logFinder;
 


### PR DESCRIPTION
- Increase max block depth from 1000 to 10000 and make it configurable.
- Does not matter if bloom is on.
- Teku's default max request is 10000.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)
- [X] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

_Optional. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
