### PR TITLE
Allow setting bucket size to 16 or higher

### DIFF
--- a/src/Nethermind/Nethermind.Network.Discovery.Test/NodeLifecycleManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/NodeLifecycleManagerTests.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using FluentAssertions;
+using MathNet.Numerics.Random;
 using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
@@ -105,6 +107,45 @@ namespace Nethermind.Network.Discovery.Test
             nodeManager.ProcessPongMsg(new PongMsg(node.Address, GetExpirationTime(), sentPing!.Mdc!));
 
             Assert.IsTrue(nodeManager.IsBonded);
+        }
+
+        [Test]
+        public async Task handling_neighbour_msg_will_limit_result_to_12()
+        {
+            IDiscoveryConfig discoveryConfig = new DiscoveryConfig();
+            discoveryConfig.PongTimeout = 50;
+            discoveryConfig.BucketSize = 32;
+            discoveryConfig.BucketsCount = 1;
+
+            _nodeTable = new NodeTable(new NodeDistanceCalculator(discoveryConfig), discoveryConfig, _networkConfig, LimboLogs.Instance);
+            _nodeTable.Initialize(TestItem.PublicKeyA);
+
+            Node node = new(TestItem.PublicKeyB, _host, _port);
+            NodeLifecycleManager nodeManager = new(node, _discoveryManagerMock, _nodeTable, _evictionManagerMock, _nodeStatsMock, new NodeRecord(), _discoveryConfigMock, Timestamper.Default, _loggerMock);
+
+            await BondWithSelf(nodeManager, node);
+
+            for (int i = 0; i < 32; i++)
+            {
+                _nodeTable.AddNode(
+                    new Node(
+                        new PublicKey(Random.Shared.NextBytes(64)),
+                        "127.0.0.1",
+                        i
+                    ));
+            }
+
+            NeighborsMsg? sentMsg = null;
+            _discoveryManagerMock.SendMessage(Arg.Do<NeighborsMsg>(msg =>
+            {
+                sentMsg = msg;
+            }));
+
+            nodeManager.ProcessFindNodeMsg(new FindNodeMsg(TestItem.PublicKeyA, 1, new byte[] { 0 }));
+
+            Assert.IsNotNull(sentMsg);
+            _nodeTable.Buckets[0].BondedItemsCount.Should().Be(32);
+            sentMsg!.Nodes.Length.Should().Be(12);
         }
 
         [Test]
@@ -300,5 +341,19 @@ namespace Nethermind.Network.Discovery.Test
                 _nodeIds[i] = new PublicKey(nodeIdBytes);
             }
         }
+
+        private async Task BondWithSelf(NodeLifecycleManager nodeManager, Node node)
+        {
+            byte[] mdc = new byte[32];
+            PingMsg? sentPing = null;
+            _discoveryManagerMock.SendMessage(Arg.Do<PingMsg>(msg =>
+            {
+                msg.Mdc = mdc;
+                sentPing = msg;
+            }));
+            await nodeManager.SendPingAsync();
+            nodeManager.ProcessPongMsg(new PongMsg(node.Address, GetExpirationTime(), sentPing!.Mdc!));
+        }
+
     }
 }

--- a/src/Nethermind/Nethermind.Network.Discovery/DiscoveryConfig.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/DiscoveryConfig.cs
@@ -7,7 +7,7 @@ namespace Nethermind.Network.Discovery;
 
 public class DiscoveryConfig : IDiscoveryConfig
 {
-    public int BucketSize { get; set; } = 12;
+    public int BucketSize { get; set; } = 16;
 
     public int BucketsCount { get; set; } = 256;
 

--- a/src/Nethermind/Nethermind.Network.Discovery/IDiscoveryConfig.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/IDiscoveryConfig.cs
@@ -11,79 +11,79 @@ public interface IDiscoveryConfig : IConfig
     /// <summary>
     /// Kademlia - k
     /// </summary>
-    [ConfigItem(DisabledForCli = true)]
+    [ConfigItem]
     int BucketSize { get; set; }
 
     /// <summary>
     /// Buckets count
     /// </summary>
-    [ConfigItem(DisabledForCli = true)]
+    [ConfigItem]
     int BucketsCount { get; set; }
 
     /// <summary>
     /// Kademlia - alpha
     /// </summary>
-    [ConfigItem(DisabledForCli = true)]
+    [ConfigItem]
     int Concurrency { get; }
 
     /// <summary>
     /// Kademlia - b
     /// </summary>
-    [ConfigItem(DisabledForCli = true)]
+    [ConfigItem]
     int BitsPerHop { get; }
 
     /// <summary>
     /// Max Discovery Rounds
     /// </summary>
-    [ConfigItem(DisabledForCli = true)]
+    [ConfigItem]
     int MaxDiscoveryRounds { get; }
 
     /// <summary>
     /// Eviction check interval in ms
     /// </summary>
-    [ConfigItem(DisabledForCli = true)]
+    [ConfigItem]
     int EvictionCheckInterval { get; }
 
     /// <summary>
     /// Send Node Timeout in ms
     /// </summary>
-    [ConfigItem(DisabledForCli = true)]
+    [ConfigItem]
     int SendNodeTimeout { get; }
 
     /// <summary>
     /// Pong Timeout in ms
     /// </summary>
-    [ConfigItem(DisabledForCli = true)]
+    [ConfigItem]
     int PongTimeout { get; set; }
 
     /// <summary>
     /// Boot Node Pong Timeout in ms
     /// </summary>
-    [ConfigItem(DisabledForCli = true)]
+    [ConfigItem]
     int BootnodePongTimeout { get; }
 
     /// <summary>
     /// Pong Timeout in ms
     /// </summary>
-    [ConfigItem(DisabledForCli = true)]
+    [ConfigItem]
     int PingRetryCount { get; }
 
     /// <summary>
     /// Time between running discovery processes in milliseconds
     /// </summary>
-    [ConfigItem(DisabledForCli = true)]
+    [ConfigItem]
     int DiscoveryInterval { get; }
 
     /// <summary>
     /// Time between persisting discovered nodes in milliseconds
     /// </summary>
-    [ConfigItem(DisabledForCli = true)]
+    [ConfigItem]
     int DiscoveryPersistenceInterval { get; }
 
     /// <summary>
     /// Time between discovery cycles in milliseconds
     /// </summary>
-    [ConfigItem(DisabledForCli = true)]
+    [ConfigItem]
     int DiscoveryNewCycleWaitTime { get; }
 
     /// <summary>
@@ -94,18 +94,18 @@ public interface IDiscoveryConfig : IConfig
     /// <summary>
     /// Timeout for closing UDP channel in milliseconds
     /// </summary>
-    [ConfigItem(DisabledForCli = true)]
+    [ConfigItem]
     int UdpChannelCloseTimeout { get; }
 
     /// <summary>
     /// Maximum count of NodeLifecycleManagers stored in memory
     /// </summary>
-    [ConfigItem(DisabledForCli = true)]
+    [ConfigItem]
     int MaxNodeLifecycleManagersCount { get; }
 
     /// <summary>
     /// Count of NodeLifecycleManagers to remove in one cleanup cycle
     /// </summary>
-    [ConfigItem(DisabledForCli = true)]
+    [ConfigItem]
     int NodeLifecycleManagersCleanupCount { get; }
 }

--- a/src/Nethermind/Nethermind.Network.Discovery/Lifecycle/NodeLifecycleManager.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Lifecycle/NodeLifecycleManager.cs
@@ -197,7 +197,10 @@ public class NodeLifecycleManager : INodeLifecycleManager
         NodeStats.AddNodeStatsEvent(NodeStatsEventType.DiscoveryFindNodeIn);
         RefreshNodeContactTime();
 
-        Node[] nodes = _nodeTable.GetClosestNodes(msg.SearchedNodeId).ToArray();
+        Node[] nodes = _nodeTable
+            .GetClosestNodes(msg.SearchedNodeId)
+            .Take(12) // Otherwise it the payload may become too big.
+            .ToArray();
         SendNeighbors(nodes);
     }
 

--- a/src/Nethermind/Nethermind.Network.Discovery/Lifecycle/NodeLifecycleManager.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Lifecycle/NodeLifecycleManager.cs
@@ -199,7 +199,7 @@ public class NodeLifecycleManager : INodeLifecycleManager
 
         Node[] nodes = _nodeTable
             .GetClosestNodes(msg.SearchedNodeId)
-            .Take(12) // Otherwise it the payload may become too big.
+            .Take(12) // Otherwise the payload may become too big, which is out of spec.
             .ToArray();
         SendNeighbors(nodes);
     }


### PR DESCRIPTION
- Set back discovery bucket size to 16, which is what the spec said.
- Also improve speed at which new peer is discovered.
- Set limit of neighbour msg to 12, which prevent it from becoming too big in case of ipv6 address.
- Allow setting discovery config from CLI.

## Types of changes

#### What types of changes does your code introduce?

- [X] Optimization

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [X] No

#### Requires explanation in Release Notes

- [X] Maybe

`Improved peer discovery`
