### PR TITLE
Keccaks: Skip unneeded array allocations

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.Ethash/Ethash.cs
+++ b/src/Nethermind/Nethermind.Consensus.Ethash/Ethash.cs
@@ -128,7 +128,7 @@ namespace Nethermind.Consensus.Ethash
                 seed = ValueKeccak.Compute(seed.Bytes);
             }
 
-            return new Keccak(seed.Bytes.ToArray());
+            return new Keccak(seed.Bytes);
         }
 
         private readonly BigInteger _2To256 = BigInteger.Pow(2, 256);

--- a/src/Nethermind/Nethermind.Core/Crypto/Keccak.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/Keccak.cs
@@ -575,6 +575,6 @@ namespace Nethermind.Core.Crypto
             return !(a == b);
         }
 
-        public Keccak ToKeccak() => new(Bytes.ToArray());
+        public Keccak ToKeccak() => new(Bytes);
     }
 }

--- a/src/Nethermind/Nethermind.Evm/Precompiles/EcRecoverPrecompile.cs
+++ b/src/Nethermind/Nethermind.Evm/Precompiles/EcRecoverPrecompile.cs
@@ -43,7 +43,7 @@ namespace Nethermind.Evm.Precompiles
             inputData.Span[..Math.Min(128, inputData.Length)]
                 .CopyTo(inputDataSpan[..Math.Min(128, inputData.Length)]);
 
-            Keccak hash = new(inputDataSpan[..32].ToArray());
+            Keccak hash = new(inputDataSpan[..32]);
             Span<byte> vBytes = inputDataSpan.Slice(32, 32);
             Span<byte> r = inputDataSpan.Slice(64, 32);
             Span<byte> s = inputDataSpan.Slice(96, 32);

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -1963,7 +1963,7 @@ public class VirtualMachine : IVirtualMachine
                         Keccak[] topics = new Keccak[topicsCount];
                         for (int i = 0; i < topicsCount; i++)
                         {
-                            topics[i] = new Keccak(stack.PopBytes().ToArray());
+                            topics[i] = new Keccak(stack.PopBytes());
                         }
 
                         LogEntry logEntry = new(

--- a/src/Nethermind/Nethermind.Network/Rlpx/Handshake/AuthMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/Handshake/AuthMessageSerializer.cs
@@ -56,7 +56,7 @@ namespace Nethermind.Network.Rlpx.Handshake
             AuthMessage authMessage = new AuthMessage();
             Span<byte> msg = msgBytes.ReadAllBytesAsSpan();
             authMessage.Signature = new Signature(msg[..(SigLength - 1)], msg[64]);
-            authMessage.EphemeralPublicHash = new Keccak(msg.Slice(EphemeralHashOffset, EphemeralHashLength).ToArray());
+            authMessage.EphemeralPublicHash = new Keccak(msg.Slice(EphemeralHashOffset, EphemeralHashLength));
             authMessage.PublicKey = new PublicKey(msg.Slice(PublicKeyOffset, PublicKeyLength));
             authMessage.Nonce = msg.Slice(NonceOffset, NonceLength).ToArray();
             authMessage.IsTokenUsed = msg[IsTokenUsedOffset] == 0x01;

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -837,7 +837,7 @@ namespace Nethermind.Serialization.Rlp
                     return Keccak.EmptyTreeHash;
                 }
 
-                return new Keccak(keccakSpan.ToArray());
+                return new Keccak(keccakSpan);
             }
 
             public Keccak? DecodeZeroPrefixKeccak()

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpStream.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpStream.cs
@@ -871,7 +871,7 @@ namespace Nethermind.Serialization.Rlp
                 return Keccak.EmptyTreeHash;
             }
 
-            return new Keccak(keccakSpan.ToArray());
+            return new Keccak(keccakSpan);
         }
 
         public ValueKeccak? DecodeValueKeccak()

--- a/src/Nethermind/Nethermind.State/Witnesses/WitnessingStore.cs
+++ b/src/Nethermind/Nethermind.State/Witnesses/WitnessingStore.cs
@@ -59,7 +59,7 @@ namespace Nethermind.State.Witnesses
 
         public void Touch(ReadOnlySpan<byte> key)
         {
-            _witnessCollector.Add(new Keccak(key.ToArray()));
+            _witnessCollector.Add(new Keccak(key));
         }
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
@@ -82,7 +82,7 @@ namespace Nethermind.Synchronization.SnapSync
             {
                 AccountRangePartition partition = new AccountRangePartition();
 
-                Keccak startingPath = new Keccak(Keccak.Zero.Bytes.ToArray());
+                Keccak startingPath = new Keccak(Keccak.Zero.Bytes);
                 startingPath.Bytes[0] = curStartingPath;
 
                 partition.NextAccountPath = startingPath;
@@ -99,7 +99,7 @@ namespace Nethermind.Synchronization.SnapSync
                 }
                 else
                 {
-                    limitPath = new Keccak(Keccak.Zero.Bytes.ToArray());
+                    limitPath = new Keccak(Keccak.Zero.Bytes);
                     limitPath.Bytes[0] = curStartingPath;
                 }
 


### PR DESCRIPTION
## Changes

- Now Keccak isn't backed by a separate array; using `.ToArray` to construct from a Span is just an unneeded allocation

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No