### PR TITLE
Minor changes to run single node workflow

### DIFF
--- a/.github/workflows/run-a-single-node-from-branch.yml
+++ b/.github/workflows/run-a-single-node-from-branch.yml
@@ -106,11 +106,11 @@ jobs:
         GITHUB_USER: ${{ secrets.REPOSITORY_DISPATCH_USER }} 
         GITHUB_TOKEN: ${{ secrets.REPOSITORY_DISPATCH_TOKEN }}
         INPUTS: >
-          '{
+          {
             "repo": "${{ env.REPO }}",
             "tag": "${{ env.CLEAN_REF }}",
             "dockerfile": "Dockerfile"
-          }'
+          }
 
     - name: Set Repo and Org Variables
       run: |

--- a/.github/workflows/run-a-single-node-from-branch.yml
+++ b/.github/workflows/run-a-single-node-from-branch.yml
@@ -148,21 +148,33 @@ jobs:
         echo "BASE_TAG=${{ needs.create_docker_image.outputs.base_tag }}" >> $GITHUB_ENV
 
     - name: Trigger Node creation Repo Action
-      uses: benc-uk/workflow-dispatch@v1
-      with:
-          workflow: run-single-node.yml
-          repo: NethermindEth/post-merge-smoke-tests
-          ref: "main"
-          token: "${{ secrets.REPOSITORY_DISPATCH_TOKEN }}"
-          inputs: '{
-                     "github_username": "${{ github.actor }}",
-                     "base_tag": "${{ env.BASE_TAG }}",
-                     "config_file": "${{ inputs.config }}",
-                     "nethermind_branch": "${{ env.CLEAN_REF }}",
-                     "network": "${{ inputs.network }}",
-                     "cl_client": "${{ inputs.cl_client }}",
-                     "additional_options": "{\"cl_custom_image\":\"${{ inputs.cl_custom_image }}\", \"timeout\":\"${{ inputs.timeout }}\", \"non_validator_mode\":${{ inputs.non_validator_mode }}, \"volume_size\":\"${{ inputs.volume }}\", \"additional_nethermind_flags\":\"${{ inputs.additional_nethermind_flags }}\", \"additional_cl_flags\":\"${{ inputs.additional_cl_flags }}\", \"ssh_keys\":\"${{ inputs.ssh_keys }}\"}"
-                   }'
+      run: |
+        echo $INPUTS | gh -R $WORKFLOW_REPO workflow run $WORKFLOW_ID --ref $WORKFLOW_REF --json
+      env:
+        WORKFLOW_ID: 'run-single-node.yml'
+        WORKFLOW_REF: main
+        WORKFLOW_REPO: NethermindEth/post-merge-smoke-tests
+        GITHUB_USER: ${{ secrets.REPOSITORY_DISPATCH_USER }} 
+        GITHUB_TOKEN: ${{ secrets.REPOSITORY_DISPATCH_TOKEN }}
+        INPUTS: >
+          {
+            "github_username": "${{ github.actor }}",
+            "base_tag": "${{ env.BASE_TAG }}",
+            "config_file": "${{ inputs.config }}",
+            "nethermind_branch": "${{ env.CLEAN_REF }}",
+            "network": "${{ inputs.network }}",
+            "cl_client": "${{ inputs.cl_client }}",
+            "additional_options": 
+              "{
+                \"cl_custom_image\":\"${{ inputs.cl_custom_image }}\",
+                \"timeout\":\"${{ inputs.timeout }}\",
+                \"non_validator_mode\":\"${{ inputs.non_validator_mode }}\",
+                \"volume\":\"${{ inputs.volume }}\",
+                \"additional_nethermind_flags\":\"${{ inputs.additional_nethermind_flags }}\",
+                \"additional_cl_flags\":\"${{ inputs.additional_cl_flags }}\",
+                \"ssh_keys\":\"${{ inputs.ssh_keys }}\"
+              }"
+          }
 
     - name: Wait for creation of node
       env:

--- a/.github/workflows/run-a-single-node-from-branch.yml
+++ b/.github/workflows/run-a-single-node-from-branch.yml
@@ -64,6 +64,10 @@ on:
         description: "SSH Keys to be installed in the smoke test nodes (separated by commas without space in-between commas) for example: key1,key2,key3"
         default: ""
         required: false
+      smoke_tests_ref:
+        description: "Ref of the smoke tests repository to be used for smoke tests"
+        default: "main"
+        required: false
       
 jobs:
   create_docker_image:
@@ -72,7 +76,7 @@ jobs:
       base_tag: ${{ steps.set-base-tag.outputs.base_tag }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Prepare docker tag
       id: prepare_ref
@@ -98,21 +102,25 @@ jobs:
         echo "REPO=$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
     
     - name: Trigger Docker Build Action with Cleaned Ref
-      uses: benc-uk/workflow-dispatch@v1
-      with:
-          workflow: build-nethermind-docker-images.yml
-          ref: "${{ github.ref }}"
-          token: "${{ secrets.REPOSITORY_DISPATCH_TOKEN }}"
-          inputs: '{
-              "repo": "${{ env.REPO }}",
-              "tag": "${{ env.CLEAN_REF }}",
-              "dockerfile": "Dockerfile"
-           }'
+      run: |
+        echo $INPUTS | gh workflow run $WORKFLOW_ID --ref $WORKFLOW_REF --json
+      env:
+        WORKFLOW_ID: 'build-nethermind-docker-images.yml'
+        WORKFLOW_REF: ${{ github.ref }}
+        GITHUB_USER: ${{ secrets.REPOSITORY_DISPATCH_USER }} 
+        GITHUB_TOKEN: ${{ secrets.REPOSITORY_DISPATCH_TOKEN }}
+        INPUTS: >
+          '{
+            "repo": "${{ env.REPO }}",
+            "tag": "${{ env.CLEAN_REF }}",
+            "dockerfile": "Dockerfile"
+          }'
 
     - name: Set Repo and Org Variables
       run: |
         echo "ORG_NAME=$(echo $GITHUB_REPOSITORY | cut -d / -f 1)" >> $GITHUB_ENV
         echo "REPO_NAME=$(echo $GITHUB_REPOSITORY | cut -d / -f 2)" >> $GITHUB_ENV
+
     - name: Wait for Docker Build Action to complete
       env:
         GITHUB_TOKEN: ${{ secrets.REPOSITORY_DISPATCH_TOKEN }}
@@ -133,7 +141,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Prepare docker tag
       id: prepare_ref
@@ -152,7 +160,7 @@ jobs:
         echo $INPUTS | gh -R $WORKFLOW_REPO workflow run $WORKFLOW_ID --ref $WORKFLOW_REF --json
       env:
         WORKFLOW_ID: 'run-single-node.yml'
-        WORKFLOW_REF: main
+        WORKFLOW_REF: ${{ inputs.smoke_tests_ref }}
         WORKFLOW_REPO: NethermindEth/post-merge-smoke-tests
         GITHUB_USER: ${{ secrets.REPOSITORY_DISPATCH_USER }} 
         GITHUB_TOKEN: ${{ secrets.REPOSITORY_DISPATCH_TOKEN }}

--- a/.github/workflows/run-a-single-node-from-branch.yml
+++ b/.github/workflows/run-a-single-node-from-branch.yml
@@ -64,11 +64,7 @@ on:
         description: "SSH Keys to be installed in the smoke test nodes (separated by commas without space in-between commas) for example: key1,key2,key3"
         default: ""
         required: false
-      smoke_tests_ref:
-        description: "Ref of the smoke tests repository to be used for smoke tests"
-        default: "main"
-        required: false
-      
+
 jobs:
   create_docker_image:
     runs-on: ubuntu-latest
@@ -160,7 +156,7 @@ jobs:
         echo $INPUTS | gh -R $WORKFLOW_REPO workflow run $WORKFLOW_ID --ref $WORKFLOW_REF --json
       env:
         WORKFLOW_ID: 'run-single-node.yml'
-        WORKFLOW_REF: ${{ inputs.smoke_tests_ref }}
+        WORKFLOW_REF: main
         WORKFLOW_REPO: NethermindEth/post-merge-smoke-tests
         GITHUB_USER: ${{ secrets.REPOSITORY_DISPATCH_USER }} 
         GITHUB_TOKEN: ${{ secrets.REPOSITORY_DISPATCH_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -409,3 +409,4 @@ src/Nethermind/Nethermind.BeaconNode.Host/release
 src/Nethermind/Nethermind.Runner/git-hash
 keystore/
 /.githooks
+.vscode

--- a/scripts/wait-for-workflow-completed.sh
+++ b/scripts/wait-for-workflow-completed.sh
@@ -75,6 +75,7 @@ while true; do
       exit 1
     else
       echo "✅ The workflow completed successfully! Exiting."
+      echo "👀 Check workflow details at: https://github.com/${ORG_NAME}/${REPO_NAME}/actions/runs/$run_id"
       break
     fi
   fi


### PR DESCRIPTION
Changes:
- Remove usage of external action to trigger workflows and use GitHub CLI instead
- Print link to run single node workflow on smoke tests repository
