### PR TITLE
Bugfix - exchangeCapabilites based on ChainSpec

### DIFF
--- a/src/Nethermind/Nethermind.Core/Specs/ISpecProvider.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/ISpecProvider.cs
@@ -79,6 +79,6 @@ namespace Nethermind.Core.Specs
         /// <remarks> The default value is long.MaxValue for block numbers and ulong.MaxValue for timestamps
         /// for every new not yet scheduled EIP. Because of that we can't use long.MaxValue and
         /// ulong.MaxValue for GetFinalSpec that is why we have long.MaxValue-1, ulong.MaxValue-1 </remarks>
-        IReleaseSpec GetFinalSpec() => GetSpec(long.MaxValue-1, ulong.MaxValue-1);
+        IReleaseSpec GetFinalSpec() => GetSpec(long.MaxValue - 1, ulong.MaxValue - 1);
     }
 }

--- a/src/Nethermind/Nethermind.Core/Specs/ISpecProvider.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/ISpecProvider.cs
@@ -75,7 +75,10 @@ namespace Nethermind.Core.Specs
         /// <summary>
         /// Resolves a spec for all planned forks applied.
         /// </summary>
-        /// <returns>A spec for all planned forks applied</returns>
+        /// <returns>A spec for all planned forks applied</
+        /// The default value is long.MaxValue for block numbers and ulong.MaxValue for timestamps
+        /// for every new not yet scheduled EIP. Because of that we can't use long.MaxValue and
+        /// ulong.MaxValue for GetFinalSpec that is why we have long.MaxValue-1, ulong.MaxValue-1
         IReleaseSpec GetFinalSpec() => GetSpec(long.MaxValue-1, ulong.MaxValue-1);
     }
 }

--- a/src/Nethermind/Nethermind.Core/Specs/ISpecProvider.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/ISpecProvider.cs
@@ -76,6 +76,6 @@ namespace Nethermind.Core.Specs
         /// Resolves a spec for all planned forks applied.
         /// </summary>
         /// <returns>A spec for all planned forks applied</returns>
-        IReleaseSpec GetFinalSpec() => GetSpec(long.MaxValue, ulong.MaxValue);
+        IReleaseSpec GetFinalSpec() => GetSpec(long.MaxValue-1, ulong.MaxValue-1);
     }
 }

--- a/src/Nethermind/Nethermind.Core/Specs/ISpecProvider.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/ISpecProvider.cs
@@ -76,9 +76,9 @@ namespace Nethermind.Core.Specs
         /// Resolves a spec for all planned forks applied.
         /// </summary>
         /// <returns>A spec for all planned forks applied</
-        /// The default value is long.MaxValue for block numbers and ulong.MaxValue for timestamps
+        /// <remarks> The default value is long.MaxValue for block numbers and ulong.MaxValue for timestamps
         /// for every new not yet scheduled EIP. Because of that we can't use long.MaxValue and
-        /// ulong.MaxValue for GetFinalSpec that is why we have long.MaxValue-1, ulong.MaxValue-1
+        /// ulong.MaxValue for GetFinalSpec that is why we have long.MaxValue-1, ulong.MaxValue-1 </remarks>
         IReleaseSpec GetFinalSpec() => GetSpec(long.MaxValue-1, ulong.MaxValue-1);
     }
 }

--- a/src/Nethermind/Nethermind.HealthChecks.Test/NodeHealthServiceTests.cs
+++ b/src/Nethermind/Nethermind.HealthChecks.Test/NodeHealthServiceTests.cs
@@ -469,22 +469,22 @@ namespace Nethermind.HealthChecks.Test
 
         private class CustomRpcCapabilitiesProvider : IRpcCapabilitiesProvider
         {
-            private readonly Dictionary<string, bool> _capabilities = new();
+            private readonly Dictionary<string, (bool Enabled, bool WarnIfMissing)> _capabilities = new();
 
             public CustomRpcCapabilitiesProvider(IReadOnlyList<string> enabledCapabilities, IReadOnlyList<string> disabledCapabilities)
             {
                 foreach (string capability in enabledCapabilities)
                 {
-                    _capabilities[capability] = true;
+                    _capabilities[capability] = (true, true);
                 }
 
                 foreach (string capability in disabledCapabilities)
                 {
-                    _capabilities[capability] = false;
+                    _capabilities[capability] = (false, false);
                 }
             }
 
-            public IReadOnlyDictionary<string, bool> GetEngineCapabilities()
+            public IReadOnlyDictionary<string, (bool Enabled, bool WarnIfMissing)> GetEngineCapabilities()
             {
                 return _capabilities;
             }

--- a/src/Nethermind/Nethermind.HealthChecks/NodeHealthService.cs
+++ b/src/Nethermind/Nethermind.HealthChecks/NodeHealthService.cs
@@ -175,7 +175,7 @@ namespace Nethermind.HealthChecks
             bool result = false;
             foreach (var capability in capabilities)
             {
-                if (capability.Value)
+                if (capability.Value.Enabled)
                 {
                     result |= UpdateStatsAndCheckInvoked(capability.Key, now);
                 }

--- a/src/Nethermind/Nethermind.JsonRpc/IRpcCapabilitiesProvider.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/IRpcCapabilitiesProvider.cs
@@ -7,5 +7,5 @@ namespace Nethermind.JsonRpc;
 
 public interface IRpcCapabilitiesProvider
 {
-    IReadOnlyDictionary<string, bool> GetEngineCapabilities();
+    IReadOnlyDictionary<string, (bool Enabled, bool WarnIfMissing)> GetEngineCapabilities();
 }

--- a/src/Nethermind/Nethermind.Merge.AuRa.Test/AuRaMergeEngineModuleTests.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa.Test/AuRaMergeEngineModuleTests.cs
@@ -35,7 +35,7 @@ namespace Nethermind.Merge.AuRa.Test;
 
 public class AuRaMergeEngineModuleTests : EngineModuleTests
 {
-    protected override MergeTestBlockchain CreateBaseBlockChain(
+    protected override MergeTestBlockchain CreateBaseBlockchain(
         IMergeConfig? mergeConfig = null,
         IPayloadPreparationService? mockedPayloadService = null,
         ILogManager? logManager = null)

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
@@ -37,7 +37,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task getPayloadV1_should_allow_asking_multiple_times_by_same_payload_id()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
 
         Keccak startingHead = chain.BlockTree.HeadHash;
@@ -58,7 +58,7 @@ public partial class EngineModuleTests
     public async Task getPayloadV1_should_return_error_if_called_after_cleanup_timer()
     {
         MergeConfig mergeConfig = new() { SecondsPerSlot = 1, TerminalTotalDifficulty = "0" };
-        using MergeTestBlockchain chain = await CreateBlockchain(mergeConfig);
+        using MergeTestBlockchain chain = await CreateBlockChain(mergeConfig);
         BlockImprovementContextFactory improvementContextFactory = new(chain.BlockProductionTrigger, TimeSpan.FromSeconds(1));
         TimeSpan timePerSlot = TimeSpan.FromMilliseconds(10);
         chain.PayloadPreparationService = new PayloadPreparationService(
@@ -89,7 +89,7 @@ public partial class EngineModuleTests
     public async Task getPayloadV1_picks_transactions_from_pool_v1()
     {
         using SemaphoreSlim blockImprovementLock = new(0);
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak startingHead = chain.BlockTree.HeadHash;
         uint count = 3;
@@ -136,7 +136,7 @@ public partial class EngineModuleTests
     [TestCaseSource(nameof(WaitTestCases))]
     public async Task<int> getPayloadV1_waits_for_block_production(TimeSpan delay)
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
 
         DelayBlockImprovementContextFactory improvementContextFactory = new(chain.BlockProductionTrigger, TimeSpan.FromSeconds(10), delay);
         chain.PayloadPreparationService = new PayloadPreparationService(
@@ -167,7 +167,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task getPayloadV1_return_correct_block_values_for_empty_block()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak startingHead = chain.BlockTree.HeadHash;
         Keccak? random = TestItem.KeccakF;
@@ -192,7 +192,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task getPayloadV1_should_return_error_if_there_was_no_corresponding_prepare_call()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak startingHead = chain.BlockTree.HeadHash;
         ulong timestamp = Timestamper.UnixTime.Seconds;
@@ -219,7 +219,7 @@ public partial class EngineModuleTests
         IBlockProductionContext improvementContext = Substitute.For<IBlockProductionContext>();
         improvementContext.CurrentBestBlock.Returns(block);
         payloadPreparationService.GetPayload(Arg.Any<string>()).Returns(improvementContext);
-        using MergeTestBlockchain chain = await CreateBlockchain(null, payloadPreparationService);
+        using MergeTestBlockchain chain = await CreateBlockChain(null, payloadPreparationService);
 
         IEngineRpcModule rpc = CreateEngineModule(chain);
         string result = RpcTest.TestSerializedRequest(rpc, "engine_getPayloadV1", payload.ToHexString(true));
@@ -258,7 +258,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task getPayload_should_serialize_unknown_payload_response_properly()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         byte[] payloadId = Bytes.FromHexString("0x1111111111111111");
 
@@ -272,7 +272,7 @@ public partial class EngineModuleTests
     public async Task consecutive_blockImprovements_should_be_disposed()
     {
         MergeConfig mergeConfig = new() { SecondsPerSlot = 1, TerminalTotalDifficulty = "0" };
-        using MergeTestBlockchain chain = await CreateBlockchain(mergeConfig);
+        using MergeTestBlockchain chain = await CreateBlockChain(mergeConfig);
         StoringBlockImprovementContextFactory improvementContextFactory = new(new MockBlockImprovementContextFactory());
         TimeSpan delay = TimeSpan.FromMilliseconds(10);
         TimeSpan timePerSlot = 10 * delay;
@@ -308,7 +308,7 @@ public partial class EngineModuleTests
     public async Task getPayloadV1_picks_transactions_from_pool_constantly_improving_blocks()
     {
         using SemaphoreSlim blockImprovementLock = new(0);
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         TimeSpan delay = TimeSpan.FromMilliseconds(10);
         TimeSpan timePerSlot = 50 * delay;
         StoringBlockImprovementContextFactory improvementContextFactory = new(new BlockImprovementContextFactory(chain.BlockProductionTrigger, TimeSpan.FromSeconds(chain.MergeConfig.SecondsPerSlot)));
@@ -354,7 +354,7 @@ public partial class EngineModuleTests
     public async Task getPayloadV1_doesnt_wait_for_improvement_when_block_is_not_empty()
     {
         using SemaphoreSlim blockImprovementLock = new(0);
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         TimeSpan delay = TimeSpan.FromMilliseconds(10);
         TimeSpan timePerSlot = 50 * delay;
         StoringBlockImprovementContextFactory improvementContextFactory = new(new DelayBlockImprovementContextFactory(chain.BlockProductionTrigger, TimeSpan.FromSeconds(chain.MergeConfig.SecondsPerSlot), 3 * delay));
@@ -412,7 +412,7 @@ public partial class EngineModuleTests
         }
 
         using SemaphoreSlim blockImprovementLock = new(0);
-        using MergeTestBlockchain chain = await CreateBlockchain(new TestSingleReleaseSpecProvider(London.Instance), logManager);
+        using MergeTestBlockchain chain = await CreateBlockChain(new TestSingleReleaseSpecProvider(London.Instance), logManager);
         TimeSpan delay = TimeSpan.FromMilliseconds(10);
         TimeSpan timePerSlot = 4 * delay;
         StoringBlockImprovementContextFactory improvementContextFactory = new(new BlockImprovementContextFactory(chain.BlockProductionTrigger, TimeSpan.FromSeconds(chain.MergeConfig.SecondsPerSlot)));
@@ -488,7 +488,7 @@ public partial class EngineModuleTests
     public async Task Empty_block_is_valid_V1()
     {
         using SemaphoreSlim blockImprovementLock = new(0);
-        using MergeTestBlockchain chain = await CreateBlockchain(new TestSingleReleaseSpecProvider(London.Instance));
+        using MergeTestBlockchain chain = await CreateBlockChain(new TestSingleReleaseSpecProvider(London.Instance));
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak blockX = chain.BlockTree.HeadHash;
         await rpc.engine_forkchoiceUpdatedV1(
@@ -504,7 +504,7 @@ public partial class EngineModuleTests
     public virtual async Task Empty_block_is_valid_with_withdrawals_V2()
     {
         using SemaphoreSlim blockImprovementLock = new(0);
-        using MergeTestBlockchain chain = await CreateBlockchain(new TestSingleReleaseSpecProvider(Shanghai.Instance));
+        using MergeTestBlockchain chain = await CreateBlockChain(new TestSingleReleaseSpecProvider(Shanghai.Instance));
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak blockX = chain.BlockTree.HeadHash;
         await rpc.engine_forkchoiceUpdatedV2(

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
@@ -37,7 +37,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task getPayloadV1_should_allow_asking_multiple_times_by_same_payload_id()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
 
         Keccak startingHead = chain.BlockTree.HeadHash;
@@ -58,7 +58,7 @@ public partial class EngineModuleTests
     public async Task getPayloadV1_should_return_error_if_called_after_cleanup_timer()
     {
         MergeConfig mergeConfig = new() { SecondsPerSlot = 1, TerminalTotalDifficulty = "0" };
-        using MergeTestBlockchain chain = await CreateBlockChain(mergeConfig);
+        using MergeTestBlockchain chain = await CreateBlockchain(mergeConfig);
         BlockImprovementContextFactory improvementContextFactory = new(chain.BlockProductionTrigger, TimeSpan.FromSeconds(1));
         TimeSpan timePerSlot = TimeSpan.FromMilliseconds(10);
         chain.PayloadPreparationService = new PayloadPreparationService(
@@ -89,7 +89,7 @@ public partial class EngineModuleTests
     public async Task getPayloadV1_picks_transactions_from_pool_v1()
     {
         using SemaphoreSlim blockImprovementLock = new(0);
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak startingHead = chain.BlockTree.HeadHash;
         uint count = 3;
@@ -136,7 +136,7 @@ public partial class EngineModuleTests
     [TestCaseSource(nameof(WaitTestCases))]
     public async Task<int> getPayloadV1_waits_for_block_production(TimeSpan delay)
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
 
         DelayBlockImprovementContextFactory improvementContextFactory = new(chain.BlockProductionTrigger, TimeSpan.FromSeconds(10), delay);
         chain.PayloadPreparationService = new PayloadPreparationService(
@@ -167,7 +167,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task getPayloadV1_return_correct_block_values_for_empty_block()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak startingHead = chain.BlockTree.HeadHash;
         Keccak? random = TestItem.KeccakF;
@@ -192,7 +192,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task getPayloadV1_should_return_error_if_there_was_no_corresponding_prepare_call()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak startingHead = chain.BlockTree.HeadHash;
         ulong timestamp = Timestamper.UnixTime.Seconds;
@@ -219,7 +219,7 @@ public partial class EngineModuleTests
         IBlockProductionContext improvementContext = Substitute.For<IBlockProductionContext>();
         improvementContext.CurrentBestBlock.Returns(block);
         payloadPreparationService.GetPayload(Arg.Any<string>()).Returns(improvementContext);
-        using MergeTestBlockchain chain = await CreateBlockChain(null, payloadPreparationService);
+        using MergeTestBlockchain chain = await CreateBlockchain(null, payloadPreparationService);
 
         IEngineRpcModule rpc = CreateEngineModule(chain);
         string result = RpcTest.TestSerializedRequest(rpc, "engine_getPayloadV1", payload.ToHexString(true));
@@ -258,7 +258,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task getPayload_should_serialize_unknown_payload_response_properly()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         byte[] payloadId = Bytes.FromHexString("0x1111111111111111");
 
@@ -272,7 +272,7 @@ public partial class EngineModuleTests
     public async Task consecutive_blockImprovements_should_be_disposed()
     {
         MergeConfig mergeConfig = new() { SecondsPerSlot = 1, TerminalTotalDifficulty = "0" };
-        using MergeTestBlockchain chain = await CreateBlockChain(mergeConfig);
+        using MergeTestBlockchain chain = await CreateBlockchain(mergeConfig);
         StoringBlockImprovementContextFactory improvementContextFactory = new(new MockBlockImprovementContextFactory());
         TimeSpan delay = TimeSpan.FromMilliseconds(10);
         TimeSpan timePerSlot = 10 * delay;
@@ -308,7 +308,7 @@ public partial class EngineModuleTests
     public async Task getPayloadV1_picks_transactions_from_pool_constantly_improving_blocks()
     {
         using SemaphoreSlim blockImprovementLock = new(0);
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         TimeSpan delay = TimeSpan.FromMilliseconds(10);
         TimeSpan timePerSlot = 50 * delay;
         StoringBlockImprovementContextFactory improvementContextFactory = new(new BlockImprovementContextFactory(chain.BlockProductionTrigger, TimeSpan.FromSeconds(chain.MergeConfig.SecondsPerSlot)));
@@ -354,7 +354,7 @@ public partial class EngineModuleTests
     public async Task getPayloadV1_doesnt_wait_for_improvement_when_block_is_not_empty()
     {
         using SemaphoreSlim blockImprovementLock = new(0);
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         TimeSpan delay = TimeSpan.FromMilliseconds(10);
         TimeSpan timePerSlot = 50 * delay;
         StoringBlockImprovementContextFactory improvementContextFactory = new(new DelayBlockImprovementContextFactory(chain.BlockProductionTrigger, TimeSpan.FromSeconds(chain.MergeConfig.SecondsPerSlot), 3 * delay));
@@ -412,7 +412,7 @@ public partial class EngineModuleTests
         }
 
         using SemaphoreSlim blockImprovementLock = new(0);
-        using MergeTestBlockchain chain = await CreateBlockChain(new TestSingleReleaseSpecProvider(London.Instance), logManager);
+        using MergeTestBlockchain chain = await CreateBlockchain(new TestSingleReleaseSpecProvider(London.Instance), logManager);
         TimeSpan delay = TimeSpan.FromMilliseconds(10);
         TimeSpan timePerSlot = 4 * delay;
         StoringBlockImprovementContextFactory improvementContextFactory = new(new BlockImprovementContextFactory(chain.BlockProductionTrigger, TimeSpan.FromSeconds(chain.MergeConfig.SecondsPerSlot)));
@@ -488,7 +488,7 @@ public partial class EngineModuleTests
     public async Task Empty_block_is_valid_V1()
     {
         using SemaphoreSlim blockImprovementLock = new(0);
-        using MergeTestBlockchain chain = await CreateBlockChain(new TestSingleReleaseSpecProvider(London.Instance));
+        using MergeTestBlockchain chain = await CreateBlockchain(new TestSingleReleaseSpecProvider(London.Instance));
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak blockX = chain.BlockTree.HeadHash;
         await rpc.engine_forkchoiceUpdatedV1(
@@ -504,7 +504,7 @@ public partial class EngineModuleTests
     public virtual async Task Empty_block_is_valid_with_withdrawals_V2()
     {
         using SemaphoreSlim blockImprovementLock = new(0);
-        using MergeTestBlockchain chain = await CreateBlockChain(new TestSingleReleaseSpecProvider(Shanghai.Instance));
+        using MergeTestBlockchain chain = await CreateBlockchain(new TestSingleReleaseSpecProvider(Shanghai.Instance));
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak blockX = chain.BlockTree.HeadHash;
         await rpc.engine_forkchoiceUpdatedV2(

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
@@ -58,7 +58,7 @@ public partial class EngineModuleTests
     public async Task getPayloadV1_should_return_error_if_called_after_cleanup_timer()
     {
         MergeConfig mergeConfig = new() { SecondsPerSlot = 1, TerminalTotalDifficulty = "0" };
-        using MergeTestBlockchain chain = await CreateBlockChain(mergeConfig);
+        using MergeTestBlockchain chain = await CreateBlockChain(null, mergeConfig);
         BlockImprovementContextFactory improvementContextFactory = new(chain.BlockProductionTrigger, TimeSpan.FromSeconds(1));
         TimeSpan timePerSlot = TimeSpan.FromMilliseconds(10);
         chain.PayloadPreparationService = new PayloadPreparationService(
@@ -219,7 +219,7 @@ public partial class EngineModuleTests
         IBlockProductionContext improvementContext = Substitute.For<IBlockProductionContext>();
         improvementContext.CurrentBestBlock.Returns(block);
         payloadPreparationService.GetPayload(Arg.Any<string>()).Returns(improvementContext);
-        using MergeTestBlockchain chain = await CreateBlockChain(null, payloadPreparationService);
+        using MergeTestBlockchain chain = await CreateBlockChain(null, null, payloadPreparationService);
 
         IEngineRpcModule rpc = CreateEngineModule(chain);
         string result = RpcTest.TestSerializedRequest(rpc, "engine_getPayloadV1", payload.ToHexString(true));
@@ -272,7 +272,7 @@ public partial class EngineModuleTests
     public async Task consecutive_blockImprovements_should_be_disposed()
     {
         MergeConfig mergeConfig = new() { SecondsPerSlot = 1, TerminalTotalDifficulty = "0" };
-        using MergeTestBlockchain chain = await CreateBlockChain(mergeConfig);
+        using MergeTestBlockchain chain = await CreateBlockChain(null, mergeConfig);
         StoringBlockImprovementContextFactory improvementContextFactory = new(new MockBlockImprovementContextFactory());
         TimeSpan delay = TimeSpan.FromMilliseconds(10);
         TimeSpan timePerSlot = 10 * delay;

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.RelayBuilder.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.RelayBuilder.cs
@@ -32,7 +32,7 @@ public partial class EngineModuleTests
     public async Task forkchoiceUpdatedV1_should_communicate_with_boost_relay()
     {
         MergeConfig mergeConfig = new() { SecondsPerSlot = 1, TerminalTotalDifficulty = "0" };
-        using MergeTestBlockchain chain = await CreateBlockChain(mergeConfig);
+        using MergeTestBlockchain chain = await CreateBlockchain(mergeConfig);
         IBoostRelay boostRelay = Substitute.For<IBoostRelay>();
         boostRelay.GetPayloadAttributes(Arg.Any<PayloadAttributes>(), Arg.Any<CancellationToken>())
             .Returns(c =>
@@ -91,7 +91,7 @@ public partial class EngineModuleTests
         string blockHash, string parentHash)
     {
         MergeConfig mergeConfig = new() { SecondsPerSlot = 1, TerminalTotalDifficulty = "0" };
-        using MergeTestBlockchain chain = await CreateBlockChain(mergeConfig);
+        using MergeTestBlockchain chain = await CreateBlockchain(mergeConfig);
         IJsonSerializer serializer = chain.JsonSerializer;
 
         ulong timestamp = Timestamper.UnixTime.Seconds;
@@ -181,7 +181,7 @@ public partial class EngineModuleTests
     public async Task forkchoiceUpdatedV1_should_ignore_gas_limit([Values(false, true)] bool relay)
     {
         MergeConfig mergeConfig = new() { SecondsPerSlot = 1, TerminalTotalDifficulty = "0" };
-        using MergeTestBlockchain chain = await CreateBlockChain(mergeConfig);
+        using MergeTestBlockchain chain = await CreateBlockchain(mergeConfig);
         IBlockImprovementContextFactory improvementContextFactory;
         if (relay)
         {

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.RelayBuilder.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.RelayBuilder.cs
@@ -32,7 +32,7 @@ public partial class EngineModuleTests
     public async Task forkchoiceUpdatedV1_should_communicate_with_boost_relay()
     {
         MergeConfig mergeConfig = new() { SecondsPerSlot = 1, TerminalTotalDifficulty = "0" };
-        using MergeTestBlockchain chain = await CreateBlockchain(mergeConfig);
+        using MergeTestBlockchain chain = await CreateBlockChain(mergeConfig);
         IBoostRelay boostRelay = Substitute.For<IBoostRelay>();
         boostRelay.GetPayloadAttributes(Arg.Any<PayloadAttributes>(), Arg.Any<CancellationToken>())
             .Returns(c =>
@@ -91,7 +91,7 @@ public partial class EngineModuleTests
         string blockHash, string parentHash)
     {
         MergeConfig mergeConfig = new() { SecondsPerSlot = 1, TerminalTotalDifficulty = "0" };
-        using MergeTestBlockchain chain = await CreateBlockchain(mergeConfig);
+        using MergeTestBlockchain chain = await CreateBlockChain(mergeConfig);
         IJsonSerializer serializer = chain.JsonSerializer;
 
         ulong timestamp = Timestamper.UnixTime.Seconds;
@@ -181,7 +181,7 @@ public partial class EngineModuleTests
     public async Task forkchoiceUpdatedV1_should_ignore_gas_limit([Values(false, true)] bool relay)
     {
         MergeConfig mergeConfig = new() { SecondsPerSlot = 1, TerminalTotalDifficulty = "0" };
-        using MergeTestBlockchain chain = await CreateBlockchain(mergeConfig);
+        using MergeTestBlockchain chain = await CreateBlockChain(mergeConfig);
         IBlockImprovementContextFactory improvementContextFactory;
         if (relay)
         {

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.RelayBuilder.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.RelayBuilder.cs
@@ -32,7 +32,7 @@ public partial class EngineModuleTests
     public async Task forkchoiceUpdatedV1_should_communicate_with_boost_relay()
     {
         MergeConfig mergeConfig = new() { SecondsPerSlot = 1, TerminalTotalDifficulty = "0" };
-        using MergeTestBlockchain chain = await CreateBlockChain(mergeConfig);
+        using MergeTestBlockchain chain = await CreateBlockChain(null, mergeConfig);
         IBoostRelay boostRelay = Substitute.For<IBoostRelay>();
         boostRelay.GetPayloadAttributes(Arg.Any<PayloadAttributes>(), Arg.Any<CancellationToken>())
             .Returns(c =>
@@ -91,7 +91,7 @@ public partial class EngineModuleTests
         string blockHash, string parentHash)
     {
         MergeConfig mergeConfig = new() { SecondsPerSlot = 1, TerminalTotalDifficulty = "0" };
-        using MergeTestBlockchain chain = await CreateBlockChain(mergeConfig);
+        using MergeTestBlockchain chain = await CreateBlockChain(null, mergeConfig);
         IJsonSerializer serializer = chain.JsonSerializer;
 
         ulong timestamp = Timestamper.UnixTime.Seconds;
@@ -181,7 +181,7 @@ public partial class EngineModuleTests
     public async Task forkchoiceUpdatedV1_should_ignore_gas_limit([Values(false, true)] bool relay)
     {
         MergeConfig mergeConfig = new() { SecondsPerSlot = 1, TerminalTotalDifficulty = "0" };
-        using MergeTestBlockchain chain = await CreateBlockChain(mergeConfig);
+        using MergeTestBlockchain chain = await CreateBlockChain(null, mergeConfig);
         IBlockImprovementContextFactory improvementContextFactory;
         if (relay)
         {

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
@@ -52,16 +52,16 @@ public partial class EngineModuleTests
         IPayloadPreparationService? mockedPayloadService = null, ILogManager? logManager = null) =>
         new(mergeConfig, mockedPayloadService, logManager);
 
-    protected async Task<MergeTestBlockchain> CreateBlockchain(IReleaseSpec? releaseSpec, IMergeConfig? mergeConfig = null)
-        => await CreateBlockchain(mergeConfig, null, releaseSpec);
+    protected async Task<MergeTestBlockchain> CreateBlockChain(IReleaseSpec? releaseSpec, IMergeConfig? mergeConfig = null)
+        => await CreateBlockChain(mergeConfig, null, releaseSpec);
 
 
-    protected async Task<MergeTestBlockchain> CreateBlockchain(IMergeConfig? mergeConfig = null,
+    protected async Task<MergeTestBlockchain> CreateBlockChain(IMergeConfig? mergeConfig = null,
         IPayloadPreparationService? mockedPayloadService = null, IReleaseSpec? releaseSpec = null)
         => await CreateBaseBlockchain(mergeConfig, mockedPayloadService)
             .Build(new TestSingleReleaseSpecProvider(releaseSpec ?? London.Instance));
 
-    protected async Task<MergeTestBlockchain> CreateBlockchain(ISpecProvider specProvider,
+    protected async Task<MergeTestBlockchain> CreateBlockChain(ISpecProvider specProvider,
         ILogManager? logManager = null)
         => await CreateBaseBlockchain(null, null, logManager).Build(specProvider);
 

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
@@ -48,22 +48,22 @@ public partial class EngineModuleTests
         return KzgPolynomialCommitments.InitializeAsync();
     }
 
-    protected virtual MergeTestBlockchain CreateBaseBlockChain(IMergeConfig? mergeConfig = null,
+    protected virtual MergeTestBlockchain CreateBaseBlockchain(IMergeConfig? mergeConfig = null,
         IPayloadPreparationService? mockedPayloadService = null, ILogManager? logManager = null) =>
         new(mergeConfig, mockedPayloadService, logManager);
 
-    protected async Task<MergeTestBlockchain> CreateBlockChain(IReleaseSpec? releaseSpec, IMergeConfig? mergeConfig = null)
-        => await CreateBlockChain(mergeConfig, null, releaseSpec);
+    protected async Task<MergeTestBlockchain> CreateBlockchain(IReleaseSpec? releaseSpec, IMergeConfig? mergeConfig = null)
+        => await CreateBlockchain(mergeConfig, null, releaseSpec);
 
 
-    protected async Task<MergeTestBlockchain> CreateBlockChain(IMergeConfig? mergeConfig = null,
+    protected async Task<MergeTestBlockchain> CreateBlockchain(IMergeConfig? mergeConfig = null,
         IPayloadPreparationService? mockedPayloadService = null, IReleaseSpec? releaseSpec = null)
-        => await CreateBaseBlockChain(mergeConfig, mockedPayloadService)
+        => await CreateBaseBlockchain(mergeConfig, mockedPayloadService)
             .Build(new TestSingleReleaseSpecProvider(releaseSpec ?? London.Instance));
 
-    protected async Task<MergeTestBlockchain> CreateBlockChain(ISpecProvider specProvider,
+    protected async Task<MergeTestBlockchain> CreateBlockchain(ISpecProvider specProvider,
         ILogManager? logManager = null)
-        => await CreateBaseBlockChain(null, null, logManager).Build(specProvider);
+        => await CreateBaseBlockchain(null, null, logManager).Build(specProvider);
 
     private IEngineRpcModule CreateEngineModule(MergeTestBlockchain chain, ISyncConfig? syncConfig = null, TimeSpan? newPayloadTimeout = null, int newPayloadCacheSize = 50)
     {

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
@@ -52,9 +52,8 @@ public partial class EngineModuleTests
         IPayloadPreparationService? mockedPayloadService = null, ILogManager? logManager = null) =>
         new(mergeConfig, mockedPayloadService, logManager);
 
-    protected async Task<MergeTestBlockchain> CreateShanghaiBlockChain(IMergeConfig? mergeConfig = null,
-        IPayloadPreparationService? mockedPayloadService = null)
-        => await CreateBlockChain(mergeConfig, mockedPayloadService, Shanghai.Instance);
+    protected async Task<MergeTestBlockchain> CreateBlockChain(IReleaseSpec? releaseSpec, IMergeConfig? mergeConfig = null)
+        => await CreateBlockChain(mergeConfig, null, releaseSpec);
 
 
     protected async Task<MergeTestBlockchain> CreateBlockChain(IMergeConfig? mergeConfig = null,
@@ -121,7 +120,7 @@ public partial class EngineModuleTests
             new GetPayloadBodiesByHashV1Handler(chain.BlockTree, chain.LogManager),
             new GetPayloadBodiesByRangeV1Handler(chain.BlockTree, chain.LogManager),
             new ExchangeTransitionConfigurationV1Handler(chain.PoSSwitcher, chain.LogManager),
-            new ExchangeCapabilitiesHandler(capabilitiesProvider, chain.SpecProvider, chain.LogManager),
+            new ExchangeCapabilitiesHandler(capabilitiesProvider, chain.LogManager),
             chain.SpecProvider,
             new GCKeeper(NoGCStrategy.Instance, chain.LogManager),
             chain.LogManager);

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
@@ -52,12 +52,9 @@ public partial class EngineModuleTests
         IPayloadPreparationService? mockedPayloadService = null, ILogManager? logManager = null) =>
         new(mergeConfig, mockedPayloadService, logManager);
 
-    protected async Task<MergeTestBlockchain> CreateBlockChain(IReleaseSpec? releaseSpec, IMergeConfig? mergeConfig = null)
-        => await CreateBlockChain(mergeConfig, null, releaseSpec);
 
-
-    protected async Task<MergeTestBlockchain> CreateBlockChain(IMergeConfig? mergeConfig = null,
-        IPayloadPreparationService? mockedPayloadService = null, IReleaseSpec? releaseSpec = null)
+    protected async Task<MergeTestBlockchain> CreateBlockChain(IReleaseSpec? releaseSpec = null, IMergeConfig? mergeConfig = null,
+        IPayloadPreparationService? mockedPayloadService = null)
         => await CreateBaseBlockchain(mergeConfig, mockedPayloadService)
             .Build(new TestSingleReleaseSpecProvider(releaseSpec ?? London.Instance));
 

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Synchronization.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Synchronization.cs
@@ -34,7 +34,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task forkChoiceUpdatedV1_unknown_block_initiates_syncing()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak? startingHead = chain.BlockTree.HeadHash;
         BlockHeader parent = Build.A.BlockHeader
@@ -88,7 +88,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task forkChoiceUpdatedV1_unknown_block_parent_while_syncing_initiates_new_sync()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak? startingHead = chain.BlockTree.HeadHash;
         BlockHeader parent = Build.A.BlockHeader
@@ -178,7 +178,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task should_return_invalid_lvh_null_on_invalid_blocks_during_the_sync()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak? startingHead = chain.BlockTree.HeadHash;
         BlockHeader parent = Build.A.BlockHeader
@@ -226,7 +226,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task newPayloadV1_can_insert_blocks_from_cache_when_syncing()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak startingHead = chain.BlockTree.HeadHash;
 
@@ -271,7 +271,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task first_new_payload_set_beacon_main_chain()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak? startingHead = chain.BlockTree.HeadHash;
         BlockHeader parent = Build.A.BlockHeader
@@ -312,7 +312,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task repeated_new_payloads_do_not_change_metadata()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak? startingHead = chain.BlockTree.HeadHash;
         BlockHeader parent = Build.A.BlockHeader
@@ -361,7 +361,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task Can_set_beacon_pivot_in_new_payload_if_null()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak lastHash = (await ProduceBranchV1(rpc, chain, 20, CreateParentBlockRequestOnHead(chain.BlockTree), true)).LastOrDefault()?.BlockHash ?? Keccak.Zero;
         chain.BlockTree.HeadHash.Should().Be(lastHash);
@@ -396,7 +396,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task BeaconMainChain_is_correctly_set_when_block_was_not_processed()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak lastHash = (await ProduceBranchV1(rpc, chain, 20, CreateParentBlockRequestOnHead(chain.BlockTree), true)).LastOrDefault()?.BlockHash ?? Keccak.Zero;
         chain.BlockTree.HeadHash.Should().Be(lastHash);
@@ -432,7 +432,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task Repeated_block_do_not_change_metadata()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak lastHash = (await ProduceBranchV1(rpc, chain, 20, CreateParentBlockRequestOnHead(chain.BlockTree), true)).LastOrDefault()?.BlockHash ?? Keccak.Zero;
         chain.BlockTree.HeadHash.Should().Be(lastHash);
@@ -470,7 +470,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task second_new_payload_should_not_set_beacon_main_chain()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak? startingHead = chain.BlockTree.HeadHash;
         BlockHeader parent = Build.A.BlockHeader
@@ -530,7 +530,7 @@ public partial class EngineModuleTests
     [TestCase(3, 4, 0)]
     public async Task should_reorg_during_the_sync(int initialChainPayloadsCount, int reorgedChainPayloadCount, int? reorgToIndex = null)
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak? startingHead = chain.BlockTree.HeadHash;
         BlockHeader parent = Build.A.BlockHeader
@@ -585,7 +585,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task Blocks_from_cache_inserted_when_fast_headers_sync_finish_before_newPayloadV1_request()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         Keccak startingHead = chain.BlockTree.HeadHash;
         IEngineRpcModule rpc = CreateEngineModule(chain);
         ExecutionPayload[] requests = CreateBlockRequestBranch(new ExecutionPayload(chain.BlockTree.Head!), Address.Zero, 7);
@@ -631,7 +631,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task Maintain_correct_pointers_for_beacon_sync_in_archive_sync()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak startingHead = chain.BlockTree.HeadHash;
         // create 7 block gap
@@ -736,7 +736,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task Blocks_before_pivots_should_not_be_added_if_node_has_never_been_in_sync()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         BlockTree syncedBlockTree = Build.A.BlockTree(chain.BlockTree.Head!, chain.SpecProvider).WithPostMergeRules().OfChainLength(5).TestObject;
         ISyncConfig syncConfig = new SyncConfig
         {
@@ -758,7 +758,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task Blocks_before_pivots_should_not_be_added_if_node_has_been_synced()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         BlockTree syncedBlockTree = Build.A.BlockTree(chain.BlockTree.Head!, chain.SpecProvider).WithPostMergeRules().OfChainLength(5).TestObject;
         ISyncConfig syncConfig = new SyncConfig
         {
@@ -784,7 +784,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task Maintain_correct_pointers_for_beacon_sync_in_fast_sync()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         BlockTree syncedBlockTree = Build.A.BlockTree(chain.BlockTree.Head!).OfChainLength(5).TestObject;
         ISyncConfig syncConfig = new SyncConfig
         {
@@ -850,7 +850,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task Invalid_block_can_create_invalid_best_state_issue_but_recalculating_tree_levels_will_fix_it()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak lastHash = (await ProduceBranchV1(rpc, chain, 30, CreateParentBlockRequestOnHead(chain.BlockTree), true))
             .LastOrDefault()?.BlockHash ?? Keccak.Zero;
@@ -887,7 +887,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task MultiSyncModeSelector_should_fix_block_tree_levels_if_needed()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak lastHash = (await ProduceBranchV1(rpc, chain, 30, CreateParentBlockRequestOnHead(chain.BlockTree), true))
             .LastOrDefault()?.BlockHash ?? Keccak.Zero;

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Synchronization.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Synchronization.cs
@@ -34,7 +34,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task forkChoiceUpdatedV1_unknown_block_initiates_syncing()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak? startingHead = chain.BlockTree.HeadHash;
         BlockHeader parent = Build.A.BlockHeader
@@ -88,7 +88,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task forkChoiceUpdatedV1_unknown_block_parent_while_syncing_initiates_new_sync()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak? startingHead = chain.BlockTree.HeadHash;
         BlockHeader parent = Build.A.BlockHeader
@@ -178,7 +178,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task should_return_invalid_lvh_null_on_invalid_blocks_during_the_sync()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak? startingHead = chain.BlockTree.HeadHash;
         BlockHeader parent = Build.A.BlockHeader
@@ -226,7 +226,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task newPayloadV1_can_insert_blocks_from_cache_when_syncing()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak startingHead = chain.BlockTree.HeadHash;
 
@@ -271,7 +271,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task first_new_payload_set_beacon_main_chain()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak? startingHead = chain.BlockTree.HeadHash;
         BlockHeader parent = Build.A.BlockHeader
@@ -312,7 +312,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task repeated_new_payloads_do_not_change_metadata()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak? startingHead = chain.BlockTree.HeadHash;
         BlockHeader parent = Build.A.BlockHeader
@@ -361,7 +361,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task Can_set_beacon_pivot_in_new_payload_if_null()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak lastHash = (await ProduceBranchV1(rpc, chain, 20, CreateParentBlockRequestOnHead(chain.BlockTree), true)).LastOrDefault()?.BlockHash ?? Keccak.Zero;
         chain.BlockTree.HeadHash.Should().Be(lastHash);
@@ -396,7 +396,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task BeaconMainChain_is_correctly_set_when_block_was_not_processed()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak lastHash = (await ProduceBranchV1(rpc, chain, 20, CreateParentBlockRequestOnHead(chain.BlockTree), true)).LastOrDefault()?.BlockHash ?? Keccak.Zero;
         chain.BlockTree.HeadHash.Should().Be(lastHash);
@@ -432,7 +432,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task Repeated_block_do_not_change_metadata()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak lastHash = (await ProduceBranchV1(rpc, chain, 20, CreateParentBlockRequestOnHead(chain.BlockTree), true)).LastOrDefault()?.BlockHash ?? Keccak.Zero;
         chain.BlockTree.HeadHash.Should().Be(lastHash);
@@ -470,7 +470,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task second_new_payload_should_not_set_beacon_main_chain()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak? startingHead = chain.BlockTree.HeadHash;
         BlockHeader parent = Build.A.BlockHeader
@@ -530,7 +530,7 @@ public partial class EngineModuleTests
     [TestCase(3, 4, 0)]
     public async Task should_reorg_during_the_sync(int initialChainPayloadsCount, int reorgedChainPayloadCount, int? reorgToIndex = null)
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak? startingHead = chain.BlockTree.HeadHash;
         BlockHeader parent = Build.A.BlockHeader
@@ -585,7 +585,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task Blocks_from_cache_inserted_when_fast_headers_sync_finish_before_newPayloadV1_request()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         Keccak startingHead = chain.BlockTree.HeadHash;
         IEngineRpcModule rpc = CreateEngineModule(chain);
         ExecutionPayload[] requests = CreateBlockRequestBranch(new ExecutionPayload(chain.BlockTree.Head!), Address.Zero, 7);
@@ -631,7 +631,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task Maintain_correct_pointers_for_beacon_sync_in_archive_sync()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak startingHead = chain.BlockTree.HeadHash;
         // create 7 block gap
@@ -736,7 +736,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task Blocks_before_pivots_should_not_be_added_if_node_has_never_been_in_sync()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         BlockTree syncedBlockTree = Build.A.BlockTree(chain.BlockTree.Head!, chain.SpecProvider).WithPostMergeRules().OfChainLength(5).TestObject;
         ISyncConfig syncConfig = new SyncConfig
         {
@@ -758,7 +758,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task Blocks_before_pivots_should_not_be_added_if_node_has_been_synced()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         BlockTree syncedBlockTree = Build.A.BlockTree(chain.BlockTree.Head!, chain.SpecProvider).WithPostMergeRules().OfChainLength(5).TestObject;
         ISyncConfig syncConfig = new SyncConfig
         {
@@ -784,7 +784,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task Maintain_correct_pointers_for_beacon_sync_in_fast_sync()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         BlockTree syncedBlockTree = Build.A.BlockTree(chain.BlockTree.Head!).OfChainLength(5).TestObject;
         ISyncConfig syncConfig = new SyncConfig
         {
@@ -850,7 +850,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task Invalid_block_can_create_invalid_best_state_issue_but_recalculating_tree_levels_will_fix_it()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak lastHash = (await ProduceBranchV1(rpc, chain, 30, CreateParentBlockRequestOnHead(chain.BlockTree), true))
             .LastOrDefault()?.BlockHash ?? Keccak.Zero;
@@ -887,7 +887,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task MultiSyncModeSelector_should_fix_block_tree_levels_if_needed()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak lastHash = (await ProduceBranchV1(rpc, chain, 30, CreateParentBlockRequestOnHead(chain.BlockTree), true))
             .LastOrDefault()?.BlockHash ?? Keccak.Zero;

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
@@ -49,7 +49,7 @@ public partial class EngineModuleTests
         "0x6454408c425ddd96")]
     public virtual async Task processing_block_should_serialize_valid_responses(string blockHash, string latestValidHash, string payloadId)
     {
-        using MergeTestBlockchain chain = await CreateBlockchain(new MergeConfig()
+        using MergeTestBlockchain chain = await CreateBlockChain(new MergeConfig()
         {
             TerminalTotalDifficulty = "0"
         });
@@ -122,7 +122,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task can_parse_forkchoiceUpdated_with_implicit_null_payloadAttributes()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         var forkChoiceUpdatedParams = new
         {
@@ -145,7 +145,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task engine_forkchoiceUpdatedV1_with_payload_attributes_should_create_block_on_top_of_genesis_and_not_change_head()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak startingHead = chain.BlockTree.HeadHash;
         ulong timestamp = 30;
@@ -179,7 +179,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task forkchoiceUpdatedV1_should_not_create_block_or_change_head_with_unknown_parent()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak startingHead = chain.BlockTree.HeadHash;
         Keccak notExistingHash = TestItem.KeccakH;
@@ -205,7 +205,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task executePayloadV1_accepts_previously_assembled_block_multiple_times([Values(1, 3)] int times)
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak startingHead = chain.BlockTree.HeadHash;
         BlockHeader startingBestSuggestedHeader = chain.BlockTree.BestSuggestedHeader!;
@@ -227,7 +227,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task executePayloadV1_accepts_previously_prepared_block_multiple_times([Values(1, 3)] int times)
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak startingHead = chain.BlockTree.HeadHash;
         BlockHeader startingBestSuggestedHeader = chain.BlockTree.BestSuggestedHeader!;
@@ -249,7 +249,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task block_should_not_be_canonical_before_forkchoiceUpdatedV1()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
 
         ExecutionPayload getPayloadResult = await BuildAndGetPayloadResult(chain, rpc);
@@ -267,7 +267,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task block_should_not_be_canonical_after_reorg()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak startingHead = chain.BlockTree.HeadHash;
         Keccak finalizedHash = Keccak.Zero;
@@ -362,7 +362,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task executePayloadV1_unknown_parentHash_return_syncing()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         ExecutionPayload getPayloadResult = await BuildAndGetPayloadResult(chain, rpc);
         Keccak blockHash = getPayloadResult.BlockHash;
@@ -379,7 +379,7 @@ public partial class EngineModuleTests
     [TestCaseSource(nameof(WrongInputTestsV1))]
     public async Task executePayloadV1_rejects_incorrect_input(Action<ExecutionPayload> breakerAction)
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         ExecutionPayload getPayloadResult = await BuildAndGetPayloadResult(chain, rpc);
         breakerAction(getPayloadResult);
@@ -395,7 +395,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task executePayloadV1_rejects_invalid_blockHash()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         ExecutionPayload getPayloadResult = await BuildAndGetPayloadResult(chain, rpc);
         getPayloadResult.BlockHash = TestItem.KeccakC;
@@ -407,7 +407,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task executePayloadV1_rejects_block_with_invalid_timestamp()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         ExecutionPayload getPayloadResult = await BuildAndGetPayloadResult(chain, rpc);
         getPayloadResult.Timestamp = (ulong)chain.BlockTree.Head!.Timestamp - 1;
@@ -421,7 +421,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task executePayloadV1_rejects_block_with_invalid_receiptsRoot()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         ExecutionPayload getPayloadResult = await BuildAndGetPayloadResult(chain, rpc);
         getPayloadResult.ReceiptsRoot = TestItem.KeccakA;
@@ -480,7 +480,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task forkchoiceUpdatedV1_should_work_with_zero_keccak_for_finalization()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak startingHead = chain.BlockTree.HeadHash;
         ExecutionPayload executionPayload = await SendNewBlockV1(rpc, chain);
@@ -500,7 +500,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task forkchoiceUpdatedV1_should_update_finalized_block_hash()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         TestRpcBlockchain testRpc = await CreateTestRpc(chain);
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak startingHead = chain.BlockTree.HeadHash;
@@ -529,7 +529,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task forkchoiceUpdatedV1_should_update_safe_block_hash()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         TestRpcBlockchain testRpc = await CreateTestRpc(chain);
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak startingHead = chain.BlockTree.HeadHash;
@@ -558,7 +558,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task forkchoiceUpdatedV1_should_work_with_zero_keccak_as_safe_block()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak startingHead = chain.BlockTree.HeadHash;
         ExecutionPayload executionPayload = await SendNewBlockV1(rpc, chain);
@@ -578,7 +578,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task forkchoiceUpdatedV1_with_no_payload_attributes_should_change_head()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak startingHead = chain.BlockTree.HeadHash;
         ExecutionPayload executionPayload = await SendNewBlockV1(rpc, chain);
@@ -598,7 +598,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task forkChoiceUpdatedV1_to_unknown_block_fails()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         ForkchoiceStateV1 forkchoiceStateV1 = new(TestItem.KeccakF, TestItem.KeccakF, TestItem.KeccakF);
         ResultWrapper<ForkchoiceUpdatedV1Result> forkchoiceUpdatedResult = await rpc.engine_forkchoiceUpdatedV1(forkchoiceStateV1);
@@ -609,7 +609,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task forkChoiceUpdatedV1_to_unknown_safeBlock_hash_should_fail()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak startingHead = chain.BlockTree.HeadHash;
         ExecutionPayload executionPayload = await SendNewBlockV1(rpc, chain);
@@ -626,7 +626,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task forkChoiceUpdatedV1_no_common_branch_fails()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak? startingHead = chain.BlockTree.HeadHash;
         Block parent = Build.A.Block.WithNumber(2).WithParentHash(TestItem.KeccakA).WithNonce(0).WithDifficulty(0).TestObject;
@@ -650,7 +650,7 @@ public partial class EngineModuleTests
     [Test, NonParallelizable]
     public async Task forkChoiceUpdatedV1_block_still_processing()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
 
         IEngineRpcModule rpc = CreateEngineModule(chain, newPayloadTimeout: TimeSpan.FromMilliseconds(100));
         Keccak startingHead = chain.BlockTree.HeadHash;
@@ -673,7 +673,7 @@ public partial class EngineModuleTests
     [Test, NonParallelizable]
     public async Task AlreadyKnown_not_cached_block_should_return_valid()
     {
-        using MergeTestBlockchain? chain = await CreateBlockchain();
+        using MergeTestBlockchain? chain = await CreateBlockChain();
 
         IEngineRpcModule? rpc = CreateEngineModule(chain, newPayloadTimeout: TimeSpan.FromMilliseconds(100), newPayloadCacheSize: 0);
         Block? head = chain.BlockTree.Head!;
@@ -704,7 +704,7 @@ public partial class EngineModuleTests
     [Test, NonParallelizable]
     public async Task Invalid_block_on_processing_wont_be_accepted_if_sent_twice_in_a_row_when_block_processing_queue_is_not_empty()
     {
-        using MergeTestBlockchain? chain = await CreateBlockchain();
+        using MergeTestBlockchain? chain = await CreateBlockChain();
 
         IEngineRpcModule? rpc = CreateEngineModule(chain, newPayloadTimeout: TimeSpan.FromMilliseconds(100), newPayloadCacheSize: 10);
         Block? head = chain.BlockTree.Head!;
@@ -739,7 +739,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task forkchoiceUpdatedV1_should_change_head_when_all_parameters_are_the_newHeadHash()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         ExecutionPayload executionPayload = await SendNewBlockV1(rpc, chain);
         Keccak newHeadHash = executionPayload.BlockHash;
@@ -755,7 +755,7 @@ public partial class EngineModuleTests
     public async Task Can_transition_from_PoW_chain()
     {
         using MergeTestBlockchain chain =
-            await CreateBlockchain(new MergeConfig() { TerminalTotalDifficulty = "1000001" });
+            await CreateBlockChain(new MergeConfig() { TerminalTotalDifficulty = "1000001" });
         IEngineRpcModule rpc = CreateEngineModule(chain);
 
         // adding PoW block
@@ -774,7 +774,7 @@ public partial class EngineModuleTests
     [TestCase(1000001)]
     public async Task executePayloadV1_should_not_accept_blocks_with_incorrect_ttd(long? terminalTotalDifficulty)
     {
-        using MergeTestBlockchain chain = await CreateBlockchain(new MergeConfig()
+        using MergeTestBlockchain chain = await CreateBlockChain(new MergeConfig()
         {
             TerminalTotalDifficulty = $"{terminalTotalDifficulty}"
         });
@@ -790,7 +790,7 @@ public partial class EngineModuleTests
     [TestCase(1000001)]
     public async Task forkchoiceUpdatedV1_should_not_accept_blocks_with_incorrect_ttd(long? terminalTotalDifficulty)
     {
-        using MergeTestBlockchain chain = await CreateBlockchain(new MergeConfig()
+        using MergeTestBlockchain chain = await CreateBlockChain(new MergeConfig()
         {
             TerminalTotalDifficulty = $"{terminalTotalDifficulty}"
         });
@@ -804,7 +804,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task executePayloadV1_on_top_of_terminal_block()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain(new MergeConfig()
+        using MergeTestBlockchain chain = await CreateBlockChain(new MergeConfig()
         {
             TerminalTotalDifficulty = $"{1900000}"
         });
@@ -835,7 +835,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task executePayloadV1_on_top_of_not_processed_invalid_terminal_block()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain(new MergeConfig()
+        using MergeTestBlockchain chain = await CreateBlockChain(new MergeConfig()
         {
             TerminalTotalDifficulty = $"{1900000}"
         });
@@ -880,7 +880,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task executePayloadV1_on_top_of_not_processed_terminal_block()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain(new MergeConfig()
+        using MergeTestBlockchain chain = await CreateBlockChain(new MergeConfig()
         {
             TerminalTotalDifficulty = $"{1900000}"
         });
@@ -925,7 +925,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task executePayloadV1_accepts_first_block()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         ExecutionPayload executionPayload = CreateBlockRequest(CreateParentBlockRequestOnHead(chain.BlockTree), TestItem.AddressD);
         ResultWrapper<PayloadStatusV1> resultWrapper = await rpc.engine_newPayloadV1(executionPayload);
@@ -936,7 +936,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task executePayloadV1_calculate_hash_for_cached_blocks()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         ExecutionPayload executionPayload = CreateBlockRequest(
             CreateParentBlockRequestOnHead(chain.BlockTree),
@@ -954,7 +954,7 @@ public partial class EngineModuleTests
     [TestCase(30)]
     public async Task can_progress_chain_one_by_one_v1(int count)
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak lastHash = (await ProduceBranchV1(rpc, chain, count, CreateParentBlockRequestOnHead(chain.BlockTree), true))
             .LastOrDefault()?.BlockHash ?? Keccak.Zero;
@@ -967,7 +967,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task forkchoiceUpdatedV1_can_reorganize_to_last_block()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
 
         async Task CanReorganizeToBlock(ExecutionPayload block, MergeTestBlockchain testChain)
@@ -999,7 +999,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task forkchoiceUpdatedV1_head_block_after_reorg()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
 
         async Task CanReorganizeToBlock(ExecutionPayload block, MergeTestBlockchain testChain)
@@ -1022,7 +1022,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task newPayloadV1_should_return_accepted_for_side_branch()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         ExecutionPayload executionPayload = CreateBlockRequest(CreateParentBlockRequestOnHead(chain.BlockTree), TestItem.AddressD);
         ResultWrapper<PayloadStatusV1> resultWrapper = await rpc.engine_newPayloadV1(executionPayload);
@@ -1042,7 +1042,7 @@ public partial class EngineModuleTests
     [TestCase(true)]
     public async Task executePayloadV1_processes_passed_transactions(bool moveHead)
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         IReadOnlyList<ExecutionPayload> branch = await ProduceBranchV1(rpc, chain, 8, CreateParentBlockRequestOnHead(chain.BlockTree), moveHead);
 
@@ -1079,7 +1079,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task executePayloadV1_transactions_produce_receipts()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         IReadOnlyList<ExecutionPayload> branch = await ProduceBranchV1(rpc, chain, 1, CreateParentBlockRequestOnHead(chain.BlockTree), false);
 
@@ -1156,7 +1156,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task ExecutionPayloadV1_set_and_get_transactions_roundtrip()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         Keccak startingHead = chain.BlockTree.HeadHash;
         uint count = 3;
         int value = 10;
@@ -1183,7 +1183,7 @@ public partial class EngineModuleTests
     public async Task payloadV1_no_suggestedFeeRecipient_in_config()
     {
         using MergeTestBlockchain chain =
-            await CreateBlockchain(new MergeConfig() { TerminalTotalDifficulty = "0" });
+            await CreateBlockChain(new MergeConfig() { TerminalTotalDifficulty = "0" });
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak startingHead = chain.BlockTree.HeadHash;
         ulong timestamp = Timestamper.UnixTime.Seconds;
@@ -1201,7 +1201,7 @@ public partial class EngineModuleTests
     public async Task exchangeTransitionConfiguration_return_expected_results(long clTtd, string terminalBlockHash)
     {
         using MergeTestBlockchain chain =
-            await CreateBlockchain(new MergeConfig() { TerminalTotalDifficulty = "1000001", TerminalBlockHash = new Keccak("0x191dc9697d77129ee5b6f6d57074d2c854a38129913e3fdd3d9f0ebc930503a6").ToString(true), TerminalBlockNumber = 1 });
+            await CreateBlockChain(new MergeConfig() { TerminalTotalDifficulty = "1000001", TerminalBlockHash = new Keccak("0x191dc9697d77129ee5b6f6d57074d2c854a38129913e3fdd3d9f0ebc930503a6").ToString(true), TerminalBlockNumber = 1 });
         IEngineRpcModule rpc = CreateEngineModule(chain);
 
         TransitionConfigurationV1 result = rpc.engine_exchangeTransitionConfigurationV1(new TransitionConfigurationV1()
@@ -1221,7 +1221,7 @@ public partial class EngineModuleTests
     public async Task exchangeTransitionConfiguration_return_with_empty_Nethermind_configuration(long clTtd, string terminalBlockHash)
     {
         using MergeTestBlockchain chain =
-            await CreateBlockchain(new MergeConfig() { });
+            await CreateBlockChain(new MergeConfig() { });
         IEngineRpcModule rpc = CreateEngineModule(chain);
 
         TransitionConfigurationV1 result = rpc.engine_exchangeTransitionConfigurationV1(new TransitionConfigurationV1()
@@ -1281,7 +1281,7 @@ public partial class EngineModuleTests
     public async Task repeat_the_same_payload_after_fcu_should_return_valid_and_be_ignored()
     {
         using MergeTestBlockchain chain =
-            await CreateBlockchain(new MergeConfig() { TerminalTotalDifficulty = "0" });
+            await CreateBlockChain(new MergeConfig() { TerminalTotalDifficulty = "0" });
         IEngineRpcModule rpc = CreateEngineModule(chain);
 
         // Correct new payload
@@ -1308,7 +1308,7 @@ public partial class EngineModuleTests
     public async Task payloadV1_invalid_parent_hash()
     {
         using MergeTestBlockchain chain =
-            await CreateBlockchain(new MergeConfig() { TerminalTotalDifficulty = "0" });
+            await CreateBlockChain(new MergeConfig() { TerminalTotalDifficulty = "0" });
         IEngineRpcModule rpc = CreateEngineModule(chain);
 
         // Correct new payload
@@ -1377,7 +1377,7 @@ public partial class EngineModuleTests
     public async Task inconsistent_finalized_hash()
     {
         using MergeTestBlockchain chain =
-            await CreateBlockchain(new MergeConfig() { TerminalTotalDifficulty = "0" });
+            await CreateBlockChain(new MergeConfig() { TerminalTotalDifficulty = "0" });
         IEngineRpcModule rpc = CreateEngineModule(chain);
 
         ExecutionPayload blockRequestResult1 = CreateBlockRequest(
@@ -1413,7 +1413,7 @@ public partial class EngineModuleTests
     public async Task inconsistent_safe_hash()
     {
         using MergeTestBlockchain chain =
-            await CreateBlockchain(new MergeConfig() { TerminalTotalDifficulty = "0" });
+            await CreateBlockChain(new MergeConfig() { TerminalTotalDifficulty = "0" });
         IEngineRpcModule rpc = CreateEngineModule(chain);
 
         ExecutionPayload blockRequestResult1 = CreateBlockRequest(
@@ -1450,7 +1450,7 @@ public partial class EngineModuleTests
     public async Task payloadV1_latest_block_after_reorg()
     {
         using MergeTestBlockchain chain =
-            await CreateBlockchain(new MergeConfig() { TerminalTotalDifficulty = "0" });
+            await CreateBlockChain(new MergeConfig() { TerminalTotalDifficulty = "0" });
         IEngineRpcModule rpc = CreateEngineModule(chain);
 
         Keccak prevRandao1 = TestItem.KeccakA;
@@ -1549,7 +1549,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task Should_return_capabilities()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain(Cancun.Instance);
+        using MergeTestBlockchain chain = await CreateBlockChain(Cancun.Instance);
         IEngineRpcModule rpcModule = CreateEngineModule(chain);
         IOrderedEnumerable<string> expected = typeof(IEngineRpcModule).GetMethods()
             .Select(m => m.Name)
@@ -1592,7 +1592,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task Should_warn_for_missing_capabilities()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         chain.LogManager = Substitute.For<ILogManager>();
         chain.LogManager.GetClassLogger().IsWarn.Returns(true);
 

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
@@ -49,7 +49,7 @@ public partial class EngineModuleTests
         "0x6454408c425ddd96")]
     public virtual async Task processing_block_should_serialize_valid_responses(string blockHash, string latestValidHash, string payloadId)
     {
-        using MergeTestBlockchain chain = await CreateBlockChain(new MergeConfig()
+        using MergeTestBlockchain chain = await CreateBlockchain(new MergeConfig()
         {
             TerminalTotalDifficulty = "0"
         });
@@ -122,7 +122,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task can_parse_forkchoiceUpdated_with_implicit_null_payloadAttributes()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         var forkChoiceUpdatedParams = new
         {
@@ -145,7 +145,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task engine_forkchoiceUpdatedV1_with_payload_attributes_should_create_block_on_top_of_genesis_and_not_change_head()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak startingHead = chain.BlockTree.HeadHash;
         ulong timestamp = 30;
@@ -179,7 +179,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task forkchoiceUpdatedV1_should_not_create_block_or_change_head_with_unknown_parent()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak startingHead = chain.BlockTree.HeadHash;
         Keccak notExistingHash = TestItem.KeccakH;
@@ -205,7 +205,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task executePayloadV1_accepts_previously_assembled_block_multiple_times([Values(1, 3)] int times)
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak startingHead = chain.BlockTree.HeadHash;
         BlockHeader startingBestSuggestedHeader = chain.BlockTree.BestSuggestedHeader!;
@@ -227,7 +227,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task executePayloadV1_accepts_previously_prepared_block_multiple_times([Values(1, 3)] int times)
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak startingHead = chain.BlockTree.HeadHash;
         BlockHeader startingBestSuggestedHeader = chain.BlockTree.BestSuggestedHeader!;
@@ -249,7 +249,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task block_should_not_be_canonical_before_forkchoiceUpdatedV1()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
 
         ExecutionPayload getPayloadResult = await BuildAndGetPayloadResult(chain, rpc);
@@ -267,7 +267,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task block_should_not_be_canonical_after_reorg()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak startingHead = chain.BlockTree.HeadHash;
         Keccak finalizedHash = Keccak.Zero;
@@ -362,7 +362,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task executePayloadV1_unknown_parentHash_return_syncing()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         ExecutionPayload getPayloadResult = await BuildAndGetPayloadResult(chain, rpc);
         Keccak blockHash = getPayloadResult.BlockHash;
@@ -379,7 +379,7 @@ public partial class EngineModuleTests
     [TestCaseSource(nameof(WrongInputTestsV1))]
     public async Task executePayloadV1_rejects_incorrect_input(Action<ExecutionPayload> breakerAction)
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         ExecutionPayload getPayloadResult = await BuildAndGetPayloadResult(chain, rpc);
         breakerAction(getPayloadResult);
@@ -395,7 +395,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task executePayloadV1_rejects_invalid_blockHash()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         ExecutionPayload getPayloadResult = await BuildAndGetPayloadResult(chain, rpc);
         getPayloadResult.BlockHash = TestItem.KeccakC;
@@ -407,7 +407,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task executePayloadV1_rejects_block_with_invalid_timestamp()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         ExecutionPayload getPayloadResult = await BuildAndGetPayloadResult(chain, rpc);
         getPayloadResult.Timestamp = (ulong)chain.BlockTree.Head!.Timestamp - 1;
@@ -421,7 +421,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task executePayloadV1_rejects_block_with_invalid_receiptsRoot()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         ExecutionPayload getPayloadResult = await BuildAndGetPayloadResult(chain, rpc);
         getPayloadResult.ReceiptsRoot = TestItem.KeccakA;
@@ -436,7 +436,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task executePayloadV1_result_is_fail_when_blockchainprocessor_report_exception()
     {
-        using MergeTestBlockchain chain = await CreateBaseBlockChain(null, null)
+        using MergeTestBlockchain chain = await CreateBaseBlockchain(null, null)
             .Build(new TestSingleReleaseSpecProvider(London.Instance));
         IEngineRpcModule rpc = CreateEngineModule(chain);
 
@@ -453,7 +453,7 @@ public partial class EngineModuleTests
     [TestCase(false)]
     public virtual async Task executePayloadV1_accepts_already_known_block(bool throttleBlockProcessor)
     {
-        using MergeTestBlockchain chain = await CreateBaseBlockChain()
+        using MergeTestBlockchain chain = await CreateBaseBlockchain()
             .ThrottleBlockProcessor(throttleBlockProcessor ? 100 : 0)
             .Build(new TestSingleReleaseSpecProvider(London.Instance));
 
@@ -480,7 +480,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task forkchoiceUpdatedV1_should_work_with_zero_keccak_for_finalization()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak startingHead = chain.BlockTree.HeadHash;
         ExecutionPayload executionPayload = await SendNewBlockV1(rpc, chain);
@@ -500,7 +500,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task forkchoiceUpdatedV1_should_update_finalized_block_hash()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         TestRpcBlockchain testRpc = await CreateTestRpc(chain);
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak startingHead = chain.BlockTree.HeadHash;
@@ -529,7 +529,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task forkchoiceUpdatedV1_should_update_safe_block_hash()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         TestRpcBlockchain testRpc = await CreateTestRpc(chain);
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak startingHead = chain.BlockTree.HeadHash;
@@ -558,7 +558,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task forkchoiceUpdatedV1_should_work_with_zero_keccak_as_safe_block()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak startingHead = chain.BlockTree.HeadHash;
         ExecutionPayload executionPayload = await SendNewBlockV1(rpc, chain);
@@ -578,7 +578,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task forkchoiceUpdatedV1_with_no_payload_attributes_should_change_head()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak startingHead = chain.BlockTree.HeadHash;
         ExecutionPayload executionPayload = await SendNewBlockV1(rpc, chain);
@@ -598,7 +598,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task forkChoiceUpdatedV1_to_unknown_block_fails()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         ForkchoiceStateV1 forkchoiceStateV1 = new(TestItem.KeccakF, TestItem.KeccakF, TestItem.KeccakF);
         ResultWrapper<ForkchoiceUpdatedV1Result> forkchoiceUpdatedResult = await rpc.engine_forkchoiceUpdatedV1(forkchoiceStateV1);
@@ -609,7 +609,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task forkChoiceUpdatedV1_to_unknown_safeBlock_hash_should_fail()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak startingHead = chain.BlockTree.HeadHash;
         ExecutionPayload executionPayload = await SendNewBlockV1(rpc, chain);
@@ -626,7 +626,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task forkChoiceUpdatedV1_no_common_branch_fails()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak? startingHead = chain.BlockTree.HeadHash;
         Block parent = Build.A.Block.WithNumber(2).WithParentHash(TestItem.KeccakA).WithNonce(0).WithDifficulty(0).TestObject;
@@ -650,7 +650,7 @@ public partial class EngineModuleTests
     [Test, NonParallelizable]
     public async Task forkChoiceUpdatedV1_block_still_processing()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
 
         IEngineRpcModule rpc = CreateEngineModule(chain, newPayloadTimeout: TimeSpan.FromMilliseconds(100));
         Keccak startingHead = chain.BlockTree.HeadHash;
@@ -673,7 +673,7 @@ public partial class EngineModuleTests
     [Test, NonParallelizable]
     public async Task AlreadyKnown_not_cached_block_should_return_valid()
     {
-        using MergeTestBlockchain? chain = await CreateBlockChain();
+        using MergeTestBlockchain? chain = await CreateBlockchain();
 
         IEngineRpcModule? rpc = CreateEngineModule(chain, newPayloadTimeout: TimeSpan.FromMilliseconds(100), newPayloadCacheSize: 0);
         Block? head = chain.BlockTree.Head!;
@@ -704,7 +704,7 @@ public partial class EngineModuleTests
     [Test, NonParallelizable]
     public async Task Invalid_block_on_processing_wont_be_accepted_if_sent_twice_in_a_row_when_block_processing_queue_is_not_empty()
     {
-        using MergeTestBlockchain? chain = await CreateBlockChain();
+        using MergeTestBlockchain? chain = await CreateBlockchain();
 
         IEngineRpcModule? rpc = CreateEngineModule(chain, newPayloadTimeout: TimeSpan.FromMilliseconds(100), newPayloadCacheSize: 10);
         Block? head = chain.BlockTree.Head!;
@@ -739,7 +739,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task forkchoiceUpdatedV1_should_change_head_when_all_parameters_are_the_newHeadHash()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         ExecutionPayload executionPayload = await SendNewBlockV1(rpc, chain);
         Keccak newHeadHash = executionPayload.BlockHash;
@@ -755,7 +755,7 @@ public partial class EngineModuleTests
     public async Task Can_transition_from_PoW_chain()
     {
         using MergeTestBlockchain chain =
-            await CreateBlockChain(new MergeConfig() { TerminalTotalDifficulty = "1000001" });
+            await CreateBlockchain(new MergeConfig() { TerminalTotalDifficulty = "1000001" });
         IEngineRpcModule rpc = CreateEngineModule(chain);
 
         // adding PoW block
@@ -774,7 +774,7 @@ public partial class EngineModuleTests
     [TestCase(1000001)]
     public async Task executePayloadV1_should_not_accept_blocks_with_incorrect_ttd(long? terminalTotalDifficulty)
     {
-        using MergeTestBlockchain chain = await CreateBlockChain(new MergeConfig()
+        using MergeTestBlockchain chain = await CreateBlockchain(new MergeConfig()
         {
             TerminalTotalDifficulty = $"{terminalTotalDifficulty}"
         });
@@ -790,7 +790,7 @@ public partial class EngineModuleTests
     [TestCase(1000001)]
     public async Task forkchoiceUpdatedV1_should_not_accept_blocks_with_incorrect_ttd(long? terminalTotalDifficulty)
     {
-        using MergeTestBlockchain chain = await CreateBlockChain(new MergeConfig()
+        using MergeTestBlockchain chain = await CreateBlockchain(new MergeConfig()
         {
             TerminalTotalDifficulty = $"{terminalTotalDifficulty}"
         });
@@ -804,7 +804,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task executePayloadV1_on_top_of_terminal_block()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain(new MergeConfig()
+        using MergeTestBlockchain chain = await CreateBlockchain(new MergeConfig()
         {
             TerminalTotalDifficulty = $"{1900000}"
         });
@@ -835,7 +835,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task executePayloadV1_on_top_of_not_processed_invalid_terminal_block()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain(new MergeConfig()
+        using MergeTestBlockchain chain = await CreateBlockchain(new MergeConfig()
         {
             TerminalTotalDifficulty = $"{1900000}"
         });
@@ -880,7 +880,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task executePayloadV1_on_top_of_not_processed_terminal_block()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain(new MergeConfig()
+        using MergeTestBlockchain chain = await CreateBlockchain(new MergeConfig()
         {
             TerminalTotalDifficulty = $"{1900000}"
         });
@@ -925,7 +925,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task executePayloadV1_accepts_first_block()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         ExecutionPayload executionPayload = CreateBlockRequest(CreateParentBlockRequestOnHead(chain.BlockTree), TestItem.AddressD);
         ResultWrapper<PayloadStatusV1> resultWrapper = await rpc.engine_newPayloadV1(executionPayload);
@@ -936,7 +936,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task executePayloadV1_calculate_hash_for_cached_blocks()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         ExecutionPayload executionPayload = CreateBlockRequest(
             CreateParentBlockRequestOnHead(chain.BlockTree),
@@ -954,7 +954,7 @@ public partial class EngineModuleTests
     [TestCase(30)]
     public async Task can_progress_chain_one_by_one_v1(int count)
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak lastHash = (await ProduceBranchV1(rpc, chain, count, CreateParentBlockRequestOnHead(chain.BlockTree), true))
             .LastOrDefault()?.BlockHash ?? Keccak.Zero;
@@ -967,7 +967,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task forkchoiceUpdatedV1_can_reorganize_to_last_block()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
 
         async Task CanReorganizeToBlock(ExecutionPayload block, MergeTestBlockchain testChain)
@@ -999,7 +999,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task forkchoiceUpdatedV1_head_block_after_reorg()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
 
         async Task CanReorganizeToBlock(ExecutionPayload block, MergeTestBlockchain testChain)
@@ -1022,7 +1022,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task newPayloadV1_should_return_accepted_for_side_branch()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         ExecutionPayload executionPayload = CreateBlockRequest(CreateParentBlockRequestOnHead(chain.BlockTree), TestItem.AddressD);
         ResultWrapper<PayloadStatusV1> resultWrapper = await rpc.engine_newPayloadV1(executionPayload);
@@ -1042,7 +1042,7 @@ public partial class EngineModuleTests
     [TestCase(true)]
     public async Task executePayloadV1_processes_passed_transactions(bool moveHead)
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         IReadOnlyList<ExecutionPayload> branch = await ProduceBranchV1(rpc, chain, 8, CreateParentBlockRequestOnHead(chain.BlockTree), moveHead);
 
@@ -1079,7 +1079,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task executePayloadV1_transactions_produce_receipts()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         IReadOnlyList<ExecutionPayload> branch = await ProduceBranchV1(rpc, chain, 1, CreateParentBlockRequestOnHead(chain.BlockTree), false);
 
@@ -1156,7 +1156,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task ExecutionPayloadV1_set_and_get_transactions_roundtrip()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         Keccak startingHead = chain.BlockTree.HeadHash;
         uint count = 3;
         int value = 10;
@@ -1183,7 +1183,7 @@ public partial class EngineModuleTests
     public async Task payloadV1_no_suggestedFeeRecipient_in_config()
     {
         using MergeTestBlockchain chain =
-            await CreateBlockChain(new MergeConfig() { TerminalTotalDifficulty = "0" });
+            await CreateBlockchain(new MergeConfig() { TerminalTotalDifficulty = "0" });
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak startingHead = chain.BlockTree.HeadHash;
         ulong timestamp = Timestamper.UnixTime.Seconds;
@@ -1201,7 +1201,7 @@ public partial class EngineModuleTests
     public async Task exchangeTransitionConfiguration_return_expected_results(long clTtd, string terminalBlockHash)
     {
         using MergeTestBlockchain chain =
-            await CreateBlockChain(new MergeConfig() { TerminalTotalDifficulty = "1000001", TerminalBlockHash = new Keccak("0x191dc9697d77129ee5b6f6d57074d2c854a38129913e3fdd3d9f0ebc930503a6").ToString(true), TerminalBlockNumber = 1 });
+            await CreateBlockchain(new MergeConfig() { TerminalTotalDifficulty = "1000001", TerminalBlockHash = new Keccak("0x191dc9697d77129ee5b6f6d57074d2c854a38129913e3fdd3d9f0ebc930503a6").ToString(true), TerminalBlockNumber = 1 });
         IEngineRpcModule rpc = CreateEngineModule(chain);
 
         TransitionConfigurationV1 result = rpc.engine_exchangeTransitionConfigurationV1(new TransitionConfigurationV1()
@@ -1221,7 +1221,7 @@ public partial class EngineModuleTests
     public async Task exchangeTransitionConfiguration_return_with_empty_Nethermind_configuration(long clTtd, string terminalBlockHash)
     {
         using MergeTestBlockchain chain =
-            await CreateBlockChain(new MergeConfig() { });
+            await CreateBlockchain(new MergeConfig() { });
         IEngineRpcModule rpc = CreateEngineModule(chain);
 
         TransitionConfigurationV1 result = rpc.engine_exchangeTransitionConfigurationV1(new TransitionConfigurationV1()
@@ -1281,7 +1281,7 @@ public partial class EngineModuleTests
     public async Task repeat_the_same_payload_after_fcu_should_return_valid_and_be_ignored()
     {
         using MergeTestBlockchain chain =
-            await CreateBlockChain(new MergeConfig() { TerminalTotalDifficulty = "0" });
+            await CreateBlockchain(new MergeConfig() { TerminalTotalDifficulty = "0" });
         IEngineRpcModule rpc = CreateEngineModule(chain);
 
         // Correct new payload
@@ -1308,7 +1308,7 @@ public partial class EngineModuleTests
     public async Task payloadV1_invalid_parent_hash()
     {
         using MergeTestBlockchain chain =
-            await CreateBlockChain(new MergeConfig() { TerminalTotalDifficulty = "0" });
+            await CreateBlockchain(new MergeConfig() { TerminalTotalDifficulty = "0" });
         IEngineRpcModule rpc = CreateEngineModule(chain);
 
         // Correct new payload
@@ -1377,7 +1377,7 @@ public partial class EngineModuleTests
     public async Task inconsistent_finalized_hash()
     {
         using MergeTestBlockchain chain =
-            await CreateBlockChain(new MergeConfig() { TerminalTotalDifficulty = "0" });
+            await CreateBlockchain(new MergeConfig() { TerminalTotalDifficulty = "0" });
         IEngineRpcModule rpc = CreateEngineModule(chain);
 
         ExecutionPayload blockRequestResult1 = CreateBlockRequest(
@@ -1413,7 +1413,7 @@ public partial class EngineModuleTests
     public async Task inconsistent_safe_hash()
     {
         using MergeTestBlockchain chain =
-            await CreateBlockChain(new MergeConfig() { TerminalTotalDifficulty = "0" });
+            await CreateBlockchain(new MergeConfig() { TerminalTotalDifficulty = "0" });
         IEngineRpcModule rpc = CreateEngineModule(chain);
 
         ExecutionPayload blockRequestResult1 = CreateBlockRequest(
@@ -1450,7 +1450,7 @@ public partial class EngineModuleTests
     public async Task payloadV1_latest_block_after_reorg()
     {
         using MergeTestBlockchain chain =
-            await CreateBlockChain(new MergeConfig() { TerminalTotalDifficulty = "0" });
+            await CreateBlockchain(new MergeConfig() { TerminalTotalDifficulty = "0" });
         IEngineRpcModule rpc = CreateEngineModule(chain);
 
         Keccak prevRandao1 = TestItem.KeccakA;
@@ -1549,7 +1549,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task Should_return_capabilities()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain(Cancun.Instance);
+        using MergeTestBlockchain chain = await CreateBlockchain(Cancun.Instance);
         IEngineRpcModule rpcModule = CreateEngineModule(chain);
         IOrderedEnumerable<string> expected = typeof(IEngineRpcModule).GetMethods()
             .Select(m => m.Name)
@@ -1592,7 +1592,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task Should_warn_for_missing_capabilities()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         chain.LogManager = Substitute.For<ILogManager>();
         chain.LogManager.GetClassLogger().IsWarn.Returns(true);
 

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
@@ -847,6 +847,51 @@ public partial class EngineModuleTests
     }
 
     [Test]
+    public async Task executePayloadV1_on_top_of_not_processed_invalid_terminal_block()
+    {
+        using MergeTestBlockchain chain = await CreateBlockChain(null, new MergeConfig()
+        {
+            TerminalTotalDifficulty = $"{1900000}"
+        });
+        IEngineRpcModule rpc = CreateEngineModule(chain);
+        Block newBlock = Build.A.Block.WithNumber(chain.BlockTree.Head!.Number)
+            .WithParent(chain.BlockTree.Head!)
+            .WithNonce(0)
+            .WithDifficulty(1000000)
+            .WithTotalDifficulty(2000000L)
+            .WithStateRoot(new Keccak("0x1ef7300d8961797263939a3d29bbba4ccf1702fabf02d8ad7a20b454edb6fd2f")).TestObject;
+        newBlock.CalculateHash();
+        Block oneMoreTerminalBlock = Build.A.Block.WithNumber(chain.BlockTree.Head!.Number)
+            .WithParent(chain.BlockTree.Head!)
+            .WithNonce(0)
+            .WithDifficulty(900000)
+            .WithTotalDifficulty(1900000L)
+            .WithStateRoot(new Keccak("0x1ef7300d8961797263939a3d29bfba4ccf1702fabf02d8ad7a20b454edb6fd2f")).TestObject; //incorrect state root
+
+        using SemaphoreSlim bestBlockProcessed = new(0);
+        chain.BlockTree.NewHeadBlock += (s, e) =>
+        {
+            if (e.Block.Hash == newBlock!.Hash)
+                bestBlockProcessed.Release(1);
+        };
+        await chain.BlockTree.SuggestBlockAsync(newBlock);
+        (await bestBlockProcessed.WaitAsync(TimeSpan.FromSeconds(5))).Should().Be(true);
+
+        oneMoreTerminalBlock.CalculateHash();
+        await chain.BlockTree.SuggestBlockAsync(oneMoreTerminalBlock);
+
+        Block firstPoSBlock = Build.A.Block.WithParent(oneMoreTerminalBlock).
+            WithNumber(oneMoreTerminalBlock.Number + 1)
+            .WithStateRoot(new Keccak("0x1ef7300d8961797263939a3d29bbba4ccf1702fabf02d8ad7a20b454edb6fd2f"))
+            .WithDifficulty(0).WithNonce(0).TestObject;
+        firstPoSBlock.CalculateHash();
+        ExecutionPayload executionPayload = new(firstPoSBlock);
+        ResultWrapper<PayloadStatusV1> resultWrapper = await rpc.engine_newPayloadV1(executionPayload);
+        resultWrapper.Data.Status.Should().Be(PayloadStatus.Invalid);
+        resultWrapper.Data.LatestValidHash.Should().Be(Keccak.Zero);
+    }
+
+    [Test]
     public async Task executePayloadV1_accepts_first_block()
     {
         using MergeTestBlockchain chain = await CreateBlockChain();

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V2.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V2.cs
@@ -39,7 +39,7 @@ public partial class EngineModuleTests
         string stateRoot, string payloadId)
     {
         using MergeTestBlockchain chain =
-            await CreateBlockChain(Shanghai.Instance, new MergeConfig { TerminalTotalDifficulty = "0" });
+            await CreateBlockchain(Shanghai.Instance, new MergeConfig { TerminalTotalDifficulty = "0" });
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak startingHead = chain.BlockTree.HeadHash;
         Keccak prevRandao = Keccak.Zero;
@@ -171,7 +171,7 @@ public partial class EngineModuleTests
     [Test]
     public virtual async Task forkchoiceUpdatedV1_should_fail_with_withdrawals()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain(new MergeConfig { TerminalTotalDifficulty = "0" });
+        using MergeTestBlockchain chain = await CreateBlockchain(new MergeConfig { TerminalTotalDifficulty = "0" });
         IEngineRpcModule rpcModule = CreateEngineModule(chain);
         var fcuState = new
         {
@@ -208,7 +208,7 @@ public partial class EngineModuleTests
         string BlockHash
         ) input)
     {
-        using MergeTestBlockchain chain = await CreateBlockChain(null, null, input.Spec);
+        using MergeTestBlockchain chain = await CreateBlockchain(null, null, input.Spec);
         IEngineRpcModule rpcModule = CreateEngineModule(chain);
         var fcuState = new
         {
@@ -240,7 +240,7 @@ public partial class EngineModuleTests
     [Test]
     public virtual async Task getPayloadV2_empty_block_should_have_zero_value()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
 
         Keccak startingHead = chain.BlockTree.HeadHash;
@@ -266,7 +266,7 @@ public partial class EngineModuleTests
     public virtual async Task getPayloadV2_received_fees_should_be_equal_to_block_value_in_result()
     {
         using SemaphoreSlim blockImprovementLock = new(0);
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
 
         Address feeRecipient = TestItem.AddressA;
@@ -310,7 +310,7 @@ public partial class EngineModuleTests
     public virtual async Task getPayloadV2_should_fail_on_unknown_payload()
     {
         using SemaphoreSlim blockImprovementLock = new(0);
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
 
         byte[] payloadId = Bytes.FromHexString("0x0");
@@ -325,7 +325,7 @@ public partial class EngineModuleTests
         getPayloadBodiesByHashV1_should_return_payload_bodies_in_order_of_request_block_hashes_and_null_for_unknown_hashes(
             IList<Withdrawal> withdrawals)
     {
-        using MergeTestBlockchain chain = await CreateBlockChain(Shanghai.Instance);
+        using MergeTestBlockchain chain = await CreateBlockchain(Shanghai.Instance);
         IEngineRpcModule rpc = CreateEngineModule(chain);
         ExecutionPayload executionPayload1 = await SendNewBlockV2(rpc, chain, withdrawals);
         Transaction[] txs = BuildTransactions(
@@ -353,7 +353,7 @@ public partial class EngineModuleTests
         getPayloadBodiesByRangeV1_should_return_payload_bodies_in_order_of_request_range_and_null_for_unknown_indexes(
             IList<Withdrawal> withdrawals)
     {
-        using MergeTestBlockchain chain = await CreateBlockChain(Shanghai.Instance);
+        using MergeTestBlockchain chain = await CreateBlockchain(Shanghai.Instance);
         IEngineRpcModule rpc = CreateEngineModule(chain);
         ExecutionPayload executionPayload1 = await SendNewBlockV2(rpc, chain, withdrawals);
         Transaction[] txs = BuildTransactions(
@@ -377,7 +377,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task getPayloadBodiesByRangeV1_empty_response()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         IEnumerable<ExecutionPayloadBodyV1Result?> payloadBodies =
             rpc.engine_getPayloadBodiesByRangeV1(1, 1).Result.Data;
@@ -389,7 +389,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task getPayloadBodiesByRangeV1_should_fail_when_too_many_payloads_requested()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Task<ResultWrapper<IEnumerable<ExecutionPayloadBodyV1Result?>>> result =
             rpc.engine_getPayloadBodiesByRangeV1(1, 1025);
@@ -400,7 +400,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task getPayloadBodiesByHashV1_should_fail_when_too_many_payloads_requested()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak[] hashes = Enumerable.Repeat(TestItem.KeccakA, 1025).ToArray();
         Task<ResultWrapper<IEnumerable<ExecutionPayloadBodyV1Result?>>> result =
@@ -412,7 +412,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task getPayloadBodiesByRangeV1_should_fail_when_params_below_1()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Task<ResultWrapper<IEnumerable<ExecutionPayloadBodyV1Result?>>> result =
             rpc.engine_getPayloadBodiesByRangeV1(0, 1);
@@ -427,7 +427,7 @@ public partial class EngineModuleTests
     [TestCaseSource(nameof(GetPayloadWithdrawalsTestCases))]
     public virtual async Task getPayloadBodiesByRangeV1_should_return_canonical(IList<Withdrawal> withdrawals)
     {
-        using MergeTestBlockchain chain = await CreateBlockChain(Shanghai.Instance);
+        using MergeTestBlockchain chain = await CreateBlockchain(Shanghai.Instance);
         IEngineRpcModule rpc = CreateEngineModule(chain);
         ExecutionPayload executionPayload1 = await SendNewBlockV2(rpc, chain, withdrawals);
 
@@ -504,7 +504,7 @@ public partial class EngineModuleTests
         blockTree.Head.Returns(Build.A.Block.WithNumber(5).TestObject);
         blockTree.FindBlock(Arg.Any<long>()).Returns(input.Impl);
 
-        using MergeTestBlockchain chain = await CreateBlockChain(Shanghai.Instance);
+        using MergeTestBlockchain chain = await CreateBlockchain(Shanghai.Instance);
         chain.BlockTree = blockTree;
 
         IEngineRpcModule rpc = CreateEngineModule(chain);
@@ -523,7 +523,7 @@ public partial class EngineModuleTests
             .Returns(i => Build.A.Block.WithNumber(i.ArgAt<long>(0)).TestObject);
         blockTree.Head.Returns(Build.A.Block.WithNumber(5).TestObject);
 
-        using MergeTestBlockchain chain = await CreateBlockChain(Shanghai.Instance);
+        using MergeTestBlockchain chain = await CreateBlockchain(Shanghai.Instance);
         chain.BlockTree = blockTree;
 
         IEngineRpcModule rpc = CreateEngineModule(chain);
@@ -536,7 +536,7 @@ public partial class EngineModuleTests
     [Test]
     public virtual async Task newPayloadV1_should_fail_with_withdrawals()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain(new MergeConfig { TerminalTotalDifficulty = "0" });
+        using MergeTestBlockchain chain = await CreateBlockchain(new MergeConfig { TerminalTotalDifficulty = "0" });
         IEngineRpcModule rpcModule = CreateEngineModule(chain);
         ExecutionPayload expectedPayload = new()
         {
@@ -575,7 +575,7 @@ public partial class EngineModuleTests
         string BlockHash
         ) input)
     {
-        using MergeTestBlockchain chain = await CreateBlockChain(null, null, input.Spec);
+        using MergeTestBlockchain chain = await CreateBlockchain(null, null, input.Spec);
         IEngineRpcModule rpcModule = CreateEngineModule(chain);
         Keccak blockHash = new(input.BlockHash);
         Keccak startingHead = chain.BlockTree.HeadHash;
@@ -636,7 +636,7 @@ public partial class EngineModuleTests
         Withdrawal[]? Withdrawals,
         bool IsValid) input)
     {
-        using MergeTestBlockchain chain = await CreateBlockChain(null, null, input.ReleaseSpec);
+        using MergeTestBlockchain chain = await CreateBlockchain(null, null, input.ReleaseSpec);
         IEngineRpcModule rpc = CreateEngineModule(chain);
         ExecutionPayload executionPayload = CreateBlockRequest(CreateParentBlockRequestOnHead(chain.BlockTree),
             TestItem.AddressD, input.Withdrawals);
@@ -652,7 +652,7 @@ public partial class EngineModuleTests
     public virtual async Task Can_apply_withdrawals_correctly(
         (Withdrawal[][] Withdrawals, (Address Account, UInt256 BalanceIncrease)[] ExpectedAccountIncrease) input)
     {
-        using MergeTestBlockchain chain = await CreateBlockChain(Shanghai.Instance);
+        using MergeTestBlockchain chain = await CreateBlockchain(Shanghai.Instance);
         IEngineRpcModule rpc = CreateEngineModule(chain);
 
         // get initial balances
@@ -702,7 +702,7 @@ public partial class EngineModuleTests
         );
 
         // Genesis, Timestamp = 1
-        using MergeTestBlockchain chain = await CreateBlockChain(specProvider);
+        using MergeTestBlockchain chain = await CreateBlockchain(specProvider);
         IEngineRpcModule rpc = CreateEngineModule(chain);
 
         // Block without withdrawals, Timestamp = 2

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V2.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V2.cs
@@ -39,7 +39,7 @@ public partial class EngineModuleTests
         string stateRoot, string payloadId)
     {
         using MergeTestBlockchain chain =
-            await CreateShanghaiBlockChain(new MergeConfig { TerminalTotalDifficulty = "0" });
+            await CreateBlockChain(Shanghai.Instance, new MergeConfig { TerminalTotalDifficulty = "0" });
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak startingHead = chain.BlockTree.HeadHash;
         Keccak prevRandao = Keccak.Zero;
@@ -325,7 +325,7 @@ public partial class EngineModuleTests
         getPayloadBodiesByHashV1_should_return_payload_bodies_in_order_of_request_block_hashes_and_null_for_unknown_hashes(
             IList<Withdrawal> withdrawals)
     {
-        using MergeTestBlockchain chain = await CreateShanghaiBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockChain(Shanghai.Instance);
         IEngineRpcModule rpc = CreateEngineModule(chain);
         ExecutionPayload executionPayload1 = await SendNewBlockV2(rpc, chain, withdrawals);
         Transaction[] txs = BuildTransactions(
@@ -353,7 +353,7 @@ public partial class EngineModuleTests
         getPayloadBodiesByRangeV1_should_return_payload_bodies_in_order_of_request_range_and_null_for_unknown_indexes(
             IList<Withdrawal> withdrawals)
     {
-        using MergeTestBlockchain chain = await CreateShanghaiBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockChain(Shanghai.Instance);
         IEngineRpcModule rpc = CreateEngineModule(chain);
         ExecutionPayload executionPayload1 = await SendNewBlockV2(rpc, chain, withdrawals);
         Transaction[] txs = BuildTransactions(
@@ -427,7 +427,7 @@ public partial class EngineModuleTests
     [TestCaseSource(nameof(GetPayloadWithdrawalsTestCases))]
     public virtual async Task getPayloadBodiesByRangeV1_should_return_canonical(IList<Withdrawal> withdrawals)
     {
-        using MergeTestBlockchain chain = await CreateShanghaiBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockChain(Shanghai.Instance);
         IEngineRpcModule rpc = CreateEngineModule(chain);
         ExecutionPayload executionPayload1 = await SendNewBlockV2(rpc, chain, withdrawals);
 
@@ -504,7 +504,7 @@ public partial class EngineModuleTests
         blockTree.Head.Returns(Build.A.Block.WithNumber(5).TestObject);
         blockTree.FindBlock(Arg.Any<long>()).Returns(input.Impl);
 
-        using MergeTestBlockchain chain = await CreateShanghaiBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockChain(Shanghai.Instance);
         chain.BlockTree = blockTree;
 
         IEngineRpcModule rpc = CreateEngineModule(chain);
@@ -523,7 +523,7 @@ public partial class EngineModuleTests
             .Returns(i => Build.A.Block.WithNumber(i.ArgAt<long>(0)).TestObject);
         blockTree.Head.Returns(Build.A.Block.WithNumber(5).TestObject);
 
-        using MergeTestBlockchain chain = await CreateShanghaiBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockChain(Shanghai.Instance);
         chain.BlockTree = blockTree;
 
         IEngineRpcModule rpc = CreateEngineModule(chain);
@@ -652,7 +652,7 @@ public partial class EngineModuleTests
     public virtual async Task Can_apply_withdrawals_correctly(
         (Withdrawal[][] Withdrawals, (Address Account, UInt256 BalanceIncrease)[] ExpectedAccountIncrease) input)
     {
-        using MergeTestBlockchain chain = await CreateShanghaiBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockChain(Shanghai.Instance);
         IEngineRpcModule rpc = CreateEngineModule(chain);
 
         // get initial balances

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V2.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V2.cs
@@ -39,7 +39,7 @@ public partial class EngineModuleTests
         string stateRoot, string payloadId)
     {
         using MergeTestBlockchain chain =
-            await CreateBlockchain(Shanghai.Instance, new MergeConfig { TerminalTotalDifficulty = "0" });
+            await CreateBlockChain(Shanghai.Instance, new MergeConfig { TerminalTotalDifficulty = "0" });
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak startingHead = chain.BlockTree.HeadHash;
         Keccak prevRandao = Keccak.Zero;
@@ -171,7 +171,7 @@ public partial class EngineModuleTests
     [Test]
     public virtual async Task forkchoiceUpdatedV1_should_fail_with_withdrawals()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain(new MergeConfig { TerminalTotalDifficulty = "0" });
+        using MergeTestBlockchain chain = await CreateBlockChain(new MergeConfig { TerminalTotalDifficulty = "0" });
         IEngineRpcModule rpcModule = CreateEngineModule(chain);
         var fcuState = new
         {
@@ -208,7 +208,7 @@ public partial class EngineModuleTests
         string BlockHash
         ) input)
     {
-        using MergeTestBlockchain chain = await CreateBlockchain(null, null, input.Spec);
+        using MergeTestBlockchain chain = await CreateBlockChain(null, null, input.Spec);
         IEngineRpcModule rpcModule = CreateEngineModule(chain);
         var fcuState = new
         {
@@ -240,7 +240,7 @@ public partial class EngineModuleTests
     [Test]
     public virtual async Task getPayloadV2_empty_block_should_have_zero_value()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
 
         Keccak startingHead = chain.BlockTree.HeadHash;
@@ -266,7 +266,7 @@ public partial class EngineModuleTests
     public virtual async Task getPayloadV2_received_fees_should_be_equal_to_block_value_in_result()
     {
         using SemaphoreSlim blockImprovementLock = new(0);
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
 
         Address feeRecipient = TestItem.AddressA;
@@ -310,7 +310,7 @@ public partial class EngineModuleTests
     public virtual async Task getPayloadV2_should_fail_on_unknown_payload()
     {
         using SemaphoreSlim blockImprovementLock = new(0);
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
 
         byte[] payloadId = Bytes.FromHexString("0x0");
@@ -325,7 +325,7 @@ public partial class EngineModuleTests
         getPayloadBodiesByHashV1_should_return_payload_bodies_in_order_of_request_block_hashes_and_null_for_unknown_hashes(
             IList<Withdrawal> withdrawals)
     {
-        using MergeTestBlockchain chain = await CreateBlockchain(Shanghai.Instance);
+        using MergeTestBlockchain chain = await CreateBlockChain(Shanghai.Instance);
         IEngineRpcModule rpc = CreateEngineModule(chain);
         ExecutionPayload executionPayload1 = await SendNewBlockV2(rpc, chain, withdrawals);
         Transaction[] txs = BuildTransactions(
@@ -353,7 +353,7 @@ public partial class EngineModuleTests
         getPayloadBodiesByRangeV1_should_return_payload_bodies_in_order_of_request_range_and_null_for_unknown_indexes(
             IList<Withdrawal> withdrawals)
     {
-        using MergeTestBlockchain chain = await CreateBlockchain(Shanghai.Instance);
+        using MergeTestBlockchain chain = await CreateBlockChain(Shanghai.Instance);
         IEngineRpcModule rpc = CreateEngineModule(chain);
         ExecutionPayload executionPayload1 = await SendNewBlockV2(rpc, chain, withdrawals);
         Transaction[] txs = BuildTransactions(
@@ -377,7 +377,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task getPayloadBodiesByRangeV1_empty_response()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         IEnumerable<ExecutionPayloadBodyV1Result?> payloadBodies =
             rpc.engine_getPayloadBodiesByRangeV1(1, 1).Result.Data;
@@ -389,7 +389,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task getPayloadBodiesByRangeV1_should_fail_when_too_many_payloads_requested()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Task<ResultWrapper<IEnumerable<ExecutionPayloadBodyV1Result?>>> result =
             rpc.engine_getPayloadBodiesByRangeV1(1, 1025);
@@ -400,7 +400,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task getPayloadBodiesByHashV1_should_fail_when_too_many_payloads_requested()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Keccak[] hashes = Enumerable.Repeat(TestItem.KeccakA, 1025).ToArray();
         Task<ResultWrapper<IEnumerable<ExecutionPayloadBodyV1Result?>>> result =
@@ -412,7 +412,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task getPayloadBodiesByRangeV1_should_fail_when_params_below_1()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
         Task<ResultWrapper<IEnumerable<ExecutionPayloadBodyV1Result?>>> result =
             rpc.engine_getPayloadBodiesByRangeV1(0, 1);
@@ -427,7 +427,7 @@ public partial class EngineModuleTests
     [TestCaseSource(nameof(GetPayloadWithdrawalsTestCases))]
     public virtual async Task getPayloadBodiesByRangeV1_should_return_canonical(IList<Withdrawal> withdrawals)
     {
-        using MergeTestBlockchain chain = await CreateBlockchain(Shanghai.Instance);
+        using MergeTestBlockchain chain = await CreateBlockChain(Shanghai.Instance);
         IEngineRpcModule rpc = CreateEngineModule(chain);
         ExecutionPayload executionPayload1 = await SendNewBlockV2(rpc, chain, withdrawals);
 
@@ -504,7 +504,7 @@ public partial class EngineModuleTests
         blockTree.Head.Returns(Build.A.Block.WithNumber(5).TestObject);
         blockTree.FindBlock(Arg.Any<long>()).Returns(input.Impl);
 
-        using MergeTestBlockchain chain = await CreateBlockchain(Shanghai.Instance);
+        using MergeTestBlockchain chain = await CreateBlockChain(Shanghai.Instance);
         chain.BlockTree = blockTree;
 
         IEngineRpcModule rpc = CreateEngineModule(chain);
@@ -523,7 +523,7 @@ public partial class EngineModuleTests
             .Returns(i => Build.A.Block.WithNumber(i.ArgAt<long>(0)).TestObject);
         blockTree.Head.Returns(Build.A.Block.WithNumber(5).TestObject);
 
-        using MergeTestBlockchain chain = await CreateBlockchain(Shanghai.Instance);
+        using MergeTestBlockchain chain = await CreateBlockChain(Shanghai.Instance);
         chain.BlockTree = blockTree;
 
         IEngineRpcModule rpc = CreateEngineModule(chain);
@@ -536,7 +536,7 @@ public partial class EngineModuleTests
     [Test]
     public virtual async Task newPayloadV1_should_fail_with_withdrawals()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain(new MergeConfig { TerminalTotalDifficulty = "0" });
+        using MergeTestBlockchain chain = await CreateBlockChain(new MergeConfig { TerminalTotalDifficulty = "0" });
         IEngineRpcModule rpcModule = CreateEngineModule(chain);
         ExecutionPayload expectedPayload = new()
         {
@@ -575,7 +575,7 @@ public partial class EngineModuleTests
         string BlockHash
         ) input)
     {
-        using MergeTestBlockchain chain = await CreateBlockchain(null, null, input.Spec);
+        using MergeTestBlockchain chain = await CreateBlockChain(null, null, input.Spec);
         IEngineRpcModule rpcModule = CreateEngineModule(chain);
         Keccak blockHash = new(input.BlockHash);
         Keccak startingHead = chain.BlockTree.HeadHash;
@@ -636,7 +636,7 @@ public partial class EngineModuleTests
         Withdrawal[]? Withdrawals,
         bool IsValid) input)
     {
-        using MergeTestBlockchain chain = await CreateBlockchain(null, null, input.ReleaseSpec);
+        using MergeTestBlockchain chain = await CreateBlockChain(null, null, input.ReleaseSpec);
         IEngineRpcModule rpc = CreateEngineModule(chain);
         ExecutionPayload executionPayload = CreateBlockRequest(CreateParentBlockRequestOnHead(chain.BlockTree),
             TestItem.AddressD, input.Withdrawals);
@@ -652,7 +652,7 @@ public partial class EngineModuleTests
     public virtual async Task Can_apply_withdrawals_correctly(
         (Withdrawal[][] Withdrawals, (Address Account, UInt256 BalanceIncrease)[] ExpectedAccountIncrease) input)
     {
-        using MergeTestBlockchain chain = await CreateBlockchain(Shanghai.Instance);
+        using MergeTestBlockchain chain = await CreateBlockChain(Shanghai.Instance);
         IEngineRpcModule rpc = CreateEngineModule(chain);
 
         // get initial balances
@@ -702,7 +702,7 @@ public partial class EngineModuleTests
         );
 
         // Genesis, Timestamp = 1
-        using MergeTestBlockchain chain = await CreateBlockchain(specProvider);
+        using MergeTestBlockchain chain = await CreateBlockChain(specProvider);
         IEngineRpcModule rpc = CreateEngineModule(chain);
 
         // Block without withdrawals, Timestamp = 2

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V2.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V2.cs
@@ -171,7 +171,7 @@ public partial class EngineModuleTests
     [Test]
     public virtual async Task forkchoiceUpdatedV1_should_fail_with_withdrawals()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain(new MergeConfig { TerminalTotalDifficulty = "0" });
+        using MergeTestBlockchain chain = await CreateBlockChain(null, new MergeConfig { TerminalTotalDifficulty = "0" });
         IEngineRpcModule rpcModule = CreateEngineModule(chain);
         var fcuState = new
         {
@@ -208,7 +208,7 @@ public partial class EngineModuleTests
         string BlockHash
         ) input)
     {
-        using MergeTestBlockchain chain = await CreateBlockChain(null, null, input.Spec);
+        using MergeTestBlockchain chain = await CreateBlockChain(input.Spec);
         IEngineRpcModule rpcModule = CreateEngineModule(chain);
         var fcuState = new
         {
@@ -536,7 +536,7 @@ public partial class EngineModuleTests
     [Test]
     public virtual async Task newPayloadV1_should_fail_with_withdrawals()
     {
-        using MergeTestBlockchain chain = await CreateBlockChain(new MergeConfig { TerminalTotalDifficulty = "0" });
+        using MergeTestBlockchain chain = await CreateBlockChain(null, new MergeConfig { TerminalTotalDifficulty = "0" });
         IEngineRpcModule rpcModule = CreateEngineModule(chain);
         ExecutionPayload expectedPayload = new()
         {
@@ -575,7 +575,7 @@ public partial class EngineModuleTests
         string BlockHash
         ) input)
     {
-        using MergeTestBlockchain chain = await CreateBlockChain(null, null, input.Spec);
+        using MergeTestBlockchain chain = await CreateBlockChain(input.Spec);
         IEngineRpcModule rpcModule = CreateEngineModule(chain);
         Keccak blockHash = new(input.BlockHash);
         Keccak startingHead = chain.BlockTree.HeadHash;
@@ -636,7 +636,7 @@ public partial class EngineModuleTests
         Withdrawal[]? Withdrawals,
         bool IsValid) input)
     {
-        using MergeTestBlockchain chain = await CreateBlockChain(null, null, input.ReleaseSpec);
+        using MergeTestBlockchain chain = await CreateBlockChain(input.ReleaseSpec);
         IEngineRpcModule rpc = CreateEngineModule(chain);
         ExecutionPayload executionPayload = CreateBlockRequest(CreateParentBlockRequestOnHead(chain.BlockTree),
             TestItem.AddressD, input.Withdrawals);

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V3.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V3.cs
@@ -36,7 +36,7 @@ public partial class EngineModuleTests
     public async Task GetPayloadV3_should_fail_on_unknown_payload()
     {
         using SemaphoreSlim blockImprovementLock = new(0);
-        using MergeTestBlockchain chain = await CreateBlockChain();
+        using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
 
         byte[] payloadId = Bytes.FromHexString("0x0");
@@ -75,7 +75,7 @@ public partial class EngineModuleTests
     private async Task<(IEngineRpcModule, string)> BuildAndGetPayloadV3Result(
         IReleaseSpec spec, int transactionCount = 0)
     {
-        MergeTestBlockchain chain = await CreateBlockChain(releaseSpec: spec, null);
+        MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: spec, null);
         IEngineRpcModule rpcModule = CreateEngineModule(chain);
         if (transactionCount is not 0)
         {

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V3.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V3.cs
@@ -36,7 +36,7 @@ public partial class EngineModuleTests
     public async Task GetPayloadV3_should_fail_on_unknown_payload()
     {
         using SemaphoreSlim blockImprovementLock = new(0);
-        using MergeTestBlockchain chain = await CreateBlockchain();
+        using MergeTestBlockchain chain = await CreateBlockChain();
         IEngineRpcModule rpc = CreateEngineModule(chain);
 
         byte[] payloadId = Bytes.FromHexString("0x0");
@@ -75,7 +75,7 @@ public partial class EngineModuleTests
     private async Task<(IEngineRpcModule, string)> BuildAndGetPayloadV3Result(
         IReleaseSpec spec, int transactionCount = 0)
     {
-        MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: spec, null);
+        MergeTestBlockchain chain = await CreateBlockChain(releaseSpec: spec, null);
         IEngineRpcModule rpcModule = CreateEngineModule(chain);
         if (transactionCount is not 0)
         {

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V3.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V3.cs
@@ -75,7 +75,7 @@ public partial class EngineModuleTests
     private async Task<(IEngineRpcModule, string)> BuildAndGetPayloadV3Result(
         IReleaseSpec spec, int transactionCount = 0)
     {
-        MergeTestBlockchain chain = await CreateBlockChain(releaseSpec: spec);
+        MergeTestBlockchain chain = await CreateBlockChain(releaseSpec: spec, null);
         IEngineRpcModule rpcModule = CreateEngineModule(chain);
         if (transactionCount is not 0)
         {

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/EngineRpcCapabilitiesProvider.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/EngineRpcCapabilitiesProvider.cs
@@ -11,7 +11,7 @@ namespace Nethermind.HealthChecks;
 
 public class EngineRpcCapabilitiesProvider : IRpcCapabilitiesProvider
 {
-    private static readonly ConcurrentDictionary<string, bool> _capabilities = new();
+    private readonly ConcurrentDictionary<string, (bool Enabled, bool WarnIfMissing)> _capabilities = new();
 
     private readonly ISpecProvider _specProvider;
 
@@ -19,30 +19,30 @@ public class EngineRpcCapabilitiesProvider : IRpcCapabilitiesProvider
     {
         _specProvider = specProvider;
     }
-    public IReadOnlyDictionary<string, bool> GetEngineCapabilities()
+    public IReadOnlyDictionary<string, (bool Enabled, bool WarnIfMissing)> GetEngineCapabilities()
     {
         if (_capabilities.IsEmpty)
         {
             IReleaseSpec spec = _specProvider.GetFinalSpec();
 
             #region The Merge
-            _capabilities[nameof(IEngineRpcModule.engine_exchangeTransitionConfigurationV1)] = true;
-            _capabilities[nameof(IEngineRpcModule.engine_forkchoiceUpdatedV1)] = true;
-            _capabilities[nameof(IEngineRpcModule.engine_getPayloadV1)] = true;
-            _capabilities[nameof(IEngineRpcModule.engine_newPayloadV1)] = true;
+            _capabilities[nameof(IEngineRpcModule.engine_exchangeTransitionConfigurationV1)] = (true, false);
+            _capabilities[nameof(IEngineRpcModule.engine_forkchoiceUpdatedV1)] = (true, true);
+            _capabilities[nameof(IEngineRpcModule.engine_getPayloadV1)] = (true, true);
+            _capabilities[nameof(IEngineRpcModule.engine_newPayloadV1)] = (true, true);
             #endregion
 
             #region Shanghai
-            _capabilities[nameof(IEngineRpcModule.engine_forkchoiceUpdatedV2)] = spec.WithdrawalsEnabled;
-            _capabilities[nameof(IEngineRpcModule.engine_getPayloadBodiesByHashV1)] = false;
-            _capabilities[nameof(IEngineRpcModule.engine_getPayloadBodiesByRangeV1)] = false;
-            _capabilities[nameof(IEngineRpcModule.engine_getPayloadV2)] = spec.WithdrawalsEnabled;
-            _capabilities[nameof(IEngineRpcModule.engine_newPayloadV2)] = spec.WithdrawalsEnabled;
+            _capabilities[nameof(IEngineRpcModule.engine_forkchoiceUpdatedV2)] = (spec.WithdrawalsEnabled, spec.WithdrawalsEnabled);
+            _capabilities[nameof(IEngineRpcModule.engine_getPayloadBodiesByHashV1)] = (spec.WithdrawalsEnabled, false);
+            _capabilities[nameof(IEngineRpcModule.engine_getPayloadBodiesByRangeV1)] = (spec.WithdrawalsEnabled, false);
+            _capabilities[nameof(IEngineRpcModule.engine_getPayloadV2)] = (spec.WithdrawalsEnabled, spec.WithdrawalsEnabled);
+            _capabilities[nameof(IEngineRpcModule.engine_newPayloadV2)] = (spec.WithdrawalsEnabled, spec.WithdrawalsEnabled);
             #endregion
 
             #region Cancun
-            _capabilities[nameof(IEngineRpcModule.engine_getPayloadV3)] = spec.IsEip4844Enabled;
-            _capabilities[nameof(IEngineRpcModule.engine_newPayloadV3)] = spec.IsEip4844Enabled;
+            _capabilities[nameof(IEngineRpcModule.engine_getPayloadV3)] = (spec.IsEip4844Enabled, spec.IsEip4844Enabled);
+            _capabilities[nameof(IEngineRpcModule.engine_newPayloadV3)] = (spec.IsEip4844Enabled, spec.IsEip4844Enabled);
             #endregion
         }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
@@ -338,7 +338,7 @@ public partial class MergePlugin : IConsensusWrapperPlugin, ISynchronizationPlug
                 new GetPayloadBodiesByHashV1Handler(_api.BlockTree, _api.LogManager),
                 new GetPayloadBodiesByRangeV1Handler(_api.BlockTree, _api.LogManager),
                 new ExchangeTransitionConfigurationV1Handler(_poSSwitcher, _api.LogManager),
-                new ExchangeCapabilitiesHandler(_api.RpcCapabilitiesProvider, _api.SpecProvider, _api.LogManager),
+                new ExchangeCapabilitiesHandler(_api.RpcCapabilitiesProvider, _api.LogManager),
                 _api.SpecProvider,
                 new GCKeeper(new NoSyncGcRegionStrategy(_api.SyncModeSelector, _mergeConfig), _api.LogManager),
                 _api.LogManager);


### PR DESCRIPTION
## Changes

Correct fix to @flcl42 workaround hotfix https://github.com/NethermindEth/nethermind/pull/5787 

If Canun is not set in chainspec we won't send V3 methods
If Shanghai is not set in chainspec we won't send V2 methods etc

Let's be careful about gnosis because it will mean that we will use V1 for gnosis.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Before merging requires testing with gnosis nodes and one mainnet. I will do it after the reviews
