### PR TITLE
Perf/keccak with valuekeccak

### DIFF
--- a/src/Nethermind/Nethermind.Abi.Test/AbiTests.cs
+++ b/src/Nethermind/Nethermind.Abi.Test/AbiTests.cs
@@ -384,7 +384,7 @@ public class AbiTests
             AbiType.Address,
             AbiType.Address);
 
-        byte[] encoded = _abiEncoder.Encode(AbiEncodingStyle.Packed, abiDef, assetId.Bytes, units, value, expiryTime, salt, Address.Zero, Address.Zero);
+        byte[] encoded = _abiEncoder.Encode(AbiEncodingStyle.Packed, abiDef, assetId.BytesToArray(), units, value, expiryTime, salt, Address.Zero, Address.Zero);
         Assert.That(encoded.Length, Is.EqualTo(108));
     }
 

--- a/src/Nethermind/Nethermind.Abi/AbiBytes.cs
+++ b/src/Nethermind/Nethermind.Abi/AbiBytes.cs
@@ -61,7 +61,7 @@ namespace Nethermind.Abi
 
             if (arg is Keccak hash && Length == 32)
             {
-                return Encode(hash.Bytes, packed);
+                return Encode(hash.Bytes.ToArray(), packed);
             }
 
             throw new AbiException(AbiEncodingExceptionMessage);

--- a/src/Nethermind/Nethermind.AccountAbstraction.Test/AccountAbstractionRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.AccountAbstraction.Test/AccountAbstractionRpcModuleTests.cs
@@ -130,7 +130,7 @@ namespace Nethermind.AccountAbstraction.Test
                     Transaction entryPointTx = Core.Test.Builders.Build.A.Transaction.WithTo(singletonFactoryAddress).WithData(createEntryPointBytes).WithGasLimit(6_000_000).WithNonce(chain.State.GetNonce(ContractCreatorPrivateKey.Address)).WithValue(0).SignedAndResolved(ContractCreatorPrivateKey).TestObject;
                     await chain.AddBlock(true, entryPointTx);
 
-                    Address computedAddress = new(Keccak.Compute(Bytes.Concat(Bytes.FromHexString("0xff"), singletonFactoryAddress.Bytes, Bytes.Zero32, Keccak.Compute(entryPointConstructorBytes).Bytes)).Bytes.TakeLast(20).ToArray());
+                    Address computedAddress = new(Keccak.Compute(Bytes.Concat(Bytes.FromHexString("0xff"), singletonFactoryAddress.Bytes, Bytes.Zero32, Keccak.Compute(entryPointConstructorBytes).Bytes)).BytesToArray().TakeLast(20).ToArray());
 
                     TxReceipt createEntryPointTxReceipt = chain.Bridge.GetReceipt(entryPointTx.Hash!);
                     createEntryPointTxReceipt.Error.Should().BeNullOrEmpty($"Contract transaction {computedAddress!} was not deployed.");

--- a/src/Nethermind/Nethermind.AuRa.Test/Validators/ReportingContractBasedValidatorTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/Validators/ReportingContractBasedValidatorTests.cs
@@ -35,7 +35,7 @@ namespace Nethermind.AuRa.Test.Validators
         public void Report_malicious_sends_transaction([Values(true, false)] bool reportingValidator)
         {
             TestContext context = new(true);
-            byte[] proof = TestItem.KeccakA.Bytes;
+            byte[] proof = TestItem.KeccakA.BytesToArray();
             Transaction transaction = Build.A.Transaction.TestObject;
             context.ReportingValidatorContract.ReportMalicious(MaliciousMinerAddress, 5, proof).Returns(transaction);
             context.Validator.ReportMalicious(reportingValidator ? MaliciousMinerAddress : NodeAddress, 5, proof, IReportingValidator.MaliciousCause.DuplicateStep);
@@ -56,7 +56,7 @@ namespace Nethermind.AuRa.Test.Validators
         public void Resend_malicious_transactions([Values(0, 5, 15)] int validatorsToReport, [Values(1, 4)] long blockNumber)
         {
             ReportingContractBasedValidator.Cache cache = new();
-            byte[] proof = TestItem.KeccakA.Bytes;
+            byte[] proof = TestItem.KeccakA.BytesToArray();
             Transaction transaction = Build.A.Transaction.TestObject;
             TestContext context = new(false, cache);
             for (ulong i = 5; i < 20; i++)
@@ -98,7 +98,7 @@ namespace Nethermind.AuRa.Test.Validators
         public void Adds_transactions_to_block([Values(0, 5, 15)] int validatorsToReport, [Values(0, 2, 10, 20)] long parentBlockNumber, [Values(false, true)] bool emitInitChangeCallable)
         {
             TestContext context = new(true);
-            byte[] proof = TestItem.KeccakA.Bytes;
+            byte[] proof = TestItem.KeccakA.BytesToArray();
             Transaction transaction = Build.A.Transaction.TestObject;
             context.ContractBasedValidator.Validators = new[] { MaliciousMinerAddress, NodeAddress };
             ulong startReportBlockNumber = 5;

--- a/src/Nethermind/Nethermind.Benchmark/Core/BytesCompareBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Core/BytesCompareBenchmarks.cs
@@ -18,11 +18,11 @@ namespace Nethermind.Benchmarks.Core
 
         private (byte[] A, byte[] B)[] _scenarios = new[]
         {
-            (Keccak.Zero.Bytes, Keccak.Zero.Bytes),
-            (Keccak.Zero.Bytes, Keccak.EmptyTreeHash.Bytes),
-            (Keccak.EmptyTreeHash.Bytes, Keccak.EmptyTreeHash.Bytes),
-            (Keccak.OfAnEmptyString.Bytes, Keccak.EmptyTreeHash.Bytes),
-            (Keccak.OfAnEmptyString.Bytes, Keccak.EmptyTreeHash.Bytes),
+            (Keccak.Zero.BytesToArray(), Keccak.Zero.BytesToArray()),
+            (Keccak.Zero.BytesToArray(), Keccak.EmptyTreeHash.BytesToArray()),
+            (Keccak.EmptyTreeHash.BytesToArray(), Keccak.EmptyTreeHash.BytesToArray()),
+            (Keccak.OfAnEmptyString.BytesToArray(), Keccak.EmptyTreeHash.BytesToArray()),
+            (Keccak.OfAnEmptyString.BytesToArray(), Keccak.EmptyTreeHash.BytesToArray()),
             (TestItem.AddressA.Bytes, TestItem.AddressB.Bytes),
         };
 

--- a/src/Nethermind/Nethermind.Benchmark/Core/BytesIsZeroBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Core/BytesIsZeroBenchmarks.cs
@@ -16,9 +16,9 @@ namespace Nethermind.Benchmarks.Core
 
         private byte[][] _scenarios = new byte[][]
         {
-            Keccak.Zero.Bytes,
-            Keccak.EmptyTreeHash.Bytes,
-            Keccak.OfAnEmptyString.Bytes,
+            Keccak.Zero.BytesToArray(),
+            Keccak.EmptyTreeHash.BytesToArray(),
+            Keccak.OfAnEmptyString.BytesToArray(),
             TestItem.AddressA.Bytes,
             Address.Zero.Bytes,
         };

--- a/src/Nethermind/Nethermind.Benchmark/Core/BytesPadBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Core/BytesPadBenchmarks.cs
@@ -17,7 +17,7 @@ namespace Nethermind.Benchmarks.Core
         {
             new byte[]{0},
             new byte[]{1},
-            Keccak.Zero.Bytes,
+            Keccak.Zero.BytesToArray(),
             TestItem.AddressA.Bytes
         };
 

--- a/src/Nethermind/Nethermind.Benchmark/Core/BytesReverseBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Core/BytesReverseBenchmarks.cs
@@ -20,8 +20,8 @@ namespace Nethermind.Benchmarks.Core
 
         private byte[][] _scenarios = new[]
         {
-            Keccak.Zero.Bytes,
-            Keccak.EmptyTreeHash.Bytes,
+            Keccak.Zero.BytesToArray(),
+            Keccak.EmptyTreeHash.BytesToArray(),
             TestItem.AddressA.Bytes
         };
 

--- a/src/Nethermind/Nethermind.Benchmark/Core/Keccak256Benchmarks.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Core/Keccak256Benchmarks.cs
@@ -47,7 +47,7 @@ namespace Nethermind.Benchmarks.Core
         [Benchmark(Baseline = true)]
         public byte[] Current()
         {
-            return Keccak.Compute(_a).Bytes;
+            return Keccak.Compute(_a).BytesToArray();
         }
 
         [Benchmark]

--- a/src/Nethermind/Nethermind.Benchmark/Core/ToHexBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Core/ToHexBenchmarks.cs
@@ -11,7 +11,7 @@ namespace Nethermind.Benchmarks.Core
 {
     public class ToHexBenchmarks
     {
-        private byte[] bytes = TestItem.KeccakA.Bytes;
+        private byte[] bytes = TestItem.KeccakA.BytesToArray();
 
         [Params(true, false)]
         public bool OddNumber;

--- a/src/Nethermind/Nethermind.Benchmark/Store/HexPrefixFromBytesBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Store/HexPrefixFromBytesBenchmarks.cs
@@ -16,8 +16,8 @@ namespace Nethermind.Benchmarks.Store
 
         private byte[][] _scenarios = new byte[][]
         {
-            Keccak.EmptyTreeHash.Bytes,
-            Keccak.Zero.Bytes,
+            Keccak.EmptyTreeHash.BytesToArray(),
+            Keccak.Zero.BytesToArray(),
             TestItem.AddressA.Bytes,
         };
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/Receipts/PersistentReceiptStorageTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Receipts/PersistentReceiptStorageTests.cs
@@ -133,7 +133,7 @@ namespace Nethermind.Blockchain.Test.Receipts
 
             TestMemDb blocksDb = (TestMemDb)_receiptsDb.GetColumnDb(ReceiptsColumns.Blocks);
             blocksDb.KeyWasRead(blockNumPrefixed.ToArray(), 0);
-            blocksDb.KeyWasRead(block.Hash.Bytes, 1);
+            blocksDb.KeyWasRead(block.Hash.BytesToArray(), 1);
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Blockchain.Test/Receipts/ReceiptsIteratorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Receipts/ReceiptsIteratorTests.cs
@@ -38,15 +38,15 @@ public class ReceiptsIteratorTests
         iterator.TryGetNext(out TxReceiptStructRef receipt).Should().BeTrue();
         iterator.RecoverIfNeeded(ref receipt);
         receipt.Sender.Bytes.ToArray().Should().BeEquivalentTo(TestItem.AddressA.Bytes);
-        receipt.TxHash.Bytes.ToArray().Should().BeEquivalentTo(block.Transactions[0].Hash.Bytes);
+        receipt.TxHash.Bytes.ToArray().Should().BeEquivalentTo(block.Transactions[0].Hash.BytesToArray());
         iterator.TryGetNext(out receipt).Should().BeTrue();
         iterator.RecoverIfNeeded(ref receipt);
         receipt.Sender.Bytes.ToArray().Should().BeEquivalentTo(TestItem.AddressB.Bytes);
-        receipt.TxHash.Bytes.ToArray().Should().BeEquivalentTo(block.Transactions[1].Hash.Bytes);
+        receipt.TxHash.Bytes.ToArray().Should().BeEquivalentTo(block.Transactions[1].Hash.BytesToArray());
         iterator.TryGetNext(out receipt).Should().BeTrue();
         iterator.RecoverIfNeeded(ref receipt);
         receipt.Sender.Bytes.ToArray().Should().BeEquivalentTo(TestItem.AddressC.Bytes);
-        receipt.TxHash.Bytes.ToArray().Should().BeEquivalentTo(block.Transactions[1].Hash.Bytes);
+        receipt.TxHash.Bytes.ToArray().Should().BeEquivalentTo(block.Transactions[1].Hash.BytesToArray());
     }
 
     [Test]
@@ -74,7 +74,7 @@ public class ReceiptsIteratorTests
         iterator.TryGetNext(out receipt).Should().BeTrue();
         iterator.RecoverIfNeeded(ref receipt);
         receipt.Sender.Bytes.ToArray().Should().BeEquivalentTo(TestItem.AddressC.Bytes);
-        receipt.TxHash.Bytes.ToArray().Should().BeEquivalentTo(block.Transactions[1].Hash.Bytes);
+        receipt.TxHash.Bytes.ToArray().Should().BeEquivalentTo(block.Transactions[1].Hash.BytesToArray());
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
@@ -356,7 +356,7 @@ namespace Nethermind.Blockchain.Receipts
             {
                 foreach (Transaction tx in block.Transactions)
                 {
-                    batch[tx.Hash.Bytes] = block.Hash.Bytes;
+                    batch[tx.Hash.Bytes] = block.Hash.BytesToArray();
                 }
             }
         }

--- a/src/Nethermind/Nethermind.Consensus.AuRa/Contracts/RandomContract.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/Contracts/RandomContract.cs
@@ -110,7 +110,7 @@ namespace Nethermind.Consensus.AuRa.Contracts
                     : !isCommitted
                         ? IRandomContract.Phase.BeforeCommit
                         : IRandomContract.Phase.Committed
-                : !isCommitted // We apparently entered too late to make a commitment, wait until we get a chance again. 
+                : !isCommitted // We apparently entered too late to make a commitment, wait until we get a chance again.
                   || revealed
                     ? IRandomContract.Phase.Waiting
                     : IRandomContract.Phase.Reveal;
@@ -182,7 +182,7 @@ namespace Nethermind.Consensus.AuRa.Contracts
         /// <param name="secretHash">The Keccak-256 hash of the validator's secret.</param>
         /// <param name="cipher">The cipher of the validator's secret. Can be used by the node to restore the lost secret after the node is restarted (see the `getCipher` getter).</param>
         /// <returns>Transaction to be included in block.</returns>
-        public Transaction CommitHash(in Keccak secretHash, byte[] cipher) => GenerateTransaction<GeneratedTransaction>(nameof(CommitHash), SignerAddress, secretHash.Bytes, cipher);
+        public Transaction CommitHash(in Keccak secretHash, byte[] cipher) => GenerateTransaction<GeneratedTransaction>(nameof(CommitHash), SignerAddress, secretHash.BytesToArray(), cipher);
 
         /// <summary>
         /// Called by the validator's node to XOR its number with the current random seed.

--- a/src/Nethermind/Nethermind.Consensus.AuRa/Contracts/RegisterContract.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/Contracts/RegisterContract.cs
@@ -57,6 +57,6 @@ namespace Nethermind.Consensus.AuRa.Contracts
         public Address GetAddress(BlockHeader header, string key) =>
             // 2 arguments: name and key (category)
             Constant.Call<Address>(
-                new CallInfo(header, nameof(GetAddress), Address.Zero, Keccak.Compute(key).Bytes, DnsAddressRecord) { MissingContractResult = MissingGetAddressResult });
+                new CallInfo(header, nameof(GetAddress), Address.Zero, Keccak.Compute(key).BytesToArray(), DnsAddressRecord) { MissingContractResult = MissingGetAddressResult });
     }
 }

--- a/src/Nethermind/Nethermind.Consensus.AuRa/Contracts/TxPriorityContract.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/Contracts/TxPriorityContract.cs
@@ -20,7 +20,7 @@ namespace Nethermind.Consensus.AuRa.Contracts
 {
     /// <summary>
     /// Permission contract for <see cref="ITxPool"/> transaction ordering
-    /// <seealso cref="https://github.com/poanetwork/posdao-contracts/blob/master/contracts/TxPriority.sol"/> 
+    /// <seealso cref="https://github.com/poanetwork/posdao-contracts/blob/master/contracts/TxPriority.sol"/>
     /// </summary>
     public partial class TxPriorityContract : Contract
     {
@@ -94,7 +94,7 @@ namespace Nethermind.Consensus.AuRa.Contracts
         private Destination DecodeDestination(LogEntry log, BlockHeader blockHeader) =>
             new Destination(
                 new Address(log.Topics[1]),
-                log.Topics[2].Bytes.Slice(0, 4),
+                log.Topics[2].Bytes.Slice(0, 4).ToArray(),
                 AbiType.UInt256.DecodeUInt(log.Data, 0, false).Item1,
                 DestinationSource.Contract,
                 blockHeader.Number);

--- a/src/Nethermind/Nethermind.Consensus.Clique/SnapshotManager.cs
+++ b/src/Nethermind/Nethermind.Consensus.Clique/SnapshotManager.cs
@@ -219,7 +219,7 @@ namespace Nethermind.Consensus.Clique
 
         private static Keccak GetSnapshotKey(Keccak blockHash)
         {
-            byte[] hashBytes = blockHash.Bytes;
+            Span<byte> hashBytes = blockHash.Bytes;
             byte[] keyBytes = new byte[hashBytes.Length];
             for (int i = 0; i < _snapshotBytes.Length; i++) keyBytes[i] = (byte)(hashBytes[i] ^ _snapshotBytes[i]);
 

--- a/src/Nethermind/Nethermind.Consensus.Ethash/Ethash.cs
+++ b/src/Nethermind/Nethermind.Consensus.Ethash/Ethash.cs
@@ -96,7 +96,7 @@ namespace Nethermind.Consensus.Ethash
         }
 
         /// <summary>
-        /// Improvement from @AndreaLanfranchi 
+        /// Improvement from @AndreaLanfranchi
         /// </summary>
         /// <param name="number"></param>
         /// <returns></returns>
@@ -122,13 +122,13 @@ namespace Nethermind.Consensus.Ethash
 
         public static Keccak GetSeedHash(uint epoch)
         {
-            byte[] seed = new byte[32];
+            ValueKeccak seed = new ValueKeccak();
             for (uint i = 0; i < epoch; i++)
             {
-                seed = Keccak.Compute(seed).Bytes; // TODO: optimize
+                seed = ValueKeccak.Compute(seed.Bytes); // TODO: optimize
             }
 
-            return new Keccak(seed);
+            return new Keccak(seed.Bytes.ToArray());
         }
 
         private readonly BigInteger _2To256 = BigInteger.Pow(2, 256);
@@ -142,7 +142,7 @@ namespace Nethermind.Consensus.Ethash
             return BitConverter.ToUInt64(buffer, 0);
         }
 
-        private bool IsLessOrEqualThanTarget(byte[] result, in UInt256 difficulty)
+        private bool IsLessOrEqualThanTarget(ReadOnlySpan<byte> result, in UInt256 difficulty)
         {
             UInt256 resultAsInteger = new(result, true);
             BigInteger target = BigInteger.Divide(_2To256, (BigInteger)difficulty);
@@ -167,9 +167,9 @@ namespace Nethermind.Consensus.Ethash
             byte[] mixHash;
             while (true)
             {
-                byte[] result;
+                ValueKeccak result;
                 (mixHash, result, _) = Hashimoto(fullSize, dataSet, headerHashed, null, nonce);
-                if (IsLessOrEqualThanTarget(result, header.Difficulty))
+                if (IsLessOrEqualThanTarget(result.Bytes, header.Difficulty))
                 {
                     break;
                 }
@@ -228,13 +228,13 @@ namespace Nethermind.Consensus.Ethash
 
             ulong fullSize = GetDataSize(epoch);
             Keccak headerHashed = GetTruncatedHash(header);
-            (byte[] _, byte[] result, bool isValid) = Hashimoto(fullSize, dataSet, headerHashed, header.MixHash, header.Nonce);
+            (byte[] _, ValueKeccak result, bool isValid) = Hashimoto(fullSize, dataSet, headerHashed, header.MixHash, header.Nonce);
             if (!isValid)
             {
                 return false;
             }
 
-            return IsLessOrEqualThanTarget(result, header.Difficulty);
+            return IsLessOrEqualThanTarget(result.Bytes, header.Difficulty);
         }
 
         private readonly Stopwatch _cacheStopwatch = new();
@@ -260,7 +260,7 @@ namespace Nethermind.Consensus.Ethash
             return headerHashed;
         }
 
-        public (byte[], byte[], bool) Hashimoto(ulong fullSize, IEthashDataSet dataSet, Keccak headerHash, Keccak expectedMixHash, ulong nonce)
+        public (byte[], ValueKeccak, bool) Hashimoto(ulong fullSize, IEthashDataSet dataSet, Keccak headerHash, Keccak expectedMixHash, ulong nonce)
         {
             uint hashesInFull = (uint)(fullSize / HashBytes); // TODO: at current rate would cover around 200 years... but will the block rate change? what with private chains with shorter block times?
             const uint wordsInMix = MixBytes / WordBytes;
@@ -269,7 +269,7 @@ namespace Nethermind.Consensus.Ethash
             byte[] nonceBytes = new byte[8];
             BinaryPrimitives.WriteUInt64LittleEndian(nonceBytes, nonce);
 
-            byte[] headerAndNonceHashed = Keccak512.Compute(Bytes.Concat(headerHash.Bytes, nonceBytes)).Bytes; // this tests fine
+            byte[] headerAndNonceHashed = Keccak512.Compute(Bytes.Concat(headerHash.BytesToArray(), nonceBytes)).Bytes; // this tests fine
             uint[] mixInts = new uint[MixBytes / WordBytes];
 
             for (int i = 0; i < hashesInMix; i++)
@@ -305,7 +305,7 @@ namespace Nethermind.Consensus.Ethash
                 return (null, null, false);
             }
 
-            return (cmix, Keccak.Compute(Bytes.Concat(headerAndNonceHashed, cmix)).Bytes, true); // this tests fine
+            return (cmix, ValueKeccak.Compute(Bytes.Concat(headerAndNonceHashed, cmix)), true); // this tests fine
         }
     }
 }

--- a/src/Nethermind/Nethermind.Consensus.Ethash/Ethash.cs
+++ b/src/Nethermind/Nethermind.Consensus.Ethash/Ethash.cs
@@ -125,7 +125,7 @@ namespace Nethermind.Consensus.Ethash
             ValueKeccak seed = new ValueKeccak();
             for (uint i = 0; i < epoch; i++)
             {
-                seed = ValueKeccak.Compute(seed.Bytes); // TODO: optimize
+                seed = ValueKeccak.Compute(seed.Bytes);
             }
 
             return new Keccak(seed.Bytes.ToArray());

--- a/src/Nethermind/Nethermind.Consensus/Signer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Signer.cs
@@ -38,7 +38,7 @@ namespace Nethermind.Consensus
         public Signature Sign(Keccak message)
         {
             if (!CanSign) throw new InvalidOperationException("Cannot sign without provided key.");
-            byte[] rs = Ecdsa.SignCompact(message.Bytes, _key!.KeyBytes, out int v);
+            byte[] rs = SpanSecP256k1.SignCompact(message.Bytes, _key!.KeyBytes, out int v);
             return new Signature(rs, v);
         }
 

--- a/src/Nethermind/Nethermind.Consensus/Signer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Signer.cs
@@ -38,7 +38,7 @@ namespace Nethermind.Consensus
         public Signature Sign(Keccak message)
         {
             if (!CanSign) throw new InvalidOperationException("Cannot sign without provided key.");
-            byte[] rs = SecP256k1.SignCompact(message.Bytes, _key!.KeyBytes, out int v);
+            byte[] rs = Ecdsa.SignCompact(message.Bytes, _key!.KeyBytes, out int v);
             return new Signature(rs, v);
         }
 

--- a/src/Nethermind/Nethermind.Core.Test/Crypto/SignatureTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Crypto/SignatureTests.cs
@@ -41,7 +41,7 @@ public class SignatureTests
         var signatureObject = new Signature(signatureSlice, recoveryId);
         var keccak = Keccak.Compute(Bytes.Concat(messageType, data));
         Span<byte> publicKey = stackalloc byte[65];
-        bool result = SecP256k1.RecoverKeyFromCompact(publicKey, keccak.Bytes, signatureObject.Bytes, signatureObject.RecoveryId, false);
+        bool result = Ecdsa.RecoverKeyFromCompact(publicKey, keccak.Bytes, signatureObject.Bytes, signatureObject.RecoveryId, false);
         result.Should().BeTrue();
     }
 }

--- a/src/Nethermind/Nethermind.Core.Test/Crypto/SignatureTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Crypto/SignatureTests.cs
@@ -41,7 +41,7 @@ public class SignatureTests
         var signatureObject = new Signature(signatureSlice, recoveryId);
         var keccak = Keccak.Compute(Bytes.Concat(messageType, data));
         Span<byte> publicKey = stackalloc byte[65];
-        bool result = Ecdsa.RecoverKeyFromCompact(publicKey, keccak.Bytes, signatureObject.Bytes, signatureObject.RecoveryId, false);
+        bool result = SpanSecP256k1.RecoverKeyFromCompact(publicKey, keccak.Bytes, signatureObject.Bytes, signatureObject.RecoveryId, false);
         result.Should().BeTrue();
     }
 }

--- a/src/Nethermind/Nethermind.Core.Test/KeccakTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/KeccakTests.cs
@@ -29,8 +29,7 @@ namespace Nethermind.Core.Test
             byte[] bytes = new byte[32];
             new Random(42).NextBytes(bytes);
 
-            Keccak theBytes = Keccak.Compute(bytes);
-            string result = theBytes.ToString();
+            string result = Keccak.Compute(bytes).ToString();
 
             KeccakHash keccakHash = KeccakHash.Create();
             keccakHash.Reset();

--- a/src/Nethermind/Nethermind.Core.Test/KeccakTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/KeccakTests.cs
@@ -29,7 +29,8 @@ namespace Nethermind.Core.Test
             byte[] bytes = new byte[32];
             new Random(42).NextBytes(bytes);
 
-            string result = Keccak.Compute(bytes).ToString();
+            Keccak theBytes = Keccak.Compute(bytes);
+            string result = theBytes.ToString();
 
             KeccakHash keccakHash = KeccakHash.Create();
             keccakHash.Reset();

--- a/src/Nethermind/Nethermind.Core/Address.cs
+++ b/src/Nethermind/Nethermind.Core/Address.cs
@@ -24,7 +24,7 @@ namespace Nethermind.Core
 
         public byte[] Bytes { get; }
 
-        public Address(Keccak keccak) : this(keccak.Bytes.Slice(12, ByteLength)) { }
+        public Address(Keccak keccak) : this(keccak.Bytes.Slice(12, ByteLength).ToArray()) { }
 
         public Address(in ValueKeccak keccak) : this(keccak.BytesAsSpan.Slice(12, ByteLength).ToArray()) { }
 

--- a/src/Nethermind/Nethermind.Core/Crypto/Keccak.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/Keccak.cs
@@ -195,38 +195,23 @@ namespace Nethermind.Core.Crypto
     [DebuggerStepThrough]
     public readonly struct KeccakKey : IEquatable<KeccakKey>, IComparable<KeccakKey>
     {
-        public byte[] Bytes { get; }
+        private readonly ValueKeccak _innerKeccak;
 
-        private KeccakKey(byte[] bytes)
+        private KeccakKey(ValueKeccak bytes)
         {
-            Bytes = bytes;
+            _innerKeccak = bytes;
         }
 
-        public static implicit operator KeccakKey(Keccak k) => new(k.Bytes.ToArray());
+        public static implicit operator KeccakKey(Keccak k) => new(k.ValueKeccak);
 
         public int CompareTo(KeccakKey other)
         {
-            return Extensions.Bytes.Comparer.Compare(Bytes, other.Bytes);
+            return _innerKeccak.CompareTo(other._innerKeccak);
         }
 
         public bool Equals(KeccakKey other)
         {
-            if (ReferenceEquals(Bytes, other.Bytes))
-            {
-                return true;
-            }
-
-            if (Bytes is null)
-            {
-                return other.Bytes is null;
-            }
-
-            if (other.Bytes is null)
-            {
-                return false;
-            }
-
-            return Extensions.Bytes.AreEqual(Bytes, other.Bytes);
+            return _innerKeccak.Equals(other._innerKeccak);
         }
 
         public override bool Equals(object? obj)
@@ -236,18 +221,7 @@ namespace Nethermind.Core.Crypto
 
         public override int GetHashCode()
         {
-            if (Bytes is null) return 0;
-
-            long v0 = Unsafe.ReadUnaligned<long>(ref MemoryMarshal.GetArrayDataReference(Bytes));
-            long v1 = Unsafe.ReadUnaligned<long>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Bytes), sizeof(long)));
-            long v2 = Unsafe.ReadUnaligned<long>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Bytes), sizeof(long) * 2));
-            long v3 = Unsafe.ReadUnaligned<long>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Bytes), sizeof(long) * 3));
-
-            v0 ^= v1;
-            v2 ^= v3;
-            v0 ^= v2;
-
-            return (int)v0 ^ (int)(v0 >> 32);
+            return _innerKeccak.GetHashCode();
         }
     }
 

--- a/src/Nethermind/Nethermind.Core/Crypto/Keccak.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/Keccak.cs
@@ -52,7 +52,7 @@ namespace Nethermind.Core.Crypto
 
         public static implicit operator ValueKeccak(Keccak? keccak)
         {
-            return new ValueKeccak(keccak?.Bytes);
+            return keccak!._innerKeccak;
         }
 
         public ValueKeccak(byte[]? bytes)
@@ -119,7 +119,7 @@ namespace Nethermind.Core.Crypto
 
         public bool Equals(ValueKeccak other) => _bytes.Equals(other._bytes);
 
-        public bool Equals(Keccak? other) => BytesAsSpan.SequenceEqual(other?.Bytes);
+        public bool Equals(Keccak? other) => Equals(other?._innerKeccak);
 
         public override int GetHashCode()
         {
@@ -182,7 +182,7 @@ namespace Nethermind.Core.Crypto
             Bytes = bytes;
         }
 
-        public static implicit operator KeccakKey(Keccak k) => new(k.Bytes);
+        public static implicit operator KeccakKey(Keccak k) => new(k.Bytes.ToArray());
 
         public int CompareTo(KeccakKey other)
         {
@@ -268,7 +268,8 @@ namespace Nethermind.Core.Crypto
         /// </summary>
         public static Keccak MaxValue { get; } = new("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 
-        public byte[] Bytes { get; }
+        public Span<byte> Bytes => _innerKeccak.BytesAsSpan;
+        internal ValueKeccak _innerKeccak { get; }
 
         public Keccak(string hexString)
             : this(Extensions.Bytes.FromHexString(hexString)) { }
@@ -280,7 +281,7 @@ namespace Nethermind.Core.Crypto
                 throw new ArgumentException($"{nameof(Keccak)} must be {Size} bytes and was {bytes.Length} bytes", nameof(bytes));
             }
 
-            Bytes = bytes;
+            _innerKeccak = new ValueKeccak(bytes);
         }
 
         public override string ToString()
@@ -349,7 +350,7 @@ namespace Nethermind.Core.Crypto
 
         public int CompareTo(Keccak? other)
         {
-            return Extensions.Bytes.Comparer.Compare(Bytes, other?.Bytes);
+            return Nullable.Compare(_innerKeccak, other?._innerKeccak);
         }
 
         public override bool Equals(object? obj)
@@ -359,10 +360,10 @@ namespace Nethermind.Core.Crypto
 
         public override int GetHashCode()
         {
-            long v0 = Unsafe.ReadUnaligned<long>(ref MemoryMarshal.GetArrayDataReference(Bytes));
-            long v1 = Unsafe.ReadUnaligned<long>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Bytes), sizeof(long)));
-            long v2 = Unsafe.ReadUnaligned<long>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Bytes), sizeof(long) * 2));
-            long v3 = Unsafe.ReadUnaligned<long>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Bytes), sizeof(long) * 3));
+            long v0 = Unsafe.ReadUnaligned<long>(ref MemoryMarshal.GetArrayDataReference(Bytes.ToArray()));
+            long v1 = Unsafe.ReadUnaligned<long>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Bytes.ToArray()), sizeof(long)));
+            long v2 = Unsafe.ReadUnaligned<long>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Bytes.ToArray()), sizeof(long) * 2));
+            long v3 = Unsafe.ReadUnaligned<long>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Bytes.ToArray()), sizeof(long) * 3));
             v0 ^= v1;
             v2 ^= v3;
             v0 ^= v2;
@@ -397,22 +398,22 @@ namespace Nethermind.Core.Crypto
 
         public static bool operator >(Keccak? k1, Keccak? k2)
         {
-            return Extensions.Bytes.Comparer.Compare(k1?.Bytes, k2?.Bytes) > 0;
+            return Nullable.Compare(k1?._innerKeccak, k2?._innerKeccak) > 0;
         }
 
         public static bool operator <(Keccak? k1, Keccak? k2)
         {
-            return Extensions.Bytes.Comparer.Compare(k1?.Bytes, k2?.Bytes) < 0;
+            return Nullable.Compare(k1?._innerKeccak, k2?._innerKeccak) < 0;
         }
 
         public static bool operator >=(Keccak? k1, Keccak? k2)
         {
-            return Extensions.Bytes.Comparer.Compare(k1?.Bytes, k2?.Bytes) >= 0;
+            return Nullable.Compare(k1?._innerKeccak, k2?._innerKeccak) >= 0;
         }
 
         public static bool operator <=(Keccak? k1, Keccak? k2)
         {
-            return Extensions.Bytes.Comparer.Compare(k1?.Bytes, k2?.Bytes) <= 0;
+            return Nullable.Compare(k1?._innerKeccak, k2?._innerKeccak) <= 0;
         }
 
         public KeccakStructRef ToStructRef() => new(Bytes);

--- a/src/Nethermind/Nethermind.Core/Crypto/Keccak.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/Keccak.cs
@@ -197,6 +197,8 @@ namespace Nethermind.Core.Crypto
     {
         private readonly ValueKeccak _innerKeccak;
 
+        public ReadOnlySpan<byte> Bytes => _innerKeccak.Bytes;
+
         private KeccakKey(ValueKeccak bytes)
         {
             _innerKeccak = bytes;

--- a/src/Nethermind/Nethermind.Core/Crypto/Keccak.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/Keccak.cs
@@ -268,8 +268,10 @@ namespace Nethermind.Core.Crypto
         /// </summary>
         public static Keccak MaxValue { get; } = new("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 
+        [ThreadStatic] static byte[]? _threadStaticBytes;
+
         public Span<byte> Bytes => _innerKeccak.BytesAsSpan;
-        internal ValueKeccak _innerKeccak { get; }
+        internal ValueKeccak _innerKeccak;
 
         public Keccak(string hexString)
             : this(Extensions.Bytes.FromHexString(hexString)) { }
@@ -417,6 +419,23 @@ namespace Nethermind.Core.Crypto
         }
 
         public KeccakStructRef ToStructRef() => new(Bytes);
+
+        public byte[] BytesToArray()
+        {
+            // Used to track which piece of code need to create a copy of array
+            return Bytes.ToArray();
+        }
+
+        /// <summary>
+        /// Return a thread static byte array. Can't use this for two keccak at the same time.
+        /// </summary>
+        /// <returns></returns>
+        public byte[] CreateThreadStaticByte()
+        {
+            if (_threadStaticBytes == null) _threadStaticBytes = new byte[Size];
+            Bytes.CopyTo(_threadStaticBytes);
+            return _threadStaticBytes;
+        }
     }
 
     public ref struct KeccakStructRef

--- a/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
@@ -195,6 +195,12 @@ namespace Nethermind.Core.Extensions
             return bytes.AsSpan().WithoutLeadingZeros();
         }
 
+        public static Span<byte> WithoutLeadingZerosOrEmpty(this Span<byte> bytes)
+        {
+            if (bytes.IsNullOrEmpty()) return Array.Empty<byte>();
+            return bytes.WithoutLeadingZeros();
+        }
+
         public static Span<byte> WithoutLeadingZeros(this Span<byte> bytes)
         {
             if (bytes.Length == 0) return new byte[] { 0 };
@@ -274,6 +280,33 @@ namespace Nethermind.Core.Extensions
                 position += parts[i].Length;
             }
 
+            return result;
+        }
+
+        public static byte[] Concat(ReadOnlySpan<byte> part1, ReadOnlySpan<byte> part2)
+        {
+            byte[] result = new byte[part1.Length + part2.Length];
+            part1.CopyTo(result);
+            part2.CopyTo(result.AsSpan(part1.Length));
+            return result;
+        }
+
+        public static byte[] Concat(ReadOnlySpan<byte> part1, ReadOnlySpan<byte> part2, ReadOnlySpan<byte> part3)
+        {
+            byte[] result = new byte[part1.Length + part2.Length + part3.Length];
+            part1.CopyTo(result);
+            part2.CopyTo(result.AsSpan(part1.Length));
+            part3.CopyTo(result.AsSpan(part1.Length + part2.Length));
+            return result;
+        }
+
+        public static byte[] Concat(ReadOnlySpan<byte> part1, ReadOnlySpan<byte> part2, ReadOnlySpan<byte> part3, ReadOnlySpan<byte> part4)
+        {
+            byte[] result = new byte[part1.Length + part2.Length + part3.Length + part4.Length];
+            part1.CopyTo(result);
+            part2.CopyTo(result.AsSpan(part1.Length));
+            part3.CopyTo(result.AsSpan(part1.Length + part2.Length));
+            part4.CopyTo(result.AsSpan(part1.Length + part2.Length + part3.Length));
             return result;
         }
 
@@ -558,6 +591,12 @@ namespace Nethermind.Core.Extensions
             public readonly byte[] Bytes;
             public readonly int LeadingZeros;
             public readonly bool WithZeroX;
+        }
+
+        public static string ByteArrayToHexViaLookup32Safe(ReadOnlySpan<byte> bytes, bool withZeroX)
+        {
+            // TODO: Make this zero copy
+            return ByteArrayToHexViaLookup32Safe(bytes.ToArray(), withZeroX);
         }
 
         [DebuggerStepThrough]

--- a/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
@@ -593,12 +593,6 @@ namespace Nethermind.Core.Extensions
             public readonly bool WithZeroX;
         }
 
-        public static string ByteArrayToHexViaLookup32Safe(ReadOnlySpan<byte> bytes, bool withZeroX)
-        {
-            // TODO: Make this zero copy
-            return ByteArrayToHexViaLookup32Safe(bytes.ToArray(), withZeroX);
-        }
-
         [DebuggerStepThrough]
         public static string ByteArrayToHexViaLookup32Safe(byte[] bytes, bool withZeroX)
         {

--- a/src/Nethermind/Nethermind.Core/Extensions/SpanExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/SpanExtensions.cs
@@ -136,5 +136,13 @@ namespace Nethermind.Core.Extensions
         public static bool IsNull<T>(this in Span<T> span) => Unsafe.IsNullRef(ref MemoryMarshal.GetReference(span));
         public static bool IsNullOrEmpty<T>(this in ReadOnlySpan<T> span) => span.Length == 0;
         public static bool IsNull<T>(this in ReadOnlySpan<T> span) => Unsafe.IsNullRef(ref MemoryMarshal.GetReference(span));
+
+        public static Memory<T> Concat<T>(this in Span<T> span, Span<T> span2)
+        {
+            T[] newMemory = new T[span.Length + span2.Length];
+            span.CopyTo(newMemory);
+            span2.CopyTo(newMemory.AsSpan(span.Length));
+            return newMemory;
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Core/Extensions/SpanExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/SpanExtensions.cs
@@ -136,13 +136,5 @@ namespace Nethermind.Core.Extensions
         public static bool IsNull<T>(this in Span<T> span) => Unsafe.IsNullRef(ref MemoryMarshal.GetReference(span));
         public static bool IsNullOrEmpty<T>(this in ReadOnlySpan<T> span) => span.Length == 0;
         public static bool IsNull<T>(this in ReadOnlySpan<T> span) => Unsafe.IsNullRef(ref MemoryMarshal.GetReference(span));
-
-        public static Memory<T> Concat<T>(this in Span<T> span, Span<T> span2)
-        {
-            T[] newMemory = new T[span.Length + span2.Length];
-            span.CopyTo(newMemory);
-            span2.CopyTo(newMemory.AsSpan(span.Length));
-            return newMemory;
-        }
     }
 }

--- a/src/Nethermind/Nethermind.Crypto/Ecdsa.cs
+++ b/src/Nethermind/Nethermind.Crypto/Ecdsa.cs
@@ -19,7 +19,7 @@ namespace Nethermind.Crypto
                 throw new ArgumentException("Invalid private key", nameof(privateKey));
             }
 
-            byte[] signatureBytes = SignCompact(message.Bytes, privateKey.KeyBytes, out int recoveryId);
+            byte[] signatureBytes = SpanSecP256k1.SignCompact(message.Bytes, privateKey.KeyBytes, out int recoveryId);
 
             //// https://bitcoin.stackexchange.com/questions/59820/sign-a-tx-with-low-s-value-using-openssl
 
@@ -51,7 +51,7 @@ namespace Nethermind.Crypto
         public PublicKey? RecoverPublicKey(Signature signature, Keccak message)
         {
             Span<byte> publicKey = stackalloc byte[65];
-            bool success = RecoverKeyFromCompact(publicKey, message.Bytes, signature.Bytes, signature.RecoveryId, false);
+            bool success = SpanSecP256k1.RecoverKeyFromCompact(publicKey, message.Bytes, signature.Bytes, signature.RecoveryId, false);
             if (!success)
             {
                 return null;
@@ -63,7 +63,7 @@ namespace Nethermind.Crypto
         public CompressedPublicKey? RecoverCompressedPublicKey(Signature signature, Keccak message)
         {
             Span<byte> publicKey = stackalloc byte[33];
-            bool success = RecoverKeyFromCompact(publicKey, message.Bytes, signature.Bytes, signature.RecoveryId, true);
+            bool success = SpanSecP256k1.RecoverKeyFromCompact(publicKey, message.Bytes, signature.Bytes, signature.RecoveryId, true);
             if (!success)
             {
                 return null;
@@ -76,20 +76,6 @@ namespace Nethermind.Crypto
         {
             byte[] deserialized = SecP256k1.Decompress(compressedPublicKey.Bytes);
             return new PublicKey(deserialized);
-        }
-
-        public static byte[]? SignCompact(Span<byte> message, Span<byte> privateKey, out int recoveryId)
-        {
-            // TODO: this is a hack to make it work with the current SecP256k1 implementation.
-            // Should be removed once the binding is updated
-            return SecP256k1.SignCompact(message.ToArray(), privateKey.ToArray(), out recoveryId);
-        }
-
-        internal static bool RecoverKeyFromCompact(Span<byte> publicKey, Span<byte> messageHash, Span<byte> signature, int recoveryId, bool compressed)
-        {
-            // TODO: this is a hack to make it work with the current SecP256k1 implementation.
-            // Should be removed once the binding is updated
-            return SecP256k1.RecoverKeyFromCompact(publicKey, messageHash.ToArray(), signature.ToArray(), recoveryId, compressed);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Crypto/EthereumEcdsa.cs
+++ b/src/Nethermind/Nethermind.Crypto/EthereumEcdsa.cs
@@ -119,7 +119,7 @@ namespace Nethermind.Crypto
         public Address? RecoverAddress(Span<byte> signatureBytes, Keccak message)
         {
             Span<byte> publicKey = stackalloc byte[65];
-            bool success = RecoverKeyFromCompact(
+            bool success = SpanSecP256k1.RecoverKeyFromCompact(
                 publicKey,
                 message.Bytes,
                 signatureBytes[..64],

--- a/src/Nethermind/Nethermind.Crypto/EthereumEcdsa.cs
+++ b/src/Nethermind/Nethermind.Crypto/EthereumEcdsa.cs
@@ -119,7 +119,7 @@ namespace Nethermind.Crypto
         public Address? RecoverAddress(Span<byte> signatureBytes, Keccak message)
         {
             Span<byte> publicKey = stackalloc byte[65];
-            bool success = SecP256k1.RecoverKeyFromCompact(
+            bool success = RecoverKeyFromCompact(
                 publicKey,
                 message.Bytes,
                 signatureBytes[..64],

--- a/src/Nethermind/Nethermind.Crypto/SpanSecP256k1.cs
+++ b/src/Nethermind/Nethermind.Crypto/SpanSecP256k1.cs
@@ -7,7 +7,6 @@ namespace Nethermind.Crypto;
 /// </summary>
 public static class SpanSecP256k1
 {
-
     [ThreadStatic] private static byte[]? _signMessageHash;
     [ThreadStatic] private static byte[]? _signPrivateKey;
 
@@ -43,6 +42,7 @@ public static class SpanSecP256k1
     }
 
     [ThreadStatic] private static byte[]? _recoverMessageHash;
+
     public static bool RecoverKeyFromCompact(Span<byte> publicKey, Span<byte> messageHash, Span<byte> signature, int recoveryId, bool compressed)
     {
         byte[] messageHashArray;

--- a/src/Nethermind/Nethermind.Crypto/SpanSecP256k1.cs
+++ b/src/Nethermind/Nethermind.Crypto/SpanSecP256k1.cs
@@ -1,0 +1,63 @@
+using System;
+
+namespace Nethermind.Crypto;
+
+/// <summary>
+/// Span wrapper upon SecP256k1. Try to avoid allocations if given span is of Keccak size.
+/// </summary>
+public static class SpanSecP256k1
+{
+
+    [ThreadStatic] private static byte[]? _signMessageHash;
+    [ThreadStatic] private static byte[]? _signPrivateKey;
+
+    public static byte[]? SignCompact(Span<byte> messageHash, Span<byte> privateKey, out int recoveryId)
+    {
+        byte[] messageHashArray;
+        if (messageHash.Length == 32)
+        {
+            if (_signMessageHash == null) _signMessageHash = new byte[32];
+            messageHash.CopyTo(_signMessageHash);
+            messageHashArray = _signMessageHash;
+        }
+        else
+        {
+            // Why? Dont know...
+            messageHashArray = messageHash.ToArray();
+        }
+
+        byte[] privateKeyArray;
+        if (privateKey.Length == 32)
+        {
+            if (_signPrivateKey == null) _signPrivateKey = new byte[32];
+            privateKey.CopyTo(_signPrivateKey);
+            privateKeyArray = _signPrivateKey;
+        }
+        else
+        {
+            // Why? Dont know...
+            privateKeyArray = privateKey.ToArray();
+        }
+
+        return SecP256k1.SignCompact(messageHashArray, privateKeyArray, out recoveryId);
+    }
+
+    [ThreadStatic] private static byte[]? _recoverMessageHash;
+    public static bool RecoverKeyFromCompact(Span<byte> publicKey, Span<byte> messageHash, Span<byte> signature, int recoveryId, bool compressed)
+    {
+        byte[] messageHashArray;
+        if (messageHash.Length == 32)
+        {
+            if (_recoverMessageHash == null) _recoverMessageHash = new byte[32];
+            messageHash.CopyTo(_recoverMessageHash);
+            messageHashArray = _recoverMessageHash;
+        }
+        else
+        {
+            // Why? Dont know...
+            messageHashArray = messageHash.ToArray();
+        }
+
+        return SecP256k1.RecoverKeyFromCompact(publicKey, messageHashArray, signature, recoveryId, compressed);
+    }
+}

--- a/src/Nethermind/Nethermind.Db.Test/MemDbTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/MemDbTests.cs
@@ -31,7 +31,7 @@ namespace Nethermind.Db.Test
             MemDb memDb = new(10, 10);
             memDb.Set(TestItem.KeccakA, new byte[] { 1, 2, 3 });
             memDb.Get(TestItem.KeccakA);
-            KeyValuePair<byte[], byte[]>[] some = memDb[new[] { TestItem.KeccakA.Bytes }];
+            KeyValuePair<byte[], byte[]>[] some = memDb[new[] { TestItem.KeccakA.BytesToArray() }];
         }
 
         [Test]
@@ -107,7 +107,7 @@ namespace Nethermind.Db.Test
             MemDb memDb = new();
             memDb.Set(TestItem.KeccakA, _sampleValue);
             memDb.Set(TestItem.KeccakB, _sampleValue);
-            KeyValuePair<byte[], byte[]>[] result = memDb[new[] { TestItem.KeccakB.Bytes, TestItem.KeccakB.Bytes, TestItem.KeccakC.Bytes }];
+            KeyValuePair<byte[], byte[]>[] result = memDb[new[] { TestItem.KeccakB.BytesToArray(), TestItem.KeccakB.BytesToArray(), TestItem.KeccakC.BytesToArray() }];
             result.Should().HaveCount(3);
             result[0].Value.Should().NotBeNull();
             result[1].Value.Should().NotBeNull();

--- a/src/Nethermind/Nethermind.Db/DbExtensions.cs
+++ b/src/Nethermind/Nethermind.Db/DbExtensions.cs
@@ -74,7 +74,7 @@ namespace Nethermind.Db
 
         public static KeyValuePair<byte[], byte[]>[] MultiGet(this IDb db, IEnumerable<KeccakKey> keys)
         {
-            var k = keys.Select(k => k.Bytes).ToArray();
+            var k = keys.Select(k => k.Bytes.ToArray()).ToArray();
             return db[k];
         }
 

--- a/src/Nethermind/Nethermind.Evm.Test/EvmPooledMemoryTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/EvmPooledMemoryTests.cs
@@ -65,7 +65,7 @@ namespace Nethermind.Evm.Test
         {
             const int offset = 3;
             byte[] expectedEmptyRead = new byte[32 - offset];
-            byte[] expectedKeccakRead = TestItem.KeccakA.Bytes;
+            byte[] expectedKeccakRead = TestItem.KeccakA.BytesToArray();
             EvmPooledMemory memory = new();
             memory.Save((UInt256)offset, expectedKeccakRead);
             ulong initialSize = memory.Size;

--- a/src/Nethermind/Nethermind.Evm.Test/VirtualMachineTestsBase.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/VirtualMachineTestsBase.cs
@@ -246,7 +246,7 @@ namespace Nethermind.Evm.Test
 
         protected void AssertStorage(UInt256 address, Keccak value)
         {
-            Assert.That(TestState.Get(new StorageCell(Recipient, address)).PadLeft(32), Is.EqualTo(value.Bytes), "storage");
+            Assert.That(TestState.Get(new StorageCell(Recipient, address)).PadLeft(32), Is.EqualTo(value.BytesToArray()), "storage");
         }
 
         protected void AssertStorage(UInt256 address, ReadOnlySpan<byte> value)

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -1392,7 +1392,7 @@ public class VirtualMachine : IVirtualMachine
                         stack.PopUInt256(out UInt256 a);
                         long number = a > long.MaxValue ? long.MaxValue : (long)a;
                         Keccak blockHash = _blockhashProvider.GetBlockhash(txCtx.Header, number);
-                        stack.PushBytes(blockHash?.Bytes ?? BytesZero32);
+                        stack.PushBytes(blockHash != null ? blockHash.Bytes : BytesZero32);
 
                         if (isTrace)
                         {
@@ -1417,8 +1417,7 @@ public class VirtualMachine : IVirtualMachine
 
                         if (txCtx.Header.IsPostMerge)
                         {
-                            byte[] random = txCtx.Header.Random.Bytes;
-                            stack.PushBytes(random);
+                            stack.PushBytes(txCtx.Header.Random.Bytes);
                         }
                         else
                         {

--- a/src/Nethermind/Nethermind.KeyStore/FileKeyStore.cs
+++ b/src/Nethermind/Nethermind.KeyStore/FileKeyStore.cs
@@ -157,7 +157,7 @@ namespace Nethermind.KeyStore
             byte[] decryptKey;
             if (kdf == "scrypt" && cipherType == "aes-128-cbc")
             {
-                decryptKey = Keccak.Compute(derivedKey.Slice(0, 16)).Bytes.Slice(0, 16);
+                decryptKey = Keccak.Compute(derivedKey.Slice(0, 16)).Bytes.Slice(0, 16).ToArray();
             }
             else
             {
@@ -238,7 +238,7 @@ namespace Nethermind.KeyStore
             var cipherType = _config.Cipher;
             if (kdf == "scrypt" && cipherType == "aes-128-cbc")
             {
-                encryptKey = Keccak.Compute(derivedKey.Slice(0, 16)).Bytes.Slice(0, 16);
+                encryptKey = Keccak.Compute(derivedKey.Slice(0, 16)).Bytes.Slice(0, 16).ToArray();
             }
             else
             {

--- a/src/Nethermind/Nethermind.Network.Test/NetTestVectors.cs
+++ b/src/Nethermind/Nethermind.Network.Test/NetTestVectors.cs
@@ -35,16 +35,16 @@ namespace Nethermind.Network.Test
         public static (EncryptionSecrets A, EncryptionSecrets B) GetSecretsPair()
         {
             EncryptionHandshake handshakeA = new();
-            handshakeA.InitiatorNonce = TestItem.KeccakA.Bytes;
-            handshakeA.RecipientNonce = TestItem.KeccakB.Bytes;
+            handshakeA.InitiatorNonce = TestItem.KeccakA.BytesToArray();
+            handshakeA.RecipientNonce = TestItem.KeccakB.BytesToArray();
             handshakeA.EphemeralPrivateKey = TestItem.PrivateKeyA;
             handshakeA.RemoteEphemeralPublicKey = TestItem.PrivateKeyB.PublicKey;
             handshakeA.AckPacket = new Packet(new byte[128]);
             handshakeA.AuthPacket = new Packet(new byte[128]);
 
             EncryptionHandshake handshakeB = new();
-            handshakeB.InitiatorNonce = TestItem.KeccakA.Bytes;
-            handshakeB.RecipientNonce = TestItem.KeccakB.Bytes;
+            handshakeB.InitiatorNonce = TestItem.KeccakA.BytesToArray();
+            handshakeB.RecipientNonce = TestItem.KeccakB.BytesToArray();
             handshakeB.EphemeralPrivateKey = TestItem.PrivateKeyB;
             handshakeB.RemoteEphemeralPublicKey = TestItem.PrivateKeyA.PublicKey;
             handshakeB.AckPacket = new Packet(new byte[128]);

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V63/NodeDataMessageSeralizerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V63/NodeDataMessageSeralizerTests.cs
@@ -23,14 +23,14 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V63
         [Test]
         public void Roundtrip()
         {
-            byte[][] data = { TestItem.KeccakA.Bytes, TestItem.KeccakB.Bytes, TestItem.KeccakC.Bytes };
+            byte[][] data = { TestItem.KeccakA.BytesToArray(), TestItem.KeccakB.BytesToArray(), TestItem.KeccakC.BytesToArray() };
             Test(data);
         }
 
         [Test]
         public void Zero_roundtrip()
         {
-            byte[][] data = { TestItem.KeccakA.Bytes, TestItem.KeccakB.Bytes, TestItem.KeccakC.Bytes };
+            byte[][] data = { TestItem.KeccakA.BytesToArray(), TestItem.KeccakB.BytesToArray(), TestItem.KeccakC.BytesToArray() };
             Test(data);
         }
 
@@ -43,7 +43,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V63
         [Test]
         public void Roundtrip_with_nulls()
         {
-            byte[][] data = { TestItem.KeccakA.Bytes, Array.Empty<byte>(), TestItem.KeccakC.Bytes };
+            byte[][] data = { TestItem.KeccakA.BytesToArray(), Array.Empty<byte>(), TestItem.KeccakC.BytesToArray() };
             Test(data);
         }
     }

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Les/ContractCodesMessageSerializerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Les/ContractCodesMessageSerializerTests.cs
@@ -14,7 +14,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Les
         [Test]
         public void RoundTrip()
         {
-            byte[][] data = { TestItem.KeccakA.Bytes, TestItem.KeccakB.Bytes, TestItem.KeccakC.Bytes };
+            byte[][] data = { TestItem.KeccakA.BytesToArray(), TestItem.KeccakB.BytesToArray(), TestItem.KeccakC.BytesToArray() };
             ContractCodesMessage message = new(data, 13452, 134);
 
             ContractCodesMessageSerializer serializer = new();

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Les/HelperTrieProofsMessageSerializerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Les/HelperTrieProofsMessageSerializerTests.cs
@@ -17,17 +17,17 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Les
         {
             byte[][] proofs = new byte[][]
             {
-                TestItem.KeccakA.Bytes,
-                TestItem.KeccakB.Bytes,
-                TestItem.KeccakC.Bytes,
-                TestItem.KeccakD.Bytes,
-                TestItem.KeccakE.Bytes,
-                TestItem.KeccakF.Bytes,
+                TestItem.KeccakA.BytesToArray(),
+                TestItem.KeccakB.BytesToArray(),
+                TestItem.KeccakC.BytesToArray(),
+                TestItem.KeccakD.BytesToArray(),
+                TestItem.KeccakE.BytesToArray(),
+                TestItem.KeccakF.BytesToArray(),
             };
             byte[][] auxData = new byte[][]
             {
-                TestItem.KeccakG.Bytes,
-                TestItem.KeccakH.Bytes,
+                TestItem.KeccakG.BytesToArray(),
+                TestItem.KeccakH.BytesToArray(),
                 Rlp.Encode(Build.A.BlockHeader.TestObject).Bytes,
             };
             var message = new HelperTrieProofsMessage(proofs, auxData, 324, 734);

--- a/src/Nethermind/Nethermind.Network/ForkInfo.cs
+++ b/src/Nethermind/Nethermind.Network/ForkInfo.cs
@@ -31,7 +31,7 @@ namespace Nethermind.Network
             DictForks = new();
             Forks = new (ForkActivation Activation, ForkId Id)[transitionActivations.Length + 1];
             byte[] blockNumberBytes = new byte[8];
-            uint crc = Crc32Algorithm.Append(0, genesisHash.Bytes);
+            uint crc = Crc32Algorithm.Append(0, genesisHash.CreateThreadStaticByte());
             // genesis fork activation
             SetFork(0, crc, ((0, null), new ForkId(crc, transitionActivations.Length > 0 ? transitionActivations[0].Activation : 0)));
             for (int index = 0; index < transitionActivations.Length; index++)

--- a/src/Nethermind/Nethermind.Network/ForkInfo.cs
+++ b/src/Nethermind/Nethermind.Network/ForkInfo.cs
@@ -31,7 +31,7 @@ namespace Nethermind.Network
             DictForks = new();
             Forks = new (ForkActivation Activation, ForkId Id)[transitionActivations.Length + 1];
             byte[] blockNumberBytes = new byte[8];
-            uint crc = Crc32Algorithm.Append(0, genesisHash.CreateThreadStaticByte());
+            uint crc = Crc32Algorithm.Append(0, genesisHash.ThreadStaticBytes());
             // genesis fork activation
             SetFork(0, crc, ((0, null), new ForkId(crc, transitionActivations.Length > 0 ? transitionActivations[0].Activation : 0)));
             for (int index = 0; index < transitionActivations.Length; index++)

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Les/LesProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Les/LesProtocolHandler.cs
@@ -256,7 +256,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Les
             // todo - enum?
             if (request.AuxiliaryData == 1)
             {
-                auxData.Add(cht.RootHash.Bytes);
+                auxData.Add(cht.RootHash.BytesToArray());
                 return;
             }
             else if (request.AuxiliaryData == 2)

--- a/src/Nethermind/Nethermind.Network/Rlpx/Handshake/HandshakeService.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/Handshake/HandshakeService.cs
@@ -255,11 +255,11 @@ namespace Nethermind.Network.Rlpx.Handshake
             Span<byte> sharedSecret = ValueKeccak.Compute(tempConcat).BytesAsSpan;
             //            byte[] token = Keccak.Compute(sharedSecret).Bytes;
             sharedSecret.CopyTo(tempConcat.Slice(32, 32));
-            byte[] aesSecret = Keccak.Compute(tempConcat).Bytes;
+            byte[] aesSecret = Keccak.Compute(tempConcat).BytesToArray();
 
             sharedSecret.Clear();
             aesSecret.CopyTo(tempConcat.Slice(32, 32));
-            byte[] macSecret = Keccak.Compute(tempConcat).Bytes;
+            byte[] macSecret = Keccak.Compute(tempConcat).BytesToArray();
 
             ephemeralSharedSecret.Clear();
             handshake.Secrets = new EncryptionSecrets();

--- a/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/Migrations/ReceiptMigrationTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/Migrations/ReceiptMigrationTests.cs
@@ -10,6 +10,7 @@ using Nethermind.Blockchain.Receipts;
 using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
@@ -67,7 +68,7 @@ namespace Nethermind.Runner.Test.Ethereum.Steps.Migrations
             context.DbProvider.ReceiptsDb.Returns(receiptColumenDb);
             receiptColumenDb.RemoveFunc = (key) =>
             {
-                if (key.Equals(lastTransaction.Bytes)) guard.Set();
+                if (Bytes.AreEqual(key, lastTransaction.Bytes)) guard.Set();
             };
 
             ReceiptMigration migration = new(context);

--- a/src/Nethermind/Nethermind.Serialization.Json/KeccakConverter.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/KeccakConverter.cs
@@ -18,7 +18,7 @@ namespace Nethermind.Serialization.Json
             }
             else
             {
-                writer.WriteValue(Bytes.ByteArrayToHexViaLookup32Safe(value.Bytes, true));
+                writer.WriteValue(value.Bytes.ToHexString(true));
             }
         }
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -474,7 +474,7 @@ namespace Nethermind.Serialization.Rlp
 
             byte[] result = new byte[LengthOfKeccakRlp];
             result[0] = 160;
-            Buffer.BlockCopy(keccak.Bytes, 0, result, 1, 32);
+            keccak.Bytes.CopyTo(result.AsSpan()[1..]);
             return new Rlp(result);
         }
 

--- a/src/Nethermind/Nethermind.State.Test/Witnesses/WitnessingStoreTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/Witnesses/WitnessingStoreTests.cs
@@ -123,11 +123,11 @@ namespace Nethermind.Store.Test.Witnesses
             }
         }
 
-        private static readonly byte[] Key1 = TestItem.KeccakA.Bytes;
+        private static readonly byte[] Key1 = TestItem.KeccakA.BytesToArray();
 
-        private static readonly byte[] Key2 = TestItem.KeccakB.Bytes;
+        private static readonly byte[] Key2 = TestItem.KeccakB.BytesToArray();
 
-        private static readonly byte[] Key3 = TestItem.KeccakC.Bytes;
+        private static readonly byte[] Key3 = TestItem.KeccakC.BytesToArray();
 
         private static readonly byte[] Value1 = { 1 };
 

--- a/src/Nethermind/Nethermind.State/StorageTree.cs
+++ b/src/Nethermind/Nethermind.State/StorageTree.cs
@@ -29,7 +29,7 @@ namespace Nethermind.State
             {
                 UInt256 index = (UInt256)i;
                 index.ToBigEndian(buffer);
-                Cache[index] = Keccak.Compute(buffer).Bytes;
+                Cache[index] = Keccak.Compute(buffer).BytesToArray();
             }
         }
 

--- a/src/Nethermind/Nethermind.State/Witnesses/WitnessCollector.cs
+++ b/src/Nethermind/Nethermind.State/Witnesses/WitnessCollector.cs
@@ -61,7 +61,7 @@ namespace Nethermind.State.Witnesses
                 for (var index = 0; index < collected.Length; index++)
                 {
                     Keccak keccak = collected[index];
-                    keccak.Bytes.AsSpan().CopyTo(witnessSpan.Slice(i * Keccak.Size, Keccak.Size));
+                    keccak.Bytes.CopyTo(witnessSpan.Slice(i * Keccak.Size, Keccak.Size));
                     i++;
                 }
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncServerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncServerTests.cs
@@ -603,7 +603,7 @@ namespace Nethermind.Synchronization.Test
             trieStore.FinishBlockCommit(TrieType.State, 1, node);
 
             stateDb.KeyExists(nodeKey).Should().BeFalse();
-            ctx.SyncServer.GetNodeData(new[] { nodeKey }, NodeDataType.All).Should().BeEquivalentTo(new[] { TestItem.KeccakB.Bytes });
+            ctx.SyncServer.GetNodeData(new[] { nodeKey }, NodeDataType.All).Should().BeEquivalentTo(new[] { TestItem.KeccakB.BytesToArray() });
         }
 
         private class Context

--- a/src/Nethermind/Nethermind.Trie.Test/CacheTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/CacheTests.cs
@@ -24,7 +24,7 @@ namespace Nethermind.Trie.Test
         {
             MemCountingCache cache = new(1024, string.Empty);
             cache.Set(Keccak.Zero, new byte[0]);
-            cache.MemorySize.Should().Be(376);
+            cache.MemorySize.Should().Be(344);
         }
 
         [Test]
@@ -35,7 +35,7 @@ namespace Nethermind.Trie.Test
             cache.Set(TestItem.KeccakB, new byte[0]);
             cache.Set(TestItem.KeccakC, new byte[0]);
             cache.Set(TestItem.KeccakD, new byte[0]);
-            cache.MemorySize.Should().Be(800);
+            cache.MemorySize.Should().Be(672);
         }
 
         [Test]
@@ -46,16 +46,16 @@ namespace Nethermind.Trie.Test
             cache.Set(TestItem.KeccakB, new byte[0]);
             cache.Set(TestItem.KeccakC, new byte[0]);
 
-            cache.MemorySize.Should().Be(584);
+            cache.MemorySize.Should().Be(488);
             cache.Get(TestItem.KeccakA).Should().NotBeNull();
 
             cache.Set(TestItem.KeccakD, new byte[0]);
-            cache.MemorySize.Should().Be(584);
+            cache.MemorySize.Should().Be(488);
             cache.Get(TestItem.KeccakB).Should().BeNull();
             cache.Get(TestItem.KeccakD).Should().NotBeNull();
 
             cache.Set(TestItem.KeccakE, new byte[0]);
-            cache.MemorySize.Should().Be(584);
+            cache.MemorySize.Should().Be(488);
             cache.Get(TestItem.KeccakB).Should().BeNull();
             cache.Get(TestItem.KeccakC).Should().BeNull();
             cache.Get(TestItem.KeccakE).Should().NotBeNull();
@@ -71,11 +71,11 @@ namespace Nethermind.Trie.Test
 
             cache.Set(TestItem.KeccakA, null);
 
-            cache.MemorySize.Should().Be(480);
+            cache.MemorySize.Should().Be(416);
             cache.Get(TestItem.KeccakA).Should().BeNull();
 
             cache.Set(TestItem.KeccakD, new byte[0]);
-            cache.MemorySize.Should().Be(584);
+            cache.MemorySize.Should().Be(488);
             cache.Get(TestItem.KeccakB).Should().NotBeNull();
             cache.Get(TestItem.KeccakD).Should().NotBeNull();
         }

--- a/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
@@ -75,7 +75,7 @@ namespace Nethermind.Trie.Test.Pruning
             using TrieStore trieStore = new(testMemDb, No.Pruning, No.Persistence, _logManager);
             trieStore.CommitNode(1234, new NodeCommitInfo(trieNode), WriteFlags.LowPriority);
             trieStore.FinishBlockCommit(TrieType.State, 1234, trieNode, WriteFlags.LowPriority);
-            testMemDb.KeyWasWrittenWithFlags(trieNode.Keccak.Bytes, WriteFlags.LowPriority);
+            testMemDb.KeyWasWrittenWithFlags(trieNode.Keccak.BytesToArray(), WriteFlags.LowPriority);
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Trie.Test/TrieNodeResolverWithReadFlagsTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieNodeResolverWithReadFlagsTests.cs
@@ -22,9 +22,9 @@ public class TrieNodeResolverWithReadFlagsTests
         TrieNodeResolverWithReadFlags resolver = new(trieStore, theFlags);
 
         Keccak theKeccak = TestItem.KeccakA;
-        memDb[theKeccak.Bytes] = TestItem.KeccakA.Bytes;
+        memDb[theKeccak.Bytes] = TestItem.KeccakA.BytesToArray();
         resolver.LoadRlp(theKeccak);
 
-        memDb.KeyWasReadWithFlags(theKeccak.Bytes, theFlags);
+        memDb.KeyWasReadWithFlags(theKeccak.BytesToArray(), theFlags);
     }
 }

--- a/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
@@ -586,7 +586,7 @@ namespace Nethermind.Trie.Test
         public void Size_of_an_unknown_node_with_keccak_is_correct()
         {
             TrieNode trieNode = new(NodeType.Unknown, Keccak.Zero);
-            trieNode.GetMemorySize(false).Should().Be(136);
+            trieNode.GetMemorySize(false).Should().Be(104);
         }
 
         [Test]
@@ -623,7 +623,7 @@ namespace Nethermind.Trie.Test
         [Test]
         public void Size_of_keccak_is_correct()
         {
-            Keccak.MemorySize.Should().Be(80);
+            Keccak.MemorySize.Should().Be(48);
         }
 
         [Test]
@@ -715,7 +715,7 @@ namespace Nethermind.Trie.Test
             trieNode.SetChild(0, child);
 
             trieNode.PrunePersistedRecursively(1);
-            trieNode.GetMemorySize(false).Should().Be(176);
+            trieNode.GetMemorySize(false).Should().Be(144);
         }
 
         [Test]
@@ -728,7 +728,7 @@ namespace Nethermind.Trie.Test
             trieNode.PrunePersistedRecursively(1);
             TrieNode cloned = trieNode.Clone();
 
-            cloned.GetMemorySize(false).Should().Be(176);
+            cloned.GetMemorySize(false).Should().Be(144);
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
@@ -957,7 +957,7 @@ namespace Nethermind.Trie.Test
 
                 HeavyLeaf = new TrieNode(NodeType.Leaf);
                 HeavyLeaf.Key = new byte[20];
-                HeavyLeaf.Value = Keccak.EmptyTreeHash.Bytes.Concat(Keccak.EmptyTreeHash.Bytes).ToArray();
+                HeavyLeaf.Value = Bytes.Concat(Keccak.EmptyTreeHash.Bytes, Keccak.EmptyTreeHash.Bytes);
 
                 Account account = new(100);
                 AccountDecoder decoder = new();

--- a/src/Nethermind/Nethermind.Trie/BatchedTrieVisitor.cs
+++ b/src/Nethermind/Nethermind.Trie/BatchedTrieVisitor.cs
@@ -124,7 +124,7 @@ public class BatchedTrieVisitor
     // Determine the locality of the key. I guess if you use paprika or something, you'd need to modify this.
     int CalculatePartitionIdx(ValueKeccak key)
     {
-        uint number = BinaryPrimitives.ReadUInt32BigEndian(key.Span);
+        uint number = BinaryPrimitives.ReadUInt32BigEndian(key.Bytes);
         return (int)(number * (ulong)_partitionCount / uint.MaxValue);
     }
 

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -810,7 +810,7 @@ namespace Nethermind.Trie.Pruning
                 void PersistNode(TrieNode n)
                 {
                     Keccak? hash = n.Keccak;
-                    if (hash?.Bytes is not null)
+                    if (hash is not null)
                     {
                         store[hash.Bytes] = n.FullRlp;
                         int persistedNodesCount = Interlocked.Increment(ref persistedNodes);

--- a/src/Nethermind/Nethermind.Trie/TreeDumper.cs
+++ b/src/Nethermind/Nethermind.Trie/TreeDumper.cs
@@ -49,12 +49,12 @@ namespace Nethermind.Trie
 
         public void VisitBranch(TrieNode node, TrieVisitContext trieVisitContext)
         {
-            _builder.AppendLine($"{GetPrefix(trieVisitContext)}BRANCH | -> {(node.Keccak?.Bytes ?? node.FullRlp)?.ToHexString()}");
+            _builder.AppendLine($"{GetPrefix(trieVisitContext)}BRANCH | -> {KeccakOrRlpStringOfNode(node)}");
         }
 
         public void VisitExtension(TrieNode node, TrieVisitContext trieVisitContext)
         {
-            _builder.AppendLine($"{GetPrefix(trieVisitContext)}EXTENSION {Nibbles.FromBytes(node.Key).ToPackedByteArray().ToHexString(false)} -> {(node.Keccak?.Bytes ?? node.FullRlp)?.ToHexString()}");
+            _builder.AppendLine($"{GetPrefix(trieVisitContext)}EXTENSION {Nibbles.FromBytes(node.Key).ToPackedByteArray().ToHexString(false)} -> {KeccakOrRlpStringOfNode(node)}");
         }
 
         private AccountDecoder decoder = new();
@@ -62,7 +62,7 @@ namespace Nethermind.Trie
         public void VisitLeaf(TrieNode node, TrieVisitContext trieVisitContext, byte[] value = null)
         {
             string leafDescription = trieVisitContext.IsStorage ? "LEAF " : "ACCOUNT ";
-            _builder.AppendLine($"{GetPrefix(trieVisitContext)}{leafDescription} {Nibbles.FromBytes(node.Key).ToPackedByteArray().ToHexString(false)} -> {(node.Keccak?.Bytes ?? node.FullRlp)?.ToHexString()}");
+            _builder.AppendLine($"{GetPrefix(trieVisitContext)}{leafDescription} {Nibbles.FromBytes(node.Key).ToPackedByteArray().ToHexString(false)} -> {KeccakOrRlpStringOfNode(node)}");
             if (!trieVisitContext.IsStorage)
             {
                 Account account = decoder.Decode(new RlpStream(value));
@@ -84,6 +84,11 @@ namespace Nethermind.Trie
         public override string ToString()
         {
             return _builder.ToString();
+        }
+
+        private string? KeccakOrRlpStringOfNode(TrieNode node)
+        {
+            return node.Keccak != null ? node.Keccak!.Bytes.ToHexString() : node.FullRlp?.ToHexString();
         }
     }
 }

--- a/src/Nethermind/Nethermind.Trie/TrieNode.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using Nethermind.Core;
@@ -187,6 +188,11 @@ namespace Nethermind.Trie
             IsDirty = isDirty;
 
             _rlpStream = rlp.AsRlpStream();
+        }
+
+        public TrieNode(NodeType nodeType, Keccak keccak, ReadOnlySpan<byte> rlp)
+            : this(nodeType, keccak, rlp.ToArray())
+        {
         }
 
         public TrieNode(NodeType nodeType, Keccak keccak, byte[] rlp)

--- a/src/Nethermind/Nethermind.Wallet/DevKeyStoreWallet.cs
+++ b/src/Nethermind/Nethermind.Wallet/DevKeyStoreWallet.cs
@@ -100,7 +100,7 @@ namespace Nethermind.Wallet
                 key = _keyStore.GetKey(address, passphrase).PrivateKey;
             }
 
-            var rs = SecP256k1.SignCompact(message.Bytes, key.KeyBytes, out int v);
+            var rs = Ecdsa.SignCompact(message.Bytes, key.KeyBytes, out int v);
             return new Signature(rs, v);
         }
 
@@ -116,7 +116,7 @@ namespace Nethermind.Wallet
                 throw new SecurityException("Can only sign without passphrase when account is unlocked.");
             }
 
-            var rs = SecP256k1.SignCompact(message.Bytes, key.KeyBytes, out int v);
+            var rs = Ecdsa.SignCompact(message.Bytes, key.KeyBytes, out int v);
             return new Signature(rs, v);
         }
     }

--- a/src/Nethermind/Nethermind.Wallet/DevKeyStoreWallet.cs
+++ b/src/Nethermind/Nethermind.Wallet/DevKeyStoreWallet.cs
@@ -100,7 +100,7 @@ namespace Nethermind.Wallet
                 key = _keyStore.GetKey(address, passphrase).PrivateKey;
             }
 
-            var rs = Ecdsa.SignCompact(message.Bytes, key.KeyBytes, out int v);
+            var rs = SpanSecP256k1.SignCompact(message.Bytes, key.KeyBytes, out int v);
             return new Signature(rs, v);
         }
 
@@ -116,7 +116,7 @@ namespace Nethermind.Wallet
                 throw new SecurityException("Can only sign without passphrase when account is unlocked.");
             }
 
-            var rs = Ecdsa.SignCompact(message.Bytes, key.KeyBytes, out int v);
+            var rs = SpanSecP256k1.SignCompact(message.Bytes, key.KeyBytes, out int v);
             return new Signature(rs, v);
         }
     }

--- a/src/Nethermind/Nethermind.Wallet/DevWallet.cs
+++ b/src/Nethermind/Nethermind.Wallet/DevWallet.cs
@@ -117,7 +117,7 @@ namespace Nethermind.Wallet
 
         public Signature Sign(Keccak message, Address address)
         {
-            var rs = SecP256k1.SignCompact(message.Bytes, _keys[address].KeyBytes, out int v);
+            var rs = Ecdsa.SignCompact(message.Bytes, _keys[address].KeyBytes, out int v);
             return new Signature(rs, v);
         }
     }

--- a/src/Nethermind/Nethermind.Wallet/DevWallet.cs
+++ b/src/Nethermind/Nethermind.Wallet/DevWallet.cs
@@ -117,7 +117,7 @@ namespace Nethermind.Wallet
 
         public Signature Sign(Keccak message, Address address)
         {
-            var rs = Ecdsa.SignCompact(message.Bytes, _keys[address].KeyBytes, out int v);
+            var rs = SpanSecP256k1.SignCompact(message.Bytes, _keys[address].KeyBytes, out int v);
             return new Signature(rs, v);
         }
     }

--- a/src/Nethermind/Nethermind.Wallet/ProtectedKeyStoreWallet.cs
+++ b/src/Nethermind/Nethermind.Wallet/ProtectedKeyStoreWallet.cs
@@ -97,7 +97,7 @@ namespace Nethermind.Wallet
         {
             var protectedPrivateKey = (ProtectedPrivateKey)_unlockedAccounts.Get(address.ToString());
             using PrivateKey key = protectedPrivateKey is not null ? protectedPrivateKey.Unprotect() : getPrivateKeyWhenNotFound();
-            var rs = Ecdsa.SignCompact(message.Bytes, key.KeyBytes, out int v);
+            var rs = SpanSecP256k1.SignCompact(message.Bytes, key.KeyBytes, out int v);
             return new Signature(rs, v);
         }
     }

--- a/src/Nethermind/Nethermind.Wallet/ProtectedKeyStoreWallet.cs
+++ b/src/Nethermind/Nethermind.Wallet/ProtectedKeyStoreWallet.cs
@@ -97,7 +97,7 @@ namespace Nethermind.Wallet
         {
             var protectedPrivateKey = (ProtectedPrivateKey)_unlockedAccounts.Get(address.ToString());
             using PrivateKey key = protectedPrivateKey is not null ? protectedPrivateKey.Unprotect() : getPrivateKeyWhenNotFound();
-            var rs = SecP256k1.SignCompact(message.Bytes, key.KeyBytes, out int v);
+            var rs = Ecdsa.SignCompact(message.Bytes, key.KeyBytes, out int v);
             return new Signature(rs, v);
         }
     }


### PR DESCRIPTION
- Like #5526 but only replace byte[] to ValueKeccak and try to minimize other change. Most change is in tests.
- When combined with #5708, reduce memory allocation per call slightly.

![Screenshot from 2023-05-22 14-16-43](https://github.com/NethermindEth/nethermind/assets/1841324/540efecc-9dee-4ffa-b577-74ebc19c76f4)

## Changes

- Use ValueKeccak as underlying data for Keccak instead of byte[].
- Copied Keccak and ValueKeccak implementation from #5526.
- Wrap `SecP256k1` to `SpanSecP256k1` that provide span interface.

## Types of changes

#### What types of changes does your code introduce?

- [X] Optimization
- [X] Refactoring

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

- Have not tested full sync.