### PR TITLE
Perf/smoother peer discovery

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/RateLimiterTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/RateLimiterTests.cs
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Nethermind.Core.Test;
+
+public class RateLimiterTests
+{
+    [TestCase(10, 1, 1000)]
+    [TestCase(10, 1, 100)]
+    [TestCase(100, 1, 100)]
+    [TestCase(1000, 1, 100)]
+    [TestCase(10, 4, 1000)]
+    [TestCase(10, 4, 100)]
+    [TestCase(100, 4, 100)]
+    [TestCase(1000, 4, 100)]
+    public async Task RateLimiter_should_delay_wait_to_rate_limit(int eventPerSec, int concurrency, int durationMs)
+    {
+        RateLimiter rateLimiter = new(eventPerSec);
+
+        TimeSpan duration = TimeSpan.FromMilliseconds(durationMs);
+        DateTimeOffset startTime = DateTimeOffset.Now;
+        DateTimeOffset deadline = startTime + duration;
+        long counter = 0;
+
+        Task[] tasks = Enumerable.Range(0, concurrency).Select(async (_) =>
+        {
+            while (DateTimeOffset.Now < deadline)
+            {
+                Interlocked.Increment(ref counter);
+                await rateLimiter.WaitAsync(CancellationToken.None);
+            }
+        }).ToArray();
+
+        Task.WaitAll(tasks);
+
+        int effectivePerSec = (int)(counter / (DateTimeOffset.Now - startTime).TotalSeconds);
+        effectivePerSec.Should().BeInRange(eventPerSec - 10, eventPerSec + 10);
+    }
+
+    [Test]
+    public async Task RateLimiter_should_throw_when_cancelled()
+    {
+        RateLimiter rateLimiter = new(1);
+        await rateLimiter.WaitAsync(CancellationToken.None);
+        CancellationTokenSource cts = new();
+        Task waitTask = rateLimiter.WaitAsync(cts.Token);
+        cts.Cancel();
+
+        Func<Task> act = async () => await waitTask;
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+}

--- a/src/Nethermind/Nethermind.Core.Test/RateLimiterTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/RateLimiterTests.cs
@@ -12,12 +12,10 @@ namespace Nethermind.Core.Test;
 
 public class RateLimiterTests
 {
-    [TestCase(10, 1, 1000)]
-    [TestCase(10, 1, 100)]
+    [TestCase(100, 1, 1000)]
     [TestCase(100, 1, 100)]
     [TestCase(1000, 1, 100)]
-    [TestCase(10, 4, 1000)]
-    [TestCase(10, 4, 100)]
+    [TestCase(100, 4, 1000)]
     [TestCase(100, 4, 100)]
     [TestCase(1000, 4, 100)]
     public async Task RateLimiter_should_delay_wait_to_rate_limit(int eventPerSec, int concurrency, int durationMs)
@@ -41,7 +39,7 @@ public class RateLimiterTests
         Task.WaitAll(tasks);
 
         int effectivePerSec = (int)(counter / (DateTimeOffset.Now - startTime).TotalSeconds);
-        effectivePerSec.Should().BeInRange(eventPerSec - 10, eventPerSec + 10);
+        effectivePerSec.Should().BeInRange((int)(eventPerSec * 0.9), (int)(eventPerSec * 1.1));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Core.Test/RateLimiterTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/RateLimiterTests.cs
@@ -40,7 +40,7 @@ public class RateLimiterTests
         Task.WaitAll(tasks);
 
         int effectivePerSec = (int)(counter / (DateTimeOffset.Now - startTime).TotalSeconds);
-        effectivePerSec.Should().BeInRange((int)(eventPerSec * 0.8), (int)(eventPerSec * 1.1));
+        effectivePerSec.Should().BeInRange((int)(eventPerSec * 0.5), (int)(eventPerSec * 1.1));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Core.Test/RateLimiterTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/RateLimiterTests.cs
@@ -10,6 +10,7 @@ using NUnit.Framework;
 
 namespace Nethermind.Core.Test;
 
+[Parallelizable(ParallelScope.Self)]
 public class RateLimiterTests
 {
     [TestCase(100, 1, 1000)]

--- a/src/Nethermind/Nethermind.Core.Test/RateLimiterTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/RateLimiterTests.cs
@@ -48,7 +48,7 @@ public class RateLimiterTests
         RateLimiter rateLimiter = new(1);
         await rateLimiter.WaitAsync(CancellationToken.None);
         CancellationTokenSource cts = new();
-        Task waitTask = rateLimiter.WaitAsync(cts.Token);
+        ValueTask waitTask = rateLimiter.WaitAsync(cts.Token);
         cts.Cancel();
 
         Func<Task> act = async () => await waitTask;

--- a/src/Nethermind/Nethermind.Core.Test/RateLimiterTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/RateLimiterTests.cs
@@ -54,4 +54,12 @@ public class RateLimiterTests
         Func<Task> act = async () => await waitTask;
         await act.Should().ThrowAsync<OperationCanceledException>();
     }
+
+    [Test]
+    public async Task RateLimiter_should_return_true_on_is_throttled_if_throttled()
+    {
+        RateLimiter rateLimiter = new(1);
+        await rateLimiter.WaitAsync(CancellationToken.None);
+        rateLimiter.IsThrottled().Should().BeTrue();
+    }
 }

--- a/src/Nethermind/Nethermind.Core.Test/RateLimiterTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/RateLimiterTests.cs
@@ -39,7 +39,7 @@ public class RateLimiterTests
         Task.WaitAll(tasks);
 
         int effectivePerSec = (int)(counter / (DateTimeOffset.Now - startTime).TotalSeconds);
-        effectivePerSec.Should().BeInRange((int)(eventPerSec * 0.9), (int)(eventPerSec * 1.1));
+        effectivePerSec.Should().BeInRange((int)(eventPerSec * 0.8), (int)(eventPerSec * 1.1));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Core/RateLimiter.cs
+++ b/src/Nethermind/Nethermind.Core/RateLimiter.cs
@@ -24,7 +24,7 @@ public class RateLimiter
 
     private RateLimiter(double intervalSec)
     {
-        _delay = (long) (Stopwatch.Frequency * intervalSec);
+        _delay = (long)(Stopwatch.Frequency * intervalSec);
 
         _nextSlot = GetCurrentTick();
     }

--- a/src/Nethermind/Nethermind.Core/RateLimiter.cs
+++ b/src/Nethermind/Nethermind.Core/RateLimiter.cs
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nethermind.Core;
+
+/// <summary>
+/// Simple rate limiter that limits rate of event, by delaying the caller so that a minimum amount of time elapsed
+/// between event.
+/// </summary>
+public class RateLimiter
+{
+    private TimeSpan _delay;
+    private DateTimeOffset _nextSlot;
+    private SpinLock _spinLock = new();
+
+    public RateLimiter(int eventPerSec) : this(1.0 / eventPerSec)
+    {
+    }
+
+    private RateLimiter(double intervalSec)
+    {
+        _delay = TimeSpan.FromSeconds(intervalSec);
+        _nextSlot = DateTimeOffset.Now;
+    }
+
+    public async Task WaitAsync(CancellationToken ctx)
+    {
+        while (true)
+        {
+            TimeSpan toWait;
+            bool taken = false;
+            while (!taken)
+            {
+                _spinLock.Enter(ref taken);
+            }
+            try
+            {
+                DateTimeOffset now = DateTimeOffset.Now;
+                if (now >= _nextSlot)
+                {
+                    _nextSlot = now + _delay;
+                    return;
+                }
+
+                toWait = _nextSlot - now;
+            }
+            finally
+            {
+                _spinLock.Exit();
+            }
+
+            if (toWait < TimeSpan.Zero) continue;
+
+            await Task.Delay(toWait, ctx);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Core/RateLimiter.cs
+++ b/src/Nethermind/Nethermind.Core/RateLimiter.cs
@@ -64,7 +64,7 @@ public class RateLimiter
                 return;
             }
 
-            long toWait = _nextSlot - now;
+            long toWait = originalNextSlot - now;
             if (toWait < 0) continue;
 
             await Task.Delay(TimeSpan.FromMilliseconds(TickToMs(toWait)), ctx);

--- a/src/Nethermind/Nethermind.Core/RateLimiter.cs
+++ b/src/Nethermind/Nethermind.Core/RateLimiter.cs
@@ -27,6 +27,11 @@ public class RateLimiter
         _nextSlot = DateTimeOffset.Now;
     }
 
+    public bool IsThrottled()
+    {
+        return DateTimeOffset.Now < _nextSlot;
+    }
+
     public async Task WaitAsync(CancellationToken ctx)
     {
         while (true)

--- a/src/Nethermind/Nethermind.Network.Stats/StatsParameters.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/StatsParameters.cs
@@ -45,7 +45,10 @@ namespace Nethermind.Stats
 
         public Dictionary<DisconnectReason, TimeSpan> DelayDueToLocalDisconnect { get; } = new()
         {
-            { DisconnectReason.UselessPeer, TimeSpan.FromMinutes(15) }
+            { DisconnectReason.UselessPeer, TimeSpan.FromMinutes(15) },
+
+            // Its actually protocol init timeout, when status message is not received in time.
+            { DisconnectReason.ReceiveMessageTimeout, TimeSpan.FromMinutes(5) },
         };
 
         public Dictionary<DisconnectReason, TimeSpan> DelayDueToRemoteDisconnect { get; } = new()
@@ -57,7 +60,7 @@ namespace Nethermind.Stats
 
             // This is pretty much 80% of the disconnect reason. We don't wanna delay this though... it could be
             // that other peer disconnect from the peer.
-            { DisconnectReason.TooManyPeers, TimeSpan.FromMinutes(1) }
+            { DisconnectReason.TooManyPeers, TimeSpan.FromMinutes(1) },
         };
 
         public Dictionary<NodeStatsEventType, TimeSpan> DelayDueToEvent { get; } = new()

--- a/src/Nethermind/Nethermind.Network.Stats/StatsParameters.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/StatsParameters.cs
@@ -41,7 +41,7 @@ namespace Nethermind.Stats
 
         public int[] FailedConnectionDelays { get; }
 
-        public int[] DisconnectDelays { get; }
+        public int[] DisconnectDelays { get; set;  }
 
         public Dictionary<DisconnectReason, TimeSpan> DelayDueToLocalDisconnect { get; } = new()
         {

--- a/src/Nethermind/Nethermind.Network.Stats/StatsParameters.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/StatsParameters.cs
@@ -53,12 +53,9 @@ namespace Nethermind.Stats
 
         public Dictionary<DisconnectReason, TimeSpan> DelayDueToRemoteDisconnect { get; } = new()
         {
-            // Actual explicit ClientQuitting is very rare, but internally we also use this status for connection
-            // closed, which can happen if remote client close connection without giving any reason.
-            // It is unclear why we have such large number of these, but it seems that it is usually transient.
             { DisconnectReason.ClientQuitting, TimeSpan.FromMinutes(1) },
 
-            // This is pretty much 80% of the disconnect reason. We don't wanna delay this though... it could be
+            // This is pretty much 80% of the disconnect reason. We don't wanna delay this too much though... it could be
             // that other peer disconnect from the peer.
             { DisconnectReason.TooManyPeers, TimeSpan.FromMinutes(1) },
         };

--- a/src/Nethermind/Nethermind.Network.Stats/StatsParameters.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/StatsParameters.cs
@@ -53,7 +53,11 @@ namespace Nethermind.Stats
             // Actual explicit ClientQuitting is very rare, but internally we also use this status for connection
             // closed, which can happen if remote client close connection without giving any reason.
             // It is unclear why we have such large number of these, but it seems that it is usually transient.
-            { DisconnectReason.ClientQuitting, TimeSpan.FromMinutes(1) }
+            { DisconnectReason.ClientQuitting, TimeSpan.FromMinutes(1) },
+
+            // This is pretty much 80% of the disconnect reason. We don't wanna delay this though... it could be
+            // that other peer disconnect from the peer.
+            { DisconnectReason.TooManyPeers, TimeSpan.FromMinutes(1) }
         };
 
         public Dictionary<NodeStatsEventType, TimeSpan> DelayDueToEvent { get; } = new()

--- a/src/Nethermind/Nethermind.Network.Stats/StatsParameters.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/StatsParameters.cs
@@ -45,7 +45,7 @@ namespace Nethermind.Stats
 
         public Dictionary<DisconnectReason, TimeSpan> DelayDueToLocalDisconnect { get; } = new()
         {
-            { DisconnectReason.UselessPeer, TimeSpan.FromMinutes(5) }
+            { DisconnectReason.UselessPeer, TimeSpan.FromMinutes(15) }
         };
 
         public Dictionary<DisconnectReason, TimeSpan> DelayDueToRemoteDisconnect { get; } = new()

--- a/src/Nethermind/Nethermind.Network.Stats/StatsParameters.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/StatsParameters.cs
@@ -41,7 +41,7 @@ namespace Nethermind.Stats
 
         public int[] FailedConnectionDelays { get; }
 
-        public int[] DisconnectDelays { get; set;  }
+        public int[] DisconnectDelays { get; set; }
 
         public Dictionary<DisconnectReason, TimeSpan> DelayDueToLocalDisconnect { get; } = new()
         {

--- a/src/Nethermind/Nethermind.Network.Stats/StatsParameters.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/StatsParameters.cs
@@ -54,10 +54,6 @@ namespace Nethermind.Stats
         public Dictionary<DisconnectReason, TimeSpan> DelayDueToRemoteDisconnect { get; } = new()
         {
             { DisconnectReason.ClientQuitting, TimeSpan.FromMinutes(1) },
-
-            // This is pretty much 80% of the disconnect reason. We don't wanna delay this too much though... it could be
-            // that other peer disconnect from the peer.
-            { DisconnectReason.TooManyPeers, TimeSpan.FromMinutes(1) },
         };
 
         public Dictionary<NodeStatsEventType, TimeSpan> DelayDueToEvent { get; } = new()

--- a/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
@@ -16,12 +16,10 @@ using Nethermind.Core.Timers;
 using Nethermind.Crypto;
 using Nethermind.Logging;
 using Nethermind.Network.Config;
-using Nethermind.Network.Discovery;
 using Nethermind.Network.P2P;
 using Nethermind.Network.P2P.Analyzers;
 using Nethermind.Network.P2P.EventArg;
 using Nethermind.Network.Rlpx;
-using Nethermind.Network.StaticNodes;
 using Nethermind.Stats;
 using Nethermind.Stats.Model;
 using NSubstitute;
@@ -267,11 +265,11 @@ namespace Nethermind.Network.Test
             ctx.PeerPool.Start();
             ctx.PeerManager.Start();
             await Task.Delay(_travisDelayLong);
-            Assert.That(ctx.RlpxPeer.ConnectAsyncCallsCount, Is.EqualTo(25));
+            Assert.That(ctx.RlpxPeer.ConnectAsyncCallsCount, Is.AtLeast(25));
             ctx.DisconnectAllSessions();
 
             await Task.Delay(_travisDelayLong);
-            Assert.That(ctx.RlpxPeer.ConnectAsyncCallsCount, Is.EqualTo(50));
+            Assert.That(ctx.RlpxPeer.ConnectAsyncCallsCount, Is.AtLeast(50));
         }
 
         [Test, Retry(5)]
@@ -387,7 +385,7 @@ namespace Nethermind.Network.Test
             {
                 currentCount += 25;
                 maxCount += 50;
-                await Task.Delay(_travisDelay);
+                Assert.That(() => ctx.RlpxPeer.ConnectAsyncCallsCount, Is.InRange(currentCount, maxCount).After(_travisDelay * 2, 10));
                 ctx.RlpxPeer.ConnectAsyncCallsCount.Should().BeInRange(currentCount, maxCount);
                 ctx.HandshakeAllSessions();
                 await Task.Delay(_travisDelay);

--- a/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
@@ -385,7 +385,7 @@ namespace Nethermind.Network.Test
             {
                 currentCount += 25;
                 maxCount += 50;
-                Assert.That(() => ctx.RlpxPeer.ConnectAsyncCallsCount, Is.InRange(currentCount, maxCount).After(_travisDelay * 2, 10));
+                Assert.That(() => ctx.RlpxPeer.ConnectAsyncCallsCount, Is.InRange(currentCount, maxCount).After(_travisDelayLonger * 2, 10));
                 ctx.RlpxPeer.ConnectAsyncCallsCount.Should().BeInRange(currentCount, maxCount);
                 ctx.HandshakeAllSessions();
                 await Task.Delay(_travisDelay);

--- a/src/Nethermind/Nethermind.Network/Config/INetworkConfig.cs
+++ b/src/Nethermind/Nethermind.Network/Config/INetworkConfig.cs
@@ -86,6 +86,9 @@ namespace Nethermind.Network.Config
         [ConfigItem(DefaultValue = "0", HiddenFromDocs = true, Description = "[TECHNICAL] Number of concurrent outgoing connections. Reduce this if your ISP throttles from having open too many connections. Default is 0 which means same as processor count.")]
         int NumConcurrentOutgoingConnects { get; set; }
 
+        [ConfigItem(DefaultValue = "20", Description = "[TECHNICAL] Max number of new outgoing connections per second. Default is 20.")]
+        int MaxOutgoingConnectPerSec { get; set; }
+
         [ConfigItem(DefaultValue = "2000", HiddenFromDocs = true, Description = "[TECHNICAL] Outgoing connection timeout in ms. Default is 2 seconds.")]
         int ConnectTimeoutMs { get; set; }
 

--- a/src/Nethermind/Nethermind.Network/Config/NetworkConfig.cs
+++ b/src/Nethermind/Nethermind.Network/Config/NetworkConfig.cs
@@ -35,6 +35,7 @@ namespace Nethermind.Network.Config
         public int P2PPort { get; set; } = 30303;
         public long SimulateSendLatencyMs { get; set; } = 0;
         public int NumConcurrentOutgoingConnects { get; set; } = 0;
+        public int MaxOutgoingConnectPerSec { get; set; } = 20;
         public int ConnectTimeoutMs { get; set; } = 2000;
         public int ProcessingThreadCount { get; set; } = 1;
     }

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -278,7 +278,7 @@ namespace Nethermind.Network
                             break;
                         }
 
-                        await taskChannel.Writer.WriteAsync(peer);
+                        await taskChannel.Writer.WriteAsync(peer, _cancellationTokenSource.Token);
                     }
 
                     if (_logger.IsTrace)

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -608,10 +608,8 @@ namespace Nethermind.Network
         [Todo(Improve.MissingFunctionality, "Add cancellation support for the peer connection (so it does not wait for the 10sec timeout")]
         private async Task SetupOutgoingPeerConnection(Peer peer, bool cancelIfThrottled = false)
         {
-            if (cancelIfThrottled)
-            {
-                if (_outgoingConnectionRateLimiter.IsThrottled()) return;
-            }
+            if (cancelIfThrottled && _outgoingConnectionRateLimiter.IsThrottled()) return;
+
             await _outgoingConnectionRateLimiter.WaitAsync(_cancellationTokenSource.Token);
 
             // Can happen when In connection is received from the same peer and is initialized before we get here
@@ -647,6 +645,7 @@ namespace Nethermind.Network
             }
 
             Interlocked.Increment(ref _newActiveNodes);
+            _peerUpdateRequested.Set();
         }
 
         private async Task<bool> InitializeOutgoingPeerConnection(Peer candidate)

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -122,7 +122,7 @@ namespace Nethermind.Network
                     // fire and forget - all the surrounding logic will be executed
                     // exceptions can be lost here without issues
                     // this for rapid connections to newly discovered peers without having to go through the UpdatePeerLoop
-                    SetupOutgoingPeerConnection(peer);
+                    SetupOutgoingPeerConnection(peer, cancelIfThrottled: true);
                 }
 #pragma warning restore 4014
             }
@@ -606,8 +606,12 @@ namespace Nethermind.Network
         #region Outgoing connection handling
 
         [Todo(Improve.MissingFunctionality, "Add cancellation support for the peer connection (so it does not wait for the 10sec timeout")]
-        private async Task SetupOutgoingPeerConnection(Peer peer)
+        private async Task SetupOutgoingPeerConnection(Peer peer, bool cancelIfThrottled = false)
         {
+            if (cancelIfThrottled)
+            {
+                if (_outgoingConnectionRateLimiter.IsThrottled()) return;
+            }
             await _outgoingConnectionRateLimiter.WaitAsync(_cancellationTokenSource.Token);
 
             // Can happen when In connection is received from the same peer and is initialized before we get here

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -350,7 +350,7 @@ namespace Nethermind.Network
 
         private bool EnsureAvailableActivePeerSlot()
         {
-            if (_pending < AvailableActivePeersCount)
+            if (AvailableActivePeersCount - _pending > 0)
             {
                 return true;
             }
@@ -360,14 +360,14 @@ namespace Nethermind.Network
             // the active peer count to go down within this time window.
             DateTimeOffset deadline = DateTimeOffset.Now + Timeouts.Handshake +
                                       TimeSpan.FromMilliseconds(_networkConfig.ConnectTimeoutMs);
-            while (DateTimeOffset.Now < deadline && _pending >= AvailableActivePeersCount)
+            while (DateTimeOffset.Now < deadline && (AvailableActivePeersCount - _pending) <= 0)
             {
                 // The signal is not very reliable. So we just do like a simple pool.
                 _peerUpdateRequested.Reset();
                 _peerUpdateRequested.Wait(TimeSpan.FromMilliseconds(10));
             }
 
-            return _pending < AvailableActivePeersCount;
+            return AvailableActivePeersCount - _pending > 0;
         }
 
 


### PR DESCRIPTION
- The way new outgoing connection is spawned tend to be spiky, spawning <thread count> number of  connection in bulk. There are also several wait time in an attempt to not spawn too much connection. 
- This changes that by having a pool of tasks listening to a blocking channel which is feed by the main peer connection loop. In another word, the peer connection loop is blocked if all thread/task is in use, allowing for an early `break` if active peer is full. No need to estimate how much you need to push to the threads, which results in much higher thread/task utilization. 
- To throttle, an explicit rate limiter is added with a new config `--Network.MaxOutgoingConnectPerSec` which default to 20, which matches the current peak rate. Unthrottled, peak with 32 thread is about 80 connection per sec.
- The result is, inconsistent as always. But you can set the limit to 999999 and DOS your router if you want. 

| Run | Time to reach 100 peer (minute) |
| ------ | --------------------------------- |
| Before | 25 |
| After (10 connect per sec) | 25 |
| After (20 connect per sec) | 30 |
| Before | 40 |
| After (10 connect per sec) | 45 | 
| After (no limit) | 25 |
| After (no limit) | 30 |
| After (no limit ) | 30 |

![Screenshot from 2023-06-22 09-15-01](https://github.com/NethermindEth/nethermind/assets/1841324/fee2cf77-9b13-484f-83e3-4ca631eeb2c1)

## Changes

- _List the changes_

## Types of changes

#### What types of changes does your code introduce?

- [X] Optimization

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No
