### PR TITLE
Fix max write buffer number is 0 on holesky.

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
@@ -162,8 +162,8 @@ public class DbConfig : IDbConfig
     public ulong? MetadataCompactionReadAhead { get; set; }
     public IDictionary<string, string>? MetadataDbAdditionalRocksDbOptions { get; set; }
 
-    public ulong StateDbWriteBufferSize { get; set; }
-    public uint StateDbWriteBufferNumber { get; set; }
+    public ulong StateDbWriteBufferSize { get; set; } = (ulong)16.MB();
+    public uint StateDbWriteBufferNumber { get; set; } = 4;
     public ulong StateDbBlockCacheSize { get; set; }
     public bool StateDbCacheIndexAndFilterBlocks { get; set; }
     public int? StateDbMaxOpenFiles { get; set; }

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -10,9 +10,11 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using ConcurrentCollections;
+using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Exceptions;
 using Nethermind.Core.Extensions;
 using Nethermind.Db.Rocks.Config;
 using Nethermind.Db.Rocks.Statistics;
@@ -375,6 +377,7 @@ public class DbOnTheRocks : IDbWithSpan, ITunableDb
         ulong writeBufferSize = dbConfig.WriteBufferSize;
         options.SetWriteBufferSize(writeBufferSize);
         int writeBufferNumber = (int)dbConfig.WriteBufferNumber;
+        if (writeBufferNumber < 1) throw new InvalidConfigurationException($"Error initializing {Name} db. Max write buffer number must be more than 1. max write buffer number: {writeBufferNumber}", ExitCodes.GeneralError);
         options.SetMaxWriteBufferNumber(writeBufferNumber);
 
         lock (_dbsByPath)


### PR DESCRIPTION
- It turns out, holesky's state sync hang due to unable to write to DB. Errors at statedb log is:
```
2023/10/24-13:56:58.071176 164930 [WARN] [db/column_family.cc:933] [default] Stopping writes because we have 0 immutable memtables (waiting for flush), max_write_buffer_number is set to 0
```
- It turns out, max write buffer was set to 0. This likely works fine during snap sync as the default heavy write tune temporarily set a high max write buffer number, but during state sync, it would revert back to 0.
- Normally, memoryhintman would set the value. However, holesky does not have memory hint applied so the default value of 0 was used, causing the hang.
- This PR set a default value of 4, and throw errors if it detect that it was configured to 0.

## Changes

- Set default max write buffer num to 4.
- Throw error if it detect max write buffer of 0.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

## Notes on testing

- Reproducable locally if I remove memory hint that I always apply.
- Confimed state sync can complete now.