### PR TITLE
Perf/set malloc ops

### DIFF
--- a/src/Nethermind/Nethermind.Api/IInitConfig.cs
+++ b/src/Nethermind/Nethermind.Api/IInitConfig.cs
@@ -73,6 +73,9 @@ namespace Nethermind.Api
 
         [ConfigItem(Description = "A hint for the max memory that will allow us to configure the DB and Netty memory allocations.", DefaultValue = "null")]
         long? MemoryHint { get; set; }
+
+        [ConfigItem(Description = "[TECHNICAL] Disable setting malloc options. Set to true if using different memory allocator or manually setting malloc opts.", DefaultValue = "false", HiddenFromDocs = true)]
+        bool DisableMallocOpts { get; set; }
     }
 
     public enum DiagnosticMode

--- a/src/Nethermind/Nethermind.Api/InitConfig.cs
+++ b/src/Nethermind/Nethermind.Api/InitConfig.cs
@@ -31,6 +31,7 @@ namespace Nethermind.Api
 
         public string RpcDbUrl { get; set; } = String.Empty;
         public long? MemoryHint { get; set; }
+        public bool DisableMallocOpts { get; set; } = false;
 
         [Obsolete("Use DiagnosticMode with MemDb instead")]
         public bool UseMemDb

--- a/src/Nethermind/Nethermind.Core.Test/Memory/MallocHelperTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Memory/MallocHelperTests.cs
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using FluentAssertions;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Memory;
+using NUnit.Framework;
+
+namespace Nethermind.Core.Test.Memory;
+
+public class MallocHelperTests
+{
+    [Test]
+    public void TestMallOpts()
+    {
+        MallocHelper.Instance.MallOpt(MallocHelper.Option.M_MMAP_THRESHOLD, (int)128.KiB()).Should().BeTrue();
+    }
+}

--- a/src/Nethermind/Nethermind.Core/Memory/MallocHelper.cs
+++ b/src/Nethermind/Nethermind.Core/Memory/MallocHelper.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Runtime.InteropServices;
 
 namespace Nethermind.Core.Memory;
@@ -18,6 +19,10 @@ public class MallocHelper
 
     public bool MallOpt(Option option, int value)
     {
+        // Windows can't find libc and osx does not have the method for some reason
+        // FreeBSD uses jemalloc by default anyway....
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) return true;
+
         return mallopt((int)option, value) == 1;
     }
 

--- a/src/Nethermind/Nethermind.Core/Memory/MallocHelper.cs
+++ b/src/Nethermind/Nethermind.Core/Memory/MallocHelper.cs
@@ -21,7 +21,7 @@ public class MallocHelper
         return mallopt((int)option, value) == 1;
     }
 
-    public enum Option: int
+    public enum Option : int
     {
         M_MMAP_THRESHOLD = -3
     }

--- a/src/Nethermind/Nethermind.Core/Memory/MallocHelper.cs
+++ b/src/Nethermind/Nethermind.Core/Memory/MallocHelper.cs
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Runtime.InteropServices;
+
+namespace Nethermind.Core.Memory;
+
+/// <summary>
+/// Wrapper around malloc apis
+/// </summary>
+public class MallocHelper
+{
+    [DllImport("libc")]
+    private static extern int mallopt(int opts, int value);
+
+    private static MallocHelper? _instance;
+    public static MallocHelper Instance => _instance ??= new MallocHelper();
+
+    public bool MallOpt(Option option, int value)
+    {
+        return mallopt((int)option, value) == 1;
+    }
+
+    public enum Option: int
+    {
+        M_MMAP_THRESHOLD = -3
+    }
+}

--- a/src/Nethermind/Nethermind.Init/MemoryHintMan.cs
+++ b/src/Nethermind/Nethermind.Init/MemoryHintMan.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Diagnostics;
 using System.IO;
-using System.Runtime.InteropServices;
 using DotNetty.Buffers;
 using Nethermind.Api;
 using Nethermind.Blockchain.Synchronization;

--- a/src/Nethermind/Nethermind.Runner.Test/MemoryHintManTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/MemoryHintManTests.cs
@@ -6,11 +6,13 @@ using FluentAssertions;
 using Nethermind.Api;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core.Extensions;
+using Nethermind.Core.Memory;
 using Nethermind.Db.Rocks.Config;
 using Nethermind.Init;
 using Nethermind.Logging;
 using Nethermind.Network.Config;
 using Nethermind.TxPool;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Nethermind.Runner.Test
@@ -27,6 +29,7 @@ namespace Nethermind.Runner.Test
         private ITxPoolConfig _txPoolConfig;
         private INetworkConfig _networkConfig;
         private MemoryHintMan _memoryHintMan;
+        private MallocHelper _mallocHelper;
 
         [SetUp]
         public void Setup()
@@ -36,7 +39,8 @@ namespace Nethermind.Runner.Test
             _initConfig = new InitConfig();
             _txPoolConfig = new TxPoolConfig();
             _networkConfig = new NetworkConfig();
-            _memoryHintMan = new MemoryHintMan(LimboLogs.Instance);
+            _mallocHelper = Substitute.For<MallocHelper>();
+            _memoryHintMan = new MemoryHintMan(LimboLogs.Instance, _mallocHelper);
         }
 
         private void SetMemoryAllowances(uint cpuCount)
@@ -165,6 +169,23 @@ namespace Nethermind.Runner.Test
             _initConfig.MemoryHint = memoryHint;
             SetMemoryAllowances(1);
             Trie.MemoryAllowance.TrieNodeCacheCount.Should().BeGreaterThan(0);
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void Big_value_at_memory_hint(bool shouldSetMallocOpts)
+        {
+            _initConfig.DisableMallocOpts = !shouldSetMallocOpts;
+            SetMemoryAllowances(1);
+
+            if (shouldSetMallocOpts)
+            {
+                _mallocHelper.Received().MallOpt(Arg.Any<MallocHelper.Option>(), Arg.Any<int>());
+            }
+            else
+            {
+                _mallocHelper.DidNotReceive().MallOpt(Arg.Any<MallocHelper.Option>(), Arg.Any<int>());
+            }
         }
     }
 }


### PR DESCRIPTION
Related to #6107

- Set `M_MMAP_THRESHOLD` to 64KiB.
- On 32 thread machine, reduces malloc memory fragmentation overhead from 12.5GB to 5GB. Should do less on machine with less core, but there should still be reduction in memory.
- Only works on Linux. FreeBSD already uses jemalloc by default and jemalloc noop the mallopt call.
- Average System CPU time percentage during sync increase from about 23% to 24%.

- Graph is (Before, After, After + #6111)
![Screenshot_2023-09-21_11-55-29](https://github.com/NethermindEth/nethermind/assets/1841324/4ef9e0ba-531e-4a01-9eda-d675fe3dac16)

## Changes

- Set `M_MMAP_TRESHOLD` to 64KiB via `mallopts`.

## Types of changes

#### What types of changes does your code introduce?

- [X] Optimization

## Testing

#### Requires testing

- [X] Yes

#### If yes, did you write tests?

- [X] Yes

#### Notes on testing

- Does not seems to noticably effect sync time. It probably slow it down marginally.

## Documentation

- [X] Linux
- [X] OSX (skipped)
- [X] Windows (skipped)
