### PR TITLE
Ignore last broken line in FileDb

### DIFF
--- a/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
@@ -534,12 +534,12 @@ namespace Nethermind.Core.Extensions
             return ByteArrayToHexViaLookup32(bytes, false, false, false);
         }
 
-        public static void StreamHex(this byte[] bytes, StreamWriter streamWriter)
+        public static void StreamHex(this byte[] bytes, TextWriter streamWriter)
         {
             bytes.AsSpan().StreamHex(streamWriter);
         }
 
-        public static void StreamHex(this Span<byte> bytes, StreamWriter streamWriter)
+        public static void StreamHex(this Span<byte> bytes, TextWriter streamWriter)
         {
             for (int i = 0; i < bytes.Length; i++)
             {

--- a/src/Nethermind/Nethermind.Db/SimpleFilePublicKeyDb.cs
+++ b/src/Nethermind/Nethermind.Db/SimpleFilePublicKeyDb.cs
@@ -123,7 +123,7 @@ namespace Nethermind.Db
             try
             {
                 using StreamWriter fileWriter = new(DbPath);
-                StringBuilder lineBuilder = new(256);
+                StringBuilder lineBuilder = new(400); // longest found in practice was 320, adding some headroom
                 using StringWriter lineWriter = new(lineBuilder);
                 foreach ((byte[] key, byte[]? value) in snapshot)
                 {

--- a/src/Nethermind/Nethermind.Db/SimpleFilePublicKeyDb.cs
+++ b/src/Nethermind/Nethermind.Db/SimpleFilePublicKeyDb.cs
@@ -268,7 +268,7 @@ namespace Nethermind.Db
             ArrayPool<byte>.Shared.Return(rentedBuffer);
             if (bytes.Length > 0)
             {
-                ThrowInvalidDataException();
+                if (_logger.IsWarn) _logger.Warn($"Malformed {Name}. Ignoring...");
             }
 
             void RecordError(Span<byte> data)
@@ -276,13 +276,8 @@ namespace Nethermind.Db
                 if (_logger.IsError)
                 {
                     string line = Encoding.UTF8.GetString(data);
-                    _logger.Error($"Error when loading data from {Name} - expected two items separated by a comma and got '{line}')");
+                    if (_logger.IsError) _logger.Error($"Error when loading data from {Name} - expected two items separated by a comma and got '{line}')");
                 }
-            }
-
-            static void ThrowInvalidDataException()
-            {
-                throw new InvalidDataException("Malformed data");
             }
         }
 

--- a/src/Nethermind/Nethermind.Db/SimpleFilePublicKeyDb.cs
+++ b/src/Nethermind/Nethermind.Db/SimpleFilePublicKeyDb.cs
@@ -122,15 +122,21 @@ namespace Nethermind.Db
             if (_logger.IsDebug) _logger.Debug($"Saving data in {DbPath} | backup stored in {backup.BackupPath}");
             try
             {
-                using StreamWriter streamWriter = new(DbPath);
+                using StreamWriter fileWriter = new(DbPath);
                 foreach ((byte[] key, byte[] value) in snapshot)
                 {
                     if (value is not null)
                     {
-                        key.StreamHex(streamWriter);
-                        streamWriter.Write(',');
-                        value.StreamHex(streamWriter);
-                        streamWriter.WriteLine();
+                        StringBuilder lineBuilder = new();
+                        using (StringWriter lineWriter = new(lineBuilder))
+                        {
+                            key.StreamHex(lineWriter);
+                            lineWriter.Write(',');
+                            value.StreamHex(lineWriter);
+                            lineWriter.WriteLine();
+                        }
+
+                        fileWriter.Write(lineBuilder.ToString());
                     }
                 }
             }


### PR DESCRIPTION
Fixes Closes Resolves #
#5700 
During file update client might be terminated, so last line might be broken.

## Changes

- Do not throw on malformed data

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No


