### PR TITLE
Improve Nethermind executable rename handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,9 @@ RUN if [ "$TARGETARCH" = "amd64" ]; \
       -p:BuildTimestamp=$BUILD_TIMESTAMP -p:Commit=$COMMIT_HASH -p:Deterministic=true ; \
     fi
 
+# A temporary symlink to support the old executable name
+RUN ln -s -r out/nethermind out/Nethermind.Runner
+
 FROM --platform=$TARGETPLATFORM mcr.microsoft.com/dotnet/aspnet:7.0-jammy
 
 ARG TARGETPLATFORM

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -28,6 +28,9 @@ RUN if [ "$TARGETARCH" = "amd64" ]; \
         -p:BuildTimestamp=$BUILD_TIMESTAMP -p:Commit=$COMMIT_HASH ; \
     fi
 
+# A temporary symlink to support the old executable name
+RUN ln -s -r out/nethermind out/Nethermind.Runner
+
 RUN dotnet tool install --tool-path /dotnetcore-tools dotnet-trace && \
     dotnet tool install --tool-path /dotnetcore-tools dotnet-dump && \
     dotnet tool install --tool-path /dotnetcore-tools dotnet-gcdump

--- a/scripts/deployment/build-runner.sh
+++ b/scripts/deployment/build-runner.sh
@@ -25,9 +25,9 @@ do
   cp -r configs $output_path/$rid
   mkdir $output_path/$rid/keystore
 
-  # A temporary symlink for Linux to support existing scripts if any
+  # A temporary symlink for Linux and macOS to support existing scripts if any
   # To be removed after a few months
-  [[ $rid == linux* ]] && ln -s -r $output_path/$rid/nethermind $output_path/$rid/Nethermind.Runner
+  [[ $rid != win* ]] && ln -s -r $output_path/$rid/nethermind $output_path/$rid/Nethermind.Runner
 done
 
 cd ..


### PR DESCRIPTION
## Changes

Added symlinks for Docker files and macOS to support the old `Nethermind.Runner` name

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Tested manually.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

This is an improvement for the Nethermind executable rename introduced in #5908 and addresses the cases where users use the old entrypoint when deriving from Nethermind Docker file.
