### PR TITLE
Explicitly flush WAL on state sync finish

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/TestMemDb.cs
+++ b/src/Nethermind/Nethermind.Core.Test/TestMemDb.cs
@@ -24,6 +24,8 @@ public class TestMemDb : MemDb, ITunableDb
     public Func<byte[], byte[]>? ReadFunc { get; set; }
     public Action<byte[]>? RemoveFunc { get; set; }
 
+    public bool WasFlushed { get; set; }
+
     [MethodImpl(MethodImplOptions.Synchronized)]
     public override byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)
     {
@@ -101,5 +103,10 @@ public class TestMemDb : MemDb, ITunableDb
     public override IBatch StartBatch()
     {
         return new InMemoryBatch(this);
+    }
+
+    public override void Flush()
+    {
+        WasFlushed = true;
     }
 }

--- a/src/Nethermind/Nethermind.Db/DbExtensions.cs
+++ b/src/Nethermind/Nethermind.Db/DbExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Nethermind.Core;
 using Nethermind.Core.Caching;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
@@ -18,9 +19,9 @@ namespace Nethermind.Db
             return new(db, createInMemoryWriteStore);
         }
 
-        public static void Set(this IDb db, Keccak key, byte[] value)
+        public static void Set(this IDb db, Keccak key, byte[] value, WriteFlags writeFlags = WriteFlags.None)
         {
-            db[key.Bytes] = value;
+            db.Set(key.Bytes, value, writeFlags);
         }
 
         public static byte[]? Get(this IDb db, Keccak key)

--- a/src/Nethermind/Nethermind.Db/MemDb.cs
+++ b/src/Nethermind/Nethermind.Db/MemDb.cs
@@ -77,7 +77,7 @@ namespace Nethermind.Db
 
         public IDb Innermost => this;
 
-        public void Flush()
+        public virtual void Flush()
         {
         }
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
@@ -98,9 +98,9 @@ namespace Nethermind.Synchronization.Test.FastSync
 
             await ActivateAndWait(ctx, dbContext, 1024);
 
-
             dbContext.CompareTrees("END");
             dbContext.CompareCodeDbs();
+            dbContext.AssertFlushed();
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTestsBase.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTestsBase.cs
@@ -7,10 +7,12 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Core.Timers;
 using Nethermind.Db;
@@ -157,10 +159,10 @@ namespace Nethermind.Synchronization.Test.FastSync
             {
                 _logger = logger;
                 RemoteDb = new MemDb();
-                LocalDb = new MemDb();
+                LocalDb = new TestMemDb();
                 RemoteStateDb = RemoteDb;
                 LocalStateDb = LocalDb;
-                LocalCodeDb = new MemDb();
+                LocalCodeDb = new TestMemDb();
                 RemoteCodeDb = new MemDb();
                 RemoteTrieStore = new TrieStore(RemoteStateDb, logManager);
 
@@ -168,10 +170,10 @@ namespace Nethermind.Synchronization.Test.FastSync
                 LocalStateTree = new StateTree(new TrieStore(LocalStateDb, logManager), logManager);
             }
 
-            public IDb RemoteCodeDb { get; }
-            public IDb LocalCodeDb { get; }
+            public MemDb RemoteCodeDb { get; }
+            public TestMemDb LocalCodeDb { get; }
             public MemDb RemoteDb { get; }
-            public MemDb LocalDb { get; }
+            public TestMemDb LocalDb { get; }
             public ITrieStore RemoteTrieStore { get; }
             public IDb RemoteStateDb { get; }
             public IDb LocalStateDb { get; }
@@ -217,6 +219,12 @@ namespace Nethermind.Synchronization.Test.FastSync
 
                 //            Assert.AreEqual(dbContext._remoteDb.Keys.OrderBy(k => k, Bytes.Comparer).ToArray(), _localDb.Keys.OrderBy(k => k, Bytes.Comparer).ToArray(), "keys");
                 //            Assert.AreEqual(dbContext._remoteDb.Values.OrderBy(k => k, Bytes.Comparer).ToArray(), _localDb.Values.OrderBy(k => k, Bytes.Comparer).ToArray(), "values");
+            }
+
+            public void AssertFlushed()
+            {
+                LocalDb.WasFlushed.Should().BeTrue();
+                LocalCodeDb.WasFlushed.Should().BeTrue();
             }
         }
 

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
@@ -694,26 +694,8 @@ namespace Nethermind.Synchronization.FastSync
             {
                 if (_logger.IsInfo) _logger.Info($"Saving root {syncItem.Hash} of {_branchProgress.CurrentSyncBlock}");
 
-
-                _stateDbLock.EnterWriteLock();
-                try
-                {
-                    _stateDb.Flush();
-                }
-                finally
-                {
-                    _stateDbLock.ExitWriteLock();
-                }
-
-                _codeDbLock.EnterWriteLock();
-                try
-                {
-                    _codeDb.Flush();
-                }
-                finally
-                {
-                    _codeDbLock.ExitWriteLock();
-                }
+                _stateDb.Flush();
+                _codeDb.Flush();
 
                 Interlocked.Exchange(ref _rootSaved, 1);
             }

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
@@ -694,6 +694,27 @@ namespace Nethermind.Synchronization.FastSync
             {
                 if (_logger.IsInfo) _logger.Info($"Saving root {syncItem.Hash} of {_branchProgress.CurrentSyncBlock}");
 
+
+                _stateDbLock.EnterWriteLock();
+                try
+                {
+                    _stateDb.Flush();
+                }
+                finally
+                {
+                    _stateDbLock.ExitWriteLock();
+                }
+
+                _codeDbLock.EnterWriteLock();
+                try
+                {
+                    _codeDb.Flush();
+                }
+                finally
+                {
+                    _codeDbLock.ExitWriteLock();
+                }
+
                 Interlocked.Exchange(ref _rootSaved, 1);
             }
 


### PR DESCRIPTION
Address #5996

- Seems like there could be a case where after restart root node is missing.
- Not sure why, as WAL file would be able to recover it even in case of unclean shutdown.
- In any case, adding an explicit flush on root save.

## Changes

- Add explicit flush on healing root save

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
#### If yes, did you write tests?

- [X] Yes

#### Notes on testing

- Not sure if its even reproducable in the first place.