### PR TITLE
Make Engine *V3s handle V3 requests only

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc/ErrorType.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/ErrorType.cs
@@ -87,5 +87,9 @@ namespace Nethermind.JsonRpc
         /// </summary>
         public const int UnknownBlockError = -39001;
 
+        /// <summary>
+        /// Unsupported fork error
+        /// </summary>
+        public const int UnsupportedFork = -38005;
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.HelperFunctions.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.HelperFunctions.cs
@@ -68,11 +68,11 @@ namespace Nethermind.Merge.Plugin.Test
             return Enumerable.Range(0, (int)count).Select(i => BuildTransaction((uint)i, account)).ToArray();
         }
 
-        private ExecutionPayload CreateParentBlockRequestOnHead(IBlockTree blockTree)
+        private ExecutionPayloadV3 CreateParentBlockRequestOnHead(IBlockTree blockTree)
         {
             Block? head = blockTree.Head;
             if (head is null) throw new NotSupportedException();
-            return new ExecutionPayload()
+            return new ExecutionPayloadV3()
             {
                 BlockNumber = head.Number,
                 BlockHash = head.Hash!,
@@ -86,7 +86,7 @@ namespace Nethermind.Merge.Plugin.Test
 
         private static ExecutionPayload CreateBlockRequest(ExecutionPayload parent, Address miner, IList<Withdrawal>? withdrawals = null, ulong? dataGasUsed = null, ulong? excessDataGas = null, Transaction[]? transactions = null)
         {
-            ExecutionPayload blockRequest = new()
+            ExecutionPayloadV3 blockRequest = new()
             {
                 ParentHash = parent.BlockHash,
                 FeeRecipient = miner,
@@ -98,9 +98,17 @@ namespace Nethermind.Merge.Plugin.Test
                 LogsBloom = Bloom.Empty,
                 Timestamp = parent.Timestamp + 1,
                 Withdrawals = withdrawals,
-                DataGasUsed = dataGasUsed,
-                ExcessDataGas = excessDataGas,
             };
+
+            if (dataGasUsed is not null)
+            {
+                blockRequest.DataGasUsed = dataGasUsed.Value;
+            }
+
+            if (excessDataGas is not null)
+            {
+                blockRequest.ExcessDataGas = excessDataGas.Value;
+            }
 
             blockRequest.SetTransactions(transactions ?? Array.Empty<Transaction>());
             TryCalculateHash(blockRequest, out Keccak? hash);

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
@@ -80,12 +80,15 @@ public partial class EngineModuleTests
         return new EngineRpcModule(
             new GetPayloadV1Handler(
                 chain.PayloadPreparationService!,
+                chain.SpecProvider!,
                 chain.LogManager),
             new GetPayloadV2Handler(
                 chain.PayloadPreparationService!,
+                chain.SpecProvider!,
                 chain.LogManager),
             new GetPayloadV3Handler(
                 chain.PayloadPreparationService!,
+                chain.SpecProvider!,
                 chain.LogManager),
             new NewPayloadHandler(
                 chain.BlockValidator,

--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayloadV3.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayloadV3.cs
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+using Newtonsoft.Json;
+
+namespace Nethermind.Merge.Plugin.Data;
+
+/// <summary>
+/// Represents an object mapping the <c>ExecutionPayloadV3</c> structure of the beacon chain spec.
+/// </summary>
+[JsonObject(ItemRequired = Required.Always)]
+public class ExecutionPayloadV3 : ExecutionPayload
+{
+    public ExecutionPayloadV3() { } // Needed for tests
+
+    public ExecutionPayloadV3(Block block) : base(block)
+    {
+    }
+}

--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/GetPayloadV2Result.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/GetPayloadV2Result.cs
@@ -17,7 +17,7 @@ public class GetPayloadV2Result
 
     public UInt256 BlockValue { get; }
 
-    public ExecutionPayload ExecutionPayload { get; }
+    public virtual ExecutionPayload ExecutionPayload { get; }
 
     public override string ToString() => $"{{ExecutionPayload: {ExecutionPayload}, Fees: {BlockValue}}}";
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/GetPayloadV3Result.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/GetPayloadV3Result.cs
@@ -10,10 +10,13 @@ public class GetPayloadV3Result : GetPayloadV2Result
 {
     public GetPayloadV3Result(Block block, UInt256 blockFees, BlobsBundleV1 blobsBundle) : base(block, blockFees)
     {
+        ExecutionPayload = new(block);
         BlobsBundle = blobsBundle;
     }
 
     public BlobsBundleV1 BlobsBundle { get; }
+
+    public override ExecutionPayloadV3 ExecutionPayload { get; }
 
     public override string ToString() =>
         $"{{ExecutionPayload: {ExecutionPayload}, Fees: {BlockValue}, BlobsBundle blobs count: {BlobsBundle.Blobs.Length}}}";

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetPayloadV1Handler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetPayloadV1Handler.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using Nethermind.Core.Specs;
 using Nethermind.Logging;
 using Nethermind.Merge.Plugin.BlockProduction;
 using Nethermind.Merge.Plugin.Data;
@@ -24,8 +25,8 @@ namespace Nethermind.Merge.Plugin.Handlers;
 /// </remarks>
 public class GetPayloadV1Handler : GetPayloadHandlerBase<ExecutionPayload>
 {
-    public GetPayloadV1Handler(IPayloadPreparationService payloadPreparationService, ILogManager logManager) : base(
-        1, payloadPreparationService, logManager)
+    public GetPayloadV1Handler(IPayloadPreparationService payloadPreparationService, ISpecProvider specProvider, ILogManager logManager) : base(
+        1, payloadPreparationService, specProvider, logManager)
     {
     }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetPayloadV2Handler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetPayloadV2Handler.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using Nethermind.Core.Specs;
 using Nethermind.Logging;
 using Nethermind.Merge.Plugin.BlockProduction;
 using Nethermind.Merge.Plugin.Data;
@@ -13,8 +14,8 @@ namespace Nethermind.Merge.Plugin.Handlers;
 /// </summary>
 public class GetPayloadV2Handler : GetPayloadHandlerBase<GetPayloadV2Result>
 {
-    public GetPayloadV2Handler(IPayloadPreparationService payloadPreparationService, ILogManager logManager) : base(
-        2, payloadPreparationService, logManager)
+    public GetPayloadV2Handler(IPayloadPreparationService payloadPreparationService, ISpecProvider specProvider, ILogManager logManager) : base(
+        2, payloadPreparationService, specProvider, logManager)
     {
     }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetPayloadV3Handler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetPayloadV3Handler.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using Nethermind.Core.Specs;
 using Nethermind.Logging;
 using Nethermind.Merge.Plugin.BlockProduction;
 using Nethermind.Merge.Plugin.Data;
@@ -13,11 +14,15 @@ namespace Nethermind.Merge.Plugin.Handlers;
 /// </summary>
 public class GetPayloadV3Handler : GetPayloadHandlerBase<GetPayloadV3Result>
 {
-    public GetPayloadV3Handler(IPayloadPreparationService payloadPreparationService, ILogManager logManager) : base(
-        3, payloadPreparationService, logManager)
+    public GetPayloadV3Handler(IPayloadPreparationService payloadPreparationService, ISpecProvider specProvider, ILogManager logManager) : base(
+        3, payloadPreparationService, specProvider, logManager)
     {
     }
 
     protected override GetPayloadV3Result GetPayloadResultFromBlock(IBlockProductionContext context) =>
         new(context.CurrentBestBlock!, context.BlockFees, new BlobsBundleV1(context.CurrentBestBlock!));
+
+    protected override bool IsProperFork(IBlockProductionContext blockProductionContext, ISpecProvider specProvider)
+        => blockProductionContext.CurrentBestBlock is not null &&
+            specProvider.GetSpec(blockProductionContext.CurrentBestBlock.Header).IsEip4844Enabled;
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/IEngineRpcModule.Cancun.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/IEngineRpcModule.Cancun.cs
@@ -14,7 +14,7 @@ public partial interface IEngineRpcModule : IRpcModule
         Description = "Verifies the payload according to the execution environment rules and returns the verification status and hash of the last valid block.",
         IsSharable = true,
         IsImplemented = true)]
-    Task<ResultWrapper<PayloadStatusV1>> engine_newPayloadV3(ExecutionPayload executionPayload, byte[][]? blobVersionedHashes = null);
+    Task<ResultWrapper<PayloadStatusV1>> engine_newPayloadV3(ExecutionPayloadV3 executionPayload, byte[]?[] blobVersionedHashes);
 
     [JsonRpcMethod(
         Description = "Returns the most recent version of an execution payload and fees with respect to the transaction set contained by the mempool.",

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
@@ -307,9 +307,9 @@ public partial class MergePlugin : IConsensusWrapperPlugin, ISynchronizationPlug
             _api.RpcCapabilitiesProvider = new EngineRpcCapabilitiesProvider(_api.SpecProvider);
 
             IEngineRpcModule engineRpcModule = new EngineRpcModule(
-                new GetPayloadV1Handler(payloadPreparationService, _api.LogManager),
-                new GetPayloadV2Handler(payloadPreparationService, _api.LogManager),
-                new GetPayloadV3Handler(payloadPreparationService, _api.LogManager),
+                new GetPayloadV1Handler(payloadPreparationService, _api.SpecProvider, _api.LogManager),
+                new GetPayloadV2Handler(payloadPreparationService, _api.SpecProvider, _api.LogManager),
+                new GetPayloadV3Handler(payloadPreparationService, _api.SpecProvider, _api.LogManager),
                 new NewPayloadHandler(
                     _api.BlockValidator,
                     _api.BlockTree,


### PR DESCRIPTION
Implements https://github.com/ethereum/execution-apis/pull/418/files

`engine_getPayloadV3`, `engine_newPayloadV3` to handle Cancun payloads only.

## Changes

- Make all fields required
- Return `-38005: Unsupported fork`, when V3 is called for a pre-Cancun payload

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Requires Cancun fork