### PR TITLE
Perf/NoWAL during OldBodies

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Blocks/BlockStoreTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Blocks/BlockStoreTests.cs
@@ -5,6 +5,7 @@ using System;
 using FluentAssertions;
 using Nethermind.Blockchain.Blocks;
 using Nethermind.Core;
+using Nethermind.Core.Extensions;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Serialization.Rlp;
@@ -31,6 +32,19 @@ public class BlockStoreTests
         store.Delete(block.Number, block.Hash!);
 
         store.Get(block.Number, block.Hash!, cached).Should().BeNull();
+    }
+
+    [Test]
+    public void Test_insert_would_pass_in_writeflag()
+    {
+        TestMemDb db = new TestMemDb();
+        BlockStore store = new BlockStore(db);
+
+        Block block = Build.A.Block.WithNumber(1).TestObject;
+        store.Insert(block, WriteFlags.DisableWAL);
+
+        byte[] key = Bytes.Concat(block.Number.ToBigEndianByteArray(), block.Hash!.BytesToArray());
+        db.KeyWasWrittenWithFlags(key, WriteFlags.DisableWAL);
     }
 
     [TestCase(true)]

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -275,7 +275,7 @@ namespace Nethermind.Blockchain
         }
 
         public AddBlockResult Insert(Block block, BlockTreeInsertBlockOptions insertBlockOptions = BlockTreeInsertBlockOptions.None,
-            BlockTreeInsertHeaderOptions insertHeaderOptions = BlockTreeInsertHeaderOptions.None)
+            BlockTreeInsertHeaderOptions insertHeaderOptions = BlockTreeInsertHeaderOptions.None, WriteFlags blockWriteFlags = WriteFlags.None)
         {
             bool skipCanAcceptNewBlocks = (insertBlockOptions & BlockTreeInsertBlockOptions.SkipCanAcceptNewBlocks) != 0;
             if (!CanAcceptNewBlocks)
@@ -293,7 +293,7 @@ namespace Nethermind.Blockchain
                 throw new InvalidOperationException("Genesis block should not be inserted.");
             }
 
-            _blockStore.Insert(block);
+            _blockStore.Insert(block, writeFlags: blockWriteFlags);
             _headerStore.InsertBlockNumber(block.Hash, block.Number);
 
             bool saveHeader = (insertBlockOptions & BlockTreeInsertBlockOptions.SaveHeader) != 0;

--- a/src/Nethermind/Nethermind.Blockchain/Blocks/BlockStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Blocks/BlockStore.cs
@@ -42,7 +42,7 @@ public class BlockStore : IBlockStore
         return _blockDb.Get(key);
     }
 
-    public void Insert(Block block)
+    public void Insert(Block block, WriteFlags writeFlags = WriteFlags.None)
     {
         if (block.Hash is null)
         {

--- a/src/Nethermind/Nethermind.Blockchain/Blocks/BlockStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Blocks/BlockStore.cs
@@ -53,7 +53,7 @@ public class BlockStore : IBlockStore
         // by avoiding encoding back to RLP here (allocations measured on a sample 3M blocks Goerli fast sync
         using NettyRlpStream newRlp = _blockDecoder.EncodeToNewNettyStream(block);
 
-        _blockDb.Set(block.Number, block.Hash, newRlp.AsSpan());
+        _blockDb.Set(block.Number, block.Hash, newRlp.AsSpan(), writeFlags);
     }
 
     private static void GetBlockNumPrefixedKey(long blockNumber, Hash256 blockHash, Span<byte> output)

--- a/src/Nethermind/Nethermind.Blockchain/Blocks/IBlockStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Blocks/IBlockStore.cs
@@ -13,7 +13,7 @@ namespace Nethermind.Blockchain.Blocks;
 /// </summary>
 public interface IBlockStore
 {
-    void Insert(Block block);
+    void Insert(Block block, WriteFlags writeFlags = WriteFlags.None);
     void Delete(long blockNumber, Hash256 blockHash);
     Block? Get(long blockNumber, Hash256 blockHash, bool shouldCache = true);
     ReceiptRecoveryBlock? GetReceiptRecoveryBlock(long blockNumber, Hash256 blockHash);

--- a/src/Nethermind/Nethermind.Blockchain/IBlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/IBlockTree.cs
@@ -77,7 +77,7 @@ namespace Nethermind.Blockchain
         /// <param name="block">Block to add</param>
         /// <returns>Result of the operation, eg. Added, AlreadyKnown, etc.</returns>
         AddBlockResult Insert(Block block, BlockTreeInsertBlockOptions insertBlockOptions = BlockTreeInsertBlockOptions.None,
-            BlockTreeInsertHeaderOptions insertHeaderOptions = BlockTreeInsertHeaderOptions.None);
+            BlockTreeInsertHeaderOptions insertHeaderOptions = BlockTreeInsertHeaderOptions.None, WriteFlags bodiesWriteFlags = WriteFlags.None);
 
         void UpdateHeadBlock(Hash256 blockHash);
 

--- a/src/Nethermind/Nethermind.Blockchain/ReadOnlyBlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/ReadOnlyBlockTree.cs
@@ -68,7 +68,7 @@ namespace Nethermind.Blockchain
         public ChainLevelInfo FindLevel(long number) => _wrapped.FindLevel(number);
         public BlockInfo FindCanonicalBlockInfo(long blockNumber) => _wrapped.FindCanonicalBlockInfo(blockNumber);
 
-        public AddBlockResult Insert(Block block, BlockTreeInsertBlockOptions insertBlockOptions = BlockTreeInsertBlockOptions.None, BlockTreeInsertHeaderOptions insertHeaderOptions = BlockTreeInsertHeaderOptions.None) =>
+        public AddBlockResult Insert(Block block, BlockTreeInsertBlockOptions insertBlockOptions = BlockTreeInsertBlockOptions.None, BlockTreeInsertHeaderOptions insertHeaderOptions = BlockTreeInsertHeaderOptions.None, WriteFlags blockWriteFlags = WriteFlags.None) =>
             throw new InvalidOperationException($"{nameof(ReadOnlyBlockTree)} does not expect {nameof(Insert)} calls");
 
         public void Insert(IEnumerable<Block> blocks) => throw new InvalidOperationException($"{nameof(ReadOnlyBlockTree)} does not expect {nameof(Insert)} calls");

--- a/src/Nethermind/Nethermind.Core.Test/TestMemDb.cs
+++ b/src/Nethermind/Nethermind.Core.Test/TestMemDb.cs
@@ -24,7 +24,8 @@ public class TestMemDb : MemDb, ITunableDb
     public Func<byte[], byte[]>? ReadFunc { get; set; }
     public Action<byte[]>? RemoveFunc { get; set; }
 
-    public bool WasFlushed { get; set; }
+    public bool WasFlushed => FlushCount > 0;
+    public int FlushCount { get; set; } = 0;
 
     [MethodImpl(MethodImplOptions.Synchronized)]
     public override byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)
@@ -107,6 +108,6 @@ public class TestMemDb : MemDb, ITunableDb
 
     public override void Flush()
     {
-        WasFlushed = true;
+        FlushCount++;
     }
 }

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -128,10 +128,9 @@ public class ColumnDb : IDbWithSpan
         return _rocksDb.GetSpan(key, _columnFamily);
     }
 
-    public void PutSpan(ReadOnlySpan<byte> key, ReadOnlySpan<byte> value)
+    public void PutSpan(ReadOnlySpan<byte> key, ReadOnlySpan<byte> value, WriteFlags writeFlags = WriteFlags.None)
     {
-        _mainDb.UpdateWriteMetrics();
-        _rocksDb.Put(key, value, _columnFamily, _mainDb.WriteOptions);
+        _mainDb.SetWithColumnFamily(key, _columnFamily, value, writeFlags);
     }
 
     public void DangerousReleaseMemory(in Span<byte> span) => _rocksDb.DangerousReleaseMemory(span);

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -509,7 +509,7 @@ public class DbOnTheRocks : IDbWithSpan, ITunableDb
         SetWithColumnFamily(key, null, value, flags);
     }
 
-    internal void SetWithColumnFamily(ReadOnlySpan<byte> key, ColumnFamilyHandle? cf, byte[]? value, WriteFlags flags = WriteFlags.None)
+    internal void SetWithColumnFamily(ReadOnlySpan<byte> key, ColumnFamilyHandle? cf, ReadOnlySpan<byte> value, WriteFlags flags = WriteFlags.None)
     {
         if (_isDisposing)
         {
@@ -520,7 +520,7 @@ public class DbOnTheRocks : IDbWithSpan, ITunableDb
 
         try
         {
-            if (value is null)
+            if (value.IsNull())
             {
                 _db.Remove(key, cf, WriteFlagsToWriteOptions(flags));
             }
@@ -596,24 +596,9 @@ public class DbOnTheRocks : IDbWithSpan, ITunableDb
         }
     }
 
-    public void PutSpan(ReadOnlySpan<byte> key, ReadOnlySpan<byte> value)
+    public void PutSpan(ReadOnlySpan<byte> key, ReadOnlySpan<byte> value, WriteFlags writeFlags)
     {
-        if (_isDisposing)
-        {
-            throw new ObjectDisposedException($"Attempted to write form a disposed database {Name}");
-        }
-
-        UpdateWriteMetrics();
-
-        try
-        {
-            _db.Put(key, value, null, WriteOptions);
-        }
-        catch (RocksDbSharpException e)
-        {
-            CreateMarkerIfCorrupt(e);
-            throw;
-        }
+        SetWithColumnFamily(key, null, value, writeFlags);
     }
 
     public void DangerousReleaseMemory(in Span<byte> span)

--- a/src/Nethermind/Nethermind.Db.Rpc/RpcDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rpc/RpcDb.cs
@@ -107,9 +107,9 @@ namespace Nethermind.Db.Rpc
             return Get(key);
         }
 
-        public void PutSpan(ReadOnlySpan<byte> key, ReadOnlySpan<byte> value)
+        public void PutSpan(ReadOnlySpan<byte> key, ReadOnlySpan<byte> value, WriteFlags writeFlags)
         {
-            Set(key, value.ToArray());
+            Set(key, value.ToArray(), writeFlags);
         }
 
         public void DangerousReleaseMemory(in Span<byte> span)

--- a/src/Nethermind/Nethermind.Db/DbExtensions.cs
+++ b/src/Nethermind/Nethermind.Db/DbExtensions.cs
@@ -74,15 +74,15 @@ namespace Nethermind.Db
             }
         }
 
-        public static void Set(this IDb db, ReadOnlySpan<byte> key, ReadOnlySpan<byte> value)
+        public static void Set(this IDb db, ReadOnlySpan<byte> key, ReadOnlySpan<byte> value, WriteFlags writeFlags = WriteFlags.None)
         {
             if (db is IDbWithSpan dbWithSpan)
             {
-                dbWithSpan.PutSpan(key, value);
+                dbWithSpan.PutSpan(key, value, flags: writeFlags);
             }
             else
             {
-                db[key] = value.ToArray();
+                db.Set(key, value.ToArray(), flags: writeFlags);
             }
         }
 

--- a/src/Nethermind/Nethermind.Db/DbExtensions.cs
+++ b/src/Nethermind/Nethermind.Db/DbExtensions.cs
@@ -49,11 +49,11 @@ namespace Nethermind.Db
             }
         }
 
-        public static void Set(this IDb db, long blockNumber, Hash256 key, Span<byte> value)
+        public static void Set(this IDb db, long blockNumber, Hash256 key, Span<byte> value, WriteFlags writeFlags = WriteFlags.None)
         {
             Span<byte> blockNumberPrefixedKey = stackalloc byte[40];
             GetBlockNumPrefixedKey(blockNumber, key, blockNumberPrefixedKey);
-            db.Set(blockNumberPrefixedKey, value);
+            db.Set(blockNumberPrefixedKey, value, writeFlags);
         }
 
         private static void GetBlockNumPrefixedKey(long blockNumber, ValueHash256 blockHash, Span<byte> output)

--- a/src/Nethermind/Nethermind.Db/IDbWithSpan.cs
+++ b/src/Nethermind/Nethermind.Db/IDbWithSpan.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Buffers;
+using Nethermind.Core;
 using Nethermind.Core.Buffers;
 using Nethermind.Core.Extensions;
 
@@ -16,7 +17,7 @@ namespace Nethermind.Db
         /// <param name="key"></param>
         /// <returns>Can return null or empty Span on missing key</returns>
         Span<byte> GetSpan(ReadOnlySpan<byte> key);
-        void PutSpan(ReadOnlySpan<byte> key, ReadOnlySpan<byte> value);
+        void PutSpan(ReadOnlySpan<byte> key, ReadOnlySpan<byte> value, WriteFlags flags = WriteFlags.None);
         void DangerousReleaseMemory(in Span<byte> span);
         MemoryManager<byte>? GetOwnedMemory(ReadOnlySpan<byte> key)
         {

--- a/src/Nethermind/Nethermind.Db/MemDb.cs
+++ b/src/Nethermind/Nethermind.Db/MemDb.cs
@@ -114,9 +114,9 @@ namespace Nethermind.Db
             return Get(key).AsSpan();
         }
 
-        public void PutSpan(ReadOnlySpan<byte> key, ReadOnlySpan<byte> value)
+        public void PutSpan(ReadOnlySpan<byte> key, ReadOnlySpan<byte> value, WriteFlags writeFlags)
         {
-            Set(key, value.ToArray());
+            Set(key, value.ToArray(), writeFlags);
         }
 
         public void DangerousReleaseMemory(in Span<byte> span)

--- a/src/Nethermind/Nethermind.Db/ReadOnlyDb.cs
+++ b/src/Nethermind/Nethermind.Db/ReadOnlyDb.cs
@@ -96,14 +96,14 @@ namespace Nethermind.Db
         }
 
         public Span<byte> GetSpan(ReadOnlySpan<byte> key) => _memDb.Get(key).AsSpan();
-        public void PutSpan(ReadOnlySpan<byte> keyBytes, ReadOnlySpan<byte> value)
+        public void PutSpan(ReadOnlySpan<byte> keyBytes, ReadOnlySpan<byte> value, WriteFlags writeFlags = WriteFlags.None)
         {
             if (!_createInMemWriteStore)
             {
                 throw new InvalidOperationException($"This {nameof(ReadOnlyDb)} did not expect any writes.");
             }
 
-            _memDb.Set(keyBytes, value.ToArray());
+            _memDb.Set(keyBytes, value.ToArray(), writeFlags);
         }
 
         public void DangerousReleaseMemory(in Span<byte> span) { }

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/BodiesSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/BodiesSyncFeedTests.cs
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Nethermind.Blockchain;
+using Nethermind.Blockchain.Synchronization;
+using Nethermind.Core;
+using Nethermind.Core.Test;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Logging;
+using Nethermind.Synchronization.FastBlocks;
+using Nethermind.Synchronization.ParallelSync;
+using Nethermind.Synchronization.Peers;
+using Nethermind.Synchronization.Reporting;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Synchronization.Test.FastBlocks;
+
+public class BodiesSyncFeedTests
+{
+    [Test]
+    public async Task ShouldCallFlushPeriodically()
+    {
+        BlockTree syncingFromBlockTree = Build.A.BlockTree()
+            .OfChainLength(100)
+            .TestObject;
+
+        TestMemDb blocksDb = new TestMemDb();
+        BlockTree syncingTooBlockTree = Build.A.BlockTree()
+            .WithBlocksDb(blocksDb)
+            .TestObject;
+
+        for (int i = 1; i < 100; i++)
+        {
+            Block block = syncingFromBlockTree.FindBlock(i, BlockTreeLookupOptions.None)!;
+            syncingTooBlockTree.Insert(block.Header);
+        }
+
+        Block pivot = syncingFromBlockTree.FindBlock(99, BlockTreeLookupOptions.None)!;
+
+        SyncConfig syncConfig = new SyncConfig()
+        {
+            FastSync = true,
+            PivotHash = pivot.Hash!.ToString(),
+            PivotNumber = pivot.Number.ToString(),
+            AncientBodiesBarrier = 0,
+            FastBlocks = true,
+            DownloadBodiesInFastSync = true,
+        };
+
+        BodiesSyncFeed syncFeed = new BodiesSyncFeed(
+            Substitute.For<ISyncModeSelector>(),
+            syncingTooBlockTree,
+            Substitute.For<ISyncPeerPool>(),
+            syncConfig,
+            new NullSyncReport(),
+            blocksDb,
+            LimboLogs.Instance,
+            flushDbInterval: 10
+        );
+
+        syncFeed.InitializeFeed();
+        BodiesSyncBatch req = (await syncFeed.PrepareRequest())!;
+        blocksDb.FlushCount.Should().Be(1);
+
+        async Task HandleAndPrepareNextRequest()
+        {
+            req.Response = new OwnedBlockBodies(req.Infos.Take(8).Select((info) =>
+                syncingFromBlockTree.FindBlock(info!.BlockNumber, BlockTreeLookupOptions.None)!.Body).ToArray());
+
+            syncFeed.HandleResponse(req);
+            req = (await syncFeed.PrepareRequest())!;
+        }
+
+        await HandleAndPrepareNextRequest();
+        blocksDb.FlushCount.Should().Be(1);
+
+        await HandleAndPrepareNextRequest();
+        blocksDb.FlushCount.Should().Be(2);
+
+        await HandleAndPrepareNextRequest();
+        blocksDb.FlushCount.Should().Be(2);
+
+        await HandleAndPrepareNextRequest();
+        blocksDb.FlushCount.Should().Be(3);
+    }
+}

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
@@ -137,8 +137,10 @@ namespace Nethermind.Synchronization.FastBlocks
                 }
             }
 
-            if ((_blockTree.LowestInsertedBodyNumber ?? long.MaxValue) - _syncStatusList.LowestInsertWithoutGaps > _flushDbInterval)
-            {
+            if (
+                (_blockTree.LowestInsertedBodyNumber ?? long.MaxValue) - _syncStatusList.LowestInsertWithoutGaps > _flushDbInterval ||
+                _syncStatusList.LowestInsertWithoutGaps <= _barrier // Other state depends on LowestInsertedBodyNumber, so this need to flush or it wont finish
+            ) {
                 Flush();
             }
 

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
@@ -8,7 +8,7 @@ using Nethermind.Blockchain;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
-using Nethermind.Core.Specs;
+using Nethermind.Db;
 using Nethermind.Logging;
 using Nethermind.State.Proofs;
 using Nethermind.Stats.Model;
@@ -22,13 +22,14 @@ namespace Nethermind.Synchronization.FastBlocks
     public class BodiesSyncFeed : ActivatedSyncFeed<BodiesSyncBatch?>
     {
         private int _requestSize = GethSyncLimits.MaxBodyFetch;
+        private const long FlushDbInterval = 100000; // About every 10GB on mainnet
 
         private readonly ILogger _logger;
         private readonly IBlockTree _blockTree;
         private readonly ISyncConfig _syncConfig;
         private readonly ISyncReport _syncReport;
-        private readonly ISpecProvider _specProvider;
         private readonly ISyncPeerPool _syncPeerPool;
+        private readonly IDbMeta _blocksDb;
 
         private long _pivotNumber;
         private long _barrier;
@@ -41,7 +42,7 @@ namespace Nethermind.Synchronization.FastBlocks
             ISyncPeerPool syncPeerPool,
             ISyncConfig syncConfig,
             ISyncReport syncReport,
-            ISpecProvider specProvider,
+            IDbMeta blocksDb,
             ILogManager logManager) : base(syncModeSelector)
         {
             _logger = logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
@@ -49,7 +50,7 @@ namespace Nethermind.Synchronization.FastBlocks
             _syncPeerPool = syncPeerPool ?? throw new ArgumentNullException(nameof(syncPeerPool));
             _syncConfig = syncConfig ?? throw new ArgumentNullException(nameof(syncConfig));
             _syncReport = syncReport ?? throw new ArgumentNullException(nameof(syncReport));
-            _specProvider = specProvider ?? throw new ArgumentNullException(nameof(specProvider));
+            _blocksDb = blocksDb ?? throw new ArgumentNullException(nameof(blocksDb));
 
             if (!_syncConfig.FastBlocks)
             {
@@ -115,6 +116,7 @@ namespace Nethermind.Synchronization.FastBlocks
             _syncReport.FastBlocksBodies.MarkEnd();
             _syncReport.BodiesInQueue.Update(0);
             _syncReport.BodiesInQueue.MarkEnd();
+            Flush();
         }
 
         public override Task<BodiesSyncBatch?> PrepareRequest(CancellationToken token = default)
@@ -132,9 +134,18 @@ namespace Nethermind.Synchronization.FastBlocks
                 }
             }
 
-            _blockTree.LowestInsertedBodyNumber = _syncStatusList.LowestInsertWithoutGaps;
+            if ((_blockTree.LowestInsertedBodyNumber ?? long.MaxValue) - _syncStatusList.LowestInsertWithoutGaps > FlushDbInterval)
+            {
+                Flush();
+            }
 
             return Task.FromResult(batch);
+        }
+
+        private void Flush()
+        {
+            _blocksDb.Flush();
+            _blockTree.LowestInsertedBodyNumber = _syncStatusList.LowestInsertWithoutGaps;
         }
 
         public override SyncResponseHandlingResult HandleResponse(BodiesSyncBatch? batch, PeerInfo peer = null)
@@ -234,7 +245,7 @@ namespace Nethermind.Synchronization.FastBlocks
 
         private void InsertOneBlock(Block block)
         {
-            _blockTree.Insert(block, BlockTreeInsertBlockOptions.SkipCanAcceptNewBlocks);
+            _blockTree.Insert(block, BlockTreeInsertBlockOptions.SkipCanAcceptNewBlocks, bodiesWriteFlags: WriteFlags.DisableWAL);
             _syncStatusList.MarkInserted(block.Number);
         }
 

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
@@ -149,8 +149,9 @@ namespace Nethermind.Synchronization.FastBlocks
 
         private void Flush()
         {
+            long lowestInsertedAtPoint = _syncStatusList.LowestInsertWithoutGaps;
             _blocksDb.Flush();
-            _blockTree.LowestInsertedBodyNumber = _syncStatusList.LowestInsertWithoutGaps;
+            _blockTree.LowestInsertedBodyNumber = lowestInsertedAtPoint;
         }
 
         public override SyncResponseHandlingResult HandleResponse(BodiesSyncBatch? batch, PeerInfo peer = null)

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
@@ -140,7 +140,8 @@ namespace Nethermind.Synchronization.FastBlocks
             if (
                 (_blockTree.LowestInsertedBodyNumber ?? long.MaxValue) - _syncStatusList.LowestInsertWithoutGaps > _flushDbInterval ||
                 _syncStatusList.LowestInsertWithoutGaps <= _barrier // Other state depends on LowestInsertedBodyNumber, so this need to flush or it wont finish
-            ) {
+            )
+            {
                 Flush();
             }
 

--- a/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
@@ -267,7 +267,7 @@ namespace Nethermind.Synchronization
             {
                 if (_syncConfig.DownloadBodiesInFastSync)
                 {
-                    _bodiesFeed = new BodiesSyncFeed(_syncMode, _blockTree, _syncPeerPool, _syncConfig, _syncReport, _specProvider, _logManager);
+                    _bodiesFeed = new BodiesSyncFeed(_syncMode, _blockTree, _syncPeerPool, _syncConfig, _syncReport, _dbProvider.BlocksDb, _logManager);
 
                     SyncDispatcher<BodiesSyncBatch> bodiesDispatcher = CreateDispatcher(
                         _bodiesFeed,


### PR DESCRIPTION
- Most of the write IO during old bodies are actually due to WAL (Write Ahead Log) file, which is the mechanism for which rocksdb recover on unclean shutdown.
- This PR disable WAL writes for bodies writes from OldBodies.
- For recovery, the LowestInsertedBlockNumber is not updated on all request, instead it is updated every 100000 blocks, at which point an explicit flush is also triggered to make sure the memtables are written at that point.
- This reduces total writes during OldBodies by about 60-70% or so. This is more than 50% because the WAL file are not compressed and the bodies are compressed to about 60-70% on flush.
- No change in bodies sync time. Unless your SSD can't sustain about 350MB/s of writes before and you have really fast internet.
- Graph is after, before, after, before.
![Screenshot_2023-10-26_14-07-00](https://github.com/NethermindEth/nethermind/assets/1841324/3012fe15-ea40-4abf-b696-c9162ddeb485)

## Changes

- Add WriteFlags to PutSpan.
- Add WriteFlags to BlockTree.Insert
- Set nowal during old bodies.

## Types of changes

#### What types of changes does your code introduce?

- [X] Optimization

## Testing

#### Requires testing

- [X] Yes

#### If yes, did you write tests?

- [X] Yes

#### Notes on testing

- Manually `kill -s KILL` nethermind a couple of time during sync. Then run a custom python script to verify all expected blocks is present. Verified, it resumed slightly before the point it was killed