### PR TITLE
Fix old blocks downloaded beyond old barrier

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/SyncStatusListTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/SyncStatusListTests.cs
@@ -46,7 +46,7 @@ namespace Nethermind.Synchronization.Test.FastBlocks
         }
 
         [Test]
-        public void Can_will_not_go_below_ancient_barrier()
+        public void Will_not_go_below_ancient_barrier()
         {
             IBlockTree blockTree = Substitute.For<IBlockTree>();
             blockTree.FindCanonicalBlockInfo(Arg.Any<long>()).Returns(new BlockInfo(TestItem.KeccakA, 0));

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/SyncStatusListTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/SyncStatusListTests.cs
@@ -4,7 +4,13 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using FluentAssertions;
+using Nethermind.Blockchain;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Test.Builders;
 using Nethermind.Synchronization.FastBlocks;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Nethermind.Synchronization.Test.FastBlocks
@@ -32,12 +38,24 @@ namespace Nethermind.Synchronization.Test.FastBlocks
         {
             const int length = 4096;
 
-
             FastBlockStatusList list = CreateFastBlockStatusList(length, false);
             for (int i = 0; i < length; i++)
             {
                 Assert.IsTrue((FastBlockStatus)(i % 3) == list[i]);
             }
+        }
+
+        [Test]
+        public void Can_will_not_go_below_ancient_barrier()
+        {
+            IBlockTree blockTree = Substitute.For<IBlockTree>();
+            blockTree.FindCanonicalBlockInfo(Arg.Any<long>()).Returns(new BlockInfo(TestItem.KeccakA, 0));
+            SyncStatusList syncStatusList = new SyncStatusList(blockTree, 1000, null, 900);
+
+            BlockInfo?[] infos = new BlockInfo?[500];
+            syncStatusList.GetInfosForBatch(infos);
+
+            infos.Count((it) => it != null).Should().Be(101);
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
@@ -81,7 +81,8 @@ namespace Nethermind.Synchronization.FastBlocks
             _syncStatusList = new SyncStatusList(
                 _blockTree,
                 _pivotNumber,
-                _blockTree.LowestInsertedBodyNumber);
+                _blockTree.LowestInsertedBodyNumber,
+                _syncConfig.AncientBodiesBarrier);
         }
 
         protected override SyncMode ActivationSyncModes { get; } = SyncMode.FastBodies & ~SyncMode.FastBlocks;

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/ReceiptsSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/ReceiptsSyncFeed.cs
@@ -90,7 +90,8 @@ namespace Nethermind.Synchronization.FastBlocks
             _syncStatusList = new SyncStatusList(
                 _blockTree,
                 _pivotNumber,
-                _receiptStorage.LowestInsertedReceiptBlockNumber);
+                _receiptStorage.LowestInsertedReceiptBlockNumber,
+                _syncConfig.AncientReceiptsBarrier);
         }
 
         protected override SyncMode ActivationSyncModes { get; }


### PR DESCRIPTION
- OldBodies and OldReceipts seems to download beyond ancient barrier.
- It will stop eventually after the barrier bodies/receipts is saved, but before that other blocks can be saved causing unexpected ethgetlogs and such.

## Changes

- Add a lower bound to SyncStatusList.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes

#### If yes, did you write tests?

- [X] Yes

#### Notes on testing

- Confirms old blocks and receipts now missing cleanly beyond ancient barrier.