### PR TITLE
Add fast test for balance < tx.Value + gas

### DIFF
--- a/src/Nethermind/Nethermind.TxPool/Filters/BalanceZeroFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/BalanceZeroFilter.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Nethermind.Core;
-using Nethermind.Core.Specs;
 using Nethermind.Int256;
 using Nethermind.Logging;
 
@@ -13,15 +12,11 @@ namespace Nethermind.TxPool.Filters
     /// </summary>
     internal sealed class BalanceZeroFilter : IIncomingTxFilter
     {
-        private readonly IChainHeadSpecProvider _specProvider;
-        private readonly IChainHeadInfoProvider _headInfo;
         private readonly bool _thereIsPriorityContract;
         private readonly ILogger _logger;
 
-        public BalanceZeroFilter(IChainHeadInfoProvider headInfo, bool thereIsPriorityContract, ILogger logger)
+        public BalanceZeroFilter(bool thereIsPriorityContract, ILogger logger)
         {
-            _specProvider = headInfo.SpecProvider;
-            _headInfo = headInfo;
             _thereIsPriorityContract = thereIsPriorityContract;
             _logger = logger;
         }
@@ -48,9 +43,8 @@ namespace Nethermind.TxPool.Filters
                     AcceptTxResult.InsufficientFunds.WithMessage($"Balance is {balance} less than sending value {tx.Value}");
             }
 
-            IReleaseSpec spec = _specProvider.GetCurrentHeadSpec();
-            UInt256 affordableGasPrice = tx.CalculateGasPrice(spec.IsEip1559Enabled, _headInfo.CurrentBaseFee);
-            if (UInt256.AddOverflow(affordableGasPrice, tx.Value, out UInt256 txCostAndValue))
+            if (UInt256.MultiplyOverflow(tx.MaxFeePerGas, (UInt256)tx.GasLimit, out UInt256 txCostAndValue) ||
+                UInt256.AddOverflow(txCostAndValue, tx.Value, out txCostAndValue))
             {
                 Metrics.PendingTransactionsBalanceBelowValue++;
                 if (_logger.IsTrace)

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -110,7 +110,7 @@ namespace Nethermind.TxPool
                 new NullHashTxFilter(), // needs to be first as it assigns the hash
                 new AlreadyKnownTxFilter(_hashCache, _logger),
                 new UnknownSenderFilter(ecdsa, _logger),
-                new BalanceZeroFilter(_headInfo, thereIsPriorityContract, _logger),
+                new BalanceZeroFilter(thereIsPriorityContract, _logger),
                 new BalanceTooLowFilter(_transactions, _logger),
                 new LowNonceFilter(_logger), // has to be after UnknownSenderFilter as it uses sender
                 new GapNonceFilter(_transactions, _logger),

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -110,7 +110,7 @@ namespace Nethermind.TxPool
                 new NullHashTxFilter(), // needs to be first as it assigns the hash
                 new AlreadyKnownTxFilter(_hashCache, _logger),
                 new UnknownSenderFilter(ecdsa, _logger),
-                new BalanceZeroFilter(thereIsPriorityContract, _logger),
+                new BalanceZeroFilter(_headInfo, thereIsPriorityContract, _logger),
                 new BalanceTooLowFilter(_transactions, _logger),
                 new LowNonceFilter(_logger), // has to be after UnknownSenderFilter as it uses sender
                 new GapNonceFilter(_transactions, _logger),


### PR DESCRIPTION
## Changes

- Will be currently be rejected later in pipeline by `BalanceTooLowFilter`; however that iterates and considers all txs from the account; can do an earlier reject in `BalanceZeroFilter` just for the current tx in solation

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No