### PR TITLE
[Fix][PivotUpdator] Update receipts and bodies Barriers

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
@@ -420,6 +420,7 @@ public partial class MergePlugin : IConsensusWrapperPlugin, ISynchronizationPlug
                 _blockCacheService,
                 _beaconSync,
                 _api.DbProvider.MetadataDb,
+                _api.SyncProgressResolver,
                 _api.LogManager);
 
             SyncReport syncReport = new(_api.SyncPeerPool, _api.NodeStatsManager, _api.SyncModeSelector, _syncConfig, _beaconPivot, _api.LogManager);

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
@@ -31,7 +31,7 @@ namespace Nethermind.Synchronization.FastBlocks
         private readonly ISyncPeerPool _syncPeerPool;
 
         private long _pivotNumber;
-        private readonly long _barrier;
+        private long _barrier;
 
         private SyncStatusList _syncStatusList;
 
@@ -58,7 +58,7 @@ namespace Nethermind.Synchronization.FastBlocks
             }
 
             _pivotNumber = _syncConfig.PivotNumberParsed;
-            _barrier = _barrier = _syncConfig.AncientBodiesBarrierCalc;
+            _barrier = _syncConfig.AncientBodiesBarrierCalc;
             if (_logger.IsInfo) _logger.Info($"Using pivot {_pivotNumber} and barrier {_barrier} in bodies sync");
 
             ResetSyncStatusList();
@@ -69,6 +69,7 @@ namespace Nethermind.Synchronization.FastBlocks
             if (_pivotNumber < _syncConfig.PivotNumberParsed)
             {
                 _pivotNumber = _syncConfig.PivotNumberParsed;
+                _barrier = _syncConfig.AncientBodiesBarrierCalc;
                 if (_logger.IsInfo) _logger.Info($"Changed pivot in bodies sync. Now using pivot {_pivotNumber} and barrier {_barrier}");
                 ResetSyncStatusList();
             }

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/ReceiptsSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/ReceiptsSyncFeed.cs
@@ -36,7 +36,7 @@ namespace Nethermind.Synchronization.FastBlocks
 
         private SyncStatusList _syncStatusList;
         private long _pivotNumber;
-        private readonly long _barrier;
+        private long _barrier;
 
         private bool ShouldFinish => !_syncConfig.DownloadReceiptsInFastSync || AllReceiptsDownloaded;
         private bool AllReceiptsDownloaded => _receiptStorage.LowestInsertedReceiptBlockNumber <= _barrier;
@@ -78,6 +78,7 @@ namespace Nethermind.Synchronization.FastBlocks
             if (_pivotNumber < _syncConfig.PivotNumberParsed)
             {
                 _pivotNumber = _syncConfig.PivotNumberParsed;
+                _barrier = _syncConfig.AncientReceiptsBarrierCalc;
                 if (_logger.IsInfo) _logger.Info($"Changed pivot in receipts sync. Now using pivot {_pivotNumber} and barrier {_barrier}");
                 ResetSyncStatusList();
             }

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/ISyncProgressResolver.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/ISyncProgressResolver.cs
@@ -10,6 +10,8 @@ namespace Nethermind.Synchronization.ParallelSync
 {
     public interface ISyncProgressResolver
     {
+        void UpdateBarriers();
+
         long FindBestFullState();
 
         long FindBestHeader();

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncProgressResolver.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncProgressResolver.cs
@@ -31,10 +31,10 @@ namespace Nethermind.Synchronization.ParallelSync
         private readonly ISyncConfig _syncConfig;
 
         // ReSharper disable once NotAccessedField.Local
-        private ILogger _logger;
+        private readonly ILogger _logger;
 
-        private readonly long _bodiesBarrier;
-        private readonly long _receiptsBarrier;
+        private long _bodiesBarrier;
+        private long _receiptsBarrier;
 
         public SyncProgressResolver(IBlockTree blockTree,
             IReceiptStorage receiptStorage,
@@ -52,6 +52,12 @@ namespace Nethermind.Synchronization.ParallelSync
             _progressTracker = progressTracker ?? throw new ArgumentNullException(nameof(progressTracker));
             _syncConfig = syncConfig ?? throw new ArgumentNullException(nameof(syncConfig));
 
+            _bodiesBarrier = _syncConfig.AncientBodiesBarrierCalc;
+            _receiptsBarrier = _syncConfig.AncientReceiptsBarrierCalc;
+        }
+
+        public void UpdateBarriers()
+        {
             _bodiesBarrier = _syncConfig.AncientBodiesBarrierCalc;
             _receiptsBarrier = _syncConfig.AncientReceiptsBarrierCalc;
         }


### PR DESCRIPTION
Fixes #6053

## Changes

- update barriers in receipt and bodies sync feeds when initialized if pivot has updated.
- update barriers in `SyncProgressResolver`

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No
#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

_If yes, fill in the details here. Remove if not applicable._
- [Fix] bug with PivotUpdator not updating barriers
