### PR TITLE
Fix fast header may miss a retried batch

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/FastHeadersSyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/FastHeadersSyncTests.cs
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Nethermind.Blockchain;
@@ -339,6 +341,81 @@ namespace Nethermind.Synchronization.Test.FastBlocks
             feed.InitializeFeed();
             var result = await feed.PrepareRequest();
             result.EndNumber.Should().Be(499);
+        }
+
+        [Test]
+        public async Task Will_never_lose_batch_on_invalid_batch()
+        {
+            IBlockTree blockTree = Substitute.For<IBlockTree>();
+            blockTree.LowestInsertedHeader.Returns(Build.A.BlockHeader.WithNumber(1000).TestObject);
+            ISyncReport report = Substitute.For<ISyncReport>();
+            report.HeadersInQueue.Returns(new MeasuredProgress());
+            MeasuredProgress measuredProgress = new();
+            report.FastBlocksHeaders.Returns(measuredProgress);
+            HeadersSyncFeed feed = new(
+                Substitute.For<ISyncModeSelector>(),
+                blockTree,
+                Substitute.For<ISyncPeerPool>(),
+                new SyncConfig
+                {
+                    FastSync = true,
+                    FastBlocks = true,
+                    PivotNumber = "1000",
+                    PivotHash = Keccak.Zero.ToString(),
+                    PivotTotalDifficulty = "1000"
+                }, report, LimboLogs.Instance);
+            feed.InitializeFeed();
+
+            List<HeadersSyncBatch> batches = new();
+            while (true)
+            {
+                HeadersSyncBatch? batch = await feed.PrepareRequest();
+                if (batch == null) break;
+                batches.Add(batch);
+            }
+            int totalBatchCount = batches.Count;
+
+            Channel<HeadersSyncBatch> batchToProcess = Channel.CreateBounded<HeadersSyncBatch>(batches.Count);
+            foreach (HeadersSyncBatch headersSyncBatch in batches)
+            {
+                await batchToProcess.Writer.WriteAsync(headersSyncBatch);
+            }
+            batches.Clear();
+
+            Task requestTasks = Task.Run(async () =>
+            {
+                for (int i = 0; i < 100000; i++)
+                {
+                    var batch = await feed.PrepareRequest();
+                    if (batch == null)
+                    {
+                        await Task.Delay(1);
+                        continue;
+                    }
+
+                    await batchToProcess.Writer.WriteAsync(batch);
+                }
+
+                batchToProcess.Writer.Complete();
+            });
+
+            BlockHeader randomBlockHeader = Build.A.BlockHeader.WithNumber(999999).TestObject;
+            await foreach (HeadersSyncBatch headersSyncBatch in batchToProcess.Reader.ReadAllAsync())
+            {
+                headersSyncBatch.Response = new[] { randomBlockHeader };
+                feed.HandleResponse(headersSyncBatch);
+            }
+
+            await requestTasks;
+
+            while (true)
+            {
+                HeadersSyncBatch? batch = await feed.PrepareRequest();
+                if (batch == null) break;
+                batches.Add(batch);
+            }
+
+            batches.Count().Should().Be(totalBatchCount);
         }
 
         private class ResettableHeaderSyncFeed : HeadersSyncFeed

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
@@ -394,7 +394,7 @@ namespace Nethermind.Synchronization.FastBlocks
             _resetLock.EnterReadLock();
             try
             {
-                if (!_sent.Contains(batch))
+                if (!_sent.TryRemove(batch))
                 {
                     if (_logger.IsDebug) _logger.Debug("Ignoring batch not in sent record");
                     return SyncResponseHandlingResult.Ignored;
@@ -426,7 +426,6 @@ namespace Nethermind.Synchronization.FastBlocks
                 finally
                 {
                     batch.MarkHandlingEnd();
-                    _sent.TryRemove(batch);
                 }
             }
             finally


### PR DESCRIPTION
- When a header sync batch is deemed invalid, it is retried by adding to a `_pending` queue.
- In another thread, the pending batch may get dequeue and sent out which involve adding it to a `_sent` set.
- However, the processing of the invalid block, may remove back the batch from `_sent` after adding it to `_pending` queue, causing the batch to be unrecognized and missed. 

## Changes

- Remove batch from `_sent` before processing it.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes

#### If yes, did you write tests?

- [X] Yes

#### Notes on testing

- Tested by adding a 1% random failure in `InsertHeader`. 
- Unit tests can reliably hang also.