### PR TITLE
Less contention for OldReceipts and OldBodies

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -1705,7 +1705,7 @@ namespace Nethermind.Blockchain
         /// <returns></returns>
         private bool ShouldCache(long number)
         {
-            return number == 0L || Head is null || number > Head.Number - CacheSize && number <= Head.Number + 1;
+            return number == 0L || Head is null || number <= Head.Number + 1;
         }
 
         public ChainLevelInfo? FindLevel(long number)
@@ -1726,7 +1726,7 @@ namespace Nethermind.Blockchain
                 return null;
             }
 
-            Block block = _blockStore.Get(blockHash, false);
+            Block block = _blockStore.Get(blockHash, shouldCache: false);
             if (block is null)
             {
                 bool allowInvalid = (options & BlockTreeLookupOptions.AllowInvalid) == BlockTreeLookupOptions.AllowInvalid;

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -37,7 +37,8 @@ namespace Nethermind.Blockchain
 
         internal static Keccak HeadAddressInDb = Keccak.Zero;
 
-        private const int CacheSize = 64;
+        // SyncProgressResolver MaxLookupBack is 128, add 16 wiggle room
+        private const int CacheSize = 128 + 16;
 
         private readonly LruCache<KeccakKey, BlockHeader> _headerCache =
             new(CacheSize, CacheSize, "headers");
@@ -827,7 +828,7 @@ namespace Nethermind.Blockchain
                 return null;
             }
 
-            BlockHeader? header = _headerDb.Get(blockHash, _headerDecoder, _headerCache, false);
+            BlockHeader? header = _headerDb.Get(blockHash, _headerDecoder, _headerCache, shouldCache: false);
             if (header is null)
             {
                 bool allowInvalid = (options & BlockTreeLookupOptions.AllowInvalid) == BlockTreeLookupOptions.AllowInvalid;

--- a/src/Nethermind/Nethermind.Blockchain/Blocks/BlockStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Blocks/BlockStore.cs
@@ -17,7 +17,7 @@ public class BlockStore : IBlockStore
     private readonly IDb _blockDb;
     private readonly IDbWithSpan? _blockDbAsSpan;
     private readonly BlockDecoder _blockDecoder = new();
-    private const int CacheSize = 64;
+    private const int CacheSize = 128 + 32;
 
     private readonly LruCache<KeccakKey, Block>
         _blockCache = new(CacheSize, CacheSize, "blocks");

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Nethermind.Blockchain.Blocks;
 using Nethermind.Core;
@@ -173,8 +174,10 @@ namespace Nethermind.Blockchain.Receipts
             }
         }
 
+        [SkipLocalsInit]
         private unsafe Span<byte> GetReceiptData(long blockNumber, Keccak blockHash)
         {
+            Span<byte> blockNumPrefixed = stackalloc byte[40];
             if (_legacyHashKey)
             {
                 Span<byte> receiptsData = _blocksDb.GetSpan(blockHash);
@@ -183,7 +186,6 @@ namespace Nethermind.Blockchain.Receipts
                     return receiptsData;
                 }
 
-                Span<byte> blockNumPrefixed = stackalloc byte[40];
                 GetBlockNumPrefixedKey(blockNumber, blockHash, blockNumPrefixed);
 
 #pragma warning disable CS9080
@@ -194,7 +196,6 @@ namespace Nethermind.Blockchain.Receipts
             }
             else
             {
-                Span<byte> blockNumPrefixed = stackalloc byte[40];
                 GetBlockNumPrefixedKey(blockNumber, blockHash, blockNumPrefixed);
 
                 Span<byte> receiptsData = _blocksDb.GetSpan(blockNumPrefixed);
@@ -258,6 +259,7 @@ namespace Nethermind.Blockchain.Receipts
             return result;
         }
 
+        [SkipLocalsInit]
         public void Insert(Block block, TxReceipt[]? txReceipts, bool ensureCanonical = true)
         {
             txReceipts ??= Array.Empty<TxReceipt>();
@@ -325,24 +327,22 @@ namespace Nethermind.Blockchain.Receipts
             _receiptsCache.Clear();
         }
 
+        [SkipLocalsInit]
         public bool HasBlock(long blockNumber, Keccak blockHash)
         {
             if (_receiptsCache.Contains(blockHash)) return true;
 
+            Span<byte> blockNumPrefixed = stackalloc byte[40];
             if (_legacyHashKey)
             {
                 if (_blocksDb.KeyExists(blockHash)) return true;
 
-                Span<byte> blockNumPrefixed = stackalloc byte[40];
                 GetBlockNumPrefixedKey(blockNumber, blockHash, blockNumPrefixed);
-
                 return _blocksDb.KeyExists(blockNumPrefixed);
             }
             else
             {
-                Span<byte> blockNumPrefixed = stackalloc byte[40];
                 GetBlockNumPrefixedKey(blockNumber, blockHash, blockNumPrefixed);
-
                 return _blocksDb.KeyExists(blockNumPrefixed) || _blocksDb.KeyExists(blockHash);
             }
         }

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/SyncStatusListTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/SyncStatusListTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Threading.Tasks;
 
 using DotNetty.Codecs;
 
@@ -31,7 +32,7 @@ namespace Nethermind.Synchronization.Test.FastBlocks
         [Test]
         public void Can_read_back_all_set_values()
         {
-            const long length = 500;
+            const long length = 4096;
 
             FastBlockStatusList list = new(length);
             for (int i = 0; i < length; i++)
@@ -41,6 +42,25 @@ namespace Nethermind.Synchronization.Test.FastBlocks
             for (int i = 0; i < length; i++)
             {
                 Assert.IsTrue((FastBlockStatus)(i % 3) == list[i]);
+            }
+        }
+
+        [Test]
+        public void Can_read_back_all_parallel_set_values()
+        {
+            const long length = 4096;
+
+            for (var len = 0; len < length; len++)
+            {
+                FastBlockStatusList list = new(len);
+                Parallel.For(0, len, (i) =>
+                {
+                    list[i] = (FastBlockStatus)(i % 3);
+                });
+                Parallel.For(0, len, (i) =>
+                {
+                    Assert.IsTrue((FastBlockStatus)(i % 3) == list[i]);
+                });
             }
         }
     }

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
@@ -210,12 +210,12 @@ namespace Nethermind.Synchronization.FastBlocks
                             _syncPeerPool.ReportBreachOfProtocol(batch.ResponseSourcePeer, InitiateDisconnectReason.InvalidTxOrUncle, "invalid tx or uncles root");
                         }
 
-                        _syncStatusList.MarkUnknown(blockInfo.BlockNumber);
+                        _syncStatusList.MarkPending(blockInfo.BlockNumber);
                     }
                 }
                 else
                 {
-                    _syncStatusList.MarkUnknown(blockInfo.BlockNumber);
+                    _syncStatusList.MarkPending(blockInfo.BlockNumber);
                 }
             }
 

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
@@ -210,12 +210,12 @@ namespace Nethermind.Synchronization.FastBlocks
                             _syncPeerPool.ReportBreachOfProtocol(batch.ResponseSourcePeer, InitiateDisconnectReason.InvalidTxOrUncle, "invalid tx or uncles root");
                         }
 
-                        _syncStatusList.MarkPending(blockInfo.BlockNumber);
+                        _syncStatusList.MarkPending(blockInfo);
                     }
                 }
                 else
                 {
-                    _syncStatusList.MarkPending(blockInfo.BlockNumber);
+                    _syncStatusList.MarkPending(blockInfo);
                 }
             }
 

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastBlockStatus.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastBlockStatus.cs
@@ -5,7 +5,7 @@ namespace Nethermind.Synchronization.FastBlocks;
 
 internal enum FastBlockStatus : byte
 {
-    Unknown = 0,
+    Pending = 0,
     Sent = 1,
     Inserted = 2,
 }

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/ReceiptsSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/ReceiptsSyncFeed.cs
@@ -234,7 +234,7 @@ namespace Nethermind.Synchronization.FastBlocks
                                 if (_logger.IsWarn) _logger.Warn($"Could not find block {blockInfo.BlockHash}");
                             }
 
-                            _syncStatusList.MarkPending(blockInfo.BlockNumber);
+                            _syncStatusList.MarkPending(blockInfo);
                         }
                         else
                         {
@@ -246,7 +246,7 @@ namespace Nethermind.Synchronization.FastBlocks
                             }
                             catch (InvalidDataException)
                             {
-                                _syncStatusList.MarkPending(blockInfo.BlockNumber);
+                                _syncStatusList.MarkPending(blockInfo);
                             }
                         }
                     }
@@ -260,14 +260,14 @@ namespace Nethermind.Synchronization.FastBlocks
                             _syncPeerPool.ReportBreachOfProtocol(batch.ResponseSourcePeer, InitiateDisconnectReason.InvalidReceiptRoot, "invalid tx or uncles root");
                         }
 
-                        _syncStatusList.MarkPending(blockInfo.BlockNumber);
+                        _syncStatusList.MarkPending(blockInfo);
                     }
                 }
                 else
                 {
                     if (blockInfo is not null)
                     {
-                        _syncStatusList.MarkPending(blockInfo.BlockNumber);
+                        _syncStatusList.MarkPending(blockInfo);
                     }
                 }
             }

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/ReceiptsSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/ReceiptsSyncFeed.cs
@@ -234,7 +234,7 @@ namespace Nethermind.Synchronization.FastBlocks
                                 if (_logger.IsWarn) _logger.Warn($"Could not find block {blockInfo.BlockHash}");
                             }
 
-                            _syncStatusList.MarkUnknown(blockInfo.BlockNumber);
+                            _syncStatusList.MarkPending(blockInfo.BlockNumber);
                         }
                         else
                         {
@@ -246,7 +246,7 @@ namespace Nethermind.Synchronization.FastBlocks
                             }
                             catch (InvalidDataException)
                             {
-                                _syncStatusList.MarkUnknown(blockInfo.BlockNumber);
+                                _syncStatusList.MarkPending(blockInfo.BlockNumber);
                             }
                         }
                     }
@@ -260,14 +260,14 @@ namespace Nethermind.Synchronization.FastBlocks
                             _syncPeerPool.ReportBreachOfProtocol(batch.ResponseSourcePeer, InitiateDisconnectReason.InvalidReceiptRoot, "invalid tx or uncles root");
                         }
 
-                        _syncStatusList.MarkUnknown(blockInfo.BlockNumber);
+                        _syncStatusList.MarkPending(blockInfo.BlockNumber);
                     }
                 }
                 else
                 {
                     if (blockInfo is not null)
                     {
-                        _syncStatusList.MarkUnknown(blockInfo.BlockNumber);
+                        _syncStatusList.MarkPending(blockInfo.BlockNumber);
                     }
                 }
             }

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/ReceiptsSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/ReceiptsSyncFeed.cs
@@ -206,9 +206,10 @@ namespace Nethermind.Synchronization.FastBlocks
             bool hasBreachedProtocol = false;
             int validResponsesCount = 0;
 
-            for (int i = 0; i < batch.Infos.Length; i++)
+            BlockInfo?[] blockInfos = batch.Infos;
+            for (int i = 0; i < blockInfos.Length; i++)
             {
-                BlockInfo? blockInfo = batch.Infos[i];
+                BlockInfo? blockInfo = blockInfos[i];
                 TxReceipt[]? receipts = (batch.Response?.Length ?? 0) <= i
                     ? null
                     : (batch.Response![i] ?? Array.Empty<TxReceipt>());
@@ -288,18 +289,19 @@ namespace Nethermind.Synchronization.FastBlocks
 
         private void AdjustRequestSize(ReceiptsSyncBatch batch, int validResponsesCount)
         {
-            lock (_syncStatusList)
+            int currentRequestSize = Volatile.Read(ref _requestSize);
+            int requestSize = currentRequestSize;
+            if (validResponsesCount == batch.Infos.Length)
             {
-                if (validResponsesCount == batch.Infos.Length)
-                {
-                    _requestSize = Math.Min(256, _requestSize * 2);
-                }
-
-                if (validResponsesCount == 0)
-                {
-                    _requestSize = Math.Max(4, _requestSize / 2);
-                }
+                requestSize = Math.Min(256, currentRequestSize * 2);
             }
+
+            if (validResponsesCount == 0)
+            {
+                requestSize = Math.Max(4, currentRequestSize / 2);
+            }
+
+            Interlocked.CompareExchange(ref _requestSize, requestSize, currentRequestSize);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/ReceiptsSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/ReceiptsSyncFeed.cs
@@ -240,7 +240,7 @@ namespace Nethermind.Synchronization.FastBlocks
                         {
                             try
                             {
-                                _receiptStorage.Insert(block, prepared);
+                                _receiptStorage.Insert(block, prepared, ensureCanonical: true);
                                 _syncStatusList.MarkInserted(block.Number);
                                 validResponsesCount++;
                             }

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/SyncStatusList.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/SyncStatusList.cs
@@ -36,8 +36,7 @@ namespace Nethermind.Synchronization.FastBlocks
         public void GetInfosForBatch(BlockInfo?[] blockInfos)
         {
             int collected = 0;
-            long currentNumber = LowestInsertWithoutGaps;
-
+            long currentNumber = Volatile.Read(ref _lowestInsertWithoutGaps);
             while (collected < blockInfos.Length && currentNumber != 0)
             {
                 if (blockInfos[collected] is not null)
@@ -62,10 +61,10 @@ namespace Nethermind.Synchronization.FastBlocks
                 }
                 else if (status == FastBlockStatus.Inserted)
                 {
-                    long l = LowestInsertWithoutGaps;
-                    if (currentNumber == l)
+                    long currentLowest = Volatile.Read(ref _lowestInsertWithoutGaps);
+                    if (currentNumber == currentLowest)
                     {
-                        if (Interlocked.CompareExchange(ref _lowestInsertWithoutGaps, l - 1, l) == l)
+                        if (Interlocked.CompareExchange(ref _lowestInsertWithoutGaps, currentLowest - 1, currentLowest) == currentLowest)
                         {
                             Interlocked.Decrement(ref _queueSize);
                         }

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/SyncStatusList.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/SyncStatusList.cs
@@ -14,7 +14,7 @@ namespace Nethermind.Synchronization.FastBlocks
         private long _queueSize;
         private readonly IBlockTree _blockTree;
         private readonly FastBlockStatusList _statuses;
-        private readonly LruCache<long, BlockInfo> _cache = new(maxCapacity: 16, startCapacity: 16, "blockInfo Cache");
+        private readonly LruCache<long, BlockInfo> _cache = new(maxCapacity: 64, startCapacity: 64, "blockInfo Cache");
 
         public long LowestInsertWithoutGaps { get; private set; }
         public long QueueSize => _queueSize;


### PR DESCRIPTION
## Changes

- Make `FastBlockStatusList` methods atomic reducing lock requirements
- Increase some LruCache sizes to match the scan length + n

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No