### PR TITLE
Fix accidentally set low priority

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -519,12 +519,12 @@ public class DbOnTheRocks : IDbWithSpan, ITunableDb
             return _lowPriorityAndNoWalWrite;
         }
 
-        if ((flags & WriteFlags.DisableWAL) != 0)
+        if ((flags & WriteFlags.DisableWAL) == WriteFlags.DisableWAL)
         {
             return _noWalWrite;
         }
 
-        if ((flags & WriteFlags.LowPriority) != 0)
+        if ((flags & WriteFlags.LowPriority) == WriteFlags.LowPriority)
         {
             return _lowPriorityWriteOptions;
         }

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -514,7 +514,7 @@ public class DbOnTheRocks : IDbWithSpan, ITunableDb
 
     public WriteOptions? WriteFlagsToWriteOptions(WriteFlags flags)
     {
-        if ((flags & WriteFlags.LowPriorityAndNoWAL) != 0)
+        if ((flags & WriteFlags.LowPriorityAndNoWAL) == WriteFlags.LowPriorityAndNoWAL)
         {
             return _lowPriorityAndNoWalWrite;
         }

--- a/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
@@ -47,13 +47,15 @@ namespace Nethermind.Db.Test
 
             WriteOptions? options = db.WriteFlagsToWriteOptions(WriteFlags.LowPriority);
             Native.Instance.rocksdb_writeoptions_get_low_pri(options.Handle).Should().BeTrue();
+            Native.Instance.rocksdb_writeoptions_get_disable_WAL(options.Handle).Should().BeFalse();
 
             options = db.WriteFlagsToWriteOptions(WriteFlags.LowPriority | WriteFlags.DisableWAL);
             Native.Instance.rocksdb_writeoptions_get_low_pri(options.Handle).Should().BeTrue();
-            Native.Instance.rocksdb_writeoptions_get_disable_WAL(options.Handle).Should().Be(true);
+            Native.Instance.rocksdb_writeoptions_get_disable_WAL(options.Handle).Should().BeTrue();
 
             options = db.WriteFlagsToWriteOptions(WriteFlags.DisableWAL);
-            Native.Instance.rocksdb_writeoptions_get_disable_WAL(options.Handle).Should().Be(true);
+            Native.Instance.rocksdb_writeoptions_get_low_pri(options.Handle).Should().BeFalse();
+            Native.Instance.rocksdb_writeoptions_get_disable_WAL(options.Handle).Should().BeTrue();
         }
 
         [Test]


### PR DESCRIPTION
- Fix accidentally set LowPriority write flag when DisableWal is set causing snap sync to be very slow.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Snapsync can now reach above 250k node per sec, which seems to be the limit with low priority write.
