### PR TITLE
fix AggregateException being thrown instead of TimeoutException

### DIFF
--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroProtocolHandlerBase.cs
@@ -73,7 +73,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
                 if (Logger.IsTrace) Logger.Trace($"{this} speed is {request.ResponseSize}/{elapsed} = {bytesPerMillisecond}");
                 StatsManager.ReportTransferSpeedEvent(Session.Node, speedType, bytesPerMillisecond);
 
-                return task.Result;
+                return await task;
             }
 
             StatsManager.ReportTransferSpeedEvent(Session.Node, speedType, 0L);


### PR DESCRIPTION
## Changes

- awaits the task instead of Task.Result to unpack exception

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_