### PR TITLE
Make pivot update attempts infinite

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
@@ -61,7 +61,7 @@ namespace Nethermind.Blockchain.Synchronization
         [ConfigItem(DisabledForCli = true, HiddenFromDocs = true)]
         Keccak? PivotHashParsed => PivotHash is null ? null : new Keccak(Bytes.FromHexString(PivotHash));
 
-        [ConfigItem(Description = "Max number of attempts (seconds) to update pivot block basing on Forkchoice message from Consensus Layer. Only for PoS chains.", DefaultValue = "900")]
+        [ConfigItem(Description = "Max number of attempts (seconds) to update pivot block basing on Forkchoice message from Consensus Layer. Only for PoS chains. Infinite by default.", DefaultValue = "2147483647")]
         int MaxAttemptsToUpdatePivot { get; set; }
 
         [ConfigItem(Description = "[EXPERIMENTAL] Defines the earliest body downloaded in fast sync when DownloadBodiesInFastSync is enabled. Actual values used will be Math.Max(1, Math.Min(PivotNumber, AncientBodiesBarrier))", DefaultValue = "0")]

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
@@ -49,7 +49,7 @@ namespace Nethermind.Blockchain.Synchronization
             get => FastSync || SnapSync ? _pivotHash : null;
             set => _pivotHash = value;
         }
-        public int MaxAttemptsToUpdatePivot { get; set; } = 900;
+        public int MaxAttemptsToUpdatePivot { get; set; } = int.MaxValue;
         public bool WitnessProtocolEnabled { get; set; } = false;
         public bool SnapSync { get; set; } = false;
         public int SnapSyncAccountRangePartitionCount { get; set; } = 8;

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/PivotUpdator.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/PivotUpdator.cs
@@ -141,7 +141,7 @@ public class PivotUpdator
 
         if (finalizedBlockHash is null || finalizedBlockHash == Keccak.Zero)
         {
-            if (_logger.IsInfo && _attemptsLeft % 10 == 0) _logger.Info($"Waiting for Forkchoice message from Consensus Layer to set fresh pivot block. {_attemptsLeft} attempts left");
+            if (_logger.IsInfo && _attemptsLeft % 10 == 0) _logger.Info($"Waiting for Forkchoice message from Consensus Layer to set fresh pivot block.");
 
             return null;
         }
@@ -217,7 +217,7 @@ public class PivotUpdator
             }
         }
 
-        if (_logger.IsInfo && _attemptsLeft % 10 == 0) _logger.Info($"Potential new pivot block hash: {finalizedBlockHash}. Waiting for pivot block header. {_attemptsLeft} attempts left");
+        if (_logger.IsInfo && _attemptsLeft % 10 == 0) _logger.Info($"Potential new pivot block hash: {finalizedBlockHash}. Waiting for pivot block header.");
         return null;
     }
 


### PR DESCRIPTION
Resolves #5986

## Changes

- Change `MaxAttemptsToUpdatePivot` to infinite in practice (`int.MaxValue` equal 0x7fffffff, equal 2147483647, equal ~68 years)
- remove `attempts left` from logs

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: change of config value

## Testing

#### Requires testing

- [ ] Yes
- [x] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No