### PR TITLE
Fix RocksDB dependency issues on macOS x64

### DIFF
--- a/src/Nethermind/Directory.Packages.props
+++ b/src/Nethermind/Directory.Packages.props
@@ -62,7 +62,7 @@
     <PackageVersion Include="prometheus-net.AspNetCore" Version="8.0.0" />
     <PackageVersion Include="ReadLine" Version="2.0.1" />
     <PackageVersion Include="RichardSzalay.MockHttp" Version="6.0.0" />
-    <PackageVersion Include="RocksDB" Version="8.0.0.37452" />
+    <PackageVersion Include="RocksDB" Version="8.0.0.37755" />
     <PackageVersion Include="SCrypt" Version="2.0.0.2" />
     <PackageVersion Include="Seq.Api" Version="2023.1.0" />
     <PackageVersion Include="Shouldly" Version="4.1.0" />


### PR DESCRIPTION
## Changes

Since recent Nethermind versions don't work on macOS x64, this PR updates the RocksDB package that addresses dependency issues with bzip2 on that platform.
The RocksDB version has _not_ been changed.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Tested manually.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

I suggest this be included in the upcoming v1.20.0 release. And as a next step, upgrade to RocksDB v8.3.
