### PR TITLE
Fix missed cache miss hint

### DIFF
--- a/src/Nethermind/Nethermind.Trie.Test/TrieNodeResolverWithReadFlagsTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieNodeResolverWithReadFlagsTests.cs
@@ -27,4 +27,19 @@ public class TrieNodeResolverWithReadFlagsTests
 
         memDb.KeyWasReadWithFlags(theKeccak.BytesToArray(), theFlags);
     }
+
+    [Test]
+    public void LoadRlp_combine_passed_fleag()
+    {
+        ReadFlags theFlags = ReadFlags.HintCacheMiss;
+        TestMemDb memDb = new();
+        ITrieStore trieStore = new TrieStore(memDb, LimboLogs.Instance);
+        TrieNodeResolverWithReadFlags resolver = new(trieStore, theFlags);
+
+        Keccak theKeccak = TestItem.KeccakA;
+        memDb[theKeccak.Bytes] = TestItem.KeccakA.BytesToArray();
+        resolver.LoadRlp(theKeccak, ReadFlags.HintReadAhead);
+
+        memDb.KeyWasReadWithFlags(theKeccak.BytesToArray(), theFlags | ReadFlags.HintReadAhead);
+    }
 }

--- a/src/Nethermind/Nethermind.Trie/TrieNodeResolverWithReadFlags.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNodeResolverWithReadFlags.cs
@@ -27,7 +27,7 @@ public class TrieNodeResolverWithReadFlags : ITrieNodeResolver
     {
         if (flags != ReadFlags.None)
         {
-            return _baseResolver.LoadRlp(hash, flags);
+            return _baseResolver.LoadRlp(hash, flags | _defaultFlags);
         }
 
         return _baseResolver.LoadRlp(hash, _defaultFlags);


### PR DESCRIPTION
- Fix `HintCacheMiss` read flags was missed causing trie visitor to not run with that flag, which nullify #5463.
- On worst case, this reduces verify trie throughput from 1.5M nodes per sec to 0.5M nodes persec.
- On slower speed, probably does not make any difference.


## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No