### PR TITLE
Fix/nethermind not sending hello on disconnect

### DIFF
--- a/src/Nethermind/Nethermind.Network.Test/P2P/SessionTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/SessionTests.cs
@@ -14,6 +14,7 @@ using Nethermind.Network.P2P.ProtocolHandlers;
 using Nethermind.Network.Rlpx;
 using Nethermind.Stats.Model;
 using NSubstitute;
+using NSubstitute.ReceivedExtensions;
 using NUnit.Framework;
 
 namespace Nethermind.Network.Test.P2P
@@ -513,7 +514,7 @@ namespace Nethermind.Network.Test.P2P
         }
 
         [Test]
-        public void DelayDisconnect_UntilAfterInitialize()
+        public void Delay_disconnect_until_after_initialize()
         {
             Session session = new(30312, new Node(TestItem.PublicKeyA, "127.0.0.1", 8545), _channel, NullDisconnectsAnalyzer.Instance, LimboLogs.Instance);
             session.Handshake(TestItem.PublicKeyA);
@@ -525,6 +526,30 @@ namespace Nethermind.Network.Test.P2P
             session.Init(5, _channelHandlerContext, _packetSender);
 
             p2p.Received().DisconnectProtocol(Arg.Any<DisconnectReason>(), Arg.Any<string?>());
+        }
+
+        [Test]
+        public void Protocol_handler_can_send_message_on_disconnect()
+        {
+            Session session = new(30312, new Node(TestItem.PublicKeyA, "127.0.0.1", 8545), _channel, NullDisconnectsAnalyzer.Instance, LimboLogs.Instance);
+            session.Handshake(TestItem.PublicKeyA);
+            session.InitiateDisconnect(DisconnectReason.TooManyPeers);
+
+            IProtocolHandler p2p = BuildHandler("p2p", 10);
+            session.AddProtocolHandler(p2p);
+
+            p2p.When(it => it.DisconnectProtocol(Arg.Any<DisconnectReason>(), Arg.Any<string>()))
+                .Do((_) =>
+                {
+                    session.DeliverMessage(PingMessage.Instance);
+                });
+
+            session.Init(5, _channelHandlerContext, _packetSender);
+            session.InitiateDisconnect(DisconnectReason.Other);
+
+            _packetSender
+                .Received()
+                .Enqueue(PingMessage.Instance);
         }
 
         [Test, Retry(3)]

--- a/src/Nethermind/Nethermind.Network.Test/P2P/SessionTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/SessionTests.cs
@@ -512,6 +512,21 @@ namespace Nethermind.Network.Test.P2P
             p2p.DidNotReceive().HandleMessage(Arg.Is<Packet>(p => p.Protocol == "p2p" && p.PacketType == 3));
         }
 
+        [Test]
+        public void DelayDisconnect_UntilAfterInitialize()
+        {
+            Session session = new(30312, new Node(TestItem.PublicKeyA, "127.0.0.1", 8545), _channel, NullDisconnectsAnalyzer.Instance, LimboLogs.Instance);
+            session.Handshake(TestItem.PublicKeyA);
+            session.InitiateDisconnect(DisconnectReason.TooManyPeers);
+
+            IProtocolHandler p2p = BuildHandler("p2p", 10);
+            session.AddProtocolHandler(p2p);
+
+            session.Init(5, _channelHandlerContext, _packetSender);
+
+            p2p.Received().DisconnectProtocol(Arg.Any<DisconnectReason>(), Arg.Any<string?>());
+        }
+
         [Test, Retry(3)]
         [Parallelizable(ParallelScope.None)] // It touches global metrics
         public void Can_receive_messages()

--- a/src/Nethermind/Nethermind.Network/P2P/Session.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Session.cs
@@ -73,6 +73,7 @@ namespace Nethermind.Network.P2P
         }
 
         public bool IsClosing => State > SessionState.Initialized;
+        private bool IsClosed => State > SessionState.DisconnectingProtocols;
         public bool IsNetworkIdMatched { get; set; }
         public int LocalPort { get; set; }
         public PublicKey? RemoteNodeId { get; set; }
@@ -211,7 +212,9 @@ namespace Nethermind.Network.P2P
                     throw new InvalidOperationException($"{nameof(DeliverMessage)} called {this}");
                 }
 
-                if (IsClosing)
+                // Must allow sending out packet when `DisconnectingProtocols` so that we can send out disconnect reason
+                // and hello (part of protocol)
+                if (IsClosed)
                 {
                     return 1;
                 }

--- a/src/Nethermind/Nethermind.Network/P2P/Session.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Session.cs
@@ -356,19 +356,6 @@ namespace Nethermind.Network.P2P
             DoInitiateDisconnect(disconnectReason, details);
         }
 
-        private void EnsureWillDisconnect()
-        {
-            Task.Factory.StartNew(async () =>
-            {
-                // We're not waiting for anything. Just in case something happen in between handshake to init.
-                await Task.Delay(100);
-                if (_disconnectAfterInitialized != null)
-                {
-                    DoInitiateDisconnect(_disconnectAfterInitialized.Value.Item1, _disconnectAfterInitialized.Value.Item2, true);
-                }
-            }, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default);
-        }
-
         private void DoInitiateDisconnect(DisconnectReason disconnectReason, string? details = null, bool ignoreUninitialized = false)
         {
             EthDisconnectReason ethDisconnectReason = disconnectReason.ToEthDisconnectReason();
@@ -415,7 +402,6 @@ namespace Nethermind.Network.P2P
                     if (_disconnectAfterInitialized != null) return;
 
                     _disconnectAfterInitialized = (disconnectReason, details);
-                    EnsureWillDisconnect();
                     return;
                 }
 

--- a/src/Nethermind/Nethermind.Network/P2P/Session.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Session.cs
@@ -353,11 +353,6 @@ namespace Nethermind.Network.P2P
 
         public void InitiateDisconnect(DisconnectReason disconnectReason, string? details = null)
         {
-            DoInitiateDisconnect(disconnectReason, details);
-        }
-
-        private void DoInitiateDisconnect(DisconnectReason disconnectReason, string? details = null, bool ignoreUninitialized = false)
-        {
             EthDisconnectReason ethDisconnectReason = disconnectReason.ToEthDisconnectReason();
 
             bool ShouldDisconnectStaticNode()
@@ -397,7 +392,7 @@ namespace Nethermind.Network.P2P
                     return;
                 }
 
-                if (!ignoreUninitialized && State == SessionState.HandshakeComplete)
+                if (State <= SessionState.HandshakeComplete)
                 {
                     if (_disconnectAfterInitialized != null) return;
 


### PR DESCRIPTION
- Here is a graph of the client that disconnect with the error message TooManyPeers. Notice that a major client is missing from it.
![Screenshot_2023-11-02_22-57-10](https://github.com/NethermindEth/nethermind/assets/1841324/4a8cd4af-3c8d-40fc-8fa8-e05ae0eee836)
- Thats because we did not send any hello message on too many peer. The rlpx hello message must be send out before any other message including nethermind. 
- This involve making sure that the protocol handler are initialized first (which send the hello) and then disconnect.

## Changes

- Fix nethermind not sending out hello message before disconnect.
- Fix nethermind not sending out disconnect reason? Not sure how it worked before.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Manually connect with another node with with additional logging to make sure disconnect reason is received. Confirmed both client id and disconnect reason is available.
