### PR TITLE
Add initialization; use latest Ckzg version

### DIFF
--- a/src/Nethermind/Directory.Packages.props
+++ b/src/Nethermind/Directory.Packages.props
@@ -9,7 +9,7 @@
     <PackageVersion Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="6.0.5" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.5" />
     <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.5" />
-    <PackageVersion Include="Ckzg.Bindings" Version="0.1.2.537" />
+    <PackageVersion Include="Ckzg.Bindings" Version="0.1.2.591" />
     <PackageVersion Include="Colorful.Console" Version="1.2.15" />
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
     <PackageVersion Include="ConcurrentHashSet" Version="1.3.0" />

--- a/src/Nethermind/Nethermind.Precompiles.Benchmark/PointEvaluationBenchmark.cs
+++ b/src/Nethermind/Nethermind.Precompiles.Benchmark/PointEvaluationBenchmark.cs
@@ -2,12 +2,18 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Nethermind.Crypto;
 using Nethermind.Evm.Precompiles;
 
 namespace Nethermind.Precompiles.Benchmark;
 
 public class PointEvaluationBenchmark : PrecompileBenchmarkBase
 {
+    [GlobalSetup]
+    public async Task GlobalSetup() => await KzgPolynomialCommitments.InitializeAsync();
+
     protected override IEnumerable<IPrecompile> Precompiles => new[] { PointEvaluationPrecompile.Instance };
     protected override string InputsDirectory => "point_evaluation";
 }


### PR DESCRIPTION
The Point Evaluation precompile (eip-4844) benchmarks require Ckzg being initialized before run

The performance is good in comparison with other implementations ( https://github.com/imapp-pl/benchmarking/tree/precompiles_benchmark/shanghai#client-comparison )

```markdown
|   Method |            Input |       Mean |   Error |  StdDev | Ratio | Alloc Ratio |
|--------- |----------------- |-----------:|--------:|--------:|------:|------------:|
| Baseline |      fuzzcorp-33 |   109.7 us | 1.23 us | 2.93 us |  1.00 |        1.00 |
|          |                  |            |         |         |       |             |
| Baseline |      fuzzcorp-95 |   109.5 us | 0.77 us | 1.17 us |  1.00 |        1.00 |
|          |                  |            |         |         |       |             |
| Baseline | pointEvaluation1 | 1,104.5 us | 9.74 us | 8.13 us |  1.00 |        1.00 |
```
## Changes

- Add initialization
- Update library

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No
