### PR TITLE
Rebroadcast all persistent txs if PeerNotificationThreshold is 100

### DIFF
--- a/src/Nethermind/Nethermind.TxPool.Test/TxBroadcasterTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxBroadcasterTests.cs
@@ -540,7 +540,7 @@ public class TxBroadcasterTests
     [Test]
     public void should_rebroadcast_all_persistent_transactions_if_PeerNotificationThreshold_is_100([Values(true, false)] bool shouldBroadcastAll)
     {
-        _txPoolConfig = new TxPoolConfig(){ Size = 100, PeerNotificationThreshold = shouldBroadcastAll ? 100 : 5 };
+        _txPoolConfig = new TxPoolConfig() { Size = 100, PeerNotificationThreshold = shouldBroadcastAll ? 100 : 5 };
         _broadcaster = new TxBroadcaster(_comparer, TimerFactory.Default, _txPoolConfig, _headInfo, _logManager);
 
         for (int i = 0; i < _txPoolConfig.Size; i++)

--- a/src/Nethermind/Nethermind.TxPool.Test/TxBroadcasterTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxBroadcasterTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -551,6 +552,12 @@ public class TxBroadcasterTests
             _broadcaster.Broadcast(tx, true);
         }
 
-        _broadcaster.GetPersistentTxsToSend().TransactionsToSend.Count.Should().Be(shouldBroadcastAll ? 100 : 1);
+        Transaction[] pickedTxs = _broadcaster.GetPersistentTxsToSend().TransactionsToSend.ToArray();
+        pickedTxs.Length.Should().Be(shouldBroadcastAll ? 100 : 1);
+
+        for (int i = 0; i < pickedTxs.Length; i++)
+        {
+            pickedTxs[i].Nonce.Should().Be((UInt256)i);
+        }
     }
 }

--- a/src/Nethermind/Nethermind.TxPool/ITxPoolConfig.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxPoolConfig.cs
@@ -7,7 +7,7 @@ namespace Nethermind.TxPool
 {
     public interface ITxPoolConfig : IConfig
     {
-        [ConfigItem(DefaultValue = "5", Description = "Defines average percent of tx hashes from persistent broadcast send to peer together with hashes of last added txs.")]
+        [ConfigItem(DefaultValue = "5", Description = "Defines average percent of tx hashes from persistent broadcast send to peer together with hashes of last added txs. Set this value to 100 if you want to broadcast all transactions.")]
         int PeerNotificationThreshold { get; set; }
 
         [ConfigItem(DefaultValue = "2048", Description = "Max number of transactions held in mempool (more transactions in mempool mean more memory used")]

--- a/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
@@ -178,7 +178,11 @@ namespace Nethermind.TxPool
             List<Transaction>? persistentTxsToSend = null;
             List<Transaction>? persistentHashesToSend = null;
 
-            foreach (Transaction tx in _persistentTxs.GetFirsts())
+            IEnumerable<Transaction> txsToPickFrom = _txPoolConfig.PeerNotificationThreshold == 100
+                ? _persistentTxs.GetSnapshot()
+                : _persistentTxs.GetFirsts();
+
+            foreach (Transaction tx in txsToPickFrom)
             {
                 if (numberOfPersistentTxsToBroadcast > 0)
                 {

--- a/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
@@ -178,7 +178,8 @@ namespace Nethermind.TxPool
             List<Transaction>? persistentTxsToSend = null;
             List<Transaction>? persistentHashesToSend = null;
 
-            IEnumerable<Transaction> txsToPickFrom = _txPoolConfig.PeerNotificationThreshold == 100
+            bool broadcastAllTxs = _txPoolConfig.PeerNotificationThreshold == 100;
+            IEnumerable<Transaction> txsToPickFrom = broadcastAllTxs
                 ? _persistentTxs.GetSnapshot()
                 : _persistentTxs.GetFirsts();
 


### PR DESCRIPTION
## Changes

- Right now we are rebroadcasting only one tx per sender per block, which has perfect sense with low `PeerNotificationThreshold` (e.g. default value: 5), but doesn't have sense if someone wants to rebroadcast all persistent transactions. This PR is changing source of persistent transactions from `_persistentTxs.GetFirsts()` (one per sender) to `_persistentTxs.GetSnapshot()` (all) if `PeerNotificationThreshold` is set to 100

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No