### PR TITLE
Don't add Keccaks during cache pruning

### DIFF
--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -509,15 +509,16 @@ namespace Nethermind.Trie.Pruning
                 if (node.IsPersisted)
                 {
                     if (_logger.IsTrace) _logger.Trace($"Removing persisted {node} from memory.");
-                    if (node.Keccak is null)
+                    Keccak? keccak = node.Keccak;
+                    if (keccak is null)
                     {
-                        node.ResolveKey(this, true); // TODO: hack
-                        if (node.Keccak != key)
+                        keccak = node.GenerateKey(this, isRoot: true);
+                        if (keccak != key)
                         {
-                            throw new InvalidOperationException($"Persisted {node} {key} != {node.Keccak}");
+                            throw new InvalidOperationException($"Persisted {node} {key} != {keccak}");
                         }
                     }
-                    _dirtyNodes.Remove(node.Keccak);
+                    _dirtyNodes.Remove(keccak);
 
                     Metrics.PrunedPersistedNodesCount++;
                 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -251,6 +251,12 @@ namespace Nethermind.Trie.Pruning
                     if (!ReferenceEquals(cachedNodeCopy, node))
                     {
                         if (_logger.IsTrace) _logger.Trace($"Replacing {node} with its cached copy {cachedNodeCopy}.");
+                        cachedNodeCopy.ResolveKey(this, nodeCommitInfo.IsRoot);
+                        if (node.Keccak != cachedNodeCopy.Keccak)
+                        {
+                            throw new InvalidOperationException($"The hash of replacement node {cachedNodeCopy} is not the same as the original {node}.");
+                        }
+
                         if (!nodeCommitInfo.IsRoot)
                         {
                             nodeCommitInfo.NodeParent!.ReplaceChildRef(nodeCommitInfo.ChildPositionAtParent, cachedNodeCopy);

--- a/src/Nethermind/Nethermind.Trie/TrieNode.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.cs
@@ -318,6 +318,17 @@ namespace Nethermind.Trie
                 return;
             }
 
+            Keccak = GenerateKey(tree, isRoot);
+        }
+
+        public Keccak? GenerateKey(ITrieNodeResolver tree, bool isRoot)
+        {
+            Keccak? keccak = Keccak;
+            if (keccak is not null)
+            {
+                return keccak;
+            }
+
             if (FullRlp is null || IsDirty)
             {
                 FullRlp = RlpEncode(tree);
@@ -330,8 +341,10 @@ namespace Nethermind.Trie
             if (FullRlp.Length >= 32 || isRoot)
             {
                 Metrics.TreeNodeHashCalculations++;
-                Keccak = Keccak.Compute(FullRlp);
+                return Keccak.Compute(FullRlp);
             }
+
+            return null;
         }
 
         public bool TryResolveStorageRootHash(ITrieNodeResolver resolver, out Keccak? storageRootHash)


### PR DESCRIPTION
## Changes

- During `PruneCache` it can add Keccak's to TrieNodes that are small enough to be Rlp'd in parent so shouldn't have a Keccak.
- This change just generates the key rather than altering the TrieNode; thus treating it as readonly

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No
