### PR TITLE
Decline payloadv2 with v3 fields

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.HelperFunctions.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.HelperFunctions.cs
@@ -84,13 +84,16 @@ namespace Nethermind.Merge.Plugin.Test
             };
         }
 
-        private static ExecutionPayload CreateBlockRequest(ExecutionPayload parent, Address miner, IList<Withdrawal>? withdrawals = null, Transaction[]? transactions = null)
-            => CreateBlockRequestInternal<ExecutionPayload>(parent, miner, withdrawals, transactions: transactions);
+        private static ExecutionPayload CreateBlockRequest(ExecutionPayload parent, Address miner, IList<Withdrawal>? withdrawals = null,
+                ulong? blobGasUsed = null, ulong? excessBlobGas = null, Transaction[]? transactions = null, Keccak? parentBeaconBlockRoot = null)
+            => CreateBlockRequestInternal<ExecutionPayload>(parent, miner, withdrawals, blobGasUsed, excessBlobGas, transactions: transactions, parentBeaconBlockRoot: parentBeaconBlockRoot);
 
-        private static ExecutionPayloadV3 CreateBlockRequestV3(ExecutionPayload parent, Address miner, IList<Withdrawal>? withdrawals = null, ulong? blobGasUsed = null, ulong? excessBlobGas = null, Transaction[]? transactions = null)
-            => CreateBlockRequestInternal<ExecutionPayloadV3>(parent, miner, withdrawals, blobGasUsed, excessBlobGas, transactions: transactions);
+        private static ExecutionPayloadV3 CreateBlockRequestV3(ExecutionPayload parent, Address miner, IList<Withdrawal>? withdrawals = null,
+                ulong? blobGasUsed = null, ulong? excessBlobGas = null, Transaction[]? transactions = null, Keccak? parentBeaconBlockRoot = null)
+            => CreateBlockRequestInternal<ExecutionPayloadV3>(parent, miner, withdrawals, blobGasUsed, excessBlobGas, transactions: transactions, parentBeaconBlockRoot: parentBeaconBlockRoot);
 
-        private static T CreateBlockRequestInternal<T>(ExecutionPayload parent, Address miner, IList<Withdrawal>? withdrawals = null, ulong? blobGasUsed = null, ulong? excessBlobGas = null, Transaction[]? transactions = null) where T : ExecutionPayload, new()
+        private static T CreateBlockRequestInternal<T>(ExecutionPayload parent, Address miner, IList<Withdrawal>? withdrawals = null,
+                ulong? blobGasUsed = null, ulong? excessBlobGas = null, Transaction[]? transactions = null, Keccak? parentBeaconBlockRoot = null) where T : ExecutionPayload, new()
         {
             T blockRequest = new()
             {
@@ -104,13 +107,10 @@ namespace Nethermind.Merge.Plugin.Test
                 LogsBloom = Bloom.Empty,
                 Timestamp = parent.Timestamp + 1,
                 Withdrawals = withdrawals,
+                BlobGasUsed = blobGasUsed,
+                ExcessBlobGas = excessBlobGas,
+                ParentBeaconBlockRoot = parentBeaconBlockRoot,
             };
-
-            if (blockRequest is ExecutionPayloadV3 blockRequestV3)
-            {
-                blockRequestV3.BlobGasUsed = blobGasUsed;
-                blockRequestV3.ExcessBlobGas = excessBlobGas;
-            }
 
             blockRequest.SetTransactions(transactions ?? Array.Empty<Transaction>());
             TryCalculateHash(blockRequest, out Keccak? hash);

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V3.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V3.cs
@@ -60,6 +60,20 @@ public partial class EngineModuleTests
         Assert.That(result.ErrorCode, Is.EqualTo(ErrorCodes.UnsupportedFork));
     }
 
+    [TestCaseSource(nameof(CancunFieldsTestSource))]
+    public async Task<int> NewPayloadV2_should_decline_pre_cancun_with_cancun_fields(ulong? blobGasUsed, ulong? excessBlobGas, Keccak? parentBlockBeaconRoot)
+    {
+        MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: Shanghai.Instance);
+        IEngineRpcModule rpcModule = CreateEngineModule(chain);
+        ExecutionPayload executionPayload = CreateBlockRequest(
+            CreateParentBlockRequestOnHead(chain.BlockTree), TestItem.AddressD, withdrawals: Array.Empty<Withdrawal>(),
+                blobGasUsed: blobGasUsed, excessBlobGas: excessBlobGas, parentBeaconBlockRoot: parentBlockBeaconRoot);
+
+        ResultWrapper<PayloadStatusV1> result = await rpcModule.engine_newPayloadV2(executionPayload);
+
+        return result.ErrorCode;
+    }
+
     [Test]
     public async Task NewPayloadV3_should_decline_pre_cancun_payloads()
     {
@@ -356,6 +370,48 @@ public partial class EngineModuleTests
             {
                 ExpectedResult = PayloadStatus.Invalid,
                 TestName = "One hash more than expected",
+            };
+        }
+    }
+
+    public static IEnumerable<TestCaseData> CancunFieldsTestSource
+    {
+        get
+        {
+            yield return new TestCaseData(null, null, null)
+            {
+                ExpectedResult = ErrorCodes.None,
+                TestName = "No Cancun fields",
+            };
+            yield return new TestCaseData(0ul, null, null)
+            {
+                ExpectedResult = ErrorCodes.InvalidParams,
+                TestName = $"{nameof(ExecutionPayloadV3.BlobGasUsed)} is set",
+            };
+            yield return new TestCaseData(null, 0ul, null)
+            {
+                ExpectedResult = ErrorCodes.InvalidParams,
+                TestName = $"{nameof(ExecutionPayloadV3.ExcessBlobGas)} is set",
+            };
+            yield return new TestCaseData(null, null, Keccak.Zero)
+            {
+                ExpectedResult = ErrorCodes.InvalidParams,
+                TestName = $"{nameof(ExecutionPayloadV3.ParentBeaconBlockRoot)} is set",
+            };
+            yield return new TestCaseData(1ul, 1ul, null)
+            {
+                ExpectedResult = ErrorCodes.InvalidParams,
+                TestName = $"Multiple fields #1",
+            };
+            yield return new TestCaseData(1ul, 1ul, Keccak.Zero)
+            {
+                ExpectedResult = ErrorCodes.InvalidParams,
+                TestName = $"Multiple fields #2",
+            };
+            yield return new TestCaseData(1ul, null, Keccak.Zero)
+            {
+                ExpectedResult = ErrorCodes.InvalidParams,
+                TestName = $"Multiple fields #3",
             };
         }
     }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayload.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayload.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
@@ -12,6 +11,7 @@ using Nethermind.Int256;
 using Nethermind.Merge.Plugin.Handlers;
 using Nethermind.Serialization.Rlp;
 using Nethermind.State.Proofs;
+using Newtonsoft.Json;
 
 namespace Nethermind.Merge.Plugin.Data;
 
@@ -93,6 +93,25 @@ public class ExecutionPayload : IForkValidator, IExecutionPayloadParams
 
 
     /// <summary>
+    /// Gets or sets <see cref="Block.BlobGasUsed"/> as defined in
+    /// <see href="https://eips.ethereum.org/EIPS/eip-4844">EIP-4844</see>.
+    /// </summary>
+    public ulong? BlobGasUsed { get; set; }
+
+    /// <summary>
+    /// Gets or sets <see cref="Block.ExcessBlobGas"/> as defined in
+    /// <see href="https://eips.ethereum.org/EIPS/eip-4844">EIP-4844</see>.
+    /// </summary>
+    public ulong? ExcessBlobGas { get; set; }
+
+    /// <summary>
+    /// Gets or sets <see cref="Block.ParentBeaconBlockRoot"/> as defined in
+    /// <see href="https://eips.ethereum.org/EIPS/eip-4788">EIP-4788</see>.
+    /// </summary>
+    [JsonIgnore]
+    public Keccak? ParentBeaconBlockRoot { get; set; }
+
+    /// <summary>
     /// Creates the execution block from payload.
     /// </summary>
     /// <param name="block">When this method returns, contains the execution block.</param>
@@ -169,7 +188,7 @@ public class ExecutionPayload : IForkValidator, IExecutionPayloadParams
 
     public virtual ValidationResult ValidateParams(IReleaseSpec spec, int version, out string? error)
     {
-        int GetVersion() => Withdrawals is null ? 1 : 2;
+        int GetVersion() => Withdrawals is null ? 1 : (BlobGasUsed is null && ExcessBlobGas is null && ParentBeaconBlockRoot is null ? 2 : 3);
 
         if (spec.IsEip4844Enabled)
         {

--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayloadV3.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayloadV3.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System.Diagnostics.CodeAnalysis;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
 using Nethermind.Int256;
@@ -22,18 +21,6 @@ public class ExecutionPayloadV3 : ExecutionPayload
         BlobGasUsed = block.BlobGasUsed;
         ExcessBlobGas = block.ExcessBlobGas;
     }
-
-    /// <summary>
-    /// Gets or sets <see cref="Block.BlobGasUsed"/> as defined in
-    /// <see href="https://eips.ethereum.org/EIPS/eip-4844">EIP-4844</see>.
-    /// </summary>
-    public ulong? BlobGasUsed { get; set; }
-
-    /// <summary>
-    /// Gets or sets <see cref="Block.ExcessBlobGas"/> as defined in
-    /// <see href="https://eips.ethereum.org/EIPS/eip-4844">EIP-4844</see>.
-    /// </summary>
-    public ulong? ExcessBlobGas { get; set; }
 
     public override bool TryGetBlock(out Block? block, UInt256? totalDifficulty = null)
     {


### PR DESCRIPTION
NewPayloadV3 fields should be detected and declined when passed to NewPayloadV2

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No
