### PR TITLE
Perf/valuekeccak sorted batch

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
@@ -342,7 +342,7 @@ namespace Nethermind.Blockchain.Receipts
 
         public void EnsureCanonical(Block block)
         {
-            using IBatch batch = _transactionDb.StartBatch();
+            using IKeccakBatch batch = _transactionDb.StartBatch().ToKeccakBatch();
 
             long headNumber = _blockTree.FindBestSuggestedHeader()?.Number ?? 0;
 
@@ -352,14 +352,14 @@ namespace Nethermind.Blockchain.Receipts
             {
                 foreach (Transaction tx in block.Transactions)
                 {
-                    batch[tx.Hash.Bytes] = Rlp.Encode(block.Number).Bytes;
+                    batch[tx.Hash] = Rlp.Encode(block.Number).Bytes;
                 }
             }
             else
             {
                 foreach (Transaction tx in block.Transactions)
                 {
-                    batch[tx.Hash.Bytes] = block.Hash.BytesToArray();
+                    batch[tx.Hash] = block.Hash.BytesToArray();
                 }
             }
         }

--- a/src/Nethermind/Nethermind.Core.Test/KeccakSortedBatchTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/KeccakSortedBatchTests.cs
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Test.Builders;
+using NUnit.Framework;
+
+namespace Nethermind.Core.Test;
+
+public class KeccakSortedBatchTests
+{
+    [Test]
+    public void Test_BatchWillSort()
+    {
+        TestBatch baseBatch = new TestBatch();
+
+        IKeccakBatch keccakBatch = baseBatch.ToKeccakBatch();
+
+        IList<byte[]> expectedOrder = new List<byte[]>();
+        for (int i = 0; i < 10; i++)
+        {
+            keccakBatch[TestItem.ValueKeccaks[i]] = TestItem.ValueKeccaks[i].ToByteArray();
+            expectedOrder.Add(TestItem.ValueKeccaks[i].ToByteArray());
+        }
+
+        baseBatch.DisposeCalled.Should().BeFalse();
+        baseBatch.SettedValues.Count.Should().Be(0);
+
+        keccakBatch.Dispose();
+
+        baseBatch.DisposeCalled.Should().BeTrue();
+        expectedOrder = expectedOrder.Order(Bytes.Comparer).ToList();
+        baseBatch.SettedValues.Should().BeEquivalentTo(expectedOrder);
+    }
+
+    private class TestBatch : IBatch
+    {
+        public bool DisposeCalled { get; set; }
+        public List<byte[]> SettedValues { get; set; } = new();
+
+        public void Dispose()
+        {
+            DisposeCalled = true;
+        }
+
+        public byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)
+        {
+            return null;
+        }
+
+        public void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None)
+        {
+            SettedValues.Add(key.ToArray());
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Core/IKeccakBatch.cs
+++ b/src/Nethermind/Nethermind.Core/IKeccakBatch.cs
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Core.Crypto;
+
+namespace Nethermind.Core
+{
+    public interface IKeccakBatch : IDisposable {
+        byte[]? this[ValueKeccak key]
+        {
+            get => Get(key);
+            set => Set(key, value);
+        }
+
+        byte[]? Get(ValueKeccak key, ReadFlags flags = ReadFlags.None);
+        void Set(ValueKeccak key, byte[]? value, WriteFlags flags = WriteFlags.None);
+    }
+}

--- a/src/Nethermind/Nethermind.Core/KeccakSortedBatch.cs
+++ b/src/Nethermind/Nethermind.Core/KeccakSortedBatch.cs
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using Nethermind.Core.Crypto;
+
+namespace Nethermind.Core;
+
+/// <summary>
+/// Rocksdb's skiplist memtable have a fast path when the keys are inserted in ascending order. Otherwise, its seems
+/// to be limited to 1Mil writes per second.
+/// TODO: FlatDB layout need different key type to match the DB ordering.
+/// </summary>
+public class KeccakSortedBatch: IKeccakBatch
+{
+    private const int InitialBatchSize = 300;
+    private static readonly int MaxCached = Environment.ProcessorCount;
+
+    private static readonly ConcurrentQueue<Dictionary<ValueKeccak, byte[]?>> s_cache = new();
+
+    private readonly IBatch _baseBatch;
+    private WriteFlags _writeFlags = WriteFlags.None;
+    private bool _isDisposed;
+
+    private Dictionary<ValueKeccak, byte[]?> _batchData = CreateOrGetFromCache();
+
+    public KeccakSortedBatch(IBatch dbOnTheRocks)
+    {
+        _baseBatch = dbOnTheRocks;
+    }
+
+    public void Dispose()
+    {
+        if (_isDisposed)
+        {
+            return;
+        }
+        _isDisposed = true;
+
+        Dictionary<ValueKeccak, byte[]?> batchData = _batchData;
+        // Clear the _batchData reference so is null if Get is called.
+        _batchData = null!;
+        if (batchData.Count == 0)
+        {
+            // No data to write, skip empty batches
+            ReturnToCache(batchData);
+            _baseBatch.Dispose();
+            return;
+        }
+
+        // Sort the batch by key
+        foreach (KeyValuePair<ValueKeccak, byte[]?> kv in batchData.OrderBy(i => i.Key))
+        {
+            _baseBatch.Set(kv.Key.BytesAsSpan, kv.Value, _writeFlags);
+        }
+        ReturnToCache(batchData);
+
+        _baseBatch.Dispose();
+    }
+
+    public byte[]? Get(ValueKeccak key, ReadFlags flags = ReadFlags.None)
+    {
+        // Not checking _isDisposing here as for some reason, sometimes is is read after dispose
+        return _batchData?.TryGetValue(key, out var value) ?? false ? value : _baseBatch.Get(key.BytesAsSpan, flags);
+    }
+
+    public void Delete(ValueKeccak key)
+    {
+        if (_isDisposed)
+        {
+            throw new ObjectDisposedException($"Attempted to write a disposed batch");
+        }
+
+        _batchData[key] = null;
+    }
+
+    public void Set(ValueKeccak key, byte[]? value, WriteFlags flags = WriteFlags.None)
+    {
+        if (_isDisposed)
+        {
+            throw new ObjectDisposedException($"Attempted to write a disposed batch");
+        }
+
+        _batchData[key] = value;
+
+        _writeFlags = flags;
+    }
+
+    private static Dictionary<ValueKeccak, byte[]?> CreateOrGetFromCache()
+    {
+        if (s_cache.TryDequeue(out Dictionary<ValueKeccak, byte[]?>? batchData))
+        {
+            return batchData;
+        }
+
+        return new(InitialBatchSize);
+    }
+
+    private static void ReturnToCache(Dictionary<ValueKeccak, byte[]?> batchData)
+    {
+        if (s_cache.Count >= MaxCached) return;
+
+        batchData.Clear();
+        batchData.TrimExcess(capacity: InitialBatchSize);
+        s_cache.Enqueue(batchData);
+    }
+}
+
+public static class BatchExtensions {
+    public static KeccakSortedBatch ToKeccakBatch(this IBatch batch)
+    {
+        return new KeccakSortedBatch(batch);
+    }
+}

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -92,7 +92,7 @@ public class ColumnDb : IDbWithSpan
             }
             else
             {
-                _underlyingBatch.Set(key, value, _columnDb._columnFamily);
+                _underlyingBatch.Set(key, value, _columnDb._columnFamily, flags);
             }
         }
     }

--- a/src/Nethermind/Nethermind.State.Test/StateTreeTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StateTreeTests.cs
@@ -62,7 +62,7 @@ namespace Nethermind.Store.Test
             tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb1eeeeeb0"), _account0);
             tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb1eeeeeb1"), _account0);
             tree.Commit(0);
-            Assert.That(db.WritesCount, Is.EqualTo(6), "writes"); // extension, branch, leaf, extension, branch, 2x same leaf
+            Assert.That(db.WritesCount, Is.EqualTo(7), "writes"); // extension, branch, leaf, extension, branch, 2x same leaf
             Assert.That(Trie.Metrics.TreeNodeHashCalculations, Is.EqualTo(7), "hashes");
             Assert.That(Trie.Metrics.TreeNodeRlpEncodings, Is.EqualTo(7), "encodings");
         }

--- a/src/Nethermind/Nethermind.State.Test/StateTreeTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StateTreeTests.cs
@@ -62,7 +62,7 @@ namespace Nethermind.Store.Test
             tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb1eeeeeb0"), _account0);
             tree.Set(new Keccak("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb1eeeeeb1"), _account0);
             tree.Commit(0);
-            Assert.That(db.WritesCount, Is.EqualTo(7), "writes"); // extension, branch, leaf, extension, branch, 2x same leaf
+            Assert.That(db.WritesCount, Is.EqualTo(6), "writes"); // extension, branch, leaf, extension, branch, 2x same leaf
             Assert.That(Trie.Metrics.TreeNodeHashCalculations, Is.EqualTo(7), "hashes");
             Assert.That(Trie.Metrics.TreeNodeRlpEncodings, Is.EqualTo(7), "encodings");
         }

--- a/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
@@ -908,6 +908,7 @@ namespace Nethermind.Trie.Test
             leaf2.ResolveKey(trieStore, false);
             leaf2.Seal();
             trieStore.CommitNode(0, new NodeCommitInfo(leaf2));
+            trieStore.FinishBlockCommit(TrieType.State, 0, leaf2);
 
             TrieNode trieNode = new(NodeType.Branch);
             trieNode.SetChild(1, leaf1);


### PR DESCRIPTION
- Write batch sort keys before writing to rocksdb as it improve throughput.
- Problem is, on path based statedb the key size doubled and the key count also doubled which increase its overhead.
- Additionally the key insertion pattern of path based statedb is already partially sorted so this is not needed.
- Removing the sort improve sync time by about 20% to 25% on path based statedb.
- This PR extract the logic, expose ValueKeccak key and explicitly enable it on TrieStore and receipts tx hash. 

## Changes

- _List the changes_

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [ ] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
