### PR TITLE
Fix length calculations of blob-type txs

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Encoding/ShardBlobTxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/ShardBlobTxDecoderTests.cs
@@ -33,7 +33,7 @@ public partial class ShardBlobTxDecoderTests
     [TestCaseSource(nameof(TestCaseSource))]
     public void Roundtrip_ExecutionPayloadForm_for_shard_blobs((Transaction Tx, string Description) testCase)
     {
-        RlpStream rlpStream = new RlpStream(_txDecoder.GetLength(testCase.Tx));
+        RlpStream rlpStream = new RlpStream(_txDecoder.GetLength(testCase.Tx, RlpBehaviors.None));
         _txDecoder.Encode(rlpStream, testCase.Tx);
         rlpStream.Position = 0;
         Transaction? decoded = _txDecoder.Decode(rlpStream);

--- a/src/Nethermind/Nethermind.Core/Transaction.cs
+++ b/src/Nethermind/Nethermind.Core/Transaction.cs
@@ -136,7 +136,7 @@ namespace Nethermind.Core
         /// </summary>
         public int GetLength(ITransactionSizeCalculator sizeCalculator)
         {
-            return _size ??= sizeCalculator.GetNetworkTxLength(this);
+            return _size ??= sizeCalculator.GetLength(this);
         }
 
         public string ToShortString()
@@ -201,7 +201,7 @@ namespace Nethermind.Core
     /// <remarks>Created because of cyclic dependencies between Core and Rlp modules</remarks>
     public interface ITransactionSizeCalculator
     {
-        int GetNetworkTxLength(Transaction tx);
+        int GetLength(Transaction tx);
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Core/Transaction.cs
+++ b/src/Nethermind/Nethermind.Core/Transaction.cs
@@ -136,7 +136,7 @@ namespace Nethermind.Core
         /// </summary>
         public int GetLength(ITransactionSizeCalculator sizeCalculator)
         {
-            return _size ??= sizeCalculator.GetLength(this);
+            return _size ??= sizeCalculator.GetNetworkTxLength(this);
         }
 
         public string ToShortString()
@@ -201,7 +201,7 @@ namespace Nethermind.Core
     /// <remarks>Created because of cyclic dependencies between Core and Rlp modules</remarks>
     public interface ITransactionSizeCalculator
     {
-        int GetLength(Transaction tx);
+        int GetNetworkTxLength(Transaction tx);
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandlerTests.cs
@@ -489,7 +489,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
         [TestCase(10000)]
         public void should_send_txs_with_size_exceeding_MaxPacketSize_in_more_than_one_TransactionsMessage(int txCount)
         {
-            int sizeOfOneTestTransaction = _txDecoder.GetLength(Build.A.Transaction.SignedAndResolved().TestObject);
+            int sizeOfOneTestTransaction = Build.A.Transaction.SignedAndResolved().TestObject.GetLength();
             int maxNumberOfTxsInOneMsg = TransactionsMessage.MaxPacketSize / sizeOfOneTestTransaction; // it's 1055
             int nonFullMsgTxsCount = txCount % maxNumberOfTxsInOneMsg;
             int messagesCount = txCount / maxNumberOfTxsInOneMsg + (nonFullMsgTxsCount > 0 ? 1 : 0);

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoder.cs
@@ -25,7 +25,7 @@ namespace Nethermind.Serialization.Rlp
 
         public int GetLength(Transaction tx)
         {
-            return GetLength(tx, RlpBehaviors.None);
+            return GetLength(tx, RlpBehaviors.InMempoolForm);
         }
     }
     public class SystemTxDecoder : TxDecoder<SystemTransaction> { }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoder.cs
@@ -9,7 +9,7 @@ using Nethermind.Serialization.Rlp.Eip2930;
 
 namespace Nethermind.Serialization.Rlp
 {
-    public class TxDecoder : TxDecoder<Transaction>, ITransactionSizeCalculator
+    public class TxDecoder : TxDecoder<Transaction>
     {
         public const int MaxDelayedHashTxnSize = 32768;
         public static TxDecoder Instance = new TxDecoder();
@@ -21,11 +21,6 @@ namespace Nethermind.Serialization.Rlp
 
         public TxDecoder(bool lazyHash) : base(lazyHash)
         {
-        }
-
-        public int GetNetworkTxLength(Transaction tx)
-        {
-            return GetLength(tx, RlpBehaviors.InMempoolForm);
         }
     }
     public class SystemTxDecoder : TxDecoder<SystemTransaction> { }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoder.cs
@@ -674,7 +674,7 @@ namespace Nethermind.Serialization.Rlp
                    + Rlp.LengthOf(item.BlobVersionedHashes);
         }
 
-        private int GetShardBlobNetwrokWrapperContentLength(T item, int txContentLength)
+        private int GetShardBlobNetworkWrapperContentLength(T item, int txContentLength)
         {
             ShardBlobNetworkWrapper networkWrapper = item.NetworkWrapper as ShardBlobNetworkWrapper;
             return Rlp.LengthOfSequence(txContentLength)
@@ -726,7 +726,7 @@ namespace Nethermind.Serialization.Rlp
                 switch (item.Type)
                 {
                     case TxType.Blob:
-                        contentLength = GetShardBlobNetwrokWrapperContentLength(item, contentLength);
+                        contentLength = GetShardBlobNetworkWrapperContentLength(item, contentLength);
                         break;
                 }
             }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoder.cs
@@ -23,7 +23,7 @@ namespace Nethermind.Serialization.Rlp
         {
         }
 
-        public int GetLength(Transaction tx)
+        public int GetNetworkTxLength(Transaction tx)
         {
             return GetLength(tx, RlpBehaviors.InMempoolForm);
         }

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -1593,6 +1593,22 @@ namespace Nethermind.TxPool.Test
             result.Should().Be(expectedResult ? AcceptTxResult.Accepted : AcceptTxResult.FeeTooLowToCompete);
         }
 
+        [TestCase(0, 97)]
+        [TestCase(1, 131324)]
+        [TestCase(2, 262534)]
+        [TestCase(3, 393741)]
+        [TestCase(4, 524948)]
+        [TestCase(5, 656156)]
+        [TestCase(6, 787365)]
+        public void should_calculate_size_of_blob_tx_correctly(int numberOfBlobs, int expectedLength)
+        {
+            Transaction blobTx = Build.A.Transaction
+                .WithShardBlobTxTypeAndFields(numberOfBlobs)
+                .SignedAndResolved()
+                .TestObject;
+            blobTx.GetLength().Should().Be(expectedLength);
+        }
+
         private IDictionary<ITxPoolPeer, PrivateKey> GetPeers(int limit = 100)
         {
             var peers = new Dictionary<ITxPoolPeer, PrivateKey>();

--- a/src/Nethermind/Nethermind.TxPool/NetworkTransactionSizeCalculator.cs
+++ b/src/Nethermind/Nethermind.TxPool/NetworkTransactionSizeCalculator.cs
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+using Nethermind.Serialization.Rlp;
+
+namespace Nethermind.TxPool;
+
+public class NetworkTransactionSizeCalculator : ITransactionSizeCalculator
+{
+    private readonly TxDecoder _txDecoder;
+
+    public NetworkTransactionSizeCalculator(TxDecoder txDecoder)
+    {
+        _txDecoder = txDecoder;
+    }
+
+    public int GetLength(Transaction tx)
+    {
+        return _txDecoder.GetLength(tx, RlpBehaviors.InMempoolForm);
+    }
+}

--- a/src/Nethermind/Nethermind.TxPool/TransactionExtensions.cs
+++ b/src/Nethermind/Nethermind.TxPool/TransactionExtensions.cs
@@ -14,7 +14,7 @@ namespace Nethermind.TxPool
     public static class TransactionExtensions
     {
         private static readonly long MaxSizeOfTxForBroadcast = 128.KiB(); //128KB, as proposed in https://eips.ethereum.org/EIPS/eip-5793
-        private static readonly ITransactionSizeCalculator _transactionSizeCalculator = new TxDecoder();
+        private static readonly ITransactionSizeCalculator _transactionSizeCalculator = new NetworkTransactionSizeCalculator(new TxDecoder());
 
         public static int GetLength(this Transaction tx)
         {


### PR DESCRIPTION
## Changes

- fix calculating length of blob-type transactions
Without `RlpBehaviors.InMempoolForm` in `GetLength` of `ITransactionSizeCalculator` actual blobs were not included in calculation of tx size.
While calculating content length we were not entering here:
https://github.com/NethermindEth/nethermind/blob/master/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoder.cs#L724-L732
Which caused not adding size of actual blobs:
https://github.com/NethermindEth/nethermind/blob/master/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoder.cs#L677-L684
And it causes, that we are sending huge messages on 4844 devnets which are rejected by peers (e.g. `PooledTransactionsMessage` with size 147x bigger than expected and 19x bigger than biggest possible 6-blob tx). Also our `NewPooledTransactionHashesMessage` in `eth68` version has not correct sizes of blob txs.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No