### PR TITLE
Feature/disable tx gossip during sync

### DIFF
--- a/src/Nethermind/Nethermind.Api/IApiWithBlockchain.cs
+++ b/src/Nethermind/Nethermind.Api/IApiWithBlockchain.cs
@@ -68,6 +68,7 @@ namespace Nethermind.Api
         INonceManager? NonceManager { get; set; }
         ITxPool? TxPool { get; set; }
         ITxPoolInfoProvider? TxPoolInfoProvider { get; set; }
+        CompositeTxGossipPolicy TxGossipPolicy { get; }
         IWitnessCollector? WitnessCollector { get; set; }
         IWitnessRepository? WitnessRepository { get; set; }
         IHealthHintService? HealthHintService { get; set; }

--- a/src/Nethermind/Nethermind.Api/NethermindApi.cs
+++ b/src/Nethermind/Nethermind.Api/NethermindApi.cs
@@ -232,5 +232,6 @@ namespace Nethermind.Api
         public CompositePruningTrigger PruningTrigger { get; } = new();
         public ISnapProvider? SnapProvider { get; set; }
         public IProcessExitSource? ProcessExit { get; set; }
+        public CompositeTxGossipPolicy TxGossipPolicy { get; } = new();
     }
 }

--- a/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/InitializeBlockchainAuRa.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/InitializeBlockchainAuRa.cs
@@ -278,6 +278,7 @@ public class InitializeBlockchainAuRa : InitializeBlockchain
             _api.TxValidator,
             _api.LogManager,
             CreateTxPoolTxComparer(txPriorityContract, localDataSource),
+            _api.TxGossipPolicy,
             new TxFilterAdapter(_api.BlockTree, txPoolFilter, _api.LogManager),
             txPriorityContract is not null || localDataSource is not null);
     }

--- a/src/Nethermind/Nethermind.Hive/HivePlugin.cs
+++ b/src/Nethermind/Nethermind.Hive/HivePlugin.cs
@@ -52,6 +52,8 @@ namespace Nethermind.Hive
                 if (_api.FileSystem is null) throw new ArgumentNullException(nameof(_api.FileSystem));
                 if (_api.BlockValidator is null) throw new ArgumentNullException(nameof(_api.BlockValidator));
 
+                _api.TxGossipPolicy.Policies.Clear();
+
                 HiveRunner hiveRunner = new(
                     _api.BlockTree,
                     _api.BlockProcessingQueue,

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeBlockchain.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeBlockchain.cs
@@ -35,6 +35,7 @@ using Nethermind.Logging;
 using Nethermind.Serialization.Json;
 using Nethermind.State;
 using Nethermind.State.Witnesses;
+using Nethermind.Synchronization.ParallelSync;
 using Nethermind.Synchronization.Witness;
 using Nethermind.Trie;
 using Nethermind.Trie.Pruning;
@@ -332,7 +333,8 @@ namespace Nethermind.Init.Steps
                 _api.Config<ITxPoolConfig>(),
                 _api.TxValidator!,
                 _api.LogManager,
-                CreateTxPoolTxComparer());
+                CreateTxPoolTxComparer(),
+                _api.TxGossipPolicy);
 
         protected IComparer<Transaction> CreateTxPoolTxComparer() => _api.TransactionComparerProvider!.GetDefaultComparer();
 

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -39,6 +39,7 @@ using Nethermind.Synchronization.ParallelSync;
 using Nethermind.Synchronization.Peers;
 using Nethermind.Synchronization.Reporting;
 using Nethermind.Synchronization.SnapSync;
+using Nethermind.TxPool;
 
 namespace Nethermind.Init.Steps;
 
@@ -131,6 +132,11 @@ public class InitializeNetwork : IStep
         }
 
         _api.SyncModeSelector ??= CreateMultiSyncModeSelector(syncProgressResolver);
+        if (_api.TxGossipPolicy.TxGossipPolicy == ShouldGossip.Instance)
+        {
+            _api.TxGossipPolicy.TxGossipPolicy = new SyncedTxGossipPolicy(_api.SyncModeSelector);
+        }
+
         _api.EthSyncingInfo = new EthSyncingInfo(_api.BlockTree!, _api.ReceiptStorage!, _syncConfig, _api.SyncModeSelector, _api.LogManager);
         _api.DisposeStack.Push(_api.SyncModeSelector);
 
@@ -526,7 +532,8 @@ public class InitializeNetwork : IStep
             peerStorage,
             forkInfo,
             _api.GossipPolicy,
-            _api.LogManager);
+            _api.LogManager,
+            _api.TxGossipPolicy);
 
         if (_syncConfig.WitnessProtocolEnabled)
         {

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -132,10 +132,8 @@ public class InitializeNetwork : IStep
         }
 
         _api.SyncModeSelector ??= CreateMultiSyncModeSelector(syncProgressResolver);
-        if (_api.TxGossipPolicy.TxGossipPolicy == ShouldGossip.Instance)
-        {
-            _api.TxGossipPolicy.TxGossipPolicy = new SyncedTxGossipPolicy(_api.SyncModeSelector);
-        }
+        _api.TxGossipPolicy.Policies.Remove(ShouldGossip.Instance);
+        _api.TxGossipPolicy.Policies.Add(new SyncedTxGossipPolicy(_api.SyncModeSelector));
 
         _api.EthSyncingInfo = new EthSyncingInfo(_api.BlockTree!, _api.ReceiptStorage!, _syncConfig, _api.SyncModeSelector, _api.LogManager);
         _api.DisposeStack.Push(_api.SyncModeSelector);

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -132,7 +132,6 @@ public class InitializeNetwork : IStep
         }
 
         _api.SyncModeSelector ??= CreateMultiSyncModeSelector(syncProgressResolver);
-        _api.TxGossipPolicy.Policies.Remove(ShouldGossip.Instance);
         _api.TxGossipPolicy.Policies.Add(new SyncedTxGossipPolicy(_api.SyncModeSelector));
 
         _api.EthSyncingInfo = new EthSyncingInfo(_api.BlockTree!, _api.ReceiptStorage!, _syncConfig, _api.SyncModeSelector, _api.LogManager);

--- a/src/Nethermind/Nethermind.Network.Benchmark/Eth62ProtocolHandlerBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Network.Benchmark/Eth62ProtocolHandlerBenchmarks.cs
@@ -65,7 +65,7 @@ namespace Nethermind.Network.Benchmarks
             ISyncServer syncSrv = Substitute.For<ISyncServer>();
             BlockHeader head = Build.A.BlockHeader.WithNumber(1).TestObject;
             syncSrv.Head.Returns(head);
-            _handler = new Eth62ProtocolHandler(session, _ser, stats, syncSrv, txPool, ShouldGossip.Instance, LimboLogs.Instance);
+            _handler = new Eth62ProtocolHandler(session, _ser, stats, syncSrv, txPool, Consensus.ShouldGossip.Instance, LimboLogs.Instance);
             _handler.DisableTxFiltering();
 
             StatusMessage statusMessage = new StatusMessage();

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandlerTests.cs
@@ -69,7 +69,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
             _gossipPolicy.ShouldGossipBlock(Arg.Any<BlockHeader>()).Returns(true);
             _gossipPolicy.ShouldDisconnectGossipingNodes.Returns(false);
             _txGossipPolicy = Substitute.For<ITxGossipPolicy>();
-            _txGossipPolicy.CanGossipTransactions.Returns(true);
+            _txGossipPolicy.ShouldListenToGossippedTransactions.Returns(true);
             _txGossipPolicy.ShouldGossipTransaction(Arg.Any<Transaction>()).Returns(true);
             _handler = new Eth62ProtocolHandler(
                 _session,
@@ -383,7 +383,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
         [Test]
         public void Can_handle_transactions([Values(true, false)] bool canGossipTransactions)
         {
-            _txGossipPolicy.CanGossipTransactions.Returns(canGossipTransactions);
+            _txGossipPolicy.ShouldListenToGossippedTransactions.Returns(canGossipTransactions);
             TransactionsMessage msg = new(new List<Transaction>(Build.A.Transaction.SignedAndResolved().TestObjectNTimes(3)));
 
             HandleIncomingStatusMessage();

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandlerTests.cs
@@ -38,14 +38,15 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
     [TestFixture, Parallelizable(ParallelScope.Self)]
     public class Eth62ProtocolHandlerTests
     {
-        private ISession _session;
-        private IMessageSerializationService _svc;
-        private ISyncServer _syncManager;
-        private ITxPool _transactionPool;
-        private Block _genesisBlock;
-        private Eth62ProtocolHandler _handler;
-        private IGossipPolicy _gossipPolicy;
+        private ISession _session = null!;
+        private IMessageSerializationService _svc = null!;
+        private ISyncServer _syncManager = null!;
+        private ITxPool _transactionPool = null!;
+        private Block _genesisBlock = null!;
+        private Eth62ProtocolHandler _handler = null!;
+        private IGossipPolicy _gossipPolicy = null!;
         private readonly TxDecoder _txDecoder = new();
+        private ITxGossipPolicy _txGossipPolicy = null!;
 
         [SetUp]
         public void Setup()
@@ -67,6 +68,9 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
             _gossipPolicy.CanGossipBlocks.Returns(true);
             _gossipPolicy.ShouldGossipBlock(Arg.Any<BlockHeader>()).Returns(true);
             _gossipPolicy.ShouldDisconnectGossipingNodes.Returns(false);
+            _txGossipPolicy = Substitute.For<ITxGossipPolicy>();
+            _txGossipPolicy.CanGossipTransactions.Returns(true);
+            _txGossipPolicy.ShouldGossipTransaction(Arg.Any<Transaction>()).Returns(true);
             _handler = new Eth62ProtocolHandler(
                 _session,
                 _svc,
@@ -74,7 +78,8 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
                 _syncManager,
                 _transactionPool,
                 _gossipPolicy,
-                LimboLogs.Instance);
+                LimboLogs.Instance,
+                _txGossipPolicy);
             _handler.Init();
         }
 
@@ -376,12 +381,14 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
         }
 
         [Test]
-        public void Can_handle_transactions()
+        public void Can_handle_transactions([Values(true, false)] bool canGossipTransactions)
         {
+            _txGossipPolicy.CanGossipTransactions.Returns(canGossipTransactions);
             TransactionsMessage msg = new(new List<Transaction>(Build.A.Transaction.SignedAndResolved().TestObjectNTimes(3)));
 
             HandleIncomingStatusMessage();
             HandleZeroMessage(msg, Eth62MessageCode.Transactions);
+            _transactionPool.Received(canGossipTransactions ? 3 : 0).SubmitTx(Arg.Any<Transaction>(), TxHandlingOptions.None);
         }
 
         [Test]
@@ -550,9 +557,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
 
         private void HandleIncomingStatusMessage()
         {
-            var statusMsg = new StatusMessage();
-            statusMsg.GenesisHash = _genesisBlock.Hash;
-            statusMsg.BestHash = _genesisBlock.Hash;
+            var statusMsg = new StatusMessage { GenesisHash = _genesisBlock.Hash, BestHash = _genesisBlock.Hash };
 
             IByteBuffer statusPacket = _svc.ZeroSerialize(statusMsg);
             statusPacket.ReadByte();

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandlerTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net;
+using DotNetty.Buffers;
 using FluentAssertions;
 using Nethermind.Consensus;
 using Nethermind.Core;
@@ -14,9 +15,11 @@ using Nethermind.Core.Timers;
 using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.Network.P2P;
+using Nethermind.Network.P2P.Subprotocols.Eth.V62;
 using Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages;
 using Nethermind.Network.P2P.Subprotocols.Eth.V65;
 using Nethermind.Network.P2P.Subprotocols.Eth.V65.Messages;
+using Nethermind.Network.Rlpx;
 using Nethermind.Network.Test.Builders;
 using Nethermind.Stats;
 using Nethermind.Stats.Model;
@@ -30,14 +33,15 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V65
     [TestFixture, Parallelizable(ParallelScope.Self)]
     public class Eth65ProtocolHandlerTests
     {
-        private ISession _session;
-        private IMessageSerializationService _svc;
-        private ISyncServer _syncManager;
-        private ITxPool _transactionPool;
-        private IPooledTxsRequestor _pooledTxsRequestor;
-        private ISpecProvider _specProvider;
-        private Block _genesisBlock;
-        private Eth65ProtocolHandler _handler;
+        private ISession _session = null!;
+        private IMessageSerializationService _svc = null!;
+        private ISyncServer _syncManager = null!;
+        private ITxPool _transactionPool = null!;
+        private IPooledTxsRequestor _pooledTxsRequestor = null!;
+        private ISpecProvider _specProvider = null!;
+        private Block _genesisBlock = null!;
+        private Eth65ProtocolHandler _handler = null!;
+        private ITxGossipPolicy _txGossipPolicy = null!;
 
         [SetUp]
         public void Setup()
@@ -57,6 +61,9 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V65
             _syncManager.Head.Returns(_genesisBlock.Header);
             _syncManager.Genesis.Returns(_genesisBlock.Header);
             ITimerFactory timerFactory = Substitute.For<ITimerFactory>();
+            _txGossipPolicy = Substitute.For<ITxGossipPolicy>();
+            _txGossipPolicy.CanGossipTransactions.Returns(true);
+            _txGossipPolicy.ShouldGossipTransaction(Arg.Any<Transaction>()).Returns(true);
             _handler = new Eth65ProtocolHandler(
                 _session,
                 _svc,
@@ -66,7 +73,8 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V65
                 _pooledTxsRequestor,
                 Policy.FullGossip,
                 new ForkInfo(_specProvider, _genesisBlock.Header.Hash!),
-                LimboLogs.Instance);
+                LimboLogs.Instance,
+                _txGossipPolicy);
             _handler.Init();
         }
 
@@ -165,6 +173,35 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V65
             GetPooledTransactionsMessage request = new(new Keccak[2048]);
             PooledTransactionsMessage response = _handler.FulfillPooledTransactionsRequest(request, new List<Transaction>());
             response.Transactions.Count.Should().Be(numberOfTxsInOneMsg);
+        }
+
+        [Test]
+        public void should_handle_NewPooledTransactionHashesMessage([Values(true, false)] bool canGossipTransactions)
+        {
+            _txGossipPolicy.CanGossipTransactions.Returns(canGossipTransactions);
+            NewPooledTransactionHashesMessage msg = new(new[] { TestItem.KeccakA, TestItem.KeccakB });
+            IMessageSerializationService serializationService = Build.A.SerializationService().WithEth65().TestObject;
+
+            HandleIncomingStatusMessage();
+            HandleZeroMessage(msg, Eth65MessageCode.NewPooledTransactionHashes);
+
+            _pooledTxsRequestor.Received(canGossipTransactions ? 1 : 0).RequestTransactions(Arg.Any<Action<GetPooledTransactionsMessage>>(), Arg.Any<IReadOnlyList<Keccak>>());
+        }
+
+        private void HandleZeroMessage<T>(T msg, int messageCode) where T : MessageBase
+        {
+            IByteBuffer getBlockHeadersPacket = _svc.ZeroSerialize(msg);
+            getBlockHeadersPacket.ReadByte();
+            _handler.HandleMessage(new ZeroPacket(getBlockHeadersPacket) { PacketType = (byte)messageCode });
+        }
+
+        private void HandleIncomingStatusMessage()
+        {
+            var statusMsg = new StatusMessage { GenesisHash = _genesisBlock.Hash, BestHash = _genesisBlock.Hash };
+
+            IByteBuffer statusPacket = _svc.ZeroSerialize(statusMsg);
+            statusPacket.ReadByte();
+            _handler.HandleMessage(new ZeroPacket(statusPacket) { PacketType = 0 });
         }
     }
 }

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandlerTests.cs
@@ -62,7 +62,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V65
             _syncManager.Genesis.Returns(_genesisBlock.Header);
             ITimerFactory timerFactory = Substitute.For<ITimerFactory>();
             _txGossipPolicy = Substitute.For<ITxGossipPolicy>();
-            _txGossipPolicy.CanGossipTransactions.Returns(true);
+            _txGossipPolicy.ShouldListenToGossippedTransactions.Returns(true);
             _txGossipPolicy.ShouldGossipTransaction(Arg.Any<Transaction>()).Returns(true);
             _handler = new Eth65ProtocolHandler(
                 _session,
@@ -178,7 +178,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V65
         [Test]
         public void should_handle_NewPooledTransactionHashesMessage([Values(true, false)] bool canGossipTransactions)
         {
-            _txGossipPolicy.CanGossipTransactions.Returns(canGossipTransactions);
+            _txGossipPolicy.ShouldListenToGossippedTransactions.Returns(canGossipTransactions);
             NewPooledTransactionHashesMessage msg = new(new[] { TestItem.KeccakA, TestItem.KeccakB });
             IMessageSerializationService serializationService = Build.A.SerializationService().WithEth65().TestObject;
 

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandlerTests.cs
@@ -46,15 +46,15 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V66
     [TestFixture, Parallelizable(ParallelScope.Self)]
     public class Eth66ProtocolHandlerTests
     {
-        private ISession _session;
-        private IMessageSerializationService _svc;
-        private ISyncServer _syncManager;
-        private ITxPool _transactionPool;
-        private IPooledTxsRequestor _pooledTxsRequestor;
-        private IGossipPolicy _gossipPolicy;
-        private ISpecProvider _specProvider;
-        private Block _genesisBlock;
-        private Eth66ProtocolHandler _handler;
+        private ISession _session = null!;
+        private IMessageSerializationService _svc = null!;
+        private ISyncServer _syncManager = null!;
+        private ITxPool _transactionPool = null!;
+        private IPooledTxsRequestor _pooledTxsRequestor = null!;
+        private IGossipPolicy _gossipPolicy = null!;
+        private ISpecProvider _specProvider = null!;
+        private Block _genesisBlock = null!;
+        private Eth66ProtocolHandler _handler = null!;
 
         [SetUp]
         public void Setup()

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V67/Eth67ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V67/Eth67ProtocolHandlerTests.cs
@@ -33,15 +33,15 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V67;
 [TestFixture, Parallelizable(ParallelScope.Self)]
 public class Eth67ProtocolHandlerTests
 {
-    private ISession _session;
-    private IMessageSerializationService _svc;
-    private ISyncServer _syncManager;
-    private ITxPool _transactionPool;
-    private IPooledTxsRequestor _pooledTxsRequestor;
-    private IGossipPolicy _gossipPolicy;
-    private ISpecProvider _specProvider;
-    private Block _genesisBlock;
-    private Eth66ProtocolHandler _handler;
+    private ISession _session = null!;
+    private IMessageSerializationService _svc = null!;
+    private ISyncServer _syncManager = null!;
+    private ITxPool _transactionPool = null!;
+    private IPooledTxsRequestor _pooledTxsRequestor = null!;
+    private IGossipPolicy _gossipPolicy = null!;
+    private ISpecProvider _specProvider = null!;
+    private Block _genesisBlock = null!;
+    private Eth66ProtocolHandler _handler = null!;
 
     [SetUp]
     public void Setup()

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandlerTests.cs
@@ -35,15 +35,16 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V68;
 
 public class Eth68ProtocolHandlerTests
 {
-    private ISession _session;
-    private IMessageSerializationService _svc;
-    private ISyncServer _syncManager;
-    private ITxPool _transactionPool;
-    private IPooledTxsRequestor _pooledTxsRequestor;
-    private IGossipPolicy _gossipPolicy;
-    private ISpecProvider _specProvider;
-    private Block _genesisBlock;
-    private Eth68ProtocolHandler _handler;
+    private ISession _session = null!;
+    private IMessageSerializationService _svc = null!;
+    private ISyncServer _syncManager = null!;
+    private ITxPool _transactionPool = null!;
+    private IPooledTxsRequestor _pooledTxsRequestor = null!;
+    private IGossipPolicy _gossipPolicy = null!;
+    private ISpecProvider _specProvider = null!;
+    private Block _genesisBlock = null!;
+    private Eth68ProtocolHandler _handler = null!;
+    private ITxGossipPolicy _txGossipPolicy = null!;
 
     [SetUp]
     public void Setup()
@@ -64,6 +65,9 @@ public class Eth68ProtocolHandlerTests
         _syncManager.Head.Returns(_genesisBlock.Header);
         _syncManager.Genesis.Returns(_genesisBlock.Header);
         ITimerFactory timerFactory = Substitute.For<ITimerFactory>();
+        _txGossipPolicy = Substitute.For<ITxGossipPolicy>();
+        _txGossipPolicy.CanGossipTransactions.Returns(true);
+        _txGossipPolicy.ShouldGossipTransaction(Arg.Any<Transaction>()).Returns(true);
         _handler = new Eth68ProtocolHandler(
             _session,
             _svc,
@@ -72,8 +76,9 @@ public class Eth68ProtocolHandlerTests
             _transactionPool,
             _pooledTxsRequestor,
             _gossipPolicy,
-            new ForkInfo(_specProvider, _genesisBlock.Header.Hash),
-            LimboLogs.Instance);
+            new ForkInfo(_specProvider, _genesisBlock.Header.Hash!),
+            LimboLogs.Instance,
+            _txGossipPolicy);
         _handler.Init();
     }
 
@@ -96,19 +101,18 @@ public class Eth68ProtocolHandlerTests
         _handler.HeadNumber.Should().Be(0);
     }
 
-    [TestCase(0)]
-    [TestCase(1)]
-    [TestCase(2)]
-    [TestCase(100)]
-    public void Can_handle_NewPooledTransactions_message(int txCount)
+    [Test]
+    public void Can_handle_NewPooledTransactions_message([Values(0, 1, 2, 100)] int txCount, [Values(true, false)] bool canGossipTransactions)
     {
+        _txGossipPolicy.CanGossipTransactions.Returns(canGossipTransactions);
+
         GenerateLists(txCount, out List<byte> types, out List<int> sizes, out List<Keccak> hashes);
 
         var msg = new NewPooledTransactionHashesMessage68(types, sizes, hashes);
 
         HandleIncomingStatusMessage();
         HandleZeroMessage(msg, Eth68MessageCode.NewPooledTransactionHashes);
-        _pooledTxsRequestor.Received().RequestTransactionsEth66(Arg.Any<Action<GetPooledTransactionsMessage>>(),
+        _pooledTxsRequestor.Received(canGossipTransactions ? 1 : 0).RequestTransactionsEth66(Arg.Any<Action<GetPooledTransactionsMessage>>(),
             Arg.Any<IReadOnlyList<Keccak>>());
     }
 

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandlerTests.cs
@@ -66,7 +66,7 @@ public class Eth68ProtocolHandlerTests
         _syncManager.Genesis.Returns(_genesisBlock.Header);
         ITimerFactory timerFactory = Substitute.For<ITimerFactory>();
         _txGossipPolicy = Substitute.For<ITxGossipPolicy>();
-        _txGossipPolicy.CanGossipTransactions.Returns(true);
+        _txGossipPolicy.ShouldListenToGossippedTransactions.Returns(true);
         _txGossipPolicy.ShouldGossipTransaction(Arg.Any<Transaction>()).Returns(true);
         _handler = new Eth68ProtocolHandler(
             _session,
@@ -104,7 +104,7 @@ public class Eth68ProtocolHandlerTests
     [Test]
     public void Can_handle_NewPooledTransactions_message([Values(0, 1, 2, 100)] int txCount, [Values(true, false)] bool canGossipTransactions)
     {
-        _txGossipPolicy.CanGossipTransactions.Returns(canGossipTransactions);
+        _txGossipPolicy.ShouldListenToGossippedTransactions.Returns(canGossipTransactions);
 
         GenerateLists(txCount, out List<byte> types, out List<int> sizes, out List<Keccak> hashes);
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandler.cs
@@ -63,7 +63,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
         public override int MessageIdSpaceSize => 8;
         public override string Name => "eth62";
         protected override TimeSpan InitTimeout => Timeouts.Eth62Status;
-        protected bool CanReceiveTransactions => _txGossipPolicy.CanGossipTransactions;
+        protected bool CanReceiveTransactions => _txGossipPolicy.ShouldListenToGossippedTransactions;
 
         public override event EventHandler<ProtocolInitializedEventArgs>? ProtocolInitialized;
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandler.cs
@@ -20,7 +20,9 @@ using Nethermind.Network.Rlpx;
 using Nethermind.Stats;
 using Nethermind.Stats.Model;
 using Nethermind.Synchronization;
+using Nethermind.Synchronization.ParallelSync;
 using Nethermind.TxPool;
+using ShouldGossip = Nethermind.Consensus.ShouldGossip;
 
 namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
 {
@@ -30,20 +32,23 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
         private readonly TxFloodController _floodController;
         protected readonly ITxPool _txPool;
         private readonly IGossipPolicy _gossipPolicy;
+        private readonly ITxGossipPolicy _txGossipPolicy;
         private readonly LruKeyCache<Keccak> _lastBlockNotificationCache = new(10, "LastBlockNotificationCache");
 
-        public Eth62ProtocolHandler(
-            ISession session,
+        public Eth62ProtocolHandler(ISession session,
             IMessageSerializationService serializer,
             INodeStatsManager statsManager,
             ISyncServer syncServer,
             ITxPool txPool,
             IGossipPolicy gossipPolicy,
-            ILogManager logManager) : base(session, serializer, statsManager, syncServer, logManager)
+            ILogManager logManager,
+            ITxGossipPolicy? transactionsGossipPolicy = null)
+            : base(session, serializer, statsManager, syncServer, logManager)
         {
             _floodController = new TxFloodController(this, Timestamper.Default, Logger);
             _txPool = txPool ?? throw new ArgumentNullException(nameof(txPool));
             _gossipPolicy = gossipPolicy ?? throw new ArgumentNullException(nameof(gossipPolicy));
+            _txGossipPolicy = transactionsGossipPolicy ?? TxPool.ShouldGossip.Instance;
 
             EnsureGossipPolicy();
         }
@@ -58,6 +63,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
         public override int MessageIdSpaceSize => 8;
         public override string Name => "eth62";
         protected override TimeSpan InitTimeout => Timeouts.Eth62Status;
+        protected bool CanReceiveTransactions => _txGossipPolicy.CanGossipTransactions;
 
         public override event EventHandler<ProtocolInitializedEventArgs>? ProtocolInitialized;
 
@@ -153,17 +159,26 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
                     break;
                 case Eth62MessageCode.Transactions:
                     Metrics.Eth62TransactionsReceived++;
-                    if (_floodController.IsAllowed())
+                    if (CanReceiveTransactions)
                     {
-                        TransactionsMessage txMsg = Deserialize<TransactionsMessage>(message.Content);
-                        ReportIn(txMsg, size);
-                        Handle(txMsg);
+                        if (_floodController.IsAllowed())
+                        {
+                            TransactionsMessage txMsg = Deserialize<TransactionsMessage>(message.Content);
+                            ReportIn(txMsg, size);
+                            Handle(txMsg);
+                        }
+                        else
+                        {
+                            const string txFlooding = $"Ignoring {nameof(TransactionsMessage)} because of message flooding.";
+                            ReportIn(txFlooding, size);
+                        }
                     }
                     else
                     {
-                        const string txFlooding = $"Ignoring {nameof(TransactionsMessage)} because of message flooding.";
-                        ReportIn(txFlooding, size);
+                        const string ignored = $"{nameof(TransactionsMessage)} ignored, syncing";
+                        ReportIn(ignored, size);
                     }
+
                     break;
                 case Eth62MessageCode.GetBlockHeaders:
                     GetBlockHeadersMessage getBlockHeadersMessage

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V63/Eth63ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V63/Eth63ProtocolHandler.cs
@@ -16,6 +16,7 @@ using Nethermind.Network.P2P.Subprotocols.Eth.V63.Messages;
 using Nethermind.Network.Rlpx;
 using Nethermind.Stats;
 using Nethermind.Synchronization;
+using Nethermind.Synchronization.ParallelSync;
 using Nethermind.TxPool;
 
 namespace Nethermind.Network.P2P.Subprotocols.Eth.V63
@@ -32,7 +33,9 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V63
             ISyncServer syncServer,
             ITxPool txPool,
             IGossipPolicy gossipPolicy,
-            ILogManager logManager) : base(session, serializer, nodeStatsManager, syncServer, txPool, gossipPolicy, logManager)
+            ILogManager logManager,
+            ITxGossipPolicy? transactionsGossipPolicy = null)
+            : base(session, serializer, nodeStatsManager, syncServer, txPool, gossipPolicy, logManager, transactionsGossipPolicy)
         {
             _nodeDataRequests = new MessageQueue<GetNodeDataMessage, byte[][]>(Send);
             _receiptsRequests = new MessageQueue<GetReceiptsMessage, TxReceipt[][]>(Send);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V64/Eth64ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V64/Eth64ProtocolHandler.cs
@@ -11,6 +11,7 @@ using Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages;
 using Nethermind.Network.P2P.Subprotocols.Eth.V63;
 using Nethermind.Stats;
 using Nethermind.Synchronization;
+using Nethermind.Synchronization.ParallelSync;
 using Nethermind.TxPool;
 
 namespace Nethermind.Network.P2P.Subprotocols.Eth.V64
@@ -29,7 +30,9 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V64
             ITxPool txPool,
             IGossipPolicy gossipPolicy,
             ForkInfo forkInfo,
-            ILogManager logManager) : base(session, serializer, nodeStatsManager, syncServer, txPool, gossipPolicy, logManager)
+            ILogManager logManager,
+            ITxGossipPolicy? transactionsGossipPolicy = null)
+            : base(session, serializer, nodeStatsManager, syncServer, txPool, gossipPolicy, logManager, transactionsGossipPolicy)
         {
             _forkInfo = forkInfo ?? throw new ArgumentNullException(nameof(forkInfo));
         }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V67/Eth67ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V67/Eth67ProtocolHandler.cs
@@ -10,6 +10,7 @@ using Nethermind.Network.P2P.Subprotocols.Eth.V66;
 using Nethermind.Network.Rlpx;
 using Nethermind.Stats;
 using Nethermind.Synchronization;
+using Nethermind.Synchronization.ParallelSync;
 using Nethermind.TxPool;
 
 namespace Nethermind.Network.P2P.Subprotocols.Eth.V67;
@@ -27,8 +28,9 @@ public class Eth67ProtocolHandler : Eth66ProtocolHandler
         IPooledTxsRequestor pooledTxsRequestor,
         IGossipPolicy gossipPolicy,
         ForkInfo forkInfo,
-        ILogManager logManager)
-        : base(session, serializer, nodeStatsManager, syncServer, txPool, pooledTxsRequestor, gossipPolicy, forkInfo, logManager)
+        ILogManager logManager,
+        ITxGossipPolicy? transactionsGossipPolicy = null)
+        : base(session, serializer, nodeStatsManager, syncServer, txPool, pooledTxsRequestor, gossipPolicy, forkInfo, logManager, transactionsGossipPolicy)
     {
     }
 

--- a/src/Nethermind/Nethermind.Network/ProtocolsManager.cs
+++ b/src/Nethermind/Nethermind.Network/ProtocolsManager.cs
@@ -27,6 +27,7 @@ using Nethermind.Stats.Model;
 using Nethermind.Synchronization;
 using Nethermind.Synchronization.Peers;
 using Nethermind.TxPool;
+using ShouldGossip = Nethermind.TxPool.ShouldGossip;
 
 namespace Nethermind.Network
 {
@@ -50,11 +51,12 @@ namespace Nethermind.Network
         private readonly INetworkStorage _peerStorage;
         private readonly ForkInfo _forkInfo;
         private readonly IGossipPolicy _gossipPolicy;
+        private readonly ITxGossipPolicy _txGossipPolicy;
         private readonly ILogManager _logManager;
         private readonly ILogger _logger;
         private readonly IDictionary<string, Func<ISession, int, IProtocolHandler>> _protocolFactories;
         private readonly HashSet<Capability> _capabilities = new();
-        public event EventHandler<ProtocolInitializedEventArgs> P2PProtocolInitialized;
+        public event EventHandler<ProtocolInitializedEventArgs>? P2PProtocolInitialized;
 
         public ProtocolsManager(
             ISyncPeerPool syncPeerPool,
@@ -69,7 +71,8 @@ namespace Nethermind.Network
             INetworkStorage peerStorage,
             ForkInfo forkInfo,
             IGossipPolicy gossipPolicy,
-            ILogManager logManager)
+            ILogManager logManager,
+            ITxGossipPolicy? transactionsGossipPolicy = null)
         {
             _syncPool = syncPeerPool ?? throw new ArgumentNullException(nameof(syncPeerPool));
             _syncServer = syncServer ?? throw new ArgumentNullException(nameof(syncServer));
@@ -83,6 +86,7 @@ namespace Nethermind.Network
             _peerStorage = peerStorage ?? throw new ArgumentNullException(nameof(peerStorage));
             _forkInfo = forkInfo ?? throw new ArgumentNullException(nameof(forkInfo));
             _gossipPolicy = gossipPolicy ?? throw new ArgumentNullException(nameof(gossipPolicy));
+            _txGossipPolicy = transactionsGossipPolicy ?? ShouldGossip.Instance;
             _logManager = logManager ?? throw new ArgumentNullException(nameof(logManager));
             _logger = _logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
 
@@ -184,9 +188,9 @@ namespace Nethermind.Network
                 {
                     var ethHandler = version switch
                     {
-                        66 => new Eth66ProtocolHandler(session, _serializer, _stats, _syncServer, _txPool, _pooledTxsRequestor, _gossipPolicy, _forkInfo, _logManager),
-                        67 => new Eth67ProtocolHandler(session, _serializer, _stats, _syncServer, _txPool, _pooledTxsRequestor, _gossipPolicy, _forkInfo, _logManager),
-                        68 => new Eth68ProtocolHandler(session, _serializer, _stats, _syncServer, _txPool, _pooledTxsRequestor, _gossipPolicy, _forkInfo, _logManager),
+                        66 => new Eth66ProtocolHandler(session, _serializer, _stats, _syncServer, _txPool, _pooledTxsRequestor, _gossipPolicy, _forkInfo, _logManager, _txGossipPolicy),
+                        67 => new Eth67ProtocolHandler(session, _serializer, _stats, _syncServer, _txPool, _pooledTxsRequestor, _gossipPolicy, _forkInfo, _logManager, _txGossipPolicy),
+                        68 => new Eth68ProtocolHandler(session, _serializer, _stats, _syncServer, _txPool, _pooledTxsRequestor, _gossipPolicy, _forkInfo, _logManager, _txGossipPolicy),
                         _ => throw new NotSupportedException($"Eth protocol version {version} is not supported.")
                     };
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncedTxGossipPolicyTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncedTxGossipPolicyTests.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Nethermind.Synchronization.ParallelSync;

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncedTxGossipPolicyTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncedTxGossipPolicyTests.cs
@@ -1,0 +1,27 @@
+﻿// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Synchronization.ParallelSync;
+using NUnit.Framework;
+
+namespace Nethermind.Synchronization.Test.ParallelSync;
+
+public class SyncedTxGossipPolicyTests
+{
+    [TestCase(SyncMode.FastSync, ExpectedResult = false)]
+    [TestCase(SyncMode.SnapSync, ExpectedResult = false)]
+    [TestCase(SyncMode.StateNodes, ExpectedResult = false)]
+    [TestCase(SyncMode.FastSync | SyncMode.StateNodes, ExpectedResult = false)]
+    [TestCase(SyncMode.FastHeaders, ExpectedResult = false)]
+    [TestCase(SyncMode.BeaconHeaders, ExpectedResult = false)]
+    [TestCase(SyncMode.FastHeaders | SyncMode.BeaconHeaders | SyncMode.SnapSync, ExpectedResult = false)]
+    [TestCase(SyncMode.WaitingForBlock, ExpectedResult = true)]
+    [TestCase(SyncMode.FastBodies | SyncMode.WaitingForBlock, ExpectedResult = true)]
+    [TestCase(SyncMode.FastReceipts | SyncMode.WaitingForBlock, ExpectedResult = true)]
+    [TestCase(SyncMode.FastBodies | SyncMode.FastSync, ExpectedResult = false)]
+    [TestCase(SyncMode.Full, ExpectedResult = false)]
+    [TestCase(SyncMode.DbLoad, ExpectedResult = false)]
+    [TestCase(SyncMode.Disconnected, ExpectedResult = false)]
+    public bool can_gossip(SyncMode mode) =>
+        new SyncedTxGossipPolicy(new StaticSelector(mode)).CanGossipTransactions;
+}

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncedTxGossipPolicyTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncedTxGossipPolicyTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Nethermind.Synchronization.ParallelSync;
+using Nethermind.TxPool;
 using NUnit.Framework;
 
 namespace Nethermind.Synchronization.Test.ParallelSync;
@@ -22,6 +23,7 @@ public class SyncedTxGossipPolicyTests
     [TestCase(SyncMode.Full, ExpectedResult = false)]
     [TestCase(SyncMode.DbLoad, ExpectedResult = false)]
     [TestCase(SyncMode.Disconnected, ExpectedResult = false)]
+    [TestCase(SyncMode.UpdatingPivot, ExpectedResult = false)]
     public bool can_gossip(SyncMode mode) =>
-        new SyncedTxGossipPolicy(new StaticSelector(mode)).CanGossipTransactions;
+        ((ITxGossipPolicy)new SyncedTxGossipPolicy(new StaticSelector(mode))).ShouldListenToGossippedTransactions;
 }

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
@@ -33,7 +33,7 @@ namespace Nethermind.Synchronization.ParallelSync
     ///     - Beacon modes are allied directly.
     ///     - If no Beacon mode is applied and we have good peers on the network we apply <see cref="SyncMode.Full"/>,.
     /// </remarks>
-    public class MultiSyncModeSelector : ISyncModeSelector, IDisposable
+    public class MultiSyncModeSelector : ISyncModeSelector
     {
         /// <summary>
         /// Number of blocks before the best peer's head when we switch from fast sync to full sync

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncedTxGossipPolicy.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncedTxGossipPolicy.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncedTxGossipPolicy.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncedTxGossipPolicy.cs
@@ -15,5 +15,5 @@ public class SyncedTxGossipPolicy : ITxGossipPolicy
         _syncModeSelector = syncModeSelector;
     }
 
-    public bool CanGossipTransactions => (_syncModeSelector.Current & SyncMode.WaitingForBlock) != 0;
+    public bool ShouldListenToGossippedTransactions => (_syncModeSelector.Current & SyncMode.WaitingForBlock) != 0;
 }

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncedTxGossipPolicy.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncedTxGossipPolicy.cs
@@ -1,0 +1,19 @@
+﻿// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.TxPool;
+
+namespace Nethermind.Synchronization.ParallelSync;
+
+public class SyncedTxGossipPolicy : ITxGossipPolicy
+{
+    private readonly ISyncModeSelector _syncModeSelector;
+
+    public SyncedTxGossipPolicy(ISyncModeSelector syncModeSelector)
+    {
+        _syncModeSelector = syncModeSelector;
+    }
+
+    public bool CanGossipTransactions => (_syncModeSelector.Current & SyncMode.WaitingForBlock) != 0;
+}

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -1628,6 +1628,7 @@ namespace Nethermind.TxPool.Test
                 new TxValidator(_specProvider.ChainId),
                 _logManager,
                 transactionComparerProvider.GetDefaultComparer(),
+                ShouldGossip.Instance,
                 incomingTxFilter,
                 thereIsPriorityContract);
         }

--- a/src/Nethermind/Nethermind.TxPool/ITxGossipPolicy.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxGossipPolicy.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;

--- a/src/Nethermind/Nethermind.TxPool/ITxGossipPolicy.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxGossipPolicy.cs
@@ -9,14 +9,14 @@ namespace Nethermind.TxPool;
 public interface ITxGossipPolicy
 {
     bool CanGossipTransactions { get; }
-    bool CanGossipTransaction(Transaction tx) => CanGossipTransactions;
+    bool ShouldGossipTransaction(Transaction tx) => CanGossipTransactions;
 }
 
 public class CompositeTxGossipPolicy : ITxGossipPolicy
 {
     public ITxGossipPolicy TxGossipPolicy { get; set; } = ShouldGossip.Instance;
     public bool CanGossipTransactions => TxGossipPolicy.CanGossipTransactions;
-    public bool CanGossipTransaction(Transaction tx) => TxGossipPolicy.CanGossipTransaction(tx);
+    public bool ShouldGossipTransaction(Transaction tx) => TxGossipPolicy.ShouldGossipTransaction(tx);
 }
 
 public class ShouldGossip : ITxGossipPolicy

--- a/src/Nethermind/Nethermind.TxPool/ITxGossipPolicy.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxGossipPolicy.cs
@@ -16,8 +16,7 @@ public interface ITxGossipPolicy
 
 public class CompositeTxGossipPolicy : ITxGossipPolicy
 {
-    public List<ITxGossipPolicy> Policies { get; } = new() { ShouldGossip.Instance };
-
+    public List<ITxGossipPolicy> Policies { get; } = new();
     public bool CanGossipTransactions => Policies.All(static p => p.CanGossipTransactions);
     public bool ShouldGossipTransaction(Transaction tx) => Policies.All(p => p.ShouldGossipTransaction(tx));
 }

--- a/src/Nethermind/Nethermind.TxPool/ITxGossipPolicy.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxGossipPolicy.cs
@@ -10,13 +10,15 @@ namespace Nethermind.TxPool;
 
 public interface ITxGossipPolicy
 {
-    bool CanGossipTransactions { get; }
-    bool ShouldGossipTransaction(Transaction tx) => CanGossipTransactions;
+    bool ShouldListenToGossippedTransactions => true;
+    bool CanGossipTransactions => true;
+    bool ShouldGossipTransaction(Transaction tx) => true;
 }
 
 public class CompositeTxGossipPolicy : ITxGossipPolicy
 {
     public List<ITxGossipPolicy> Policies { get; } = new();
+    public bool ShouldListenToGossippedTransactions => Policies.All(static p => p.ShouldListenToGossippedTransactions);
     public bool CanGossipTransactions => Policies.All(static p => p.CanGossipTransactions);
     public bool ShouldGossipTransaction(Transaction tx) => Policies.All(p => p.ShouldGossipTransaction(tx));
 }
@@ -24,5 +26,4 @@ public class CompositeTxGossipPolicy : ITxGossipPolicy
 public class ShouldGossip : ITxGossipPolicy
 {
     public static readonly ShouldGossip Instance = new();
-    public bool CanGossipTransactions => true;
 }

--- a/src/Nethermind/Nethermind.TxPool/ITxGossipPolicy.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxGossipPolicy.cs
@@ -1,0 +1,26 @@
+﻿// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Core;
+
+namespace Nethermind.TxPool;
+
+public interface ITxGossipPolicy
+{
+    bool CanGossipTransactions { get; }
+    bool CanGossipTransaction(Transaction tx) => CanGossipTransactions;
+}
+
+public class CompositeTxGossipPolicy : ITxGossipPolicy
+{
+    public ITxGossipPolicy TxGossipPolicy { get; set; } = ShouldGossip.Instance;
+    public bool CanGossipTransactions => TxGossipPolicy.CanGossipTransactions;
+    public bool CanGossipTransaction(Transaction tx) => TxGossipPolicy.CanGossipTransaction(tx);
+}
+
+public class ShouldGossip : ITxGossipPolicy
+{
+    public static readonly ShouldGossip Instance = new();
+    public bool CanGossipTransactions => true;
+}

--- a/src/Nethermind/Nethermind.TxPool/ITxGossipPolicy.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxGossipPolicy.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Nethermind.Core;
 
 namespace Nethermind.TxPool;
@@ -14,9 +16,10 @@ public interface ITxGossipPolicy
 
 public class CompositeTxGossipPolicy : ITxGossipPolicy
 {
-    public ITxGossipPolicy TxGossipPolicy { get; set; } = ShouldGossip.Instance;
-    public bool CanGossipTransactions => TxGossipPolicy.CanGossipTransactions;
-    public bool ShouldGossipTransaction(Transaction tx) => TxGossipPolicy.ShouldGossipTransaction(tx);
+    public List<ITxGossipPolicy> Policies { get; } = new() { ShouldGossip.Instance };
+
+    public bool CanGossipTransactions => Policies.All(static p => p.CanGossipTransactions);
+    public bool ShouldGossipTransaction(Transaction tx) => Policies.All(p => p.ShouldGossipTransaction(tx));
 }
 
 public class ShouldGossip : ITxGossipPolicy

--- a/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using Nethermind.Core;
@@ -23,17 +24,7 @@ namespace Nethermind.TxPool
     {
         private readonly ITxPoolConfig _txPoolConfig;
         private readonly IChainHeadInfoProvider _headInfo;
-
-        /// <summary>
-        /// Notification threshold randomizer seed
-        /// </summary>
-        private static int _seed = Environment.TickCount;
-
-        /// <summary>
-        /// Random number generator for peer notification threshold - no need to be securely random.
-        /// </summary>
-        private static readonly ThreadLocal<Random> Random =
-            new(() => new Random(Interlocked.Increment(ref _seed)));
+        private readonly ITxGossipPolicy _txGossipPolicy;
 
         /// <summary>
         /// Timer for rebroadcasting pending own transactions.
@@ -73,10 +64,12 @@ namespace Nethermind.TxPool
             ITimerFactory timerFactory,
             ITxPoolConfig txPoolConfig,
             IChainHeadInfoProvider chainHeadInfoProvider,
-            ILogManager? logManager)
+            ILogManager? logManager,
+            ITxGossipPolicy? transactionsGossipPolicy = null)
         {
             _txPoolConfig = txPoolConfig;
             _headInfo = chainHeadInfoProvider;
+            _txGossipPolicy = transactionsGossipPolicy ?? ShouldGossip.Instance;
             _logger = logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
             _persistentTxs = new TxDistinctSortedPool(MemoryAllowance.MemPoolSize, comparer, logManager);
             _accumulatedTemporaryTxs = new ResettableList<Transaction>(512, 4);
@@ -106,7 +99,9 @@ namespace Nethermind.TxPool
         {
             NotifyPeersAboutLocalTx(tx);
             if (tx.Hash is not null)
+            {
                 _persistentTxs.TryInsert(tx.Hash, tx);
+            }
         }
 
         private void BroadcastOnce(Transaction tx)
@@ -259,31 +254,38 @@ namespace Nethermind.TxPool
 
         private void Notify(ITxPoolPeer peer, IEnumerable<Transaction> txs, bool sendFullTx)
         {
-            try
+            if (_txGossipPolicy.CanGossipTransactions)
             {
-                peer.SendNewTransactions(txs, sendFullTx);
-                if (_logger.IsTrace) _logger.Trace($"Notified {peer} about transactions.");
-            }
-            catch (Exception e)
-            {
-                if (_logger.IsError) _logger.Error($"Failed to notify {peer} about transactions.", e);
+                try
+                {
+
+                    peer.SendNewTransactions(txs.Where(t => _txGossipPolicy.CanGossipTransaction(t)), sendFullTx);
+                    if (_logger.IsTrace) _logger.Trace($"Notified {peer} about transactions.");
+                }
+                catch (Exception e)
+                {
+                    if (_logger.IsError) _logger.Error($"Failed to notify {peer} about transactions.", e);
+                }
             }
         }
 
         private void NotifyPeersAboutLocalTx(Transaction tx)
         {
-            if (_logger.IsDebug) _logger.Debug($"Broadcasting new local transaction {tx.Hash} to all peers");
-
-            foreach ((_, ITxPoolPeer peer) in _peers)
+            if (_txGossipPolicy.CanGossipTransaction(tx))
             {
-                try
+                if (_logger.IsDebug) _logger.Debug($"Broadcasting new local transaction {tx.Hash} to all peers");
+
+                foreach ((_, ITxPoolPeer peer) in _peers)
                 {
-                    peer.SendNewTransaction(tx);
-                    if (_logger.IsTrace) _logger.Trace($"Notified {peer} about transaction {tx.Hash}.");
-                }
-                catch (Exception e)
-                {
-                    if (_logger.IsError) _logger.Error($"Failed to notify {peer} about transaction {tx.Hash}.", e);
+                    try
+                    {
+                        peer.SendNewTransaction(tx);
+                        if (_logger.IsTrace) _logger.Trace($"Notified {peer} about transaction {tx.Hash}.");
+                    }
+                    catch (Exception e)
+                    {
+                        if (_logger.IsError) _logger.Error($"Failed to notify {peer} about transaction {tx.Hash}.", e);
+                    }
                 }
             }
         }

--- a/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
@@ -259,7 +259,7 @@ namespace Nethermind.TxPool
                 try
                 {
 
-                    peer.SendNewTransactions(txs.Where(t => _txGossipPolicy.CanGossipTransaction(t)), sendFullTx);
+                    peer.SendNewTransactions(txs.Where(t => _txGossipPolicy.ShouldGossipTransaction(t)), sendFullTx);
                     if (_logger.IsTrace) _logger.Trace($"Notified {peer} about transactions.");
                 }
                 catch (Exception e)
@@ -271,7 +271,7 @@ namespace Nethermind.TxPool
 
         private void NotifyPeersAboutLocalTx(Transaction tx)
         {
-            if (_txGossipPolicy.CanGossipTransaction(tx))
+            if (_txGossipPolicy.CanGossipTransactions && _txGossipPolicy.ShouldGossipTransaction(tx))
             {
                 if (_logger.IsDebug) _logger.Debug($"Broadcasting new local transaction {tx.Hash} to all peers");
 

--- a/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
@@ -271,21 +271,20 @@ namespace Nethermind.TxPool
 
         private void NotifyPeersAboutLocalTx(Transaction tx)
         {
-            if (_txGossipPolicy.CanGossipTransactions && _txGossipPolicy.ShouldGossipTransaction(tx))
-            {
-                if (_logger.IsDebug) _logger.Debug($"Broadcasting new local transaction {tx.Hash} to all peers");
+            if (!_txGossipPolicy.CanGossipTransactions || !_txGossipPolicy.ShouldGossipTransaction(tx)) return;
 
-                foreach ((_, ITxPoolPeer peer) in _peers)
+            if (_logger.IsDebug) _logger.Debug($"Broadcasting new local transaction {tx.Hash} to all peers");
+
+            foreach ((_, ITxPoolPeer peer) in _peers)
+            {
+                try
                 {
-                    try
-                    {
-                        peer.SendNewTransaction(tx);
-                        if (_logger.IsTrace) _logger.Trace($"Notified {peer} about transaction {tx.Hash}.");
-                    }
-                    catch (Exception e)
-                    {
-                        if (_logger.IsError) _logger.Error($"Failed to notify {peer} about transaction {tx.Hash}.", e);
-                    }
+                    peer.SendNewTransaction(tx);
+                    if (_logger.IsTrace) _logger.Trace($"Notified {peer} about transaction {tx.Hash}.");
+                }
+                catch (Exception e)
+                {
+                    if (_logger.IsError) _logger.Error($"Failed to notify {peer} about transaction {tx.Hash}.", e);
                 }
             }
         }

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -65,22 +65,23 @@ namespace Nethermind.TxPool
         /// This class stores all known pending transactions that can be used for block production
         /// (by miners or validators) or simply informing other nodes about known pending transactions (broadcasting).
         /// </summary>
-        /// <param name="txStorage">Tx storage used to reject known transactions.</param>
         /// <param name="ecdsa">Used to recover sender addresses from transaction signatures.</param>
         /// <param name="chainHeadInfoProvider"></param>
         /// <param name="txPoolConfig"></param>
         /// <param name="validator"></param>
         /// <param name="logManager"></param>
         /// <param name="comparer"></param>
+        /// <param name="transactionsGossipPolicy"></param>
         /// <param name="incomingTxFilter"></param>
         /// <param name="thereIsPriorityContract"></param>
-        public TxPool(
-            IEthereumEcdsa ecdsa,
+        /// <param name="txStorage">Tx storage used to reject known transactions.</param>
+        public TxPool(IEthereumEcdsa ecdsa,
             IChainHeadInfoProvider chainHeadInfoProvider,
             ITxPoolConfig txPoolConfig,
             ITxValidator validator,
             ILogManager? logManager,
             IComparer<Transaction> comparer,
+            ITxGossipPolicy? transactionsGossipPolicy = null,
             IIncomingTxFilter? incomingTxFilter = null,
             bool thereIsPriorityContract = false)
         {
@@ -94,7 +95,7 @@ namespace Nethermind.TxPool
             AddNodeInfoEntryForTxPool();
 
             _transactions = new TxDistinctSortedPool(MemoryAllowance.MemPoolSize, comparer, logManager);
-            _broadcaster = new TxBroadcaster(comparer, TimerFactory.Default, txPoolConfig, chainHeadInfoProvider, logManager);
+            _broadcaster = new TxBroadcaster(comparer, TimerFactory.Default, txPoolConfig, chainHeadInfoProvider, logManager, transactionsGossipPolicy);
 
             _headInfo.HeadChanged += OnHeadChange;
 
@@ -154,7 +155,6 @@ namespace Nethermind.TxPool
 
         private void OnHeadChange(object? sender, BlockReplacementEventArgs e)
         {
-            // TODO: I think this is dangerous if many blocks are processed one after another
             try
             {
                 // Clear snapshot


### PR DESCRIPTION
Resolves #5391

## Changes
- Introduce `ITxGossipPolicy` that can decide if tx's can be gossiped and if particullar transaction can be gossiped (requested feature by user for a plugin)
- Based on the policy don't gossip the transactions in the pool
- Based on policy ignore transactions or transactions hashes that are gossiped to the node
- Create a policy that allows gossiping transaction depending on `SyncMode` 

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No