### PR TITLE
Remove HTTP log spam on default settings

### DIFF
--- a/src/Nethermind/Nethermind.Runner/Logging/NLogConfigurator.cs
+++ b/src/Nethermind/Nethermind.Runner/Logging/NLogConfigurator.cs
@@ -71,6 +71,7 @@ namespace Nethermind.Runner.Logging
 
             foreach (LoggingRule rule in LogManager.Configuration.LoggingRules)
             {
+                // WORKAROUND: Skip modifying 'JsonWebAPI*' rules since we want to preserve the original config on the 'NLog.config' file
                 if (rule.LoggerNamePattern == "JsonWebAPI*") { continue; }
 
                 foreach (var ruleTarget in rule.Targets)

--- a/src/Nethermind/Nethermind.Runner/Logging/NLogConfigurator.cs
+++ b/src/Nethermind/Nethermind.Runner/Logging/NLogConfigurator.cs
@@ -71,6 +71,8 @@ namespace Nethermind.Runner.Logging
 
             foreach (LoggingRule rule in LogManager.Configuration.LoggingRules)
             {
+                if (rule.LoggerNamePattern == "JsonWebAPI*") { continue; }
+
                 foreach (var ruleTarget in rule.Targets)
                 {
                     if (ruleTarget.Name != "seq")


### PR DESCRIPTION
Fixes #6017

## Changes

- Do not change the log levels of `JsonWebAPI*` rules.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Tested on VM using with and without the `--log info` flag.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Passing `--log info` as a argument results in the same logging settings as not passing any argument.
