### PR TITLE
Fix incorrect exitcode in SIGTERM and SIGINT.

### DIFF
--- a/src/Nethermind/Nethermind.Config/ExitCodes.cs
+++ b/src/Nethermind/Nethermind.Config/ExitCodes.cs
@@ -15,4 +15,9 @@ public static class ExitCodes
     public const int TooLongExtraData = 102;
     public const int ConflictingConfigurations = 103;
     public const int LowDiskSpace = 104;
+
+    // Posix exit code
+    // https://tldp.org/LDP/abs/html/exitcodes.html
+    public const int SigInt = 130; // 128 + 2 (sigint)
+    public const int SigTerm = 143; // 128 + 15 (sigterm)
 }

--- a/src/Nethermind/Nethermind.Monitoring/MonitoringService.cs
+++ b/src/Nethermind/Nethermind.Monitoring/MonitoringService.cs
@@ -80,7 +80,8 @@ namespace Nethermind.Monitoring
             }
             if (_exposePort is not null)
             {
-                IMetricServer metricServer = new KestrelMetricServer(_exposePort.Value);
+                // KestrelMetricServer intercept SIGTERM causing exitcode to be incorrect
+                IMetricServer metricServer = new MetricServer(_exposePort.Value);
                 metricServer.Start();
             }
             await Task.Factory.StartNew(() => _metricsController.StartUpdating(), TaskCreationOptions.LongRunning);

--- a/src/Nethermind/Nethermind.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Runner/Program.cs
@@ -109,16 +109,7 @@ public static class Program
         _logger.Info("Nethermind starting initialization.");
         _logger.Info($"Client version: {ProductInfo.ClientId}");
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            AppDomain.CurrentDomain.ProcessExit += CurrentDomainOnProcessExit;
-        }
-        else
-        {
-            PosixSignalRegistration.Create(PosixSignal.SIGINT, OnSigInt);
-            PosixSignalRegistration.Create(PosixSignal.SIGTERM, OnSigTerm);
-        }
-
+        AppDomain.CurrentDomain.ProcessExit += CurrentDomainOnProcessExit;
         AssemblyLoadContext.Default.ResolvingUnmanagedDll += OnResolvingUnmanagedDll;
 
         GlobalDiagnosticsContext.Set("version", ProductInfo.Version);
@@ -470,18 +461,6 @@ public static class Program
     {
         _processExitSource.Exit(ExitCodes.SigInt);
         e.Cancel = true;
-    }
-
-    private static void OnSigInt(PosixSignalContext obj)
-    {
-        _processExitSource.Exit(ExitCodes.SigInt);
-        _appClosed.Wait();
-    }
-
-    private static void OnSigTerm(PosixSignalContext obj)
-    {
-        _processExitSource.Exit(ExitCodes.SigTerm);
-        _appClosed.Wait();
     }
 
     private static void LogMemoryConfiguration()

--- a/src/Nethermind/Nethermind.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Runner/Program.cs
@@ -457,12 +457,6 @@ public static class Program
         _appClosed.Wait();
     }
 
-    private static void ConsoleOnCancelKeyPress(object? sender, ConsoleCancelEventArgs e)
-    {
-        _processExitSource.Exit(ExitCodes.SigInt);
-        e.Cancel = true;
-    }
-
     private static void LogMemoryConfiguration()
     {
         if (_logger.IsDebug)
@@ -512,6 +506,12 @@ public static class Program
             keyStoreConfig.KeyStoreDirectory ??= string.Empty.GetApplicationResourcePath("keystore");
             initConfig.LogDirectory ??= string.Empty.GetApplicationResourcePath("logs");
         }
+    }
+
+    private static void ConsoleOnCancelKeyPress(object? sender, ConsoleCancelEventArgs e)
+    {
+        _processExitSource.Exit(ExitCodes.SigInt);
+        e.Cancel = true;
     }
 
     private static void ConfigureSeqLogger(IConfigProvider configProvider)

--- a/src/Nethermind/Nethermind.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Runner/Program.cs
@@ -462,7 +462,7 @@ public static class Program
 
     private static void CurrentDomainOnProcessExit(object? sender, EventArgs e)
     {
-        _processExitSource.Exit(ExitCodes.Ok);
+        _processExitSource.Exit(ExitCodes.SigTerm);
         _appClosed.Wait();
     }
 


### PR DESCRIPTION
- Long overdue fix on incorrect exit code on sigterm/sigint.
- On POSIX, when given SIGTERM/SIGINT, the application should exit with a specific exit code instead of 0.
- Without this, a script may not behave as expected. For example, if I have a script something like this, which sync, then remove the directory then sync again, on the first nethermind run, when I ctrl-c, I would expect it to stop the whole script. Instead, it remove the directory and start the second run.
```
nethermind --Sync.ExitOnSynced true
rm -rf thedir
nethermind --Sync.ExitOnSynced true
```

## Changes

- Return proper exit code.
- Also consolidate the various exit signal.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

- On linux SIGTERM: :heavy_check_mark: 
- On linux SIGINT: :heavy_check_mark: 
- On mac SIGTERM: ✔️ 
- On windows: :heavy_check_mark: 
- Exit after sync should have code 0: :heavy_check_mark: 
