### PR TITLE
More efficient EvmPooledMemory

### DIFF
--- a/src/Nethermind/Nethermind.Evm/EvmPooledMemory.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmPooledMemory.cs
@@ -46,8 +46,8 @@ namespace Nethermind.Evm
 
         public void SaveByte(in UInt256 location, byte value)
         {
-            CheckMemoryAccessViolation(in location, in WordSize256, out ulong newLength);
-            UpdateSize(newLength);
+            CheckMemoryAccessViolation(in location, in WordSize256);
+            UpdateSize(in location, in UInt256.One);
 
             _memory![(long)location] = value;
         }

--- a/src/Nethermind/Nethermind.Evm/EvmStack.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmStack.cs
@@ -301,7 +301,7 @@ namespace Nethermind.Evm
             return ref _bytes[Head * 32];
         }
 
-        public Span<byte> PopBytes()
+        public Span<byte> PopWord256()
         {
             if (Head-- == 0)
             {

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -826,7 +826,7 @@ public class VirtualMachine : IVirtualMachine
                         Metrics.ModExpOpcode++;
 
                         stack.PopUInt256(out UInt256 baseInt);
-                        Span<byte> exp = stack.PopBytes();
+                        Span<byte> exp = stack.PopWord256();
 
                         int leadingZeros = exp.LeadingZerosCount();
                         if (leadingZeros != 32)
@@ -869,7 +869,7 @@ public class VirtualMachine : IVirtualMachine
 
                         int position = 31 - (int)a;
 
-                        Span<byte> b = stack.PopBytes();
+                        Span<byte> b = stack.PopWord256();
                         sbyte sign = (sbyte)b[position];
 
                         if (sign >= 0)
@@ -957,8 +957,8 @@ public class VirtualMachine : IVirtualMachine
                     {
                         if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
 
-                        Span<byte> a = stack.PopBytes();
-                        Span<byte> b = stack.PopBytes();
+                        Span<byte> a = stack.PopWord256();
+                        Span<byte> b = stack.PopWord256();
                         if (a.SequenceEqual(b))
                         {
                             stack.PushOne();
@@ -974,7 +974,7 @@ public class VirtualMachine : IVirtualMachine
                     {
                         if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
 
-                        Span<byte> a = stack.PopBytes();
+                        Span<byte> a = stack.PopWord256();
                         if (a.SequenceEqual(BytesZero32))
                         {
                             stack.PushOne();
@@ -990,8 +990,8 @@ public class VirtualMachine : IVirtualMachine
                     {
                         if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
 
-                        Span<byte> a = stack.PopBytes();
-                        Span<byte> b = stack.PopBytes();
+                        Span<byte> a = stack.PopWord256();
+                        Span<byte> b = stack.PopWord256();
 
                         if (_simdOperationsEnabled)
                         {
@@ -1019,8 +1019,8 @@ public class VirtualMachine : IVirtualMachine
                     {
                         if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
 
-                        Span<byte> a = stack.PopBytes();
-                        Span<byte> b = stack.PopBytes();
+                        Span<byte> a = stack.PopWord256();
+                        Span<byte> b = stack.PopWord256();
 
                         if (_simdOperationsEnabled)
                         {
@@ -1048,8 +1048,8 @@ public class VirtualMachine : IVirtualMachine
                     {
                         if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
 
-                        Span<byte> a = stack.PopBytes();
-                        Span<byte> b = stack.PopBytes();
+                        Span<byte> a = stack.PopWord256();
+                        Span<byte> b = stack.PopWord256();
 
                         if (_simdOperationsEnabled)
                         {
@@ -1077,7 +1077,7 @@ public class VirtualMachine : IVirtualMachine
                     {
                         if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
 
-                        Span<byte> a = stack.PopBytes();
+                        Span<byte> a = stack.PopWord256();
 
                         if (_simdOperationsEnabled)
                         {
@@ -1105,7 +1105,7 @@ public class VirtualMachine : IVirtualMachine
                         if (!UpdateGas(GasCostOf.VeryLow, ref gasAvailable)) goto OutOfGas;
 
                         stack.PopUInt256(out UInt256 position);
-                        Span<byte> bytes = stack.PopBytes();
+                        Span<byte> bytes = stack.PopWord256();
 
                         if (position >= BigInt32)
                         {
@@ -1528,10 +1528,10 @@ public class VirtualMachine : IVirtualMachine
 
                         stack.PopUInt256(out UInt256 memPosition);
 
-                        Span<byte> data = stack.PopBytes();
+                        Span<byte> word = stack.PopWord256();
                         if (!UpdateMemoryCost(vmState, ref gasAvailable, in memPosition, 32)) goto OutOfGas;
-                        vmState.Memory.SaveWord(in memPosition, data);
-                        if (_txTracer.IsTracingInstructions) _txTracer.ReportMemoryChange((long)memPosition, data.SliceWithZeroPadding(0, 32, PadDirection.Left));
+                        vmState.Memory.SaveWord(in memPosition, word);
+                        if (_txTracer.IsTracingInstructions) _txTracer.ReportMemoryChange((long)memPosition, word.SliceWithZeroPadding(0, 32, PadDirection.Left));
 
                         break;
                     }
@@ -1589,7 +1589,7 @@ public class VirtualMachine : IVirtualMachine
                         }
 
                         stack.PopUInt256(out UInt256 storageIndex);
-                        Span<byte> newValue = stack.PopBytes();
+                        Span<byte> newValue = stack.PopWord256();
                         bool newIsZero = newValue.IsZero();
                         if (!newIsZero)
                         {
@@ -1753,7 +1753,7 @@ public class VirtualMachine : IVirtualMachine
                         if (!UpdateGas(gasCost, ref gasAvailable)) goto OutOfGas;
 
                         stack.PopUInt256(out UInt256 storageIndex);
-                        Span<byte> newValue = stack.PopBytes();
+                        Span<byte> newValue = stack.PopWord256();
                         bool newIsZero = newValue.IsZero();
                         if (!newIsZero)
                         {
@@ -1788,7 +1788,7 @@ public class VirtualMachine : IVirtualMachine
                         if (!UpdateGas(GasCostOf.High, ref gasAvailable)) goto OutOfGas;
 
                         stack.PopUInt256(out UInt256 jumpDest);
-                        Span<byte> condition = stack.PopBytes();
+                        Span<byte> condition = stack.PopWord256();
                         if (!condition.SequenceEqual(BytesZero32))
                         {
                             if (!Jump(jumpDest, ref programCounter, in env)) goto InvalidJumpDestination;
@@ -1963,7 +1963,7 @@ public class VirtualMachine : IVirtualMachine
                         Keccak[] topics = new Keccak[topicsCount];
                         for (int i = 0; i < topicsCount; i++)
                         {
-                            topics[i] = new Keccak(stack.PopBytes());
+                            topics[i] = new Keccak(stack.PopWord256());
                         }
 
                         LogEntry logEntry = new(
@@ -1992,7 +1992,7 @@ public class VirtualMachine : IVirtualMachine
                         Span<byte> salt = null;
                         if (instruction == Instruction.CREATE2)
                         {
-                            salt = stack.PopBytes();
+                            salt = stack.PopWord256();
                         }
 
                         //EIP-3860


### PR DESCRIPTION
## Changes

- Reduce conversions `int` -> `UInt256`
- Single reg256 copy for `SaveWord` rather than invoking `Span.CopyTo`

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No
