### PR TITLE
Add arm64 as arch for ppa

### DIFF
--- a/scripts/deployment/debian/control
+++ b/scripts/deployment/debian/control
@@ -7,7 +7,7 @@ Standards-Version: 4.5.0
 Homepage: https://nethermind.io
 
 Package: nethermind
-Architecture: amd64
+Architecture: amd64 arm64
 Multi-Arch: foreign
 Depends: libsnappy-dev, libc6-dev, libc6, unzip, jq, curl, wget
 Description: An Ethereum client built on .NET


### PR DESCRIPTION
Fixes #4959 

## Changes

- Adds "arm64" as architecture in the debian control file, used when building on PPA. 

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [X] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

I've build the package locally using debuild, although I'm not sure if this is the right way to properly test it. I already enabled arm64 support on Launchpad side, but the latest build was only available on amd64. I am assuming it's because of this missing architecture. 

More info is here: https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-architecture -> 5.6.8. Architecture