### PR TITLE
Perf/prefix headers key with blocknumber

### DIFF
--- a/src/Nethermind/Nethermind.AuRa.Test/Validators/ReportingContractBasedValidatorTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/Validators/ReportingContractBasedValidatorTests.cs
@@ -77,7 +77,7 @@ namespace Nethermind.AuRa.Test.Validators
                 .ShouldValidatorReport(Arg.Is<BlockHeader>(h => h.Number == blockNumber - 1), NodeAddress, MaliciousMinerAddress, Arg.Any<UInt256>())
                 .Returns(0 < validatorsToReport, Enumerable.Range(1, 15).Select(i => i < validatorsToReport).ToArray());
 
-            context.ContractBasedValidator.BlockTree.FindHeader(Arg.Any<Keccak>(), BlockTreeLookupOptions.None)
+            context.ContractBasedValidator.BlockTree.FindHeader(Arg.Any<Keccak>(), BlockTreeLookupOptions.None, blockNumber: Arg.Any<long>())
                 .Returns(Build.A.BlockHeader.WithNumber(blockNumber - 1).TestObject);
 
             bool isPosDao = blockNumber >= context.PosdaoTransition;

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockFinderExtensionsTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockFinderExtensionsTests.cs
@@ -23,8 +23,8 @@ namespace Nethermind.Blockchain.Test
             parent.TotalDifficulty.Should().BeNull(); // just to avoid the testing rig change without this test being updated
 
             IBlockFinder blockFinder = Substitute.For<IBlockFinder>();
-            blockFinder.FindHeader(child.ParentHash!, BlockTreeLookupOptions.TotalDifficultyNotNeeded).Returns(parent);
-            blockFinder.FindHeader(child.ParentHash!, BlockTreeLookupOptions.None).Returns(parentWithTotalDiff);
+            blockFinder.FindHeader(child.ParentHash!, BlockTreeLookupOptions.TotalDifficultyNotNeeded, blockNumber: child.Number-1).Returns(parent);
+            blockFinder.FindHeader(child.ParentHash!, BlockTreeLookupOptions.None, blockNumber: child.Number-1).Returns(parentWithTotalDiff);
 
             blockFinder.FindParentHeader(child, BlockTreeLookupOptions.TotalDifficultyNotNeeded).Should().Be(parent);
             blockFinder.FindParentHeader(child, BlockTreeLookupOptions.None)!.TotalDifficulty.Should().Be((UInt256?)UInt256.One);

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockFinderExtensionsTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockFinderExtensionsTests.cs
@@ -23,8 +23,8 @@ namespace Nethermind.Blockchain.Test
             parent.TotalDifficulty.Should().BeNull(); // just to avoid the testing rig change without this test being updated
 
             IBlockFinder blockFinder = Substitute.For<IBlockFinder>();
-            blockFinder.FindHeader(child.ParentHash!, BlockTreeLookupOptions.TotalDifficultyNotNeeded, blockNumber: child.Number-1).Returns(parent);
-            blockFinder.FindHeader(child.ParentHash!, BlockTreeLookupOptions.None, blockNumber: child.Number-1).Returns(parentWithTotalDiff);
+            blockFinder.FindHeader(child.ParentHash!, BlockTreeLookupOptions.TotalDifficultyNotNeeded, blockNumber: child.Number - 1).Returns(parent);
+            blockFinder.FindHeader(child.ParentHash!, BlockTreeLookupOptions.None, blockNumber: child.Number - 1).Returns(parentWithTotalDiff);
 
             blockFinder.FindParentHeader(child, BlockTreeLookupOptions.TotalDifficultyNotNeeded).Should().Be(parent);
             blockFinder.FindParentHeader(child, BlockTreeLookupOptions.None)!.TotalDifficulty.Should().Be((UInt256?)UInt256.One);

--- a/src/Nethermind/Nethermind.Blockchain.Test/Blocks/HeaderStoreTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Blocks/HeaderStoreTests.cs
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using FluentAssertions;
+using Nethermind.Blockchain.Headers;
+using Nethermind.Core;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Db;
+using Nethermind.Serialization.Rlp;
+using NUnit.Framework;
+
+namespace Nethermind.Blockchain.Test.Blocks;
+
+public class HeaderStoreTests
+{
+
+    [Test]
+    public void TestCanStoreAndGetHeader()
+    {
+        HeaderStore store = new(new MemDb(), new MemDb());
+
+        BlockHeader header = Build.A.BlockHeader.WithNumber(100).TestObject;
+        BlockHeader header2 = Build.A.BlockHeader.WithNumber(102).TestObject;
+
+        store.Get(header.Hash!).Should().BeNull();
+        store.Get(header2.Hash!).Should().BeNull();
+
+        store.Store(header);
+        store.Get(header.Hash!)!.Hash.Should().Be(header.Hash!);
+        store.Get(header2.Hash!).Should().BeNull();
+
+        store.Store(header2);
+        store.Get(header.Hash!)!.Hash.Should().Be(header.Hash!);
+        store.Get(header2.Hash!)!.Hash.Should().Be(header2.Hash!);
+    }
+
+    [Test]
+    public void TestCanReadHeaderStoredWithHash()
+    {
+        IDb headerDb = new MemDb();
+        HeaderStore store = new(headerDb, new MemDb());
+
+        BlockHeader header = Build.A.BlockHeader.WithNumber(100).TestObject;
+        headerDb.Set(header.Hash!, new HeaderDecoder().Encode(header).Bytes);
+
+        store.Get(header.Hash!)!.Hash.Should().Be(header.Hash!);
+    }
+
+    [Test]
+    public void TestCanReadCacheHeader()
+    {
+        HeaderStore store = new(new MemDb(), new MemDb());
+
+        BlockHeader header = Build.A.BlockHeader.WithNumber(100).TestObject;
+        store.Cache(header);
+        store.Get(header.Hash!)!.Hash.Should().Be(header.Hash!);
+    }
+
+    [Test]
+    public void TestCanDeleteHeader()
+    {
+        HeaderStore store = new(new MemDb(), new MemDb());
+        BlockHeader header = Build.A.BlockHeader.WithNumber(100).TestObject;
+        store.Store(header);
+        store.Delete(header.Hash!);
+
+        store.Get(header.Hash!).Should().BeNull();
+    }
+
+    [Test]
+    public void TestCanDeleteHeaderStoredWithHash()
+    {
+        IDb headerDb = new MemDb();
+        HeaderStore store = new(headerDb, new MemDb());
+
+        BlockHeader header = Build.A.BlockHeader.WithNumber(100).TestObject;
+        headerDb.Set(header.Hash!, new HeaderDecoder().Encode(header).Bytes);
+
+        store.Delete(header.Hash!);
+        store.Get(header.Hash!)!.Should().BeNull();
+    }
+
+}

--- a/src/Nethermind/Nethermind.Blockchain.Test/Blocks/HeaderStoreTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Blocks/HeaderStoreTests.cs
@@ -25,12 +25,12 @@ public class HeaderStoreTests
         store.Get(header.Hash!).Should().BeNull();
         store.Get(header2.Hash!).Should().BeNull();
 
-        store.Store(header);
+        store.Insert(header);
         store.Get(header.Hash!)!.Hash.Should().Be(header.Hash!);
         store.Get(header.Hash!, blockNumber: header.Number)!.Hash.Should().Be(header.Hash!);
         store.Get(header2.Hash!).Should().BeNull();
 
-        store.Store(header2);
+        store.Insert(header2);
         store.Get(header.Hash!)!.Hash.Should().Be(header.Hash!);
         store.Get(header2.Hash!, blockNumber: header2.Number)!.Hash.Should().Be(header2.Hash!);
     }
@@ -62,7 +62,7 @@ public class HeaderStoreTests
     {
         HeaderStore store = new(new MemDb(), new MemDb());
         BlockHeader header = Build.A.BlockHeader.WithNumber(100).TestObject;
-        store.Store(header);
+        store.Insert(header);
         store.Delete(header.Hash!);
 
         store.Get(header.Hash!).Should().BeNull();

--- a/src/Nethermind/Nethermind.Blockchain.Test/Blocks/HeaderStoreTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Blocks/HeaderStoreTests.cs
@@ -27,11 +27,12 @@ public class HeaderStoreTests
 
         store.Store(header);
         store.Get(header.Hash!)!.Hash.Should().Be(header.Hash!);
+        store.Get(header.Hash!, blockNumber: header.Number)!.Hash.Should().Be(header.Hash!);
         store.Get(header2.Hash!).Should().BeNull();
 
         store.Store(header2);
         store.Get(header.Hash!)!.Hash.Should().Be(header.Hash!);
-        store.Get(header2.Hash!)!.Hash.Should().Be(header2.Hash!);
+        store.Get(header2.Hash!, blockNumber: header2.Number)!.Hash.Should().Be(header2.Hash!);
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -435,7 +435,7 @@ namespace Nethermind.Blockchain
         public BlockHeader? FindHeader(long number, BlockTreeLookupOptions options)
         {
             Keccak blockHash = GetBlockHashOnMainOrBestDifficultyHash(number);
-            return blockHash is null ? null : FindHeader(blockHash, options);
+            return blockHash is null ? null : FindHeader(blockHash, options, blockNumber: number);
         }
 
         public Keccak? FindBlockHash(long blockNumber) => GetBlockHashOnMainOrBestDifficultyHash(blockNumber);

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -205,7 +205,7 @@ namespace Nethermind.Blockchain
             }
 
             _bloomStorage.Store(header.Number, header.Bloom);
-            _headerStore.Store(header);
+            _headerStore.Insert(header);
 
             bool isOnMainChain = (headerOptions & BlockTreeInsertHeaderOptions.NotOnMainChain) == 0;
             BlockInfo blockInfo = new(header.Hash, header.TotalDifficulty ?? 0);
@@ -365,7 +365,7 @@ namespace Nethermind.Blockchain
 
             if (!isKnown)
             {
-                _headerStore.Store(header);
+                _headerStore.Insert(header);
             }
 
             if (!isKnown || fillBeaconBlock)

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -440,7 +440,7 @@ namespace Nethermind.Blockchain
 
         public Keccak? FindBlockHash(long blockNumber) => GetBlockHashOnMainOrBestDifficultyHash(blockNumber);
 
-        public BlockHeader? FindHeader(Keccak? blockHash, BlockTreeLookupOptions options)
+        public BlockHeader? FindHeader(Keccak? blockHash, BlockTreeLookupOptions options, long? blockNumber = null)
         {
             if (blockHash is null || blockHash == Keccak.Zero)
             {
@@ -448,7 +448,7 @@ namespace Nethermind.Blockchain
                 return null;
             }
 
-            BlockHeader? header = _headerStore.Get(blockHash, shouldCache: false);
+            BlockHeader? header = _headerStore.Get(blockHash, shouldCache: false, blockNumber: blockNumber);
             if (header is null)
             {
                 bool allowInvalid = (options & BlockTreeLookupOptions.AllowInvalid) == BlockTreeLookupOptions.AllowInvalid;

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Blockchain.Blocks;
 using Nethermind.Blockchain.Find;
+using Nethermind.Blockchain.Headers;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core;
 using Nethermind.Core.Attributes;
@@ -34,26 +35,18 @@ namespace Nethermind.Blockchain
         public static readonly byte[] LowestInsertedBodyNumberDbEntryAddress = ((long)0).ToBigEndianByteArrayWithoutLeadingZeros();
         private static byte[] StateHeadHashDbEntryAddress = new byte[16];
         internal static Keccak DeletePointerAddressInDb = new(new BitArray(32 * 8, true).ToBytes());
-
         internal static Keccak HeadAddressInDb = Keccak.Zero;
-
-        // SyncProgressResolver MaxLookupBack is 128, add 16 wiggle room
-        private const int CacheSize = 128 + 16;
-
-        private readonly LruCache<ValueKeccak, BlockHeader> _headerCache =
-            new(CacheSize, CacheSize, "headers");
 
         private const int BestKnownSearchLimit = 256_000_000;
 
         private readonly IBlockStore _blockStore;
-        private readonly IDb _headerDb;
+        private readonly IHeaderStore _headerStore;
         private readonly IDb _blockInfoDb;
         private readonly IDb _metadataDb;
 
         private readonly LruCache<ValueKeccak, Block> _invalidBlocks =
             new(128, 128, "invalid blocks");
 
-        private readonly HeaderDecoder _headerDecoder = new();
         private readonly ILogger _logger;
         private readonly ISpecProvider _specProvider;
         private readonly IBloomStorage _bloomStorage;
@@ -114,7 +107,7 @@ namespace Nethermind.Blockchain
 
         public BlockTree(
             IBlockStore? blockStore,
-            IDb? headerDb,
+            IHeaderStore? headerDb,
             IDb? blockInfoDb,
             IDb? metadataDb,
             IChainLevelInfoRepository? chainLevelInfoRepository,
@@ -125,7 +118,7 @@ namespace Nethermind.Blockchain
         {
             _logger = logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
             _blockStore = blockStore ?? throw new ArgumentNullException(nameof(blockStore));
-            _headerDb = headerDb ?? throw new ArgumentNullException(nameof(headerDb));
+            _headerStore = headerDb ?? throw new ArgumentNullException(nameof(headerDb));
             _blockInfoDb = blockInfoDb ?? throw new ArgumentNullException(nameof(blockInfoDb));
             _metadataDb = metadataDb ?? throw new ArgumentNullException(nameof(metadataDb));
             _specProvider = specProvider ?? throw new ArgumentNullException(nameof(specProvider));
@@ -212,14 +205,7 @@ namespace Nethermind.Blockchain
             }
 
             _bloomStorage.Store(header.Number, header.Bloom);
-
-            // validate hash here
-            // using previously received header RLPs would allows us to save 2GB allocations on a sample
-            // 3M Goerli blocks fast sync
-            using (NettyRlpStream newRlp = _headerDecoder.EncodeToNewNettyStream(header))
-            {
-                _headerDb.Set(header.Hash, newRlp.AsSpan());
-            }
+            _headerStore.Store(header);
 
             bool isOnMainChain = (headerOptions & BlockTreeInsertHeaderOptions.NotOnMainChain) == 0;
             BlockInfo blockInfo = new(header.Hash, header.TotalDifficulty ?? 0);
@@ -379,8 +365,7 @@ namespace Nethermind.Blockchain
 
             if (!isKnown)
             {
-                using NettyRlpStream newRlp = _headerDecoder.EncodeToNewNettyStream(header);
-                _headerDb.Set(header.Hash, newRlp.AsSpan());
+                _headerStore.Store(header);
             }
 
             if (!isKnown || fillBeaconBlock)
@@ -463,7 +448,7 @@ namespace Nethermind.Blockchain
                 return null;
             }
 
-            BlockHeader? header = _headerDb.Get(blockHash, _headerDecoder, _headerCache, shouldCache: false);
+            BlockHeader? header = _headerStore.Get(blockHash, shouldCache: false);
             if (header is null)
             {
                 bool allowInvalid = (options & BlockTreeLookupOptions.AllowInvalid) == BlockTreeLookupOptions.AllowInvalid;
@@ -515,7 +500,7 @@ namespace Nethermind.Blockchain
 
             if (header is not null && ShouldCache(header.Number))
             {
-                _headerCache.Set(blockHash, header);
+                _headerStore.Cache(header);
             }
 
             return header;
@@ -799,8 +784,7 @@ namespace Nethermind.Blockchain
 
                 if (_logger.IsInfo) _logger.Info($"Deleting invalid block {currentHash} at level {currentNumber}");
                 _blockStore.Delete(currentHash);
-                _headerCache.Delete(currentHash);
-                _headerDb.Delete(currentHash);
+                _headerStore.Delete(currentHash);
 
                 if (nextHash is null)
                 {
@@ -888,7 +872,7 @@ namespace Nethermind.Blockchain
                 if (ShouldCache(block.Number))
                 {
                     _blockStore.Cache(block);
-                    _headerCache.Set(block.Hash, block.Header);
+                    _headerStore.Cache(block.Header);
                 }
 
                 ChainLevelInfo? level = LoadLevel(block.Number);
@@ -962,7 +946,7 @@ namespace Nethermind.Blockchain
                 if (ShouldCache(block.Number))
                 {
                     _blockStore.Cache(block);
-                    _headerCache.Set(block.Hash, block.Header);
+                    _headerStore.Cache(block.Header);
                 }
 
                 // we only force update head block for last block in processed blocks
@@ -1363,7 +1347,7 @@ namespace Nethermind.Blockchain
             if (block is not null && ShouldCache(block.Number))
             {
                 _blockStore.Cache(block);
-                _headerCache.Set(blockHash, block.Header);
+                _headerStore.Cache(block.Header);
             }
 
             return block;
@@ -1556,7 +1540,7 @@ namespace Nethermind.Blockchain
                         Keccak blockHash = blockInfo.BlockHash;
                         _blockInfoDb.Delete(blockHash);
                         _blockStore.Delete(blockHash);
-                        _headerDb.Delete(blockHash);
+                        _headerStore.Delete(blockHash);
                     }
                 }
             }

--- a/src/Nethermind/Nethermind.Blockchain/Find/IBlockFinder.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Find/IBlockFinder.cs
@@ -25,6 +25,7 @@ namespace Nethermind.Blockchain.Find
 
         Block? FindBlock(long blockNumber, BlockTreeLookupOptions options);
 
+        /// Find a header. blockNumber is optional, but specifying it can improve performance.
         BlockHeader? FindHeader(Keccak blockHash, BlockTreeLookupOptions options, long? blockNumber = null);
 
         BlockHeader? FindHeader(long blockNumber, BlockTreeLookupOptions options);

--- a/src/Nethermind/Nethermind.Blockchain/Find/IBlockFinder.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Find/IBlockFinder.cs
@@ -25,7 +25,7 @@ namespace Nethermind.Blockchain.Find
 
         Block? FindBlock(long blockNumber, BlockTreeLookupOptions options);
 
-        BlockHeader? FindHeader(Keccak blockHash, BlockTreeLookupOptions options);
+        BlockHeader? FindHeader(Keccak blockHash, BlockTreeLookupOptions options, long? blockNumber = null);
 
         BlockHeader? FindHeader(long blockNumber, BlockTreeLookupOptions options);
 
@@ -63,7 +63,7 @@ namespace Nethermind.Blockchain.Find
 
         public Block? FindSafeBlock() => SafeHash is null ? null : FindBlock(SafeHash, BlockTreeLookupOptions.None);
 
-        public BlockHeader? FindHeader(Keccak blockHash) => FindHeader(blockHash, BlockTreeLookupOptions.None);
+        public BlockHeader? FindHeader(Keccak blockHash, long? blockNumber = null) => FindHeader(blockHash, BlockTreeLookupOptions.None, blockNumber: blockNumber);
 
         public BlockHeader? FindHeader(long blockNumber) => FindHeader(blockNumber, BlockTreeLookupOptions.RequireCanonical);
 

--- a/src/Nethermind/Nethermind.Blockchain/Find/IBlockFinderExtensions.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Find/IBlockFinderExtensions.cs
@@ -20,7 +20,7 @@ namespace Nethermind.Blockchain.Find
                         $"Cannot find parent when parent hash is null on block with hash {header.Hash}.");
                 }
 
-                BlockHeader parent = finder.FindHeader(header.ParentHash, options, blockNumber: header.Number-1);
+                BlockHeader parent = finder.FindHeader(header.ParentHash, options, blockNumber: header.Number - 1);
                 header.MaybeParent = new WeakReference<BlockHeader>(parent);
                 return parent;
             }
@@ -34,7 +34,7 @@ namespace Nethermind.Blockchain.Find
                         $"Cannot find parent when parent hash is null on block with hash {header.Hash}.");
                 }
 
-                BlockHeader parent = finder.FindHeader(header.ParentHash, options, blockNumber: header.Number-1);
+                BlockHeader parent = finder.FindHeader(header.ParentHash, options, blockNumber: header.Number - 1);
                 header.MaybeParent.SetTarget(parent);
                 return parent;
             }
@@ -47,7 +47,7 @@ namespace Nethermind.Blockchain.Find
                         $"Cannot find parent when parent hash is null on block with hash {header.Hash}.");
                 }
 
-                BlockHeader? fromDb = finder.FindHeader(header.ParentHash, options, blockNumber: header.Number-1);
+                BlockHeader? fromDb = finder.FindHeader(header.ParentHash, options, blockNumber: header.Number - 1);
                 maybeParent.TotalDifficulty = fromDb?.TotalDifficulty;
             }
 

--- a/src/Nethermind/Nethermind.Blockchain/Find/IBlockFinderExtensions.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Find/IBlockFinderExtensions.cs
@@ -20,7 +20,7 @@ namespace Nethermind.Blockchain.Find
                         $"Cannot find parent when parent hash is null on block with hash {header.Hash}.");
                 }
 
-                BlockHeader parent = finder.FindHeader(header.ParentHash, options);
+                BlockHeader parent = finder.FindHeader(header.ParentHash, options, blockNumber: header.Number-1);
                 header.MaybeParent = new WeakReference<BlockHeader>(parent);
                 return parent;
             }
@@ -34,7 +34,7 @@ namespace Nethermind.Blockchain.Find
                         $"Cannot find parent when parent hash is null on block with hash {header.Hash}.");
                 }
 
-                BlockHeader parent = finder.FindHeader(header.ParentHash, options);
+                BlockHeader parent = finder.FindHeader(header.ParentHash, options, blockNumber: header.Number-1);
                 header.MaybeParent.SetTarget(parent);
                 return parent;
             }
@@ -47,7 +47,7 @@ namespace Nethermind.Blockchain.Find
                         $"Cannot find parent when parent hash is null on block with hash {header.Hash}.");
                 }
 
-                BlockHeader? fromDb = finder.FindHeader(header.ParentHash, options);
+                BlockHeader? fromDb = finder.FindHeader(header.ParentHash, options, blockNumber: header.Number-1);
                 maybeParent.TotalDifficulty = fromDb?.TotalDifficulty;
             }
 

--- a/src/Nethermind/Nethermind.Blockchain/Headers/HeaderStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Headers/HeaderStore.cs
@@ -12,7 +12,7 @@ using Nethermind.Serialization.Rlp;
 
 namespace Nethermind.Blockchain.Headers;
 
-public class HeaderStore: IHeaderStore
+public class HeaderStore : IHeaderStore
 {
     // SyncProgressResolver MaxLookupBack is 128, add 16 wiggle room
     private const int CacheSize = 128 + 16;

--- a/src/Nethermind/Nethermind.Blockchain/Headers/HeaderStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Headers/HeaderStore.cs
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+using Nethermind.Core.Caching;
+using Nethermind.Core.Crypto;
+using Nethermind.Db;
+using Nethermind.Serialization.Rlp;
+
+namespace Nethermind.Blockchain.Headers;
+
+public class HeaderStore: IHeaderStore
+{
+    // SyncProgressResolver MaxLookupBack is 128, add 16 wiggle room
+    private const int CacheSize = 128 + 16;
+
+    private readonly IDb _db;
+    private readonly HeaderDecoder _headerDecoder = new();
+    private readonly LruCache<ValueKeccak, BlockHeader> _headerCache =
+        new(CacheSize, CacheSize, "headers");
+
+
+    public HeaderStore(IDb db)
+    {
+        _db = db;
+    }
+
+    public void Store(BlockHeader header)
+    {
+        // validate hash here
+        // using previously received header RLPs would allows us to save 2GB allocations on a sample
+        // 3M Goerli blocks fast sync
+        using NettyRlpStream newRlp = _headerDecoder.EncodeToNewNettyStream(header);
+        _db.Set(header.Hash, newRlp.AsSpan());
+    }
+
+    public BlockHeader Get(Keccak blockHash, bool shouldCache)
+    {
+        return _db.Get(blockHash, _headerDecoder, _headerCache, shouldCache: false);
+    }
+
+    public void Cache(BlockHeader header)
+    {
+        _headerCache.Set(header.Hash, header);
+    }
+
+    public void Delete(Keccak blockHash)
+    {
+        _db.Delete(blockHash);
+        _headerCache.Delete(blockHash);
+    }
+}

--- a/src/Nethermind/Nethermind.Blockchain/Headers/HeaderStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Headers/HeaderStore.cs
@@ -43,18 +43,17 @@ public class HeaderStore : IHeaderStore
 
     public BlockHeader? Get(Keccak blockHash, bool shouldCache = false, long? blockNumber = null)
     {
+        blockNumber ??= GetBlockNumberFromBlockNumberDb(blockHash);
+
         if (blockNumber == null)
         {
-            blockNumber = GetBlockNumberFromBlockNumberDb(blockHash);
+            return _headerDb.Get(blockHash, _headerDecoder, _headerCache, shouldCache: shouldCache);
         }
 
-        if (blockNumber != null)
+        BlockHeader? withNumber = _headerDb.Get(blockNumber.Value, blockHash, _headerDecoder, _headerCache, shouldCache: shouldCache);
+        if (withNumber != null)
         {
-            BlockHeader? withNumber = _headerDb.Get(blockNumber.Value, blockHash, _headerDecoder, _headerCache, shouldCache: shouldCache);
-            if (withNumber != null)
-            {
-                return withNumber;
-            }
+            return withNumber;
         }
 
         return _headerDb.Get(blockHash, _headerDecoder, _headerCache, shouldCache: shouldCache);

--- a/src/Nethermind/Nethermind.Blockchain/Headers/HeaderStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Headers/HeaderStore.cs
@@ -29,7 +29,7 @@ public class HeaderStore : IHeaderStore
         _blockNumberDb = blockNumberDb;
     }
 
-    public void Store(BlockHeader header)
+    public void Insert(BlockHeader header)
     {
         // validate hash here
         // using previously received header RLPs would allows us to save 2GB allocations on a sample
@@ -76,13 +76,13 @@ public class HeaderStore : IHeaderStore
 
     private long? GetBlockNumberFromBlockNumberDb(Keccak blockHash)
     {
-        Span<byte> numberSpan = _blockNumberDb.Get(blockHash);
-        if (numberSpan.IsNullOrEmpty()) return null;
-        if (numberSpan.Length != 8)
+        byte[] numberBytes = _blockNumberDb.Get(blockHash);
+        if (numberBytes == null) return null;
+        if (numberBytes.Length != 8)
         {
-            throw new Exception($"Unexpected number span length: {numberSpan.Length}");
+            throw new Exception($"Unexpected number span length: {numberBytes.Length}");
         }
 
-        return BinaryPrimitives.ReadInt64BigEndian(numberSpan);
+        return BinaryPrimitives.ReadInt64BigEndian(numberBytes);
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Headers/IHeaderStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Headers/IHeaderStore.cs
@@ -9,7 +9,7 @@ namespace Nethermind.Blockchain.Headers;
 public interface IHeaderStore
 {
     void Store(BlockHeader header);
-    BlockHeader Get(Keccak blockHash, bool shouldCache);
+    BlockHeader? Get(Keccak blockHash, bool shouldCache, long? blockNumber = null);
     void Cache(BlockHeader header);
     void Delete(Keccak blockHash);
 }

--- a/src/Nethermind/Nethermind.Blockchain/Headers/IHeaderStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Headers/IHeaderStore.cs
@@ -8,7 +8,7 @@ namespace Nethermind.Blockchain.Headers;
 
 public interface IHeaderStore
 {
-    void Store(BlockHeader header);
+    void Insert(BlockHeader header);
     BlockHeader? Get(Keccak blockHash, bool shouldCache, long? blockNumber = null);
     void Cache(BlockHeader header);
     void Delete(Keccak blockHash);

--- a/src/Nethermind/Nethermind.Blockchain/Headers/IHeaderStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Headers/IHeaderStore.cs
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+
+namespace Nethermind.Blockchain.Headers;
+
+public interface IHeaderStore
+{
+    void Store(BlockHeader header);
+    BlockHeader Get(Keccak blockHash, bool shouldCache);
+    void Cache(BlockHeader header);
+    void Delete(Keccak blockHash);
+}

--- a/src/Nethermind/Nethermind.Blockchain/ReadOnlyBlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/ReadOnlyBlockTree.cs
@@ -95,7 +95,7 @@ namespace Nethermind.Blockchain
 
         public Block FindBlock(Keccak blockHash, BlockTreeLookupOptions options) => _wrapped.FindBlock(blockHash, options);
 
-        public BlockHeader FindHeader(Keccak blockHash, BlockTreeLookupOptions options) => _wrapped.FindHeader(blockHash, options);
+        public BlockHeader FindHeader(Keccak blockHash, BlockTreeLookupOptions options, long? blockNumber = null) => _wrapped.FindHeader(blockHash, options, blockNumber: blockNumber);
 
         public BlockHeader FindHeader(long blockNumber, BlockTreeLookupOptions options) => _wrapped.FindHeader(blockNumber, options);
         public Keccak FindBlockHash(long blockNumber) => _wrapped.FindBlockHash(blockNumber);

--- a/src/Nethermind/Nethermind.Core.Test/Builders/BlockTreeBuilder.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Builders/BlockTreeBuilder.cs
@@ -44,6 +44,7 @@ namespace Nethermind.Core.Test.Builders
         {
             BlocksDb = new TestMemDb();
             HeadersDb = new TestMemDb();
+            BlockNumbersDb = new TestMemDb();
             BlockInfoDb = new TestMemDb();
             MetadataDb = new TestMemDb();
 
@@ -119,13 +120,14 @@ namespace Nethermind.Core.Test.Builders
         }
 
         public IDb HeadersDb { get; set; }
+        public IDb BlockNumbersDb { get; set; }
 
         private IHeaderStore? _headerStore;
         public IHeaderStore HeaderStore
         {
             get
             {
-                return _headerStore ??= new HeaderStore(HeadersDb);
+                return _headerStore ??= new HeaderStore(HeadersDb, BlockNumbersDb);
             }
             set
             {
@@ -369,7 +371,7 @@ namespace Nethermind.Core.Test.Builders
         public BlockTreeBuilder WithDatabaseFrom(BlockTreeBuilder otherBuilder)
         {
             BlockStore = otherBuilder.BlockStore;
-            HeadersDb = otherBuilder.HeadersDb;
+            HeaderStore = otherBuilder.HeaderStore;
             BlockInfoDb = otherBuilder.BlockInfoDb;
             MetadataDb = otherBuilder.MetadataDb;
 

--- a/src/Nethermind/Nethermind.Core.Test/Builders/BlockTreeBuilder.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Builders/BlockTreeBuilder.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Blocks;
 using Nethermind.Blockchain.Find;
+using Nethermind.Blockchain.Headers;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core.Crypto;
@@ -74,7 +75,7 @@ namespace Nethermind.Core.Test.Builders
 
                     _blockTree = new BlockTree(
                         BlockStore,
-                        HeadersDb,
+                        HeaderStore,
                         BlockInfoDb,
                         MetadataDb,
                         ChainLevelInfoRepository,
@@ -118,6 +119,19 @@ namespace Nethermind.Core.Test.Builders
         }
 
         public IDb HeadersDb { get; set; }
+
+        private IHeaderStore? _headerStore;
+        public IHeaderStore HeaderStore
+        {
+            get
+            {
+                return _headerStore ??= new HeaderStore(HeadersDb);
+            }
+            set
+            {
+                _headerStore = value;
+            }
+        }
 
         public IDb BlockInfoDb { get; set; }
 

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
@@ -79,7 +79,7 @@ public class DbConfig : IDbConfig
     public bool? BlockNumbersDbUseDirectIoForFlushAndCompactions { get; set; }
     public ulong? BlockNumbersDbCompactionReadAhead { get; set; }
     public IDictionary<string, string>? BlockNumbersDbAdditionalRocksDbOptions { get; set; }
-    public ulong? BlockNumbersDbMaxBytesForLevelBase { get; set; } = (ulong)8.MiB();
+    public ulong? BlockNumbersDbMaxBytesForLevelBase { get; set; } = (ulong)16.MiB();
 
     public ulong BlockInfosDbWriteBufferSize { get; set; } = (ulong)8.MiB();
     public uint BlockInfosDbWriteBufferNumber { get; set; } = 4;

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
@@ -61,7 +61,7 @@ public class DbConfig : IDbConfig
     public bool HeadersDbCacheIndexAndFilterBlocks { get; set; } = false;
     public int? HeadersDbMaxOpenFiles { get; set; }
     public long? HeadersDbMaxBytesPerSec { get; set; }
-    public int? HeadersDbBlockSize { get; set; }
+    public int? HeadersDbBlockSize { get; set; } = 32 * 1024;
     public bool? HeadersDbUseDirectReads { get; set; }
     public bool? HeadersDbUseDirectIoForFlushAndCompactions { get; set; }
     public ulong? HeadersDbCompactionReadAhead { get; set; }

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
@@ -68,6 +68,19 @@ public class DbConfig : IDbConfig
     public IDictionary<string, string>? HeadersDbAdditionalRocksDbOptions { get; set; }
     public ulong? HeadersDbMaxBytesForLevelBase { get; set; } = (ulong)128.MiB();
 
+    public ulong BlockNumbersDbWriteBufferSize { get; set; } = (ulong)8.MiB();
+    public uint BlockNumbersDbWriteBufferNumber { get; set; } = 2;
+    public ulong BlockNumbersDbBlockCacheSize { get; set; }
+    public bool BlockNumbersDbCacheIndexAndFilterBlocks { get; set; }
+    public int? BlockNumbersDbMaxOpenFiles { get; set; }
+    public long? BlockNumbersDbMaxBytesPerSec { get; set; }
+    public int? BlockNumbersDbBlockSize { get; set; } = 4 * 1024;
+    public bool? BlockNumbersDbUseDirectReads { get; set; }
+    public bool? BlockNumbersDbUseDirectIoForFlushAndCompactions { get; set; }
+    public ulong? BlockNumbersDbCompactionReadAhead { get; set; }
+    public IDictionary<string, string>? BlockNumbersDbAdditionalRocksDbOptions { get; set; }
+    public ulong? BlockNumbersDbMaxBytesForLevelBase { get; set; } = (ulong)8.MiB();
+
     public ulong BlockInfosDbWriteBufferSize { get; set; } = (ulong)8.MiB();
     public uint BlockInfosDbWriteBufferNumber { get; set; } = 4;
     public ulong BlockInfosDbBlockCacheSize { get; set; } = 0;

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/IDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/IDbConfig.cs
@@ -69,6 +69,19 @@ public interface IDbConfig : IConfig
     IDictionary<string, string>? HeadersDbAdditionalRocksDbOptions { get; set; }
     ulong? HeadersDbMaxBytesForLevelBase { get; set; }
 
+    ulong BlockNumbersDbWriteBufferSize { get; set; }
+    uint BlockNumbersDbWriteBufferNumber { get; set; }
+    ulong BlockNumbersDbBlockCacheSize { get; set; }
+    bool BlockNumbersDbCacheIndexAndFilterBlocks { get; set; }
+    int? BlockNumbersDbMaxOpenFiles { get; set; }
+    long? BlockNumbersDbMaxBytesPerSec { get; set; }
+    int? BlockNumbersDbBlockSize { get; set; }
+    bool? BlockNumbersDbUseDirectReads { get; set; }
+    bool? BlockNumbersDbUseDirectIoForFlushAndCompactions { get; set; }
+    ulong? BlockNumbersDbCompactionReadAhead { get; set; }
+    IDictionary<string, string>? BlockNumbersDbAdditionalRocksDbOptions { get; set; }
+    ulong? BlockNumbersDbMaxBytesForLevelBase { get; set; }
+
     ulong BlockInfosDbWriteBufferSize { get; set; }
     uint BlockInfosDbWriteBufferNumber { get; set; }
     ulong BlockInfosDbBlockCacheSize { get; set; }

--- a/src/Nethermind/Nethermind.Db/DbExtensions.cs
+++ b/src/Nethermind/Nethermind.Db/DbExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Nethermind.Core;
 using Nethermind.Core.Caching;
 using Nethermind.Core.Crypto;
@@ -132,6 +133,7 @@ namespace Nethermind.Db
             db.Remove(key.Bytes);
         }
 
+        [SkipLocalsInit]
         public static void Delete(this IDb db, long blockNumber, Keccak hash)
         {
             Span<byte> key = stackalloc byte[40];
@@ -167,6 +169,7 @@ namespace Nethermind.Db
             db.Remove(key.ToBigEndianByteArrayWithoutLeadingZeros());
         }
 
+        [SkipLocalsInit]
         public static TItem? Get<TItem>(this IDb db, long blockNumber, ValueKeccak hash, IRlpStreamDecoder<TItem> decoder,
             LruCache<ValueKeccak, TItem> cache = null, bool shouldCache = true) where TItem : class
         {

--- a/src/Nethermind/Nethermind.Db/DbExtensions.cs
+++ b/src/Nethermind/Nethermind.Db/DbExtensions.cs
@@ -193,7 +193,8 @@ namespace Nethermind.Db
             IRlpStreamDecoder<TItem> decoder,
             LruCache<TCacheKey, TItem> cache = null,
             bool shouldCache = true
-        ) where TItem : class {
+        ) where TItem : class
+        {
             TItem item = cache?.Get(cacheKey);
             if (item is null)
             {

--- a/src/Nethermind/Nethermind.Db/DbNames.cs
+++ b/src/Nethermind/Nethermind.Db/DbNames.cs
@@ -10,6 +10,7 @@ namespace Nethermind.Db
         public const string Code = "code";
         public const string Blocks = "blocks";
         public const string Headers = "headers";
+        public const string BlockNumbers = "blockNumbers";
         public const string Receipts = "receipts";
         public const string BlockInfos = "blockInfos";
         public const string Bloom = "bloom";

--- a/src/Nethermind/Nethermind.Db/IDbProvider.cs
+++ b/src/Nethermind/Nethermind.Db/IDbProvider.cs
@@ -20,6 +20,7 @@ namespace Nethermind.Db
         public IColumnsDb<ReceiptsColumns> ReceiptsDb => GetDb<IColumnsDb<ReceiptsColumns>>(DbNames.Receipts);
         public IDb BlocksDb => GetDb<IDb>(DbNames.Blocks);
         public IDb HeadersDb => GetDb<IDb>(DbNames.Headers);
+        public IDb BlockNumbersDb => GetDb<IDb>(DbNames.BlockNumbers);
         public IDb BlockInfosDb => GetDb<IDb>(DbNames.BlockInfos);
 
         // BloomDB progress / config (does not contain blooms - they are kept in bloom storage)

--- a/src/Nethermind/Nethermind.Db/Metrics.cs
+++ b/src/Nethermind/Nethermind.Db/Metrics.cs
@@ -103,6 +103,14 @@ namespace Nethermind.Db
         public static long HeaderDbWrites { get; set; }
 
         [CounterMetric]
+        [Description("Number of BlockNumbers DB reads.")]
+        public static long BlockNumberDbReads { get; set; }
+
+        [CounterMetric]
+        [Description("Number of BlockNumbers DB writes.")]
+        public static long BlockNumberDbWrites { get; set; }
+
+        [CounterMetric]
         [Description("Number of Witness DB reads.")]
         public static long WitnessDbReads { get; set; }
 

--- a/src/Nethermind/Nethermind.Db/StandardDbInitializer.cs
+++ b/src/Nethermind/Nethermind.Db/StandardDbInitializer.cs
@@ -42,6 +42,7 @@ namespace Nethermind.Db
         {
             RegisterDb(BuildRocksDbSettings(DbNames.Blocks, () => Metrics.BlocksDbReads++, () => Metrics.BlocksDbWrites++));
             RegisterDb(BuildRocksDbSettings(DbNames.Headers, () => Metrics.HeaderDbReads++, () => Metrics.HeaderDbWrites++));
+            RegisterDb(BuildRocksDbSettings(DbNames.BlockNumbers, () => Metrics.BlockNumberDbReads++, () => Metrics.BlockNumberDbWrites++));
             RegisterDb(BuildRocksDbSettings(DbNames.BlockInfos, () => Metrics.BlockInfosDbReads++, () => Metrics.BlockInfosDbWrites++));
 
             RocksDbSettings stateDbSettings = BuildRocksDbSettings(DbNames.State, () => Metrics.StateDbReads++, () => Metrics.StateDbWrites++);

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeBlockTree.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeBlockTree.cs
@@ -51,7 +51,7 @@ namespace Nethermind.Init.Steps
                 _set.ChainLevelInfoRepository = new ChainLevelInfoRepository(_get.DbProvider!.BlockInfosDb);
 
             IBlockStore blockStore = new BlockStore(_get.DbProvider.BlocksDb);
-            IHeaderStore headerStore = new HeaderStore(_get.DbProvider.HeadersDb);
+            IHeaderStore headerStore = new HeaderStore(_get.DbProvider.HeadersDb, _get.DbProvider.BlockNumbersDb);
 
             IBlockTree blockTree = _set.BlockTree = new BlockTree(
                 blockStore,

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeBlockTree.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeBlockTree.cs
@@ -8,6 +8,7 @@ using Nethermind.Api;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Blocks;
 using Nethermind.Blockchain.Find;
+using Nethermind.Blockchain.Headers;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Consensus;
@@ -50,10 +51,11 @@ namespace Nethermind.Init.Steps
                 _set.ChainLevelInfoRepository = new ChainLevelInfoRepository(_get.DbProvider!.BlockInfosDb);
 
             IBlockStore blockStore = new BlockStore(_get.DbProvider.BlocksDb);
+            IHeaderStore headerStore = new HeaderStore(_get.DbProvider.HeadersDb);
 
             IBlockTree blockTree = _set.BlockTree = new BlockTree(
                 blockStore,
-                _get.DbProvider.HeadersDb,
+                headerStore,
                 _get.DbProvider.BlockInfosDb,
                 _get.DbProvider.MetadataDb,
                 chainLevelInfoRepository,

--- a/src/Nethermind/Nethermind.JsonRpc.Benchmark/EthModuleBenchmarks.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Benchmark/EthModuleBenchmarks.cs
@@ -6,6 +6,7 @@ using Nethermind.Blockchain;
 using Nethermind.Blockchain.Blocks;
 using Nethermind.Blockchain.Filters;
 using Nethermind.Blockchain.Find;
+using Nethermind.Blockchain.Headers;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Consensus.Processing;
 using Nethermind.Consensus.Rewards;
@@ -67,7 +68,7 @@ namespace Nethermind.JsonRpc.Benchmark
             ChainLevelInfoRepository chainLevelInfoRepository = new(blockInfoDb);
             BlockTree blockTree = new(
                 new BlockStore(dbProvider.BlocksDb),
-                dbProvider.HeadersDb,
+                new HeaderStore(dbProvider.HeadersDb, dbProvider.BlockNumbersDb),
                 dbProvider.BlockInfosDb,
                 dbProvider.MetadataDb,
                 chainLevelInfoRepository,

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
@@ -126,7 +126,7 @@ public class ForkchoiceUpdatedHandler : IForkchoiceUpdatedHandler
 
         if (!blockInfo.WasProcessed)
         {
-            BlockHeader? blockParent = _blockTree.FindHeader(newHeadBlock.ParentHash!, blockNumber: newHeadBlock.Number-1);
+            BlockHeader? blockParent = _blockTree.FindHeader(newHeadBlock.ParentHash!, blockNumber: newHeadBlock.Number - 1);
             if (blockParent is null)
             {
                 if (_logger.IsInfo) _logger.Info($"Parent of block {newHeadBlock} not available. Starting new beacon header. sync.");

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
@@ -126,7 +126,7 @@ public class ForkchoiceUpdatedHandler : IForkchoiceUpdatedHandler
 
         if (!blockInfo.WasProcessed)
         {
-            BlockHeader? blockParent = _blockTree.FindHeader(newHeadBlock.ParentHash!);
+            BlockHeader? blockParent = _blockTree.FindHeader(newHeadBlock.ParentHash!, blockNumber: newHeadBlock.Number-1);
             if (blockParent is null)
             {
                 if (_logger.IsInfo) _logger.Info($"Parent of block {newHeadBlock} not available. Starting new beacon header. sync.");

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
@@ -162,7 +162,7 @@ namespace Nethermind.Synchronization.FastBlocks
 
         private bool TryPrepareBlock(BlockInfo blockInfo, BlockBody blockBody, out Block? block)
         {
-            BlockHeader header = _blockTree.FindHeader(blockInfo.BlockHash);
+            BlockHeader header = _blockTree.FindHeader(blockInfo.BlockHash, blockNumber: blockInfo.BlockNumber);
             Keccak rootHash = TxTrie.CalculateRoot(blockBody.Transactions);
             bool txRootIsValid = rootHash == header.TxRoot;
             bool unclesHashIsValid = UnclesHash.Calculate(blockBody.Uncles) == header.UnclesHash;

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/ReceiptsSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/ReceiptsSyncFeed.cs
@@ -178,7 +178,7 @@ namespace Nethermind.Synchronization.FastBlocks
 
         private bool TryPrepareReceipts(BlockInfo blockInfo, TxReceipt[] receipts, out TxReceipt[]? preparedReceipts)
         {
-            BlockHeader? header = _blockTree.FindHeader(blockInfo.BlockHash);
+            BlockHeader? header = _blockTree.FindHeader(blockInfo.BlockHash, blockNumber: blockInfo.BlockNumber);
             if (header is null)
             {
                 if (_logger.IsWarn) _logger.Warn("Could not find header for requested blockhash.");


### PR DESCRIPTION
- Prefix header key with blocknumber.
- A header seems to take up 600 bytes. This means on a 16k blocksize you can fit 26 headers. On workload that fetch consecutive block header, this would reduce iops and bandwidth use by a factor of 26, with further increase by increasing blocksize if deemed worthy.
- Also significantly reduce compactions writes by about 80MBps, which is about 8% of total write bandwidth during sync.
- However, this requires another database to store the blockhash->blocknumber association which take up around 800MB.
- Graph is (after, before)
![Screenshot_2023-10-08_15-54-12](https://github.com/NethermindEth/nethermind/assets/1841324/407f0b3b-258d-4be3-b3bc-7c2e5c34df20)
- When using another nethermind instance to sync old headers, the headers per-iops increase from slightly under 1 to 5-10. Increasing block size to 32K increase this slightly to 10 to 12.. Bytes per header down from 16KB to about 1KB.
- Graph is (before, after, before, after)
![Screenshot_2023-10-09_09-52-08](https://github.com/NethermindEth/nethermind/assets/1841324/9d2cb204-24f4-4871-86b7-8941632dc67c)

## Changes

- Encapsulate header storage concern to a new class 'HeaderStore'.
- The 'Get' method of the header store accept an optional blocknumber which if absence, will fetch the blcoknumber from a blocknumber database.
- Modified blocktree to expose this optional blocknumber and specify it where its available.

## Types of changes

#### What types of changes does your code introduce?

- [X] Optimization
## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

