### PR TITLE
[cancun] [eip6780] apply danno's clarification: disable eth burn on preexisting contract when inheritor equals contract address

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/Eip6780Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip6780Tests.cs
@@ -82,12 +82,12 @@ namespace Nethermind.Evm.Test
             else
                 AssertDestroyed();
         }
-        
+
         [TestCase(0ul, false)]
         [TestCase(MainnetSpecProvider.CancunBlockTimestamp, true)]
         public void self_destruct_not_in_same_transaction_should_not_burn(ulong timestamp, bool onlyOnSameTransaction)
         {
-            _selfDestructCode =  Prepare.EvmCode
+            _selfDestructCode = Prepare.EvmCode
                 .SELFDESTRUCT(_contractAddress)
                 .Done;
             _initCode = Prepare.EvmCode

--- a/src/Nethermind/Nethermind.Evm.Test/Eip6780Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip6780Tests.cs
@@ -82,6 +82,40 @@ namespace Nethermind.Evm.Test
             else
                 AssertDestroyed();
         }
+        
+        [TestCase(0ul, false)]
+        [TestCase(MainnetSpecProvider.CancunBlockTimestamp, true)]
+        public void self_destruct_not_in_same_transaction_should_not_burn(ulong timestamp, bool onlyOnSameTransaction)
+        {
+            _selfDestructCode =  Prepare.EvmCode
+                .SELFDESTRUCT(_contractAddress)
+                .Done;
+            _initCode = Prepare.EvmCode
+                .ForInitOf(_selfDestructCode)
+                .Done;
+            byte[] contractCall = Prepare.EvmCode
+                .Call(_contractAddress, 100000)
+                .Op(Instruction.STOP).Done;
+            Transaction initTx = Build.A.Transaction.WithCode(_initCode).WithValue(99.Ether()).WithGasLimit(_gasLimit).SignedAndResolved(_ecdsa, TestItem.PrivateKeyA).TestObject;
+            Transaction tx1 = Build.A.Transaction.WithCode(contractCall).WithGasLimit(_gasLimit).WithNonce(1).SignedAndResolved(_ecdsa, TestItem.PrivateKeyA).TestObject;
+            Block block = Build.A.Block.WithNumber(BlockNumber)
+                .WithTimestamp(timestamp)
+                .WithTransactions(initTx, tx1).WithGasLimit(2 * _gasLimit).TestObject;
+
+            _processor.Execute(initTx, block.Header, NullTxTracer.Instance);
+            UInt256 contractBalanceAfterInit = TestState.GetBalance(_contractAddress);
+            _processor.Execute(tx1, block.Header, NullTxTracer.Instance);
+
+            contractBalanceAfterInit.Should().Be(99.Ether());
+            if (onlyOnSameTransaction)
+                TestState.GetBalance(_contractAddress).Should().Be(99.Ether()); // not burnt
+            else
+                TestState.GetBalance(_contractAddress).Should().Be(0); // burnt
+            if (onlyOnSameTransaction)
+                AssertNotDestroyed();
+            else
+                AssertDestroyed();
+        }
 
         [Test]
         public void self_destruct_in_same_transaction()

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -2340,7 +2340,8 @@ ReturnFailure:
         if (!ChargeAccountAccessGas(ref gasAvailable, vmState, inheritor, spec, false)) return false;
 
         Address executingAccount = vmState.Env.ExecutingAccount;
-        if (!spec.SelfdestructOnlyOnSameTransaction || vmState.CreateList.Contains(executingAccount))
+        bool createInSameTx = vmState.CreateList.Contains(executingAccount);
+        if (!spec.SelfdestructOnlyOnSameTransaction || createInSameTx)
             vmState.DestroyList.Add(executingAccount);
 
         UInt256 result = _state.GetBalance(executingAccount);
@@ -2365,8 +2366,8 @@ ReturnFailure:
             _state.AddToBalance(inheritor, result, spec);
         }
 
-        if (spec.SelfdestructOnlyOnSameTransaction && !vmState.CreateList.Contains(executingAccount) && inheritor.Equals(executingAccount))
-            return true;
+        if (spec.SelfdestructOnlyOnSameTransaction && !createInSameTx && inheritor.Equals(executingAccount))
+            return true; // dont burn eth when contract is not destroyed per EIP clarification
 
         _state.SubtractFromBalance(executingAccount, result, spec);
         return true;

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -342,7 +342,7 @@ internal sealed class VirtualMachine<TLogger> : IVirtualMachine
                 currentState = _stateStack.Pop();
                 currentState.IsContinuation = true;
                 currentState.GasAvailable += previousState.GasAvailable;
-                bool previousStateSucceeded = true;
+                bool previousStateSucceeded = true; 
 
                 if (!callResult.ShouldRevert)
                 {
@@ -2365,7 +2365,8 @@ ReturnFailure:
             _state.AddToBalance(inheritor, result, spec);
         }
 
-        _state.SubtractFromBalance(executingAccount, result, spec);
+        if (spec.SelfdestructOnlyOnSameTransaction && !vmState.CreateList.Contains(executingAccount) && !inheritor.Equals(executingAccount))
+            _state.SubtractFromBalance(executingAccount, result, spec);
         return true;
     }
 

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -342,7 +342,7 @@ internal sealed class VirtualMachine<TLogger> : IVirtualMachine
                 currentState = _stateStack.Pop();
                 currentState.IsContinuation = true;
                 currentState.GasAvailable += previousState.GasAvailable;
-                bool previousStateSucceeded = true; 
+                bool previousStateSucceeded = true;
 
                 if (!callResult.ShouldRevert)
                 {

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -2365,8 +2365,10 @@ ReturnFailure:
             _state.AddToBalance(inheritor, result, spec);
         }
 
-        if (spec.SelfdestructOnlyOnSameTransaction && !vmState.CreateList.Contains(executingAccount) && !inheritor.Equals(executingAccount))
-            _state.SubtractFromBalance(executingAccount, result, spec);
+        if (spec.SelfdestructOnlyOnSameTransaction && !vmState.CreateList.Contains(executingAccount) && inheritor.Equals(executingAccount))
+            return true;
+
+        _state.SubtractFromBalance(executingAccount, result, spec);
         return true;
     }
 


### PR DESCRIPTION
context here:
https://github.com/ethereum/EIPs/pull/7308
## Changes

- disable eth burn on preexisting contract when inheritor equals contract address for cancun

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

