### PR TITLE
Use blob gas instead of count

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/TestEip4844Config.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TestEip4844Config.cs
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+
+namespace Nethermind.Consensus.Producers.Test;
+
+public class TestEip4844Config : IEip4844Config
+{
+    public TestEip4844Config(ulong? maxBlobGasPerBlock = null)
+    {
+        MaxBlobGasPerBlock = maxBlobGasPerBlock ?? Eip4844Constants.MaxBlobGasPerBlock;
+    }
+
+    public ulong MaxBlobGasPerBlock { get; }
+
+    public ulong GasPerBlob => Eip4844Constants.GasPerBlob;
+
+    public int GetMaxBlobsPerBlock() => (int)(MaxBlobGasPerBlock / GasPerBlob);
+}

--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionSelectorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionSelectorTests.cs
@@ -146,7 +146,6 @@ namespace Nethermind.Blockchain.Test
             }
         }
 
-
         public static IEnumerable EnoughShardBlobTransactionsSelectedTestCases
         {
             get

--- a/src/Nethermind/Nethermind.Blockchain.Test/TxPoolSourceTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TxPoolSourceTests.cs
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Consensus.Transactions;
+using Nethermind.Logging;
+using Nethermind.Specs.Forks;
+using Nethermind.TxPool;
+using NUnit.Framework;
+using Nethermind.Consensus.Comparers;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Specs;
+using Nethermind.Core;
+using System.Linq;
+using System.Collections.Generic;
+using NSubstitute;
+
+namespace Nethermind.Consensus.Producers.Test;
+
+public class TxPoolSourceTests
+{
+    [TestCaseSource(nameof(BlobTransactionsWithBlobGasLimitPerBlock))]
+    public void GetTransactions_should_respect_customizable_blob_gas_limit(int[] blobCountPerTx, ulong customMaxBlobGasPerBlock)
+    {
+        TestSingleReleaseSpecProvider specProvider = new(Cancun.Instance);
+        TransactionComparerProvider transactionComparerProvider = new(specProvider, Build.A.BlockTree().TestObject);
+
+        ITxPool txPool = Substitute.For<ITxPool>();
+        Dictionary<Address, Transaction[]> transactionsWithBlobs = blobCountPerTx
+            .Select((blobsCount, index) => (blobCount: blobsCount, index))
+            .ToDictionary(
+                pair => new Address((new byte[19]).Concat(new byte[] { (byte)pair.index }).ToArray()),
+                pair => new Transaction[] { Build.A.Transaction.WithShardBlobTxTypeAndFields(pair.blobCount).TestObject });
+        txPool.GetPendingTransactions().Returns(new Transaction[0]);
+        txPool.GetPendingLightBlobTransactionsBySender().Returns(transactionsWithBlobs);
+
+        ITxFilterPipeline txFilterPipeline = Substitute.For<ITxFilterPipeline>();
+        txFilterPipeline.Execute(Arg.Any<Transaction>(), Arg.Any<BlockHeader>()).Returns(true);
+
+        TestEip4844Config eip4844Config = new(customMaxBlobGasPerBlock);
+
+        TxPoolTxSource transactionSelector = new(txPool, specProvider, transactionComparerProvider, LimboLogs.Instance, txFilterPipeline, eip4844Config);
+
+        IEnumerable<Transaction> txs = transactionSelector.GetTransactions(new BlockHeader { }, long.MaxValue);
+        int blobsCount = txs.Sum(tx => tx.BlobVersionedHashes?.Length ?? 0);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That((ulong)blobsCount * eip4844Config.GasPerBlob, Is.LessThanOrEqualTo(eip4844Config.MaxBlobGasPerBlock));
+            Assert.That(blobsCount, Is.LessThanOrEqualTo(eip4844Config.GetMaxBlobsPerBlock()));
+        });
+    }
+
+    public static IEnumerable<TestCaseData> BlobTransactionsWithBlobGasLimitPerBlock()
+    {
+        yield return new TestCaseData(new int[] { 1, 2, 4 }, Eip4844Constants.GasPerBlob * 6);
+        yield return new TestCaseData(new int[] { 1, 2, 6 }, Eip4844Constants.GasPerBlob * 6);
+        yield return new TestCaseData(new int[] { 1, 6 }, Eip4844Constants.GasPerBlob * 6);
+        yield return new TestCaseData(new int[] { 6, 1, 5 }, Eip4844Constants.GasPerBlob * 6);
+        yield return new TestCaseData(new int[] { 1, 2 }, Eip4844Constants.GasPerBlob * 2);
+        yield return new TestCaseData(new int[] { 1, 1 }, Eip4844Constants.GasPerBlob * 2);
+        yield return new TestCaseData(new int[] { 2, 1 }, Eip4844Constants.GasPerBlob * 2);
+        yield return new TestCaseData(new int[] { 2, 2 }, Eip4844Constants.GasPerBlob * 2);
+        yield return new TestCaseData(new int[] { 3 }, Eip4844Constants.GasPerBlob * 2);
+    }
+}

--- a/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
@@ -60,7 +60,7 @@ namespace Nethermind.Consensus.Producers
 
             int checkedTransactions = 0;
             int selectedTransactions = 0;
-            using ArrayPoolList<Transaction> selectedBlobTxs = new(Eip4844Constants.MaxBlobsPerBlock);
+            using ArrayPoolList<Transaction> selectedBlobTxs = new((int)(Eip4844Constants.MaxBlobGasPerBlock / Eip4844Constants.GasPerBlob));
 
             SelectBlobTransactions(blobTransactions, parent, spec, selectedBlobTxs);
 
@@ -121,21 +121,21 @@ namespace Nethermind.Consensus.Producers
         {
             int checkedBlobTransactions = 0;
             int selectedBlobTransactions = 0;
-            int blobsCounter = 0;
+            UInt256 blobGasCounter = 0;
             UInt256 blobGasPrice = UInt256.Zero;
 
             foreach (Transaction blobTx in blobTransactions)
             {
-                if (blobsCounter == Eip4844Constants.MaxBlobsPerBlock)
+                if (blobGasCounter >= Eip4844Constants.MaxBlobGasPerBlock)
                 {
-                    if (_logger.IsTrace) _logger.Trace($"Declining {blobTx.ToShortString()}, no more blob space. Block already have {blobsCounter} which is max value allowed.");
+                    if (_logger.IsTrace) _logger.Trace($"Declining {blobTx.ToShortString()}, no more blob space. Block already have {blobGasCounter} blob gas which is max value allowed.");
                     break;
                 }
 
                 checkedBlobTransactions++;
 
-                int txAmountOfBlobs = blobTx.BlobVersionedHashes?.Length ?? 0;
-                if (blobsCounter + txAmountOfBlobs > Eip4844Constants.MaxBlobsPerBlock)
+                ulong txBlobGas = (ulong)(blobTx.BlobVersionedHashes?.Length ?? 0) * Eip4844Constants.GasPerBlob;
+                if (txBlobGas > Eip4844Constants.MaxBlobGasPerBlock - blobGasCounter)
                 {
                     if (_logger.IsTrace) _logger.Trace($"Declining {blobTx.ToShortString()}, not enough blob space.");
                     continue;
@@ -162,8 +162,8 @@ namespace Nethermind.Consensus.Producers
                     continue;
                 }
 
-                blobsCounter += txAmountOfBlobs;
-                if (_logger.IsTrace) _logger.Trace($"Selected shard blob tx {fullBlobTx.ToShortString()} to be potentially included in block, total blobs included: {blobsCounter}.");
+                blobGasCounter += txBlobGas;
+                if (_logger.IsTrace) _logger.Trace($"Selected shard blob tx {fullBlobTx.ToShortString()} to be potentially included in block, total blob gas included: {blobGasCounter}.");
 
                 selectedBlobTransactions++;
                 selectedBlobTxs.Add(fullBlobTx);

--- a/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
@@ -60,7 +60,7 @@ namespace Nethermind.Consensus.Producers
 
             int checkedTransactions = 0;
             int selectedTransactions = 0;
-            using ArrayPoolList<Transaction> selectedBlobTxs = new((int)(Eip4844Constants.MaxBlobGasPerBlock / Eip4844Constants.GasPerBlob));
+            using ArrayPoolList<Transaction> selectedBlobTxs = new(Eip4844Constants.GetMaxBlobsPerBlock());
 
             SelectBlobTransactions(blobTransactions, parent, spec, selectedBlobTxs);
 

--- a/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
@@ -10,7 +10,6 @@ using Nethermind.Consensus.Comparers;
 using Nethermind.Consensus.Transactions;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
-using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Evm;
 using Nethermind.Int256;
@@ -29,19 +28,22 @@ namespace Nethermind.Consensus.Producers
         private readonly ITxFilterPipeline _txFilterPipeline;
         private readonly ISpecProvider _specProvider;
         protected readonly ILogger _logger;
+        private readonly IEip4844Config _eip4844Config;
 
         public TxPoolTxSource(
             ITxPool? transactionPool,
             ISpecProvider? specProvider,
             ITransactionComparerProvider? transactionComparerProvider,
             ILogManager? logManager,
-            ITxFilterPipeline? txFilterPipeline)
+            ITxFilterPipeline? txFilterPipeline,
+            IEip4844Config? eip4844ConstantsProvider = null)
         {
             _transactionPool = transactionPool ?? throw new ArgumentNullException(nameof(transactionPool));
             _transactionComparerProvider = transactionComparerProvider ?? throw new ArgumentNullException(nameof(transactionComparerProvider));
             _txFilterPipeline = txFilterPipeline ?? throw new ArgumentNullException(nameof(txFilterPipeline));
             _specProvider = specProvider ?? throw new ArgumentNullException(nameof(specProvider));
             _logger = logManager?.GetClassLogger<TxPoolTxSource>() ?? throw new ArgumentNullException(nameof(logManager));
+            _eip4844Config = eip4844ConstantsProvider ?? ConstantEip4844Config.Instance;
         }
 
         public IEnumerable<Transaction> GetTransactions(BlockHeader parent, long gasLimit, PayloadAttributes? payloadAttributes = null)
@@ -60,7 +62,7 @@ namespace Nethermind.Consensus.Producers
 
             int checkedTransactions = 0;
             int selectedTransactions = 0;
-            using ArrayPoolList<Transaction> selectedBlobTxs = new(Eip4844Constants.GetMaxBlobsPerBlock());
+            using ArrayPoolList<Transaction> selectedBlobTxs = new(_eip4844Config.GetMaxBlobsPerBlock());
 
             SelectBlobTransactions(blobTransactions, parent, spec, selectedBlobTxs);
 
@@ -126,7 +128,7 @@ namespace Nethermind.Consensus.Producers
 
             foreach (Transaction blobTx in blobTransactions)
             {
-                if (blobGasCounter >= Eip4844Constants.MaxBlobGasPerBlock)
+                if (blobGasCounter >= _eip4844Config.MaxBlobGasPerBlock)
                 {
                     if (_logger.IsTrace) _logger.Trace($"Declining {blobTx.ToShortString()}, no more blob space. Block already have {blobGasCounter} blob gas which is max value allowed.");
                     break;
@@ -134,8 +136,8 @@ namespace Nethermind.Consensus.Producers
 
                 checkedBlobTransactions++;
 
-                ulong txBlobGas = (ulong)(blobTx.BlobVersionedHashes?.Length ?? 0) * Eip4844Constants.GasPerBlob;
-                if (txBlobGas > Eip4844Constants.MaxBlobGasPerBlock - blobGasCounter)
+                ulong txBlobGas = (ulong)(blobTx.BlobVersionedHashes?.Length ?? 0) * _eip4844Config.GasPerBlob;
+                if (txBlobGas > _eip4844Config.MaxBlobGasPerBlock - blobGasCounter)
                 {
                     if (_logger.IsTrace) _logger.Trace($"Declining {blobTx.ToShortString()}, not enough blob space.");
                     continue;

--- a/src/Nethermind/Nethermind.Consensus/Transactions/SinglePendingTxSelector.cs
+++ b/src/Nethermind/Nethermind.Consensus/Transactions/SinglePendingTxSelector.cs
@@ -24,6 +24,5 @@ namespace Nethermind.Consensus.Transactions
                 .Take(1);
 
         public override string ToString() => $"{nameof(SinglePendingTxSelector)} [ {_innerSource} ]";
-
     }
 }

--- a/src/Nethermind/Nethermind.Core/Eip4844Constants.cs
+++ b/src/Nethermind/Nethermind.Core/Eip4844Constants.cs
@@ -16,7 +16,7 @@ public class Eip4844Constants
     /// <remarks>Defaults to 2e17.</remarks>
     public const ulong GasPerBlob = 1 << 17;
 
-    public const int MaxBlobsPerBlock = 6;
+    private const int MaxBlobsPerBlock = 6;
     public const int MinBlobsPerTransaction = 1;
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Core/Eip4844Constants.cs
+++ b/src/Nethermind/Nethermind.Core/Eip4844Constants.cs
@@ -10,14 +10,31 @@ namespace Nethermind.Core;
 /// </summary>
 public class Eip4844Constants
 {
+    public const int MinBlobsPerTransaction = 1;
+
     /// <summary>
     /// Gets the <c>GAS_PER_BLOB</c> parameter.
     /// </summary>
-    /// <remarks>Defaults to 2e17.</remarks>
-    public const ulong GasPerBlob = 1 << 17;
+    /// <remarks>Defaults to 131072.</remarks>
+    public const ulong GasPerBlob = 131072;
 
-    private const int MaxBlobsPerBlock = 6;
-    public const int MinBlobsPerTransaction = 1;
+    /// <summary>
+    /// Gets the <c>TARGET_BLOB_GAS_PER_BLOCK</c> parameter.
+    /// </summary>
+    /// <remarks>Defaults to 393216.</remarks>
+    public static ulong TargetBlobGasPerBlock { get; private set; } = MaxBlobGasPerBlock / 2;
+
+    /// <summary>
+    /// Gets the <c>MAX_BLOB_GAS_PER_BLOCK</c> parameter.
+    /// </summary>
+    /// <remarks>Defaults to 786432.</remarks>
+    public static ulong MaxBlobGasPerBlock { get; private set; } = 786432;
+
+    /// <summary>
+    /// Gets the <c>MAX_BLOB_GAS_PER_BLOCK</c> parameter.
+    /// </summary>
+    /// <remarks>The same as <see cref="MaxBlobGasPerBlock"/>.</remarks>
+    public static ulong MaxBlobGasPerTransaction => MaxBlobGasPerBlock;
 
     /// <summary>
     /// Gets the <c>BLOB_GASPRICE_UPDATE_FRACTION</c> parameter.
@@ -26,24 +43,11 @@ public class Eip4844Constants
     public static UInt256 BlobGasPriceUpdateFraction { get; private set; } = 3338477;
 
     /// <summary>
-    /// Gets the <c>MAX_BLOB_GAS_PER_BLOCK</c> parameter.
-    /// </summary>
-    /// <remarks>Defaults to 786432.</remarks>
-    public static ulong MaxBlobGasPerBlock { get; private set; } = GasPerBlob * MaxBlobsPerBlock;
-
-    public static ulong MaxBlobGasPerTransaction => MaxBlobGasPerBlock;
-
-    /// <summary>
     /// Gets the <c>MIN_BLOB_GASPRICE</c> parameter, in wei.
     /// </summary>
     /// <remarks>Defaults to 1.</remarks>
     public static UInt256 MinBlobGasPrice { get; private set; } = 1;
 
-    /// <summary>
-    /// Gets the <c>TARGET_BLOB_GAS_PER_BLOCK</c> parameter.
-    /// </summary>
-    /// <remarks>Defaults to 393216.</remarks>
-    public static ulong TargetBlobGasPerBlock { get; private set; } = MaxBlobGasPerBlock / 2;
 
     // The parameter mutators are kept separate deliberately to ensure no accidental value changes.
     public static void OverrideIfAny(
@@ -64,4 +68,6 @@ public class Eip4844Constants
         if (targetBlobGasPerBlock.HasValue)
             TargetBlobGasPerBlock = targetBlobGasPerBlock.Value;
     }
+
+    public static int GetMaxBlobsPerBlock() => (int)(MaxBlobGasPerBlock / GasPerBlob);
 }

--- a/src/Nethermind/Nethermind.Core/Eip4844Constants.cs
+++ b/src/Nethermind/Nethermind.Core/Eip4844Constants.cs
@@ -19,12 +19,6 @@ public class Eip4844Constants
     public const ulong GasPerBlob = 131072;
 
     /// <summary>
-    /// Gets the <c>TARGET_BLOB_GAS_PER_BLOCK</c> parameter.
-    /// </summary>
-    /// <remarks>Defaults to 393216.</remarks>
-    public static ulong TargetBlobGasPerBlock { get; private set; } = MaxBlobGasPerBlock / 2;
-
-    /// <summary>
     /// Gets the <c>MAX_BLOB_GAS_PER_BLOCK</c> parameter.
     /// </summary>
     /// <remarks>Defaults to 786432.</remarks>
@@ -35,6 +29,12 @@ public class Eip4844Constants
     /// </summary>
     /// <remarks>The same as <see cref="MaxBlobGasPerBlock"/>.</remarks>
     public static ulong MaxBlobGasPerTransaction => MaxBlobGasPerBlock;
+
+    /// <summary>
+    /// Gets the <c>TARGET_BLOB_GAS_PER_BLOCK</c> parameter.
+    /// </summary>
+    /// <remarks>Defaults to 393216.</remarks>
+    public static ulong TargetBlobGasPerBlock { get; private set; } = MaxBlobGasPerBlock / 2;
 
     /// <summary>
     /// Gets the <c>BLOB_GASPRICE_UPDATE_FRACTION</c> parameter.

--- a/src/Nethermind/Nethermind.Core/IEip4844Config.cs
+++ b/src/Nethermind/Nethermind.Core/IEip4844Config.cs
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.Core;
+
+/// <summary>
+/// <see cref="Eip4844Constants" /> wrapper, made for testing convenience.
+/// </summary>
+public interface IEip4844Config
+{
+    ulong MaxBlobGasPerBlock { get; }
+    ulong GasPerBlob { get; }
+    int GetMaxBlobsPerBlock();
+}
+
+public class ConstantEip4844Config : IEip4844Config
+{
+    public ulong MaxBlobGasPerBlock => Eip4844Constants.MaxBlobGasPerBlock;
+    public ulong GasPerBlob => Eip4844Constants.GasPerBlob;
+    public int GetMaxBlobsPerBlock() => Eip4844Constants.GetMaxBlobsPerBlock();
+
+    static ConstantEip4844Config() => Instance = new ConstantEip4844Config();
+    private ConstantEip4844Config() { }
+
+    public static IEip4844Config Instance { get; private set; }
+}

--- a/src/Nethermind/Nethermind.TxPool/LightTransaction.cs
+++ b/src/Nethermind/Nethermind.TxPool/LightTransaction.cs
@@ -16,7 +16,7 @@ namespace Nethermind.TxPool;
 public class LightTransaction : Transaction
 {
     private static readonly Dictionary<int, byte[][]> _blobVersionedHashesCache =
-        Enumerable.Range(1, (int)(Eip4844Constants.MaxBlobGasPerBlock / Eip4844Constants.GasPerBlob)).ToDictionary(i => i, i => new byte[i][]);
+        Enumerable.Range(1, Eip4844Constants.GetMaxBlobsPerBlock()).ToDictionary(i => i, i => new byte[i][]);
 
 
     public LightTransaction(Transaction fullTx)

--- a/src/Nethermind/Nethermind.TxPool/LightTransaction.cs
+++ b/src/Nethermind/Nethermind.TxPool/LightTransaction.cs
@@ -16,7 +16,7 @@ namespace Nethermind.TxPool;
 public class LightTransaction : Transaction
 {
     private static readonly Dictionary<int, byte[][]> _blobVersionedHashesCache =
-        Enumerable.Range(1, Eip4844Constants.MaxBlobsPerBlock).ToDictionary(i => i, i => new byte[i][]);
+        Enumerable.Range(1, (int)(Eip4844Constants.MaxBlobGasPerBlock / Eip4844Constants.GasPerBlob)).ToDictionary(i => i, i => new byte[i][]);
 
 
     public LightTransaction(Transaction fullTx)


### PR DESCRIPTION
All blob calculations should use blob gas and do not rely on max blob count to be consistent

## Changes

- Use blob gas instead of count

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

