### PR TITLE
Add NewPayload timoeut based on config

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin/IMergeConfig.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/IMergeConfig.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using Nethermind.Config;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
@@ -55,5 +56,8 @@ namespace Nethermind.Merge.Plugin
 
         [ConfigItem(Description = "Requests the GC to release process memory back to OS. Accept values `-1` which disables it, `0` which releases every time, and any positive integer which does it after that many EngineApi calls.", DefaultValue = "75")]
         public int CollectionsPerDecommit { get; set; }
+
+        [ConfigItem(Description = "Maximum time in seconds for NewPayload request to be executed.")]
+        public int NewPayloadTimeout { get; }
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/IMergeConfig.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/IMergeConfig.cs
@@ -57,7 +57,7 @@ namespace Nethermind.Merge.Plugin
         [ConfigItem(Description = "Requests the GC to release process memory back to OS. Accept values `-1` which disables it, `0` which releases every time, and any positive integer which does it after that many EngineApi calls.", DefaultValue = "75")]
         public int CollectionsPerDecommit { get; set; }
 
-        [ConfigItem(Description = "Maximum time in seconds for NewPayload request to be executed.")]
+        [ConfigItem(Description = "Maximum time in seconds for NewPayload request to be executed.", DefaultValue = "7", HiddenFromDocs = true)]
         public int NewPayloadTimeout { get; }
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergeConfig.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergeConfig.cs
@@ -31,6 +31,6 @@ namespace Nethermind.Merge.Plugin
 
         public int CollectionsPerDecommit { get; set; } = 75;
 
-        public int NewPayloadTimeout { get; set; }
+        public int NewPayloadTimeout { get; set; } = 7;
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergeConfig.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergeConfig.cs
@@ -30,5 +30,7 @@ namespace Nethermind.Merge.Plugin
         public GcCompaction CompactMemory { get; set; } = GcCompaction.Yes;
 
         public int CollectionsPerDecommit { get; set; } = 75;
+
+        public int NewPayloadTimeout { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
@@ -323,7 +323,7 @@ public partial class MergePlugin : IConsensusWrapperPlugin, ISynchronizationPlug
                     _invalidChainTracker,
                     _beaconSync,
                     _api.LogManager,
-                    _mergeConfig.NewPayloadTimeout == 0 ? null : TimeSpan.FromSeconds(_mergeConfig.NewPayloadTimeout)),
+                    TimeSpan.FromSeconds(_mergeConfig.NewPayloadTimeout)),
                 new ForkchoiceUpdatedHandler(
                     _api.BlockTree,
                     _blockFinalizationManager,

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
@@ -322,7 +322,8 @@ public partial class MergePlugin : IConsensusWrapperPlugin, ISynchronizationPlug
                     _api.BlockProcessingQueue,
                     _invalidChainTracker,
                     _beaconSync,
-                    _api.LogManager),
+                    _api.LogManager,
+                    _mergeConfig.NewPayloadTimeout == 0 ? null : TimeSpan.FromSeconds(_mergeConfig.NewPayloadTimeout)),
                 new ForkchoiceUpdatedHandler(
                     _api.BlockTree,
                     _blockFinalizationManager,


### PR DESCRIPTION
Solves: #5951

Add option to manipulate timeout for newPayload - needed for Block Processing tests in case of some blocks being processed slower than expected. 

## Changes

- _Add new flag --Merge.NewPayloadTimeout_

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [X] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [X] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [X] Yes
- [ ] No

_New parameter which allows to manipulate maximum time to process `engine_newPayload` requests. 
Current default value is 7 seconds.
Usage example: 
`--Merge.NewPayloadTimeout=10` _

## Remarks

_Optional. Remove if not applicable._
