### PR TITLE
Perf/buffersize adjustment

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
@@ -104,7 +104,7 @@ namespace Nethermind.Blockchain.Synchronization
         [ConfigItem(Description = "[EXPERIMENTAL] Only for non validator nodes! If set to true, DownloadReceiptsInFastSync and/or DownloadBodiesInFastSync can be set to false.", DefaultValue = "false")]
         public bool NonValidatorNode { get; set; }
 
-        [ConfigItem(Description = "[EXPERIMENTAL] Optimize db for write during sync. Significantly reduce total writes written and some sync time if you are not network limited.", DefaultValue = "Default")]
+        [ConfigItem(Description = "[EXPERIMENTAL] Optimize db for write during sync. Significantly reduce total writes written and some sync time if you are not network limited.", DefaultValue = "WriteBias")]
         public ITunableDb.TuneType TuneDbMode { get; set; }
 
         [ConfigItem(Description = "[EXPERIMENTAL] Optimize db for write during sync just for blocks db. Useful for turning on blobs file.", DefaultValue = "EnableBlobFiles")]

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
@@ -60,7 +60,7 @@ namespace Nethermind.Blockchain.Synchronization
         public bool StrictMode { get; set; } = false;
         public bool BlockGossipEnabled { get; set; } = true;
         public bool NonValidatorNode { get; set; } = false;
-        public ITunableDb.TuneType TuneDbMode { get; set; } = ITunableDb.TuneType.Default;
+        public ITunableDb.TuneType TuneDbMode { get; set; } = ITunableDb.TuneType.WriteBias;
         public ITunableDb.TuneType BlocksDbTuneDbMode { get; set; } = ITunableDb.TuneType.EnableBlobFiles;
         public int MaxProcessingThreads { get; set; }
         public bool ExitOnSynced { get; set; } = false;

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
@@ -26,6 +26,7 @@ public class DbConfig : IDbConfig
     public bool? DisableCompression { get; set; } = false;
     public ulong? CompactionReadAhead { get; set; }
     public IDictionary<string, string>? AdditionalRocksDbOptions { get; set; }
+    public ulong? MaxBytesForLevelBase { get; set; } = (ulong)256.MiB();
 
     public ulong ReceiptsDbWriteBufferSize { get; set; } = (ulong)8.MiB();
     public uint ReceiptsDbWriteBufferNumber { get; set; } = 4;
@@ -62,6 +63,7 @@ public class DbConfig : IDbConfig
     public bool? HeadersDbUseDirectIoForFlushAndCompactions { get; set; }
     public ulong? HeadersDbCompactionReadAhead { get; set; }
     public IDictionary<string, string>? HeadersDbAdditionalRocksDbOptions { get; set; }
+    public ulong? HeadersDbMaxBytesForLevelBase { get; set; } = (ulong)128.MiB();
 
     public ulong BlockInfosDbWriteBufferSize { get; set; } = (ulong)8.MiB();
     public uint BlockInfosDbWriteBufferNumber { get; set; } = 4;

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/IDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/IDbConfig.cs
@@ -27,6 +27,7 @@ public interface IDbConfig : IConfig
     bool? DisableCompression { get; set; }
     ulong? CompactionReadAhead { get; set; }
     IDictionary<string, string>? AdditionalRocksDbOptions { get; set; }
+    ulong? MaxBytesForLevelBase { get; set; }
 
     ulong ReceiptsDbWriteBufferSize { get; set; }
     uint ReceiptsDbWriteBufferNumber { get; set; }
@@ -63,6 +64,7 @@ public interface IDbConfig : IConfig
     bool? HeadersDbUseDirectIoForFlushAndCompactions { get; set; }
     ulong? HeadersDbCompactionReadAhead { get; set; }
     IDictionary<string, string>? HeadersDbAdditionalRocksDbOptions { get; set; }
+    ulong? HeadersDbMaxBytesForLevelBase { get; set; }
 
     ulong BlockInfosDbWriteBufferSize { get; set; }
     uint BlockInfosDbWriteBufferNumber { get; set; }

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/PerTableDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/PerTableDbConfig.cs
@@ -48,6 +48,7 @@ public class PerTableDbConfig
     public uint StatsDumpPeriodSec => _dbConfig.StatsDumpPeriodSec;
     public bool? DisableCompression => ReadConfig<bool?>(nameof(DisableCompression));
     public ulong? CompactionReadAhead => ReadConfig<ulong?>(nameof(CompactionReadAhead));
+    public ulong MaxBytesForLevelBase => ReadConfig<ulong>(nameof(MaxBytesForLevelBase));
 
     private T? ReadConfig<T>(string propertyName)
     {

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -1123,9 +1123,7 @@ public class DbOnTheRocks : IDbWithSpan, ITunableDb
                 // user config may not be able to handle this.
                 // With all those cons, this result in the minimum write amplification possible via tweaking compaction
                 // without changing memory budget. Not recommended for mainnet, unless you are very desperate.
-                IDictionary<string, string> heavyWriteOption = GetHeavyWriteOptions(2048);
-                heavyWriteOption["disable_auto_compactions"] = "true";
-                ApplyOptions(heavyWriteOption);
+                ApplyOptions(GetDisableCompactionOptions());
                 break;
             case ITunableDb.TuneType.EnableBlobFiles:
                 ApplyOptions(GetBlobFilesOptions());

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -1082,10 +1082,9 @@ public class DbOnTheRocks : IDbWithSpan, ITunableDb
             // than read measured from process. It is likely that most files are cached as I have 128GB of RAM.
             // Also notice that the heavier the tune, the higher the reads.
             case ITunableDb.TuneType.WriteBias:
-                // The default l1SizeTarget is 256MB, so the compaction is fairly light. But the default options is not very
-                // efficient for write amplification to conserve memory, so the write amplification reduction is noticeable.
-                // Does not seems to impact sync performance, might improve sync time slightly if user is IO limited.
-                ApplyOptions(GetHeavyWriteOptions(32));
+                // Keep the same l1 size but apply other adjustment which should increase buffer number and make
+                // l0 the same size as l1.
+                ApplyOptions(GetHeavyWriteOptions(_perTableDbConfig.MaxBytesForLevelBase / (ulong)8.MiB()));
                 break;
             case ITunableDb.TuneType.HeavyWrite:
                 // Compaction spikes are clear at this point. Will definitely affect attestation performance.

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -1191,7 +1191,7 @@ public class DbOnTheRocks : IDbWithSpan, ITunableDb
 
         return new Dictionary<string, string>()
         {
-            { "write_buffer_size", 8.MiB().ToString() },
+            { "write_buffer_size", bufferSize.ToString() },
             { "max_write_buffer_number", maxBufferNumber.ToString() },
 
             { "max_bytes_for_level_base", l1SizeTarget.ToString() },

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -1073,15 +1073,16 @@ public class DbOnTheRocks : IDbWithSpan, ITunableDb
             // smoothens this spike somewhat by not blocking writes while allowing compaction to happen in background
             // at 1/10th the specified speed (if rate limited).
             //
-            // Read and writes written on different tune during mainnet sync in TB.
-            // +-----------------------------+---------------+-------------+---------------+---------------+-------------+---------------+
-            // | L0FileNumTarget             | Total (W/R)   | State       | Code          | Header        | Blocks      | Receipts      |
-            // +-----------------------------+---------------+-------------+---------------+---------------+-------------+---------------+
-            // | 4 (Default)                 | 5.055 / 2.649 | 2.27 / 2.31 | 0.242 / 0.243 | 0.123 / 0.133 | 1.14 / 0.01 | 1.280 / 0.953 |
-            // | 64 (WriteBias)              | 4.962 / 3.041 | 2.12 / 2.14 | 0.049 / 0.035 | 0.132 / 0.122 | 1.14 / 0.01 | 1.080 / 0.734 |
-            // | 256 (HeavyWrite)            | 3.592 / 1.998 | 1.32 / 1.26 | 0.032 / 0.018 | 0.116 / 0.104 | 1.14 / 0.01 | 0.984 / 0.606 |
-            // | 1024 (AggressiveHeavyWrite) | 3.029 / 2.172 | 0.92 / 0.79 | 0.024 / 0.008 | 0.118 / 0.106 | 1.14 / 0.01 | 0.827 / 0.431 |
-            // +-----------------------------+---------------+-------------+---------------+--------------+-------------+----------------+
+            // Total writes written on different tune during mainnet sync in TB.
+            // +-----------------------+-------+-------+-------+-------+-------+---------+
+            // | L0FileNumTarget       | Total | State | Code  | Header| Blocks| Receipts |
+            // +-----------------------+-------+-------+-------+-------+-------+---------+
+            // | Default               | 5.055 | 2.27  | 0.242 | 0.123 | 1.14  | 1.280   |
+            // | WriteBias             | 4.962 | 2.12  | 0.049 | 0.132 | 1.14  | 1.080   |
+            // | HeavyWrite            | 3.592 | 1.32  | 0.032 | 0.116 | 1.14  | 0.984   |
+            // | AggressiveHeavyWrite  | 3.029 | 0.92  | 0.024 | 0.118 | 1.14  | 0.827   |
+            // | DisableCompaction     | 2.215 | 0.36  | 0.031 | 0.137 | 1.14  | 0.547   |
+            // +-----------------------+-------+-------+-------+-------+-------+---------+
             // Note, in practice on my machine, the reads does not reach the SSD. Read measured from SSD is much lower
             // than read measured from process. It is likely that most files are cached as I have 128GB of RAM.
             // Also notice that the heavier the tune, the higher the reads.

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -388,6 +388,7 @@ public class DbOnTheRocks : IDbWithSpan, ITunableDb
         options.SetRecycleLogFileNum(dbConfig
             .RecycleLogFileNum); // potential optimization for reusing allocated log files
 
+        options.SetMaxBytesForLevelBase(dbConfig.MaxBytesForLevelBase);
         options.SetUseDirectReads(dbConfig.UseDirectReads.GetValueOrDefault());
         options.SetUseDirectIoForFlushAndCompaction(dbConfig.UseDirectIoForFlushAndCompactions.GetValueOrDefault());
 
@@ -1150,7 +1151,7 @@ public class DbOnTheRocks : IDbWithSpan, ITunableDb
             { "level0_slowdown_writes_trigger", 20.ToString() },
             { "level0_stop_writes_trigger", 36.ToString() },
 
-            { "max_bytes_for_level_base", 256.MiB().ToString() },
+            { "max_bytes_for_level_base", _perTableDbConfig.MaxBytesForLevelBase.ToString() },
             { "target_file_size_base", 64.MiB().ToString() },
             { "disable_auto_compactions", "false" },
 

--- a/src/Nethermind/Nethermind.Init/MemoryHintMan.cs
+++ b/src/Nethermind/Nethermind.Init/MemoryHintMan.cs
@@ -299,7 +299,7 @@ namespace Nethermind.Init
             // remove optimize for point lookup here?
             return new DbNeeds(
                 preferredBuffers,
-                16.MB(), // min buffer size
+                1.MB(), // min buffer size
                 64.MB(), // max buffer size
                 0, // min block cache
                 0, // max block cache
@@ -312,7 +312,7 @@ namespace Nethermind.Init
             // remove optimize for point lookup here?
             return new DbNeeds(
                 preferredBuffers,
-                4.MB(), // min buffer size
+                1.MB(), // min buffer size
                 8.MB(), // max buffer size
                 1.MB(), // min block cache
                 512.MB(), // max block cache
@@ -324,11 +324,11 @@ namespace Nethermind.Init
             uint preferredBuffers = Math.Min(cpuCount, 2u);
             return new DbNeeds(
                 preferredBuffers,
-                16.MB(), // min buffer size
+                4.MB(), // min buffer size
                 16.MB(), // max buffer size
                 1.MB(), // min block cache
                 1.GB(), // max block cache
-                0.02m); // db memory %
+                0.05m); // db memory %
         }
 
         private DbNeeds GetBlocksNeeds(uint cpuCount)
@@ -371,7 +371,7 @@ namespace Nethermind.Init
             uint preferredBuffers = Math.Min(cpuCount, 2u);
             return new DbNeeds(
                 preferredBuffers,
-                4.MB(), // min buffer size
+                1.MB(), // min buffer size
                 4.MB(), // max buffer size
                 0, // min block cache
                 0, // max block cache

--- a/src/Nethermind/Nethermind.Init/MemoryHintMan.cs
+++ b/src/Nethermind/Nethermind.Init/MemoryHintMan.cs
@@ -239,7 +239,7 @@ namespace Nethermind.Init
 
             long maxWantedMemory = Math.Max(minMemory, (long)(memoryHint * maxPercentage));
             long availableDynamic = minMemory >= maxWantedMemory ? 0L : maxWantedMemory - minMemory;
-            long availableForBuffer = (long)(availableDynamic * 0.05m);
+            long availableForBuffer = (long)(availableDynamic * 0.2m);
             long bufferDynamic = Math.Min(maxBufferMem, availableForBuffer);
             long bufferMem = minBufferMem + bufferDynamic;
             long cacheDynamic = availableDynamic - bufferDynamic;

--- a/src/Nethermind/Nethermind.Init/MemoryHintMan.cs
+++ b/src/Nethermind/Nethermind.Init/MemoryHintMan.cs
@@ -171,49 +171,49 @@ namespace Nethermind.Init
 
             DbMemory = _remainingMemory;
             long remaining = DbMemory;
-            DbNeeds dbNeeds = GetHeaderNeeds(cpuCount, syncConfig);
+            DbNeeds dbNeeds = GetHeaderNeeds(cpuCount);
             DbGets dbGets = GiveItWhatYouCan(dbNeeds, DbMemory, remaining);
             remaining -= dbGets.CacheMem + dbGets.Buffers * dbGets.SingleBufferMem;
             dbConfig.HeadersDbWriteBufferNumber = dbGets.Buffers;
             dbConfig.HeadersDbWriteBufferSize = (ulong)dbGets.SingleBufferMem;
             dbConfig.HeadersDbBlockCacheSize = (ulong)dbGets.CacheMem;
 
-            dbNeeds = GetBlocksNeeds(cpuCount, syncConfig);
+            dbNeeds = GetBlocksNeeds(cpuCount);
             dbGets = GiveItWhatYouCan(dbNeeds, DbMemory, remaining);
             remaining -= dbGets.CacheMem + dbGets.Buffers * dbGets.SingleBufferMem;
             dbConfig.BlocksDbWriteBufferNumber = dbGets.Buffers;
             dbConfig.BlocksDbWriteBufferSize = (ulong)dbGets.SingleBufferMem;
             dbConfig.BlocksDbBlockCacheSize = (ulong)dbGets.CacheMem;
 
-            dbNeeds = GetBlockInfosNeeds(cpuCount, syncConfig);
+            dbNeeds = GetBlockInfosNeeds(cpuCount);
             dbGets = GiveItWhatYouCan(dbNeeds, DbMemory, remaining);
             remaining -= dbGets.CacheMem + dbGets.Buffers * dbGets.SingleBufferMem;
             dbConfig.BlockInfosDbWriteBufferNumber = dbGets.Buffers;
             dbConfig.BlockInfosDbWriteBufferSize = (ulong)dbGets.SingleBufferMem;
             dbConfig.BlockInfosDbBlockCacheSize = (ulong)dbGets.CacheMem;
 
-            dbNeeds = GetReceiptsNeeds(cpuCount, syncConfig);
+            dbNeeds = GetReceiptsNeeds(cpuCount);
             dbGets = GiveItWhatYouCan(dbNeeds, DbMemory, remaining);
             remaining -= dbGets.CacheMem + dbGets.Buffers * dbGets.SingleBufferMem;
             dbConfig.ReceiptsDbWriteBufferNumber = dbGets.Buffers;
             dbConfig.ReceiptsDbWriteBufferSize = (ulong)dbGets.SingleBufferMem;
             dbConfig.ReceiptsDbBlockCacheSize = (ulong)dbGets.CacheMem;
 
-            dbNeeds = GetCodeNeeds(cpuCount, syncConfig);
+            dbNeeds = GetCodeNeeds(cpuCount);
             dbGets = GiveItWhatYouCan(dbNeeds, DbMemory, remaining);
             remaining -= dbGets.CacheMem + dbGets.Buffers * dbGets.SingleBufferMem;
             dbConfig.CodeDbWriteBufferNumber = dbGets.Buffers;
             dbConfig.CodeDbWriteBufferSize = (ulong)dbGets.SingleBufferMem;
             dbConfig.CodeDbBlockCacheSize = (ulong)dbGets.CacheMem;
 
-            dbNeeds = GetPendingTxNeeds(cpuCount, syncConfig);
+            dbNeeds = GetPendingTxNeeds(cpuCount);
             dbGets = GiveItWhatYouCan(dbNeeds, DbMemory, remaining);
             remaining -= dbGets.CacheMem + dbGets.Buffers * dbGets.SingleBufferMem;
             dbConfig.PendingTxsDbWriteBufferNumber = dbGets.Buffers;
             dbConfig.PendingTxsDbWriteBufferSize = (ulong)dbGets.SingleBufferMem;
             dbConfig.PendingTxsDbBlockCacheSize = (ulong)dbGets.CacheMem;
 
-            dbNeeds = GetStateNeeds(cpuCount, syncConfig);
+            dbNeeds = GetStateNeeds(cpuCount);
             dbGets = GiveItWhatYouCan(dbNeeds, DbMemory, remaining);
             remaining -= dbGets.CacheMem + dbGets.Buffers * dbGets.SingleBufferMem;
             dbConfig.StateDbWriteBufferNumber = dbGets.Buffers;
@@ -293,47 +293,47 @@ namespace Nethermind.Init
             public decimal PreferredMemoryPercentage { get; set; }
         }
 
-        private DbNeeds GetStateNeeds(uint cpuCount, ISyncConfig syncConfig)
+        private DbNeeds GetStateNeeds(uint cpuCount)
         {
-            uint preferredBuffers = Math.Min(cpuCount, syncConfig.FastSync ? 8u : 4u);
+            uint preferredBuffers = Math.Min(cpuCount, 2u);
             // remove optimize for point lookup here?
             return new DbNeeds(
                 preferredBuffers,
-                1.MB(), // min buffer size
+                16.MB(), // min buffer size
                 64.MB(), // max buffer size
                 0, // min block cache
                 0, // max block cache
                 1m); // db memory %
         }
 
-        private DbNeeds GetBlockInfosNeeds(uint cpuCount, ISyncConfig syncConfig)
+        private DbNeeds GetBlockInfosNeeds(uint cpuCount)
         {
-            uint preferredBuffers = Math.Min(cpuCount, syncConfig.FastBlocks ? 4u : 2u);
+            uint preferredBuffers = Math.Min(cpuCount, 2u);
             // remove optimize for point lookup here?
             return new DbNeeds(
                 preferredBuffers,
-                1.MB(), // min buffer size
+                4.MB(), // min buffer size
                 8.MB(), // max buffer size
                 1.MB(), // min block cache
                 512.MB(), // max block cache
                 0.02m); // db memory %
         }
 
-        private DbNeeds GetHeaderNeeds(uint cpuCount, ISyncConfig syncConfig)
+        private DbNeeds GetHeaderNeeds(uint cpuCount)
         {
-            uint preferredBuffers = Math.Min(cpuCount, syncConfig.FastBlocks ? 4u : 2u);
+            uint preferredBuffers = Math.Min(cpuCount, 2u);
             return new DbNeeds(
                 preferredBuffers,
-                1.MB(), // min buffer size
-                8.MB(), // max buffer size
+                16.MB(), // min buffer size
+                16.MB(), // max buffer size
                 1.MB(), // min block cache
                 1.GB(), // max block cache
                 0.02m); // db memory %
         }
 
-        private DbNeeds GetBlocksNeeds(uint cpuCount, ISyncConfig syncConfig)
+        private DbNeeds GetBlocksNeeds(uint cpuCount)
         {
-            uint preferredBuffers = Math.Min(cpuCount, syncConfig.FastBlocks ? 4u : 2u);
+            uint preferredBuffers = Math.Min(cpuCount, 2u);
             return new DbNeeds(
                 preferredBuffers,
                 4.MB(), // min buffer size
@@ -343,9 +343,9 @@ namespace Nethermind.Init
                 0.04m); // db memory %
         }
 
-        private DbNeeds GetReceiptsNeeds(uint cpuCount, ISyncConfig syncConfig)
+        private DbNeeds GetReceiptsNeeds(uint cpuCount)
         {
-            uint preferredBuffers = Math.Min(cpuCount, syncConfig.FastBlocks ? 4u : 2u);
+            uint preferredBuffers = Math.Min(cpuCount, 2u);
             return new DbNeeds(
                 preferredBuffers,
                 2.MB(), // min buffer size
@@ -355,7 +355,7 @@ namespace Nethermind.Init
                 0.01m); // db memory %
         }
 
-        private DbNeeds GetPendingTxNeeds(uint cpuCount, ISyncConfig syncConfig)
+        private DbNeeds GetPendingTxNeeds(uint cpuCount)
         {
             return new DbNeeds(
                 4,
@@ -366,12 +366,12 @@ namespace Nethermind.Init
                 0.01m); // db memory %
         }
 
-        private DbNeeds GetCodeNeeds(uint cpuCount, ISyncConfig syncConfig)
+        private DbNeeds GetCodeNeeds(uint cpuCount)
         {
-            uint preferredBuffers = Math.Min(cpuCount, syncConfig.FastSync ? 4u : 2u);
+            uint preferredBuffers = Math.Min(cpuCount, 2u);
             return new DbNeeds(
                 preferredBuffers,
-                1.MB(), // min buffer size
+                4.MB(), // min buffer size
                 4.MB(), // max buffer size
                 0, // min block cache
                 0, // max block cache


### PR DESCRIPTION
# Adjust write buffer size and and write buffer number
 
- HeadersDb actually consumes almost 300MBps during sync due to its very low buffer size causing write amplification factor for l1 of 25. This is actually almost 20% of write bandwith and almost 30% on path based statedb+heavywrite.
- At the same time it turns out StateDb is stalling due to waiting for memtable to flush. 
- Increasing max num of write buffer number however, will increase max memtable memory usage. So ideally you can't increase both of them at the same time.
- This PR make it so that `WriteBias` tune increase write buffer number but reduces its size and turn it on by default. Also it increase write buffer size by default when no tune is running.
- And other minor change.
- This reduces HeadersDb total write amp factor from 33.5 to 13.5, reducing its writes to about 90MBps. 

## Changes

- Disable setting more max write buffer using fast sync config, setting it only to 2.
- Increase percentage of available memory to use for write buffer from 5% to 20%.
- Increase min buffer size for headers db from 1MB to 4MB.
- Make db tune specify 8MB x 16 of write buffer, overriding the db's config when active.
- Turn on `WriteBias` tune by default.
- Disable `SetMinWriteBufferNumberToMerge` as it does not make any difference compared to just increasing write buffer size.
- Expose `MaxBytesForLevelBase` and set it to 128MB for headers db.

## Types of changes

#### What types of changes does your code introduce?

- [X] Optimization

## Testing

#### Requires testing

- [X] Yes

#### If yes, did you write tests?

- [X] No: Config change.

#### Notes on testing

