### PR TITLE
Fix/disconnect deserialize exception

### DIFF
--- a/src/Nethermind/Nethermind.Network.Test/P2P/DisconnectMessageSerializerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/DisconnectMessageSerializerTests.cs
@@ -33,6 +33,9 @@ namespace Nethermind.Network.Test.P2P
             Assert.That((DisconnectReason)deserialized.Reason, Is.EqualTo(DisconnectReason.Other), "reason");
         }
 
+        [TestCase("", DisconnectReason.DisconnectRequested)]
+        [TestCase("00", DisconnectReason.DisconnectRequested)]
+        [TestCase("10", DisconnectReason.Other)]
         [TestCase("82c104", DisconnectReason.TooManyPeers)]
         public void Can_read_other_format_message(string hex, DisconnectReason expectedReason)
         {

--- a/src/Nethermind/Nethermind.Network.Test/P2P/DisconnectMessageSerializerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/DisconnectMessageSerializerTests.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using FluentAssertions;
 using Nethermind.Core.Extensions;
 using Nethermind.Network.P2P.Messages;
 using Nethermind.Stats.Model;
@@ -32,14 +33,13 @@ namespace Nethermind.Network.Test.P2P
             Assert.That((DisconnectReason)deserialized.Reason, Is.EqualTo(DisconnectReason.Other), "reason");
         }
 
-        // does this format happen more often?
-        //        [Test]
-        //        public void Can_read_other_format_message()
-        //        {
-        //            DisconnectMessageSerializer serializer = new DisconnectMessageSerializer();
-        //            byte[] serialized = Bytes.FromHexString("0204c108");
-        //            DisconnectMessage deserialized = serializer.Deserialize(serialized);
-        //            Assert.AreEqual(DisconnectReason.Other, (DisconnectReason)deserialized.Reason, "reason");
-        //        }
+        [TestCase("82c104", DisconnectReason.TooManyPeers)]
+        public void Can_read_other_format_message(string hex, DisconnectReason expectedReason)
+        {
+            DisconnectMessageSerializer serializer = new DisconnectMessageSerializer();
+            byte[] serialized = Bytes.FromHexString(hex);
+            DisconnectMessage deserialized = serializer.Deserialize(serialized);
+            deserialized.Reason.Should().Be((int)expectedReason);
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Network.Test/Rlpx/ZeroNettyP2PHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/Rlpx/ZeroNettyP2PHandlerTests.cs
@@ -3,11 +3,16 @@
 
 using System;
 using System.Threading.Tasks;
+using DotNetty.Buffers;
 using DotNetty.Transport.Channels;
+using FluentAssertions;
 using Nethermind.Core.Exceptions;
+using Nethermind.Core.Extensions;
 using Nethermind.Logging;
 using Nethermind.Network.P2P;
 using Nethermind.Network.P2P.ProtocolHandlers;
+using Nethermind.Network.Rlpx;
+using Nethermind.Serialization.Rlp;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -38,6 +43,32 @@ public class ZeroNettyP2PHandlerTests
         handler.ExceptionCaught(channelHandlerContext, new TestInternalNethermindException());
 
         await channelHandlerContext.DidNotReceive().DisconnectAsync();
+    }
+
+    [Test]
+    public void When_not_a_snappy_encoded_data_then_pass_data_directly()
+    {
+        IChannelHandlerContext channelHandlerContext = Substitute.For<IChannelHandlerContext>();
+        channelHandlerContext.Allocator.Returns(UnpooledByteBufferAllocator.Default);
+
+        byte[] msg = Bytes.FromHexString("0x10");
+
+        ISession session = Substitute.For<ISession>();
+        session.When(s => s.ReceiveMessage(Arg.Any<ZeroPacket>()))
+            .Do(c =>
+            {
+                ZeroPacket packet = (ZeroPacket)c[0];
+                packet.Content.ReadAllBytesAsArray().Should().BeEquivalentTo(msg);
+            });
+
+        ZeroNettyP2PHandler handler = new ZeroNettyP2PHandler(session, LimboLogs.Instance);
+        handler.EnableSnappy();
+
+        IByteBuffer buff = Unpooled.Buffer(2);
+        buff.WriteBytes(msg);
+        ZeroPacket packet = new ZeroPacket(buff);
+
+        handler.ChannelRead(channelHandlerContext, packet);
     }
 
     private class TestInternalNethermindException : Exception, IInternalNethermindException

--- a/src/Nethermind/Nethermind.Network/P2P/Messages/DisconnectMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Messages/DisconnectMessageSerializer.cs
@@ -36,6 +36,12 @@ namespace Nethermind.Network.P2P.Messages
                 return new DisconnectMessage((DisconnectReason)msgBytes.GetByte(0));
             }
 
+            if (msgBytes.ReadableBytes == 0)
+            {
+                // Sometimes 0x00 was sent, uncompressed, which interpreted as empty buffer by snappy.
+                return new DisconnectMessage(DisconnectReason.DisconnectRequested);
+            }
+
             Span<byte> msg = msgBytes.ReadAllBytesAsSpan();
             Rlp.ValueDecoderContext rlpStream = msg.AsRlpValueContext();
             if (!rlpStream.IsSequenceNext())

--- a/src/Nethermind/Nethermind.Network/P2P/Messages/DisconnectMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Messages/DisconnectMessageSerializer.cs
@@ -29,9 +29,6 @@ namespace Nethermind.Network.P2P.Messages
         }
 
 
-        private byte[] breach1 = Bytes.FromHexString("0204c104");
-        private byte[] breach2 = Bytes.FromHexString("0204c180");
-
         public DisconnectMessage Deserialize(IByteBuffer msgBytes)
         {
             if (msgBytes.ReadableBytes == 1)
@@ -40,13 +37,12 @@ namespace Nethermind.Network.P2P.Messages
             }
 
             Span<byte> msg = msgBytes.ReadAllBytesAsSpan();
-            if (msg.SequenceEqual(breach1)
-                || msg.SequenceEqual(breach2))
+            Rlp.ValueDecoderContext rlpStream = msg.AsRlpValueContext();
+            if (!rlpStream.IsSequenceNext())
             {
-                return new DisconnectMessage(DisconnectReason.Other);
+                rlpStream = new Rlp.ValueDecoderContext(rlpStream.DecodeByteArraySpan());
             }
 
-            Rlp.ValueDecoderContext rlpStream = msg.AsRlpValueContext();
             rlpStream.ReadSequenceLength();
             int reason = rlpStream.DecodeInt();
             DisconnectMessage disconnectMessage = new DisconnectMessage(reason);

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroNettyP2PHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroNettyP2PHandler.cs
@@ -65,7 +65,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
                 try
                 {
                     int length = SnappyCodec.Uncompress(content.Array, content.ArrayOffset + content.ReaderIndex,
-                        content.ReadableBytes, output.Array, output.ArrayOffset);
+                        content.ReadableBytes, output.Array, output.ArrayOffset + output.WriterIndex);
                     output.SetWriterIndex(output.WriterIndex + length);
                 }
                 catch (InvalidDataException)


### PR DESCRIPTION
- Fix deserialize exception on disconnect message and invalid data exception, also on disconnect message it turns out.
- Should not do much in terms of peer discovery, but helps cleanup metrics as they should be marked correctly now.

## Changes

- Add path to account for strange encoding.
- Pass uncompressed data directly.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- No more such exception so far.
