### PR TITLE
Fix sync pivot not set when dbload

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorFastSyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorFastSyncTests.cs
@@ -78,6 +78,17 @@ namespace Nethermind.Synchronization.Test.ParallelSync
         }
 
         [Test]
+        public void Load_from_without_merge_sync_pivot_resolved()
+        {
+            Scenario.GoesLikeThis(_needToWaitForHeaders)
+                .WhenMergeSyncPivotNotResolvedYet()
+                .WhateverThePeerPoolLooks()
+                .WhenThisNodeIsLoadingBlocksFromDb()
+                .ThenInAnyFastSyncConfiguration()
+                .TheSyncModeShouldBe(SyncMode.DbLoad | SyncMode.UpdatingPivot);
+        }
+
+        [Test]
         public void Simple_archive()
         {
             Scenario.GoesLikeThis(_needToWaitForHeaders)

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorTests.Scenario.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorTests.Scenario.cs
@@ -834,6 +834,21 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                     _needToWaitForHeaders = needToWaitForHeaders;
                     return this;
                 }
+
+                public ScenarioBuilder WhenMergeSyncPivotNotResolvedYet()
+                {
+                    _syncProgressSetups.Add(
+                        () =>
+                        {
+                            SyncConfig.MaxAttemptsToUpdatePivot = 3;
+                            BeaconSyncStrategy = Substitute.For<IBeaconSyncStrategy>();
+                            BeaconSyncStrategy.GetFinalizedHash().Returns(TestItem.KeccakA);
+                            return "merge sync pivot not resolved yet";
+                        }
+                    );
+
+                    return this;
+                }
             }
 
             public static ScenarioBuilder GoesLikeThis(bool needToWaitForHeaders) =>

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
@@ -134,12 +134,17 @@ namespace Nethermind.Synchronization.ParallelSync
         public void Update()
         {
             _pivotNumber = _syncConfig.PivotNumberParsed;
+            bool shouldBeInUpdatingPivot = ShouldBeInUpdatingPivot();
 
             SyncMode newModes;
             string reason = string.Empty;
             if (_syncProgressResolver.IsLoadingBlocksFromDb())
             {
                 newModes = SyncMode.DbLoad;
+                if (shouldBeInUpdatingPivot)
+                {
+                    newModes |= SyncMode.UpdatingPivot;
+                }
             }
             else if (!_syncConfig.SynchronizationEnabled)
             {
@@ -149,7 +154,6 @@ namespace Nethermind.Synchronization.ParallelSync
             else
             {
                 bool inBeaconControl = _beaconSyncStrategy.ShouldBeInBeaconModeControl();
-                bool shouldBeInUpdatingPivot = ShouldBeInUpdatingPivot();
                 (UInt256? peerDifficulty, long? peerBlock) = ReloadDataFromPeers();
                 // if there are no peers that we could use then we cannot sync
                 if (peerDifficulty is null || peerBlock is null || peerBlock == 0)


### PR DESCRIPTION
- Fixes random `Unable to find beacon header at height 18051001. This is unexpected, forcing a new beacon sync.` and `Peer sent orphaned blocks/headers inside the batch`.
- When `BlockTree.AcceptVisitor` take too long (I don't know how @kamilchodola did that), `DbLoad` in MSMS will get activated and pivot updater will get deactivated and disabled. This causes it to not update sync pivot. On restart, the pivot updated will reactivate and set a different sync pivot, but blocktree already initialized various pointers with respect to old pivot causing forward sync to start from before the sync pivot which causes the errors.
- Step to reproduce:
  - Make sure CL is synced.
  - Add `Thread.Sleep(1000)` in `ReviewBlockTree` around line 67.
  - Add `Thread.Sleep(1000)` in `BlockTree.AcceptVisitor` around line 22.
  - Probably add some sleep in FastHeaderSyncFeed to slow it down or it might complete downloading header to the hardcoded sync pivot which causes it to work.
  - Start until it start `FastHeader`.
  - Stop it.
  - Remove thread sleep in `BlockTree.AcceptVisitor`.
  - Start again.

```
2023-09-06 08:07:06.2098|INFO|9|Waiting for Forkchoice message from Consensus Layer to set fresh pivot block [0s] 
2023-09-06 08:07:06.5426|INFO|9|Sync mode changed from Disconnected to UpdatingPivot 
2023-09-06 08:07:06.7182|INFO|21|Skipping pivot update 
2023-09-06 08:07:06.7182|INFO|21|Sync mode changed from UpdatingPivot to DbLoad 
2023-09-06 08:07:06.7637|INFO|22|Beacon Numbers resolved, level = 0, header = 0, body = 0 
2023-09-06 08:07:06.7637|DEBUG|22|Completed visiting blocks in DB at level 18051000 - best known 0 
2023-09-06 08:07:06.8955|DEBUG|24|Step ReviewBlockTree          executed in 1151ms 
2023-09-06 08:07:06.8955|DEBUG|24|ReviewBlockTree          complete 
2023-09-06 08:07:07.7418|INFO|25|Sync mode changed from DbLoad to Disconnected 
2023-09-06 08:07:15.9050|INFO|22|Sync mode changed from Disconnected to FastHeaders 
2023-09-06 08:07:17.4703|INFO|17|Old Headers           0 / 18,051,000 (  0.00 %) | queue         0 | current            0 Blk/s | total            0 Blk/s 

// After restart
2023-09-06 08:08:17.9008|INFO|10|Sync mode changed from Disconnected to UpdatingPivot 
2023-09-06 08:14:15.3420|INFO|145|New beacon pivot: 18076068 (0xa7784ace97a902977004f8a6fe4f56610a04730e97aced32762138804cd61f9d) 
2023-09-06 08:14:18.5621|INFO|135|New pivot block has been set based on ForkChoiceUpdate from CL. Pivot block number: 18076003, hash: 0x59b05ce84a097ff7a357d8c679c4ce3e77ca4e54c8776c5da4de2020d1453766
2023-09-06 08:14:18.7270|INFO|135|Changing state UpdatingPivot to FastHeaders, BeaconHeaders at processed: 0 | state: 0 | block: 0 | header: 18051000 | target block: 18076085 | peer block: 18076152 
2023-09-06 08:14:18.7270|INFO|135|Sync mode changed from UpdatingPivot to FastHeaders, BeaconHeaders 
2023-09-06 08:14:30.6972|ERROR|98|Peer sent orphaned blocks/headers inside the batch 
```

## Changes

- Dont disable UpdatingPivot on dbload.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Need to test premerge network also.