### PR TITLE
Add support for specifying address in CLI

### DIFF
--- a/src/Nethermind/Nethermind.Cli/Program.cs
+++ b/src/Nethermind/Nethermind.Cli/Program.cs
@@ -31,6 +31,7 @@ namespace Nethermind.Cli
             _ = app.HelpOption("-?|-h|--help");
 
             var colorSchemeOption = app.Option("-cs|--colorScheme <colorScheme>", "Color Scheme. Possible values: Basic|Dracula", CommandOptionType.SingleValue);
+            var nodeAddressOption = app.Option("-a|--address <address>", "Node Address", CommandOptionType.SingleValue);
 
             app.OnExecute(() =>
             {
@@ -55,7 +56,10 @@ namespace Nethermind.Cli
                 moduleLoader.DiscoverAndLoadModules();
                 ReadLine.AutoCompletionHandler = new AutoCompletionHandler(moduleLoader);
 
-                nodeManager.SwitchUri(new Uri("http://localhost:8545"));
+                string nodeAddress = nodeAddressOption.HasValue()
+                    ? nodeAddressOption.Value()
+                    : "http://localhost:8545";
+                nodeManager.SwitchUri(new Uri(nodeAddress));
                 historyManager.Init();
                 TestConnection(nodeManager, engine, cliConsole);
                 cliConsole.WriteLine();


### PR DESCRIPTION
Closes #5582

## Changes

- Add an extra `-a|--address` option to specify a node address
- Default address is still `http://localhost:8545`

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

Manually tested on Linux (Fedora 37). There is no automated test suite for CLI options since there are only 2, color scheme and the newly introduced address (I don't think it's worth to add unit tests for this).

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No