### PR TITLE
Disable removing tx index on archive

### DIFF
--- a/src/Nethermind/Nethermind.Runner/configs/chiado_archive.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/chiado_archive.cfg
@@ -21,6 +21,9 @@
     "SecondsPerSlot": 5,
     "TargetBlockGasLimit": 30000000
   },
+  "Receipt": {
+    "TxLookupLimit": 0
+  },
   "AuRaMerge": {
     "Enabled": false
   },

--- a/src/Nethermind/Nethermind.Runner/configs/energyweb_archive.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/energyweb_archive.cfg
@@ -27,6 +27,9 @@
   "Pruning": {
     "Mode": "None"
   },
+  "Receipt": {
+    "TxLookupLimit": 0
+  },
   "Merge": {
 	"Enabled": false
   }

--- a/src/Nethermind/Nethermind.Runner/configs/exosama_archive.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/exosama_archive.cfg
@@ -9,6 +9,9 @@
   "Sync": {
     "UseGethLimitsInFastBlocks": false
   },
+  "Receipt": {
+    "TxLookupLimit": 0
+  },
   "EthStats": {
     "Name": "Nethermind Exosama Archive"
   },

--- a/src/Nethermind/Nethermind.Runner/configs/gnosis_archive.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/gnosis_archive.cfg
@@ -17,6 +17,9 @@
     "SecondsPerSlot": 5,
     "TargetBlockGasLimit": 30000000
   },
+  "Receipt": {
+    "TxLookupLimit": 0
+  },
   "EthStats": {
     "Name": "Nethermind Gnosis Archive"
   },

--- a/src/Nethermind/Nethermind.Runner/configs/goerli_archive.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/goerli_archive.cfg
@@ -19,6 +19,9 @@
   "Blocks": {
     "TargetBlockGasLimit": 30000000
   },
+  "Receipt": {
+    "TxLookupLimit": 0
+  },
   "Bloom": {
     "IndexLevelBucketSizes" : [16, 16, 16, 16]
   },

--- a/src/Nethermind/Nethermind.Runner/configs/kovan_archive.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/kovan_archive.cfg
@@ -10,7 +10,10 @@
     "Size": 1024
   },
   "Sync": {
-    "TotalDifficultyOverrides": [148240, 19430113280] 
+    "TotalDifficultyOverrides": [148240, 19430113280]
+  },
+  "Receipt": {
+    "TxLookupLimit": 0
   },
   "EthStats": {
     "Name": "Nethermind kovan"

--- a/src/Nethermind/Nethermind.Runner/configs/mainnet_archive.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/mainnet_archive.cfg
@@ -22,6 +22,9 @@
   "Blocks": {
     "TargetBlockGasLimit": 30000000
   },
+  "Receipt": {
+    "TxLookupLimit": 0
+  },
   "Pruning": {
     "Mode": "None"
   },

--- a/src/Nethermind/Nethermind.Runner/configs/poacore_archive.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/poacore_archive.cfg
@@ -12,6 +12,9 @@
   "Metrics": {
     "NodeName": "POA Core Archive"
   },
+  "Receipt": {
+    "TxLookupLimit": 0
+  },
   "Bloom": {
     "IndexLevelBucketSizes" : [16, 16, 16, 16]
   },

--- a/src/Nethermind/Nethermind.Runner/configs/rinkeby_archive.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/rinkeby_archive.cfg
@@ -8,11 +8,14 @@
   },
   "TxPool": {
     "Size": 1024
-  },    
+  },
+  "Receipt": {
+    "TxLookupLimit": 0
+  },
   "Metrics": {
     "NodeName": "Rinkeby Archive"
   },
   "Pruning": {
     "Mode": "None"
-  }    
+  }
 }

--- a/src/Nethermind/Nethermind.Runner/configs/ropsten_archive.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/ropsten_archive.cfg
@@ -15,6 +15,9 @@
   "Metrics": {
     "NodeName": "Ropsten Archive"
   },
+  "Receipt": {
+    "TxLookupLimit": 0
+  },
   "Pruning": {
     "Mode": "None"
   },

--- a/src/Nethermind/Nethermind.Runner/configs/sepolia_archive.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/sepolia_archive.cfg
@@ -16,6 +16,9 @@
   "Blocks": {
     "TargetBlockGasLimit": 30000000
   },
+  "Receipt": {
+    "TxLookupLimit": 0
+  },
   "JsonRpc": {
     "Enabled": true,
     "Timeout": 20000,

--- a/src/Nethermind/Nethermind.Runner/configs/volta_archive.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/volta_archive.cfg
@@ -1,5 +1,5 @@
 {
-  "Init": {       
+  "Init": {
     "ChainSpecPath": "chainspec/volta.json",
     "GenesisHash": "0xebd8b413ca7b7f84a8dd20d17519ce2b01954c74d94a0a739a3e416abe0e43e5",
     "BaseDbPath": "nethermind_db/volta_archive",
@@ -8,12 +8,15 @@
   },
   "Network": {
     "ActivePeersMaxCount": 25
-  },    
+  },
   "EthStats": {
     "Name": "Nethermind Volta"
   },
   "Metrics": {
     "NodeName": "Volta Archive"
+  },
+  "Receipt": {
+    "TxLookupLimit": 0
   },
   "Mining": {
       "MinGasPrice": 1

--- a/src/Nethermind/Nethermind.Runner/configs/xdai_archive.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/xdai_archive.cfg
@@ -17,6 +17,9 @@
     "SecondsPerSlot": 5,
     "TargetBlockGasLimit": 30000000
   },
+  "Receipt": {
+    "TxLookupLimit": 0
+  },
   "EthStats": {
     "Name": "Nethermind xDai"
   },


### PR DESCRIPTION
- Removing old tx lookup index saves about 65GB. But archive node probably wants to store everything.

## Changes

- Dont remove old tx lookup index on archive config.

## Types of changes

[X] Config change

#### What types of changes does your code introduce?

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

