### PR TITLE
Refactor/always use blocktree builder in tests

### DIFF
--- a/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
@@ -22,6 +22,7 @@ using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
+using Nethermind.Core.Test.Builders;
 using Nethermind.Crypto;
 using Nethermind.Db;
 using Nethermind.Db.Blooms;
@@ -128,8 +129,10 @@ namespace Ethereum.Test.Base
 
             TrieStore trieStore = new(stateDb, _logManager);
             IWorldState stateProvider = new WorldState(trieStore, codeDb, _logManager);
-            MemDb blockInfoDb = new MemDb();
-            IBlockTree blockTree = new BlockTree(new MemDb(), new MemDb(), blockInfoDb, new ChainLevelInfoRepository(blockInfoDb), specProvider, NullBloomStorage.Instance, _logManager);
+            IBlockTree blockTree = Build.A.BlockTree()
+                .WithSpecProvider(specProvider)
+                .WithoutSettingHead
+                .TestObject;
             ITransactionComparerProvider transactionComparerProvider = new TransactionComparerProvider(specProvider, blockTree);
             IStateReader stateReader = new StateReader(trieStore, codeDb, _logManager);
             IChainHeadInfoProvider chainHeadInfoProvider = new ChainHeadInfoProvider(specProvider, blockTree, stateReader);

--- a/src/Nethermind/Nethermind.AuRa.Test/AuRaBlockFinalizationManagerTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/AuRaBlockFinalizationManagerTests.cs
@@ -50,7 +50,7 @@ namespace Nethermind.AuRa.Test
             finalizationManager.LastFinalizedBlockLevel.Should().Be(1);
         }
 
-        private void FinalizeToLevel(long upperLevel, ChainLevelInfoRepository chainLevelInfoRepository)
+        private void FinalizeToLevel(long upperLevel, IChainLevelInfoRepository chainLevelInfoRepository)
         {
             for (long i = 0; i <= upperLevel; i++)
             {

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
@@ -47,7 +47,7 @@ namespace Nethermind.Blockchain.Test
                 .WithBlocksDb(_blocksDb)
                 .WithHeadersDb(_headersDb)
                 .WithBlockInfoDb(_blocksInfosDb)
-                .WithNoHead;
+                .WithoutSettingHead;
             return builder.TestObject;
         }
 
@@ -224,7 +224,7 @@ namespace Nethermind.Blockchain.Test
             MemDb blockInfosDb = new MemDb();
             BlockTreeBuilder builder = Build.A.BlockTree()
                 .WithBlockInfoDb(blockInfosDb)
-                .WithNoHead;
+                .WithoutSettingHead;
             IBlockStore blockStore = builder.BlockStore;
             BlockTree tree = builder.TestObject;
 
@@ -240,7 +240,7 @@ namespace Nethermind.Blockchain.Test
 
             blockInfosDb.Set(BlockTree.DeletePointerAddressInDb, block1.Hash!.Bytes);
             BlockTree tree2 = Build.A.BlockTree()
-                .WithNoHead
+                .WithoutSettingHead
                 .WithDatabaseFrom(builder)
                 .TestObject;
 
@@ -263,7 +263,7 @@ namespace Nethermind.Blockchain.Test
             MemDb blockInfosDb = new();
             BlockTreeBuilder builder = Build.A.BlockTree()
                 .WithBlockInfoDb(blockInfosDb)
-                .WithNoHead;
+                .WithoutSettingHead;
             IBlockStore blockStore = builder.BlockStore;
             BlockTree tree = builder.TestObject;
 
@@ -287,7 +287,7 @@ namespace Nethermind.Blockchain.Test
 
             blockInfosDb.Set(BlockTree.DeletePointerAddressInDb, block1.Hash!.Bytes);
             BlockTree tree2 = Build.A.BlockTree()
-                .WithNoHead
+                .WithoutSettingHead
                 .WithDatabaseFrom(builder)
                 .TestObject;
 
@@ -323,7 +323,7 @@ namespace Nethermind.Blockchain.Test
             };
 
             BlockTree blockTree = Build.A.BlockTree()
-                .WithNoHead
+                .WithoutSettingHead
                 .WithBlocksDb(_blocksDb)
                 .WithHeadersDb(_headersDb)
                 .WithBlockInfoDb(blocksInfosDb)
@@ -798,7 +798,7 @@ namespace Nethermind.Blockchain.Test
             blockInfosDb.Set(0, Rlp.Encode(level).Bytes);
 
             BlockTree blockTree = Build.A.BlockTree()
-                .WithNoHead
+                .WithoutSettingHead
                 .WithBlockStore(blockStore)
                 .WithHeadersDb(headersDb)
                 .WithBlockInfoDb(blockInfosDb)
@@ -814,7 +814,7 @@ namespace Nethermind.Blockchain.Test
             TestMemDb blockInfosDb = new();
 
             BlockTree blockTree = Build.A.BlockTree()
-                .WithNoHead
+                .WithoutSettingHead
                 .WithBlockInfoDb(blockInfosDb)
                 .TestObject;
 
@@ -918,7 +918,7 @@ namespace Nethermind.Blockchain.Test
             TestMemDb blockInfosDb = new();
 
             BlockTree blockTree = Build.A.BlockTree()
-                .WithNoHead
+                .WithoutSettingHead
                 .WithBlockInfoDb(blockInfosDb)
                 .TestObject;
             Block block0 = Build.A.Block.WithNumber(0).WithDifficulty(1).TestObject;
@@ -964,7 +964,7 @@ namespace Nethermind.Blockchain.Test
             BlockStore blockStore = new(new MemDb());
             MemDb blockInfosDb = new();
             BlockTree tree = Build.A.BlockTree()
-                .WithNoHead
+                .WithoutSettingHead
                 .WithBlockInfoDb(blockInfosDb)
                 .WithBlockStore(blockStore)
                 .TestObject;
@@ -1003,7 +1003,7 @@ namespace Nethermind.Blockchain.Test
             ChainLevelInfoRepository repository = new(blockInfosDb);
 
             BlockTree tree = Build.A.BlockTree()
-                .WithNoHead
+                .WithoutSettingHead
                 .WithBlockInfoDb(blockInfosDb)
                 .WithBlockStore(blockStore)
                 .TestObject;
@@ -1058,7 +1058,7 @@ namespace Nethermind.Blockchain.Test
         public void After_removing_invalid_block_will_not_accept_it_again()
         {
             BlockTree tree = Build.A.BlockTree()
-                .WithNoHead
+                .WithoutSettingHead
                 .TestObject;
 
             Block block0 = Build.A.Block.WithNumber(0).WithDifficulty(1).TestObject;
@@ -1080,7 +1080,7 @@ namespace Nethermind.Blockchain.Test
         public void After_deleting_invalid_block_will_accept_other_blocks()
         {
             BlockTree tree = Build.A.BlockTree()
-                .WithNoHead
+                .WithoutSettingHead
                 .TestObject;
 
             Block block0 = Build.A.Block.WithNumber(0).WithDifficulty(1).TestObject;
@@ -1104,7 +1104,7 @@ namespace Nethermind.Blockchain.Test
         public void When_deleting_invalid_block_does_not_delete_blocks_that_are_not_its_descendants()
         {
             BlockTree tree = Build.A.BlockTree()
-                .WithNoHead
+                .WithoutSettingHead
                 .TestObject;
 
             Block block0 = Build.A.Block.WithNumber(0).WithDifficulty(1).TestObject;
@@ -1147,7 +1147,7 @@ namespace Nethermind.Blockchain.Test
             BlockTreeBuilder builder = Build.A
                 .BlockTree()
                 .WithSyncConfig(syncConfig)
-                .WithNoHead;
+                .WithoutSettingHead;
             BlockTree tree = builder.TestObject;
             tree.SuggestBlock(Build.A.Block.Genesis.TestObject);
 
@@ -1182,7 +1182,7 @@ namespace Nethermind.Blockchain.Test
             BlockTreeBuilder builder = Build.A.BlockTree()
                 .WithBlocksDb(blocksDb)
                 .WithSyncConfig(syncConfig)
-                .WithNoHead;
+                .WithoutSettingHead;
 
             BlockTree tree = builder.TestObject;
 
@@ -1196,7 +1196,7 @@ namespace Nethermind.Blockchain.Test
             }
 
             BlockTree loadedTree = Build.A.BlockTree()
-                .WithNoHead
+                .WithoutSettingHead
                 .WithDatabaseFrom(builder)
                 .WithSyncConfig(syncConfig)
                 .TestObject;
@@ -1244,7 +1244,7 @@ namespace Nethermind.Blockchain.Test
             };
 
             BlockTreeBuilder builder = Build.A.BlockTree()
-                .WithNoHead
+                .WithoutSettingHead
                 .WithSyncConfig(syncConfig);
 
             BlockTree tree = builder.TestObject;
@@ -1259,7 +1259,7 @@ namespace Nethermind.Blockchain.Test
             }
 
             BlockTree loadedTree = Build.A.BlockTree()
-                .WithNoHead
+                .WithoutSettingHead
                 .WithDatabaseFrom(builder)
                 .WithSyncConfig(syncConfig)
                 .TestObject;
@@ -1281,7 +1281,7 @@ namespace Nethermind.Blockchain.Test
             };
 
             BlockTreeBuilder builder = Build.A.BlockTree()
-                .WithNoHead
+                .WithoutSettingHead
                 .WithMetadataDb(metadataDb)
                 .WithSyncConfig(syncConfig);
 
@@ -1314,7 +1314,7 @@ namespace Nethermind.Blockchain.Test
             tree.BestPersistedState = 50;
 
             BlockTree loadedTree = Build.A.BlockTree()
-                .WithNoHead
+                .WithoutSettingHead
                 .WithDatabaseFrom(builder)
                 .WithSyncConfig(syncConfig)
                 .TestObject;
@@ -1333,7 +1333,7 @@ namespace Nethermind.Blockchain.Test
                 PivotNumber = pivotNumber.ToString(),
             };
             BlockTreeBuilder builder = Build.A.BlockTree()
-                .WithNoHead
+                .WithoutSettingHead
                 .WithSyncConfig(syncConfig);
 
             BlockTree tree = builder.TestObject;
@@ -1350,7 +1350,7 @@ namespace Nethermind.Blockchain.Test
             tree.SuggestHeader(Build.A.BlockHeader.WithNumber(pivotNumber + 1).WithParent(pivotBlock!.Header).TestObject);
 
             BlockTree loadedTree = Build.A.BlockTree()
-                .WithNoHead
+                .WithoutSettingHead
                 .WithDatabaseFrom(builder)
                 .WithSyncConfig(syncConfig)
                 .TestObject;
@@ -1374,7 +1374,7 @@ namespace Nethermind.Blockchain.Test
             BlockTreeBuilder treeBuilder = Build.A.BlockTree().OfChainLength(head + 1);
 
             BlockTree loadedTree = Build.A.BlockTree()
-                .WithNoHead
+                .WithoutSettingHead
                 .WithDatabaseFrom(treeBuilder)
                 .WithSyncConfig(syncConfig)
                 .TestObject;
@@ -1393,7 +1393,7 @@ namespace Nethermind.Blockchain.Test
             };
 
             BlockTree tree = Build.A.BlockTree()
-                .WithNoHead
+                .WithoutSettingHead
                 .WithSyncConfig(syncConfig)
                 .TestObject;
 
@@ -1417,7 +1417,7 @@ namespace Nethermind.Blockchain.Test
             specProvider.UpdateMergeTransitionInfo(null, 0);
 
             BlockTree tree = Build.A.BlockTree()
-                .WithNoHead
+                .WithoutSettingHead
                 .WithSyncConfig(syncConfig)
                 .WithSpecProvider(specProvider)
                 .TestObject;
@@ -1491,7 +1491,7 @@ namespace Nethermind.Blockchain.Test
             Block lastBlock = previousBlock;
 
             BlockTree loadedTree = Build.A.BlockTree()
-                .WithNoHead
+                .WithoutSettingHead
                 .WithSyncConfig(syncConfig)
                 .WithDatabaseFrom(builder)
                 .TestObject;
@@ -1506,7 +1506,7 @@ namespace Nethermind.Blockchain.Test
 
             IBloomStorage bloomStorage = Substitute.For<IBloomStorage>();
             BlockTree blockTree = Build.A.BlockTree()
-                .WithNoHead
+                .WithoutSettingHead
                 .WithBloomStorage(bloomStorage)
                 .TestObject;
                 // new(blocksDb, headersDb, blockInfosDb, new ChainLevelInfoRepository(blockInfosDb), OlympicSpecProvider.Instance, bloomStorage, LimboLogs.Instance);

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
@@ -1509,7 +1509,7 @@ namespace Nethermind.Blockchain.Test
                 .WithoutSettingHead
                 .WithBloomStorage(bloomStorage)
                 .TestObject;
-                // new(blocksDb, headersDb, blockInfosDb, new ChainLevelInfoRepository(blockInfosDb), OlympicSpecProvider.Instance, bloomStorage, LimboLogs.Instance);
+            // new(blocksDb, headersDb, blockInfosDb, new ChainLevelInfoRepository(blockInfosDb), OlympicSpecProvider.Instance, bloomStorage, LimboLogs.Instance);
             Block block0 = Build.A.Block.WithNumber(0).WithDifficulty(1).TestObject;
             Block block1A = Build.A.Block.WithNumber(1).WithDifficulty(2).WithTransactions(t1).WithParent(block0).TestObject;
             Block block1B = Build.A.Block.WithNumber(1).WithDifficulty(3).WithTransactions(t2).WithParent(block0).TestObject;

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockchainProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockchainProcessorTests.cs
@@ -189,13 +189,11 @@ namespace Nethermind.Blockchain.Test
             public ProcessingTestContext(bool startProcessor)
             {
                 _logger = _logManager.GetClassLogger();
-                MemDb blockDb = new();
-                MemDb blockInfoDb = new();
-                MemDb headersDb = new();
-
                 IStateReader stateReader = Substitute.For<IStateReader>();
 
-                _blockTree = new BlockTree(blockDb, headersDb, blockInfoDb, new ChainLevelInfoRepository(blockInfoDb), MainnetSpecProvider.Instance, NullBloomStorage.Instance, LimboLogs.Instance);
+                _blockTree = Build.A.BlockTree()
+                    .WithNoHead
+                    .TestObject;
                 _blockProcessor = new BlockProcessorMock(_logManager, stateReader);
                 _recoveryStep = new RecoveryStepMock(_logManager);
                 _processor = new BlockchainProcessor(_blockTree, _blockProcessor, _recoveryStep, stateReader, LimboLogs.Instance, BlockchainProcessor.Options.Default);

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockchainProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockchainProcessorTests.cs
@@ -192,7 +192,7 @@ namespace Nethermind.Blockchain.Test
                 IStateReader stateReader = Substitute.For<IStateReader>();
 
                 _blockTree = Build.A.BlockTree()
-                    .WithNoHead
+                    .WithoutSettingHead
                     .TestObject;
                 _blockProcessor = new BlockProcessorMock(_logManager, stateReader);
                 _recoveryStep = new RecoveryStepMock(_logManager);

--- a/src/Nethermind/Nethermind.Blockchain.Test/Producers/DevBlockproducerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Producers/DevBlockproducerTests.cs
@@ -41,12 +41,10 @@ namespace Nethermind.Blockchain.Test.Producers
             dbProvider.RegisterDb(DbNames.Code, new MemDb());
             dbProvider.RegisterDb(DbNames.Metadata, new MemDb());
 
-            BlockTree blockTree = new(
-                dbProvider,
-                new ChainLevelInfoRepository(dbProvider),
-                specProvider,
-                NullBloomStorage.Instance,
-                LimboLogs.Instance);
+            BlockTree blockTree = Build.A.BlockTree()
+                .WithNoHead
+                .TestObject;
+
             TrieStore trieStore = new(
                 dbProvider.RegisteredDbs[DbNames.State],
                 NoPruning.Instance,

--- a/src/Nethermind/Nethermind.Blockchain.Test/Producers/DevBlockproducerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Producers/DevBlockproducerTests.cs
@@ -42,7 +42,7 @@ namespace Nethermind.Blockchain.Test.Producers
             dbProvider.RegisterDb(DbNames.Metadata, new MemDb());
 
             BlockTree blockTree = Build.A.BlockTree()
-                .WithNoHead
+                .WithoutSettingHead
                 .TestObject;
 
             TrieStore trieStore = new(

--- a/src/Nethermind/Nethermind.Blockchain.Test/ReorgTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/ReorgTests.cs
@@ -47,7 +47,7 @@ namespace Nethermind.Blockchain.Test
                 new TransactionComparerProvider(specProvider, _blockTree);
 
             _blockTree = Build.A.BlockTree()
-                .WithNoHead
+                .WithoutSettingHead
                 .WithSpecProvider(specProvider)
                 .TestObject;
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/ReorgTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/ReorgTests.cs
@@ -41,19 +41,16 @@ namespace Nethermind.Blockchain.Test
             TrieStore trieStore = new(new MemDb(), LimboLogs.Instance);
             WorldState stateProvider = new(trieStore, memDbProvider.CodeDb, LimboLogs.Instance);
             StateReader stateReader = new(trieStore, memDbProvider.CodeDb, LimboLogs.Instance);
-            ChainLevelInfoRepository chainLevelInfoRepository = new(memDbProvider);
             ISpecProvider specProvider = MainnetSpecProvider.Instance;
-            IBloomStorage bloomStorage = NullBloomStorage.Instance;
             EthereumEcdsa ecdsa = new(1, LimboLogs.Instance);
             ITransactionComparerProvider transactionComparerProvider =
                 new TransactionComparerProvider(specProvider, _blockTree);
-            _blockTree = new BlockTree(
-                memDbProvider,
-                chainLevelInfoRepository,
-                specProvider,
-                bloomStorage,
-                new SyncConfig(),
-                LimboLogs.Instance);
+
+            _blockTree = Build.A.BlockTree()
+                .WithNoHead
+                .WithSpecProvider(specProvider)
+                .TestObject;
+
             TxPool.TxPool txPool = new(
                 ecdsa,
                 new ChainHeadInfoProvider(specProvider, _blockTree, stateProvider),

--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/HeaderValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/HeaderValidatorTests.cs
@@ -39,6 +39,7 @@ namespace Nethermind.Blockchain.Test.Validators
             _ethash = new EthashSealValidator(LimboLogs.Instance, calculator, new CryptoRandom(), new Ethash(LimboLogs.Instance), Timestamper.Default);
             _testLogger = new TestLogger();
             _blockTree = Build.A.BlockTree()
+                .WithSpecProvider(FrontierSpecProvider.Instance)
                 .WithoutSettingHead
                 .TestObject;
             _specProvider = new TestSingleReleaseSpecProvider(Byzantium.Instance);
@@ -294,6 +295,7 @@ namespace Nethermind.Blockchain.Test.Validators
 
             {
                 _blockTree = Build.A.BlockTree()
+                    .WithSpecProvider(FrontierSpecProvider.Instance)
                     .WithoutSettingHead
                     .TestObject;
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/HeaderValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/HeaderValidatorTests.cs
@@ -39,7 +39,7 @@ namespace Nethermind.Blockchain.Test.Validators
             _ethash = new EthashSealValidator(LimboLogs.Instance, calculator, new CryptoRandom(), new Ethash(LimboLogs.Instance), Timestamper.Default);
             _testLogger = new TestLogger();
             _blockTree = Build.A.BlockTree()
-                .WithNoHead
+                .WithoutSettingHead
                 .TestObject;
             _specProvider = new TestSingleReleaseSpecProvider(Byzantium.Instance);
 
@@ -294,7 +294,7 @@ namespace Nethermind.Blockchain.Test.Validators
 
             {
                 _blockTree = Build.A.BlockTree()
-                    .WithNoHead
+                    .WithoutSettingHead
                     .TestObject;
 
                 Block genesis = Build.A.Block.WithDifficulty((UInt256)genesisTd).TestObject;

--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/HeaderValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/HeaderValidatorTests.cs
@@ -12,15 +12,11 @@ using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Crypto;
-using Nethermind.Db;
-using Nethermind.Db.Blooms;
 using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.Specs;
 using Nethermind.Specs.Forks;
 using Nethermind.Specs.Test;
-using Nethermind.State.Repositories;
-using NSubstitute;
 using NUnit.Framework;
 
 namespace Nethermind.Blockchain.Test.Validators
@@ -42,8 +38,9 @@ namespace Nethermind.Blockchain.Test.Validators
             EthashDifficultyCalculator calculator = new(new TestSingleReleaseSpecProvider(Frontier.Instance));
             _ethash = new EthashSealValidator(LimboLogs.Instance, calculator, new CryptoRandom(), new Ethash(LimboLogs.Instance), Timestamper.Default);
             _testLogger = new TestLogger();
-            MemDb blockInfoDb = new();
-            _blockTree = new BlockTree(new MemDb(), new MemDb(), blockInfoDb, new ChainLevelInfoRepository(blockInfoDb), FrontierSpecProvider.Instance, Substitute.For<IBloomStorage>(), LimboLogs.Instance);
+            _blockTree = Build.A.BlockTree()
+                .WithNoHead
+                .TestObject;
             _specProvider = new TestSingleReleaseSpecProvider(Byzantium.Instance);
 
             _validator = new HeaderValidator(_blockTree, _ethash, _specProvider, new OneLoggerLogManager(_testLogger));
@@ -296,10 +293,9 @@ namespace Nethermind.Blockchain.Test.Validators
             _block.Header.Hash = _block.CalculateHash();
 
             {
-                MemDb blockInfoDb = new();
-                _blockTree = new BlockTree(new MemDb(), new MemDb(), blockInfoDb,
-                    new ChainLevelInfoRepository(blockInfoDb),
-                    FrontierSpecProvider.Instance, Substitute.For<IBloomStorage>(), LimboLogs.Instance);
+                _blockTree = Build.A.BlockTree()
+                    .WithNoHead
+                    .TestObject;
 
                 Block genesis = Build.A.Block.WithDifficulty((UInt256)genesisTd).TestObject;
                 _blockTree.SuggestBlock(genesis);

--- a/src/Nethermind/Nethermind.Blockchain.Test/Visitors/DbBlocksLoaderTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Visitors/DbBlocksLoaderTests.cs
@@ -105,6 +105,7 @@ namespace Nethermind.Blockchain.Test.Visitors
                     .WithBlockStore(blockStore)
                     .WithHeadersDb(headersDb)
                     .WithBlockInfoDb(blockInfosDb)
+                    .WithSpecProvider(OlympicSpecProvider.Instance)
                     .TestObject;
 
                 DbBlocksLoader loader = new(blockTree, LimboNoErrorLogger.Instance);

--- a/src/Nethermind/Nethermind.Blockchain.Test/Visitors/DbBlocksLoaderTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Visitors/DbBlocksLoaderTests.cs
@@ -56,7 +56,7 @@ namespace Nethermind.Blockchain.Test.Visitors
                 headersDb.Set(genesisBlock.Header.Hash, Rlp.Encode(genesisBlock.Header).Bytes);
 
                 BlockTree blockTree = Build.A.BlockTree()
-                    .WithNoHead
+                    .WithoutSettingHead
                     .WithBlockStore(blockStore)
                     .WithHeadersDb(headersDb)
                     .WithBlockInfoDb(blockInfosDb)
@@ -101,7 +101,7 @@ namespace Nethermind.Blockchain.Test.Visitors
                 headersDb.Set(genesisBlock.Header.Hash, Rlp.Encode(genesisBlock.Header).Bytes);
 
                 BlockTree blockTree = Build.A.BlockTree()
-                    .WithNoHead
+                    .WithoutSettingHead
                     .WithBlockStore(blockStore)
                     .WithHeadersDb(headersDb)
                     .WithBlockInfoDb(blockInfosDb)
@@ -121,7 +121,7 @@ namespace Nethermind.Blockchain.Test.Visitors
             MemDb blockInfosDb = new();
 
             BlockTreeBuilder builder = Build.A.BlockTree()
-                .WithNoHead
+                .WithoutSettingHead
                 .WithBlockInfoDb(blockInfosDb)
                 .WithBlockStore(blockStore);
 
@@ -150,7 +150,7 @@ namespace Nethermind.Blockchain.Test.Visitors
 
             BlockTree tree2 = Build.A.BlockTree()
                 .WithDatabaseFrom(builder)
-                .WithNoHead
+                .WithoutSettingHead
                 .TestObject;
 
             CancellationTokenSource tokenSource = new();
@@ -191,7 +191,7 @@ namespace Nethermind.Blockchain.Test.Visitors
             MemDb blockInfosDb = new();
 
             BlockTreeBuilder builder = Build.A.BlockTree()
-                .WithNoHead
+                .WithoutSettingHead
                 .WithBlockInfoDb(blockInfosDb)
                 .WithBlockStore(blockStore);
             BlockTree tree1 = builder.TestObject;
@@ -209,7 +209,7 @@ namespace Nethermind.Blockchain.Test.Visitors
             tree1.UpdateMainChain(block0);
 
             BlockTree tree2 = Build.A.BlockTree()
-                .WithNoHead
+                .WithoutSettingHead
                 .WithDatabaseFrom(builder)
                 .TestObject;
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/Visitors/DbBlocksLoaderTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Visitors/DbBlocksLoaderTests.cs
@@ -4,6 +4,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Nethermind.Blockchain.Blocks;
 using Nethermind.Blockchain.Visitors;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
@@ -30,7 +31,7 @@ namespace Nethermind.Blockchain.Test.Visitors
             {
                 Block genesisBlock = Build.A.Block.Genesis.TestObject;
 
-                MemDb blocksDb = new();
+                BlockStore blockStore = new(new MemDb());
                 MemDb blockInfosDb = new();
                 MemDb headersDb = new();
 
@@ -38,7 +39,7 @@ namespace Nethermind.Blockchain.Test.Visitors
                 for (int i = 0; i < testTree.Head!.Number + 1; i++)
                 {
                     Block ithBlock = testTree.FindBlock(i, BlockTreeLookupOptions.None)!;
-                    blocksDb.Set(ithBlock.Hash!, Rlp.Encode(ithBlock).Bytes);
+                    blockStore.Insert(ithBlock);
 
                     headersDb.Set(ithBlock.Hash!, Rlp.Encode(ithBlock.Header).Bytes);
 
@@ -54,14 +55,13 @@ namespace Nethermind.Blockchain.Test.Visitors
                 blockInfosDb.Set(Keccak.Zero, genesisBlock.Header.Hash!.Bytes);
                 headersDb.Set(genesisBlock.Header.Hash, Rlp.Encode(genesisBlock.Header).Bytes);
 
-                BlockTree blockTree = new(
-                    blocksDb,
-                    headersDb,
-                    blockInfosDb,
-                    new ChainLevelInfoRepository(blockInfosDb),
-                    OlympicSpecProvider.Instance,
-                    NullBloomStorage.Instance,
-                    LimboLogs.Instance);
+                BlockTree blockTree = Build.A.BlockTree()
+                    .WithNoHead
+                    .WithBlockStore(blockStore)
+                    .WithHeadersDb(headersDb)
+                    .WithBlockInfoDb(blockInfosDb)
+                    .WithSpecProvider(OlympicSpecProvider.Instance)
+                    .TestObject;
 
                 DbBlocksLoader loader = new(blockTree, LimboNoErrorLogger.Instance);
                 await blockTree.Accept(loader, CancellationToken.None);
@@ -77,7 +77,7 @@ namespace Nethermind.Blockchain.Test.Visitors
             {
                 Block genesisBlock = Build.A.Block.Genesis.TestObject;
 
-                MemDb blocksDb = new();
+                BlockStore blockStore = new(new MemDb());
                 MemDb blockInfosDb = new();
                 MemDb headersDb = new();
 
@@ -85,7 +85,7 @@ namespace Nethermind.Blockchain.Test.Visitors
                 for (int i = 0; i < testTree.Head!.Number + 1; i++)
                 {
                     Block ithBlock = testTree.FindBlock(i, BlockTreeLookupOptions.None)!;
-                    blocksDb.Set(ithBlock.Hash!, Rlp.Encode(ithBlock).Bytes);
+                    blockStore.Insert(ithBlock);
 
                     headersDb.Set(ithBlock.Hash!, Rlp.Encode(ithBlock.Header).Bytes);
 
@@ -100,14 +100,12 @@ namespace Nethermind.Blockchain.Test.Visitors
                 blockInfosDb.Set(Keccak.Zero, genesisBlock.Header.Hash!.Bytes);
                 headersDb.Set(genesisBlock.Header.Hash, Rlp.Encode(genesisBlock.Header).Bytes);
 
-                BlockTree blockTree = new(
-                    blocksDb,
-                    headersDb,
-                    blockInfosDb,
-                    new ChainLevelInfoRepository(blockInfosDb),
-                    OlympicSpecProvider.Instance,
-                    NullBloomStorage.Instance,
-                    LimboLogs.Instance);
+                BlockTree blockTree = Build.A.BlockTree()
+                    .WithNoHead
+                    .WithBlockStore(blockStore)
+                    .WithHeadersDb(headersDb)
+                    .WithBlockInfoDb(blockInfosDb)
+                    .TestObject;
 
                 DbBlocksLoader loader = new(blockTree, LimboNoErrorLogger.Instance);
                 await blockTree.Accept(loader, CancellationToken.None);
@@ -119,18 +117,16 @@ namespace Nethermind.Blockchain.Test.Visitors
         [Test, Timeout(Timeout.MaxTestTime)]
         public async Task Can_load_from_DB_when_there_is_an_invalid_block_in_DB_and_a_valid_branch()
         {
-            MemDb blocksDb = new();
+            BlockStore blockStore = new(new MemDb());
             MemDb blockInfosDb = new();
-            MemDb headersDb = new();
 
-            BlockTree tree1 = new(
-                blocksDb,
-                headersDb,
-                blockInfosDb,
-                new ChainLevelInfoRepository(blockInfosDb),
-                MainnetSpecProvider.Instance,
-                NullBloomStorage.Instance,
-                LimboLogs.Instance);
+            BlockTreeBuilder builder = Build.A.BlockTree()
+                .WithNoHead
+                .WithBlockInfoDb(blockInfosDb)
+                .WithBlockStore(blockStore);
+
+            BlockTree tree1 = builder
+                .TestObject;
 
             Block block0 = Build.A.Block.WithNumber(0).WithDifficulty(1).TestObject;
             Block block1 = Build.A.Block.WithNumber(1).WithDifficulty(2).WithParent(block0).TestObject;
@@ -152,14 +148,10 @@ namespace Nethermind.Blockchain.Test.Visitors
 
             tree1.UpdateMainChain(block0);
 
-            BlockTree tree2 = new(
-                blocksDb,
-                headersDb,
-                blockInfosDb,
-                new ChainLevelInfoRepository(blockInfosDb),
-                MainnetSpecProvider.Instance,
-                NullBloomStorage.Instance,
-                LimboLogs.Instance);
+            BlockTree tree2 = Build.A.BlockTree()
+                .WithDatabaseFrom(builder)
+                .WithNoHead
+                .TestObject;
 
             CancellationTokenSource tokenSource = new();
             tokenSource.CancelAfter(_dbLoadTimeout);
@@ -183,9 +175,9 @@ namespace Nethermind.Blockchain.Test.Visitors
             tree2.Head!.Header.Should().BeEquivalentTo(block3B.Header, options => { return options.Excluding(t => t.MaybeParent); });
             tree2.BestSuggestedHeader.Should().BeEquivalentTo(block3B.Header, options => { return options.Excluding(t => t.MaybeParent); });
 
-            Assert.IsNull(blocksDb.Get(block1.Hash!), "block 1");
-            Assert.IsNull(blocksDb.Get(block2.Hash!), "block 2");
-            Assert.IsNull(blocksDb.Get(block3.Hash!), "block 3");
+            Assert.IsNull(blockStore.Get(block1.Hash!), "block 1");
+            Assert.IsNull(blockStore.Get(block2.Hash!), "block 2");
+            Assert.IsNull(blockStore.Get(block3.Hash!), "block 3");
 
             Assert.NotNull(blockInfosDb.Get(1), "level 1");
             Assert.NotNull(blockInfosDb.Get(2), "level 2");
@@ -195,18 +187,14 @@ namespace Nethermind.Blockchain.Test.Visitors
         [Test, Timeout(Timeout.MaxTestTime)]
         public async Task Can_load_from_DB_when_there_is_only_an_invalid_chain_in_DB()
         {
-            MemDb blocksDb = new();
+            BlockStore blockStore = new(new MemDb());
             MemDb blockInfosDb = new();
-            MemDb headersDb = new();
 
-            BlockTree tree1 = new(
-                blocksDb,
-                headersDb,
-                blockInfosDb,
-                new ChainLevelInfoRepository(blockInfosDb),
-                MainnetSpecProvider.Instance,
-                NullBloomStorage.Instance,
-                LimboLogs.Instance);
+            BlockTreeBuilder builder = Build.A.BlockTree()
+                .WithNoHead
+                .WithBlockInfoDb(blockInfosDb)
+                .WithBlockStore(blockStore);
+            BlockTree tree1 = builder.TestObject;
 
             Block block0 = Build.A.Block.WithNumber(0).WithDifficulty(1).TestObject;
             Block block1 = Build.A.Block.WithNumber(1).WithDifficulty(2).WithParent(block0).TestObject;
@@ -220,14 +208,10 @@ namespace Nethermind.Blockchain.Test.Visitors
 
             tree1.UpdateMainChain(block0);
 
-            BlockTree tree2 = new(
-                blocksDb,
-                headersDb,
-                blockInfosDb,
-                new ChainLevelInfoRepository(blockInfosDb),
-                MainnetSpecProvider.Instance,
-                NullBloomStorage.Instance,
-                LimboLogs.Instance);
+            BlockTree tree2 = Build.A.BlockTree()
+                .WithNoHead
+                .WithDatabaseFrom(builder)
+                .TestObject;
 
             CancellationTokenSource tokenSource = new();
             tokenSource.CancelAfter(_dbLoadTimeout);
@@ -253,9 +237,9 @@ namespace Nethermind.Blockchain.Test.Visitors
             Assert.That(tree2.Head!.Hash, Is.EqualTo(block0.Hash), "head");
             Assert.That(tree2.BestSuggestedHeader!.Hash, Is.EqualTo(block0.Hash), "suggested");
 
-            Assert.IsNull(blocksDb.Get(block1.Hash!), "block 1");
-            Assert.IsNull(blocksDb.Get(block2.Hash!), "block 2");
-            Assert.IsNull(blocksDb.Get(block3.Hash!), "block 3");
+            Assert.IsNull(blockStore.Get(block1.Hash!), "block 1");
+            Assert.IsNull(blockStore.Get(block2.Hash!), "block 2");
+            Assert.IsNull(blockStore.Get(block3.Hash!), "block 3");
 
             Assert.IsNull(blockInfosDb.Get(1), "level 1");
             Assert.IsNull(blockInfosDb.Get(2), "level 2");

--- a/src/Nethermind/Nethermind.Blockchain.Test/Visitors/StartupTreeFixerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Visitors/StartupTreeFixerTests.cs
@@ -44,7 +44,7 @@ namespace Nethermind.Blockchain.Test.Visitors
             MemDb blockInfosDb = new();
             BlockTreeBuilder builder = Build.A.BlockTree();
             BlockTree tree = builder
-                .WithNoHead
+                .WithoutSettingHead
                 .WithBlockInfoDb(blockInfosDb)
                 .TestObject;
             Block block0 = Build.A.Block.WithNumber(0).WithDifficulty(1).TestObject;
@@ -68,7 +68,7 @@ namespace Nethermind.Blockchain.Test.Visitors
             blockInfosDb.Delete(3);
 
             tree = Build.A.BlockTree()
-                .WithNoHead
+                .WithoutSettingHead
                 .WithDatabaseFrom(builder)
                 .TestObject;
 
@@ -193,7 +193,7 @@ namespace Nethermind.Blockchain.Test.Visitors
             MemDb blockInfosDb = new();
 
             BlockTree tree = Build.A.BlockTree()
-                .WithNoHead
+                .WithoutSettingHead
                 .WithBlockInfoDb(blockInfosDb)
                 .TestObject;
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/Visitors/StartupTreeFixerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Visitors/StartupTreeFixerTests.cs
@@ -41,10 +41,12 @@ namespace Nethermind.Blockchain.Test.Visitors
         [Test, Timeout(Timeout.MaxTestTime)]
         public async Task Deletes_everything_after_the_missing_level()
         {
-            MemDb blocksDb = new();
             MemDb blockInfosDb = new();
-            MemDb headersDb = new();
-            BlockTree tree = new(blocksDb, headersDb, blockInfosDb, new ChainLevelInfoRepository(blockInfosDb), MainnetSpecProvider.Instance, NullBloomStorage.Instance, LimboLogs.Instance);
+            BlockTreeBuilder builder = Build.A.BlockTree();
+            BlockTree tree = builder
+                .WithNoHead
+                .WithBlockInfoDb(blockInfosDb)
+                .TestObject;
             Block block0 = Build.A.Block.WithNumber(0).WithDifficulty(1).TestObject;
             Block block1 = Build.A.Block.WithNumber(1).WithDifficulty(2).WithParent(block0).TestObject;
             Block block2 = Build.A.Block.WithNumber(2).WithDifficulty(3).WithParent(block1).TestObject;
@@ -65,7 +67,10 @@ namespace Nethermind.Blockchain.Test.Visitors
 
             blockInfosDb.Delete(3);
 
-            tree = new BlockTree(blocksDb, headersDb, blockInfosDb, new ChainLevelInfoRepository(blockInfosDb), MainnetSpecProvider.Instance, NullBloomStorage.Instance, LimboLogs.Instance);
+            tree = Build.A.BlockTree()
+                .WithNoHead
+                .WithDatabaseFrom(builder)
+                .TestObject;
 
             StartupBlockTreeFixer fixer = new(new SyncConfig(), tree, new MemDb(), LimboNoErrorLogger.Instance);
             await tree.Accept(fixer, CancellationToken.None);
@@ -185,10 +190,13 @@ namespace Nethermind.Blockchain.Test.Visitors
         [Test, Timeout(Timeout.MaxTestTime)]
         public async Task When_head_block_is_followed_by_a_block_bodies_gap_it_should_delete_all_levels_after_the_gap_start()
         {
-            MemDb blocksDb = new();
             MemDb blockInfosDb = new();
-            MemDb headersDb = new();
-            BlockTree tree = new(blocksDb, headersDb, blockInfosDb, new ChainLevelInfoRepository(blockInfosDb), MainnetSpecProvider.Instance, NullBloomStorage.Instance, LimboLogs.Instance);
+
+            BlockTree tree = Build.A.BlockTree()
+                .WithNoHead
+                .WithBlockInfoDb(blockInfosDb)
+                .TestObject;
+
             Block block0 = Build.A.Block.WithNumber(0).WithDifficulty(1).TestObject;
             Block block1 = Build.A.Block.WithNumber(1).WithDifficulty(2).WithParent(block0).TestObject;
             Block block2 = Build.A.Block.WithNumber(2).WithDifficulty(3).WithParent(block1).TestObject;

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -124,33 +124,6 @@ namespace Nethermind.Blockchain
         }
 
         public BlockTree(
-            IDbProvider? dbProvider,
-            IChainLevelInfoRepository? chainLevelInfoRepository,
-            ISpecProvider? specProvider,
-            IBloomStorage? bloomStorage,
-            ISyncConfig? syncConfig,
-            ILogManager? logManager)
-            : this(new BlockStore(dbProvider?.BlocksDb), dbProvider?.HeadersDb, dbProvider?.BlockInfosDb, dbProvider?.MetadataDb,
-                chainLevelInfoRepository, specProvider, bloomStorage, syncConfig, logManager)
-        {
-        }
-
-        /*
-        public BlockTree(
-            IDb? blockDb,
-            IDb? headerDb,
-            IDb? blockInfoDb,
-            IChainLevelInfoRepository? chainLevelInfoRepository,
-            ISpecProvider? specProvider,
-            IBloomStorage? bloomStorage,
-            ILogManager? logManager)
-            : this(new BlockStore(blockDb), headerDb, blockInfoDb, new MemDb(), chainLevelInfoRepository, specProvider, bloomStorage,
-                new SyncConfig(), logManager)
-        {
-        }
-        */
-
-        public BlockTree(
             IDb? blockDb,
             IDb? headerDb,
             IDb? blockInfoDb,

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -135,6 +135,7 @@ namespace Nethermind.Blockchain
         {
         }
 
+        /*
         public BlockTree(
             IDb? blockDb,
             IDb? headerDb,
@@ -147,6 +148,7 @@ namespace Nethermind.Blockchain
                 new SyncConfig(), logManager)
         {
         }
+        */
 
         public BlockTree(
             IDb? blockDb,

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -31,7 +31,7 @@ namespace Nethermind.Blockchain
     public partial class BlockTree : IBlockTree
     {
         // there is not much logic in the addressing here
-        private static readonly byte[] LowestInsertedBodyNumberDbEntryAddress = ((long)0).ToBigEndianByteArrayWithoutLeadingZeros();
+        public static readonly byte[] LowestInsertedBodyNumberDbEntryAddress = ((long)0).ToBigEndianByteArrayWithoutLeadingZeros();
         private static byte[] StateHeadHashDbEntryAddress = new byte[16];
         internal static Keccak DeletePointerAddressInDb = new(new BitArray(32 * 8, true).ToBytes());
 
@@ -111,32 +111,6 @@ namespace Nethermind.Blockchain
         public bool CanAcceptNewBlocks => _canAcceptNewBlocksCounter == 0;
 
         private TaskCompletionSource<bool>? _taskCompletionSource;
-
-        public BlockTree(
-            IDbProvider? dbProvider,
-            IChainLevelInfoRepository? chainLevelInfoRepository,
-            ISpecProvider? specProvider,
-            IBloomStorage? bloomStorage,
-            ILogManager? logManager)
-            : this(new BlockStore(dbProvider?.BlocksDb), dbProvider?.HeadersDb, dbProvider?.BlockInfosDb, dbProvider?.MetadataDb,
-                chainLevelInfoRepository, specProvider, bloomStorage, new SyncConfig(), logManager)
-        {
-        }
-
-        public BlockTree(
-            IDb? blockDb,
-            IDb? headerDb,
-            IDb? blockInfoDb,
-            IDb? metadataDb,
-            IChainLevelInfoRepository? chainLevelInfoRepository,
-            ISpecProvider? specProvider,
-            IBloomStorage? bloomStorage,
-            ISyncConfig? syncConfig,
-            ILogManager? logManager)
-            : this(new BlockStore(blockDb), headerDb, blockInfoDb, metadataDb, chainLevelInfoRepository, specProvider, bloomStorage,
-                syncConfig, logManager)
-        {
-        }
 
         public BlockTree(
             IBlockStore? blockStore,

--- a/src/Nethermind/Nethermind.Blockchain/Blocks/BlockStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Blocks/BlockStore.cs
@@ -60,7 +60,7 @@ public class BlockStore : IBlockStore
         _blockCache.Delete(blockHash);
     }
 
-    public Block? Get(Keccak blockHash, bool shouldCache)
+    public Block? Get(Keccak blockHash, bool shouldCache = false)
     {
 
         return _blockDb.Get(blockHash, _blockDecoder, _blockCache, shouldCache);

--- a/src/Nethermind/Nethermind.Clique.Test/CliqueBlockProducerTests.cs
+++ b/src/Nethermind/Nethermind.Clique.Test/CliqueBlockProducerTests.cs
@@ -100,7 +100,7 @@ namespace Nethermind.Clique.Test
 
                 BlockTree blockTree = Build.A.BlockTree()
                     .WithBlocksDb(blocksDb)
-                    .WithNoHead
+                    .WithoutSettingHead
                     .TestObject;
 
                 blockTree.NewHeadBlock += (sender, args) => { _blockEvents[privateKey].Set(); };

--- a/src/Nethermind/Nethermind.Clique.Test/CliqueBlockProducerTests.cs
+++ b/src/Nethermind/Nethermind.Clique.Test/CliqueBlockProducerTests.cs
@@ -85,9 +85,6 @@ namespace Nethermind.Clique.Test
                 _blockEvents.Add(privateKey, newHeadBlockEvent);
 
                 MemDb blocksDb = new();
-                MemDb headersDb = new();
-                MemDb blockInfoDb = new();
-
                 MemDb stateDb = new();
                 MemDb codeDb = new();
 
@@ -101,7 +98,10 @@ namespace Nethermind.Clique.Test
                 stateProvider.Commit(goerliSpecProvider.GenesisSpec);
                 stateProvider.CommitTree(0);
 
-                BlockTree blockTree = new(blocksDb, headersDb, blockInfoDb, new ChainLevelInfoRepository(blockInfoDb), goerliSpecProvider, NullBloomStorage.Instance, nodeLogManager);
+                BlockTree blockTree = Build.A.BlockTree()
+                    .WithBlocksDb(blocksDb)
+                    .WithNoHead
+                    .TestObject;
 
                 blockTree.NewHeadBlock += (sender, args) => { _blockEvents[privateKey].Set(); };
                 ITransactionComparerProvider transactionComparerProvider =

--- a/src/Nethermind/Nethermind.Clique.Test/CliqueBlockProducerTests.cs
+++ b/src/Nethermind/Nethermind.Clique.Test/CliqueBlockProducerTests.cs
@@ -99,6 +99,7 @@ namespace Nethermind.Clique.Test
                 stateProvider.CommitTree(0);
 
                 BlockTree blockTree = Build.A.BlockTree()
+                    .WithSpecProvider(goerliSpecProvider)
                     .WithBlocksDb(blocksDb)
                     .WithoutSettingHead
                     .TestObject;

--- a/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
@@ -143,7 +143,7 @@ public class TestBlockchain : IDisposable
 
         BlockTree = Builders.Build.A.BlockTree()
             .WithSpecProvider(SpecProvider)
-            .WithNoHead
+            .WithoutSettingHead
             .TestObject;
 
         ReadOnlyState = new ChainHeadReadOnlyStateProvider(BlockTree, StateReader);

--- a/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
@@ -141,10 +141,11 @@ public class TestBlockchain : IDisposable
         ReadOnlyTrieStore = TrieStore.AsReadOnly(StateDb);
         StateReader = new StateReader(ReadOnlyTrieStore, CodeDb, LogManager);
 
-        IDb blockDb = new MemDb();
-        IDb headerDb = new MemDb();
-        IDb blockInfoDb = new MemDb();
-        BlockTree = new BlockTree(blockDb, headerDb, blockInfoDb, new ChainLevelInfoRepository(blockInfoDb), SpecProvider, NullBloomStorage.Instance, LimboLogs.Instance);
+        BlockTree = Builders.Build.A.BlockTree()
+            .WithSpecProvider(SpecProvider)
+            .WithNoHead
+            .TestObject;
+
         ReadOnlyState = new ChainHeadReadOnlyStateProvider(BlockTree, StateReader);
         TransactionComparerProvider = new TransactionComparerProvider(SpecProvider, BlockTree);
         TxPool = CreateTxPool();

--- a/src/Nethermind/Nethermind.Core.Test/Builders/BlockTreeBuilder.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Builders/BlockTreeBuilder.cs
@@ -42,7 +42,6 @@ namespace Nethermind.Core.Test.Builders
         public BlockTreeBuilder(Block genesisBlock, ISpecProvider specProvider)
         {
             BlocksDb = new TestMemDb();
-            BlockStore = new BlockStore(BlocksDb);
             HeadersDb = new TestMemDb();
             BlockInfoDb = new TestMemDb();
             MetadataDb = new TestMemDb();
@@ -77,11 +76,11 @@ namespace Nethermind.Core.Test.Builders
                         BlockStore,
                         HeadersDb,
                         BlockInfoDb,
-                        new MemDb(),
+                        MetadataDb,
                         ChainLevelInfoRepository,
                         _specProvider,
                         BloomStorage,
-                        new SyncConfig(),
+                        SyncConfig,
                         LimboLogs.Instance);
                 }
 
@@ -100,6 +99,8 @@ namespace Nethermind.Core.Test.Builders
         }
 
         public IBloomStorage BloomStorage { get; set; } = Substitute.For<IBloomStorage>();
+
+        public ISyncConfig SyncConfig { get; set; } = new SyncConfig();
 
         public IDb BlocksDb { get; set; }
 
@@ -122,9 +123,9 @@ namespace Nethermind.Core.Test.Builders
 
         public IDb MetadataDb { get; set; }
 
-        private ChainLevelInfoRepository? _chainLevelInfoRepository;
+        private IChainLevelInfoRepository? _chainLevelInfoRepository;
 
-        public ChainLevelInfoRepository ChainLevelInfoRepository
+        public IChainLevelInfoRepository ChainLevelInfoRepository
         {
             get
             {
@@ -390,9 +391,27 @@ namespace Nethermind.Core.Test.Builders
             return this;
         }
 
+        public BlockTreeBuilder WithMetadataDb(IDb metadataDb)
+        {
+            MetadataDb = metadataDb;
+            return this;
+        }
+
         public BlockTreeBuilder WithBloomStorage(IBloomStorage bloomStorage)
         {
             BloomStorage = bloomStorage;
+            return this;
+        }
+
+        public BlockTreeBuilder WithSyncConfig(ISyncConfig syncConfig)
+        {
+            SyncConfig = syncConfig;
+            return this;
+        }
+
+        public BlockTreeBuilder WithChainLevelInfoRepository(IChainLevelInfoRepository chainLevelInfoRepository)
+        {
+            ChainLevelInfoRepository = chainLevelInfoRepository;
             return this;
         }
     }

--- a/src/Nethermind/Nethermind.Core.Test/Builders/BlockTreeBuilder.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Builders/BlockTreeBuilder.cs
@@ -50,7 +50,7 @@ namespace Nethermind.Core.Test.Builders
             _specProvider = specProvider;
         }
 
-        public BlockTreeBuilder WithNoHead
+        public BlockTreeBuilder WithoutSettingHead
         {
             get
             {

--- a/src/Nethermind/Nethermind.Core.Test/Builders/BlockTreeBuilder.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Builders/BlockTreeBuilder.cs
@@ -158,6 +158,15 @@ namespace Nethermind.Core.Test.Builders
 
         public bool PostMergeBlockTree { get; set; }
 
+        public BlockTreeBuilder WithRealBloom
+        {
+            get
+            {
+                BloomStorage = new BloomStorage(new BloomConfig(), HeadersDb, new InMemoryDictionaryFileStoreFactory());
+                return this;
+            }
+        }
+
 
         public BlockTreeBuilder OfChainLength(int chainLength, int splitVariant = 0, int splitFrom = 0, bool withWithdrawals = false, params Address[] blockBeneficiaries)
         {

--- a/src/Nethermind/Nethermind.Core.Test/Builders/BlockTreeBuilder.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Builders/BlockTreeBuilder.cs
@@ -129,12 +129,7 @@ namespace Nethermind.Core.Test.Builders
         {
             get
             {
-                if (_chainLevelInfoRepository == null)
-                {
-                    _chainLevelInfoRepository = new ChainLevelInfoRepository(BlockInfoDb);
-                }
-
-                return _chainLevelInfoRepository;
+                return _chainLevelInfoRepository ??= new ChainLevelInfoRepository(BlockInfoDb);
             }
             private set
             {

--- a/src/Nethermind/Nethermind.JsonRpc.Benchmark/EthModuleBenchmarks.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Benchmark/EthModuleBenchmarks.cs
@@ -3,6 +3,7 @@
 
 using BenchmarkDotNet.Attributes;
 using Nethermind.Blockchain;
+using Nethermind.Blockchain.Blocks;
 using Nethermind.Blockchain.Filters;
 using Nethermind.Blockchain.Find;
 using Nethermind.Blockchain.Receipts;
@@ -64,7 +65,16 @@ namespace Nethermind.JsonRpc.Benchmark
             StateReader stateReader = new(trieStore, codeDb, LimboLogs.Instance);
 
             ChainLevelInfoRepository chainLevelInfoRepository = new(blockInfoDb);
-            BlockTree blockTree = new(dbProvider, chainLevelInfoRepository, specProvider, NullBloomStorage.Instance, LimboLogs.Instance);
+            BlockTree blockTree = new(
+                new BlockStore(dbProvider.BlocksDb),
+                dbProvider.HeadersDb,
+                dbProvider.BlockInfosDb,
+                dbProvider.MetadataDb,
+                chainLevelInfoRepository,
+                specProvider,
+                NullBloomStorage.Instance,
+                new SyncConfig(),
+                LimboLogs.Instance);
             _blockhashProvider = new BlockhashProvider(blockTree, LimboLogs.Instance);
             _virtualMachine = new VirtualMachine(_blockhashProvider, specProvider, LimboLogs.Instance);
 

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/BoundedModulePoolTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/BoundedModulePoolTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core.Specs;
+using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
 using Nethermind.Specs;
 using Nethermind.JsonRpc.Modules;
@@ -32,19 +33,14 @@ public class BoundedModulePoolTests
     private BoundedModulePool<IEthRpcModule> _modulePool = null!;
 
     [SetUp]
-    public async Task Initialize()
+    public Task Initialize()
     {
-        ISpecProvider specProvider = MainnetSpecProvider.Instance;
         ITxPool txPool = NullTxPool.Instance;
-        IDbProvider dbProvider = await TestMemDbProvider.InitAsync();
 
-        BlockTree blockTree = new(
-            dbProvider,
-            new ChainLevelInfoRepository(dbProvider.BlockInfosDb),
-            specProvider,
-            new BloomStorage(new BloomConfig(), dbProvider.HeadersDb, new InMemoryDictionaryFileStoreFactory()),
-            new SyncConfig(),
-            LimboLogs.Instance);
+        BlockTree blockTree = Build.A
+            .BlockTree()
+            .WithRealBloom
+            .TestObject;
 
         _modulePool = new BoundedModulePool<IEthRpcModule>(new EthModuleFactory(
             txPool,
@@ -60,6 +56,8 @@ public class BoundedModulePoolTests
             Substitute.For<IGasPriceOracle>(),
             Substitute.For<IEthSyncingInfo>()),
              1, 1000);
+
+        return Task.CompletedTask;
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/ParityRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/ParityRpcModuleTests.cs
@@ -68,10 +68,10 @@ namespace Nethermind.JsonRpc.Test.Modules
 
             WorldState stateProvider = new(new TrieStore(new MemDb(), LimboLogs.Instance), new MemDb(), LimboLogs.Instance);
 
-            IDb blockDb = new MemDb();
-            IDb headerDb = new MemDb();
-            IDb blockInfoDb = new MemDb();
-            _blockTree = new BlockTree(blockDb, headerDb, blockInfoDb, new ChainLevelInfoRepository(blockInfoDb), specProvider, NullBloomStorage.Instance, logger);
+            _blockTree = Build.A.BlockTree()
+                .WithNoHead
+                .WithSpecProvider(specProvider)
+                .TestObject;
 
             _txPool = new TxPool.TxPool(_ethereumEcdsa,
                 new ChainHeadInfoProvider(new FixedForkActivationChainHeadSpecProvider(specProvider), _blockTree, stateProvider),

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/ParityRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/ParityRpcModuleTests.cs
@@ -69,7 +69,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             WorldState stateProvider = new(new TrieStore(new MemDb(), LimboLogs.Instance), new MemDb(), LimboLogs.Instance);
 
             _blockTree = Build.A.BlockTree()
-                .WithNoHead
+                .WithoutSettingHead
                 .WithSpecProvider(specProvider)
                 .TestObject;
 

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SingletonModulePoolTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SingletonModulePoolTests.cs
@@ -20,6 +20,7 @@ using NUnit.Framework;
 using BlockTree = Nethermind.Blockchain.BlockTree;
 using System.Threading.Tasks;
 using Nethermind.Blockchain.Receipts;
+using Nethermind.Core.Test.Builders;
 using Nethermind.Facade.Eth;
 using Nethermind.JsonRpc.Modules.Eth.GasPrice;
 
@@ -33,12 +34,13 @@ namespace Nethermind.JsonRpc.Test.Modules
         private EthModuleFactory _factory = null!;
 
         [SetUp]
-        public async Task Initialize()
+        public Task Initialize()
         {
-            ISpecProvider specProvider = MainnetSpecProvider.Instance;
             ITxPool txPool = NullTxPool.Instance;
-            IDbProvider dbProvider = await TestMemDbProvider.InitAsync();
-            BlockTree blockTree = new(dbProvider, new ChainLevelInfoRepository(dbProvider.BlockInfosDb), specProvider, NullBloomStorage.Instance, new SyncConfig(), LimboLogs.Instance);
+
+            BlockTree blockTree = Build.A.BlockTree()
+                .TestObject;
+
             _factory = new EthModuleFactory(
                 txPool,
                 Substitute.For<ITxSender>(),
@@ -52,6 +54,7 @@ namespace Nethermind.JsonRpc.Test.Modules
                 Substitute.For<IReceiptStorage>(),
                 Substitute.For<IGasPriceOracle>(),
                 Substitute.For<IEthSyncingInfo>());
+            return Task.CompletedTask;
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Nethermind.Blockchain;
+using Nethermind.Blockchain.Blocks;
 using Nethermind.Blockchain.Filters;
 using Nethermind.Blockchain.Find;
 using Nethermind.Blockchain.Receipts;
@@ -293,19 +294,11 @@ namespace Nethermind.JsonRpc.Test.Modules
         [Test]
         public void NewHeadSubscription_should_send_notifications_when_adding_multiple_blocks_at_once_and_after_reorgs()
         {
-            MemDb blocksDb = new();
-            MemDb headersDb = new();
-            MemDb blocksInfosDb = new();
-            ChainLevelInfoRepository chainLevelInfoRepository = new(blocksInfosDb);
             MainnetSpecProvider specProvider = MainnetSpecProvider.Instance;
-            BlockTree blockTree = new(
-                blocksDb,
-                headersDb,
-                blocksInfosDb,
-                chainLevelInfoRepository,
-                specProvider,
-                NullBloomStorage.Instance,
-                LimboLogs.Instance);
+            BlockTree blockTree = Build.A.BlockTree()
+                .WithNoHead
+                .WithSpecProvider(specProvider)
+                .TestObject;
 
             NewHeadSubscription newHeadSubscription = new(_jsonRpcDuplexClient, blockTree, _logManager, specProvider);
             ConcurrentQueue<JsonRpcResult> jsonRpcResult = new();
@@ -350,19 +343,12 @@ namespace Nethermind.JsonRpc.Test.Modules
         [Test]
         public void NewHeadSubscription_should_send_notifications_in_order()
         {
-            MemDb blocksDb = new();
-            MemDb headersDb = new();
-            MemDb blocksInfosDb = new();
-            ChainLevelInfoRepository chainLevelInfoRepository = new(blocksInfosDb);
             MainnetSpecProvider specProvider = MainnetSpecProvider.Instance;
-            BlockTree blockTree = new(
-                blocksDb,
-                headersDb,
-                blocksInfosDb,
-                chainLevelInfoRepository,
-                specProvider,
-                NullBloomStorage.Instance,
-                LimboLogs.Instance);
+
+            BlockTree blockTree = Build.A.BlockTree()
+                .WithNoHead
+                .WithSpecProvider(specProvider)
+                .TestObject;
 
             NewHeadSubscription newHeadSubscription = new(_jsonRpcDuplexClient, blockTree, _logManager, specProvider);
             ConcurrentQueue<JsonRpcResult> jsonRpcResult = new();

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
@@ -296,7 +296,7 @@ namespace Nethermind.JsonRpc.Test.Modules
         {
             MainnetSpecProvider specProvider = MainnetSpecProvider.Instance;
             BlockTree blockTree = Build.A.BlockTree()
-                .WithNoHead
+                .WithoutSettingHead
                 .WithSpecProvider(specProvider)
                 .TestObject;
 
@@ -346,7 +346,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             MainnetSpecProvider specProvider = MainnetSpecProvider.Instance;
 
             BlockTree blockTree = Build.A.BlockTree()
-                .WithNoHead
+                .WithoutSettingHead
                 .WithSpecProvider(specProvider)
                 .TestObject;
 

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Trace/ParityStyleTracerTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Trace/ParityStyleTracerTests.cs
@@ -47,13 +47,12 @@ namespace Nethermind.JsonRpc.Test.Modules.Trace
         [SetUp]
         public void Setup()
         {
-            IDb blocksDb = new MemDb();
-            IDb blocksInfoDb = new MemDb();
-            IDb headersDb = new MemDb();
-            IDb metadataDb = new MemDb();
-            ChainLevelInfoRepository repository = new(blocksInfoDb);
             ISpecProvider specProvider = MainnetSpecProvider.Instance;
-            _blockTree = new BlockTree(blocksDb, headersDb, blocksInfoDb, metadataDb, repository, specProvider, NullBloomStorage.Instance, new SyncConfig(), LimboLogs.Instance);
+
+            _blockTree = Build.A.BlockTree()
+                .WithNoHead
+                .WithSpecProvider(specProvider)
+                .TestObject;
 
             MemDb stateDb = new();
             MemDb codeDb = new();

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Trace/ParityStyleTracerTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Trace/ParityStyleTracerTests.cs
@@ -50,7 +50,7 @@ namespace Nethermind.JsonRpc.Test.Modules.Trace
             ISpecProvider specProvider = MainnetSpecProvider.Instance;
 
             _blockTree = Build.A.BlockTree()
-                .WithNoHead
+                .WithoutSettingHead
                 .WithSpecProvider(specProvider)
                 .TestObject;
 

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/BlockTreeTests.cs
@@ -42,8 +42,8 @@ public partial class BlockTreeTests
             .TestObject;
 
         BlockTree syncedTree = Build.A.BlockTree(genesisBlock, specProvider)
-            .OfChainLength(syncedTreeSize)
             .WithoutSettingHead
+            .OfChainLength(syncedTreeSize)
             .TestObject;
 
         return (notSyncedTree, syncedTree);
@@ -71,8 +71,9 @@ public partial class BlockTreeTests
         TestSpecProvider specProvider = new(London.Instance);
         specProvider.TerminalTotalDifficulty = (UInt256)9999900;
 
-        BlockTree tree = Build.A.BlockTree().OfChainLength(10)
+        BlockTree tree = Build.A.BlockTree()
             .WithSpecProvider(specProvider)
+            .OfChainLength(10)
             .TestObject;
         PoSSwitcher poSSwitcher = new(new MergeConfig(), new SyncConfig(), new MemDb(), tree, specProvider, LimboLogs.Instance);
 
@@ -89,8 +90,9 @@ public partial class BlockTreeTests
     {
         TestSpecProvider specProvider = new(London.Instance);
         specProvider.TerminalTotalDifficulty = (UInt256)9999900;
-        BlockTree tree = Build.A.BlockTree().OfChainLength(10)
+        BlockTree tree = Build.A.BlockTree()
             .WithSpecProvider(specProvider)
+            .OfChainLength(10)
             .TestObject;
         PoSSwitcher poSSwitcher = new(new MergeConfig(), new SyncConfig(), new MemDb(), tree, specProvider, LimboLogs.Instance);
 
@@ -269,15 +271,15 @@ public partial class BlockTreeTests
                 if (ttd is not null) testSpecProvider.TerminalTotalDifficulty = ttd;
 
                 NotSyncedTreeBuilder = Build.A.BlockTree()
-                    .OfChainLength(notSyncedTreeSize, splitVariant: splitVariant, splitFrom: splitFrom)
-                    .WithSpecProvider(testSpecProvider);
+                    .WithSpecProvider(testSpecProvider)
+                    .OfChainLength(notSyncedTreeSize, splitVariant: splitVariant, splitFrom: splitFrom);
                 NotSyncedTree = NotSyncedTreeBuilder.TestObject;
 
                 if (syncedTreeSize > 0)
                 {
                     _syncedTreeBuilder = Build.A.BlockTree()
-                        .OfChainLength(syncedTreeSize, splitVariant: syncedSplitVariant, splitFrom: syncedSplitFrom)
-                        .WithSpecProvider(testSpecProvider);
+                        .WithSpecProvider(testSpecProvider)
+                        .OfChainLength(syncedTreeSize, splitVariant: syncedSplitVariant, splitFrom: syncedSplitFrom);
 
                     SyncedTree = _syncedTreeBuilder.TestObject;
                 }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/BlockTreeTests.cs
@@ -35,30 +35,16 @@ public partial class BlockTreeTests
         Block genesisBlock = Build.A.Block.WithNumber(0).TestObject;
         TestSpecProvider specProvider = new(London.Instance);
         specProvider.TerminalTotalDifficulty = 0;
-        ;
-        BlockTreeBuilder treeBuilder = Build.A.BlockTree(genesisBlock, specProvider).OfChainLength(notSyncedTreeSize);
-        BlockTree notSyncedTree = new(
-            treeBuilder.BlocksDb,
-            treeBuilder.HeadersDb,
-            treeBuilder.BlockInfoDb,
-            treeBuilder.MetadataDb,
-            treeBuilder.ChainLevelInfoRepository,
-            MainnetSpecProvider.Instance,
-            NullBloomStorage.Instance,
-            new SyncConfig(),
-            LimboLogs.Instance);
 
-        BlockTreeBuilder syncedTreeBuilder = Build.A.BlockTree(genesisBlock, specProvider).OfChainLength(syncedTreeSize);
-        BlockTree syncedTree = new(
-            syncedTreeBuilder.BlocksDb,
-            syncedTreeBuilder.HeadersDb,
-            syncedTreeBuilder.BlockInfoDb,
-            syncedTreeBuilder.MetadataDb,
-            syncedTreeBuilder.ChainLevelInfoRepository,
-            specProvider,
-            NullBloomStorage.Instance,
-            new SyncConfig(),
-            LimboLogs.Instance);
+        BlockTreeBuilder treeBuilder = Build.A.BlockTree(genesisBlock, specProvider).OfChainLength(notSyncedTreeSize);
+        BlockTree notSyncedTree = Build.A.BlockTree()
+            .WithDatabaseFrom(treeBuilder)
+            .TestObject;
+
+        BlockTree syncedTree = Build.A.BlockTree(genesisBlock, specProvider)
+            .OfChainLength(syncedTreeSize)
+            .WithNoHead
+            .TestObject;
 
         return (notSyncedTree, syncedTree);
     }
@@ -69,17 +55,9 @@ public partial class BlockTreeTests
         Block genesisBlock = Build.A.Block.WithNumber(0).TestObject;
         TestSpecProvider specProvider = new(London.Instance);
         specProvider.TerminalTotalDifficulty = 0;
+
         BlockTreeBuilder treeBuilder = Build.A.BlockTree(genesisBlock, specProvider).OfChainLength(10);
-        BlockTree tree = new(
-            treeBuilder.BlocksDb,
-            treeBuilder.HeadersDb,
-            treeBuilder.BlockInfoDb,
-            treeBuilder.MetadataDb,
-            treeBuilder.ChainLevelInfoRepository,
-            MainnetSpecProvider.Instance,
-            NullBloomStorage.Instance,
-            new SyncConfig(),
-            LimboLogs.Instance);
+        BlockTree tree = Build.A.BlockTree().WithDatabaseFrom(treeBuilder).WithNoHead.BlockTree;
 
         Assert.That(tree.BestKnownNumber, Is.EqualTo(9));
         Assert.That(tree.BestSuggestedBody!.Number, Is.EqualTo(9));
@@ -92,17 +70,10 @@ public partial class BlockTreeTests
         // every block has difficulty 1000000, block 9 TD: 10000000
         TestSpecProvider specProvider = new(London.Instance);
         specProvider.TerminalTotalDifficulty = (UInt256)9999900;
-        BlockTreeBuilder treeBuilder = Build.A.BlockTree().OfChainLength(10);
-        BlockTree tree = new(
-            treeBuilder.BlocksDb,
-            treeBuilder.HeadersDb,
-            treeBuilder.BlockInfoDb,
-            treeBuilder.MetadataDb,
-            treeBuilder.ChainLevelInfoRepository,
-            specProvider,
-            NullBloomStorage.Instance,
-            new SyncConfig(),
-            LimboLogs.Instance);
+
+        BlockTree tree = Build.A.BlockTree().OfChainLength(10)
+            .WithSpecProvider(specProvider)
+            .TestObject;
         PoSSwitcher poSSwitcher = new(new MergeConfig(), new SyncConfig(), new MemDb(), tree, specProvider, LimboLogs.Instance);
 
         Block? block8 = tree.FindBlock(8, BlockTreeLookupOptions.None);
@@ -118,17 +89,9 @@ public partial class BlockTreeTests
     {
         TestSpecProvider specProvider = new(London.Instance);
         specProvider.TerminalTotalDifficulty = (UInt256)9999900;
-        BlockTreeBuilder treeBuilder = Build.A.BlockTree().OfChainLength(10);
-        BlockTree tree = new(
-            treeBuilder.BlocksDb,
-            treeBuilder.HeadersDb,
-            treeBuilder.BlockInfoDb,
-            treeBuilder.MetadataDb,
-            treeBuilder.ChainLevelInfoRepository,
-            specProvider,
-            NullBloomStorage.Instance,
-            new SyncConfig(),
-            LimboLogs.Instance);
+        BlockTree tree = Build.A.BlockTree().OfChainLength(10)
+            .WithSpecProvider(specProvider)
+            .TestObject;
         PoSSwitcher poSSwitcher = new(new MergeConfig(), new SyncConfig(), new MemDb(), tree, specProvider, LimboLogs.Instance);
 
         Block? block7 = tree.FindBlock(7, BlockTreeLookupOptions.None);
@@ -152,17 +115,12 @@ public partial class BlockTreeTests
         // every block has difficulty 1000000, block 9 TD: 10000000
         TestSpecProvider specProvider = new(London.Instance);
         specProvider.TerminalTotalDifficulty = (UInt256)9999900;
-        BlockTreeBuilder treeBuilder = Build.A.BlockTree().OfChainLength(10);
-        BlockTree tree = new(
-            treeBuilder.BlocksDb,
-            treeBuilder.HeadersDb,
-            treeBuilder.BlockInfoDb,
-            treeBuilder.MetadataDb,
-            treeBuilder.ChainLevelInfoRepository,
-            specProvider,
-            NullBloomStorage.Instance,
-            new SyncConfig(),
-            LimboLogs.Instance);
+
+        BlockTree tree = Build.A.BlockTree()
+            .WithSpecProvider(specProvider)
+            .OfChainLength(10)
+            .TestObject;
+
         PoSSwitcher poSSwitcher = new(new MergeConfig(), new SyncConfig(), new MemDb(), tree, specProvider, LimboLogs.Instance);
 
         Block? block8 = tree.FindBlock(8, BlockTreeLookupOptions.None);
@@ -309,31 +267,19 @@ public partial class BlockTreeTests
             {
                 TestSpecProvider testSpecProvider = new TestSpecProvider(London.Instance);
                 if (ttd is not null) testSpecProvider.TerminalTotalDifficulty = ttd;
-                NotSyncedTreeBuilder = Build.A.BlockTree().OfChainLength(notSyncedTreeSize, splitVariant: splitVariant, splitFrom: splitFrom);
-                NotSyncedTree = new(
-                    NotSyncedTreeBuilder.BlocksDb,
-                    NotSyncedTreeBuilder.HeadersDb,
-                    NotSyncedTreeBuilder.BlockInfoDb,
-                    NotSyncedTreeBuilder.MetadataDb,
-                    NotSyncedTreeBuilder.ChainLevelInfoRepository,
-                    testSpecProvider,
-                    NullBloomStorage.Instance,
-                    new SyncConfig(),
-                    LimboLogs.Instance);
+
+                NotSyncedTreeBuilder = Build.A.BlockTree()
+                    .OfChainLength(notSyncedTreeSize, splitVariant: splitVariant, splitFrom: splitFrom)
+                    .WithSpecProvider(testSpecProvider);
+                NotSyncedTree = NotSyncedTreeBuilder.TestObject;
 
                 if (syncedTreeSize > 0)
                 {
-                    _syncedTreeBuilder = Build.A.BlockTree().OfChainLength(syncedTreeSize, splitVariant: syncedSplitVariant, splitFrom: syncedSplitFrom);
-                    SyncedTree = new(
-                        _syncedTreeBuilder.BlocksDb,
-                        _syncedTreeBuilder.HeadersDb,
-                        _syncedTreeBuilder.BlockInfoDb,
-                        _syncedTreeBuilder.MetadataDb,
-                        _syncedTreeBuilder.ChainLevelInfoRepository,
-                        testSpecProvider,
-                        NullBloomStorage.Instance,
-                        new SyncConfig(),
-                        LimboLogs.Instance);
+                    _syncedTreeBuilder = Build.A.BlockTree()
+                        .OfChainLength(syncedTreeSize, splitVariant: syncedSplitVariant, splitFrom: syncedSplitFrom)
+                        .WithSpecProvider(testSpecProvider);
+
+                    SyncedTree = _syncedTreeBuilder.TestObject;
                 }
 
                 _beaconPivot = new BeaconPivot(new SyncConfig(), new MemDb(), SyncedTree, LimboLogs.Instance);
@@ -523,16 +469,10 @@ public partial class BlockTreeTests
 
             public ScenarioBuilder Restart()
             {
-                NotSyncedTree = new(
-                    NotSyncedTreeBuilder!.BlocksDb,
-                    NotSyncedTreeBuilder.HeadersDb,
-                    NotSyncedTreeBuilder.BlockInfoDb,
-                    NotSyncedTreeBuilder.MetadataDb,
-                    NotSyncedTreeBuilder.ChainLevelInfoRepository,
-                    MainnetSpecProvider.Instance,
-                    NullBloomStorage.Instance,
-                    new SyncConfig(),
-                    LimboLogs.Instance);
+                NotSyncedTree = Build.A.BlockTree()
+                    .WithNoHead
+                    .WithDatabaseFrom(NotSyncedTreeBuilder)
+                    .TestObject;
                 _chainLevelHelper = new ChainLevelHelper(NotSyncedTree, _beaconPivot!, new SyncConfig(), LimboLogs.Instance);
                 return this;
             }
@@ -846,17 +786,9 @@ public partial class BlockTreeTests
     [Test]
     public void MarkChainAsProcessed_does_not_change_main_chain()
     {
-        BlockTreeBuilder blockTreeBuilder = Build.A.BlockTree().OfChainLength(9);
-        BlockTree blockTree = new(
-            blockTreeBuilder.BlocksDb,
-            blockTreeBuilder.HeadersDb,
-            blockTreeBuilder.BlockInfoDb,
-            blockTreeBuilder.MetadataDb,
-            blockTreeBuilder.ChainLevelInfoRepository,
-            MainnetSpecProvider.Instance,
-            NullBloomStorage.Instance,
-            new SyncConfig(),
-            LimboLogs.Instance);
+        BlockTree blockTree = Build.A.BlockTree()
+            .OfChainLength(9)
+            .TestObject;
         Block? parentBlock = blockTree.FindBlock(8, BlockTreeLookupOptions.None);
         Block newBlock = Build.A.Block.WithHeader(Build.A.BlockHeader.WithParent(parentBlock!.Header).TestObject).TestObject;
         AddBlockResult addBlockResult = blockTree.SuggestBlock(newBlock);

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/BlockTreeTests.cs
@@ -43,7 +43,7 @@ public partial class BlockTreeTests
 
         BlockTree syncedTree = Build.A.BlockTree(genesisBlock, specProvider)
             .OfChainLength(syncedTreeSize)
-            .WithNoHead
+            .WithoutSettingHead
             .TestObject;
 
         return (notSyncedTree, syncedTree);
@@ -57,7 +57,7 @@ public partial class BlockTreeTests
         specProvider.TerminalTotalDifficulty = 0;
 
         BlockTreeBuilder treeBuilder = Build.A.BlockTree(genesisBlock, specProvider).OfChainLength(10);
-        BlockTree tree = Build.A.BlockTree().WithDatabaseFrom(treeBuilder).WithNoHead.BlockTree;
+        BlockTree tree = Build.A.BlockTree().WithDatabaseFrom(treeBuilder).WithoutSettingHead.BlockTree;
 
         Assert.That(tree.BestKnownNumber, Is.EqualTo(9));
         Assert.That(tree.BestSuggestedBody!.Number, Is.EqualTo(9));
@@ -470,7 +470,7 @@ public partial class BlockTreeTests
             public ScenarioBuilder Restart()
             {
                 NotSyncedTree = Build.A.BlockTree()
-                    .WithNoHead
+                    .WithoutSettingHead
                     .WithDatabaseFrom(NotSyncedTreeBuilder)
                     .TestObject;
                 _chainLevelHelper = new ChainLevelHelper(NotSyncedTree, _beaconPivot!, new SyncConfig(), LimboLogs.Instance);

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/BeaconHeadersSyncTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/BeaconHeadersSyncTests.cs
@@ -43,9 +43,10 @@ public class BeaconHeadersSyncTests
             {
                 if (_blockTree is null)
                 {
-                    IDb blockInfoDb = new MemDb();
                     Block genesis = Build.A.Block.Genesis.TestObject;
-                    _blockTree = new BlockTree(new MemDb(), new MemDb(), blockInfoDb, new ChainLevelInfoRepository(blockInfoDb), MainnetSpecProvider.Instance, NullBloomStorage.Instance, LimboLogs.Instance);
+                    _blockTree = Build.A.BlockTree()
+                        .WithNoHead
+                        .TestObject;
                     _blockTree.SuggestBlock(genesis);
                     _blockTree.UpdateMainChain(new[] { genesis }, true); // MSMS do validity check on this
                 }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/BeaconHeadersSyncTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/BeaconHeadersSyncTests.cs
@@ -45,7 +45,7 @@ public class BeaconHeadersSyncTests
                 {
                     Block genesis = Build.A.Block.Genesis.TestObject;
                     _blockTree = Build.A.BlockTree()
-                        .WithNoHead
+                        .WithoutSettingHead
                         .TestObject;
                     _blockTree.SuggestBlock(genesis);
                     _blockTree.UpdateMainChain(new[] { genesis }, true); // MSMS do validity check on this

--- a/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/Migrations/ReceiptMigrationTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/Migrations/ReceiptMigrationTests.cs
@@ -46,7 +46,7 @@ namespace Nethermind.Runner.Test.Ethereum.Steps.Migrations
 
             BlockTreeBuilder blockTreeBuilder = Core.Test.Builders.Build.A.BlockTree().OfChainLength(chainLength);
             IBlockTree blockTree = blockTreeBuilder.TestObject;
-            ChainLevelInfoRepository chainLevelInfoRepository = blockTreeBuilder.ChainLevelInfoRepository;
+            IChainLevelInfoRepository chainLevelInfoRepository = blockTreeBuilder.ChainLevelInfoRepository;
 
             InMemoryReceiptStorage inMemoryReceiptStorage = new(true) { MigratedBlockNumber = currentMigratedBlockNumber };
             InMemoryReceiptStorage outMemoryReceiptStorage = new(true) { MigratedBlockNumber = currentMigratedBlockNumber };

--- a/src/Nethermind/Nethermind.State/Repositories/ChainLevelInfoRepository.cs
+++ b/src/Nethermind/Nethermind.State/Repositories/ChainLevelInfoRepository.cs
@@ -18,11 +18,6 @@ namespace Nethermind.State.Repositories
 
         private readonly IDb _blockInfoDb;
 
-        public ChainLevelInfoRepository(IDbProvider dbProvider)
-            : this(dbProvider.BlockInfosDb)
-        {
-        }
-
         public ChainLevelInfoRepository(IDb blockInfoDb)
         {
             _blockInfoDb = blockInfoDb ?? throw new ArgumentNullException(nameof(blockInfoDb));

--- a/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.Merge.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.Merge.cs
@@ -434,8 +434,8 @@ public partial class BlockDownloaderTests
 
         public override IBlockTree BlockTree => _blockTreeScenario?.NotSyncedTree ?? base.BlockTree;
 
-        private MemDb? _metadataDb;
-        private MemDb MetadataDb => (_metadataDb ?? _blockTreeScenario?.NotSyncedTreeBuilder.MetadataDb) ?? (_metadataDb ??= new MemDb());
+        private IDb? _metadataDb;
+        private IDb MetadataDb => (_metadataDb ?? _blockTreeScenario?.NotSyncedTreeBuilder.MetadataDb) ?? (_metadataDb ??= new MemDb());
 
         private MergeConfig? _mergeConfig;
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
@@ -928,7 +928,11 @@ namespace Nethermind.Synchronization.Test
                 {
                     if (_blockTree is null)
                     {
-                        _blockTree = new BlockTree(new MemDb(), new MemDb(), _blockInfoDb, new ChainLevelInfoRepository(_blockInfoDb), SpecProvider, NullBloomStorage.Instance, LimboLogs.Instance);
+                        _blockTree = Build.A.BlockTree()
+                            .WithNoHead
+                            .WithSpecProvider(SpecProvider)
+                            .WithBlockInfoDb(_blockInfoDb)
+                            .TestObject;
                         _blockTree.SuggestBlock(_genesis);
                     }
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
@@ -929,7 +929,7 @@ namespace Nethermind.Synchronization.Test
                     if (_blockTree is null)
                     {
                         _blockTree = Build.A.BlockTree()
-                            .WithNoHead
+                            .WithoutSettingHead
                             .WithSpecProvider(SpecProvider)
                             .WithBlockInfoDb(_blockInfoDb)
                             .TestObject;

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/FastHeadersSyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/FastHeadersSyncTests.cs
@@ -14,11 +14,7 @@ using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Test.Builders;
-using Nethermind.Db;
-using Nethermind.Db.Blooms;
 using Nethermind.Logging;
-using Nethermind.Specs;
-using Nethermind.State.Repositories;
 using Nethermind.Stats.Model;
 using Nethermind.Synchronization.FastBlocks;
 using Nethermind.Synchronization.ParallelSync;
@@ -35,17 +31,9 @@ namespace Nethermind.Synchronization.Test.FastBlocks
     public class FastHeadersSyncTests
     {
         [Test]
-        public async Task Will_fail_if_launched_without_fast_blocks_enabled()
+        public Task Will_fail_if_launched_without_fast_blocks_enabled()
         {
-            IDbProvider memDbProvider = await TestMemDbProvider.InitAsync();
-            BlockTree blockTree = new(
-                blockDb: memDbProvider.BlocksDb,
-                headerDb: memDbProvider.HeadersDb,
-                blockInfoDb: memDbProvider.BlockInfosDb,
-                chainLevelInfoRepository: new ChainLevelInfoRepository(memDbProvider.BlockInfosDb),
-                specProvider: MainnetSpecProvider.Instance,
-                bloomStorage: NullBloomStorage.Instance,
-                logManager: LimboLogs.Instance);
+            BlockTree blockTree = Build.A.BlockTree().WithNoHead.TestObject;
 
             Assert.Throws<InvalidOperationException>(() =>
             {
@@ -57,20 +45,15 @@ namespace Nethermind.Synchronization.Test.FastBlocks
                     syncReport: Substitute.For<ISyncReport>(),
                     logManager: LimboLogs.Instance);
             });
+
+            return Task.CompletedTask;
         }
 
         [Test]
         public async Task Can_prepare_3_requests_in_a_row()
         {
-            IDbProvider memDbProvider = await TestMemDbProvider.InitAsync();
-            BlockTree blockTree = new(
-                blockDb: memDbProvider.BlocksDb,
-                headerDb: memDbProvider.HeadersDb,
-                blockInfoDb: memDbProvider.BlockInfosDb,
-                chainLevelInfoRepository: new ChainLevelInfoRepository(memDbProvider.BlockInfosDb),
-                specProvider: MainnetSpecProvider.Instance,
-                bloomStorage: NullBloomStorage.Instance,
-                logManager: LimboLogs.Instance);
+            BlockTree blockTree = Build.A.BlockTree().WithNoHead.TestObject;
+
             HeadersSyncFeed feed = new(
                 syncModeSelector: Substitute.For<ISyncModeSelector>(),
                 blockTree: blockTree,
@@ -94,10 +77,8 @@ namespace Nethermind.Synchronization.Test.FastBlocks
         [Test]
         public async Task When_next_header_hash_update_is_delayed_do_not_drop_peer()
         {
-            IDbProvider memDbProvider = await TestMemDbProvider.InitAsync();
             BlockTree remoteBlockTree = Build.A.BlockTree().OfHeadersOnly.OfChainLength(1001).TestObject;
-
-            BlockTree blockTree = new(memDbProvider.BlocksDb, memDbProvider.HeadersDb, memDbProvider.BlockInfosDb, new ChainLevelInfoRepository(memDbProvider.BlockInfosDb), MainnetSpecProvider.Instance, NullBloomStorage.Instance, LimboLogs.Instance);
+            BlockTree blockTree = Build.A.BlockTree().WithNoHead.TestObject;
 
             ISyncReport syncReport = Substitute.For<ISyncReport>();
             syncReport.FastBlocksHeaders.Returns(new MeasuredProgress());
@@ -162,10 +143,8 @@ namespace Nethermind.Synchronization.Test.FastBlocks
         [Test]
         public async Task Can_prepare_several_request_and_ignore_request_from_previous_sequence()
         {
-            IDbProvider memDbProvider = await TestMemDbProvider.InitAsync();
             BlockTree remoteBlockTree = Build.A.BlockTree().OfHeadersOnly.OfChainLength(501).TestObject;
-
-            BlockTree blockTree = new(memDbProvider.BlocksDb, memDbProvider.HeadersDb, memDbProvider.BlockInfosDb, new ChainLevelInfoRepository(memDbProvider.BlockInfosDb), MainnetSpecProvider.Instance, NullBloomStorage.Instance, LimboLogs.Instance);
+            BlockTree blockTree = Build.A.BlockTree().WithNoHead.TestObject;
 
             ISyncReport syncReport = Substitute.For<ISyncReport>();
             syncReport.FastBlocksHeaders.Returns(new MeasuredProgress());
@@ -213,17 +192,8 @@ namespace Nethermind.Synchronization.Test.FastBlocks
         [Test]
         public async Task Will_dispatch_when_only_partially_processed_dependency()
         {
-            IDbProvider memDbProvider = await TestMemDbProvider.InitAsync();
             BlockTree remoteBlockTree = Build.A.BlockTree().OfHeadersOnly.OfChainLength(2001).TestObject;
-
-            BlockTree blockTree = new(
-                blockDb: memDbProvider.BlocksDb,
-                headerDb: memDbProvider.HeadersDb,
-                blockInfoDb: memDbProvider.BlockInfosDb,
-                chainLevelInfoRepository: new ChainLevelInfoRepository(memDbProvider.BlockInfosDb),
-                specProvider: MainnetSpecProvider.Instance,
-                bloomStorage: NullBloomStorage.Instance,
-                logManager: LimboLogs.Instance);
+            BlockTree blockTree = Build.A.BlockTree().WithNoHead.TestObject;
 
             ISyncReport syncReport = Substitute.For<ISyncReport>();
             syncReport.FastBlocksHeaders.Returns(new MeasuredProgress());
@@ -291,17 +261,9 @@ namespace Nethermind.Synchronization.Test.FastBlocks
         [Test]
         public async Task Can_reset_and_not_hang_when_a_batch_is_processing()
         {
-            IDbProvider memDbProvider = await TestMemDbProvider.InitAsync();
             BlockTree remoteBlockTree = Build.A.BlockTree().OfHeadersOnly.OfChainLength(501).TestObject;
 
-            BlockTree blockTree = new(
-                blockDb: memDbProvider.BlocksDb,
-                headerDb: memDbProvider.HeadersDb,
-                blockInfoDb: memDbProvider.BlockInfosDb,
-                chainLevelInfoRepository: new ChainLevelInfoRepository(memDbProvider.BlockInfosDb),
-                specProvider: MainnetSpecProvider.Instance,
-                bloomStorage: NullBloomStorage.Instance,
-                logManager: LimboLogs.Instance);
+            BlockTree blockTree = Build.A.BlockTree().WithNoHead.TestObject;
 
             ISyncReport syncReport = Substitute.For<ISyncReport>();
             syncReport.FastBlocksHeaders.Returns(new MeasuredProgress());
@@ -365,15 +327,7 @@ namespace Nethermind.Synchronization.Test.FastBlocks
         [Test]
         public async Task Can_keep_returning_nulls_after_all_batches_were_prepared()
         {
-            IDbProvider memDbProvider = await TestMemDbProvider.InitAsync();
-            BlockTree blockTree = new(
-                blockDb: memDbProvider.BlocksDb,
-                headerDb: memDbProvider.HeadersDb,
-                blockInfoDb: memDbProvider.BlockInfosDb,
-                chainLevelInfoRepository: new ChainLevelInfoRepository(memDbProvider.BlockInfosDb),
-                specProvider: MainnetSpecProvider.Instance,
-                bloomStorage: NullBloomStorage.Instance,
-                logManager: LimboLogs.Instance);
+            BlockTree blockTree = Build.A.BlockTree().WithNoHead.TestObject;
             HeadersSyncFeed feed = new(
                 syncModeSelector: Substitute.For<ISyncModeSelector>(),
                 blockTree: blockTree,

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/FastHeadersSyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/FastHeadersSyncTests.cs
@@ -33,7 +33,7 @@ namespace Nethermind.Synchronization.Test.FastBlocks
         [Test]
         public Task Will_fail_if_launched_without_fast_blocks_enabled()
         {
-            BlockTree blockTree = Build.A.BlockTree().WithNoHead.TestObject;
+            BlockTree blockTree = Build.A.BlockTree().WithoutSettingHead.TestObject;
 
             Assert.Throws<InvalidOperationException>(() =>
             {
@@ -52,7 +52,7 @@ namespace Nethermind.Synchronization.Test.FastBlocks
         [Test]
         public async Task Can_prepare_3_requests_in_a_row()
         {
-            BlockTree blockTree = Build.A.BlockTree().WithNoHead.TestObject;
+            BlockTree blockTree = Build.A.BlockTree().WithoutSettingHead.TestObject;
 
             HeadersSyncFeed feed = new(
                 syncModeSelector: Substitute.For<ISyncModeSelector>(),
@@ -78,7 +78,7 @@ namespace Nethermind.Synchronization.Test.FastBlocks
         public async Task When_next_header_hash_update_is_delayed_do_not_drop_peer()
         {
             BlockTree remoteBlockTree = Build.A.BlockTree().OfHeadersOnly.OfChainLength(1001).TestObject;
-            BlockTree blockTree = Build.A.BlockTree().WithNoHead.TestObject;
+            BlockTree blockTree = Build.A.BlockTree().WithoutSettingHead.TestObject;
 
             ISyncReport syncReport = Substitute.For<ISyncReport>();
             syncReport.FastBlocksHeaders.Returns(new MeasuredProgress());
@@ -144,7 +144,7 @@ namespace Nethermind.Synchronization.Test.FastBlocks
         public async Task Can_prepare_several_request_and_ignore_request_from_previous_sequence()
         {
             BlockTree remoteBlockTree = Build.A.BlockTree().OfHeadersOnly.OfChainLength(501).TestObject;
-            BlockTree blockTree = Build.A.BlockTree().WithNoHead.TestObject;
+            BlockTree blockTree = Build.A.BlockTree().WithoutSettingHead.TestObject;
 
             ISyncReport syncReport = Substitute.For<ISyncReport>();
             syncReport.FastBlocksHeaders.Returns(new MeasuredProgress());
@@ -193,7 +193,7 @@ namespace Nethermind.Synchronization.Test.FastBlocks
         public async Task Will_dispatch_when_only_partially_processed_dependency()
         {
             BlockTree remoteBlockTree = Build.A.BlockTree().OfHeadersOnly.OfChainLength(2001).TestObject;
-            BlockTree blockTree = Build.A.BlockTree().WithNoHead.TestObject;
+            BlockTree blockTree = Build.A.BlockTree().WithoutSettingHead.TestObject;
 
             ISyncReport syncReport = Substitute.For<ISyncReport>();
             syncReport.FastBlocksHeaders.Returns(new MeasuredProgress());
@@ -263,7 +263,7 @@ namespace Nethermind.Synchronization.Test.FastBlocks
         {
             BlockTree remoteBlockTree = Build.A.BlockTree().OfHeadersOnly.OfChainLength(501).TestObject;
 
-            BlockTree blockTree = Build.A.BlockTree().WithNoHead.TestObject;
+            BlockTree blockTree = Build.A.BlockTree().WithoutSettingHead.TestObject;
 
             ISyncReport syncReport = Substitute.For<ISyncReport>();
             syncReport.FastBlocksHeaders.Returns(new MeasuredProgress());
@@ -327,7 +327,7 @@ namespace Nethermind.Synchronization.Test.FastBlocks
         [Test]
         public async Task Can_keep_returning_nulls_after_all_batches_were_prepared()
         {
-            BlockTree blockTree = Build.A.BlockTree().WithNoHead.TestObject;
+            BlockTree blockTree = Build.A.BlockTree().WithoutSettingHead.TestObject;
             HeadersSyncFeed feed = new(
                 syncModeSelector: Substitute.For<ISyncModeSelector>(),
                 blockTree: blockTree,

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncThreadTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncThreadTests.cs
@@ -27,9 +27,7 @@ using Nethermind.Logging;
 using Nethermind.Specs;
 using Nethermind.Specs.Forks;
 using Nethermind.State;
-using Nethermind.State.Repositories;
 using Nethermind.Stats;
-using Nethermind.Db.Blooms;
 using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Synchronization.Blocks;
 using Nethermind.Synchronization.ParallelSync;
@@ -248,9 +246,6 @@ namespace Nethermind.Synchronization.Test
                 new(ConstantinopleFix.Instance, MainnetSpecProvider.Instance.NetworkId, MainnetSpecProvider.Instance.ChainId);
 
             IDbProvider dbProvider = TestMemDbProvider.Init();
-            IDb blockDb = dbProvider.BlocksDb;
-            IDb headerDb = dbProvider.HeadersDb;
-            IDb blockInfoDb = dbProvider.BlockInfosDb;
             IDb codeDb = dbProvider.CodeDb;
             IDb stateDb = dbProvider.StateDb;
 
@@ -265,8 +260,7 @@ namespace Nethermind.Synchronization.Test
             InMemoryReceiptStorage receiptStorage = new();
 
             EthereumEcdsa ecdsa = new(specProvider.ChainId, logManager);
-            BlockTree tree = new(blockDb, headerDb, blockInfoDb, new ChainLevelInfoRepository(blockInfoDb),
-                specProvider, NullBloomStorage.Instance, logManager);
+            BlockTree tree = Build.A.BlockTree().WithNoHead.TestObject;
             ITransactionComparerProvider transactionComparerProvider =
                 new TransactionComparerProvider(specProvider, tree);
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncThreadTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncThreadTests.cs
@@ -260,7 +260,7 @@ namespace Nethermind.Synchronization.Test
             InMemoryReceiptStorage receiptStorage = new();
 
             EthereumEcdsa ecdsa = new(specProvider.ChainId, logManager);
-            BlockTree tree = Build.A.BlockTree().WithNoHead.TestObject;
+            BlockTree tree = Build.A.BlockTree().WithoutSettingHead.TestObject;
             ITransactionComparerProvider transactionComparerProvider =
                 new TransactionComparerProvider(specProvider, tree);
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
@@ -309,10 +309,8 @@ namespace Nethermind.Synchronization.Test
                 IDbProvider dbProvider = TestMemDbProvider.Init();
                 IDb stateDb = new MemDb();
                 IDb codeDb = dbProvider.CodeDb;
-                MemDb blockInfoDb = new();
-                BlockTree = new BlockTree(new MemDb(), new MemDb(), blockInfoDb,
-                    new ChainLevelInfoRepository(blockInfoDb),
-                    new TestSingleReleaseSpecProvider(Constantinople.Instance), NullBloomStorage.Instance, _logManager);
+                BlockTree = Build.A.BlockTree().WithNoHead.TestObject;
+
                 ITimerFactory timerFactory = Substitute.For<ITimerFactory>();
                 NodeStatsManager stats = new(timerFactory, _logManager);
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
@@ -309,7 +309,10 @@ namespace Nethermind.Synchronization.Test
                 IDbProvider dbProvider = TestMemDbProvider.Init();
                 IDb stateDb = new MemDb();
                 IDb codeDb = dbProvider.CodeDb;
-                BlockTree = Build.A.BlockTree().WithoutSettingHead.TestObject;
+                BlockTree = Build.A.BlockTree()
+                    .WithSpecProvider(new TestSingleReleaseSpecProvider(Constantinople.Instance))
+                    .WithoutSettingHead
+                    .TestObject;
 
                 ITimerFactory timerFactory = Substitute.For<ITimerFactory>();
                 NodeStatsManager stats = new(timerFactory, _logManager);

--- a/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
@@ -309,7 +309,7 @@ namespace Nethermind.Synchronization.Test
                 IDbProvider dbProvider = TestMemDbProvider.Init();
                 IDb stateDb = new MemDb();
                 IDb codeDb = dbProvider.CodeDb;
-                BlockTree = Build.A.BlockTree().WithNoHead.TestObject;
+                BlockTree = Build.A.BlockTree().WithoutSettingHead.TestObject;
 
                 ITimerFactory timerFactory = Substitute.For<ITimerFactory>();
                 NodeStatsManager stats = new(timerFactory, _logManager);


### PR DESCRIPTION
- Remove three BlockTree constructor, keeping only one.
- Always use BlockTreeBuilder to make BlockTree in unit tests.
- Reduce changes needed to change blocktree.

## Types of changes

#### What types of changes does your code introduce?

- [X] Refactoring

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No
