### PR TITLE
Reduce Evm Stackspace clearing

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Processing/ProcessingStats.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ProcessingStats.cs
@@ -148,7 +148,33 @@ namespace Nethermind.Consensus.Processing
                         > 15 => whiteText,
                         _ => resetColor
                     };
-                    _logger.Info($"- Block{(chunkBlocks > 1 ? "s" : " ")}{(chunkBlocks == 1 ? mgasColor : "")}           {chunkMGas,7:F2}{resetColor} MGas   | {chunkTx,6:N0}    txs | calls {chunkCalls,6:N0} {darkGreyText}({chunkEmptyCalls,3:N0}){resetColor}  | sload {chunkSload,7:N0} | sstore {chunkSstore,6:N0} | create {chunkCreates,3:N0}{(currentSelfDestructs - _lastSelfDestructs > 0 ? $"{darkGreyText}({-(currentSelfDestructs - _lastSelfDestructs),3:N0}){resetColor}" : "")}");
+                    var sstoreColor = chunkBlocks > 1 ? "" : chunkSstore switch
+                    {
+                        > 3500 => redText,
+                        > 2500 => orangeText,
+                        > 2000 => yellowText,
+                        > 1500 => whiteText,
+                        > 900 when chunkCalls > 900 => whiteText,
+                        _ => ""
+                    };
+                    var callsColor = chunkBlocks > 1 ? "" : chunkCalls switch
+                    {
+                        > 3500 => redText,
+                        > 2500 => orangeText,
+                        > 2000 => yellowText,
+                        > 1500 => whiteText,
+                        > 900 when chunkSstore > 900 => whiteText,
+                        _ => ""
+                    };
+                    var createsColor = chunkBlocks > 1 ? "" : chunkCreates switch
+                    {
+                        > 300 => redText,
+                        > 200 => orangeText,
+                        > 150 => yellowText,
+                        > 75 => whiteText,
+                        _ => ""
+                    };
+                    _logger.Info($"- Block{(chunkBlocks > 1 ? "s" : " ")}{(chunkBlocks == 1 ? mgasColor : "")}           {chunkMGas,7:F2}{resetColor} MGas   | {chunkTx,6:N0}    txs | calls {callsColor}{chunkCalls,6:N0}{darkGreyText} {darkGreyText}({chunkEmptyCalls,3:N0}){resetColor}  | sload {chunkSload,7:N0} | sstore {sstoreColor}{chunkSstore,6:N0}{resetColor} | create {createsColor}{chunkCreates,3:N0}{resetColor}{(currentSelfDestructs - _lastSelfDestructs > 0 ? $"{darkGreyText}({-(currentSelfDestructs - _lastSelfDestructs),3:N0}){resetColor}" : "")}");
                     _logger.Info($"- Block throughput {mgasPerSecond,7:F2} MGas/s | {txps,9:F2} t/s |         {bps,7:F2} b/s | recv  {recoveryQueueSize,7:N0} | proc   {blockQueueSize,6:N0}");
                     // Only output the total throughput in debug mode
                     _logger.Debug($"- Total throughput {totalMgasPerSecond,7:F2} MGas/s | {totalTxPerSecond,9:F2} t/s |         {totalBlocksPerSecond,7:F2} b/s | Gas gwei: {Evm.Metrics.MinGasPrice:N2} .. {Math.Max(Evm.Metrics.MinGasPrice, Evm.Metrics.EstMedianGasPrice):N2} ({Evm.Metrics.AveGasPrice:N2}) .. {Evm.Metrics.MaxGasPrice:N2}");

--- a/src/Nethermind/Nethermind.Core/Buffers/LargerArrayPool.cs
+++ b/src/Nethermind/Nethermind.Core/Buffers/LargerArrayPool.cs
@@ -11,7 +11,7 @@ namespace Nethermind.Core.Buffers
     {
         static readonly LargerArrayPool s_instance = new();
 
-        public static new ArrayPool<byte> Shared => s_instance;
+        public static new LargerArrayPool Shared => s_instance;
 
         public const int LargeBufferSize = 8 * 1024 * 1024;
         const int ArrayPoolLimit = 1024 * 1024;

--- a/src/Nethermind/Nethermind.Evm.Benchmark/EvmBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/EvmBenchmarks.cs
@@ -65,7 +65,7 @@ namespace Nethermind.Evm.Benchmark
         [Benchmark]
         public void ExecuteCode()
         {
-            _virtualMachine.Run(_evmState, _stateProvider, _txTracer);
+            _virtualMachine.Run<VirtualMachine.NotTracing>(_evmState, _stateProvider, _txTracer);
             _stateProvider.Reset();
         }
     }

--- a/src/Nethermind/Nethermind.Evm.Benchmark/EvmStackBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/EvmStackBenchmarks.cs
@@ -31,7 +31,7 @@ namespace Nethermind.Evm.Benchmark
         [ArgumentsSource(nameof(ValueSource))]
         public UInt256 Uint256(UInt256 v)
         {
-            EvmStack stack = new(_stack.AsSpan(), 0, NullTxTracer.Instance);
+            EvmStack<VirtualMachine.NotTracing> stack = new(_stack.AsSpan(), 0, NullTxTracer.Instance);
 
             stack.PushUInt256(in v);
             stack.PopUInt256(out UInt256 value);
@@ -52,7 +52,7 @@ namespace Nethermind.Evm.Benchmark
         [ArgumentsSource(nameof(ValueSource))]
         public Int256.Int256 Int256(UInt256 v)
         {
-            EvmStack stack = new(_stack.AsSpan(), 0, NullTxTracer.Instance);
+            EvmStack<VirtualMachine.NotTracing> stack = new(_stack.AsSpan(), 0, NullTxTracer.Instance);
 
             stack.PushSignedInt256(new Int256.Int256(v));
             stack.PopSignedInt256(out Int256.Int256 value);
@@ -72,7 +72,7 @@ namespace Nethermind.Evm.Benchmark
         [Benchmark(OperationsPerInvoke = 4)]
         public byte Byte()
         {
-            EvmStack stack = new(_stack.AsSpan(), 0, NullTxTracer.Instance);
+            EvmStack<VirtualMachine.NotTracing> stack = new(_stack.AsSpan(), 0, NullTxTracer.Instance);
 
             byte b = 1;
 
@@ -94,7 +94,7 @@ namespace Nethermind.Evm.Benchmark
         [Benchmark(OperationsPerInvoke = 4)]
         public void PushZero()
         {
-            EvmStack stack = new(_stack.AsSpan(), 0, NullTxTracer.Instance);
+            EvmStack<VirtualMachine.NotTracing> stack = new(_stack.AsSpan(), 0, NullTxTracer.Instance);
 
             stack.PushZero();
             stack.PushZero();
@@ -105,7 +105,7 @@ namespace Nethermind.Evm.Benchmark
         [Benchmark(OperationsPerInvoke = 4)]
         public void PushOne()
         {
-            EvmStack stack = new(_stack.AsSpan(), 0, NullTxTracer.Instance);
+            EvmStack<VirtualMachine.NotTracing> stack = new(_stack.AsSpan(), 0, NullTxTracer.Instance);
 
             stack.PushOne();
             stack.PushOne();
@@ -116,7 +116,7 @@ namespace Nethermind.Evm.Benchmark
         [Benchmark(OperationsPerInvoke = 4)]
         public void Swap()
         {
-            EvmStack stack = new(_stack.AsSpan(), 2, NullTxTracer.Instance);
+            EvmStack<VirtualMachine.NotTracing> stack = new(_stack.AsSpan(), 2, NullTxTracer.Instance);
 
             stack.Swap(2);
             stack.Swap(2);
@@ -127,7 +127,7 @@ namespace Nethermind.Evm.Benchmark
         [Benchmark(OperationsPerInvoke = 4)]
         public void Dup()
         {
-            EvmStack stack = new(_stack.AsSpan(), 1, NullTxTracer.Instance);
+            EvmStack<VirtualMachine.NotTracing> stack = new(_stack.AsSpan(), 1, NullTxTracer.Instance);
 
             stack.Dup(1);
             stack.Dup(1);

--- a/src/Nethermind/Nethermind.Evm.Benchmark/MultipleUnsignedOperations.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/MultipleUnsignedOperations.cs
@@ -96,7 +96,7 @@ public class MultipleUnsignedOperations
     [Benchmark]
     public void ExecuteCode()
     {
-        _virtualMachine.Run(_evmState, _stateProvider, _txTracer);
+        _virtualMachine.Run<VirtualMachine.NotTracing>(_evmState, _stateProvider, _txTracer);
         _stateProvider.Reset();
     }
 

--- a/src/Nethermind/Nethermind.Evm.Benchmark/StaticCallBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/StaticCallBenchmarks.cs
@@ -104,10 +104,17 @@ namespace Nethermind.Evm.Benchmark
             _evmState = new EvmState(100_000_000L, _environment, ExecutionType.Transaction, true, _stateProvider.TakeSnapshot(), false);
         }
 
-        [Benchmark]
+        [Benchmark(Baseline = true)]
         public void ExecuteCode()
         {
-            _virtualMachine.Run(_evmState, _stateProvider, _txTracer);
+            _virtualMachine.Run<VirtualMachine.IsTracing>(_evmState, _stateProvider, _txTracer);
+            _stateProvider.Reset();
+        }
+
+        [Benchmark]
+        public void ExecuteCodeNoTracing()
+        {
+            _virtualMachine.Run<VirtualMachine.NotTracing>(_evmState, _stateProvider, _txTracer);
             _stateProvider.Reset();
         }
 

--- a/src/Nethermind/Nethermind.Evm.Test/CmpTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/CmpTests.cs
@@ -1,35 +1,20 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using Nethermind.Core;
-using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Specs;
 using NUnit.Framework;
 
 namespace Nethermind.Evm.Test
 {
-    [TestFixture(true)]
-    [TestFixture(false)]
     [Parallelizable(ParallelScope.Self)]
     public class CmpTests : VirtualMachineTestsBase
     {
-        private readonly bool _simdDisabled;
         protected override long BlockNumber => MainnetSpecProvider.ConstantinopleFixBlockNumber;
-
-        public CmpTests(bool simdDisabled)
-        {
-            _simdDisabled = simdDisabled;
-        }
 
         [Test]
         public void Gt()
         {
-            if (_simdDisabled)
-            {
-                Machine.DisableSimdInstructions();
-            }
-
             byte[] a = Bytes.FromHexString("0xf0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0ff");
             byte[] b = Bytes.FromHexString("0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f");
             byte[] result = Bytes.FromHexString("0x0000000000000000000000000000000000000000000000000000000000000000");
@@ -49,11 +34,6 @@ namespace Nethermind.Evm.Test
         [Test]
         public void Lt()
         {
-            if (_simdDisabled)
-            {
-                Machine.DisableSimdInstructions();
-            }
-
             byte[] a = Bytes.FromHexString("0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f");
             byte[] b = Bytes.FromHexString("0xf0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0");
             byte[] result = Bytes.FromHexString("0x0000000000000000000000000000000000000000000000000000000000000000");
@@ -73,11 +53,6 @@ namespace Nethermind.Evm.Test
         [Test]
         public void Eq()
         {
-            if (_simdDisabled)
-            {
-                Machine.DisableSimdInstructions();
-            }
-
             byte[] a = Bytes.FromHexString("0xf0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0");
             byte[] b = Bytes.FromHexString("0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f");
             byte[] result = Bytes.FromHexString("0x0000000000000000000000000000000000000000000000000000000000000000");

--- a/src/Nethermind/Nethermind.Evm.Test/SimdTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/SimdTests.cs
@@ -2,35 +2,20 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using Nethermind.Core;
-using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Specs;
 using NUnit.Framework;
 
 namespace Nethermind.Evm.Test
 {
-    [TestFixture(true)]
-    [TestFixture(false)]
     [Parallelizable(ParallelScope.Self)]
     public class SimdTests : VirtualMachineTestsBase
     {
-        private readonly bool _simdDisabled;
         protected override long BlockNumber => MainnetSpecProvider.ConstantinopleFixBlockNumber;
-
-        public SimdTests(bool simdDisabled)
-        {
-            _simdDisabled = simdDisabled;
-        }
 
         [Test]
         public void And()
         {
-            if (_simdDisabled)
-            {
-                Machine.DisableSimdInstructions();
-            }
-
             byte[] a = Bytes.FromHexString("0xf0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0ff");
             byte[] b = Bytes.FromHexString("0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f");
             byte[] result = Bytes.FromHexString("0x000000000000000000000000000000000000000000000000000000000000000f");
@@ -50,11 +35,6 @@ namespace Nethermind.Evm.Test
         [Test]
         public void Or()
         {
-            if (_simdDisabled)
-            {
-                Machine.DisableSimdInstructions();
-            }
-
             byte[] a = Bytes.FromHexString("0xf0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0");
             byte[] b = Bytes.FromHexString("0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f");
             byte[] result = Bytes.FromHexString("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
@@ -74,11 +54,6 @@ namespace Nethermind.Evm.Test
         [Test]
         public void Xor()
         {
-            if (_simdDisabled)
-            {
-                Machine.DisableSimdInstructions();
-            }
-
             byte[] a = Bytes.FromHexString("0xf0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0");
             byte[] b = Bytes.FromHexString("0xff0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f");
             byte[] result = Bytes.FromHexString("0x0fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
@@ -98,11 +73,6 @@ namespace Nethermind.Evm.Test
         [Test]
         public void Not()
         {
-            if (_simdDisabled)
-            {
-                Machine.DisableSimdInstructions();
-            }
-
             byte[] a = Bytes.FromHexString("0xf0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0");
             byte[] result = Bytes.FromHexString("0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f");
 

--- a/src/Nethermind/Nethermind.Evm/ByteArrayExtensions.cs
+++ b/src/Nethermind/Nethermind.Evm/ByteArrayExtensions.cs
@@ -2,13 +2,19 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Runtime.CompilerServices;
+
 using Nethermind.Int256;
 
 namespace Nethermind.Evm
 {
     public static class ByteArrayExtensions
     {
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private static ZeroPaddedSpan SliceWithZeroPadding(this Span<byte> span, int startIndex, int length, PadDirection padDirection)
+            => ((ReadOnlySpan<byte>)span).SliceWithZeroPadding(startIndex, length, padDirection);
+
+        private static ZeroPaddedSpan SliceWithZeroPadding(this ReadOnlySpan<byte> span, int startIndex, int length, PadDirection padDirection)
         {
             if (startIndex >= span.Length)
             {
@@ -28,26 +34,6 @@ namespace Nethermind.Evm
             return new ZeroPaddedSpan(span.Slice(startIndex, copiedLength), length - copiedLength, padDirection);
         }
 
-        private static ZeroPaddedMemory MemoryWithZeroPadding(this ReadOnlyMemory<byte> memory, int startIndex, int length, PadDirection padDirection)
-        {
-            if (startIndex >= memory.Length)
-            {
-                return new ZeroPaddedMemory(default, length, padDirection);
-            }
-
-            if (length == 1)
-            {
-                // why do we return zero length here?
-                // it was passing all the tests like this...
-                // return bytes.Length == 0 ? new byte[0] : new[] {bytes[startIndex]};
-                return memory.Length == 0 ? new ZeroPaddedMemory(default, 0, padDirection) : new ZeroPaddedMemory(memory.Slice(startIndex, 1), 0, padDirection);
-                // return bytes.Length == 0 ? new ZeroPaddedSpan(default, 1) : new ZeroPaddedSpan(bytes.Slice(startIndex, 1), 0);
-            }
-
-            int copiedLength = Math.Min(memory.Length - startIndex, length);
-            return new ZeroPaddedMemory(memory.Slice(startIndex, copiedLength), length - copiedLength, padDirection);
-        }
-
         public static ZeroPaddedSpan SliceWithZeroPadding(this Span<byte> span, scoped in UInt256 startIndex, int length, PadDirection padDirection = PadDirection.Right)
         {
             if (startIndex >= span.Length || startIndex > int.MaxValue)
@@ -58,17 +44,17 @@ namespace Nethermind.Evm
             return SliceWithZeroPadding(span, (int)startIndex, length, padDirection);
         }
 
-        public static ZeroPaddedMemory SliceWithZeroPadding(this ReadOnlyMemory<byte> bytes, scoped in UInt256 startIndex, int length, PadDirection padDirection = PadDirection.Right)
+        public static ZeroPaddedSpan SliceWithZeroPadding(this ReadOnlyMemory<byte> bytes, scoped in UInt256 startIndex, int length, PadDirection padDirection = PadDirection.Right)
         {
             if (startIndex >= bytes.Length || startIndex > int.MaxValue)
             {
-                return new ZeroPaddedMemory(default, length, PadDirection.Right);
+                return new ZeroPaddedSpan(default, length, PadDirection.Right);
             }
 
-            return MemoryWithZeroPadding(bytes, (int)startIndex, length, padDirection);
+            return SliceWithZeroPadding(bytes.Span, (int)startIndex, length, padDirection);
         }
 
-        public static ZeroPaddedSpan SliceWithZeroPadding(this byte[] bytes, in UInt256 startIndex, int length, PadDirection padDirection = PadDirection.Right) =>
+        public static ZeroPaddedSpan SliceWithZeroPadding(this byte[] bytes, scoped in UInt256 startIndex, int length, PadDirection padDirection = PadDirection.Right) =>
             bytes.AsSpan().SliceWithZeroPadding(startIndex, length, padDirection);
 
         public static ZeroPaddedSpan SliceWithZeroPadding(this byte[] bytes, int startIndex, int length, PadDirection padDirection = PadDirection.Right) =>

--- a/src/Nethermind/Nethermind.Evm/EvmPooledMemory.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmPooledMemory.cs
@@ -100,7 +100,7 @@ namespace Nethermind.Evm
             Array.Copy(value, 0, _memory!, (long)location, value.Length);
         }
 
-        public void Save(in UInt256 location, ZeroPaddedSpan value)
+        public void Save(in UInt256 location, in ZeroPaddedSpan value)
         {
             if (value.Length == 0)
             {
@@ -116,7 +116,7 @@ namespace Nethermind.Evm
             _memory.AsSpan(intLocation + value.Span.Length, value.PaddingLength).Clear();
         }
 
-        public void Save(in UInt256 location, ZeroPaddedMemory value)
+        public void Save(in UInt256 location, in ZeroPaddedMemory value)
         {
             if (value.Length == 0)
             {

--- a/src/Nethermind/Nethermind.Evm/EvmPooledMemory.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmPooledMemory.cs
@@ -20,7 +20,7 @@ namespace Nethermind.Evm
         public const int WordSize = 32;
         private static readonly UInt256 WordSize256 = WordSize;
 
-        private static readonly ArrayPool<byte> Pool = LargerArrayPool.Shared;
+        private static readonly LargerArrayPool Pool = LargerArrayPool.Shared;
 
         private int _lastZeroedSize;
 
@@ -28,7 +28,7 @@ namespace Nethermind.Evm
         public ulong Length { get; private set; }
         public ulong Size { get; private set; }
 
-        public void SaveWord(in UInt256 location, Span<byte> word)
+        public void SaveWord(in UInt256 location, ReadOnlySpan<byte> word)
         {
             if (word.Length != WordSize) ThrowArgumentOutOfRangeException();
 
@@ -253,6 +253,7 @@ namespace Nethermind.Evm
             if (_memory is not null)
             {
                 Pool.Return(_memory);
+                _memory = null;
             }
         }
 

--- a/src/Nethermind/Nethermind.Evm/EvmPooledMemory.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmPooledMemory.cs
@@ -28,7 +28,7 @@ namespace Nethermind.Evm
         public ulong Length { get; private set; }
         public ulong Size { get; private set; }
 
-        public void SaveWord(in UInt256 location, ReadOnlySpan<byte> word)
+        public void SaveWord(in UInt256 location, Span<byte> word)
         {
             if (word.Length != WordSize) ThrowArgumentOutOfRangeException();
 
@@ -140,7 +140,7 @@ namespace Nethermind.Evm
             return _memory.AsSpan((int)location, WordSize);
         }
 
-        public Span<byte> LoadSpan(in UInt256 location, in UInt256 length)
+        public Span<byte> LoadSpan(scoped in UInt256 location, scoped in UInt256 length)
         {
             if (length.IsZero)
             {

--- a/src/Nethermind/Nethermind.Evm/EvmStack.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmStack.cs
@@ -41,7 +41,7 @@ namespace Nethermind.Evm
 
         private ITxTracer _tracer;
 
-        public void PushBytes(scoped in Span<byte> value)
+        public void PushBytes(scoped in ReadOnlySpan<byte> value)
         {
             if (_tracer.IsTracingInstructions) _tracer.ReportStackPush(value);
 

--- a/src/Nethermind/Nethermind.Evm/EvmStack.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmStack.cs
@@ -43,7 +43,7 @@ namespace Nethermind.Evm
 
         private ITxTracer _tracer;
 
-        public void PushBytes(scoped in ReadOnlySpan<byte> value)
+        public void PushBytes(scoped in Span<byte> value)
         {
             if (typeof(TTracing) == typeof(IsTracing)) _tracer.ReportStackPush(value);
 
@@ -311,14 +311,25 @@ namespace Nethermind.Evm
 
         public bool PeekUInt256IsZero()
         {
-            int head = Head - 1;
-            if (head <= 0)
+            int head = Head;
+            if (head-- == 0)
             {
                 return false;
             }
 
             ref byte bytes = ref _bytes[head * WordSize];
             return Unsafe.ReadUnaligned<UInt256>(ref bytes).IsZero;
+        }
+
+        public Span<byte> PeekWord256()
+        {
+            int head = Head;
+            if (head-- == 0)
+            {
+                EvmStack.ThrowEvmStackUnderflowException();
+            }
+
+            return _bytes.Slice(head * WordSize, WordSize);
         }
 
         public Address PopAddress()

--- a/src/Nethermind/Nethermind.Evm/EvmStack.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmStack.cs
@@ -35,13 +35,9 @@ namespace Nethermind.Evm
             _bytes = bytes;
             Head = head;
             _tracer = txTracer;
-            Register = _bytes.Slice(MaxStackSize * WordSize, WordSize);
-            Register.Clear();
         }
 
         public int Head;
-
-        public Span<byte> Register;
 
         private Span<byte> _bytes;
 
@@ -89,6 +85,18 @@ namespace Nethermind.Evm
             {
                 EvmStack.ThrowEvmStackOverflowException();
             }
+        }
+
+        public ref byte PushBytesRef()
+        {
+            ref byte bytes = ref _bytes[Head * WordSize];
+
+            if (++Head >= MaxStackSize)
+            {
+                EvmStack.ThrowEvmStackOverflowException();
+            }
+
+            return ref bytes;
         }
 
         public void PushBytes(scoped in ZeroPaddedMemory value)
@@ -323,7 +331,7 @@ namespace Nethermind.Evm
             return new Address(_bytes.Slice(Head * WordSize + WordSize - AddressSize, AddressSize).ToArray());
         }
 
-        private ref byte PopBytesByRef()
+        public ref byte PopBytesByRef()
         {
             if (Head-- == 0)
             {

--- a/src/Nethermind/Nethermind.Evm/EvmStack.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmStack.cs
@@ -196,11 +196,11 @@ namespace Nethermind.Evm
                 Vector256<ulong> permute = Unsafe.As<UInt256, Vector256<ulong>>(ref Unsafe.AsRef(value));
                 Vector256<ulong> convert = Avx2.Permute4x64(permute, 0b_01_00_11_10);
                 Word shuffle = Vector256.Create(
-                    (byte) 
-                    31 ,30 ,29 ,28 ,27 ,26 ,25 ,24,
-                    23 ,22 ,21 ,20 ,19 ,18 ,17 ,16,
-                    15 ,14 ,13 ,12 ,11 ,10 ,9 ,8, 
-                    7 ,6 ,5 ,4 ,3 ,2 ,1 ,0);
+                    (byte)
+                    31, 30, 29, 28, 27, 26, 25, 24,
+                    23, 22, 21, 20, 19, 18, 17, 16,
+                    15, 14, 13, 12, 11, 10, 9, 8,
+                    7, 6, 5, 4, 3, 2, 1, 0);
                 Unsafe.WriteUnaligned(ref bytes, Avx2.Shuffle(Unsafe.As<Vector256<ulong>, Word>(ref convert), shuffle));
             }
             else
@@ -269,11 +269,11 @@ namespace Nethermind.Evm
             {
                 Word data = Unsafe.ReadUnaligned<Word>(ref bytes);
                 Word shuffle = Vector256.Create(
-                    (byte) 
-                    31 ,30 ,29 ,28 ,27 ,26 ,25 ,24,
-                    23 ,22 ,21 ,20 ,19 ,18 ,17 ,16,
-                    15 ,14 ,13 ,12 ,11 ,10 ,9 ,8, 
-                    7 ,6 ,5 ,4 ,3 ,2 ,1 ,0);
+                    (byte)
+                    31, 30, 29, 28, 27, 26, 25, 24,
+                    23, 22, 21, 20, 19, 18, 17, 16,
+                    15, 14, 13, 12, 11, 10, 9, 8,
+                    7, 6, 5, 4, 3, 2, 1, 0);
                 Word convert = Avx2.Shuffle(data, shuffle);
                 Vector256<ulong> permute = Avx2.Permute4x64(Unsafe.As<Word, Vector256<ulong>>(ref convert), 0b_01_00_11_10);
                 result = Unsafe.As<Vector256<ulong>, UInt256>(ref permute);

--- a/src/Nethermind/Nethermind.Evm/EvmStack.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmStack.cs
@@ -400,7 +400,7 @@ namespace Nethermind.Evm
         }
     }
 
-    internal static class EvmStack
+    public static class EvmStack
     {
         public const int RegisterLength = 1;
         public const int MaxStackSize = 1025;

--- a/src/Nethermind/Nethermind.Evm/EvmState.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmState.cs
@@ -260,7 +260,7 @@ namespace Nethermind.Evm
 
         public bool IsCold(Address? address) => !_accessedAddresses.Contains(address);
 
-        public bool IsCold(StorageCell storageCell) => !_accessedStorageCells.Contains(storageCell);
+        public bool IsCold(in StorageCell storageCell) => !_accessedStorageCells.Contains(storageCell);
 
         public void WarmUp(AccessList? accessList)
         {
@@ -279,7 +279,7 @@ namespace Nethermind.Evm
 
         public void WarmUp(Address address) => _accessedAddresses.Add(address);
 
-        public void WarmUp(StorageCell storageCell) => _accessedStorageCells.Add(storageCell);
+        public void WarmUp(in StorageCell storageCell) => _accessedStorageCells.Add(storageCell);
 
         public void CommitToParent(EvmState parentState)
         {

--- a/src/Nethermind/Nethermind.Evm/IEvmMemory.cs
+++ b/src/Nethermind/Nethermind.Evm/IEvmMemory.cs
@@ -10,7 +10,7 @@ namespace Nethermind.Evm
     public interface IEvmMemory : IDisposable
     {
         ulong Size { get; }
-        void SaveWord(in UInt256 location, Span<byte> word);
+        void SaveWord(in UInt256 location, ReadOnlySpan<byte> word);
         void SaveByte(in UInt256 location, byte value);
         void Save(in UInt256 location, Span<byte> value);
         void Save(in UInt256 location, byte[] value);
@@ -53,7 +53,7 @@ namespace Nethermind.Evm
 
         public ulong Size => _pooled.Size - _offset / 32;
 
-        public void SaveWord(in UInt256 location, Span<byte> word)
+        public void SaveWord(in UInt256 location, ReadOnlySpan<byte> word)
         {
             _pooled.SaveWord(location + _offset, word);
         }

--- a/src/Nethermind/Nethermind.Evm/IEvmMemory.cs
+++ b/src/Nethermind/Nethermind.Evm/IEvmMemory.cs
@@ -10,7 +10,7 @@ namespace Nethermind.Evm
     public interface IEvmMemory : IDisposable
     {
         ulong Size { get; }
-        void SaveWord(in UInt256 location, ReadOnlySpan<byte> word);
+        void SaveWord(in UInt256 location, Span<byte> word);
         void SaveByte(in UInt256 location, byte value);
         void Save(in UInt256 location, Span<byte> value);
         void Save(in UInt256 location, byte[] value);
@@ -53,7 +53,7 @@ namespace Nethermind.Evm
 
         public ulong Size => _pooled.Size - _offset / 32;
 
-        public void SaveWord(in UInt256 location, ReadOnlySpan<byte> word)
+        public void SaveWord(in UInt256 location, Span<byte> word)
         {
             _pooled.SaveWord(location + _offset, word);
         }

--- a/src/Nethermind/Nethermind.Evm/IVirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/IVirtualMachine.cs
@@ -7,11 +7,14 @@ using Nethermind.Evm.CodeAnalysis;
 using Nethermind.Evm.Tracing;
 using Nethermind.State;
 
+using static Nethermind.Evm.VirtualMachine;
+
 namespace Nethermind.Evm
 {
     public interface IVirtualMachine
     {
-        TransactionSubstate Run(EvmState state, IWorldState worldState, ITxTracer tracer);
+        TransactionSubstate Run<TTracingActions>(EvmState state, IWorldState worldState, ITxTracer txTracer)
+            where TTracingActions : struct, IIsTracing;
 
         CodeInfo GetCachedCodeInfo(IWorldState worldState, Address codeSource, IReleaseSpec spec);
     }

--- a/src/Nethermind/Nethermind.Evm/Metrics.cs
+++ b/src/Nethermind/Nethermind.Evm/Metrics.cs
@@ -13,22 +13,6 @@ namespace Nethermind.Evm;
 public class Metrics
 {
     [CounterMetric]
-    [Description("Number of EXTCODESIZE opcodes executed.")]
-    public static long ExtCodeSizeOpcode;
-
-    [CounterMetric]
-    [Description("Number of EXTCODESIZE ISZERO optimizations.")]
-    public static long ExtCodeSizeOptimizedIsZero;
-
-    [CounterMetric]
-    [Description("Number of EXTCODESIZE GT optimizations.")]
-    public static long ExtCodeSizeOptimizedGT;
-
-    [CounterMetric]
-    [Description("Number of EXTCODESIZE EQ optimizations.")]
-    public static long ExtCodeSizeOptimizedEQ;
-
-    [CounterMetric]
     [Description("Number of EVM exceptions thrown by contracts.")]
     public static long EvmExceptions { get; set; }
 

--- a/src/Nethermind/Nethermind.Evm/Tracing/ITxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/ITxTracer.cs
@@ -305,7 +305,7 @@ namespace Nethermind.Evm.Tracing
         /// <param name="newValue"></param>
         /// <param name="currentValue"></param>
         /// <remarks>Depends on <see cref="IsTracingOpLevelStorage"/></remarks>
-        void SetOperationTransientStorage(Address storageCellAddress, UInt256 storageIndex, Span<byte> newValue, byte[] currentValue) { }
+        void SetOperationTransientStorage(Address storageCellAddress, UInt256 storageIndex, ReadOnlySpan<byte> newValue, byte[] currentValue) { }
 
         /// <summary>
         ///

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -18,6 +18,8 @@ using Nethermind.State;
 using Nethermind.State.Tracing;
 using Transaction = Nethermind.Core.Transaction;
 
+using static Nethermind.Evm.VirtualMachine;
+
 namespace Nethermind.Evm.TransactionProcessing
 {
     public class TransactionProcessor : ITransactionProcessor
@@ -364,7 +366,14 @@ namespace Nethermind.Evm.TransactionProcessing
                         state.WarmUp(block.GasBeneficiary);
                     }
 
-                    substate = _virtualMachine.Run(state, _worldState, txTracer);
+                    if (!txTracer.IsTracingActions)
+                    {
+                        substate = _virtualMachine.Run<NotTracing>(state, _worldState, txTracer);
+                    }
+                    else
+                    {
+                        substate = _virtualMachine.Run<IsTracing>(state, _worldState, txTracer);
+                    }
                     unspentGas = state.GasAvailable;
 
                     if (txTracer.IsTracingAccess)

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -486,7 +486,7 @@ namespace Nethermind.Evm.TransactionProcessing
                         state.WarmUp(header.GasBeneficiary);
                     }
 
-                    if (!txTracer.IsTracingActions)
+                    if (!tracer.IsTracingActions)
                     {
                         substate = _virtualMachine.Run<NotTracing>(state, _worldState, tracer);
                     }

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -1524,9 +1524,8 @@ OutOfGas:
                     {
                         Metrics.TloadOpcode++;
                         if (!spec.TransientStorageEnabled) goto InvalidInstruction;
-                        var gasCost = GasCostOf.TLoad;
 
-                        if (!UpdateGas(gasCost, ref gasAvailable)) goto OutOfGas;
+                        if (!UpdateGas(GasCostOf.TLoad, ref gasAvailable)) goto OutOfGas;
 
                         stack.PopUInt256(out result);
                         StorageCell storageCell = new(env.ExecutingAccount, result);
@@ -1548,8 +1547,7 @@ OutOfGas:
 
                         if (vmState.IsStatic) goto StaticCallViolation;
 
-                        long gasCost = GasCostOf.TStore;
-                        if (!UpdateGas(gasCost, ref gasAvailable)) goto OutOfGas;
+                        if (!UpdateGas(GasCostOf.TStore, ref gasAvailable)) goto OutOfGas;
 
                         stack.PopUInt256(out result);
                         bytes = stack.PopWord256();
@@ -1626,16 +1624,10 @@ OutOfGas:
                     }
                 case Instruction.PUSH0:
                     {
-                        if (spec.IncludePush0Instruction)
-                        {
-                            if (!UpdateGas(GasCostOf.Base, ref gasAvailable)) goto OutOfGas;
+                        if (!spec.IncludePush0Instruction) goto InvalidInstruction;
+                        if (!UpdateGas(GasCostOf.Base, ref gasAvailable)) goto OutOfGas;
 
-                            stack.PushZero();
-                        }
-                        else
-                        {
-                            goto InvalidInstruction;
-                        }
+                        stack.PushZero();
                         break;
                     }
                 case Instruction.PUSH1:

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -635,7 +635,7 @@ public class VirtualMachine : IVirtualMachine
             vmState.Memory.Save(in localPreviousDest, previousCallOutput);
         }
 
-        return ExecuteCode(vmState, ref stack, ref gasAvailable, spec);
+        return ExecuteCode(vmState, ref stack, gasAvailable, spec);
 Empty:
         return CallResult.Empty;
 OutOfGas:
@@ -643,7 +643,7 @@ OutOfGas:
     }
 
     [SkipLocalsInit]
-    private CallResult ExecuteCode(EvmState vmState, scoped ref EvmStack stack, scoped ref long gasAvailable, IReleaseSpec spec)
+    private CallResult ExecuteCode(EvmState vmState, scoped ref EvmStack stack, long gasAvailable, IReleaseSpec spec)
     {
         bool isTrace = _logger.IsTrace;
         bool traceOpcodes = _txTracer.IsTracingInstructions;
@@ -652,7 +652,7 @@ OutOfGas:
         ref readonly TxExecutionContext txCtx = ref env.TxExecutionContext;
         Span<byte> code = env.CodeInfo.MachineCode.AsSpan();
         int programCounter = vmState.ProgramCounter;
-        
+
 #if DEBUG
         DebugTracer? debugger = _txTracer.GetTracer<DebugTracer>();
 #endif
@@ -1510,16 +1510,16 @@ OutOfGas:
                         break;
                     }
                 case Instruction.SSTORE:
-                {
-                    Metrics.SstoreOpcode++;
+                    {
+                        Metrics.SstoreOpcode++;
 
-                    if (vmState.IsStatic) goto StaticCallViolation;
+                        if (vmState.IsStatic) goto StaticCallViolation;
 
-                    if (!InstructionSStore(vmState, ref stack, ref gasAvailable, spec))
-                        goto OutOfGas;
+                        if (!InstructionSStore(vmState, ref stack, ref gasAvailable, spec))
+                            goto OutOfGas;
 
-                    break;
-                }
+                        break;
+                    }
                 case Instruction.TLOAD:
                     {
                         Metrics.TloadOpcode++;

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -1145,7 +1145,7 @@ OutOfGas:
 
                             ZeroPaddedMemory callDataSlice = env.InputData.SliceWithZeroPadding(b, (int)result);
                             vmState.Memory.Save(in a, callDataSlice);
-                            if (_txTracer.IsTracingInstructions)
+                            if (traceOpcodes)
                             {
                                 _txTracer.ReportMemoryChange((long)a, callDataSlice);
                             }
@@ -1174,7 +1174,7 @@ OutOfGas:
 
                             ZeroPaddedSpan codeSlice = code.SliceWithZeroPadding(b, (int)result);
                             vmState.Memory.Save(in a, codeSlice);
-                            if (_txTracer.IsTracingInstructions) _txTracer.ReportMemoryChange((long)a, codeSlice);
+                            if (traceOpcodes) _txTracer.ReportMemoryChange((long)a, codeSlice);
                         }
 
                         break;
@@ -1279,7 +1279,7 @@ OutOfGas:
                             byte[] externalCode = GetCachedCodeInfo(_worldState, address, spec).MachineCode;
                             ZeroPaddedSpan callDataSlice = externalCode.SliceWithZeroPadding(b, (int)result);
                             vmState.Memory.Save(in a, callDataSlice);
-                            if (_txTracer.IsTracingInstructions)
+                            if (traceOpcodes)
                             {
                                 _txTracer.ReportMemoryChange((long)a, callDataSlice);
                             }
@@ -1317,7 +1317,7 @@ OutOfGas:
 
                             ZeroPaddedSpan returnDataSlice = _returnDataBuffer.AsSpan().SliceWithZeroPadding(b, (int)result);
                             vmState.Memory.Save(in a, returnDataSlice);
-                            if (_txTracer.IsTracingInstructions)
+                            if (traceOpcodes)
                             {
                                 _txTracer.ReportMemoryChange((long)a, returnDataSlice);
                             }
@@ -1453,7 +1453,7 @@ OutOfGas:
                         stack.PopUInt256(out result);
                         if (!UpdateMemoryCost(vmState, ref gasAvailable, in result, 32)) goto OutOfGas;
                         bytes = vmState.Memory.LoadSpan(in result);
-                        if (_txTracer.IsTracingInstructions) _txTracer.ReportMemoryChange(result, bytes);
+                        if (traceOpcodes) _txTracer.ReportMemoryChange(result, bytes);
 
                         stack.PushBytes(bytes);
                         break;
@@ -1467,7 +1467,7 @@ OutOfGas:
                         bytes = stack.PopWord256();
                         if (!UpdateMemoryCost(vmState, ref gasAvailable, in result, 32)) goto OutOfGas;
                         vmState.Memory.SaveWord(in result, bytes);
-                        if (_txTracer.IsTracingInstructions) _txTracer.ReportMemoryChange((long)result, bytes.SliceWithZeroPadding(0, 32, PadDirection.Left));
+                        if (traceOpcodes) _txTracer.ReportMemoryChange((long)result, bytes.SliceWithZeroPadding(0, 32, PadDirection.Left));
 
                         break;
                     }
@@ -1479,7 +1479,7 @@ OutOfGas:
                         byte data = stack.PopByte();
                         if (!UpdateMemoryCost(vmState, ref gasAvailable, in result, UInt256.One)) goto OutOfGas;
                         vmState.Memory.SaveByte(in result, data);
-                        if (_txTracer.IsTracingInstructions) _txTracer.ReportMemoryChange((long)result, data);
+                        if (traceOpcodes) _txTracer.ReportMemoryChange((long)result, data);
 
                         break;
                     }
@@ -1872,7 +1872,7 @@ OutOfGas:
                             _returnDataBuffer = Array.Empty<byte>();
                             stack.PushZero();
 
-                            if (_txTracer.IsTracingInstructions)
+                            if (traceOpcodes)
                             {
                                 // very specific for Parity trace, need to find generalization - very peculiar 32 length...
                                 ReadOnlyMemory<byte> memoryTrace = vmState.Memory.Inspect(in dataOffset, 32);
@@ -1880,11 +1880,11 @@ OutOfGas:
                             }
 
                             if (isTrace) _logger.Trace("FAIL - call depth");
-                            if (_txTracer.IsTracingInstructions) _txTracer.ReportOperationRemainingGas(gasAvailable);
-                            if (_txTracer.IsTracingInstructions) _txTracer.ReportOperationError(EvmExceptionType.NotEnoughBalance);
+                            if (traceOpcodes) _txTracer.ReportOperationRemainingGas(gasAvailable);
+                            if (traceOpcodes) _txTracer.ReportOperationError(EvmExceptionType.NotEnoughBalance);
 
                             UpdateGasUp(gasLimitUl, ref gasAvailable);
-                            if (_txTracer.IsTracingInstructions) _txTracer.ReportGasUpdateForVmTrace(gasLimitUl, gasAvailable);
+                            if (traceOpcodes) _txTracer.ReportGasUpdateForVmTrace(gasLimitUl, gasAvailable);
                             break;
                         }
 

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -685,7 +685,8 @@ OutOfGas:
         Unsafe.SkipInit(out Int256.Int256 sb);
         Unsafe.SkipInit(out UInt256 result);
         object returnData;
-        while (programCounter < code.Length)
+        uint codeLength = (uint)code.Length;
+        while ((uint)programCounter < codeLength)
         {
 #if DEBUG
             debugger?.TryWait(ref vmState, ref programCounter, ref gasAvailable, ref stack.Head);


### PR DESCRIPTION
As there are a large number of `CALL`/`DELEGATECALL`/`STATICCALL` per transaction and each call becomes both a call and call back the `ExecuteCall`/`Code` method is executed many times. On currently on entering the method it zeros 9136 bytes of stack.

Some blocks can make up to 4k+ calls meaning 8k+ method entries for these heavy blocks or 70MB. Also the method is 26.5kb of asm which reduces the Jits willingness to optimize and is a large code chunk for a hot loop.

e.g. in the example below 7 blocks execute 724 txs which calls ExecuteCall 10.5k times meaning 92MB of stack needs to be cleared

![image](https://github.com/NethermindEth/nethermind/assets/1142958/5b432186-aabe-4942-9b38-09e5296e60c3)

This change reduces to to 1328 bytes of stack or 78MB less in the example above; and reduced the hot loop from 26.5kB to 17.2kB so is more likely to be hotter in the CPU L1 execution cache (32KB - 48KB)

## Changes

- Split `ExecuteCall`-> `ExecuteCall`+`ExecuteCode`; the first being setup and second being hot loop to reduce register pressure on the loop from the setup.
- Reuse large struct stack variables; as the Jit will allocate a spot in the stack for each declaration
- Reduce method code/repeats for failures
- Move Sstore to own method, uses a fair amount of stack variables and not commonly called as %
- Move Log to own method, uses a fair amount of stack variables and not commonly called as %
- Move create to own method, uses a fair amount of stack variables and not commonly called as %
- Move SelfDestruct to own method, uses a fair amount of stack variables and not commonly called (i.e max once)
- Move Return to own method, uses a fair amount of stack variables and not commonly called (i.e max once)
- Move Call to own method, uses a fair amount of stack variables and not commonly called (i.e max once)
- Use struct based Generic parameters and type checks for tracing to effectively remove all the code and the `if` checks from the compiled Asm when tracing is not enabled (the Jit will generate a new method for each different struct generic parameter, so can use this to make compile time if checks and then remove the branching and dead code)

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

_Optional. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
