### PR TITLE
Perf/Reduce number of files in DB.

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
@@ -40,7 +40,7 @@ public class DbConfig : IDbConfig
     public bool? ReceiptsDbUseDirectReads { get; set; }
     public bool? ReceiptsDbUseDirectIoForFlushAndCompactions { get; set; }
     public ulong? ReceiptsDbCompactionReadAhead { get; set; }
-    public ulong ReceiptsDbTargetFileSizeBase { get; set; } = (ulong) 256.MiB();
+    public ulong ReceiptsDbTargetFileSizeBase { get; set; } = (ulong)256.MiB();
     public IDictionary<string, string>? ReceiptsDbAdditionalRocksDbOptions { get; set; }
 
     public ulong BlocksDbWriteBufferSize { get; set; } = (ulong)8.MiB();

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
@@ -27,6 +27,8 @@ public class DbConfig : IDbConfig
     public ulong? CompactionReadAhead { get; set; }
     public IDictionary<string, string>? AdditionalRocksDbOptions { get; set; }
     public ulong? MaxBytesForLevelBase { get; set; } = (ulong)256.MiB();
+    public ulong TargetFileSizeBase { get; set; } = (ulong)64.MiB();
+    public int TargetFileSizeMultiplier { get; set; } = 1;
 
     public ulong ReceiptsDbWriteBufferSize { get; set; } = (ulong)8.MiB();
     public uint ReceiptsDbWriteBufferNumber { get; set; } = 4;
@@ -38,6 +40,7 @@ public class DbConfig : IDbConfig
     public bool? ReceiptsDbUseDirectReads { get; set; }
     public bool? ReceiptsDbUseDirectIoForFlushAndCompactions { get; set; }
     public ulong? ReceiptsDbCompactionReadAhead { get; set; }
+    public ulong ReceiptsDbTargetFileSizeBase { get; set; } = (ulong) 256.MiB();
     public IDictionary<string, string>? ReceiptsDbAdditionalRocksDbOptions { get; set; }
 
     public ulong BlocksDbWriteBufferSize { get; set; } = (ulong)8.MiB();
@@ -157,6 +160,7 @@ public class DbConfig : IDbConfig
     public bool? StateDbUseDirectIoForFlushAndCompactions { get; set; } = false;
     public ulong? StateDbCompactionReadAhead { get; set; }
     public bool? StateDbDisableCompression { get; set; } = false;
+    public int StateDbTargetFileSizeMultiplier { get; set; } = 2;
     public IDictionary<string, string>? StateDbAdditionalRocksDbOptions { get; set; }
 
     public uint RecycleLogFileNum { get; set; } = 0;

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/IDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/IDbConfig.cs
@@ -28,6 +28,8 @@ public interface IDbConfig : IConfig
     ulong? CompactionReadAhead { get; set; }
     IDictionary<string, string>? AdditionalRocksDbOptions { get; set; }
     ulong? MaxBytesForLevelBase { get; set; }
+    ulong TargetFileSizeBase { get; set; }
+    int TargetFileSizeMultiplier { get; set; }
 
     ulong ReceiptsDbWriteBufferSize { get; set; }
     uint ReceiptsDbWriteBufferNumber { get; set; }
@@ -39,6 +41,7 @@ public interface IDbConfig : IConfig
     bool? ReceiptsDbUseDirectReads { get; set; }
     bool? ReceiptsDbUseDirectIoForFlushAndCompactions { get; set; }
     ulong? ReceiptsDbCompactionReadAhead { get; set; }
+    ulong ReceiptsDbTargetFileSizeBase { get; set; }
     IDictionary<string, string>? ReceiptsDbAdditionalRocksDbOptions { get; set; }
 
     ulong BlocksDbWriteBufferSize { get; set; }
@@ -157,6 +160,7 @@ public interface IDbConfig : IConfig
     bool? StateDbUseDirectIoForFlushAndCompactions { get; set; }
     ulong? StateDbCompactionReadAhead { get; set; }
     bool? StateDbDisableCompression { get; set; }
+    int StateDbTargetFileSizeMultiplier { get; set; }
     IDictionary<string, string>? StateDbAdditionalRocksDbOptions { get; set; }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/PerTableDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/PerTableDbConfig.cs
@@ -49,6 +49,8 @@ public class PerTableDbConfig
     public bool? DisableCompression => ReadConfig<bool?>(nameof(DisableCompression));
     public ulong? CompactionReadAhead => ReadConfig<ulong?>(nameof(CompactionReadAhead));
     public ulong MaxBytesForLevelBase => ReadConfig<ulong>(nameof(MaxBytesForLevelBase));
+    public ulong TargetFileSizeBase => ReadConfig<ulong>(nameof(TargetFileSizeBase));
+    public int TargetFileSizeMultiplier => ReadConfig<int>(nameof(TargetFileSizeMultiplier));
 
     private T? ReadConfig<T>(string propertyName)
     {

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -358,6 +358,13 @@ public class DbOnTheRocks : IDbWithSpan, ITunableDb
             options.SetMaxOpenFiles(dbConfig.MaxOpenFiles.Value);
         }
 
+        // Target size of each SST file.
+        options.SetTargetFileSizeBase(dbConfig.TargetFileSizeBase);
+
+        // Multiply the target size of SST file by this much every level down. Does not have much downside on
+        // hash based DB, but might disable some move optimization on db with blocknumber key.
+        options.SetTargetFileSizeMultiplier(dbConfig.TargetFileSizeMultiplier);
+
         if (dbConfig.MaxBytesPerSec.HasValue)
         {
             _rateLimiter =
@@ -1159,7 +1166,7 @@ public class DbOnTheRocks : IDbWithSpan, ITunableDb
             { "level0_stop_writes_trigger", 36.ToString() },
 
             { "max_bytes_for_level_base", _perTableDbConfig.MaxBytesForLevelBase.ToString() },
-            { "target_file_size_base", 64.MiB().ToString() },
+            { "target_file_size_base", _perTableDbConfig.TargetFileSizeBase.ToString() },
             { "disable_auto_compactions", "false" },
 
             { "enable_blob_files", "false" },

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -1256,7 +1256,13 @@ public class DbOnTheRocks : IDbWithSpan, ITunableDb
         {
             { "enable_blob_files", "true" },
             { "blob_compression_type", "kSnappyCompression" },
-            { "write_buffer_size", 64.MiB().ToString() },
+
+            // Make file size big, so we have less of them.
+            { "write_buffer_size", 256.MiB().ToString() },
+            // Current memtable + 2 concurrent writes. Can't have too many of these as it take up RAM.
+            { "max_write_buffer_number", 3.ToString() },
+
+            // These two are SST files instead of the blobs, which are now much smaller.
             { "max_bytes_for_level_base", 4.MiB().ToString() },
             { "target_file_size_base", 1.MiB().ToString() },
         };


### PR DESCRIPTION
- Expose file size base and file size multiplier, and specify default for statedb and receipts db.
- Adjust blobfile parameter to reduce number of file.
- Reduce number of file from about 16000 to 6000.
- Does not seems to affect write amp much.

## Changes
- Set multiplier for statedb to 2.
- Set file size base for receipts db to 256MB.
- Increase write buffer size during 

## Types of changes

#### What types of changes does your code introduce?

- [X] Optimization

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

- Verified with `find | wc` and rocksdb's stat.
