### PR TITLE
Refactor `IWithdrawalContract`

### DIFF
--- a/src/Nethermind/Nethermind.Merge.AuRa.Test/AuraWithdrawalProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa.Test/AuraWithdrawalProcessorTests.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Builders;
-using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.Merge.AuRa.Contracts;
 using Nethermind.Merge.AuRa.Withdrawals;
@@ -46,7 +45,6 @@ public class AuraWithdrawalProcessorTests
         Address[] addresses = Array.Empty<Address>();
         contract.ExecuteWithdrawals(
             block.Header,
-            4,
             Arg.Do<IList<ulong>>(a => values = a.ToArray()),
             Arg.Do<IList<Address>>(a => addresses = a.ToArray()));
 
@@ -56,7 +54,6 @@ public class AuraWithdrawalProcessorTests
             .Received(1)
             .ExecuteWithdrawals(
                 Arg.Is(block.Header),
-                Arg.Is<UInt256>(4),
                 Arg.Is<IList<ulong>>(a => values.SequenceEqual(new[] { 1_000_000UL, 2_000_000UL })),
                 Arg.Is<IList<Address>>(a => addresses.SequenceEqual(new[] { Address.SystemUser, Address.Zero })));
     }
@@ -78,7 +75,6 @@ public class AuraWithdrawalProcessorTests
             .Received(0)
             .ExecuteWithdrawals(
                 Arg.Any<BlockHeader>(),
-                Arg.Any<UInt256>(),
                 Arg.Any<ulong[]>(),
                 Arg.Any<Address[]>());
     }

--- a/src/Nethermind/Nethermind.Merge.AuRa/Contracts/IWithdrawalContract.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa/Contracts/IWithdrawalContract.cs
@@ -3,11 +3,10 @@
 
 using System.Collections.Generic;
 using Nethermind.Core;
-using Nethermind.Int256;
 
 namespace Nethermind.Merge.AuRa.Contracts;
 
 public interface IWithdrawalContract
 {
-    void ExecuteWithdrawals(BlockHeader blockHeader, UInt256 failedMaxCount, IList<ulong> amounts, IList<Address> addresses);
+    void ExecuteWithdrawals(BlockHeader blockHeader, IList<ulong> amounts, IList<Address> addresses);
 }

--- a/src/Nethermind/Nethermind.Merge.AuRa/Contracts/WithdrawalContract.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa/Contracts/WithdrawalContract.cs
@@ -26,12 +26,12 @@ public class WithdrawalContract : CallableContract, IWithdrawalContract
         Address contractAddress)
         : base(transactionProcessor, abiEncoder, contractAddress) { }
 
-    public void ExecuteWithdrawals(BlockHeader blockHeader, UInt256 failedMaxCount, IList<ulong> amounts, IList<Address> addresses)
+    public void ExecuteWithdrawals(BlockHeader blockHeader, IList<ulong> amounts, IList<Address> addresses)
     {
         ArgumentNullException.ThrowIfNull(blockHeader);
         ArgumentNullException.ThrowIfNull(amounts);
         ArgumentNullException.ThrowIfNull(addresses);
 
-        Call(blockHeader, "executeSystemWithdrawals", Address.SystemUser, GasLimit, failedMaxCount, amounts, addresses);
+        Call(blockHeader, "executeSystemWithdrawals", Address.SystemUser, GasLimit, UInt256.Zero, amounts, addresses);
     }
 }

--- a/src/Nethermind/Nethermind.Merge.AuRa/Withdrawals/AuraWithdrawalProcessor.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa/Withdrawals/AuraWithdrawalProcessor.cs
@@ -9,7 +9,6 @@ using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Specs;
 using Nethermind.Evm;
-using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.Merge.AuRa.Contracts;
 
@@ -18,7 +17,6 @@ namespace Nethermind.Merge.AuRa.Withdrawals;
 public class AuraWithdrawalProcessor : IWithdrawalProcessor
 {
     private readonly IWithdrawalContract _contract;
-    private readonly UInt256 _failedWithdrawalsMaxCount = 4;
     private readonly ILogger _logger;
 
     public AuraWithdrawalProcessor(IWithdrawalContract contract, ILogManager logManager)
@@ -52,7 +50,7 @@ public class AuraWithdrawalProcessor : IWithdrawalProcessor
 
         try
         {
-            _contract.ExecuteWithdrawals(block.Header, _failedWithdrawalsMaxCount, amounts, addresses);
+            _contract.ExecuteWithdrawals(block.Header, amounts, addresses);
         }
         catch (Exception ex) when (ex is ArgumentNullException || ex is EvmException)
         {


### PR DESCRIPTION
## Changes

Removed `failedMaxCount` parameter as no longer needed from the `IWithdrawalContract.ExecuteWithdrawals` method.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Testing on devnet.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
