### PR TITLE
Fix `eth_syncing` in young chains

### DIFF
--- a/src/Nethermind/Nethermind.Facade/Eth/EthSyncingInfo.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/EthSyncingInfo.cs
@@ -47,7 +47,7 @@ namespace Nethermind.Facade.Eth
                 return ReturnSyncing(headNumberOrZero, bestSuggestedNumber, syncMode);
             }
 
-            if (_syncConfig.FastSync)
+            if (_syncConfig.FastSync && _syncConfig.PivotNumberParsed != 0)
             {
                 if (_syncConfig.DownloadReceiptsInFastSync &&
                     (_receiptStorage.LowestInsertedReceiptBlockNumber is null || _receiptStorage.LowestInsertedReceiptBlockNumber > _syncConfig.AncientReceiptsBarrierCalc))

--- a/src/Nethermind/Nethermind.Facade/Eth/EthSyncingInfo.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/EthSyncingInfo.cs
@@ -47,17 +47,24 @@ namespace Nethermind.Facade.Eth
                 return ReturnSyncing(headNumberOrZero, bestSuggestedNumber, syncMode);
             }
 
-            if (_syncConfig.FastSync && _syncConfig.PivotNumberParsed != 0)
+            // If we're on FastSync mode and the pivot number is not defined (it's 0), then we might never need to download receipts/bodies
+            // so we cannot check for the `LowestInsertedReceiptBlockNumber`.
+            // On the other hand, if we do have a PivotNumber then we should download receipts/bodies, so we check if we're still downloading them.
+            bool needsToDownloadReceiptsAndBodies = _syncConfig.PivotNumberParsed != 0;
+            if (_syncConfig.FastSync && needsToDownloadReceiptsAndBodies)
             {
-                if (_syncConfig.DownloadReceiptsInFastSync &&
-                    (_receiptStorage.LowestInsertedReceiptBlockNumber is null || _receiptStorage.LowestInsertedReceiptBlockNumber > _syncConfig.AncientReceiptsBarrierCalc))
+                bool isDownloadingReceipts = _receiptStorage.LowestInsertedReceiptBlockNumber is null
+                                             || _receiptStorage.LowestInsertedReceiptBlockNumber > _syncConfig.AncientReceiptsBarrierCalc;
+                if (_syncConfig.DownloadReceiptsInFastSync && isDownloadingReceipts)
                 {
                     if (_logger.IsTrace) _logger.Trace($"Receipts not finished - EthSyncingInfo - HighestBlock: {bestSuggestedNumber}, CurrentBlock: {headNumberOrZero}, AncientReceiptsBarrier: {_syncConfig.AncientReceiptsBarrierCalc}. LowestInsertedBodyNumber: {_blockTree.LowestInsertedBodyNumber} LowestInsertedReceiptBlockNumber: {_receiptStorage.LowestInsertedReceiptBlockNumber}");
                     return ReturnSyncing(headNumberOrZero, bestSuggestedNumber, syncMode);
                 }
 
-                if (_syncConfig.DownloadBodiesInFastSync &&
-                    (_blockTree.LowestInsertedBodyNumber is null || _blockTree.LowestInsertedBodyNumber > _syncConfig.AncientBodiesBarrierCalc))
+
+                bool isDownloadingBodies = _blockTree.LowestInsertedBodyNumber is null
+                                           || _blockTree.LowestInsertedBodyNumber > _syncConfig.AncientBodiesBarrierCalc;
+                if (_syncConfig.DownloadBodiesInFastSync && isDownloadingBodies)
                 {
                     if (_logger.IsTrace) _logger.Trace($"Bodies not finished - EthSyncingInfo - HighestBlock: {bestSuggestedNumber}, CurrentBlock: {headNumberOrZero}, AncientBodiesBarrier: {_syncConfig.AncientBodiesBarrierCalc}. LowestInsertedBodyNumber: {_blockTree.LowestInsertedBodyNumber} LowestInsertedReceiptBlockNumber: {_receiptStorage.LowestInsertedReceiptBlockNumber}");
                     return ReturnSyncing(headNumberOrZero, bestSuggestedNumber, syncMode);


### PR DESCRIPTION
Fixes #6153

## Changes

- Fix edge case where `eth_syncing` never returned false given that receipts were never downloaded.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Tested on a VM running Holesky with the current default config (https://github.com/NethermindEth/nethermind/blob/9c40c81de03a3f9d4f4f5e10cf93eef767f71071/src/Nethermind/Nethermind.Runner/configs/holesky.cfg) and with `PivotNumber: 100`

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

The justification as to why this fixes the issue is complex and more details will be provided as part of the discussion on this PR.
