### PR TITLE
Adjust name of cli assembly in docs generator

### DIFF
--- a/src/Nethermind/Nethermind.GitBook/RpcAndCliDataProvider.cs
+++ b/src/Nethermind/Nethermind.GitBook/RpcAndCliDataProvider.cs
@@ -48,7 +48,7 @@ namespace Nethermind.GitBook
 
         private List<Type> GetCliModules()
         {
-            Assembly assembly = Assembly.Load("Nethermind.Cli");
+            Assembly assembly = Assembly.Load("nethermind-cli");
             List<Type> cliModules = new List<Type>();
 
             foreach (Type type in assembly.GetTypes()


### PR DESCRIPTION
## Changes

- auto docs generation is broken after recent changes in naming (`Nethermind.Cli` => `nethermind-cli`). This PR is fixing it.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No