### PR TITLE
Make flaky tests explicit for `JsonRpc.Test`

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcSocketsClientTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcSocketsClientTests.cs
@@ -63,7 +63,6 @@ public class JsonRpcSocketsClientTests
         }
 
         [Test]
-        [Retry(5)]
         [TestCase(2)]
         [TestCase(10)]
         [TestCase(50)]
@@ -108,7 +107,6 @@ public class JsonRpcSocketsClientTests
             Assert.That(sent, Is.EqualTo(received));
         }
 
-        [Retry(5)]
         [TestCase(2)]
         [TestCase(10)]
         [TestCase(50)]
@@ -172,10 +170,10 @@ public class JsonRpcSocketsClientTests
         }
     }
 
+    [Explicit]
     public class UsingWebSockets
     {
         [Test]
-        [Retry(5)]
         [TestCase(2)]
         [TestCase(10)]
         [TestCase(50)]
@@ -221,7 +219,6 @@ public class JsonRpcSocketsClientTests
             Assert.That(sent, Is.EqualTo(received));
         }
 
-        [Retry(5)]
         [TestCase(2)]
         [TestCase(10)]
         [TestCase(50)]


### PR DESCRIPTION
## Changes

- Make tests related to WebSockets explicit

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Tests that rely on WebSockets are marked as explicit due to issues running them on CI.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
