### PR TITLE
Don't apply EXTCODESIZE optimization if tracing

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeTxTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeTxTracerTests.cs
@@ -388,7 +388,7 @@ namespace Nethermind.Evm.Test.Tracing
             Assert.That(entry.Operation, Is.EqualTo("EXTCODESIZE"));
             Assert.That(entry.Stack[^1], Is.EqualTo("866833515b6d086c607f".PadLeft(64, '0')));
             Assert.That(entry.Stack.Count, Is.EqualTo(8));
-            
+
             entry = trace.Entries[^2];
             Assert.That(entry.Pc, Is.EqualTo(26));
             Assert.That(entry.Operation, Is.EqualTo("ISZERO"));

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeTxTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeTxTracerTests.cs
@@ -373,5 +373,33 @@ namespace Nethermind.Evm.Test.Tracing
             Assert.That(trace.Entries[6].Memory[0], Is.EqualTo(SampleHexData1.PadLeft(64, '0')), "entry[6][0]");
             Assert.That(trace.Entries[6].Memory[1], Is.EqualTo(SampleHexData2.PadLeft(64, '0')), "entry[6][1]");
         }
+
+        [Test]
+        public void Can_trace_extcodesize_optimization()
+        {
+            // From https://github.com/NethermindEth/nethermind/issues/5717
+            byte[] code = Bytes.FromHexString("0x60246044607460d1606b60b9603369866833515b6d086c607f3b15749e4886579008320052006f");
+
+            GethLikeTxTrace trace = ExecuteAndTrace(code);
+            GethTxTraceEntry entry;
+
+            entry = trace.Entries[^3];
+            Assert.That(entry.Pc, Is.EqualTo(25));
+            Assert.That(entry.Operation, Is.EqualTo("EXTCODESIZE"));
+            Assert.That(entry.Stack[^1], Is.EqualTo("866833515b6d086c607f".PadLeft(64, '0')));
+            Assert.That(entry.Stack.Count, Is.EqualTo(8));
+            
+            entry = trace.Entries[^2];
+            Assert.That(entry.Pc, Is.EqualTo(26));
+            Assert.That(entry.Operation, Is.EqualTo("ISZERO"));
+            Assert.That(entry.Stack[^1], Is.EqualTo("0".PadLeft(64, '0')));
+            Assert.That(entry.Stack.Count, Is.EqualTo(8));
+
+            entry = trace.Entries[^1];
+            Assert.That(entry.Pc, Is.EqualTo(27));
+            Assert.That(entry.Operation, Is.EqualTo("PUSH21"));
+            Assert.That(entry.Stack[^1], Is.EqualTo("1".PadLeft(64, '0')));
+            Assert.That(entry.Stack.Count, Is.EqualTo(8));
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -1249,7 +1249,7 @@ public class VirtualMachine : IVirtualMachine
                         Address address = stack.PopAddress();
                         if (!ChargeAccountAccessGas(ref gasAvailable, vmState, address, spec)) goto OutOfGas;
 
-                        if (programCounter < code.Length)
+                        if (!traceOpcodes && programCounter < code.Length)
                         {
                             bool optimizeAccess = false;
                             Instruction nextInstruction = (Instruction)code[programCounter];
@@ -1282,11 +1282,6 @@ public class VirtualMachine : IVirtualMachine
                                 // is is a common pattern to check if address is a contract
                                 // however we can just check the address's loaded CodeHash
                                 // to reduce storage access from trying to load the code
-                                if (traceOpcodes)
-                                {
-                                    EndInstructionTrace(gasAvailable, vmState.Memory?.Size ?? 0);
-                                    StartInstructionTrace(Instruction.ISZERO, vmState, gasAvailable, programCounter, in stack);
-                                }
 
                                 programCounter++;
                                 // Add gas cost for ISZERO, GT, or EQ


### PR DESCRIPTION
Resolves #5717

## Changes

- Don't apply EXTCODESIZE optimization if tracing

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No