### PR TITLE
Skip docker image creation if default master is used

### DIFF
--- a/.github/workflows/run-a-single-node-from-branch.yml
+++ b/.github/workflows/run-a-single-node-from-branch.yml
@@ -102,7 +102,12 @@ jobs:
     - name: Check if master branch and default additional_options
       id: check_conditions
       run: |
-        if [[ "${{ github.ref }}" == "refs/heads/master" && "${{ steps.extract_dockerfile.outputs.dockerfile }}" == "Dockerfile" && "${{ steps.extract_dockerfile.outputs.build-config  }}" == "release" ]]; then
+        if { 
+          [[ "${{ github.ref }}" == "refs/heads/master" ]] || 
+          [[ "${{ github.ref }}" == "refs/heads/kch/optimize_oneClick" ]]
+        } && 
+        [[ "${{ steps.extract_dockerfile.outputs.dockerfile }}" == "Dockerfile" ]] && 
+        [[ "${{ steps.extract_dockerfile.outputs.build-config }}" == "release" ]]; then
           echo "skip=true" >> $GITHUB_OUTPUT
         else
           echo "skip=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/run-a-single-node-from-branch.yml
+++ b/.github/workflows/run-a-single-node-from-branch.yml
@@ -106,13 +106,13 @@ jobs:
         [[ "${{ github.ref }}" == "refs/heads/master" ]] && 
         [[ "${{ steps.extract_dockerfile.outputs.dockerfile }}" == "Dockerfile" ]] && 
         [[ "${{ steps.extract_dockerfile.outputs.build-config }}" == "release" ]]; then
-          echo "skip=true" >> $GITHUB_OUTPUT
+          echo "skip_docker_build=true" >> $GITHUB_OUTPUT
         else
-          echo "skip=false" >> $GITHUB_OUTPUT
+          echo "skip_docker_build=false" >> $GITHUB_OUTPUT
         fi
 
     - name: Trigger Docker Build Action with Cleaned Ref
-      if: steps.check_conditions.outputs.skip != 'true'
+      if: steps.check_conditions.outputs.skip_docker_build != 'true'
       uses: benc-uk/workflow-dispatch@v1
       env:
         ADDITIONAL_OPTIONS: ${{ inputs.additional_options }}
@@ -127,7 +127,7 @@ jobs:
            }'
         
     - name: Wait for Docker Build Action to complete
-      if: steps.check_conditions.outputs.skip != 'true'
+      if: steps.check_conditions.outputs.skip_docker_build != 'true'
       env:
         GITHUB_TOKEN: ${{ secrets.REPOSITORY_DISPATCH_TOKEN }}
         WORKFLOW_ID: 'publish-docker.yml'

--- a/.github/workflows/run-a-single-node-from-branch.yml
+++ b/.github/workflows/run-a-single-node-from-branch.yml
@@ -94,7 +94,23 @@ jobs:
         echo "dockerfile=$(echo '${{ inputs.additional_options }}' | jq -r .default_dockerfile)" >> $GITHUB_OUTPUT
         echo "build-config=$(echo '${{ inputs.additional_options }}' | jq -r .default_dockerfile_build_type | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
 
+    - name: Set Repo and Org Variables
+      run: |
+        echo "ORG_NAME=$(echo $GITHUB_REPOSITORY | cut -d / -f 1)" >> $GITHUB_ENV
+        echo "REPO_NAME=$(echo $GITHUB_REPOSITORY | cut -d / -f 2)" >> $GITHUB_ENV
+        
+    - name: Check if master branch and default additional_options
+      id: check_conditions
+      run: |
+        DEFAULT_OPTIONS='{"timeout":"24", "default_dockerfile":"Dockerfile", "default_dockerfile_build_type":"release", "ssh_keys":"", "allowed_ips":""}'
+        if [[ "${{ github.ref }}" == "refs/heads/master" && "${{ github.event.inputs.additional_options }}" == "$DEFAULT_OPTIONS" ]]; then
+          echo "skip=true" >> $GITHUB_OUTPUT
+        else
+          echo "skip=false" >> $GITHUB_OUTPUT
+        fi
+
     - name: Trigger Docker Build Action with Cleaned Ref
+      if: steps.check_conditions.outputs.skip != 'true'
       uses: benc-uk/workflow-dispatch@v1
       env:
         ADDITIONAL_OPTIONS: ${{ inputs.additional_options }}
@@ -107,12 +123,9 @@ jobs:
               "dockerfile": "${{ steps.extract_dockerfile.outputs.dockerfile }}",
               "build-config": "${{ steps.extract_dockerfile.outputs.build-config }}"
            }'
-
-    - name: Set Repo and Org Variables
-      run: |
-        echo "ORG_NAME=$(echo $GITHUB_REPOSITORY | cut -d / -f 1)" >> $GITHUB_ENV
-        echo "REPO_NAME=$(echo $GITHUB_REPOSITORY | cut -d / -f 2)" >> $GITHUB_ENV
+        
     - name: Wait for Docker Build Action to complete
+      if: steps.check_conditions.outputs.skip != 'true'
       env:
         GITHUB_TOKEN: ${{ secrets.REPOSITORY_DISPATCH_TOKEN }}
         WORKFLOW_ID: 'publish-docker.yml'

--- a/.github/workflows/run-a-single-node-from-branch.yml
+++ b/.github/workflows/run-a-single-node-from-branch.yml
@@ -102,7 +102,7 @@ jobs:
     - name: Check if master branch and default additional_options
       id: check_conditions
       run: |
-        if [[ "${{ github.ref }}" == "refs/heads/master" && "${{ steps.extract_dockerfile.outputs.dockerfile }}" == "Dockerfile" && "${{ steps.extract_dockerfile.outputs.build-config  }}" == "release" ]]; then
+        if [[ "${{ github.ref }}" == "refs/heads/kch/optimize_oneClick" && "${{ steps.extract_dockerfile.outputs.dockerfile }}" == "Dockerfile" && "${{ steps.extract_dockerfile.outputs.build-config  }}" == "release" ]]; then
           echo "skip=true" >> $GITHUB_OUTPUT
         else
           echo "skip=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/run-a-single-node-from-branch.yml
+++ b/.github/workflows/run-a-single-node-from-branch.yml
@@ -109,7 +109,7 @@ jobs:
         fi
 
     - name: Trigger Docker Build Action with Cleaned Ref
-      if: steps.check_conditions.outputs.skip != true
+      if: steps.check_conditions.outputs.skip != 'true'
       uses: benc-uk/workflow-dispatch@v1
       env:
         ADDITIONAL_OPTIONS: ${{ inputs.additional_options }}
@@ -124,7 +124,7 @@ jobs:
            }'
         
     - name: Wait for Docker Build Action to complete
-      if: steps.check_conditions.outputs.skip != true
+      if: steps.check_conditions.outputs.skip != 'true'
       env:
         GITHUB_TOKEN: ${{ secrets.REPOSITORY_DISPATCH_TOKEN }}
         WORKFLOW_ID: 'publish-docker.yml'

--- a/.github/workflows/run-a-single-node-from-branch.yml
+++ b/.github/workflows/run-a-single-node-from-branch.yml
@@ -124,7 +124,7 @@ jobs:
            }'
         
     - name: Wait for Docker Build Action to complete
-      if: steps.check_conditions.outputs.skip != 'true'
+      if: steps.check_conditions.outputs.skip != true
       env:
         GITHUB_TOKEN: ${{ secrets.REPOSITORY_DISPATCH_TOKEN }}
         WORKFLOW_ID: 'publish-docker.yml'

--- a/.github/workflows/run-a-single-node-from-branch.yml
+++ b/.github/workflows/run-a-single-node-from-branch.yml
@@ -83,10 +83,6 @@ jobs:
 
     - name: Creating a node with NodeName="DevNode-${{ github.actor }}-${{ env.BASE_TAG }}-${{ env.CLEAN_REF }}-${{ inputs.network }}-${{ inputs.cl_client }}"
       run: echo "NodeName='DevNode-${{ github.actor }}-${{ env.BASE_TAG }}-${{ env.CLEAN_REF }}-${{ inputs.network }}-${{ inputs.cl_client }}'"
-    
-    - name: Set Repo Variable
-      run: |
-        echo "REPO=$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
     - name: Extract dockerfile from additional_options
       id: extract_dockerfile
@@ -96,8 +92,8 @@ jobs:
 
     - name: Set Repo and Org Variables
       run: |
-        echo "ORG_NAME=$(echo $GITHUB_REPOSITORY | cut -d / -f 1)" >> $GITHUB_ENV
-        echo "REPO_NAME=$(echo $GITHUB_REPOSITORY | cut -d / -f 2)" >> $GITHUB_ENV
+        echo "ORG_NAME=${{ github.repository_owner }}" >> $GITHUB_ENV
+        echo "REPO_NAME=${{ github.event.repository.name }}" >> $GITHUB_ENV
         
     - name: Check if master branch and default additional_options
       id: check_conditions

--- a/.github/workflows/run-a-single-node-from-branch.yml
+++ b/.github/workflows/run-a-single-node-from-branch.yml
@@ -102,7 +102,7 @@ jobs:
     - name: Check if master branch and default additional_options
       id: check_conditions
       run: |
-        if [[ "${{ github.ref }}" == "refs/heads/kch/optimize_oneClick" && "${{ steps.extract_dockerfile.outputs.dockerfile }}" == "Dockerfile" && "${{ steps.extract_dockerfile.outputs.build-config  }}" == "release" ]]; then
+        if [[ "${{ github.ref }}" == "refs/heads/master" && "${{ steps.extract_dockerfile.outputs.dockerfile }}" == "Dockerfile" && "${{ steps.extract_dockerfile.outputs.build-config  }}" == "release" ]]; then
           echo "skip=true" >> $GITHUB_OUTPUT
         else
           echo "skip=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/run-a-single-node-from-branch.yml
+++ b/.github/workflows/run-a-single-node-from-branch.yml
@@ -102,15 +102,14 @@ jobs:
     - name: Check if master branch and default additional_options
       id: check_conditions
       run: |
-        DEFAULT_OPTIONS='{"timeout":"24", "default_dockerfile":"Dockerfile", "default_dockerfile_build_type":"release", "ssh_keys":"", "allowed_ips":""}'
-        if [[ "${{ github.ref }}" == "refs/heads/master" && "${{ github.event.inputs.additional_options }}" == "$DEFAULT_OPTIONS" ]]; then
+        if [[ "${{ github.ref }}" == "refs/heads/master" && "${{ steps.extract_dockerfile.outputs.dockerfile }}" == "Dockerfile" && "${{ steps.extract_dockerfile.outputs.build-config  }}" == "release" ]]; then
           echo "skip=true" >> $GITHUB_OUTPUT
         else
           echo "skip=false" >> $GITHUB_OUTPUT
         fi
 
     - name: Trigger Docker Build Action with Cleaned Ref
-      if: steps.check_conditions.outputs.skip != 'true'
+      if: steps.check_conditions.outputs.skip != true
       uses: benc-uk/workflow-dispatch@v1
       env:
         ADDITIONAL_OPTIONS: ${{ inputs.additional_options }}

--- a/.github/workflows/run-a-single-node-from-branch.yml
+++ b/.github/workflows/run-a-single-node-from-branch.yml
@@ -102,10 +102,8 @@ jobs:
     - name: Check if master branch and default additional_options
       id: check_conditions
       run: |
-        if { 
-          [[ "${{ github.ref }}" == "refs/heads/master" ]] || 
-          [[ "${{ github.ref }}" == "refs/heads/kch/optimize_oneClick" ]]
-        } && 
+        if 
+        [[ "${{ github.ref }}" == "refs/heads/master" ]] && 
         [[ "${{ steps.extract_dockerfile.outputs.dockerfile }}" == "Dockerfile" ]] && 
         [[ "${{ steps.extract_dockerfile.outputs.build-config }}" == "release" ]]; then
           echo "skip=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Changes

- Do not build master image if default config is used since this one is being built after each commit merged to master branch

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [X] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

Tested on this run when `kch/optimize_oneClick` was also added to the check next to master branch - as expected it skipped two steps for triggering and waiting for docker image to be done
https://github.com/NethermindEth/nethermind/actions/runs/6089715555

Tested on this run where only master branch was checked (final version) - as expected it triggers build since it was triggered from `kch/optimize_oneClick` branch:
https://github.com/NethermindEth/nethermind/actions/runs/6089729660

## Documentation

#### Requires documentation update

- [ ] Yes
- [X] No


#### Requires explanation in Release Notes

- [ ] Yes
- [X] No