### PR TITLE
Handle concurrent WebSockets messages

### DIFF
--- a/src/Nethermind/Nethermind.AccountAbstraction/Subscribe/NewPendingUserOpsSubscription.cs
+++ b/src/Nethermind/Nethermind.AccountAbstraction/Subscribe/NewPendingUserOpsSubscription.cs
@@ -60,18 +60,13 @@ namespace Nethermind.AccountAbstraction.Subscribe
 
         private void OnNewPending(object? sender, UserOperationEventArgs e)
         {
-            ScheduleAction(() =>
+            ScheduleAction(async () =>
             {
                 JsonRpcResult result;
-                if (_includeUserOperations)
-                {
-                    result = CreateSubscriptionMessage(new { UserOperation = new UserOperationRpc(e.UserOperation), e.EntryPoint });
-                }
-                else
-                {
-                    result = CreateSubscriptionMessage(new { UserOperation = e.UserOperation.RequestId, e.EntryPoint });
-                }
-                JsonRpcDuplexClient.SendJsonRpcResult(result);
+                result = _includeUserOperations
+                    ? CreateSubscriptionMessage(new { UserOperation = new UserOperationRpc(e.UserOperation), e.EntryPoint })
+                    : CreateSubscriptionMessage(new { UserOperation = e.UserOperation.RequestId, e.EntryPoint });
+                await JsonRpcDuplexClient.SendJsonRpcResult(result);
                 if (_logger.IsTrace) _logger.Trace($"newPendingUserOperations subscription {Id} printed hash of newPendingUserOperations.");
             });
         }
@@ -89,5 +84,3 @@ namespace Nethermind.AccountAbstraction.Subscribe
         }
     }
 }
-
-

--- a/src/Nethermind/Nethermind.AccountAbstraction/Subscribe/NewReceivedUserOpsSubscription.cs
+++ b/src/Nethermind/Nethermind.AccountAbstraction/Subscribe/NewReceivedUserOpsSubscription.cs
@@ -60,18 +60,13 @@ namespace Nethermind.AccountAbstraction.Subscribe
 
         private void OnNewReceived(object? sender, UserOperationEventArgs e)
         {
-            ScheduleAction(() =>
+            ScheduleAction(async () =>
             {
                 JsonRpcResult result;
-                if (_includeUserOperations)
-                {
-                    result = CreateSubscriptionMessage(new { UserOperation = new UserOperationRpc(e.UserOperation), e.EntryPoint });
-                }
-                else
-                {
-                    result = CreateSubscriptionMessage(new { UserOperation = e.UserOperation.RequestId, e.EntryPoint });
-                }
-                JsonRpcDuplexClient.SendJsonRpcResult(result);
+                result = _includeUserOperations
+                    ? CreateSubscriptionMessage(new { UserOperation = new UserOperationRpc(e.UserOperation), e.EntryPoint })
+                    : CreateSubscriptionMessage(new { UserOperation = e.UserOperation.RequestId, e.EntryPoint });
+                await JsonRpcDuplexClient.SendJsonRpcResult(result);
                 if (_logger.IsTrace) _logger.Trace($"newReceivedUserOperations subscription {Id} printed hash of newReceivedUserOperations.");
             });
         }
@@ -89,5 +84,3 @@ namespace Nethermind.AccountAbstraction.Subscribe
         }
     }
 }
-
-

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
@@ -805,8 +805,8 @@ namespace Nethermind.JsonRpc.Test.Modules
         }
 
         [TestCase(2)]
+        [TestCase(5)]
         [TestCase(10)]
-        [TestCase(50)]
         [Explicit("Requires a WS server running")]
         public async Task NewPendingTransactionSubscription_multiple_fast_messages(int messages)
         {

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
@@ -804,9 +804,11 @@ namespace Nethermind.JsonRpc.Test.Modules
             expectedResult.Should().Be(serialized);
         }
 
-        [Test]
+        [TestCase(2)]
+        [TestCase(10)]
+        [TestCase(50)]
         [Explicit("Requires a WS server running")]
-        public async Task NewPendingTransactionSubscription_multiple_fast_messages()
+        public async Task NewPendingTransactionSubscription_multiple_fast_messages(int messages)
         {
             ITxPool txPool = Substitute.For<ITxPool>();
 
@@ -829,7 +831,7 @@ namespace Nethermind.JsonRpc.Test.Modules
                 txPool: txPool,
                 logManager: LimboLogs.Instance);
 
-            for (int i = 0; i < 10; i++)
+            for (int i = 0; i < messages; i++)
             {
                 Transaction tx = new();
                 txPool.NewPending += Raise.EventWith(new TxEventArgs(tx));

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
@@ -5,11 +5,11 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.WebSockets;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Nethermind.Blockchain;
-using Nethermind.Blockchain.Blocks;
 using Nethermind.Blockchain.Filters;
 using Nethermind.Blockchain.Find;
 using Nethermind.Blockchain.Receipts;
@@ -18,17 +18,16 @@ using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Builders;
-using Nethermind.Db;
-using Nethermind.Db.Blooms;
 using Nethermind.Facade.Eth;
 using Nethermind.Int256;
 using Nethermind.JsonRpc.Modules;
 using Nethermind.JsonRpc.Modules.Eth;
 using Nethermind.JsonRpc.Modules.Subscribe;
+using Nethermind.JsonRpc.WebSockets;
 using Nethermind.Logging;
 using Nethermind.Serialization.Json;
+using Nethermind.Sockets;
 using Nethermind.Specs;
-using Nethermind.State.Repositories;
 using Nethermind.Synchronization.ParallelSync;
 using Nethermind.TxPool;
 using Newtonsoft.Json;
@@ -803,6 +802,41 @@ namespace Nethermind.JsonRpc.Test.Modules
             string serialized = _jsonSerializer.Serialize(jsonRpcResult.Response);
             var expectedResult = string.Concat("{\"jsonrpc\":\"2.0\",\"method\":\"eth_subscription\",\"params\":{\"subscription\":\"", subscriptionId, "\",\"result\":{\"nonce\":\"0x0\",\"blockHash\":null,\"blockNumber\":null,\"transactionIndex\":null,\"to\":\"0x0000000000000000000000000000000000000000\",\"value\":\"0x1\",\"gasPrice\":\"0x1\",\"gas\":\"0x5208\",\"input\":\"0x\",\"type\":\"0x0\"}}}");
             expectedResult.Should().Be(serialized);
+        }
+
+        [Test]
+        [Explicit("Requires a WS server running")]
+        public async Task NewPendingTransactionSubscription_multiple_fast_messages()
+        {
+            ITxPool txPool = Substitute.For<ITxPool>();
+
+            using ClientWebSocket socket = new();
+            await socket.ConnectAsync(new Uri("ws://localhost:1337/"), CancellationToken.None);
+
+            using ISocketHandler handler = new WebSocketHandler(socket, NullLogManager.Instance);
+            using JsonRpcSocketsClient client = new(
+                clientName: "TestClient",
+                handler: handler,
+                endpointType: RpcEndpoint.Ws,
+                jsonRpcProcessor: null!,
+                jsonRpcService: null!,
+                jsonRpcLocalStats: new NullJsonRpcLocalStats(),
+                jsonSerializer: new EthereumJsonSerializer()
+            );
+
+            using NewPendingTransactionsSubscription subscription = new(
+                jsonRpcDuplexClient: client,
+                txPool: txPool,
+                logManager: LimboLogs.Instance);
+
+            for (int i = 0; i < 10; i++)
+            {
+                Transaction tx = new();
+                txPool.NewPending += Raise.EventWith(new TxEventArgs(tx));
+            }
+
+            // Wait until all messages are sent
+            await Task.Delay(10_000);
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/DroppedPendingTransactionsSubscription.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/DroppedPendingTransactionsSubscription.cs
@@ -26,10 +26,10 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
 
         private void OnEvicted(object? sender, TxEventArgs e)
         {
-            ScheduleAction(() =>
+            ScheduleAction(async () =>
             {
                 JsonRpcResult result = CreateSubscriptionMessage(e.Transaction.Hash);
-                JsonRpcDuplexClient.SendJsonRpcResult(result);
+                await JsonRpcDuplexClient.SendJsonRpcResult(result);
                 if (_logger.IsTrace)
                     _logger.Trace(
                         $"DroppedPendingTransactions subscription {Id} printed hash of DroppedPendingTransaction.");

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/LogsSubscription.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/LogsSubscription.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Filters;
 using Nethermind.Blockchain.Find;
@@ -62,10 +63,10 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
 
         private void TryPublishReceiptsInBackground(BlockHeader blockHeader, Func<TxReceipt[]> getReceipts, string eventName, bool removed)
         {
-            ScheduleAction(() => TryPublishEvent(blockHeader, getReceipts(), eventName, removed));
+            ScheduleAction(async () => await TryPublishEvent(blockHeader, getReceipts(), eventName, removed));
         }
 
-        private void TryPublishEvent(BlockHeader blockHeader, TxReceipt[] receipts, string eventName, bool removed)
+        private async Task TryPublishEvent(BlockHeader blockHeader, TxReceipt[] receipts, string eventName, bool removed)
         {
             BlockHeader fromBlock = _blockTree.FindHeader(_filter.FromBlock);
             BlockHeader toBlock = _blockTree.FindHeader(_filter.ToBlock, true);
@@ -80,7 +81,7 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
                 foreach (var filterLog in filterLogs)
                 {
                     JsonRpcResult result = CreateSubscriptionMessage(filterLog);
-                    JsonRpcDuplexClient.SendJsonRpcResult(result);
+                    await JsonRpcDuplexClient.SendJsonRpcResult(result);
                     if (_logger.IsTrace) _logger.Trace($"Logs subscription {Id} printed new log.");
                 }
             }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/NewHeadSubscription.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/NewHeadSubscription.cs
@@ -36,11 +36,11 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
 
         private void OnBlockAddedToMain(object? sender, BlockReplacementEventArgs e)
         {
-            ScheduleAction(() =>
+            ScheduleAction(async () =>
             {
                 JsonRpcResult result = CreateSubscriptionMessage(new BlockForRpc(e.Block, _includeTransactions, _specProvider));
 
-                JsonRpcDuplexClient.SendJsonRpcResult(result);
+                await JsonRpcDuplexClient.SendJsonRpcResult(result);
                 if (_logger.IsTrace) _logger.Trace($"NewHeads subscription {Id} printed new block");
             });
         }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/NewPendingTransactionsSubscription.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/NewPendingTransactionsSubscription.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Threading.Tasks;
 using Nethermind.JsonRpc.Data;
 using Nethermind.JsonRpc.Modules.Eth;
 using Nethermind.Logging;
@@ -31,10 +32,10 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
 
         private void OnNewPending(object? sender, TxEventArgs e)
         {
-            ScheduleAction(() =>
+            ScheduleAction(async () =>
             {
                 JsonRpcResult result = CreateSubscriptionMessage(_includeTransactions ? new TransactionForRpc(e.Transaction) : e.Transaction.Hash);
-                JsonRpcDuplexClient.SendJsonRpcResult(result);
+                await JsonRpcDuplexClient.SendJsonRpcResult(result);
                 if (_logger.IsTrace) _logger.Trace($"NewPendingTransactions subscription {Id} printed hash of NewPendingTransaction.");
             });
         }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/SyncingSubscription.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/SyncingSubscription.cs
@@ -46,7 +46,7 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
 
         private void OnConditionsChange(object? sender, BlockEventArgs e)
         {
-            ScheduleAction(() =>
+            ScheduleAction(async () =>
             {
                 SyncingResult syncingResult = _ethSyncingInfo.GetFullInfo();
                 bool isSyncing = syncingResult.IsSyncing;
@@ -78,7 +78,7 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
                 }
 
 
-                JsonRpcDuplexClient.SendJsonRpcResult(result);
+                await JsonRpcDuplexClient.SendJsonRpcResult(result);
                 _logger.Trace($"Syncing subscription {Id} printed SyncingResult object.");
             });
         }


### PR DESCRIPTION
Fixes #6169

## Changes

- Use `Task` instead of `Action` when dealing with subscription messages.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

An integration test was added to reproduce the reported issue. The test is annotated with `[Explicit]` since it requires an external WebSockets server running. We could make the test self contained by running a local server but this has produced issues in the past on CI (https://github.com/NethermindEth/nethermind/pull/6102).

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No