### PR TITLE
Adjust snap request threshold

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/ProgressTrackerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/ProgressTrackerTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Nethermind.Blockchain;
+using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
 using Nethermind.Logging;
@@ -83,5 +84,53 @@ public class ProgressTrackerTests
         (request, finished) = progressTracker.GetNextRequest();
         request.Should().BeNull();
         finished.Should().BeFalse();
+    }
+
+    [Test]
+    public void Will_deque_code_request_if_high_even_if_storage_queue_is_not_empty()
+    {
+        BlockTree blockTree = Build.A.BlockTree().WithBlocks(Build.A.Block.TestObject).TestObject;
+        ProgressTracker progressTracker = new ProgressTracker(blockTree, new MemDb(), LimboLogs.Instance);
+
+        for (int i = 0; i < ProgressTracker.HIGH_STORAGE_QUEUE_SIZE - 1; i++)
+        {
+            progressTracker.EnqueueAccountStorage(new PathWithAccount() {
+                Path = TestItem.ValueKeccaks[0]
+            });
+        }
+
+        for (int i = 0; i < ProgressTracker.HIGH_CODES_QUEUE_SIZE; i++)
+        {
+            progressTracker.EnqueueCodeHashes(new ValueKeccak[] {TestItem.ValueKeccaks[0]});
+        }
+
+        (SnapSyncBatch request, bool _) = progressTracker.GetNextRequest();
+
+        request.CodesRequest.Should().NotBeNull();
+        request.StorageRangeRequest.Should().BeNull();
+    }
+
+    [Test]
+    public void Will_deque_storage_request_if_high()
+    {
+        BlockTree blockTree = Build.A.BlockTree().WithBlocks(Build.A.Block.TestObject).TestObject;
+        ProgressTracker progressTracker = new ProgressTracker(blockTree, new MemDb(), LimboLogs.Instance);
+
+        for (int i = 0; i < ProgressTracker.HIGH_STORAGE_QUEUE_SIZE; i++)
+        {
+            progressTracker.EnqueueAccountStorage(new PathWithAccount() {
+                Path = TestItem.ValueKeccaks[0]
+            });
+        }
+
+        for (int i = 0; i < ProgressTracker.HIGH_CODES_QUEUE_SIZE; i++)
+        {
+            progressTracker.EnqueueCodeHashes(new ValueKeccak[] {TestItem.ValueKeccaks[0]});
+        }
+
+        (SnapSyncBatch request, bool _) = progressTracker.GetNextRequest();
+
+        request.CodesRequest.Should().BeNull();
+        request.StorageRangeRequest.Should().NotBeNull();
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/ProgressTrackerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/ProgressTrackerTests.cs
@@ -94,14 +94,15 @@ public class ProgressTrackerTests
 
         for (int i = 0; i < ProgressTracker.HIGH_STORAGE_QUEUE_SIZE - 1; i++)
         {
-            progressTracker.EnqueueAccountStorage(new PathWithAccount() {
+            progressTracker.EnqueueAccountStorage(new PathWithAccount()
+            {
                 Path = TestItem.ValueKeccaks[0]
             });
         }
 
         for (int i = 0; i < ProgressTracker.HIGH_CODES_QUEUE_SIZE; i++)
         {
-            progressTracker.EnqueueCodeHashes(new ValueKeccak[] {TestItem.ValueKeccaks[0]});
+            progressTracker.EnqueueCodeHashes(new ValueKeccak[] { TestItem.ValueKeccaks[0] });
         }
 
         (SnapSyncBatch request, bool _) = progressTracker.GetNextRequest();
@@ -118,14 +119,15 @@ public class ProgressTrackerTests
 
         for (int i = 0; i < ProgressTracker.HIGH_STORAGE_QUEUE_SIZE; i++)
         {
-            progressTracker.EnqueueAccountStorage(new PathWithAccount() {
+            progressTracker.EnqueueAccountStorage(new PathWithAccount()
+            {
                 Path = TestItem.ValueKeccaks[0]
             });
         }
 
         for (int i = 0; i < ProgressTracker.HIGH_CODES_QUEUE_SIZE; i++)
         {
-            progressTracker.EnqueueCodeHashes(new ValueKeccak[] {TestItem.ValueKeccaks[0]});
+            progressTracker.EnqueueCodeHashes(new ValueKeccak[] { TestItem.ValueKeccaks[0] });
         }
 
         (SnapSyncBatch request, bool _) = progressTracker.GetNextRequest();

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
@@ -21,9 +21,9 @@ namespace Nethermind.Synchronization.SnapSync
         private const string NO_REQUEST = "Skipped Request";
 
         private const int STORAGE_BATCH_SIZE = 1_200;
-        private const int HIGH_STORAGE_QUEUE_SIZE = STORAGE_BATCH_SIZE * 100;
+        public const int HIGH_STORAGE_QUEUE_SIZE = STORAGE_BATCH_SIZE * 100;
         private const int CODES_BATCH_SIZE = 1_000;
-        private const int HIGH_CODES_QUEUE_SIZE = CODES_BATCH_SIZE * 5;
+        public const int HIGH_CODES_QUEUE_SIZE = CODES_BATCH_SIZE * 5;
         private readonly byte[] ACC_PROGRESS_KEY = Encoding.ASCII.GetBytes("AccountProgressKey");
 
         // This does not need to be a lot as it spawn other requests. In fact 8 is probably too much. It is severely

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
@@ -21,7 +21,9 @@ namespace Nethermind.Synchronization.SnapSync
         private const string NO_REQUEST = "Skipped Request";
 
         private const int STORAGE_BATCH_SIZE = 1_200;
+        private const int HIGH_STORAGE_QUEUE_SIZE = STORAGE_BATCH_SIZE * 100;
         private const int CODES_BATCH_SIZE = 1_000;
+        private const int HIGH_CODES_QUEUE_SIZE = CODES_BATCH_SIZE * 5;
         private readonly byte[] ACC_PROGRESS_KEY = Encoding.ASCII.GetBytes("AccountProgressKey");
 
         // This does not need to be a lot as it spawn other requests. In fact 8 is probably too much. It is severely
@@ -142,93 +144,37 @@ namespace Nethermind.Synchronization.SnapSync
 
             if (!AccountsToRefresh.IsEmpty)
             {
-                Interlocked.Increment(ref _activeAccRefreshRequests);
-
-                LogRequest($"AccountsToRefresh:{AccountsToRefresh.Count}");
-
-                int queueLength = AccountsToRefresh.Count;
-                AccountWithStorageStartingHash[] paths = new AccountWithStorageStartingHash[queueLength];
-
-                for (int i = 0; i < queueLength && AccountsToRefresh.TryDequeue(out var acc); i++)
-                {
-                    paths[i] = acc;
-                }
-
-                request.AccountsToRefreshRequest = new AccountsToRefreshRequest() { RootHash = rootHash, Paths = paths };
-
-                return (request, false);
-
+                return DequeAccountToRefresh(request, rootHash);
             }
 
             if (ShouldRequestAccountRequests() && AccountRangeReadyForRequest.TryDequeue(out AccountRangePartition partition))
             {
-                Interlocked.Increment(ref _activeAccountRequests);
-
-                AccountRange range = new(
-                    rootHash,
-                    partition.NextAccountPath,
-                    partition.AccountPathLimit,
-                    blockNumber);
-
-                LogRequest("AccountRange");
-
-                request.AccountRangeRequest = range;
-
-                return (request, false);
+                return CreateAccountRangeRequest(rootHash, partition, blockNumber, request);
             }
-            else if (TryDequeNextSlotRange(out StorageRange slotRange))
+
+            if (TryDequeNextSlotRange(out StorageRange slotRange))
             {
-                slotRange.RootHash = rootHash;
-                slotRange.BlockNumber = blockNumber;
-
-                LogRequest($"NextSlotRange:{slotRange.Accounts.Length}");
-
-                request.StorageRangeRequest = slotRange;
-
-                return (request, false);
+                return CreateNextSlowRangeRequest(slotRange, rootHash, blockNumber, request);
             }
-            else if (!StoragesToRetrieve.IsEmpty)
+
+            if (StoragesToRetrieve.Count >= HIGH_STORAGE_QUEUE_SIZE)
             {
-                Interlocked.Increment(ref _activeStorageRequests);
-
-                // TODO: optimize this
-                List<PathWithAccount> storagesToQuery = new(STORAGE_BATCH_SIZE);
-                for (int i = 0; i < STORAGE_BATCH_SIZE && StoragesToRetrieve.TryDequeue(out PathWithAccount storage); i++)
-                {
-                    storagesToQuery.Add(storage);
-                }
-
-                StorageRange storageRange = new()
-                {
-                    RootHash = rootHash,
-                    Accounts = storagesToQuery.ToArray(),
-                    StartingHash = ValueKeccak.Zero,
-                    BlockNumber = blockNumber
-                };
-
-                LogRequest($"StoragesToRetrieve:{storagesToQuery.Count}");
-
-                request.StorageRangeRequest = storageRange;
-
-                return (request, false);
+                return DequeStorageToRetrieveRequest(rootHash, blockNumber, request);
             }
-            else if (!CodesToRetrieve.IsEmpty)
+
+            if (CodesToRetrieve.Count >= HIGH_CODES_QUEUE_SIZE)
             {
-                Interlocked.Increment(ref _activeCodeRequests);
+                return DequeCodeRequest(request);
+            }
 
-                // TODO: optimize this
-                List<ValueKeccak> codesToQuery = new(CODES_BATCH_SIZE);
-                for (int i = 0; i < CODES_BATCH_SIZE && CodesToRetrieve.TryDequeue(out ValueKeccak codeHash); i++)
-                {
-                    codesToQuery.Add(codeHash);
-                }
-                codesToQuery.Sort();
+            if (!StoragesToRetrieve.IsEmpty)
+            {
+                return DequeStorageToRetrieveRequest(rootHash, blockNumber, request);
+            }
 
-                LogRequest($"CodesToRetrieve:{codesToQuery.Count}");
-
-                request.CodesRequest = codesToQuery.ToArray();
-
-                return (request, false);
+            if (!CodesToRetrieve.IsEmpty)
+            {
+                return DequeCodeRequest(request);
             }
 
             bool rangePhaseFinished = IsSnapGetRangesFinished();
@@ -243,9 +189,109 @@ namespace Nethermind.Synchronization.SnapSync
             return (null, IsSnapGetRangesFinished());
         }
 
+        private (SnapSyncBatch request, bool finished) DequeCodeRequest(SnapSyncBatch request)
+        {
+            Interlocked.Increment(ref _activeCodeRequests);
+
+            // TODO: optimize this
+            List<ValueKeccak> codesToQuery = new(CODES_BATCH_SIZE);
+            for (int i = 0; i < CODES_BATCH_SIZE && CodesToRetrieve.TryDequeue(out ValueKeccak codeHash); i++)
+            {
+                codesToQuery.Add(codeHash);
+            }
+
+            codesToQuery.Sort();
+
+            LogRequest($"CodesToRetrieve:{codesToQuery.Count}");
+
+            request.CodesRequest = codesToQuery.ToArray();
+
+            return (request, false);
+        }
+
+        private (SnapSyncBatch request, bool finished) DequeStorageToRetrieveRequest(Keccak rootHash, long blockNumber,
+            SnapSyncBatch request)
+        {
+            Interlocked.Increment(ref _activeStorageRequests);
+
+            // TODO: optimize this
+            List<PathWithAccount> storagesToQuery = new(STORAGE_BATCH_SIZE);
+            for (int i = 0; i < STORAGE_BATCH_SIZE && StoragesToRetrieve.TryDequeue(out PathWithAccount storage); i++)
+            {
+                storagesToQuery.Add(storage);
+            }
+
+            StorageRange storageRange = new()
+            {
+                RootHash = rootHash,
+                Accounts = storagesToQuery.ToArray(),
+                StartingHash = ValueKeccak.Zero,
+                BlockNumber = blockNumber
+            };
+
+            LogRequest($"StoragesToRetrieve:{storagesToQuery.Count}");
+
+            request.StorageRangeRequest = storageRange;
+
+            return (request, false);
+        }
+
+        private (SnapSyncBatch request, bool finished) CreateNextSlowRangeRequest(StorageRange slotRange, Keccak rootHash,
+            long blockNumber, SnapSyncBatch request)
+        {
+            slotRange.RootHash = rootHash;
+            slotRange.BlockNumber = blockNumber;
+
+            LogRequest($"NextSlotRange:{slotRange.Accounts.Length}");
+
+            request.StorageRangeRequest = slotRange;
+
+            return (request, false);
+        }
+
+        private (SnapSyncBatch request, bool finished) CreateAccountRangeRequest(Keccak rootHash,
+            AccountRangePartition partition, long blockNumber, SnapSyncBatch request)
+        {
+            Interlocked.Increment(ref _activeAccountRequests);
+
+            AccountRange range = new(
+                rootHash,
+                partition.NextAccountPath,
+                partition.AccountPathLimit,
+                blockNumber);
+
+            LogRequest("AccountRange");
+
+            request.AccountRangeRequest = range;
+
+            return (request, false);
+        }
+
+        private (SnapSyncBatch request, bool finished) DequeAccountToRefresh(SnapSyncBatch request, Keccak rootHash)
+        {
+            Interlocked.Increment(ref _activeAccRefreshRequests);
+
+            LogRequest($"AccountsToRefresh:{AccountsToRefresh.Count}");
+
+            int queueLength = AccountsToRefresh.Count;
+            AccountWithStorageStartingHash[] paths = new AccountWithStorageStartingHash[queueLength];
+
+            for (int i = 0; i < queueLength && AccountsToRefresh.TryDequeue(out var acc); i++)
+            {
+                paths[i] = acc;
+            }
+
+            request.AccountsToRefreshRequest = new AccountsToRefreshRequest() { RootHash = rootHash, Paths = paths };
+
+            return (request, false);
+        }
+
         private bool ShouldRequestAccountRequests()
         {
-            return _activeAccountRequests < _accountRangePartitionCount && NextSlotRange.Count < 10 && StoragesToRetrieve.Count < 5 * STORAGE_BATCH_SIZE && CodesToRetrieve.Count < 5 * CODES_BATCH_SIZE;
+            return _activeAccountRequests < _accountRangePartitionCount
+                   && NextSlotRange.Count < 10
+                   && StoragesToRetrieve.Count < HIGH_STORAGE_QUEUE_SIZE
+                   && CodesToRetrieve.Count < HIGH_CODES_QUEUE_SIZE;
         }
 
         public void EnqueueCodeHashes(ReadOnlySpan<ValueKeccak> codeHashes)


### PR DESCRIPTION
- Adjust some request threshold for snap request queuing.
- Reduces the amount no request to dispatch during snap sync, but sync time too inconsistent to know for sure if it affect anything.
- Increase storage queue size before skipping account range request.
- Check for high code queue first before dequeing not full storage queue.

![Screenshot from 2023-06-20 19-14-34](https://github.com/NethermindEth/nethermind/assets/1841324/0b1687d3-95ea-4f4e-8a66-63ab557a50ab)

## Changes

- Slight refactor.
- Adjust threshold.

## Types of changes

#### What types of changes does your code introduce?

- [X] Optimization
- [X] Refactoring

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Definitely can sync.