### PR TITLE
Fix `eth_getLogs` filtering for empty addresses list

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Filters/AddressFilterTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Filters/AddressFilterTests.cs
@@ -52,6 +52,29 @@ public class AddressFilterTests
     }
 
     [Test]
+    public void Accepts_any_address()
+    {
+        AddressFilter filter = AddressFilter.AnyAddress;
+
+        filter.Accepts(_address1).Should().BeTrue();
+        filter.Accepts(_address2).Should().BeTrue();
+        filter.Accepts(_address3).Should().BeTrue();
+    }
+
+    [Test]
+    public void Accepts_any_address_by_ref()
+    {
+        AddressFilter filter = AddressFilter.AnyAddress;
+
+        AddressStructRef address1Ref = _address1.ToStructRef();
+        AddressStructRef address2Ref = _address2.ToStructRef();
+        AddressStructRef address3Ref = _address3.ToStructRef();
+        filter.Accepts(ref address1Ref).Should().BeTrue();
+        filter.Accepts(ref address2Ref).Should().BeTrue();
+        filter.Accepts(ref address3Ref).Should().BeTrue();
+    }
+
+    [Test]
     public void Accepts_any_address_when_set_is_null()
     {
         AddressFilter filter = new AddressFilter(addresses: null!);

--- a/src/Nethermind/Nethermind.Blockchain.Test/Filters/AddressFilterTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Filters/AddressFilterTests.cs
@@ -185,6 +185,29 @@ public class AddressFilterTests
         filter.Matches(ref bloomRef).Should().BeFalse();
     }
 
+    [Test]
+    public void Matches_bloom_using_any_address()
+    {
+        AddressFilter filter = AddressFilter.AnyAddress;
+
+        filter.Matches(BloomFromAddress(TestItem.AddressA)).Should().BeTrue();
+        filter.Matches(BloomFromAddress(TestItem.AddressB)).Should().BeTrue();
+        filter.Matches(BloomFromAddress(TestItem.AddressC)).Should().BeTrue();
+    }
+
+    [Test]
+    public void Matches_bloom_using_any_address_by_ref()
+    {
+        AddressFilter filter = AddressFilter.AnyAddress;
+
+        BloomStructRef bloomARef = BloomFromAddress(TestItem.AddressA).ToStructRef();
+        BloomStructRef bloomBRef = BloomFromAddress(TestItem.AddressB).ToStructRef();
+        BloomStructRef bloomCRef = BloomFromAddress(TestItem.AddressC).ToStructRef();
+        filter.Matches(ref bloomARef).Should().BeTrue();
+        filter.Matches(ref bloomBRef).Should().BeTrue();
+        filter.Matches(ref bloomCRef).Should().BeTrue();
+    }
+
     private static Core.Bloom BloomFromAddress(Address address)
     {
         LogEntry entry = new LogEntry(address, new byte[]{ }, new Keccak[]{ });

--- a/src/Nethermind/Nethermind.Blockchain.Test/Filters/AddressFilterTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Filters/AddressFilterTests.cs
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Generic;
+using FluentAssertions;
+using Nethermind.Blockchain.Filters;
+using Nethermind.Core;
+using Nethermind.Int256;
+using NUnit.Framework;
+
+namespace Nethermind.Blockchain.Test.Filters;
+
+[TestFixture]
+public class AddressFilterTests
+{
+    private static readonly Address _address1 = Address.FromNumber(UInt256.Parse("1"));
+    private static readonly Address _address2 = Address.FromNumber(UInt256.Parse("2"));
+    private static readonly Address _address3 = Address.FromNumber(UInt256.Parse("3"));
+
+    [Test]
+    public void Accepts_a_specific_address()
+    {
+        AddressFilter filter = new AddressFilter(_address1);
+
+        filter.Accepts(_address1).Should().BeTrue();
+    }
+
+    [Test]
+    public void Rejects_different_address()
+    {
+        AddressFilter filter = new AddressFilter(_address1);
+
+        filter.Accepts(_address2).Should().BeFalse();
+    }
+
+    [Test]
+    public void Accepts_any_address_when_set_is_null()
+    {
+        AddressFilter filter = new AddressFilter(addresses: null!);
+
+        filter.Accepts(_address1).Should().BeTrue();
+        filter.Accepts(_address2).Should().BeTrue();
+        filter.Accepts(_address3).Should().BeTrue();
+    }
+
+    [Test]
+    public void Accepts_any_address_when_set_is_empty()
+    {
+        HashSet<Address> addresses = new();
+        AddressFilter filter = new AddressFilter(addresses);
+
+        filter.Accepts(_address1).Should().BeTrue();
+        filter.Accepts(_address2).Should().BeTrue();
+        filter.Accepts(_address3).Should().BeTrue();
+    }
+
+    [Test]
+    public void Accepts_only_addresses_in_a_set()
+    {
+        HashSet<Address> addresses = new()
+        {
+            _address1, _address3
+        };
+        AddressFilter filter = new AddressFilter(addresses);
+
+        filter.Accepts(_address1).Should().BeTrue();
+        filter.Accepts(_address2).Should().BeFalse();
+        filter.Accepts(_address3).Should().BeTrue();
+    }
+}

--- a/src/Nethermind/Nethermind.Blockchain.Test/Filters/AddressFilterTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Filters/AddressFilterTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using FluentAssertions;
 using Nethermind.Blockchain.Filters;
 using Nethermind.Core;
+using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
 using NUnit.Framework;
 
@@ -147,5 +148,31 @@ public class AddressFilterTests
         filter.Accepts(ref addressARef).Should().BeTrue();
         filter.Accepts(ref addressBRef).Should().BeFalse();
         filter.Accepts(ref addressCRef).Should().BeTrue();
+    }
+
+    [Test]
+    public void Matches_bloom_using_specific_address()
+    {
+        AddressFilter filter = new AddressFilter(TestItem.AddressA);
+        Core.Bloom bloom = BloomFromAddress(TestItem.AddressA);
+
+        filter.Matches(bloom).Should().BeTrue();
+    }
+
+    [Test]
+    public void Matches_bloom_using_specific_address_by_ref()
+    {
+        AddressFilter filter = new AddressFilter(TestItem.AddressA);
+        BloomStructRef bloomRef = BloomFromAddress(TestItem.AddressA).ToStructRef();
+
+        filter.Matches(ref bloomRef).Should().BeTrue();
+    }
+
+    private static Core.Bloom BloomFromAddress(Address address)
+    {
+        LogEntry entry = new LogEntry(address, new byte[]{ }, new Keccak[]{ });
+        Core.Bloom bloom = new Core.Bloom(new[] { entry });
+
+        return bloom;
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain.Test/Filters/AddressFilterTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Filters/AddressFilterTests.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using FluentAssertions;
 using Nethermind.Blockchain.Filters;
 using Nethermind.Core;
-using Nethermind.Int256;
+using Nethermind.Core.Test.Builders;
 using NUnit.Framework;
 
 namespace Nethermind.Blockchain.Test.Filters;
@@ -13,42 +13,38 @@ namespace Nethermind.Blockchain.Test.Filters;
 [TestFixture]
 public class AddressFilterTests
 {
-    private static readonly Address _address1 = Address.FromNumber(UInt256.Parse("1"));
-    private static readonly Address _address2 = Address.FromNumber(UInt256.Parse("2"));
-    private static readonly Address _address3 = Address.FromNumber(UInt256.Parse("3"));
-
     [Test]
     public void Accepts_a_specific_address()
     {
-        AddressFilter filter = new AddressFilter(_address1);
+        AddressFilter filter = new AddressFilter(TestItem.AddressA);
 
-        filter.Accepts(_address1).Should().BeTrue();
+        filter.Accepts(TestItem.AddressA).Should().BeTrue();
     }
 
     [Test]
     public void Accepts_a_specific_address_by_ref()
     {
-        AddressFilter filter = new AddressFilter(_address1);
+        AddressFilter filter = new AddressFilter(TestItem.AddressA);
 
-        AddressStructRef @ref = _address1.ToStructRef();
+        AddressStructRef @ref = TestItem.AddressA.ToStructRef();
         filter.Accepts(ref @ref).Should().BeTrue();
     }
 
     [Test]
     public void Rejects_different_address()
     {
-        AddressFilter filter = new AddressFilter(_address1);
+        AddressFilter filter = new AddressFilter(TestItem.AddressA);
 
-        filter.Accepts(_address2).Should().BeFalse();
+        filter.Accepts(TestItem.AddressB).Should().BeFalse();
     }
 
     [Test]
     public void Rejects_different_address_by_ref()
     {
-        AddressFilter filter = new AddressFilter(_address1);
+        AddressFilter filter = new AddressFilter(TestItem.AddressA);
 
-        AddressStructRef address2Ref = _address2.ToStructRef();
-        filter.Accepts(ref address2Ref).Should().BeFalse();
+        AddressStructRef addressBRef = TestItem.AddressB.ToStructRef();
+        filter.Accepts(ref addressBRef).Should().BeFalse();
     }
 
     [Test]
@@ -56,9 +52,9 @@ public class AddressFilterTests
     {
         AddressFilter filter = AddressFilter.AnyAddress;
 
-        filter.Accepts(_address1).Should().BeTrue();
-        filter.Accepts(_address2).Should().BeTrue();
-        filter.Accepts(_address3).Should().BeTrue();
+        filter.Accepts(TestItem.AddressA).Should().BeTrue();
+        filter.Accepts(TestItem.AddressB).Should().BeTrue();
+        filter.Accepts(TestItem.AddressC).Should().BeTrue();
     }
 
     [Test]
@@ -66,12 +62,12 @@ public class AddressFilterTests
     {
         AddressFilter filter = AddressFilter.AnyAddress;
 
-        AddressStructRef address1Ref = _address1.ToStructRef();
-        AddressStructRef address2Ref = _address2.ToStructRef();
-        AddressStructRef address3Ref = _address3.ToStructRef();
-        filter.Accepts(ref address1Ref).Should().BeTrue();
-        filter.Accepts(ref address2Ref).Should().BeTrue();
-        filter.Accepts(ref address3Ref).Should().BeTrue();
+        AddressStructRef addressARef = TestItem.AddressA.ToStructRef();
+        AddressStructRef addressBRef = TestItem.AddressB.ToStructRef();
+        AddressStructRef addressCRef = TestItem.AddressC.ToStructRef();
+        filter.Accepts(ref addressARef).Should().BeTrue();
+        filter.Accepts(ref addressBRef).Should().BeTrue();
+        filter.Accepts(ref addressCRef).Should().BeTrue();
     }
 
     [Test]
@@ -79,9 +75,9 @@ public class AddressFilterTests
     {
         AddressFilter filter = new AddressFilter(addresses: null!);
 
-        filter.Accepts(_address1).Should().BeTrue();
-        filter.Accepts(_address2).Should().BeTrue();
-        filter.Accepts(_address3).Should().BeTrue();
+        filter.Accepts(TestItem.AddressA).Should().BeTrue();
+        filter.Accepts(TestItem.AddressB).Should().BeTrue();
+        filter.Accepts(TestItem.AddressC).Should().BeTrue();
     }
 
     [Test]
@@ -89,12 +85,12 @@ public class AddressFilterTests
     {
         AddressFilter filter = new AddressFilter(addresses: null!);
 
-        AddressStructRef address1Ref = _address1.ToStructRef();
-        AddressStructRef address2Ref = _address2.ToStructRef();
-        AddressStructRef address3Ref = _address3.ToStructRef();
-        filter.Accepts(ref address1Ref).Should().BeTrue();
-        filter.Accepts(ref address2Ref).Should().BeTrue();
-        filter.Accepts(ref address3Ref).Should().BeTrue();
+        AddressStructRef addressARef = TestItem.AddressA.ToStructRef();
+        AddressStructRef addressBRef = TestItem.AddressB.ToStructRef();
+        AddressStructRef addressCRef = TestItem.AddressC.ToStructRef();
+        filter.Accepts(ref addressARef).Should().BeTrue();
+        filter.Accepts(ref addressBRef).Should().BeTrue();
+        filter.Accepts(ref addressCRef).Should().BeTrue();
     }
 
     [Test]
@@ -103,9 +99,9 @@ public class AddressFilterTests
         HashSet<Address> addresses = new();
         AddressFilter filter = new AddressFilter(addresses);
 
-        filter.Accepts(_address1).Should().BeTrue();
-        filter.Accepts(_address2).Should().BeTrue();
-        filter.Accepts(_address3).Should().BeTrue();
+        filter.Accepts(TestItem.AddressA).Should().BeTrue();
+        filter.Accepts(TestItem.AddressB).Should().BeTrue();
+        filter.Accepts(TestItem.AddressC).Should().BeTrue();
     }
 
     [Test]
@@ -114,12 +110,12 @@ public class AddressFilterTests
         HashSet<Address> addresses = new();
         AddressFilter filter = new AddressFilter(addresses);
 
-        AddressStructRef address1Ref = _address1.ToStructRef();
-        AddressStructRef address2Ref = _address2.ToStructRef();
-        AddressStructRef address3Ref = _address3.ToStructRef();
-        filter.Accepts(ref address1Ref).Should().BeTrue();
-        filter.Accepts(ref address2Ref).Should().BeTrue();
-        filter.Accepts(ref address3Ref).Should().BeTrue();
+        AddressStructRef addressARef = TestItem.AddressA.ToStructRef();
+        AddressStructRef addressBRef = TestItem.AddressB.ToStructRef();
+        AddressStructRef addressCRef = TestItem.AddressC.ToStructRef();
+        filter.Accepts(ref addressARef).Should().BeTrue();
+        filter.Accepts(ref addressBRef).Should().BeTrue();
+        filter.Accepts(ref addressCRef).Should().BeTrue();
     }
 
     [Test]
@@ -127,13 +123,13 @@ public class AddressFilterTests
     {
         HashSet<Address> addresses = new()
         {
-            _address1, _address3
+            TestItem.AddressA, TestItem.AddressC
         };
         AddressFilter filter = new AddressFilter(addresses);
 
-        filter.Accepts(_address1).Should().BeTrue();
-        filter.Accepts(_address2).Should().BeFalse();
-        filter.Accepts(_address3).Should().BeTrue();
+        filter.Accepts(TestItem.AddressA).Should().BeTrue();
+        filter.Accepts(TestItem.AddressB).Should().BeFalse();
+        filter.Accepts(TestItem.AddressC).Should().BeTrue();
     }
 
     [Test]
@@ -141,15 +137,15 @@ public class AddressFilterTests
     {
         HashSet<Address> addresses = new()
         {
-            _address1, _address3
+            TestItem.AddressA, TestItem.AddressC
         };
         AddressFilter filter = new AddressFilter(addresses);
 
-        AddressStructRef address1Ref = _address1.ToStructRef();
-        AddressStructRef address2Ref = _address2.ToStructRef();
-        AddressStructRef address3Ref = _address3.ToStructRef();
-        filter.Accepts(ref address1Ref).Should().BeTrue();
-        filter.Accepts(ref address2Ref).Should().BeFalse();
-        filter.Accepts(ref address3Ref).Should().BeTrue();
+        AddressStructRef addressARef = TestItem.AddressA.ToStructRef();
+        AddressStructRef addressBRef = TestItem.AddressB.ToStructRef();
+        AddressStructRef addressCRef = TestItem.AddressC.ToStructRef();
+        filter.Accepts(ref addressARef).Should().BeTrue();
+        filter.Accepts(ref addressBRef).Should().BeFalse();
+        filter.Accepts(ref addressCRef).Should().BeTrue();
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain.Test/Filters/AddressFilterTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Filters/AddressFilterTests.cs
@@ -72,29 +72,6 @@ public class AddressFilterTests
     }
 
     [Test]
-    public void Accepts_any_address_when_set_is_null()
-    {
-        AddressFilter filter = new AddressFilter(addresses: null!);
-
-        filter.Accepts(TestItem.AddressA).Should().BeTrue();
-        filter.Accepts(TestItem.AddressB).Should().BeTrue();
-        filter.Accepts(TestItem.AddressC).Should().BeTrue();
-    }
-
-    [Test]
-    public void Accepts_any_address_when_set_is_null_by_ref()
-    {
-        AddressFilter filter = new AddressFilter(addresses: null!);
-
-        AddressStructRef addressARef = TestItem.AddressA.ToStructRef();
-        AddressStructRef addressBRef = TestItem.AddressB.ToStructRef();
-        AddressStructRef addressCRef = TestItem.AddressC.ToStructRef();
-        filter.Accepts(ref addressARef).Should().BeTrue();
-        filter.Accepts(ref addressBRef).Should().BeTrue();
-        filter.Accepts(ref addressCRef).Should().BeTrue();
-    }
-
-    [Test]
     public void Accepts_any_address_when_set_is_empty()
     {
         HashSet<Address> addresses = new();
@@ -224,6 +201,29 @@ public class AddressFilterTests
     {
         HashSet<Address> addresses = new();
         AddressFilter filter = new AddressFilter(addresses);
+
+        BloomStructRef bloomARef = BloomFromAddress(TestItem.AddressA).ToStructRef();
+        BloomStructRef bloomBRef = BloomFromAddress(TestItem.AddressB).ToStructRef();
+        BloomStructRef bloomCRef = BloomFromAddress(TestItem.AddressC).ToStructRef();
+        filter.Matches(ref bloomARef).Should().BeTrue();
+        filter.Matches(ref bloomBRef).Should().BeTrue();
+        filter.Matches(ref bloomCRef).Should().BeTrue();
+    }
+
+    [Test]
+    public void Matches_any_bloom_when_set_is_forced_null()
+    {
+        AddressFilter filter = new AddressFilter(addresses: null!);
+
+        filter.Matches(BloomFromAddress(TestItem.AddressA)).Should().BeTrue();
+        filter.Matches(BloomFromAddress(TestItem.AddressB)).Should().BeTrue();
+        filter.Matches(BloomFromAddress(TestItem.AddressC)).Should().BeTrue();
+    }
+
+    [Test]
+    public void Matches_any_bloom_when_set_is_forced_null_by_ref()
+    {
+        AddressFilter filter = new AddressFilter(addresses: null!);
 
         BloomStructRef bloomARef = BloomFromAddress(TestItem.AddressA).ToStructRef();
         BloomStructRef bloomBRef = BloomFromAddress(TestItem.AddressB).ToStructRef();

--- a/src/Nethermind/Nethermind.Blockchain.Test/Filters/AddressFilterTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Filters/AddressFilterTests.cs
@@ -26,11 +26,29 @@ public class AddressFilterTests
     }
 
     [Test]
+    public void Accepts_a_specific_address_by_ref()
+    {
+        AddressFilter filter = new AddressFilter(_address1);
+
+        AddressStructRef @ref = _address1.ToStructRef();
+        filter.Accepts(ref @ref).Should().BeTrue();
+    }
+
+    [Test]
     public void Rejects_different_address()
     {
         AddressFilter filter = new AddressFilter(_address1);
 
         filter.Accepts(_address2).Should().BeFalse();
+    }
+
+    [Test]
+    public void Rejects_different_address_by_ref()
+    {
+        AddressFilter filter = new AddressFilter(_address1);
+
+        AddressStructRef address2Ref = _address2.ToStructRef();
+        filter.Accepts(ref address2Ref).Should().BeFalse();
     }
 
     [Test]
@@ -41,6 +59,19 @@ public class AddressFilterTests
         filter.Accepts(_address1).Should().BeTrue();
         filter.Accepts(_address2).Should().BeTrue();
         filter.Accepts(_address3).Should().BeTrue();
+    }
+
+    [Test]
+    public void Accepts_any_address_when_set_is_null_by_ref()
+    {
+        AddressFilter filter = new AddressFilter(addresses: null!);
+
+        AddressStructRef address1Ref = _address1.ToStructRef();
+        AddressStructRef address2Ref = _address2.ToStructRef();
+        AddressStructRef address3Ref = _address3.ToStructRef();
+        filter.Accepts(ref address1Ref).Should().BeTrue();
+        filter.Accepts(ref address2Ref).Should().BeTrue();
+        filter.Accepts(ref address3Ref).Should().BeTrue();
     }
 
     [Test]
@@ -55,6 +86,20 @@ public class AddressFilterTests
     }
 
     [Test]
+    public void Accepts_any_address_when_set_is_empty_by_ref()
+    {
+        HashSet<Address> addresses = new();
+        AddressFilter filter = new AddressFilter(addresses);
+
+        AddressStructRef address1Ref = _address1.ToStructRef();
+        AddressStructRef address2Ref = _address2.ToStructRef();
+        AddressStructRef address3Ref = _address3.ToStructRef();
+        filter.Accepts(ref address1Ref).Should().BeTrue();
+        filter.Accepts(ref address2Ref).Should().BeTrue();
+        filter.Accepts(ref address3Ref).Should().BeTrue();
+    }
+
+    [Test]
     public void Accepts_only_addresses_in_a_set()
     {
         HashSet<Address> addresses = new()
@@ -66,5 +111,22 @@ public class AddressFilterTests
         filter.Accepts(_address1).Should().BeTrue();
         filter.Accepts(_address2).Should().BeFalse();
         filter.Accepts(_address3).Should().BeTrue();
+    }
+
+    [Test]
+    public void Accepts_only_addresses_in_a_set_by_ref()
+    {
+        HashSet<Address> addresses = new()
+        {
+            _address1, _address3
+        };
+        AddressFilter filter = new AddressFilter(addresses);
+
+        AddressStructRef address1Ref = _address1.ToStructRef();
+        AddressStructRef address2Ref = _address2.ToStructRef();
+        AddressStructRef address3Ref = _address3.ToStructRef();
+        filter.Accepts(ref address1Ref).Should().BeTrue();
+        filter.Accepts(ref address2Ref).Should().BeFalse();
+        filter.Accepts(ref address3Ref).Should().BeTrue();
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain.Test/Filters/AddressFilterTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Filters/AddressFilterTests.cs
@@ -208,6 +208,62 @@ public class AddressFilterTests
         filter.Matches(ref bloomCRef).Should().BeTrue();
     }
 
+    [Test]
+    public void Matches_any_bloom_when_set_is_empty()
+    {
+        HashSet<Address> addresses = new();
+        AddressFilter filter = new AddressFilter(addresses);
+
+        filter.Matches(BloomFromAddress(TestItem.AddressA)).Should().BeTrue();
+        filter.Matches(BloomFromAddress(TestItem.AddressB)).Should().BeTrue();
+        filter.Matches(BloomFromAddress(TestItem.AddressC)).Should().BeTrue();
+    }
+
+    [Test]
+    public void Matches_any_bloom_when_set_is_empty_by_ref()
+    {
+        HashSet<Address> addresses = new();
+        AddressFilter filter = new AddressFilter(addresses);
+
+        BloomStructRef bloomARef = BloomFromAddress(TestItem.AddressA).ToStructRef();
+        BloomStructRef bloomBRef = BloomFromAddress(TestItem.AddressB).ToStructRef();
+        BloomStructRef bloomCRef = BloomFromAddress(TestItem.AddressC).ToStructRef();
+        filter.Matches(ref bloomARef).Should().BeTrue();
+        filter.Matches(ref bloomBRef).Should().BeTrue();
+        filter.Matches(ref bloomCRef).Should().BeTrue();
+    }
+
+    [Test]
+    public void Matches_any_bloom_using_addresses_set()
+    {
+        HashSet<Address> addresses = new()
+        {
+            TestItem.AddressA, TestItem.AddressC
+        };
+        AddressFilter filter = new AddressFilter(addresses);
+
+        filter.Matches(BloomFromAddress(TestItem.AddressA)).Should().BeTrue();
+        filter.Matches(BloomFromAddress(TestItem.AddressB)).Should().BeFalse();
+        filter.Matches(BloomFromAddress(TestItem.AddressC)).Should().BeTrue();
+    }
+
+    [Test]
+    public void Matches_any_bloom_using_addresses_set_by_ref()
+    {
+        HashSet<Address> addresses = new()
+        {
+            TestItem.AddressA, TestItem.AddressC
+        };
+        AddressFilter filter = new AddressFilter(addresses);
+
+        BloomStructRef bloomARef = BloomFromAddress(TestItem.AddressA).ToStructRef();
+        BloomStructRef bloomBRef = BloomFromAddress(TestItem.AddressB).ToStructRef();
+        BloomStructRef bloomCRef = BloomFromAddress(TestItem.AddressC).ToStructRef();
+        filter.Matches(ref bloomARef).Should().BeTrue();
+        filter.Matches(ref bloomBRef).Should().BeFalse();
+        filter.Matches(ref bloomCRef).Should().BeTrue();
+    }
+
     private static Core.Bloom BloomFromAddress(Address address)
     {
         LogEntry entry = new LogEntry(address, new byte[]{ }, new Keccak[]{ });

--- a/src/Nethermind/Nethermind.Blockchain.Test/Filters/AddressFilterTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Filters/AddressFilterTests.cs
@@ -168,6 +168,23 @@ public class AddressFilterTests
         filter.Matches(ref bloomRef).Should().BeTrue();
     }
 
+    [Test]
+    public void Does_not_match_bloom_using_different_address()
+    {
+        AddressFilter filter = new AddressFilter(TestItem.AddressA);
+
+        filter.Matches(BloomFromAddress(TestItem.AddressB)).Should().BeFalse();
+    }
+
+    [Test]
+    public void Does_not_match_bloom_using_different_address_by_ref()
+    {
+        AddressFilter filter = new AddressFilter(TestItem.AddressA);
+        BloomStructRef bloomRef = BloomFromAddress(TestItem.AddressB).ToStructRef();
+
+        filter.Matches(ref bloomRef).Should().BeFalse();
+    }
+
     private static Core.Bloom BloomFromAddress(Address address)
     {
         LogEntry entry = new LogEntry(address, new byte[]{ }, new Keccak[]{ });

--- a/src/Nethermind/Nethermind.Facade/Filters/AddressFilter.cs
+++ b/src/Nethermind/Nethermind.Facade/Filters/AddressFilter.cs
@@ -24,8 +24,8 @@ namespace Nethermind.Blockchain.Filters
             Addresses = addresses;
         }
 
-        public Address? Address { get; set; }
-        public HashSet<Address>? Addresses { get; set; }
+        private Address? Address { get; }
+        private HashSet<Address>? Addresses { get; }
         private Bloom.BloomExtract[] AddressesBloomExtracts => _addressesBloomIndexes ??= CalculateBloomExtracts();
         private Bloom.BloomExtract AddressBloomExtract => _addressBloomExtract ??= Bloom.GetExtract(Address);
 

--- a/src/Nethermind/Nethermind.Facade/Filters/AddressFilter.cs
+++ b/src/Nethermind/Nethermind.Facade/Filters/AddressFilter.cs
@@ -9,7 +9,7 @@ namespace Nethermind.Blockchain.Filters
 {
     public class AddressFilter
     {
-        public static AddressFilter AnyAddress = new((Address)null);
+        public static readonly AddressFilter AnyAddress = new(addresses: new HashSet<Address>());
 
         private Bloom.BloomExtract[] _addressesBloomIndexes;
         private Bloom.BloomExtract? _addressBloomExtract;

--- a/src/Nethermind/Nethermind.Facade/Filters/AddressFilter.cs
+++ b/src/Nethermind/Nethermind.Facade/Filters/AddressFilter.cs
@@ -31,7 +31,7 @@ namespace Nethermind.Blockchain.Filters
 
         public bool Accepts(Address address)
         {
-            if (Addresses is not null)
+            if (Addresses is not null && Addresses.Count > 0)
             {
                 return Addresses.Contains(address);
             }
@@ -41,7 +41,7 @@ namespace Nethermind.Blockchain.Filters
 
         public bool Accepts(ref AddressStructRef address)
         {
-            if (Addresses is not null)
+            if (Addresses is not null && Addresses.Count > 0)
             {
                 foreach (var a in Addresses)
                 {

--- a/src/Nethermind/Nethermind.Facade/Filters/AddressFilter.cs
+++ b/src/Nethermind/Nethermind.Facade/Filters/AddressFilter.cs
@@ -31,7 +31,7 @@ namespace Nethermind.Blockchain.Filters
 
         public bool Accepts(Address address)
         {
-            if (Addresses is not null && Addresses.Count > 0)
+            if (Addresses?.Count > 0)
             {
                 return Addresses.Contains(address);
             }
@@ -41,7 +41,7 @@ namespace Nethermind.Blockchain.Filters
 
         public bool Accepts(ref AddressStructRef address)
         {
-            if (Addresses is not null && Addresses.Count > 0)
+            if (Addresses?.Count > 0)
             {
                 foreach (var a in Addresses)
                 {

--- a/src/Nethermind/Nethermind.Facade/Filters/AddressFilter.cs
+++ b/src/Nethermind/Nethermind.Facade/Filters/AddressFilter.cs
@@ -11,7 +11,7 @@ namespace Nethermind.Blockchain.Filters
     {
         public static readonly AddressFilter AnyAddress = new(addresses: new HashSet<Address>());
 
-        private Bloom.BloomExtract[] _addressesBloomIndexes;
+        private Bloom.BloomExtract[]? _addressesBloomIndexes;
         private Bloom.BloomExtract? _addressBloomExtract;
 
         public AddressFilter(Address address)

--- a/src/Nethermind/Nethermind.Facade/Filters/AddressFilter.cs
+++ b/src/Nethermind/Nethermind.Facade/Filters/AddressFilter.cs
@@ -11,8 +11,8 @@ namespace Nethermind.Blockchain.Filters
     {
         public static AddressFilter AnyAddress = new((Address)null);
 
-        private Core.Bloom.BloomExtract[] _addressesBloomIndexes;
-        private Core.Bloom.BloomExtract? _addressBloomExtract;
+        private Bloom.BloomExtract[] _addressesBloomIndexes;
+        private Bloom.BloomExtract? _addressBloomExtract;
 
         public AddressFilter(Address address)
         {
@@ -26,8 +26,8 @@ namespace Nethermind.Blockchain.Filters
 
         public Address? Address { get; set; }
         public HashSet<Address>? Addresses { get; set; }
-        private Core.Bloom.BloomExtract[] AddressesBloomExtracts => _addressesBloomIndexes ??= CalculateBloomExtracts();
-        private Core.Bloom.BloomExtract AddressBloomExtract => _addressBloomExtract ??= Core.Bloom.GetExtract(Address);
+        private Bloom.BloomExtract[] AddressesBloomExtracts => _addressesBloomIndexes ??= CalculateBloomExtracts();
+        private Bloom.BloomExtract AddressBloomExtract => _addressBloomExtract ??= Bloom.GetExtract(Address);
 
         public bool Accepts(Address address)
         {
@@ -54,7 +54,7 @@ namespace Nethermind.Blockchain.Filters
             return Address is null || Address == address;
         }
 
-        public bool Matches(Core.Bloom bloom)
+        public bool Matches(Bloom bloom)
         {
             if (Addresses is not null)
             {
@@ -71,14 +71,11 @@ namespace Nethermind.Blockchain.Filters
 
                 return result;
             }
-            else if (Address is null)
+            if (Address is null)
             {
                 return true;
             }
-            else
-            {
-                return bloom.Matches(AddressBloomExtract);
-            }
+            return bloom.Matches(AddressBloomExtract);
         }
 
         public bool Matches(ref BloomStructRef bloom)
@@ -98,16 +95,13 @@ namespace Nethermind.Blockchain.Filters
 
                 return result;
             }
-            else if (Address is null)
+            if (Address is null)
             {
                 return true;
             }
-            else
-            {
-                return bloom.Matches(AddressBloomExtract);
-            }
+            return bloom.Matches(AddressBloomExtract);
         }
 
-        private Core.Bloom.BloomExtract[] CalculateBloomExtracts() => Addresses.Select(Core.Bloom.GetExtract).ToArray();
+        private Bloom.BloomExtract[] CalculateBloomExtracts() => Addresses.Select(Bloom.GetExtract).ToArray();
     }
 }


### PR DESCRIPTION
Fixes #6084

## Changes

- Improve filtering to accept any address when the address list is empty

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No