### PR TITLE
Dont stop peer connection on any exception

### DIFF
--- a/src/Nethermind/Nethermind.Network.Discovery/DiscoveryApp.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/DiscoveryApp.cs
@@ -180,7 +180,9 @@ public class DiscoveryApp : IDiscoveryApp
         if (_logger.IsDebug) _logger.Debug("Activated discovery channel.");
 
         //Make sure this is non blocking code, otherwise netty will not process messages
-        Task.Run(() => OnChannelActivated(_appShutdownSource.Token)).ContinueWith
+        Task.Factory
+            .StartNew(() => OnChannelActivated(_appShutdownSource.Token), _appShutdownSource.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default)
+            .ContinueWith
         (
             t =>
             {

--- a/src/Nethermind/Nethermind.Network.Discovery/DiscoveryApp.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/DiscoveryApp.cs
@@ -179,7 +179,9 @@ public class DiscoveryApp : IDiscoveryApp
     {
         if (_logger.IsDebug) _logger.Debug("Activated discovery channel.");
 
-        //Make sure this is non blocking code, otherwise netty will not process messages
+        // Make sure this is non blocking code, otherwise netty will not process messages
+        // Explicitly use TaskScheduler.Default, otherwise it will use dotnetty's task scheduler which have a habit of
+        // not working sometimes.
         Task.Factory
             .StartNew(() => OnChannelActivated(_appShutdownSource.Token), _appShutdownSource.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default)
             .ContinueWith

--- a/src/Nethermind/Nethermind.Network.Discovery/DiscoveryManager.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/DiscoveryManager.cs
@@ -228,7 +228,7 @@ public class DiscoveryManager : IDiscoveryManager
     private TaskCompletionSource<DiscoveryMsg> GetCompletionSource(Keccak senderAddressHash, int messageType)
     {
         MessageTypeKey key = new(senderAddressHash, messageType);
-        TaskCompletionSource<DiscoveryMsg> completionSource = _waitingEvents.GetOrAdd(key, new TaskCompletionSource<DiscoveryMsg>());
+        TaskCompletionSource<DiscoveryMsg> completionSource = _waitingEvents.GetOrAdd(key, new TaskCompletionSource<DiscoveryMsg>(TaskCreationOptions.RunContinuationsAsynchronously));
         return completionSource;
     }
 

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -216,7 +216,8 @@ namespace Nethermind.Network
                     }
                     catch (Exception e)
                     {
-                        if (_logger.IsDebug) _logger.Debug($"Error setting up connection to {peer}, {e}");
+                        // This is strictly speaking not related to the connection, but something outside of it.
+                        if (_logger.IsError) _logger.Error($"Error setting up connection to {peer}, {e}");
                     }
                 }
                 if (_logger.IsDebug) _logger.Debug($"Connect worker {idx} completed");

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -307,12 +307,12 @@ namespace Nethermind.Network
                         previousActivePeersCount = activePeersCount;
                     }
 
-                    if (_logger.IsTrace)
+                    if (_logger.IsDebug)
                     {
                         if (_logCounter % 5 == 0)
                         {
                             string nl = Environment.NewLine;
-                            _logger.Trace($"{nl}{nl}All active peers: {nl} {string.Join(nl, _peerPool.ActivePeers.Values.Select(x => $"{x.Node:s} | P2P: {_stats.GetOrAdd(x.Node).DidEventHappen(NodeStatsEventType.P2PInitialized)} | Eth62: {_stats.GetOrAdd(x.Node).DidEventHappen(NodeStatsEventType.Eth62Initialized)} | {_stats.GetOrAdd(x.Node).P2PNodeDetails?.ClientId} | {_stats.GetOrAdd(x.Node).ToString()}"))} {nl}{nl}");
+                            _logger.Debug($"{nl}{nl}All active peers: {nl} {string.Join(nl, _peerPool.ActivePeers.Values.Select(x => $"{x.Node:s} | P2P: {_stats.GetOrAdd(x.Node).DidEventHappen(NodeStatsEventType.P2PInitialized)} | Eth62: {_stats.GetOrAdd(x.Node).DidEventHappen(NodeStatsEventType.Eth62Initialized)} | {_stats.GetOrAdd(x.Node).P2PNodeDetails?.ClientId} | {_stats.GetOrAdd(x.Node).ToString()}"))} {nl}{nl}");
                         }
 
                         _logCounter++;

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -214,6 +214,11 @@ namespace Nethermind.Network
                     {
                         await SetupOutgoingPeerConnection(peer);
                     }
+                    catch (TaskCanceledException)
+                    {
+                        if (_logger.IsDebug) _logger.Debug($"Connect worker {idx} cancelled");
+                        break;
+                    }
                     catch (Exception e)
                     {
                         // This is strictly speaking not related to the connection, but something outside of it.

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -295,14 +295,14 @@ namespace Nethermind.Network
                         await taskChannel.Writer.WriteAsync(peer, _cancellationTokenSource.Token);
                     }
 
-                    if (_logger.IsTrace)
+                    if (_logger.IsTrace || (_logger.IsDebug && _logCounter % 5 == 0))
                     {
                         List<KeyValuePair<PublicKey, Peer>>? activePeers = _peerPool.ActivePeers.ToList();
                         int activePeersCount = activePeers.Count;
                         if (activePeersCount != previousActivePeersCount)
                         {
                             string countersLog = string.Join(", ", _currentSelection.Counters.Select(x => $"{x.Key.ToString()}: {x.Value}"));
-                            _logger.Trace($"RunPeerUpdate | {countersLog}, Incompatible: {GetIncompatibleDesc(_currentSelection.Incompatible)}, EligibleCandidates: {_currentSelection.Candidates.Count}, " +
+                            _logger.Debug($"RunPeerUpdate | {countersLog}, Incompatible: {GetIncompatibleDesc(_currentSelection.Incompatible)}, EligibleCandidates: {_currentSelection.Candidates.Count}, " +
                                           $"Tried: {_tryCount}, Rounds: {_connectionRounds}, Failed initial connect: {_failedInitialConnect}, Established initial connect: {_newActiveNodes}, " +
                                           $"Current candidate peers: {_peerPool.PeerCount}, Current active peers: {activePeers.Count} " +
                                           $"[InOut: {activePeers.Count(x => x.Value.OutSession is not null && x.Value.InSession is not null)} | " +
@@ -313,16 +313,15 @@ namespace Nethermind.Network
                         previousActivePeersCount = activePeersCount;
                     }
 
-                    if (_logger.IsDebug)
+                    if (_logger.IsTrace)
                     {
                         if (_logCounter % 5 == 0)
                         {
                             string nl = Environment.NewLine;
-                            _logger.Debug($"{nl}{nl}All active peers: {nl} {string.Join(nl, _peerPool.ActivePeers.Values.Select(x => $"{x.Node:s} | P2P: {_stats.GetOrAdd(x.Node).DidEventHappen(NodeStatsEventType.P2PInitialized)} | Eth62: {_stats.GetOrAdd(x.Node).DidEventHappen(NodeStatsEventType.Eth62Initialized)} | {_stats.GetOrAdd(x.Node).P2PNodeDetails?.ClientId} | {_stats.GetOrAdd(x.Node).ToString()}"))} {nl}{nl}");
+                            _logger.Trace($"{nl}{nl}All active peers: {nl} {string.Join(nl, _peerPool.ActivePeers.Values.Select(x => $"{x.Node:s} | P2P: {_stats.GetOrAdd(x.Node).DidEventHappen(NodeStatsEventType.P2PInitialized)} | Eth62: {_stats.GetOrAdd(x.Node).DidEventHappen(NodeStatsEventType.Eth62Initialized)} | {_stats.GetOrAdd(x.Node).P2PNodeDetails?.ClientId} | {_stats.GetOrAdd(x.Node).ToString()}"))} {nl}{nl}");
                         }
-
-                        _logCounter++;
                     }
+                    _logCounter++;
 
                     if (EnsureAvailableActivePeerSlot())
                     {


### PR DESCRIPTION
Addresses #6014

- ~~On one of the log @kamilchodola gave, the peer loop exited very early without any exception.~~ mistake in task handling causes it to not wait for worker thread exit, but not a problem.
- ~~There is a mistake in the tasks handling which hide the exception probably.~~
- ~~This fixes it and make sure it does not stop trying on exception.~~
- Discovery thread does not seems to start after initial bootnodes connection.
- Seems like task scheduler from dotnetty, maybe hanging.
- Switching to explicitly running default task scheduler.

## Changes

- Fix connection loop exception accidentally hidden.
 
## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Well, nothing bad happened for sure. 