### PR TITLE
Storage Trie optimizations

### DIFF
--- a/src/Nethermind/Nethermind.Benchmark/State/StorageTreeHashCacheBenchmark.cs
+++ b/src/Nethermind/Nethermind.Benchmark/State/StorageTreeHashCacheBenchmark.cs
@@ -15,7 +15,7 @@ namespace Nethermind.Benchmarks.State
     public class StorageTreeHashCacheBenchmark
     {
         private const int CellIndexMemoizationCount = 16;
-        private static readonly int _count = 1024 * 2;
+        private static readonly int _count = StorageTree.CacheSize * 2;
         private static readonly byte[] _value = { 1 };
         private StorageTree _storage;
 
@@ -30,10 +30,10 @@ namespace Nethermind.Benchmarks.State
             }
         }
 
-        [Benchmark(OperationsPerInvoke = 1024)]
+        [Benchmark(OperationsPerInvoke = StorageTree.CacheSize)]
         public void CellIndexes_cached()
         {
-            for (int i = 0; i < 1024; i++)
+            for (int i = 0; i < StorageTree.CacheSize; i++)
             {
                 _storage.Get((UInt256)i);
             }
@@ -47,7 +47,7 @@ namespace Nethermind.Benchmarks.State
 
             for (int i = 0; i < size; i++)
             {
-                _storage.Get((UInt256)i + cachedOffset);
+                _storage.Get((UInt256)i + cachedOffset, true);
             }
 
             for (int i = 0; i < size; i++)
@@ -64,7 +64,7 @@ namespace Nethermind.Benchmarks.State
 
             for (int i = 0; i < size; i++)
             {
-                _storage.Get((UInt256)i + cachedOffset);
+                _storage.Get((UInt256)i + cachedOffset, true);
             }
 
             for (int i = 0; i < size; i++)

--- a/src/Nethermind/Nethermind.Benchmark/State/StorageTreeHashCacheBenchmark.cs
+++ b/src/Nethermind/Nethermind.Benchmark/State/StorageTreeHashCacheBenchmark.cs
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using BenchmarkDotNet.Attributes;
+using Nethermind.Core.Extensions;
+using Nethermind.Db;
+using Nethermind.Int256;
+using Nethermind.Logging;
+using Nethermind.State;
+using Nethermind.Trie.Pruning;
+
+namespace Nethermind.Benchmarks.State
+{
+    [MemoryDiagnoser]
+    public class StorageTreeHashCacheBenchmark
+    {
+        private const int CellIndexMemoizationCount = 16;
+        private static readonly int _count = 1024 * 2;
+        private static readonly byte[] _value = { 1 };
+        private StorageTree _storage;
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            _storage = new StorageTree(new TrieStore(new MemDb(), LimboLogs.Instance), LimboLogs.Instance);
+
+            for (int i = 0; i < _count; i++)
+            {
+                _storage.Set((UInt256)i, i.ToByteArray());
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = 1024)]
+        public void CellIndexes_cached()
+        {
+            for (int i = 0; i < 1024; i++)
+            {
+                _storage.Get((UInt256)i);
+            }
+        }
+
+        [Benchmark]
+        public void CellIndexes_memoized_for_writes()
+        {
+            const int size = CellIndexMemoizationCount;
+            const int cachedOffset = 10000;
+
+            for (int i = 0; i < size; i++)
+            {
+                _storage.Get((UInt256)i + cachedOffset);
+            }
+
+            for (int i = 0; i < size; i++)
+            {
+                _storage.Set((UInt256)i + cachedOffset, _value);
+            }
+        }
+
+        [Benchmark]
+        public void CellIndexes_beyond_memoization_for_writes()
+        {
+            const int size = CellIndexMemoizationCount * 2;
+            const int cachedOffset = 10000;
+
+            for (int i = 0; i < size; i++)
+            {
+                _storage.Get((UInt256)i + cachedOffset);
+            }
+
+            for (int i = 0; i < size; i++)
+            {
+                _storage.Set((UInt256)i + cachedOffset, _value);
+            }
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -238,7 +238,7 @@ namespace Nethermind.State
             StorageTree tree = GetOrCreateStorage(storageCell.Address);
 
             Db.Metrics.StorageTreeReads++;
-            byte[] value = tree.Get(storageCell.Index);
+            byte[] value = tree.Get(storageCell.Index, true);
             PushToRegistryOnly(storageCell, value);
             return value;
         }

--- a/src/Nethermind/Nethermind.State/StateReader.cs
+++ b/src/Nethermind/Nethermind.State/StateReader.cs
@@ -41,7 +41,7 @@ namespace Nethermind.State
             }
 
             Metrics.StorageTreeReads++;
-            return _storage.Get(index, storageRoot);
+            return _storage.Get(index, false, storageRoot);
         }
 
         public UInt256 GetBalance(Hash256 stateRoot, Address address)

--- a/src/Nethermind/Nethermind.State/StorageTree.cs
+++ b/src/Nethermind/Nethermind.State/StorageTree.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
@@ -16,16 +15,18 @@ namespace Nethermind.State
 {
     public class StorageTree : PatriciaTree
     {
-        private static readonly UInt256 CacheSize = 1024;
+        private static readonly UInt256 CacheSizeU = CacheSize;
 
-        private static readonly int CacheSizeInt = (int)CacheSize;
+        public const int CacheSize = 1024;
 
-        private static readonly byte[][] Cache = new byte[CacheSizeInt][];
+        private static readonly byte[][] Cache = new byte[CacheSize][];
+
+        private KeyHashCache _cache;
 
         static StorageTree()
         {
             Span<byte> buffer = stackalloc byte[32];
-            for (int i = 0; i < CacheSizeInt; i++)
+            for (int i = 0; i < CacheSize; i++)
             {
                 UInt256 index = (UInt256)i;
                 index.ToBigEndian(buffer);
@@ -45,11 +46,29 @@ namespace Nethermind.State
             TrieType = TrieType.Storage;
         }
 
-        private static void GetKey(in UInt256 index, in Span<byte> key)
+        private void GetKey(in UInt256 index, in Span<byte> key, KeyHints hint)
         {
-            if (index < CacheSize)
+            if (index < CacheSizeU)
             {
                 Cache[(int)index].CopyTo(key);
+                return;
+            }
+
+            if (hint == KeyHints.Set)
+            {
+                // if set try to find first as it's likely it was read first
+                if (_cache.TryGet(in index, key))
+                {
+                    return;
+                }
+            }
+            else if (hint == KeyHints.GetMightBeFollowedByWrite)
+            {
+                // get might be followed by write, try cache the input
+                index.ToBigEndian(key);
+                KeccakHash.ComputeHashBytesToSpan(key, key);
+                _cache.Set(in index, key);
+
                 return;
             }
 
@@ -59,12 +78,19 @@ namespace Nethermind.State
             KeccakHash.ComputeHashBytesToSpan(key, key);
         }
 
+        enum KeyHints
+        {
+            GetMightBeFollowedByWrite,
+            GetProbablyNotFollowedByWrite,
+            Set,
+        }
 
         [SkipLocalsInit]
-        public byte[] Get(in UInt256 index, Hash256? storageRoot = null)
+        public byte[] Get(in UInt256 index, bool potentialWriteNext = false, Hash256? storageRoot = null)
         {
             Span<byte> key = stackalloc byte[32];
-            GetKey(index, key);
+            GetKey(index, key,
+                potentialWriteNext ? KeyHints.GetMightBeFollowedByWrite : KeyHints.GetProbablyNotFollowedByWrite);
 
             byte[]? value = Get(key, storageRoot);
             if (value is null)
@@ -80,9 +106,11 @@ namespace Nethermind.State
         public void Set(in UInt256 index, byte[] value)
         {
             Span<byte> key = stackalloc byte[32];
-            GetKey(index, key);
+            GetKey(index, key, KeyHints.Set);
             SetInternal(key, value);
         }
+
+        public void ResetHashCache() => _cache = default;
 
         public void Set(in ValueHash256 key, byte[] value, bool rlpEncode = true)
         {
@@ -99,6 +127,54 @@ namespace Nethermind.State
             {
                 Rlp rlpEncoded = rlpEncode ? Rlp.Encode(value) : new Rlp(value);
                 Set(rawKey, rlpEncoded);
+            }
+        }
+
+        struct KeyHashCache
+        {
+            private const int Size = 16;
+            private Cell[]? _cells = null;
+
+            public KeyHashCache()
+            {
+            }
+
+            struct Cell
+            {
+                public int HashCode;
+                public UInt256 Value;
+#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
+                public ValueHash256 Hash;
+#pragma warning restore CS0649 // Field is never assigned to, and will always have its default value
+            }
+
+            public void Set(in UInt256 value, Span<byte> hash)
+            {
+                _cells ??= new Cell[Size];
+
+                int cellHashCode = value.GetHashCode();
+                ref Cell cell = ref _cells![cellHashCode % Size];
+
+                cell.HashCode = cellHashCode;
+                cell.Value = value;
+                hash.CopyTo(cell.Hash.BytesAsSpan);
+            }
+
+            public bool TryGet(in UInt256 value, Span<byte> hash)
+            {
+                if (_cells == null)
+                    return false;
+
+                int cellHashCode = value.GetHashCode();
+                ref readonly Cell cell = ref _cells![cellHashCode % Size];
+
+                if (cell.HashCode == cellHashCode && cell.Value == value)
+                {
+                    cell.Hash.BytesAsSpan.CopyTo(hash);
+                    return true;
+                }
+
+                return false;
             }
         }
     }

--- a/src/Nethermind/Nethermind.State/StorageTree.cs
+++ b/src/Nethermind/Nethermind.State/StorageTree.cs
@@ -20,7 +20,7 @@ namespace Nethermind.State
 
         private static readonly int CacheSizeInt = (int)CacheSize;
 
-        private static readonly Dictionary<UInt256, byte[]> Cache = new(CacheSizeInt);
+        private static readonly byte[][] Cache = new byte[CacheSizeInt][];
 
         static StorageTree()
         {
@@ -29,7 +29,7 @@ namespace Nethermind.State
             {
                 UInt256 index = (UInt256)i;
                 index.ToBigEndian(buffer);
-                Cache[index] = Keccak.Compute(buffer).BytesToArray();
+                Cache[(int)index] = Keccak.Compute(buffer).BytesToArray();
             }
         }
 
@@ -49,7 +49,7 @@ namespace Nethermind.State
         {
             if (index < CacheSize)
             {
-                Cache[index].CopyTo(key);
+                Cache[(int)index].CopyTo(key);
                 return;
             }
 

--- a/src/Nethermind/Nethermind.State/StorageTree.cs
+++ b/src/Nethermind/Nethermind.State/StorageTree.cs
@@ -152,8 +152,8 @@ namespace Nethermind.State
             {
                 _cells ??= new Cell[Size];
 
-                int cellHashCode = value.GetHashCode();
-                ref Cell cell = ref _cells![cellHashCode % Size];
+                int cellHashCode = FastHash(value);
+                ref Cell cell = ref _cells![cellHashCode & (Size - 1)];
 
                 cell.HashCode = cellHashCode;
                 cell.Value = value;
@@ -165,8 +165,8 @@ namespace Nethermind.State
                 if (_cells == null)
                     return false;
 
-                int cellHashCode = value.GetHashCode();
-                ref readonly Cell cell = ref _cells![cellHashCode % Size];
+                int cellHashCode = FastHash(value);
+                ref readonly Cell cell = ref _cells![cellHashCode & (Size - 1)];
 
                 if (cell.HashCode == cellHashCode && cell.Value == value)
                 {
@@ -175,6 +175,12 @@ namespace Nethermind.State
                 }
 
                 return false;
+            }
+
+            private static int FastHash(in UInt256 v)
+            {
+                ulong xor = v.u0 ^ v.u1 ^ v.u2 ^ v.u3;
+                return unchecked((int)((xor >> 32) ^ xor));
             }
         }
     }


### PR DESCRIPTION
This PR introduces a few small optimizations in the `StorageTrie` component.

## Changes

- `Cache` that includes the precomputed Keccaks of indexes is now a simple array that allows faster indexing
   - improvement: 40ns on looking up all the values
- getting a `StorageCell` value will memoize the calculated key in a small cache. This should help in addressing scenarios like ERC20 when the storage access provides the Read-Update-Write behavior and the same cell is re-entered to store the value.  For ERC20, like `WrappedEther` for a transfer it will be two pairs of Read-Update-Write.
   - improvement at range of a fraction of a microsecond for a single RUW

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

Compare timing with a node from `master`

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Benchmarks

```bash
BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.22621.2428/22H2/2022Update/SunValley2)
12th Gen Intel Core i9-12900HK, 1 CPU, 20 logical and 14 physical cores
.NET SDK=7.0.113
  [Host]     : .NET 7.0.13 (7.0.1323.51816), X64 RyuJIT AVX2
  DefaultJob : .NET 7.0.13 (7.0.1323.51816), X64 RyuJIT AVX2
```

### Before

|                                    Method |        Mean |     Error |    StdDev |
|------------------------------------------ |------------:|----------:|----------:|
|                        CellIndexes_cached |    942.4 ns |   7.72 ns |   6.84 ns |
|           CellIndexes_memoized_for_writes | 39,835.2 ns | 424.63 ns | 397.20 ns |
| CellIndexes_beyond_memoization_for_writes | 78,823.6 ns | 472.35 ns | 418.73 ns |

### After

|                                    Method |        Mean |     Error |    StdDev |
|------------------------------------------ |------------:|----------:|----------:|
|                        CellIndexes_cached |    907.1 ns |  17.82 ns |  26.68 ns |
|           CellIndexes_memoized_for_writes | 35,375.8 ns | 335.33 ns | 280.01 ns |
| CellIndexes_beyond_memoization_for_writes | 77,059.5 ns | 441.10 ns | 344.38 ns |