### PR TITLE
Feature/feed DNS to discv4

### DIFF
--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -560,7 +560,7 @@ public class InitializeNetwork : IStep
         EnrRecordParser enrRecordParser = new(nodeRecordSigner);
         EnrDiscovery enrDiscovery = new(enrRecordParser, _api.LogManager); // initialize with a proper network
 
-        if (_networkConfig.DisableDiscV4DnsFeeder)
+        if (!_networkConfig.DisableDiscV4DnsFeeder)
         {
             // Feed some nodes into discoveryApp in case all bootnodes is faulty.
             _api.DisposeStack.Push(new NodeSourceToDiscV4Feeder(enrDiscovery, _api.DiscoveryApp, 50));

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -559,7 +559,13 @@ public class InitializeNetwork : IStep
         NodeRecordSigner nodeRecordSigner = new(_api.EthereumEcdsa, new PrivateKeyGenerator().Generate());
         EnrRecordParser enrRecordParser = new(nodeRecordSigner);
         EnrDiscovery enrDiscovery = new(enrRecordParser, _api.LogManager); // initialize with a proper network
-        _api.DisposeStack.Push(new EnrToDiscv4Feeder(enrDiscovery, _api.DiscoveryApp));
+
+        if (_networkConfig.DisableDiscV4DnsFeeder)
+        {
+            // Feed some nodes into discoveryApp in case all bootnodes is faulty.
+            _api.DisposeStack.Push(new NodeSourceToDiscV4Feeder(enrDiscovery, _api.DiscoveryApp, 50));
+        }
+
         CompositeNodeSource nodeSources = new(_api.StaticNodesManager, nodesLoader, enrDiscovery, _api.DiscoveryApp);
         _api.PeerPool = new PeerPool(nodeSources, _api.NodeStatsManager, peerStorage, _networkConfig, _api.LogManager);
         _api.PeerManager = new PeerManager(

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -559,6 +559,7 @@ public class InitializeNetwork : IStep
         NodeRecordSigner nodeRecordSigner = new(_api.EthereumEcdsa, new PrivateKeyGenerator().Generate());
         EnrRecordParser enrRecordParser = new(nodeRecordSigner);
         EnrDiscovery enrDiscovery = new(enrRecordParser, _api.LogManager); // initialize with a proper network
+        _api.DisposeStack.Push(new EnrToDiscv4Feeder(enrDiscovery, _api.DiscoveryApp));
         CompositeNodeSource nodeSources = new(_api.StaticNodesManager, nodesLoader, enrDiscovery, _api.DiscoveryApp);
         _api.PeerPool = new PeerPool(nodeSources, _api.NodeStatsManager, peerStorage, _networkConfig, _api.LogManager);
         _api.PeerManager = new PeerManager(

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/NodeSourceToDiscV4Feeder.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/NodeSourceToDiscV4Feeder.cs
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core.Test.Builders;
+using Nethermind.Stats.Model;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Network.Discovery.Test;
+
+public class NodeSourceToDiscV4FeederTests
+{
+    [Test]
+    public void Test_ShouldAddNodeToDiscover()
+    {
+        INodeSource source = Substitute.For<INodeSource>();
+        IDiscoveryApp discoveryApp = Substitute.For<IDiscoveryApp>();
+        using NodeSourceToDiscV4Feeder feeder = new(source, discoveryApp, 10);
+        source.NodeAdded += Raise.EventWith(new NodeEventArgs(new Node(TestItem.PublicKeyA, TestItem.IPEndPointA)));
+
+        discoveryApp.Received().AddNodeToDiscovery(Arg.Any<Node>());
+    }
+
+    [Test]
+    public void Test_ShouldLimitAddedNode()
+    {
+        INodeSource source = Substitute.For<INodeSource>();
+        IDiscoveryApp discoveryApp = Substitute.For<IDiscoveryApp>();
+        using NodeSourceToDiscV4Feeder feeder = new(source, discoveryApp, 10);
+
+        for (int i = 0; i < 20; i++)
+        {
+            source.NodeAdded += Raise.EventWith(new NodeEventArgs(new Node(TestItem.PublicKeyA, TestItem.IPEndPointA)));
+        }
+
+        discoveryApp.Received(10).AddNodeToDiscovery(Arg.Any<Node>());
+    }
+}

--- a/src/Nethermind/Nethermind.Network.Discovery/EnrToDiscv4Feeder.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/EnrToDiscv4Feeder.cs
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.Network.Discovery;
+
+public class EnrToDiscv4Feeder: IDisposable
+{
+    private readonly INodeSource _nodeSource;
+    private readonly IDiscoveryApp _discoveryApp;
+
+    public EnrToDiscv4Feeder(INodeSource nodeSource, IDiscoveryApp discoveryApp)
+    {
+        nodeSource.NodeAdded += AddToDiscoveryApp;
+        _nodeSource = nodeSource;
+        _discoveryApp = discoveryApp;
+    }
+
+    private void AddToDiscoveryApp(object? sender, NodeEventArgs e)
+    {
+        _discoveryApp.AddNodeToDiscovery(e.Node);
+    }
+
+    public void Dispose()
+    {
+        _nodeSource.NodeAdded -= AddToDiscoveryApp;
+    }
+}

--- a/src/Nethermind/Nethermind.Network.Discovery/NodeSourceToDiscV4Feeder.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/NodeSourceToDiscV4Feeder.cs
@@ -3,20 +3,25 @@
 
 namespace Nethermind.Network.Discovery;
 
-public class EnrToDiscv4Feeder: IDisposable
+public class NodeSourceToDiscV4Feeder : IDisposable
 {
     private readonly INodeSource _nodeSource;
     private readonly IDiscoveryApp _discoveryApp;
+    private readonly int _maxNodes;
+    private int _addedNodes = 0;
 
-    public EnrToDiscv4Feeder(INodeSource nodeSource, IDiscoveryApp discoveryApp)
+    public NodeSourceToDiscV4Feeder(INodeSource nodeSource, IDiscoveryApp discoveryApp, int maxNodes)
     {
         nodeSource.NodeAdded += AddToDiscoveryApp;
         _nodeSource = nodeSource;
         _discoveryApp = discoveryApp;
+        _maxNodes = maxNodes;
     }
 
     private void AddToDiscoveryApp(object? sender, NodeEventArgs e)
     {
+        if (_addedNodes >= _maxNodes) return;
+        _addedNodes++;
         _discoveryApp.AddNodeToDiscovery(e.Node);
     }
 

--- a/src/Nethermind/Nethermind.Network/Config/INetworkConfig.cs
+++ b/src/Nethermind/Nethermind.Network/Config/INetworkConfig.cs
@@ -97,5 +97,8 @@ namespace Nethermind.Network.Config
 
         [ConfigItem(DefaultValue = null, HiddenFromDocs = true, Description = "[TECHNICAL] Only allow peer with clientId matching this regex. Useful for testing. eg: 'besu' to only connect to BeSU")]
         string? ClientIdMatcher { get; set; }
+
+        [ConfigItem(DefaultValue = "false", HiddenFromDocs = true, Description = "[TECHNICAL] Disable feeding ENR DNS records to discv4 table")]
+        bool DisableDiscV4DnsFeeder { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.Network/Config/NetworkConfig.cs
+++ b/src/Nethermind/Nethermind.Network/Config/NetworkConfig.cs
@@ -39,5 +39,6 @@ namespace Nethermind.Network.Config
         public int ConnectTimeoutMs { get; set; } = 2000;
         public int ProcessingThreadCount { get; set; } = 1;
         public string? ClientIdMatcher { get; set; } = null;
+        public bool DisableDiscV4DnsFeeder { get; set; } = false;
     }
 }


### PR DESCRIPTION
- On goerli, all the bootnodes does not response for some reason.
- To compensate for that, this adds a code that feeds nodes from DNS discovery to disv4 to somewhat seed it.
- Unlike with disv4, entry from dns may be offline (disv4 wait for Pong message).
- This seems to cause some noise, so it limit the number of added record to 50. The amount does not strictly matter much, it just need one node that can respond.

## Changes

- Seed discv4 with dns.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)
## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation
