### PR TITLE
Fix old blocks hang on insert failure

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/TestMemDb.cs
+++ b/src/Nethermind/Nethermind.Core.Test/TestMemDb.cs
@@ -22,6 +22,7 @@ public class TestMemDb : MemDb, ITunableDb
     private List<ITunableDb.TuneType> _tuneTypes = new();
 
     public Func<byte[], byte[]>? ReadFunc { get; set; }
+    public Func<byte[], byte[]?, bool>? WriteFunc { get; set; }
     public Action<byte[]>? RemoveFunc { get; set; }
 
     public bool WasFlushed => FlushCount > 0;
@@ -40,6 +41,8 @@ public class TestMemDb : MemDb, ITunableDb
     public override void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None)
     {
         _writes.Add(((key.ToArray(), value), flags));
+
+        if (WriteFunc?.Invoke(key.ToArray(), value) == false) return;
         base.Set(key, value, flags);
     }
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/ReceiptSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ReceiptSyncFeedTests.cs
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Nethermind.Blockchain;
+using Nethermind.Blockchain.Receipts;
+using Nethermind.Blockchain.Synchronization;
+using Nethermind.Core;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Logging;
+using Nethermind.Specs;
+using Nethermind.Synchronization.FastBlocks;
+using Nethermind.Synchronization.ParallelSync;
+using Nethermind.Synchronization.Peers;
+using Nethermind.Synchronization.Reporting;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Synchronization.Test;
+
+public class ReceiptSyncFeedTests
+{
+
+    [Test]
+    public async Task ShouldRecoverOnInsertFailure()
+    {
+        InMemoryReceiptStorage syncingFromReceiptStore = new InMemoryReceiptStorage();
+        BlockTree syncingFromBlockTree = Build.A.BlockTree()
+            .WithTransactions(syncingFromReceiptStore)
+            .OfChainLength(100)
+            .TestObject;
+
+        BlockTree syncingTooBlockTree = Build.A.BlockTree()
+            .TestObject;
+
+        for (int i = 1; i < 100; i++)
+        {
+            Block block = syncingFromBlockTree.FindBlock(i, BlockTreeLookupOptions.None)!;
+            syncingTooBlockTree.Insert(block.Header);
+            syncingTooBlockTree.Insert(block);
+        }
+
+        Block pivot = syncingFromBlockTree.FindBlock(99, BlockTreeLookupOptions.None)!;
+
+        SyncConfig syncConfig = new()
+        {
+            FastSync = true,
+            PivotHash = pivot.Hash!.ToString(),
+            PivotNumber = pivot.Number.ToString(),
+            AncientBodiesBarrier = 0,
+            FastBlocks = true,
+            DownloadBodiesInFastSync = true,
+        };
+
+        IReceiptStorage receiptStorage = Substitute.For<IReceiptStorage>();
+        ReceiptsSyncFeed syncFeed = new ReceiptsSyncFeed(
+            Substitute.For<ISyncModeSelector>(),
+            MainnetSpecProvider.Instance,
+            syncingTooBlockTree,
+            receiptStorage,
+            Substitute.For<ISyncPeerPool>(),
+            syncConfig,
+            new NullSyncReport(),
+            LimboLogs.Instance
+        );
+        syncFeed.InitializeFeed();
+
+        ReceiptsSyncBatch req = (await syncFeed.PrepareRequest())!;
+        req.Response = req.Infos.Take(8).Select((info) => syncingFromReceiptStore.Get(info!.BlockHash)).ToArray();
+
+        receiptStorage
+            .When((it) => it.Insert(Arg.Any<Block>(), Arg.Any<TxReceipt[]?>(), Arg.Any<bool>()))
+            .Do((callInfo) =>
+            {
+                Block block = (Block)callInfo[0];
+                if (block.Number == 95) throw new Exception("test exception");
+            });
+
+        Func<SyncResponseHandlingResult> act = () => syncFeed.HandleResponse(req);
+        act.Should().Throw<Exception>();
+        req = (await syncFeed.PrepareRequest())!;
+
+        req.Infos[0]!.BlockNumber.Should().Be(95);
+    }
+}

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
@@ -171,6 +171,15 @@ namespace Nethermind.Synchronization.FastBlocks
                     ? SyncResponseHandlingResult.NoProgress
                     : SyncResponseHandlingResult.OK;
             }
+            catch (Exception)
+            {
+                foreach (BlockInfo batchInfo in batch.Infos)
+                {
+                    _syncStatusList.MarkPending(batchInfo);
+                }
+
+                throw;
+            }
             finally
             {
                 batch.Response?.Dispose();

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
@@ -175,6 +175,7 @@ namespace Nethermind.Synchronization.FastBlocks
             {
                 foreach (BlockInfo batchInfo in batch.Infos)
                 {
+                    if (batchInfo == null) break;
                     _syncStatusList.MarkPending(batchInfo);
                 }
 

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
@@ -173,9 +173,9 @@ namespace Nethermind.Synchronization.FastBlocks
             }
             catch (Exception)
             {
-                foreach (BlockInfo batchInfo in batch.Infos)
+                foreach (BlockInfo? batchInfo in batch.Infos)
                 {
-                    if (batchInfo == null) break;
+                    if (batchInfo is null) break;
                     _syncStatusList.MarkPending(batchInfo);
                 }
 

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/ReceiptsSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/ReceiptsSyncFeed.cs
@@ -170,6 +170,15 @@ namespace Nethermind.Synchronization.FastBlocks
                 int added = InsertReceipts(batch);
                 return added == 0 ? SyncResponseHandlingResult.NoProgress : SyncResponseHandlingResult.OK;
             }
+            catch (Exception)
+            {
+                foreach (BlockInfo batchInfo in batch.Infos)
+                {
+                    _syncStatusList.MarkPending(batchInfo);
+                }
+
+                throw;
+            }
             finally
             {
                 batch?.MarkHandlingEnd();

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/ReceiptsSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/ReceiptsSyncFeed.cs
@@ -172,9 +172,9 @@ namespace Nethermind.Synchronization.FastBlocks
             }
             catch (Exception)
             {
-                foreach (BlockInfo batchInfo in batch.Infos)
+                foreach (BlockInfo? batchInfo in batch.Infos)
                 {
-                    if (batchInfo == null) break;
+                    if (batchInfo is null) break;
                     _syncStatusList.MarkPending(batchInfo);
                 }
 

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/ReceiptsSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/ReceiptsSyncFeed.cs
@@ -174,6 +174,7 @@ namespace Nethermind.Synchronization.FastBlocks
             {
                 foreach (BlockInfo batchInfo in batch.Infos)
                 {
+                    if (batchInfo == null) break;
                     _syncStatusList.MarkPending(batchInfo);
                 }
 


### PR DESCRIPTION
- I was trying to find a solution to the situation where *netty memory pool grew when block insert slow down which causes high memory pressure which slows down block insert* when I found out that if block insert failed due to OOM even temporarily, old bodies will get stuck.
- This make sure to re-mark all block and receipt for download as pending on failure.

## Changes

- Make sure to mark block info as pending on failure.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Tested by randomly throwing exception in blockstore.