### PR TITLE
Move detailed peer logging to debug, add diversity

### DIFF
--- a/src/Nethermind/Nethermind.Network.Stats/Model/Node.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/Model/Node.cs
@@ -170,31 +170,31 @@ namespace Nethermind.Stats.Model
             {
                 return NodeClientType.Unknown;
             }
-            else if (clientId.Contains("BeSu", StringComparison.InvariantCultureIgnoreCase))
+            else if (clientId.Contains(nameof(NodeClientType.Besu), StringComparison.OrdinalIgnoreCase))
             {
-                return NodeClientType.BeSu;
+                return NodeClientType.Besu;
             }
-            else if (clientId.Contains("Geth", StringComparison.InvariantCultureIgnoreCase))
+            else if (clientId.Contains(nameof(NodeClientType.Geth), StringComparison.OrdinalIgnoreCase))
             {
                 return NodeClientType.Geth;
             }
-            else if (clientId.Contains("Nethermind", StringComparison.InvariantCultureIgnoreCase))
+            else if (clientId.Contains(nameof(NodeClientType.Nethermind), StringComparison.OrdinalIgnoreCase))
             {
                 return NodeClientType.Nethermind;
             }
-            else if (clientId.Contains("Erigon", StringComparison.InvariantCultureIgnoreCase))
+            else if (clientId.Contains(nameof(NodeClientType.Erigon), StringComparison.OrdinalIgnoreCase))
             {
                 return NodeClientType.Erigon;
             }
-            else if (clientId.Contains("Parity", StringComparison.InvariantCultureIgnoreCase))
+            else if (clientId.Contains(nameof(NodeClientType.Parity), StringComparison.OrdinalIgnoreCase))
             {
                 return NodeClientType.Parity;
             }
-            else if (clientId.Contains("OpenEthereum", StringComparison.InvariantCultureIgnoreCase))
+            else if (clientId.Contains(nameof(NodeClientType.OpenEthereum), StringComparison.OrdinalIgnoreCase))
             {
                 return NodeClientType.OpenEthereum;
             }
-            else if (clientId.Contains("Trinity", StringComparison.InvariantCultureIgnoreCase))
+            else if (clientId.Contains(nameof(NodeClientType.Trinity), StringComparison.OrdinalIgnoreCase))
             {
                 return NodeClientType.Trinity;
             }

--- a/src/Nethermind/Nethermind.Network.Stats/Model/Node.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/Model/Node.cs
@@ -182,6 +182,10 @@ namespace Nethermind.Stats.Model
             {
                 return NodeClientType.Nethermind;
             }
+            else if (clientId.Contains("Erigon", StringComparison.InvariantCultureIgnoreCase))
+            {
+                return NodeClientType.Erigon;
+            }
             else if (clientId.Contains("Parity", StringComparison.InvariantCultureIgnoreCase))
             {
                 return NodeClientType.Parity;

--- a/src/Nethermind/Nethermind.Network.Stats/Model/NodeClientType.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/Model/NodeClientType.cs
@@ -5,12 +5,13 @@ namespace Nethermind.Stats.Model
 {
     public enum NodeClientType
     {
+        Unknown = 0,
         BeSu,
         Geth,
         Nethermind,
         Parity,
         OpenEthereum,
         Trinity,
-        Unknown
+        Erigon,
     }
 }

--- a/src/Nethermind/Nethermind.Network.Stats/Model/NodeClientType.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/Model/NodeClientType.cs
@@ -6,7 +6,7 @@ namespace Nethermind.Stats.Model
     public enum NodeClientType
     {
         Unknown = 0,
-        BeSu,
+        Besu,
         Geth,
         Nethermind,
         Parity,

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
@@ -270,6 +270,7 @@ namespace Nethermind.Synchronization.Test.ParallelSync
             }
         }
 
+        [Retry(tryCount: 5)]
         [TestCase(false, 1, 1, 8)]
         [TestCase(true, 1, 1, 24)]
         [TestCase(true, 2, 1, 32)]

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloaderLimits.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloaderLimits.cs
@@ -14,7 +14,7 @@ namespace Nethermind.Synchronization.Blocks
         {
             return peer.PeerClientType switch
             {
-                NodeClientType.BeSu => BeSuSyncLimits.MaxBodyFetch,
+                NodeClientType.Besu => BeSuSyncLimits.MaxBodyFetch,
                 NodeClientType.Geth => GethSyncLimits.MaxBodyFetch,
                 NodeClientType.Nethermind => NethermindSyncLimits.MaxBodyFetch,
                 NodeClientType.Parity => ParitySyncLimits.MaxBodyFetch,
@@ -29,7 +29,7 @@ namespace Nethermind.Synchronization.Blocks
         {
             return peer.PeerClientType switch
             {
-                NodeClientType.BeSu => BeSuSyncLimits.MaxReceiptFetch,
+                NodeClientType.Besu => BeSuSyncLimits.MaxReceiptFetch,
                 NodeClientType.Geth => GethSyncLimits.MaxReceiptFetch,
                 NodeClientType.Nethermind => NethermindSyncLimits.MaxReceiptFetch,
                 NodeClientType.Parity => ParitySyncLimits.MaxReceiptFetch,
@@ -43,7 +43,7 @@ namespace Nethermind.Synchronization.Blocks
         {
             return peer.PeerClientType switch
             {
-                NodeClientType.BeSu => BeSuSyncLimits.MaxHeaderFetch,
+                NodeClientType.Besu => BeSuSyncLimits.MaxHeaderFetch,
                 NodeClientType.Geth => GethSyncLimits.MaxHeaderFetch,
                 NodeClientType.Nethermind => NethermindSyncLimits.MaxHeaderFetch,
                 NodeClientType.Parity => ParitySyncLimits.MaxHeaderFetch,

--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeersReport.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeersReport.cs
@@ -104,7 +104,7 @@ namespace Nethermind.Synchronization.Peers
                 _stringBuilder.Append(" Active: ");
                 activeContexts.AppendTo(_stringBuilder, "None");
                 _stringBuilder.Append(" | Sleeping: ");
-                activeContexts.AppendTo(_stringBuilder, "All");
+                sleepingContexts.AppendTo(_stringBuilder, "All");
                 _stringBuilder.Append(" |");
 
                 bool isFirst = true;

--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeersReport.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeersReport.cs
@@ -104,7 +104,7 @@ namespace Nethermind.Synchronization.Peers
                 _stringBuilder.Append(" Active: ");
                 activeContexts.AppendTo(_stringBuilder, "None");
                 _stringBuilder.Append(" | Sleeping: ");
-                sleepingContexts.AppendTo(_stringBuilder, "All");
+                sleepingContexts.AppendTo(_stringBuilder, activeContexts.Total != 0 ? "None" : "All");
                 _stringBuilder.Append(" |");
 
                 bool isFirst = true;
@@ -230,7 +230,6 @@ namespace Nethermind.Synchronization.Peers
 
                 bool added = false;
 
-                if (None > 0) AddComma(sb, ref added).Append(None).Append(" Not Syncing");
                 if (Headers > 0) AddComma(sb, ref added).Append(Headers).Append(" Headers");
                 if (Bodies > 0) AddComma(sb, ref added).Append(Bodies).Append(" Bodies");
                 if (Receipts > 0) AddComma(sb, ref added).Append(Receipts).Append(" Receipts");

--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeersReport.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeersReport.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Text;
 using Nethermind.Logging;
 using Nethermind.Stats;
+using Nethermind.Stats.Model;
 
 namespace Nethermind.Synchronization.Peers
 {
@@ -86,7 +87,7 @@ namespace Nethermind.Synchronization.Peers
         {
             lock (_writeLock)
             {
-                IEnumerable<IGrouping<string, PeerInfo>> peerGroups = peers.GroupBy(peerInfo => ParseClientInfo(peerInfo.SyncPeer.ClientId));
+                IEnumerable<IGrouping<NodeClientType, PeerInfo>> peerGroups = peers.GroupBy(peerInfo => peerInfo.SyncPeer.ClientType);
                 float sum = peerGroups.Sum(x => x.Count());
 
                 _stringBuilder.Append(header);
@@ -109,19 +110,6 @@ namespace Nethermind.Synchronization.Peers
                 string result = _stringBuilder.ToString();
                 _stringBuilder.Clear();
                 return result;
-            }
-        }
-
-        private string ParseClientInfo(string clientInfo)
-        {
-            int index = clientInfo.IndexOf('/');
-            if (index > 0)
-            {
-                return clientInfo[..index];
-            }
-            else
-            {
-                return "Unknown";
             }
         }
 

--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeersReport.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeersReport.cs
@@ -97,8 +97,8 @@ namespace Nethermind.Synchronization.Peers
                 PeersContextCounts sleepingContexts = new();
                 foreach (PeerInfo peerInfo in peers)
                 {
-                    CountContexts(peerInfo.AllocatedContexts, activeContexts);
-                    CountContexts(peerInfo.SleepingContexts, sleepingContexts);
+                    CountContexts(peerInfo.AllocatedContexts, ref activeContexts);
+                    CountContexts(peerInfo.SleepingContexts, ref sleepingContexts);
                 }
 
                 _stringBuilder.Append(" Active: ");
@@ -126,7 +126,7 @@ namespace Nethermind.Synchronization.Peers
                 return result;
             }
 
-            static void CountContexts(AllocationContexts contexts, PeersContextCounts contextCounts)
+            static void CountContexts(AllocationContexts contexts, ref PeersContextCounts contextCounts)
             {
                 contextCounts.Total++;
                 if (contexts == AllocationContexts.None)
@@ -208,7 +208,7 @@ namespace Nethermind.Synchronization.Peers
             _currentInitializedPeerCount = initializedPeerCount;
         }
 
-        private class PeersContextCounts
+        private struct PeersContextCounts
         {
             public int None { get; set; }
             public int Headers { get; set; }

--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeersReport.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeersReport.cs
@@ -104,7 +104,7 @@ namespace Nethermind.Synchronization.Peers
                 _stringBuilder.Append(" Active: ");
                 activeContexts.AppendTo(_stringBuilder, "None");
                 _stringBuilder.Append(" | Sleeping: ");
-                sleepingContexts.AppendTo(_stringBuilder, activeContexts.Total != 0 ? "None" : "All");
+                sleepingContexts.AppendTo(_stringBuilder, activeContexts.Total != activeContexts.None ? "None" : "All");
                 _stringBuilder.Append(" |");
 
                 bool isFirst = true;

--- a/src/Nethermind/Nethermind.Synchronization/Reporting/SyncReport.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Reporting/SyncReport.cs
@@ -75,6 +75,11 @@ namespace Nethermind.Synchronization.Reporting
 
         private void TimerOnElapsed(object? sender, EventArgs e)
         {
+            if (_reportId % SyncReportFrequency == 0)
+            {
+                WriteSyncReport();
+            }
+
             if (_reportId % SyncFullPeersReportFrequency == 0)
             {
                 _syncPeersReport.WriteFullReport();
@@ -82,10 +87,6 @@ namespace Nethermind.Synchronization.Reporting
             else if (_reportId % SyncAllocatedPeersReportFrequency == 0)
             {
                 _syncPeersReport.WriteAllocatedReport();
-            }
-            else if (_reportId % SyncReportFrequency == 0)
-            {
-                WriteSyncReport();
             }
 
             _reportId++;

--- a/src/Nethermind/Nethermind.Synchronization/Reporting/SyncReport.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Reporting/SyncReport.cs
@@ -75,11 +75,6 @@ namespace Nethermind.Synchronization.Reporting
 
         private void TimerOnElapsed(object? sender, EventArgs e)
         {
-            if (_reportId % SyncReportFrequency == 0)
-            {
-                WriteSyncReport();
-            }
-
             if (_reportId % SyncFullPeersReportFrequency == 0)
             {
                 _syncPeersReport.WriteFullReport();
@@ -87,6 +82,10 @@ namespace Nethermind.Synchronization.Reporting
             else if (_reportId % SyncAllocatedPeersReportFrequency == 0)
             {
                 _syncPeersReport.WriteAllocatedReport();
+            }
+            else if (_reportId % SyncReportFrequency == 0)
+            {
+                WriteSyncReport();
             }
 
             _reportId++;
@@ -174,7 +173,7 @@ namespace Nethermind.Synchronization.Reporting
             {
                 if (_reportId % PeerCountFrequency == 0)
                 {
-                    _logger.Info($"Peers | with known best block: {_syncPeerPool.InitializedPeersCount} | all: {_syncPeerPool.PeerCount} |");
+                    _logger.Info(_syncPeersReport.MakeSummaryReportForPeers(_syncPeerPool.InitializedPeers ,$"Peers | with known best block: {_syncPeerPool.InitializedPeersCount} | all: {_syncPeerPool.PeerCount}"));
                 }
             }
 

--- a/src/Nethermind/Nethermind.Synchronization/Reporting/SyncReport.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Reporting/SyncReport.cs
@@ -173,7 +173,7 @@ namespace Nethermind.Synchronization.Reporting
             {
                 if (_reportId % PeerCountFrequency == 0)
                 {
-                    _logger.Info(_syncPeersReport.MakeSummaryReportForPeers(_syncPeerPool.InitializedPeers ,$"Peers | with known best block: {_syncPeerPool.InitializedPeersCount} | all: {_syncPeerPool.PeerCount}"));
+                    _logger.Info(_syncPeersReport.MakeSummaryReportForPeers(_syncPeerPool.InitializedPeers, $"Peers | with known best block: {_syncPeerPool.InitializedPeersCount} | all: {_syncPeerPool.PeerCount}"));
                 }
             }
 


### PR DESCRIPTION
## Changes

- Move detailed (line per peer) to Debug
- Add diversity to single line logs

```
2023-06-09 06:42:15.8209|Allocated sync peers 72(72)/100 | Geth (51.39 %), Nethermind (30.56 %), erigon (13.89 %), besu (2.78 %), Unknown (1.39 %)
2023-06-09 06:42:30.9419|Peers | with known best block: 71 | all: 71 | Geth (52.11 %), Nethermind (30.99 %), erigon (14.08 %), besu (2.82 %)
``` 

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: Logging changes

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No