### PR TITLE
Allow specifying concurrent new connection count and connect timeout

### DIFF
--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -484,6 +484,7 @@ public class InitializeNetwork : IStep
             _api.NodeKey.PublicKey,
             _networkConfig.P2PPort,
             _networkConfig.LocalIp,
+            _networkConfig.ConnectTimeoutMs,
             encryptionHandshakeServiceA,
             _api.SessionMonitor,
             _api.DisconnectsAnalyzer,

--- a/src/Nethermind/Nethermind.Network.Test/Rlpx/RlpxPeerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/Rlpx/RlpxPeerTests.cs
@@ -24,7 +24,7 @@ namespace Nethermind.Network.Test.Rlpx
         {
             RlpxHost host = new(
                 Substitute.For<IMessageSerializationService>(),
-                TestItem.PublicKeyA, GegAvailableLocalPort(), null,
+                TestItem.PublicKeyA, GegAvailableLocalPort(), null, 2000,
                 Substitute.For<IHandshakeService>(),
                 Substitute.For<ISessionMonitor>(),
                 NullDisconnectsAnalyzer.Instance,

--- a/src/Nethermind/Nethermind.Network/Config/INetworkConfig.cs
+++ b/src/Nethermind/Nethermind.Network/Config/INetworkConfig.cs
@@ -82,5 +82,11 @@ namespace Nethermind.Network.Config
 
         [ConfigItem(DefaultValue = "0", HiddenFromDocs = true, Description = "[TECHNICAL] Introduce a fixed latency for all p2p message send. Useful for testing higher latency network or simulate slower network for testing purpose.")]
         long SimulateSendLatencyMs { get; set; }
+
+        [ConfigItem(DefaultValue = "0", HiddenFromDocs = true, Description = "[TECHNICAL] Number of concurrent outgoing connection. Reduce this if your ISP is the kind that hangs up on you if you open too many connections. Default is 0 which means same as processor count.")]
+        int NumConcurrentOutgoingConnects { get; set; }
+
+        [ConfigItem(DefaultValue = "2000", HiddenFromDocs = true, Description = "[TECHNICAL] Outgoing connection timeout in ms. Default is 2 seconds.")]
+        int ConnectTimeoutMs { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.Network/Config/NetworkConfig.cs
+++ b/src/Nethermind/Nethermind.Network/Config/NetworkConfig.cs
@@ -34,5 +34,7 @@ namespace Nethermind.Network.Config
         public int DiscoveryPort { get; set; } = 30303;
         public int P2PPort { get; set; } = 30303;
         public long SimulateSendLatencyMs { get; set; } = 0;
+        public int NumConcurrentOutgoingConnects { get; set; } = 0;
+        public int ConnectTimeoutMs { get; set; } = 2000;
     }
 }

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -54,7 +54,7 @@ namespace Nethermind.Network
         private Task _peerUpdateLoopTask;
 
         private readonly CancellationTokenSource _cancellationTokenSource = new();
-        private static readonly int _parallelism = Environment.ProcessorCount;
+        private readonly int _parallelism;
 
         public PeerManager(
             IRlpxHost rlpxHost,
@@ -67,6 +67,12 @@ namespace Nethermind.Network
             _rlpxHost = rlpxHost ?? throw new ArgumentNullException(nameof(rlpxHost));
             _stats = stats ?? throw new ArgumentNullException(nameof(stats));
             _networkConfig = networkConfig ?? throw new ArgumentNullException(nameof(networkConfig));
+            _parallelism = networkConfig.NumConcurrentOutgoingConnects;
+            if (_parallelism == 0)
+            {
+                _parallelism = Environment.ProcessorCount;
+            }
+
             _peerPool = peerPool;
             _candidates = new List<PeerStats>(networkConfig.MaxActivePeers * 2);
         }

--- a/src/Nethermind/Nethermind.Network/Timeouts.cs
+++ b/src/Nethermind/Nethermind.Network/Timeouts.cs
@@ -7,7 +7,6 @@ namespace Nethermind.Network
 {
     public static class Timeouts
     {
-        public static readonly TimeSpan InitialConnection = TimeSpan.FromSeconds(2);
         public static readonly TimeSpan TcpClose = TimeSpan.FromSeconds(5);
         public static readonly TimeSpan Eth = Synchronization.Timeouts.Eth;
         public static readonly TimeSpan P2PPing = TimeSpan.FromSeconds(3);


### PR DESCRIPTION
- On some ISP (mine) if you try to sync nethermind, the internet somewhat hangs.
- Its not a bandwith issue, its just how the ISP throttle the connection. Nethermind works fine with a proxy.
- Reducing concurrent connection count and increasing connect timeout seems to work for me to prevent the hangs, but sync peer count take some time to increase. 

## Changes

- Allow specifying concurrent outgoing connection.

## Types of changes

#### What types of changes does your code introduce?

- [X] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

- Testing...
