### PR TITLE
Feature/disable wal flag

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPrunerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPrunerTests.cs
@@ -173,7 +173,7 @@ namespace Nethermind.Blockchain.Test.FullPruning
             public IStateReader StateReader { get; }
             public FullPruner Pruner { get; }
             public MemDb TrieDb { get; }
-            public MemDb CopyDb { get; }
+            public TestMemDb CopyDb { get; }
 
             public IProcessExitSource ProcessExitSource { get; } = Substitute.For<IProcessExitSource>();
 
@@ -250,6 +250,7 @@ namespace Nethermind.Blockchain.Test.FullPruning
                 foreach (KeyValuePair<byte[], byte[]?> keyValuePair in TrieDb.GetAll())
                 {
                     CopyDb[keyValuePair.Key].Should().BeEquivalentTo(keyValuePair.Value);
+                    CopyDb.KeyWasWrittenWithFlags(keyValuePair.Key, WriteFlags.LowPriority | WriteFlags.DisableWAL);
                 }
             }
         }

--- a/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPruningDiskTest.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPruningDiskTest.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using FluentAssertions.Extensions;
 using Nethermind.Blockchain.FullPruning;
 using Nethermind.Config;
 using Nethermind.Core;
@@ -141,7 +142,10 @@ namespace Nethermind.Blockchain.Test.FullPruning
 
                 await WriteFileStructure(chain);
 
-                chain.PruningDb.InnerDbName.Should().Be($"State{time + 1}");
+                Assert.That(
+                    () => chain.PruningDb.InnerDbName,
+                    Is.EqualTo($"State{time + 1}").After(1000, 100)
+                    );
 
                 HashSet<byte[]> currentItems = chain.DbProvider.StateDb.GetAllValues().ToHashSet(Bytes.EqualityComparer);
                 currentItems.IsSubsetOf(allItems).Should().BeTrue();

--- a/src/Nethermind/Nethermind.Blockchain/FullPruning/FullPruner.cs
+++ b/src/Nethermind/Nethermind.Blockchain/FullPruning/FullPruner.cs
@@ -176,13 +176,11 @@ namespace Nethermind.Blockchain.FullPruning
             {
                 pruning.MarkStart();
 
-                WriteFlags writeFlags = WriteFlags.LowPriority;
-                if (_pruningConfig.FullPruningDisableLowPriorityWrites)
+                WriteFlags writeFlags = WriteFlags.DisableWAL;
+                if (!_pruningConfig.FullPruningDisableLowPriorityWrites)
                 {
-                    writeFlags = WriteFlags.None;
+                    writeFlags |= WriteFlags.LowPriority;
                 }
-
-                writeFlags |= WriteFlags.DisableWAL;
 
                 using CopyTreeVisitor copyTreeVisitor = new(pruning, writeFlags, _logManager);
                 VisitingOptions visitingOptions = new()

--- a/src/Nethermind/Nethermind.Blockchain/FullPruning/FullPruner.cs
+++ b/src/Nethermind/Nethermind.Blockchain/FullPruning/FullPruner.cs
@@ -182,6 +182,8 @@ namespace Nethermind.Blockchain.FullPruning
                     writeFlags = WriteFlags.None;
                 }
 
+                writeFlags |= WriteFlags.DisableWAL;
+
                 using CopyTreeVisitor copyTreeVisitor = new(pruning, writeFlags, _logManager);
                 VisitingOptions visitingOptions = new()
                 {

--- a/src/Nethermind/Nethermind.Core/IKeyValueStore.cs
+++ b/src/Nethermind/Nethermind.Core/IKeyValueStore.cs
@@ -39,12 +39,14 @@ namespace Nethermind.Core
     [Flags]
     public enum WriteFlags
     {
-        None,
+        None = 0,
 
         // Hint that this is a low priority write
-        LowPriority,
+        LowPriority = 1,
 
         // Hint that this write does not require durable writes, as if it crash, it'll start over anyway.
-        DisableWAL,
+        DisableWAL = 2,
+
+        LowPriorityAndNoWAL = LowPriority | DisableWAL,
     }
 }

--- a/src/Nethermind/Nethermind.Core/IKeyValueStore.cs
+++ b/src/Nethermind/Nethermind.Core/IKeyValueStore.cs
@@ -44,7 +44,7 @@ namespace Nethermind.Core
         // Hint that this is a low priority write
         LowPriority,
 
-        // Hint that this write does not require consistent writes.
+        // Hint that this write does not require durable writes, as if it crash, it'll start over anyway.
         DisableWAL,
     }
 }

--- a/src/Nethermind/Nethermind.Core/IKeyValueStore.cs
+++ b/src/Nethermind/Nethermind.Core/IKeyValueStore.cs
@@ -36,11 +36,15 @@ namespace Nethermind.Core
         HintReadAhead = 2,
     }
 
+    [Flags]
     public enum WriteFlags
     {
         None,
 
         // Hint that this is a low priority write
         LowPriority,
+
+        // Hint that this write does not require consistent writes.
+        DisableWAL,
     }
 }

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -39,15 +39,7 @@ public class ColumnDb : IDbWithSpan
 
     public void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None)
     {
-        UpdateWriteMetrics();
-        if (value is null)
-        {
-            _rocksDb.Remove(key, _columnFamily, _mainDb.WriteFlagsToWriteOptions(flags));
-        }
-        else
-        {
-            _rocksDb.Put(key, value, _columnFamily, _mainDb.WriteFlagsToWriteOptions(flags));
-        }
+        _mainDb.SetWithColumnFamily(key, _columnFamily, value, flags);
     }
 
     public KeyValuePair<byte[], byte[]?>[] this[byte[][] keys] =>
@@ -122,11 +114,6 @@ public class ColumnDb : IDbWithSpan
     /// </summary>
     /// <exception cref="NotSupportedException"></exception>
     public void Clear() { throw new NotSupportedException(); }
-
-    private void UpdateWriteMetrics() => _mainDb.UpdateWriteMetrics();
-
-    private void UpdateReadMetrics() => _mainDb.UpdateReadMetrics();
-
     public long GetSize() => _mainDb.GetSize();
     public long GetCacheSize() => _mainDb.GetCacheSize();
     public long GetIndexSize() => _mainDb.GetIndexSize();

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -514,7 +514,7 @@ public class DbOnTheRocks : IDbWithSpan, ITunableDb
 
     public WriteOptions? WriteFlagsToWriteOptions(WriteFlags flags)
     {
-        if ((flags & WriteFlags.LowPriority) != 0 && (flags & WriteFlags.DisableWAL) != 0)
+        if ((flags & WriteFlags.LowPriorityAndNoWAL) != 0)
         {
             return _lowPriorityAndNoWalWrite;
         }

--- a/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
@@ -205,7 +205,7 @@ namespace Nethermind.Db.Test
                     LimboLogs.Instance, new List<ReceiptsColumns>() { ReceiptsColumns.Blocks });
                 _dbDisposable = columnsDb;
 
-                _db = (ColumnDb) columnsDb.GetColumnDb(ReceiptsColumns.Blocks);
+                _db = (ColumnDb)columnsDb.GetColumnDb(ReceiptsColumns.Blocks);
             }
             else
             {

--- a/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
@@ -40,94 +40,20 @@ namespace Nethermind.Db.Test
         }
 
         [Test]
-        public void Smoke_test()
+        public void WriteOptions_is_correct()
         {
             IDbConfig config = new DbConfig();
             DbOnTheRocks db = new(DbPath, GetRocksDbSettings(DbPath, "Blocks"), config, LimboLogs.Instance);
-            db[new byte[] { 1, 2, 3 }] = new byte[] { 4, 5, 6 };
-            Assert.That(db[new byte[] { 1, 2, 3 }], Is.EqualTo(new byte[] { 4, 5, 6 }));
 
             WriteOptions? options = db.WriteFlagsToWriteOptions(WriteFlags.LowPriority);
-            RocksDbSharp.Native.Instance.rocksdb_writeoptions_get_low_pri(options.Handle).Should().BeTrue();
+            Native.Instance.rocksdb_writeoptions_get_low_pri(options.Handle).Should().BeTrue();
 
-            db.Set(new byte[] { 2, 3, 4 }, new byte[] { 5, 6, 7 }, WriteFlags.LowPriority);
-            Assert.That(db[new byte[] { 2, 3, 4 }], Is.EqualTo(new byte[] { 5, 6, 7 }));
-        }
+            options = db.WriteFlagsToWriteOptions(WriteFlags.LowPriority | WriteFlags.DisableWAL);
+            Native.Instance.rocksdb_writeoptions_get_low_pri(options.Handle).Should().BeTrue();
+            Native.Instance.rocksdb_writeoptions_get_disable_WAL(options.Handle).Should().Be(true);
 
-        [Test]
-        public void Smoke_test_readahead()
-        {
-            IDbConfig config = new DbConfig();
-            DbOnTheRocks db = new("blocks", GetRocksDbSettings("blocks", "Blocks"), config, LimboLogs.Instance);
-            db[new byte[] { 1, 2, 3 }] = new byte[] { 4, 5, 6 };
-            Assert.That(db.Get(new byte[] { 1, 2, 3 }, ReadFlags.HintReadAhead), Is.EqualTo(new byte[] { 4, 5, 6 }));
-        }
-
-        [Test]
-        public void Smoke_test_span()
-        {
-            IDbConfig config = new DbConfig();
-            DbOnTheRocks db = new(DbPath, GetRocksDbSettings(DbPath, "Blocks"), config, LimboLogs.Instance);
-            byte[] key = new byte[] { 1, 2, 3 };
-            byte[] value = new byte[] { 4, 5, 6 };
-            db.PutSpan(key, value);
-            Span<byte> readSpan = db.GetSpan(key);
-            Assert.That(readSpan.ToArray(), Is.EqualTo(new byte[] { 4, 5, 6 }));
-            db.DangerousReleaseMemory(readSpan);
-        }
-
-        [Test]
-        public void Smoke_test_column_db()
-        {
-            IDbConfig config = new DbConfig();
-            using ColumnsDb<ReceiptsColumns> columnsDb = new(DbPath, GetRocksDbSettings(DbPath, "Blocks"), config,
-                LimboLogs.Instance, new List<ReceiptsColumns>() { ReceiptsColumns.Blocks });
-            IDbWithSpan? db = columnsDb.GetColumnDb(ReceiptsColumns.Blocks);
-            db[new byte[] { 1, 2, 3 }] = new byte[] { 4, 5, 6 };
-            Assert.That(db[new byte[] { 1, 2, 3 }], Is.EqualTo(new byte[] { 4, 5, 6 }));
-        }
-
-        [Test]
-        public void Can_get_all_on_empty()
-        {
-            IDbConfig config = new DbConfig();
-            DbOnTheRocks db = new("testIterator", GetRocksDbSettings("testIterator", "TestIterator"), config, LimboLogs.Instance);
-            try
-            {
-                // ReSharper disable once ReturnValueOfPureMethodIsNotUsed
-                _ = db.GetAll().ToList();
-            }
-            finally
-            {
-                db.Clear();
-                db.Dispose();
-            }
-        }
-
-        [Test]
-        public void Smoke_test_iterator()
-        {
-            IDbConfig config = new DbConfig();
-            DbOnTheRocks db = new(DbPath, GetRocksDbSettings(DbPath, "Blocks"), config, LimboLogs.Instance);
-            db[new byte[] { 1, 2, 3 }] = new byte[] { 4, 5, 6 };
-
-            KeyValuePair<byte[], byte[]>[] allValues = db.GetAll().ToArray()!;
-            allValues[0].Key.Should().BeEquivalentTo(new byte[] { 1, 2, 3 });
-            allValues[0].Value.Should().BeEquivalentTo(new byte[] { 4, 5, 6 });
-        }
-
-        [Test]
-        public void Columns_db_smoke_test_iterator()
-        {
-            IDbConfig config = new DbConfig();
-            using ColumnsDb<ReceiptsColumns> columnsDb = new(DbPath, GetRocksDbSettings(DbPath, "Blocks"), config,
-                LimboLogs.Instance, new List<ReceiptsColumns>() { ReceiptsColumns.Blocks });
-            IDbWithSpan? db = columnsDb.GetColumnDb(ReceiptsColumns.Blocks);
-            db[new byte[] { 1, 2, 3 }] = new byte[] { 4, 5, 6 };
-
-            KeyValuePair<byte[], byte[]>[] allValues = db.GetAll().ToArray()!;
-            allValues[0].Key.Should().BeEquivalentTo(new byte[] { 1, 2, 3 });
-            allValues[0].Value.Should().BeEquivalentTo(new byte[] { 4, 5, 6 });
+            options = db.WriteFlagsToWriteOptions(WriteFlags.DisableWAL);
+            Native.Instance.rocksdb_writeoptions_get_disable_WAL(options.Handle).Should().Be(true);
         }
 
         [Test]
@@ -245,35 +171,111 @@ namespace Nethermind.Db.Test
                 WriteBufferSize = (ulong)1.KiB()
             };
         }
+    }
 
-        [Test]
-        public void Test_columndb_put_and_get_span_correctly_store_value()
+    [TestFixture(true)]
+    [TestFixture(false)]
+    [Parallelizable(ParallelScope.None)]
+    public class DbOnTheRocksDbTests
+    {
+        string DbPath => "testdb/" + TestContext.CurrentContext.Test.Name;
+        private IDbWithSpan _db = null!;
+        IDisposable? _dbDisposable = null!;
+
+        private bool _useColumnDb = false;
+
+        public DbOnTheRocksDbTests(bool useColumnDb)
         {
-            string path = Path.Join(Path.GetTempPath(), "test");
-            Directory.CreateDirectory(path);
-            try
+            _useColumnDb = useColumnDb;
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            if (Directory.Exists(DbPath))
+            {
+                Directory.Delete(DbPath, true);
+            }
+
+            Directory.CreateDirectory(DbPath);
+            if (_useColumnDb)
             {
                 IDbConfig config = new DbConfig();
-                using ColumnsDb<ReceiptsColumns> columnDb = new(path, GetRocksDbSettings(DbPath, "Blocks"), config,
+                ColumnsDb<ReceiptsColumns> columnsDb = new(DbPath, GetRocksDbSettings(DbPath, "Blocks"), config,
                     LimboLogs.Instance, new List<ReceiptsColumns>() { ReceiptsColumns.Blocks });
+                _dbDisposable = columnsDb;
 
-                using IDbWithSpan db = columnDb.GetColumnDb(ReceiptsColumns.Blocks);
-
-                Keccak key = Keccak.Compute("something");
-                Keccak value = Keccak.Compute("something");
-
-                db.KeyExists(key.Bytes).Should().BeFalse();
-                db.PutSpan(key.Bytes, value.Bytes);
-                db.KeyExists(key.Bytes).Should().BeTrue();
-                Span<byte> data = db.GetSpan(key.Bytes);
-                data.SequenceEqual(value.Bytes);
-                db.DangerousReleaseMemory(data);
+                _db = (ColumnDb) columnsDb.GetColumnDb(ReceiptsColumns.Blocks);
             }
-            finally
+            else
             {
-                Directory.Delete(path, true);
+                IDbConfig config = new DbConfig();
+                _db = new DbOnTheRocks(DbPath, GetRocksDbSettings(DbPath, "Blocks"), config, LimboLogs.Instance);
+                _dbDisposable = _db;
             }
         }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _dbDisposable?.Dispose();
+        }
+
+        [Test]
+        public void Smoke_test()
+        {
+            _db[new byte[] { 1, 2, 3 }] = new byte[] { 4, 5, 6 };
+            Assert.That(_db[new byte[] { 1, 2, 3 }], Is.EqualTo(new byte[] { 4, 5, 6 }));
+
+            _db.Set(new byte[] { 2, 3, 4 }, new byte[] { 5, 6, 7 }, WriteFlags.LowPriority);
+            Assert.That(_db[new byte[] { 2, 3, 4 }], Is.EqualTo(new byte[] { 5, 6, 7 }));
+        }
+
+        [Test]
+        public void Smoke_test_readahead()
+        {
+            _db[new byte[] { 1, 2, 3 }] = new byte[] { 4, 5, 6 };
+            Assert.That(_db.Get(new byte[] { 1, 2, 3 }, ReadFlags.HintReadAhead), Is.EqualTo(new byte[] { 4, 5, 6 }));
+        }
+
+        [Test]
+        public void Smoke_test_span()
+        {
+            byte[] key = new byte[] { 1, 2, 3 };
+            byte[] value = new byte[] { 4, 5, 6 };
+            _db.PutSpan(key, value);
+            Span<byte> readSpan = _db.GetSpan(key);
+            Assert.That(readSpan.ToArray(), Is.EqualTo(new byte[] { 4, 5, 6 }));
+            _db.DangerousReleaseMemory(readSpan);
+        }
+
+        private static RocksDbSettings GetRocksDbSettings(string dbPath, string dbName)
+        {
+            return new(dbName, dbPath)
+            {
+                BlockCacheSize = (ulong)1.KiB(),
+                CacheIndexAndFilterBlocks = false,
+                WriteBufferNumber = 4,
+                WriteBufferSize = (ulong)1.KiB()
+            };
+        }
+
+        [Test]
+        public void Can_get_all_on_empty()
+        {
+            _ = _db.GetAll().ToList();
+        }
+
+        [Test]
+        public void Smoke_test_iterator()
+        {
+            _db[new byte[] { 1, 2, 3 }] = new byte[] { 4, 5, 6 };
+
+            KeyValuePair<byte[], byte[]>[] allValues = _db.GetAll().ToArray()!;
+            allValues[0].Key.Should().BeEquivalentTo(new byte[] { 1, 2, 3 });
+            allValues[0].Value.Should().BeEquivalentTo(new byte[] { 4, 5, 6 });
+        }
+
     }
 
     class CorruptedDbOnTheRocks : DbOnTheRocks

--- a/src/Nethermind/Nethermind.Db/FullPruning/FullPruningDb.cs
+++ b/src/Nethermind/Nethermind.Db/FullPruning/FullPruningDb.cs
@@ -171,6 +171,7 @@ namespace Nethermind.Db.FullPruning
 
         private void FinishPruning()
         {
+            _pruningContext?.CloningDb?.Flush();
             IDb oldDb = Interlocked.Exchange(ref _currentDb, _pruningContext?.CloningDb);
             ClearOldDb(oldDb);
         }

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProviderHelper.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProviderHelper.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
+using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Serialization.Rlp;
@@ -73,7 +74,7 @@ namespace Nethermind.Synchronization.SnapSync
 
             StitchBoundaries(sortedBoundaryList, tree.TrieStore);
 
-            tree.Commit(blockNumber, skipRoot: true);
+            tree.Commit(blockNumber, skipRoot: true, WriteFlags.DisableWAL);
 
             return (AddRangeResult.OK, moreChildrenToRight, accountsWithStorage, codeHashes);
         }
@@ -115,7 +116,7 @@ namespace Nethermind.Synchronization.SnapSync
 
             StitchBoundaries(sortedBoundaryList, tree.TrieStore);
 
-            tree.Commit(blockNumber);
+            tree.Commit(blockNumber, writeFlags: WriteFlags.DisableWAL);
 
             return (AddRangeResult.OK, moreChildrenToRight);
         }

--- a/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
@@ -66,6 +66,19 @@ namespace Nethermind.Trie.Test.Pruning
         }
 
         [Test]
+        public void When_commit_forward_write_flag_if_available()
+        {
+            TrieNode trieNode = new(NodeType.Leaf, Keccak.Zero);
+
+            TestMemDb testMemDb = new TestMemDb();
+
+            using TrieStore trieStore = new(testMemDb, No.Pruning, No.Persistence, _logManager);
+            trieStore.CommitNode(1234, new NodeCommitInfo(trieNode), WriteFlags.LowPriority);
+            trieStore.FinishBlockCommit(TrieType.State, 1234, trieNode, WriteFlags.LowPriority);
+            testMemDb.KeyWasWrittenWithFlags(trieNode.Keccak.Bytes, WriteFlags.LowPriority);
+        }
+
+        [Test]
         public void Should_always_announce_block_number_when_pruning_disabled_and_persisting()
         {
             TrieNode trieNode = new(NodeType.Leaf, Keccak.Zero) { LastSeen = 1 };

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -143,7 +143,7 @@ namespace Nethermind.Trie
                 while (_currentCommit.TryDequeue(out NodeCommitInfo node))
                 {
                     if (_logger.IsTrace) _logger.Trace($"Committing {node} in {blockNumber}");
-                    TrieStore.CommitNode(blockNumber, node);
+                    TrieStore.CommitNode(blockNumber, node, writeFlags: writeFlags);
                 }
 
                 // reset objects

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -124,7 +124,7 @@ namespace Nethermind.Trie
             }
         }
 
-        public void Commit(long blockNumber, bool skipRoot = false)
+        public void Commit(long blockNumber, bool skipRoot = false, WriteFlags writeFlags = WriteFlags.None)
         {
             if (_currentCommit is null)
             {
@@ -151,7 +151,7 @@ namespace Nethermind.Trie
                 SetRootHash(RootRef.Keccak!, true);
             }
 
-            TrieStore.FinishBlockCommit(TrieType, blockNumber, RootRef);
+            TrieStore.FinishBlockCommit(TrieType, blockNumber, RootRef, writeFlags);
             if (_logger.IsDebug) _logger.Debug($"Finished committing block {blockNumber}");
         }
 

--- a/src/Nethermind/Nethermind.Trie/Pruning/ITrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ITrieStore.cs
@@ -11,7 +11,7 @@ namespace Nethermind.Trie.Pruning
     {
         void CommitNode(long blockNumber, NodeCommitInfo nodeCommitInfo);
 
-        void FinishBlockCommit(TrieType trieType, long blockNumber, TrieNode? root);
+        void FinishBlockCommit(TrieType trieType, long blockNumber, TrieNode? root, WriteFlags writeFlags = WriteFlags.None);
 
         bool IsPersisted(Keccak keccak);
         bool IsPersisted(in ValueKeccak keccak);

--- a/src/Nethermind/Nethermind.Trie/Pruning/ITrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ITrieStore.cs
@@ -9,7 +9,7 @@ namespace Nethermind.Trie.Pruning
 {
     public interface ITrieStore : ITrieNodeResolver, IReadOnlyKeyValueStore, IDisposable
     {
-        void CommitNode(long blockNumber, NodeCommitInfo nodeCommitInfo);
+        void CommitNode(long blockNumber, NodeCommitInfo nodeCommitInfo, WriteFlags writeFlags = WriteFlags.None);
 
         void FinishBlockCommit(TrieType trieType, long blockNumber, TrieNode? root, WriteFlags writeFlags = WriteFlags.None);
 

--- a/src/Nethermind/Nethermind.Trie/Pruning/NullTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/NullTrieStore.cs
@@ -13,7 +13,7 @@ namespace Nethermind.Trie.Pruning
 
         public static NullTrieStore Instance { get; } = new();
 
-        public void CommitNode(long blockNumber, NodeCommitInfo nodeCommitInfo) { }
+        public void CommitNode(long blockNumber, NodeCommitInfo nodeCommitInfo, WriteFlags flags = WriteFlags.None) { }
 
         public void FinishBlockCommit(TrieType trieType, long blockNumber, TrieNode? root, WriteFlags flags = WriteFlags.None) { }
 

--- a/src/Nethermind/Nethermind.Trie/Pruning/NullTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/NullTrieStore.cs
@@ -15,7 +15,7 @@ namespace Nethermind.Trie.Pruning
 
         public void CommitNode(long blockNumber, NodeCommitInfo nodeCommitInfo) { }
 
-        public void FinishBlockCommit(TrieType trieType, long blockNumber, TrieNode? root) { }
+        public void FinishBlockCommit(TrieType trieType, long blockNumber, TrieNode? root, WriteFlags flags = WriteFlags.None) { }
 
         public void HackPersistOnShutdown() { }
 

--- a/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStore.cs
@@ -37,9 +37,7 @@ namespace Nethermind.Trie.Pruning
 
         public void CommitNode(long blockNumber, NodeCommitInfo nodeCommitInfo) { }
 
-        public void FinishBlockCommit(TrieType trieType, long blockNumber, TrieNode? root) { }
-
-        public void HackPersistOnShutdown() { }
+        public void FinishBlockCommit(TrieType trieType, long blockNumber, TrieNode? root, WriteFlags flags = WriteFlags.None) { }
 
         public event EventHandler<ReorgBoundaryReached> ReorgBoundaryReached
         {

--- a/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStore.cs
@@ -35,7 +35,7 @@ namespace Nethermind.Trie.Pruning
             return new ReadOnlyTrieStore(_trieStore, keyValueStore);
         }
 
-        public void CommitNode(long blockNumber, NodeCommitInfo nodeCommitInfo) { }
+        public void CommitNode(long blockNumber, NodeCommitInfo nodeCommitInfo, WriteFlags flags = WriteFlags.None) { }
 
         public void FinishBlockCommit(TrieType trieType, long blockNumber, TrieNode? root, WriteFlags flags = WriteFlags.None) { }
 

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -204,7 +204,7 @@ namespace Nethermind.Trie.Pruning
             }
         }
 
-        public void CommitNode(long blockNumber, NodeCommitInfo nodeCommitInfo)
+        public void CommitNode(long blockNumber, NodeCommitInfo nodeCommitInfo, WriteFlags writeFlags = WriteFlags.None)
         {
             if (blockNumber < 0) throw new ArgumentOutOfRangeException(nameof(blockNumber));
             EnsureCommitSetExistsForBlock(blockNumber);
@@ -234,7 +234,7 @@ namespace Nethermind.Trie.Pruning
 
                 if (!_pruningStrategy.PruningEnabled)
                 {
-                    Persist(node, blockNumber);
+                    Persist(node, blockNumber, writeFlags);
                 }
 
                 CommittedNodesCount++;

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -269,7 +269,7 @@ namespace Nethermind.Trie.Pruning
             return node;
         }
 
-        public void FinishBlockCommit(TrieType trieType, long blockNumber, TrieNode? root)
+        public void FinishBlockCommit(TrieType trieType, long blockNumber, TrieNode? root, WriteFlags writeFlags = WriteFlags.None)
         {
             if (blockNumber < 0) throw new ArgumentOutOfRangeException(nameof(blockNumber));
             EnsureCommitSetExistsForBlock(blockNumber);
@@ -290,7 +290,7 @@ namespace Nethermind.Trie.Pruning
                     bool shouldPersistSnapshot = _persistenceStrategy.ShouldPersist(set.BlockNumber);
                     if (shouldPersistSnapshot)
                     {
-                        Persist(set);
+                        Persist(set, writeFlags);
                     }
                     else
                     {
@@ -623,9 +623,9 @@ namespace Nethermind.Trie.Pruning
         /// for the block represented by this commit set.
         /// </summary>
         /// <param name="commitSet">A commit set of a block which root is to be persisted.</param>
-        private void Persist(BlockCommitSet commitSet)
+        private void Persist(BlockCommitSet commitSet, WriteFlags writeFlags = WriteFlags.None)
         {
-            void PersistNode(TrieNode tn) => Persist(tn, commitSet.BlockNumber);
+            void PersistNode(TrieNode tn) => Persist(tn, commitSet.BlockNumber, writeFlags);
 
             try
             {
@@ -652,7 +652,7 @@ namespace Nethermind.Trie.Pruning
             PruneCurrentSet();
         }
 
-        private void Persist(TrieNode currentNode, long blockNumber)
+        private void Persist(TrieNode currentNode, long blockNumber, WriteFlags writeFlags = WriteFlags.None)
         {
             _currentBatch ??= _keyValueStore.StartBatch();
             if (currentNode is null)
@@ -669,7 +669,7 @@ namespace Nethermind.Trie.Pruning
                 // to prevent it from being removed from cache and also want to have it persisted.
 
                 if (_logger.IsTrace) _logger.Trace($"Persisting {nameof(TrieNode)} {currentNode} in snapshot {blockNumber}.");
-                _currentBatch[currentNode.Keccak.Bytes] = currentNode.FullRlp;
+                _currentBatch.Set(currentNode.Keccak.Bytes, currentNode.FullRlp, writeFlags);
                 currentNode.IsPersisted = true;
                 currentNode.LastSeen = Math.Max(blockNumber, currentNode.LastSeen ?? 0);
                 PersistedNodesCount++;


### PR DESCRIPTION
- The WAL files in rocksdb is its durability mechanism which allow it to recover writes in crashes where the memtable was not flushed to the disk. 
- In case of snapsync or full pruning, if it crash, it will have to start over meaning the WAL is unnecessary, so disabling it saves some writes. The amount saved should be roughly the size of the DB, which is around 160GB.
- For full pruning (32GB mem budget), total writes goes down from 1.7TB to 1.5TB. Total time remains at 40minute, probably because SSD warmed up or some other limit.
- For snap sync (HeavyWrite tune), total writes goes down from 3.28TB to 2.93TB. Took similar amount of time (1 hour vs 50 minute). 
- I guess instead of `DisableWAL` a better more universal term for flag would be `NoDurable`, `NonDurable`, `DurabilityNotRequired` or something, but can't find a good one. Got idea?

## Changes

- Add `DisableWAL` write flag. Integrate with RocksDB, SnapSync and FullPruning.
- Slight change with snap sync, code save where it uses write batch instead.
- Refactor rocksdb's smoke test to use same test for column and non-column db.
- Add an explicit flush when full pruning complete.

## Types of changes

#### What types of changes does your code introduce?

- [X] Optimization
- [X] Refactoring

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
