### PR TITLE
Fix unable to decode auth message with invalid version

### DIFF
--- a/src/Nethermind/Nethermind.Network.Test/Rlpx/Handshake/AuthEip8MessageSerializerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/Rlpx/Handshake/AuthEip8MessageSerializerTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using DotNetty.Buffers;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
@@ -9,6 +10,7 @@ using Nethermind.Crypto;
 using Nethermind.Logging;
 using Nethermind.Network.Rlpx.Handshake;
 using NUnit.Framework;
+using Org.BouncyCastle.Utilities.Encoders;
 
 namespace Nethermind.Network.Test.Rlpx.Handshake
 {
@@ -59,6 +61,16 @@ namespace Nethermind.Network.Test.Rlpx.Handshake
         {
             EthereumEcdsa ecdsa = new(BlockchainIds.Olympic, LimboLogs.Instance);
             TestEncodeDecode(ecdsa);
+        }
+
+        [Test]
+        public void TestBadVersion()
+        {
+            string rawMsg = "f8bab841b054620e0d28697f4d4cbc1b25873d45ba17a62d724fea574982b76885ba164423b0160e39943610fe8c795f5d5167e2f3b5d52452d255a6dfb95d8339f0361f00b840a84e79d9c17895ec9720603c950293a5570727240e83774c128ea1654e64880ae2b1384167cab68dc3b2e7d1a741220a98c9842f36c5daa6094e586914516928a016e33b0bacaa8a7b493e2e43ec1bdb45b28f2f9111066228fb3c1063ffd8067d932b383f24302935273b29302a2f2b3d2621212a0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+            IByteBuffer byteBuffer = Unpooled.Buffer();
+            byteBuffer.WriteBytes(Hex.Decode(rawMsg));
+
+            _serializer.Deserialize(byteBuffer);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Network/Rlpx/Handshake/AuthEip8MessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/Handshake/AuthEip8MessageSerializer.cs
@@ -51,7 +51,6 @@ namespace Nethermind.Network.Rlpx.Handshake
             authMessage.Signature = signature;
             authMessage.PublicKey = new PublicKey(rlpStream.DecodeByteArraySpan());
             authMessage.Nonce = rlpStream.DecodeByteArray();
-            _ = rlpStream.DecodeInt();
             return authMessage;
         }
     }

--- a/src/Nethermind/Nethermind.Network/Rlpx/NettyHandshakeHandler.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/NettyHandshakeHandler.cs
@@ -161,11 +161,6 @@ namespace Nethermind.Network.Rlpx
             _initCompletionSource?.SetResult(input);
             _session.Handshake(_handshake.RemoteNodeId);
 
-            if (_role == HandshakeRole.Recipient)
-            {
-                if (_logger.IsTrace) _logger.Trace($"Registering {nameof(OneTimeLengthFieldBasedFrameDecoder)}  for {RemoteId} @ {context.Channel.RemoteAddress}");
-                context.Channel.Pipeline.AddLast("enc-handshake-dec", new OneTimeLengthFieldBasedFrameDecoder());
-            }
             if (_logger.IsTrace) _logger.Trace($"Registering {nameof(ReadTimeoutHandler)} for {RemoteId} @ {context.Channel.RemoteAddress}");
             context.Channel.Pipeline.AddLast(new ReadTimeoutHandler(TimeSpan.FromSeconds(30))); // read timeout instead of session monitoring
             if (_logger.IsTrace) _logger.Trace($"Registering {nameof(ZeroFrameDecoder)} for {RemoteId} @ {context.Channel.RemoteAddress}");

--- a/src/Nethermind/Nethermind.Network/Rlpx/RlpxHost.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/RlpxHost.cs
@@ -222,11 +222,7 @@ namespace Nethermind.Network.Rlpx
 
             IChannelPipeline pipeline = channel.Pipeline;
             pipeline.AddLast(new LoggingHandler(session.Direction.ToString().ToUpper(), LogLevel.TRACE));
-
-            if (session.Direction == ConnectionDirection.Out)
-            {
-                pipeline.AddLast("enc-handshake-dec", new OneTimeLengthFieldBasedFrameDecoder());
-            }
+            pipeline.AddLast("enc-handshake-dec", new OneTimeLengthFieldBasedFrameDecoder());
             pipeline.AddLast("enc-handshake-handler", handshakeHandler);
 
             channel.CloseCompletion.ContinueWith(async x =>


### PR DESCRIPTION
Resolves #6116

- Fix auth message decode throws an exception when attempting to decode auth message with string version.
- Fix sometimes the auth payload is not complete.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Tested with fuzzer.
- Node, when using fuzzer, the second try that use the same connection will disconnect the connection due to invalid header mac. Which IFAIK is expected.