### PR TITLE
Feature/ratelimit discovery messages

### DIFF
--- a/src/Nethermind/Nethermind.Network.Discovery.Test/DiscoveryManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/DiscoveryManagerTests.cs
@@ -81,10 +81,10 @@ namespace Nethermind.Network.Discovery.Test
             await Task.Delay(500);
 
             // expecting to send pong
-            _msgSender.Received(1).SendMsg(Arg.Is<PongMsg>(m => m.FarAddress!.Address.ToString() == Host && m.FarAddress.Port == Port));
+            await _msgSender.Received(1).SendMsg(Arg.Is<PongMsg>(m => m.FarAddress!.Address.ToString() == Host && m.FarAddress.Port == Port));
 
             // send pings to  new node
-            _msgSender.Received().SendMsg(Arg.Is<PingMsg>(m => m.FarAddress!.Address.ToString() == Host && m.FarAddress.Port == Port));
+            await _msgSender.Received().SendMsg(Arg.Is<PingMsg>(m => m.FarAddress!.Address.ToString() == Host && m.FarAddress.Port == Port));
         }
 
         [Test, Ignore("Add bonding"), Retry(3)]
@@ -163,8 +163,8 @@ namespace Nethermind.Network.Discovery.Test
             Assert.That(manager?.State, Is.EqualTo(NodeLifecycleState.Active));
 
             //sending FindNode to expect Neighbors
-            manager?.SendFindNode(_nodeTable.MasterNode!.Id.Bytes);
-            _msgSender.Received(1).SendMsg(Arg.Is<FindNodeMsg>(m => m.FarAddress!.Address.ToString() == Host && m.FarAddress.Port == Port));
+            await manager!.SendFindNode(_nodeTable.MasterNode!.Id.Bytes);
+            await _msgSender.Received(1).SendMsg(Arg.Is<FindNodeMsg>(m => m.FarAddress!.Address.ToString() == Host && m.FarAddress.Port == Port));
 
             //receiving findNode
             NeighborsMsg msg = new(_publicKey, GetExpirationTime(), _nodes);
@@ -173,8 +173,8 @@ namespace Nethermind.Network.Discovery.Test
 
             //expecting to send 3 pings to both nodes
             await Task.Delay(600);
-            _msgSender.Received(3).SendMsg(Arg.Is<PingMsg>(m => m.FarAddress!.Address.ToString() == _nodes[0].Host && m.FarAddress.Port == _nodes[0].Port));
-            _msgSender.Received(3).SendMsg(Arg.Is<PingMsg>(m => m.FarAddress!.Address.ToString() == _nodes[1].Host && m.FarAddress.Port == _nodes[1].Port));
+            await _msgSender.Received(3).SendMsg(Arg.Is<PingMsg>(m => m.FarAddress!.Address.ToString() == _nodes[0].Host && m.FarAddress.Port == _nodes[0].Port));
+            await _msgSender.Received(3).SendMsg(Arg.Is<PingMsg>(m => m.FarAddress!.Address.ToString() == _nodes[1].Host && m.FarAddress.Port == _nodes[1].Port));
         }
 
         private void ReceiveSomePong()

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/DiscoveryManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/DiscoveryManagerTests.cs
@@ -197,7 +197,7 @@ namespace Nethermind.Network.Discovery.Test
         {
             SetupDiscoveryManager(new DiscoveryConfig()
             {
-                OutgoingMessageRateLimit = 5
+                MaxOutgoingMessagePerSecond = 5
             });
 
             Stopwatch sw = Stopwatch.StartNew();

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/NettyDiscoveryHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/NettyDiscoveryHandlerTests.cs
@@ -75,7 +75,7 @@ namespace Nethermind.Network.Discovery.Test
                 FarAddress = _address2
             };
 
-            _discoveryHandlers[0].SendMsg(msg);
+            await _discoveryHandlers[0].SendMsg(msg);
             await SleepWhileWaiting();
             _discoveryManagersMocks[1].Received(1).OnIncomingMsg(Arg.Is<DiscoveryMsg>(x => x.MsgType == MsgType.Ping));
 
@@ -84,7 +84,7 @@ namespace Nethermind.Network.Discovery.Test
                 FarAddress = _address
             };
 
-            _discoveryHandlers[1].SendMsg(msg2);
+            await _discoveryHandlers[1].SendMsg(msg2);
             await SleepWhileWaiting();
             _discoveryManagersMocks[0].Received(1).OnIncomingMsg(Arg.Is<DiscoveryMsg>(x => x.MsgType == MsgType.Ping));
 
@@ -102,7 +102,7 @@ namespace Nethermind.Network.Discovery.Test
                 FarAddress = _address2
             };
 
-            _discoveryHandlers[0].SendMsg(msg);
+            await _discoveryHandlers[0].SendMsg(msg);
             await SleepWhileWaiting();
             _discoveryManagersMocks[1].Received(1).OnIncomingMsg(Arg.Is<DiscoveryMsg>(x => x.MsgType == MsgType.Pong));
 
@@ -110,7 +110,7 @@ namespace Nethermind.Network.Discovery.Test
             {
                 FarAddress = _address
             };
-            _discoveryHandlers[1].SendMsg(msg2);
+            await _discoveryHandlers[1].SendMsg(msg2);
             await SleepWhileWaiting();
             _discoveryManagersMocks[0].Received(1).OnIncomingMsg(Arg.Is<DiscoveryMsg>(x => x.MsgType == MsgType.Pong));
 
@@ -128,7 +128,7 @@ namespace Nethermind.Network.Discovery.Test
                 FarAddress = _address2
             };
 
-            _discoveryHandlers[0].SendMsg(msg);
+            await _discoveryHandlers[0].SendMsg(msg);
             await SleepWhileWaiting();
             _discoveryManagersMocks[1].Received(1).OnIncomingMsg(Arg.Is<DiscoveryMsg>(x => x.MsgType == MsgType.FindNode));
 
@@ -137,7 +137,7 @@ namespace Nethermind.Network.Discovery.Test
                 FarAddress = _address
             };
 
-            _discoveryHandlers[1].SendMsg(msg2);
+            await _discoveryHandlers[1].SendMsg(msg2);
             await SleepWhileWaiting();
             _discoveryManagersMocks[0].Received(1).OnIncomingMsg(Arg.Is<DiscoveryMsg>(x => x.MsgType == MsgType.FindNode));
 
@@ -155,7 +155,7 @@ namespace Nethermind.Network.Discovery.Test
                 FarAddress = _address2
             };
 
-            _discoveryHandlers[0].SendMsg(msg);
+            await _discoveryHandlers[0].SendMsg(msg);
             await SleepWhileWaiting();
             _discoveryManagersMocks[1].Received(1).OnIncomingMsg(Arg.Is<DiscoveryMsg>(x => x.MsgType == MsgType.Neighbors));
 
@@ -164,7 +164,7 @@ namespace Nethermind.Network.Discovery.Test
                 FarAddress = _address,
             };
 
-            _discoveryHandlers[1].SendMsg(msg2);
+            await _discoveryHandlers[1].SendMsg(msg2);
             await SleepWhileWaiting();
             _discoveryManagersMocks[0].Received(1).OnIncomingMsg(Arg.Is<DiscoveryMsg>(x => x.MsgType == MsgType.Neighbors));
 

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/NodeLifecycleManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/NodeLifecycleManagerTests.cs
@@ -97,7 +97,7 @@ namespace Nethermind.Network.Discovery.Test
 
             byte[] mdc = new byte[32];
             PingMsg? sentPing = null;
-            _discoveryManagerMock.SendMessage(Arg.Do<PingMsg>(msg =>
+            await _discoveryManagerMock.SendMessageAsync(Arg.Do<PingMsg>(msg =>
             {
                 msg.Mdc = mdc;
                 sentPing = msg;
@@ -168,7 +168,7 @@ namespace Nethermind.Network.Discovery.Test
                 .Received(0)
                 .GetNodeLifecycleManager(Arg.Any<Node>(), Arg.Any<bool>());
 
-            nodeManager.SendFindNode(Array.Empty<byte>());
+            await nodeManager.SendFindNode(Array.Empty<byte>());
 
             Node[] firstNodes = TestItem.PublicKeys
                 .Take(12)
@@ -388,7 +388,7 @@ namespace Nethermind.Network.Discovery.Test
         {
             byte[] mdc = new byte[32];
             PingMsg? sentPing = null;
-            _discoveryManagerMock.SendMessage(Arg.Do<PingMsg>(msg =>
+            await _discoveryManagerMock.SendMessageAsync(Arg.Do<PingMsg>(msg =>
             {
                 msg.Mdc = mdc;
                 sentPing = msg;

--- a/src/Nethermind/Nethermind.Network.Discovery/DiscoveryConfig.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/DiscoveryConfig.cs
@@ -39,7 +39,7 @@ public class DiscoveryConfig : IDiscoveryConfig
 
     public float DropFullBucketNodeProbability { get; set; } = 0.05f;
 
-    public int OutgoingMessageRateLimit { get; set; } = 100;
+    public int MaxOutgoingMessagePerSecond { get; set; } = 100;
 
     public string Bootnodes { get; set; } = string.Empty;
 }

--- a/src/Nethermind/Nethermind.Network.Discovery/DiscoveryConfig.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/DiscoveryConfig.cs
@@ -36,7 +36,10 @@ public class DiscoveryConfig : IDiscoveryConfig
     public int MaxNodeLifecycleManagersCount { get; set; } = 8000;
 
     public int NodeLifecycleManagersCleanupCount { get; set; } = 4000;
+
     public float DropFullBucketNodeProbability { get; set; } = 0.05f;
+
+    public int OutgoingMessageRateLimit { get; set; } = 100;
 
     public string Bootnodes { get; set; } = string.Empty;
 }

--- a/src/Nethermind/Nethermind.Network.Discovery/DiscoveryManager.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/DiscoveryManager.cs
@@ -40,7 +40,7 @@ public class DiscoveryManager : IDiscoveryManager
         _nodeTable = nodeTable ?? throw new ArgumentNullException(nameof(nodeTable));
         _discoveryStorage = discoveryStorage ?? throw new ArgumentNullException(nameof(discoveryStorage));
         _nodeLifecycleManagerFactory.DiscoveryManager = this;
-        _outgoingMessageRateLimiter = new RateLimiter(discoveryConfig.OutgoingMessageRateLimit);
+        _outgoingMessageRateLimiter = new RateLimiter(discoveryConfig.MaxOutgoingMessagePerSecond);
     }
 
     public IMsgSender MsgSender

--- a/src/Nethermind/Nethermind.Network.Discovery/IDiscoveryConfig.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/IDiscoveryConfig.cs
@@ -111,4 +111,7 @@ public interface IDiscoveryConfig : IConfig
 
     [ConfigItem(DefaultValue = "0.05")]
     float DropFullBucketNodeProbability { get; set; }
+
+    [ConfigItem(Description = "Limit number of outgoing discovery message per second.", DefaultValue = "100", HiddenFromDocs = true)]
+    int OutgoingMessageRateLimit { get; set; }
 }

--- a/src/Nethermind/Nethermind.Network.Discovery/IDiscoveryConfig.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/IDiscoveryConfig.cs
@@ -113,5 +113,5 @@ public interface IDiscoveryConfig : IConfig
     float DropFullBucketNodeProbability { get; set; }
 
     [ConfigItem(Description = "Limit number of outgoing discovery message per second.", DefaultValue = "100", HiddenFromDocs = true)]
-    int OutgoingMessageRateLimit { get; set; }
+    int MaxOutgoingMessagePerSecond { get; set; }
 }

--- a/src/Nethermind/Nethermind.Network.Discovery/IDiscoveryManager.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/IDiscoveryManager.cs
@@ -13,6 +13,7 @@ public interface IDiscoveryManager : IDiscoveryMsgListener
     IMsgSender MsgSender { set; }
     INodeLifecycleManager? GetNodeLifecycleManager(Node node, bool isPersisted = false);
     void SendMessage(DiscoveryMsg discoveryMsg);
+    Task SendMessageAsync(DiscoveryMsg discoveryMsg);
     Task<bool> WasMessageReceived(Hash256 senderIdHash, MsgType msgType, int timeout);
     event EventHandler<NodeEventArgs> NodeDiscovered;
 

--- a/src/Nethermind/Nethermind.Network.Discovery/IMsgSender.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/IMsgSender.cs
@@ -7,5 +7,5 @@ namespace Nethermind.Network.Discovery;
 
 public interface IMsgSender
 {
-    void SendMsg(DiscoveryMsg discoveryMsg);
+    Task SendMsg(DiscoveryMsg discoveryMsg);
 }

--- a/src/Nethermind/Nethermind.Network.Discovery/Lifecycle/INodeLifecycleManager.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Lifecycle/INodeLifecycleManager.cs
@@ -18,7 +18,7 @@ public interface INodeLifecycleManager
     void ProcessFindNodeMsg(FindNodeMsg msg);
     void ProcessEnrRequestMsg(EnrRequestMsg enrRequestMessage);
     void ProcessEnrResponseMsg(EnrResponseMsg msg);
-    void SendFindNode(byte[] searchedNodeId);
+    Task SendFindNode(byte[] searchedNodeId);
     Task SendPingAsync();
 
     void StartEvictionProcess();

--- a/src/Nethermind/Nethermind.Network.Discovery/Lifecycle/NodeLifecycleManager.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Lifecycle/NodeLifecycleManager.cs
@@ -223,7 +223,7 @@ public class NodeLifecycleManager : INodeLifecycleManager
 
     private long _lastEnrSequence;
 
-    public void SendFindNode(byte[] searchedNodeId)
+    public async Task SendFindNode(byte[] searchedNodeId)
     {
         if (!IsBonded)
         {
@@ -237,7 +237,7 @@ public class NodeLifecycleManager : INodeLifecycleManager
 
         FindNodeMsg msg = new(ManagedNode.Address, CalculateExpirationTime(), searchedNodeId);
         _isNeighborsExpected = true;
-        _discoveryManager.SendMessage(msg);
+        await _discoveryManager.SendMessageAsync(msg);
         NodeStats.AddNodeStatsEvent(NodeStatsEventType.DiscoveryFindNodeOut);
     }
 
@@ -365,7 +365,7 @@ public class NodeLifecycleManager : INodeLifecycleManager
         try
         {
             _lastSentPing = msg;
-            _discoveryManager.SendMessage(msg);
+            await _discoveryManager.SendMessageAsync(msg);
             NodeStats.AddNodeStatsEvent(NodeStatsEventType.DiscoveryPingOut);
 
             bool result = await _discoveryManager.WasMessageReceived(ManagedNode.IdHash, MsgType.Pong, _discoveryConfig.PongTimeout);

--- a/src/Nethermind/Nethermind.Network.Discovery/NettyDiscoveryHandler.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/NettyDiscoveryHandler.cs
@@ -65,7 +65,7 @@ public class NettyDiscoveryHandler : SimpleChannelInboundHandler<DatagramPacket>
         context.Flush();
     }
 
-    public async void SendMsg(DiscoveryMsg discoveryMsg)
+    public async Task SendMsg(DiscoveryMsg discoveryMsg)
     {
         IByteBuffer msgBuffer;
         try

--- a/src/Nethermind/Nethermind.Network.Discovery/NodesLocator.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/NodesLocator.cs
@@ -201,7 +201,10 @@ public class NodesLocator : INodesLocator
         {
             INodeLifecycleManager? nodeManager = _discoveryManager.GetNodeLifecycleManager(destinationNode);
 
-            nodeManager?.SendFindNode(searchedNodeId ?? _masterNode!.Id.Bytes);
+            if (nodeManager != null)
+            {
+                await nodeManager.SendFindNode(searchedNodeId ?? _masterNode!.Id.Bytes);
+            }
 
             return await _discoveryManager.WasMessageReceived(destinationNode.IdHash, MsgType.Neighbors, _discoveryConfig.SendNodeTimeout)
                 ? Result.Success

--- a/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
@@ -81,7 +81,7 @@ namespace Nethermind.Network.Test
             Assert.That(ctx.RlpxPeer.ConnectAsyncCallsCount, Is.EqualTo(1));
         }
 
-        [Test]
+        [Test, Retry(3)]
         public async Task Will_only_connect_up_to_max_peers()
         {
             await using Context ctx = new(1);


### PR DESCRIPTION
- Add option `--Discovery.OutgoingMessageRateLimit`.
- May help in some cases where user's internet can't handle this much UDP packet.
- Default is 100, which is effectively not limited as the current rate is about 20 to 70.
- Reducing it noticably reduce the rate at which peer pool grow.
![Screenshot_2023-11-10_16-07-49](https://github.com/NethermindEth/nethermind/assets/1841324/53ab2e4b-8339-4177-9d9d-74dd6314391d)

## Changes

- Expose async task from message sender.
- Modified calls to async where possible.

## Types of changes

- [X] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Tested manually.