### PR TITLE
Update clique-validators.sh

### DIFF
--- a/scripts/private-networking/clique-validators.sh
+++ b/scripts/private-networking/clique-validators.sh
@@ -7,7 +7,7 @@ set -e
 DEBIAN_FRONTEND=noninteractive
 
 # Install required packages
-#sudo apt-get install -y docker-compose docker.io jq pwgen
+#sudo apt-get install -y docker-compose docker.io jq openssl
 
 main() {
 mkdir private-networking
@@ -34,7 +34,7 @@ for i in $(seq 1 $validators);
 do 
     PORT=$(( 30301 + $i ))
     PRIVATE_IP=10.5.0.$(( 1 + $i ))
-    KEY=$(pwgen 64 1 | tr '[:lower:]' '[:upper:]') 
+    KEY=$(openssl rand -hex 32 | tr '[:lower:]' '[:upper:]') 
     writeNethermindConfig $i $PORT $PRIVATE_IP $KEY
 done
 


### PR DESCRIPTION
## Changes

- use openssl to generate hex string. pwgen does not generate a hex string

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

_Optional. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
