### PR TITLE
Skip alloc for zero sstore

### DIFF
--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -2662,8 +2662,7 @@ ReturnFailure:
 
         if (!newSameAsCurrent)
         {
-            Span<byte> valueToStore = newIsZero ? BytesZero : bytes;
-            _state.Set(in storageCell, valueToStore.ToArray());
+            _state.Set(in storageCell, newIsZero ? BytesZero : bytes.ToArray());
         }
 
         if (typeof(TTracingInstructions) == typeof(IsTracing))


### PR DESCRIPTION
## Changes

- Skip `.ToArray` for zeros as already have the array

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No
