### PR TITLE
Make EIP-4844 parameters configurable

### DIFF
--- a/src/Nethermind/Chains/chiado.json
+++ b/src/Nethermind/Chains/chiado.json
@@ -40,11 +40,14 @@
     }
   },
   "params": {
+    "blobGasPriceUpdateFraction": "0x10fafa",
     "networkID": 10200,
     "gasLimitBoundDivisor": "0x400",
+    "maxBlobGasPerBlock": "0x40000",
     "maximumExtraDataSize": "0x20",
     "maxCodeSize": "0x6000",
     "maxCodeSizeTransitionTimestamp": "0x646e0e4c",
+    "minBlobGasPrice": "0x3b9aca00",
     "minGasLimit": "0x1388",
     "eip140Transition": "0x0",
     "eip211Transition": "0x0",
@@ -73,6 +76,7 @@
     "eip1559FeeCollector": "0x1559000000000000000000000000000000000000",
     "eip1559FeeCollectorTransition": 0,
     "registrar": "0x6000000000000000000000000000000000000000",
+    "targetBlobGasPerBlock": "0x20000",
     "transactionPermissionContract": "0x4000000000000000000000000000000000000001",
     "transactionPermissionContractTransition": "0x0",
     "terminalTotalDifficulty": "231707791542740786049188744689299064356246512"

--- a/src/Nethermind/Chains/gnosis.json
+++ b/src/Nethermind/Chains/gnosis.json
@@ -41,11 +41,14 @@
     }
   },
   "params": {
+    "blobGasPriceUpdateFraction": "0x10fafa",
     "networkID": "100",
     "gasLimitBoundDivisor": "0x400",
+    "maxBlobGasPerBlock": "0x40000",
     "maximumExtraDataSize": "0x20",
     "maxCodeSize": "0x6000",
     "maxCodeSizeTransitionTimestamp": "0x64c8edbc",
+    "minBlobGasPrice": "0x3b9aca00",
     "minGasLimit": "0x1388",
     "eip140Transition": "0x0",
     "eip211Transition": "0x0",
@@ -80,6 +83,7 @@
     "eip1559FeeCollector": "0x6BBe78ee9e474842Dbd4AB4987b3CeFE88426A92",
     "eip1559FeeCollectorTransition": 19040000,
     "registrar": "0x6B53721D4f2Fb9514B85f5C49b197D857e36Cf03",
+    "targetBlobGasPerBlock": "0x20000",
     "transactionPermissionContract": "0x7Dd7032AA75A37ea0b150f57F899119C7379A78b",
     "transactionPermissionContractTransition": 9186425,
     "terminalTotalDifficulty": "8626000000000000000000058750000000000000000000"

--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionSelectorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionSelectorTests.cs
@@ -160,7 +160,7 @@ namespace Nethermind.Blockchain.Test
                     tx.MaxFeePerBlobGas = 1;
                 });
                 maxTransactionsSelected.Transactions[1].BlobVersionedHashes =
-                    new byte[Eip4844Constants.MaxBlobGasPerTransaction / Eip4844Constants.BlobGasPerBlob - 1][];
+                    new byte[Eip4844Constants.MaxBlobGasPerTransaction / Eip4844Constants.GasPerBlob - 1][];
                 maxTransactionsSelected.ExpectedSelectedTransactions.AddRange(
                     maxTransactionsSelected.Transactions.OrderBy(t => t.Nonce).Take(2));
                 yield return new TestCaseData(maxTransactionsSelected).SetName("Enough transactions selected");
@@ -174,7 +174,7 @@ namespace Nethermind.Blockchain.Test
                     enoughTransactionsSelected.Transactions.OrderBy(t => t.Nonce).ToArray();
                 expectedSelectedTransactions[0].Type = TxType.Blob;
                 expectedSelectedTransactions[0].BlobVersionedHashes =
-                    new byte[Eip4844Constants.MaxBlobGasPerTransaction / Eip4844Constants.BlobGasPerBlob][];
+                    new byte[Eip4844Constants.MaxBlobGasPerTransaction / Eip4844Constants.GasPerBlob][];
                 expectedSelectedTransactions[0].MaxFeePerBlobGas = 1;
                 expectedSelectedTransactions[1].Type = TxType.Blob;
                 expectedSelectedTransactions[1].BlobVersionedHashes = new byte[1][];

--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/ShardBlobBlockValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/ShardBlobBlockValidatorTests.cs
@@ -32,10 +32,7 @@ public class ShardBlobBlockValidatorTests
             .TestObject);
     }
 
-    [TestCase(0ul, ExpectedResult = true)]
-    [TestCase(Eip4844Constants.MaxBlobGasPerBlock - Eip4844Constants.BlobGasPerBlob, ExpectedResult = true)]
-    [TestCase(Eip4844Constants.MaxBlobGasPerBlock, ExpectedResult = true)]
-    [TestCase(Eip4844Constants.MaxBlobGasPerBlock + Eip4844Constants.BlobGasPerBlob, ExpectedResult = false)]
+    [TestCaseSource(nameof(BlobsPerBlockCountTestCases))]
     public bool Blobs_per_block_count_is_valid(ulong blobGasUsed)
     {
         ISpecProvider specProvider = new CustomSpecProvider(((ForkActivation)0, Cancun.Instance));
@@ -46,59 +43,66 @@ public class ShardBlobBlockValidatorTests
                 .WithWithdrawals(TestItem.WithdrawalA_1Eth)
                 .WithBlobGasUsed(blobGasUsed)
                 .WithExcessBlobGas(0)
-                .WithTransactions(Enumerable.Range(0, (int)(blobGasUsed / Eip4844Constants.BlobGasPerBlob))
-                    .Select(i => Build.A.Transaction.WithType(TxType.Blob)
-                                                    .WithMaxFeePerBlobGas(ulong.MaxValue)
-                                                    .WithBlobVersionedHashes(1).TestObject).ToArray())
+                .WithTransactions(Enumerable.Range(0, (int)(blobGasUsed / Eip4844Constants.GasPerBlob))
+                    .Select(i => Build.A.Transaction
+                        .WithType(TxType.Blob)
+                        .WithMaxFeePerBlobGas(ulong.MaxValue)
+                        .WithBlobVersionedHashes(1).TestObject).ToArray())
                 .TestObject);
     }
 
-    public static IEnumerable<TestCaseData> BlobGasFieldsPerForkTestCases
+    private static IEnumerable<TestCaseData> BlobsPerBlockCountTestCases()
     {
-        get
+        yield return new TestCaseData(0UL) { ExpectedResult = true };
+
+        yield return new TestCaseData(Eip4844Constants.MaxBlobGasPerBlock - Eip4844Constants.GasPerBlob) { ExpectedResult = true };
+
+        yield return new TestCaseData(Eip4844Constants.MaxBlobGasPerBlock) { ExpectedResult = true };
+
+        yield return new TestCaseData(Eip4844Constants.MaxBlobGasPerBlock + Eip4844Constants.GasPerBlob) { ExpectedResult = false };
+    }
+
+    private static IEnumerable<TestCaseData> BlobGasFieldsPerForkTestCases()
+    {
+        yield return new TestCaseData(Shanghai.Instance, null, null)
         {
-            yield return new TestCaseData(Shanghai.Instance, null, null)
-            {
-                TestName = "Blob gas fields are not set pre-Cancun",
-                ExpectedResult = true
-            };
-            yield return new TestCaseData(Shanghai.Instance, 0ul, null)
-            {
-                TestName = "BlobGasUsed is set pre-Cancun",
-                ExpectedResult = false
-            };
-            yield return new TestCaseData(Shanghai.Instance, null, 0ul)
-            {
-                TestName = "ExcessBlobGas is set pre-Cancun",
-                ExpectedResult = false
-            };
-            yield return new TestCaseData(Shanghai.Instance, 0ul, 0ul)
-            {
-                TestName = "Blob gas fields are set pre-Cancun",
-                ExpectedResult = false
-            };
-
-
-            yield return new TestCaseData(Cancun.Instance, null, null)
-            {
-                TestName = "Blob gas fields are not set post-Cancun",
-                ExpectedResult = false
-            };
-            yield return new TestCaseData(Cancun.Instance, 0ul, null)
-            {
-                TestName = "Just BlobGasUsed is set post-Cancun",
-                ExpectedResult = false
-            };
-            yield return new TestCaseData(Cancun.Instance, null, 0ul)
-            {
-                TestName = "Just ExcessBlobGas is set post-Cancun",
-                ExpectedResult = false
-            };
-            yield return new TestCaseData(Cancun.Instance, 0ul, 0ul)
-            {
-                TestName = "Blob gas fields are set post-Cancun",
-                ExpectedResult = true
-            };
-        }
+            TestName = "Blob gas fields are not set pre-Cancun",
+            ExpectedResult = true
+        };
+        yield return new TestCaseData(Shanghai.Instance, 0ul, null)
+        {
+            TestName = "BlobGasUsed is set pre-Cancun",
+            ExpectedResult = false
+        };
+        yield return new TestCaseData(Shanghai.Instance, null, 0ul)
+        {
+            TestName = "ExcessBlobGas is set pre-Cancun",
+            ExpectedResult = false
+        };
+        yield return new TestCaseData(Shanghai.Instance, 0ul, 0ul)
+        {
+            TestName = "Blob gas fields are set pre-Cancun",
+            ExpectedResult = false
+        };
+        yield return new TestCaseData(Cancun.Instance, null, null)
+        {
+            TestName = "Blob gas fields are not set post-Cancun",
+            ExpectedResult = false
+        };
+        yield return new TestCaseData(Cancun.Instance, 0ul, null)
+        {
+            TestName = "Just BlobGasUsed is set post-Cancun",
+            ExpectedResult = false
+        };
+        yield return new TestCaseData(Cancun.Instance, null, 0ul)
+        {
+            TestName = "Just ExcessBlobGas is set post-Cancun",
+            ExpectedResult = false
+        };
+        yield return new TestCaseData(Cancun.Instance, 0ul, 0ul)
+        {
+            TestName = "Blob gas fields are set post-Cancun",
+            ExpectedResult = true
+        };
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
@@ -498,19 +498,19 @@ public class TxValidatorTests
                 TestName = "More than minimum BlobVersionedHashes",
                 ExpectedResult = true
             };
-            yield return new TestCaseData(MakeTestObject((int)(Eip4844Constants.MaxBlobGasPerBlock / Eip4844Constants.BlobGasPerBlob - 1))
+            yield return new TestCaseData(MakeTestObject((int)(Eip4844Constants.MaxBlobGasPerBlock / Eip4844Constants.GasPerBlob - 1))
                 .SignedAndResolved().TestObject)
             {
                 TestName = "Less than maximum BlobVersionedHashes",
                 ExpectedResult = true
             };
-            yield return new TestCaseData(MakeTestObject((int)(Eip4844Constants.MaxBlobGasPerBlock / Eip4844Constants.BlobGasPerBlob))
+            yield return new TestCaseData(MakeTestObject((int)(Eip4844Constants.MaxBlobGasPerBlock / Eip4844Constants.GasPerBlob))
                 .SignedAndResolved().TestObject)
             {
                 TestName = "Maximum BlobVersionedHashes",
                 ExpectedResult = true
             };
-            yield return new TestCaseData(MakeTestObject((int)(Eip4844Constants.MaxBlobGasPerBlock / Eip4844Constants.BlobGasPerBlob + 1))
+            yield return new TestCaseData(MakeTestObject((int)(Eip4844Constants.MaxBlobGasPerBlock / Eip4844Constants.GasPerBlob + 1))
                 .SignedAndResolved().TestObject)
             {
                 TestName = "Too many BlobVersionedHashes",

--- a/src/Nethermind/Nethermind.Core/Eip4844Constants.cs
+++ b/src/Nethermind/Nethermind.Core/Eip4844Constants.cs
@@ -5,15 +5,42 @@ using Nethermind.Int256;
 
 namespace Nethermind.Core;
 
+/// <summary>
+/// Represents the <see href="https://eips.ethereum.org/EIPS/eip-4844#parameters">EIP-4844</see> parameters.
+/// </summary>
 public class Eip4844Constants
 {
+    /// <summary>
+    /// Gets the <c>GAS_PER_BLOB</c> parameter.
+    /// </summary>
+    /// <remarks>Defaults to 2e17.</remarks>
+    public const ulong GasPerBlob = 1 << 17;
+
     public const int MinBlobsPerTransaction = 1;
 
-    public const ulong BlobGasPerBlob = 1 << 17;
-    public const ulong TargetBlobGasPerBlock = BlobGasPerBlob * 3;
-    public const ulong MaxBlobGasPerBlock = BlobGasPerBlob * 6;
-    public const ulong MaxBlobGasPerTransaction = MaxBlobGasPerBlock;
+    /// <summary>
+    /// Gets the <c>BLOB_GASPRICE_UPDATE_FRACTION</c> parameter.
+    /// </summary>
+    /// <remarks>Defaults to 3338477.</remarks>
+    public static UInt256 BlobGasPriceUpdateFraction { get; set; } = 3338477;
 
-    public static readonly UInt256 BlobGasUpdateFraction = 3338477;
-    public static readonly UInt256 MinBlobGasPrice = 1;
+    /// <summary>
+    /// Gets the <c>MAX_BLOB_GAS_PER_BLOCK</c> parameter.
+    /// </summary>
+    /// <remarks>Defaults to 786432.</remarks>
+    public static ulong MaxBlobGasPerBlock { get; set; } = GasPerBlob * 6;
+
+    public static ulong MaxBlobGasPerTransaction => MaxBlobGasPerBlock;
+
+    /// <summary>
+    /// Gets the <c>MIN_BLOB_GASPRICE</c> parameter, in wei.
+    /// </summary>
+    /// <remarks>Defaults to 1.</remarks>
+    public static UInt256 MinBlobGasPrice { get; set; } = 1;
+
+    /// <summary>
+    /// Gets the <c>TARGET_BLOB_GAS_PER_BLOCK</c> parameter.
+    /// </summary>
+    /// <remarks>Defaults to 393216.</remarks>
+    public static ulong TargetBlobGasPerBlock { get; set; } = GasPerBlob * 3;
 }

--- a/src/Nethermind/Nethermind.Core/Eip4844Constants.cs
+++ b/src/Nethermind/Nethermind.Core/Eip4844Constants.cs
@@ -22,13 +22,13 @@ public class Eip4844Constants
     /// Gets the <c>BLOB_GASPRICE_UPDATE_FRACTION</c> parameter.
     /// </summary>
     /// <remarks>Defaults to 3338477.</remarks>
-    public static UInt256 BlobGasPriceUpdateFraction { get; set; } = 3338477;
+    public static UInt256 BlobGasPriceUpdateFraction { get; private set; } = 3338477;
 
     /// <summary>
     /// Gets the <c>MAX_BLOB_GAS_PER_BLOCK</c> parameter.
     /// </summary>
     /// <remarks>Defaults to 786432.</remarks>
-    public static ulong MaxBlobGasPerBlock { get; set; } = GasPerBlob * 6;
+    public static ulong MaxBlobGasPerBlock { get; private set; } = GasPerBlob * 6;
 
     public static ulong MaxBlobGasPerTransaction => MaxBlobGasPerBlock;
 
@@ -36,11 +36,22 @@ public class Eip4844Constants
     /// Gets the <c>MIN_BLOB_GASPRICE</c> parameter, in wei.
     /// </summary>
     /// <remarks>Defaults to 1.</remarks>
-    public static UInt256 MinBlobGasPrice { get; set; } = 1;
+    public static UInt256 MinBlobGasPrice { get; private set; } = 1;
 
     /// <summary>
     /// Gets the <c>TARGET_BLOB_GAS_PER_BLOCK</c> parameter.
     /// </summary>
     /// <remarks>Defaults to 393216.</remarks>
-    public static ulong TargetBlobGasPerBlock { get; set; } = GasPerBlob * 3;
+    public static ulong TargetBlobGasPerBlock { get; private set; } = GasPerBlob * 3;
+
+    // The parameter mutators are kept separate deliberately to ensure no accidental value changes.
+    #region Mutators
+    public static void OverrideBlobGasPriceUpdateFraction(UInt256 value) => BlobGasPriceUpdateFraction = value;
+
+    public static void OverrideMaxBlobGasPerBlock(ulong value) => MaxBlobGasPerBlock = value;
+
+    public static void OverrideMinBlobGasPrice(UInt256 value) => MinBlobGasPrice = value;
+
+    public static void OverrideTargetBlobGasPerBlock(ulong value) => TargetBlobGasPerBlock = value;
+    #endregion
 }

--- a/src/Nethermind/Nethermind.Core/Eip4844Constants.cs
+++ b/src/Nethermind/Nethermind.Core/Eip4844Constants.cs
@@ -16,6 +16,7 @@ public class Eip4844Constants
     /// <remarks>Defaults to 2e17.</remarks>
     public const ulong GasPerBlob = 1 << 17;
 
+    public const int MaxBlobsPerBlock = 6;
     public const int MinBlobsPerTransaction = 1;
 
     /// <summary>
@@ -28,7 +29,7 @@ public class Eip4844Constants
     /// Gets the <c>MAX_BLOB_GAS_PER_BLOCK</c> parameter.
     /// </summary>
     /// <remarks>Defaults to 786432.</remarks>
-    public static ulong MaxBlobGasPerBlock { get; private set; } = GasPerBlob * 6;
+    public static ulong MaxBlobGasPerBlock { get; private set; } = GasPerBlob * MaxBlobsPerBlock;
 
     public static ulong MaxBlobGasPerTransaction => MaxBlobGasPerBlock;
 
@@ -42,7 +43,7 @@ public class Eip4844Constants
     /// Gets the <c>TARGET_BLOB_GAS_PER_BLOCK</c> parameter.
     /// </summary>
     /// <remarks>Defaults to 393216.</remarks>
-    public static ulong TargetBlobGasPerBlock { get; private set; } = GasPerBlob * 3;
+    public static ulong TargetBlobGasPerBlock { get; private set; } = MaxBlobGasPerBlock / 2;
 
     // The parameter mutators are kept separate deliberately to ensure no accidental value changes.
     #region Mutators

--- a/src/Nethermind/Nethermind.Evm.Test/BlobGasCalculatorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/BlobGasCalculatorTests.cs
@@ -68,21 +68,21 @@ public class BlobGasCalculatorTests
     public static IEnumerable<(ulong parentExcessBlobGas, int parentBlobsCount, ulong expectedExcessBlobGas)> ExcessBlobGasTestCaseSource()
     {
         yield return (0, 0, 0);
-        yield return (0, (int)(Eip4844Constants.TargetBlobGasPerBlock / Eip4844Constants.BlobGasPerBlob) - 1, 0);
-        yield return (0, (int)(Eip4844Constants.TargetBlobGasPerBlock / Eip4844Constants.BlobGasPerBlob), 0);
-        yield return (100000, (int)(Eip4844Constants.TargetBlobGasPerBlock / Eip4844Constants.BlobGasPerBlob), 100000);
-        yield return (0, (int)(Eip4844Constants.TargetBlobGasPerBlock / Eip4844Constants.BlobGasPerBlob) + 1, Eip4844Constants.BlobGasPerBlob * 1);
-        yield return (Eip4844Constants.TargetBlobGasPerBlock, 1, Eip4844Constants.BlobGasPerBlob * 1);
+        yield return (0, (int)(Eip4844Constants.TargetBlobGasPerBlock / Eip4844Constants.GasPerBlob) - 1, 0);
+        yield return (0, (int)(Eip4844Constants.TargetBlobGasPerBlock / Eip4844Constants.GasPerBlob), 0);
+        yield return (100000, (int)(Eip4844Constants.TargetBlobGasPerBlock / Eip4844Constants.GasPerBlob), 100000);
+        yield return (0, (int)(Eip4844Constants.TargetBlobGasPerBlock / Eip4844Constants.GasPerBlob) + 1, Eip4844Constants.GasPerBlob * 1);
+        yield return (Eip4844Constants.TargetBlobGasPerBlock, 1, Eip4844Constants.GasPerBlob * 1);
         yield return (Eip4844Constants.TargetBlobGasPerBlock, 0, 0);
-        yield return (Eip4844Constants.TargetBlobGasPerBlock, 2, Eip4844Constants.BlobGasPerBlob * 2);
-        yield return (Eip4844Constants.MaxBlobGasPerBlock, 1, Eip4844Constants.TargetBlobGasPerBlock + Eip4844Constants.BlobGasPerBlob * 1);
+        yield return (Eip4844Constants.TargetBlobGasPerBlock, 2, Eip4844Constants.GasPerBlob * 2);
+        yield return (Eip4844Constants.MaxBlobGasPerBlock, 1, Eip4844Constants.TargetBlobGasPerBlock + Eip4844Constants.GasPerBlob * 1);
         yield return (
             Eip4844Constants.MaxBlobGasPerBlock,
-            (int)(Eip4844Constants.TargetBlobGasPerBlock / Eip4844Constants.BlobGasPerBlob),
+            (int)(Eip4844Constants.TargetBlobGasPerBlock / Eip4844Constants.GasPerBlob),
             Eip4844Constants.MaxBlobGasPerBlock);
         yield return (
             Eip4844Constants.MaxBlobGasPerBlock,
-            (int)(Eip4844Constants.MaxBlobGasPerBlock / Eip4844Constants.BlobGasPerBlob),
+            (int)(Eip4844Constants.MaxBlobGasPerBlock / Eip4844Constants.GasPerBlob),
             Eip4844Constants.MaxBlobGasPerBlock * 2 - Eip4844Constants.TargetBlobGasPerBlock
             );
     }

--- a/src/Nethermind/Nethermind.Evm.Test/TransactionProcessorEip4844Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/TransactionProcessorEip4844Tests.cs
@@ -81,22 +81,22 @@ internal class TransactionProcessorEip4844Tests
 
     public static IEnumerable<TestCaseData> BalanceIsAffectedByBlobGasTestCaseSource()
     {
-        yield return new TestCaseData((UInt256)(GasCostOf.Transaction + Eip4844Constants.BlobGasPerBlob), 1, 1ul, 0ul, 0ul)
+        yield return new TestCaseData((UInt256)(GasCostOf.Transaction + Eip4844Constants.GasPerBlob), 1, 1ul, 0ul, 0ul)
         {
             TestName = "Blob gas consumed for 1 blob, minimal balance",
-            ExpectedResult = (UInt256)(GasCostOf.Transaction + Eip4844Constants.BlobGasPerBlob),
+            ExpectedResult = (UInt256)(GasCostOf.Transaction + Eip4844Constants.GasPerBlob),
         };
         yield return new TestCaseData(1.Ether(), 1, 1ul, 0ul, 0ul)
         {
             TestName = "Blob gas consumed for 1 blob",
-            ExpectedResult = (UInt256)(GasCostOf.Transaction + Eip4844Constants.BlobGasPerBlob),
+            ExpectedResult = (UInt256)(GasCostOf.Transaction + Eip4844Constants.GasPerBlob),
         };
         yield return new TestCaseData(1.Ether(), 2, 1ul, 0ul, 0ul)
         {
             TestName = "Blob gas consumed for 2 blobs",
-            ExpectedResult = (UInt256)(GasCostOf.Transaction + 2 * Eip4844Constants.BlobGasPerBlob),
+            ExpectedResult = (UInt256)(GasCostOf.Transaction + 2 * Eip4844Constants.GasPerBlob),
         };
-        yield return new TestCaseData(1.Ether(), (int)(Eip4844Constants.MaxBlobGasPerTransaction / Eip4844Constants.BlobGasPerBlob), 1ul, 0ul, 0ul)
+        yield return new TestCaseData(1.Ether(), (int)(Eip4844Constants.MaxBlobGasPerTransaction / Eip4844Constants.GasPerBlob), 1ul, 0ul, 0ul)
         {
             TestName = "Blob gas consumed for max blobs",
             ExpectedResult = (UInt256)(GasCostOf.Transaction + Eip4844Constants.MaxBlobGasPerTransaction),
@@ -104,43 +104,43 @@ internal class TransactionProcessorEip4844Tests
         yield return new TestCaseData(1.Ether(), 1, 10ul, 0ul, 0ul)
         {
             TestName = $"Blob gas consumed for 1 blob, with {nameof(Transaction.MaxFeePerBlobGas)} more than needed",
-            ExpectedResult = (UInt256)(GasCostOf.Transaction + Eip4844Constants.BlobGasPerBlob),
+            ExpectedResult = (UInt256)(GasCostOf.Transaction + Eip4844Constants.GasPerBlob),
         };
-        yield return new TestCaseData(1.Ether(), 1, 10ul, (ulong)Eip4844Constants.BlobGasUpdateFraction, 0ul)
+        yield return new TestCaseData(1.Ether(), 1, 10ul, (ulong)Eip4844Constants.BlobGasPriceUpdateFraction, 0ul)
         {
             TestName = $"Blob gas consumed for 1 blob, with blob gas price hiking",
-            ExpectedResult = (UInt256)(GasCostOf.Transaction + Eip4844Constants.BlobGasPerBlob * 2),
+            ExpectedResult = (UInt256)(GasCostOf.Transaction + Eip4844Constants.GasPerBlob * 2),
         };
-        yield return new TestCaseData(1.Ether(), 1, 10ul, (ulong)Eip4844Constants.BlobGasUpdateFraction, 2ul)
+        yield return new TestCaseData(1.Ether(), 1, 10ul, (ulong)Eip4844Constants.BlobGasPriceUpdateFraction, 2ul)
         {
             TestName = $"Blob gas consumed for 1 blob, with blob gas price hiking and some {nameof(Transaction.Value)}",
-            ExpectedResult = (UInt256)(GasCostOf.Transaction + Eip4844Constants.BlobGasPerBlob * 2 + 2),
+            ExpectedResult = (UInt256)(GasCostOf.Transaction + Eip4844Constants.GasPerBlob * 2 + 2),
         };
     }
 
     public static IEnumerable<TestCaseData> BalanceIsNotAffectedWhenNotEnoughFunds()
     {
-        yield return new TestCaseData((UInt256)(GasCostOf.Transaction + Eip4844Constants.BlobGasPerBlob - 1), 1, 1ul, 0ul, 0ul)
+        yield return new TestCaseData((UInt256)(GasCostOf.Transaction + Eip4844Constants.GasPerBlob - 1), 1, 1ul, 0ul, 0ul)
         {
             TestName = $"Rejected if balance is not enough, all funds are returned",
             ExpectedResult = UInt256.Zero,
         };
-        yield return new TestCaseData((UInt256)(GasCostOf.Transaction + Eip4844Constants.BlobGasPerBlob + 41), 1, 1ul, 0ul, 42ul)
+        yield return new TestCaseData((UInt256)(GasCostOf.Transaction + Eip4844Constants.GasPerBlob + 41), 1, 1ul, 0ul, 42ul)
         {
             TestName = $"Rejected if balance is not enough to cover {nameof(Transaction.Value)} also, all funds are returned",
             ExpectedResult = UInt256.Zero,
         };
-        yield return new TestCaseData((UInt256)(GasCostOf.Transaction + Eip4844Constants.BlobGasPerBlob), 1, 10ul, (ulong)Eip4844Constants.BlobGasUpdateFraction, 0ul)
+        yield return new TestCaseData((UInt256)(GasCostOf.Transaction + Eip4844Constants.GasPerBlob), 1, 10ul, (ulong)Eip4844Constants.BlobGasPriceUpdateFraction, 0ul)
         {
             TestName = $"Rejected if balance is not enough due to blob gas price hiking, all funds are returned",
             ExpectedResult = UInt256.Zero,
         };
-        yield return new TestCaseData((UInt256)(GasCostOf.Transaction + Eip4844Constants.BlobGasPerBlob), 1, 2ul, 0ul, 0ul)
+        yield return new TestCaseData((UInt256)(GasCostOf.Transaction + Eip4844Constants.GasPerBlob), 1, 2ul, 0ul, 0ul)
         {
             TestName = $"Rejected if balance does not cover {nameof(Transaction.MaxFeePerBlobGas)}, all funds are returned",
             ExpectedResult = UInt256.Zero,
         };
-        yield return new TestCaseData((UInt256)(GasCostOf.Transaction + 2 * Eip4844Constants.BlobGasPerBlob + 41), 1, 2ul, 0ul, 42ul)
+        yield return new TestCaseData((UInt256)(GasCostOf.Transaction + 2 * Eip4844Constants.GasPerBlob + 41), 1, 2ul, 0ul, 42ul)
         {
             TestName = $"Rejected if balance does not cover {nameof(Transaction.MaxFeePerBlobGas)} + {nameof(Transaction.Value)}, all funds are returned",
             ExpectedResult = UInt256.Zero,

--- a/src/Nethermind/Nethermind.Evm/BlobGasCalculator.cs
+++ b/src/Nethermind/Nethermind.Evm/BlobGasCalculator.cs
@@ -10,7 +10,7 @@ namespace Nethermind.Evm;
 public static class BlobGasCalculator
 {
     public static ulong CalculateBlobGas(int blobCount) =>
-        (ulong)blobCount * Eip4844Constants.BlobGasPerBlob;
+        (ulong)blobCount * Eip4844Constants.GasPerBlob;
 
     public static ulong CalculateBlobGas(Transaction transaction) =>
         CalculateBlobGas(transaction.BlobVersionedHashes?.Length ?? 0);
@@ -85,7 +85,7 @@ public static class BlobGasCalculator
             return false;
         }
 
-        return !FakeExponentialOverflow(Eip4844Constants.MinBlobGasPrice, excessBlobGas, Eip4844Constants.BlobGasUpdateFraction, out blobGasPricePerUnit);
+        return !FakeExponentialOverflow(Eip4844Constants.MinBlobGasPrice, excessBlobGas, Eip4844Constants.BlobGasPriceUpdateFraction, out blobGasPricePerUnit);
     }
 
     public static ulong? CalculateExcessBlobGas(BlockHeader? parentBlockHeader, IReleaseSpec releaseSpec)

--- a/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecBasedSpecProviderTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecBasedSpecProviderTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Reflection;
 using FluentAssertions;
 using Nethermind.Core;
+using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Int256;
 using Nethermind.Logging;
@@ -258,6 +259,14 @@ public class ChainSpecBasedSpecProviderTests
         VerifyGnosisShanghaiExceptions(preShanghaiSpec, postShanghaiSpec);
         GetTransitionTimestamps(chainSpec.Parameters).Should().AllSatisfy(
             t => ValidateSlotByTimestamp(t, ChiadoSpecProvider.BeaconChainGenesisTimestamp, GnosisBlockTime).Should().BeTrue());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(Eip4844Constants.BlobGasPriceUpdateFraction, Is.EqualTo((UInt256)1112826));
+            Assert.That(Eip4844Constants.MaxBlobGasPerBlock, Is.EqualTo(262144));
+            Assert.That(Eip4844Constants.MinBlobGasPrice, Is.EqualTo(1.GWei()));
+            Assert.That(Eip4844Constants.TargetBlobGasPerBlock, Is.EqualTo(131072));
+        });
     }
 
     [Test]
@@ -301,6 +310,14 @@ public class ChainSpecBasedSpecProviderTests
         VerifyGnosisShanghaiExceptions(preShanghaiSpec, postShanghaiSpec);
         GetTransitionTimestamps(chainSpec.Parameters).Should().AllSatisfy(
             t => ValidateSlotByTimestamp(t, GnosisSpecProvider.BeaconChainGenesisTimestamp, GnosisBlockTime).Should().BeTrue());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(Eip4844Constants.BlobGasPriceUpdateFraction, Is.EqualTo((UInt256)1112826));
+            Assert.That(Eip4844Constants.MaxBlobGasPerBlock, Is.EqualTo(262144));
+            Assert.That(Eip4844Constants.MinBlobGasPrice, Is.EqualTo(1.GWei()));
+            Assert.That(Eip4844Constants.TargetBlobGasPerBlock, Is.EqualTo(131072));
+        });
     }
 
     private void VerifyGnosisShanghaiExceptions(IReleaseSpec preShanghaiSpec, IReleaseSpec postShanghaiSpec)
@@ -452,6 +469,11 @@ public class ChainSpecBasedSpecProviderTests
                      .Where(p => p.Name != nameof(IReleaseSpec.Eip1559TransitionBlock))
                      .Where(p => p.Name != nameof(IReleaseSpec.WithdrawalTimestamp))
                      .Where(p => p.Name != nameof(IReleaseSpec.Eip4844TransitionTimestamp))
+
+                     // Skip EIP-4844 parameter validation
+                     .Where(p => p.Name != nameof(Eip4844Constants.MaxBlobGasPerBlock))
+                     .Where(p => p.Name != nameof(Eip4844Constants.MinBlobGasPrice))
+                     .Where(p => p.Name != nameof(Eip4844Constants.TargetBlobGasPerBlock))
 
                      // handle gnosis specific exceptions
                      .Where(p => !isGnosis || p.Name != nameof(IReleaseSpec.MaxCodeSize))

--- a/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecBasedSpecProviderTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecBasedSpecProviderTests.cs
@@ -471,6 +471,7 @@ public class ChainSpecBasedSpecProviderTests
                      .Where(p => p.Name != nameof(IReleaseSpec.Eip4844TransitionTimestamp))
 
                      // Skip EIP-4844 parameter validation
+                     .Where(p => p.Name != nameof(Eip4844Constants.BlobGasPriceUpdateFraction))
                      .Where(p => p.Name != nameof(Eip4844Constants.MaxBlobGasPerBlock))
                      .Where(p => p.Name != nameof(Eip4844Constants.MinBlobGasPrice))
                      .Where(p => p.Name != nameof(Eip4844Constants.TargetBlobGasPerBlock))

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
@@ -117,5 +117,31 @@ namespace Nethermind.Specs.ChainSpecStyle
         public ulong? Eip6780TransitionTimestamp { get; set; }
         public ulong? Eip4788TransitionTimestamp { get; set; }
         public Address Eip4788ContractAddress { get; set; }
+
+        #region EIP-4844 parameters
+        /// <summary>
+        /// Gets or sets the <c>BLOB_GASPRICE_UPDATE_FRACTION</c> parameter defined in
+        /// <see href="https://eips.ethereum.org/EIPS/eip-4844#parameters">EIP-4844</see>.
+        /// </summary>
+        public UInt256? BlobGasPriceUpdateFraction { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <c>MAX_BLOB_GAS_PER_BLOCK</c> parameter defined in
+        /// <see href="https://eips.ethereum.org/EIPS/eip-4844#parameters">EIP-4844</see>.
+        /// </summary>
+        public ulong? MaxBlobGasPerBlock { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <c>MIN_BLOB_GASPRICE</c> parameter, in wei, defined in
+        /// <see href="https://eips.ethereum.org/EIPS/eip-4844#parameters">EIP-4844</see>.
+        /// </summary>
+        public UInt256? MinBlobGasPrice { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <c>TARGET_BLOB_GAS_PER_BLOCK</c> parameter defined in
+        /// <see href="https://eips.ethereum.org/EIPS/eip-4844#parameters">EIP-4844</see>.
+        /// </summary>
+        public ulong? TargetBlobGasPerBlock { get; set; }
+        #endregion
     }
 }

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
@@ -170,6 +170,11 @@ public class ChainSpecLoader : IChainSpecLoader
         Eip1559Constants.ElasticityMultiplier = chainSpec.Parameters.Eip1559ElasticityMultiplier;
         Eip1559Constants.ForkBaseFee = chainSpec.Parameters.Eip1559BaseFeeInitialValue;
         Eip1559Constants.BaseFeeMaxChangeDenominator = chainSpec.Parameters.Eip1559BaseFeeMaxChangeDenominator;
+
+        Eip4844Constants.BlobGasPriceUpdateFraction = chainSpecJson.Params.MaxBlobGasPerBlock ?? Eip4844Constants.BlobGasPriceUpdateFraction;
+        Eip4844Constants.MaxBlobGasPerBlock = chainSpecJson.Params.MaxBlobGasPerBlock ?? Eip4844Constants.MaxBlobGasPerBlock;
+        Eip4844Constants.MinBlobGasPrice = chainSpecJson.Params.MinBlobGasPrice ?? Eip4844Constants.MinBlobGasPrice;
+        Eip4844Constants.TargetBlobGasPerBlock = chainSpecJson.Params.TargetBlobGasPerBlock ?? Eip4844Constants.TargetBlobGasPerBlock;
     }
 
     private static void ValidateParams(ChainSpecParamsJson parameters)

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
@@ -171,7 +171,7 @@ public class ChainSpecLoader : IChainSpecLoader
         Eip1559Constants.ForkBaseFee = chainSpec.Parameters.Eip1559BaseFeeInitialValue;
         Eip1559Constants.BaseFeeMaxChangeDenominator = chainSpec.Parameters.Eip1559BaseFeeMaxChangeDenominator;
 
-        Eip4844Constants.BlobGasPriceUpdateFraction = chainSpecJson.Params.MaxBlobGasPerBlock ?? Eip4844Constants.BlobGasPriceUpdateFraction;
+        Eip4844Constants.BlobGasPriceUpdateFraction = chainSpecJson.Params.BlobGasPriceUpdateFraction ?? Eip4844Constants.BlobGasPriceUpdateFraction;
         Eip4844Constants.MaxBlobGasPerBlock = chainSpecJson.Params.MaxBlobGasPerBlock ?? Eip4844Constants.MaxBlobGasPerBlock;
         Eip4844Constants.MinBlobGasPrice = chainSpecJson.Params.MinBlobGasPrice ?? Eip4844Constants.MinBlobGasPrice;
         Eip4844Constants.TargetBlobGasPerBlock = chainSpecJson.Params.TargetBlobGasPerBlock ?? Eip4844Constants.TargetBlobGasPerBlock;

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
@@ -171,10 +171,17 @@ public class ChainSpecLoader : IChainSpecLoader
         Eip1559Constants.ForkBaseFee = chainSpec.Parameters.Eip1559BaseFeeInitialValue;
         Eip1559Constants.BaseFeeMaxChangeDenominator = chainSpec.Parameters.Eip1559BaseFeeMaxChangeDenominator;
 
-        Eip4844Constants.BlobGasPriceUpdateFraction = chainSpecJson.Params.BlobGasPriceUpdateFraction ?? Eip4844Constants.BlobGasPriceUpdateFraction;
-        Eip4844Constants.MaxBlobGasPerBlock = chainSpecJson.Params.MaxBlobGasPerBlock ?? Eip4844Constants.MaxBlobGasPerBlock;
-        Eip4844Constants.MinBlobGasPrice = chainSpecJson.Params.MinBlobGasPrice ?? Eip4844Constants.MinBlobGasPrice;
-        Eip4844Constants.TargetBlobGasPerBlock = chainSpecJson.Params.TargetBlobGasPerBlock ?? Eip4844Constants.TargetBlobGasPerBlock;
+        if (chainSpecJson.Params.BlobGasPriceUpdateFraction.HasValue)
+            Eip4844Constants.OverrideBlobGasPriceUpdateFraction(chainSpecJson.Params.BlobGasPriceUpdateFraction.Value);
+
+        if (chainSpecJson.Params.MaxBlobGasPerBlock.HasValue)
+            Eip4844Constants.OverrideMaxBlobGasPerBlock(chainSpecJson.Params.MaxBlobGasPerBlock.Value);
+
+        if (chainSpecJson.Params.MinBlobGasPrice.HasValue)
+            Eip4844Constants.OverrideMinBlobGasPrice(chainSpecJson.Params.MinBlobGasPrice.Value);
+
+        if (chainSpecJson.Params.TargetBlobGasPerBlock.HasValue)
+            Eip4844Constants.OverrideTargetBlobGasPerBlock(chainSpecJson.Params.TargetBlobGasPerBlock.Value);
     }
 
     private static void ValidateParams(ChainSpecParamsJson parameters)

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
@@ -144,5 +144,15 @@ namespace Nethermind.Specs.ChainSpecStyle.Json
         public ulong? Eip6780TransitionTimestamp { get; set; }
         public ulong? Eip4788TransitionTimestamp { get; set; }
         public Address Eip4788ContractAddress { get; set; }
+
+        #region EIP-4844 parameters
+        public UInt256? BlobGasPriceUpdateFraction { get; set; }
+
+        public ulong? MaxBlobGasPerBlock { get; set; }
+
+        public UInt256? MinBlobGasPrice { get; set; }
+
+        public ulong? TargetBlobGasPerBlock { get; set; }
+        #endregion
     }
 }

--- a/src/Nethermind/Nethermind.TxPool/TransactionExtensions.cs
+++ b/src/Nethermind/Nethermind.TxPool/TransactionExtensions.cs
@@ -81,7 +81,7 @@ namespace Nethermind.TxPool
             if (tx.SupportsBlobs)
             {
                 // if tx.SupportsBlobs and has BlobVersionedHashes = null, it will throw on earlier step of validation, in TxValidator
-                overflow |= UInt256.MultiplyOverflow(Eip4844Constants.BlobGasPerBlob, (UInt256)tx.BlobVersionedHashes!.Length, out UInt256 blobGas);
+                overflow |= UInt256.MultiplyOverflow(Eip4844Constants.GasPerBlob, (UInt256)tx.BlobVersionedHashes!.Length, out UInt256 blobGas);
                 overflow |= UInt256.MultiplyOverflow(blobGas, tx.MaxFeePerBlobGas ?? UInt256.MaxValue, out UInt256 blobGasCost);
                 overflow |= UInt256.AddOverflow(cumulativeCost, blobGasCost, out cumulativeCost);
             }

--- a/tools/SendBlobs/BlobSender.cs
+++ b/tools/SendBlobs/BlobSender.cs
@@ -164,7 +164,7 @@ internal class BlobSender
                     //case "8": maxFeePerDataGas = 42_000_000_000; break;
                     case "9": proofs = proofs.Skip(1).ToArray(); break;
                     case "10": commitments = commitments.Skip(1).ToArray(); break;
-                    case "11": maxFeePerDataGas = UInt256.MaxValue / Eip4844Constants.BlobGasPerBlob + 1; break;
+                    case "11": maxFeePerDataGas = UInt256.MaxValue / Eip4844Constants.GasPerBlob + 1; break;
                 }
 
                 UInt256 adjustedMaxPriorityFeePerGas = maxPriorityFeeGasArgs == 0 ? maxPriorityFeePerGas : maxPriorityFeeGasArgs;


### PR DESCRIPTION
## Changes

- Made the following EIP-4844 parameters configurable with chain spec:
    - `BLOB_GASPRICE_UPDATE_FRACTION` 
    - `MAX_BLOB_GAS_PER_BLOCK`
    - `MIN_BLOB_GASPRICE`
    - `TARGET_BLOB_GAS_PER_BLOCK`
    
  The default EIP-4844 parameters can be overridden by defining them in a chain spec file (e.g., `gnosis.json`). Otherwise, the hardcoded defaults are used.
- Refactored some parameter names to match the ones in EIP-4844.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
