### PR TITLE
Perf/minor rlpstream tweak

### DIFF
--- a/src/Nethermind/Nethermind.Serialization.Rlp/NettyRlpStream.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/NettyRlpStream.cs
@@ -70,6 +70,12 @@ namespace Nethermind.Serialization.Rlp
             return span;
         }
 
+        public override Span<byte> Peek(int offset, int length)
+        {
+            Span<byte> span = _buffer.Array.AsSpan(_buffer.ArrayOffset + _buffer.ReaderIndex + offset, length);
+            return span;
+        }
+
         public override byte PeekByte()
         {
             byte result = _buffer.ReadByte();

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpStream.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpStream.cs
@@ -873,13 +873,13 @@ namespace Nethermind.Serialization.Rlp
 
         protected virtual void SkipBytes(int length)
         {
-            Position += length;
+            _position += length;
         }
 
         public virtual Span<byte> Read(int length)
         {
             Span<byte> data = Data.AsSpan(_position, length);
-            Position += length;
+            _position += length;
             return data;
         }
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpStream.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpStream.cs
@@ -692,7 +692,7 @@ namespace Nethermind.Serialization.Rlp
         public (int PrefixLength, int ContentLength) PeekPrefixAndContentLength()
         {
             (int prefixLength, int contentLength) result;
-            int prefix = ReadByte();
+            int prefix = PeekByte();
             if (prefix <= 128)
             {
                 result = (0, 1);


### PR DESCRIPTION
## Minor rlpstream improvement

- Improve PatriciaTree benchmark by about 9%.
- Works by:
  - `PeekPrefixAndContentLength` without changing `Position`.
  - Use `_position` instead of virtual property `Position` whenever it is safe to do so (array backed RlpStream).

|   Method |     Mean |   Error |  StdDev |   Gen0 |   Gen1 | Allocated |
|--------- |---------:|--------:|--------:|-------:|-------:|----------:|
| Before | 164.2 us | 1.55 us | 2.32 us | 1.7090 | 0.4883 | 152.98 KB |
| After | 149.4 us | 1.55 us | 2.32 us | 1.7090 | 0.4883 | 152.98 KB |

## Changes

- Make `PeekPrefixAndContentLength` not change `Position`.
- Use `_position` instead of virtual property `Position` whenever safe.

## Types of changes

#### What types of changes does your code introduce?

- [X] Optimization
- [ ] Other: _Description_

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

- Existing unit tests passed.
- Can sync and process block as usual.