### PR TITLE
Select proper drive when using `VolumeFreeSpace` trigger

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/DiskFreeSpacePruningTriggerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/DiskFreeSpacePruningTriggerTests.cs
@@ -25,7 +25,6 @@ namespace Nethermind.Blockchain.Test.FullPruning
             string path = "path";
             IFileSystem fileSystem = Substitute.For<IFileSystem>();
             fileSystem.Path.GetFullPath(path).Returns(path);
-            fileSystem.Path.GetPathRoot(path).Returns(path);
             fileSystem.DriveInfo.New(path).AvailableFreeSpace.Returns(availableFreeSpace);
 
             bool triggered = false;

--- a/src/Nethermind/Nethermind.Blockchain/FullPruning/DiskFreeSpacePruningTrigger.cs
+++ b/src/Nethermind/Nethermind.Blockchain/FullPruning/DiskFreeSpacePruningTrigger.cs
@@ -27,8 +27,8 @@ namespace Nethermind.Blockchain.FullPruning
 
         private void OnTick(object? sender, EventArgs e)
         {
-            string driveName = _fileSystem.Path.GetPathRoot(_fileSystem.Path.GetFullPath(_path));
-            IDriveInfo drive = _fileSystem.DriveInfo.New(driveName);
+            string fullPath = _fileSystem.Path.GetFullPath(_path);
+            IDriveInfo drive = _fileSystem.DriveInfo.New(fullPath);
             if (drive.AvailableFreeSpace < _threshold)
             {
                 Prune?.Invoke(this, new PruningTriggerEventArgs());


### PR DESCRIPTION
Fixes #6258, #5738

## Changes

- Do not use `PathRoot` to find the proper drive.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Tested on a Fedora 38 machine (Linux) using the real filesystem with 3 drives.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Our tests mock the real filesystem (using `IFilesystem` and `NSubstitute`) so we cannot actually be sure that we're picking the appropriate drives.

On my machine, I could verify that the proper drive was being picked up with the following test:

```C#
// It would be great if we could verify that we're picking the correct drives on Windows too:
// [TestCase(@"C:\")]
// [TestCase(@"D:\")]
[TestCase("/home/emlautarom1")]
[TestCase("/run/media/emlautarom1/Toshiba")]
[TestCase("/run/media/emlautarom1/EC8AEBDD8AEBA1F6")]
public void triggers_target_the_proper_drive(string path)
{
    IFileSystem fs = new FileSystem();
    string driveName = fs.Path.GetFullPath(path);
    IDriveInfo drive = fs.DriveInfo.New(driveName);
    Console.WriteLine($"Drive {drive}, free space: {drive.AvailableFreeSpace * (Math.Pow(10, -9))} GB");
}
```

Any suggestion on how to actually unit test `DiskFreeSpacePruningTrigger` to ensure that the proper drive is being selected is welcome.