### PR TITLE
Fix on handshake failure not disconnecting connection

### DIFF
--- a/src/Nethermind/Nethermind.Network.Test/Rlpx/Handshake/NettyHandshakeHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/Rlpx/Handshake/NettyHandshakeHandlerTests.cs
@@ -16,6 +16,7 @@ using Nethermind.Network.P2P.ProtocolHandlers;
 using Nethermind.Network.Rlpx;
 using Nethermind.Network.Rlpx.Handshake;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using NUnit.Framework;
 
 namespace Nethermind.Network.Test.Rlpx.Handshake
@@ -64,6 +65,10 @@ namespace Nethermind.Network.Test.Rlpx.Handshake
 
         private NettyHandshakeHandler CreateHandler(HandshakeRole handshakeRole = HandshakeRole.Recipient)
         {
+            if (handshakeRole == HandshakeRole.Recipient)
+            {
+                _session.Node.Throws(new InvalidOperationException("property throw on incoming connection before handshake"));
+            }
             return new NettyHandshakeHandler(_serializationService, _handshakeService, _session, handshakeRole, _logger, _group, TimeSpan.Zero);
         }
 
@@ -210,6 +215,17 @@ namespace Nethermind.Network.Test.Rlpx.Handshake
 
             received.Should().BeTrue();
             _handshakeService.Received(1).Ack(Arg.Any<EncryptionHandshake>(), Arg.Any<Packet>());
+        }
+
+        [Test]
+        public async Task Handler_disconnect_on_exception()
+        {
+            NettyHandshakeHandler handler = CreateHandler();
+
+            IChannelHandlerContext context = Substitute.For<IChannelHandlerContext>();
+            handler.ExceptionCaught(context, new Exception("any exception"));
+
+            await context.Received().DisconnectAsync();
         }
     }
 }

--- a/src/Nethermind/Nethermind.Network.Test/Rlpx/Handshake/NettyHandshakeHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/Rlpx/Handshake/NettyHandshakeHandlerTests.cs
@@ -68,6 +68,7 @@ namespace Nethermind.Network.Test.Rlpx.Handshake
             if (handshakeRole == HandshakeRole.Recipient)
             {
                 _session.Node.Throws(new InvalidOperationException("property throw on incoming connection before handshake"));
+                _session.RemoteNodeId.Returns((PublicKey)null); // Incoming connection have null remote node id until handshake finished
             }
             return new NettyHandshakeHandler(_serializationService, _handshakeService, _session, handshakeRole, _logger, _group, TimeSpan.Zero);
         }

--- a/src/Nethermind/Nethermind.Network/Rlpx/NettyHandshakeHandler.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/NettyHandshakeHandler.cs
@@ -110,7 +110,15 @@ namespace Nethermind.Network.Rlpx
 
         public override void ExceptionCaught(IChannelHandlerContext context, Exception exception)
         {
-            string clientId = _session?.Node?.ToString(Node.Format.Console) ?? $"unknown {_session?.RemoteHost}";
+            string clientId = $"unknown {_session?.RemoteHost}";
+            try
+            {
+                clientId = _session?.Node?.ToString(Node.Format.Console);
+            }
+            catch (Exception)
+            {
+            }
+
             //In case of SocketException we log it as debug to avoid noise
             if (exception is SocketException)
             {
@@ -127,7 +135,7 @@ namespace Nethermind.Network.Rlpx
                 }
             }
 
-            base.ExceptionCaught(context, exception);
+            _ = context.DisconnectAsync();
         }
 
         protected override void ChannelRead0(IChannelHandlerContext context, IByteBuffer input)

--- a/src/Nethermind/Nethermind.Network/Rlpx/NettyHandshakeHandler.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/NettyHandshakeHandler.cs
@@ -111,13 +111,7 @@ namespace Nethermind.Network.Rlpx
         public override void ExceptionCaught(IChannelHandlerContext context, Exception exception)
         {
             string clientId = $"unknown {_session?.RemoteHost}";
-            try
-            {
-                clientId = _session?.Node?.ToString(Node.Format.Console);
-            }
-            catch (Exception)
-            {
-            }
+            if (_session.RemoteNodeId != null) clientId = _session?.Node?.ToString(Node.Format.Console);
 
             //In case of SocketException we log it as debug to avoid noise
             if (exception is SocketException)


### PR DESCRIPTION
- When the exception handler did not explicitly handle the exception, the exception will pass down to the next handler, which if its the tail, it'll do nothing.
- This add an explicit disconnect on exception.
- Also fix the method itself throwing exception.

## Changes

- Add explicit disconnect on `ExceptionCaught`
- Wrap trying to get client id string so that on exception, it does nothing.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes

#### If yes, did you write tests?

- [X] Yes

#### Notes on testing

- Verified with a custom spammer.