### PR TITLE
Fix/fix json stats report

### DIFF
--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -552,9 +552,7 @@ public class InitializeNetwork : IStep
 
         string chainName = BlockchainIds.GetBlockchainName(_api.ChainSpec!.NetworkId).ToLowerInvariant();
         string domain = _networkConfig.DiscoveryDns ?? $"all.{chainName}.ethdisco.net";
-#pragma warning disable CS4014
-        enrDiscovery.SearchTree(domain).ContinueWith(t =>
-#pragma warning restore CS4014
+        _ = enrDiscovery.SearchTree(domain).ContinueWith(t =>
         {
             if (t.IsFaulted)
             {

--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcLocalStats.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcLocalStats.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Nethermind.Core;
 using Nethermind.Core.Test;
@@ -31,54 +32,54 @@ namespace Nethermind.JsonRpc.Test
         }
 
         [Test]
-        public void Success_average_is_fine()
+        public async Task Success_average_is_fine()
         {
             JsonRpcLocalStats localStats = new(_manualTimestamper, _config, _logManager);
-            localStats.ReportCall("A", 100, true);
-            localStats.ReportCall("A", 200, true);
+            await localStats.ReportCall("A", 100, true);
+            await localStats.ReportCall("A", 200, true);
             MakeTimePass();
-            localStats.ReportCall("A", 300, true);
+            await localStats.ReportCall("A", 300, true);
             CheckLogLine("A|2|150|200|0|0|0|");
             CheckLogLine("TOTAL|2|150|200|0|0|0|");
         }
 
         [Test]
-        public void Single_average_is_fine()
+        public async Task Single_average_is_fine()
         {
             JsonRpcLocalStats localStats = new(_manualTimestamper, _config, _logManager);
-            localStats.ReportCall("A", 100, true);
+            await localStats.ReportCall("A", 100, true);
             MakeTimePass();
-            localStats.ReportCall("A", 300, true);
+            await localStats.ReportCall("A", 300, true);
             CheckLogLine("A|1|100|100|0|0|0|");
             CheckLogLine("TOTAL|1|100|100|0|0|0|");
         }
 
         [Test]
-        public void Swaps_properly()
+        public async Task Swaps_properly()
         {
             JsonRpcLocalStats localStats = new(_manualTimestamper, _config, _logManager);
-            localStats.ReportCall("A", 100, true);
+            await localStats.ReportCall("A", 100, true);
             MakeTimePass();
-            localStats.ReportCall("A", 300, true);
+            await localStats.ReportCall("A", 300, true);
             CheckLogLine("A|1|100|100|0|0|0|");
             _testLogger.LogList.Clear();
             MakeTimePass();
-            localStats.ReportCall("A", 500, true);
+            await localStats.ReportCall("A", 500, true);
             CheckLogLine("A|1|300|300|0|0|0|");
             _testLogger.LogList.Clear();
             MakeTimePass();
-            localStats.ReportCall("A", 700, true);
+            await localStats.ReportCall("A", 700, true);
             CheckLogLine("A|1|500|500|0|0|0|");
             _testLogger.LogList.Clear();
         }
 
         [Test]
-        public void Calls_do_not_delay_report()
+        public async Task Calls_do_not_delay_report()
         {
             JsonRpcLocalStats localStats = new(_manualTimestamper, _config, _logManager);
             for (int i = 0; i < 100; i++)
             {
-                localStats.ReportCall("A", 300, true);
+                await localStats.ReportCall("A", 300, true);
                 MakeTimePass(60);
             }
 
@@ -109,45 +110,45 @@ namespace Nethermind.JsonRpc.Test
         }
 
         [Test]
-        public void Multiple_have_no_decimal_places()
+        public async Task Multiple_have_no_decimal_places()
         {
             JsonRpcLocalStats localStats = new(_manualTimestamper, _config, _logManager);
-            localStats.ReportCall("A", 30, true);
-            localStats.ReportCall("A", 20, true);
-            localStats.ReportCall("A", 50, true);
-            localStats.ReportCall("A", 60, false);
-            localStats.ReportCall("A", 40, false);
-            localStats.ReportCall("A", 100, false);
+            await localStats.ReportCall("A", 30, true);
+            await localStats.ReportCall("A", 20, true);
+            await localStats.ReportCall("A", 50, true);
+            await localStats.ReportCall("A", 60, false);
+            await localStats.ReportCall("A", 40, false);
+            await localStats.ReportCall("A", 100, false);
             MakeTimePass();
-            localStats.ReportCall("A", 300, true);
+            await localStats.ReportCall("A", 300, true);
             CheckLogLine("A|3|33|50|3|67|100|");
             CheckLogLine("TOTAL|3|33|50|3|67|100|");
         }
 
         [Test]
-        public void Single_of_each_is_fine()
+        public async Task Single_of_each_is_fine()
         {
             JsonRpcLocalStats localStats = new(_manualTimestamper, _config, _logManager);
-            localStats.ReportCall("A", 25, true);
-            localStats.ReportCall("A", 125, false);
-            localStats.ReportCall("B", 75, true);
-            localStats.ReportCall("B", 175, false);
+            await localStats.ReportCall("A", 25, true);
+            await localStats.ReportCall("A", 125, false);
+            await localStats.ReportCall("B", 75, true);
+            await localStats.ReportCall("B", 175, false);
             MakeTimePass();
-            localStats.ReportCall("A", 300, true);
+            await localStats.ReportCall("A", 300, true);
             CheckLogLine("A|1|25|25|1|125|125|");
             CheckLogLine("B|1|75|75|1|175|175|");
             CheckLogLine("TOTAL|2|50|75|2|150|175|");
         }
 
         [Test]
-        public void Orders_alphabetically()
+        public async Task Orders_alphabetically()
         {
             JsonRpcLocalStats localStats = new(_manualTimestamper, _config, _logManager);
-            localStats.ReportCall("C", 1, true);
-            localStats.ReportCall("A", 2, true);
-            localStats.ReportCall("B", 3, false);
+            await localStats.ReportCall("C", 1, true);
+            await localStats.ReportCall("A", 2, true);
+            await localStats.ReportCall("B", 3, false);
             MakeTimePass();
-            localStats.ReportCall("A", 300, true);
+            await localStats.ReportCall("A", 300, true);
             _testLogger.LogList[0].IndexOf("A   ", StringComparison.InvariantCulture).Should().BeLessThan(_testLogger.LogList[0].IndexOf("B   ", StringComparison.InvariantCulture));
             _testLogger.LogList[0].IndexOf("B   ", StringComparison.InvariantCulture).Should().BeLessThan(_testLogger.LogList[0].IndexOf("C   ", StringComparison.InvariantCulture));
         }

--- a/src/Nethermind/Nethermind.JsonRpc/IJsonRpcLocalStats.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/IJsonRpcLocalStats.cs
@@ -20,7 +20,7 @@ namespace Nethermind.JsonRpc
 
     public interface IJsonRpcLocalStats
     {
-        void ReportCall(in RpcReport report, long elapsedMicroseconds = 0, long? size = null);
+        void ReportCall(RpcReport report, long elapsedMicroseconds = 0, long? size = null);
 
         MethodStats GetMethodStats(string methodName);
     }

--- a/src/Nethermind/Nethermind.JsonRpc/IJsonRpcLocalStats.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/IJsonRpcLocalStats.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Nethermind.JsonRpc
 {
@@ -20,7 +21,7 @@ namespace Nethermind.JsonRpc
 
     public interface IJsonRpcLocalStats
     {
-        void ReportCall(RpcReport report, long elapsedMicroseconds = 0, long? size = null);
+        Task ReportCall(RpcReport report, long elapsedMicroseconds = 0, long? size = null);
 
         MethodStats GetMethodStats(string methodName);
     }

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcLocalStats.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcLocalStats.cs
@@ -34,23 +34,23 @@ namespace Nethermind.JsonRpc
 
         public MethodStats GetMethodStats(string methodName) => _allTimeStats.GetValueOrDefault(methodName, new MethodStats());
 
-        public void ReportCall(string method, long handlingTimeMicroseconds, bool success) =>
+        public Task ReportCall(string method, long handlingTimeMicroseconds, bool success) =>
             ReportCall(new RpcReport(method, handlingTimeMicroseconds, success));
 
-        public void ReportCall(RpcReport report, long elapsedMicroseconds = 0, long? size = null)
+        public Task ReportCall(RpcReport report, long elapsedMicroseconds = 0, long? size = null)
         {
             if (string.IsNullOrWhiteSpace(report.Method))
             {
-                return;
+                return Task.CompletedTask;
             }
 
             if (!_logger.IsInfo)
             {
-                return;
+                return Task.CompletedTask;
             }
 
             // we don't want to block RPC calls any longer than required
-            Task.Run(() =>
+            return Task.Run(() =>
             {
                 BuildReport();
 
@@ -97,16 +97,15 @@ namespace Nethermind.JsonRpc
             });
         }
 
-
         private const string ReportHeader = "method                                  | " +
-                                    "successes | " +
-                                    " avg time (µs) | " +
-                                    " max time (µs) | " +
-                                    "   errors | " +
-                                    " avg time (µs) | " +
-                                    " max time (µs) |" +
-                                    " avg size |" +
-                                    " total size |";
+                                            "successes | " +
+                                            " avg time (µs) | " +
+                                            " max time (µs) | " +
+                                            "   errors | " +
+                                            " avg time (µs) | " +
+                                            " max time (µs) |" +
+                                            " avg size |" +
+                                            " total size |";
 
         private static readonly string _divider = new('-', ReportHeader.Length);
 

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcLocalStats.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcLocalStats.cs
@@ -21,7 +21,7 @@ namespace Nethermind.JsonRpc
         private ConcurrentDictionary<string, MethodStats> _currentStats = new();
         private ConcurrentDictionary<string, MethodStats> _previousStats = new();
         private readonly ConcurrentDictionary<string, MethodStats> _allTimeStats = new();
-        private DateTime _lastReport = DateTime.MinValue;
+        private DateTime _lastReport;
         private readonly ILogger _logger;
         private readonly StringBuilder _reportStringBuilder = new();
 
@@ -30,6 +30,7 @@ namespace Nethermind.JsonRpc
             _timestamper = timestamper ?? throw new ArgumentNullException(nameof(timestamper));
             _logger = logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
             _reportingInterval = TimeSpan.FromSeconds(jsonRpcConfig.ReportIntervalSeconds);
+            _lastReport = timestamper.UtcNow;
         }
 
         public MethodStats GetMethodStats(string methodName) => _allTimeStats.GetValueOrDefault(methodName, new MethodStats());

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcLocalStats.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcLocalStats.cs
@@ -8,6 +8,7 @@ using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using Nethermind.Core;
 using Nethermind.Logging;
 
@@ -16,19 +17,17 @@ namespace Nethermind.JsonRpc
     public class JsonRpcLocalStats : IJsonRpcLocalStats
     {
         private readonly ITimestamper _timestamper;
-        private readonly IJsonRpcConfig _jsonRpcConfig;
         private readonly TimeSpan _reportingInterval;
-
         private ConcurrentDictionary<string, MethodStats> _currentStats = new();
         private ConcurrentDictionary<string, MethodStats> _previousStats = new();
         private readonly ConcurrentDictionary<string, MethodStats> _allTimeStats = new();
         private DateTime _lastReport = DateTime.MinValue;
         private readonly ILogger _logger;
+        private readonly StringBuilder _reportStringBuilder = new();
 
         public JsonRpcLocalStats(ITimestamper timestamper, IJsonRpcConfig jsonRpcConfig, ILogManager logManager)
         {
             _timestamper = timestamper ?? throw new ArgumentNullException(nameof(timestamper));
-            _jsonRpcConfig = jsonRpcConfig ?? throw new ArgumentNullException(nameof(jsonRpcConfig));
             _logger = logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
             _reportingInterval = TimeSpan.FromSeconds(jsonRpcConfig.ReportIntervalSeconds);
         }
@@ -45,17 +44,19 @@ namespace Nethermind.JsonRpc
                 return;
             }
 
+            if (!_logger.IsInfo)
+            {
+                return;
+            }
+
             DateTime thisTime = _timestamper.UtcNow;
             if (thisTime - _lastReport > _reportingInterval)
             {
-                _lastReport = thisTime;
-                BuildReport();
+                Task.Run(BuildReport);
             }
 
-            _currentStats.TryGetValue(report.Method, out MethodStats methodStats);
-            _allTimeStats.TryGetValue(report.Method, out MethodStats allTimeMethodStats);
-            methodStats ??= _currentStats.GetOrAdd(report.Method, _ => new MethodStats());
-            allTimeMethodStats ??= _allTimeStats.GetOrAdd(report.Method, _ => new MethodStats());
+            MethodStats methodStats = _currentStats.GetOrAdd(report.Method, _ => new MethodStats());
+            MethodStats allTimeMethodStats = _allTimeStats.GetOrAdd(report.Method, _ => new MethodStats());
 
             long reportHandlingTimeMicroseconds = elapsedMicroseconds == 0 ? report.HandlingTimeMicroseconds : elapsedMicroseconds;
 
@@ -96,61 +97,74 @@ namespace Nethermind.JsonRpc
             }
         }
 
+
+        private const string ReportHeader = "method                                  | " +
+                                    "successes | " +
+                                    " avg time (µs) | " +
+                                    " max time (µs) | " +
+                                    "   errors | " +
+                                    " avg time (µs) | " +
+                                    " max time (µs) |" +
+                                    " avg size |" +
+                                    " total size |";
+
+        private static readonly string _divider = new('-', ReportHeader.Length);
+
         private void BuildReport()
         {
-            if (!_logger.IsInfo)
+            DateTime thisTime = _timestamper.UtcNow;
+            if (thisTime - _lastReport <= _reportingInterval)
             {
                 return;
             }
 
-            Swap();
-
-            if (!_previousStats.Any())
+            lock (_logger)
             {
-                return;
+                if (thisTime - _lastReport <= _reportingInterval)
+                {
+                    return;
+                }
+
+                _lastReport = thisTime;
+
+                Swap();
+
+                if (!_previousStats.Any())
+                {
+                    return;
+                }
+
+                _reportStringBuilder.AppendLine("***** JSON RPC report *****");
+                _reportStringBuilder.AppendLine(_divider);
+                _reportStringBuilder.AppendLine(ReportHeader);
+                _reportStringBuilder.AppendLine(_divider);
+                MethodStats total = new();
+                foreach (KeyValuePair<string, MethodStats> methodStats in _previousStats.OrderBy(kv => kv.Key))
+                {
+                    total.AvgTimeOfSuccesses = total.Successes + methodStats.Value.Successes == 0
+                        ? 0
+                        : (total.AvgTimeOfSuccesses * total.Successes + methodStats.Value.Successes * methodStats.Value.AvgTimeOfSuccesses)
+                          / (total.Successes + methodStats.Value.Successes);
+                    total.AvgTimeOfErrors = total.Errors + methodStats.Value.Errors == 0
+                        ? 0
+                        : (total.AvgTimeOfErrors * total.Errors + methodStats.Value.Errors * methodStats.Value.AvgTimeOfErrors)
+                          / (total.Errors + methodStats.Value.Errors);
+                    total.Successes += methodStats.Value.Successes;
+                    total.Errors += methodStats.Value.Errors;
+                    total.MaxTimeOfSuccess = Math.Max(total.MaxTimeOfSuccess, methodStats.Value.MaxTimeOfSuccess);
+                    total.MaxTimeOfError = Math.Max(total.MaxTimeOfError, methodStats.Value.MaxTimeOfError);
+                    total.TotalSize += methodStats.Value.TotalSize;
+                    _reportStringBuilder.AppendLine(PrepareReportLine(methodStats.Key, methodStats.Value));
+                }
+
+                _reportStringBuilder.AppendLine(_divider);
+                _reportStringBuilder.AppendLine(PrepareReportLine("TOTAL", total));
+                _reportStringBuilder.AppendLine(_divider);
+
+                _logger.Info(_reportStringBuilder.ToString());
+                _reportStringBuilder.Clear();
+                _previousStats.Clear();
             }
-
-            const string reportHeader = "method                                  | " +
-                                        "successes | " +
-                                        " avg time (µs) | " +
-                                        " max time (µs) | " +
-                                        "   errors | " +
-                                        " avg time (µs) | " +
-                                        " max time (µs) |" +
-                                        " avg size |" +
-                                        " total size |";
-
-            StringBuilder stringBuilder = new();
-            stringBuilder.AppendLine("***** JSON RPC report *****");
-            string divider = new(Enumerable.Repeat('-', reportHeader.Length).ToArray());
-            stringBuilder.AppendLine(divider);
-            stringBuilder.AppendLine(reportHeader);
-            stringBuilder.AppendLine(divider);
-            MethodStats total = new();
-            foreach (KeyValuePair<string, MethodStats> methodStats in _previousStats.OrderBy(kv => kv.Key))
-            {
-                total.AvgTimeOfSuccesses = total.Successes + methodStats.Value.Successes == 0
-                    ? 0
-                    : (total.AvgTimeOfSuccesses * total.Successes + methodStats.Value.Successes * methodStats.Value.AvgTimeOfSuccesses)
-                      / (total.Successes + methodStats.Value.Successes);
-                total.AvgTimeOfErrors = total.Errors + methodStats.Value.Errors == 0
-                    ? 0
-                    : (total.AvgTimeOfErrors * total.Errors + methodStats.Value.Errors * methodStats.Value.AvgTimeOfErrors)
-                      / (total.Errors + methodStats.Value.Errors);
-                total.Successes += methodStats.Value.Successes;
-                total.Errors += methodStats.Value.Errors;
-                total.MaxTimeOfSuccess = Math.Max(total.MaxTimeOfSuccess, methodStats.Value.MaxTimeOfSuccess);
-                total.MaxTimeOfError = Math.Max(total.MaxTimeOfError, methodStats.Value.MaxTimeOfError);
-                total.TotalSize += methodStats.Value.TotalSize;
-                stringBuilder.AppendLine(PrepareReportLine(methodStats.Key, methodStats.Value));
-            }
-
-            stringBuilder.AppendLine(divider);
-            stringBuilder.AppendLine(PrepareReportLine("TOTAL", total));
-            stringBuilder.AppendLine(divider);
-
-            _logger.Info(stringBuilder.ToString());
-            _previousStats.Clear();
         }
 
         private void Swap()
@@ -159,19 +173,15 @@ namespace Nethermind.JsonRpc
         }
 
         [Pure]
-        private string PrepareReportLine(in string key, MethodStats methodStats)
-        {
-            string reportLine = $"{key,-40}| " +
-                                $"{methodStats.Successes.ToString(),9} | " +
-                                $"{methodStats.AvgTimeOfSuccesses.ToString("0", CultureInfo.InvariantCulture),14} | " +
-                                $"{methodStats.MaxTimeOfSuccess.ToString(CultureInfo.InvariantCulture),14} | " +
-                                $"{methodStats.Errors.ToString(),9} | " +
-                                $"{methodStats.AvgTimeOfErrors.ToString("0", CultureInfo.InvariantCulture),14} | " +
-                                $"{methodStats.MaxTimeOfError.ToString(CultureInfo.InvariantCulture),14} | " +
-                                $"{methodStats.AvgSize.ToString("0", CultureInfo.InvariantCulture),8} | " +
-                                $"{methodStats.TotalSize.ToString("0", CultureInfo.InvariantCulture),10} | ";
-
-            return reportLine;
-        }
+        private string PrepareReportLine(in string key, MethodStats methodStats) =>
+            $"{key,-40}| " +
+            $"{methodStats.Successes.ToString(),9} | " +
+            $"{methodStats.AvgTimeOfSuccesses.ToString("0", CultureInfo.InvariantCulture),14} | " +
+            $"{methodStats.MaxTimeOfSuccess.ToString(CultureInfo.InvariantCulture),14} | " +
+            $"{methodStats.Errors.ToString(),9} | " +
+            $"{methodStats.AvgTimeOfErrors.ToString("0", CultureInfo.InvariantCulture),14} | " +
+            $"{methodStats.MaxTimeOfError.ToString(CultureInfo.InvariantCulture),14} | " +
+            $"{methodStats.AvgSize.ToString("0", CultureInfo.InvariantCulture),8} | " +
+            $"{methodStats.TotalSize.ToString("0", CultureInfo.InvariantCulture),10} | ";
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/WebSockets/JsonRpcSocketsClient.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/WebSockets/JsonRpcSocketsClient.cs
@@ -71,12 +71,12 @@ namespace Nethermind.JsonRpc.WebSockets
                 if (result.IsCollection)
                 {
                     long handlingTimeMicroseconds = stopwatch.ElapsedMicroseconds();
-                    _jsonRpcLocalStats.ReportCall(new RpcReport("# collection serialization #", handlingTimeMicroseconds, true), handlingTimeMicroseconds, singleResponseSize);
+                    _ = _jsonRpcLocalStats.ReportCall(new RpcReport("# collection serialization #", handlingTimeMicroseconds, true), handlingTimeMicroseconds, singleResponseSize);
                 }
                 else
                 {
                     long handlingTimeMicroseconds = stopwatch.ElapsedMicroseconds();
-                    _jsonRpcLocalStats.ReportCall(result.Report!.Value, handlingTimeMicroseconds, singleResponseSize);
+                    _ = _jsonRpcLocalStats.ReportCall(result.Report!.Value, handlingTimeMicroseconds, singleResponseSize);
                 }
                 stopwatch.Restart();
             }
@@ -133,7 +133,7 @@ namespace Nethermind.JsonRpc.WebSockets
 
                             isFirst = false;
                             singleResponseSize += await SendJsonRpcResultEntry(entry, false);
-                            _jsonRpcLocalStats.ReportCall(entry.Report);
+                            _ = _jsonRpcLocalStats.ReportCall(entry.Report);
 
                             // We reached the limit and don't want to responded to more request in the batch
                             if (!_jsonRpcContext.IsAuthenticated && singleResponseSize > _maxBatchResponseBodySize)

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/PeerRefresher.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/PeerRefresher.cs
@@ -65,9 +65,7 @@ public class PeerRefresher : IPeerRefresher, IAsyncDisposable
         _lastRefresh = DateTime.Now;
         foreach (PeerInfo peer in _syncPeerPool.AllPeers)
         {
-#pragma warning disable CS4014
-            StartPeerRefreshTask(peer.SyncPeer, headBlockhash, headParentBlockhash, finalizedBlockhash);
-#pragma warning restore CS4014
+            _ = StartPeerRefreshTask(peer.SyncPeer, headBlockhash, headParentBlockhash, finalizedBlockhash);
         }
     }
 

--- a/src/Nethermind/Nethermind.Network/P2P/PacketSender.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/PacketSender.cs
@@ -41,10 +41,8 @@ namespace Nethermind.Network.P2P
             int length = buffer.ReadableBytes;
 
             // Running in background
-#pragma warning disable CS4014
-            SendBuffer(buffer);
-#pragma warning restore CS4014
-
+            _ = SendBuffer(buffer);
+            
             return length;
         }
 

--- a/src/Nethermind/Nethermind.Network/P2P/PacketSender.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/PacketSender.cs
@@ -42,7 +42,7 @@ namespace Nethermind.Network.P2P
 
             // Running in background
             _ = SendBuffer(buffer);
-            
+
             return length;
         }
 

--- a/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
+++ b/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
@@ -195,7 +195,7 @@ namespace Nethermind.Runner.JsonRpc
 
                                                 first = false;
                                                 responseSize += jsonSerializer.Serialize(resultStream, entry.Response);
-                                                jsonRpcLocalStats.ReportCall(entry.Report);
+                                                _ = jsonRpcLocalStats.ReportCall(entry.Report);
 
                                                 // We reached the limit and don't want to responded to more request in the batch
                                                 if (!jsonRpcContext.IsAuthenticated && responseSize > jsonRpcConfig.MaxBatchResponseBodySize)
@@ -248,7 +248,7 @@ namespace Nethermind.Runner.JsonRpc
                             }
 
                             long handlingTimeMicroseconds = stopwatch.ElapsedMicroseconds();
-                            jsonRpcLocalStats.ReportCall(result.IsCollection
+                            _ = jsonRpcLocalStats.ReportCall(result.IsCollection
                                 ? new RpcReport("# collection serialization #", handlingTimeMicroseconds, true)
                                 : result.Report.Value, handlingTimeMicroseconds, responseSize);
 

--- a/src/Nethermind/Nethermind.Sockets.Test/WebSocketExtensionsTests.cs
+++ b/src/Nethermind/Nethermind.Sockets.Test/WebSocketExtensionsTests.cs
@@ -153,8 +153,8 @@ namespace Nethermind.Sockets.Test
 
             Assert.That(Metrics.JsonRpcBytesReceivedWebSockets, Is.EqualTo(1024));
             Assert.That(Metrics.JsonRpcBytesSentWebSockets, Is.EqualTo(400));
-            localStats.Received(1).ReportCall(Arg.Any<RpcReport>(), Arg.Any<long>(), 100);
-            localStats.Received(1).ReportCall(Arg.Any<RpcReport>(), Arg.Any<long>(), 300);
+            await localStats.Received(1).ReportCall(Arg.Any<RpcReport>(), Arg.Any<long>(), 100);
+            await localStats.Received(1).ReportCall(Arg.Any<RpcReport>(), Arg.Any<long>(), 300);
         }
 
         [Test]


### PR DESCRIPTION
## Changes

- locks `JsonRpcLocalStats.BuildReport` to avoid conflicts between threads
- Moves as much JSON RPC reporting to background, to avoid blocking JSON RPC execution times, if there is lock contention
- Moves `_divider` to static variable, avoiding allocating it each time.
- Caches and reuses `StringBuilder` avoiding allocating it each time.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Testing in app logs