### PR TITLE
Return full REVERT error message

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "dotnet.defaultSolution": "src/Nethermind/Nethermind.sln"
+}

--- a/src/Nethermind/Nethermind.Evm.Test/TransactionSubstateTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/TransactionSubstateTests.cs
@@ -4,6 +4,7 @@
 using System;
 using FluentAssertions;
 using Nethermind.Core;
+using Nethermind.Core.Extensions;
 using NUnit.Framework;
 
 namespace Nethermind.Evm.Test
@@ -41,6 +42,70 @@ namespace Nethermind.Evm.Test
                 true,
                 true);
             transactionSubstate.Error.Should().Be("Reverted 0x0506070809");
+        }
+
+        [Test]
+        [Description($"Replace with {nameof(should_return_proper_revert_error_when_revert_custom_error)} once fixed")]
+        public void should_return_proper_revert_error_when_revert_custom_error_badly_implemented()
+        {
+            // See: https://github.com/NethermindEth/nethermind/issues/6024
+
+            string input =
+                "0x220266b600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000001741413231206469646e2774207061792070726566756e64000000000000000000";
+            byte[] data = Bytes.FromHexString(input);
+            ReadOnlyMemory<byte> readOnlyMemory = new(data);
+            TransactionSubstate transactionSubstate = new(
+                readOnlyMemory,
+                0,
+                new ArraySegment<Address>(),
+                new LogEntry[] { },
+                true,
+                true);
+            transactionSubstate.Error.Should().Be($"Reverted {input}");
+        }
+
+        [Test]
+        [Ignore("Badly implemented")]
+        public void should_return_proper_revert_error_when_revert_custom_error()
+        {
+            byte[] data = {
+                0x22, 0x02, 0x66, 0xb6, // Keccak of 'FailedOp(uint256,string) == 0x220266b6'
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x17,
+                0x41, 0x41, 0x32, 0x31, 0x20, 0x64, 0x69, 0x64, 0x6e, 0x27, 0x74, 0x20, 0x70, 0x61, 0x79, 0x20, 0x70, 0x72, 0x65, 0x66, 0x75, 0x6e, 0x64, // "AA21 didn't pay prefund"
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+            ReadOnlyMemory<byte> readOnlyMemory = new(data);
+            TransactionSubstate transactionSubstate = new(
+                readOnlyMemory,
+                0,
+                new ArraySegment<Address>(),
+                new LogEntry[] { },
+                true,
+                true);
+            transactionSubstate.Error.Should().Be("Reverted 0x41413231206469646e2774207061792070726566756e64");
+        }
+
+        [Test]
+        [Ignore("Badly implemented in several clients (geth, erigon, Nethermind)")]
+        public void should_return_proper_revert_error_eip_140_test_case()
+        {
+            // See: https://eips.ethereum.org/EIPS/eip-140
+
+            byte[] data = {
+                0x6c, 0x72, 0x65, 0x76, 0x65, 0x72, 0x74, 0x65, 0x64, 0x20, 0x64, 0x61, 0x74, 0x61, // "lreverted data'
+                0x60, 0x00, 0x55, 0x7f,
+                0x72, 0x65, 0x76, 0x65, 0x72, 0x74, 0x20, 0x6d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, // "revert message"
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x60, 0x00, 0x52, 0x60, 0x0e, 0x60, 0x00, 0xfd,
+            };
+            ReadOnlyMemory<byte> readOnlyMemory = new(data);
+            TransactionSubstate transactionSubstate = new(
+                readOnlyMemory,
+                0,
+                new ArraySegment<Address>(),
+                new LogEntry[] { },
+                true,
+                true);
+            transactionSubstate.Error.Should().Be("Reverted 0x726576657274206d657373616765");
         }
     }
 }

--- a/src/Nethermind/Nethermind.Evm.Test/TransactionSubstateTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/TransactionSubstateTests.cs
@@ -50,9 +50,9 @@ namespace Nethermind.Evm.Test
         {
             // See: https://github.com/NethermindEth/nethermind/issues/6024
 
-            string input =
+            string hex =
                 "0x220266b600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000001741413231206469646e2774207061792070726566756e64000000000000000000";
-            byte[] data = Bytes.FromHexString(input);
+            byte[] data = Bytes.FromHexString(hex);
             ReadOnlyMemory<byte> readOnlyMemory = new(data);
             TransactionSubstate transactionSubstate = new(
                 readOnlyMemory,
@@ -61,7 +61,7 @@ namespace Nethermind.Evm.Test
                 new LogEntry[] { },
                 true,
                 true);
-            transactionSubstate.Error.Should().Be($"Reverted {input}");
+            transactionSubstate.Error.Should().Be($"Reverted {hex}");
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Evm.Test/TransactionSubstateTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/TransactionSubstateTests.cs
@@ -84,28 +84,5 @@ namespace Nethermind.Evm.Test
                 true);
             transactionSubstate.Error.Should().Be("Reverted 0x41413231206469646e2774207061792070726566756e64");
         }
-
-        [Test]
-        [Ignore("Badly implemented in several clients (geth, erigon, Nethermind)")]
-        public void should_return_proper_revert_error_eip_140_test_case()
-        {
-            // See: https://eips.ethereum.org/EIPS/eip-140
-
-            byte[] data = {
-                0x6c, 0x72, 0x65, 0x76, 0x65, 0x72, 0x74, 0x65, 0x64, 0x20, 0x64, 0x61, 0x74, 0x61, // "lreverted data'
-                0x60, 0x00, 0x55, 0x7f,
-                0x72, 0x65, 0x76, 0x65, 0x72, 0x74, 0x20, 0x6d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, // "revert message"
-                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x60, 0x00, 0x52, 0x60, 0x0e, 0x60, 0x00, 0xfd,
-            };
-            ReadOnlyMemory<byte> readOnlyMemory = new(data);
-            TransactionSubstate transactionSubstate = new(
-                readOnlyMemory,
-                0,
-                new ArraySegment<Address>(),
-                new LogEntry[] { },
-                true,
-                true);
-            transactionSubstate.Error.Should().Be("Reverted 0x726576657274206d657373616765");
-        }
     }
 }

--- a/src/Nethermind/Nethermind.Evm.Test/VirtualMachineTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/VirtualMachineTests.cs
@@ -545,4 +545,15 @@ public class VirtualMachineTests : VirtualMachineTestsBase
         TestAllTracerWithOutput receipt = Execute(MainnetSpecProvider.GrayGlacierBlockNumber, 100000, code, timestamp: MainnetSpecProvider.CancunBlockTimestamp);
         Assert.That(receipt.GasSpent, Is.EqualTo(GasCostOf.Transaction + GasCostOf.VeryLow * 2 + GasCostOf.TStore), "gas");
     }
+
+    [Test]
+    public void Revert() {
+        // See: https://eips.ethereum.org/EIPS/eip-140
+
+        byte[] code = Bytes.FromHexString("0x6c726576657274656420646174616000557f726576657274206d657373616765000000000000000000000000000000000000600052600e6000fd");
+        TestAllTracerWithOutput receipt = Execute(blockNumber: MainnetSpecProvider.ByzantiumBlockNumber, 100_000, code);
+
+        Assert.That(receipt.Error, Is.EqualTo("Reverted 0x726576657274206d657373616765"));
+        Assert.That(receipt.GasSpent, Is.EqualTo(GasCostOf.Transaction + 20024));
+    }
 }

--- a/src/Nethermind/Nethermind.Evm/TransactionSubstate.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionSubstate.cs
@@ -83,12 +83,6 @@ public class TransactionSubstate
             return null;
         }
 
-        if (!span.Slice(0, RevertPrefix).IsZero())
-        {
-            // Fail if the prefix is not '0x00000000'
-            return null;
-        }
-
         try
         {
             int start = (int)new UInt256(span.Slice(RevertPrefix, sizeof(UInt256)), isBigEndian: true);
@@ -98,7 +92,7 @@ public class TransactionSubstate
             }
 
             int length = (int)new UInt256(span.Slice(RevertPrefix + start, sizeof(UInt256)), isBigEndian: true);
-            if (checked(RevertPrefix + start + sizeof(UInt256) + length) > span.Length)
+            if (checked(RevertPrefix + start + sizeof(UInt256) + length) != span.Length)
             {
                 return null;
             }

--- a/src/Nethermind/Nethermind.Evm/TransactionSubstate.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionSubstate.cs
@@ -7,92 +7,87 @@ using Nethermind.Core;
 using Nethermind.Core.Extensions;
 using Nethermind.Int256;
 
-namespace Nethermind.Evm
+namespace Nethermind.Evm;
+
+public class TransactionSubstate
 {
-    public class TransactionSubstate
+    private static readonly List<Address> _emptyDestroyList = new(0);
+    private static readonly List<LogEntry> _emptyLogs = new(0);
+
+    private const string SomeError = "error";
+    private const string Revert = "revert";
+
+    private const int RevertPrefix = 4;
+
+    private const string RevertedErrorMessagePrefix = "Reverted ";
+
+    public bool IsError => Error is not null && !ShouldRevert;
+    public string? Error { get; }
+    public ReadOnlyMemory<byte> Output { get; }
+    public bool ShouldRevert { get; }
+    public long Refund { get; }
+    public IReadOnlyCollection<LogEntry> Logs { get; }
+    public IReadOnlyCollection<Address> DestroyList { get; }
+
+    public TransactionSubstate(EvmExceptionType exceptionType, bool isTracerConnected)
     {
-        private static List<Address> _emptyDestroyList = new(0);
-        private static List<LogEntry> _emptyLogs = new(0);
+        Error = isTracerConnected ? exceptionType.ToString() : SomeError;
+        Refund = 0;
+        DestroyList = _emptyDestroyList;
+        Logs = _emptyLogs;
+        ShouldRevert = false;
+    }
 
-        private const string SomeError = "error";
-        private const string Revert = "revert";
+    public unsafe TransactionSubstate(
+        ReadOnlyMemory<byte> output,
+        long refund,
+        IReadOnlyCollection<Address> destroyList,
+        IReadOnlyCollection<LogEntry> logs,
+        bool shouldRevert,
+        bool isTracerConnected)
+    {
+        Output = output;
+        Refund = refund;
+        DestroyList = destroyList;
+        Logs = logs;
+        ShouldRevert = shouldRevert;
 
-        public TransactionSubstate(EvmExceptionType exceptionType, bool isTracerConnected)
+        if (!ShouldRevert)
         {
-            Error = isTracerConnected ? exceptionType.ToString() : SomeError;
-            Refund = 0;
-            DestroyList = _emptyDestroyList;
-            Logs = _emptyLogs;
-            ShouldRevert = false;
+            Error = null;
+            return;
         }
 
-        public unsafe TransactionSubstate(
-            ReadOnlyMemory<byte> output,
-            long refund,
-            IReadOnlyCollection<Address> destroyList,
-            IReadOnlyCollection<LogEntry> logs,
-            bool shouldRevert,
-            bool isTracerConnected)
+        Error = Revert;
+
+        if (!isTracerConnected)
+            return;
+
+        if (Output.Length <= 0)
+            return;
+
+        ReadOnlySpan<byte> span = Output.Span;
+        if (span.Length >= sizeof(UInt256) * 2 + RevertPrefix)
         {
-            const int revertPrefix = 4;
-
-            Output = output;
-            Refund = refund;
-            DestroyList = destroyList;
-            Logs = logs;
-            ShouldRevert = shouldRevert;
-            if (ShouldRevert)
+            try
             {
-                Error = Revert;
-                if (isTracerConnected)
+                int start = (int)new UInt256(span.Slice(RevertPrefix, sizeof(UInt256)), isBigEndian: true);
+                if (start + RevertPrefix + sizeof(UInt256) <= span.Length)
                 {
-                    if (Output.Length > 0)
+                    int length = (int)new UInt256(span.Slice(start + RevertPrefix, sizeof(UInt256)), isBigEndian: true);
+                    if (checked(start + RevertPrefix + sizeof(UInt256) + length) <= span.Length)
                     {
-                        ReadOnlySpan<byte> span = Output.Span;
-                        if (span.Length >= sizeof(UInt256) * 2 + revertPrefix)
-                        {
-                            try
-                            {
-                                int start = (int)(new UInt256(span.Slice(revertPrefix, sizeof(UInt256)), isBigEndian: true));
-                                if (start + revertPrefix + sizeof(UInt256) <= span.Length)
-                                {
-                                    int length = (int)new UInt256(span.Slice(start + revertPrefix, sizeof(UInt256)), isBigEndian: true);
-                                    if (checked(start + revertPrefix + sizeof(UInt256) + length) <= span.Length)
-                                    {
-                                        Error = string.Concat("Reverted ",
-                                            span.Slice(start + sizeof(UInt256) + revertPrefix, length).ToHexString(true));
-                                        return;
-                                    }
-                                }
-                            }
-                            catch
-                            {
-                                // ignore
-                            }
-                        }
-
-                        Error = string.Concat("Reverted ", span.ToHexString(true));
+                        Error = string.Concat(RevertedErrorMessagePrefix, span.Slice(start + sizeof(UInt256) + RevertPrefix, length).ToHexString(true));
+                        return;
                     }
                 }
             }
-            else
+            catch
             {
-                Error = null;
+                // ignore
             }
         }
 
-        public bool IsError => Error is not null && !ShouldRevert;
-
-        public string Error { get; }
-
-        public ReadOnlyMemory<byte> Output { get; }
-
-        public bool ShouldRevert { get; }
-
-        public long Refund { get; }
-
-        public IReadOnlyCollection<LogEntry> Logs { get; }
-
-        public IReadOnlyCollection<Address> DestroyList { get; }
+        Error = string.Concat(RevertedErrorMessagePrefix, span.ToHexString(true));
     }
 }


### PR DESCRIPTION
Fixes #6024

## Changes

- Return the full error message on `REVERT` when parsing fails

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- Added test that reproduce the issue described in the referenced ticket.
- Added test for EIP-140: https://eips.ethereum.org/EIPS/eip-140

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

This fix only results in compatibility with other clients like geth and erigon.