### PR TITLE
Change LruCache to use two generations

### DIFF
--- a/src/Nethermind/Nethermind.Core/Caching/LinkedListNode.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/LinkedListNode.cs
@@ -6,7 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Nethermind.Core.Caching;
 
-[DebuggerDisplay("{Value} (AccessCount)")]
+[DebuggerDisplay("{Value} ({AccessCount})")]
 internal sealed class LinkedListNode<T>
 {
     internal LinkedListNode<T>? Next;

--- a/src/Nethermind/Nethermind.Core/Caching/LruCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/LruCache.cs
@@ -165,7 +165,7 @@ namespace Nethermind.Core.Caching
         private void Replace(TKey key, TValue value)
         {
             LinkedListNode<LruCacheItem>? node;
-            if (MultiAccessCount > _maxCapacity / 2)
+            if (MultiAccessCount > _maxCapacity / 2 || _singleAccessLru is null)
             {
                 MultiAccessCount--;
                 node = _multiAccessLru;
@@ -181,7 +181,10 @@ namespace Nethermind.Core.Caching
                 ThrowInvalidOperationException();
             }
 
-            _cacheMap.Remove(node!.Value.Key);
+            if (!_cacheMap.Remove(node.Value.Key))
+            {
+                ThrowInvalidOperationException();
+            }
 
             node.Value = new(key, value);
             node.AccessCount = 1;

--- a/src/Nethermind/Nethermind.Core/Caching/LruCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/LruCache.cs
@@ -167,8 +167,10 @@ namespace Nethermind.Core.Caching
         {
             LinkedListNode<LruCacheItem>? node;
             if (_singleAccessLru is null ||
-                (MultiAccessCount > _maxCapacity / 2
-                 // Only if last access was earlier than the oldest single access item
+                // Reserve 1/4 of the cache for multi access items.
+                // Prefer the single access item to evict,
+                // if multi-access item was accessed more recently.
+                (MultiAccessCount > _maxCapacity / 4
                  && _multiAccessLru!.LastAccessSec < _singleAccessLru.LastAccessSec))
             {
                 MultiAccessCount--;

--- a/src/Nethermind/Nethermind.Core/Caching/LruCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/LruCache.cs
@@ -168,7 +168,7 @@ namespace Nethermind.Core.Caching
             LinkedListNode<LruCacheItem>? node;
             if (_singleAccessLru is null ||
                 (MultiAccessCount > _maxCapacity / 2
-                // Only if last access was earlier than the oldest single access item
+                 // Only if last access was earlier than the oldest single access item
                  && _multiAccessLru!.LastAccessSec < _singleAccessLru.LastAccessSec))
             {
                 MultiAccessCount--;

--- a/src/Nethermind/Nethermind.Core/Caching/LruCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/LruCache.cs
@@ -168,12 +168,16 @@ namespace Nethermind.Core.Caching
             if (MultiAccessCount > _maxCapacity / 2 || _singleAccessLru is null)
             {
                 MultiAccessCount--;
+                SingleAccessCount++;
                 node = _multiAccessLru;
+                Debug.Assert(node is not null && node.AccessCount > 1);
+                LinkedListNode<LruCacheItem>.Remove(ref _multiAccessLru, node);
             }
             else
             {
-                // Don't decrement SingleAccessCount as we will just increment it again
                 node = _singleAccessLru;
+                Debug.Assert(node is not null && node.AccessCount == 1);
+                LinkedListNode<LruCacheItem>.Remove(ref _singleAccessLru, node);
             }
 
             if (node is null)

--- a/src/Nethermind/Nethermind.Core/Caching/LruKeyCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/LruKeyCache.cs
@@ -119,12 +119,16 @@ namespace Nethermind.Core.Caching
             if (MultiAccessCount > _maxCapacity / 2 || _singleAccessLru is null)
             {
                 MultiAccessCount--;
+                SingleAccessCount++;
                 node = _multiAccessLru;
+                Debug.Assert(node is not null && node.AccessCount > 1);
+                LinkedListNode<TKey>.Remove(ref _multiAccessLru, node);
             }
             else
             {
-                SingleAccessCount--;
                 node = _singleAccessLru;
+                Debug.Assert(node is not null && node.AccessCount == 1);
+                LinkedListNode<TKey>.Remove(ref _singleAccessLru, node);
             }
 
             if (node is null)

--- a/src/Nethermind/Nethermind.Core/Caching/LruKeyCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/LruKeyCache.cs
@@ -45,6 +45,7 @@ namespace Nethermind.Core.Caching
             _cacheMap.Clear();
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public bool Get(TKey key)
         {
             if (_cacheMap.TryGetValue(key, out LinkedListNode<TKey>? node))

--- a/src/Nethermind/Nethermind.Core/Caching/LruKeyCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/LruKeyCache.cs
@@ -120,7 +120,7 @@ namespace Nethermind.Core.Caching
             LinkedListNode<TKey>? node;
             if (_singleAccessLru is null ||
                 (MultiAccessCount > _maxCapacity / 2
-                // Only if last access was earlier than the oldest single access item
+                 // Only if last access was earlier than the oldest single access item
                  && _multiAccessLru!.LastAccessSec < _singleAccessLru.LastAccessSec))
             {
                 MultiAccessCount--;

--- a/src/Nethermind/Nethermind.Core/Caching/LruKeyCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/LruKeyCache.cs
@@ -119,8 +119,10 @@ namespace Nethermind.Core.Caching
         {
             LinkedListNode<TKey>? node;
             if (_singleAccessLru is null ||
-                (MultiAccessCount > _maxCapacity / 2
-                 // Only if last access was earlier than the oldest single access item
+                // Reserve 1/4 of the cache for multi access items.
+                // Prefer the single access item to evict,
+                // if multi-access item was accessed more recently.
+                (MultiAccessCount > _maxCapacity / 4
                  && _multiAccessLru!.LastAccessSec < _singleAccessLru.LastAccessSec))
             {
                 MultiAccessCount--;

--- a/src/Nethermind/Nethermind.Core/Caching/MemCountingCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/MemCountingCache.cs
@@ -165,7 +165,7 @@ namespace Nethermind.Core.Caching
         private void Replace(ValueKeccak key, byte[] value)
         {
             LinkedListNode<LruCacheItem>? node;
-            if (MultiAccessCount > _maxCapacity / 2)
+            if (MultiAccessCount > _maxCapacity / 2 || _singleAccessLru is null)
             {
                 MultiAccessCount--;
                 node = _multiAccessLru;
@@ -181,7 +181,10 @@ namespace Nethermind.Core.Caching
                 ThrowInvalidOperationException();
             }
 
-            _cacheMap.Remove(node!.Value.Key);
+            if (!_cacheMap.Remove(node.Value.Key))
+            {
+                ThrowInvalidOperationException();
+            }
 
             node.Value = new(key, value);
             node.AccessCount = 1;
@@ -197,7 +200,7 @@ namespace Nethermind.Core.Caching
             throw new InvalidOperationException(
                 $"{nameof(MemCountingCache)} called {nameof(Replace)} when empty.");
         }
-        
+
         [DebuggerDisplay("{Key}:{Value}")]
         private struct LruCacheItem
         {

--- a/src/Nethermind/Nethermind.Core/Caching/MemCountingCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/MemCountingCache.cs
@@ -24,6 +24,8 @@ namespace Nethermind.Core.Caching
             80 /* Dictionary */ +
             MemorySizes.SmallObjectOverhead +
             MemorySizes.SmallObjectOverhead +
+            MemorySizes.SmallObjectOverhead +
+            8 /* sizeof(int) * 2 */ +
             8 /* sizeof(int) aligned */;
 
         private const int PostInitMemorySize =
@@ -185,6 +187,7 @@ namespace Nethermind.Core.Caching
                 ThrowInvalidOperationException();
             }
 
+            MemorySize += MemorySizes.Align(value.Length) - MemorySizes.Align(node.Value.Value.Length);
             if (!_cacheMap.Remove(node.Value.Key))
             {
                 ThrowInvalidOperationException();

--- a/src/Nethermind/Nethermind.Core/Caching/MemCountingCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/MemCountingCache.cs
@@ -169,8 +169,10 @@ namespace Nethermind.Core.Caching
         {
             LinkedListNode<LruCacheItem>? node;
             if (_singleAccessLru is null ||
-                (MultiAccessCount > _maxCapacity / 2
-                 // Only if last access was earlier than the oldest single access item
+                // Reserve 1/4 of the cache for multi access items.
+                // Prefer the single access item to evict,
+                // if multi-access item was accessed more recently.
+                (MultiAccessCount > _maxCapacity / 4
                  && _multiAccessLru!.LastAccessSec < _singleAccessLru.LastAccessSec))
             {
                 MultiAccessCount--;

--- a/src/Nethermind/Nethermind.Core/Caching/MemCountingCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/MemCountingCache.cs
@@ -170,7 +170,7 @@ namespace Nethermind.Core.Caching
             LinkedListNode<LruCacheItem>? node;
             if (_singleAccessLru is null ||
                 (MultiAccessCount > _maxCapacity / 2
-                // Only if last access was earlier than the oldest single access item
+                 // Only if last access was earlier than the oldest single access item
                  && _multiAccessLru!.LastAccessSec < _singleAccessLru.LastAccessSec))
             {
                 MultiAccessCount--;

--- a/src/Nethermind/Nethermind.Core/Caching/MemCountingCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/MemCountingCache.cs
@@ -168,12 +168,16 @@ namespace Nethermind.Core.Caching
             if (MultiAccessCount > _maxCapacity / 2 || _singleAccessLru is null)
             {
                 MultiAccessCount--;
+                SingleAccessCount++;
                 node = _multiAccessLru;
+                Debug.Assert(node is not null && node.AccessCount > 1);
+                LinkedListNode<LruCacheItem>.Remove(ref _multiAccessLru, node);
             }
             else
             {
-                SingleAccessCount--;
                 node = _singleAccessLru;
+                Debug.Assert(node is not null && node.AccessCount == 1);
+                LinkedListNode<LruCacheItem>.Remove(ref _singleAccessLru, node);
             }
 
             if (node is null)

--- a/src/Nethermind/Nethermind.Core/Caching/SpanLruCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/SpanLruCache.cs
@@ -160,8 +160,10 @@ namespace Nethermind.Core.Caching
         {
             LinkedListNode<LruCacheItem>? node;
             if (_singleAccessLru is null ||
-                (MultiAccessCount > _maxCapacity / 2
-                 // Only if last access was earlier than the oldest single access item
+                // Reserve 1/4 of the cache for multi access items.
+                // Prefer the single access item to evict,
+                // if multi-access item was accessed more recently.
+                (MultiAccessCount > _maxCapacity / 4
                  && _multiAccessLru!.LastAccessSec < _singleAccessLru.LastAccessSec))
             {
                 MultiAccessCount--;

--- a/src/Nethermind/Nethermind.Core/Caching/SpanLruCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/SpanLruCache.cs
@@ -158,7 +158,7 @@ namespace Nethermind.Core.Caching
         private void Replace(ReadOnlySpan<TKey> key, TValue value)
         {
             LinkedListNode<LruCacheItem>? node;
-            if (MultiAccessCount > _maxCapacity / 2)
+            if (MultiAccessCount > _maxCapacity / 2 || _singleAccessLru is null)
             {
                 MultiAccessCount--;
                 node = _multiAccessLru;
@@ -174,7 +174,10 @@ namespace Nethermind.Core.Caching
                 ThrowInvalidOperationException();
             }
 
-            _cacheMap.Remove(node!.Value.Key);
+            if (!_cacheMap.Remove(node.Value.Key))
+            {
+                ThrowInvalidOperationException();
+            }
 
             TKey[] keyAsArray = key.ToArray();
             node.Value = new(keyAsArray, value);

--- a/src/Nethermind/Nethermind.Core/Caching/SpanLruCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/SpanLruCache.cs
@@ -161,7 +161,7 @@ namespace Nethermind.Core.Caching
             LinkedListNode<LruCacheItem>? node;
             if (_singleAccessLru is null ||
                 (MultiAccessCount > _maxCapacity / 2
-                // Only if last access was earlier than the oldest single access item
+                 // Only if last access was earlier than the oldest single access item
                  && _multiAccessLru!.LastAccessSec < _singleAccessLru.LastAccessSec))
             {
                 MultiAccessCount--;

--- a/src/Nethermind/Nethermind.Core/Caching/SpanLruCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/SpanLruCache.cs
@@ -161,12 +161,16 @@ namespace Nethermind.Core.Caching
             if (MultiAccessCount > _maxCapacity / 2 || _singleAccessLru is null)
             {
                 MultiAccessCount--;
+                SingleAccessCount++;
                 node = _multiAccessLru;
+                Debug.Assert(node is not null && node.AccessCount > 1);
+                LinkedListNode<LruCacheItem>.Remove(ref _multiAccessLru, node);
             }
             else
             {
-                SingleAccessCount--;
                 node = _singleAccessLru;
+                Debug.Assert(node is not null && node.AccessCount == 1);
+                LinkedListNode<LruCacheItem>.Remove(ref _singleAccessLru, node);
             }
 
             if (node is null)

--- a/src/Nethermind/Nethermind.Core/Collections/SpanDictionary.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/SpanDictionary.cs
@@ -778,6 +778,73 @@ ReturnNotFound:
             return false;
         }
 
+        public bool Remove(ReadOnlySpan<TKey> key, [MaybeNullWhen(false)] out TValue value)
+        {
+            // This overload is a copy of the overload Remove(ReadOnlySpan<TKey> key) with one additional
+            // statement to copy the value for entry being removed into the output parameter.
+            // Code has been intentionally duplicated for performance reasons.
+
+            if (_buckets != null)
+            {
+                Debug.Assert(_entries != null, "entries should be non-null");
+                uint collisionCount = 0;
+                uint hashCode = (uint)(_comparer?.GetHashCode(key) ?? key.GetHashCode());
+                ref int bucket = ref GetBucket(hashCode);
+                Entry[]? entries = _entries;
+                int last = -1;
+                int i = bucket - 1; // Value in buckets is 1-based
+                while (i >= 0)
+                {
+                    ref Entry entry = ref entries[i];
+
+                    if (entry.hashCode == hashCode && _comparer!.Equals(entry.key, key))
+                    {
+                        if (last < 0)
+                        {
+                            bucket = entry.next + 1; // Value in buckets is 1-based
+                        }
+                        else
+                        {
+                            entries[last].next = entry.next;
+                        }
+
+                        value = entry.value;
+
+                        Debug.Assert((StartOfFreeList - _freeList) < 0, "shouldn't underflow because max hashtable length is MaxPrimeArrayLength = 0x7FEFFFFD(2146435069) _freelist underflow threshold 2147483646");
+                        entry.next = StartOfFreeList - _freeList;
+
+                        if (RuntimeHelpers.IsReferenceOrContainsReferences<TKey[]>())
+                        {
+                            entry.key = default!;
+                        }
+
+                        if (RuntimeHelpers.IsReferenceOrContainsReferences<TValue>())
+                        {
+                            entry.value = default!;
+                        }
+
+                        _freeList = i;
+                        _freeCount++;
+                        return true;
+                    }
+
+                    last = i;
+                    i = entry.next;
+
+                    collisionCount++;
+                    if (collisionCount > (uint)entries.Length)
+                    {
+                        // The chain of entries forms a loop; which means a concurrent update has happened.
+                        // Break out of the loop and throw, rather than looping forever.
+                        throw new InvalidOperationException("Concurrent operations not supported");
+                    }
+                }
+            }
+
+            value = default;
+            return false;
+        }
+
         public bool Remove(TKey[] key, [MaybeNullWhen(false)] out TValue value)
         {
             // This overload is a copy of the overload Remove(TKey[] key) with one additional

--- a/src/Nethermind/Nethermind.Db/Metrics.cs
+++ b/src/Nethermind/Nethermind.Db/Metrics.cs
@@ -39,6 +39,10 @@ namespace Nethermind.Db
         public static long CodeDbReads { get; set; }
 
         [CounterMetric]
+        [Description("Number of Code Cache hits.")]
+        public static long CodeCacheHits { get; set; }
+
+        [CounterMetric]
         [Description("Number of Code DB writes.")]
         public static long CodeDbWrites { get; set; }
 

--- a/src/Nethermind/Nethermind.Evm/CodeAnalysis/CodeInfo.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeAnalysis/CodeInfo.cs
@@ -2,9 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections;
-using System.Reflection.PortableExecutable;
-using System.Threading;
 using Nethermind.Evm.Precompiles;
 
 namespace Nethermind.Evm.CodeAnalysis

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -400,6 +400,7 @@ public class VirtualMachine : IVirtualMachine
         else
         {
             // need to touch code so that any collectors that track database access are informed
+            Db.Metrics.CodeCacheHits++;
             worldState.TouchCode(codeHash);
         }
 

--- a/src/Nethermind/Nethermind.State.Test/CachingStoreTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/CachingStoreTests.cs
@@ -3,6 +3,7 @@
 
 using FluentAssertions;
 using Nethermind.Core;
+using Nethermind.Core.Caching;
 using Nethermind.Core.Test;
 using Nethermind.Db;
 using Nethermind.Trie;
@@ -72,6 +73,130 @@ namespace Nethermind.Store.Test
             ctx.Wrapped.KeyWasRead(Key1, 1);
             ctx.Wrapped.KeyWasRead(Key2, 0);
             ctx.Wrapped.KeyWasRead(Key3, 0);
+        }
+
+        [Test]
+        public void LruCache_AddingItems()
+        {
+            var cache = new LruCache<int, string>(maxCapacity: 2, startCapacity: 2, "test");
+
+            cache.Set(1, "one");
+            cache.Set(2, "two");
+
+            Assert.IsTrue(cache.TryGet(1, out _));
+            Assert.IsTrue(cache.TryGet(2, out _));
+        }
+
+        [Test]
+        public void LruCache_Eviction()
+        {
+            var cache = new LruCache<int, string>(maxCapacity: 2, startCapacity: 2, "test");
+
+            cache.Set(1, "one");
+            cache.Set(2, "two");
+            cache.Set(3, "three");  // This should evict "one"
+
+            Assert.IsFalse(cache.TryGet(1, out _));
+            Assert.IsTrue(cache.TryGet(2, out _));
+            Assert.IsTrue(cache.TryGet(3, out _));
+        }
+
+        [Test]
+        public void LruCache_Reordering()
+        {
+            var cache = new LruCache<int, string>(maxCapacity: 3, startCapacity: 3, "test");
+
+            cache.Set(1, "one");
+            cache.Set(2, "two");
+            cache.Set(3, "three"); // At this point, "one" should be the LRU item
+
+            cache.TryGet(1, out _); // This should move "one" to the MRU position
+
+            cache.Set(4, "four"); // This should evict "two", which is now LRU
+
+            Assert.IsFalse(cache.TryGet(2, out _));
+            Assert.IsTrue(cache.TryGet(1, out _));
+            Assert.IsTrue(cache.TryGet(3, out _));
+            Assert.IsTrue(cache.TryGet(4, out _));
+        }
+
+        [Test]
+        public void LruCache_SingleUseMultiUseRatio()
+        {
+            LruCache<int, string> cache = new (maxCapacity: 4, startCapacity: 4, "test");
+
+            cache.Set(1, "one");
+            cache.Set(2, "two");
+            cache.Set(3, "three");
+            cache.Set(4, "four");
+
+            // At this point, all items are single-use
+            Assert.That(cache.SingleAccessCount, Is.EqualTo(4));
+            Assert.That(cache.MultiAccessCount, Is.EqualTo(0));
+
+            // Access an item to promote it to multi-use
+            cache.TryGet(1, out _);
+            Assert.That(cache.SingleAccessCount, Is.EqualTo(3));
+            Assert.That(cache.MultiAccessCount, Is.EqualTo(1));
+
+            // Add a new item, this should evict a single-use item
+            cache.Set(5, "five");
+            Assert.That(cache.SingleAccessCount, Is.EqualTo(3));
+            Assert.That(cache.MultiAccessCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void LruCache_Remove()
+        {
+            LruCache<int, string> cache = new (maxCapacity: 4, startCapacity: 4, "test");
+
+            cache.Set(1, "one");
+            cache.Set(2, "two");
+            cache.Set(3, "three");
+            cache.Set(4, "four");
+
+            Assert.IsTrue(cache.Delete(1));
+            Assert.IsFalse(cache.TryGet(1, out _));
+            Assert.That(cache.SingleAccessCount, Is.EqualTo(3));
+            Assert.That(cache.MultiAccessCount, Is.EqualTo(0));
+
+            cache.TryGet(2, out _);
+            Assert.IsTrue(cache.Delete(2));
+            Assert.IsFalse(cache.TryGet(2, out _));
+            Assert.That(cache.SingleAccessCount, Is.EqualTo(2));
+            Assert.That(cache.MultiAccessCount, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void LruCache_DeleteFromMiddleOfSections()
+        {
+            LruCache<int, string> cache = new (maxCapacity: 6, startCapacity: 6, "test");
+
+            cache.Set(1, "one");
+            cache.Set(2, "two");
+            cache.Set(3, "three");
+            cache.Set(4, "four");
+
+            // Accessing an item to promote it to multi-use
+            cache.TryGet(2, out _);
+
+            cache.Set(5, "five");
+            cache.Set(6, "six");
+
+            // At this point, cache order should be 2 (multi-use), 1, 3, 4, 5, 6 (single-use)
+
+            // Delete an item from the middle of the single-use section (4)
+            Assert.That(cache.SingleAccessCount, Is.EqualTo(5));
+            Assert.IsTrue(cache.Delete(4));
+            Assert.IsFalse(cache.TryGet(4, out _));
+            Assert.That(cache.SingleAccessCount, Is.EqualTo(4));
+            Assert.That(cache.MultiAccessCount, Is.EqualTo(1));
+
+            // Delete an item from the multi-use section (2)
+            Assert.IsTrue(cache.Delete(2));
+            Assert.IsFalse(cache.TryGet(2, out _));
+            Assert.That(cache.SingleAccessCount, Is.EqualTo(4));
+            Assert.That(cache.MultiAccessCount, Is.EqualTo(0));
         }
 
         private class Context

--- a/src/Nethermind/Nethermind.State.Test/CachingStoreTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/CachingStoreTests.cs
@@ -123,7 +123,7 @@ namespace Nethermind.Store.Test
         [Test]
         public void LruCache_SingleUseMultiUseRatio()
         {
-            LruCache<int, string> cache = new (maxCapacity: 4, startCapacity: 4, "test");
+            LruCache<int, string> cache = new(maxCapacity: 4, startCapacity: 4, "test");
 
             cache.Set(1, "one");
             cache.Set(2, "two");
@@ -148,7 +148,7 @@ namespace Nethermind.Store.Test
         [Test]
         public void LruCache_Remove()
         {
-            LruCache<int, string> cache = new (maxCapacity: 4, startCapacity: 4, "test");
+            LruCache<int, string> cache = new(maxCapacity: 4, startCapacity: 4, "test");
 
             cache.Set(1, "one");
             cache.Set(2, "two");
@@ -170,7 +170,7 @@ namespace Nethermind.Store.Test
         [Test]
         public void LruCache_DeleteFromMiddleOfSections()
         {
-            LruCache<int, string> cache = new (maxCapacity: 6, startCapacity: 6, "test");
+            LruCache<int, string> cache = new(maxCapacity: 6, startCapacity: 6, "test");
 
             cache.Set(1, "one");
             cache.Set(2, "two");

--- a/src/Nethermind/Nethermind.Trie.Test/CacheTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/CacheTests.cs
@@ -16,7 +16,7 @@ namespace Nethermind.Trie.Test
         public void Cache_initial_memory_calculated_correctly()
         {
             MemCountingCache cache = new(1024, string.Empty);
-            cache.MemorySize.Should().Be(136);
+            cache.MemorySize.Should().Be(168);
         }
 
         [Test]
@@ -24,7 +24,7 @@ namespace Nethermind.Trie.Test
         {
             MemCountingCache cache = new(1024, string.Empty);
             cache.Set(Keccak.Zero, new byte[0]);
-            cache.MemorySize.Should().Be(376);
+            cache.MemorySize.Should().Be(408);
         }
 
         [Test]
@@ -35,27 +35,27 @@ namespace Nethermind.Trie.Test
             cache.Set(TestItem.KeccakB, new byte[0]);
             cache.Set(TestItem.KeccakC, new byte[0]);
             cache.Set(TestItem.KeccakD, new byte[0]);
-            cache.MemorySize.Should().Be(800);
+            cache.MemorySize.Should().Be(832);
         }
 
         [Test]
         public void Limit_by_memory_works_fine()
         {
-            MemCountingCache cache = new(584, string.Empty);
+            MemCountingCache cache = new(616, string.Empty);
             cache.Set(TestItem.KeccakA, new byte[0]);
             cache.Set(TestItem.KeccakB, new byte[0]);
             cache.Set(TestItem.KeccakC, new byte[0]);
 
-            cache.MemorySize.Should().Be(584);
+            cache.MemorySize.Should().Be(616);
             cache.Get(TestItem.KeccakA).Should().NotBeNull();
 
             cache.Set(TestItem.KeccakD, new byte[0]);
-            cache.MemorySize.Should().Be(584);
+            cache.MemorySize.Should().Be(616);
             cache.Get(TestItem.KeccakB).Should().BeNull();
             cache.Get(TestItem.KeccakD).Should().NotBeNull();
 
             cache.Set(TestItem.KeccakE, new byte[0]);
-            cache.MemorySize.Should().Be(584);
+            cache.MemorySize.Should().Be(616);
             cache.Get(TestItem.KeccakB).Should().BeNull();
             cache.Get(TestItem.KeccakC).Should().BeNull();
             cache.Get(TestItem.KeccakE).Should().NotBeNull();
@@ -71,11 +71,11 @@ namespace Nethermind.Trie.Test
 
             cache.Set(TestItem.KeccakA, null);
 
-            cache.MemorySize.Should().Be(480);
+            cache.MemorySize.Should().Be(616);
             cache.Get(TestItem.KeccakA).Should().BeNull();
 
             cache.Set(TestItem.KeccakD, new byte[0]);
-            cache.MemorySize.Should().Be(584);
+            cache.MemorySize.Should().Be(720);
             cache.Get(TestItem.KeccakB).Should().NotBeNull();
             cache.Get(TestItem.KeccakD).Should().NotBeNull();
         }

--- a/src/Nethermind/Nethermind.TxPool/Metrics.cs
+++ b/src/Nethermind/Nethermind.TxPool/Metrics.cs
@@ -69,6 +69,14 @@ namespace Nethermind.TxPool
         public static long PendingTransactionsWithExpensiveFiltering { get; set; }
 
         [CounterMetric]
+        [Description("Number of pending transactions looking up Account that were serviced by cache.")]
+        public static long PendingTransactionAccountCacheHit { get; set; }
+
+        [CounterMetric]
+        [Description("Number of pending transactions looking up Account that were not in cache.")]
+        public static long PendingTransactionAccountCacheMiss { get; set; }
+
+        [CounterMetric]
         [Description("Number of already known pending transactions.")]
         public static long PendingTransactionsKnown { get; set; }
 


### PR DESCRIPTION
## Changes

- Reserve 1/4 of the LruCache for items that are accessed more than once (hold onto them for longer); so a run of only once used items doesn't clear the whole cache; and only evict if last access was older than single access item's last access. (i.e queue position maintained)

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No