### PR TITLE
Rename SHA3 opcode to KECCAK256

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/BytecodeBuilderExtensionsTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/BytecodeBuilderExtensionsTests.cs
@@ -249,11 +249,10 @@ namespace Nethermind.Evm.Test
                         Instruction.AND,
                         Instruction.OR,
                         Instruction.XOR,
-                        Instruction.SHA3,
+                        Instruction.KECCAK256,
                         Instruction.SHL,
                         Instruction.SHR,
                         Instruction.SAR,
-                        Instruction.SHA3,
                         Instruction.RETURN,
                         Instruction.REVERT,
 

--- a/src/Nethermind/Nethermind.Evm.Test/GasPriceExtractorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/GasPriceExtractorTests.cs
@@ -53,7 +53,7 @@ namespace Nethermind.Evm.Test
                     .Op(Instruction.CALLDATACOPY)
                     .PushData("0x0200")
                     .PushData(0)
-                    .Op(Instruction.SHA3)
+                    .Op(Instruction.KECCAK256)
                     .Done;
 
             (Block block, Transaction transaction) = PrepareTx(

--- a/src/Nethermind/Nethermind.Evm.Test/InvalidOpcodeTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/InvalidOpcodeTests.cs
@@ -24,7 +24,7 @@ namespace Nethermind.Evm.Test
             Instruction.MOD, Instruction.SMOD, Instruction.ADDMOD, Instruction.MULMOD, Instruction.EXP,
             Instruction.SIGNEXTEND, Instruction.LT, Instruction.GT, Instruction.SLT, Instruction.SGT,
             Instruction.EQ, Instruction.ISZERO, Instruction.AND, Instruction.OR, Instruction.XOR, Instruction.NOT,
-            Instruction.BYTE, Instruction.SHA3, Instruction.ADDRESS, Instruction.BALANCE, Instruction.ORIGIN,
+            Instruction.BYTE, Instruction.KECCAK256, Instruction.ADDRESS, Instruction.BALANCE, Instruction.ORIGIN,
             Instruction.CALLER, Instruction.CALLVALUE, Instruction.CALLDATALOAD, Instruction.CALLDATASIZE,
             Instruction.CALLDATACOPY, Instruction.CODESIZE, Instruction.CODECOPY, Instruction.GASPRICE,
             Instruction.EXTCODESIZE, Instruction.EXTCODECOPY, Instruction.BLOCKHASH, Instruction.COINBASE,

--- a/src/Nethermind/Nethermind.Evm.Test/Keccak256Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Keccak256Tests.cs
@@ -10,7 +10,7 @@ namespace Nethermind.Evm.Test
 {
     [TestFixture]
     [Parallelizable(ParallelScope.All)]
-    public class Sha3Tests : VirtualMachineTestsBase
+    public class Keccak256Tests : VirtualMachineTestsBase
     {
         protected override long BlockNumber => RinkebySpecProvider.ConstantinopleFixBlockNumber;
 

--- a/src/Nethermind/Nethermind.Evm.Test/Sha3Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Sha3Tests.cs
@@ -33,7 +33,7 @@ namespace Nethermind.Evm.Test
                 .Op(Instruction.JUMPDEST)
                 .PushData(32)
                 .PushData(0)
-                .Op(Instruction.SHA3)
+                .Op(Instruction.KECCAK256)
                 .Op(Instruction.POP)
                 .PushData(0)
                 .Op(Instruction.JUMP)

--- a/src/Nethermind/Nethermind.Evm/ByteCodeBuilderExtensions.cs
+++ b/src/Nethermind/Nethermind.Evm/ByteCodeBuilderExtensions.cs
@@ -210,9 +210,9 @@ namespace Nethermind.Evm
             => @this.PushSingle(bytes)
                     .PushSingle(pos)
                     .Op(Instruction.BYTE);
-        public static Prepare SHA3(this Prepare @this, UInt256? pos = null, UInt256? len = null)
+        public static Prepare KECCAK256(this Prepare @this, UInt256? pos = null, UInt256? len = null)
             => @this.PushSequence(len, pos)
-                    .Op(Instruction.SHA3);
+                    .Op(Instruction.KECCAK256);
         public static Prepare SHL(this Prepare @this, UInt256? lhs = null, UInt256? rhs = null)
             => @this.PushSequence(rhs, lhs)
                     .Op(Instruction.SHL);

--- a/src/Nethermind/Nethermind.Evm/Instruction.cs
+++ b/src/Nethermind/Nethermind.Evm/Instruction.cs
@@ -40,7 +40,7 @@ namespace Nethermind.Evm
         SHR = 0x1c, // EIP-145
         SAR = 0x1d, // EIP-145
 
-        SHA3 = 0x20,
+        KECCAK256 = 0x20,
 
         ADDRESS = 0x30,
         BALANCE = 0x31,

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -1184,7 +1184,7 @@ OutOfGas:
 
                         break;
                     }
-                case Instruction.SHA3:
+                case Instruction.KECCAK256:
                     {
                         stack.PopUInt256(out a);
                         stack.PopUInt256(out b);


### PR DESCRIPTION
Fixes Closes Resolves #

_Please choose one of the keywords above to refer to the issue this PR solves followed by the issue number (e.g. Fixes #000). If no issue number, remove the line. Also, remove everything marked optional that is not applicable. Remove this note after reading._

## Changes

- Align with other clients with regards to opcode 0x20 naming : SHA3 -> KECCAK256

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
