### PR TITLE
Add sync testnets after master merge

### DIFF
--- a/.github/workflows/sync-testnets.yml
+++ b/.github/workflows/sync-testnets.yml
@@ -2,13 +2,14 @@ name: Sync Testnets
 
 on:
   push:
-    branches: ["master"]
+    branches: ["master", "kch/add_sync_testnets"]
   workflow_dispatch:
 
 jobs:
   chiado:
     name: "Run sync of chiado testnet"
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -70,6 +71,7 @@ jobs:
   sepolia:
     name: "Run sync of sepolia testnet"
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -124,6 +126,25 @@ jobs:
           done
           sleep 60
           echo "Sedge is synced."
+          
+      - name: Verify health of a node
+        run: |
+          countValid=$(docker compose logs | grep -c -E "Valid.")
+          countWaitingForBlock=$(docker compose logs | grep -c -E "WaitingForBlock")
+          if [ $countValid -lt 1 ]; then
+            echo "Error: No lines found for 'Valid.' - probably node is not progressing well."
+            exit 1
+          fi
+          if [ $countWaitingForBlock -lt 1 ]; then
+            echo "Error: No lines found for 'WaitingForBlock' - probably node is not progressing well."
+            exit 1
+          fi
+          
+          count=$(docker-compose logs --no-color | grep -c -E "Invalid|Exception")
+          if [ $count -gt 0 ]; then
+            echo "Error: Lines found for 'Invalid' or 'Exception'"
+            exit 1
+          fi
           
       - name: Display Docker logs        
         working-directory: sedge

--- a/.github/workflows/sync-testnets.yml
+++ b/.github/workflows/sync-testnets.yml
@@ -54,7 +54,7 @@ jobs:
           docker compose up -d
 
       - name: Wait for Chiado to sync
-        rrun: |
+        run: |
           # Check if Docker container is running
           MAX_RETRIES=10
           RETRY_COUNT=0

--- a/.github/workflows/sync-testnets.yml
+++ b/.github/workflows/sync-testnets.yml
@@ -78,18 +78,17 @@ jobs:
       - name: Verify health of a node
         working-directory: sedge
         run: |
-          dockerLogs=$(docker compose logs execution) || exit 10
+          dockerLogs=$(docker compose logs execution)
       
-          countValid=$(echo "$dockerLogs" | grep -c -E "Valid. Result of a new payload:") || exit 10
+          countValid=$(echo "$dockerLogs" | grep -c "Valid. Result of a new payload:")
           if [ $countValid -lt 1 ]; then
             echo "Error: No lines found for 'Valid. Result of a new payload:' - probably node is not progressing well." || exit 20
           fi
           
-          count=$(echo "$dockerLogs" | grep -c -E "Invalid|Exception") || exit 10
+          count=$(echo "$dockerLogs" | grep -c -E "Invalid|Exception")
           if [ $count -gt 0 ]; then
             echo "Error: Lines found for 'Invalid' or 'Exception'"
-            echo "$dockerLogs" | grep -E "Invalid|Exception" || exit 10
-            exit 30
+            echo "$dockerLogs" | grep "Invalid|Exception" || exit 30
           fi
           
   sepolia:
@@ -164,16 +163,17 @@ jobs:
       - name: Verify health of a node
         working-directory: sedge
         run: |
-          dockerLogs=$(docker compose logs execution) || exit 10
+          dockerLogs=$(docker compose logs execution)
       
-          countValid=$(echo "$dockerLogs" | grep -c -E "Valid. Result of a new payload:") || exit 10
+          countValid=$(echo "$dockerLogs" | grep -c "Valid. Result of a new payload:")
           if [ $countValid -lt 1 ]; then
+            echo "Count of Valid: $countValid"
             echo "Error: No lines found for 'Valid. Result of a new payload:' - probably node is not progressing well." || exit 20
           fi
           
-          count=$(echo "$dockerLogs" | grep -c -E "Invalid|Exception") || exit 10
+          count=$(echo "$dockerLogs" | grep -c -E "Invalid|Exception")
           if [ $count -gt 0 ]; then
+            echo "Count of Invalid: $count"
             echo "Error: Lines found for 'Invalid' or 'Exception'"
-            echo "$dockerLogs" | grep -E "Invalid|Exception" || exit 10
-            exit 30
+            echo "$dockerLogs" | grep -E "Invalid|Exception" || exit 30
           fi

--- a/.github/workflows/sync-testnets.yml
+++ b/.github/workflows/sync-testnets.yml
@@ -92,21 +92,26 @@ jobs:
       - name: Verify health of a node
         working-directory: sedge
         run: |
-          dockerLogs=$(docker compose logs execution)
+          dockerLogs=$(docker compose logs execution 2>/dev/null) || exit 10
       
-          countValid=$(echo "$dockerLogs" | grep -c "Valid. Result of a new payload:")
+          validLines=$(echo "$dockerLogs" | grep -E "Valid. Result of a new payload:") || exit 10
+          countValid=$(echo "$validLines" | wc -l)
           if [ $countValid -lt 1 ]; then
-            echo "Count of Valid: $countValid"
-            echo "Error: No lines found for 'Valid. Result of a new payload:' - probably node is not progressing well." || exit 20
+            echo "Error: No lines found for 'Valid. Result of a new payload:' - probably node is not progressing well."
+            exit 20
           fi
-          
-          count=$(echo "$dockerLogs" | grep -c -E "Invalid|Exception")
-          if [ $count -gt 0 ]; then
-            echo "Count of Invalid: $count"
+      
+          invalidLines=$(echo "$dockerLogs" | grep -E "Invalid|Exception") || exit 10
+          countInvalid=$(echo "$invalidLines" | wc -l)
+          if [ $countInvalid -gt 0 ]; then
             echo "Error: Lines found for 'Invalid' or 'Exception'"
-            echo "$dockerLogs" | grep -E "Invalid|Exception" || exit 30
+            echo "$invalidLines"
+            exit 30
           fi
-
+      
+          # If the script reaches this point, it means there were valid lines and no invalid lines.
+          echo "Valid lines:"
+          echo "$validLines"
           
   sepolia:
     name: "Run sync of sepolia testnet"
@@ -194,17 +199,23 @@ jobs:
       - name: Verify health of a node
         working-directory: sedge
         run: |
-          dockerLogs=$(docker compose logs execution)
+          dockerLogs=$(docker compose logs execution 2>/dev/null) || exit 10
       
-          countValid=$(echo "$dockerLogs" | grep -c "Valid. Result of a new payload:")
+          validLines=$(echo "$dockerLogs" | grep -E "Valid. Result of a new payload:") || exit 10
+          countValid=$(echo "$validLines" | wc -l)
           if [ $countValid -lt 1 ]; then
-            echo "Count of Valid: $countValid"
-            echo "Error: No lines found for 'Valid. Result of a new payload:' - probably node is not progressing well." || exit 20
+            echo "Error: No lines found for 'Valid. Result of a new payload:' - probably node is not progressing well."
+            exit 20
           fi
-          
-          count=$(echo "$dockerLogs" | grep -c -E "Invalid|Exception")
-          if [ $count -gt 0 ]; then
-            echo "Count of Invalid: $count"
+      
+          invalidLines=$(echo "$dockerLogs" | grep -E "Invalid|Exception") || exit 10
+          countInvalid=$(echo "$invalidLines" | wc -l)
+          if [ $countInvalid -gt 0 ]; then
             echo "Error: Lines found for 'Invalid' or 'Exception'"
-            echo "$dockerLogs" | grep -E "Invalid|Exception" || exit 30
+            echo "$invalidLines"
+            exit 30
           fi
+      
+          # If the script reaches this point, it means there were valid lines and no invalid lines.
+          echo "Valid lines:"
+          echo "$validLines"

--- a/.github/workflows/sync-testnets.yml
+++ b/.github/workflows/sync-testnets.yml
@@ -70,22 +70,16 @@ jobs:
       - name: Verify health of a node
         working-directory: sedge
         run: |
-          countValid=$(docker compose logs | grep -c -E "Valid.")
-          countWaitingForBlock=$(docker compose logs | grep -c -E "WaitingForBlock")
+          countValid=$(docker compose logs | grep -c -E "Valid. Result of a new payload:")
           if [ $countValid -lt 1 ]; then
-            echo "Error: No lines found for 'Valid.' - probably node is not progressing well."
-            exit 1
-          fi
-          if [ $countWaitingForBlock -lt 1 ]; then
-            echo "Error: No lines found for 'WaitingForBlock' - probably node is not progressing well."
+            echo "Error: No lines found for 'Valid. Result of a new payload:' - probably node is not progressing well."
             exit 1
           fi
           
           count=$(docker compose logs | grep -c -E "Invalid|Exception")
           if [ $count -gt 0 ]; then
-            docker compose logs | grep "Invalid|Exception"
             echo "Error: Lines found for 'Invalid' or 'Exception'"
-            exit 1
+            docker compose logs | grep -E "Invalid|Exception" && exit 2
           fi
   sepolia:
     name: "Run sync of sepolia testnet"
@@ -151,20 +145,14 @@ jobs:
       - name: Verify health of a node
         working-directory: sedge
         run: |
-          countValid=$(docker compose logs | grep -c -E "Valid.")
-          countWaitingForBlock=$(docker compose logs | grep -c -E "WaitingForBlock")
+          countValid=$(docker compose logs | grep -c -E "Valid. Result of a new payload:")
           if [ $countValid -lt 1 ]; then
-            echo "Error: No lines found for 'Valid.' - probably node is not progressing well."
-            exit 1
-          fi
-          if [ $countWaitingForBlock -lt 1 ]; then
-            echo "Error: No lines found for 'WaitingForBlock' - probably node is not progressing well."
+            echo "Error: No lines found for 'Valid. Result of a new payload:' - probably node is not progressing well."
             exit 1
           fi
           
           count=$(docker compose logs | grep -c -E "Invalid|Exception")
           if [ $count -gt 0 ]; then
-            docker compose logs | grep "Invalid|Exception"
             echo "Error: Lines found for 'Invalid' or 'Exception'"
-            exit 1
-          fi        
+            docker compose logs | grep -E "Invalid|Exception" && exit 2
+          fi

--- a/.github/workflows/sync-testnets.yml
+++ b/.github/workflows/sync-testnets.yml
@@ -48,17 +48,25 @@ jobs:
           -c lighthouse:sigp/lighthouse:latest -e nethermind:current_branch_image \
           --el-extra-flag Sync.NonValidatorNode=true --el-extra-flag Sync.DownloadBodiesInFastSync=false \
           --el-extra-flag Sync.DownloadReceiptsInFastSync=false \
+          --el-extra-flag JsonRpc.EnabledModules=[Eth,Subscribe,Trace,TxPool,Web3,Personal,Proof,Net,Parity,Health,Rpc,Debug] \
           --cl-extra-flag checkpoint-sync-url=http://139.144.26.89:4000/
           echo 'Running sedge...'
           docker compose up -d
 
       - name: Wait for Chiado to sync
         run: |
-          RESULT=""
-          while [ "$RESULT" != "false" ]; do
-            echo "Waiting for Sedge to sync..."
+          SYNCING_RESULT=""
+          DEBUG_RESULT=""
+          while [[ "$SYNCING_RESULT" != "false" ]] || [[ "$DEBUG_RESULT" != *"WaitingForBlock"* ]]; do
             sleep 10
-            RESULT=$(curl --data '{"method":"eth_syncing","params":[],"id":1,"jsonrpc":"2.0"}' -H "Content-Type: application/json" localhost:8545 | jq .result)
+            RESPONSE_SYNCING=$(curl -s --data '{"method":"eth_syncing","params":[],"id":1,"jsonrpc":"2.0"}' -H "Content-Type: application/json" localhost:8545)
+            SYNCING_RESULT=$(echo $RESPONSE_SYNCING | jq .result)
+            echo "eth_syncing endpoint response: $RESPONSE_SYNCING"
+      
+            RESPONSE_DEBUG=$(curl -s --data '{"method":"debug_getSyncStage","params":[],"id":1,"jsonrpc":"2.0"}' -H "Content-Type: application/json" localhost:8545)
+            DEBUG_RESULT=$(echo $RESPONSE_DEBUG | jq -r .result)
+            echo "debug_getSyncStage endpoint response: $RESPONSE_DEBUG"
+            
           done
           sleep 60
           echo "Sedge is synced."
@@ -67,19 +75,25 @@ jobs:
         working-directory: sedge
         run: docker compose logs
         
-      - name: Verify health of a Nethermind client
+      - name: Verify health of a node
         working-directory: sedge
         run: |
-          countValid=$(docker compose logs execution | grep -c -E "Valid. Result of a new payload:")
+          echo "Checking docker compose logs..."
+          dockerLogs=$(docker compose logs execution)
+          echo "Docker logs: $dockerLogs"
+      
+          countValid=$(echo "$dockerLogs" | grep -c -E "Valid. Result of a new payload:")
+          echo "CountValid: $countValid"
           if [ $countValid -lt 1 ]; then
             echo "Error: No lines found for 'Valid. Result of a new payload:' - probably node is not progressing well."
             exit 1
           fi
           
-          count=$(docker compose logs execution | grep -c -E "Invalid|Exception")
+          count=$(echo "$dockerLogs" | grep -c -E "Invalid|Exception")
+          echo "Count: $count"
           if [ $count -gt 0 ]; then
             echo "Error: Lines found for 'Invalid' or 'Exception'"
-            docker compose logs | grep -E "Invalid|Exception" && exit 2
+            echo "$dockerLogs" | grep -E "Invalid|Exception" && exit 2
           fi
   sepolia:
     name: "Run sync of sepolia testnet"
@@ -123,17 +137,25 @@ jobs:
           -c lighthouse:sigp/lighthouse:latest -e nethermind:current_branch_image \
           --el-extra-flag Sync.NonValidatorNode=true --el-extra-flag Sync.DownloadBodiesInFastSync=false \
           --el-extra-flag Sync.DownloadReceiptsInFastSync=false \
+          --el-extra-flag JsonRpc.EnabledModules=[Eth,Subscribe,Trace,TxPool,Web3,Personal,Proof,Net,Parity,Health,Rpc,Debug] \
           --cl-extra-flag checkpoint-sync-url=https://beaconstate-sepolia.chainsafe.io
           echo 'Running sedge...'
           docker compose up -d
 
       - name: Wait for Sepolia to sync
         run: |
-          RESULT=""
-          while [ "$RESULT" != "false" ]; do
-            echo "Waiting for Sedge to sync..."
+          SYNCING_RESULT=""
+          DEBUG_RESULT=""
+          while [[ "$SYNCING_RESULT" != "false" ]] || [[ "$DEBUG_RESULT" != *"WaitingForBlock"* ]]; do
             sleep 10
-            RESULT=$(curl --data '{"method":"eth_syncing","params":[],"id":1,"jsonrpc":"2.0"}' -H "Content-Type: application/json" localhost:8545 | jq .result)
+            RESPONSE_SYNCING=$(curl -s --data '{"method":"eth_syncing","params":[],"id":1,"jsonrpc":"2.0"}' -H "Content-Type: application/json" localhost:8545)
+            SYNCING_RESULT=$(echo $RESPONSE_SYNCING | jq .result)
+            echo "eth_syncing endpoint response: $RESPONSE_SYNCING"
+      
+            RESPONSE_DEBUG=$(curl -s --data '{"method":"debug_getSyncStage","params":[],"id":1,"jsonrpc":"2.0"}' -H "Content-Type: application/json" localhost:8545)
+            DEBUG_RESULT=$(echo $RESPONSE_DEBUG | jq -r .result)
+            echo "debug_getSyncStage endpoint response: $RESPONSE_DEBUG"
+            
           done
           sleep 60
           echo "Sedge is synced."
@@ -142,17 +164,23 @@ jobs:
         working-directory: sedge
         run: docker compose logs
           
-      - name: Verify health of a Nethermind client
+      - name: Verify health of a node
         working-directory: sedge
         run: |
-          countValid=$(docker compose logs execution | grep -c -E "Valid. Result of a new payload:")
+          echo "Checking docker compose logs..."
+          dockerLogs=$(docker compose logs execution)
+          echo "Docker logs: $dockerLogs"
+      
+          countValid=$(echo "$dockerLogs" | grep -c -E "Valid. Result of a new payload:")
+          echo "CountValid: $countValid"
           if [ $countValid -lt 1 ]; then
             echo "Error: No lines found for 'Valid. Result of a new payload:' - probably node is not progressing well."
             exit 1
           fi
           
-          count=$(docker compose logs execution | grep -c -E "Invalid|Exception")
+          count=$(echo "$dockerLogs" | grep -c -E "Invalid|Exception")
+          echo "Count: $count"
           if [ $count -gt 0 ]; then
             echo "Error: Lines found for 'Invalid' or 'Exception'"
-            docker compose logs execution | grep -E "Invalid|Exception" && exit 2
+            echo "$dockerLogs" | grep -E "Invalid|Exception" && exit 2
           fi

--- a/.github/workflows/sync-testnets.yml
+++ b/.github/workflows/sync-testnets.yml
@@ -68,6 +68,24 @@ jobs:
             echo "Error: Docker container 'sedge-execution-client' is not running after $MAX_RETRIES attempts."
             exit 404
           fi
+          
+          # Check readiness of the service
+          RETRY_COUNT=0
+          while [[ $RETRY_COUNT -lt $MAX_RETRIES ]]; do
+            RESPONSE=$(curl -s --data '{"method":"eth_syncing","params":[],"id":1,"jsonrpc":"2.0"}' -H "Content-Type: application/json" localhost:8545)
+            if [[ $? -eq 0 ]] && [[ -n "$RESPONSE" ]]; then
+              break
+            else
+              echo "Service not ready. Retrying in 10 seconds..."
+              let "RETRY_COUNT+=1"
+              sleep 10
+            fi
+          done
+          
+          if [[ $RETRY_COUNT -eq $MAX_RETRIES ]]; then
+            echo "Error: Service not ready after $MAX_RETRIES attempts."
+            exit 403
+          fi
       
           SYNCING_RESULT=""
           DEBUG_RESULT=""
@@ -92,6 +110,8 @@ jobs:
       - name: Verify health of a node
         working-directory: sedge
         run: |
+          set +e
+          
           dockerLogs=$(docker compose logs execution 2>/dev/null)
       
           validLines=$(echo "$dockerLogs" | grep -E "Valid. Result of a new payload:")
@@ -175,6 +195,24 @@ jobs:
             echo "Error: Docker container 'sedge-execution-client' is not running after $MAX_RETRIES attempts."
             exit 404
           fi
+          
+          # Check readiness of the service
+          RETRY_COUNT=0
+          while [[ $RETRY_COUNT -lt $MAX_RETRIES ]]; do
+            RESPONSE=$(curl -s --data '{"method":"eth_syncing","params":[],"id":1,"jsonrpc":"2.0"}' -H "Content-Type: application/json" localhost:8545)
+            if [[ $? -eq 0 ]] && [[ -n "$RESPONSE" ]]; then
+              break
+            else
+              echo "Service not ready. Retrying in 10 seconds..."
+              let "RETRY_COUNT+=1"
+              sleep 10
+            fi
+          done
+          
+          if [[ $RETRY_COUNT -eq $MAX_RETRIES ]]; then
+            echo "Error: Service not ready after $MAX_RETRIES attempts."
+            exit 403
+          fi
       
           SYNCING_RESULT=""
           DEBUG_RESULT=""
@@ -199,6 +237,8 @@ jobs:
       - name: Verify health of a node
         working-directory: sedge
         run: |
+          set +e
+          
           dockerLogs=$(docker compose logs execution 2>/dev/null)
       
           validLines=$(echo "$dockerLogs" | grep -E "Valid. Result of a new payload:")

--- a/.github/workflows/sync-testnets.yml
+++ b/.github/workflows/sync-testnets.yml
@@ -78,23 +78,20 @@ jobs:
       - name: Verify health of a node
         working-directory: sedge
         run: |
-          echo "Checking docker compose logs..."
-          dockerLogs=$(docker compose logs execution)
-          echo "Docker logs: $dockerLogs"
+          dockerLogs=$(docker compose logs execution) || exit 10
       
-          countValid=$(echo "$dockerLogs" | grep -c -E "Valid. Result of a new payload:")
-          echo "CountValid: $countValid"
+          countValid=$(echo "$dockerLogs" | grep -c -E "Valid. Result of a new payload:") || exit 10
           if [ $countValid -lt 1 ]; then
-            echo "Error: No lines found for 'Valid. Result of a new payload:' - probably node is not progressing well."
-            exit 1
+            echo "Error: No lines found for 'Valid. Result of a new payload:' - probably node is not progressing well." || exit 20
           fi
           
-          count=$(echo "$dockerLogs" | grep -c -E "Invalid|Exception")
-          echo "Count: $count"
+          count=$(echo "$dockerLogs" | grep -c -E "Invalid|Exception") || exit 10
           if [ $count -gt 0 ]; then
             echo "Error: Lines found for 'Invalid' or 'Exception'"
-            echo "$dockerLogs" | grep -E "Invalid|Exception" && exit 2
+            echo "$dockerLogs" | grep -E "Invalid|Exception" || exit 10
+            exit 30
           fi
+          
   sepolia:
     name: "Run sync of sepolia testnet"
     runs-on: ubuntu-latest
@@ -167,20 +164,16 @@ jobs:
       - name: Verify health of a node
         working-directory: sedge
         run: |
-          echo "Checking docker compose logs..."
-          dockerLogs=$(docker compose logs execution)
-          echo "Docker logs: $dockerLogs"
+          dockerLogs=$(docker compose logs execution) || exit 10
       
-          countValid=$(echo "$dockerLogs" | grep -c -E "Valid. Result of a new payload:")
-          echo "CountValid: $countValid"
+          countValid=$(echo "$dockerLogs" | grep -c -E "Valid. Result of a new payload:") || exit 10
           if [ $countValid -lt 1 ]; then
-            echo "Error: No lines found for 'Valid. Result of a new payload:' - probably node is not progressing well."
-            exit 1
+            echo "Error: No lines found for 'Valid. Result of a new payload:' - probably node is not progressing well." || exit 20
           fi
           
-          count=$(echo "$dockerLogs" | grep -c -E "Invalid|Exception")
-          echo "Count: $count"
+          count=$(echo "$dockerLogs" | grep -c -E "Invalid|Exception") || exit 10
           if [ $count -gt 0 ]; then
             echo "Error: Lines found for 'Invalid' or 'Exception'"
-            echo "$dockerLogs" | grep -E "Invalid|Exception" && exit 2
+            echo "$dockerLogs" | grep -E "Invalid|Exception" || exit 10
+            exit 30
           fi

--- a/.github/workflows/sync-testnets.yml
+++ b/.github/workflows/sync-testnets.yml
@@ -62,7 +62,11 @@ jobs:
           done
           sleep 60
           echo "Sedge is synced."
-      
+                
+      - name: Display Docker logs        
+        working-directory: sedge
+        run: docker compose logs
+        
       - name: Verify health of a node
         working-directory: sedge
         run: |
@@ -77,15 +81,12 @@ jobs:
             exit 1
           fi
           
-          count=$(docker-compose logs --no-color | grep -c -E "Invalid|Exception")
+          count=$(docker compose logs | grep -c -E "Invalid|Exception")
           if [ $count -gt 0 ]; then
+            docker compose logs | grep "Invalid|Exception"
             echo "Error: Lines found for 'Invalid' or 'Exception'"
             exit 1
           fi
-          
-      - name: Display Docker logs        
-        working-directory: sedge
-        run: docker compose logs
   sepolia:
     name: "Run sync of sepolia testnet"
     runs-on: ubuntu-latest
@@ -142,6 +143,10 @@ jobs:
           done
           sleep 60
           echo "Sedge is synced."
+      
+      - name: Display Docker logs        
+        working-directory: sedge
+        run: docker compose logs
           
       - name: Verify health of a node
         working-directory: sedge
@@ -157,12 +162,9 @@ jobs:
             exit 1
           fi
           
-          count=$(docker-compose logs --no-color | grep -c -E "Invalid|Exception")
+          count=$(docker compose logs | grep -c -E "Invalid|Exception")
           if [ $count -gt 0 ]; then
+            docker compose logs | grep "Invalid|Exception"
             echo "Error: Lines found for 'Invalid' or 'Exception'"
             exit 1
-          fi
-          
-      - name: Display Docker logs        
-        working-directory: sedge
-        run: docker compose logs
+          fi        

--- a/.github/workflows/sync-testnets.yml
+++ b/.github/workflows/sync-testnets.yml
@@ -24,7 +24,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Build docker image
-        run: docker buildx build --platform=linux/amd64 -t current_branch_image -f Dockerfile --build-arg COMMIT_HASH=${{ steps.settings.outputs.COMMIT_HASH }} --build-arg BUILD_TIMESTAMP=${{ steps.settings.outputs.BUILD_TIMESTAMP}} .
+        run: docker buildx build --platform=linux/amd64 -t current_branch_image -f Dockerfile --build-arg COMMIT_HASH=${{ steps.settings.outputs.COMMIT_HASH }} --build-arg BUILD_TIMESTAMP=${{ steps.settings.outputs.BUILD_TIMESTAMP}} --load .
 
       - name: Setup Go environment
         uses: actions/setup-go@v4.0.0
@@ -103,7 +103,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Build docker image
-        run: docker buildx build --platform=linux/amd64 -t current_branch_image -f Dockerfile --build-arg COMMIT_HASH=${{ steps.settings.outputs.COMMIT_HASH }} --build-arg BUILD_TIMESTAMP=${{ steps.settings.outputs.BUILD_TIMESTAMP}} .
+        run: docker buildx build --platform=linux/amd64 -t current_branch_image -f Dockerfile --build-arg COMMIT_HASH=${{ steps.settings.outputs.COMMIT_HASH }} --build-arg BUILD_TIMESTAMP=${{ steps.settings.outputs.BUILD_TIMESTAMP}} --load .
 
       - name: Setup Go environment
         uses: actions/setup-go@v4.0.0

--- a/.github/workflows/sync-testnets.yml
+++ b/.github/workflows/sync-testnets.yml
@@ -67,16 +67,16 @@ jobs:
         working-directory: sedge
         run: docker compose logs
         
-      - name: Verify health of a node
+      - name: Verify health of a Nethermind client
         working-directory: sedge
         run: |
-          countValid=$(docker compose logs | grep -c -E "Valid. Result of a new payload:")
+          countValid=$(docker compose logs execution | grep -c -E "Valid. Result of a new payload:")
           if [ $countValid -lt 1 ]; then
             echo "Error: No lines found for 'Valid. Result of a new payload:' - probably node is not progressing well."
             exit 1
           fi
           
-          count=$(docker compose logs | grep -c -E "Invalid|Exception")
+          count=$(docker compose logs execution | grep -c -E "Invalid|Exception")
           if [ $count -gt 0 ]; then
             echo "Error: Lines found for 'Invalid' or 'Exception'"
             docker compose logs | grep -E "Invalid|Exception" && exit 2
@@ -142,17 +142,17 @@ jobs:
         working-directory: sedge
         run: docker compose logs
           
-      - name: Verify health of a node
+      - name: Verify health of a Nethermind client
         working-directory: sedge
         run: |
-          countValid=$(docker compose logs | grep -c -E "Valid. Result of a new payload:")
+          countValid=$(docker compose logs execution | grep -c -E "Valid. Result of a new payload:")
           if [ $countValid -lt 1 ]; then
             echo "Error: No lines found for 'Valid. Result of a new payload:' - probably node is not progressing well."
             exit 1
           fi
           
-          count=$(docker compose logs | grep -c -E "Invalid|Exception")
+          count=$(docker compose logs execution | grep -c -E "Invalid|Exception")
           if [ $count -gt 0 ]; then
             echo "Error: Lines found for 'Invalid' or 'Exception'"
-            docker compose logs | grep -E "Invalid|Exception" && exit 2
+            docker compose logs execution | grep -E "Invalid|Exception" && exit 2
           fi

--- a/.github/workflows/sync-testnets.yml
+++ b/.github/workflows/sync-testnets.yml
@@ -1,0 +1,130 @@
+name: Sync Testnets
+
+on:
+  push:
+    branches: ["master"]
+  workflow_dispatch:
+
+jobs:
+  chiado:
+    name: "Run sync of chiado testnet"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
+          
+      - name: Configure settings
+        id: settings
+        run: |
+          echo "BUILD_TIMESTAMP=$(date '+%s')" >> $GITHUB_OUTPUT
+          echo "COMMIT_HASH=$(git describe --always --exclude=* --abbrev=40)" >> $GITHUB_OUTPUT
+          
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build docker image
+        run: docker buildx build --platform=linux/amd64 -t current_branch_image -f Dockerfile --build-arg COMMIT_HASH=${{ steps.settings.outputs.COMMIT_HASH }} --build-arg BUILD_TIMESTAMP=${{ steps.settings.outputs.BUILD_TIMESTAMP}} .
+
+      - name: Setup Go environment
+        uses: actions/setup-go@v4.0.0
+
+      - name: Install Sedge environment
+        run: |
+          echo "Downloading sedge sources..."
+          git clone https://github.com/NethermindEth/sedge.git sedge --branch main --single-branch
+          echo "Sources downloaded."
+          cd sedge
+          echo "Building sedge..."
+          make compile
+
+      - name: Run Sedge
+        working-directory: sedge
+        run: |
+          echo 'Generating sedge docker...'
+          ./build/sedge deps install
+          ./build/sedge generate --logging none -p $GITHUB_WORKSPACE/sedge \
+          full-node --map-all --no-mev-boost --no-validator --network chiado \
+          -c lighthouse:sigp/lighthouse:latest -e nethermind:current_branch_image \
+          --el-extra-flag Sync.NonValidatorNode=true --el-extra-flag Sync.DownloadBodiesInFastSync=false \
+          --el-extra-flag Sync.DownloadReceiptsInFastSync=false \
+          --cl-extra-flag checkpoint-sync-url=http://139.144.26.89:4000/
+          echo 'Running sedge...'
+          docker compose up -d
+
+      - name: Wait for Chiado to sync
+        run: |
+          RESULT=""
+          while [ "$RESULT" != "false" ]; do
+            echo "Waiting for Sedge to sync..."
+            sleep 10
+            RESULT=$(curl --data '{"method":"eth_syncing","params":[],"id":1,"jsonrpc":"2.0"}' -H "Content-Type: application/json" localhost:8545 | jq .result)
+          done
+          sleep 60
+          echo "Sedge is synced."
+          
+      - name: Display Docker logs        
+        working-directory: sedge
+        run: docker compose logs
+  sepolia:
+    name: "Run sync of sepolia testnet"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
+          
+      - name: Configure settings
+        id: settings
+        run: |
+          echo "BUILD_TIMESTAMP=$(date '+%s')" >> $GITHUB_OUTPUT
+          echo "COMMIT_HASH=$(git describe --always --exclude=* --abbrev=40)" >> $GITHUB_OUTPUT
+          
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build docker image
+        run: docker buildx build --platform=linux/amd64 -t current_branch_image -f Dockerfile --build-arg COMMIT_HASH=${{ steps.settings.outputs.COMMIT_HASH }} --build-arg BUILD_TIMESTAMP=${{ steps.settings.outputs.BUILD_TIMESTAMP}} .
+
+      - name: Setup Go environment
+        uses: actions/setup-go@v4.0.0
+
+      - name: Install Sedge environment
+        run: |
+          echo "Downloading sedge sources..."
+          git clone https://github.com/NethermindEth/sedge.git sedge --branch main --single-branch
+          echo "Sources downloaded."
+          cd sedge
+          echo "Building sedge..."
+          make compile
+
+      - name: Run Sedge
+        working-directory: sedge
+        run: |
+          echo 'Generating sedge docker...'
+          ./build/sedge deps install
+          ./build/sedge generate --logging none -p $GITHUB_WORKSPACE/sedge \
+          full-node --map-all --no-mev-boost --no-validator --network sepolia \
+          -c lighthouse:sigp/lighthouse:latest -e nethermind:current_branch_image \
+          --el-extra-flag Sync.NonValidatorNode=true --el-extra-flag Sync.DownloadBodiesInFastSync=false \
+          --el-extra-flag Sync.DownloadReceiptsInFastSync=false \
+          --cl-extra-flag checkpoint-sync-url=https://beaconstate-sepolia.chainsafe.io
+          echo 'Running sedge...'
+          docker compose up -d
+
+      - name: Wait for Sepolia to sync
+        run: |
+          RESULT=""
+          while [ "$RESULT" != "false" ]; do
+            echo "Waiting for Sedge to sync..."
+            sleep 10
+            RESULT=$(curl --data '{"method":"eth_syncing","params":[],"id":1,"jsonrpc":"2.0"}' -H "Content-Type: application/json" localhost:8545 | jq .result)
+          done
+          sleep 60
+          echo "Sedge is synced."
+          
+      - name: Display Docker logs        
+        working-directory: sedge
+        run: docker compose logs

--- a/.github/workflows/sync-testnets.yml
+++ b/.github/workflows/sync-testnets.yml
@@ -64,6 +64,7 @@ jobs:
           echo "Sedge is synced."
       
       - name: Verify health of a node
+        working-directory: sedge
         run: |
           countValid=$(docker compose logs | grep -c -E "Valid.")
           countWaitingForBlock=$(docker compose logs | grep -c -E "WaitingForBlock")
@@ -143,6 +144,7 @@ jobs:
           echo "Sedge is synced."
           
       - name: Verify health of a node
+        working-directory: sedge
         run: |
           countValid=$(docker compose logs | grep -c -E "Valid.")
           countWaitingForBlock=$(docker compose logs | grep -c -E "WaitingForBlock")

--- a/.github/workflows/sync-testnets.yml
+++ b/.github/workflows/sync-testnets.yml
@@ -115,22 +115,22 @@ jobs:
           set +e
           
           dockerLogs=$(docker compose logs execution 2>/dev/null)
-      
+
           validLines=$(echo "$dockerLogs" | grep -E "Valid. Result of a new payload:")
-          countValid=$(echo "$validLines" | wc -l)
+          countValid=$(if [ -z "$validLines" ]; then echo 0; else echo "$validLines" | wc -l; fi)
           if [ $countValid -lt 1 ]; then
             echo "Error: No lines found for 'Valid. Result of a new payload:' - probably node is not progressing well."
             exit 20
           fi
-      
+          
           invalidLines=$(echo "$dockerLogs" | grep -E "Invalid|Exception")
-          countInvalid=$(echo "$invalidLines" | wc -l)
+          countInvalid=$(if [ -z "$invalidLines" ]; then echo 0; else echo "$invalidLines" | wc -l; fi)
           if [ $countInvalid -gt 0 ]; then
             echo "Error: Lines found for 'Invalid' or 'Exception'"
             echo "$invalidLines"
             exit 30
           fi
-      
+          
           # If the script reaches this point, it means there were valid lines and no invalid lines.
           echo "Valid lines:"
           echo "$validLines"
@@ -244,22 +244,22 @@ jobs:
           set +e
           
           dockerLogs=$(docker compose logs execution 2>/dev/null)
-      
+
           validLines=$(echo "$dockerLogs" | grep -E "Valid. Result of a new payload:")
-          countValid=$(echo "$validLines" | wc -l)
+          countValid=$(if [ -z "$validLines" ]; then echo 0; else echo "$validLines" | wc -l; fi)
           if [ $countValid -lt 1 ]; then
             echo "Error: No lines found for 'Valid. Result of a new payload:' - probably node is not progressing well."
             exit 20
           fi
-      
+          
           invalidLines=$(echo "$dockerLogs" | grep -E "Invalid|Exception")
-          countInvalid=$(echo "$invalidLines" | wc -l)
+          countInvalid=$(if [ -z "$invalidLines" ]; then echo 0; else echo "$invalidLines" | wc -l; fi)
           if [ $countInvalid -gt 0 ]; then
             echo "Error: Lines found for 'Invalid' or 'Exception'"
             echo "$invalidLines"
             exit 30
           fi
-      
+          
           # If the script reaches this point, it means there were valid lines and no invalid lines.
           echo "Valid lines:"
           echo "$validLines"

--- a/.github/workflows/sync-testnets.yml
+++ b/.github/workflows/sync-testnets.yml
@@ -54,7 +54,21 @@ jobs:
           docker compose up -d
 
       - name: Wait for Chiado to sync
-        run: |
+        rrun: |
+          # Check if Docker container is running
+          MAX_RETRIES=10
+          RETRY_COUNT=0
+          while [[ ! "$(docker inspect -f '{{.State.Status}}' sedge-execution-client 2>/dev/null)" =~ "running" ]] && [[ $RETRY_COUNT -lt $MAX_RETRIES ]]; do
+            echo "Docker container 'sedge-execution-client' is not running. Retrying in 10 seconds..."
+            let "RETRY_COUNT+=1"
+            sleep 10
+          done
+      
+          if [[ ! "$(docker inspect -f '{{.State.Status}}' sedge-execution-client 2>/dev/null)" =~ "running" ]]; then
+            echo "Error: Docker container 'sedge-execution-client' is not running after $MAX_RETRIES attempts."
+            exit 404
+          fi
+      
           SYNCING_RESULT=""
           DEBUG_RESULT=""
           while [[ "$SYNCING_RESULT" != "false" ]] || [[ "$DEBUG_RESULT" != *"WaitingForBlock"* ]]; do
@@ -62,11 +76,11 @@ jobs:
             RESPONSE_SYNCING=$(curl -s --data '{"method":"eth_syncing","params":[],"id":1,"jsonrpc":"2.0"}' -H "Content-Type: application/json" localhost:8545)
             SYNCING_RESULT=$(echo $RESPONSE_SYNCING | jq .result)
             echo "eth_syncing endpoint response: $RESPONSE_SYNCING"
-      
+        
             RESPONSE_DEBUG=$(curl -s --data '{"method":"debug_getSyncStage","params":[],"id":1,"jsonrpc":"2.0"}' -H "Content-Type: application/json" localhost:8545)
             DEBUG_RESULT=$(echo $RESPONSE_DEBUG | jq -r .result)
             echo "debug_getSyncStage endpoint response: $RESPONSE_DEBUG"
-            
+      
           done
           sleep 60
           echo "Sedge is synced."
@@ -82,14 +96,17 @@ jobs:
       
           countValid=$(echo "$dockerLogs" | grep -c "Valid. Result of a new payload:")
           if [ $countValid -lt 1 ]; then
+            echo "Count of Valid: $countValid"
             echo "Error: No lines found for 'Valid. Result of a new payload:' - probably node is not progressing well." || exit 20
           fi
           
           count=$(echo "$dockerLogs" | grep -c -E "Invalid|Exception")
           if [ $count -gt 0 ]; then
+            echo "Count of Invalid: $count"
             echo "Error: Lines found for 'Invalid' or 'Exception'"
-            echo "$dockerLogs" | grep "Invalid|Exception" || exit 30
+            echo "$dockerLogs" | grep -E "Invalid|Exception" || exit 30
           fi
+
           
   sepolia:
     name: "Run sync of sepolia testnet"
@@ -140,6 +157,20 @@ jobs:
 
       - name: Wait for Sepolia to sync
         run: |
+          # Check if Docker container is running
+          MAX_RETRIES=10
+          RETRY_COUNT=0
+          while [[ ! "$(docker inspect -f '{{.State.Status}}' sedge-execution-client 2>/dev/null)" =~ "running" ]] && [[ $RETRY_COUNT -lt $MAX_RETRIES ]]; do
+            echo "Docker container 'sedge-execution-client' is not running. Retrying in 10 seconds..."
+            let "RETRY_COUNT+=1"
+            sleep 10
+          done
+      
+          if [[ ! "$(docker inspect -f '{{.State.Status}}' sedge-execution-client 2>/dev/null)" =~ "running" ]]; then
+            echo "Error: Docker container 'sedge-execution-client' is not running after $MAX_RETRIES attempts."
+            exit 404
+          fi
+      
           SYNCING_RESULT=""
           DEBUG_RESULT=""
           while [[ "$SYNCING_RESULT" != "false" ]] || [[ "$DEBUG_RESULT" != *"WaitingForBlock"* ]]; do
@@ -147,11 +178,11 @@ jobs:
             RESPONSE_SYNCING=$(curl -s --data '{"method":"eth_syncing","params":[],"id":1,"jsonrpc":"2.0"}' -H "Content-Type: application/json" localhost:8545)
             SYNCING_RESULT=$(echo $RESPONSE_SYNCING | jq .result)
             echo "eth_syncing endpoint response: $RESPONSE_SYNCING"
-      
+        
             RESPONSE_DEBUG=$(curl -s --data '{"method":"debug_getSyncStage","params":[],"id":1,"jsonrpc":"2.0"}' -H "Content-Type: application/json" localhost:8545)
             DEBUG_RESULT=$(echo $RESPONSE_DEBUG | jq -r .result)
             echo "debug_getSyncStage endpoint response: $RESPONSE_DEBUG"
-            
+      
           done
           sleep 60
           echo "Sedge is synced."

--- a/.github/workflows/sync-testnets.yml
+++ b/.github/workflows/sync-testnets.yml
@@ -92,16 +92,16 @@ jobs:
       - name: Verify health of a node
         working-directory: sedge
         run: |
-          dockerLogs=$(docker compose logs execution 2>/dev/null) || exit 10
+          dockerLogs=$(docker compose logs execution 2>/dev/null)
       
-          validLines=$(echo "$dockerLogs" | grep -E "Valid. Result of a new payload:") || exit 10
+          validLines=$(echo "$dockerLogs" | grep -E "Valid. Result of a new payload:")
           countValid=$(echo "$validLines" | wc -l)
           if [ $countValid -lt 1 ]; then
             echo "Error: No lines found for 'Valid. Result of a new payload:' - probably node is not progressing well."
             exit 20
           fi
       
-          invalidLines=$(echo "$dockerLogs" | grep -E "Invalid|Exception") || exit 10
+          invalidLines=$(echo "$dockerLogs" | grep -E "Invalid|Exception")
           countInvalid=$(echo "$invalidLines" | wc -l)
           if [ $countInvalid -gt 0 ]; then
             echo "Error: Lines found for 'Invalid' or 'Exception'"
@@ -199,16 +199,16 @@ jobs:
       - name: Verify health of a node
         working-directory: sedge
         run: |
-          dockerLogs=$(docker compose logs execution 2>/dev/null) || exit 10
+          dockerLogs=$(docker compose logs execution 2>/dev/null)
       
-          validLines=$(echo "$dockerLogs" | grep -E "Valid. Result of a new payload:") || exit 10
+          validLines=$(echo "$dockerLogs" | grep -E "Valid. Result of a new payload:")
           countValid=$(echo "$validLines" | wc -l)
           if [ $countValid -lt 1 ]; then
             echo "Error: No lines found for 'Valid. Result of a new payload:' - probably node is not progressing well."
             exit 20
           fi
       
-          invalidLines=$(echo "$dockerLogs" | grep -E "Invalid|Exception") || exit 10
+          invalidLines=$(echo "$dockerLogs" | grep -E "Invalid|Exception")
           countInvalid=$(echo "$invalidLines" | wc -l)
           if [ $countInvalid -gt 0 ]; then
             echo "Error: Lines found for 'Invalid' or 'Exception'"

--- a/.github/workflows/sync-testnets.yml
+++ b/.github/workflows/sync-testnets.yml
@@ -2,7 +2,7 @@ name: Sync Testnets
 
 on:
   push:
-    branches: ["master", "kch/add_sync_testnets"]
+    branches: ["master"]
   workflow_dispatch:
 
 jobs:
@@ -102,7 +102,6 @@ jobs:
             echo "debug_getSyncStage endpoint response: $RESPONSE_DEBUG"
       
           done
-          sleep 60
           echo "Sedge is synced."
                 
       - name: Display Docker logs        
@@ -231,7 +230,6 @@ jobs:
             echo "debug_getSyncStage endpoint response: $RESPONSE_DEBUG"
       
           done
-          sleep 60
           echo "Sedge is synced."
       
       - name: Display Docker logs        

--- a/.github/workflows/sync-testnets.yml
+++ b/.github/workflows/sync-testnets.yml
@@ -54,7 +54,9 @@ jobs:
           docker compose up -d
 
       - name: Wait for Chiado to sync
-        run: |
+        run: |        
+          set +e
+          
           # Check if Docker container is running
           MAX_RETRIES=10
           RETRY_COUNT=0
@@ -182,6 +184,8 @@ jobs:
 
       - name: Wait for Sepolia to sync
         run: |
+          set +e
+          
           # Check if Docker container is running
           MAX_RETRIES=10
           RETRY_COUNT=0

--- a/.github/workflows/sync-testnets.yml
+++ b/.github/workflows/sync-testnets.yml
@@ -13,8 +13,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.ref }}
           
       - name: Configure settings
         id: settings
@@ -64,6 +62,25 @@ jobs:
           done
           sleep 60
           echo "Sedge is synced."
+      
+      - name: Verify health of a node
+        run: |
+          countValid=$(docker compose logs | grep -c -E "Valid.")
+          countWaitingForBlock=$(docker compose logs | grep -c -E "WaitingForBlock")
+          if [ $countValid -lt 1 ]; then
+            echo "Error: No lines found for 'Valid.' - probably node is not progressing well."
+            exit 1
+          fi
+          if [ $countWaitingForBlock -lt 1 ]; then
+            echo "Error: No lines found for 'WaitingForBlock' - probably node is not progressing well."
+            exit 1
+          fi
+          
+          count=$(docker-compose logs --no-color | grep -c -E "Invalid|Exception")
+          if [ $count -gt 0 ]; then
+            echo "Error: Lines found for 'Invalid' or 'Exception'"
+            exit 1
+          fi
           
       - name: Display Docker logs        
         working-directory: sedge
@@ -75,8 +92,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.ref }}
           
       - name: Configure settings
         id: settings


### PR DESCRIPTION
Syncs two testnets on master branch.
Will output logs after sync for some detailed analysis.
Will do only Forwards Sync, Beacon Sync, Snap Ranges and State Healing + additional 1 minute to process few blocks afterwards.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [X] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

Action is started multiple times and green.
https://github.com/NethermindEth/nethermind/actions/runs/4948894182

#### Possible improvements

Add some checks which will help to recognize if sync is OK (need to be very basic one which will catch obvious issues)
Maybe some docker image creation speed up (some local image which will be faster instead of pushing to docker-hub but not sure if possible). - **DONE**
Slightly better VM for Sepolia to sync faster but is okaish.