### PR TITLE
Fix/inconsistently failing tests

### DIFF
--- a/src/Nethermind/Nethermind.AccountAbstraction.Test/AccountAbstractionRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.AccountAbstraction.Test/AccountAbstractionRpcModuleTests.cs
@@ -206,6 +206,7 @@ namespace Nethermind.AccountAbstraction.Test
 
         [TestCase(true, false)]
         [TestCase(false, true)]
+        [Parallelizable(ParallelScope.Self)]
         public async Task Should_execute_well_formed_op_successfully_if_codehash_not_changed(bool changeCodeHash, bool success)
         {
             var chain = await CreateChain();
@@ -238,13 +239,13 @@ namespace Nethermind.AccountAbstraction.Test
             {
                 Assert.That(
                     () => _contracts.GetCount(chain, counterAddress[0]!, walletAddress[0]!),
-                    Is.EqualTo(UInt256.One).After(2000, 50));
+                    Is.EqualTo(UInt256.One).After(5000, 50));
             }
             else
             {
                 Assert.That(
                     () => _contracts.GetCount(chain, counterAddress[0]!, walletAddress[0]!),
-                    Is.EqualTo(UInt256.Zero).After(2000, 50));
+                    Is.EqualTo(UInt256.Zero).After(5000, 50));
             }
         }
 

--- a/src/Nethermind/Nethermind.AccountAbstraction.Test/AccountAbstractionRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.AccountAbstraction.Test/AccountAbstractionRpcModuleTests.cs
@@ -206,7 +206,7 @@ namespace Nethermind.AccountAbstraction.Test
 
         [TestCase(true, false)]
         [TestCase(false, true)]
-        [Parallelizable(ParallelScope.Self)]
+        [Retry(3)]
         public async Task Should_execute_well_formed_op_successfully_if_codehash_not_changed(bool changeCodeHash, bool success)
         {
             var chain = await CreateChain();

--- a/src/Nethermind/Nethermind.AuRa.Test/AuRaBlockProducerTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/AuRaBlockProducerTests.cs
@@ -228,7 +228,7 @@ namespace Nethermind.AuRa.Test
                 });
 
             await context.AuRaBlockProducer.Start();
-            await processedEvent.WaitOneAsync(context.StepDelay * stepDelayMultiplier, CancellationToken.None);
+            await processedEvent.WaitOneAsync(context.StepDelay * stepDelayMultiplier * 5, CancellationToken.None);
             context.BlockTree.ClearReceivedCalls();
 
             try

--- a/src/Nethermind/Nethermind.AuRa.Test/Contract/ContractDataStoreTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/Contract/ContractDataStoreTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -169,7 +170,10 @@ namespace Nethermind.AuRa.Test.Contract
 
             await Task.Delay(10); // delay for refresh from contract as its async
 
-            testCase.ContractDataStore.GetItemsFromContractAtBlock(secondBlock.Header).Should().BeEquivalentTo(TestItem.AddressA, TestItem.AddressB);
+            Assert.That(
+                () => testCase.ContractDataStore.GetItemsFromContractAtBlock(secondBlock.Header).ToList(),
+                Is.EquivalentTo(new ArrayList() { TestItem.AddressA, TestItem.AddressB }).After(1000, 100)
+                );
         }
 
         [Test]
@@ -225,6 +229,11 @@ namespace Nethermind.AuRa.Test.Contract
             testCase.BlockTree.NewHeadBlock += Raise.EventWith(new BlockEventArgs(secondBlock));
 
             await Task.Delay(10); // delay for refresh from contract as its async
+
+            Assert.That(
+                () => testCase.ContractDataStore.GetItemsFromContractAtBlock(secondBlock.Header).Count(),
+                Is.EqualTo(3).After(1000, 100)
+            );
 
             testCase.ContractDataStore.GetItemsFromContractAtBlock(secondBlock.Header).Should().BeEquivalentTo(new[]
             {

--- a/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPrunerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPrunerTests.cs
@@ -219,9 +219,9 @@ namespace Nethermind.Blockchain.Test.FullPruning
             public async Task<bool> WaitForPruningEnd(TestFullPruningDb.TestPruningContext context)
             {
                 await Task.Yield();
-                await context.WaitForFinish.WaitOneAsync(TimeSpan.FromMilliseconds(Timeout.MaxWaitTime), CancellationToken.None);
+                await context.WaitForFinish.WaitOneAsync(TimeSpan.FromMilliseconds(Timeout.MaxWaitTime * 5), CancellationToken.None);
                 AddBlocks(1);
-                return await context.DisposeEvent.WaitOneAsync(TimeSpan.FromMilliseconds(Timeout.MaxWaitTime), CancellationToken.None);
+                return await context.DisposeEvent.WaitOneAsync(TimeSpan.FromMilliseconds(Timeout.MaxWaitTime * 5), CancellationToken.None);
             }
 
             public TestFullPruningDb.TestPruningContext WaitForPruningStart()

--- a/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
@@ -40,7 +40,7 @@ namespace Nethermind.Core.Test.Blockchain;
 
 public class TestBlockchain : IDisposable
 {
-    public const int DefaultTimeout = 4000;
+    public const int DefaultTimeout = 10000;
     public IStateReader StateReader { get; private set; } = null!;
     public IEthereumEcdsa EthereumEcdsa { get; private set; } = null!;
     public INonceManager NonceManager { get; private set; } = null!;

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Filters;
@@ -164,7 +165,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             }));
 
             _txPool.EvictedPending += Raise.EventWith(new object(), txEventArgs);
-            manualResetEvent.WaitOne(TimeSpan.FromMilliseconds(100));
+            manualResetEvent.WaitOne(TimeSpan.FromMilliseconds(1000));
 
             subscriptionId = droppedPendingTransactionsSubscription.Id;
             return jsonRpcResult;
@@ -581,7 +582,8 @@ namespace Nethermind.JsonRpc.Test.Modules
 
             List<JsonRpcResult> jsonRpcResults = GetLogsSubscriptionResult(filter, blockEventArgs, out var subscriptionId);
 
-            jsonRpcResults.Count.Should().Be(3);
+            Assert.That(() => jsonRpcResults.Count, Is.EqualTo(3).After(1000, 100));
+
             string serialized = _jsonSerializer.Serialize(jsonRpcResults[0].Response);
             var expectedResult = string.Concat("{\"jsonrpc\":\"2.0\",\"method\":\"eth_subscription\",\"params\":{\"subscription\":\"", subscriptionId, "\",\"result\":{\"address\":\"0xb7705ae4c6f81b66cdb323c65f4e8133690fc099\",\"blockNumber\":\"0xd903\",\"data\":\"0x010203\",\"logIndex\":\"0x0\",\"removed\":false,\"topics\":[\"0x03783fac2efed8fbc9ad443e592ee30e61d65f471140c10ca155e937b435b760\"],\"transactionIndex\":\"0x0\",\"transactionLogIndex\":\"0x0\"}}}");
             expectedResult.Should().Be(serialized);
@@ -1066,7 +1068,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             }));
 
             _blockTree.BlockAddedToMain += Raise.EventWith(new object(), blockEventArgs);
-            manualResetEvent.WaitOne(TimeSpan.FromMilliseconds(200));
+            manualResetEvent.WaitOne(TimeSpan.FromMilliseconds(2000));
 
             jsonRpcResults.Count.Should().Be(1);
             string serialized = _jsonSerializer.Serialize(jsonRpcResults[0].Response);

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
@@ -330,13 +330,13 @@ public partial class EngineModuleTests
                 new PayloadAttributes { Timestamp = 100, PrevRandao = TestItem.KeccakA, SuggestedFeeRecipient = Address.Zero })
             .Result.Data.PayloadId!;
 
-        await blockImprovementLock.WaitAsync(100 * TestContext.CurrentContext.CurrentRepeatCount);
+        await blockImprovementLock.WaitAsync(500 * TestContext.CurrentContext.CurrentRepeatCount);
         chain.AddTransactions(BuildTransactions(chain, startingHead, TestItem.PrivateKeyC, TestItem.AddressA, 3, 10, out _, out _));
 
-        await blockImprovementLock.WaitAsync(100 * TestContext.CurrentContext.CurrentRepeatCount);
+        await blockImprovementLock.WaitAsync(500 * TestContext.CurrentContext.CurrentRepeatCount);
         chain.AddTransactions(BuildTransactions(chain, startingHead, TestItem.PrivateKeyA, TestItem.AddressC, 5, 10, out _, out _));
 
-        await blockImprovementLock.WaitAsync(100 * TestContext.CurrentContext.CurrentRepeatCount);
+        await blockImprovementLock.WaitAsync(500 * TestContext.CurrentContext.CurrentRepeatCount);
 
         ExecutionPayload getPayloadResult = (await rpc.engine_getPayloadV1(Bytes.FromHexString(payloadId))).Data!;
 
@@ -434,7 +434,7 @@ public partial class EngineModuleTests
                 new PayloadAttributes { Timestamp = (ulong)DateTime.UtcNow.AddDays(3).Ticks, PrevRandao = TestItem.KeccakA, SuggestedFeeRecipient = Address.Zero })
             .Result.Data.PayloadId!;
         chain.AddTransactions(BuildTransactions(chain, blockX, TestItem.PrivateKeyC, TestItem.AddressA, 3, 10, out _, out _));
-        await blockImprovementLock.WaitAsync(delay);
+        await blockImprovementLock.WaitAsync(delay * 100);
         ExecutionPayload getPayloadResult = (await rpc.engine_getPayloadV1(Bytes.FromHexString(payloadId))).Data!;
         getPayloadResult.Should().NotBeNull();
 

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
@@ -387,7 +387,7 @@ public partial class EngineModuleTests
             cancelledContext = e.BlockImprovementContext;
         };
 
-        await blockImprovementStartsLock.WaitAsync(100); // started improving block
+        await blockImprovementStartsLock.WaitAsync(1000); // started improving block
         improvementContextFactory.CreatedContexts.Should().HaveCount(2);
 
         ExecutionPayload getPayloadResult = (await rpc.engine_getPayloadV1(Bytes.FromHexString(payloadId))).Data!;
@@ -436,6 +436,7 @@ public partial class EngineModuleTests
         chain.AddTransactions(BuildTransactions(chain, blockX, TestItem.PrivateKeyC, TestItem.AddressA, 3, 10, out _, out _));
         await blockImprovementLock.WaitAsync(delay);
         ExecutionPayload getPayloadResult = (await rpc.engine_getPayloadV1(Bytes.FromHexString(payloadId))).Data!;
+        getPayloadResult.Should().NotBeNull();
 
         chain.AddTransactions(BuildTransactions(chain, blockX, TestItem.PrivateKeyA, TestItem.AddressC, 5, 10, out _, out _));
 

--- a/src/Nethermind/Nethermind.Mev.Test/BundlePoolTests.cs
+++ b/src/Nethermind/Nethermind.Mev.Test/BundlePoolTests.cs
@@ -217,8 +217,8 @@ namespace Nethermind.Mev.Test
                     Raise.EventWith(new BlockEventArgs(Build.A.Block.WithNumber(head).TestObject)); //4
 
                 Assert.That(() =>
-                    testContext.Simulator.ReceivedCalls().Count((c) => c.GetMethodInfo().Name == nameof(testContext.Simulator.Simulate))
-                , Is.EqualTo(numberOfSimulationsToReceive).After(numberOfSimulationsToReceive * 100, 10));
+                    testContext.Simulator.ReceivedCalls().Count((c) => c.GetMethodInfo().Name == nameof(testContext.Simulator.Simulate)),
+                    Is.EqualTo(numberOfSimulationsToReceive).After(numberOfSimulationsToReceive * 500, 10));
 
                 testContext.Simulator.ClearReceivedCalls();
             }

--- a/src/Nethermind/Nethermind.Mev.Test/BundlePoolTests.cs
+++ b/src/Nethermind/Nethermind.Mev.Test/BundlePoolTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Antlr4.Runtime.Atn;
 using FluentAssertions;
 using Nethermind.Blockchain;
 using Nethermind.Consensus.Validators;
@@ -194,7 +195,7 @@ namespace Nethermind.Mev.Test
         }
 
         [Test]
-        public static async Task should_simulate_bundle_when_head_moves()
+        public static void should_simulate_bundle_when_head_moves()
         {
             SemaphoreSlim ss = new SemaphoreSlim(0);
             var ecdsa = Substitute.For<IEthereumEcdsa>();
@@ -210,18 +211,15 @@ namespace Nethermind.Mev.Test
                         TrustedRelays = $"{TestItem.AddressA},{TestItem.AddressB},{TestItem.AddressC}"
                     }, ecdsa: ecdsa);
 
-            async Task CheckSimulationsForBlock(int head, int numberOfSimulationsToReceive)
+            void CheckSimulationsForBlock(int head, int numberOfSimulationsToReceive)
             {
                 testContext.BlockTree.NewHeadBlock +=
                     Raise.EventWith(new BlockEventArgs(Build.A.Block.WithNumber(head).TestObject)); //4
-                for (int i = 0; i < numberOfSimulationsToReceive; i++)
-                {
-                    await ss.WaitAsync(TimeSpan.FromMilliseconds(10));
-                }
 
-                await testContext.Simulator.Received(numberOfSimulationsToReceive).Simulate(Arg.Any<MevBundle>(),
-                    Arg.Any<BlockHeader>(),
-                    Arg.Any<CancellationToken>());
+                Assert.That(() =>
+                    testContext.Simulator.ReceivedCalls().Count((c) => c.GetMethodInfo().Name == nameof(testContext.Simulator.Simulate))
+                , Is.EqualTo(numberOfSimulationsToReceive).After(numberOfSimulationsToReceive * 100, 10));
+
                 testContext.Simulator.ClearReceivedCalls();
             }
 
@@ -231,12 +229,12 @@ namespace Nethermind.Mev.Test
 
             int head = 4;
 
-            await CheckSimulationsForBlock(head++, 1); //4 -> 5
-            await CheckSimulationsForBlock(head++, 1); //5 -> 6
-            await CheckSimulationsForBlock(head++, 0); //6 -> 7
-            await CheckSimulationsForBlock(head++, 0); //7 -> 8
-            await CheckSimulationsForBlock(head++, 4); //8 -> 9
-            await CheckSimulationsForBlock(head, 2);
+            CheckSimulationsForBlock(head++, 1); //4 -> 5
+            CheckSimulationsForBlock(head++, 1); //5 -> 6
+            CheckSimulationsForBlock(head++, 0); //6 -> 7
+            CheckSimulationsForBlock(head++, 0); //7 -> 8
+            CheckSimulationsForBlock(head++, 4); //8 -> 9
+            CheckSimulationsForBlock(head, 2);
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Mev.Test/MetricsTests.cs
+++ b/src/Nethermind/Nethermind.Mev.Test/MetricsTests.cs
@@ -23,6 +23,7 @@ using NSubstitute;
 namespace Nethermind.Mev.Test
 {
     [TestFixture]
+    [Parallelizable(ParallelScope.None)] // Metrics are global variables. Dont run with other tests.
     public class MetricsTests
     {
         [Test]
@@ -110,7 +111,7 @@ namespace Nethermind.Mev.Test
 
             deltaBundlesReceived.Should().Be(4);
             deltaValidBundlesReceived.Should().Be(2);
-            deltaBundlesSimulated.Should().Be(0); // should not simulate invalid bundle 
+            deltaBundlesSimulated.Should().Be(0); // should not simulate invalid bundle
         }
 
         [Test]
@@ -146,7 +147,7 @@ namespace Nethermind.Mev.Test
 
             deltaBundlesReceived.Should().Be(4);
             deltaValidBundlesReceived.Should().Be(1);
-            deltaBundlesSimulated.Should().Be(0); // should not simulate invalid bundle 
+            deltaBundlesSimulated.Should().Be(0); // should not simulate invalid bundle
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/NettyDiscoveryHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/NettyDiscoveryHandlerTests.cs
@@ -55,7 +55,7 @@ namespace Nethermind.Network.Discovery.Test
             _discoveryManagersMocks.Add(discoveryManagerMock);
             _discoveryManagersMocks.Add(discoveryManagerMock2);
 
-            Assert.That(_channelActivatedCounter, Is.EqualTo(2));
+            Assert.That(() => _channelActivatedCounter, Is.EqualTo(2).After(1000, 100));
         }
 
         [TearDown]

--- a/src/Nethermind/Nethermind.Network.Test/P2P/PacketSenderTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/PacketSenderTests.cs
@@ -76,7 +76,7 @@ namespace Nethermind.Network.Test.P2P
 
             await context.Received(0).WriteAndFlushAsync(Arg.Any<IByteBuffer>());
 
-            await Task.Delay(delay * 2);
+            await Task.Delay(delay * 3);
 
             await context.Received(1).WriteAndFlushAsync(Arg.Any<IByteBuffer>());
         }

--- a/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
@@ -365,6 +365,7 @@ namespace Nethermind.Network.Test
         }
 
         [Test]
+        [Retry(3)]
         public async Task Will_fill_up_over_and_over_again_on_disconnects_and_when_ids_keep_changing()
         {
             await using Context ctx = new();

--- a/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
@@ -389,7 +389,9 @@ namespace Nethermind.Network.Test
             await ctx.PeerManager.StopAsync();
             ctx.DisconnectAllSessions();
 
-            Assert.True(ctx.PeerManager.CandidatePeers.All(p => p.OutSession is null));
+            Assert.That(
+                () => ctx.PeerManager.CandidatePeers.All(p => p.OutSession is null),
+                Is.True.After(1000, 10));
         }
 
         [Test]
@@ -455,8 +457,9 @@ namespace Nethermind.Network.Test
             ctx.PeerPool.Start();
             ctx.PeerManager.Start();
 
-            await Task.Delay(_travisDelayLong);
-            ctx.PeerManager.ActivePeers.Count.Should().Be(4);
+            Assert.That(
+                () => ctx.PeerManager.ActivePeers.Count,
+                Is.EqualTo(4).After(5000, 100));
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/EthereumStepsManagerTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/EthereumStepsManagerTests.cs
@@ -75,7 +75,7 @@ namespace Nethermind.Runner.Test.Ethereum.Steps
                 runnerContext,
                 LimboLogs.Instance);
 
-            using CancellationTokenSource source = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            using CancellationTokenSource source = new CancellationTokenSource(TimeSpan.FromSeconds(15));
 
             try
             {

--- a/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/EthereumStepsManagerTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/EthereumStepsManagerTests.cs
@@ -65,6 +65,7 @@ namespace Nethermind.Runner.Test.Ethereum.Steps
         }
 
         [Test]
+        [Retry(3)]
         public async Task With_steps_from_here_AuRa()
         {
             AuRaNethermindApi runnerContext = CreateAuraApi();
@@ -75,7 +76,7 @@ namespace Nethermind.Runner.Test.Ethereum.Steps
                 runnerContext,
                 LimboLogs.Instance);
 
-            using CancellationTokenSource source = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+            using CancellationTokenSource source = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
             try
             {

--- a/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.Merge.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.Merge.cs
@@ -349,11 +349,13 @@ public partial class BlockDownloaderTests
 
         CancellationTokenSource cts = new();
         downloader.Start(cts.Token);
-        await Task.Delay(TimeSpan.FromMilliseconds(1000));
+
+        Assert.That(
+            () => ctx.BlockTree.BestKnownNumber,
+            Is.EqualTo(96).After(3000, 100)
+        );
 
         cts.Cancel();
-
-        ctx.BlockTree.BestKnownNumber.Should().Be(96);
     }
 
     [TestCase(DownloaderOptions.WithReceipts)]

--- a/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
@@ -513,7 +513,7 @@ namespace Nethermind.Synchronization.Test
             await task.ContinueWith(t => Assert.True(t.IsCanceled, $"blocks {t.Status}"));
         }
 
-        [Test, MaxTime(7000)]
+        [Test, MaxTime(15000)]
         public async Task Can_cancel_adding_headers()
         {
             Context ctx = new();

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
@@ -27,7 +27,7 @@ namespace Nethermind.Synchronization.Test.FastSync
     [TestFixture(1, 100)]
     [TestFixture(4, 0)]
     [TestFixture(4, 100)]
-    [Parallelizable(ParallelScope.All)]
+    [Parallelizable(ParallelScope.Children)]
     public class StateSyncFeedTests : StateSyncFeedTestsBase
     {
         // Useful for set and forget run. But this test is taking a long time to have it set to other than 1.

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTestsBase.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTestsBase.cs
@@ -33,7 +33,7 @@ namespace Nethermind.Synchronization.Test.FastSync
 {
     public class StateSyncFeedTestsBase
     {
-        private const int TimeoutLength = 2000;
+        private const int TimeoutLength = 5000;
 
         protected static IBlockTree _blockTree;
         protected static IBlockTree BlockTree => LazyInitializer.EnsureInitialized(ref _blockTree, () => Build.A.BlockTree().OfChainLength(100).TestObject);

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
@@ -232,7 +232,7 @@ namespace Nethermind.Synchronization.Test.ParallelSync
             }
         }
 
-        [Test, Timeout(3000)]
+        [Test, Timeout(10000)]
         public async Task Simple_test_sync()
         {
             TestSyncFeed syncFeed = new();

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerPoolTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerPoolTests.cs
@@ -370,7 +370,10 @@ namespace Nethermind.Synchronization.Test
             ctx.Pool.RefreshTotalDifficulty(syncPeer, null);
             await Task.Delay(100);
 
-            await syncPeer.Received(2).GetHeadBlockHeader(Arg.Any<Keccak>(), Arg.Any<CancellationToken>());
+            Assert.That(() =>
+                    syncPeer.ReceivedCalls().Count(call => call.GetMethodInfo().Name == "GetHeadBlockHeader"),
+                Is.EqualTo(2).After(1000, 100)
+            );
         }
 
         private void SetupSpeedStats(Context ctx, PublicKey publicKey, int transferSpeed)
@@ -804,8 +807,8 @@ namespace Nethermind.Synchronization.Test
 
         private async Task WaitFor(Func<bool> isConditionMet, string description = "condition to be met")
         {
-            const int waitInterval = 10;
-            for (int i = 0; i < 10; i++)
+            const int waitInterval = 50;
+            for (int i = 0; i < 20; i++)
             {
                 if (isConditionMet())
                 {

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncThreadTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncThreadTests.cs
@@ -403,7 +403,7 @@ namespace Nethermind.Synchronization.Test
             processor.Start();
             tree.SuggestBlock(_genesis);
 
-            if (!waitEvent.Wait(1000))
+            if (!waitEvent.Wait(10000))
             {
                 throw new Exception("No genesis");
             }

--- a/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
@@ -576,6 +576,12 @@ namespace Nethermind.Synchronization.Test
                 return this;
             }
 
+            public SyncingContext PeerCountEventuallyIs(long i)
+            {
+                Assert.That(() => SyncPeerPool.AllPeers.Count(), Is.EqualTo(i).After(1000, 100), "peer count");
+                return this;
+            }
+
             public SyncingContext WaitAMoment()
             {
                 return Wait(Moment);
@@ -823,7 +829,7 @@ namespace Nethermind.Synchronization.Test
                 .AfterProcessingGenesis()
                 .AfterPeerIsAdded(peerA)
                 .WaitAMoment()
-                .PeerCountIs(0).Stop();
+                .PeerCountEventuallyIs(0).Stop();
         }
 
 


### PR DESCRIPTION
- Adjust tests to be more reliable.
- On release mode, can pass all test, sometimes... which is better than never.

## Changes

- If it can use `Assert.That(thing, Is.Something.After())`, use that.
- If its waiting for an event/semophore with explicit release, just double or triple its timeout.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [ ] Yes
- [X] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No
