### PR TITLE
Less aggressive peer discovery

### DIFF
--- a/src/Nethermind/Nethermind.Core/Crypto/PublicKey.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/PublicKey.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Nethermind.Core.Extensions;
@@ -96,7 +97,17 @@ namespace Nethermind.Core.Crypto
 
         public override int GetHashCode()
         {
-            return MemoryMarshal.Read<int>(Bytes);
+            byte[] bytes = Bytes;
+            long l0 = Unsafe.ReadUnaligned<long>(ref MemoryMarshal.GetArrayDataReference(bytes));
+            long l1 = Unsafe.ReadUnaligned<long>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(bytes), sizeof(long)));
+            long l2 = Unsafe.ReadUnaligned<long>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(bytes), sizeof(long) * 2));
+            long l3 = Unsafe.ReadUnaligned<long>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(bytes), sizeof(long) * 3));
+            long l4 = Unsafe.ReadUnaligned<long>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(bytes), sizeof(long) * 4));
+            long l5 = Unsafe.ReadUnaligned<long>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(bytes), sizeof(long) * 5));
+            long l6 = Unsafe.ReadUnaligned<long>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(bytes), sizeof(long) * 6));
+            long l7 = Unsafe.ReadUnaligned<long>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(bytes), sizeof(long) * 7));
+            l0 ^= l1 ^ l2 ^ l3 ^ l4 ^ l5 ^ l6 ^ l7;
+            return (int)(l0 ^ (l0 >> 32));
         }
 
         public override string ToString()

--- a/src/Nethermind/Nethermind.Network/Peer.cs
+++ b/src/Nethermind/Nethermind.Network/Peer.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Nethermind.Network.P2P;
+using Nethermind.Stats;
 using Nethermind.Stats.Model;
 
 namespace Nethermind.Network
@@ -15,11 +16,15 @@ namespace Nethermind.Network
     /// The logic for choosing which session to drop has to be consistent between the two peers - we use the PublicKey
     /// comparison to choose the connection direction in the same way on both sides.
     /// </summary>
-    public class Peer
+    public sealed class Peer
     {
-        public Peer(Node node)
+        public Peer(Node node) : this(node, null)
+        { }
+
+        public Peer(Node node, INodeStats stats)
         {
             Node = node;
+            Stats = stats;
         }
 
         public bool IsAwaitingConnection { get; set; }
@@ -29,6 +34,8 @@ namespace Nethermind.Network
         /// and any extra attributes that we assign to a network node (static / trusted / bootnode).
         /// </summary>
         public Node Node { get; }
+
+        internal INodeStats Stats { get; }
 
         /// <summary>
         /// An incoming session to the Node which can be in one of many states.

--- a/src/Nethermind/Nethermind.Network/PeerPool.cs
+++ b/src/Nethermind/Nethermind.Network/PeerPool.cs
@@ -95,7 +95,7 @@ namespace Nethermind.Network
                 if (_logger.IsDebug) _logger.Debug(
                     $"Adding a {(arg.Node.IsBootnode ? "bootnode" : "stored")} candidate peer {arg.Node:s}");
             }
-            Peer peer = new(arg.Node);
+            Peer peer = new(arg.Node, _stats.GetOrAdd(arg.Node));
             if (arg.Node.IsStatic)
             {
                 arg.Statics.TryAdd(arg.Node.Id, peer);
@@ -107,7 +107,8 @@ namespace Nethermind.Network
 
         private Peer CreateNew(PublicKey key, (NetworkNode Node, ConcurrentDictionary<PublicKey, Peer> Statics) arg)
         {
-            Peer peer = new(new(arg.Node));
+            Node node = new(arg.Node);
+            Peer peer = new(node, _stats.GetOrAdd(node));
 
             PeerAdded?.Invoke(this, new PeerEventArgs(peer));
             return peer;


### PR DESCRIPTION
## Changes

When the number of connected Peers is not at max (fairly common) and the Peer's db is fairly mature; the reconnection will accesses the `NodeStatsManager`'s nodeStats ConcurrentDictionary more frequently than the VM calls UpdateGas (which is every op executed)

![image](https://github.com/NethermindEth/nethermind/assets/1142958/ee5a795a-8b74-4243-b6af-674055b5cbf8)

- Cache hashcode in Node
- Replace locking in NodeStatsLight with `Volatile.Read` and `Interlocked.Increment`
- Stop NodeStatsManager timer running while executing
- Cache INodeStats object in Peer rather than looking it up from ConcurrentDictionary on each method call
- Throttle `PeerManager` if in a hot discovery loop; by up to 50ms per set of candidates

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No