### PR TITLE
Implement default jwt-secret paths

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc/IJsonRpcConfig.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/IJsonRpcConfig.cs
@@ -108,7 +108,7 @@ namespace Nethermind.JsonRpc
                           "Defaults to number of logical processes.")]
         int? EthModuleConcurrentInstances { get; set; }
 
-        [ConfigItem(Description = "Path to file with hex encoded secret for jwt authentication", DefaultValue = "keystore/jwt-secret")]
+        [ConfigItem(Description = "Path to file with hex encoded secret for jwt authentication")]
         public string JwtSecretFile { get; set; }
 
         [ConfigItem(Description = "It shouldn't be set to true for production nodes. If set to true all modules can work without RPC authentication.", DefaultValue = "false", HiddenFromDocs = true)]

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcConfig.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcConfig.cs
@@ -38,7 +38,7 @@ namespace Nethermind.JsonRpc
         public string CallsFilterFilePath { get; set; } = "Data/jsonrpc.filter";
         public long? MaxRequestBodySize { get; set; } = 30000000;
         public int? EthModuleConcurrentInstances { get; set; } = null;
-        public string JwtSecretFile { get; set; } = "keystore/jwt-secret";
+        public string JwtSecretFile { get; set; }
         public bool UnsecureDevNoRpcAuthentication { get; set; }
         public int? MaxLoggedRequestParametersCharacters { get; set; } = null;
         public string[]? MethodsLoggingFiltering { get; set; } =
@@ -56,4 +56,3 @@ namespace Nethermind.JsonRpc
         public long? MaxBatchResponseBodySize { get; set; } = 30.MB();
     };
 };
-


### PR DESCRIPTION
Resolves #5948

## Changes

- Remove default value for JsonRpc.JwtSecretFile
- implement default jwt-secret paths

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Testing this is hard since it's all IO methods, but since it's now a more complex logic flow, maybe its worth it? 

## Documentation

#### Requires documentation update

- [ ] Yes
- [ ] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

Should we update the docs and/or the release notes with the new files paths?