### PR TITLE
Don't override `HealthCheckService` log levels

### DIFF
--- a/src/Nethermind/Nethermind.Runner/Logging/NLogConfigurator.cs
+++ b/src/Nethermind/Nethermind.Runner/Logging/NLogConfigurator.cs
@@ -69,10 +69,16 @@ namespace Nethermind.Runner.Logging
 
             Console.WriteLine($"Enabling log level override: {logLevel.ToUpperInvariant()}");
 
+            // There are some rules for which we don't want to override the log level
+            // but instead preserve the original config defined in the 'NLog.config' file
+            string[] ignoredRuleNames =
+            {
+                "JsonWebAPI*",
+                "JsonWebAPI.Microsoft.Extensions.Diagnostics.HealthChecks.DefaultHealthCheckService",
+            };
             foreach (LoggingRule rule in LogManager.Configuration.LoggingRules)
             {
-                // WORKAROUND: Skip modifying 'JsonWebAPI*' rules since we want to preserve the original config on the 'NLog.config' file
-                if (rule.LoggerNamePattern == "JsonWebAPI*") { continue; }
+                if (ignoredRuleNames.Contains(rule.LoggerNamePattern)) { continue; }
 
                 foreach (var ruleTarget in rule.Targets)
                 {


### PR DESCRIPTION
Fixes #6017

## Changes

- Don't override `HealthCheckService` log levels

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Similar to #6097. We missed an extra rule related to JSON Web API Health Checks, so we're adding it here.