### PR TITLE
Decrease `MaxSizeOfTxForBroadcast` from 128KB to 4KB

### DIFF
--- a/src/Nethermind/Nethermind.TxPool.Test/TxBroadcasterTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxBroadcasterTests.cs
@@ -451,7 +451,9 @@ public class TxBroadcasterTests
     }
 
     [TestCase(1_000, true)]
-    [TestCase(128 * 1024, true)]
+    [TestCase(4 * 1024, true)]
+    [TestCase(4 * 1024 + 1, false)]
+    [TestCase(128 * 1024, false)]
     [TestCase(128 * 1024 + 1, false)]
     [TestCase(1_000_000, false)]
     public void should_broadcast_full_local_tx_up_to_max_size_and_only_announce_if_larger(int txSize, bool shouldBroadcastFullTx)

--- a/src/Nethermind/Nethermind.TxPool/TransactionExtensions.cs
+++ b/src/Nethermind/Nethermind.TxPool/TransactionExtensions.cs
@@ -13,7 +13,7 @@ namespace Nethermind.TxPool
 {
     public static class TransactionExtensions
     {
-        private static readonly long MaxSizeOfTxForBroadcast = 128.KiB(); //128KB, as proposed in https://eips.ethereum.org/EIPS/eip-5793
+        private static readonly long MaxSizeOfTxForBroadcast = 4.KiB(); //4KB, as in Geth https://github.com/ethereum/go-ethereum/pull/27618
         private static readonly ITransactionSizeCalculator _transactionSizeCalculator = new TxDecoder();
 
         public static int GetLength(this Transaction tx)


### PR DESCRIPTION
## Changes

**This PR is changing `MaxSizeOfTxForBroadcast` from 128KB (as initially proposed here https://eips.ethereum.org/EIPS/eip-5793#motivation) to 4KB (as recently changed in Geth https://github.com/ethereum/go-ethereum/pull/27618)**

### Nethermind approach for broadcasting/announcing transactions:

#### 1) Transactions from network
- after adding tx to TxPool, tx hash is collected
- every 1s we are sending tx hashes collected in last 1s to all peers (announcing transactions)

#### 2) Transactions from RPC endpoint (local transactions)
#### 2a) blob-type txs or txs larger than `MaxSizeOfTxForBroadcast`
- announcing (sending tx hash) to all peers just after adding it to the TxPool or to persistentTxs pool
- after processing of every block (so on mainnet every ~12s) reannouncing top 5% of local txs, after ensuring that `MaxFeePerGas >= current basefee`
#### 2b) other txs (not blob-type or smaller than `MaxSizeOfTxForBroadcast`)
- broadcasting (sending full tx) to all peers just after adding it to the TxPool or to persistentTxs pool
- after processing of every block (so on mainnet every ~12s) rebroadcasting top 5% of local txs, after ensuring that `MaxFeePerGas >= current basefee`

We are already not broadcasting network transactions at all (not sending as full txs - only announcing, so sending hashes), which I believe in Geth is main reason of this change. Adjusting value of `MaxSizeOfTxForBroadcast` will have an impact only on transactions from RPC endpoint with sizes between 4KB and 128KB - before changes it is broadcasted (send as ful tx), after this PR it will be only announced (sent as tx hashes). Anyway it is good to change to avoid potential issues with broadcasting larger transactions than expected by peers.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: adjust configurable value - so a bit bugfix, a bit refactoring, a bit optimization

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes - adjusted existing one
- [ ] No

Additionally, I checked devp2p hive tests - there is no regression 🟢 

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No