### PR TITLE
Feature/stop on finish sync

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
@@ -112,5 +112,8 @@ namespace Nethermind.Blockchain.Synchronization
 
         [ConfigItem(Description = "[TECHNICAL] Specify max num of thread used for processing. Default is same as logical core count.", DefaultValue = "0")]
         public int MaxProcessingThreads { get; set; }
+
+        [ConfigItem(Description = "Exit Nethermind once sync is finished", DefaultValue = "false")]
+        public bool ExitOnSynced { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
@@ -63,6 +63,7 @@ namespace Nethermind.Blockchain.Synchronization
         public ITunableDb.TuneType TuneDbMode { get; set; } = ITunableDb.TuneType.Default;
         public ITunableDb.TuneType BlocksDbTuneDbMode { get; set; } = ITunableDb.TuneType.EnableBlobFiles;
         public int MaxProcessingThreads { get; set; }
+        public bool ExitOnSynced { get; set; } = false;
 
         public override string ToString()
         {

--- a/src/Nethermind/Nethermind.Config/IProcessExitSource.cs
+++ b/src/Nethermind/Nethermind.Config/IProcessExitSource.cs
@@ -17,7 +17,7 @@ public class ProcessExitSource : IProcessExitSource
     private CancellationTokenSource _cancellationTokenSource = new();
     public int ExitCode { get; set; } = ExitCodes.Ok;
 
-    private TaskCompletionSource _exitResult = new TaskCompletionSource();
+    private readonly TaskCompletionSource _exitResult = new();
 
     public Task ExitTask => _exitResult.Task;
 

--- a/src/Nethermind/Nethermind.Config/IProcessExitSource.cs
+++ b/src/Nethermind/Nethermind.Config/IProcessExitSource.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Threading;
+using System.Threading.Tasks;
 using Nethermind.Core.Extensions;
 
 namespace Nethermind.Config;
@@ -16,6 +17,10 @@ public class ProcessExitSource : IProcessExitSource
     private CancellationTokenSource _cancellationTokenSource = new();
     public int ExitCode { get; set; } = ExitCodes.Ok;
 
+    private TaskCompletionSource _exitResult = new TaskCompletionSource();
+
+    public Task ExitTask => _exitResult.Task;
+
     public CancellationToken Token => _cancellationTokenSource!.Token;
 
     public void Exit(int exitCode)
@@ -23,6 +28,7 @@ public class ProcessExitSource : IProcessExitSource
         if (CancellationTokenExtensions.CancelDisposeAndClear(ref _cancellationTokenSource))
         {
             ExitCode = exitCode;
+            _exitResult.SetResult();
         }
     }
 }

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -178,6 +178,7 @@ public class InitializeNetwork : IStep
                 _api.BlockDownloaderFactory,
                 _api.Pivot,
                 syncReport,
+                _api.ProcessExit!,
                 _api.LogManager);
         }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/MergePluginTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/MergePluginTests.cs
@@ -57,6 +57,7 @@ namespace Nethermind.Merge.Plugin.Test
                 _context.TransactionComparerProvider,
                 miningConfig,
                 _context.LogManager!);
+            _context.ProcessExit = Substitute.For<IProcessExitSource>();
             _context.ChainSpec!.Clique = new CliqueParameters()
             {
                 Epoch = CliqueConfig.Default.Epoch,

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
@@ -453,6 +453,7 @@ public partial class MergePlugin : IConsensusWrapperPlugin, ISynchronizationPlug
                 _poSSwitcher,
                 _mergeConfig,
                 _invalidChainTracker,
+                _api.ProcessExit!,
                 _api.LogManager,
                 syncReport);
         }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeSynchronizer.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeSynchronizer.cs
@@ -4,6 +4,7 @@
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Blockchain.Synchronization;
+using Nethermind.Config;
 using Nethermind.Consensus;
 using Nethermind.Consensus.Processing;
 using Nethermind.Consensus.Validators;
@@ -44,6 +45,7 @@ public class MergeSynchronizer : Synchronizer
         IPoSSwitcher poSSwitcher,
         IMergeConfig mergeConfig,
         IInvalidChainTracker invalidChainTracker,
+        IProcessExitSource exitSource,
         ILogManager logManager,
         ISyncReport syncReport)
         : base(
@@ -59,6 +61,7 @@ public class MergeSynchronizer : Synchronizer
             blockDownloaderFactory,
             pivot,
             syncReport,
+            exitSource,
             logManager)
     {
         _invalidChainTracker = invalidChainTracker;

--- a/src/Nethermind/Nethermind.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Runner/Program.cs
@@ -53,6 +53,7 @@ public static class Program
     private static readonly ProcessExitSource _processExitSource = new();
     private static readonly TaskCompletionSource<object?> _cancelKeySource = new();
     private static readonly TaskCompletionSource<object?> _processExit = new();
+    private static readonly TaskCompletionSource<object?> _exitSourceExit = new();
     private static readonly ManualResetEventSlim _appClosed = new(true);
 
     public static void Main(string[] args)
@@ -198,7 +199,7 @@ public static class Program
             {
                 await ethereumRunner.Start(_processExitSource.Token);
 
-                _ = await Task.WhenAny(_cancelKeySource.Task, _processExit.Task);
+                _ = await Task.WhenAny(_cancelKeySource.Task, _processExit.Task, _processExitSource.ExitTask);
             }
             catch (TaskCanceledException)
             {
@@ -279,8 +280,8 @@ public static class Program
             }
 
             foreach (PropertyInfo propertyInfo in configType
-                .GetProperties(BindingFlags.Public | BindingFlags.Instance)
-                .OrderBy(p => p.Name))
+                         .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                         .OrderBy(p => p.Name))
             {
                 ConfigItemAttribute? configItemAttribute = propertyInfo.GetCustomAttribute<ConfigItemAttribute>();
                 if (!(configItemAttribute?.DisabledForCli ?? false))
@@ -543,9 +544,9 @@ public static class Program
             .Append("Commit: ").AppendLine(ProductInfo.Commit)
             .Append("Build Date: ").AppendLine(ProductInfo.BuildTimestamp.ToString("u"))
             .Append("OS: ")
-                .Append(ProductInfo.OS)
-                .Append(' ')
-                .AppendLine(ProductInfo.OSArchitecture)
+            .Append(ProductInfo.OS)
+            .Append(' ')
+            .AppendLine(ProductInfo.OSArchitecture)
             .Append("Runtime: ").AppendLine(ProductInfo.Runtime);
 
         return info.ToString();

--- a/src/Nethermind/Nethermind.Synchronization.Test/ExitOnSyncCompleteTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ExitOnSyncCompleteTests.cs
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Threading.Tasks;
+using Nethermind.Config;
+using Nethermind.Logging;
+using Nethermind.Synchronization.ParallelSync;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Synchronization.Test;
+
+public class ExitOnSyncCompleteTests
+{
+
+    [Test]
+    public async Task TestWillExit()
+    {
+        ISyncModeSelector syncMode = Substitute.For<ISyncModeSelector>();
+        IProcessExitSource exitSource = Substitute.For<IProcessExitSource>();
+        TimeSpan exitConditionDuration = TimeSpan.FromMilliseconds(10);
+
+        ExitOnSyncComplete.WatchForExit(syncMode, exitSource, LimboLogs.Instance, exitConditionDuration: exitConditionDuration);
+
+        syncMode.Changed += Raise.EventWith(this, new SyncModeChangedEventArgs(SyncMode.All, SyncMode.WaitingForBlock));
+        await Task.Delay(exitConditionDuration);
+        syncMode.Changed += Raise.EventWith(this, new SyncModeChangedEventArgs(SyncMode.All, SyncMode.WaitingForBlock));
+
+        exitSource.Received().Exit(0);
+    }
+
+    [Test]
+    public async Task TestWillNotExitIfStillSyncing()
+    {
+        ISyncModeSelector syncMode = Substitute.For<ISyncModeSelector>();
+        IProcessExitSource exitSource = Substitute.For<IProcessExitSource>();
+        TimeSpan exitConditionDuration = TimeSpan.FromMilliseconds(10);
+
+        ExitOnSyncComplete.WatchForExit(syncMode, exitSource, LimboLogs.Instance, exitConditionDuration: exitConditionDuration);
+
+        syncMode.Changed += Raise.EventWith(this, new SyncModeChangedEventArgs(SyncMode.All, SyncMode.WaitingForBlock));
+        await Task.Delay(exitConditionDuration);
+        syncMode.Changed += Raise.EventWith(this, new SyncModeChangedEventArgs(SyncMode.All, SyncMode.FastBlocks));
+
+        exitSource.DidNotReceive().Exit(0);
+    }
+}

--- a/src/Nethermind/Nethermind.Synchronization.Test/ExitOnSyncCompleteTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ExitOnSyncCompleteTests.cs
@@ -21,7 +21,7 @@ public class ExitOnSyncCompleteTests
         IProcessExitSource exitSource = Substitute.For<IProcessExitSource>();
         TimeSpan exitConditionDuration = TimeSpan.FromMilliseconds(10);
 
-        ExitOnSyncComplete.WatchForExit(syncMode, exitSource, LimboLogs.Instance, exitConditionDuration: exitConditionDuration);
+        exitSource.WatchForExit(syncMode, LimboLogs.Instance, exitConditionDuration: exitConditionDuration);
 
         syncMode.Changed += Raise.EventWith(this, new SyncModeChangedEventArgs(SyncMode.All, SyncMode.WaitingForBlock));
         await Task.Delay(exitConditionDuration);
@@ -37,7 +37,7 @@ public class ExitOnSyncCompleteTests
         IProcessExitSource exitSource = Substitute.For<IProcessExitSource>();
         TimeSpan exitConditionDuration = TimeSpan.FromMilliseconds(10);
 
-        ExitOnSyncComplete.WatchForExit(syncMode, exitSource, LimboLogs.Instance, exitConditionDuration: exitConditionDuration);
+        exitSource.WatchForExit(syncMode, LimboLogs.Instance, exitConditionDuration: exitConditionDuration);
 
         syncMode.Changed += Raise.EventWith(this, new SyncModeChangedEventArgs(SyncMode.All, SyncMode.WaitingForBlock));
         await Task.Delay(exitConditionDuration);

--- a/src/Nethermind/Nethermind.Synchronization.Test/OldStyleFullSynchronizerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/OldStyleFullSynchronizerTests.cs
@@ -9,6 +9,7 @@ using Nethermind.Blockchain;
 using Nethermind.Blockchain.Find;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Blockchain.Synchronization;
+using Nethermind.Config;
 using Nethermind.Consensus;
 using Nethermind.Consensus.Validators;
 using Nethermind.Core;
@@ -92,6 +93,7 @@ namespace Nethermind.Synchronization.Test
                 blockDownloaderFactory,
                 pivot,
                 syncReport,
+                Substitute.For<IProcessExitSource>(),
                 LimboLogs.Instance);
             _syncServer = new SyncServer(
                 trieStore.AsKeyValueStore(),

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncThreadTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncThreadTests.cs
@@ -374,6 +374,7 @@ namespace Nethermind.Synchronization.Test
                 blockDownloaderFactory,
                 pivot,
                 syncReport,
+                Substitute.For<IProcessExitSource>(),
                 logManager);
             SyncServer syncServer = new(
                 trieStore.AsKeyValueStore(),

--- a/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
@@ -11,6 +11,7 @@ using Nethermind.Blockchain;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Blockchain.Test.Validators;
+using Nethermind.Config;
 using Nethermind.Consensus;
 using Nethermind.Consensus.Processing;
 using Nethermind.Consensus.Validators;
@@ -379,6 +380,7 @@ namespace Nethermind.Synchronization.Test
                         poSSwitcher,
                         mergeConfig,
                         invalidChainTracker,
+                        Substitute.For<IProcessExitSource>(),
                         _logManager,
                         syncReport);
                 }
@@ -409,6 +411,7 @@ namespace Nethermind.Synchronization.Test
                         blockDownloaderFactory,
                         pivot,
                         syncReport,
+                        Substitute.For<IProcessExitSource>(),
                         _logManager);
                 }
 

--- a/src/Nethermind/Nethermind.Synchronization/ExitOnSyncComplete.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ExitOnSyncComplete.cs
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Config;
+using Nethermind.Logging;
+using Nethermind.Synchronization.ParallelSync;
+
+namespace Nethermind.Synchronization;
+
+public class ExitOnSyncComplete
+{
+    public ExitOnSyncComplete(
+        ISyncModeSelector syncMode,
+        IProcessExitSource exitSource,
+        ILogManager logManager
+    ) {
+        ILogger logger = logManager.GetClassLogger();
+
+        DateTime lastExitConditionTime = DateTime.MaxValue;
+        TimeSpan exitConditionDuration = TimeSpan.FromSeconds(5);
+        syncMode.Changed += ((sender, args) =>
+        {
+            if (args.Current is SyncMode.WaitingForBlock or SyncMode.None)
+            {
+                if (lastExitConditionTime == DateTime.MaxValue)
+                {
+                    lastExitConditionTime = DateTime.Now;
+                }
+                else if (DateTime.Now - lastExitConditionTime > exitConditionDuration)
+                {
+                    logger.Info($"Sync finished. Exiting....");
+                    exitSource.Exit(0);
+                }
+            }
+            else
+            {
+                lastExitConditionTime = DateTime.MaxValue;
+            }
+        });
+    }
+}

--- a/src/Nethermind/Nethermind.Synchronization/ExitOnSyncComplete.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ExitOnSyncComplete.cs
@@ -8,17 +8,22 @@ using Nethermind.Synchronization.ParallelSync;
 
 namespace Nethermind.Synchronization;
 
-public class ExitOnSyncComplete
+public static class ExitOnSyncComplete
 {
-    public ExitOnSyncComplete(
+    public static void WatchForExit(
         ISyncModeSelector syncMode,
         IProcessExitSource exitSource,
-        ILogManager logManager
-    ) {
+        ILogManager logManager,
+        TimeSpan? exitConditionDuration = null
+    )
+    {
         ILogger logger = logManager.GetClassLogger();
 
+        // Usually there are time where the mode changed to WaitingForBlock temporarily. So there need to be a small
+        // wait to make sure the sync more really is completed.
+        exitConditionDuration ??= TimeSpan.FromSeconds(5);
+
         DateTime lastExitConditionTime = DateTime.MaxValue;
-        TimeSpan exitConditionDuration = TimeSpan.FromSeconds(5);
         syncMode.Changed += ((sender, args) =>
         {
             if (args.Current is SyncMode.WaitingForBlock or SyncMode.None)

--- a/src/Nethermind/Nethermind.Synchronization/ExitOnSyncComplete.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ExitOnSyncComplete.cs
@@ -20,7 +20,7 @@ public static class ExitOnSyncComplete
         ILogger logger = logManager.GetClassLogger();
 
         // Usually there are time where the mode changed to WaitingForBlock temporarily. So there need to be a small
-        // wait to make sure the sync more really is completed.
+        // wait to make sure the sync really is completed.
         exitConditionDuration ??= TimeSpan.FromSeconds(5);
 
         DateTime lastExitConditionTime = DateTime.MaxValue;

--- a/src/Nethermind/Nethermind.Synchronization/IProcessExitSourceExtensions.cs
+++ b/src/Nethermind/Nethermind.Synchronization/IProcessExitSourceExtensions.cs
@@ -8,14 +8,13 @@ using Nethermind.Synchronization.ParallelSync;
 
 namespace Nethermind.Synchronization;
 
-public static class ExitOnSyncComplete
+public static class IProcessExitSourceExtensions
 {
     public static void WatchForExit(
+        this IProcessExitSource exitSource,
         ISyncModeSelector syncMode,
-        IProcessExitSource exitSource,
         ILogManager logManager,
-        TimeSpan? exitConditionDuration = null
-    )
+        TimeSpan? exitConditionDuration = null)
     {
         ILogger logger = logManager.GetClassLogger();
 

--- a/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
@@ -349,37 +349,6 @@ namespace Nethermind.Synchronization
                     _receiptsFeed?.FeedTask ?? Task.CompletedTask));
         }
 
-        public void WatchForExit(
-            IProcessExitSource exitSource,
-            TimeSpan? exitConditionDuration = null
-        )
-        {
-            // Usually there are time where the mode changed to WaitingForBlock temporarily. So there need to be a small
-            // wait to make sure the sync more really is completed.
-            exitConditionDuration ??= TimeSpan.FromSeconds(5);
-
-            DateTime lastExitConditionTime = DateTime.MaxValue;
-            _syncMode.Changed += ((sender, args) =>
-            {
-                if (args.Current is SyncMode.WaitingForBlock or SyncMode.None)
-                {
-                    if (lastExitConditionTime == DateTime.MaxValue)
-                    {
-                        lastExitConditionTime = DateTime.Now;
-                    }
-                    else if (DateTime.Now - lastExitConditionTime > exitConditionDuration)
-                    {
-                        _logger.Info($"Sync finished. Exiting....");
-                        exitSource.Exit(0);
-                    }
-                }
-                else
-                {
-                    lastExitConditionTime = DateTime.MaxValue;
-                }
-            });
-        }
-
         public void Dispose()
         {
             CancellationTokenExtensions.CancelDisposeAndClear(ref _syncCancellation);

--- a/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Blockchain.Synchronization;
+using Nethermind.Config;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Db;
@@ -57,6 +58,7 @@ namespace Nethermind.Synchronization
         private HeadersSyncFeed? _headersFeed;
         private BodiesSyncFeed? _bodiesFeed;
         private ReceiptsSyncFeed? _receiptsFeed;
+        private IProcessExitSource _exitSource;
 
         public Synchronizer(
             IDbProvider dbProvider,
@@ -71,6 +73,7 @@ namespace Nethermind.Synchronization
             IBlockDownloaderFactory blockDownloaderFactory,
             IPivot pivot,
             ISyncReport syncReport,
+            IProcessExitSource processExitSource,
             ILogManager logManager)
         {
             _dbProvider = dbProvider ?? throw new ArgumentNullException(nameof(dbProvider));
@@ -85,6 +88,7 @@ namespace Nethermind.Synchronization
             _pivot = pivot ?? throw new ArgumentNullException(nameof(pivot));
             _syncPeerPool = peerPool ?? throw new ArgumentNullException(nameof(peerPool));
             _nodeStatsManager = nodeStatsManager ?? throw new ArgumentNullException(nameof(nodeStatsManager));
+            _exitSource = processExitSource ?? throw new ArgumentNullException(nameof(processExitSource));
             _logManager = logManager ?? throw new ArgumentNullException(nameof(logManager));
             _syncReport = syncReport ?? throw new ArgumentNullException(nameof(syncReport));
         }
@@ -118,6 +122,11 @@ namespace Nethermind.Synchronization
             if (_syncConfig.TuneDbMode != ITunableDb.TuneType.Default)
             {
                 SetupDbOptimizer();
+            }
+
+            if (_syncConfig.ExitOnSynced)
+            {
+                new ExitOnSyncComplete(_syncMode, _exitSource, _logManager);
             }
         }
 

--- a/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
@@ -126,7 +126,7 @@ namespace Nethermind.Synchronization
 
             if (_syncConfig.ExitOnSynced)
             {
-                new ExitOnSyncComplete(_syncMode, _exitSource, _logManager);
+                ExitOnSyncComplete.WatchForExit(_syncMode, _exitSource, _logManager);
             }
         }
 
@@ -347,6 +347,37 @@ namespace Nethermind.Synchronization
                     _headersFeed?.FeedTask ?? Task.CompletedTask,
                     _bodiesFeed?.FeedTask ?? Task.CompletedTask,
                     _receiptsFeed?.FeedTask ?? Task.CompletedTask));
+        }
+
+        public void WatchForExit(
+            IProcessExitSource exitSource,
+            TimeSpan? exitConditionDuration = null
+        )
+        {
+            // Usually there are time where the mode changed to WaitingForBlock temporarily. So there need to be a small
+            // wait to make sure the sync more really is completed.
+            exitConditionDuration ??= TimeSpan.FromSeconds(5);
+
+            DateTime lastExitConditionTime = DateTime.MaxValue;
+            _syncMode.Changed += ((sender, args) =>
+            {
+                if (args.Current is SyncMode.WaitingForBlock or SyncMode.None)
+                {
+                    if (lastExitConditionTime == DateTime.MaxValue)
+                    {
+                        lastExitConditionTime = DateTime.Now;
+                    }
+                    else if (DateTime.Now - lastExitConditionTime > exitConditionDuration)
+                    {
+                        _logger.Info($"Sync finished. Exiting....");
+                        exitSource.Exit(0);
+                    }
+                }
+                else
+                {
+                    lastExitConditionTime = DateTime.MaxValue;
+                }
+            });
         }
 
         public void Dispose()

--- a/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
@@ -126,7 +126,7 @@ namespace Nethermind.Synchronization
 
             if (_syncConfig.ExitOnSynced)
             {
-                ExitOnSyncComplete.WatchForExit(_syncMode, _exitSource, _logManager);
+                _exitSource.WatchForExit(_syncMode, _logManager);
             }
         }
 


### PR DESCRIPTION
- Add a flag to exit on sync complete.
- Works by waiting for `WaitingForBlock` or `None` sync state.
- Also fix exitsource not working.

## Changes

- Add a flag to exit on sync complete.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)
- [X] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Confirmed can exit after snap sync if bodies and receipts is disabled.
- Confirmed will exit after receipts finished.

## Documentation

#### Requires documentation update

- [X] Yes

#### Requires explanation in Release Notes

- [X] Yes

#### Remarks

- Probably fix #5999 also.
