### PR TITLE
Perf/release peer early

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
@@ -106,5 +106,8 @@ namespace Nethermind.Blockchain.Synchronization
 
         [ConfigItem(Description = "[EXPERIMENTAL] Optimize db for write during sync. Significantly reduce total writes written and some sync time if you are not network limited.", DefaultValue = "Default")]
         public ITunableDb.TuneType TuneDbMode { get; set; }
+
+        [ConfigItem(Description = "[TECHNICAL] Specify max num of thread used for processing. Default is same as logical core count.", DefaultValue = "0")]
+        public int MaxProcessingThread { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
@@ -108,6 +108,6 @@ namespace Nethermind.Blockchain.Synchronization
         public ITunableDb.TuneType TuneDbMode { get; set; }
 
         [ConfigItem(Description = "[TECHNICAL] Specify max num of thread used for processing. Default is same as logical core count.", DefaultValue = "0")]
-        public int MaxProcessingThread { get; set; }
+        public int MaxProcessingThreads { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
@@ -61,7 +61,7 @@ namespace Nethermind.Blockchain.Synchronization
         public bool BlockGossipEnabled { get; set; } = true;
         public bool NonValidatorNode { get; set; } = false;
         public ITunableDb.TuneType TuneDbMode { get; set; } = ITunableDb.TuneType.Default;
-        public int MaxProcessingThread { get; set; }
+        public int MaxProcessingThreads { get; set; }
 
         public override string ToString()
         {

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
@@ -61,6 +61,7 @@ namespace Nethermind.Blockchain.Synchronization
         public bool BlockGossipEnabled { get; set; } = true;
         public bool NonValidatorNode { get; set; } = false;
         public ITunableDb.TuneType TuneDbMode { get; set; } = ITunableDb.TuneType.Default;
+        public int MaxProcessingThread { get; set; }
 
         public override string ToString()
         {

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -140,7 +140,9 @@ public class InitializeNetwork : IStep
         {
             SyncReport syncReport = new(_api.SyncPeerPool!, _api.NodeStatsManager!, _api.SyncModeSelector, _syncConfig, _api.Pivot, _api.LogManager);
 
-            _api.BlockDownloaderFactory ??= new BlockDownloaderFactory(_api.SpecProvider!,
+            _api.BlockDownloaderFactory ??= new BlockDownloaderFactory(
+                _syncConfig.MaxProcessingThread,
+                _api.SpecProvider!,
                 _api.BlockTree!,
                 _api.ReceiptStorage!,
                 _api.BlockValidator!,

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -141,7 +141,7 @@ public class InitializeNetwork : IStep
             SyncReport syncReport = new(_api.SyncPeerPool!, _api.NodeStatsManager!, _api.SyncModeSelector, _syncConfig, _api.Pivot, _api.LogManager);
 
             _api.BlockDownloaderFactory ??= new BlockDownloaderFactory(
-                _syncConfig.MaxProcessingThread,
+                _syncConfig.MaxProcessingThreads,
                 _api.SpecProvider!,
                 _api.BlockTree!,
                 _api.ReceiptStorage!,

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
@@ -424,6 +424,7 @@ public partial class MergePlugin : IConsensusWrapperPlugin, ISynchronizationPlug
             SyncReport syncReport = new(_api.SyncPeerPool, _api.NodeStatsManager, _api.SyncModeSelector, _syncConfig, _beaconPivot, _api.LogManager);
 
             _api.BlockDownloaderFactory = new MergeBlockDownloaderFactory(
+                _syncConfig.MaxProcessingThread,
                 _poSSwitcher,
                 _beaconPivot,
                 _api.SpecProvider,

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
@@ -424,7 +424,7 @@ public partial class MergePlugin : IConsensusWrapperPlugin, ISynchronizationPlug
             SyncReport syncReport = new(_api.SyncPeerPool, _api.NodeStatsManager, _api.SyncModeSelector, _syncConfig, _beaconPivot, _api.LogManager);
 
             _api.BlockDownloaderFactory = new MergeBlockDownloaderFactory(
-                _syncConfig.MaxProcessingThread,
+                _syncConfig.MaxProcessingThreads,
                 _poSSwitcher,
                 _beaconPivot,
                 _api.SpecProvider,

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconHeadersSyncDispatcher.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconHeadersSyncDispatcher.cs
@@ -11,11 +11,12 @@ namespace Nethermind.Merge.Plugin.Synchronization;
 public class BeaconHeadersSyncDispatcher : HeadersSyncDispatcher
 {
     public BeaconHeadersSyncDispatcher(
+        int maxNumberOfProcessingThread,
         ISyncFeed<HeadersSyncBatch> syncFeed,
         ISyncPeerPool syncPeerPool,
         IPeerAllocationStrategyFactory<FastBlocksBatch> peerAllocationStrategy,
         ILogManager logManager)
-        : base(syncFeed, syncPeerPool, peerAllocationStrategy, logManager)
+        : base(maxNumberOfProcessingThread, syncFeed, syncPeerPool, peerAllocationStrategy, logManager)
     {
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeBlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeBlockDownloader.cs
@@ -40,7 +40,9 @@ namespace Nethermind.Merge.Plugin.Synchronization
         private readonly IPoSSwitcher _poSSwitcher;
         private readonly ISyncProgressResolver _syncProgressResolver;
 
-        public MergeBlockDownloader(IPoSSwitcher posSwitcher,
+        public MergeBlockDownloader(
+            int maxNumberOfProcessingThread,
+            IPoSSwitcher posSwitcher,
             IBeaconPivot beaconPivot,
             ISyncFeed<BlocksRequest?>? feed,
             ISyncPeerPool? syncPeerPool,
@@ -55,7 +57,7 @@ namespace Nethermind.Merge.Plugin.Synchronization
             ISyncProgressResolver syncProgressResolver,
             ILogManager logManager,
             SyncBatchSize? syncBatchSize = null)
-            : base(feed, syncPeerPool, blockTree, blockValidator, sealValidator, syncReport, receiptStorage,
+            : base(maxNumberOfProcessingThread, feed, syncPeerPool, blockTree, blockValidator, sealValidator, syncReport, receiptStorage,
                 specProvider, new MergeBlocksSyncPeerAllocationStrategyFactory(posSwitcher, beaconPivot, logManager),
                 betterPeerStrategy, logManager, syncBatchSize)
         {

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeBlockDownloaderFactory.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeBlockDownloaderFactory.cs
@@ -35,8 +35,11 @@ namespace Nethermind.Merge.Plugin.Synchronization
         private readonly ISyncReport _syncReport;
         private readonly ISyncProgressResolver _syncProgressResolver;
         private readonly IChainLevelHelper _chainLevelHelper;
+        private readonly int _maxNumberOfProcessingThread;
 
-        public MergeBlockDownloaderFactory(IPoSSwitcher poSSwitcher,
+        public MergeBlockDownloaderFactory(
+            int maxNumberOfProcessingThread,
+            IPoSSwitcher poSSwitcher,
             IBeaconPivot beaconPivot,
             ISpecProvider specProvider,
             IBlockTree blockTree,
@@ -51,6 +54,7 @@ namespace Nethermind.Merge.Plugin.Synchronization
             ISyncProgressResolver syncProgressResolver,
             ILogManager logManager)
         {
+            _maxNumberOfProcessingThread = maxNumberOfProcessingThread;
             _poSSwitcher = poSSwitcher ?? throw new ArgumentNullException(nameof(poSSwitcher));
             _beaconPivot = beaconPivot ?? throw new ArgumentNullException(nameof(beaconPivot));
             _specProvider = specProvider ?? throw new ArgumentNullException(nameof(specProvider));
@@ -68,7 +72,8 @@ namespace Nethermind.Merge.Plugin.Synchronization
 
         public BlockDownloader Create(ISyncFeed<BlocksRequest?> syncFeed)
         {
-            return new MergeBlockDownloader(_poSSwitcher, _beaconPivot, syncFeed, _syncPeerPool, _blockTree, _blockValidator,
+            return new MergeBlockDownloader(
+                _maxNumberOfProcessingThread, _poSSwitcher, _beaconPivot, syncFeed, _syncPeerPool, _blockTree, _blockValidator,
                 _sealValidator, _syncReport, _receiptStorage, _specProvider, _betterPeerStrategy, _chainLevelHelper,
                 _syncProgressResolver, _logManager);
         }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeSynchronizer.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeSynchronizer.cs
@@ -83,7 +83,7 @@ public class MergeSynchronizer : Synchronizer
         BeaconHeadersSyncFeed beaconHeadersFeed =
             new(_poSSwitcher, _syncMode, _blockTree, _syncPeerPool, _syncConfig, _syncReport, _pivot, _mergeConfig, _invalidChainTracker, _logManager);
         BeaconHeadersSyncDispatcher beaconHeadersDispatcher =
-            new(_syncConfig.MaxProcessingThread, beaconHeadersFeed!, _syncPeerPool, fastFactory, _logManager);
+            new(_syncConfig.MaxProcessingThreads, beaconHeadersFeed!, _syncPeerPool, fastFactory, _logManager);
         beaconHeadersDispatcher.Start(_syncCancellation!.Token).ContinueWith(t =>
         {
             if (t.IsFaulted)

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeSynchronizer.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeSynchronizer.cs
@@ -83,7 +83,7 @@ public class MergeSynchronizer : Synchronizer
         BeaconHeadersSyncFeed beaconHeadersFeed =
             new(_poSSwitcher, _syncMode, _blockTree, _syncPeerPool, _syncConfig, _syncReport, _pivot, _mergeConfig, _invalidChainTracker, _logManager);
         BeaconHeadersSyncDispatcher beaconHeadersDispatcher =
-            new(beaconHeadersFeed!, _syncPeerPool, fastFactory, _logManager);
+            new(_syncConfig.MaxProcessingThread, beaconHeadersFeed!, _syncPeerPool, fastFactory, _logManager);
         beaconHeadersDispatcher.Start(_syncCancellation!.Token).ContinueWith(t =>
         {
             if (t.IsFaulted)

--- a/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.Merge.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.Merge.cs
@@ -468,6 +468,7 @@ public partial class BlockDownloaderTests
             get
             {
                 return _mergeBlockDownloader ??= new(
+                    0,
                     PosSwitcher,
                     BeaconPivot,
                     Feed,

--- a/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
@@ -994,6 +994,7 @@ namespace Nethermind.Synchronization.Test
 
             private BlockDownloader _blockDownloader;
             public virtual BlockDownloader BlockDownloader => _blockDownloader ??= new BlockDownloader(
+                0,
                 Feed,
                 PeerPool,
                 BlockTree,

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/SnapProtocolTests/StateSyncDispatcherTester.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/SnapProtocolTests/StateSyncDispatcherTester.cs
@@ -17,10 +17,11 @@ namespace Nethermind.Synchronization.Test.FastSync.SnapProtocolTests
 {
     public class StateSyncDispatcherTester : StateSyncDispatcher
     {
-        public StateSyncDispatcherTester(ISyncFeed<StateSyncBatch> syncFeed,
-    ISyncPeerPool syncPeerPool,
-    IPeerAllocationStrategyFactory<StateSyncBatch> peerAllocationStrategy,
-    ILogManager logManager) : base(syncFeed, syncPeerPool, peerAllocationStrategy, logManager)
+        public StateSyncDispatcherTester(
+            ISyncFeed<StateSyncBatch> syncFeed,
+            ISyncPeerPool syncPeerPool,
+            IPeerAllocationStrategyFactory<StateSyncBatch> peerAllocationStrategy,
+            ILogManager logManager) : base(0, syncFeed, syncPeerPool, peerAllocationStrategy, logManager)
         {
         }
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTestsBase.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTestsBase.cs
@@ -114,7 +114,7 @@ namespace Nethermind.Synchronization.Test.FastSync
             ctx.TreeFeed = new(SyncMode.StateNodes, dbContext.LocalCodeDb, dbContext.LocalStateDb, blockTree, _logManager);
             ctx.Feed = new StateSyncFeed(ctx.SyncModeSelector, ctx.TreeFeed, _logManager);
             ctx.StateSyncDispatcher =
-                new StateSyncDispatcher(ctx.Feed, ctx.Pool, new StateSyncAllocationStrategyFactory(), _logManager);
+                new StateSyncDispatcher(0, ctx.Feed, ctx.Pool, new StateSyncAllocationStrategyFactory(), _logManager);
             ctx.StateSyncDispatcher.Start(CancellationToken.None);
             return ctx;
         }

--- a/src/Nethermind/Nethermind.Synchronization.Test/OldStyleFullSynchronizerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/OldStyleFullSynchronizerTests.cs
@@ -70,6 +70,7 @@ namespace Nethermind.Synchronization.Test
             Pivot pivot = new(syncConfig);
             SyncReport syncReport = new(_pool, stats, syncModeSelector, syncConfig, pivot, LimboLogs.Instance);
             BlockDownloaderFactory blockDownloaderFactory = new(
+                0,
                 MainnetSpecProvider.Instance,
                 _blockTree,
                 _receiptStorage,

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
@@ -123,7 +123,7 @@ namespace Nethermind.Synchronization.Test.ParallelSync
         private class TestDispatcher : SyncDispatcher<TestBatch>
         {
             public TestDispatcher(ISyncFeed<TestBatch> syncFeed, ISyncPeerPool syncPeerPool, IPeerAllocationStrategyFactory<TestBatch> peerAllocationStrategy)
-                : base(syncFeed, syncPeerPool, peerAllocationStrategy, LimboLogs.Instance)
+                : base(0, syncFeed, syncPeerPool, peerAllocationStrategy, LimboLogs.Instance)
             {
             }
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
@@ -282,7 +282,7 @@ namespace Nethermind.Synchronization.Test.ParallelSync
             syncFeed.Activate();
             await Task.Delay(100);
 
-            syncFeed.HighestRequested.Should().Be(expectedHighestRequest);
+            Assert.That(() => syncFeed.HighestRequested, Is.EqualTo(expectedHighestRequest).After(2000, 100));
             syncFeed.UnlockResponse();
         }
     }

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
@@ -29,12 +29,20 @@ namespace Nethermind.Synchronization.Test.ParallelSync
     {
         private class TestSyncPeerPool : ISyncPeerPool
         {
+            private readonly SemaphoreSlim _peerSemaphore;
+
+            public TestSyncPeerPool(int peerCount = 1)
+            {
+                _peerSemaphore = new SemaphoreSlim(peerCount, peerCount);
+            }
+
             public void Dispose()
             {
             }
 
-            public Task<SyncPeerAllocation> Allocate(IPeerAllocationStrategy peerAllocationStrategy, AllocationContexts contexts, int timeoutMilliseconds = 0)
+            public async Task<SyncPeerAllocation> Allocate(IPeerAllocationStrategy peerAllocationStrategy, AllocationContexts contexts, int timeoutMilliseconds = 0)
             {
+                await _peerSemaphore.WaitAsync();
                 ISyncPeer syncPeer = Substitute.For<ISyncPeer>();
                 syncPeer.ClientId.Returns("Nethermind");
                 syncPeer.TotalDifficulty.Returns(UInt256.One);
@@ -43,11 +51,12 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                     Substitute.For<IEnumerable<PeerInfo>>(),
                     Substitute.For<INodeStatsManager>(),
                     Substitute.For<IBlockTree>());
-                return Task.FromResult(allocation);
+                return allocation;
             }
 
             public void Free(SyncPeerAllocation syncPeerAllocation)
             {
+                _peerSemaphore.Release();
             }
 
             public void ReportNoSyncProgress(PeerInfo peerInfo, AllocationContexts contexts)
@@ -122,8 +131,8 @@ namespace Nethermind.Synchronization.Test.ParallelSync
 
         private class TestDispatcher : SyncDispatcher<TestBatch>
         {
-            public TestDispatcher(ISyncFeed<TestBatch> syncFeed, ISyncPeerPool syncPeerPool, IPeerAllocationStrategyFactory<TestBatch> peerAllocationStrategy)
-                : base(0, syncFeed, syncPeerPool, peerAllocationStrategy, LimboLogs.Instance)
+            public TestDispatcher(int maxNumberOfProcessingThread, ISyncFeed<TestBatch> syncFeed, ISyncPeerPool syncPeerPool, IPeerAllocationStrategyFactory<TestBatch> peerAllocationStrategy)
+                : base(maxNumberOfProcessingThread, syncFeed, syncPeerPool, peerAllocationStrategy, LimboLogs.Instance)
             {
             }
 
@@ -151,21 +160,35 @@ namespace Nethermind.Synchronization.Test.ParallelSync
 
         private class TestSyncFeed : SyncFeed<TestBatch>
         {
-            public TestSyncFeed(bool isMultiFeed = true)
+            public TestSyncFeed(bool isMultiFeed = true, int max = 64)
             {
                 IsMultiFeed = isMultiFeed;
+                Max = max;
             }
 
-            public const int Max = 64;
+            public int Max;
 
-            private int _highestRequested;
+            public int HighestRequested;
 
             public HashSet<int> _results = new();
 
             private ConcurrentQueue<TestBatch> _returned = new();
 
+            private ManualResetEvent _responseLock = new ManualResetEvent(true);
+
+            public void LockResponse()
+            {
+                _responseLock.Reset();
+            }
+
+            public void UnlockResponse()
+            {
+                _responseLock.Set();
+            }
+
             public override SyncResponseHandlingResult HandleResponse(TestBatch response, PeerInfo peer = null)
             {
+                _responseLock.WaitOne();
                 if (response.Result is null)
                 {
                     Console.WriteLine("Handling failed response");
@@ -206,7 +229,7 @@ namespace Nethermind.Synchronization.Test.ParallelSync
 
                     int start;
 
-                    if (_highestRequested >= Max)
+                    if (HighestRequested >= Max)
                     {
                         Console.WriteLine("Pending: " + _pendingRequests);
                         if (_pendingRequests == 0)
@@ -220,8 +243,8 @@ namespace Nethermind.Synchronization.Test.ParallelSync
 
                     lock (_results)
                     {
-                        start = _highestRequested;
-                        _highestRequested += 8;
+                        start = HighestRequested;
+                        HighestRequested += 8;
                     }
 
                     testBatch = new TestBatch(start, 8);
@@ -236,14 +259,31 @@ namespace Nethermind.Synchronization.Test.ParallelSync
         public async Task Simple_test_sync()
         {
             TestSyncFeed syncFeed = new();
-            TestDispatcher dispatcher = new(syncFeed, new TestSyncPeerPool(), new StaticPeerAllocationStrategyFactory<TestBatch>(FirstFree.Instance));
+            TestDispatcher dispatcher = new(0, syncFeed, new TestSyncPeerPool(), new StaticPeerAllocationStrategyFactory<TestBatch>(FirstFree.Instance));
             Task executorTask = dispatcher.Start(CancellationToken.None);
             syncFeed.Activate();
             await executorTask;
-            for (int i = 0; i < TestSyncFeed.Max; i++)
+            for (int i = 0; i < syncFeed.Max; i++)
             {
                 syncFeed._results.Contains(i).Should().BeTrue(i.ToString());
             }
+        }
+
+        [TestCase(false, 1, 1, 8)]
+        [TestCase(true, 1, 1, 24)]
+        [TestCase(true, 2, 1, 32)]
+        [TestCase(true, 1, 2, 32)]
+        public async Task Test_release_before_processing_complete(bool isMultiSync, int processingThread, int peerCount, int expectedHighestRequest)
+        {
+            TestSyncFeed syncFeed = new(isMultiSync, 999999);
+            syncFeed.LockResponse();
+            TestDispatcher dispatcher = new(processingThread, syncFeed, new TestSyncPeerPool(peerCount), new StaticPeerAllocationStrategyFactory<TestBatch>(FirstFree.Instance));
+            Task executorTask = dispatcher.Start(CancellationToken.None);
+            syncFeed.Activate();
+            await Task.Delay(100);
+
+            syncFeed.HighestRequested.Should().Be(expectedHighestRequest);
+            syncFeed.UnlockResponse();
         }
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncThreadTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncThreadTests.cs
@@ -351,7 +351,9 @@ namespace Nethermind.Synchronization.Test
             MultiSyncModeSelector selector = new(resolver, syncPeerPool, syncConfig, No.BeaconSync, bestPeerStrategy, logManager);
             Pivot pivot = new(syncConfig);
             SyncReport syncReport = new(syncPeerPool, nodeStatsManager, selector, syncConfig, pivot, LimboLogs.Instance);
-            BlockDownloaderFactory blockDownloaderFactory = new(MainnetSpecProvider.Instance,
+            BlockDownloaderFactory blockDownloaderFactory = new(
+                0,
+            MainnetSpecProvider.Instance,
                 tree,
                 NullReceiptStorage.Instance,
                 blockValidator,

--- a/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
@@ -348,6 +348,7 @@ namespace Nethermind.Synchronization.Test
                 {
                     SyncReport syncReport = new(SyncPeerPool, stats, syncModeSelector, syncConfig, beaconPivot, _logManager);
                     blockDownloaderFactory = new MergeBlockDownloaderFactory(
+                        0,
                         poSSwitcher,
                         beaconPivot,
                         MainnetSpecProvider.Instance,
@@ -385,6 +386,7 @@ namespace Nethermind.Synchronization.Test
                 {
                     SyncReport syncReport = new(SyncPeerPool, stats, syncModeSelector, syncConfig, pivot, _logManager);
                     blockDownloaderFactory = new BlockDownloaderFactory(
+                        0,
                         MainnetSpecProvider.Instance,
                         BlockTree,
                         NullReceiptStorage.Instance,

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
@@ -53,6 +53,7 @@ namespace Nethermind.Synchronization.Blocks
         private readonly int[] _ancestorJumps = { 1, 2, 3, 8, 16, 32, 64, 128, 256, 384, 512, 640, 768, 896, 1024 };
 
         public BlockDownloader(
+            int maxNumberOfProcessingThread,
             ISyncFeed<BlocksRequest?>? feed,
             ISyncPeerPool? syncPeerPool,
             IBlockTree? blockTree,
@@ -65,7 +66,7 @@ namespace Nethermind.Synchronization.Blocks
             IBetterPeerStrategy betterPeerStrategy,
             ILogManager? logManager,
             SyncBatchSize? syncBatchSize = null)
-            : base(feed, syncPeerPool, blockSyncPeerAllocationStrategyFactory, logManager)
+            : base(maxNumberOfProcessingThread, feed, syncPeerPool, blockSyncPeerAllocationStrategyFactory, logManager)
         {
             _blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
             _blockValidator = blockValidator ?? throw new ArgumentNullException(nameof(blockValidator));

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/IBlockDownloaderFactory.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/IBlockDownloaderFactory.cs
@@ -18,6 +18,7 @@ namespace Nethermind.Synchronization.Blocks
 {
     public class BlockDownloaderFactory : IBlockDownloaderFactory
     {
+        private readonly int _maxNumberOfProcessingThread;
         private readonly ISpecProvider _specProvider;
         private readonly IBlockTree _blockTree;
         private readonly IReceiptStorage _receiptStorage;
@@ -29,6 +30,7 @@ namespace Nethermind.Synchronization.Blocks
         private readonly ISyncReport _syncReport;
 
         public BlockDownloaderFactory(
+            int maxNumberOfProcessingThread,
             ISpecProvider specProvider,
             IBlockTree blockTree,
             IReceiptStorage receiptStorage,
@@ -39,6 +41,7 @@ namespace Nethermind.Synchronization.Blocks
             ISyncReport syncReport,
             ILogManager logManager)
         {
+            _maxNumberOfProcessingThread = maxNumberOfProcessingThread;
             _specProvider = specProvider ?? throw new ArgumentNullException(nameof(specProvider));
             _blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
             _receiptStorage = receiptStorage ?? throw new ArgumentNullException(nameof(receiptStorage));
@@ -53,8 +56,19 @@ namespace Nethermind.Synchronization.Blocks
 
         public BlockDownloader Create(ISyncFeed<BlocksRequest?> syncFeed)
         {
-            return new(syncFeed, _syncPeerPool, _blockTree, _blockValidator, _sealValidator, _syncReport,
-                _receiptStorage, _specProvider, new BlocksSyncPeerAllocationStrategyFactory(), _betterPeerStrategy, _logManager);
+            return new(
+                _maxNumberOfProcessingThread,
+                syncFeed,
+                _syncPeerPool,
+                _blockTree,
+                _blockValidator,
+                 _sealValidator,
+                _syncReport,
+                _receiptStorage,
+                _specProvider,
+                new BlocksSyncPeerAllocationStrategyFactory(),
+                _betterPeerStrategy,
+                _logManager);
         }
     }
 

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncDispatcher.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncDispatcher.cs
@@ -18,11 +18,12 @@ namespace Nethermind.Synchronization.FastBlocks
     public class BodiesSyncDispatcher : SyncDispatcher<BodiesSyncBatch>
     {
         public BodiesSyncDispatcher(
+            int maxNumberOfProcessingThread,
             ISyncFeed<BodiesSyncBatch> syncFeed,
             ISyncPeerPool syncPeerPool,
             IPeerAllocationStrategyFactory<BodiesSyncBatch> peerAllocationStrategy,
             ILogManager logManager)
-            : base(syncFeed, syncPeerPool, peerAllocationStrategy, logManager)
+            : base(maxNumberOfProcessingThread, syncFeed, syncPeerPool, peerAllocationStrategy, logManager)
         {
         }
 

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/HeadersSyncDispatcher.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/HeadersSyncDispatcher.cs
@@ -15,11 +15,12 @@ namespace Nethermind.Synchronization.FastBlocks
     public class HeadersSyncDispatcher : SyncDispatcher<HeadersSyncBatch>
     {
         public HeadersSyncDispatcher(
+            int maxNumberOfProcessingThread,
             ISyncFeed<HeadersSyncBatch> syncFeed,
             ISyncPeerPool syncPeerPool,
             IPeerAllocationStrategyFactory<FastBlocksBatch> peerAllocationStrategy,
             ILogManager logManager)
-            : base(syncFeed, syncPeerPool, peerAllocationStrategy, logManager)
+            : base(maxNumberOfProcessingThread, syncFeed, syncPeerPool, peerAllocationStrategy, logManager)
         {
         }
 

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/ReceiptsSyncDispatcher.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/ReceiptsSyncDispatcher.cs
@@ -18,11 +18,12 @@ namespace Nethermind.Synchronization.FastBlocks
     public class ReceiptsSyncDispatcher : SyncDispatcher<ReceiptsSyncBatch>
     {
         public ReceiptsSyncDispatcher(
+            int maxNumberOfProcessingThread,
             ISyncFeed<ReceiptsSyncBatch> syncFeed,
             ISyncPeerPool syncPeerPool,
             IPeerAllocationStrategyFactory<ReceiptsSyncBatch> peerAllocationStrategy,
             ILogManager logManager)
-            : base(syncFeed, syncPeerPool, peerAllocationStrategy, logManager)
+            : base(maxNumberOfProcessingThread, syncFeed, syncPeerPool, peerAllocationStrategy, logManager)
         {
         }
 

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncDispatcher.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncDispatcher.cs
@@ -151,11 +151,12 @@ namespace Nethermind.Synchronization.ParallelSync
 
             if (Feed.IsMultiFeed)
             {
-                // Don't free if num of concurrent processing threads is limited
-                // Otherwise, it'll keep downloading more requests.
+                // Limit multithreaded feed concurrency. Note, this also blocks freeing the allocation, which is deliberate.
+                // otherwise, we will keep spawning requests without processing it fast enough, which consume memory.
                 await _concurrentProcessingSemaphore.WaitAsync(cancellationToken);
-                Free(allocation);
             }
+
+            Free(allocation);
 
             try
             {
@@ -172,10 +173,6 @@ namespace Nethermind.Synchronization.ParallelSync
                 if (Feed.IsMultiFeed)
                 {
                     _concurrentProcessingSemaphore.Release();
-                }
-                else
-                {
-                    Free(allocation);
                 }
             }
         }

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncDispatcher.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncDispatcher.cs
@@ -16,8 +16,13 @@ namespace Nethermind.Synchronization.SnapSync
 {
     public class SnapSyncDispatcher : SyncDispatcher<SnapSyncBatch>
     {
-        public SnapSyncDispatcher(ISyncFeed<SnapSyncBatch>? syncFeed, ISyncPeerPool? syncPeerPool, IPeerAllocationStrategyFactory<SnapSyncBatch>? peerAllocationStrategy, ILogManager? logManager)
-            : base(syncFeed, syncPeerPool, peerAllocationStrategy, logManager)
+        public SnapSyncDispatcher(
+            int maxNumberOfProcessingThread,
+            ISyncFeed<SnapSyncBatch>? syncFeed,
+            ISyncPeerPool? syncPeerPool,
+            IPeerAllocationStrategyFactory<SnapSyncBatch>? peerAllocationStrategy,
+            ILogManager? logManager)
+            : base(maxNumberOfProcessingThread, syncFeed, syncPeerPool, peerAllocationStrategy, logManager)
         {
         }
 

--- a/src/Nethermind/Nethermind.Synchronization/StateSync/StateSyncDispatcher.cs
+++ b/src/Nethermind/Nethermind.Synchronization/StateSync/StateSyncDispatcher.cs
@@ -20,8 +20,13 @@ namespace Nethermind.Synchronization.StateSync
 {
     public class StateSyncDispatcher : SyncDispatcher<StateSyncBatch>
     {
-        public StateSyncDispatcher(ISyncFeed<StateSyncBatch> syncFeed, ISyncPeerPool syncPeerPool, IPeerAllocationStrategyFactory<StateSyncBatch> peerAllocationStrategy, ILogManager logManager)
-            : base(syncFeed, syncPeerPool, peerAllocationStrategy, logManager)
+        public StateSyncDispatcher(
+            int maxNumberOfProcessingThread,
+            ISyncFeed<StateSyncBatch> syncFeed,
+            ISyncPeerPool syncPeerPool,
+            IPeerAllocationStrategyFactory<StateSyncBatch> peerAllocationStrategy,
+            ILogManager logManager)
+            : base(maxNumberOfProcessingThread, syncFeed, syncPeerPool, peerAllocationStrategy, logManager)
         {
         }
 

--- a/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
@@ -149,7 +149,7 @@ namespace Nethermind.Synchronization
         {
             TreeSync treeSync = new(SyncMode.StateNodes, _dbProvider.CodeDb, _dbProvider.StateDb, _blockTree, _logManager);
             _stateSyncFeed = new StateSyncFeed(_syncMode, treeSync, _logManager);
-            StateSyncDispatcher stateSyncDispatcher = new(_stateSyncFeed!, _syncPeerPool, new StateSyncAllocationStrategyFactory(), _logManager);
+            StateSyncDispatcher stateSyncDispatcher = new(_syncConfig.MaxProcessingThread, _stateSyncFeed!, _syncPeerPool, new StateSyncAllocationStrategyFactory(), _logManager);
             Task syncDispatcherTask = stateSyncDispatcher.Start(_syncCancellation.Token).ContinueWith(t =>
             {
                 if (t.IsFaulted)
@@ -166,7 +166,7 @@ namespace Nethermind.Synchronization
         private void StartSnapSyncComponents()
         {
             _snapSyncFeed = new SnapSyncFeed(_syncMode, _snapProvider, _logManager);
-            SnapSyncDispatcher dispatcher = new(_snapSyncFeed!, _syncPeerPool, new SnapSyncAllocationStrategyFactory(), _logManager);
+            SnapSyncDispatcher dispatcher = new(_syncConfig.MaxProcessingThread, _snapSyncFeed!, _syncPeerPool, new SnapSyncAllocationStrategyFactory(), _logManager);
 
             Task _ = dispatcher.Start(_syncCancellation!.Token).ContinueWith(t =>
             {
@@ -186,7 +186,7 @@ namespace Nethermind.Synchronization
             FastBlocksPeerAllocationStrategyFactory fastFactory = new();
 
             _headersFeed = new HeadersSyncFeed(_syncMode, _blockTree, _syncPeerPool, _syncConfig, _syncReport, _logManager);
-            HeadersSyncDispatcher headersDispatcher = new(_headersFeed!, _syncPeerPool, fastFactory, _logManager);
+            HeadersSyncDispatcher headersDispatcher = new(_syncConfig.MaxProcessingThread, _headersFeed!, _syncPeerPool, fastFactory, _logManager);
             Task headersTask = headersDispatcher.Start(_syncCancellation!.Token).ContinueWith(t =>
             {
                 if (t.IsFaulted)
@@ -204,7 +204,7 @@ namespace Nethermind.Synchronization
                 if (_syncConfig.DownloadBodiesInFastSync)
                 {
                     _bodiesFeed = new BodiesSyncFeed(_syncMode, _blockTree, _syncPeerPool, _syncConfig, _syncReport, _specProvider, _logManager);
-                    BodiesSyncDispatcher bodiesDispatcher = new(_bodiesFeed!, _syncPeerPool, fastFactory, _logManager);
+                    BodiesSyncDispatcher bodiesDispatcher = new(_syncConfig.MaxProcessingThread, _bodiesFeed!, _syncPeerPool, fastFactory, _logManager);
                     Task bodiesTask = bodiesDispatcher.Start(_syncCancellation.Token).ContinueWith(t =>
                     {
                         if (t.IsFaulted)
@@ -221,7 +221,7 @@ namespace Nethermind.Synchronization
                 if (_syncConfig.DownloadReceiptsInFastSync)
                 {
                     _receiptsFeed = new ReceiptsSyncFeed(_syncMode, _specProvider, _blockTree, _receiptStorage, _syncPeerPool, _syncConfig, _syncReport, _logManager);
-                    ReceiptsSyncDispatcher receiptsDispatcher = new(_receiptsFeed!, _syncPeerPool, fastFactory, _logManager);
+                    ReceiptsSyncDispatcher receiptsDispatcher = new(_syncConfig.MaxProcessingThread, _receiptsFeed!, _syncPeerPool, fastFactory, _logManager);
                     Task receiptsTask = receiptsDispatcher.Start(_syncCancellation.Token).ContinueWith(t =>
                     {
                         if (t.IsFaulted)

--- a/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
@@ -149,7 +149,7 @@ namespace Nethermind.Synchronization
         {
             TreeSync treeSync = new(SyncMode.StateNodes, _dbProvider.CodeDb, _dbProvider.StateDb, _blockTree, _logManager);
             _stateSyncFeed = new StateSyncFeed(_syncMode, treeSync, _logManager);
-            StateSyncDispatcher stateSyncDispatcher = new(_syncConfig.MaxProcessingThread, _stateSyncFeed!, _syncPeerPool, new StateSyncAllocationStrategyFactory(), _logManager);
+            StateSyncDispatcher stateSyncDispatcher = new(_syncConfig.MaxProcessingThreads, _stateSyncFeed!, _syncPeerPool, new StateSyncAllocationStrategyFactory(), _logManager);
             Task syncDispatcherTask = stateSyncDispatcher.Start(_syncCancellation.Token).ContinueWith(t =>
             {
                 if (t.IsFaulted)
@@ -166,7 +166,7 @@ namespace Nethermind.Synchronization
         private void StartSnapSyncComponents()
         {
             _snapSyncFeed = new SnapSyncFeed(_syncMode, _snapProvider, _logManager);
-            SnapSyncDispatcher dispatcher = new(_syncConfig.MaxProcessingThread, _snapSyncFeed!, _syncPeerPool, new SnapSyncAllocationStrategyFactory(), _logManager);
+            SnapSyncDispatcher dispatcher = new(_syncConfig.MaxProcessingThreads, _snapSyncFeed!, _syncPeerPool, new SnapSyncAllocationStrategyFactory(), _logManager);
 
             Task _ = dispatcher.Start(_syncCancellation!.Token).ContinueWith(t =>
             {
@@ -186,7 +186,7 @@ namespace Nethermind.Synchronization
             FastBlocksPeerAllocationStrategyFactory fastFactory = new();
 
             _headersFeed = new HeadersSyncFeed(_syncMode, _blockTree, _syncPeerPool, _syncConfig, _syncReport, _logManager);
-            HeadersSyncDispatcher headersDispatcher = new(_syncConfig.MaxProcessingThread, _headersFeed!, _syncPeerPool, fastFactory, _logManager);
+            HeadersSyncDispatcher headersDispatcher = new(_syncConfig.MaxProcessingThreads, _headersFeed!, _syncPeerPool, fastFactory, _logManager);
             Task headersTask = headersDispatcher.Start(_syncCancellation!.Token).ContinueWith(t =>
             {
                 if (t.IsFaulted)
@@ -204,7 +204,7 @@ namespace Nethermind.Synchronization
                 if (_syncConfig.DownloadBodiesInFastSync)
                 {
                     _bodiesFeed = new BodiesSyncFeed(_syncMode, _blockTree, _syncPeerPool, _syncConfig, _syncReport, _specProvider, _logManager);
-                    BodiesSyncDispatcher bodiesDispatcher = new(_syncConfig.MaxProcessingThread, _bodiesFeed!, _syncPeerPool, fastFactory, _logManager);
+                    BodiesSyncDispatcher bodiesDispatcher = new(_syncConfig.MaxProcessingThreads, _bodiesFeed!, _syncPeerPool, fastFactory, _logManager);
                     Task bodiesTask = bodiesDispatcher.Start(_syncCancellation.Token).ContinueWith(t =>
                     {
                         if (t.IsFaulted)
@@ -221,7 +221,7 @@ namespace Nethermind.Synchronization
                 if (_syncConfig.DownloadReceiptsInFastSync)
                 {
                     _receiptsFeed = new ReceiptsSyncFeed(_syncMode, _specProvider, _blockTree, _receiptStorage, _syncPeerPool, _syncConfig, _syncReport, _logManager);
-                    ReceiptsSyncDispatcher receiptsDispatcher = new(_syncConfig.MaxProcessingThread, _receiptsFeed!, _syncPeerPool, fastFactory, _logManager);
+                    ReceiptsSyncDispatcher receiptsDispatcher = new(_syncConfig.MaxProcessingThreads, _receiptsFeed!, _syncPeerPool, fastFactory, _logManager);
                     Task receiptsTask = receiptsDispatcher.Start(_syncCancellation.Token).ContinueWith(t =>
                     {
                         if (t.IsFaulted)


### PR DESCRIPTION
- Release peer allocation after downloading request, before processing request, allowing it to download other request without waiting for the processing of previous request.
- Increase snap per-peer bandwith utilization from about 60% to 80%. 
- Seems to allow saturating my local system with only about 25 peer. The effect may be amplified by the fact that faster peer will have more effect as it does not have to wait for processing.
- Limit concurrent processing tasks to number of core as before the num of processing tasks is naturally limited to num of peer.
- Graph is (before with `HeavyWrite`, after with `HeavyWrite`, before with `WriteBias`, after with `WriteBias`).
- Snap sync peer network utilization is estimated by total num of second calling `Dispatch` per second over num of geth peer as second.
- Time in response is total num of second processing response per second over 32 (num of logical core) per second.
![Screenshot from 2023-06-05 14-03-47](https://github.com/NethermindEth/nethermind/assets/1841324/e9eb9815-7f0a-4e03-86ea-1c7602807066)

## Types of changes

#### What types of changes does your code introduce?

- [X] Optimization

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- testing other blocks...