### PR TITLE
Refactor/columned db

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/TestMemColumnDb.cs
+++ b/src/Nethermind/Nethermind.Core.Test/TestMemColumnDb.cs
@@ -6,7 +6,7 @@ using Nethermind.Db;
 
 namespace Nethermind.Core.Test;
 
-public class TestMemColumnsDb<TKey> : TestMemDb, IColumnsDb<TKey>
+public class TestMemColumnsDb<TKey> : IColumnsDb<TKey>
     where TKey : notnull
 {
     private readonly IDictionary<TKey, IDbWithSpan> _columnDbs = new Dictionary<TKey, IDbWithSpan>();
@@ -26,8 +26,13 @@ public class TestMemColumnsDb<TKey> : TestMemDb, IColumnsDb<TKey>
     public IDbWithSpan GetColumnDb(TKey key) => !_columnDbs.TryGetValue(key, out var db) ? _columnDbs[key] = new TestMemDb() : db;
     public IEnumerable<TKey> ColumnKeys => _columnDbs.Keys;
 
-    public IReadOnlyDb CreateReadOnly(bool createInMemWriteStore)
+    public IColumnsDb<TKey> CreateReadOnly(bool createInMemWriteStore)
     {
         return new ReadOnlyColumnsDb<TKey>(this, createInMemWriteStore);
+    }
+
+    public IColumnsBatch<TKey> StartBatch()
+    {
+        return new InMemoryColumnBatch<TKey>(this);
     }
 }

--- a/src/Nethermind/Nethermind.Core.Test/TestMemColumnDb.cs
+++ b/src/Nethermind/Nethermind.Core.Test/TestMemColumnDb.cs
@@ -26,11 +26,6 @@ public class TestMemColumnsDb<TKey> : IColumnsDb<TKey>
     public IDbWithSpan GetColumnDb(TKey key) => !_columnDbs.TryGetValue(key, out var db) ? _columnDbs[key] = new TestMemDb() : db;
     public IEnumerable<TKey> ColumnKeys => _columnDbs.Keys;
 
-    public IColumnsDb<TKey> CreateReadOnly(bool createInMemWriteStore)
-    {
-        return new ReadOnlyColumnsDb<TKey>(this, createInMemWriteStore);
-    }
-
     public IColumnsBatch<TKey> StartBatch()
     {
         return new InMemoryColumnBatch<TKey>(this);

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -15,7 +15,6 @@ public class ColumnDb : IDbWithSpan
     private readonly RocksDb _rocksDb;
     private readonly DbOnTheRocks _mainDb;
     internal readonly ColumnFamilyHandle _columnFamily;
-    public ColumnFamilyHandle ColumnFamily => _columnFamily;
 
     private DbOnTheRocks.ManagedIterators _readaheadIterators = new();
 

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -15,6 +15,7 @@ public class ColumnDb : IDbWithSpan
     private readonly RocksDb _rocksDb;
     private readonly DbOnTheRocks _mainDb;
     internal readonly ColumnFamilyHandle _columnFamily;
+    public ColumnFamilyHandle ColumnFamily => _columnFamily;
 
     private DbOnTheRocks.ManagedIterators _readaheadIterators = new();
 
@@ -22,6 +23,7 @@ public class ColumnDb : IDbWithSpan
     {
         _rocksDb = rocksDb;
         _mainDb = mainDb;
+        if (name == "Default") name = "default";
         _columnFamily = _rocksDb.GetColumnFamily(name);
         Name = name;
     }

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -6,12 +6,10 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions;
-using System.Linq;
 using System.Reflection;
 using System.Threading;
 using ConcurrentCollections;
 using Nethermind.Core;
-using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Db.Rocks.Config;
@@ -131,8 +129,13 @@ public class DbOnTheRocks : IDbWithSpan, ITunableDb
             if (columnNames != null)
             {
                 columnFamilies = new ColumnFamilies();
-                foreach (string columnFamily in columnNames)
+                foreach (string enumColumnName in columnNames)
                 {
+                    string columnFamily = enumColumnName;
+
+                    // "default" is a special column name with rocksdb, which is what previously not specifying column goes to
+                    if (columnFamily == "Default") columnFamily = "default";
+
                     ColumnFamilyOptions options = new();
                     BuildOptions(new PerTableDbConfig(dbConfig, _settings, columnFamily), options, sharedCache);
                     columnFamilies.Add(columnFamily, options);

--- a/src/Nethermind/Nethermind.Db.Rpc/RpcDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rpc/RpcDb.cs
@@ -13,7 +13,7 @@ using Nethermind.Serialization.Json;
 
 namespace Nethermind.Db.Rpc
 {
-    public class RpcDb : IDb
+    public class RpcDb : IDb, IDbWithSpan
     {
         private readonly string _dbName;
         private readonly IJsonSerializer _jsonSerializer;
@@ -100,6 +100,20 @@ namespace Nethermind.Db.Rpc
             }
 
             return value;
+        }
+
+        public Span<byte> GetSpan(ReadOnlySpan<byte> key)
+        {
+            return Get(key);
+        }
+
+        public void PutSpan(ReadOnlySpan<byte> key, ReadOnlySpan<byte> value)
+        {
+            Set(key, value.ToArray());
+        }
+
+        public void DangerousReleaseMemory(in Span<byte> span)
+        {
         }
     }
 }

--- a/src/Nethermind/Nethermind.Db.Rpc/RpcDbFactory.cs
+++ b/src/Nethermind/Nethermind.Db.Rpc/RpcDbFactory.cs
@@ -32,13 +32,15 @@ namespace Nethermind.Db.Rpc
 
         public IColumnsDb<T> CreateColumnsDb<T>(RocksDbSettings rocksDbSettings) where T : struct, Enum
         {
-            var rocksDb = _wrappedRocksDbFactory.CreateColumnsDb<T>(rocksDbSettings);
-            return new ReadOnlyColumnsDb<T>(new RpcColumnsDb<T>(rocksDbSettings.DbName, _jsonSerializer, _jsonRpcClient, _logManager, rocksDb), true);
+            IColumnsDb<T> rocksDb = _wrappedRocksDbFactory.CreateColumnsDb<T>(rocksDbSettings);
+            return new ReadOnlyColumnsDb<T>(
+                new RpcColumnsDb<T>(rocksDbSettings.DbName, _jsonSerializer, _jsonRpcClient, _logManager, rocksDb),
+                true);
         }
 
-        public IColumnsDb<T> CreateColumnsDb<T>(string dbName)
+        public IColumnsDb<T> CreateColumnsDb<T>(string dbName) where T : struct, Enum
         {
-            var memDb = _wrappedMemDbFactory.CreateColumnsDb<T>(dbName);
+            IColumnsDb<T> memDb = _wrappedMemDbFactory.CreateColumnsDb<T>(dbName);
             return new ReadOnlyColumnsDb<T>(new RpcColumnsDb<T>(dbName, _jsonSerializer, _jsonRpcClient, _logManager, memDb), true);
         }
 

--- a/src/Nethermind/Nethermind.Db.Test/ColumnsDbTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/ColumnsDbTests.cs
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.IO;
+using FluentAssertions;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Db.Rocks;
+using Nethermind.Db.Rocks.Config;
+using Nethermind.Logging;
+using NUnit.Framework;
+
+namespace Nethermind.Db.Test;
+
+public class ColumnsDbTests
+{
+    string DbPath => "testdb/" + TestContext.CurrentContext.Test.Name;
+    private ColumnsDb<TestColumns> _db = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        if (Directory.Exists(DbPath))
+        {
+            Directory.Delete(DbPath, true);
+        }
+
+        Directory.CreateDirectory(DbPath);
+        ColumnsDb<TestColumns> columnsDb = new(DbPath,
+            new("blocks", DbPath)
+            {
+                BlockCacheSize = (ulong)1.KiB(),
+                CacheIndexAndFilterBlocks = false,
+                DeleteOnStart = true,
+                WriteBufferNumber = 4,
+                WriteBufferSize = (ulong)1.KiB()
+            },
+            new DbConfig(),
+            LimboLogs.Instance,
+            Enum.GetValues<TestColumns>()
+        );
+
+        _db = columnsDb;
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _db.Dispose();
+    }
+
+    [Test]
+    public void SmokeTest()
+    {
+        IDbWithSpan colA = _db.GetColumnDb(TestColumns.ColumnA);
+        IDbWithSpan colB = _db.GetColumnDb(TestColumns.ColumnB);
+        IDbWithSpan defaultCol = _db.GetColumnDb(TestColumns.Default);
+
+        colA.Set(TestItem.KeccakA, TestItem.KeccakA.BytesToArray());
+        colB.Set(TestItem.KeccakA, TestItem.KeccakB.BytesToArray());
+
+        colA.Get(TestItem.KeccakA).Should().BeEquivalentTo(TestItem.KeccakA.BytesToArray());
+        colB.Get(TestItem.KeccakA).Should().BeEquivalentTo(TestItem.KeccakB.BytesToArray());
+
+        defaultCol.Get(TestItem.KeccakB).Should().BeNull();
+    }
+
+    [Test]
+    public void SmokeTestDefaultColumn()
+    {
+        IDbWithSpan defaultCol = _db.GetColumnDb(TestColumns.Default);
+
+        defaultCol.Get(TestItem.KeccakB).Should().BeNull();
+        defaultCol.Set(TestItem.KeccakB, TestItem.KeccakC.BytesToArray());
+        defaultCol.Get(TestItem.KeccakB).Should().BeEquivalentTo(TestItem.KeccakC.BytesToArray());
+
+        _db.Get(TestItem.KeccakB).Should().BeEquivalentTo(TestItem.KeccakC.BytesToArray());
+    }
+
+    [Test]
+    public void TestWriteBatch_WriteToAllColumn()
+    {
+        var batch = _db.StartBatch();
+        var colA = batch.GetColumnBatch(TestColumns.ColumnA);
+        var colB = batch.GetColumnBatch(TestColumns.ColumnB);
+
+        colA.Set(TestItem.KeccakA.Bytes, TestItem.KeccakA.BytesToArray());
+        colB.Set(TestItem.KeccakA.Bytes, TestItem.KeccakB.BytesToArray());
+
+        batch.Dispose();
+
+        _db.GetColumnDb(TestColumns.ColumnA).Get(TestItem.KeccakA).Should()
+            .BeEquivalentTo(TestItem.KeccakA.BytesToArray());
+        _db.GetColumnDb(TestColumns.ColumnB).Get(TestItem.KeccakA).Should()
+            .BeEquivalentTo(TestItem.KeccakB.BytesToArray());
+    }
+
+    enum TestColumns
+    {
+        Default,
+        ColumnA,
+        ColumnB,
+    }
+}

--- a/src/Nethermind/Nethermind.Db.Test/DbProviderTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/DbProviderTests.cs
@@ -29,8 +29,8 @@ namespace Nethermind.Db.Test
             {
                 MemDbFactory memDbFactory = new MemDbFactory();
                 IColumnsDb<ReceiptsColumns> memSnapshotableDb = memDbFactory.CreateColumnsDb<ReceiptsColumns>("ColumnsDb");
-                dbProvider.RegisterDb("ColumnsDb", memSnapshotableDb);
-                IColumnsDb<ReceiptsColumns> columnsDb = dbProvider.GetDb<IColumnsDb<ReceiptsColumns>>("ColumnsDb");
+                dbProvider.RegisterColumnDb("ColumnsDb", memSnapshotableDb);
+                IColumnsDb<ReceiptsColumns> columnsDb = dbProvider.GetColumnDb<ReceiptsColumns>("ColumnsDb");
                 Assert.That(columnsDb, Is.EqualTo(memSnapshotableDb));
                 Assert.IsTrue(memSnapshotableDb is IColumnsDb<ReceiptsColumns>);
             }
@@ -43,8 +43,8 @@ namespace Nethermind.Db.Test
             {
                 MemDbFactory memDbFactory = new MemDbFactory();
                 IColumnsDb<ReceiptsColumns> memSnapshotableDb = memDbFactory.CreateColumnsDb<ReceiptsColumns>("ColumnsDb");
-                dbProvider.RegisterDb("ColumnsDb", memSnapshotableDb);
-                Assert.Throws<ArgumentException>(() => dbProvider.RegisterDb("columnsdb", new MemDb()));
+                dbProvider.RegisterColumnDb("ColumnsDb", memSnapshotableDb);
+                Assert.Throws<ArgumentException>(() => dbProvider.RegisterColumnDb("columnsdb", new MemColumnsDb<ReceiptsColumns>()));
             }
         }
 
@@ -55,8 +55,8 @@ namespace Nethermind.Db.Test
             {
                 MemDbFactory memDbFactory = new MemDbFactory();
                 IColumnsDb<ReceiptsColumns> memSnapshotableDb = memDbFactory.CreateColumnsDb<ReceiptsColumns>("ColumnsDb");
-                dbProvider.RegisterDb("ColumnsDb", memSnapshotableDb);
-                Assert.Throws<ArgumentException>(() => dbProvider.GetDb<IColumnsDb<ReceiptsColumns>>("differentdb"));
+                dbProvider.RegisterColumnDb("ColumnsDb", memSnapshotableDb);
+                Assert.Throws<ArgumentException>(() => dbProvider.GetColumnDb<ReceiptsColumns>("differentdb"));
             }
         }
     }

--- a/src/Nethermind/Nethermind.Db.Test/Rpc/RpcDbFactoryTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/Rpc/RpcDbFactoryTests.cs
@@ -19,11 +19,11 @@ namespace Nethermind.Db.Test.Rpc
         [Test]
         public void ValidateDbs()
         {
-            void ValidateDb<T>(params IDb[] dbs) where T : IDb
+            void ValidateDb<T>(params object[] dbs)
             {
-                foreach (IDb db in dbs)
+                foreach (object db in dbs)
                 {
-                    db.Should().BeAssignableTo<T>(db.Name);
+                    db.Should().BeAssignableTo<T>();
                 }
             }
 
@@ -35,11 +35,13 @@ namespace Nethermind.Db.Test.Rpc
             StandardDbInitializer standardDbInitializer = new(memDbProvider, null, rpcDbFactory, Substitute.For<IFileSystem>());
             standardDbInitializer.InitStandardDbs(true);
 
+            ValidateDb<ReadOnlyColumnsDb<ReceiptsColumns>>(
+                memDbProvider.ReceiptsDb);
+
             ValidateDb<ReadOnlyDb>(
                 memDbProvider.BlocksDb,
                 memDbProvider.BloomDb,
                 memDbProvider.HeadersDb,
-                memDbProvider.ReceiptsDb,
                 memDbProvider.BlockInfosDb);
 
             ValidateDb<ReadOnlyDb>(

--- a/src/Nethermind/Nethermind.Db/IColumnsDb.cs
+++ b/src/Nethermind/Nethermind.Db/IColumnsDb.cs
@@ -7,7 +7,7 @@ using Nethermind.Core;
 
 namespace Nethermind.Db
 {
-    public interface IColumnsDb<TKey>: IDbMeta
+    public interface IColumnsDb<TKey> : IDbMeta
     {
         IDbWithSpan GetColumnDb(TKey key);
         IEnumerable<TKey> ColumnKeys { get; }
@@ -15,7 +15,7 @@ namespace Nethermind.Db
         IColumnsBatch<TKey> StartBatch();
     }
 
-    public interface IColumnsBatch<in TKey>: IDisposable
+    public interface IColumnsBatch<in TKey> : IDisposable
     {
         IBatch GetColumnBatch(TKey key);
     }

--- a/src/Nethermind/Nethermind.Db/IColumnsDb.cs
+++ b/src/Nethermind/Nethermind.Db/IColumnsDb.cs
@@ -1,13 +1,22 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Collections.Generic;
+using Nethermind.Core;
 
 namespace Nethermind.Db
 {
-    public interface IColumnsDb<TKey> : IDbWithSpan
+    public interface IColumnsDb<TKey>: IDbMeta
     {
         IDbWithSpan GetColumnDb(TKey key);
         IEnumerable<TKey> ColumnKeys { get; }
+        public IReadOnlyColumnDb<TKey> CreateReadOnly(bool createInMemWriteStore) => new ReadOnlyColumnsDb<TKey>(this, createInMemWriteStore);
+        IColumnsBatch<TKey> StartBatch();
+    }
+
+    public interface IColumnsBatch<in TKey>: IDisposable
+    {
+        IBatch GetColumnBatch(TKey key);
     }
 }

--- a/src/Nethermind/Nethermind.Db/IDb.cs
+++ b/src/Nethermind/Nethermind.Db/IDb.cs
@@ -7,7 +7,7 @@ using Nethermind.Core;
 
 namespace Nethermind.Db
 {
-    public interface IDb : IKeyValueStoreWithBatching, IDisposable
+    public interface IDb : IKeyValueStoreWithBatching, IDbMeta, IDisposable
     {
         string Name { get; }
         KeyValuePair<byte[], byte[]?>[] this[byte[][] keys] { get; }
@@ -15,15 +15,20 @@ namespace Nethermind.Db
         IEnumerable<byte[]> GetAllValues(bool ordered = false);
         void Remove(ReadOnlySpan<byte> key);
         bool KeyExists(ReadOnlySpan<byte> key);
-        long GetSize();
-        long GetCacheSize();
-        long GetIndexSize();
-        long GetMemtableSize();
-
-        void Flush();
-        void Clear();
-        void Compact() { }
 
         public IReadOnlyDb CreateReadOnly(bool createInMemWriteStore) => new ReadOnlyDb(this, createInMemWriteStore);
+    }
+
+    // Some metadata options
+    public interface IDbMeta
+    {
+        long GetSize() => 0;
+        long GetCacheSize() => 0;
+        long GetIndexSize() => 0;
+        long GetMemtableSize() => 0;
+
+        void Flush() { }
+        void Clear() { }
+        void Compact() { }
     }
 }

--- a/src/Nethermind/Nethermind.Db/IDbProvider.cs
+++ b/src/Nethermind/Nethermind.Db/IDbProvider.cs
@@ -33,7 +33,7 @@ namespace Nethermind.Db
 
         public IDb MetadataDb => GetDb<IDb>(DbNames.Metadata);
 
-        public IColumnsDb<BlobTxsColumns> BlobTransactionsDb => GetDb<IColumnsDb<BlobTxsColumns>>(DbNames.BlobTransactions);
+        public IColumnsDb<BlobTxsColumns> BlobTransactionsDb => GetColumnDb<BlobTxsColumns>(DbNames.BlobTransactions);
 
         T GetDb<T>(string dbName) where T : class, IDb;
         IColumnsDb<T> GetColumnDb<T>(string dbName);

--- a/src/Nethermind/Nethermind.Db/IDbProvider.cs
+++ b/src/Nethermind/Nethermind.Db/IDbProvider.cs
@@ -17,7 +17,7 @@ namespace Nethermind.Db
         DbModeHint DbMode { get; }
         public IDb StateDb => GetDb<IDb>(DbNames.State);
         public IDb CodeDb => GetDb<IDb>(DbNames.Code);
-        public IColumnsDb<ReceiptsColumns> ReceiptsDb => GetDb<IColumnsDb<ReceiptsColumns>>(DbNames.Receipts);
+        public IColumnsDb<ReceiptsColumns> ReceiptsDb => GetColumnDb<ReceiptsColumns>(DbNames.Receipts);
         public IDb BlocksDb => GetDb<IDb>(DbNames.Blocks);
         public IDb HeadersDb => GetDb<IDb>(DbNames.Headers);
         public IDb BlockNumbersDb => GetDb<IDb>(DbNames.BlockNumbers);
@@ -36,9 +36,9 @@ namespace Nethermind.Db
         public IColumnsDb<BlobTxsColumns> BlobTransactionsDb => GetDb<IColumnsDb<BlobTxsColumns>>(DbNames.BlobTransactions);
 
         T GetDb<T>(string dbName) where T : class, IDb;
+        IColumnsDb<T> GetColumnDb<T>(string dbName);
 
         void RegisterDb<T>(string dbName, T db) where T : class, IDb;
-
-        IDictionary<string, IDb> RegisteredDbs { get; }
+        void RegisterColumnDb<T>(string dbName, IColumnsDb<T> db);
     }
 }

--- a/src/Nethermind/Nethermind.Db/IMemDbFactory.cs
+++ b/src/Nethermind/Nethermind.Db/IMemDbFactory.cs
@@ -1,12 +1,14 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
+
 namespace Nethermind.Db
 {
     public interface IMemDbFactory
     {
         IDb CreateDb(string dbName);
 
-        IColumnsDb<T> CreateColumnsDb<T>(string dbName);
+        IColumnsDb<T> CreateColumnsDb<T>(string dbName) where T : struct, Enum;
     }
 }

--- a/src/Nethermind/Nethermind.Db/IReadOnlyDb.cs
+++ b/src/Nethermind/Nethermind.Db/IReadOnlyDb.cs
@@ -7,4 +7,9 @@ namespace Nethermind.Db
     {
         void ClearTempChanges();
     }
+
+    public interface IReadOnlyColumnDb<T> : IColumnsDb<T>
+    {
+        void ClearTempChanges();
+    }
 }

--- a/src/Nethermind/Nethermind.Db/InMemoryBatch.cs
+++ b/src/Nethermind/Nethermind.Db/InMemoryBatch.cs
@@ -4,8 +4,9 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using Nethermind.Core;
 
-namespace Nethermind.Core
+namespace Nethermind.Db
 {
     public class InMemoryBatch : IBatch
     {

--- a/src/Nethermind/Nethermind.Db/InMemoryColumnBatch.cs
+++ b/src/Nethermind/Nethermind.Db/InMemoryColumnBatch.cs
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Generic;
+using Nethermind.Core;
+
+namespace Nethermind.Db
+{
+    public class InMemoryColumnBatch<TKey> : IColumnsBatch<TKey>
+    {
+        private IList<IBatch> _underlyingBatch = new List<IBatch>();
+        private readonly IColumnsDb<TKey> _columnsDb;
+
+        public InMemoryColumnBatch(IColumnsDb<TKey> columnsDb)
+        {
+            _columnsDb = columnsDb;
+        }
+
+        public IBatch GetColumnBatch(TKey key)
+        {
+            InMemoryBatch batch = new InMemoryBatch(_columnsDb.GetColumnDb(key));
+            _underlyingBatch.Add(batch);
+            return batch;
+        }
+
+        public void Dispose()
+        {
+            foreach (IBatch batch in _underlyingBatch)
+            {
+                batch.Dispose();
+            }
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Db/MemColumnsDb.cs
+++ b/src/Nethermind/Nethermind.Db/MemColumnsDb.cs
@@ -11,7 +11,7 @@ namespace Nethermind.Db
     {
         private readonly IDictionary<TKey, IDbWithSpan> _columnDbs = new Dictionary<TKey, IDbWithSpan>();
 
-        public MemColumnsDb(string _): this(Enum.GetValues<TKey>())
+        public MemColumnsDb(string _) : this(Enum.GetValues<TKey>())
         {
         }
 

--- a/src/Nethermind/Nethermind.Db/MemColumnsDb.cs
+++ b/src/Nethermind/Nethermind.Db/MemColumnsDb.cs
@@ -1,16 +1,17 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Nethermind.Db
 {
-    public class MemColumnsDb<TKey> : MemDb, IColumnsDb<TKey>
+    public class MemColumnsDb<TKey> : IColumnsDb<TKey> where TKey : struct, Enum
     {
         private readonly IDictionary<TKey, IDbWithSpan> _columnDbs = new Dictionary<TKey, IDbWithSpan>();
 
-        public MemColumnsDb(string name)
-            : base(name)
+        public MemColumnsDb(string _): this(Enum.GetValues<TKey>())
         {
         }
 
@@ -25,9 +26,14 @@ namespace Nethermind.Db
         public IDbWithSpan GetColumnDb(TKey key) => !_columnDbs.TryGetValue(key, out var db) ? _columnDbs[key] = new MemDb() : db;
         public IEnumerable<TKey> ColumnKeys => _columnDbs.Keys;
 
-        public IReadOnlyDb CreateReadOnly(bool createInMemWriteStore)
+        public IReadOnlyColumnDb<TKey> CreateReadOnly(bool createInMemWriteStore)
         {
             return new ReadOnlyColumnsDb<TKey>(this, createInMemWriteStore);
+        }
+
+        public IColumnsBatch<TKey> StartBatch()
+        {
+            return new InMemoryColumnBatch<TKey>(this);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Db/MemDbFactory.cs
+++ b/src/Nethermind/Nethermind.Db/MemDbFactory.cs
@@ -1,11 +1,13 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
+
 namespace Nethermind.Db
 {
     public class MemDbFactory : IMemDbFactory
     {
-        public IColumnsDb<T> CreateColumnsDb<T>(string dbName) => new MemColumnsDb<T>(dbName);
+        public IColumnsDb<T> CreateColumnsDb<T>(string dbName) where T : struct, Enum => new MemColumnsDb<T>(dbName);
 
         public IDb CreateDb(string dbName) => new MemDb(dbName);
     }

--- a/src/Nethermind/Nethermind.Db/NullMemDbFactory.cs
+++ b/src/Nethermind/Nethermind.Db/NullMemDbFactory.cs
@@ -16,7 +16,7 @@ namespace Nethermind.Db
             throw new InvalidOperationException();
         }
 
-        public IColumnsDb<T> CreateColumnsDb<T>(string dbName)
+        public IColumnsDb<T> CreateColumnsDb<T>(string dbName) where T : struct, Enum
         {
             throw new InvalidOperationException();
         }

--- a/src/Nethermind/Nethermind.Db/ReadOnlyColumnsDb.cs
+++ b/src/Nethermind/Nethermind.Db/ReadOnlyColumnsDb.cs
@@ -1,38 +1,48 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Nethermind.Db
 {
-    public class ReadOnlyColumnsDb<T> : ReadOnlyDb, IColumnsDb<T>
+    public class ReadOnlyColumnsDb<T> : IReadOnlyColumnDb<T>, IDisposable
     {
-        private readonly IColumnsDb<T> _wrappedDb;
-        private readonly bool _createInMemWriteStore;
-        private readonly IDictionary<T, ReadOnlyDb> _columnDbs = new Dictionary<T, ReadOnlyDb>();
+        private readonly IDictionary<T, IReadOnlyDb> _readOnlyColumns;
 
-        public ReadOnlyColumnsDb(IColumnsDb<T> wrappedDb, bool createInMemWriteStore) : base(wrappedDb, createInMemWriteStore)
+        public ReadOnlyColumnsDb(IColumnsDb<T> baseColumnDb, bool createInMemWriteStore)
         {
-            _wrappedDb = wrappedDb;
-            _createInMemWriteStore = createInMemWriteStore;
+            _readOnlyColumns = baseColumnDb.ColumnKeys
+                .Select(key => (key, baseColumnDb.GetColumnDb(key).CreateReadOnly(createInMemWriteStore)))
+                .ToDictionary(it => it.Item1, it => it.Item2);
         }
 
-        public IDbWithSpan GetColumnDb(T key) => _columnDbs.TryGetValue(key, out var db) ? db : _columnDbs[key] = new ReadOnlyDb(_wrappedDb.GetColumnDb(key), _createInMemWriteStore);
-
-        public IEnumerable<T> ColumnKeys => _wrappedDb.ColumnKeys;
-
-        public override void ClearTempChanges()
+        public IDbWithSpan GetColumnDb(T key)
         {
-            base.ClearTempChanges();
-            foreach (var columnDbsValue in _columnDbs.Values)
+            return (IDbWithSpan)_readOnlyColumns[key!];
+        }
+
+        public IEnumerable<T> ColumnKeys => _readOnlyColumns.Keys;
+        public IColumnsBatch<T> StartBatch()
+        {
+            return new InMemoryColumnBatch<T>(this);
+        }
+
+        public void ClearTempChanges()
+        {
+            foreach (KeyValuePair<T,IReadOnlyDb> readOnlyColumn in _readOnlyColumns)
             {
-                columnDbsValue.ClearTempChanges();
+                readOnlyColumn.Value.ClearTempChanges();
             }
         }
 
-        public IReadOnlyDb CreateReadOnly(bool createInMemWriteStore)
+        public void Dispose()
         {
-            return new ReadOnlyColumnsDb<T>(this, createInMemWriteStore);
+            foreach (KeyValuePair<T,IReadOnlyDb> readOnlyColumn in _readOnlyColumns)
+            {
+                readOnlyColumn.Value.Dispose();
+            }
         }
     }
 }

--- a/src/Nethermind/Nethermind.Db/ReadOnlyColumnsDb.cs
+++ b/src/Nethermind/Nethermind.Db/ReadOnlyColumnsDb.cs
@@ -31,7 +31,7 @@ namespace Nethermind.Db
 
         public void ClearTempChanges()
         {
-            foreach (KeyValuePair<T,IReadOnlyDb> readOnlyColumn in _readOnlyColumns)
+            foreach (KeyValuePair<T, IReadOnlyDb> readOnlyColumn in _readOnlyColumns)
             {
                 readOnlyColumn.Value.ClearTempChanges();
             }
@@ -39,7 +39,7 @@ namespace Nethermind.Db
 
         public void Dispose()
         {
-            foreach (KeyValuePair<T,IReadOnlyDb> readOnlyColumn in _readOnlyColumns)
+            foreach (KeyValuePair<T, IReadOnlyDb> readOnlyColumn in _readOnlyColumns)
             {
                 readOnlyColumn.Value.Dispose();
             }

--- a/src/Nethermind/Nethermind.Db/ReadOnlyDbProvider.cs
+++ b/src/Nethermind/Nethermind.Db/ReadOnlyDbProvider.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.IO;
 
 namespace Nethermind.Db
 {
@@ -13,6 +12,7 @@ namespace Nethermind.Db
         private readonly IDbProvider _wrappedProvider;
         private readonly bool _createInMemoryWriteStore;
         private readonly ConcurrentDictionary<string, IReadOnlyDb> _registeredDbs = new(StringComparer.InvariantCultureIgnoreCase);
+        private readonly ConcurrentDictionary<string, object> _registeredColumnDbs = new(StringComparer.InvariantCultureIgnoreCase);
 
         public ReadOnlyDbProvider(IDbProvider? wrappedProvider, bool createInMemoryWriteStore)
         {
@@ -22,27 +22,21 @@ namespace Nethermind.Db
             {
                 throw new ArgumentNullException(nameof(wrappedProvider));
             }
-
-            foreach ((string key, IDb value) in _wrappedProvider.RegisteredDbs)
-            {
-                RegisterReadOnlyDb(key, value);
-            }
         }
 
         public void Dispose()
         {
-            if (_registeredDbs is not null)
+            foreach (KeyValuePair<string, IReadOnlyDb> registeredDb in _registeredDbs)
             {
-                foreach (KeyValuePair<string, IReadOnlyDb> registeredDb in _registeredDbs)
-                {
-                    registeredDb.Value?.Dispose();
-                }
+                registeredDb.Value?.Dispose();
+            }
+            foreach (KeyValuePair<string, object> registeredColumnDb in _registeredColumnDbs)
+            {
+                (registeredColumnDb.Value as IDisposable)!.Dispose();
             }
         }
 
         public DbModeHint DbMode => _wrappedProvider.DbMode;
-
-        public IDictionary<string, IDb> RegisteredDbs => _wrappedProvider.RegisteredDbs;
 
         public void ClearTempChanges()
         {
@@ -54,32 +48,28 @@ namespace Nethermind.Db
 
         public T GetDb<T>(string dbName) where T : class, IDb
         {
-            if (!_registeredDbs.ContainsKey(dbName))
-            {
-                throw new ArgumentException($"{dbName} database has not been registered in {nameof(ReadOnlyDbProvider)}.");
-            }
-
-            _registeredDbs.TryGetValue(dbName, out IReadOnlyDb? found);
-            T result = found as T;
-            if (result is null && found is not null)
-            {
-                throw new IOException(
-                    $"An attempt was made to resolve DB {dbName} as {typeof(T)} while its type is {found.GetType()}.");
-            }
-
-            return result;
+            return (T)_registeredDbs
+                .GetOrAdd(dbName, (_) => _wrappedProvider
+                    .GetDb<T>(dbName)
+                    .CreateReadOnly(_createInMemoryWriteStore));
         }
 
-        private void RegisterReadOnlyDb<T>(string dbName, T db) where T : IDb
+        public IColumnsDb<T> GetColumnDb<T>(string dbName)
         {
-            IReadOnlyDb readonlyDb = db.CreateReadOnly(_createInMemoryWriteStore);
-            _registeredDbs.TryAdd(dbName, readonlyDb);
+            return (IColumnsDb<T>)_registeredColumnDbs
+                .GetOrAdd(dbName, (_) => _wrappedProvider
+                    .GetColumnDb<T>(dbName)
+                    .CreateReadOnly(_createInMemoryWriteStore));
         }
 
         public void RegisterDb<T>(string dbName, T db) where T : class, IDb
         {
             _wrappedProvider.RegisterDb(dbName, db);
-            RegisterReadOnlyDb(dbName, db);
+        }
+
+        public void RegisterColumnDb<T>(string dbName, IColumnsDb<T> db)
+        {
+            _wrappedProvider.RegisterColumnDb(dbName, db);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Db/ReceiptsColumns.cs
+++ b/src/Nethermind/Nethermind.Db/ReceiptsColumns.cs
@@ -5,6 +5,7 @@ namespace Nethermind.Db
 {
     public enum ReceiptsColumns
     {
+        Default,
         Transactions,
         Blocks
     }

--- a/src/Nethermind/Nethermind.Db/StandardDbInitializer.cs
+++ b/src/Nethermind/Nethermind.Db/StandardDbInitializer.cs
@@ -60,7 +60,7 @@ namespace Nethermind.Db
             }
             else
             {
-                RegisterCustomDb(DbNames.Receipts, () => new ReadOnlyColumnsDb<ReceiptsColumns>(new MemColumnsDb<ReceiptsColumns>(), false));
+                RegisterCustomColumnDb(DbNames.Receipts, () => new ReadOnlyColumnsDb<ReceiptsColumns>(new MemColumnsDb<ReceiptsColumns>(), false));
             }
             RegisterDb(BuildRocksDbSettings(DbNames.Metadata, () => Metrics.MetadataDbReads++, () => Metrics.MetadataDbWrites++));
             if (useBlobsDb)

--- a/src/Nethermind/Nethermind.Init/Steps/Migrations/ReceiptMigration.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/Migrations/ReceiptMigration.cs
@@ -322,7 +322,7 @@ namespace Nethermind.Init.Steps.Migrations
 
             // I guess some old schema need this
             {
-                using IBatch batch = _receiptsDb.StartBatch();
+                using IBatch batch = _receiptsDb.StartBatch().GetColumnBatch(ReceiptsColumns.Transactions);
                 for (int i = 0; i < notNullReceipts.Length; i++)
                 {
                     batch[notNullReceipts[i].TxHash!.Bytes] = null;

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugBridge.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugBridge.cs
@@ -55,7 +55,6 @@ public class DebugBridge : IDebugBridge
         IDb blockInfosDb = dbProvider.BlockInfosDb ?? throw new ArgumentNullException(nameof(dbProvider.BlockInfosDb));
         IDb blocksDb = dbProvider.BlocksDb ?? throw new ArgumentNullException(nameof(dbProvider.BlocksDb));
         IDb headersDb = dbProvider.HeadersDb ?? throw new ArgumentNullException(nameof(dbProvider.HeadersDb));
-        IDb receiptsDb = dbProvider.ReceiptsDb ?? throw new ArgumentNullException(nameof(dbProvider.ReceiptsDb));
         IDb codeDb = dbProvider.CodeDb ?? throw new ArgumentNullException(nameof(dbProvider.CodeDb));
         IDb metadataDb = dbProvider.MetadataDb ?? throw new ArgumentNullException(nameof(dbProvider.MetadataDb));
 
@@ -68,8 +67,13 @@ public class DebugBridge : IDebugBridge
             {DbNames.Headers, headersDb},
             {DbNames.Metadata, metadataDb},
             {DbNames.Code, codeDb},
-            {DbNames.Receipts, receiptsDb},
         };
+
+        IColumnsDb<ReceiptsColumns> receiptsDb = dbProvider.ReceiptsDb ?? throw new ArgumentNullException(nameof(dbProvider.ReceiptsDb));
+        foreach (ReceiptsColumns receiptsDbColumnKey in receiptsDb.ColumnKeys)
+        {
+            _dbMappings[DbNames.Receipts + receiptsDbColumnKey] = receiptsDb.GetColumnDb(receiptsDbColumnKey);
+        }
     }
 
     public byte[] GetDbValue(string dbName, byte[] key)

--- a/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/Migrations/ReceiptMigrationTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/Migrations/ReceiptMigrationTests.cs
@@ -68,14 +68,15 @@ namespace Nethermind.Runner.Test.Ethereum.Steps.Migrations
             }
 
             TestMemColumnsDb<ReceiptsColumns> receiptColumnDb = new();
+            TestMemDb blocksDb = (TestMemDb) receiptColumnDb.GetColumnDb(ReceiptsColumns.Blocks);
+            TestMemDb txDb = (TestMemDb) receiptColumnDb.GetColumnDb(ReceiptsColumns.Transactions);
 
             // Put the last block receipt encoding
             Block lastBlock = blockTree.FindBlock(chainLength - 1);
             TxReceipt[] receipts = inMemoryReceiptStorage.Get(lastBlock);
             using (NettyRlpStream nettyStream = receiptArrayStorageDecoder.EncodeToNewNettyStream(receipts, RlpBehaviors.Storage))
             {
-                receiptColumnDb.GetColumnDb(ReceiptsColumns.Blocks)
-                    .Set(Bytes.Concat(lastBlock.Number.ToBigEndianByteArray(), lastBlock.Hash.BytesToArray()), nettyStream.AsSpan());
+                blocksDb.Set(Bytes.Concat(lastBlock.Number.ToBigEndianByteArray(), lastBlock.Hash.BytesToArray()), nettyStream.AsSpan());
             }
 
             ManualResetEvent guard = new(false);
@@ -108,14 +109,13 @@ namespace Nethermind.Runner.Test.Ethereum.Steps.Migrations
             {
                 int blockNum = (commandStartBlockNumber ?? chainLength) - 1 - 1;
                 int txCount = blockNum * 2;
-                receiptColumnDb
-                    .KeyWasWritten((item => item.Item2 == null), txCount);
+                txDb.KeyWasWritten((item => item.Item2 == null), txCount);
                 ((TestMemDb)receiptColumnDb.GetColumnDb(ReceiptsColumns.Blocks)).KeyWasRemoved((_ => true), blockNum);
                 outMemoryReceiptStorage.Count.Should().Be(txCount);
             }
             else
             {
-                receiptColumnDb.KeyWasWritten((item => item.Item2 == null), 0);
+                txDb.KeyWasWritten((item => item.Item2 == null), 0);
             }
         }
 

--- a/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/Migrations/ReceiptMigrationTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/Migrations/ReceiptMigrationTests.cs
@@ -68,8 +68,8 @@ namespace Nethermind.Runner.Test.Ethereum.Steps.Migrations
             }
 
             TestMemColumnsDb<ReceiptsColumns> receiptColumnDb = new();
-            TestMemDb blocksDb = (TestMemDb) receiptColumnDb.GetColumnDb(ReceiptsColumns.Blocks);
-            TestMemDb txDb = (TestMemDb) receiptColumnDb.GetColumnDb(ReceiptsColumns.Transactions);
+            TestMemDb blocksDb = (TestMemDb)receiptColumnDb.GetColumnDb(ReceiptsColumns.Blocks);
+            TestMemDb txDb = (TestMemDb)receiptColumnDb.GetColumnDb(ReceiptsColumns.Transactions);
 
             // Put the last block receipt encoding
             Block lastBlock = blockTree.FindBlock(chainLength - 1);

--- a/src/Nethermind/Nethermind.Synchronization/DbTuner/SyncDbOptimizer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/DbTuner/SyncDbOptimizer.cs
@@ -11,10 +11,10 @@ namespace Nethermind.Synchronization.DbTuner;
 
 public class SyncDbTuner
 {
-    private readonly IDb _stateDb;
-    private readonly IDb _codeDb;
-    private readonly IDb _blockDb;
-    private readonly IDb _receiptDb;
+    private readonly ITunableDb? _stateDb;
+    private readonly ITunableDb? _codeDb;
+    private readonly ITunableDb? _blockDb;
+    private readonly ITunableDb? _receiptDb;
 
     private ITunableDb.TuneType _tuneType;
     private ITunableDb.TuneType _blocksDbTuneType;
@@ -24,10 +24,10 @@ public class SyncDbTuner
         ISyncFeed<SnapSyncBatch>? snapSyncFeed,
         ISyncFeed<BodiesSyncBatch>? bodiesSyncFeed,
         ISyncFeed<ReceiptsSyncBatch>? receiptSyncFeed,
-        IDb stateDb,
-        IDb codeDb,
-        IDb blockDb,
-        IDb receiptDb
+        ITunableDb? stateDb,
+        ITunableDb? codeDb,
+        ITunableDb? blockDb,
+        ITunableDb? receiptDb
     )
     {
         // Only these three make sense as they are write heavy
@@ -61,25 +61,13 @@ public class SyncDbTuner
     {
         if (e.NewState == SyncFeedState.Active)
         {
-            if (_stateDb is ITunableDb stateDb)
-            {
-                stateDb.Tune(_tuneType);
-            }
-            if (_codeDb is ITunableDb codeDb)
-            {
-                codeDb.Tune(_tuneType);
-            }
+            _stateDb?.Tune(_tuneType);
+            _codeDb?.Tune(_tuneType);
         }
         else if (e.NewState == SyncFeedState.Finished)
         {
-            if (_stateDb is ITunableDb stateDb)
-            {
-                stateDb.Tune(ITunableDb.TuneType.Default);
-            }
-            if (_codeDb is ITunableDb codeDb)
-            {
-                codeDb.Tune(ITunableDb.TuneType.Default);
-            }
+            _stateDb?.Tune(ITunableDb.TuneType.Default);
+            _codeDb?.Tune(ITunableDb.TuneType.Default);
         }
     }
 
@@ -87,17 +75,11 @@ public class SyncDbTuner
     {
         if (e.NewState == SyncFeedState.Active)
         {
-            if (_blockDb is ITunableDb blockDb)
-            {
-                blockDb.Tune(_blocksDbTuneType);
-            }
+            _blockDb?.Tune(_blocksDbTuneType);
         }
         else if (e.NewState == SyncFeedState.Finished)
         {
-            if (_blockDb is ITunableDb blockDb)
-            {
-                blockDb.Tune(ITunableDb.TuneType.Default);
-            }
+            _blockDb?.Tune(ITunableDb.TuneType.Default);
         }
     }
 
@@ -105,17 +87,11 @@ public class SyncDbTuner
     {
         if (e.NewState == SyncFeedState.Active)
         {
-            if (_receiptDb is ITunableDb receiptDb)
-            {
-                receiptDb.Tune(_tuneType);
-            }
+            _receiptDb?.Tune(_tuneType);
         }
         else if (e.NewState == SyncFeedState.Finished)
         {
-            if (_receiptDb is ITunableDb receiptDb)
-            {
-                receiptDb.Tune(ITunableDb.TuneType.Default);
-            }
+            _receiptDb?.Tune(ITunableDb.TuneType.Default);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
@@ -134,8 +134,15 @@ namespace Nethermind.Synchronization
 
         private void SetupDbOptimizer()
         {
-            new SyncDbTuner(_syncConfig, _snapSyncFeed, _bodiesFeed, _receiptsFeed, _dbProvider.StateDb, _dbProvider.CodeDb,
-                _dbProvider.BlocksDb, _dbProvider.ReceiptsDb);
+            new SyncDbTuner(
+                _syncConfig,
+                _snapSyncFeed,
+                _bodiesFeed,
+                _receiptsFeed,
+                _dbProvider.StateDb as ITunableDb,
+                _dbProvider.CodeDb as ITunableDb,
+                _dbProvider.BlocksDb as ITunableDb,
+                _dbProvider.ReceiptsDb as ITunableDb);
         }
 
         private void StartFullSyncComponents()


### PR DESCRIPTION
- Refactor column db, largely for path base state layout.
- IColumnsDb no longer inherit IDB, instead it provide `GetColumnDb`, which return `IDb`. This reduces its surface area.
- IColumnsDB now expose a `StartBatch` which return an `IColumnsBatch`, which have a `GetColumnBatch`, which returns `IBatch`, which exposes rocksdb batch write to many column.

## Types of changes

#### What types of changes does your code introduce?

- [X] Refactoring

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No
