### PR TITLE
Use AllocateUninitializedArray for LargerArrayPool

### DIFF
--- a/src/Nethermind/Nethermind.Core/Buffers/LargerArrayPool.cs
+++ b/src/Nethermind/Nethermind.Core/Buffers/LargerArrayPool.cs
@@ -44,7 +44,7 @@ namespace Nethermind.Core.Buffers
                 }
             }
 
-            return new byte[_largeBufferSize];
+            return GC.AllocateUninitializedArray<byte>(_largeBufferSize);
         }
 
         void ReturnLarge(byte[] array, bool clearArray)
@@ -78,7 +78,7 @@ namespace Nethermind.Core.Buffers
             }
 
             // too big to pool, just allocate
-            return new byte[minimumLength];
+            return GC.AllocateUninitializedArray<byte>(minimumLength);
         }
 
         public override void Return(byte[] array, bool clearArray = false)


### PR DESCRIPTION
## Changes

- Use `AllocateUninitializedArray` for `LargerArrayPool`; the array is cleared after rent anyway so don't need to double clear

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No
