### PR TITLE
Enable blobfiles for receipts also

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
@@ -107,8 +107,11 @@ namespace Nethermind.Blockchain.Synchronization
         [ConfigItem(Description = "[EXPERIMENTAL] Optimize db for write during sync. Significantly reduce total writes written and some sync time if you are not network limited.", DefaultValue = "HeavyWrite")]
         public ITunableDb.TuneType TuneDbMode { get; set; }
 
-        [ConfigItem(Description = "[EXPERIMENTAL] Optimize db for write during sync just for blocks db. Useful for turning on blobs file.", DefaultValue = "EnableBlobFiles")]
+        [ConfigItem(Description = "Optimize db for write during sync just for blocks db. Useful for turning on blobs file.", DefaultValue = "EnableBlobFiles")]
         ITunableDb.TuneType BlocksDbTuneDbMode { get; set; }
+
+        [ConfigItem(Description = "Optimize db for write during sync just for receipts db. Useful for turning on blobs file.", DefaultValue = "EnableBlobFiles")]
+        ITunableDb.TuneType ReceiptsDbTuneDbMode { get; set; }
 
         [ConfigItem(Description = "[TECHNICAL] Specify max num of thread used for processing. Default is same as logical core count.", DefaultValue = "0")]
         public int MaxProcessingThreads { get; set; }

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
@@ -62,6 +62,7 @@ namespace Nethermind.Blockchain.Synchronization
         public bool NonValidatorNode { get; set; } = false;
         public ITunableDb.TuneType TuneDbMode { get; set; } = ITunableDb.TuneType.HeavyWrite;
         public ITunableDb.TuneType BlocksDbTuneDbMode { get; set; } = ITunableDb.TuneType.EnableBlobFiles;
+        public ITunableDb.TuneType ReceiptsDbTuneDbMode { get; set; } = ITunableDb.TuneType.EnableBlobFiles;
         public int MaxProcessingThreads { get; set; }
         public bool ExitOnSynced { get; set; } = false;
         public int ExitOnSyncedWaitTimeSec { get; set; } = 60;

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -11,7 +11,7 @@ using IWriteBatch = Nethermind.Core.IWriteBatch;
 
 namespace Nethermind.Db.Rocks;
 
-public class ColumnDb : IDb
+public class ColumnDb : IDb, ITunableDb
 {
     private readonly RocksDb _rocksDb;
     private readonly DbOnTheRocks _mainDb;
@@ -125,6 +125,15 @@ public class ColumnDb : IDb
     public void Compact()
     {
         _rocksDb.CompactRange(Keccak.Zero.BytesToArray(), Keccak.MaxValue.BytesToArray(), _columnFamily);
+    }
+
+    private ITunableDb.TuneType _currentTune = ITunableDb.TuneType.Default;
+
+    public void Tune(ITunableDb.TuneType type)
+    {
+        if (_currentTune == type) return;
+        _mainDb.TuneColumn(type, _columnFamily);
+        _currentTune = type;
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Synchronization.Test/DbTuner/SyncDbTunerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/DbTuner/SyncDbTunerTests.cs
@@ -16,6 +16,7 @@ public class SyncDbTunerTests
 {
     private ITunableDb.TuneType _tuneType = ITunableDb.TuneType.HeavyWrite;
     private ITunableDb.TuneType _blocksTuneType = ITunableDb.TuneType.AggressiveHeavyWrite;
+    private ITunableDb.TuneType _receiptsBlocksTuneType = ITunableDb.TuneType.EnableBlobFiles;
     private SyncConfig _syncConfig = null!;
     private ISyncFeed<SnapSyncBatch> _snapSyncFeed = null!;
     private ISyncFeed<BodiesSyncBatch> _bodiesSyncFeed = null!;
@@ -23,7 +24,9 @@ public class SyncDbTunerTests
     private ITunableDb _stateDb = null!;
     private ITunableDb _codeDb = null!;
     private ITunableDb _blockDb = null!;
-    private ITunableDb _receiptDb = null!;
+    private ITunableDb _receiptBlockDb = null!;
+    private ITunableDb _receiptTxDb = null!;
+    private SyncDbTuner _tuner = null!;
 
     [SetUp]
     public void Setup()
@@ -40,9 +43,10 @@ public class SyncDbTunerTests
         _stateDb = Substitute.For<ITunableDb>();
         _codeDb = Substitute.For<ITunableDb>();
         _blockDb = Substitute.For<ITunableDb>();
-        _receiptDb = Substitute.For<ITunableDb>();
+        _receiptBlockDb = Substitute.For<ITunableDb>();
+        _receiptTxDb = Substitute.For<ITunableDb>();
 
-        SyncDbTuner _ = new SyncDbTuner(
+        _tuner = new SyncDbTuner(
             _syncConfig,
             _snapSyncFeed,
             _bodiesSyncFeed,
@@ -50,7 +54,8 @@ public class SyncDbTunerTests
             _stateDb,
             _codeDb,
             _blockDb,
-            _receiptDb);
+            _receiptBlockDb,
+            _receiptTxDb);
     }
 
     [Test]
@@ -74,7 +79,13 @@ public class SyncDbTunerTests
     [Test]
     public void WhenReceiptsIsOn_TriggerReceiptsDbTune()
     {
-        TestFeedAndDbTune(_receiptSyncFeed, _receiptDb);
+        TestFeedAndDbTune(_receiptSyncFeed, _receiptTxDb);
+    }
+
+    [Test]
+    public void WhenReceiptsIsOn_TriggerReceiptBlocksDbTune()
+    {
+        TestFeedAndDbTune(_receiptSyncFeed, _receiptBlockDb, _receiptsBlocksTuneType);
     }
 
     private void TestFeedAndDbTune<T>(ISyncFeed<T> feed, ITunableDb db, ITunableDb.TuneType? tuneType = null)

--- a/src/Nethermind/Nethermind.Synchronization/DbTuner/SyncDbOptimizer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/DbTuner/SyncDbOptimizer.cs
@@ -14,10 +14,12 @@ public class SyncDbTuner
     private readonly ITunableDb? _stateDb;
     private readonly ITunableDb? _codeDb;
     private readonly ITunableDb? _blockDb;
-    private readonly ITunableDb? _receiptDb;
+    private readonly ITunableDb? _receiptBlocksDb;
+    private readonly ITunableDb? _receiptTxIndexDb;
 
     private ITunableDb.TuneType _tuneType;
     private ITunableDb.TuneType _blocksDbTuneType;
+    private ITunableDb.TuneType _receiptsBlocksDbTuneType;
 
     public SyncDbTuner(
         ISyncConfig syncConfig,
@@ -27,7 +29,8 @@ public class SyncDbTuner
         ITunableDb? stateDb,
         ITunableDb? codeDb,
         ITunableDb? blockDb,
-        ITunableDb? receiptDb
+        ITunableDb? receiptBlocksDb,
+        ITunableDb? receiptTxIndexDb
     )
     {
         // Only these three make sense as they are write heavy
@@ -51,10 +54,12 @@ public class SyncDbTuner
         _stateDb = stateDb;
         _codeDb = codeDb;
         _blockDb = blockDb;
-        _receiptDb = receiptDb;
+        _receiptBlocksDb = receiptBlocksDb;
+        _receiptTxIndexDb = receiptTxIndexDb;
 
         _tuneType = syncConfig.TuneDbMode;
         _blocksDbTuneType = syncConfig.BlocksDbTuneDbMode;
+        _receiptsBlocksDbTuneType = syncConfig.ReceiptsDbTuneDbMode;
     }
 
     private void SnapStateChanged(object? sender, SyncFeedStateEventArgs e)
@@ -87,11 +92,13 @@ public class SyncDbTuner
     {
         if (e.NewState == SyncFeedState.Active)
         {
-            _receiptDb?.Tune(_tuneType);
+            _receiptBlocksDb?.Tune(_receiptsBlocksDbTuneType);
+            _receiptTxIndexDb?.Tune(_tuneType);
         }
         else if (e.NewState == SyncFeedState.Finished)
         {
-            _receiptDb?.Tune(ITunableDb.TuneType.Default);
+            _receiptBlocksDb?.Tune(ITunableDb.TuneType.Default);
+            _receiptTxIndexDb?.Tune(ITunableDb.TuneType.Default);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
@@ -121,7 +121,9 @@ namespace Nethermind.Synchronization
                 StartStateSyncComponents();
             }
 
-            if (_syncConfig.TuneDbMode != ITunableDb.TuneType.Default || _syncConfig.BlocksDbTuneDbMode != ITunableDb.TuneType.Default)
+            if (_syncConfig.TuneDbMode != ITunableDb.TuneType.Default
+                || _syncConfig.BlocksDbTuneDbMode != ITunableDb.TuneType.Default
+                || _syncConfig.ReceiptsDbTuneDbMode != ITunableDb.TuneType.Default)
             {
                 SetupDbOptimizer();
             }
@@ -142,7 +144,9 @@ namespace Nethermind.Synchronization
                 _dbProvider.StateDb as ITunableDb,
                 _dbProvider.CodeDb as ITunableDb,
                 _dbProvider.BlocksDb as ITunableDb,
-                _dbProvider.ReceiptsDb as ITunableDb);
+                _dbProvider.ReceiptsDb.GetColumnDb(ReceiptsColumns.Blocks) as ITunableDb,
+                _dbProvider.ReceiptsDb.GetColumnDb(ReceiptsColumns.Transactions) as ITunableDb
+            );
         }
 
         private void StartFullSyncComponents()


### PR DESCRIPTION
# Enable blobfiles for receipts also

- Blobfiles is a rocksdb feature that excludes the main data into a separate blob files while the existing LSM tree only point to it.
- This significantly reduce write amplification as the data itself is not included in compaction but comes with an additional iop, making it ideal for large data as the response time is insignificant compared to bandwitdh required to read it.
- The increase iops is the reason why it not enabled for receipts blocks data as `eth_getLogs` is kinda important.
- Unlike bodies where flush/key metrics range from 80k to 25k, for receipts is 15k to 12k, which is lower than the blocksize for receipts db. Also, the receipts key is already blocknumber prefixed causing it to have lower compaction.
- However, one could argue that the blocknumber prefixed receipt key+blob pointer is very easily cached on the 16kB blocksize. So the increase in iops is likely not measurable.

## Effect on sync

- Reduced total writes from 1.3TB to 0.66TB.
- Slightly lower CPU, Lower IOPs, but higher memory usage. Seems to be slightly slower sync time.
- Before, After graph.
![Screenshot_2023-09-18_16-44-33](https://github.com/NethermindEth/nethermind/assets/1841324/e7f0bed8-0ee9-41f4-858f-43592cfd589c)

## Effect on RPC

- True enough, data cache hit rate is around 100%. 
- Actually improve RPC throughput and decrease latency. This is likely because blob data does not get cached.
- Actually reduces memory usage. This is likely because lack of caching means reduced glibc malloc fragmentation.
- Does not seems to reduce iops or bytes read per call.
- For some reason, reduced disk IO but not when measured from process side. It got cached more efficiently by the OS for some reason? No idea why. Reduced memory usage I guess? (systemd-run limited to 32GB)  Same stress tests.
- Before, after, before, after
![Screenshot_2023-09-18_18-25-37](https://github.com/NethermindEth/nethermind/assets/1841324/af095f1a-b794-4691-9a3c-523acafa6203)

## Changes

- _List the changes_

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [ ] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
