### PR TITLE
Don't use decimal percentages in peers report

### DIFF
--- a/src/Nethermind/Nethermind.Runner/NLog.config
+++ b/src/Nethermind/Nethermind.Runner/NLog.config
@@ -58,7 +58,7 @@
       <!-- Brand names -->
       <highlight-word regex="((?&lt;!\\)Nethermind(?![\\/\.])|Geth|Erigon|Besu|RocksDb|Intel|AMD|Arm)" foregroundColor="Magenta" wholeWords="true" />
       <!-- Percentage progress -->
-      <highlight-word regex="[0-9]{1,3}\.[0-9]{2} \%" foregroundColor="DarkYellow" />
+      <highlight-word regex="[0-9]{1,3}\.[0-9]{2} \%|[0-9]{1,3} \%" foregroundColor="DarkYellow" />
       <!-- Denominator of nnn / NNN (de-emphasize) -->
       <highlight-word regex=" / [0-9,]+ " foregroundColor="DarkGray" />
       <!-- Short hash: 0x000...000 (de-emphasize) -->

--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeersReport.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeersReport.cs
@@ -99,7 +99,7 @@ namespace Nethermind.Synchronization.Peers
                     {
                         _stringBuilder.Append(',');
                     }
-                    _stringBuilder.Append($" {peerGroup.Key} ({peerGroup.Count() / sum,6:P2})");
+                    _stringBuilder.Append($" {peerGroup.Key} ({peerGroup.Count() / sum,3:P0})");
                 }
                 _stringBuilder.Append(" |");
 
@@ -128,7 +128,7 @@ namespace Nethermind.Synchronization.Peers
                     {
                         _stringBuilder.Append(',');
                     }
-                    _stringBuilder.Append($" {peerGroup.Key} ({peerGroup.Count() / sum,6:P2})");
+                    _stringBuilder.Append($" {peerGroup.Key} ({peerGroup.Count() / sum,3:P0})");
                 }
 
                 string result = _stringBuilder.ToString();


### PR DESCRIPTION
## Changes

- Don't use decimal percentages in peers report. Are only max 100 peers so going to decimal places doesn't add anything

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: Logging

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No