### PR TITLE
Reject non-nullable aggregate types when deserializing method parameters

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcServiceTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcServiceTests.cs
@@ -151,6 +151,24 @@ namespace Nethermind.JsonRpc.Test
         }
 
         [Test]
+        public void Eth_getTransactionReceipt_properly_fails_given_wrong_parameters()
+        {
+            IEthRpcModule ethRpcModule = Substitute.For<IEthRpcModule>();
+
+            string[] parameters = {
+                """["0x80757153e93d1b475e203406727b62a501187f63e23b8fa999279e219ee3be71"]"""
+            };
+            JsonRpcResponse response = TestRequest(ethRpcModule, "eth_getTransactionReceipt", parameters);
+
+            response.Should()
+                .BeAssignableTo<JsonRpcErrorResponse>()
+                .Which
+                .Error.Should().NotBeNull();
+            Error error = (response as JsonRpcErrorResponse)!.Error!;
+            error.Code.Should().Be(ErrorCodes.InvalidParams);
+        }
+
+        [Test]
         public void GetWorkTest()
         {
             IEthRpcModule ethRpcModule = Substitute.For<IEthRpcModule>();

--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcServiceTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcServiceTests.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO.Abstractions;
 using System.Linq;
-using System.Reflection;
 using FluentAssertions;
 using Nethermind.Blockchain.Find;
 using Nethermind.Config;
@@ -35,7 +34,6 @@ namespace Nethermind.JsonRpc.Test
         [SetUp]
         public void Initialize()
         {
-            Assembly jConfig = typeof(JsonRpcConfig).Assembly;
             _configurationProvider = new ConfigProvider();
             _logManager = LimboLogs.Instance;
             _context = new JsonRpcContext(RpcEndpoint.Http);
@@ -49,7 +47,7 @@ namespace Nethermind.JsonRpc.Test
         private JsonRpcResponse TestRequest<T>(T module, string method, params string[] parameters) where T : IRpcModule
         {
             RpcModuleProvider moduleProvider = new(new FileSystem(), _configurationProvider.GetConfig<IJsonRpcConfig>(), LimboLogs.Instance);
-            moduleProvider.Register(new SingletonModulePool<T>(new SingletonFactory<T>(module), true));
+            moduleProvider.Register(new SingletonModulePool<T>(new SingletonFactory<T>(module), allowExclusive: true));
             _jsonRpcService = new JsonRpcService(moduleProvider, _logManager, _configurationProvider.GetConfig<IJsonRpcConfig>());
             JsonRpcRequest request = RpcTest.GetJsonRequest(method, parameters);
             JsonRpcResponse response = _jsonRpcService.SendRequestAsync(request, _context).Result;
@@ -62,7 +60,7 @@ namespace Nethermind.JsonRpc.Test
         {
             IEthRpcModule ethRpcModule = Substitute.For<IEthRpcModule>();
             ISpecProvider specProvider = Substitute.For<ISpecProvider>();
-            ethRpcModule.eth_getBlockByNumber(Arg.Any<BlockParameter>(), true).ReturnsForAnyArgs(x => ResultWrapper<BlockForRpc>.Success(new BlockForRpc(Build.A.Block.WithNumber(2).TestObject, true, specProvider)));
+            ethRpcModule.eth_getBlockByNumber(Arg.Any<BlockParameter>(), true).ReturnsForAnyArgs(_ => ResultWrapper<BlockForRpc>.Success(new BlockForRpc(Build.A.Block.WithNumber(2).TestObject, true, specProvider)));
             JsonRpcSuccessResponse? response = TestRequest(ethRpcModule, "eth_getBlockByNumber", "0x1b4", "true") as JsonRpcSuccessResponse;
             Assert.That((response?.Result as BlockForRpc)?.Number, Is.EqualTo(2L));
         }
@@ -72,7 +70,7 @@ namespace Nethermind.JsonRpc.Test
         {
             IEthRpcModule ethRpcModule = Substitute.For<IEthRpcModule>();
             ISpecProvider specProvider = Substitute.For<ISpecProvider>();
-            ethRpcModule.eth_getBlockByNumber(Arg.Any<BlockParameter>(), true).ReturnsForAnyArgs(x => ResultWrapper<BlockForRpc>.Success(new BlockForRpc(Build.A.Block.WithNumber(2).TestObject, true, specProvider)));
+            ethRpcModule.eth_getBlockByNumber(Arg.Any<BlockParameter>(), true).ReturnsForAnyArgs(_ => ResultWrapper<BlockForRpc>.Success(new BlockForRpc(Build.A.Block.WithNumber(2).TestObject, true, specProvider)));
             JsonRpcSuccessResponse? response = TestRequest(ethRpcModule, "eth_getBlockByNumber", "0x1b4", "true") as JsonRpcSuccessResponse;
             Assert.That((response?.Result as BlockForRpc)?.Size, Is.EqualTo(513L));
         }
@@ -83,7 +81,7 @@ namespace Nethermind.JsonRpc.Test
             EthereumJsonSerializer serializer = new();
             string serialized = serializer.Serialize(new TransactionForRpc());
             IEthRpcModule ethRpcModule = Substitute.For<IEthRpcModule>();
-            ethRpcModule.eth_call(Arg.Any<TransactionForRpc>()).ReturnsForAnyArgs(x => ResultWrapper<string>.Success("0x1"));
+            ethRpcModule.eth_call(Arg.Any<TransactionForRpc>()).ReturnsForAnyArgs(_ => ResultWrapper<string>.Success("0x1"));
             JsonRpcSuccessResponse? response = TestRequest(ethRpcModule, "eth_call", serialized) as JsonRpcSuccessResponse;
             Assert.That(response?.Result, Is.EqualTo("0x1"));
         }
@@ -101,7 +99,7 @@ namespace Nethermind.JsonRpc.Test
         public void GetNewFilterTest()
         {
             IEthRpcModule ethRpcModule = Substitute.For<IEthRpcModule>();
-            ethRpcModule.eth_newFilter(Arg.Any<Filter>()).ReturnsForAnyArgs(x => ResultWrapper<UInt256?>.Success(1));
+            ethRpcModule.eth_newFilter(Arg.Any<Filter>()).ReturnsForAnyArgs(_ => ResultWrapper<UInt256?>.Success(1));
 
             var parameters = new
             {
@@ -128,7 +126,7 @@ namespace Nethermind.JsonRpc.Test
         {
             EthereumJsonSerializer serializer = new();
             IEthRpcModule ethRpcModule = Substitute.For<IEthRpcModule>();
-            ethRpcModule.eth_call(Arg.Any<TransactionForRpc>(), Arg.Any<BlockParameter?>()).ReturnsForAnyArgs(x => ResultWrapper<string>.Success("0x"));
+            ethRpcModule.eth_call(Arg.Any<TransactionForRpc>(), Arg.Any<BlockParameter?>()).ReturnsForAnyArgs(_ => ResultWrapper<string>.Success("0x"));
 
             string serialized = serializer.Serialize(new TransactionForRpc());
 
@@ -142,7 +140,7 @@ namespace Nethermind.JsonRpc.Test
         {
             EthereumJsonSerializer serializer = new();
             IEthRpcModule ethRpcModule = Substitute.For<IEthRpcModule>();
-            ethRpcModule.eth_call(Arg.Any<TransactionForRpc>(), Arg.Any<BlockParameter?>()).ReturnsForAnyArgs(x => ResultWrapper<string>.Success("0x"));
+            ethRpcModule.eth_call(Arg.Any<TransactionForRpc>(), Arg.Any<BlockParameter?>()).ReturnsForAnyArgs(_ => ResultWrapper<string>.Success("0x"));
 
             string serialized = serializer.Serialize(new TransactionForRpc());
 
@@ -172,7 +170,7 @@ namespace Nethermind.JsonRpc.Test
         public void GetWorkTest()
         {
             IEthRpcModule ethRpcModule = Substitute.For<IEthRpcModule>();
-            ethRpcModule.eth_getWork().ReturnsForAnyArgs(x => ResultWrapper<IEnumerable<byte[]>>.Success(new[] { Bytes.FromHexString("aa"), Bytes.FromHexString("01") }));
+            ethRpcModule.eth_getWork().ReturnsForAnyArgs(_ => ResultWrapper<IEnumerable<byte[]>>.Success(new[] { Bytes.FromHexString("aa"), Bytes.FromHexString("01") }));
             JsonRpcSuccessResponse? response = TestRequest(ethRpcModule, "eth_getWork") as JsonRpcSuccessResponse;
             byte[][]? dataList = response?.Result as byte[][];
             Assert.NotNull(dataList?.SingleOrDefault(d => d.ToHexString(true) == "0xaa"));
@@ -190,7 +188,7 @@ namespace Nethermind.JsonRpc.Test
         public void NetVersionTest()
         {
             INetRpcModule netRpcModule = Substitute.For<INetRpcModule>();
-            netRpcModule.net_version().ReturnsForAnyArgs(x => ResultWrapper<string>.Success("1"));
+            netRpcModule.net_version().ReturnsForAnyArgs(_ => ResultWrapper<string>.Success("1"));
             JsonRpcSuccessResponse? response = TestRequest(netRpcModule, "net_version") as JsonRpcSuccessResponse;
             Assert.That(response?.Result, Is.EqualTo("1"));
             Assert.IsNotInstanceOf<JsonRpcErrorResponse>(response);
@@ -200,7 +198,7 @@ namespace Nethermind.JsonRpc.Test
         public void Web3ShaTest()
         {
             IWeb3RpcModule web3RpcModule = Substitute.For<IWeb3RpcModule>();
-            web3RpcModule.web3_sha3(Arg.Any<byte[]>()).ReturnsForAnyArgs(x => ResultWrapper<Keccak>.Success(TestItem.KeccakA));
+            web3RpcModule.web3_sha3(Arg.Any<byte[]>()).ReturnsForAnyArgs(_ => ResultWrapper<Keccak>.Success(TestItem.KeccakA));
             JsonRpcSuccessResponse? response = TestRequest(web3RpcModule, "web3_sha3", "0x68656c6c6f20776f726c64") as JsonRpcSuccessResponse;
             Assert.That(response?.Result, Is.EqualTo(TestItem.KeccakA));
         }
@@ -208,13 +206,13 @@ namespace Nethermind.JsonRpc.Test
         [TestCaseSource(nameof(BlockForRpcTestSource))]
         public void BlockForRpc_should_expose_withdrawals_if_any((bool Expected, Block Block) item)
         {
-            var specProvider = Substitute.For<ISpecProvider>();
-            var rpcBlock = new BlockForRpc(item.Block, false, specProvider);
+            ISpecProvider? specProvider = Substitute.For<ISpecProvider>();
+            BlockForRpc rpcBlock = new(item.Block, false, specProvider);
 
             rpcBlock.WithdrawalsRoot.Should().BeEquivalentTo(item.Block.WithdrawalsRoot);
             rpcBlock.Withdrawals.Should().BeEquivalentTo(item.Block.Withdrawals);
 
-            var json = new EthereumJsonSerializer().Serialize(rpcBlock);
+            string? json = new EthereumJsonSerializer().Serialize(rpcBlock);
 
             json.Contains("withdrawals\"", StringComparison.Ordinal).Should().Be(item.Expected);
             json.Contains("withdrawalsRoot", StringComparison.Ordinal).Should().Be(item.Expected);

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
@@ -327,7 +327,7 @@ public class JsonRpcService : IJsonRpcService
                         executionParam = _serializer.Deserialize(new JsonTextReader(new StringReader(providedParameter)), paramType);
                         if (executionParam is null && !IsNullableParameter(expectedParameter))
                         {
-                            throw new JsonReaderException($"Cannot deserialize parameter `{providedParameter}` into type {paramType}");
+                            executionParameters.Add(Type.Missing);
                         }
                     }
                     else

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
@@ -325,6 +325,10 @@ public class JsonRpcService : IJsonRpcService
                     if (providedParameter.StartsWith('[') || providedParameter.StartsWith('{'))
                     {
                         executionParam = _serializer.Deserialize(new JsonTextReader(new StringReader(providedParameter)), paramType);
+                        if (executionParam is null && !IsNullableParameter(expectedParameter))
+                        {
+                            throw new JsonReaderException($"Cannot deserialize parameter `{providedParameter}` into type {paramType}");
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
Fixes #5805

## Changes

- Fail with `InvalidParams` when deserializing non-nullable aggregate types (ex. Arrays and Objects).

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Tested the provided example in the referenced ticket.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No