### PR TITLE
Unify reputation settings

### DIFF
--- a/src/Nethermind/Nethermind.Network.Stats/NodeStatsLight.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/NodeStatsLight.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -59,7 +60,7 @@ namespace Nethermind.Stats
 
         public long CurrentPersistedNodeReputation { get; set; }
 
-        public long NewPersistedNodeReputation(DateTime nowUTC) => IsReputationPenalized(nowUTC) ? -100 : (CurrentPersistedNodeReputation + CalculateSessionReputation()) / 2;
+        public long NewPersistedNodeReputation(DateTime nowUTC) => (CurrentPersistedNodeReputation + CalculateSessionReputation()) / 2;
 
         public P2PNodeDetails P2PNodeDetails { get; private set; }
 
@@ -83,9 +84,9 @@ namespace Nethermind.Stats
                 _lastFailedConnectionTime = DateTime.UtcNow;
             }
 
-            if (_statsParameters.DelayDueToEvent.TryGetValue(nodeStatsEventType, out TimeSpan delay))
+            if (_statsParameters.EventParams.TryGetValue(nodeStatsEventType, out (TimeSpan delay, double _) param))
             {
-                UpdateDelayConnectDeadline(DateTime.UtcNow, delay, nodeStatsEventType);
+                UpdateDelayConnectDeadline(DateTime.UtcNow, param.delay, nodeStatsEventType);
             }
 
             Increment(nodeStatsEventType);
@@ -111,16 +112,16 @@ namespace Nethermind.Stats
 
             if (disconnectType == DisconnectType.Local)
             {
-                if (_statsParameters.DelayDueToLocalDisconnect.TryGetValue(disconnectReason, out TimeSpan delay))
+                if (_statsParameters.LocalDisconnectParams.TryGetValue(disconnectReason, out (TimeSpan reconnectDelay, double reputationMultiplier) param) && param.reconnectDelay != TimeSpan.Zero)
                 {
-                    UpdateDelayConnectDeadline(nowUTC, delay, NodeStatsEventType.LocalDisconnectDelay);
+                    UpdateDelayConnectDeadline(nowUTC, param.reconnectDelay, NodeStatsEventType.LocalDisconnectDelay);
                 }
             }
             else if (disconnectType == DisconnectType.Remote)
             {
-                if (_statsParameters.DelayDueToRemoteDisconnect.TryGetValue(disconnectReason, out TimeSpan delay))
+                if (_statsParameters.RemoteDisconnectParams.TryGetValue(disconnectReason, out (TimeSpan reconnectDelay, double reputationMultiplier) param) && param.reconnectDelay != TimeSpan.Zero)
                 {
-                    UpdateDelayConnectDeadline(nowUTC, delay, NodeStatsEventType.RemoteDisconnectDelay);
+                    UpdateDelayConnectDeadline(nowUTC, param.reconnectDelay, NodeStatsEventType.RemoteDisconnectDelay);
                 }
             }
 
@@ -312,7 +313,7 @@ namespace Nethermind.Stats
 
         private long CalculateCurrentReputation(DateTime nowUTC)
         {
-            return IsReputationPenalized(nowUTC) ? -100 : CurrentPersistedNodeReputation / 2 + CalculateSessionReputation();
+            return CurrentPersistedNodeReputation / 2 + CalculateSessionReputation();
         }
 
         private bool HasDisconnectedOnce => _lastLocalDisconnect.HasValue || _lastRemoteDisconnect.HasValue;
@@ -325,8 +326,8 @@ namespace Nethermind.Stats
 
         private long CalculateSessionReputation()
         {
-            long discoveryReputation = 0;
-            long rlpxReputation = 0;
+            double discoveryReputation = 0;
+            double rlpxReputation = 1;
 
             discoveryReputation += Math.Min(GetStat(NodeStatsEventType.DiscoveryPingIn), 10) * (GetStat(NodeStatsEventType.DiscoveryPingIn) == GetStat(NodeStatsEventType.DiscoveryPingOut) ? 2 : 1);
             discoveryReputation += Math.Min(GetStat(NodeStatsEventType.DiscoveryNeighboursIn), 10) * 2;
@@ -338,76 +339,39 @@ namespace Nethermind.Stats
             rlpxReputation += GetStat(NodeStatsEventType.SyncStarted) > 0 ? 1000 : 0;
             rlpxReputation += (rlpxReputation != 0 && !HasDisconnectedOnce) ? 1 : 0;
 
-            if (HasDisconnectedOnce)
+            if (_lastLocalDisconnect != null)
             {
-                if (_lastLocalDisconnect == DisconnectReason.Other || _lastRemoteDisconnect == DisconnectReason.Other)
+                if (_statsParameters.LocalDisconnectParams.TryGetValue(_lastLocalDisconnect.Value, out (TimeSpan reconnectDelay, double reputationMultiplier) param))
                 {
-                    rlpxReputation = (long)(rlpxReputation * 0.3);
+                    rlpxReputation *= param.reputationMultiplier;
                 }
-                else if (_lastLocalDisconnect?.ToEthDisconnectReason() != EthDisconnectReason.DisconnectRequested)
+                else
                 {
-                    if (_lastRemoteDisconnect == DisconnectReason.TooManyPeers)
-                    {
-                        rlpxReputation = (long)(rlpxReputation * 0.3);
-                    }
-                    else if (_lastRemoteDisconnect?.ToEthDisconnectReason() != EthDisconnectReason.DisconnectRequested)
-                    {
-                        rlpxReputation = (long)(rlpxReputation * 0.2);
-                    }
+                    rlpxReputation *= _statsParameters.LocalDisconnectParams[DisconnectReason.Other].reputationMultiplier;
                 }
             }
 
-            if (DidEventHappen(NodeStatsEventType.ConnectionFailed))
+            if (_lastRemoteDisconnect != null)
             {
-                rlpxReputation = (long)(rlpxReputation * 0.2);
-            }
-
-            if (DidEventHappen(NodeStatsEventType.SyncInitFailed))
-            {
-                rlpxReputation = (long)(rlpxReputation * 0.3);
-            }
-
-            if (DidEventHappen(NodeStatsEventType.SyncFailed))
-            {
-                rlpxReputation = (long)(rlpxReputation * 0.4);
-            }
-
-            return discoveryReputation + 100 * rlpxReputation;
-        }
-
-        private bool IsReputationPenalized(DateTime nowUTC)
-        {
-            if (!HasDisconnectedOnce)
-            {
-                return false;
-            }
-
-
-            if (_lastLocalDisconnect.HasValue)
-            {
-                if (_statsParameters.PenalizedReputationLocalDisconnectReasons.Contains(_lastLocalDisconnect.Value))
+                if (_statsParameters.RemoteDisconnectParams.TryGetValue(_lastRemoteDisconnect.Value, out (TimeSpan reconnectDelay, double reputationMultiplier) param))
                 {
-                    return true;
+                    rlpxReputation *= param.reputationMultiplier;
+                }
+                else
+                {
+                    rlpxReputation *= _statsParameters.RemoteDisconnectParams[DisconnectReason.Other].reputationMultiplier;
                 }
             }
 
-            if (!_lastRemoteDisconnect.HasValue)
+            foreach (KeyValuePair<NodeStatsEventType,(TimeSpan reconnectDelay, double reputationMultiplier)> param in _statsParameters.EventParams)
             {
-                return false;
-            }
-
-            if (_statsParameters.PenalizedReputationRemoteDisconnectReasons.Contains(_lastRemoteDisconnect.Value))
-            {
-                if (_lastRemoteDisconnect == DisconnectReason.TooManyPeers || _lastRemoteDisconnect == DisconnectReason.AlreadyConnected)
+                if (DidEventHappen(param.Key))
                 {
-                    double timeFromLastDisconnect = nowUTC.Subtract(_lastDisconnectTime ?? DateTime.MinValue).TotalMilliseconds;
-                    return timeFromLastDisconnect < _statsParameters.PenalizedReputationTooManyPeersTimeout;
+                    rlpxReputation *= param.Value.reputationMultiplier;
                 }
-
-                return true;
             }
 
-            return false;
+            return (long)(discoveryReputation + 100 * rlpxReputation);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Network.Stats/StatsParameters.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/StatsParameters.cs
@@ -17,52 +17,51 @@ namespace Nethermind.Stats
 
         public static StatsParameters Instance { get; } = new StatsParameters();
 
-        public HashSet<DisconnectReason> PenalizedReputationLocalDisconnectReasons { get; set; } =
-            new HashSet<DisconnectReason>
-            {
-                DisconnectReason.UnexpectedIdentity,
-                DisconnectReason.IncompatibleP2PVersion,
-                DisconnectReason.UselessPeer,
-                DisconnectReason.BreachOfProtocol
-            };
-
-        public HashSet<DisconnectReason> PenalizedReputationRemoteDisconnectReasons { get; set; } =
-            new HashSet<DisconnectReason>
-            {
-                DisconnectReason.UnexpectedIdentity,
-                DisconnectReason.IncompatibleP2PVersion,
-                DisconnectReason.UselessPeer,
-                DisconnectReason.BreachOfProtocol,
-                DisconnectReason.TooManyPeers,
-                DisconnectReason.AlreadyConnected
-            };
-
-        public long PenalizedReputationTooManyPeersTimeout { get; } = 10 * 1000;
-
         public int[] FailedConnectionDelays { get; }
 
         public int[] DisconnectDelays { get; set; }
 
-        public Dictionary<DisconnectReason, TimeSpan> DelayDueToLocalDisconnect { get; } = new()
+        public Dictionary<DisconnectReason, (TimeSpan reconnectDelay, double reputationMultiplier)> LocalDisconnectParams { get; } = new()
         {
-            { DisconnectReason.UselessPeer, TimeSpan.FromMinutes(15) },
-
             // Its actually protocol init timeout, when status message is not received in time.
-            { DisconnectReason.ReceiveMessageTimeout, TimeSpan.FromMinutes(5) },
+            { DisconnectReason.ReceiveMessageTimeout, (TimeSpan.FromMinutes(5), 1.0)},
+
+            // Failed could be just timeout, or not synced.
+            { DisconnectReason.PeerRefreshFailed, (TimeSpan.FromMinutes(5), 0.5)},
+
+            { DisconnectReason.Other, (TimeSpan.Zero, 0.8)},
+
+            // These are like, very bad
+            { DisconnectReason.UnexpectedIdentity, (TimeSpan.FromMinutes(15), 0.01) },
+            { DisconnectReason.IncompatibleP2PVersion, (TimeSpan.FromMinutes(15), 0.01) },
+            { DisconnectReason.UselessPeer, (TimeSpan.FromMinutes(15), 0.01) },
+            { DisconnectReason.BreachOfProtocol, (TimeSpan.FromMinutes(15), 0.01) }
         };
 
-        public Dictionary<DisconnectReason, TimeSpan> DelayDueToRemoteDisconnect { get; } = new()
+        public Dictionary<DisconnectReason, (TimeSpan reconnectDelay, double reputationMultiplier)> RemoteDisconnectParams { get; } = new()
         {
-            { DisconnectReason.ClientQuitting, TimeSpan.FromMinutes(1) },
+            { DisconnectReason.ClientQuitting, (TimeSpan.FromMinutes(5), 0.1) },
+            { DisconnectReason.TooManyPeers, (TimeSpan.FromMinutes(1), 0.3) },
+
+            { DisconnectReason.Other, (TimeSpan.Zero, 0.8)},
+
+            // These are like, very bad
+            { DisconnectReason.UnexpectedIdentity, (TimeSpan.FromMinutes(15), 0.01) },
+            { DisconnectReason.IncompatibleP2PVersion, (TimeSpan.FromMinutes(15), 0.01) },
+            { DisconnectReason.UselessPeer, (TimeSpan.FromMinutes(15), 0.01) },
+            { DisconnectReason.BreachOfProtocol, (TimeSpan.FromMinutes(15), 0.01) },
+            { DisconnectReason.AlreadyConnected, (TimeSpan.Zero, 0.01) },
         };
 
-        public Dictionary<NodeStatsEventType, TimeSpan> DelayDueToEvent { get; } = new()
+        public Dictionary<NodeStatsEventType, (TimeSpan reconnectDelay, double reputationMultiplier)> EventParams { get; } = new()
         {
             // Geth have 30 second reconnect delay. So its useless to try again before that.
-            { NodeStatsEventType.Connecting, TimeSpan.FromSeconds(30) },
+            { NodeStatsEventType.Connecting, (TimeSpan.FromSeconds(30), 1.0) },
 
-            { NodeStatsEventType.ConnectionFailedTargetUnreachable, TimeSpan.FromMinutes(15) },
-            { NodeStatsEventType.ConnectionFailed, TimeSpan.FromMinutes(5) },
+            { NodeStatsEventType.ConnectionFailedTargetUnreachable, (TimeSpan.FromMinutes(15), 1.0) },
+            { NodeStatsEventType.ConnectionFailed, (TimeSpan.FromMinutes(5), 0.2) },
+            { NodeStatsEventType.SyncInitFailed, (TimeSpan.Zero, 0.3) },
+            { NodeStatsEventType.SyncFailed, (TimeSpan.Zero, 0.4) },
         };
     }
 }

--- a/src/Nethermind/Nethermind.Network.Test/NodeStatsTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/NodeStatsTests.cs
@@ -104,5 +104,22 @@ namespace Nethermind.Network.Test
             (isConnDelayed, _) = _nodeStats.IsConnectionDelayed(DateTime.UtcNow);
             isConnDelayed.Should().Be(connectionDelayed);
         }
+
+        [TestCase(null, DisconnectReason.Other, 200)]
+        [TestCase(DisconnectType.Local, DisconnectReason.UselessPeer, 1)]
+        [TestCase(DisconnectType.Local, DisconnectReason.PeerRefreshFailed, 50)]
+        [TestCase(DisconnectType.Local, DisconnectReason.BreachOfProtocol, 1)]
+        [TestCase(DisconnectType.Remote, DisconnectReason.ClientQuitting, 10)]
+        [TestCase(DisconnectType.Remote, DisconnectReason.BreachOfProtocol, 1)]
+        public void DisconnectReputation(DisconnectType? disconnectType, DisconnectReason reason, int reputation)
+        {
+            _nodeStats = new NodeStatsLight(_node);
+            if (disconnectType != null)
+            {
+                _nodeStats.AddNodeStatsDisconnectEvent(disconnectType.Value, reason);
+            }
+
+            _nodeStats.CurrentNodeReputation().Should().Be(reputation);
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
@@ -295,8 +295,8 @@ namespace Nethermind.Network.Test
             ctx.PeerPool.Start();
             ctx.PeerManager.Start();
 
-            TimeSpan prevConnectingDelay = StatsParameters.Instance.DelayDueToEvent[NodeStatsEventType.Connecting];
-            StatsParameters.Instance.DelayDueToEvent[NodeStatsEventType.Connecting] = TimeSpan.Zero;
+            TimeSpan prevConnectingDelay = StatsParameters.Instance.EventParams[NodeStatsEventType.Connecting].reconnectDelay;
+            StatsParameters.Instance.EventParams[NodeStatsEventType.Connecting] = (TimeSpan.Zero, 1.0);
             int[] prevDisconnectDelays = StatsParameters.Instance.DisconnectDelays;
             StatsParameters.Instance.DisconnectDelays = new[] { 0 };
 
@@ -312,7 +312,7 @@ namespace Nethermind.Network.Test
             }
             finally
             {
-                StatsParameters.Instance.DelayDueToEvent[NodeStatsEventType.Connecting] = prevConnectingDelay;
+                StatsParameters.Instance.EventParams[NodeStatsEventType.Connecting] = (prevConnectingDelay, 1.0);
                 StatsParameters.Instance.DisconnectDelays = prevDisconnectDelays;
             }
         }


### PR DESCRIPTION
- A lot of time we are connecting to a set of nodes with empty client id. There are about 312 distinct ip:port node like this, coming from 32 ip. Eventually they will get disconnected via peer refresher failed or ot they will disonnect themselves with the reason `ClientQuitting`
- Regardless of what they do, we can't just keep connecting to them as it will take connecting attempts away from other nodes.
- This make it so that `ClientQuitting` and `PeerRefreshFailed` disconnect reason got penalized more in the reputation and add reconnect delay of 5 minute.

- Graph is old bodies only. After->Before X4.
![Screenshot_2023-11-03_11-16-55](https://github.com/NethermindEth/nethermind/assets/1841324/1302f3fb-4dfd-42b4-b982-8f19827e4e4d)

## Changes

- Add `reputationMultiplier` multiplier config to disconnects and events. Refactored existing code to use it.
- Specify a disconnect delay and lower reputation for `ClientQuitting` and `PeerRefreshFailed`. 

## Types of changes

#### What types of changes does your code introduce?

- [X] Optimization

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No
