### PR TITLE
Feature/remove json rpc warn when syncing merged

### DIFF
--- a/src/Nethermind/Nethermind.Api/IApiWithBlockchain.cs
+++ b/src/Nethermind/Nethermind.Api/IApiWithBlockchain.cs
@@ -68,6 +68,7 @@ namespace Nethermind.Api
         INonceManager? NonceManager { get; set; }
         ITxPool? TxPool { get; set; }
         ITxPoolInfoProvider? TxPoolInfoProvider { get; set; }
+        CompositeTxGossipPolicy TxGossipPolicy { get; }
         IWitnessCollector? WitnessCollector { get; set; }
         IWitnessRepository? WitnessRepository { get; set; }
         IHealthHintService? HealthHintService { get; set; }

--- a/src/Nethermind/Nethermind.Api/NethermindApi.cs
+++ b/src/Nethermind/Nethermind.Api/NethermindApi.cs
@@ -232,5 +232,6 @@ namespace Nethermind.Api
         public CompositePruningTrigger PruningTrigger { get; } = new();
         public ISnapProvider? SnapProvider { get; set; }
         public IProcessExitSource? ProcessExit { get; set; }
+        public CompositeTxGossipPolicy TxGossipPolicy { get; } = new();
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Find/BlockParameter.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Find/BlockParameter.cs
@@ -61,5 +61,9 @@ namespace Nethermind.Blockchain.Find
         }
 
         public override int GetHashCode() => HashCode.Combine(Type, BlockNumber, BlockHash, RequireCanonical);
+
+        public static bool operator ==(BlockParameter? left, BlockParameter? right) => Equals(left, right);
+
+        public static bool operator !=(BlockParameter? left, BlockParameter? right) => !Equals(left, right);
     }
 }

--- a/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/InitializeBlockchainAuRa.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/InitializeBlockchainAuRa.cs
@@ -278,6 +278,7 @@ public class InitializeBlockchainAuRa : InitializeBlockchain
             _api.TxValidator,
             _api.LogManager,
             CreateTxPoolTxComparer(txPriorityContract, localDataSource),
+            _api.TxGossipPolicy,
             new TxFilterAdapter(_api.BlockTree, txPoolFilter, _api.LogManager),
             txPriorityContract is not null || localDataSource is not null);
     }

--- a/src/Nethermind/Nethermind.Core/Result.cs
+++ b/src/Nethermind/Nethermind.Core/Result.cs
@@ -9,11 +9,8 @@ namespace Nethermind.Core
 
         public string? Error { get; set; }
 
-        public static Result Fail(string error)
-        {
-            return new() { ResultType = ResultType.Failure, Error = error };
-        }
-
+        public static Result Fail(string error) => new() { ResultType = ResultType.Failure, Error = error };
+        public static Result TemporaryFail(string error) => new() { ResultType = ResultType.TemporaryFailure, Error = error };
         public static Result Success { get; } = new() { ResultType = ResultType.Success };
     }
 }

--- a/src/Nethermind/Nethermind.Core/ResultType.cs
+++ b/src/Nethermind/Nethermind.Core/ResultType.cs
@@ -6,6 +6,7 @@ namespace Nethermind.Core
     public enum ResultType
     {
         Success,
-        Failure
+        Failure,
+        TemporaryFailure
     }
 }

--- a/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
@@ -319,10 +319,10 @@ namespace Nethermind.Facade
             return filter is not null;
         }
 
-        public int NewFilter(BlockParameter fromBlock, BlockParameter toBlock,
+        public int NewFilter(BlockParameter? fromBlock, BlockParameter? toBlock,
             object? address = null, IEnumerable<object>? topics = null)
         {
-            LogFilter filter = _filterStore.CreateLogFilter(fromBlock, toBlock, address, topics);
+            LogFilter filter = _filterStore.CreateLogFilter(fromBlock ?? BlockParameter.Latest, toBlock ?? BlockParameter.Latest, address, topics);
             _filterStore.SaveFilter(filter);
             return filter.Id;
         }

--- a/src/Nethermind/Nethermind.Facade/Eth/EthSyncingInfo.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/EthSyncingInfo.cs
@@ -101,6 +101,8 @@ namespace Nethermind.Facade.Eth
             return _syncStopwatch.Elapsed;
         }
 
+        public SyncMode SyncMode => _syncModeSelector.Current;
+
         public bool IsSyncing()
         {
             return GetFullInfo().IsSyncing;

--- a/src/Nethermind/Nethermind.Facade/Eth/IEthSyncingInfo.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/IEthSyncingInfo.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using Nethermind.Synchronization.ParallelSync;
 
 namespace Nethermind.Facade.Eth
 {
@@ -12,5 +13,7 @@ namespace Nethermind.Facade.Eth
         bool IsSyncing();
 
         TimeSpan UpdateAndGetSyncTime();
+
+        SyncMode SyncMode { get; }
     }
 }

--- a/src/Nethermind/Nethermind.Facade/IBlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/IBlockchainBridge.cs
@@ -30,7 +30,7 @@ namespace Nethermind.Facade
 
         int NewBlockFilter();
         int NewPendingTransactionFilter();
-        int NewFilter(BlockParameter fromBlock, BlockParameter toBlock, object? address = null, IEnumerable<object>? topics = null);
+        int NewFilter(BlockParameter? fromBlock, BlockParameter? toBlock, object? address = null, IEnumerable<object>? topics = null);
         void UninstallFilter(int filterId);
         bool FilterExists(int filterId);
         Keccak[] GetBlockFilterChanges(int filterId);

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeBlockchain.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeBlockchain.cs
@@ -35,6 +35,7 @@ using Nethermind.Logging;
 using Nethermind.Serialization.Json;
 using Nethermind.State;
 using Nethermind.State.Witnesses;
+using Nethermind.Synchronization.ParallelSync;
 using Nethermind.Synchronization.Witness;
 using Nethermind.Trie;
 using Nethermind.Trie.Pruning;
@@ -332,7 +333,8 @@ namespace Nethermind.Init.Steps
                 _api.Config<ITxPoolConfig>(),
                 _api.TxValidator!,
                 _api.LogManager,
-                CreateTxPoolTxComparer());
+                CreateTxPoolTxComparer(),
+                _api.TxGossipPolicy);
 
         protected IComparer<Transaction> CreateTxPoolTxComparer() => _api.TransactionComparerProvider!.GetDefaultComparer();
 

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -39,6 +39,7 @@ using Nethermind.Synchronization.ParallelSync;
 using Nethermind.Synchronization.Peers;
 using Nethermind.Synchronization.Reporting;
 using Nethermind.Synchronization.SnapSync;
+using Nethermind.TxPool;
 
 namespace Nethermind.Init.Steps;
 
@@ -131,6 +132,8 @@ public class InitializeNetwork : IStep
         }
 
         _api.SyncModeSelector ??= CreateMultiSyncModeSelector(syncProgressResolver);
+        _api.TxGossipPolicy.Policies.Add(new SyncedTxGossipPolicy(_api.SyncModeSelector));
+
         _api.EthSyncingInfo = new EthSyncingInfo(_api.BlockTree!, _api.ReceiptStorage!, _syncConfig, _api.SyncModeSelector, _api.LogManager);
         _api.DisposeStack.Push(_api.SyncModeSelector);
 
@@ -526,7 +529,8 @@ public class InitializeNetwork : IStep
             peerStorage,
             forkInfo,
             _api.GossipPolicy,
-            _api.LogManager);
+            _api.LogManager,
+            _api.TxGossipPolicy);
 
         if (_syncConfig.WitnessProtocolEnabled)
         {

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TestRpcBlockchain.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TestRpcBlockchain.cs
@@ -141,7 +141,6 @@ namespace Nethermind.JsonRpc.Test.Modules
                 TxPool,
                 TxSender,
                 TestWallet,
-                ReceiptFinder,
                 LimboLogs.Instance,
                 SpecProvider,
                 GasPriceOracle,

--- a/src/Nethermind/Nethermind.JsonRpc/Error.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Error.cs
@@ -15,5 +15,8 @@ namespace Nethermind.JsonRpc
 
         [JsonProperty(PropertyName = "data", Order = 2)]
         public object? Data { get; set; }
+
+        [JsonIgnore]
+        public bool SuppressWarning { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
@@ -6,11 +6,9 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Abstractions;
-using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Nethermind.Core;
 using Nethermind.Core.Extensions;
 using Nethermind.JsonRpc.Utils;
 using Nethermind.Logging;
@@ -23,7 +21,7 @@ namespace Nethermind.JsonRpc
 {
     public class JsonRpcProcessor : IJsonRpcProcessor
     {
-        private JsonSerializer _traceSerializer;
+        private readonly JsonSerializer _traceSerializer;
         private readonly IJsonRpcConfig _jsonRpcConfig;
         private readonly ILogger _logger;
         private readonly JsonSerializer _obsoleteBasicJsonSerializer = new();
@@ -31,7 +29,7 @@ namespace Nethermind.JsonRpc
         private readonly IJsonSerializer _jsonSerializer;
         private readonly Recorder _recorder;
 
-        public JsonRpcProcessor(IJsonRpcService jsonRpcService, IJsonSerializer jsonSerializer, IJsonRpcConfig jsonRpcConfig, IFileSystem fileSystem, ILogManager logManager)
+        public JsonRpcProcessor(IJsonRpcService jsonRpcService, IJsonSerializer jsonSerializer, IJsonRpcConfig jsonRpcConfig, IFileSystem fileSystem, ILogManager? logManager)
         {
             _logger = logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
             if (fileSystem is null) throw new ArgumentNullException(nameof(fileSystem));
@@ -47,14 +45,14 @@ namespace Nethermind.JsonRpc
                 _recorder = new Recorder(recorderBaseFilePath, fileSystem, _logger);
             }
 
-            BuildTraceJsonSerializer();
+            _traceSerializer = BuildTraceJsonSerializer();
         }
 
         /// <summary>
         /// The serializer is created in a way that mimics the behaviour of the Kestrel serialization
         /// and can be used for recording and replaying JSON RPC calls.
         /// </summary>
-        private void BuildTraceJsonSerializer()
+        private JsonSerializer BuildTraceJsonSerializer()
         {
             JsonSerializerSettings jsonSettings = new()
             {
@@ -66,7 +64,7 @@ namespace Nethermind.JsonRpc
                 jsonSettings.Converters.Add(converter);
             }
 
-            _traceSerializer = JsonSerializer.Create(jsonSettings);
+            return JsonSerializer.Create(jsonSettings);
         }
 
         private IEnumerable<(JsonRpcRequest Model, List<JsonRpcRequest> Collection)> DeserializeObjectOrArray(TextReader json)
@@ -241,7 +239,11 @@ namespace Nethermind.JsonRpc
             bool isSuccess = localErrorResponse is null;
             if (!isSuccess)
             {
-                if (_logger.IsWarn) _logger.Warn($"Error when handling {request} | {_jsonSerializer.Serialize(localErrorResponse)}");
+                if (localErrorResponse.Error?.SuppressWarning == false)
+                {
+                    if (_logger.IsWarn) _logger.Warn($"Error when handling {request} | {_jsonSerializer.Serialize(localErrorResponse)}");
+                }
+
                 Metrics.JsonRpcErrors++;
             }
             else

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/BlockFinderExtensions.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/BlockFinderExtensions.cs
@@ -43,12 +43,14 @@ namespace Nethermind.JsonRpc.Modules
                 : new SearchResult<BlockHeader>(header);
         }
 
-        public static SearchResult<Block> SearchForBlock(this IBlockFinder blockFinder, BlockParameter blockParameter, bool allowNulls = false)
+        public static SearchResult<Block> SearchForBlock(this IBlockFinder blockFinder, BlockParameter? blockParameter, bool allowNulls = false)
         {
+            blockParameter ??= BlockParameter.Latest;
+
             Block block;
             if (blockParameter.RequireCanonical)
             {
-                block = blockFinder.FindBlock(blockParameter.BlockHash, BlockTreeLookupOptions.RequireCanonical);
+                block = blockFinder.FindBlock(blockParameter.BlockHash!, BlockTreeLookupOptions.RequireCanonical);
                 if (block is null && !allowNulls)
                 {
                     BlockHeader? header = blockFinder.FindHeader(blockParameter.BlockHash);

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthModuleFactory.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthModuleFactory.cs
@@ -73,7 +73,6 @@ namespace Nethermind.JsonRpc.Modules.Eth
                 _txPool,
                 _txSender,
                 _wallet,
-                _receiptStorage,
                 _logManager,
                 _specProvider,
                 _gasPriceOracle,

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
@@ -10,7 +10,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Blockchain.Filters;
 using Nethermind.Blockchain.Find;
-using Nethermind.Blockchain.Receipts;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
@@ -27,6 +26,7 @@ using Nethermind.Network.P2P;
 using Nethermind.Serialization.Rlp;
 using Nethermind.State;
 using Nethermind.State.Proofs;
+using Nethermind.Synchronization.ParallelSync;
 using Nethermind.Trie;
 using Nethermind.TxPool;
 using Nethermind.Wallet;
@@ -43,7 +43,6 @@ public partial class EthRpcModule : IEthRpcModule
     private readonly IJsonRpcConfig _rpcConfig;
     private readonly IBlockchainBridge _blockchainBridge;
     private readonly IBlockFinder _blockFinder;
-    private readonly IReceiptFinder _receiptFinder;
     private readonly IStateReader _stateReader;
     private readonly ITxPool _txPoolBridge;
     private readonly ITxSender _txSender;
@@ -57,7 +56,7 @@ public partial class EthRpcModule : IEthRpcModule
     private static bool HasStateForBlock(IBlockchainBridge blockchainBridge, BlockHeader header)
     {
         RootCheckVisitor rootCheckVisitor = new();
-        blockchainBridge.RunTreeVisitor(rootCheckVisitor, header.StateRoot);
+        blockchainBridge.RunTreeVisitor(rootCheckVisitor, header.StateRoot!);
         return rootCheckVisitor.HasRoot;
     }
 
@@ -69,7 +68,6 @@ public partial class EthRpcModule : IEthRpcModule
         ITxPool txPool,
         ITxSender txSender,
         IWallet wallet,
-        IReceiptFinder receiptFinder,
         ILogManager logManager,
         ISpecProvider specProvider,
         IGasPriceOracle gasPriceOracle,
@@ -84,7 +82,6 @@ public partial class EthRpcModule : IEthRpcModule
         _txPoolBridge = txPool ?? throw new ArgumentNullException(nameof(txPool));
         _txSender = txSender ?? throw new ArgumentNullException(nameof(txSender));
         _wallet = wallet ?? throw new ArgumentNullException(nameof(wallet));
-        _receiptFinder = receiptFinder ?? throw new ArgumentNullException(nameof(receiptFinder)); ;
         _specProvider = specProvider ?? throw new ArgumentNullException(nameof(specProvider));
         _gasPriceOracle = gasPriceOracle ?? throw new ArgumentNullException(nameof(gasPriceOracle));
         _ethSyncingInfo = ethSyncingInfo ?? throw new ArgumentNullException(nameof(ethSyncingInfo));
@@ -163,17 +160,16 @@ public partial class EthRpcModule : IEthRpcModule
         SearchResult<BlockHeader> searchResult = _blockFinder.SearchForHeader(blockParameter);
         if (searchResult.IsError)
         {
-            return Task.FromResult(ResultWrapper<UInt256?>.Fail(searchResult));
+            return Task.FromResult(GetFailureResult<UInt256?, BlockHeader>(searchResult, _ethSyncingInfo.SyncMode.IsSyncingHeaders()));
         }
 
         BlockHeader header = searchResult.Object;
-        if (!HasStateForBlock(_blockchainBridge, header))
+        if (!HasStateForBlock(_blockchainBridge, header!))
         {
-            return Task.FromResult(ResultWrapper<UInt256?>.Fail($"No state available for block {header.Hash}",
-                ErrorCodes.ResourceUnavailable));
+            return Task.FromResult(GetStateFailureResult<UInt256?>(header));
         }
 
-        Account account = _stateReader.GetAccount(header.StateRoot, address);
+        Account account = _stateReader.GetAccount(header!.StateRoot!, address);
         return Task.FromResult(ResultWrapper<UInt256?>.Success(account?.Balance ?? UInt256.Zero));
     }
 
@@ -183,44 +179,41 @@ public partial class EthRpcModule : IEthRpcModule
         SearchResult<BlockHeader> searchResult = _blockFinder.SearchForHeader(blockParameter);
         if (searchResult.IsError)
         {
-            return ResultWrapper<byte[]>.Fail(searchResult);
+            return GetFailureResult<byte[], BlockHeader>(searchResult, _ethSyncingInfo.SyncMode.IsSyncingHeaders());
         }
 
         BlockHeader? header = searchResult.Object;
-        Account account = _stateReader.GetAccount(header.StateRoot, address);
+        Account account = _stateReader.GetAccount(header!.StateRoot!, address);
         if (account is null)
         {
             return ResultWrapper<byte[]>.Success(Array.Empty<byte>());
         }
 
         byte[] storage = _stateReader.GetStorage(account.StorageRoot, positionIndex);
-        return ResultWrapper<byte[]>.Success(storage.PadLeft(32));
+        return ResultWrapper<byte[]>.Success(storage!.PadLeft(32));
     }
 
     public Task<ResultWrapper<UInt256>> eth_getTransactionCount(Address address, BlockParameter blockParameter)
     {
-
         if (blockParameter == BlockParameter.Pending)
         {
             UInt256 pendingNonce = _txPoolBridge.GetLatestPendingNonce(address);
             return Task.FromResult(ResultWrapper<UInt256>.Success(pendingNonce));
-
         }
 
         SearchResult<BlockHeader> searchResult = _blockFinder.SearchForHeader(blockParameter);
         if (searchResult.IsError)
         {
-            return Task.FromResult(ResultWrapper<UInt256>.Fail(searchResult));
+            return Task.FromResult(GetFailureResult<UInt256, BlockHeader>(searchResult, _ethSyncingInfo.SyncMode.IsSyncingHeaders()));
         }
 
         BlockHeader header = searchResult.Object;
-        if (!HasStateForBlock(_blockchainBridge, header))
+        if (!HasStateForBlock(_blockchainBridge, header!))
         {
-            return Task.FromResult(ResultWrapper<UInt256>.Fail($"No state available for block {header.Hash}",
-                ErrorCodes.ResourceUnavailable));
+            return Task.FromResult(GetStateFailureResult<UInt256>(header));
         }
 
-        Account account = _stateReader.GetAccount(header.StateRoot, address);
+        Account account = _stateReader.GetAccount(header!.StateRoot!, address);
         UInt256 nonce = account?.Nonce ?? 0;
 
         return Task.FromResult(ResultWrapper<UInt256>.Success(nonce));
@@ -229,45 +222,33 @@ public partial class EthRpcModule : IEthRpcModule
     public ResultWrapper<UInt256?> eth_getBlockTransactionCountByHash(Keccak blockHash)
     {
         SearchResult<Block> searchResult = _blockFinder.SearchForBlock(new BlockParameter(blockHash));
-        if (searchResult.IsError)
-        {
-            return ResultWrapper<UInt256?>.Fail(searchResult);
-        }
-
-        return ResultWrapper<UInt256?>.Success((UInt256)searchResult.Object.Transactions.Length);
+        return searchResult.IsError
+            ? GetFailureResult<UInt256?, Block>(searchResult, _ethSyncingInfo.SyncMode.IsSyncingBodies())
+            : ResultWrapper<UInt256?>.Success((UInt256)searchResult.Object!.Transactions.Length);
     }
 
     public ResultWrapper<UInt256?> eth_getBlockTransactionCountByNumber(BlockParameter blockParameter)
     {
         SearchResult<Block> searchResult = _blockFinder.SearchForBlock(blockParameter);
-        if (searchResult.IsError)
-        {
-            return ResultWrapper<UInt256?>.Fail(searchResult);
-        }
-
-        return ResultWrapper<UInt256?>.Success((UInt256)searchResult.Object.Transactions.Length);
+        return searchResult.IsError
+            ? GetFailureResult<UInt256?, Block>(searchResult, _ethSyncingInfo.SyncMode.IsSyncingBodies())
+            : ResultWrapper<UInt256?>.Success((UInt256)searchResult.Object!.Transactions.Length);
     }
 
     public ResultWrapper<UInt256?> eth_getUncleCountByBlockHash(Keccak blockHash)
     {
         SearchResult<Block> searchResult = _blockFinder.SearchForBlock(new BlockParameter(blockHash));
-        if (searchResult.IsError)
-        {
-            return ResultWrapper<UInt256?>.Fail(searchResult);
-        }
-
-        return ResultWrapper<UInt256?>.Success((UInt256)searchResult.Object.Uncles.Length);
+        return searchResult.IsError
+            ? GetFailureResult<UInt256?, Block>(searchResult, _ethSyncingInfo.SyncMode.IsSyncingBodies())
+            : ResultWrapper<UInt256?>.Success((UInt256)searchResult.Object!.Uncles.Length);
     }
 
     public ResultWrapper<UInt256?> eth_getUncleCountByBlockNumber(BlockParameter? blockParameter)
     {
         SearchResult<Block> searchResult = _blockFinder.SearchForBlock(blockParameter);
-        if (searchResult.IsError)
-        {
-            return ResultWrapper<UInt256?>.Fail(searchResult);
-        }
-
-        return ResultWrapper<UInt256?>.Success((UInt256)searchResult.Object.Uncles.Length);
+        return searchResult.IsError
+            ? GetFailureResult<UInt256?, Block>(searchResult, _ethSyncingInfo.SyncMode.IsSyncingBodies())
+            : ResultWrapper<UInt256?>.Success((UInt256)searchResult.Object!.Uncles.Length);
     }
 
     public ResultWrapper<byte[]> eth_getCode(Address address, BlockParameter? blockParameter = null)
@@ -275,17 +256,16 @@ public partial class EthRpcModule : IEthRpcModule
         SearchResult<BlockHeader> searchResult = _blockFinder.SearchForHeader(blockParameter);
         if (searchResult.IsError)
         {
-            return ResultWrapper<byte[]>.Fail(searchResult);
+            return GetFailureResult<byte[], BlockHeader>(searchResult, _ethSyncingInfo.SyncMode.IsSyncingHeaders());
         }
 
         BlockHeader header = searchResult.Object;
-        if (!HasStateForBlock(_blockchainBridge, header))
+        if (!HasStateForBlock(_blockchainBridge, header!))
         {
-            return ResultWrapper<byte[]>.Fail($"No state available for block {header.Hash}",
-                ErrorCodes.ResourceUnavailable);
+            return GetStateFailureResult<byte[]>(header);
         }
 
-        Account account = _stateReader.GetAccount(header.StateRoot, address);
+        Account account = _stateReader.GetAccount(header!.StateRoot!, address);
         if (account is null)
         {
             return ResultWrapper<byte[]>.Success(Array.Empty<byte>());
@@ -391,7 +371,7 @@ public partial class EthRpcModule : IEthRpcModule
         SearchResult<Block> searchResult = _blockFinder.SearchForBlock(blockParameter, true);
         if (searchResult.IsError)
         {
-            return ResultWrapper<BlockForRpc>.Fail(searchResult);
+            return GetFailureResult<BlockForRpc, Block>(searchResult, _ethSyncingInfo.SyncMode.IsSyncingBodies());
         }
 
         Block? block = searchResult.Object;
@@ -449,11 +429,11 @@ public partial class EthRpcModule : IEthRpcModule
         SearchResult<Block> searchResult = _blockFinder.SearchForBlock(new BlockParameter(blockHash));
         if (searchResult.IsError)
         {
-            return ResultWrapper<TransactionForRpc>.Fail(searchResult);
+            return GetFailureResult<TransactionForRpc, Block>(searchResult, _ethSyncingInfo.SyncMode.IsSyncingBodies());
         }
 
         Block block = searchResult.Object;
-        if (positionIndex < 0 || positionIndex > block.Transactions.Length - 1)
+        if (positionIndex < 0 || positionIndex > block!.Transactions.Length - 1)
         {
             return ResultWrapper<TransactionForRpc>.Fail("Position Index is incorrect", ErrorCodes.InvalidParams);
         }
@@ -472,11 +452,11 @@ public partial class EthRpcModule : IEthRpcModule
         SearchResult<Block> searchResult = _blockFinder.SearchForBlock(blockParameter);
         if (searchResult.IsError)
         {
-            return ResultWrapper<TransactionForRpc>.Fail(searchResult);
+            return GetFailureResult<TransactionForRpc, Block>(searchResult, _ethSyncingInfo.SyncMode.IsSyncingBodies());
         }
 
         Block? block = searchResult.Object;
-        if (positionIndex < 0 || positionIndex > block.Transactions.Length - 1)
+        if (positionIndex < 0 || positionIndex > block!.Transactions.Length - 1)
         {
             return ResultWrapper<TransactionForRpc>.Fail("Position Index is incorrect", ErrorCodes.InvalidParams);
         }
@@ -520,11 +500,11 @@ public partial class EthRpcModule : IEthRpcModule
         SearchResult<Block> searchResult = _blockFinder.SearchForBlock(blockParameter);
         if (searchResult.IsError)
         {
-            return ResultWrapper<BlockForRpc>.Fail(searchResult);
+            return GetFailureResult<BlockForRpc, Block>(searchResult, _ethSyncingInfo.SyncMode.IsSyncingBodies());
         }
 
         Block block = searchResult.Object;
-        if (positionIndex < 0 || positionIndex > block.Uncles.Length - 1)
+        if (positionIndex < 0 || positionIndex > block!.Uncles.Length - 1)
         {
             return ResultWrapper<BlockForRpc>.Fail("Position Index is incorrect", ErrorCodes.InvalidParams);
         }
@@ -612,7 +592,7 @@ public partial class EthRpcModule : IEthRpcModule
         catch (ResourceNotFoundException exception)
         {
             cancellationTokenSource.Dispose();
-            return ResultWrapper<IEnumerable<FilterLog>>.Fail(exception.Message, ErrorCodes.ResourceNotFound);
+            return GetFailureResult<IEnumerable<FilterLog>>(exception, _ethSyncingInfo.SyncMode.IsSyncingReceipts());
         }
     }
 
@@ -634,20 +614,17 @@ public partial class EthRpcModule : IEthRpcModule
             if (toBlockResult.IsError)
             {
                 cancellationTokenSource.Dispose();
-
-                return ResultWrapper<IEnumerable<FilterLog>>.Fail(toBlockResult);
+                return GetFailureResult<IEnumerable<FilterLog>, BlockHeader>(toBlockResult, _ethSyncingInfo.SyncMode.IsSyncingHeaders());
             }
 
             cancellationToken.ThrowIfCancellationRequested();
-
             fromBlockResult = _blockFinder.SearchForHeader(filter.FromBlock);
         }
 
         if (fromBlockResult.IsError)
         {
             cancellationTokenSource.Dispose();
-
-            return ResultWrapper<IEnumerable<FilterLog>>.Fail(fromBlockResult);
+            return GetFailureResult<IEnumerable<FilterLog>, BlockHeader>(fromBlockResult, _ethSyncingInfo.SyncMode.IsSyncingHeaders());
         }
 
         cancellationToken.ThrowIfCancellationRequested();
@@ -658,20 +635,19 @@ public partial class EthRpcModule : IEthRpcModule
         if (fromBlockNumber > toBlockNumber && toBlockNumber != 0)
         {
             cancellationTokenSource.Dispose();
-
             return ResultWrapper<IEnumerable<FilterLog>>.Fail($"'From' block '{fromBlockNumber}' is later than 'to' block '{toBlockNumber}'.", ErrorCodes.InvalidParams);
         }
 
         try
         {
-            IEnumerable<FilterLog> filterLogs = _blockchainBridge.GetLogs(filter.FromBlock, filter.ToBlock,
+            IEnumerable<FilterLog> filterLogs = _blockchainBridge.GetLogs(filter.FromBlock!, filter.ToBlock!,
                 filter.Address, filter.Topics, cancellationToken);
 
             return ResultWrapper<IEnumerable<FilterLog>>.Success(GetLogs(filterLogs, cancellationTokenSource));
         }
         catch (ResourceNotFoundException exception)
         {
-            return ResultWrapper<IEnumerable<FilterLog>>.Fail(exception.Message, ErrorCodes.ResourceNotFound);
+            return GetFailureResult<IEnumerable<FilterLog>>(exception, _ethSyncingInfo.SyncMode.IsSyncingReceipts());
         }
     }
 
@@ -694,30 +670,21 @@ public partial class EthRpcModule : IEthRpcModule
     public ResultWrapper<AccountProof> eth_getProof(Address accountAddress, UInt256[] storageKeys,
         BlockParameter blockParameter)
     {
-        BlockHeader header;
-        try
+        SearchResult<BlockHeader> searchResult = _blockFinder.SearchForHeader(blockParameter);
+        if (searchResult.IsError)
         {
-            header = _blockFinder.FindHeader(blockParameter);
-            if (header is null)
-            {
-                return ResultWrapper<AccountProof>.Fail($"{blockParameter} block not found",
-                    ErrorCodes.ResourceNotFound, null);
-            }
-
-            if (!HasStateForBlock(_blockchainBridge, header))
-            {
-                return ResultWrapper<AccountProof>.Fail($"No state available for block {header.Hash}",
-                    ErrorCodes.ResourceUnavailable);
-            }
+            return GetFailureResult<AccountProof, BlockHeader>(searchResult, _ethSyncingInfo.SyncMode.IsSyncingHeaders());
         }
-        catch (Exception ex)
+
+        BlockHeader header = searchResult.Object;
+
+        if (!HasStateForBlock(_blockchainBridge, header!))
         {
-            return ResultWrapper<AccountProof>.Fail(ex.Message, ErrorCodes.InternalError, null);
+            return GetStateFailureResult<AccountProof>(header);
         }
 
         AccountProofCollector accountProofCollector = new(accountAddress, storageKeys);
-        _blockchainBridge.RunTreeVisitor(accountProofCollector, header.StateRoot);
-
+        _blockchainBridge.RunTreeVisitor(accountProofCollector, header!.StateRoot!);
         return ResultWrapper<AccountProof>.Success(accountProofCollector.BuildResult());
     }
 
@@ -752,19 +719,34 @@ public partial class EthRpcModule : IEthRpcModule
 
     public ResultWrapper<AccountForRpc> eth_getAccount(Address accountAddress, BlockParameter? blockParameter)
     {
-        SearchResult<BlockHeader> searchResult = _blockFinder.SearchForHeader(blockParameter ?? BlockParameter.Latest);
+        SearchResult<BlockHeader> searchResult = _blockFinder.SearchForHeader(blockParameter);
         if (searchResult.IsError)
         {
-            // probably better forward Error of searchResult
-            return ResultWrapper<AccountForRpc>.Fail($"header not found", ErrorCodes.InvalidInput);
+            return GetFailureResult<AccountForRpc, BlockHeader>(searchResult, _ethSyncingInfo.SyncMode.IsSyncingHeaders());
         }
+
         BlockHeader header = searchResult.Object;
-        if (!HasStateForBlock(_blockchainBridge, header))
+        if (!HasStateForBlock(_blockchainBridge, header!))
         {
-            return ResultWrapper<AccountForRpc>.Fail($"No state available for {blockParameter}",
-                ErrorCodes.ResourceUnavailable);
+            return GetStateFailureResult<AccountForRpc>(header);
         }
-        Account account = _stateReader.GetAccount(header.StateRoot, accountAddress);
+
+        Account account = _stateReader.GetAccount(header!.StateRoot!, accountAddress);
         return ResultWrapper<AccountForRpc>.Success(account is null ? null : new AccountForRpc(account));
     }
+
+    private static ResultWrapper<TResult> GetFailureResult<TResult, TSearch>(SearchResult<TSearch> searchResult, bool isTemporary) where TSearch : class =>
+        isTemporary && searchResult.ErrorCode == ErrorCodes.ResourceNotFound
+            ? ResultWrapper<TResult>.TemporaryFail(searchResult)
+            : ResultWrapper<TResult>.Fail(searchResult);
+
+    private static ResultWrapper<TResult> GetFailureResult<TResult>(ResourceNotFoundException exception, bool isTemporary) =>
+        isTemporary
+            ? ResultWrapper<TResult>.TemporaryFail(exception.Message, ErrorCodes.ResourceNotFound)
+            : ResultWrapper<TResult>.Fail(exception.Message, ErrorCodes.ResourceNotFound);
+
+    private ResultWrapper<TResult> GetStateFailureResult<TResult>(BlockHeader header) =>
+        _ethSyncingInfo.SyncMode.IsSyncingState()
+            ? ResultWrapper<TResult>.TemporaryFail($"No state available for block {header.ToString(BlockHeader.Format.FullHashAndNumber)}", ErrorCodes.ResourceUnavailable)
+            : ResultWrapper<TResult>.Fail($"No state available for block {header.ToString(BlockHeader.Format.FullHashAndNumber)}", ErrorCodes.ResourceUnavailable);
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/SearchResult.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/SearchResult.cs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Nethermind.JsonRpc.Modules
 {
     public struct SearchResult<T> where T : class
@@ -19,6 +21,7 @@ namespace Nethermind.JsonRpc.Modules
             ErrorCode = 0;
         }
 
+        [MemberNotNullWhen(false, nameof(IsError))]
         public T? Object { get; set; }
 
         public string? Error { get; set; }

--- a/src/Nethermind/Nethermind.JsonRpc/ResultWrapper.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/ResultWrapper.cs
@@ -19,65 +19,43 @@ namespace Nethermind.JsonRpc
         {
         }
 
-        public static ResultWrapper<T> Fail<TSearch>(SearchResult<TSearch> searchResult) where TSearch : class
-        {
-            return new() { Result = Result.Fail(searchResult.Error), ErrorCode = searchResult.ErrorCode };
-        }
+        public static ResultWrapper<T> Fail<TSearch>(SearchResult<TSearch> searchResult) where TSearch : class =>
+            new() { Result = Result.Fail(searchResult.Error!), ErrorCode = searchResult.ErrorCode };
 
-        public static ResultWrapper<T> Fail(string error)
-        {
-            return new() { Result = Result.Fail(error), ErrorCode = ErrorCodes.InternalError };
-        }
+        public static ResultWrapper<T> Fail(string error) =>
+            new() { Result = Result.Fail(error), ErrorCode = ErrorCodes.InternalError };
 
-        public static ResultWrapper<T> Fail(Exception e)
-        {
-            return new() { Result = Result.Fail(e.ToString()), ErrorCode = ErrorCodes.InternalError };
-        }
+        public static ResultWrapper<T> Fail(Exception e) =>
+            new() { Result = Result.Fail(e.ToString()), ErrorCode = ErrorCodes.InternalError };
 
-        public static ResultWrapper<T> Fail(string error, int errorCode, T outputData)
-        {
-            return new() { Result = Result.Fail(error), ErrorCode = errorCode, Data = outputData };
-        }
+        public static ResultWrapper<T> Fail(string error, int errorCode, T outputData) =>
+            new() { Result = Result.Fail(error), ErrorCode = errorCode, Data = outputData };
 
-        public static ResultWrapper<T> Fail(string error, int errorCode)
-        {
-            return new() { Result = Result.Fail(error), ErrorCode = errorCode };
-        }
+        public static ResultWrapper<T> Fail(string error, int errorCode) =>
+            new() { Result = Result.Fail(error), ErrorCode = errorCode };
 
-        public static ResultWrapper<T> Fail(string error, T data)
-        {
-            return new() { Data = data, Result = Result.Fail(error) };
-        }
+        public static ResultWrapper<T> Fail(string error, T data) =>
+            new() { Data = data, Result = Result.Fail(error) };
 
-        public static ResultWrapper<T> Success(T data)
-        {
-            return new() { Data = data, Result = Result.Success };
-        }
+        public static ResultWrapper<T> Success(T data) =>
+            new() { Data = data, Result = Result.Success };
 
-        public Result GetResult()
-        {
-            return Result;
-        }
+        public static ResultWrapper<T> TemporaryFail(string error, int errorCode) =>
+            new() { Result = Result.TemporaryFail(error), ErrorCode = errorCode };
 
-        public object? GetData()
-        {
-            return Data;
-        }
+        public static ResultWrapper<T> TemporaryFail<TSearch>(SearchResult<TSearch> searchResult) where TSearch : class =>
+            new() { Result = Result.TemporaryFail(searchResult.Error!), ErrorCode = searchResult.ErrorCode };
 
-        public int GetErrorCode()
-        {
-            return ErrorCode;
-        }
+        public Result GetResult() => Result;
 
-        public static ResultWrapper<T> From(RpcResult<T>? rpcResult)
-        {
-            if (rpcResult is null)
-            {
-                return Fail("Missing result.");
-            }
+        public object? GetData() => Data;
 
-            return rpcResult.IsValid ? Success(rpcResult.Result) : Fail(rpcResult.Error.Message);
-        }
+        public int GetErrorCode() => ErrorCode;
+
+        public static ResultWrapper<T> From(RpcResult<T>? rpcResult) =>
+            rpcResult is null
+                ? Fail("Missing result.")
+                : rpcResult.IsValid ? Success(rpcResult.Result) : Fail(rpcResult.Error.Message);
 
         public static implicit operator Task<ResultWrapper<T>>(ResultWrapper<T> resultWrapper) => Task.FromResult(resultWrapper);
     }

--- a/src/Nethermind/Nethermind.Network.Benchmark/Eth62ProtocolHandlerBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Network.Benchmark/Eth62ProtocolHandlerBenchmarks.cs
@@ -65,7 +65,7 @@ namespace Nethermind.Network.Benchmarks
             ISyncServer syncSrv = Substitute.For<ISyncServer>();
             BlockHeader head = Build.A.BlockHeader.WithNumber(1).TestObject;
             syncSrv.Head.Returns(head);
-            _handler = new Eth62ProtocolHandler(session, _ser, stats, syncSrv, txPool, ShouldGossip.Instance, LimboLogs.Instance);
+            _handler = new Eth62ProtocolHandler(session, _ser, stats, syncSrv, txPool, Consensus.ShouldGossip.Instance, LimboLogs.Instance);
             _handler.DisableTxFiltering();
 
             StatusMessage statusMessage = new StatusMessage();

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandlerTests.cs
@@ -38,14 +38,15 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
     [TestFixture, Parallelizable(ParallelScope.Self)]
     public class Eth62ProtocolHandlerTests
     {
-        private ISession _session;
-        private IMessageSerializationService _svc;
-        private ISyncServer _syncManager;
-        private ITxPool _transactionPool;
-        private Block _genesisBlock;
-        private Eth62ProtocolHandler _handler;
-        private IGossipPolicy _gossipPolicy;
+        private ISession _session = null!;
+        private IMessageSerializationService _svc = null!;
+        private ISyncServer _syncManager = null!;
+        private ITxPool _transactionPool = null!;
+        private Block _genesisBlock = null!;
+        private Eth62ProtocolHandler _handler = null!;
+        private IGossipPolicy _gossipPolicy = null!;
         private readonly TxDecoder _txDecoder = new();
+        private ITxGossipPolicy _txGossipPolicy = null!;
 
         [SetUp]
         public void Setup()
@@ -67,6 +68,9 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
             _gossipPolicy.CanGossipBlocks.Returns(true);
             _gossipPolicy.ShouldGossipBlock(Arg.Any<BlockHeader>()).Returns(true);
             _gossipPolicy.ShouldDisconnectGossipingNodes.Returns(false);
+            _txGossipPolicy = Substitute.For<ITxGossipPolicy>();
+            _txGossipPolicy.CanGossipTransactions.Returns(true);
+            _txGossipPolicy.ShouldGossipTransaction(Arg.Any<Transaction>()).Returns(true);
             _handler = new Eth62ProtocolHandler(
                 _session,
                 _svc,
@@ -74,7 +78,8 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
                 _syncManager,
                 _transactionPool,
                 _gossipPolicy,
-                LimboLogs.Instance);
+                LimboLogs.Instance,
+                _txGossipPolicy);
             _handler.Init();
         }
 
@@ -376,12 +381,14 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
         }
 
         [Test]
-        public void Can_handle_transactions()
+        public void Can_handle_transactions([Values(true, false)] bool canGossipTransactions)
         {
+            _txGossipPolicy.CanGossipTransactions.Returns(canGossipTransactions);
             TransactionsMessage msg = new(new List<Transaction>(Build.A.Transaction.SignedAndResolved().TestObjectNTimes(3)));
 
             HandleIncomingStatusMessage();
             HandleZeroMessage(msg, Eth62MessageCode.Transactions);
+            _transactionPool.Received(canGossipTransactions ? 3 : 0).SubmitTx(Arg.Any<Transaction>(), TxHandlingOptions.None);
         }
 
         [Test]
@@ -550,9 +557,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
 
         private void HandleIncomingStatusMessage()
         {
-            var statusMsg = new StatusMessage();
-            statusMsg.GenesisHash = _genesisBlock.Hash;
-            statusMsg.BestHash = _genesisBlock.Hash;
+            var statusMsg = new StatusMessage { GenesisHash = _genesisBlock.Hash, BestHash = _genesisBlock.Hash };
 
             IByteBuffer statusPacket = _svc.ZeroSerialize(statusMsg);
             statusPacket.ReadByte();

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandlerTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net;
+using DotNetty.Buffers;
 using FluentAssertions;
 using Nethermind.Consensus;
 using Nethermind.Core;
@@ -14,9 +15,11 @@ using Nethermind.Core.Timers;
 using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.Network.P2P;
+using Nethermind.Network.P2P.Subprotocols.Eth.V62;
 using Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages;
 using Nethermind.Network.P2P.Subprotocols.Eth.V65;
 using Nethermind.Network.P2P.Subprotocols.Eth.V65.Messages;
+using Nethermind.Network.Rlpx;
 using Nethermind.Network.Test.Builders;
 using Nethermind.Stats;
 using Nethermind.Stats.Model;
@@ -30,14 +33,15 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V65
     [TestFixture, Parallelizable(ParallelScope.Self)]
     public class Eth65ProtocolHandlerTests
     {
-        private ISession _session;
-        private IMessageSerializationService _svc;
-        private ISyncServer _syncManager;
-        private ITxPool _transactionPool;
-        private IPooledTxsRequestor _pooledTxsRequestor;
-        private ISpecProvider _specProvider;
-        private Block _genesisBlock;
-        private Eth65ProtocolHandler _handler;
+        private ISession _session = null!;
+        private IMessageSerializationService _svc = null!;
+        private ISyncServer _syncManager = null!;
+        private ITxPool _transactionPool = null!;
+        private IPooledTxsRequestor _pooledTxsRequestor = null!;
+        private ISpecProvider _specProvider = null!;
+        private Block _genesisBlock = null!;
+        private Eth65ProtocolHandler _handler = null!;
+        private ITxGossipPolicy _txGossipPolicy = null!;
 
         [SetUp]
         public void Setup()
@@ -57,6 +61,9 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V65
             _syncManager.Head.Returns(_genesisBlock.Header);
             _syncManager.Genesis.Returns(_genesisBlock.Header);
             ITimerFactory timerFactory = Substitute.For<ITimerFactory>();
+            _txGossipPolicy = Substitute.For<ITxGossipPolicy>();
+            _txGossipPolicy.CanGossipTransactions.Returns(true);
+            _txGossipPolicy.ShouldGossipTransaction(Arg.Any<Transaction>()).Returns(true);
             _handler = new Eth65ProtocolHandler(
                 _session,
                 _svc,
@@ -66,7 +73,8 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V65
                 _pooledTxsRequestor,
                 Policy.FullGossip,
                 new ForkInfo(_specProvider, _genesisBlock.Header.Hash!),
-                LimboLogs.Instance);
+                LimboLogs.Instance,
+                _txGossipPolicy);
             _handler.Init();
         }
 
@@ -165,6 +173,35 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V65
             GetPooledTransactionsMessage request = new(new Keccak[2048]);
             PooledTransactionsMessage response = _handler.FulfillPooledTransactionsRequest(request, new List<Transaction>());
             response.Transactions.Count.Should().Be(numberOfTxsInOneMsg);
+        }
+
+        [Test]
+        public void should_handle_NewPooledTransactionHashesMessage([Values(true, false)] bool canGossipTransactions)
+        {
+            _txGossipPolicy.CanGossipTransactions.Returns(canGossipTransactions);
+            NewPooledTransactionHashesMessage msg = new(new[] { TestItem.KeccakA, TestItem.KeccakB });
+            IMessageSerializationService serializationService = Build.A.SerializationService().WithEth65().TestObject;
+
+            HandleIncomingStatusMessage();
+            HandleZeroMessage(msg, Eth65MessageCode.NewPooledTransactionHashes);
+
+            _pooledTxsRequestor.Received(canGossipTransactions ? 1 : 0).RequestTransactions(Arg.Any<Action<GetPooledTransactionsMessage>>(), Arg.Any<IReadOnlyList<Keccak>>());
+        }
+
+        private void HandleZeroMessage<T>(T msg, int messageCode) where T : MessageBase
+        {
+            IByteBuffer getBlockHeadersPacket = _svc.ZeroSerialize(msg);
+            getBlockHeadersPacket.ReadByte();
+            _handler.HandleMessage(new ZeroPacket(getBlockHeadersPacket) { PacketType = (byte)messageCode });
+        }
+
+        private void HandleIncomingStatusMessage()
+        {
+            var statusMsg = new StatusMessage { GenesisHash = _genesisBlock.Hash, BestHash = _genesisBlock.Hash };
+
+            IByteBuffer statusPacket = _svc.ZeroSerialize(statusMsg);
+            statusPacket.ReadByte();
+            _handler.HandleMessage(new ZeroPacket(statusPacket) { PacketType = 0 });
         }
     }
 }

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandlerTests.cs
@@ -46,15 +46,15 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V66
     [TestFixture, Parallelizable(ParallelScope.Self)]
     public class Eth66ProtocolHandlerTests
     {
-        private ISession _session;
-        private IMessageSerializationService _svc;
-        private ISyncServer _syncManager;
-        private ITxPool _transactionPool;
-        private IPooledTxsRequestor _pooledTxsRequestor;
-        private IGossipPolicy _gossipPolicy;
-        private ISpecProvider _specProvider;
-        private Block _genesisBlock;
-        private Eth66ProtocolHandler _handler;
+        private ISession _session = null!;
+        private IMessageSerializationService _svc = null!;
+        private ISyncServer _syncManager = null!;
+        private ITxPool _transactionPool = null!;
+        private IPooledTxsRequestor _pooledTxsRequestor = null!;
+        private IGossipPolicy _gossipPolicy = null!;
+        private ISpecProvider _specProvider = null!;
+        private Block _genesisBlock = null!;
+        private Eth66ProtocolHandler _handler = null!;
 
         [SetUp]
         public void Setup()

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V67/Eth67ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V67/Eth67ProtocolHandlerTests.cs
@@ -33,15 +33,15 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V67;
 [TestFixture, Parallelizable(ParallelScope.Self)]
 public class Eth67ProtocolHandlerTests
 {
-    private ISession _session;
-    private IMessageSerializationService _svc;
-    private ISyncServer _syncManager;
-    private ITxPool _transactionPool;
-    private IPooledTxsRequestor _pooledTxsRequestor;
-    private IGossipPolicy _gossipPolicy;
-    private ISpecProvider _specProvider;
-    private Block _genesisBlock;
-    private Eth66ProtocolHandler _handler;
+    private ISession _session = null!;
+    private IMessageSerializationService _svc = null!;
+    private ISyncServer _syncManager = null!;
+    private ITxPool _transactionPool = null!;
+    private IPooledTxsRequestor _pooledTxsRequestor = null!;
+    private IGossipPolicy _gossipPolicy = null!;
+    private ISpecProvider _specProvider = null!;
+    private Block _genesisBlock = null!;
+    private Eth66ProtocolHandler _handler = null!;
 
     [SetUp]
     public void Setup()

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandlerTests.cs
@@ -35,15 +35,16 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V68;
 
 public class Eth68ProtocolHandlerTests
 {
-    private ISession _session;
-    private IMessageSerializationService _svc;
-    private ISyncServer _syncManager;
-    private ITxPool _transactionPool;
-    private IPooledTxsRequestor _pooledTxsRequestor;
-    private IGossipPolicy _gossipPolicy;
-    private ISpecProvider _specProvider;
-    private Block _genesisBlock;
-    private Eth68ProtocolHandler _handler;
+    private ISession _session = null!;
+    private IMessageSerializationService _svc = null!;
+    private ISyncServer _syncManager = null!;
+    private ITxPool _transactionPool = null!;
+    private IPooledTxsRequestor _pooledTxsRequestor = null!;
+    private IGossipPolicy _gossipPolicy = null!;
+    private ISpecProvider _specProvider = null!;
+    private Block _genesisBlock = null!;
+    private Eth68ProtocolHandler _handler = null!;
+    private ITxGossipPolicy _txGossipPolicy = null!;
 
     [SetUp]
     public void Setup()
@@ -64,6 +65,9 @@ public class Eth68ProtocolHandlerTests
         _syncManager.Head.Returns(_genesisBlock.Header);
         _syncManager.Genesis.Returns(_genesisBlock.Header);
         ITimerFactory timerFactory = Substitute.For<ITimerFactory>();
+        _txGossipPolicy = Substitute.For<ITxGossipPolicy>();
+        _txGossipPolicy.CanGossipTransactions.Returns(true);
+        _txGossipPolicy.ShouldGossipTransaction(Arg.Any<Transaction>()).Returns(true);
         _handler = new Eth68ProtocolHandler(
             _session,
             _svc,
@@ -72,8 +76,9 @@ public class Eth68ProtocolHandlerTests
             _transactionPool,
             _pooledTxsRequestor,
             _gossipPolicy,
-            new ForkInfo(_specProvider, _genesisBlock.Header.Hash),
-            LimboLogs.Instance);
+            new ForkInfo(_specProvider, _genesisBlock.Header.Hash!),
+            LimboLogs.Instance,
+            _txGossipPolicy);
         _handler.Init();
     }
 
@@ -96,19 +101,18 @@ public class Eth68ProtocolHandlerTests
         _handler.HeadNumber.Should().Be(0);
     }
 
-    [TestCase(0)]
-    [TestCase(1)]
-    [TestCase(2)]
-    [TestCase(100)]
-    public void Can_handle_NewPooledTransactions_message(int txCount)
+    [Test]
+    public void Can_handle_NewPooledTransactions_message([Values(0, 1, 2, 100)] int txCount, [Values(true, false)] bool canGossipTransactions)
     {
+        _txGossipPolicy.CanGossipTransactions.Returns(canGossipTransactions);
+
         GenerateLists(txCount, out List<byte> types, out List<int> sizes, out List<Keccak> hashes);
 
         var msg = new NewPooledTransactionHashesMessage68(types, sizes, hashes);
 
         HandleIncomingStatusMessage();
         HandleZeroMessage(msg, Eth68MessageCode.NewPooledTransactionHashes);
-        _pooledTxsRequestor.Received().RequestTransactionsEth66(Arg.Any<Action<GetPooledTransactionsMessage>>(),
+        _pooledTxsRequestor.Received(canGossipTransactions ? 1 : 0).RequestTransactionsEth66(Arg.Any<Action<GetPooledTransactionsMessage>>(),
             Arg.Any<IReadOnlyList<Keccak>>());
     }
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandler.cs
@@ -20,7 +20,9 @@ using Nethermind.Network.Rlpx;
 using Nethermind.Stats;
 using Nethermind.Stats.Model;
 using Nethermind.Synchronization;
+using Nethermind.Synchronization.ParallelSync;
 using Nethermind.TxPool;
+using ShouldGossip = Nethermind.Consensus.ShouldGossip;
 
 namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
 {
@@ -30,20 +32,23 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
         private readonly TxFloodController _floodController;
         protected readonly ITxPool _txPool;
         private readonly IGossipPolicy _gossipPolicy;
+        private readonly ITxGossipPolicy _txGossipPolicy;
         private readonly LruKeyCache<Keccak> _lastBlockNotificationCache = new(10, "LastBlockNotificationCache");
 
-        public Eth62ProtocolHandler(
-            ISession session,
+        public Eth62ProtocolHandler(ISession session,
             IMessageSerializationService serializer,
             INodeStatsManager statsManager,
             ISyncServer syncServer,
             ITxPool txPool,
             IGossipPolicy gossipPolicy,
-            ILogManager logManager) : base(session, serializer, statsManager, syncServer, logManager)
+            ILogManager logManager,
+            ITxGossipPolicy? transactionsGossipPolicy = null)
+            : base(session, serializer, statsManager, syncServer, logManager)
         {
             _floodController = new TxFloodController(this, Timestamper.Default, Logger);
             _txPool = txPool ?? throw new ArgumentNullException(nameof(txPool));
             _gossipPolicy = gossipPolicy ?? throw new ArgumentNullException(nameof(gossipPolicy));
+            _txGossipPolicy = transactionsGossipPolicy ?? TxPool.ShouldGossip.Instance;
 
             EnsureGossipPolicy();
         }
@@ -58,6 +63,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
         public override int MessageIdSpaceSize => 8;
         public override string Name => "eth62";
         protected override TimeSpan InitTimeout => Timeouts.Eth62Status;
+        protected bool CanReceiveTransactions => _txGossipPolicy.CanGossipTransactions;
 
         public override event EventHandler<ProtocolInitializedEventArgs>? ProtocolInitialized;
 
@@ -153,17 +159,26 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
                     break;
                 case Eth62MessageCode.Transactions:
                     Metrics.Eth62TransactionsReceived++;
-                    if (_floodController.IsAllowed())
+                    if (CanReceiveTransactions)
                     {
-                        TransactionsMessage txMsg = Deserialize<TransactionsMessage>(message.Content);
-                        ReportIn(txMsg, size);
-                        Handle(txMsg);
+                        if (_floodController.IsAllowed())
+                        {
+                            TransactionsMessage txMsg = Deserialize<TransactionsMessage>(message.Content);
+                            ReportIn(txMsg, size);
+                            Handle(txMsg);
+                        }
+                        else
+                        {
+                            const string txFlooding = $"Ignoring {nameof(TransactionsMessage)} because of message flooding.";
+                            ReportIn(txFlooding, size);
+                        }
                     }
                     else
                     {
-                        const string txFlooding = $"Ignoring {nameof(TransactionsMessage)} because of message flooding.";
-                        ReportIn(txFlooding, size);
+                        const string ignored = $"{nameof(TransactionsMessage)} ignored, syncing";
+                        ReportIn(ignored, size);
                     }
+
                     break;
                 case Eth62MessageCode.GetBlockHeaders:
                     GetBlockHeadersMessage getBlockHeadersMessage

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V63/Eth63ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V63/Eth63ProtocolHandler.cs
@@ -16,6 +16,7 @@ using Nethermind.Network.P2P.Subprotocols.Eth.V63.Messages;
 using Nethermind.Network.Rlpx;
 using Nethermind.Stats;
 using Nethermind.Synchronization;
+using Nethermind.Synchronization.ParallelSync;
 using Nethermind.TxPool;
 
 namespace Nethermind.Network.P2P.Subprotocols.Eth.V63
@@ -32,7 +33,9 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V63
             ISyncServer syncServer,
             ITxPool txPool,
             IGossipPolicy gossipPolicy,
-            ILogManager logManager) : base(session, serializer, nodeStatsManager, syncServer, txPool, gossipPolicy, logManager)
+            ILogManager logManager,
+            ITxGossipPolicy? transactionsGossipPolicy = null)
+            : base(session, serializer, nodeStatsManager, syncServer, txPool, gossipPolicy, logManager, transactionsGossipPolicy)
         {
             _nodeDataRequests = new MessageQueue<GetNodeDataMessage, byte[][]>(Send);
             _receiptsRequests = new MessageQueue<GetReceiptsMessage, TxReceipt[][]>(Send);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V64/Eth64ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V64/Eth64ProtocolHandler.cs
@@ -11,6 +11,7 @@ using Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages;
 using Nethermind.Network.P2P.Subprotocols.Eth.V63;
 using Nethermind.Stats;
 using Nethermind.Synchronization;
+using Nethermind.Synchronization.ParallelSync;
 using Nethermind.TxPool;
 
 namespace Nethermind.Network.P2P.Subprotocols.Eth.V64
@@ -29,7 +30,9 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V64
             ITxPool txPool,
             IGossipPolicy gossipPolicy,
             ForkInfo forkInfo,
-            ILogManager logManager) : base(session, serializer, nodeStatsManager, syncServer, txPool, gossipPolicy, logManager)
+            ILogManager logManager,
+            ITxGossipPolicy? transactionsGossipPolicy = null)
+            : base(session, serializer, nodeStatsManager, syncServer, txPool, gossipPolicy, logManager, transactionsGossipPolicy)
         {
             _forkInfo = forkInfo ?? throw new ArgumentNullException(nameof(forkInfo));
         }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V67/Eth67ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V67/Eth67ProtocolHandler.cs
@@ -10,6 +10,7 @@ using Nethermind.Network.P2P.Subprotocols.Eth.V66;
 using Nethermind.Network.Rlpx;
 using Nethermind.Stats;
 using Nethermind.Synchronization;
+using Nethermind.Synchronization.ParallelSync;
 using Nethermind.TxPool;
 
 namespace Nethermind.Network.P2P.Subprotocols.Eth.V67;
@@ -27,8 +28,9 @@ public class Eth67ProtocolHandler : Eth66ProtocolHandler
         IPooledTxsRequestor pooledTxsRequestor,
         IGossipPolicy gossipPolicy,
         ForkInfo forkInfo,
-        ILogManager logManager)
-        : base(session, serializer, nodeStatsManager, syncServer, txPool, pooledTxsRequestor, gossipPolicy, forkInfo, logManager)
+        ILogManager logManager,
+        ITxGossipPolicy? transactionsGossipPolicy = null)
+        : base(session, serializer, nodeStatsManager, syncServer, txPool, pooledTxsRequestor, gossipPolicy, forkInfo, logManager, transactionsGossipPolicy)
     {
     }
 

--- a/src/Nethermind/Nethermind.Network/ProtocolsManager.cs
+++ b/src/Nethermind/Nethermind.Network/ProtocolsManager.cs
@@ -27,6 +27,7 @@ using Nethermind.Stats.Model;
 using Nethermind.Synchronization;
 using Nethermind.Synchronization.Peers;
 using Nethermind.TxPool;
+using ShouldGossip = Nethermind.TxPool.ShouldGossip;
 
 namespace Nethermind.Network
 {
@@ -50,11 +51,12 @@ namespace Nethermind.Network
         private readonly INetworkStorage _peerStorage;
         private readonly ForkInfo _forkInfo;
         private readonly IGossipPolicy _gossipPolicy;
+        private readonly ITxGossipPolicy _txGossipPolicy;
         private readonly ILogManager _logManager;
         private readonly ILogger _logger;
         private readonly IDictionary<string, Func<ISession, int, IProtocolHandler>> _protocolFactories;
         private readonly HashSet<Capability> _capabilities = new();
-        public event EventHandler<ProtocolInitializedEventArgs> P2PProtocolInitialized;
+        public event EventHandler<ProtocolInitializedEventArgs>? P2PProtocolInitialized;
 
         public ProtocolsManager(
             ISyncPeerPool syncPeerPool,
@@ -69,7 +71,8 @@ namespace Nethermind.Network
             INetworkStorage peerStorage,
             ForkInfo forkInfo,
             IGossipPolicy gossipPolicy,
-            ILogManager logManager)
+            ILogManager logManager,
+            ITxGossipPolicy? transactionsGossipPolicy = null)
         {
             _syncPool = syncPeerPool ?? throw new ArgumentNullException(nameof(syncPeerPool));
             _syncServer = syncServer ?? throw new ArgumentNullException(nameof(syncServer));
@@ -83,6 +86,7 @@ namespace Nethermind.Network
             _peerStorage = peerStorage ?? throw new ArgumentNullException(nameof(peerStorage));
             _forkInfo = forkInfo ?? throw new ArgumentNullException(nameof(forkInfo));
             _gossipPolicy = gossipPolicy ?? throw new ArgumentNullException(nameof(gossipPolicy));
+            _txGossipPolicy = transactionsGossipPolicy ?? ShouldGossip.Instance;
             _logManager = logManager ?? throw new ArgumentNullException(nameof(logManager));
             _logger = _logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
 
@@ -184,9 +188,9 @@ namespace Nethermind.Network
                 {
                     var ethHandler = version switch
                     {
-                        66 => new Eth66ProtocolHandler(session, _serializer, _stats, _syncServer, _txPool, _pooledTxsRequestor, _gossipPolicy, _forkInfo, _logManager),
-                        67 => new Eth67ProtocolHandler(session, _serializer, _stats, _syncServer, _txPool, _pooledTxsRequestor, _gossipPolicy, _forkInfo, _logManager),
-                        68 => new Eth68ProtocolHandler(session, _serializer, _stats, _syncServer, _txPool, _pooledTxsRequestor, _gossipPolicy, _forkInfo, _logManager),
+                        66 => new Eth66ProtocolHandler(session, _serializer, _stats, _syncServer, _txPool, _pooledTxsRequestor, _gossipPolicy, _forkInfo, _logManager, _txGossipPolicy),
+                        67 => new Eth67ProtocolHandler(session, _serializer, _stats, _syncServer, _txPool, _pooledTxsRequestor, _gossipPolicy, _forkInfo, _logManager, _txGossipPolicy),
+                        68 => new Eth68ProtocolHandler(session, _serializer, _stats, _syncServer, _txPool, _pooledTxsRequestor, _gossipPolicy, _forkInfo, _logManager, _txGossipPolicy),
                         _ => throw new NotSupportedException($"Eth protocol version {version} is not supported.")
                     };
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncedTxGossipPolicyTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncedTxGossipPolicyTests.cs
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Synchronization.ParallelSync;
+using NUnit.Framework;
+
+namespace Nethermind.Synchronization.Test.ParallelSync;
+
+public class SyncedTxGossipPolicyTests
+{
+    [TestCase(SyncMode.FastSync, ExpectedResult = false)]
+    [TestCase(SyncMode.SnapSync, ExpectedResult = false)]
+    [TestCase(SyncMode.StateNodes, ExpectedResult = false)]
+    [TestCase(SyncMode.FastSync | SyncMode.StateNodes, ExpectedResult = false)]
+    [TestCase(SyncMode.FastHeaders, ExpectedResult = false)]
+    [TestCase(SyncMode.BeaconHeaders, ExpectedResult = false)]
+    [TestCase(SyncMode.FastHeaders | SyncMode.BeaconHeaders | SyncMode.SnapSync, ExpectedResult = false)]
+    [TestCase(SyncMode.WaitingForBlock, ExpectedResult = true)]
+    [TestCase(SyncMode.FastBodies | SyncMode.WaitingForBlock, ExpectedResult = true)]
+    [TestCase(SyncMode.FastReceipts | SyncMode.WaitingForBlock, ExpectedResult = true)]
+    [TestCase(SyncMode.FastBodies | SyncMode.FastSync, ExpectedResult = false)]
+    [TestCase(SyncMode.Full, ExpectedResult = false)]
+    [TestCase(SyncMode.DbLoad, ExpectedResult = false)]
+    [TestCase(SyncMode.Disconnected, ExpectedResult = false)]
+    public bool can_gossip(SyncMode mode) =>
+        new SyncedTxGossipPolicy(new StaticSelector(mode)).CanGossipTransactions;
+}

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
@@ -33,7 +33,7 @@ namespace Nethermind.Synchronization.ParallelSync
     ///     - Beacon modes are allied directly.
     ///     - If no Beacon mode is applied and we have good peers on the network we apply <see cref="SyncMode.Full"/>,.
     /// </remarks>
-    public class MultiSyncModeSelector : ISyncModeSelector, IDisposable
+    public class MultiSyncModeSelector : ISyncModeSelector
     {
         /// <summary>
         /// Number of blocks before the best peer's head when we switch from fast sync to full sync

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncMode.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncMode.cs
@@ -70,5 +70,33 @@ namespace Nethermind.Synchronization.ParallelSync
     public static class SyncModeExtensions
     {
         public static bool NotSyncing(this SyncMode syncMode) => syncMode == SyncMode.WaitingForBlock || syncMode == SyncMode.Disconnected;
+
+        public static bool IsSyncingBodies(this SyncMode syncMode) =>
+            syncMode.HasFlag(SyncMode.FastHeaders) ||
+            syncMode.HasFlag(SyncMode.FastBodies) ||
+            syncMode.HasFlag(SyncMode.FastSync) ||
+            syncMode.HasFlag(SyncMode.StateNodes) ||
+            syncMode.HasFlag(SyncMode.SnapSync) ||
+            syncMode.HasFlag(SyncMode.BeaconHeaders) ||
+            syncMode.HasFlag(SyncMode.UpdatingPivot);
+
+        public static bool IsSyncingReceipts(this SyncMode syncMode) =>
+            syncMode.HasFlag(SyncMode.FastBlocks) ||
+            syncMode.HasFlag(SyncMode.FastSync) ||
+            syncMode.HasFlag(SyncMode.StateNodes) ||
+            syncMode.HasFlag(SyncMode.SnapSync) ||
+            syncMode.HasFlag(SyncMode.BeaconHeaders) ||
+            syncMode.HasFlag(SyncMode.UpdatingPivot);
+
+        public static bool IsSyncingHeaders(this SyncMode syncMode) =>
+            syncMode.HasFlag(SyncMode.FastHeaders) ||
+            syncMode.HasFlag(SyncMode.BeaconHeaders) ||
+            syncMode.HasFlag(SyncMode.UpdatingPivot);
+
+        public static bool IsSyncingState(this SyncMode syncMode) =>
+            syncMode.HasFlag(SyncMode.FastSync) ||
+            syncMode.HasFlag(SyncMode.StateNodes) ||
+            syncMode.HasFlag(SyncMode.SnapSync) ||
+            syncMode.HasFlag(SyncMode.UpdatingPivot);
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncedTxGossipPolicy.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncedTxGossipPolicy.cs
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.TxPool;
+
+namespace Nethermind.Synchronization.ParallelSync;
+
+public class SyncedTxGossipPolicy : ITxGossipPolicy
+{
+    private readonly ISyncModeSelector _syncModeSelector;
+
+    public SyncedTxGossipPolicy(ISyncModeSelector syncModeSelector)
+    {
+        _syncModeSelector = syncModeSelector;
+    }
+
+    public bool CanGossipTransactions => (_syncModeSelector.Current & SyncMode.WaitingForBlock) != 0;
+}

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -1628,6 +1628,7 @@ namespace Nethermind.TxPool.Test
                 new TxValidator(_specProvider.ChainId),
                 _logManager,
                 transactionComparerProvider.GetDefaultComparer(),
+                ShouldGossip.Instance,
                 incomingTxFilter,
                 thereIsPriorityContract);
         }

--- a/src/Nethermind/Nethermind.TxPool/ITxGossipPolicy.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxGossipPolicy.cs
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Nethermind.Core;
+
+namespace Nethermind.TxPool;
+
+public interface ITxGossipPolicy
+{
+    bool CanGossipTransactions { get; }
+    bool ShouldGossipTransaction(Transaction tx) => CanGossipTransactions;
+}
+
+public class CompositeTxGossipPolicy : ITxGossipPolicy
+{
+    public List<ITxGossipPolicy> Policies { get; } = new();
+    public bool CanGossipTransactions => Policies.All(static p => p.CanGossipTransactions);
+    public bool ShouldGossipTransaction(Transaction tx) => Policies.All(p => p.ShouldGossipTransaction(tx));
+}
+
+public class ShouldGossip : ITxGossipPolicy
+{
+    public static readonly ShouldGossip Instance = new();
+    public bool CanGossipTransactions => true;
+}

--- a/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using Nethermind.Core;
@@ -23,17 +24,7 @@ namespace Nethermind.TxPool
     {
         private readonly ITxPoolConfig _txPoolConfig;
         private readonly IChainHeadInfoProvider _headInfo;
-
-        /// <summary>
-        /// Notification threshold randomizer seed
-        /// </summary>
-        private static int _seed = Environment.TickCount;
-
-        /// <summary>
-        /// Random number generator for peer notification threshold - no need to be securely random.
-        /// </summary>
-        private static readonly ThreadLocal<Random> Random =
-            new(() => new Random(Interlocked.Increment(ref _seed)));
+        private readonly ITxGossipPolicy _txGossipPolicy;
 
         /// <summary>
         /// Timer for rebroadcasting pending own transactions.
@@ -73,10 +64,12 @@ namespace Nethermind.TxPool
             ITimerFactory timerFactory,
             ITxPoolConfig txPoolConfig,
             IChainHeadInfoProvider chainHeadInfoProvider,
-            ILogManager? logManager)
+            ILogManager? logManager,
+            ITxGossipPolicy? transactionsGossipPolicy = null)
         {
             _txPoolConfig = txPoolConfig;
             _headInfo = chainHeadInfoProvider;
+            _txGossipPolicy = transactionsGossipPolicy ?? ShouldGossip.Instance;
             _logger = logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
             _persistentTxs = new TxDistinctSortedPool(MemoryAllowance.MemPoolSize, comparer, logManager);
             _accumulatedTemporaryTxs = new ResettableList<Transaction>(512, 4);
@@ -106,7 +99,9 @@ namespace Nethermind.TxPool
         {
             NotifyPeersAboutLocalTx(tx);
             if (tx.Hash is not null)
+            {
                 _persistentTxs.TryInsert(tx.Hash, tx);
+            }
         }
 
         private void BroadcastOnce(Transaction tx)
@@ -259,19 +254,25 @@ namespace Nethermind.TxPool
 
         private void Notify(ITxPoolPeer peer, IEnumerable<Transaction> txs, bool sendFullTx)
         {
-            try
+            if (_txGossipPolicy.CanGossipTransactions)
             {
-                peer.SendNewTransactions(txs, sendFullTx);
-                if (_logger.IsTrace) _logger.Trace($"Notified {peer} about transactions.");
-            }
-            catch (Exception e)
-            {
-                if (_logger.IsError) _logger.Error($"Failed to notify {peer} about transactions.", e);
+                try
+                {
+
+                    peer.SendNewTransactions(txs.Where(t => _txGossipPolicy.ShouldGossipTransaction(t)), sendFullTx);
+                    if (_logger.IsTrace) _logger.Trace($"Notified {peer} about transactions.");
+                }
+                catch (Exception e)
+                {
+                    if (_logger.IsError) _logger.Error($"Failed to notify {peer} about transactions.", e);
+                }
             }
         }
 
         private void NotifyPeersAboutLocalTx(Transaction tx)
         {
+            if (!_txGossipPolicy.CanGossipTransactions || !_txGossipPolicy.ShouldGossipTransaction(tx)) return;
+
             if (_logger.IsDebug) _logger.Debug($"Broadcasting new local transaction {tx.Hash} to all peers");
 
             foreach ((_, ITxPoolPeer peer) in _peers)

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -65,22 +65,23 @@ namespace Nethermind.TxPool
         /// This class stores all known pending transactions that can be used for block production
         /// (by miners or validators) or simply informing other nodes about known pending transactions (broadcasting).
         /// </summary>
-        /// <param name="txStorage">Tx storage used to reject known transactions.</param>
         /// <param name="ecdsa">Used to recover sender addresses from transaction signatures.</param>
         /// <param name="chainHeadInfoProvider"></param>
         /// <param name="txPoolConfig"></param>
         /// <param name="validator"></param>
         /// <param name="logManager"></param>
         /// <param name="comparer"></param>
+        /// <param name="transactionsGossipPolicy"></param>
         /// <param name="incomingTxFilter"></param>
         /// <param name="thereIsPriorityContract"></param>
-        public TxPool(
-            IEthereumEcdsa ecdsa,
+        /// <param name="txStorage">Tx storage used to reject known transactions.</param>
+        public TxPool(IEthereumEcdsa ecdsa,
             IChainHeadInfoProvider chainHeadInfoProvider,
             ITxPoolConfig txPoolConfig,
             ITxValidator validator,
             ILogManager? logManager,
             IComparer<Transaction> comparer,
+            ITxGossipPolicy? transactionsGossipPolicy = null,
             IIncomingTxFilter? incomingTxFilter = null,
             bool thereIsPriorityContract = false)
         {
@@ -94,7 +95,7 @@ namespace Nethermind.TxPool
             AddNodeInfoEntryForTxPool();
 
             _transactions = new TxDistinctSortedPool(MemoryAllowance.MemPoolSize, comparer, logManager);
-            _broadcaster = new TxBroadcaster(comparer, TimerFactory.Default, txPoolConfig, chainHeadInfoProvider, logManager);
+            _broadcaster = new TxBroadcaster(comparer, TimerFactory.Default, txPoolConfig, chainHeadInfoProvider, logManager, transactionsGossipPolicy);
 
             _headInfo.HeadChanged += OnHeadChange;
 
@@ -154,7 +155,6 @@ namespace Nethermind.TxPool
 
         private void OnHeadChange(object? sender, BlockReplacementEventArgs e)
         {
-            // TODO: I think this is dangerous if many blocks are processed one after another
             try
             {
                 // Clear snapshot


### PR DESCRIPTION
## Changes

- Suppress warning logs when not yet synced resource is not there when calling eth_ module JSON RPC methods.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: logs

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No
