### PR TITLE
Decrease pivot logs frequency to once per 10s instead of per 1s

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/PivotUpdator.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/PivotUpdator.cs
@@ -217,7 +217,7 @@ public class PivotUpdator
             }
         }
 
-        if (_logger.IsInfo) _logger.Info($"Potential new pivot block hash: {finalizedBlockHash}. Waiting for pivot block header. {_attemptsLeft} attempts left");
+        if (_logger.IsInfo && _attemptsLeft % 10 == 0) _logger.Info($"Potential new pivot block hash: {finalizedBlockHash}. Waiting for pivot block header. {_attemptsLeft} attempts left");
         return null;
     }
 


### PR DESCRIPTION
## Changes

- decrease frequency of log `Potential new pivot block hash: {finalizedBlockHash}. Waiting for pivot block header. {_attemptsLeft} attempts left` to once per 10s instead of once per 1s

Other pivot-related log (`Waiting for Forkchoice message from Consensus Layer to set fresh pivot block. {_attemptsLeft} attempts left`) is already set to once per 10s. `Potential new pivot` is appearing for longer period of time only when there is a problem with peering, like recently on goerli network and in such scenario logs are a bit obfuscated. It's not really needed every second, so this PR is decreasing frequency

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No
