### PR TITLE
Fix eth capabilities for archive nodes

### DIFF
--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -204,7 +204,7 @@ public class InitializeNetwork : IStep
         if (_syncConfig.SnapSync || stateSyncFinished || !_syncConfig.FastSync)
         {
             // we can't add eth67 capability as default, because it needs snap protocol for syncing (GetNodeData is
-            // no longer available). Eth67 should be added if snap is enabled OR sync is finished
+            // no longer available). Eth67 should be added if snap is enabled OR sync is finished OR in archive nodes (no state sync)
             _api.ProtocolsManager!.AddSupportedCapability(new Capability(Protocol.Eth, 67));
             _api.ProtocolsManager!.AddSupportedCapability(new Capability(Protocol.Eth, 68));
         }

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -201,7 +201,7 @@ public class InitializeNetwork : IStep
 
         bool stateSyncFinished = _api.SyncProgressResolver.FindBestFullState() != 0;
 
-        if (_syncConfig.SnapSync || stateSyncFinished)
+        if (_syncConfig.SnapSync || stateSyncFinished || !_syncConfig.FastSync)
         {
             // we can't add eth67 capability as default, because it needs snap protocol for syncing (GetNodeData is
             // no longer available). Eth67 should be added if snap is enabled OR sync is finished


### PR DESCRIPTION
## Changes

Right now `eth/67` and `eth/68` capabilities are not enabled when they should if:
- node is in archive mode (`SnapSync` and `FastSync` flags are `false`)
- there is no state

Capabilites are enabled if node with any state is restarted.

It is a bit problematic for 4844 testnets and very problematic for 4844 hive tests.
It is not affecting production nodes right now, but would be a problem for archive nodes after dropping `eth/66` by Geth

After this fix, `eth/67` and `eth/68` capabilities would be enabled always for archive nodes (when `FastSync` is `false`)

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No