### PR TITLE
move the state root checking mechanism to the stateReader/worldState

### DIFF
--- a/src/Nethermind/Nethermind.AuRa.Test/AuRaBlockProducerTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/AuRaBlockProducerTests.cs
@@ -71,7 +71,7 @@ namespace Nethermind.AuRa.Test
                     block.TrySetTransactions(TransactionSource.GetTransactions(BlockTree.Head!.Header, block.GasLimit).ToArray());
                     return block;
                 });
-                StateProvider.HashStateForRoot(Arg.Any<Hash256>()).Returns(x => true);
+                StateProvider.HasStateForRoot(Arg.Any<Hash256>()).Returns(x => true);
                 InitProducer();
             }
 

--- a/src/Nethermind/Nethermind.AuRa.Test/AuRaBlockProducerTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/AuRaBlockProducerTests.cs
@@ -71,6 +71,7 @@ namespace Nethermind.AuRa.Test
                     block.TrySetTransactions(TransactionSource.GetTransactions(BlockTree.Head!.Header, block.GasLimit).ToArray());
                     return block;
                 });
+                StateProvider.HashStateForRoot(Arg.Any<Hash256>()).Returns(x => true);
                 InitProducer();
             }
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockchainProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockchainProcessorTests.cs
@@ -58,7 +58,7 @@ namespace Nethermind.Blockchain.Test
                             if (!_rootProcessed.Contains(stateRoot)) visitor.VisitMissingNode(stateRoot, new TrieVisitContext());
                         }));
 
-                    stateReader.HashStateForRoot(Arg.Any<Hash256>()).Returns(x => _rootProcessed.Contains(x[0]));
+                    stateReader.HasStateForRoot(Arg.Any<Hash256>()).Returns(x => _rootProcessed.Contains(x[0]));
                 }
 
                 public void Allow(Hash256 hash)

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockchainProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockchainProcessorTests.cs
@@ -57,6 +57,8 @@ namespace Nethermind.Blockchain.Test
                             Hash256 stateRoot = (Hash256)info[1];
                             if (!_rootProcessed.Contains(stateRoot)) visitor.VisitMissingNode(stateRoot, new TrieVisitContext());
                         }));
+
+                    stateReader.HashStateForRoot(Arg.Any<Hash256>()).Returns(x => _rootProcessed.Contains(x[0]));
                 }
 
                 public void Allow(Hash256 hash)

--- a/src/Nethermind/Nethermind.Blockchain/SpecificBlockReadOnlyStateProvider.cs
+++ b/src/Nethermind/Nethermind.Blockchain/SpecificBlockReadOnlyStateProvider.cs
@@ -59,9 +59,9 @@ namespace Nethermind.Blockchain
         public bool AccountExists(Address address) => _stateReader.GetAccount(StateRoot, address) is not null;
 
         public bool IsEmptyAccount(Address address) => GetAccount(address).IsEmpty;
-        public bool HashStateForRoot(Hash256 stateRoot)
+        public bool HasStateForRoot(Hash256 stateRoot)
         {
-            return _stateReader.HashStateForRoot(stateRoot);
+            return _stateReader.HasStateForRoot(stateRoot);
         }
 
         public bool IsDeadAccount(Address address)

--- a/src/Nethermind/Nethermind.Blockchain/SpecificBlockReadOnlyStateProvider.cs
+++ b/src/Nethermind/Nethermind.Blockchain/SpecificBlockReadOnlyStateProvider.cs
@@ -59,6 +59,10 @@ namespace Nethermind.Blockchain
         public bool AccountExists(Address address) => _stateReader.GetAccount(StateRoot, address) is not null;
 
         public bool IsEmptyAccount(Address address) => GetAccount(address).IsEmpty;
+        public bool HashStateForRoot(Hash256 stateRoot)
+        {
+            return _stateReader.HashStateForRoot(stateRoot);
+        }
 
         public bool IsDeadAccount(Address address)
         {

--- a/src/Nethermind/Nethermind.Consensus/Producers/BlockProducerBase.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/BlockProducerBase.cs
@@ -235,7 +235,7 @@ namespace Nethermind.Consensus.Producers
         /// <remarks>Should be called inside <see cref="_producingBlockLock"/> lock.</remarks>
         protected bool TrySetState(Hash256? parentStateRoot)
         {
-            if (parentStateRoot is not null && StateProvider.HashStateForRoot(parentStateRoot))
+            if (parentStateRoot is not null && StateProvider.HasStateForRoot(parentStateRoot))
             {
                 StateProvider.StateRoot = parentStateRoot;
                 return true;

--- a/src/Nethermind/Nethermind.Consensus/Producers/BlockProducerBase.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/BlockProducerBase.cs
@@ -235,14 +235,7 @@ namespace Nethermind.Consensus.Producers
         /// <remarks>Should be called inside <see cref="_producingBlockLock"/> lock.</remarks>
         protected bool TrySetState(Hash256? parentStateRoot)
         {
-            bool HasState(Hash256 stateRoot)
-            {
-                RootCheckVisitor visitor = new();
-                StateProvider.Accept(visitor, stateRoot);
-                return visitor.HasRoot;
-            }
-
-            if (parentStateRoot is not null && HasState(parentStateRoot))
+            if (parentStateRoot is not null && StateProvider.HashStateForRoot(parentStateRoot))
             {
                 StateProvider.StateRoot = parentStateRoot;
                 return true;

--- a/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
@@ -374,6 +374,11 @@ namespace Nethermind.Facade
             _processingEnv.StateReader.RunTreeVisitor(treeVisitor, stateRoot);
         }
 
+        public bool HashStateForRoot(Hash256 stateRoot)
+        {
+            throw new NotImplementedException();
+        }
+
         public IEnumerable<FilterLog> FindLogs(LogFilter filter, CancellationToken cancellationToken = default)
         {
             return _logFinder.FindLogs(filter, cancellationToken);

--- a/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
@@ -376,7 +376,7 @@ namespace Nethermind.Facade
 
         public bool HashStateForRoot(Hash256 stateRoot)
         {
-            throw new NotImplementedException();
+            return _processingEnv.StateReader.HashStateForRoot(stateRoot);
         }
 
         public IEnumerable<FilterLog> FindLogs(LogFilter filter, CancellationToken cancellationToken = default)

--- a/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
@@ -374,9 +374,9 @@ namespace Nethermind.Facade
             _processingEnv.StateReader.RunTreeVisitor(treeVisitor, stateRoot);
         }
 
-        public bool HashStateForRoot(Hash256 stateRoot)
+        public bool HasStateForRoot(Hash256 stateRoot)
         {
-            return _processingEnv.StateReader.HashStateForRoot(stateRoot);
+            return _processingEnv.StateReader.HasStateForRoot(stateRoot);
         }
 
         public IEnumerable<FilterLog> FindLogs(LogFilter filter, CancellationToken cancellationToken = default)

--- a/src/Nethermind/Nethermind.Facade/IBlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/IBlockchainBridge.cs
@@ -44,6 +44,6 @@ namespace Nethermind.Facade
         IEnumerable<FilterLog> GetLogs(BlockParameter fromBlock, BlockParameter toBlock, object? address = null, IEnumerable<object>? topics = null, CancellationToken cancellationToken = default);
         bool TryGetLogs(int filterId, out IEnumerable<FilterLog> filterLogs, CancellationToken cancellationToken = default);
         void RunTreeVisitor(ITreeVisitor treeVisitor, Hash256 stateRoot);
-        bool HashStateForRoot(Hash256 stateRoot);
+        bool HasStateForRoot(Hash256 stateRoot);
     }
 }

--- a/src/Nethermind/Nethermind.Facade/IBlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/IBlockchainBridge.cs
@@ -44,6 +44,6 @@ namespace Nethermind.Facade
         IEnumerable<FilterLog> GetLogs(BlockParameter fromBlock, BlockParameter toBlock, object? address = null, IEnumerable<object>? topics = null, CancellationToken cancellationToken = default);
         bool TryGetLogs(int filterId, out IEnumerable<FilterLog> filterLogs, CancellationToken cancellationToken = default);
         void RunTreeVisitor(ITreeVisitor treeVisitor, Hash256 stateRoot);
-
+        bool HashStateForRoot(Hash256 stateRoot);
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
@@ -56,7 +56,7 @@ public partial class EthRpcModule : IEthRpcModule
     private readonly IFeeHistoryOracle _feeHistoryOracle;
     private static bool HasStateForBlock(IBlockchainBridge blockchainBridge, BlockHeader header)
     {
-        return blockchainBridge.HashStateForRoot(header.StateRoot!);
+        return blockchainBridge.HasStateForRoot(header.StateRoot!);
     }
 
     public EthRpcModule(

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
@@ -56,9 +56,7 @@ public partial class EthRpcModule : IEthRpcModule
     private readonly IFeeHistoryOracle _feeHistoryOracle;
     private static bool HasStateForBlock(IBlockchainBridge blockchainBridge, BlockHeader header)
     {
-        RootCheckVisitor rootCheckVisitor = new();
-        blockchainBridge.RunTreeVisitor(rootCheckVisitor, header.StateRoot!);
-        return rootCheckVisitor.HasRoot;
+        return blockchainBridge.HashStateForRoot(header.StateRoot!);
     }
 
     public EthRpcModule(

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
@@ -1037,9 +1037,7 @@ public partial class EngineModuleTests
             executePayloadRequest.BlockHash = hash;
             ResultWrapper<PayloadStatusV1> result = await rpc.engine_newPayloadV1(executePayloadRequest);
             result.Data.Status.Should().Be(PayloadStatus.Valid);
-            RootCheckVisitor rootCheckVisitor = new();
-            chain.StateReader.RunTreeVisitor(rootCheckVisitor, executePayloadRequest.StateRoot);
-            rootCheckVisitor.HasRoot.Should().BeTrue();
+            chain.StateReader.HashStateForRoot(executePayloadRequest.StateRoot).Should().BeTrue();
 
             chain.StateReader.GetBalance(executePayloadRequest.StateRoot, to).Should().Be(toBalanceAfter);
             if (moveHead)
@@ -1078,9 +1076,7 @@ public partial class EngineModuleTests
             ResultWrapper<PayloadStatusV1> result = await rpc.engine_newPayloadV1(executionPayload);
 
             result.Data.Status.Should().Be(PayloadStatus.Valid);
-            RootCheckVisitor rootCheckVisitor = new();
-            chain.StateReader.RunTreeVisitor(rootCheckVisitor, executionPayload.StateRoot);
-            rootCheckVisitor.HasRoot.Should().BeTrue();
+            chain.StateReader.HashStateForRoot(executionPayload.StateRoot).Should().BeTrue();
 
             UInt256 fromBalanceAfter = chain.StateReader.GetBalance(executionPayload.StateRoot, from.Address);
             Assert.True(fromBalanceAfter < fromBalance - toBalanceAfter);

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
@@ -1037,7 +1037,7 @@ public partial class EngineModuleTests
             executePayloadRequest.BlockHash = hash;
             ResultWrapper<PayloadStatusV1> result = await rpc.engine_newPayloadV1(executePayloadRequest);
             result.Data.Status.Should().Be(PayloadStatus.Valid);
-            chain.StateReader.HashStateForRoot(executePayloadRequest.StateRoot).Should().BeTrue();
+            chain.StateReader.HasStateForRoot(executePayloadRequest.StateRoot).Should().BeTrue();
 
             chain.StateReader.GetBalance(executePayloadRequest.StateRoot, to).Should().Be(toBalanceAfter);
             if (moveHead)
@@ -1076,7 +1076,7 @@ public partial class EngineModuleTests
             ResultWrapper<PayloadStatusV1> result = await rpc.engine_newPayloadV1(executionPayload);
 
             result.Data.Status.Should().Be(PayloadStatus.Valid);
-            chain.StateReader.HashStateForRoot(executionPayload.StateRoot).Should().BeTrue();
+            chain.StateReader.HasStateForRoot(executionPayload.StateRoot).Should().BeTrue();
 
             UInt256 fromBalanceAfter = chain.StateReader.GetBalance(executionPayload.StateRoot, from.Address);
             Assert.True(fromBalanceAfter < fromBalance - toBalanceAfter);

--- a/src/Nethermind/Nethermind.Mev/MevRpcModule.cs
+++ b/src/Nethermind/Nethermind.Mev/MevRpcModule.cs
@@ -135,7 +135,7 @@ namespace Nethermind.Mev
         private bool HasStateForBlock(BlockHeader header)
         {
             if (header.StateRoot is null) return false;
-            return _stateReader.HashStateForRoot(header.StateRoot!);
+            return _stateReader.HasStateForRoot(header.StateRoot!);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Mev/MevRpcModule.cs
+++ b/src/Nethermind/Nethermind.Mev/MevRpcModule.cs
@@ -134,10 +134,8 @@ namespace Nethermind.Mev
 
         private bool HasStateForBlock(BlockHeader header)
         {
-            RootCheckVisitor rootCheckVisitor = new();
             if (header.StateRoot is null) return false;
-            _stateReader.RunTreeVisitor(rootCheckVisitor, header.StateRoot!);
-            return rootCheckVisitor.HasRoot;
+            return _stateReader.HashStateForRoot(header.StateRoot!);
         }
     }
 }

--- a/src/Nethermind/Nethermind.State/IReadOnlyStateProvider.cs
+++ b/src/Nethermind/Nethermind.State/IReadOnlyStateProvider.cs
@@ -39,6 +39,6 @@ namespace Nethermind.State
         bool IsDeadAccount(Address address);
 
         bool IsEmptyAccount(Address address);
-        bool HashStateForRoot(Hash256 stateRoot);
+        bool HasStateForRoot(Hash256 stateRoot);
     }
 }

--- a/src/Nethermind/Nethermind.State/IReadOnlyStateProvider.cs
+++ b/src/Nethermind/Nethermind.State/IReadOnlyStateProvider.cs
@@ -39,5 +39,6 @@ namespace Nethermind.State
         bool IsDeadAccount(Address address);
 
         bool IsEmptyAccount(Address address);
+        bool HashStateForRoot(Hash256 stateRoot);
     }
 }

--- a/src/Nethermind/Nethermind.State/IStateReader.cs
+++ b/src/Nethermind/Nethermind.State/IStateReader.cs
@@ -17,6 +17,6 @@ namespace Nethermind.State
         byte[]? GetCode(Hash256 codeHash);
 
         void RunTreeVisitor(ITreeVisitor treeVisitor, Hash256 stateRoot, VisitingOptions? visitingOptions = null);
-        bool HashStateForRoot(Hash256 stateRoot);
+        bool HasStateForRoot(Hash256 stateRoot);
     }
 }

--- a/src/Nethermind/Nethermind.State/IStateReader.cs
+++ b/src/Nethermind/Nethermind.State/IStateReader.cs
@@ -17,5 +17,6 @@ namespace Nethermind.State
         byte[]? GetCode(Hash256 codeHash);
 
         void RunTreeVisitor(ITreeVisitor treeVisitor, Hash256 stateRoot, VisitingOptions? visitingOptions = null);
+        bool HashStateForRoot(Hash256 stateRoot);
     }
 }

--- a/src/Nethermind/Nethermind.State/StateReader.cs
+++ b/src/Nethermind/Nethermind.State/StateReader.cs
@@ -64,7 +64,7 @@ namespace Nethermind.State
             _state.Accept(treeVisitor, rootHash, visitingOptions);
         }
 
-        public bool HashStateForRoot(Hash256 stateRoot)
+        public bool HasStateForRoot(Hash256 stateRoot)
         {
             RootCheckVisitor visitor = new();
             RunTreeVisitor(visitor, stateRoot);

--- a/src/Nethermind/Nethermind.State/StateReader.cs
+++ b/src/Nethermind/Nethermind.State/StateReader.cs
@@ -64,6 +64,13 @@ namespace Nethermind.State
             _state.Accept(treeVisitor, rootHash, visitingOptions);
         }
 
+        public bool HashStateForRoot(Hash256 stateRoot)
+        {
+            RootCheckVisitor rootCheckVisitor = new();
+            RunTreeVisitor(rootCheckVisitor, stateRoot);
+            return rootCheckVisitor.HasRoot;
+        }
+
         public byte[] GetCode(Hash256 stateRoot, Address address)
         {
             Account? account = GetState(stateRoot, address);

--- a/src/Nethermind/Nethermind.State/StateReader.cs
+++ b/src/Nethermind/Nethermind.State/StateReader.cs
@@ -66,9 +66,9 @@ namespace Nethermind.State
 
         public bool HashStateForRoot(Hash256 stateRoot)
         {
-            RootCheckVisitor rootCheckVisitor = new();
-            RunTreeVisitor(rootCheckVisitor, stateRoot);
-            return rootCheckVisitor.HasRoot;
+            RootCheckVisitor visitor = new();
+            RunTreeVisitor(visitor, stateRoot);
+            return visitor.HasRoot;
         }
 
         public byte[] GetCode(Hash256 stateRoot, Address address)

--- a/src/Nethermind/Nethermind.State/StateReaderExtensions.cs
+++ b/src/Nethermind/Nethermind.State/StateReaderExtensions.cs
@@ -38,7 +38,7 @@ namespace Nethermind.State
 
         public static bool HasStateForBlock(this IStateReader stateReader, BlockHeader header)
         {
-            return stateReader.HashStateForRoot(header.StateRoot!);
+            return stateReader.HasStateForRoot(header.StateRoot!);
         }
     }
 }

--- a/src/Nethermind/Nethermind.State/StateReaderExtensions.cs
+++ b/src/Nethermind/Nethermind.State/StateReaderExtensions.cs
@@ -38,9 +38,7 @@ namespace Nethermind.State
 
         public static bool HasStateForBlock(this IStateReader stateReader, BlockHeader header)
         {
-            RootCheckVisitor rootCheckVisitor = new();
-            stateReader.RunTreeVisitor(rootCheckVisitor, header.StateRoot);
-            return rootCheckVisitor.HasRoot;
+            return stateReader.HashStateForRoot(header.StateRoot!);
         }
     }
 }

--- a/src/Nethermind/Nethermind.State/WorldState.cs
+++ b/src/Nethermind/Nethermind.State/WorldState.cs
@@ -188,6 +188,13 @@ namespace Nethermind.State
             return _stateProvider.IsEmptyAccount(address);
         }
 
+        public bool HashStateForRoot(Hash256 stateRoot)
+        {
+            RootCheckVisitor visitor = new();
+            Accept(visitor, stateRoot);
+            return visitor.HasRoot;
+        }
+
         public void Commit(IReleaseSpec releaseSpec, bool isGenesis = false)
         {
             _persistentStorageProvider.Commit();

--- a/src/Nethermind/Nethermind.State/WorldState.cs
+++ b/src/Nethermind/Nethermind.State/WorldState.cs
@@ -188,7 +188,7 @@ namespace Nethermind.State
             return _stateProvider.IsEmptyAccount(address);
         }
 
-        public bool HashStateForRoot(Hash256 stateRoot)
+        public bool HasStateForRoot(Hash256 stateRoot)
         {
             RootCheckVisitor visitor = new();
             Accept(visitor, stateRoot);


### PR DESCRIPTION
We use the RootCheckVisitor to check if we have state for a particular state root. But this will not be the case with pathBased layout, we can directly maintain a list of stateRoot that we have at hand.
So moving the underlying logic to the stateReader and worldState would be a better idea.

## Changes

- add bool HashStateForRoot(Hash256) to IStateReader and IReadOnlyStateProvider 

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
