### PR TITLE
Reduce datetime calls in peer discovery by factor of 100

### DIFF
--- a/src/Nethermind/Nethermind.Core/Crypto/PublicKey.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/PublicKey.cs
@@ -16,6 +16,7 @@ namespace Nethermind.Core.Crypto
         private Address? _address;
 
         private byte[]? _prefixedBytes;
+        private int _hashCode;
 
         public PublicKey(string? hexString)
             : this(Core.Extensions.Bytes.FromHexString(hexString ?? throw new ArgumentNullException(nameof(hexString))))
@@ -37,6 +38,7 @@ namespace Nethermind.Core.Crypto
             }
 
             Bytes = bytes.Slice(bytes.Length - 64, 64).ToArray();
+            _hashCode = GetHashCode(Bytes);
         }
 
         public Address Address
@@ -97,7 +99,11 @@ namespace Nethermind.Core.Crypto
 
         public override int GetHashCode()
         {
-            byte[] bytes = Bytes;
+            return _hashCode;
+        }
+
+        private static int GetHashCode(byte[] bytes)
+        {
             long l0 = Unsafe.ReadUnaligned<long>(ref MemoryMarshal.GetArrayDataReference(bytes));
             long l1 = Unsafe.ReadUnaligned<long>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(bytes), sizeof(long)));
             long l2 = Unsafe.ReadUnaligned<long>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(bytes), sizeof(long) * 2));

--- a/src/Nethermind/Nethermind.Network.Benchmark/NodeStatsCtorBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Network.Benchmark/NodeStatsCtorBenchmarks.cs
@@ -11,6 +11,7 @@ namespace Nethermind.Network.Benchmarks
 {
     public class NodeStatsCtorBenchmarks
     {
+        private DateTime _now = DateTime.UtcNow;
         private Node _node;
 
         [GlobalSetup]
@@ -35,7 +36,7 @@ namespace Nethermind.Network.Benchmarks
         public long LightRep()
         {
             NodeStatsLight stats = new NodeStatsLight(_node);
-            return stats.CurrentNodeReputation;
+            return stats.CurrentNodeReputation(_now);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/RoutingTable/NodeBucketItemTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/RoutingTable/NodeBucketItemTests.cs
@@ -41,7 +41,7 @@ namespace Nethermind.Network.Discovery.Test.RoutingTable
         {
             Node node = new(TestItem.PublicKeyA, IPAddress.Loopback.ToString(), 30000);
             NodeBucketItem nodeBucketItem = new(node, DateTime.UtcNow);
-            nodeBucketItem.IsBonded.Should().BeTrue();
+            nodeBucketItem.IsBonded(DateTime.UtcNow).Should().BeTrue();
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Network.Discovery/DiscoveryApp.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/DiscoveryApp.cs
@@ -500,9 +500,10 @@ public class DiscoveryApp : IDiscoveryApp
             try
             {
                 IReadOnlyCollection<INodeLifecycleManager> managers = _discoveryManager.GetNodeLifecycleManagers();
+                DateTime utcNow = DateTime.UtcNow;
                 //we need to update all notes to update reputation
                 _discoveryStorage.UpdateNodes(managers.Select(x => new NetworkNode(x.ManagedNode.Id, x.ManagedNode.Host,
-                    x.ManagedNode.Port, x.NodeStats.NewPersistedNodeReputation)).ToArray());
+                    x.ManagedNode.Port, x.NodeStats.NewPersistedNodeReputation(utcNow))).ToArray());
 
                 if (!_discoveryStorage.AnyPendingChange())
                 {

--- a/src/Nethermind/Nethermind.Network.Discovery/DiscoveryManager.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/DiscoveryManager.cs
@@ -126,7 +126,7 @@ public class DiscoveryManager : IDiscoveryManager
             manager.OnStateChanged += ManagerOnOnStateChanged;
             if (!isPersisted)
             {
-                _discoveryStorage.UpdateNodes(new[] { new NetworkNode(manager.ManagedNode.Id, manager.ManagedNode.Host, manager.ManagedNode.Port, manager.NodeStats.NewPersistedNodeReputation) });
+                _discoveryStorage.UpdateNodes(new[] { new NetworkNode(manager.ManagedNode.Id, manager.ManagedNode.Host, manager.ManagedNode.Port, manager.NodeStats.NewPersistedNodeReputation(DateTime.UtcNow)) });
             }
 
             return manager;
@@ -280,9 +280,9 @@ public class DiscoveryManager : IDiscoveryManager
                 }
             }
         }
-
+        DateTime utcNow = DateTime.UtcNow;
         foreach ((Keccak key, INodeLifecycleManager value) in _nodeLifecycleManagers.ToArray()
-                     .OrderBy(x => x.Value.NodeStats.CurrentNodeReputation))
+                     .OrderBy(x => x.Value.NodeStats.CurrentNodeReputation(utcNow)))
         {
             if (RemoveManager((key, value.ManagedNode.Id)))
             {

--- a/src/Nethermind/Nethermind.Network.Discovery/RoutingTable/NodeBucket.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/RoutingTable/NodeBucket.cs
@@ -33,9 +33,10 @@ public class NodeBucket
             lock (_nodeBucketLock)
             {
                 LinkedListNode<NodeBucketItem>? node = _items.Last;
+                DateTime utcNow = DateTime.UtcNow;
                 while (node is not null)
                 {
-                    if (!node.Value.IsBonded)
+                    if (!node.Value.IsBonded(utcNow))
                     {
                         break;
                     }
@@ -55,9 +56,10 @@ public class NodeBucket
             {
                 int result = _items.Count;
                 LinkedListNode<NodeBucketItem>? node = _items.Last;
+                DateTime utcNow = DateTime.UtcNow;
                 while (node is not null)
                 {
-                    if (node.Value.IsBonded)
+                    if (node.Value.IsBonded(utcNow))
                     {
                         break;
                     }

--- a/src/Nethermind/Nethermind.Network.Discovery/RoutingTable/NodeBucketItem.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/RoutingTable/NodeBucketItem.cs
@@ -17,7 +17,7 @@ public class NodeBucketItem
 
     public DateTime LastContactTime { get; private set; }
 
-    public bool IsBonded => LastContactTime > DateTime.UtcNow - TimeSpan.FromDays(2);
+    public bool IsBonded(DateTime utcNow) => LastContactTime > utcNow - TimeSpan.FromDays(2);
 
     public void OnContactReceived()
     {

--- a/src/Nethermind/Nethermind.Network.Stats/INodeStats.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/INodeStats.cs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
+
 using Nethermind.Stats.Model;
 
 namespace Nethermind.Stats
@@ -19,11 +21,12 @@ namespace Nethermind.Stats
 
         void AddTransferSpeedCaptureEvent(TransferSpeedType speedType, long bytesPerMillisecond);
         long? GetAverageTransferSpeed(TransferSpeedType speedType);
-        (bool Result, NodeStatsEventType? DelayReason) IsConnectionDelayed();
-
-        long CurrentNodeReputation { get; }
+        (bool Result, NodeStatsEventType? DelayReason) IsConnectionDelayed(DateTime nowUTC);
+        
+        long CurrentNodeReputation() => CurrentNodeReputation(DateTime.UtcNow);
+        long CurrentNodeReputation(DateTime nowUTC);
         long CurrentPersistedNodeReputation { get; set; }
-        long NewPersistedNodeReputation { get; }
+        long NewPersistedNodeReputation(DateTime nowUTC);
 
         P2PNodeDetails P2PNodeDetails { get; }
         SyncPeerNodeDetails EthNodeDetails { get; }

--- a/src/Nethermind/Nethermind.Network.Stats/INodeStats.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/INodeStats.cs
@@ -22,7 +22,7 @@ namespace Nethermind.Stats
         void AddTransferSpeedCaptureEvent(TransferSpeedType speedType, long bytesPerMillisecond);
         long? GetAverageTransferSpeed(TransferSpeedType speedType);
         (bool Result, NodeStatsEventType? DelayReason) IsConnectionDelayed(DateTime nowUTC);
-        
+
         long CurrentNodeReputation() => CurrentNodeReputation(DateTime.UtcNow);
         long CurrentNodeReputation(DateTime nowUTC);
         long CurrentPersistedNodeReputation { get; set; }

--- a/src/Nethermind/Nethermind.Network.Stats/Model/Node.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/Model/Node.cs
@@ -16,7 +16,6 @@ namespace Nethermind.Stats.Model
         private string _clientId;
         private string _paddedHost;
         private string _paddedPort;
-        private int _hashCode;
 
         /// <summary>
         /// Node public key - same as in enode.
@@ -85,7 +84,6 @@ namespace Nethermind.Stats.Model
         {
             Id = id;
             IdHash = Keccak.Compute(Id.PrefixedBytes);
-            _hashCode = id.GetHashCode();
             IsStatic = isStatic;
             SetIPEndPoint(address);
         }
@@ -121,7 +119,7 @@ namespace Nethermind.Stats.Model
             return false;
         }
 
-        public override int GetHashCode() => _hashCode;
+        public override int GetHashCode() => Id.GetHashCode();
 
         public override string ToString() => ToString(Format.WithPublicKey);
 

--- a/src/Nethermind/Nethermind.Network.Stats/NodeStatsManager.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/NodeStatsManager.cs
@@ -42,8 +42,9 @@ namespace Nethermind.Stats
 
             if (deleteCount > 0)
             {
+                DateTime utcNow = DateTime.UtcNow;
                 IEnumerable<Node> toDelete = _nodeStats
-                    .OrderBy(n => n.Value.CurrentNodeReputation)
+                    .OrderBy(n => n.Value.CurrentNodeReputation(utcNow))
                     .Select(n => n.Key)
                     .Take(_nodeStats.Count - _maxCount);
 
@@ -102,7 +103,7 @@ namespace Nethermind.Stats
         public (bool Result, NodeStatsEventType? DelayReason) IsConnectionDelayed(Node node)
         {
             INodeStats stats = GetOrAdd(node);
-            return stats.IsConnectionDelayed();
+            return stats.IsConnectionDelayed(DateTime.UtcNow);
         }
 
         public CompatibilityValidationType? FindCompatibilityValidationResult(Node node)
@@ -114,7 +115,7 @@ namespace Nethermind.Stats
         public long GetCurrentReputation(Node node)
         {
             INodeStats stats = GetOrAdd(node);
-            return stats.CurrentNodeReputation;
+            return stats.CurrentNodeReputation(DateTime.UtcNow);
         }
 
         public void ReportP2PInitializationEvent(Node node, P2PNodeDetails p2PNodeDetails)
@@ -149,7 +150,7 @@ namespace Nethermind.Stats
         public long GetNewPersistedReputation(Node node)
         {
             INodeStats stats = GetOrAdd(node);
-            return stats.NewPersistedNodeReputation;
+            return stats.NewPersistedNodeReputation(DateTime.UtcNow);
         }
 
         public long GetCurrentPersistedReputation(Node node)

--- a/src/Nethermind/Nethermind.Network.Test/NetworkStorageTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/NetworkStorageTests.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Linq;
 using Nethermind.Config;
 using Nethermind.Core.Test.Builders;
@@ -68,7 +69,8 @@ namespace Nethermind.Network.Test
             };
 
             var managers = nodes.Select(CreateLifecycleManager).ToArray();
-            var networkNodes = managers.Select(x => new NetworkNode(x.ManagedNode.Id, x.ManagedNode.Host, x.ManagedNode.Port, x.NodeStats.NewPersistedNodeReputation)).ToArray();
+            DateTime utcNow = DateTime.UtcNow;
+            var networkNodes = managers.Select(x => new NetworkNode(x.ManagedNode.Id, x.ManagedNode.Host, x.ManagedNode.Port, x.NodeStats.NewPersistedNodeReputation(utcNow))).ToArray();
 
 
             _storage.StartBatch();
@@ -82,7 +84,7 @@ namespace Nethermind.Network.Test
                 Assert.IsNotNull(persistedNode);
                 Assert.That(persistedNode.Port, Is.EqualTo(manager.ManagedNode.Port));
                 Assert.That(persistedNode.Host, Is.EqualTo(manager.ManagedNode.Host));
-                Assert.That(persistedNode.Reputation, Is.EqualTo(manager.NodeStats.CurrentNodeReputation));
+                Assert.That(persistedNode.Reputation, Is.EqualTo(manager.NodeStats.CurrentNodeReputation()));
             }
 
             _storage.StartBatch();
@@ -96,13 +98,14 @@ namespace Nethermind.Network.Test
                 Assert.IsNull(persistedNode);
             }
 
+            utcNow = DateTime.UtcNow;
             foreach (INodeLifecycleManager manager in managers.Skip(1))
             {
                 NetworkNode persistedNode = persistedNodes.FirstOrDefault(x => x.NodeId.Equals(manager.ManagedNode.Id));
                 Assert.IsNotNull(persistedNode);
                 Assert.That(persistedNode.Port, Is.EqualTo(manager.ManagedNode.Port));
                 Assert.That(persistedNode.Host, Is.EqualTo(manager.ManagedNode.Host));
-                Assert.That(persistedNode.Reputation, Is.EqualTo(manager.NodeStats.CurrentNodeReputation));
+                Assert.That(persistedNode.Reputation, Is.EqualTo(manager.NodeStats.CurrentNodeReputation(utcNow)));
             }
         }
 

--- a/src/Nethermind/Nethermind.Network.Test/NodeStatsTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/NodeStatsTests.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Nethermind.Core.Test.Builders;
@@ -61,15 +62,15 @@ namespace Nethermind.Network.Test
         {
             _nodeStats = new NodeStatsLight(_node);
 
-            var isConnDelayed = _nodeStats.IsConnectionDelayed();
+            var isConnDelayed = _nodeStats.IsConnectionDelayed(DateTime.UtcNow);
             Assert.IsFalse(isConnDelayed.Result, "before disconnect");
 
             _nodeStats.AddNodeStatsDisconnectEvent(DisconnectType.Remote, DisconnectReason.Other);
-            isConnDelayed = _nodeStats.IsConnectionDelayed();
+            isConnDelayed = _nodeStats.IsConnectionDelayed(DateTime.UtcNow);
             Assert.IsTrue(isConnDelayed.Result, "just after disconnect");
             Assert.That(isConnDelayed.DelayReason, Is.EqualTo(NodeStatsEventType.Disconnect));
             await Task.Delay(125);
-            isConnDelayed = _nodeStats.IsConnectionDelayed();
+            isConnDelayed = _nodeStats.IsConnectionDelayed(DateTime.UtcNow);
             Assert.IsFalse(isConnDelayed.Result, "125ms after disconnect");
         }
 
@@ -81,11 +82,11 @@ namespace Nethermind.Network.Test
         {
             _nodeStats = new NodeStatsLight(_node);
 
-            (bool isConnDelayed, NodeStatsEventType? _) = _nodeStats.IsConnectionDelayed();
+            (bool isConnDelayed, NodeStatsEventType? _) = _nodeStats.IsConnectionDelayed(DateTime.UtcNow);
             Assert.IsFalse(isConnDelayed, "before disconnect");
 
             _nodeStats.AddNodeStatsEvent(eventType);
-            (isConnDelayed, _) = _nodeStats.IsConnectionDelayed();
+            (isConnDelayed, _) = _nodeStats.IsConnectionDelayed(DateTime.UtcNow);
             isConnDelayed.Should().Be(connectionDelayed);
         }
 
@@ -95,12 +96,12 @@ namespace Nethermind.Network.Test
         {
             _nodeStats = new NodeStatsLight(_node);
 
-            (bool isConnDelayed, NodeStatsEventType? _) = _nodeStats.IsConnectionDelayed();
+            (bool isConnDelayed, NodeStatsEventType? _) = _nodeStats.IsConnectionDelayed(DateTime.UtcNow);
             Assert.IsFalse(isConnDelayed, "before disconnect");
 
             _nodeStats.AddNodeStatsDisconnectEvent(disconnectType, reason);
             await Task.Delay(125); // Standard disconnect delay without specific handling
-            (isConnDelayed, _) = _nodeStats.IsConnectionDelayed();
+            (isConnDelayed, _) = _nodeStats.IsConnectionDelayed(DateTime.UtcNow);
             isConnDelayed.Should().Be(connectionDelayed);
         }
     }

--- a/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
@@ -299,7 +299,7 @@ namespace Nethermind.Network.Test
                 for (int i = 0; i < 10; i++)
                 {
                     currentCount += 25;
-                    await Task.Delay(_travisDelayLong);
+                    await Task.Delay(_travisDelayLonger);
                     Assert.That(ctx.RlpxPeer.ConnectAsyncCallsCount, Is.EqualTo(currentCount));
                     ctx.DisconnectAllSessions();
                 }
@@ -345,6 +345,7 @@ namespace Nethermind.Network.Test
         private int _travisDelay = 500;
 
         private int _travisDelayLong = 1000;
+        private int _travisDelayLonger = 3000;
 
         [Test]
         [Ignore("Behaviour changed that allows peers to go over max if awaiting response")]

--- a/src/Nethermind/Nethermind.Network/NetworkStorage.cs
+++ b/src/Nethermind/Nethermind.Network/NetworkStorage.cs
@@ -23,7 +23,7 @@ namespace Nethermind.Network
         private readonly Dictionary<PublicKey, NetworkNode> _nodesDict = new();
         private long _updateCounter;
         private long _removeCounter;
-        private NetworkNode[] _nodes;
+        private NetworkNode[]? _nodes;
 
         public NetworkStorage(IFullDb? fullDb, ILogManager? logManager)
         {
@@ -36,34 +36,26 @@ namespace Nethermind.Network
         public NetworkNode[] GetPersistedNodes()
         {
             NetworkNode[] nodes = _nodes;
-            return nodes is not null ? nodes : GenerateNodes();
+            return nodes ?? GenerateNodes();
         }
 
         private NetworkNode[] GenerateNodes()
         {
-            NetworkNode[] nodes;
             lock (_lock)
             {
-                nodes = _nodes;
+                NetworkNode[]? nodes = _nodes;
                 if (nodes is not null)
                 {
                     // Already updated
                     return nodes;
                 }
 
-                if (_nodesDict.Count > 0)
-                {
-                    return CopyDictToArray();
-                }
-
-                LoadFromDb();
-
                 if (_nodesDict.Count == 0)
                 {
-                    return Array.Empty<NetworkNode>();
+                    LoadFromDb();
                 }
 
-                return CopyDictToArray();
+                return _nodesDict.Count == 0 ? Array.Empty<NetworkNode>() : CopyDictToArray();
             }
         }
 

--- a/src/Nethermind/Nethermind.Network/Peer.cs
+++ b/src/Nethermind/Nethermind.Network/Peer.cs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
+
 using Nethermind.Network.P2P;
 using Nethermind.Stats;
 using Nethermind.Stats.Model;
@@ -16,7 +18,7 @@ namespace Nethermind.Network
     /// The logic for choosing which session to drop has to be consistent between the two peers - we use the PublicKey
     /// comparison to choose the connection direction in the same way on both sides.
     /// </summary>
-    public sealed class Peer
+    public sealed class Peer : IEquatable<Peer>
     {
         public Peer(Node node) : this(node, null)
         { }
@@ -51,5 +53,12 @@ namespace Nethermind.Network
         {
             return $"[Peer|{Node:s}|{InSession}|{OutSession}]";
         }
+
+        public bool Equals(Peer? other)
+        {
+            return Node.Equals(other?.Node);
+        }
+
+        public override int GetHashCode() => Node.GetHashCode();
     }
 }

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -333,9 +333,9 @@ namespace Nethermind.Network
 
                     if (_peerPool.ActivePeerCount < MaxActivePeers)
                     {
-                        // We been though all the peers once, so slight additional delay before
-                        // trying them again to avoid busy loop
-                        await Task.Delay(10_000);
+                        // We been though all the peers once, so wait TIME-WAIT additional delay before
+                        // trying them again to avoid busy loop or exhausting sockets.
+                        await Task.Delay(60_000);
                         _peerUpdateRequested.Set();
                     }
 

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -298,7 +298,7 @@ namespace Nethermind.Network
                         Interlocked.Increment(ref _connectionRounds);
 
                         long nowMs = Environment.TickCount64;
-                        if (peersTried > 10_000)
+                        if (peersTried > 1_000)
                         {
                             peersTried = 0;
                             // Wait for sockets to clear
@@ -427,7 +427,7 @@ namespace Nethermind.Network
                 hasOnlyStaticNodes = _currentSelection.PreCandidates.Count > 0;
             }
 
-            if (!_currentSelection.PreCandidates.Any() && !hasOnlyStaticNodes)
+            if (_currentSelection.PreCandidates.Count == 0 && !hasOnlyStaticNodes)
             {
                 return;
             }

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -333,6 +333,9 @@ namespace Nethermind.Network
 
                     if (_peerPool.ActivePeerCount < MaxActivePeers)
                     {
+                        // We been though all the peers once, so slight additional delay before
+                        // trying them again to avoid busy loop
+                        await Task.Delay(1000);
                         _peerUpdateRequested.Set();
                     }
 

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -335,7 +335,7 @@ namespace Nethermind.Network
                     {
                         // We been though all the peers once, so slight additional delay before
                         // trying them again to avoid busy loop
-                        await Task.Delay(1000);
+                        await Task.Delay(10_000);
                         _peerUpdateRequested.Set();
                     }
 

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -333,9 +333,10 @@ namespace Nethermind.Network
 
                     if (_peerPool.ActivePeerCount < MaxActivePeers)
                     {
+                        const int TIME_WAIT = 60_000;
                         // We been though all the peers once, so wait TIME-WAIT additional delay before
                         // trying them again to avoid busy loop or exhausting sockets.
-                        await Task.Delay(60_000);
+                        await Task.Delay(TIME_WAIT);
                         _peerUpdateRequested.Set();
                     }
 

--- a/src/Nethermind/Nethermind.Network/ProtocolsManager.cs
+++ b/src/Nethermind/Nethermind.Network/ProtocolsManager.cs
@@ -348,7 +348,7 @@ namespace Nethermind.Network
                     if (_logger.IsTrace) _logger.Trace($"Finalized {handler.ProtocolCode.ToUpper()} protocol initialization on {session} - adding sync peer {session.Node:s}");
 
                     //Add/Update peer to the storage and to sync manager
-                    _peerStorage.UpdateNode(new NetworkNode(session.Node.Id, session.Node.Host, session.Node.Port, _stats.GetOrAdd(session.Node).NewPersistedNodeReputation));
+                    _peerStorage.UpdateNode(new NetworkNode(session.Node.Id, session.Node.Host, session.Node.Port, _stats.GetOrAdd(session.Node).NewPersistedNodeReputation(DateTime.UtcNow)));
                 }
                 else
                 {


### PR DESCRIPTION
## Changes

- Reduce calls to `DateTime.UtcNow` by factor of 100 (e.g. 3M -> 30k)
- After going through 1k peers for discovery wait TIME_WAIT before continuing to allow sockets to clear
- After going through all previously known peers for discovery wait TIME_WAIT before starting again to allow sockets to clear
- NetworkStorage: `HashSet<PublicKey>`+`List<NetworkNode>` -> `Dictionary<PublicKey, NetworkNode>`

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No
