### PR TITLE
Expose wait duration to config

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
@@ -115,5 +115,8 @@ namespace Nethermind.Blockchain.Synchronization
 
         [ConfigItem(Description = "Exit Nethermind once sync is finished", DefaultValue = "false")]
         public bool ExitOnSynced { get; set; }
+
+        [ConfigItem(Description = "Specify wait time after sync finished.", DefaultValue = "60")]
+        public int ExitOnSyncedWaitTimeSec { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
@@ -64,6 +64,7 @@ namespace Nethermind.Blockchain.Synchronization
         public ITunableDb.TuneType BlocksDbTuneDbMode { get; set; } = ITunableDb.TuneType.EnableBlobFiles;
         public int MaxProcessingThreads { get; set; }
         public bool ExitOnSynced { get; set; } = false;
+        public int ExitOnSyncedWaitTimeSec { get; set; } = 60;
 
         public override string ToString()
         {

--- a/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
@@ -126,7 +126,7 @@ namespace Nethermind.Synchronization
 
             if (_syncConfig.ExitOnSynced)
             {
-                _exitSource.WatchForExit(_syncMode, _logManager);
+                _exitSource.WatchForExit(_syncMode, _logManager, TimeSpan.FromSeconds(_syncConfig.ExitOnSyncedWaitTimeSec));
             }
         }
 


### PR DESCRIPTION
- As @kamilchodola found, 5 second wait time is not enough on slower node. So increasing the default to 60 second.
- Also useful for testing where we can wait like 15 minute after sync to check block processing time.
- Also useful for testing where a synced node will automatically shutdown after the wait time. 

## Changes

- Expose wait time after sync finished.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)
- [X] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

- Seems to work.
