### PR TITLE
Fix KeccaksIterator not working when some keccak zero prefix is not i…

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Receipts/KeccaksIteratorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Receipts/KeccaksIteratorTests.cs
@@ -40,6 +40,10 @@ public class KeccaksIteratorTests
         yield return new[] { TestItem.KeccakA, TestItem.KeccakB, TestItem.KeccakC, Keccak.Zero, };
         yield return new[] { TestItem.KeccakA, new Keccak("0xffffffffffffffffffffffffffffffff00000000000000000000000000000000") };
         yield return new[] { TestItem.KeccakA, new Keccak("0x00000000000000000000000000000000ffffffffffffffffffffffffffffffff") };
+        yield return new[] { TestItem.KeccakA, new Keccak("0xffffffffffffffffffffffffffffffff00000000000000000000000000000000"), TestItem.KeccakB };
+        yield return new[] { TestItem.KeccakA, new Keccak("0x00000000000000000000000000000000ffffffffffffffffffffffffffffffff"), TestItem.KeccakB };
+        yield return new[] { new Keccak("0xffffffffffffffffffffffffffffffff00000000000000000000000000000000"), TestItem.KeccakB };
+        yield return new[] { new Keccak("0x00000000000000000000000000000000ffffffffffffffffffffffffffffffff"), TestItem.KeccakB };
     }
 
     private Keccak[] EncodeDecode(Keccak[] input)

--- a/src/Nethermind/Nethermind.Blockchain.Test/Receipts/KeccaksIteratorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Receipts/KeccaksIteratorTests.cs
@@ -28,7 +28,7 @@ public class KeccaksIteratorTests
         yield return new[] { TestItem.KeccakA };
         yield return new[] { Keccak.Zero };
         yield return new[] { TestItem.KeccakA, Keccak.Zero };
-        yield return new[] { Keccak.Zero, TestItem.KeccakA  };
+        yield return new[] { Keccak.Zero, TestItem.KeccakA };
         yield return new[] { TestItem.KeccakA, TestItem.KeccakB, TestItem.KeccakC, Keccak.Zero, };
         yield return new[] { TestItem.KeccakA, new Keccak("0xffffffffffffffffffffffffffffffff00000000000000000000000000000000") };
         yield return new[] { TestItem.KeccakA, new Keccak("0x00000000000000000000000000000000ffffffffffffffffffffffffffffffff") };

--- a/src/Nethermind/Nethermind.Blockchain.Test/Receipts/KeccaksIteratorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Receipts/KeccaksIteratorTests.cs
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Nethermind.Blockchain.Receipts;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Serialization.Rlp;
+using NUnit.Framework;
+
+namespace Nethermind.Blockchain.Test.Receipts;
+
+public class KeccaksIteratorTests
+{
+    [TestCaseSource(nameof(TestKeccaks))]
+    public void TestKeccakIteratorCorrect(Keccak[] keccak)
+    {
+        Keccak[] keccaks = new[] { TestItem.KeccakA, Keccak.Zero };
+        Keccak[] decoded = EncodeDecode(keccaks);
+        decoded.Should().BeEquivalentTo(keccaks);
+    }
+
+    public static IEnumerable<Keccak[]> TestKeccaks()
+    {
+        yield return new[] { TestItem.KeccakA };
+        yield return new[] { Keccak.Zero };
+        yield return new[] { TestItem.KeccakA, Keccak.Zero };
+        yield return new[] { Keccak.Zero, TestItem.KeccakA  };
+        yield return new[] { TestItem.KeccakA, TestItem.KeccakB, TestItem.KeccakC, Keccak.Zero, };
+        yield return new[] { TestItem.KeccakA, new Keccak("0xffffffffffffffffffffffffffffffff00000000000000000000000000000000") };
+        yield return new[] { TestItem.KeccakA, new Keccak("0x00000000000000000000000000000000ffffffffffffffffffffffffffffffff") };
+    }
+
+    private Keccak[] EncodeDecode(Keccak[] input)
+    {
+        int totalLength = 0;
+        foreach (Keccak keccak in input)
+        {
+            totalLength += Rlp.LengthOf(keccak.Bytes.WithoutLeadingZerosOrEmpty());
+        }
+        int sequenceLength = Rlp.LengthOfSequence(totalLength);
+
+        RlpStream rlpStream = new RlpStream(sequenceLength);
+        rlpStream.StartSequence(totalLength);
+        foreach (Keccak keccak in input)
+        {
+            rlpStream.Encode(keccak.Bytes.WithoutLeadingZerosOrEmpty());
+        }
+
+        Span<byte> buffer = stackalloc byte[32];
+        KeccaksIterator iterator = new(rlpStream.Data, buffer);
+
+        List<Keccak> decoded = new();
+        while (iterator.TryGetNext(out KeccakStructRef kec))
+        {
+            decoded.Add(kec.ToKeccak());
+        }
+
+        return decoded.ToArray();
+    }
+}

--- a/src/Nethermind/Nethermind.Blockchain.Test/Receipts/KeccaksIteratorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Receipts/KeccaksIteratorTests.cs
@@ -33,6 +33,7 @@ public class KeccaksIteratorTests
 
     public static IEnumerable<Keccak[]> TestKeccaks()
     {
+        yield return Array.Empty<Keccak>();
         yield return new[] { TestItem.KeccakA };
         yield return new[] { Keccak.Zero };
         yield return new[] { TestItem.KeccakA, Keccak.Zero };

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/KeccaksIterator.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/KeccaksIterator.cs
@@ -10,6 +10,7 @@ namespace Nethermind.Blockchain.Receipts
     public ref struct KeccaksIterator
     {
         private readonly int _length;
+        private readonly int _startPosition;
         private Rlp.ValueDecoderContext _decoderContext;
         private readonly Span<byte> _buffer;
         public long Index { get; private set; }
@@ -19,13 +20,14 @@ namespace Nethermind.Blockchain.Receipts
             if (buffer.Length != 32) throw new ArgumentException("Buffer must be 32 bytes long");
             _decoderContext = new Rlp.ValueDecoderContext(data);
             _length = _decoderContext.ReadSequenceLength();
+            _startPosition = _decoderContext.Position;
             _buffer = buffer;
             Index = -1;
         }
 
         public bool TryGetNext(out KeccakStructRef current)
         {
-            if (_decoderContext.Position < _length)
+            if (_decoderContext.Position < _length + _startPosition)
             {
                 _decoderContext.DecodeZeroPrefixedKeccakStructRef(out current, _buffer);
                 Index++;
@@ -40,7 +42,7 @@ namespace Nethermind.Blockchain.Receipts
 
         public void Reset()
         {
-            _decoderContext.Position = 0;
+            _decoderContext.Position = _startPosition;
             _decoderContext.ReadSequenceLength();
         }
     }

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/KeccaksIterator.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/KeccaksIterator.cs
@@ -43,7 +43,6 @@ namespace Nethermind.Blockchain.Receipts
         public void Reset()
         {
             _decoderContext.Position = _startPosition;
-            _decoderContext.ReadSequenceLength();
         }
     }
 }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -918,6 +918,10 @@ namespace Nethermind.Serialization.Rlp
                 else
                 {
                     ReadOnlySpan<byte> theSpan = DecodeByteArraySpan();
+                    if (theSpan.Length < 32)
+                    {
+                        buffer[..(32 - theSpan.Length)].Clear();
+                    }
                     theSpan.CopyTo(buffer[(32 - theSpan.Length)..]);
                     keccak = new KeccakStructRef(buffer);
                 }


### PR DESCRIPTION
- Fix keccaks iterator not correctly detect more items when other item is zero prefixed.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

