### PR TITLE
Perf/randomly drop discovery bucket entry

### DIFF
--- a/src/Nethermind/Nethermind.Network.Discovery.Test/RoutingTable/NodeBucketTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/RoutingTable/NodeBucketTests.cs
@@ -110,6 +110,37 @@ namespace Nethermind.Network.Discovery.Test.RoutingTable
             Assert.Throws<InvalidOperationException>(() => nodeBucket.ReplaceNode(nonExisting, node));
         }
 
+        [Test]
+        public void When_addingToFullBucket_then_randomlyDropEntry()
+        {
+            NodeBucket nodeBucket = new(1, 16, dropFullBucketProbability: .5f);
+            for (int i = 0; i < 16; i++)
+            {
+                Node node = new(
+                    TestItem.PublicKeys[i],
+                    IPAddress.Broadcast.ToString(),
+                    30000);
+
+                nodeBucket.AddNode(node);
+            }
+
+            int dropCount = 0;
+            for (int i = 0; i < 100; i++)
+            {
+                Node node = new(
+                    TestItem.PublicKeys[i+16],
+                    IPAddress.Broadcast.ToString(),
+                    30000);
+
+                if (nodeBucket.AddNode(node).ResultType == NodeAddResultType.Dropped)
+                {
+                    dropCount++;
+                }
+            }
+
+            dropCount.Should().BeInRange(25, 75);
+        }
+
         private static void AddNodes(NodeBucket nodeBucket, int count)
         {
             for (int i = 0; i < count; i++)

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/RoutingTable/NodeBucketTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/RoutingTable/NodeBucketTests.cs
@@ -128,7 +128,7 @@ namespace Nethermind.Network.Discovery.Test.RoutingTable
             for (int i = 0; i < 100; i++)
             {
                 Node node = new(
-                    TestItem.PublicKeys[i+16],
+                    TestItem.PublicKeys[i + 16],
                     IPAddress.Broadcast.ToString(),
                     30000);
 

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/RoutingTable/NodeBucketTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/RoutingTable/NodeBucketTests.cs
@@ -107,7 +107,7 @@ namespace Nethermind.Network.Discovery.Test.RoutingTable
                 IPAddress.Broadcast.ToString(),
                 30002);
 
-            Assert.Throws<InvalidOperationException>(() => nodeBucket.ReplaceNode(nonExisting, node));
+            Assert.DoesNotThrow(() => nodeBucket.ReplaceNode(nonExisting, node));
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Network.Discovery/DiscoveryConfig.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/DiscoveryConfig.cs
@@ -38,6 +38,7 @@ public class DiscoveryConfig : IDiscoveryConfig
     public int MaxNodeLifecycleManagersCount { get; set; } = 8000;
 
     public int NodeLifecycleManagersCleanupCount { get; set; } = 4000;
+    public float DropFullBucketNodeProbability { get; set; } = 0.05f;
 
     public string Bootnodes { get; set; } = string.Empty;
 }

--- a/src/Nethermind/Nethermind.Network.Discovery/IDiscoveryConfig.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/IDiscoveryConfig.cs
@@ -108,4 +108,7 @@ public interface IDiscoveryConfig : IConfig
     /// </summary>
     [ConfigItem(DefaultValue = "4000")]
     int NodeLifecycleManagersCleanupCount { get; }
+
+    [ConfigItem(DefaultValue = "0.05")]
+    float DropFullBucketNodeProbability { get; set; }
 }

--- a/src/Nethermind/Nethermind.Network.Discovery/Lifecycle/NodeLifecycleManager.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Lifecycle/NodeLifecycleManager.cs
@@ -171,7 +171,7 @@ public class NodeLifecycleManager : INodeLifecycleManager
         if (_lastNeighbourSize + msg.Nodes.Length == 16)
         {
             // Turns out, other client will split the neighbour msg to two msg, whose size sum up to 16.
-            // Happens practically 99% of the time.
+            // Happens about 70% of the time.
             ProcessNodes(msg);
         }
         else if (_isNeighborsExpected)

--- a/src/Nethermind/Nethermind.Network.Discovery/RoutingTable/NodeAddResult.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/RoutingTable/NodeAddResult.cs
@@ -9,13 +9,21 @@ public class NodeAddResult
 
     public NodeBucketItem? EvictionCandidate { get; private init; }
 
+    private static NodeAddResult? _added = null;
+    private static NodeAddResult? _dropped = null;
+
     public static NodeAddResult Added()
     {
-        return new NodeAddResult { ResultType = NodeAddResultType.Added };
+        return _added ?? new NodeAddResult { ResultType = NodeAddResultType.Added };
     }
 
     public static NodeAddResult Full(NodeBucketItem evictionCandidate)
     {
         return new NodeAddResult { ResultType = NodeAddResultType.Full, EvictionCandidate = evictionCandidate };
+    }
+
+    public static NodeAddResult Dropped()
+    {
+        return _dropped ?? new NodeAddResult { ResultType = NodeAddResultType.Dropped };
     }
 }

--- a/src/Nethermind/Nethermind.Network.Discovery/RoutingTable/NodeAddResultType.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/RoutingTable/NodeAddResultType.cs
@@ -6,5 +6,6 @@ namespace Nethermind.Network.Discovery.RoutingTable;
 public enum NodeAddResultType
 {
     Added,
-    Full
+    Full,
+    Dropped
 }

--- a/src/Nethermind/Nethermind.Network.Discovery/RoutingTable/NodeBucket.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/RoutingTable/NodeBucket.cs
@@ -11,12 +11,14 @@ public class NodeBucket
 {
     private readonly object _nodeBucketLock = new();
     private readonly LinkedList<NodeBucketItem> _items;
+    private readonly float _dropFullBucketProbability;
 
-    public NodeBucket(int distance, int bucketSize)
+    public NodeBucket(int distance, int bucketSize, float dropFullBucketProbability = 0.0f)
     {
         _items = new LinkedList<NodeBucketItem>();
         Distance = distance;
         BucketSize = bucketSize;
+        _dropFullBucketProbability = dropFullBucketProbability;
     }
 
     /// <summary>
@@ -83,6 +85,18 @@ public class NodeBucket
                 if (!_items.Contains(item))
                 {
                     _items.AddFirst(item);
+                }
+
+                return NodeAddResult.Added();
+            }
+
+            if (Random.Shared.NextSingle() < _dropFullBucketProbability)
+            {
+                NodeBucketItem item = new(node, DateTime.UtcNow);
+                if (!_items.Contains(item))
+                {
+                    _items.AddFirst(item);
+                    _items.RemoveLast();
                 }
 
                 return NodeAddResult.Added();

--- a/src/Nethermind/Nethermind.Network.Discovery/RoutingTable/NodeBucket.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/RoutingTable/NodeBucket.cs
@@ -99,7 +99,7 @@ public class NodeBucket
                     _items.RemoveLast();
                 }
 
-                return NodeAddResult.Added();
+                return NodeAddResult.Dropped();
             }
 
             NodeBucketItem evictionCandidate = GetEvictionCandidate();

--- a/src/Nethermind/Nethermind.Network.Discovery/RoutingTable/NodeBucket.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/RoutingTable/NodeBucket.cs
@@ -117,11 +117,6 @@ public class NodeBucket
                 _items.Remove(item);
                 AddNode(nodeToAdd);
             }
-            else
-            {
-                throw new InvalidOperationException(
-                    "Cannot replace non-existing node in the node table bucket");
-            }
         }
     }
 

--- a/src/Nethermind/Nethermind.Network.Discovery/RoutingTable/NodeTable.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/RoutingTable/NodeTable.cs
@@ -29,7 +29,7 @@ public class NodeTable : INodeTable
         Buckets = new NodeBucket[_discoveryConfig.BucketsCount];
         for (int i = 0; i < Buckets.Length; i++)
         {
-            Buckets[i] = new NodeBucket(i, _discoveryConfig.BucketSize);
+            Buckets[i] = new NodeBucket(i, _discoveryConfig.BucketSize, _discoveryConfig.DropFullBucketNodeProbability);
         }
     }
 


### PR DESCRIPTION
- The entry inside the discovery bucket tend to stay fixed and not change. And because we don't do a full dht walk, we are generally limited by the entry within the nodes from the bucket. This causes the percentage of new nodes from neighbour message to stabilize at about 10%.
- This PR add a random drop when a bucket is full which causes the entry in the bucket to change. This reduces the time to reach 8000 candidate node from 40 minute to 5 without increasing the rate of neighbour request.
- This is out of spec, but I guess since the density of the bucket based on the XOR distance stays the same, it should be fine.  (bucket with lower distance does not get touched much as its much harder to get node to fill it). 

- Run is 20%, 10%, 5%, 2%, no drop, 20%, 10%, 5%, 2%, no drop.
![Screenshot_2023-07-26_14-09-29](https://github.com/NethermindEth/nethermind/assets/1841324/3fe03af6-6782-4d4b-9689-d1be921c50d0)

## Changes

- Fix a lot of random drop of neighbour message.
- Add option to randomly drop last node if bucket is full. Default to 5%.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)
- [X] Optimization

## Testing

#### Requires testing

- [X] Yes

#### If yes, did you write tests?

- [X] Yes

#### Notes on testing

- Works on ewf.
- Mainnet can sync fine. 

#### Requires documentation update

- [X] No

#### Requires explanation in Release Notes

- [X] Yes: Improved peer discovery

### Remarks

- Not sure why not just put it at 20% or 10%. but I guess its not great for the network if the entry keep changing maybe.
- Tried other scheme such as not adding node that is known to be incompatible or drop incompatible peer first. Does not work as effective as just randomly dropping them.