### PR TITLE
Perf/compaction readahead

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
@@ -153,7 +153,7 @@ public class DbConfig : IDbConfig
     public int? StateDbBlockSize { get; set; } = 4 * 1024;
     public bool? StateDbUseDirectReads { get; set; } = false;
     public bool? StateDbUseDirectIoForFlushAndCompactions { get; set; } = false;
-    public ulong? StateDbCompactionReadAhead { get; set; } = (ulong) 32.KiB();
+    public ulong? StateDbCompactionReadAhead { get; set; } = (ulong)32.KiB();
     public bool? StateDbDisableCompression { get; set; } = false;
     public IDictionary<string, string>? StateDbAdditionalRocksDbOptions { get; set; }
 

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
@@ -153,7 +153,7 @@ public class DbConfig : IDbConfig
     public int? StateDbBlockSize { get; set; } = 4 * 1024;
     public bool? StateDbUseDirectReads { get; set; } = false;
     public bool? StateDbUseDirectIoForFlushAndCompactions { get; set; } = false;
-    public ulong? StateDbCompactionReadAhead { get; set; } = (ulong)32.KiB();
+    public ulong? StateDbCompactionReadAhead { get; set; }
     public bool? StateDbDisableCompression { get; set; } = false;
     public IDictionary<string, string>? StateDbAdditionalRocksDbOptions { get; set; }
 

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
@@ -19,12 +19,12 @@ public class DbConfig : IDbConfig
     public bool CacheIndexAndFilterBlocks { get; set; } = false;
     public int? MaxOpenFiles { get; set; }
     public long? MaxBytesPerSec { get; set; }
-    public long? MaxWriteBytesPerSec { get; set; }
     public int? BlockSize { get; set; } = 16 * 1024;
     public ulong? ReadAheadSize { get; set; } = (ulong)256.KiB();
     public bool? UseDirectReads { get; set; } = false;
     public bool? UseDirectIoForFlushAndCompactions { get; set; } = false;
     public bool? DisableCompression { get; set; } = false;
+    public ulong? CompactionReadAhead { get; set; }
     public IDictionary<string, string>? AdditionalRocksDbOptions { get; set; }
 
     public ulong ReceiptsDbWriteBufferSize { get; set; } = (ulong)8.MiB();
@@ -32,11 +32,11 @@ public class DbConfig : IDbConfig
     public ulong ReceiptsDbBlockCacheSize { get; set; } = 0;
     public bool ReceiptsDbCacheIndexAndFilterBlocks { get; set; } = false;
     public int? ReceiptsDbMaxOpenFiles { get; set; }
-    public long? ReceiptsDbMaxWriteBytesPerSec { get; set; }
     public long? ReceiptsDbMaxBytesPerSec { get; set; }
-    public int? ReceiptsBlockSize { get; set; }
-    public bool? ReceiptsUseDirectReads { get; set; } = false;
-    public bool? ReceiptsUseDirectIoForFlushAndCompactions { get; set; } = false;
+    public int? ReceiptsDbBlockSize { get; set; }
+    public bool? ReceiptsDbUseDirectReads { get; set; }
+    public bool? ReceiptsDbUseDirectIoForFlushAndCompactions { get; set; }
+    public ulong? ReceiptsDbCompactionReadAhead { get; set; }
     public IDictionary<string, string>? ReceiptsDbAdditionalRocksDbOptions { get; set; }
 
     public ulong BlocksDbWriteBufferSize { get; set; } = (ulong)8.MiB();
@@ -44,11 +44,11 @@ public class DbConfig : IDbConfig
     public ulong BlocksDbBlockCacheSize { get; set; } = 0;
     public bool BlocksDbCacheIndexAndFilterBlocks { get; set; } = false;
     public int? BlocksDbMaxOpenFiles { get; set; }
-    public long? BlocksDbMaxWriteBytesPerSec { get; set; }
     public long? BlocksDbMaxBytesPerSec { get; set; }
     public int? BlocksBlockSize { get; set; }
-    public bool? BlocksUseDirectReads { get; set; } = false;
-    public bool? BlocksUseDirectIoForFlushAndCompactions { get; set; } = false;
+    public bool? BlocksDbUseDirectReads { get; set; }
+    public bool? BlocksDbUseDirectIoForFlushAndCompactions { get; set; }
+    public ulong? BlocksDbCompactionReadAhead { get; set; }
     public IDictionary<string, string>? BlocksDbAdditionalRocksDbOptions { get; set; }
 
     public ulong HeadersDbWriteBufferSize { get; set; } = (ulong)8.MiB();
@@ -56,11 +56,11 @@ public class DbConfig : IDbConfig
     public ulong HeadersDbBlockCacheSize { get; set; } = 0;
     public bool HeadersDbCacheIndexAndFilterBlocks { get; set; } = false;
     public int? HeadersDbMaxOpenFiles { get; set; }
-    public long? HeadersDbMaxWriteBytesPerSec { get; set; }
     public long? HeadersDbMaxBytesPerSec { get; set; }
-    public int? HeadersBlockSize { get; set; } = 4 * 1024;
-    public bool? HeadersUseDirectReads { get; set; } = false;
-    public bool? HeadersUseDirectIoForFlushAndCompactions { get; set; } = false;
+    public int? HeadersDbBlockSize { get; set; }
+    public bool? HeadersDbUseDirectReads { get; set; }
+    public bool? HeadersDbUseDirectIoForFlushAndCompactions { get; set; }
+    public ulong? HeadersDbCompactionReadAhead { get; set; }
     public IDictionary<string, string>? HeadersDbAdditionalRocksDbOptions { get; set; }
 
     public ulong BlockInfosDbWriteBufferSize { get; set; } = (ulong)8.MiB();
@@ -68,11 +68,11 @@ public class DbConfig : IDbConfig
     public ulong BlockInfosDbBlockCacheSize { get; set; } = 0;
     public bool BlockInfosDbCacheIndexAndFilterBlocks { get; set; } = false;
     public int? BlockInfosDbMaxOpenFiles { get; set; }
-    public long? BlockInfosDbMaxWriteBytesPerSec { get; set; }
     public long? BlockInfosDbMaxBytesPerSec { get; set; }
-    public int? BlockInfosBlockSize { get; set; }
-    public bool? BlockInfosUseDirectReads { get; set; } = false;
-    public bool? BlockInfosUseDirectIoForFlushAndCompactions { get; set; } = false;
+    public int? BlockInfosDbBlockSize { get; set; }
+    public bool? BlockInfosDbUseDirectReads { get; set; }
+    public bool? BlockInfosDbUseDirectIoForFlushAndCompactions { get; set; }
+    public ulong? BlockInfosDbCompactionReadAhead { get; set; }
     public IDictionary<string, string>? BlockInfosDbAdditionalRocksDbOptions { get; set; }
 
     public ulong PendingTxsDbWriteBufferSize { get; set; } = (ulong)4.MiB();
@@ -80,11 +80,11 @@ public class DbConfig : IDbConfig
     public ulong PendingTxsDbBlockCacheSize { get; set; } = 0;
     public bool PendingTxsDbCacheIndexAndFilterBlocks { get; set; } = false;
     public int? PendingTxsDbMaxOpenFiles { get; set; }
-    public long? PendingTxsDbMaxWriteBytesPerSec { get; set; }
     public long? PendingTxsDbMaxBytesPerSec { get; set; }
-    public int? PendingTxsBlockSize { get; set; }
-    public bool? PendingTxsUseDirectReads { get; set; } = false;
-    public bool? PendingTxsUseDirectIoForFlushAndCompactions { get; set; } = false;
+    public int? PendingTxsDbBlockSize { get; set; }
+    public bool? PendingTxsDbUseDirectReads { get; set; }
+    public bool? PendingTxsDbUseDirectIoForFlushAndCompactions { get; set; }
+    public ulong? PendingTxsDbCompactionReadAhead { get; set; }
     public IDictionary<string, string>? PendingTxsDbAdditionalRocksDbOptions { get; set; }
 
     public ulong CodeDbWriteBufferSize { get; set; } = (ulong)2.MiB();
@@ -92,11 +92,11 @@ public class DbConfig : IDbConfig
     public ulong CodeDbBlockCacheSize { get; set; } = 0;
     public bool CodeDbCacheIndexAndFilterBlocks { get; set; } = false;
     public int? CodeDbMaxOpenFiles { get; set; }
-    public long? CodeDbMaxWriteBytesPerSec { get; set; }
     public long? CodeDbMaxBytesPerSec { get; set; }
-    public int? CodeBlockSize { get; set; }
+    public int? CodeDbBlockSize { get; set; }
     public bool? CodeUseDirectReads { get; set; } = false;
     public bool? CodeUseDirectIoForFlushAndCompactions { get; set; } = false;
+    public ulong? CodeCompactionReadAhead { get; set; }
     public IDictionary<string, string>? CodeDbAdditionalRocksDbOptions { get; set; }
 
     public ulong BloomDbWriteBufferSize { get; set; } = (ulong)1.KiB();
@@ -104,7 +104,6 @@ public class DbConfig : IDbConfig
     public ulong BloomDbBlockCacheSize { get; set; } = 0;
     public bool BloomDbCacheIndexAndFilterBlocks { get; set; } = false;
     public int? BloomDbMaxOpenFiles { get; set; }
-    public long? BloomDbMaxWriteBytesPerSec { get; set; }
     public long? BloomDbMaxBytesPerSec { get; set; }
     public IDictionary<string, string>? BloomDbAdditionalRocksDbOptions { get; set; }
 
@@ -113,11 +112,11 @@ public class DbConfig : IDbConfig
     public ulong WitnessDbBlockCacheSize { get; set; } = 0;
     public bool WitnessDbCacheIndexAndFilterBlocks { get; set; } = false;
     public int? WitnessDbMaxOpenFiles { get; set; }
-    public long? WitnessDbMaxWriteBytesPerSec { get; set; }
     public long? WitnessDbMaxBytesPerSec { get; set; }
-    public int? WitnessBlockSize { get; set; }
+    public int? WitnessDbBlockSize { get; set; }
     public bool? WitnessUseDirectReads { get; set; } = false;
     public bool? WitnessUseDirectIoForFlushAndCompactions { get; set; } = false;
+    public ulong? WitnessCompactionReadAhead { get; set; }
     public IDictionary<string, string>? WitnessDbAdditionalRocksDbOptions { get; set; }
 
     // TODO - profile and customize
@@ -126,11 +125,11 @@ public class DbConfig : IDbConfig
     public ulong CanonicalHashTrieDbBlockCacheSize { get; set; } = 0;
     public bool CanonicalHashTrieDbCacheIndexAndFilterBlocks { get; set; } = false;
     public int? CanonicalHashTrieDbMaxOpenFiles { get; set; }
-    public long? CanonicalHashTrieDbMaxWriteBytesPerSec { get; set; }
     public long? CanonicalHashTrieDbMaxBytesPerSec { get; set; }
-    public int? CanonicalHashTrieBlockSize { get; set; }
+    public int? CanonicalHashTrieDbBlockSize { get; set; }
     public bool? CanonicalHashTrieUseDirectReads { get; set; } = false;
     public bool? CanonicalHashTrieUseDirectIoForFlushAndCompactions { get; set; } = false;
+    public ulong? CanonicalHashTrieCompactionReadAhead { get; set; }
     public IDictionary<string, string>? CanonicalHashTrieDbAdditionalRocksDbOptions { get; set; }
 
     public ulong MetadataDbWriteBufferSize { get; set; } = (ulong)1.KiB();
@@ -138,11 +137,11 @@ public class DbConfig : IDbConfig
     public ulong MetadataDbBlockCacheSize { get; set; } = 0;
     public bool MetadataDbCacheIndexAndFilterBlocks { get; set; } = false;
     public int? MetadataDbMaxOpenFiles { get; set; }
-    public long? MetadataDbMaxWriteBytesPerSec { get; set; }
     public long? MetadataDbMaxBytesPerSec { get; set; }
-    public int? MetadataBlockSize { get; set; }
+    public int? MetadataDbBlockSize { get; set; }
     public bool? MetadataUseDirectReads { get; set; } = false;
     public bool? MetadataUseDirectIoForFlushAndCompactions { get; set; } = false;
+    public ulong? MetadataCompactionReadAhead { get; set; }
     public IDictionary<string, string>? MetadataDbAdditionalRocksDbOptions { get; set; }
 
     public ulong StateDbWriteBufferSize { get; set; }
@@ -150,11 +149,11 @@ public class DbConfig : IDbConfig
     public ulong StateDbBlockCacheSize { get; set; }
     public bool StateDbCacheIndexAndFilterBlocks { get; set; }
     public int? StateDbMaxOpenFiles { get; set; }
-    public long? StateDbMaxWriteBytesPerSec { get; set; }
     public long? StateDbMaxBytesPerSec { get; set; }
     public int? StateDbBlockSize { get; set; } = 4 * 1024;
     public bool? StateDbUseDirectReads { get; set; } = false;
     public bool? StateDbUseDirectIoForFlushAndCompactions { get; set; } = false;
+    public ulong? StateDbCompactionReadAhead { get; set; } = (ulong) 32.KiB();
     public bool? StateDbDisableCompression { get; set; } = false;
     public IDictionary<string, string>? StateDbAdditionalRocksDbOptions { get; set; }
 

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/IDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/IDbConfig.cs
@@ -25,6 +25,7 @@ public interface IDbConfig : IConfig
     bool? UseDirectReads { get; set; }
     bool? UseDirectIoForFlushAndCompactions { get; set; }
     bool? DisableCompression { get; set; }
+    ulong? CompactionReadAhead { get; set; }
     IDictionary<string, string>? AdditionalRocksDbOptions { get; set; }
 
     ulong ReceiptsDbWriteBufferSize { get; set; }
@@ -33,9 +34,10 @@ public interface IDbConfig : IConfig
     bool ReceiptsDbCacheIndexAndFilterBlocks { get; set; }
     int? ReceiptsDbMaxOpenFiles { get; set; }
     long? ReceiptsDbMaxBytesPerSec { get; set; }
-    int? ReceiptsBlockSize { get; set; }
-    bool? ReceiptsUseDirectReads { get; set; }
-    bool? ReceiptsUseDirectIoForFlushAndCompactions { get; set; }
+    int? ReceiptsDbBlockSize { get; set; }
+    bool? ReceiptsDbUseDirectReads { get; set; }
+    bool? ReceiptsDbUseDirectIoForFlushAndCompactions { get; set; }
+    ulong? ReceiptsDbCompactionReadAhead { get; set; }
     IDictionary<string, string>? ReceiptsDbAdditionalRocksDbOptions { get; set; }
 
     ulong BlocksDbWriteBufferSize { get; set; }
@@ -45,8 +47,9 @@ public interface IDbConfig : IConfig
     int? BlocksDbMaxOpenFiles { get; set; }
     long? BlocksDbMaxBytesPerSec { get; set; }
     int? BlocksBlockSize { get; set; }
-    bool? BlocksUseDirectReads { get; set; }
-    bool? BlocksUseDirectIoForFlushAndCompactions { get; set; }
+    bool? BlocksDbUseDirectReads { get; set; }
+    bool? BlocksDbUseDirectIoForFlushAndCompactions { get; set; }
+    ulong? BlocksDbCompactionReadAhead { get; set; }
     IDictionary<string, string>? BlocksDbAdditionalRocksDbOptions { get; set; }
 
     ulong HeadersDbWriteBufferSize { get; set; }
@@ -55,9 +58,10 @@ public interface IDbConfig : IConfig
     bool HeadersDbCacheIndexAndFilterBlocks { get; set; }
     int? HeadersDbMaxOpenFiles { get; set; }
     long? HeadersDbMaxBytesPerSec { get; set; }
-    int? HeadersBlockSize { get; set; }
-    bool? HeadersUseDirectReads { get; set; }
-    bool? HeadersUseDirectIoForFlushAndCompactions { get; set; }
+    int? HeadersDbBlockSize { get; set; }
+    bool? HeadersDbUseDirectReads { get; set; }
+    bool? HeadersDbUseDirectIoForFlushAndCompactions { get; set; }
+    ulong? HeadersDbCompactionReadAhead { get; set; }
     IDictionary<string, string>? HeadersDbAdditionalRocksDbOptions { get; set; }
 
     ulong BlockInfosDbWriteBufferSize { get; set; }
@@ -66,9 +70,10 @@ public interface IDbConfig : IConfig
     bool BlockInfosDbCacheIndexAndFilterBlocks { get; set; }
     int? BlockInfosDbMaxOpenFiles { get; set; }
     long? BlockInfosDbMaxBytesPerSec { get; set; }
-    int? BlockInfosBlockSize { get; set; }
-    bool? BlockInfosUseDirectReads { get; set; }
-    bool? BlockInfosUseDirectIoForFlushAndCompactions { get; set; }
+    int? BlockInfosDbBlockSize { get; set; }
+    bool? BlockInfosDbUseDirectReads { get; set; }
+    bool? BlockInfosDbUseDirectIoForFlushAndCompactions { get; set; }
+    ulong? BlockInfosDbCompactionReadAhead { get; set; }
     IDictionary<string, string>? BlockInfosDbAdditionalRocksDbOptions { get; set; }
 
     ulong PendingTxsDbWriteBufferSize { get; set; }
@@ -77,9 +82,10 @@ public interface IDbConfig : IConfig
     bool PendingTxsDbCacheIndexAndFilterBlocks { get; set; }
     int? PendingTxsDbMaxOpenFiles { get; set; }
     long? PendingTxsDbMaxBytesPerSec { get; set; }
-    int? PendingTxsBlockSize { get; set; }
-    bool? PendingTxsUseDirectReads { get; set; }
-    bool? PendingTxsUseDirectIoForFlushAndCompactions { get; set; }
+    int? PendingTxsDbBlockSize { get; set; }
+    bool? PendingTxsDbUseDirectReads { get; set; }
+    bool? PendingTxsDbUseDirectIoForFlushAndCompactions { get; set; }
+    ulong? PendingTxsDbCompactionReadAhead { get; set; }
     IDictionary<string, string>? PendingTxsDbAdditionalRocksDbOptions { get; set; }
 
     ulong CodeDbWriteBufferSize { get; set; }
@@ -88,9 +94,10 @@ public interface IDbConfig : IConfig
     bool CodeDbCacheIndexAndFilterBlocks { get; set; }
     int? CodeDbMaxOpenFiles { get; set; }
     long? CodeDbMaxBytesPerSec { get; set; }
-    int? CodeBlockSize { get; set; }
+    int? CodeDbBlockSize { get; set; }
     bool? CodeUseDirectReads { get; set; }
     bool? CodeUseDirectIoForFlushAndCompactions { get; set; }
+    ulong? CodeCompactionReadAhead { get; set; }
     IDictionary<string, string>? CodeDbAdditionalRocksDbOptions { get; set; }
 
     ulong BloomDbWriteBufferSize { get; set; }
@@ -107,9 +114,10 @@ public interface IDbConfig : IConfig
     bool WitnessDbCacheIndexAndFilterBlocks { get; set; }
     int? WitnessDbMaxOpenFiles { get; set; }
     long? WitnessDbMaxBytesPerSec { get; set; }
-    int? WitnessBlockSize { get; set; }
+    int? WitnessDbBlockSize { get; set; }
     bool? WitnessUseDirectReads { get; set; }
     bool? WitnessUseDirectIoForFlushAndCompactions { get; set; }
+    ulong? WitnessCompactionReadAhead { get; set; }
     IDictionary<string, string>? WitnessDbAdditionalRocksDbOptions { get; set; }
 
     ulong CanonicalHashTrieDbWriteBufferSize { get; set; }
@@ -118,9 +126,10 @@ public interface IDbConfig : IConfig
     bool CanonicalHashTrieDbCacheIndexAndFilterBlocks { get; set; }
     int? CanonicalHashTrieDbMaxOpenFiles { get; set; }
     long? CanonicalHashTrieDbMaxBytesPerSec { get; set; }
-    int? CanonicalHashTrieBlockSize { get; set; }
+    int? CanonicalHashTrieDbBlockSize { get; set; }
     bool? CanonicalHashTrieUseDirectReads { get; set; }
     bool? CanonicalHashTrieUseDirectIoForFlushAndCompactions { get; set; }
+    ulong? CanonicalHashTrieCompactionReadAhead { get; set; }
     IDictionary<string, string>? CanonicalHashTrieDbAdditionalRocksDbOptions { get; set; }
 
     ulong MetadataDbWriteBufferSize { get; set; }
@@ -129,9 +138,10 @@ public interface IDbConfig : IConfig
     bool MetadataDbCacheIndexAndFilterBlocks { get; set; }
     int? MetadataDbMaxOpenFiles { get; set; }
     long? MetadataDbMaxBytesPerSec { get; set; }
-    int? MetadataBlockSize { get; set; }
+    int? MetadataDbBlockSize { get; set; }
     bool? MetadataUseDirectReads { get; set; }
     bool? MetadataUseDirectIoForFlushAndCompactions { get; set; }
+    ulong? MetadataCompactionReadAhead { get; set; }
     IDictionary<string, string>? MetadataDbAdditionalRocksDbOptions { get; set; }
 
     ulong StateDbWriteBufferSize { get; set; }
@@ -143,6 +153,7 @@ public interface IDbConfig : IConfig
     int? StateDbBlockSize { get; set; }
     bool? StateDbUseDirectReads { get; set; }
     bool? StateDbUseDirectIoForFlushAndCompactions { get; set; }
+    ulong? StateDbCompactionReadAhead { get; set; }
     bool? StateDbDisableCompression { get; set; }
     IDictionary<string, string>? StateDbAdditionalRocksDbOptions { get; set; }
 

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/PerTableDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/PerTableDbConfig.cs
@@ -40,13 +40,14 @@ public class PerTableDbConfig
     public long? MaxBytesPerSec => ReadConfig<long?>(nameof(MaxBytesPerSec));
     public uint RecycleLogFileNum => ReadConfig<uint>(nameof(RecycleLogFileNum));
     public bool WriteAheadLogSync => ReadConfig<bool>(nameof(WriteAheadLogSync));
-    public bool UseDirectReads => ReadConfig<bool>(nameof(UseDirectReads));
-    public bool UseDirectIoForFlushAndCompactions => ReadConfig<bool>(nameof(UseDirectIoForFlushAndCompactions));
+    public bool? UseDirectReads => ReadConfig<bool?>(nameof(UseDirectReads));
+    public bool? UseDirectIoForFlushAndCompactions => ReadConfig<bool?>(nameof(UseDirectIoForFlushAndCompactions));
     public int? BlockSize => ReadConfig<int?>(nameof(BlockSize));
     public ulong? ReadAheadSize => ReadConfig<ulong?>(nameof(ReadAheadSize));
     public bool EnableDbStatistics => _dbConfig.EnableDbStatistics;
     public uint StatsDumpPeriodSec => _dbConfig.StatsDumpPeriodSec;
     public bool? DisableCompression => ReadConfig<bool?>(nameof(DisableCompression));
+    public ulong? CompactionReadAhead => ReadConfig<ulong?>(nameof(CompactionReadAhead));
 
     private T? ReadConfig<T>(string propertyName)
     {

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -425,7 +425,7 @@ public class DbOnTheRocks : IDbWithSpan, ITunableDb
             _readAheadReadOptions.SetTailing(true);
         }
 
-        if (dbConfig.CompactionReadAhead != null)
+        if (dbConfig.CompactionReadAhead != null && dbConfig.CompactionReadAhead != 0)
         {
             options.SetCompactionReadaheadSize(dbConfig.CompactionReadAhead.Value);
         }

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -389,8 +389,8 @@ public class DbOnTheRocks : IDbWithSpan, ITunableDb
         options.SetRecycleLogFileNum(dbConfig
             .RecycleLogFileNum); // potential optimization for reusing allocated log files
 
-        options.SetUseDirectReads(dbConfig.UseDirectReads);
-        options.SetUseDirectIoForFlushAndCompaction(dbConfig.UseDirectIoForFlushAndCompactions);
+        options.SetUseDirectReads(dbConfig.UseDirectReads.GetValueOrDefault());
+        options.SetUseDirectIoForFlushAndCompaction(dbConfig.UseDirectIoForFlushAndCompactions.GetValueOrDefault());
 
         // VERY important to reduce stalls. Allow L0->L1 compaction to happen with multiple thread.
         _rocksDbNative.rocksdb_options_set_max_subcompactions(options.Handle, (uint)Environment.ProcessorCount);
@@ -423,6 +423,11 @@ public class DbOnTheRocks : IDbWithSpan, ITunableDb
             _readAheadReadOptions = new ReadOptions();
             _readAheadReadOptions.SetReadaheadSize(dbConfig.ReadAheadSize ?? (ulong)256.KiB());
             _readAheadReadOptions.SetTailing(true);
+        }
+
+        if (dbConfig.CompactionReadAhead != null)
+        {
+            options.SetCompactionReadaheadSize(dbConfig.CompactionReadAhead.Value);
         }
 
         if (dbConfig.DisableCompression == true)


### PR DESCRIPTION
- It seems that the 4k block size increases read iops requirement during snap sync.
- This specify a readhead size for compaction of 32kB which reduce read iops during sync by about 4x at expense of some RAM.
- Graph is before, 32K readahead, before, 16K readahead, before, 64k readahead, before.

![Screenshot from 2023-06-30 21-40-40](https://github.com/NethermindEth/nethermind/assets/1841324/2b5393df-e405-4a5f-beda-4e0cf82f3aa4)

## Changes

- Add option to specify compaction readahead.
- Specify 32kb readahead for statedb.
- Cleanup dbconfig a little.

## Types of changes

#### What types of changes does your code introduce?

- [X] Optimization
- [X] Refactoring

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

- Impact measure via collectd.

#### Requires documentation update

- [ ] Yes
- [X] No

#### Requires explanation in Release Notes

- [X] Maybe?

User impact: Reduces iops requirement during snap sync.