### PR TITLE
Align only in peer report

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/PeerInfo.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/PeerInfo.cs
@@ -5,6 +5,7 @@ using System;
 using System.Globalization;
 using System.Net;
 using Nethermind.Network;
+using Nethermind.Stats.Model;
 
 namespace Nethermind.JsonRpc.Modules.Admin
 {
@@ -41,7 +42,7 @@ namespace Nethermind.JsonRpc.Modules.Admin
             Address = peer.Node.Address.ToString();
             IsBootnode = peer.Node.IsBootnode;
             IsStatic = peer.Node.IsStatic;
-            Enode = peer.Node.ToString("e");
+            Enode = peer.Node.ToString(Node.Format.ENode);
 
             if (includeDetails)
             {

--- a/src/Nethermind/Nethermind.Network.Stats/Model/Node.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/Model/Node.cs
@@ -124,7 +124,7 @@ namespace Nethermind.Stats.Model
 
         public override int GetHashCode() => HashCode.Combine(Id);
 
-        public override string ToString() => ToString("p");
+        public override string ToString() => ToString(Format.WithPublicKey);
 
         public string ToString(string format) => ToString(format, null);
 
@@ -132,12 +132,13 @@ namespace Nethermind.Stats.Model
         {
             return format switch
             {
-                "s" => $"{_paddedHost}:{_paddedPort}",
-                "c" => $"[Node|{_paddedHost}:{_paddedPort}|{EthDetails}|{ClientId}]",
-                "f" => $"enode://{Id.ToString(false)}@{_paddedHost}:{_paddedPort}|{ClientId}",
-                "e" => $"enode://{Id.ToString(false)}@{_paddedHost}:{_paddedPort}",
-                "p" => $"enode://{Id.ToString(false)}@{_paddedHost}:{_paddedPort}|{Id.Address}",
-                _ => $"enode://{Id.ToString(false)}@{_paddedHost}:{_paddedPort}"
+                Format.Short => $"{Host}:{Port}",
+                Format.AlignedShort => $"{_paddedHost}:{_paddedPort}",
+                Format.Console => $"[Node|{Host}:{Port}|{EthDetails}|{ClientId}]",
+                Format.WithId => $"enode://{Id.ToString(false)}@{Host}:{Port}|{ClientId}",
+                Format.ENode => $"enode://{Id.ToString(false)}@{Host}:{Port}",
+                Format.WithPublicKey => $"enode://{Id.ToString(false)}@{Host}:{Port}|{Id.Address}",
+                _ => $"enode://{Id.ToString(false)}@{Host}:{Port}"
             };
         }
 
@@ -195,6 +196,16 @@ namespace Nethermind.Stats.Model
             {
                 return NodeClientType.Unknown;
             }
+        }
+
+        public struct Format
+        {
+            public const string Short = "s";
+            public const string AlignedShort = "a";
+            public const string Console = "c";
+            public const string ENode = "e";
+            public const string WithId = "f";
+            public const string WithPublicKey = "p";
         }
     }
 }

--- a/src/Nethermind/Nethermind.Network.Stats/Model/Node.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/Model/Node.cs
@@ -198,7 +198,7 @@ namespace Nethermind.Stats.Model
             }
         }
 
-        public struct Format
+        public static class Format
         {
             public const string Short = "s";
             public const string AlignedShort = "a";

--- a/src/Nethermind/Nethermind.Network.Test/Stats/NodeTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/Stats/NodeTests.cs
@@ -28,16 +28,17 @@ namespace Nethermind.Network.Test.Stats
             node.Equals(1).Should().BeFalse();
         }
 
-        [TestCase("s", "      127.0.0.1:30303")]
-        [TestCase("c", "[Node|      127.0.0.1:30303|Details|ClientId]")]
-        [TestCase("f", "enode://a49ac7010c2e0a444dfeeabadbafa4856ba4a2d732acb86d20c577b3b365fdaeb0a70ce47f890cf2f9fca562a7ed784f76eb870a2c75c0f2ab476a70ccb67e92@      127.0.0.1:30303|ClientId")]
-        [TestCase("e", "enode://a49ac7010c2e0a444dfeeabadbafa4856ba4a2d732acb86d20c577b3b365fdaeb0a70ce47f890cf2f9fca562a7ed784f76eb870a2c75c0f2ab476a70ccb67e92@      127.0.0.1:30303")]
-        [TestCase("p", "enode://a49ac7010c2e0a444dfeeabadbafa4856ba4a2d732acb86d20c577b3b365fdaeb0a70ce47f890cf2f9fca562a7ed784f76eb870a2c75c0f2ab476a70ccb67e92@      127.0.0.1:30303|0xb7705ae4c6f81b66cdb323c65f4e8133690fc099")]
-        [TestCase("zzz", "enode://a49ac7010c2e0a444dfeeabadbafa4856ba4a2d732acb86d20c577b3b365fdaeb0a70ce47f890cf2f9fca562a7ed784f76eb870a2c75c0f2ab476a70ccb67e92@      127.0.0.1:30303")]
+        [TestCase("s", "127.0.0.1:303")]
+        [TestCase("a", "      127.0.0.1:  303")]
+        [TestCase("c", "[Node|127.0.0.1:303|Details|ClientId]")]
+        [TestCase("f", "enode://a49ac7010c2e0a444dfeeabadbafa4856ba4a2d732acb86d20c577b3b365fdaeb0a70ce47f890cf2f9fca562a7ed784f76eb870a2c75c0f2ab476a70ccb67e92@127.0.0.1:303|ClientId")]
+        [TestCase("e", "enode://a49ac7010c2e0a444dfeeabadbafa4856ba4a2d732acb86d20c577b3b365fdaeb0a70ce47f890cf2f9fca562a7ed784f76eb870a2c75c0f2ab476a70ccb67e92@127.0.0.1:303")]
+        [TestCase("p", "enode://a49ac7010c2e0a444dfeeabadbafa4856ba4a2d732acb86d20c577b3b365fdaeb0a70ce47f890cf2f9fca562a7ed784f76eb870a2c75c0f2ab476a70ccb67e92@127.0.0.1:303|0xb7705ae4c6f81b66cdb323c65f4e8133690fc099")]
+        [TestCase("zzz", "enode://a49ac7010c2e0a444dfeeabadbafa4856ba4a2d732acb86d20c577b3b365fdaeb0a70ce47f890cf2f9fca562a7ed784f76eb870a2c75c0f2ab476a70ccb67e92@127.0.0.1:303")]
         public void To_string_formats(string format, string expectedFormat)
         {
             Node GetNode(string host) =>
-                new(TestItem.PublicKeyA, host, 30303) { ClientId = "ClientId", EthDetails = "Details" };
+                new(TestItem.PublicKeyA, host, 303) { ClientId = "ClientId", EthDetails = "Details" };
 
             Node node = GetNode("127.0.0.1");
             node.ToString(format).Should().Be(expectedFormat);

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
@@ -44,7 +44,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
 
         // this means that we know what the number, hash, and total diff of the head block is
         public bool IsInitialized { get; set; }
-        public override string ToString() => $"[Peer|{Name}|{HeadNumber,8}|{Node:s}|{Session?.Direction,4}]";
+        public override string ToString() => $"[Peer|{Name}|{HeadNumber,8}|{Node:a}|{Session?.Direction,4}]";
 
         protected Keccak _remoteHeadBlockHash;
         protected readonly ITimestamper _timestamper;

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroNettyP2PHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroNettyP2PHandler.cs
@@ -9,6 +9,7 @@ using DotNetty.Transport.Channels;
 using Nethermind.Core.Exceptions;
 using Nethermind.Logging;
 using Nethermind.Network.Rlpx;
+using Nethermind.Stats.Model;
 using Snappy;
 
 namespace Nethermind.Network.P2P.ProtocolHandlers
@@ -101,7 +102,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
         public override void ExceptionCaught(IChannelHandlerContext context, Exception exception)
         {
             //In case of SocketException we log it as debug to avoid noise
-            string clientId = _session?.Node?.ToString("c") ?? $"unknown {_session?.RemoteHost}";
+            string clientId = _session?.Node?.ToString(Node.Format.Console) ?? $"unknown {_session?.RemoteHost}";
             if (exception is SocketException)
             {
                 if (_logger.IsTrace) _logger.Trace($"Error in communication with {clientId} (SocketException): {exception}");

--- a/src/Nethermind/Nethermind.Network/Rlpx/NettyHandshakeHandler.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/NettyHandshakeHandler.cs
@@ -15,6 +15,7 @@ using Nethermind.Logging;
 using Nethermind.Network.P2P;
 using Nethermind.Network.P2P.ProtocolHandlers;
 using Nethermind.Network.Rlpx.Handshake;
+using Nethermind.Stats.Model;
 
 namespace Nethermind.Network.Rlpx
 {
@@ -109,7 +110,7 @@ namespace Nethermind.Network.Rlpx
 
         public override void ExceptionCaught(IChannelHandlerContext context, Exception exception)
         {
-            string clientId = _session?.Node?.ToString("c") ?? $"unknown {_session?.RemoteHost}";
+            string clientId = _session?.Node?.ToString(Node.Format.Console) ?? $"unknown {_session?.RemoteHost}";
             //In case of SocketException we log it as debug to avoid noise
             if (exception is SocketException)
             {


### PR DESCRIPTION
Fixes Closes Resolves #
#5657 

## Changes

- Align port and ip only when printing peer report
- A bit of refactoring

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No