### PR TITLE
Rename IBatch to IWriteBatch and remove getter

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPrunerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPrunerTests.cs
@@ -150,9 +150,9 @@ namespace Nethermind.Blockchain.Test.FullPruning
             byte[] key = { 0, 1, 2 };
             TestFullPruningDb.TestPruningContext context = test.WaitForPruningStart();
 
-            using (IBatch batch = test.FullPruningDb.StartBatch())
+            using (IWriteBatch writeBatch = test.FullPruningDb.StartWriteBatch())
             {
-                batch[key] = key;
+                writeBatch[key] = key;
             }
 
             await test.WaitForPruningEnd(context);

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -1600,7 +1600,7 @@ namespace Nethermind.Blockchain
         {
             FinalizedHash = finalizedBlockHash;
             SafeHash = safeBlockHash;
-            using (_metadataDb.StartBatch())
+            using (_metadataDb.StartWriteBatch())
             {
                 _metadataDb.Set(MetadataDbKeys.FinalizedBlockHash, Rlp.Encode(FinalizedHash!).Bytes);
                 _metadataDb.Set(MetadataDbKeys.SafeBlockHash, Rlp.Encode(SafeHash!).Bytes);

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
@@ -344,7 +344,7 @@ namespace Nethermind.Blockchain.Receipts
 
         public void EnsureCanonical(Block block)
         {
-            using IBatch batch = _transactionDb.StartBatch();
+            using IWriteBatch writeBatch = _transactionDb.StartWriteBatch();
 
             long headNumber = _blockTree.FindBestSuggestedHeader()?.Number ?? 0;
 
@@ -354,14 +354,14 @@ namespace Nethermind.Blockchain.Receipts
             {
                 foreach (Transaction tx in block.Transactions)
                 {
-                    batch[tx.Hash.Bytes] = Rlp.Encode(block.Number).Bytes;
+                    writeBatch[tx.Hash.Bytes] = Rlp.Encode(block.Number).Bytes;
                 }
             }
             else
             {
                 foreach (Transaction tx in block.Transactions)
                 {
-                    batch[tx.Hash.Bytes] = block.Hash.BytesToArray();
+                    writeBatch[tx.Hash.Bytes] = block.Hash.BytesToArray();
                 }
             }
         }
@@ -374,13 +374,13 @@ namespace Nethermind.Blockchain.Receipts
                 newTxs = new HashSet<Keccak>(exceptBlock.Transactions.Select((tx) => tx.Hash));
             }
 
-            using IBatch batch = _transactionDb.StartBatch();
+            using IWriteBatch writeBatch = _transactionDb.StartWriteBatch();
             foreach (Transaction tx in block.Transactions)
             {
                 // If the tx is contained in another block, don't remove it. Used for reorg where the same tx
                 // is contained in the new block
                 if (newTxs?.Contains(tx.Hash) == true) continue;
-                batch[tx.Hash.Bytes] = null;
+                writeBatch[tx.Hash.Bytes] = null;
             }
         }
     }

--- a/src/Nethermind/Nethermind.Core.Test/TestMemColumnDb.cs
+++ b/src/Nethermind/Nethermind.Core.Test/TestMemColumnDb.cs
@@ -26,8 +26,8 @@ public class TestMemColumnsDb<TKey> : IColumnsDb<TKey>
     public IDbWithSpan GetColumnDb(TKey key) => !_columnDbs.TryGetValue(key, out var db) ? _columnDbs[key] = new TestMemDb() : db;
     public IEnumerable<TKey> ColumnKeys => _columnDbs.Keys;
 
-    public IColumnsBatch<TKey> StartBatch()
+    public IColumnsWriteBatch<TKey> StartWriteBatch()
     {
-        return new InMemoryColumnBatch<TKey>(this);
+        return new InMemoryColumnWriteBatch<TKey>(this);
     }
 }

--- a/src/Nethermind/Nethermind.Core.Test/TestMemDb.cs
+++ b/src/Nethermind/Nethermind.Core.Test/TestMemDb.cs
@@ -100,9 +100,9 @@ public class TestMemDb : MemDb, ITunableDb
         _removedKeys.Count(cond).Should().Be(times);
     }
 
-    public override IBatch StartBatch()
+    public override IWriteBatch StartWriteBatch()
     {
-        return new InMemoryBatch(this);
+        return new InMemoryWriteBatch(this);
     }
 
     public override void Flush()

--- a/src/Nethermind/Nethermind.Core/FakeWriteBatch.cs
+++ b/src/Nethermind/Nethermind.Core/FakeWriteBatch.cs
@@ -5,18 +5,18 @@ using System;
 
 namespace Nethermind.Core
 {
-    public class FakeBatch : IBatch
+    public class FakeWriteBatch : IWriteBatch
     {
         private readonly IKeyValueStore _storePretendingToSupportBatches;
 
         private readonly Action? _onDispose;
 
-        public FakeBatch(IKeyValueStore storePretendingToSupportBatches)
+        public FakeWriteBatch(IKeyValueStore storePretendingToSupportBatches)
             : this(storePretendingToSupportBatches, null)
         {
         }
 
-        public FakeBatch(IKeyValueStore storePretendingToSupportBatches, Action? onDispose)
+        public FakeWriteBatch(IKeyValueStore storePretendingToSupportBatches, Action? onDispose)
         {
             _storePretendingToSupportBatches = storePretendingToSupportBatches;
             _onDispose = onDispose;
@@ -25,11 +25,6 @@ namespace Nethermind.Core
         public void Dispose()
         {
             _onDispose?.Invoke();
-        }
-
-        public byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)
-        {
-            return _storePretendingToSupportBatches.Get(key, flags);
         }
 
         public void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None)

--- a/src/Nethermind/Nethermind.Core/IKeyValueStore.cs
+++ b/src/Nethermind/Nethermind.Core/IKeyValueStore.cs
@@ -5,15 +5,13 @@ using System;
 
 namespace Nethermind.Core
 {
-    public interface IKeyValueStore : IReadOnlyKeyValueStore
+    public interface IKeyValueStore : IReadOnlyKeyValueStore, IWriteOnlyKeyValueStore
     {
         new byte[]? this[ReadOnlySpan<byte> key]
         {
             get => Get(key);
             set => Set(key, value);
         }
-
-        void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None);
     }
 
     public interface IReadOnlyKeyValueStore
@@ -21,6 +19,16 @@ namespace Nethermind.Core
         byte[]? this[ReadOnlySpan<byte> key] => Get(key);
 
         byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None);
+    }
+
+    public interface IWriteOnlyKeyValueStore
+    {
+        byte[]? this[ReadOnlySpan<byte> key]
+        {
+            set => Set(key, value);
+        }
+
+        void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None);
     }
 
     [Flags]

--- a/src/Nethermind/Nethermind.Core/IKeyValueStoreWithBatching.cs
+++ b/src/Nethermind/Nethermind.Core/IKeyValueStoreWithBatching.cs
@@ -5,6 +5,6 @@ namespace Nethermind.Core
 {
     public interface IKeyValueStoreWithBatching : IKeyValueStore
     {
-        IBatch StartBatch();
+        IWriteBatch StartWriteBatch();
     }
 }

--- a/src/Nethermind/Nethermind.Core/IWriteBatch.cs
+++ b/src/Nethermind/Nethermind.Core/IWriteBatch.cs
@@ -5,5 +5,5 @@ using System;
 
 namespace Nethermind.Core
 {
-    public interface IBatch : IDisposable, IKeyValueStore { }
+    public interface IWriteBatch : IDisposable, IWriteOnlyKeyValueStore { }
 }

--- a/src/Nethermind/Nethermind.Core/KeyValueStoreExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/KeyValueStoreExtensions.cs
@@ -7,14 +7,14 @@ namespace Nethermind.Core
 {
     public static class KeyValueStoreExtensions
     {
-        public static IBatch LikeABatch(this IKeyValueStoreWithBatching keyValueStore)
+        public static IWriteBatch LikeABatch(this IKeyValueStoreWithBatching keyValueStore)
         {
             return LikeABatch(keyValueStore, null);
         }
 
-        public static IBatch LikeABatch(this IKeyValueStoreWithBatching keyValueStore, Action? onDispose)
+        public static IWriteBatch LikeABatch(this IKeyValueStoreWithBatching keyValueStore, Action? onDispose)
         {
-            return new FakeBatch(keyValueStore, onDispose);
+            return new FakeWriteBatch(keyValueStore, onDispose);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnsDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnsDb.cs
@@ -9,6 +9,7 @@ using Nethermind.Core;
 using Nethermind.Db.Rocks.Config;
 using Nethermind.Logging;
 using RocksDbSharp;
+using IWriteBatch = Nethermind.Core.IWriteBatch;
 
 namespace Nethermind.Db.Rocks;
 
@@ -52,9 +53,9 @@ public class ColumnsDb<T> : DbOnTheRocks, IColumnsDb<T> where T : struct, Enum
         return new ReadOnlyColumnsDb<T>(this, createInMemWriteStore);
     }
 
-    public new IColumnsBatch<T> StartBatch()
+    public new IColumnsWriteBatch<T> StartWriteBatch()
     {
-        return new RocksColumnsBatch(this);
+        return new RocksColumnsWriteBatch(this);
     }
 
     protected override void ApplyOptions(IDictionary<string, string> options)
@@ -68,52 +69,47 @@ public class ColumnsDb<T> : DbOnTheRocks, IColumnsDb<T> where T : struct, Enum
         base.ApplyOptions(options);
     }
 
-    private class RocksColumnsBatch : IColumnsBatch<T>
+    private class RocksColumnsWriteBatch : IColumnsWriteBatch<T>
     {
-        internal RocksDbBatch _batch;
+        internal RocksDbWriteBatch _writeBatch;
         private ColumnsDb<T> _columnsDb;
 
-        public RocksColumnsBatch(ColumnsDb<T> columnsDb)
+        public RocksColumnsWriteBatch(ColumnsDb<T> columnsDb)
         {
-            _batch = new RocksDbBatch(columnsDb);
+            _writeBatch = new RocksDbWriteBatch(columnsDb);
             _columnsDb = columnsDb;
         }
 
-        public IBatch GetColumnBatch(T key)
+        public IWriteBatch GetColumnBatch(T key)
         {
-            return new RocksColumnBatch(_columnsDb._columnDbs[key], this);
+            return new RocksColumnWriteBatch(_columnsDb._columnDbs[key], this);
         }
 
         public void Dispose()
         {
-            _batch.Dispose();
+            _writeBatch.Dispose();
         }
     }
 
-    private class RocksColumnBatch : IBatch
+    private class RocksColumnWriteBatch : IWriteBatch
     {
         private readonly ColumnDb _column;
-        private readonly RocksColumnsBatch _batch;
+        private readonly RocksColumnsWriteBatch _writeBatch;
 
-        public RocksColumnBatch(ColumnDb column, RocksColumnsBatch batch)
+        public RocksColumnWriteBatch(ColumnDb column, RocksColumnsWriteBatch writeBatch)
         {
             _column = column;
-            _batch = batch;
+            _writeBatch = writeBatch;
         }
 
         public void Dispose()
         {
-            _batch.Dispose();
-        }
-
-        public byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)
-        {
-            return _column.Get(key, flags);
+            _writeBatch.Dispose();
         }
 
         public void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None)
         {
-            _batch._batch.Set(key, value, _column._columnFamily, flags);
+            _writeBatch._writeBatch.Set(key, value, _column._columnFamily, flags);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Db.Rpc/RpcColumnsDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rpc/RpcColumnsDb.cs
@@ -41,9 +41,9 @@ namespace Nethermind.Db.Rpc
 
         public IEnumerable<T> ColumnKeys => Enum.GetValues<T>();
 
-        public IColumnsBatch<T> StartBatch()
+        public IColumnsWriteBatch<T> StartWriteBatch()
         {
-            return new InMemoryColumnBatch<T>(this);
+            return new InMemoryColumnWriteBatch<T>(this);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Db.Rpc/RpcDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rpc/RpcDb.cs
@@ -79,7 +79,7 @@ namespace Nethermind.Db.Rpc
 
         public IEnumerable<byte[]> GetAllValues(bool ordered = false) => _recordDb.GetAllValues();
 
-        public IBatch StartBatch()
+        public IWriteBatch StartWriteBatch()
         {
             throw new InvalidOperationException("RPC DB does not support writes");
         }

--- a/src/Nethermind/Nethermind.Db.Test/ColumnsDbTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/ColumnsDbTests.cs
@@ -81,7 +81,7 @@ public class ColumnsDbTests
     [Test]
     public void TestWriteBatch_WriteToAllColumn()
     {
-        var batch = _db.StartBatch();
+        var batch = _db.StartWriteBatch();
         var colA = batch.GetColumnBatch(TestColumns.ColumnA);
         var colB = batch.GetColumnBatch(TestColumns.ColumnB);
 

--- a/src/Nethermind/Nethermind.Db.Test/CompressingStoreTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/CompressingStoreTests.cs
@@ -79,9 +79,9 @@ namespace Nethermind.Store.Test
         {
             Context ctx = new();
 
-            using (IBatch batch = ctx.Compressed.StartBatch())
+            using (IWriteBatch writeBatch = ctx.Compressed.StartWriteBatch())
             {
-                batch[Key] = EOABytes;
+                writeBatch[Key] = EOABytes;
             }
 
             CollectionAssert.AreEqual(EOABytes, ctx.Compressed[Key]);

--- a/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
@@ -21,6 +21,7 @@ using Nethermind.Logging;
 using NSubstitute;
 using NUnit.Framework;
 using RocksDbSharp;
+using IWriteBatch = Nethermind.Core.IWriteBatch;
 
 namespace Nethermind.Db.Test
 {
@@ -124,7 +125,7 @@ namespace Nethermind.Db.Test
         {
             IDbConfig config = new DbConfig();
             DbOnTheRocks db = new("testDispose2", GetRocksDbSettings("testDispose2", "TestDispose2"), config, LimboLogs.Instance);
-            IBatch batch = db.StartBatch();
+            IWriteBatch writeBatch = db.StartWriteBatch();
             db.Dispose();
         }
 
@@ -255,14 +256,14 @@ namespace Nethermind.Db.Test
         [Test]
         public void Smoke_test_large_writes_with_nowal()
         {
-            IBatch batch = _db.StartBatch();
+            IWriteBatch writeBatch = _db.StartWriteBatch();
 
             for (int i = 0; i < 1000; i++)
             {
-                batch.Set(i.ToBigEndianByteArray(), i.ToBigEndianByteArray(), WriteFlags.DisableWAL);
+                writeBatch.Set(i.ToBigEndianByteArray(), i.ToBigEndianByteArray(), WriteFlags.DisableWAL);
             }
 
-            batch.Dispose();
+            writeBatch.Dispose();
 
             for (int i = 0; i < 1000; i++)
             {

--- a/src/Nethermind/Nethermind.Db.Test/MemDbTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/MemDbTests.cs
@@ -54,7 +54,7 @@ namespace Nethermind.Db.Test
         public void Can_use_batches_without_issues()
         {
             MemDb memDb = new();
-            using (memDb.StartBatch())
+            using (memDb.StartWriteBatch())
             {
                 memDb.Set(TestItem.KeccakA, _sampleValue);
             }

--- a/src/Nethermind/Nethermind.Db.Test/SimpleFilePublicKeyDbTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/SimpleFilePublicKeyDbTests.cs
@@ -37,7 +37,7 @@ namespace Nethermind.Db.Test
                 dict[key] = value;
             }
 
-            using (filePublicKeyDb.StartBatch())
+            using (filePublicKeyDb.StartWriteBatch())
             {
                 foreach (var kv in dict)
                 {

--- a/src/Nethermind/Nethermind.Db/CompressingDb.cs
+++ b/src/Nethermind/Nethermind.Db/CompressingDb.cs
@@ -34,25 +34,21 @@ namespace Nethermind.Db
                 set => _wrapped[key] = Compress(value);
             }
 
-            public IBatch StartBatch() => new Batch(_wrapped.StartBatch());
+            public IWriteBatch StartWriteBatch() => new WriteBatch(_wrapped.StartWriteBatch());
 
-            private class Batch : IBatch
+            private class WriteBatch : IWriteBatch
             {
-                private readonly IBatch _wrapped;
+                private readonly IWriteBatch _wrapped;
 
-                public Batch(IBatch wrapped) => _wrapped = wrapped;
+                public WriteBatch(IWriteBatch wrapped) => _wrapped = wrapped;
 
                 public void Dispose() => _wrapped.Dispose();
 
                 public void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None)
                     => _wrapped.Set(key, Compress(value), flags);
 
-                public byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)
-                    => Decompress(_wrapped.Get(key, flags));
-
                 public byte[]? this[ReadOnlySpan<byte> key]
                 {
-                    get => Decompress(_wrapped[key]);
                     set => _wrapped[key] = Compress(value);
                 }
             }

--- a/src/Nethermind/Nethermind.Db/IColumnsDb.cs
+++ b/src/Nethermind/Nethermind.Db/IColumnsDb.cs
@@ -12,11 +12,11 @@ namespace Nethermind.Db
         IDbWithSpan GetColumnDb(TKey key);
         IEnumerable<TKey> ColumnKeys { get; }
         public IReadOnlyColumnDb<TKey> CreateReadOnly(bool createInMemWriteStore) => new ReadOnlyColumnsDb<TKey>(this, createInMemWriteStore);
-        IColumnsBatch<TKey> StartBatch();
+        IColumnsWriteBatch<TKey> StartWriteBatch();
     }
 
-    public interface IColumnsBatch<in TKey> : IDisposable
+    public interface IColumnsWriteBatch<in TKey> : IDisposable
     {
-        IBatch GetColumnBatch(TKey key);
+        IWriteBatch GetColumnBatch(TKey key);
     }
 }

--- a/src/Nethermind/Nethermind.Db/InMemoryColumnBatch.cs
+++ b/src/Nethermind/Nethermind.Db/InMemoryColumnBatch.cs
@@ -6,26 +6,26 @@ using Nethermind.Core;
 
 namespace Nethermind.Db
 {
-    public class InMemoryColumnBatch<TKey> : IColumnsBatch<TKey>
+    public class InMemoryColumnWriteBatch<TKey> : IColumnsWriteBatch<TKey>
     {
-        private IList<IBatch> _underlyingBatch = new List<IBatch>();
+        private IList<IWriteBatch> _underlyingBatch = new List<IWriteBatch>();
         private readonly IColumnsDb<TKey> _columnsDb;
 
-        public InMemoryColumnBatch(IColumnsDb<TKey> columnsDb)
+        public InMemoryColumnWriteBatch(IColumnsDb<TKey> columnsDb)
         {
             _columnsDb = columnsDb;
         }
 
-        public IBatch GetColumnBatch(TKey key)
+        public IWriteBatch GetColumnBatch(TKey key)
         {
-            InMemoryBatch batch = new InMemoryBatch(_columnsDb.GetColumnDb(key));
-            _underlyingBatch.Add(batch);
-            return batch;
+            InMemoryWriteBatch writeBatch = new InMemoryWriteBatch(_columnsDb.GetColumnDb(key));
+            _underlyingBatch.Add(writeBatch);
+            return writeBatch;
         }
 
         public void Dispose()
         {
-            foreach (IBatch batch in _underlyingBatch)
+            foreach (IWriteBatch batch in _underlyingBatch)
             {
                 batch.Dispose();
             }

--- a/src/Nethermind/Nethermind.Db/InMemoryWriteBatch.cs
+++ b/src/Nethermind/Nethermind.Db/InMemoryWriteBatch.cs
@@ -8,13 +8,13 @@ using Nethermind.Core;
 
 namespace Nethermind.Db
 {
-    public class InMemoryBatch : IBatch
+    public class InMemoryWriteBatch : IWriteBatch
     {
         private readonly IKeyValueStore _store;
         private readonly ConcurrentDictionary<byte[], byte[]?> _currentItems = new();
         private WriteFlags _writeFlags = WriteFlags.None;
 
-        public InMemoryBatch(IKeyValueStore storeWithNoBatchSupport)
+        public InMemoryWriteBatch(IKeyValueStore storeWithNoBatchSupport)
         {
             _store = storeWithNoBatchSupport;
         }
@@ -33,11 +33,6 @@ namespace Nethermind.Db
         {
             _currentItems[key.ToArray()] = value;
             _writeFlags = flags;
-        }
-
-        public byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)
-        {
-            return _store.Get(key, flags);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Db/MemColumnsDb.cs
+++ b/src/Nethermind/Nethermind.Db/MemColumnsDb.cs
@@ -31,9 +31,9 @@ namespace Nethermind.Db
             return new ReadOnlyColumnsDb<TKey>(this, createInMemWriteStore);
         }
 
-        public IColumnsBatch<TKey> StartBatch()
+        public IColumnsWriteBatch<TKey> StartWriteBatch()
         {
-            return new InMemoryColumnBatch<TKey>(this);
+            return new InMemoryColumnWriteBatch<TKey>(this);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Db/MemDb.cs
+++ b/src/Nethermind/Nethermind.Db/MemDb.cs
@@ -90,7 +90,7 @@ namespace Nethermind.Db
 
         public IEnumerable<byte[]> GetAllValues(bool ordered = false) => Values;
 
-        public virtual IBatch StartBatch()
+        public virtual IWriteBatch StartWriteBatch()
         {
             return this.LikeABatch();
         }

--- a/src/Nethermind/Nethermind.Db/NullDb.cs
+++ b/src/Nethermind/Nethermind.Db/NullDb.cs
@@ -56,7 +56,7 @@ namespace Nethermind.Db
 
         public IEnumerable<byte[]> GetAllValues(bool ordered = false) => Enumerable.Empty<byte[]>();
 
-        public IBatch StartBatch()
+        public IWriteBatch StartWriteBatch()
         {
             throw new NotSupportedException();
         }

--- a/src/Nethermind/Nethermind.Db/ReadOnlyColumnsDb.cs
+++ b/src/Nethermind/Nethermind.Db/ReadOnlyColumnsDb.cs
@@ -24,9 +24,9 @@ namespace Nethermind.Db
         }
 
         public IEnumerable<T> ColumnKeys => _readOnlyColumns.Keys;
-        public IColumnsBatch<T> StartBatch()
+        public IColumnsWriteBatch<T> StartWriteBatch()
         {
-            return new InMemoryColumnBatch<T>(this);
+            return new InMemoryColumnWriteBatch<T>(this);
         }
 
         public void ClearTempChanges()

--- a/src/Nethermind/Nethermind.Db/ReadOnlyDb.cs
+++ b/src/Nethermind/Nethermind.Db/ReadOnlyDb.cs
@@ -65,7 +65,7 @@ namespace Nethermind.Db
 
         public IEnumerable<byte[]> GetAllValues(bool ordered = false) => _memDb.GetAllValues();
 
-        public IBatch StartBatch()
+        public IWriteBatch StartWriteBatch()
         {
             return this.LikeABatch();
         }

--- a/src/Nethermind/Nethermind.Db/SimpleFilePublicKeyDb.cs
+++ b/src/Nethermind/Nethermind.Db/SimpleFilePublicKeyDb.cs
@@ -101,7 +101,7 @@ namespace Nethermind.Db
 
         public IEnumerable<byte[]> GetAllValues(bool ordered = false) => _cache.Values;
 
-        public IBatch StartBatch()
+        public IWriteBatch StartWriteBatch()
         {
             return this.LikeABatch(CommitBatch);
         }

--- a/src/Nethermind/Nethermind.Init/Steps/Migrations/ReceiptMigration.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/Migrations/ReceiptMigration.cs
@@ -322,10 +322,10 @@ namespace Nethermind.Init.Steps.Migrations
 
             // I guess some old schema need this
             {
-                using IBatch batch = _receiptsDb.StartBatch().GetColumnBatch(ReceiptsColumns.Transactions);
+                using IWriteBatch writeBatch = _receiptsDb.StartWriteBatch().GetColumnBatch(ReceiptsColumns.Transactions);
                 for (int i = 0; i < notNullReceipts.Length; i++)
                 {
-                    batch[notNullReceipts[i].TxHash!.Bytes] = null;
+                    writeBatch[notNullReceipts[i].TxHash!.Bytes] = null;
                 }
             }
 
@@ -337,10 +337,10 @@ namespace Nethermind.Init.Steps.Migrations
             bool neverIndexTx = _receiptConfig.TxLookupLimit == -1;
             if (neverIndexTx || txIndexExpired)
             {
-                using IBatch batch = _txIndexDb.StartBatch();
+                using IWriteBatch writeBatch = _txIndexDb.StartWriteBatch();
                 foreach (TxReceipt? receipt in notNullReceipts)
                 {
-                    batch[receipt.TxHash!.Bytes] = null;
+                    writeBatch[receipt.TxHash!.Bytes] = null;
                 }
             }
 

--- a/src/Nethermind/Nethermind.Network/NetworkStorage.cs
+++ b/src/Nethermind/Nethermind.Network/NetworkStorage.cs
@@ -97,7 +97,7 @@ namespace Nethermind.Network
 
         private void UpdateNodeImpl(NetworkNode node)
         {
-            (_currentBatch ?? (IKeyValueStore)_fullDb)[node.NodeId.Bytes] = Rlp.Encode(node).Bytes;
+            (_currentBatch ?? (IWriteOnlyKeyValueStore)_fullDb)[node.NodeId.Bytes] = Rlp.Encode(node).Bytes;
             _updateCounter++;
 
             if (!_nodesDict.ContainsKey(node.NodeId))
@@ -125,7 +125,7 @@ namespace Nethermind.Network
 
         public void RemoveNode(PublicKey nodeId)
         {
-            (_currentBatch ?? (IKeyValueStore)_fullDb)[nodeId.Bytes] = null;
+            (_currentBatch ?? (IWriteOnlyKeyValueStore)_fullDb)[nodeId.Bytes] = null;
             _removeCounter++;
 
             RemoveLocal(nodeId);
@@ -143,11 +143,11 @@ namespace Nethermind.Network
             }
         }
 
-        private IBatch? _currentBatch;
+        private IWriteBatch? _currentBatch;
 
         public void StartBatch()
         {
-            _currentBatch = _fullDb.StartBatch();
+            _currentBatch = _fullDb.StartWriteBatch();
             _updateCounter = 0;
             _removeCounter = 0;
         }

--- a/src/Nethermind/Nethermind.State/Witnesses/WitnessingStore.cs
+++ b/src/Nethermind/Nethermind.State/Witnesses/WitnessingStore.cs
@@ -52,9 +52,9 @@ namespace Nethermind.State.Witnesses
             _wrapped.Set(key, value, flags);
         }
 
-        public IBatch StartBatch()
+        public IWriteBatch StartWriteBatch()
         {
-            return _wrapped.StartBatch();
+            return _wrapped.StartWriteBatch();
         }
 
         public void Touch(ReadOnlySpan<byte> key)

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProvider.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProvider.cs
@@ -273,7 +273,7 @@ namespace Nethermind.Synchronization.SnapSync
         {
             HashSet<ValueKeccak> set = requestedHashes.ToHashSet();
 
-            using (IBatch writeBatch = _dbProvider.CodeDb.StartBatch())
+            using (IWriteBatch writeWriteBatch = _dbProvider.CodeDb.StartWriteBatch())
             {
                 for (int i = 0; i < codes.Length; i++)
                 {
@@ -283,7 +283,7 @@ namespace Nethermind.Synchronization.SnapSync
                     if (set.Remove(codeHash))
                     {
                         Interlocked.Add(ref Metrics.SnapStateSynced, code.Length);
-                        writeBatch[codeHash.Bytes] = code;
+                        writeWriteBatch[codeHash.Bytes] = code;
                     }
                 }
             }

--- a/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
@@ -411,12 +411,12 @@ namespace Nethermind.Trie.Test.Pruning
                 return _db[key.ToArray()];
             }
 
-            public IBatch StartBatch()
+            public IWriteBatch StartWriteBatch()
             {
-                return new BadBatch();
+                return new BadWriteBatch();
             }
 
-            private class BadBatch : IBatch
+            private class BadWriteBatch : IWriteBatch
             {
                 private Dictionary<byte[], byte[]> _inBatched = new();
 
@@ -426,18 +426,12 @@ namespace Nethermind.Trie.Test.Pruning
 
                 public byte[]? this[ReadOnlySpan<byte> key]
                 {
-                    get => Get(key);
                     set => Set(key, value);
                 }
 
                 public void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None)
                 {
                     _inBatched[key.ToArray()] = value;
-                }
-
-                public byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)
-                {
-                    return _inBatched[key.ToArray()];
                 }
             }
         }

--- a/src/Nethermind/Nethermind.Trie/CachingStore.cs
+++ b/src/Nethermind/Nethermind.Trie/CachingStore.cs
@@ -70,7 +70,7 @@ namespace Nethermind.Trie
         }
 
 
-        public IBatch StartBatch() => _wrappedStore.StartBatch();
+        public IWriteBatch StartWriteBatch() => _wrappedStore.StartWriteBatch();
 
         public void PersistCache(IKeyValueStore pruningContext)
         {

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -125,7 +125,7 @@ namespace Nethermind.Trie.Pruning
 
         private int _isFirst;
 
-        private IBatch? _currentBatch = null;
+        private IWriteBatch? _currentBatch = null;
 
         private readonly DirtyNodesCache _dirtyNodes;
 
@@ -325,7 +325,7 @@ namespace Nethermind.Trie.Pruning
         public byte[] LoadRlp(Keccak keccak, IKeyValueStore? keyValueStore, ReadFlags readFlags = ReadFlags.None)
         {
             keyValueStore ??= _keyValueStore;
-            byte[]? rlp = _currentBatch?.Get(keccak.Bytes, readFlags) ?? keyValueStore.Get(keccak.Bytes, readFlags);
+            byte[]? rlp = keyValueStore.Get(keccak.Bytes, readFlags);
 
             if (rlp is null)
             {
@@ -341,7 +341,7 @@ namespace Nethermind.Trie.Pruning
 
         public bool IsPersisted(in ValueKeccak keccak)
         {
-            byte[]? rlp = _currentBatch?[keccak.Bytes] ?? _keyValueStore[keccak.Bytes];
+            byte[]? rlp = _keyValueStore[keccak.Bytes];
 
             if (rlp is null)
             {
@@ -612,7 +612,7 @@ namespace Nethermind.Trie.Pruning
 
             try
             {
-                _currentBatch ??= _keyValueStore.StartBatch();
+                _currentBatch ??= _keyValueStore.StartWriteBatch();
                 if (_logger.IsDebug) _logger.Debug($"Persisting from root {commitSet.Root} in {commitSet.BlockNumber}");
 
                 Stopwatch stopwatch = Stopwatch.StartNew();
@@ -637,7 +637,7 @@ namespace Nethermind.Trie.Pruning
 
         private void Persist(TrieNode currentNode, long blockNumber, WriteFlags writeFlags = WriteFlags.None)
         {
-            _currentBatch ??= _keyValueStore.StartBatch();
+            _currentBatch ??= _keyValueStore.StartWriteBatch();
             if (currentNode is null)
             {
                 throw new ArgumentNullException(nameof(currentNode));
@@ -826,7 +826,7 @@ namespace Nethermind.Trie.Pruning
                    && trieNode.NodeType != NodeType.Unknown
                    && trieNode.FullRlp.IsNotNull
                 ? trieNode.FullRlp.ToArray()
-                : _currentBatch?.Get(key, flags) ?? _keyValueStore.Get(key, flags);
+                : _keyValueStore.Get(key, flags);
         }
 
         public IKeyValueStore AsKeyValueStore() => _publicStore;


### PR DESCRIPTION
- IBatch's getter don't actually reflect what's written. 
- Well, we can make it work with a WriteBatchWithIndex, but that will take some CPU cycle away, and so far we don't need it.
- So I'd recommend renaming it to WriteBatch and remove the getter to prevent accidentally assuming that it can read.

## Changes

- Rename `IBatch` to `IWriteBatch`. 
- Remove getter.

#### What types of changes does your code introduce?

- [X] Refactoring

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No
