### PR TITLE
Feature/state db layout by path cache reorg

### DIFF
--- a/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
@@ -134,7 +134,7 @@ namespace Ethereum.Test.Base
                 .WithoutSettingHead
                 .TestObject;
             ITransactionComparerProvider transactionComparerProvider = new TransactionComparerProvider(specProvider, blockTree);
-            IStateReader stateReader = new StateReader(trieStore, storageTrieStore, codeDb, _logManager);
+            IStateReader stateReader = new StateReader(trieStore, codeDb, _logManager);
             IChainHeadInfoProvider chainHeadInfoProvider = new ChainHeadInfoProvider(specProvider, blockTree, stateReader);
             ITxPool transactionPool = new TxPool(ecdsa, chainHeadInfoProvider, new TxPoolConfig(), new TxValidator(specProvider.ChainId), _logManager, transactionComparerProvider.GetDefaultComparer());
 

--- a/src/Nethermind/Nethermind.AuRa.Test/Transactions/TxPermissionFilterTest.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/Transactions/TxPermissionFilterTest.cs
@@ -274,15 +274,15 @@ public class TxPermissionFilterTest
             TransactionPermissionContractVersions =
                 new LruCache<ValueKeccak, UInt256>(PermissionBasedTxFilter.Cache.MaxCacheSize, nameof(TransactionPermissionContract));
 
-                IReadOnlyTxProcessorSource txProcessorSource = new ReadOnlyTxProcessingEnv(
-                    DbProvider,
-                    ReadOnlyTrieStore,
-                    BlockTree,
-                    SpecProvider,
-                    LimboLogs.Instance);
+            IReadOnlyTxProcessorSource txProcessorSource = new ReadOnlyTxProcessingEnv(
+                DbProvider,
+                ReadOnlyTrieStore,
+                BlockTree,
+                SpecProvider,
+                LimboLogs.Instance);
 
-                VersionedTransactionPermissionContract transactionPermissionContract = new(AbiEncoder.Instance, _contractAddress, 1,
-                    new ReadOnlyTxProcessingEnv(DbProvider, ReadOnlyTrieStore, BlockTree, SpecProvider, LimboLogs.Instance), TransactionPermissionContractVersions, LimboLogs.Instance, SpecProvider);
+            VersionedTransactionPermissionContract transactionPermissionContract = new(AbiEncoder.Instance, _contractAddress, 1,
+                new ReadOnlyTxProcessingEnv(DbProvider, ReadOnlyTrieStore, BlockTree, SpecProvider, LimboLogs.Instance), TransactionPermissionContractVersions, LimboLogs.Instance, SpecProvider);
 
             TxPermissionFilterCache = new PermissionBasedTxFilter.Cache();
             PermissionBasedTxFilter = new PermissionBasedTxFilter(transactionPermissionContract, TxPermissionFilterCache, LimboLogs.Instance);

--- a/src/Nethermind/Nethermind.AuRa.Test/Transactions/TxPermissionFilterTest.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/Transactions/TxPermissionFilterTest.cs
@@ -274,16 +274,15 @@ public class TxPermissionFilterTest
             TransactionPermissionContractVersions =
                 new LruCache<ValueKeccak, UInt256>(PermissionBasedTxFilter.Cache.MaxCacheSize, nameof(TransactionPermissionContract));
 
-                IReadOnlyTrieStore trieStore = new TrieStoreByPath(DbProvider.PathStateDb, LimboLogs.Instance).AsReadOnly();
                 IReadOnlyTxProcessorSource txProcessorSource = new ReadOnlyTxProcessingEnv(
                     DbProvider,
-                    trieStore,
+                    ReadOnlyTrieStore,
                     BlockTree,
                     SpecProvider,
                     LimboLogs.Instance);
 
                 VersionedTransactionPermissionContract transactionPermissionContract = new(AbiEncoder.Instance, _contractAddress, 1,
-                    new ReadOnlyTxProcessingEnv(DbProvider, trieStore, BlockTree, SpecProvider, LimboLogs.Instance), TransactionPermissionContractVersions, LimboLogs.Instance, SpecProvider);
+                    new ReadOnlyTxProcessingEnv(DbProvider, ReadOnlyTrieStore, BlockTree, SpecProvider, LimboLogs.Instance), TransactionPermissionContractVersions, LimboLogs.Instance, SpecProvider);
 
             TxPermissionFilterCache = new PermissionBasedTxFilter.Cache();
             PermissionBasedTxFilter = new PermissionBasedTxFilter(transactionPermissionContract, TxPermissionFilterCache, LimboLogs.Instance);

--- a/src/Nethermind/Nethermind.Blockchain.Test/Visitors/StartupTreeFixerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Visitors/StartupTreeFixerTests.cs
@@ -111,9 +111,8 @@ namespace Nethermind.Blockchain.Test.Visitors
             newBlockchainProcessor.Start();
             testRpc.BlockchainProcessor = newBlockchainProcessor;
 
-            TrieStoreByPath trieStore = new TrieStoreByPath(testRpc.DbProvider.PathStateDb, LimboLogs.Instance);
             // fixing after restart
-            StartupBlockTreeFixer fixer = new(new SyncConfig(), tree, trieStore, LimboNoErrorLogger.Instance, 5);
+            StartupBlockTreeFixer fixer = new(new SyncConfig(), tree, testRpc.TrieStore, LimboNoErrorLogger.Instance, 5);
             await tree.Accept(fixer, CancellationToken.None);
 
             // waiting for N new heads

--- a/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/StartBlockProducerAuRa.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/StartBlockProducerAuRa.cs
@@ -225,13 +225,13 @@ public class StartBlockProducerAuRa
         }
     }
 
-        // TODO: Use BlockProducerEnvFactory
-        private BlockProducerEnv GetProducerChain(ITxSource? additionalTxSource)
+    // TODO: Use BlockProducerEnvFactory
+    private BlockProducerEnv GetProducerChain(ITxSource? additionalTxSource)
+    {
+        ReadOnlyTxProcessingEnv CreateReadonlyTxProcessingEnv(ReadOnlyDbProvider dbProvider, ReadOnlyBlockTree blockTree)
         {
-            ReadOnlyTxProcessingEnv CreateReadonlyTxProcessingEnv(ReadOnlyDbProvider dbProvider, ReadOnlyBlockTree blockTree)
-            {
-                return new(dbProvider, _api.ReadOnlyTrieStore, blockTree, _api.SpecProvider, _api.LogManager);
-            }
+            return new(dbProvider, _api.ReadOnlyTrieStore, blockTree, _api.SpecProvider, _api.LogManager);
+        }
 
         BlockProducerEnv Create()
         {

--- a/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
@@ -139,8 +139,7 @@ public class TestBlockchain : IDisposable
         State.Commit(SpecProvider.GenesisSpec);
         State.CommitTree(0);
 
-        //ReadOnlyTrieStore = TrieStore.AsReadOnly(StateDb);
-        ReadOnlyTrieStore = TrieStore.AsReadOnly(PathStateDb);
+        ReadOnlyTrieStore = usePathStateDb ? TrieStore.AsReadOnly(PathStateDb) : TrieStore.AsReadOnly(StateDb);
         StateReader = new StateReader(ReadOnlyTrieStore, CodeDb, LogManager);
 
         BlockTree = Builders.Build.A.BlockTree()

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
@@ -180,7 +180,7 @@ public partial class EthRpcModule : IEthRpcModule
             return ResultWrapper<byte[]>.Success(Array.Empty<byte>());
         }
 
-        byte[] storage = _stateReader.GetStorage(account.StorageRoot, address, positionIndex);
+        byte[] storage = _stateReader.GetStorage(header!.StateRoot!, account.StorageRoot, address, positionIndex);
         return ResultWrapper<byte[]>.Success(storage!.PadLeft(32));
     }
 

--- a/src/Nethermind/Nethermind.State.Test/PatriciaTreeTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/PatriciaTreeTests.cs
@@ -78,7 +78,7 @@ namespace Nethermind.Store.Test
             stateTree.Get(TestItem.AddressA);
             account = account.WithChangedBalance(2);
             stateTree.Set(TestItem.AddressA, account);
-            stateTree.Commit(0);
+            stateTree.Commit(1);
 
             Account a1 = stateTree.Get(TestItem.AddressA, rootHash);
             Account a2 = stateTree.Get(TestItem.AddressA);

--- a/src/Nethermind/Nethermind.State.Test/SnapSync/RecreateStateFromStorageRangesTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/SnapSync/RecreateStateFromStorageRangesTests.cs
@@ -49,7 +49,7 @@ namespace Nethermind.Store.Test.SnapSync
             DbProvider dbProvider = new(DbModeHint.Mem);
             dbProvider.RegisterDb(DbNames.PathState, new MemColumnsDb<StateColumns>());
             dbProvider.RegisterDb(DbNames.State, new MemDb());
-            
+
             ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
             SnapProvider snapProvider = new(progressTracker, dbProvider, LimboLogs.Instance);
             PathWithAccount pWA = new PathWithAccount(TestItem.Tree.AccountAddress0, Build.A.Account.WithBalance(1).TestObject);

--- a/src/Nethermind/Nethermind.State.Test/StateReaderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StateReaderTests.cs
@@ -147,7 +147,7 @@ namespace Nethermind.Store.Test
 
             StateReader reader =
                 new(trieStore, Substitute.For<IDb>(), Logger);
-            reader.GetStorage(stateRoot0, _address1, storageCell.Index + 1).Should().BeEquivalentTo(new byte[] { 0 });
+            reader.GetStorage(stateRoot0, null, _address1, storageCell.Index + 1).Should().BeEquivalentTo(new byte[] { 0 });
         }
 
         private Task StartTask(StateReader reader, Keccak stateRoot, UInt256 value)
@@ -171,7 +171,7 @@ namespace Nethermind.Store.Test
                     for (int i = 0; i < 1000; i++)
                     {
                         Keccak storageRoot = reader.GetStorageRoot(stateRoot, storageCell.Address);
-                        byte[] result = reader.GetStorage(storageRoot, storageCell.Address, storageCell.Index);
+                        byte[] result = reader.GetStorage(stateRoot, storageRoot, storageCell.Address, storageCell.Index);
                         result.Should().BeEquivalentTo(value);
                     }
                 });
@@ -203,7 +203,7 @@ namespace Nethermind.Store.Test
             StateReader reader = new(trieStore, dbProvider.CodeDb, Logger);
 
             var account = reader.GetAccount(state.StateRoot, _address1);
-            var retrieved = reader.GetStorage(account.StorageRoot, _address1, storageCell.Index);
+            var retrieved = reader.GetStorage(state.StateRoot, account.StorageRoot, _address1, storageCell.Index);
             //byte[] retrieved = reader.GetStorage(state.StateRoot, _address1, storageCell.Index);
             retrieved.Should().BeEquivalentTo(initialValue);
 
@@ -227,7 +227,7 @@ namespace Nethermind.Store.Test
                We will try to retrieve the value by taking the state root from the processor.*/
 
             retrieved =
-                reader.GetStorage(processorStateProvider.GetStorageRoot(storageCell.Address), storageCell.Address, storageCell.Index);
+                reader.GetStorage(processorStateProvider.StateRoot, processorStateProvider.GetStorageRoot(storageCell.Address), storageCell.Address, storageCell.Index);
             retrieved.Should().BeEquivalentTo(newValue);
 
             /* If it failed then it means that the blockchain bridge cached the previous call value */

--- a/src/Nethermind/Nethermind.State.Test/StateTreeByPathTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StateTreeByPathTests.cs
@@ -710,10 +710,10 @@ namespace Nethermind.Store.Test
 
             int numberOfAccounts = 10000;
             int numberOfBlocks = 100;
-            int numberOfUpdates = numberOfAccounts / 100;
+            int numberOfUpdates = numberOfAccounts / 10;
 
             int seed = Environment.TickCount;
-            //int seed = 367667468;
+            //int seed = 185189906;
             logger.Warn($"Seed: {seed}");
             Random _random = new Random(seed);
 
@@ -739,8 +739,8 @@ namespace Nethermind.Store.Test
             Keccak prevRootHash = tree.RootHash;
             for (int i = 1; i <= numberOfBlocks; i++)
             {
-                tree = new StateTreeByPath(pathStore, LimboLogs.Instance);
                 tree.RootHash = prevRootHash;
+                tree.ParentStateRootHash = prevRootHash;
                 for (int accountIndex = 0; accountIndex < numberOfUpdates; accountIndex++)
                 {
                     Account account = TestItem.GenerateRandomAccount();
@@ -883,6 +883,7 @@ namespace Nethermind.Store.Test
 
             //reset the trie and set context to latest root hash (block 1 not persisted)
             tree = new StateTreeByPath(pathStore, logManager);
+            pathStore.OpenContext(2, root_1);
             tree.RootHash = root_1;
 
             Assert.That(tree.Get(TestItem.AddressA).Balance, Is.EqualTo((UInt256)101));
@@ -905,6 +906,7 @@ namespace Nethermind.Store.Test
 
             //reset the trie and set context to latest root hash (block 1 not persisted)
             tree = new StateTreeByPath(pathStore, logManager);
+            pathStore.OpenContext(3, root_1);
             tree.RootHash = root_1;
 
             //get items at current root hash - data at block 1 - all reads from cache

--- a/src/Nethermind/Nethermind.State/IStateReader.cs
+++ b/src/Nethermind/Nethermind.State/IStateReader.cs
@@ -12,7 +12,7 @@ namespace Nethermind.State
     {
         Account? GetAccount(Keccak stateRoot, Address address);
 
-        byte[]? GetStorage(Keccak stateRoot, Address address, in UInt256 index);
+        byte[]? GetStorage(Keccak stateRoot, Keccak storageRoot, Address address, in UInt256 index);
 
         byte[]? GetCode(Keccak codeHash);
 

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -296,6 +296,8 @@ namespace Nethermind.State
             // they get committed to avoid reading uncleared data
             _storages[address].ClearedBySelfDestruct = true;
             _storages[address].ParentStateRootHash = stateRootHash ?? StateRoot;
+
+            if (_logger.IsTrace) _logger.Trace($"Clearing storage for address {address} - created new storage tree with parent state root hash context {_storages[address].ParentStateRootHash}");
         }
 
         private class StorageTreeFactory : IStorageTreeFactory

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -290,14 +290,12 @@ namespace Nethermind.State
             // TODO: how does it work with pruning?
             Keccak stateRootHash = null;
             if (_storages.ContainsKey(address))
-                stateRootHash = _storages[address].GetStateRootHash();
+                stateRootHash = _storages[address].ParentStateRootHash;
             _storages[address] = new StorageTree(_trieStore, Keccak.EmptyTreeHash, _logManager, address);
             // mark the tree as cleared by SD - will be used by path state to avoid reads from flat storage until
             // they get committed to avoid reading uncleared data
             _storages[address].ClearedBySelfDestruct = true;
-            _storages[address].StateRootHash = stateRootHash;
-
-
+            _storages[address].ParentStateRootHash = stateRootHash ?? StateRoot;
         }
 
         private class StorageTreeFactory : IStorageTreeFactory
@@ -305,7 +303,7 @@ namespace Nethermind.State
             public StorageTree Create(Address address, ITrieStore trieStore, Keccak storageRoot, Keccak stateRoot, ILogManager? logManager)
             {
                 StorageTree st = new(trieStore, storageRoot, logManager, address);
-                st.StateRootHash = stateRoot;
+                st.ParentStateRootHash = stateRoot;
                 return st;
             }
         }

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -288,10 +288,14 @@ namespace Nethermind.State
             // by means of CREATE 2 - notice that the cached trie may carry information about items that were not
             // touched in this block, hence were not zeroed above
             // TODO: how does it work with pruning?
+            Keccak stateRootHash = null;
+            if (_storages.ContainsKey(address))
+                stateRootHash = _storages[address].GetStateRootHash();
             _storages[address] = new StorageTree(_trieStore, Keccak.EmptyTreeHash, _logManager, address);
             // mark the tree as cleared by SD - will be used by path state to avoid reads from flat storage until
             // they get committed to avoid reading uncleared data
             _storages[address].ClearedBySelfDestruct = true;
+            _storages[address].StateRootHash = stateRootHash;
 
 
         }

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -299,7 +299,11 @@ namespace Nethermind.State
         private class StorageTreeFactory : IStorageTreeFactory
         {
             public StorageTree Create(Address address, ITrieStore trieStore, Keccak storageRoot, Keccak stateRoot, ILogManager? logManager)
-                => new(trieStore, storageRoot, logManager, address);
+            {
+                StorageTree st = new(trieStore, storageRoot, logManager, address);
+                st.StateRootHash = stateRoot;
+                return st;
+            }
         }
     }
 }

--- a/src/Nethermind/Nethermind.State/StateProvider.cs
+++ b/src/Nethermind/Nethermind.State/StateProvider.cs
@@ -80,7 +80,8 @@ namespace Nethermind.State
 
                 return _tree.RootHash;
             }
-            set {
+            set
+            {
                 if (_trieStore.Capability == TrieNodeResolverCapability.Path)
                     _tree.ParentStateRootHash = value;
 

--- a/src/Nethermind/Nethermind.State/StateProvider.cs
+++ b/src/Nethermind/Nethermind.State/StateProvider.cs
@@ -41,8 +41,11 @@ namespace Nethermind.State
         private Change?[] _changes = new Change?[StartCapacity];
         private int _currentPosition = Resettable.EmptyPosition;
 
+        private readonly ITrieStore? _trieStore;
+
         public StateProvider(ITrieStore? trieStore, IKeyValueStore? codeDb, ILogManager? logManager, StateTree? stateTree = null)
         {
+            _trieStore = trieStore;
             _logger = logManager?.GetClassLogger<StateProvider>() ?? throw new ArgumentNullException(nameof(logManager));
             _codeDb = codeDb ?? throw new ArgumentNullException(nameof(codeDb));
             Debug.Assert(trieStore is not null);

--- a/src/Nethermind/Nethermind.State/StateProvider.cs
+++ b/src/Nethermind/Nethermind.State/StateProvider.cs
@@ -80,7 +80,12 @@ namespace Nethermind.State
 
                 return _tree.RootHash;
             }
-            set => _tree.RootHash = value;
+            set {
+                if (_trieStore.Capability == TrieNodeResolverCapability.Path)
+                    _tree.ParentStateRootHash = value;
+
+                _tree.RootHash = value;
+            }
         }
 
         internal readonly IStateTree _tree;

--- a/src/Nethermind/Nethermind.State/StateReader.cs
+++ b/src/Nethermind/Nethermind.State/StateReader.cs
@@ -33,7 +33,7 @@ namespace Nethermind.State
             return GetState(stateRoot, address);
         }
 
-        public byte[]? GetStorage(Keccak storageRoot, Address accountAddress, in UInt256 index)
+        public byte[]? GetStorage(Keccak stateRoot, Keccak storageRoot, Address accountAddress, in UInt256 index)
         {
             if (storageRoot == Keccak.EmptyTreeHash)
             {
@@ -43,6 +43,7 @@ namespace Nethermind.State
             Metrics.StorageTreeReads++;
 
             StorageTree tree = new(_trieStore, storageRoot, NullLogManager.Instance, accountAddress);
+            tree.ParentStateRootHash = stateRoot;
             return tree.Get(index, storageRoot);
         }
 

--- a/src/Nethermind/Nethermind.State/StorageTree.cs
+++ b/src/Nethermind/Nethermind.State/StorageTree.cs
@@ -29,15 +29,6 @@ namespace Nethermind.State
 
         internal const byte StorageDifferentiatingByte = 128;
 
-        private Keccak _stateRootHash;
-        public Keccak StateRootHash
-        {
-            set
-            {
-                _stateRootHash = value;
-            }
-        }
-
         static StorageTree()
         {
             Span<byte> buffer = stackalloc byte[32];
@@ -142,11 +133,6 @@ namespace Nethermind.State
                 Rlp rlpEncoded = rlpEncode ? Rlp.Encode(value) : new Rlp(value);
                 Set(rawKey, rlpEncoded);
             }
-        }
-
-        public override Keccak GetStateRootHash()
-        {
-            return _stateRootHash;
         }
     }
 }

--- a/src/Nethermind/Nethermind.State/StorageTree.cs
+++ b/src/Nethermind/Nethermind.State/StorageTree.cs
@@ -48,7 +48,7 @@ namespace Nethermind.State
             : this(trieStore, Keccak.EmptyTreeHash, logManager, accountPath)
         { }
 
-        public StorageTree(ITrieStore trieStore, Keccak rootHash, ILogManager? logManager,  Address? accountAddress = null)
+        public StorageTree(ITrieStore trieStore, Keccak rootHash, ILogManager? logManager, Address? accountAddress = null)
             : base(trieStore, Keccak.EmptyTreeHash, false, true, logManager)
         {
             TrieType = TrieType.Storage;

--- a/src/Nethermind/Nethermind.State/StorageTree.cs
+++ b/src/Nethermind/Nethermind.State/StorageTree.cs
@@ -144,7 +144,7 @@ namespace Nethermind.State
             }
         }
 
-        protected override Keccak GetStateRootHash()
+        public override Keccak GetStateRootHash()
         {
             return _stateRootHash;
         }

--- a/src/Nethermind/Nethermind.State/StorageTree.cs
+++ b/src/Nethermind/Nethermind.State/StorageTree.cs
@@ -29,6 +29,15 @@ namespace Nethermind.State
 
         internal const byte StorageDifferentiatingByte = 128;
 
+        private Keccak _stateRootHash;
+        public Keccak StateRootHash
+        {
+            set
+            {
+                _stateRootHash = value;
+            }
+        }
+
         static StorageTree()
         {
             Span<byte> buffer = stackalloc byte[32];
@@ -133,6 +142,11 @@ namespace Nethermind.State
                 Rlp rlpEncoded = rlpEncode ? Rlp.Encode(value) : new Rlp(value);
                 Set(rawKey, rlpEncoded);
             }
+        }
+
+        protected override Keccak GetStateRootHash()
+        {
+            return _stateRootHash;
         }
     }
 }

--- a/src/Nethermind/Nethermind.State/TrieNodeResolverCapabilityStateExtension.cs
+++ b/src/Nethermind/Nethermind.State/TrieNodeResolverCapabilityStateExtension.cs
@@ -31,7 +31,7 @@ public static class TrieNodeResolverCapabilityStateExtension
         };
     }
 
-    public static IStateTree CreateStateStore(this TrieNodeResolverCapability capability,  IColumnsDb<StateColumns>? db, ILogManager? logManager)
+    public static IStateTree CreateStateStore(this TrieNodeResolverCapability capability, IColumnsDb<StateColumns>? db, ILogManager? logManager)
     {
         return capability switch
         {

--- a/src/Nethermind/Nethermind.State/WorldState.cs
+++ b/src/Nethermind/Nethermind.State/WorldState.cs
@@ -27,12 +27,14 @@ namespace Nethermind.State
         internal readonly StateProvider _stateProvider;
         internal readonly PersistentStorageProvider _persistentStorageProvider;
         private readonly TransientStorageProvider _transientStorageProvider;
+        private readonly ITrieStore? _trieStore;
 
         public Keccak StateRoot
         {
             get => _stateProvider.StateRoot;
             set
             {
+                _trieStore.OpenContext(value);
                 _stateProvider.StateRoot = value;
                 _persistentStorageProvider.StateRoot = value;
             }
@@ -40,6 +42,7 @@ namespace Nethermind.State
 
         public WorldState(ITrieStore? trieStore, IKeyValueStore? codeDb, ILogManager? logManager)
         {
+            _trieStore = trieStore;
             _stateProvider = new StateProvider(trieStore, codeDb, logManager);
             _persistentStorageProvider = new PersistentStorageProvider(trieStore, _stateProvider, logManager);
             _transientStorageProvider = new TransientStorageProvider(logManager);
@@ -47,6 +50,7 @@ namespace Nethermind.State
 
         internal WorldState(ITrieStore? trieStore, IKeyValueStore? codeDb, ILogManager? logManager, StateTree stateTree, IStorageTreeFactory storageTreeFactory)
         {
+            _trieStore = trieStore;
             _stateProvider = new StateProvider(trieStore, codeDb, logManager, stateTree);
             _persistentStorageProvider = new PersistentStorageProvider(trieStore, _stateProvider, logManager, storageTreeFactory);
             _transientStorageProvider = new TransientStorageProvider(logManager);

--- a/src/Nethermind/Nethermind.State/WorldState.cs
+++ b/src/Nethermind/Nethermind.State/WorldState.cs
@@ -34,7 +34,6 @@ namespace Nethermind.State
             get => _stateProvider.StateRoot;
             set
             {
-                _trieStore.OpenContext(value);
                 _stateProvider.StateRoot = value;
                 _persistentStorageProvider.StateRoot = value;
             }

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
@@ -25,13 +25,13 @@ using NUnit.Framework;
 namespace Nethermind.Synchronization.Test.FastSync
 {
     [TestFixture(TrieNodeResolverCapability.Hash, 1, 0)]
-    [TestFixture(TrieNodeResolverCapability.Hash,1, 100)]
-    [TestFixture(TrieNodeResolverCapability.Hash,4, 0)]
-    [TestFixture(TrieNodeResolverCapability.Hash,4, 100)]
-    [TestFixture(TrieNodeResolverCapability.Path,1, 0)]
-    [TestFixture(TrieNodeResolverCapability.Path,1, 100)]
-    [TestFixture(TrieNodeResolverCapability.Path,4, 0)]
-    [TestFixture(TrieNodeResolverCapability.Path,4, 100)]
+    [TestFixture(TrieNodeResolverCapability.Hash, 1, 100)]
+    [TestFixture(TrieNodeResolverCapability.Hash, 4, 0)]
+    [TestFixture(TrieNodeResolverCapability.Hash, 4, 100)]
+    [TestFixture(TrieNodeResolverCapability.Path, 1, 0)]
+    [TestFixture(TrieNodeResolverCapability.Path, 1, 100)]
+    [TestFixture(TrieNodeResolverCapability.Path, 4, 0)]
+    [TestFixture(TrieNodeResolverCapability.Path, 4, 100)]
     [Parallelizable(ParallelScope.All)]
     public class StateSyncFeedTests : StateSyncFeedTestsBase
     {

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTestsBase.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTestsBase.cs
@@ -227,15 +227,15 @@ namespace Nethermind.Synchronization.Test.FastSync
             public void LogRemoteTrieStats(Keccak? rootHash)
             {
                 TrieStatsCollector collector = new(RemoteCodeDb, _logManager);
-                RemoteStateTree.Accept(collector, rootHash?? RemoteStateTree.RootHash, new VisitingOptions { MaxDegreeOfParallelism = Environment.ProcessorCount });
-                _logger.Info($"REMOTE STATE: Starting from {rootHash?? RemoteStateTree.RootHash} {Environment.NewLine}" + collector.Stats);
+                RemoteStateTree.Accept(collector, rootHash ?? RemoteStateTree.RootHash, new VisitingOptions { MaxDegreeOfParallelism = Environment.ProcessorCount });
+                _logger.Info($"REMOTE STATE: Starting from {rootHash ?? RemoteStateTree.RootHash} {Environment.NewLine}" + collector.Stats);
             }
 
             public void LogLocalTrieStats(Keccak? rootHash)
             {
                 TrieStatsCollector collector = new(LocalCodeDb, _logManager);
-                RemoteStateTree.Accept(collector, rootHash?? LocalStateTree.RootHash, new VisitingOptions { MaxDegreeOfParallelism = Environment.ProcessorCount });
-                _logger.Info($"LOCAL STATE: Starting from {rootHash?? LocalStateTree.RootHash} {Environment.NewLine}" + collector.Stats);
+                RemoteStateTree.Accept(collector, rootHash ?? LocalStateTree.RootHash, new VisitingOptions { MaxDegreeOfParallelism = Environment.ProcessorCount });
+                _logger.Info($"LOCAL STATE: Starting from {rootHash ?? LocalStateTree.RootHash} {Environment.NewLine}" + collector.Stats);
             }
 
             public void AssertFlushed()

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/RecreateStateFromStorageRangesTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/RecreateStateFromStorageRangesTests.cs
@@ -112,7 +112,7 @@ namespace Nethermind.Synchronization.Test.SnapSync
             Keccak rootHash = _inputStorageTree!.RootHash;   // "..."
 
             // output state
-            MemColumnsDb<StateColumns> db = new ();
+            MemColumnsDb<StateColumns> db = new();
             DbProvider dbProvider = new(DbModeHint.Mem);
             dbProvider.RegisterDb(DbNames.State, db);
             ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncProgressResolverTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncProgressResolverTests.cs
@@ -68,7 +68,7 @@ namespace Nethermind.Synchronization.Test
                 PivotNumber = "1",
             };
             ProgressTracker progressTracker = new(blockTree, stateDb, LimboLogs.Instance);
-            TrieStoreByPath trieStore = new(stateDb, LimboLogs.Instance);
+            TrieStore trieStore = new(stateDb, LimboLogs.Instance);
 
             SyncProgressResolver syncProgressResolver = new(blockTree, receiptStorage, stateDb, trieStore, progressTracker, syncConfig, LimboLogs.Instance);
             Block head = Build.A.Block.WithHeader(Build.A.BlockHeader.WithNumber(5).WithStateRoot(TestItem.KeccakA).TestObject).TestObject;
@@ -89,7 +89,7 @@ namespace Nethermind.Synchronization.Test
                 PivotNumber = "1",
             };
             ProgressTracker progressTracker = new(blockTree, stateDb, LimboLogs.Instance);
-            TrieStoreByPath trieStore = new(stateDb, LimboLogs.Instance);
+            TrieStore trieStore = new(stateDb, LimboLogs.Instance);
 
             SyncProgressResolver syncProgressResolver = new(blockTree, receiptStorage, stateDb, trieStore, progressTracker, syncConfig, LimboLogs.Instance);
             Block head = Build.A.Block.WithHeader(Build.A.BlockHeader.WithNumber(5).WithStateRoot(TestItem.KeccakA).TestObject).TestObject;
@@ -114,7 +114,7 @@ namespace Nethermind.Synchronization.Test
                 PivotNumber = "1",
             };
             ProgressTracker progressTracker = new(blockTree, stateDb, LimboLogs.Instance);
-            TrieStoreByPath trieStore = new(stateDb, LimboLogs.Instance);
+            TrieStore trieStore = new(stateDb, LimboLogs.Instance);
 
             SyncProgressResolver syncProgressResolver = new(blockTree, receiptStorage, stateDb, trieStore, progressTracker, syncConfig, LimboLogs.Instance);
             Block head = Build.A.Block.WithHeader(Build.A.BlockHeader.WithNumber(5).WithStateRoot(TestItem.KeccakA).TestObject).TestObject;

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/StateSyncItemComparer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/StateSyncItemComparer.cs
@@ -9,7 +9,7 @@ using Nethermind.Core.Extensions;
 
 namespace Nethermind.Synchronization.FastSync;
 
-public class StateSyncItemComparer: IEqualityComparer<StateSyncItem>
+public class StateSyncItemComparer : IEqualityComparer<StateSyncItem>
 {
     private StateSyncItemComparer()
     {

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
@@ -704,7 +704,25 @@ namespace Nethermind.Synchronization.FastSync
                                     _stateDb.Set(syncItem.Hash, data);
                                     break;
                                 case TrieNodeResolverCapability.Path:
-                                    _stateStore.SaveNodeDirectly(0, node, withDelete: rootChanged);
+                                    if (node.IsBranch)
+                                    {
+                                        for (int childIndex = 0; childIndex < 16; childIndex++)
+                                        {
+                                            if (!node.IsChildNull(childIndex))
+                                            {
+                                                Keccak? childHash = node.GetChildHash(childIndex);
+                                                if (childHash is null)
+                                                {
+                                                    _logger.Warn($"TreeSync - processing branch with child as RLP {syncItem.PathNibbles.ToHexString()} - child {childIndex} - Prefix: {node.StoreNibblePathPrefix.ToHexString()}");
+                                                    TrieNode childNode = node.GetChild(_stateStore, childIndex);
+                                                    childNode.ResolveNode(_stateStore);
+                                                    _stateStore.PersistNode(childNode, withDelete: rootChanged);
+                                                }
+                                            }
+                                        }
+                                    }
+
+                                    _stateStore.PersistNode(node, withDelete: rootChanged);
                                     if (node.IsLeaf && _additionalLeafNibbles.TryRemove(syncItem.Hash, out List<byte> additionalNibbles))
                                     {
                                         // TODO: what is this for?
@@ -712,7 +730,7 @@ namespace Nethermind.Synchronization.FastSync
                                         {
                                             TrieNode clone = node.Clone();
                                             clone.PathToNode[^1] = nibble;
-                                            _stateStore.SaveNodeDirectly(0, clone, withDelete: rootChanged);
+                                            _stateStore.PersistNode(clone, withDelete: rootChanged);
                                         }
                                     }
                                     if (node.IsLeaf && Bytes.Comparer.Compare(node.FullPath, farRightPath) > 0)
@@ -768,14 +786,32 @@ namespace Nethermind.Synchronization.FastSync
                                     _stateDb.Set(syncItem.Hash, data);
                                     break;
                                 case TrieNodeResolverCapability.Path:
-                                    _stateStore.SaveNodeDirectly(0, node, withDelete: rootChanged);
+                                    if (node.IsBranch)
+                                    {
+                                        for (int childIndex = 0; childIndex < 16; childIndex++)
+                                        {
+                                            if (!node.IsChildNull(childIndex))
+                                            {
+                                                Keccak? childHash = node.GetChildHash(childIndex);
+                                                if (childHash is null)
+                                                {
+                                                    _logger.Warn($"TreeSync - processing branch with child as RLP {syncItem.PathNibbles.ToHexString()} - child {childIndex} - Prefix: {node.StoreNibblePathPrefix.ToHexString()}");
+                                                    TrieNode childNode = node.GetChild(_stateStore, childIndex);
+                                                    childNode.ResolveNode(_stateStore);
+                                                    _stateStore.PersistNode(childNode, withDelete: rootChanged);
+                                                }
+                                            }
+                                        }
+                                    }
+
+                                    _stateStore.PersistNode(node, withDelete: rootChanged);
                                     if (node.IsLeaf && _additionalLeafNibbles.TryRemove(syncItem.Hash, out List<byte> additionalNibbles))
                                     {
                                         foreach (byte nibble in additionalNibbles)
                                         {
                                             TrieNode clone = node.Clone();
                                             clone.PathToNode[^1] = nibble;
-                                            _stateStore.SaveNodeDirectly(0, clone, withDelete: rootChanged);
+                                            _stateStore.PersistNode(clone, withDelete: rootChanged);
                                         }
                                     }
                                     break;

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
@@ -764,7 +764,7 @@ namespace Nethermind.Synchronization.FastSync
                         {
                             Interlocked.Add(ref _data.DataSize, data.Length);
                             Interlocked.Increment(ref Metrics.SyncedStorageTrieNodes);
-                            switch (_stateStore.Capability )
+                            switch (_stateStore.Capability)
                             {
                                 case TrieNodeResolverCapability.Hash:
                                     _stateDb.Set(syncItem.Hash, data);
@@ -1146,7 +1146,7 @@ namespace Nethermind.Synchronization.FastSync
         {
             if (!node.IsBranch)
                 return;
-            
+
             for (int childIndex = 0; childIndex < 16; childIndex++)
             {
                 if (!node.IsChildNull(childIndex))

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProvider.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProvider.cs
@@ -373,7 +373,7 @@ namespace Nethermind.Synchronization.SnapSync
             public ITrieStore Create()
             {
                 //no in memory caching
-                return new TrieStoreByPath(_stateDb, _logManager); 
+                return new TrieStoreByPath(_stateDb, _logManager);
             }
 
             public bool Return(ITrieStore obj)

--- a/src/Nethermind/Nethermind.Synchronization/Trie/HealingStorageTree.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Trie/HealingStorageTree.cs
@@ -24,6 +24,7 @@ public class HealingStorageTree : StorageTree
         _address = address;
         _stateRoot = stateRoot;
         _recovery = recovery;
+        ParentStateRootHash = stateRoot;
     }
 
     public override byte[]? Get(ReadOnlySpan<byte> rawKey, Keccak? rootHash = null)

--- a/src/Nethermind/Nethermind.Trie.Test/HexPrefixTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/HexPrefixTests.cs
@@ -149,7 +149,7 @@ namespace Nethermind.Trie.Test
 
             foreach (byte[]? key in keys)
             {
-                Span<byte> nibbles =  new byte[2 * key.Length];
+                Span<byte> nibbles = new byte[2 * key.Length];
 
                 Nibbles.BytesToNibbleBytes(key, nibbles);
                 Nibbles.ToBytes(nibbles).Should().BeEquivalentTo(key);
@@ -160,7 +160,7 @@ namespace Nethermind.Trie.Test
         public void StoragePrefixTests()
         {
             byte[] storagePrefixBytes = KeccakHash.ComputeHash(TestItem.AddressA.Bytes).ToArray();
-            Span<byte> storagePrefixNibbles= stackalloc byte[2 * storagePrefixBytes.Length];
+            Span<byte> storagePrefixNibbles = stackalloc byte[2 * storagePrefixBytes.Length];
             Nibbles.BytesToNibbleBytes(storagePrefixBytes, storagePrefixNibbles);
             Nibbles.ToBytes(storagePrefixNibbles).Should().BeEquivalentTo(storagePrefixBytes);
 

--- a/src/Nethermind/Nethermind.Trie.Test/Nethermind.Trie.Test.csproj
+++ b/src/Nethermind/Nethermind.Trie.Test/Nethermind.Trie.Test.csproj
@@ -24,6 +24,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Nethermind.Core.Test\Nethermind.Core.Test.csproj" />
+    <ProjectReference Include="..\Nethermind.Db.Rocks\Nethermind.Db.Rocks.csproj" />
     <ProjectReference Include="..\Nethermind.Trie\Nethermind.Trie.csproj" />
   </ItemGroup>
 

--- a/src/Nethermind/Nethermind.Trie.Test/PathBasedStorageTreeTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/PathBasedStorageTreeTests.cs
@@ -5,5 +5,5 @@ namespace Nethermind.Trie.Test;
 
 public class PathBasedStorageTreeTests
 {
-    
+
 }

--- a/src/Nethermind/Nethermind.Trie.Test/PathDataCacheTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/PathDataCacheTests.cs
@@ -1,0 +1,302 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Test;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Db;
+using Nethermind.Logging;
+using Nethermind.Trie.ByPath;
+using Nethermind.Trie.Pruning;
+using NUnit.Framework;
+
+namespace Nethermind.Trie.Test;
+
+
+public class PathDataCacheTests
+{
+    private static readonly ILogManager Logger = NUnitLogManager.Instance;
+
+    [Test()]
+    public void Get_node_latest_version()
+    {
+        PathDataCache cache = new PathDataCache(new TrieStoreByPath(new MemColumnsDb<StateColumns>(), Logger), Logger);
+
+        byte[] path1 = Nibbles.BytesToNibbleBytes(Bytes.FromHexString("0x0000000000000000000000000000000000000000000000000000000000001234"));
+        TrieNode node = CreateResolvedLeaf(path1, 160.ToByteArray(), 60);
+        cache.AddNodeData(1, node);
+        cache.AddNodeData(1, new TrieNode(NodeType.Branch, path: Nibbles.BytesToNibbleBytes(Bytes.FromHexString("0x000000000000000000000000000000000000000000000000000000000000123")), Array.Empty<byte>()));
+
+        cache.CloseContext(10, TestItem.KeccakF);
+
+        NodeData? retrieved = cache.GetNodeDataAtRoot(TestItem.KeccakF, path1);
+
+        Assert.That(retrieved, Is.Not.Null);
+        Assert.That(retrieved.RLP, Is.EqualTo(node.FullRlp.ToArray()).Using(Bytes.EqualityComparer));
+    }
+
+    [Test()]
+    public void Get_node_using_path_and_keccak()
+    {
+        PathDataCache cache = new PathDataCache(new TrieStoreByPath(new MemColumnsDb<StateColumns>(), Logger), Logger);
+
+        byte[] path1 = Nibbles.BytesToNibbleBytes(Bytes.FromHexString("0x0000000000000000000000000000000000000000000000000000000000001234"));
+        TrieNode node = CreateResolvedLeaf(path1, 160.ToByteArray(), 60);
+        node.ResolveKey(NullTrieNodeResolver.Instance, false);
+
+        Keccak expectedKeccak = node.Keccak;
+
+        cache.AddNodeData(1, node);
+        cache.AddNodeData(1, new TrieNode(NodeType.Branch, path: Nibbles.BytesToNibbleBytes(Bytes.FromHexString("0x000000000000000000000000000000000000000000000000000000000000123")), Array.Empty<byte>()));
+
+        NodeData? retrieved = cache.GetNodeData(path1, expectedKeccak);
+
+        Assert.That(retrieved, Is.Not.Null);
+        Assert.That(retrieved.RLP, Is.EqualTo(node.FullRlp.ToArray()).Using(Bytes.EqualityComparer));
+
+        cache.AddNodeData(1, new(NodeType.Leaf, path1, TestItem.KeccakB));
+
+        retrieved = cache.GetNodeData(path1, TestItem.KeccakA);
+        Assert.That(retrieved, Is.Null);
+    }
+
+    [Test()]
+    public void Get_node_using_root_hash()
+    {
+        PathDataCache cache = new PathDataCache(new TrieStoreByPath(new MemColumnsDb<StateColumns>(), Logger), Logger);
+
+        byte[] path1 = Nibbles.BytesToNibbleBytes(Bytes.FromHexString("0x0000000000000000000000000000000000000000000000000000000000001234"));
+
+        cache.OpenContext(1, null);
+        cache.AddNodeData(1, CreateResolvedLeaf(path1, 160.ToByteArray(), 60));
+        cache.CloseContext(1, TestItem.KeccakH);
+
+        cache.OpenContext(2, TestItem.KeccakH);
+        cache.AddNodeData(2, CreateResolvedLeaf(path1, 320.ToByteArray(), 60));
+        cache.CloseContext(2, TestItem.KeccakG);
+
+        cache.OpenContext(3, TestItem.KeccakG);
+        cache.AddNodeData(3, CreateResolvedLeaf(path1, 640.ToByteArray(), 60));
+        cache.CloseContext(3, TestItem.KeccakF);
+
+        var retrieved = cache.GetNodeDataAtRoot(TestItem.KeccakH, path1);
+
+        var retrievedTrieNode = retrieved.ToTrieNode(path1);
+
+        Assert.That(retrieved, Is.Not.Null);
+        Assert.That(retrievedTrieNode.Value.ToArray(), Is.EqualTo(160.ToByteArray()).Using(Bytes.EqualityComparer));
+    }
+
+    [Test()]
+    public void Add_deleted_prefix_get_node()
+    {
+        PathDataCache cache = new(new TrieStoreByPath(new MemColumnsDb<StateColumns>(), Logger), Logger, 4);
+
+        byte[] path1 = Nibbles.BytesToNibbleBytes(Bytes.FromHexString("0x1acf000000000000000000000000000000000000000000000000000000091234"));
+        byte[] path2 = Nibbles.BytesToNibbleBytes(Bytes.FromHexString("0x1acf100000000000000000000000000000000000000000000000000000091234"));
+        byte[] path3 = Nibbles.BytesToNibbleBytes(Bytes.FromHexString("0x2acf000000000000000000000000000000000000000000000000000000091234"));
+        byte[] prefix = new byte[] { 1, 10, 12, 15 };
+
+        cache.OpenContext(1, null);
+        cache.AddNodeData(1, CreateResolvedLeaf(path1, 64000.ToByteArray(), 60));
+        cache.CloseContext(1, TestItem.KeccakH);
+
+        cache.OpenContext(2, TestItem.KeccakH);
+        cache.AddNodeData(2, CreateResolvedLeaf(path2, 64000.ToByteArray(), 60));
+        cache.CloseContext(2, TestItem.KeccakG);
+
+        cache.OpenContext(3, TestItem.KeccakG);
+        cache.AddNodeData(3, CreateResolvedLeaf(path3, 64000.ToByteArray(), 60));
+        cache.CloseContext(3, TestItem.KeccakF);
+
+        cache.OpenContext(4, TestItem.KeccakF);
+        cache.AddRemovedPrefix(4, prefix);
+        cache.CloseContext(4, TestItem.KeccakE);
+
+        Assert.That(cache.GetNodeDataAtRoot(null, path1).RLP, Is.Null);
+        Assert.That(cache.GetNodeDataAtRoot(null, path2).RLP, Is.Null);
+        Assert.That(cache.GetNodeDataAtRoot(null, path3).ToTrieNode(path3).Value.ToArray(), Is.EqualTo(64000.ToByteArray()).Using(Bytes.EqualityComparer));
+    }
+
+    [Test()]
+    public void Add_deleted_prefix_persist_get_node()
+    {
+        ITrieStore trieStore = new TrieStoreByPath(new MemColumnsDb<StateColumns>(), Logger);
+        PathDataCache cache = new(trieStore, Logger, 4);
+
+        byte[] path1 = Nibbles.BytesToNibbleBytes(Bytes.FromHexString("0x1acf000000000000000000000000000000000000000000000000000000091234"));
+        byte[] path2 = Nibbles.BytesToNibbleBytes(Bytes.FromHexString("0x1acf100000000000000000000000000000000000000000000000000000091234"));
+        byte[] path3 = Nibbles.BytesToNibbleBytes(Bytes.FromHexString("0x2acf000000000000000000000000000000000000000000000000000000091234"));
+        byte[] prefix = new byte[] { 1, 10, 12, 15 };
+
+        cache.OpenContext(1, null);
+        cache.AddNodeData(1, CreateResolvedLeaf(path1, 64000.ToByteArray(), 60));
+        cache.CloseContext(1, TestItem.KeccakH);
+
+        cache.OpenContext(2, TestItem.KeccakH);
+        cache.AddNodeData(2, CreateResolvedLeaf(path2, 64000.ToByteArray(), 60));
+        cache.CloseContext(2, TestItem.KeccakG);
+
+        cache.OpenContext(3, TestItem.KeccakG);
+        cache.AddNodeData(3, CreateResolvedLeaf(path3, 64000.ToByteArray(), 60));
+        cache.CloseContext(3, TestItem.KeccakF);
+
+        //persist path1 to DB - to later check it was successfully deleted
+        cache.PersistUntilBlock(1, TestItem.KeccakH);
+
+        cache.OpenContext(4, TestItem.KeccakF);
+        cache.AddRemovedPrefix(4, prefix);
+        cache.CloseContext(4, TestItem.KeccakE);
+
+        cache.PersistUntilBlock(4, TestItem.KeccakE);
+
+        Assert.That(() => trieStore.LoadRlp(path1), Throws.TypeOf<TrieException>());
+        Assert.That(() => trieStore.LoadRlp(path2), Throws.TypeOf<TrieException>());
+    }
+
+    [Test()]
+    public void Add_deleted_prefix_persist_get_node_2()
+    {
+        PathDataCache cache = new(new TrieStoreByPath(new MemColumnsDb<StateColumns>(), Logger), Logger, 4);
+
+        byte[] path1 = Nibbles.BytesToNibbleBytes(Bytes.FromHexString("0x1acf000000000000000000000000000000000000000000000000000000091234"));
+        byte[] path2 = Nibbles.BytesToNibbleBytes(Bytes.FromHexString("0x1acf100000000000000000000000000000000000000000000000000000091234"));
+        byte[] path3 = Nibbles.BytesToNibbleBytes(Bytes.FromHexString("0x2acf000000000000000000000000000000000000000000000000000000091234"));
+        byte[] prefix = new byte[] { 1, 10, 12, 15 };
+
+        cache.OpenContext(1, null);
+        cache.AddNodeData(1, CreateResolvedLeaf(path1, 64000.ToByteArray(), 60));
+        cache.CloseContext(1, TestItem.KeccakH);
+
+        cache.OpenContext(2, TestItem.KeccakH);
+        cache.AddNodeData(2, CreateResolvedLeaf(path2, 64000.ToByteArray(), 60));
+        cache.CloseContext(2, TestItem.KeccakG);
+
+        cache.OpenContext(3, TestItem.KeccakG);
+        cache.AddNodeData(3, CreateResolvedLeaf(path3, 64000.ToByteArray(), 60));
+        cache.CloseContext(3, TestItem.KeccakF);
+
+        //persist all nodes until this moment
+        cache.PersistUntilBlock(3, TestItem.KeccakF);
+
+        //no paths stored in cache when adding deleted prefix
+        cache.OpenContext(4, TestItem.KeccakF);
+        cache.AddRemovedPrefix(4, prefix);
+        cache.CloseContext(4, TestItem.KeccakE);
+
+        NodeData n1 = cache.GetNodeDataAtRoot(null, path1);
+        NodeData n2 = cache.GetNodeDataAtRoot(null, path2);
+
+        //should get nodes with null RLP as a marker for deleted data
+        //null returned from cache means a miss in data and load from DB
+        Assert.That(n1, Is.Not.Null);
+        Assert.That(n1.RLP, Is.Null);
+
+        Assert.That(n2, Is.Not.Null);
+        Assert.That(n2.RLP, Is.Null);
+
+        //add a node again under a prefix that has been marked as deleted
+        cache.OpenContext(5, TestItem.KeccakE);
+        cache.AddNodeData(5, CreateResolvedLeaf(path1, 64000.ToByteArray(), 60));
+        cache.CloseContext(5, TestItem.KeccakD);
+
+        Assert.That(cache.GetNodeDataAtRoot(null, path1).RLP, Is.Not.Null);
+    }
+
+    [Test()]
+    public void Test_persist_until_block_1()
+    {
+        ITrieStore trieStore = new TrieStoreByPath(new MemColumnsDb<StateColumns>(), Logger);
+        PathDataCache cache = new(trieStore, Logger);
+
+        byte[] path1 = Nibbles.BytesToNibbleBytes(Bytes.FromHexString("0x1ac0000000000000000000000000000000000000000000000000000000091234"));
+        byte[] path2 = Nibbles.BytesToNibbleBytes(Bytes.FromHexString("0x1ac1000000000000000000000000000000000000000000000000000000091234"));
+        byte[] path3 = Nibbles.BytesToNibbleBytes(Bytes.FromHexString("0x2ac0000000000000000000000000000000000000000000000000000000091234"));
+
+        cache.OpenContext(1, null);
+        cache.AddNodeData(1, CreateResolvedLeaf(path1, 64000.ToByteArray(), 60));
+        cache.CloseContext(1, TestItem.KeccakH);
+
+        cache.OpenContext(2, TestItem.KeccakH);
+        cache.AddNodeData(2, CreateResolvedLeaf(path2, 64000.ToByteArray(), 60));
+        cache.CloseContext(2, TestItem.KeccakG);
+
+        cache.OpenContext(3, TestItem.KeccakG);
+        cache.AddNodeData(3, CreateResolvedLeaf(path3, 64000.ToByteArray(), 60));
+        cache.CloseContext(3, TestItem.KeccakF);
+
+        cache.PersistUntilBlock(2, TestItem.KeccakG);
+
+        Assert.That(trieStore.LoadRlp(path1), Is.Not.Null);
+        Assert.That(trieStore.LoadRlp(path2), Is.Not.Null);
+        Assert.That(() => trieStore.LoadRlp(path3), Throws.TypeOf<TrieException>());
+    }
+
+    [Test()]
+    public void Test_persist_until_block_2()
+    {
+        ITrieStore trieStore = new TrieStoreByPath(new MemColumnsDb<StateColumns>(), Logger);
+        PathDataCache cache = new(trieStore, Logger);
+
+        byte[] path1 = Nibbles.BytesToNibbleBytes(Bytes.FromHexString("0x1ac0000000000000000000000000000000000000000000000000000000091234"));
+
+        cache.OpenContext(1, null);
+        cache.AddNodeData(1, CreateResolvedLeaf(path1, 64000.ToByteArray(), 60));
+        cache.CloseContext(1, TestItem.KeccakH);
+
+        cache.OpenContext(2, TestItem.KeccakH);
+        cache.AddNodeData(2, CreateResolvedLeaf(path1, 128000.ToByteArray(), 60));
+        cache.CloseContext(2, TestItem.KeccakG);
+
+        cache.OpenContext(3, TestItem.KeccakG);
+        cache.AddNodeData(3, CreateResolvedLeaf(path1, 256000.ToByteArray(), 60));
+        cache.CloseContext(3, TestItem.KeccakF);
+
+        cache.PersistUntilBlock(2, TestItem.KeccakG);
+
+        byte[]? rlp = trieStore.LoadRlp(path1);
+        Assert.That(rlp, Is.Not.Null);
+
+        TrieNode n = new(NodeType.Unknown, rlp);
+        n.ResolveNode(trieStore);
+
+        Assert.That(n.Value.ToArray(), Is.EqualTo(128000.ToByteArray()).Using<byte[]>(Bytes.Comparer));
+    }
+
+    [Test()]
+    public void Test_persist_until_block_3()
+    {
+        PathDataCache cache = new(new TrieStoreByPath(new MemColumnsDb<StateColumns>(), Logger), Logger, 4);
+
+        byte[] path1 = Nibbles.BytesToNibbleBytes(Bytes.FromHexString("0x1ac0000000000000000000000000000000000000000000000000000000091234"));
+
+        cache.OpenContext(1, null);
+        cache.AddNodeData(1, CreateResolvedLeaf(path1, 64000.ToByteArray(), 60));
+        cache.CloseContext(1, TestItem.KeccakA);
+
+        cache.OpenContext(2, TestItem.KeccakA);
+        cache.AddNodeData(2, CreateResolvedLeaf(path1, 128000.ToByteArray(), 60));
+        cache.CloseContext(2, TestItem.KeccakB);
+
+        cache.OpenContext(3, TestItem.KeccakB);
+        cache.AddNodeData(3, CreateResolvedLeaf(path1, 256000.ToByteArray(), 60));
+        cache.CloseContext(3, TestItem.KeccakC);
+
+        cache.PersistUntilBlock(2, TestItem.KeccakB);
+
+        //check node is not present in cache for blocks 1 & 2
+        Assert.That(cache.GetNodeDataAtRoot(TestItem.KeccakA, path1), Is.Null);
+        Assert.That(cache.GetNodeDataAtRoot(TestItem.KeccakB, path1), Is.Null);
+        //node for block 3 should still be in cache
+        Assert.That(cache.GetNodeDataAtRoot(TestItem.KeccakC, path1), Is.Not.Null);
+    }
+
+    private TrieNode CreateResolvedLeaf(byte[] path, byte[] value, int keyLength)
+    {
+        TrieNode trieNode = TrieNodeFactory.CreateLeaf(path.Slice(keyLength), value, path.Slice(0, keyLength), Array.Empty<byte>());
+        trieNode.ResolveKey(NullTrieNodeResolver.Instance, false);
+        return trieNode;
+    }
+}

--- a/src/Nethermind/Nethermind.Trie.Test/TrieByPathFuzzTesting.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieByPathFuzzTesting.cs
@@ -188,7 +188,7 @@ public class TrieByPathFuzzTesting
                         for (int j = 1; j < noOfStorage + 1; j++)
                         {
                             int index = _random.Next(1, 5000);
-                            byte[] storage = new byte[_random.Next(1,32)];
+                            byte[] storage = new byte[_random.Next(1, 32)];
                             _random.NextBytes(storage);
 
                             streamWriter.WriteLine($"{index} {storage.ToHexString()}");

--- a/src/Nethermind/Nethermind.Trie.Test/TrieByPathFuzzTesting.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieByPathFuzzTesting.cs
@@ -10,6 +10,8 @@ using Nethermind.Core.Extensions;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
+using Nethermind.Db.Rocks;
+using Nethermind.Db.Rocks.Config;
 using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
@@ -31,7 +33,7 @@ public class TrieByPathFuzzTesting
     public void SetUp()
     {
         _logManager = LimboLogs.Instance;
-        //_logManager = new NUnitLogManager(LogLevel.Info);
+        //_logManager = new NUnitLogManager(LogLevel.Trace);
         _logger = _logManager.GetClassLogger();
     }
 
@@ -40,141 +42,11 @@ public class TrieByPathFuzzTesting
     {
     }
 
+    [TestCase(4, 16, 4, null)]
+    [TestCase(8, 32, 8, null)]
     [TestCase(96, 192, 96, null)]
-    [TestCase(96, 192, 96, null)]
-    [TestCase(96, 192, 96, null)]
-    [TestCase(96, 192, 96, null)]
-    [TestCase(96, 192, 96, null)]
-    [TestCase(96, 192, 96, null)]
-    [TestCase(96, 192, 96, null)]
-    [TestCase(96, 192, 96, null)]
-    [TestCase(96, 192, 96, null)]
-    [TestCase(96, 192, 96, null)]
-    [TestCase(96, 192, 96, null)]
-    [TestCase(96, 192, 96, null)]
-    [TestCase(96, 192, 96, null)]
-    [TestCase(96, 192, 96, null)]
-    [TestCase(96, 192, 96, null)]
-    [TestCase(96, 192, 96, null)]
-    [TestCase(96, 192, 96, null)]
-    [TestCase(96, 192, 96, null)]
-    [TestCase(96, 192, 96, null)]
-    [TestCase(96, 192, 96, null)]
-    [TestCase(96, 192, 96, null)]
-    [TestCase(96, 192, 96, null)]
-    [TestCase(96, 192, 96, null)]
-    [TestCase(96, 192, 96, null)]
-    [TestCase(96, 192, 96, null)]
-    [TestCase(96, 192, 96, null)]
-    [TestCase(96, 192, 96, null)]
-    [TestCase(96, 192, 96, null)]
-    [TestCase(96, 192, 96, null)]
-    [TestCase(96, 192, 96, null)]
-    [TestCase(96, 192, 96, null)]
-    [TestCase(96, 192, 96, null)]
-    [TestCase(96, 192, 96, null)]
-    [TestCase(96, 192, 96, null)]
-    [TestCase(96, 192, 96, null)]
-    [TestCase(96, 192, 96, null)]
-    [TestCase(96, 192, 96, null)]
-    [TestCase(96, 192, 96, null)]
-    [TestCase(96, 192, 96, null)]
+    [TestCase(128, 263, 24, null)]
     [TestCase(128, 256, 128, null)]
-    [TestCase(128, 256, 128, null)]
-    [TestCase(128, 256, 128, null)]
-    [TestCase(128, 256, 128, null)]
-    [TestCase(128, 256, 128, null)]
-    [TestCase(128, 256, 128, null)]
-    [TestCase(128, 256, 128, null)]
-    [TestCase(128, 256, 128, null)]
-    [TestCase(128, 256, 128, null)]
-    [TestCase(128, 256, 128, null)]
-    [TestCase(128, 256, 128, null)]
-    [TestCase(128, 256, 128, null)]
-    [TestCase(128, 256, 128, null)]
-    [TestCase(128, 256, 128, null)]
-    [TestCase(128, 256, 128, null)]
-    [TestCase(128, 256, 128, null)]
-    [TestCase(128, 256, 128, null)]
-    [TestCase(128, 256, 128, null)]
-    [TestCase(128, 256, 128, null)]
-    [TestCase(128, 256, 128, null)]
-    [TestCase(128, 256, 128, null)]
-    [TestCase(128, 256, 128, null)]
-    [TestCase(128, 256, 128, null)]
-    [TestCase(128, 256, 128, null)]
-    [TestCase(128, 256, 128, null)]
-    [TestCase(128, 256, 128, null)]
-    [TestCase(128, 256, 128, null)]
-    [TestCase(4, 16, 4, null)]
-    [TestCase(4, 16, 4, null)]
-    [TestCase(4, 16, 4, null)]
-    [TestCase(4, 16, 4, null)]
-    [TestCase(4, 16, 4, null)]
-    [TestCase(4, 16, 4, null)]
-    [TestCase(4, 16, 4, null)]
-    [TestCase(4, 16, 4, null)]
-    [TestCase(4, 16, 4, null)]
-    [TestCase(4, 16, 4, null)]
-    [TestCase(4, 16, 4, null)]
-    [TestCase(4, 16, 4, null)]
-    [TestCase(4, 16, 4, null)]
-    [TestCase(4, 16, 4, null)]
-    [TestCase(4, 16, 4, null)]
-    [TestCase(4, 16, 4, null)]
-    [TestCase(4, 16, 4, null)]
-    [TestCase(4, 16, 4, null)]
-    [TestCase(4, 16, 4, null)]
-    [TestCase(4, 16, 4, null)]
-    [TestCase(4, 16, 4, null)]
-    [TestCase(4, 16, 4, null)]
-    [TestCase(4, 16, 4, null)]
-    [TestCase(4, 16, 4, null)]
-    [TestCase(4, 16, 4, null)]
-    [TestCase(4, 16, 4, null)]
-    [TestCase(4, 16, 4, null)]
-    [TestCase(4, 16, 4, null)]
-    [TestCase(4, 16, 4, null)]
-    [TestCase(4, 16, 4, null)]
-    [TestCase(4, 16, 4, null)]
-    [TestCase(8, 32, 8, null)]
-    [TestCase(8, 32, 8, null)]
-    [TestCase(8, 32, 8, null)]
-    [TestCase(8, 32, 8, null)]
-    [TestCase(8, 32, 8, null)]
-    [TestCase(8, 32, 8, null)]
-    [TestCase(8, 32, 8, null)]
-    [TestCase(8, 32, 8, null)]
-    [TestCase(8, 32, 8, null)]
-    [TestCase(8, 32, 8, null)]
-    [TestCase(8, 32, 8, null)]
-    [TestCase(8, 32, 8, null)]
-    [TestCase(8, 32, 8, null)]
-    [TestCase(8, 32, 8, null)]
-    [TestCase(8, 32, 8, null)]
-    [TestCase(8, 32, 8, null)]
-    [TestCase(8, 32, 8, null)]
-    [TestCase(8, 32, 8, null)]
-    [TestCase(8, 32, 8, null)]
-    [TestCase(8, 32, 8, null)]
-    [TestCase(8, 32, 8, null)]
-    [TestCase(8, 32, 8, null)]
-    [TestCase(8, 32, 8, null)]
-    [TestCase(8, 32, 8, null)]
-    [TestCase(8, 32, 8, null)]
-    [TestCase(8, 32, 8, null)]
-    [TestCase(8, 32, 8, null)]
-    [TestCase(8, 32, 8, null)]
-    [TestCase(8, 32, 8, null)]
-    [TestCase(8, 32, 8, null)]
-    [TestCase(8, 32, 8, null)]
-    [TestCase(8, 32, 8, null)]
-    [TestCase(8, 32, 8, null)]
-    [TestCase(8, 32, 8, null)]
-    [TestCase(8, 32, 8, null)]
-    [TestCase(8, 32, 8, null)]
-    [TestCase(8, 32, 8, null)]
-    [TestCase(8, 32, 8, null)]
     public void Fuzz_accounts_with_storage(
         int accountsCount,
         int blocksCount,
@@ -217,6 +89,9 @@ public class TrieByPathFuzzTesting
 
         Queue<Keccak> rootQueue = new();
 
+        //var dirInfo = Directory.CreateTempSubdirectory();
+        //ColumnsDb<StateColumns> memDb = new ColumnsDb<StateColumns>(dirInfo.FullName, new RocksDbSettings("pathState", Path.Combine(dirInfo.FullName, "pathState")), new DbConfig(), _logManager, new StateColumns[] { StateColumns.State, StateColumns.Storage });
+
         MemColumnsDb<StateColumns> memDb = new();
 
         var codeDb = new MemDb();
@@ -228,7 +103,6 @@ public class TrieByPathFuzzTesting
 
         Account[] accounts = new Account[accountsCount];
         Address[] addresses = new Address[accountsCount];
-        Dictionary<Address, List<int>> indexesPerAccount = new();
 
         for (int i = 0; i < accounts.Length; i++)
         {
@@ -266,9 +140,13 @@ public class TrieByPathFuzzTesting
                     streamWriter.WriteLine($"{address} {decoder.Encode(account)}");
 
                     bool insertStorage = false;
+                    bool selfDestruct = false;
+
                     if (stateProvider.AccountExists(address))
                     {
-                        insertStorage = true;
+                        selfDestruct = _random.Next(1, 10) < 3;
+                        insertStorage = !selfDestruct;
+
                         Account existing = stateProvider.GetAccount(address);
                         if (existing.Balance != account.Balance)
                         {
@@ -294,16 +172,22 @@ public class TrieByPathFuzzTesting
                         pathStateProvider.CreateAccount(address, account.Balance);
                     }
 
+                    if (selfDestruct)
+                    {
+                        stateProvider.ClearStorage(address);
+                        stateProvider.DeleteAccount(address);
+
+                        pathStateProvider.ClearStorage(address);
+                        pathStateProvider.DeleteAccount(address);
+                    }
+
                     if (insertStorage)
                     {
                         streamWriter.WriteLine($"{address} {decoder.Encode(account)}");
-                        int noOfStorage = _random.Next(50, 50);
-                        if (!indexesPerAccount.ContainsKey(address))
-                            indexesPerAccount[address] = new List<int>(noOfStorage);
+                        int noOfStorage = _random.Next(1, 50);
                         for (int j = 1; j < noOfStorage + 1; j++)
                         {
                             int index = _random.Next(1, 5000);
-                            indexesPerAccount[address].Add(index);
                             byte[] storage = new byte[_random.Next(1,32)];
                             _random.NextBytes(storage);
 
@@ -351,25 +235,34 @@ public class TrieByPathFuzzTesting
             stateProvider.StateRoot = currentRoot;
             pathStateProvider.StateRoot = currentRoot;
 
-            TrieStats? stats = pathStateProvider.CollectStats(codeDb, LimboLogs.Instance);
-            Assert.IsTrue(stats.MissingCode == 0);
-            Assert.IsTrue(stats.MissingState == 0);
-            Assert.IsTrue(stats.MissingStorage == 0);
-            Assert.IsTrue(stats.MissingNodes == 0);
-            foreach (Address t in addresses)
-            {
-                if (stateProvider.AccountExists(t))
-                {
-                    foreach (int index in indexesPerAccount[t])
-                    {
-                        byte[] value = stateProvider.Get(new StorageCell(t, (UInt256)index));
-                        byte[] pathValue = pathStateProvider.Get(new StorageCell(t, (UInt256)index));
-                        Assert.That(pathValue, Is.EqualTo(value).Using(Bytes.EqualityComparer), $"Storage slot at {t}.{index} incorrect");
-                    }
-                }
-            }
+            //TrieStats? stats = pathStateProvider.CollectStats(codeDb, LimboLogs.Instance);
+            //Assert.IsTrue(stats.MissingCode == 0);
+            //Assert.IsTrue(stats.MissingState == 0);
+            //Assert.IsTrue(stats.MissingStorage == 0);
+            //Assert.IsTrue(stats.MissingNodes == 0);
+
+            CompareTrees(stateProvider, pathStateProvider);
+
             verifiedBlocks++;
         }
+
+        memDb.Dispose();
+
+        Console.WriteLine($"Verified positive {verifiedBlocks}");
         _logger.Info($"Verified positive {verifiedBlocks}");
+    }
+
+    private void CompareTrees(WorldState hashState, WorldState pathState)
+    {
+        TreeDumper dumper = new TreeDumper();
+        hashState.Accept(dumper, hashState.StateRoot);
+        string remote = dumper.ToString();
+
+        dumper.Reset();
+
+        pathState.Accept(dumper, pathState.StateRoot);
+        string local = dumper.ToString();
+
+        Assert.That(local, Is.EqualTo(remote), $"{remote}{Environment.NewLine}{local}");
     }
 }

--- a/src/Nethermind/Nethermind.Trie.Test/TrieByPathWithPrefixTest.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieByPathWithPrefixTest.cs
@@ -70,7 +70,7 @@ public class TrieByPathWithPrefixTest
         using TrieStoreByPath trieStore = new(memDb, _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager)
         {
-            StorageBytePathPrefix = _keyAccountA.Concat(new[] {(byte)128}).ToArray()
+            StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
         };
         patriciaTree.Set(_keyAccountA, _longLeaf1);
         patriciaTree.Commit(0);
@@ -86,7 +86,7 @@ public class TrieByPathWithPrefixTest
         using TrieStoreByPath trieStore = new(memDb, _logManager);
         PatriciaTree patriciaTree = new PatriciaTree(trieStore, _logManager)
         {
-            StorageBytePathPrefix = _keyAccountA.Concat(new[] {(byte)128}).ToArray()
+            StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
         };
         patriciaTree.Set(_keyAccountA, _longLeaf1);
         patriciaTree.Set(_keyAccountA, _longLeaf2);
@@ -107,7 +107,7 @@ public class TrieByPathWithPrefixTest
         using TrieStoreByPath trieStore = new(memDb, _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager)
         {
-            StorageBytePathPrefix = _keyAccountA.Concat(new[] {(byte)128}).ToArray()
+            StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
         };
         patriciaTree.Set(_keyAccountA, _longLeaf1);
         patriciaTree.Commit(0);
@@ -132,7 +132,7 @@ public class TrieByPathWithPrefixTest
         using TrieStoreByPath trieStore = new(memDb, _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager)
         {
-            StorageBytePathPrefix = _keyAccountA.Concat(new[] {(byte)128}).ToArray()
+            StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
         };
         patriciaTree.Set(_keyAccountA, _longLeaf1);
         patriciaTree.Set(_keyAccountA, Array.Empty<byte>());
@@ -152,7 +152,7 @@ public class TrieByPathWithPrefixTest
         using TrieStoreByPath trieStore = new(memDb, _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager)
         {
-            StorageBytePathPrefix = _keyAccountA.Concat(new[] {(byte)128}).ToArray()
+            StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
         };
         patriciaTree.Set(_keyAccountA, _longLeaf1);
         patriciaTree.Commit(0);
@@ -174,7 +174,7 @@ public class TrieByPathWithPrefixTest
         using TrieStoreByPath trieStore = new(memDb, LimboLogs.Instance);
         PatriciaTree patriciaTree = new(trieStore, _logManager)
         {
-            StorageBytePathPrefix = _keyAccountA.Concat(new[] {(byte)128}).ToArray()
+            StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
         };
         patriciaTree.Commit(0);
         patriciaTree.Commit(1);
@@ -211,7 +211,7 @@ public class TrieByPathWithPrefixTest
         using TrieStoreByPath trieStore = new(memDb, _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager)
         {
-            StorageBytePathPrefix = _keyAccountA.Concat(new[] {(byte)128}).ToArray()
+            StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
         };
         patriciaTree.Set(_keyAccountA, _longLeaf1);
         patriciaTree.Set(_keyAccountB, _longLeaf1);
@@ -245,7 +245,7 @@ public class TrieByPathWithPrefixTest
         using TrieStoreByPath trieStore = new(memDb, _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager)
         {
-            StorageBytePathPrefix = _keyAccountA.Concat(new[] {(byte)128}).ToArray()
+            StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
         };
         patriciaTree.Set(_keyAccountA, _longLeaf1);
         patriciaTree.Set(_keyAccountB, _longLeaf1);
@@ -271,7 +271,7 @@ public class TrieByPathWithPrefixTest
         using TrieStoreByPath trieStore = new(memDb, _logManager);
         PatriciaTree patriciaTree = new(trieStore, Keccak.EmptyTreeHash, true, true, _logManager)
         {
-            StorageBytePathPrefix = _keyAccountA.Concat(new[] {(byte)128}).ToArray()
+            StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
         };
 
         for (int j = 0; j < i; j++)
@@ -299,7 +299,7 @@ public class TrieByPathWithPrefixTest
         using TrieStoreByPath trieStore = new(memDb, _logManager);
         PatriciaTree patriciaTree = new(trieStore, Keccak.EmptyTreeHash, true, true, _logManager)
         {
-            StorageBytePathPrefix = _keyAccountA.Concat(new[] {(byte)128}).ToArray()
+            StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
         };
 
         for (int j = 0; j < i; j++)
@@ -343,7 +343,7 @@ public class TrieByPathWithPrefixTest
         using TrieStoreByPath trieStore = new(memDb, _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager)
         {
-            StorageBytePathPrefix = _keyAccountA.Concat(new[] {(byte)128}).ToArray()
+            StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
         };
 
         for (int j = 0; j < i; j++)
@@ -378,7 +378,7 @@ public class TrieByPathWithPrefixTest
         using TrieStoreByPath trieStore = new(memDb, _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager)
         {
-            StorageBytePathPrefix = _keyAccountA.Concat(new[] {(byte)128}).ToArray()
+            StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
         };
 
         for (int j = 0; j < i; j++)
@@ -418,7 +418,7 @@ public class TrieByPathWithPrefixTest
         using TrieStoreByPath trieStore = new(memDb, _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager)
         {
-            StorageBytePathPrefix = _keyAccountA.Concat(new[] {(byte)128}).ToArray()
+            StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
         };
 
         for (int j = 0; j < i; j++)
@@ -453,7 +453,7 @@ public class TrieByPathWithPrefixTest
         using TrieStoreByPath trieStore = new(memDb, _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager)
         {
-            StorageBytePathPrefix = _keyAccountA.Concat(new[] {(byte)128}).ToArray()
+            StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
         };
 
         for (int j = 0; j < i; j++)
@@ -506,7 +506,7 @@ public class TrieByPathWithPrefixTest
         using TrieStoreByPath trieStore = new(memDb, _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager)
         {
-            StorageBytePathPrefix = _keyAccountA.Concat(new[] {(byte)128}).ToArray()
+            StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
         };
         patriciaTree.Set(_keyAccountA, _longLeaf1);
         patriciaTree.Set(_keyAccountB, _longLeaf1);
@@ -531,8 +531,8 @@ public class TrieByPathWithPrefixTest
 
         PatriciaTree patriciaTree = new PatriciaTree(trieStore, Keccak.EmptyTreeHash, true, true, _logManager)
         {
-            StorageBytePathPrefix = _keyAccountA.Concat(new[] {(byte)128}).ToArray()
-        };;
+            StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
+        }; ;
 
 
 
@@ -560,8 +560,8 @@ public class TrieByPathWithPrefixTest
     {
         PatriciaTree checkTree = new PatriciaTree(memDb, NUnitLogManager.Instance, capability: patriciaTree.Capability)
         {
-            StorageBytePathPrefix = _keyAccountA.Concat(new[] {(byte)128}).ToArray()
-        };;
+            StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
+        };
         checkTree.RootHash = patriciaTree.RootHash;
         return checkTree;
     }
@@ -573,7 +573,7 @@ public class TrieByPathWithPrefixTest
         using TrieStoreByPath trieStore = new(memDb, _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager)
         {
-            StorageBytePathPrefix = _keyAccountA.Concat(new[] {(byte)128}).ToArray()
+            StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
         };
         patriciaTree.Set(_keyAccountA, _longLeaf1);
         patriciaTree.Set(_keyAccountB, _longLeaf2);
@@ -591,7 +591,7 @@ public class TrieByPathWithPrefixTest
         using TrieStoreByPath trieStore = new(memDb, _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager)
         {
-            StorageBytePathPrefix = _keyAccountA.Concat(new[] {(byte)128}).ToArray()
+            StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
         };
         patriciaTree.Set(_keyAccountA, _longLeaf1);
         patriciaTree.Set(_keyAccountB, _longLeaf1);
@@ -609,7 +609,7 @@ public class TrieByPathWithPrefixTest
         using TrieStoreByPath trieStore = new(memDb, _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager)
         {
-            StorageBytePathPrefix = _keyAccountA.Concat(new[] {(byte)128}).ToArray()
+            StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
         };
         patriciaTree.Set(_keyAccountA, _longLeaf1);
         patriciaTree.Set(_keyAccountB, _longLeaf2);
@@ -633,7 +633,7 @@ public class TrieByPathWithPrefixTest
         using TrieStoreByPath trieStore = new(memDb, _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager)
         {
-            StorageBytePathPrefix = _keyAccountA.Concat(new[] {(byte)128}).ToArray()
+            StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
         };
         patriciaTree.Set(_keyAccountA, _longLeaf1);
         patriciaTree.Set(_keyAccountB, _longLeaf1);
@@ -669,7 +669,7 @@ public class TrieByPathWithPrefixTest
         using TrieStoreByPath trieStore = new(memDb, _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager)
         {
-            StorageBytePathPrefix = _keyAccountA.Concat(new[] {(byte)128}).ToArray()
+            StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
         };
         patriciaTree.Set(key1, _longLeaf1);
         patriciaTree.Set(key2, _longLeaf1);
@@ -720,7 +720,7 @@ public class TrieByPathWithPrefixTest
         using TrieStoreByPath trieStore = new(memDb, _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager)
         {
-            StorageBytePathPrefix = _keyAccountA.Concat(new[] {(byte)128}).ToArray()
+            StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
         };
         patriciaTree.Set(key1, _longLeaf1);
         patriciaTree.Set(key2, _longLeaf1);
@@ -745,7 +745,7 @@ public class TrieByPathWithPrefixTest
         using TrieStoreByPath trieStore = new(memDb, _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager)
         {
-            StorageBytePathPrefix = _keyAccountA.Concat(new[] {(byte)128}).ToArray()
+            StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
         };
         patriciaTree.Set(_keyAccountA, _longLeaf1);
         patriciaTree.Set(_keyAccountB, _longLeaf1);
@@ -918,7 +918,7 @@ public class TrieByPathWithPrefixTest
         using TrieStoreByPath trieStore = new(memDb, Persist.IfBlockOlderThan(lookupLimit), _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager)
         {
-            StorageBytePathPrefix = _keyAccountA.Concat(new[] {(byte)128}).ToArray()
+            StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
         };
 
         byte[][] accounts = new byte[accountsCount][];

--- a/src/Nethermind/Nethermind.Trie/ByPath/IPathDataCache.cs
+++ b/src/Nethermind/Nethermind.Trie/ByPath/IPathDataCache.cs
@@ -12,12 +12,11 @@ using Nethermind.Core.Crypto;
 namespace Nethermind.Trie.ByPath;
 public interface IPathDataCache
 {
-    void SetContext(Keccak keccak);
-    bool EnsureStateHistoryExists(long blockNuber, Keccak stateHash);
-    void AddNodeData(long blockNuber, Keccak stateHash, TrieNode node);
-    void AddNodeDataTransient(TrieNode node);
+    void OpenContext(Keccak parentStateRoot);
+    void CloseContext(long blockNumber, Keccak newStatRoot);
+    void AddNodeData(long blockNuber, TrieNode node);
     NodeData? GetNodeDataAtRoot(Keccak? rootHash, Span<byte> path);
     NodeData? GetNodeData(Span<byte> path, Keccak? hash);
     bool PersistUntilBlock(long blockNumber, Keccak rootHash, IBatch? batch = null);
-    void MoveTransientData(long blockNumber, Keccak stateRoot);
+    void AddRemovedPrefix(long blockNumber, ReadOnlySpan<byte> keyPrefix);
 }

--- a/src/Nethermind/Nethermind.Trie/ByPath/IPathDataCache.cs
+++ b/src/Nethermind/Nethermind.Trie/ByPath/IPathDataCache.cs
@@ -12,8 +12,8 @@ using Nethermind.Core.Crypto;
 namespace Nethermind.Trie.ByPath;
 public interface IPathDataCache
 {
-    void OpenContext(Keccak parentStateRoot);
-    void CloseContext(long blockNumber, Keccak newStatRoot);
+    void OpenContext(long blockNumber, Keccak parentStateRoot);
+    void CloseContext(long blockNumber, Keccak newStateRoot);
     void AddNodeData(long blockNuber, TrieNode node);
     NodeData? GetNodeDataAtRoot(Keccak? rootHash, Span<byte> path);
     NodeData? GetNodeData(Span<byte> path, Keccak? hash);

--- a/src/Nethermind/Nethermind.Trie/ByPath/IPathDataCache.cs
+++ b/src/Nethermind/Nethermind.Trie/ByPath/IPathDataCache.cs
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+
+namespace Nethermind.Trie.ByPath;
+public interface IPathDataCache
+{
+    void SetContext(Keccak keccak);
+    bool EnsureStateHistoryExists(long blockNuber, Keccak stateHash);
+    void AddNodeData(long blockNuber, Keccak stateHash, TrieNode node);
+    void AddNodeDataTransient(TrieNode node);
+    NodeData? GetNodeDataAtRoot(Keccak? rootHash, Span<byte> path);
+    NodeData? GetNodeData(Span<byte> path, Keccak? hash);
+    bool PersistUntilBlock(long blockNumber, Keccak rootHash, IBatch? batch = null);
+    void MoveTransientData(long blockNumber, Keccak stateRoot);
+}

--- a/src/Nethermind/Nethermind.Trie/ByPath/PathDataCache.cs
+++ b/src/Nethermind/Nethermind.Trie/ByPath/PathDataCache.cs
@@ -1,0 +1,730 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using Nethermind.Core;
+using Nethermind.Core.Collections;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Logging;
+using Nethermind.Trie.Pruning;
+
+namespace Nethermind.Trie.ByPath;
+
+public class NodeData
+{
+    public Keccak Keccak { get; }
+    public byte[]? RLP { get; }
+
+    public NodeData(byte[] data, Keccak keccak) { RLP = data; Keccak = keccak; }
+}
+
+
+public class PathDataCache : IPathDataCache
+{
+    class StateId
+    {
+        static int _stateIdSeed = 0;
+        public int Id { get; }
+        public long BlockNumber { get; set; }
+        public Keccak BlockHash { get; set; }
+
+        public StateId? ParentBlock { get; set; }
+
+        public StateId(long blockNumber, Keccak blockHash, StateId? parentBlock)
+        {
+            Id = Interlocked.Increment(ref _stateIdSeed);
+            BlockNumber = blockNumber;
+            BlockHash = blockHash;
+            ParentBlock = parentBlock;
+        }
+
+        private StateId(int id, long blockNumber, Keccak blockHash, StateId? parentBlock)
+        {
+            Id = id;
+            BlockNumber = blockNumber;
+            BlockHash = blockHash;
+            ParentBlock = parentBlock;
+        }
+
+        public StateId Clone()
+        {
+            return new StateId(Id, BlockNumber, BlockHash, ParentBlock);
+        }
+    }
+
+    class PathDataAtState
+    {
+        public int StateId { get; }
+        public NodeData Data { get; }
+        public bool ShouldPersist { get; }
+
+        public PathDataAtState(int stateId) { StateId = stateId; }
+        public PathDataAtState(int stateId, NodeData data, bool shouldPersist) { StateId = stateId; Data = data; ShouldPersist = shouldPersist; }
+    }
+
+    class PathDataAtStateComparer : IComparer<PathDataAtState>
+    {
+        public int Compare(PathDataAtState? x, PathDataAtState? y)
+        {
+            return Comparer<int>.Default.Compare(x.StateId, y.StateId);
+        }
+    }
+
+    class PathDataHistory
+    {
+        private readonly SortedSet<PathDataAtState> _nodes;
+        private readonly ReaderWriterLockSlim _lock = new();
+
+        public PathDataHistory()
+        {
+            _nodes = new SortedSet<PathDataAtState>(new PathDataAtStateComparer());
+        }
+
+        public PathDataHistory(IEnumerable<PathDataAtState> elements)
+        {
+            _nodes = new SortedSet<PathDataAtState>(new PathDataAtStateComparer());
+            _nodes.AddRange(elements);
+        }
+
+        public int Count => _nodes.Count;
+
+        public void Add(int stateId, NodeData data, bool shouldPersist)
+        {
+            try
+            {
+                _lock.EnterWriteLock();
+
+                PathDataAtState nad = new(stateId, data, shouldPersist);
+                _nodes.Remove(nad);
+                _nodes.Add(nad);
+            }
+            finally
+            {
+                _lock.ExitWriteLock();
+            }
+        }
+
+        public PathDataAtState? Get(Keccak keccak)
+        {
+            try
+            {
+                _lock.EnterReadLock();
+                foreach (PathDataAtState nodeHist in _nodes)
+                {
+                    if (nodeHist.Data.Keccak == keccak)
+                        return nodeHist;
+                }
+                return null;
+            }
+            finally
+            {
+                _lock.ExitReadLock();
+            }
+        }
+
+        public PathDataAtState? GetLatest()
+        {
+            try
+            {
+                _lock.EnterReadLock();
+                return _nodes.Max;
+            }
+            finally
+            {
+                _lock.ExitReadLock();
+            }
+        }
+
+        public PathDataAtState? GetLatestUntil(int stateId)
+        {
+            try
+            {
+                _lock.EnterReadLock();
+
+                if (_nodes.Count == 0) return null;
+                if (stateId < _nodes.Min.StateId)
+                    return null;
+
+                return _nodes.GetViewBetween(_nodes.Min, new PathDataAtState(stateId)).Max;
+            }
+            finally
+            {
+                _lock.ExitReadLock();
+            }
+        }
+        public void ClearUntil(int stateId)
+        {
+            try
+            {
+                _lock.EnterWriteLock();
+
+                if (_nodes.Count == 0 || stateId < _nodes.Min.StateId)
+                    return;
+
+                SortedSet<PathDataAtState> viewUntilBlock = _nodes.GetViewBetween(_nodes.Min, new PathDataAtState(stateId));
+                viewUntilBlock.Clear();
+            }
+            finally
+            {
+                _lock.ExitWriteLock();
+            }
+        }
+
+        public PathDataHistory? SplitAt(int stateId)
+        {
+            try
+            {
+                _lock.EnterWriteLock();
+
+                if (_nodes.Count == 0 || stateId < _nodes.Min.StateId || stateId > _nodes.Max.StateId)
+                    return null;
+
+                SortedSet<PathDataAtState> viewUntilBlock = _nodes.GetViewBetween(new PathDataAtState(stateId), _nodes.Max);
+                PathDataAtState[] copy = new PathDataAtState[viewUntilBlock.Count];
+                viewUntilBlock.CopyTo(copy);
+                PathDataHistory newHistory = new PathDataHistory(copy);
+                viewUntilBlock.Clear();
+                return newHistory;
+            }
+            finally
+            {
+                _lock.ExitWriteLock();
+            }
+        }
+    }
+
+    public PathDataCache(ITrieStore trieStore, ILogManager? logManager)
+    {
+        _trieStore = trieStore;
+        _logger = logManager?.GetClassLogger<TrieNodePathCache>() ?? throw new ArgumentNullException(nameof(logManager));
+        _branches = new ConcurrentBag<PathDataCache>();
+        _isDetached = false;
+        _transientStore = new SpanConcurrentDictionary<byte, NodeData>(Bytes.SpanNibbleEqualityComparer);
+    }
+
+    private PathDataCache(ITrieStore trieStore, ILogger? logger, StateId lastState, IEnumerable<PathDataCache> branches = null, bool isDetached = false)
+    {
+        _lastState = lastState;
+        _trieStore = trieStore;
+        _logger = logger;
+        _branches = new ConcurrentBag<PathDataCache>();
+        _isDetached = isDetached;
+        _transientStore = new SpanConcurrentDictionary<byte, NodeData>(Bytes.SpanNibbleEqualityComparer);
+        if (branches is not null)
+        {
+            foreach (var b in branches)
+                _branches.Add(b);
+        }
+    }
+
+    private StateId _lastState;
+    private bool _isDetached;
+
+    private SpanConcurrentDictionary<byte, PathDataHistory> _historyByPath = new(Bytes.SpanNibbleEqualityComparer);
+    private ConcurrentBag<PathDataCache> _branches;
+    private Keccak _context;
+    private SpanConcurrentDictionary<byte, NodeData> _transientStore;
+
+    private readonly ITrieStore _trieStore;
+    private readonly ILogger _logger;
+
+    public void SetContext(Keccak keccak)
+    {
+        if (_lastState is not null)
+            SetContextInner(keccak);
+    }
+
+    public bool EnsureStateHistoryExists(long blockNuber, Keccak stateHash)
+    {
+        if (_lastState is null)
+        {
+            _lastState = new StateId(blockNuber, stateHash, null);
+            if (_logger.IsTrace) _logger.Trace($"New initial state {blockNuber} / {stateHash}");
+        }
+
+        StateId stateId = FindState(stateHash, blockNuber);
+        if (stateId is null)
+        {
+            foreach (PathDataCache branch in _branches)
+            {
+                bool handledInBranch = branch.EnsureStateHistoryExists(blockNuber, stateHash);
+                if (handledInBranch)
+                {
+                    PrintStates("State tree after branch prep", 0);
+                    return true;
+                }
+            }
+            PathDataCache prepBranch = PrepareBranch(blockNuber, stateHash);
+            PrintStates("State tree after branch prep", 0);
+            return prepBranch is not null ? prepBranch.EnsureStateHistoryExists(blockNuber, stateHash) : false;
+        }
+        return true;
+    }
+
+    private PathDataCache GetCacheInstance(long blockNuber, Keccak stateHash)
+    {
+        if (_lastState is null)
+        {
+            _lastState = new StateId(blockNuber, stateHash, null);
+            return this;
+        }
+
+        StateId stateId = FindState(stateHash, blockNuber);
+        if (stateId is null)
+        {
+            foreach (PathDataCache branch in _branches)
+            {
+                PathDataCache innerCache = branch.GetCacheInstance(blockNuber, stateHash);
+                if (innerCache is not null)
+                    return innerCache;
+            }
+            return PrepareBranch(blockNuber, stateHash);
+        }
+        return this;
+    }
+
+    public void AddNodeDataTransient(TrieNode node)
+    {
+        NodeData nd = new(node.FullRlp.Array, node.Keccak);
+        if (node.IsLeaf)
+            _transientStore[node.StoreNibblePathPrefix.Concat(node.PathToNode).ToArray()] = nd;
+        _transientStore[node.FullPath] = nd;
+    }
+
+    public void MoveTransientData(long blockNumber, Keccak stateRoot)
+    {
+        PathDataCache targetInstabce = GetCacheInstance(blockNumber, stateRoot);
+        if (targetInstabce is null)
+            throw new Exception("Unable to create target cache instance!");
+
+        PrintStates("MoveTransientData - block state tree", 0);
+
+        StateId targetState = targetInstabce.FindState(stateRoot, blockNumber);
+        foreach (KeyValuePair<byte[], NodeData> tmpVal in _transientStore)
+        {
+            targetInstabce.AddNodeData(targetState, tmpVal.Key, tmpVal.Value);
+        }
+    }
+
+    public void AddNodeData(long blockNuber, Keccak stateHash, TrieNode node)
+    {
+        if (_logger.IsTrace) _logger.Trace($"Adding node {node.PathToNode.ToHexString()} / {node.FullPath.ToHexString()} with Keccak: {node.Keccak} at block {blockNuber}");
+        if (_lastState is null)
+        {
+            _lastState = new StateId(blockNuber, stateHash, null);
+            if (_logger.IsTrace) _logger.Trace($"New state {blockNuber} / {stateHash}");
+        }
+
+        AddNodeDataInner(blockNuber, stateHash, node);
+    }
+
+    private void AddNodeData(StateId stateId, Span<byte> path, NodeData nodeData)
+    {
+        PathDataHistory hist = GetHistoryForPath(path);
+        hist.Add(stateId.Id, nodeData, true);
+    }
+
+    private bool AddNodeDataInner(long blockNuber, Keccak stateHash, TrieNode node)
+    {
+        StateId stateId = FindState(stateHash, blockNuber);
+        if (stateId is null)
+        {
+            foreach (PathDataCache branch in _branches)
+            {
+                bool handledInBranch = branch.AddNodeDataInner(blockNuber, stateHash, node);
+                if (handledInBranch)
+                    return true;
+            }
+
+            PathDataCache prepBranch = PrepareBranch(blockNuber, stateHash);
+            return prepBranch is not null ? prepBranch.AddNodeDataInner(blockNuber, stateHash, node) : false;
+        }
+        else
+        {
+            NodeData nd = new(node.FullRlp.Array, node.Keccak);
+            if (node.IsLeaf)
+            {
+                PathDataHistory leafPointerHist = GetHistoryForPath(node.PathToNode);
+                leafPointerHist.Add(stateId.Id, nd, false);
+            }
+            PathDataHistory history = GetHistoryForPath(node.FullPath);
+            history.Add(stateId.Id, nd, true);
+
+            return true;
+        }
+    }
+
+    public NodeData? GetNodeDataAtRoot(Keccak? rootHash, Span<byte> path)
+    {
+        if (rootHash is null)
+        {
+            if (_historyByPath.TryGetValue(path, out PathDataHistory history))
+            {
+                PathDataAtState dataAtState = history.GetLatest();
+                if (dataAtState is not null)
+                    Pruning.Metrics.LoadedFromCacheNodesCount++;
+                return dataAtState.Data;
+            }
+        }
+        else
+        {
+            bool rootInBranch = false;
+            NodeData foundData = null;
+            foreach (PathDataCache branchCache in _branches)
+            {
+                rootInBranch = branchCache.GetNodeDataAtRoot(rootHash, path, out foundData);
+                if (rootInBranch)
+                    break;
+            }
+
+            StateId localState = FindState(rootHash);
+            if (rootInBranch && foundData is null)
+                localState = _lastState;
+
+            if (localState is not null && _historyByPath.TryGetValue(path, out PathDataHistory pathHistory))
+            {
+                PathDataAtState? data = pathHistory.GetLatestUntil(localState.Id);
+                if (data is not null)
+                {
+                    Pruning.Metrics.LoadedFromCacheNodesCount++;
+                    return data.Data;
+                }
+            }
+        }
+        return null;
+    }
+
+    public NodeData? GetNodeData(Span<byte> path, Keccak? hash)
+    {
+        foreach (var cache in _branches)
+        {
+            NodeData? data = cache.GetNodeData(path, hash);
+            if (data is not null)
+                return data;
+        }
+        if (_historyByPath.TryGetValue(path, out PathDataHistory history))
+        {
+            return history.Get(hash)?.Data;
+        }
+        return null;
+    }
+
+    private bool GetNodeDataAtRoot(Keccak? rootHash, Span<byte> path, out NodeData? nodeData)
+    {
+        nodeData = null;
+        StateId stateId = FindState(rootHash);
+        if (stateId is not null)
+        {
+            if (_historyByPath.TryGetValue(path, out PathDataHistory pathHistory))
+            {
+                PathDataAtState? data = pathHistory.GetLatestUntil(stateId.Id);
+                if (data is not null)
+                {
+                    nodeData = data.Data;
+                    Pruning.Metrics.LoadedFromCacheNodesCount++;
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+
+    public bool PersistUntilBlock(long blockNumber, Keccak rootHash, IBatch? batch = null)
+    {
+        Stack<PathDataCache> branches = new Stack<PathDataCache>();
+        GetBranchesToProcess(blockNumber, rootHash, branches, true, out StateId? latestState);
+        while (branches.Count > 0)
+        {
+            PathDataCache branch = branches.Pop();
+            branch.PersistUntilBlockInner(latestState, batch);
+        }
+
+        PruneUntil(blockNumber, rootHash);
+
+        return true;
+    }
+
+    private void PersistUntilBlockInner(StateId? stateId, IBatch? batch = null)
+    {
+        List<TrieNode> toPersist = new();
+        foreach (KeyValuePair<byte[], PathDataHistory> nodeVersion in _historyByPath)
+        {
+            PathDataAtState? nodeData = nodeVersion.Value.GetLatestUntil(stateId.Id);
+            if (nodeData?.ShouldPersist == true)
+            {
+                TrieNode node;
+                if (nodeVersion.Key.Length >= 66)
+                {
+                    byte[] prefix = nodeVersion.Key.Slice(0, 66);
+                    node = new(NodeType.Unknown, nodeVersion.Key.Slice(66), nodeData.Data.Keccak, nodeData.Data.RLP);
+                    node.StoreNibblePathPrefix = prefix;
+                }
+                else
+                {
+                    node = new(NodeType.Unknown, nodeVersion.Key, nodeData.Data.Keccak, nodeData.Data.RLP);
+                }
+
+                if (nodeData.Data.RLP is not null)
+                {
+                    node.ResolveNode(_trieStore);
+                    node.ResolveKey(_trieStore, nodeVersion.Key.Length == 0);
+                }
+                if (nodeData.Data.RLP is null) toPersist.Insert(0, node); else toPersist.Add(node);
+            }
+        }
+
+        foreach (TrieNode node in toPersist)
+        {
+            _trieStore.SaveNodeDirectly(stateId.BlockNumber, node, batch);
+            if (_logger.IsTrace) _logger.Trace($"Persising node {node.PathToNode.ToHexString()} / {node.FullPath.ToHexString()} with Keccak: {node.Keccak} at block {stateId.BlockNumber} / {stateId.BlockHash} Value: {node.FullRlp.ToArray()?.ToHexString()}");
+        }
+    }
+
+    public bool PruneUntil(long blockNumber, Keccak rootHash)
+    {
+        Stack<PathDataCache> branches = new Stack<PathDataCache>();
+        GetBranchesToProcess(blockNumber, rootHash, branches, false, out StateId? latestState);
+
+        if (branches.Count == 0)
+            return false;
+
+        while (branches.Count > 1)
+            branches.Pop();
+
+        PathDataCache branch = branches.Pop();
+        branch.PruneUntilInner(latestState);
+
+        if (branch != this)
+        {
+            _branches = branch._branches;
+            _historyByPath = branch._historyByPath;
+            _lastState = branch._lastState;
+        }
+
+        PrintStates("State after persist", 0);
+
+        return true;
+    }
+
+    private void PruneUntilInner(StateId stateId)
+    {
+        List<byte[]> removedPaths = new();
+        foreach (KeyValuePair<byte[], PathDataHistory> nodeVersion in _historyByPath)
+        {
+            nodeVersion.Value.ClearUntil(stateId.Id);
+            if (nodeVersion.Value.Count == 0)
+                removedPaths.Add(nodeVersion.Key);
+        }
+
+        foreach (byte[] path in removedPaths)
+            _historyByPath.Remove(path, out _);
+
+        StateId? childOfPersisted = FindStateAfter(stateId.BlockHash, stateId.BlockNumber);
+        if (childOfPersisted is not null)
+            childOfPersisted.ParentBlock = null;
+        else
+            _lastState = null;
+    }
+
+    private PathDataHistory GetHistoryForPath(Span<byte> path)
+    {
+        if (!_historyByPath.TryGetValue(path, out PathDataHistory history))
+        {
+            history = new PathDataHistory();
+            _historyByPath[path] = history;
+        }
+
+        return history;
+    }
+
+    private StateId? FindState(Keccak rootHash, long blockNumber = -1)
+    {
+        StateId stateId = _lastState;
+        while (stateId is not null)
+        {
+            if (stateId.BlockHash == rootHash && (stateId.BlockNumber == blockNumber || blockNumber == -1))
+                return stateId;
+            stateId = stateId.ParentBlock;
+        }
+        return null;
+    }
+
+    private bool SetContextInner(Keccak context)
+    {
+        foreach (PathDataCache branchCache in _branches)
+        {
+            branchCache.SetContextInner(context);
+        }
+
+        StateId? localState = FindState(context);
+        if (localState is not null)
+        {
+            if (_logger.IsTrace) _logger.Trace($"Setting context to {context} at state {localState.BlockNumber} / {localState.BlockHash}");
+            _context = context;
+            return true;
+        }
+        return false;
+    }
+
+    private bool GetBranchesToProcess(long blockNumber, Keccak stateRoot, Stack<PathDataCache> branches, bool filterDetached, out StateId? latestState)
+    {
+        StateId? localState = FindState(stateRoot, blockNumber);
+        if (localState is not null)
+        {
+            branches.Push(this);
+            latestState = localState;
+            return true;
+        }
+
+        foreach (PathDataCache branchCache in _branches)
+        {
+            if (branchCache.GetBranchesToProcess(blockNumber, stateRoot, branches, filterDetached, out latestState))
+            {
+                if (!filterDetached || !branchCache._isDetached)
+                    branches.Push(this);
+                return true;
+            }
+        }
+        latestState = null;
+        return false;
+    }
+
+    private StateId? FindStateIncludingBranches(Keccak rootHash, long blockNumber = -1)
+    {
+        foreach (PathDataCache branchCache in _branches)
+        {
+            StateId? stateInBranch = branchCache.FindStateIncludingBranches(rootHash, blockNumber);
+            if (stateInBranch is not null)
+                return stateInBranch;
+        }
+
+        StateId stateId = _lastState;
+        while (stateId is not null)
+        {
+            if (stateId.BlockHash == rootHash && (stateId.BlockNumber == blockNumber || blockNumber == -1))
+                return stateId;
+            stateId = stateId.ParentBlock;
+        }
+        return null;
+    }
+
+    private StateId? FindStateAfter(Keccak rootHash, long blockNumber)
+    {
+        StateId stateId = _lastState;
+        while (stateId.ParentBlock is not null)
+        {
+            if (stateId.ParentBlock.BlockHash == rootHash && stateId.ParentBlock.BlockNumber == blockNumber)
+                return stateId;
+            stateId = stateId.ParentBlock;
+        }
+        return null;
+    }
+
+    private StateId? FindStateWithBlockNumberOrEarlier(long blockNumber)
+    {
+        StateId stateId = _lastState;
+        while (stateId is not null)
+        {
+            if (stateId.BlockNumber <= blockNumber)
+                return stateId;
+            stateId = stateId.ParentBlock;
+        }
+        return null;
+    }
+
+    private void Add(Span<byte> path, PathDataHistory history)
+    {
+        _historyByPath[path] = history;
+    }
+
+    private PathDataCache? PrepareBranch(long blockNumber, Keccak stateHash)
+    {
+        PathDataCache newBranch = null;
+
+        //can add to end of chain?
+        if (_lastState.BlockHash == _context && _lastState.BlockNumber < blockNumber)
+        {
+            if (_logger.IsTrace) _logger.Trace($"Adding new state in current chain {blockNumber} / {stateHash} parent: {_lastState.BlockNumber} / {_lastState.BlockHash}");
+            _lastState = new StateId(blockNumber, stateHash, _lastState);
+            newBranch = this;
+        }
+        else
+        {
+            //create a new branch
+            StateId? currState = FindStateWithBlockNumberOrEarlier(blockNumber);
+            if (currState is not null)
+            {
+                if (currState.BlockNumber == blockNumber)
+                {
+                    if (_context is not null && currState.ParentBlock?.BlockHash == _context)
+                    {
+                        PathDataCache newBranchExisting = new(_trieStore, _logger, _lastState, _branches);
+
+                        foreach (KeyValuePair<byte[], PathDataHistory> histEntry in _historyByPath)
+                        {
+                            PathDataHistory? newHist = histEntry.Value.SplitAt(currState.Id);
+                            if (newHist is not null)
+                                newBranchExisting.Add(histEntry.Key, newHist);
+                        }
+                        _branches.Clear();
+                        _branches.Add(newBranchExisting);
+
+                        newBranch = new(_trieStore, _logger, new StateId(blockNumber, stateHash, null), isDetached: currState.ParentBlock is null);
+                        _branches.Add(newBranch);
+
+                        _lastState = currState.ParentBlock;
+                        currState.ParentBlock = null;
+                    }
+                    else if (currState.ParentBlock is null)
+                    {
+                        newBranch = new(_trieStore, _logger, new StateId(blockNumber, stateHash, null), isDetached: currState.ParentBlock is null);
+                        _branches.Add(newBranch);
+                    }
+                }
+                else if (_context is not null && currState.BlockNumber < blockNumber && currState.BlockHash == _context)
+                {
+                    newBranch = new(_trieStore, _logger, new StateId(blockNumber, stateHash, null), isDetached: currState.ParentBlock is null);
+                    _branches.Add(newBranch);
+                }
+            }
+        }
+
+        return newBranch;
+    }
+
+    private void PrintStates(string topLevelMsg, int level)
+    {
+        if (!_logger.IsTrace)
+            return;
+
+        _logger.Trace(topLevelMsg);
+
+        StateId stateId = _lastState;
+        Stack<StateId> stack = new Stack<StateId>();
+        while (stateId is not null)
+        {
+            stack.Push(stateId);
+            stateId = stateId.ParentBlock;
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.Append(string.Concat(Enumerable.Repeat("\t", level)));
+        while (stack.Count > 0)
+        {
+            StateId st = stack.Pop();
+            sb.Append($"[B {st.BlockNumber} | H {st.BlockHash} | I {st.Id}] -> ");
+        }
+        
+        _logger.Trace(sb.ToString());
+
+        level++;
+        foreach (PathDataCache branch in _branches)
+            branch.PrintStates(topLevelMsg, level);
+    }
+}

--- a/src/Nethermind/Nethermind.Trie/ByPath/PathDataCache.cs
+++ b/src/Nethermind/Nethermind.Trie/ByPath/PathDataCache.cs
@@ -481,7 +481,7 @@ internal class PathDataCacheInstance
 
         removedPaths.Clear();
         List<byte[]> paths = _removedPrefixes.Where(kvp => kvp.Value.Exists(st => st <= stateId.Id)).Select(kvp => kvp.Key).ToList();
-        
+
         foreach (byte[] path in paths)
         {
             List<int> states = _removedPrefixes[path];
@@ -795,7 +795,8 @@ public class PathDataCache : IPathDataCache
 
             LogCache($"After persisting block {blockNumber} / {rootHash}");
             return true;
-        } finally { _lock.ExitWriteLock(); }
+        }
+        finally { _lock.ExitWriteLock(); }
     }
 
     public void AddRemovedPrefix(long blockNumber, ReadOnlySpan<byte> keyPrefix)

--- a/src/Nethermind/Nethermind.Trie/ByPath/PathDataCache.cs
+++ b/src/Nethermind/Nethermind.Trie/ByPath/PathDataCache.cs
@@ -401,6 +401,7 @@ internal class PathDataCacheInstance
         {
             _branches = branch._branches;
             _historyByPath = branch._historyByPath;
+            _removedPrefixes = branch._removedPrefixes;
             _lastState = branch._lastState;
         }
 

--- a/src/Nethermind/Nethermind.Trie/ByPath/PathDataCache.cs
+++ b/src/Nethermind/Nethermind.Trie/ByPath/PathDataCache.cs
@@ -760,7 +760,7 @@ internal class PathDataCacheInstance
         foreach (byte[] path in removedPaths)
             _historyByPath.Remove(path, out _);
 
-        StateId? childOfPersisted = FindStateWithParent(stateId.BlockStateRoot, stateId.BlockNumber);
+        StateId? childOfPersisted = FindStateWithParent(stateId.BlockStateRoot, stateId.BlockNumber + 1);
         if (childOfPersisted is not null)
             childOfPersisted.ParentBlock = null;
         else
@@ -848,7 +848,7 @@ internal class PathDataCacheInstance
         StateId stateId = _lastState;
         while (stateId.ParentBlock is not null)
         {
-            if (stateId.ParentBlock.BlockStateRoot == rootHash && (highestBlockNumber is null || stateId.BlockNumber < highestBlockNumber))
+            if (stateId.ParentBlock.BlockStateRoot == rootHash && (highestBlockNumber is null || stateId.BlockNumber <= highestBlockNumber))
                 return stateId;
             stateId = stateId.ParentBlock;
         }
@@ -1053,15 +1053,6 @@ public class PathDataCache : IPathDataCache
             throw new ArgumentException("No cache instance opened");
 
         _openedInstance.AddRemovedPrefix(blockNumber, keyPrefix);
-    }
-
-    private PathDataCacheInstance? GetMainEqualTo(PathDataCacheInstance instance)
-    {
-        foreach (var mainInstance in _mains)
-        {
-            if (mainInstance.Equals(instance)) return mainInstance;
-        }
-        return null;
     }
 
     private PathDataCacheInstance? GetCacheInstanceForState(Keccak parentStateRoot)

--- a/src/Nethermind/Nethermind.Trie/ByPath/PathDataCache.cs
+++ b/src/Nethermind/Nethermind.Trie/ByPath/PathDataCache.cs
@@ -693,9 +693,8 @@ internal class PathDataCacheInstance
             childOfPersisted.ParentBlock = null;
         else
             _lastState = null;
-
-        _branches.Clear();
     }
+
     private void ProcessDestroyed(StateId stateId)
     {
         List<byte[]> paths = _removedPrefixes.Where(kvp => kvp.Value.Exists(st => st <= stateId.Id)).Select(kvp => kvp.Key).ToList();
@@ -897,6 +896,7 @@ public class PathDataCache : IPathDataCache
         }
 
         _openedInstance = GetCacheInstanceForState(parentStateRoot);
+        _logger.Info($"Opening context for {parentStateRoot}");
     }
 
     public void CloseContext(long blockNumber, Keccak newStatRoot)
@@ -925,7 +925,7 @@ public class PathDataCache : IPathDataCache
 
         _openedInstance = null;
 
-        LogCache("Cache at end of CloseContext");
+        LogCache($"Cache at end of CloseContext block {blockNumber} new state root: {newStatRoot}");
         
     }
 
@@ -965,9 +965,7 @@ public class PathDataCache : IPathDataCache
     {
         NodeData? data = null;
         if (_openedInstance is not null)
-        {
             data = _openedInstance.GetNodeData(path, hash);
-        }
 
         if (data is null)
         {

--- a/src/Nethermind/Nethermind.Trie/ByPath/PathDataCache.cs
+++ b/src/Nethermind/Nethermind.Trie/ByPath/PathDataCache.cs
@@ -515,7 +515,7 @@ internal class PathDataCacheInstance
         StateId? currState = FindStateWithParent(stateRoot, highestBlockNumber);
         if (currState is not null)
         {
-            PathDataCacheInstance newBranchExisting = new(_trieStore, _logger, _lastState.Clone(), this, currState.ParentBlock, _branches);
+            PathDataCacheInstance newBranchExisting = new(_trieStore, _logger, _lastState, this, currState.ParentBlock, _branches);
 
             foreach (KeyValuePair<byte[], PathDataHistory> histEntry in _historyByPath)
             {
@@ -591,8 +591,11 @@ internal class PathDataCacheInstance
         else
         {
             if (_parentInstance.SplitAt(_lastState.ParentStateHash, _lastState.BlockNumber) is not null)
+            {
                 _parentInstance._branches.Add(this);
-            return true;
+                return true;
+            }
+            return false;
         }
     }
 

--- a/src/Nethermind/Nethermind.Trie/ByPath/TrieNodeBlockCache.cs
+++ b/src/Nethermind/Nethermind.Trie/ByPath/TrieNodeBlockCache.cs
@@ -173,7 +173,7 @@ public class TrieNodeBlockCache : IPathTrieNodeCache
                 IOrderedEnumerable<TrieNode> orderedValues = nodesByPath.Values.OrderBy(tn => tn.FullRlp.ToArray(), Bytes.Comparer);
                 foreach (TrieNode? node in orderedValues)
                 {
-                    _trieStore.SaveNodeDirectly(blockNumber, node, batch);
+                    _trieStore.PersistNode(node, batch);
                     node.IsPersisted = true;
                 }
                 // Parallel.ForEach(nodesByPath.Values, node =>

--- a/src/Nethermind/Nethermind.Trie/ByPath/TrieNodeBlockCache.cs
+++ b/src/Nethermind/Nethermind.Trie/ByPath/TrieNodeBlockCache.cs
@@ -185,7 +185,7 @@ public class TrieNodeBlockCache : IPathTrieNodeCache
             currentBlockNumber++;
         }
         List<Keccak> removedRoots = new();
-        foreach(KeyValuePair<Keccak, HashSet<long>> kvp in _rootHashToBlock)
+        foreach (KeyValuePair<Keccak, HashSet<long>> kvp in _rootHashToBlock)
         {
             kvp.Value.RemoveWhere(blk => blk <= blockNumber);
             if (kvp.Value.Count == 0)

--- a/src/Nethermind/Nethermind.Trie/ByPath/TrieNodePathCache.cs
+++ b/src/Nethermind/Nethermind.Trie/ByPath/TrieNodePathCache.cs
@@ -317,7 +317,7 @@ public class TrieNodePathCache : IPathTrieNodeCache
         {
             if (node.IsPersisted)
                 continue;
-            _trieStore.SaveNodeDirectly(blockNumber, node, batch);
+            _trieStore.PersistNode(node, batch);
             node.IsPersisted = true;
         }
 

--- a/src/Nethermind/Nethermind.Trie/IPatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/IPatriciaTree.cs
@@ -10,6 +10,7 @@ namespace Nethermind.Trie;
 public interface IPatriciaTree
 {
     Keccak RootHash { get; set; }
+    Keccak ParentStateRootHash { get; set; }
     TrieNode? RootRef { get; set; }
     byte[] StoreNibblePathPrefix { get; }
     void UpdateRootHash();

--- a/src/Nethermind/Nethermind.Trie/NibbleExtensions.cs
+++ b/src/Nethermind/Nethermind.Trie/NibbleExtensions.cs
@@ -53,7 +53,7 @@ namespace Nethermind.Trie
 
         public static byte[] BytesToNibbleBytes(Span<byte> bytes)
         {
-            Span<byte> nibbles =  stackalloc byte[2 * bytes.Length];
+            Span<byte> nibbles = stackalloc byte[2 * bytes.Length];
             BytesToNibbleBytes(bytes, nibbles);
             return nibbles.ToArray();
         }

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -197,7 +197,7 @@ namespace Nethermind.Trie
             if (TrieStore.Capability == TrieNodeResolverCapability.Path)
             {
                 if (ClearedBySelfDestruct)
-                    TrieStore.MarkPrefixDeleted(blockNumber, StoreNibblePathPrefix);
+                    TrieStore.MarkPrefixDeleted(blockNumber, GetStateRootHash(), StoreNibblePathPrefix);
                 while (_deleteNodes != null && _deleteNodes.TryDequeue(out TrieNode delNode))
                     _currentCommit.Enqueue(new NodeCommitInfo(delNode));
             }
@@ -1484,7 +1484,7 @@ namespace Nethermind.Trie
             throw new MissingTrieNodeException(e.Message, e, traverseContext.UpdatePath.ToArray(), traverseContext.CurrentIndex);
         }
 
-        protected virtual Keccak GetStateRootHash()
+        public virtual Keccak GetStateRootHash()
         {
             return RootRef?.Keccak ?? Keccak.EmptyTreeHash;
         }

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -198,7 +198,7 @@ namespace Nethermind.Trie
             //process deletions - it can happend that a root is set too empty hash due to deletions - needs to be outside of root ref condition
             if (TrieStore.Capability == TrieNodeResolverCapability.Path)
             {
-                TrieStore.OpenContext(ParentStateRootHash);
+                TrieStore.OpenContext(blockNumber, ParentStateRootHash);
                 if (ClearedBySelfDestruct)
                     TrieStore.MarkPrefixDeleted(blockNumber, StoreNibblePathPrefix);
                 while (_deleteNodes != null && _deleteNodes.TryDequeue(out TrieNode delNode))
@@ -450,7 +450,6 @@ namespace Nethermind.Trie
 
         private byte[]? GetByPath(ReadOnlySpan<byte> rawKey, Keccak? rootHash = null)
         {
-            //Keccak cacheProbeRoot = rootHash;
             if (rootHash is null)
             {
                 if (RootRef is null) return null;
@@ -458,16 +457,6 @@ namespace Nethermind.Trie
                 {
                     if (_uncommitedPaths is null || _uncommitedPaths.Matches(rawKey) || ClearedBySelfDestruct)
                         return GetInternal(rawKey);
-                }
-                else
-                {
-                    //is it possible outside of unit tests?
-                    //if (RootRef.Keccak is null)
-                    //{
-                    //    RootRef.ResolveNode(TrieStore);
-                    //    RootRef.ResolveKey(TrieStore, true);
-                    //}
-                    //cacheProbeRoot = RootRef.Keccak;
                 }
             }
 

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -464,7 +464,7 @@ namespace Nethermind.Trie
             Span<byte> nibbleBytes = stackalloc byte[StoreNibblePathPrefix.Length + rawKey.Length * 2];
             StoreNibblePathPrefix.CopyTo(nibbleBytes);
             Nibbles.BytesToNibbleBytes(rawKey, nibbleBytes[StoreNibblePathPrefix.Length..]);
-            TrieNode? node = TrieStore.FindCachedOrUnknown(nibbleBytes[StoreNibblePathPrefix.Length..], StoreNibblePathPrefix, rootHash ?? ParentStateRootHash);
+            TrieNode? node = TrieStore.FindCachedOrUnknown(nibbleBytes[StoreNibblePathPrefix.Length..], StoreNibblePathPrefix, TrieType == TrieType.State ? (rootHash ?? ParentStateRootHash) : ParentStateRootHash);
 
             if (node is null)
                 return null;

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -87,6 +87,8 @@ namespace Nethermind.Trie
 
         public bool ClearedBySelfDestruct = false;
 
+        public Keccak? ParentStateRootHash { get; set; }
+
         /// <summary>
         /// Only used in EthereumTests
         /// </summary>
@@ -196,37 +198,36 @@ namespace Nethermind.Trie
             //process deletions - it can happend that a root is set too empty hash due to deletions - needs to be outside of root ref condition
             if (TrieStore.Capability == TrieNodeResolverCapability.Path)
             {
+                TrieStore.OpenContext(ParentStateRootHash);
                 if (ClearedBySelfDestruct)
-                    TrieStore.MarkPrefixDeleted(blockNumber, GetStateRootHash(), StoreNibblePathPrefix);
+                    TrieStore.MarkPrefixDeleted(blockNumber, StoreNibblePathPrefix);
                 while (_deleteNodes != null && _deleteNodes.TryDequeue(out TrieNode delNode))
                     _currentCommit.Enqueue(new NodeCommitInfo(delNode));
             }
 
-            //TrieStore.SetContext(GetStateRootHash());
-
-            bool processCommits = RootRef?.IsDirty == true;
-            if (processCommits)
+            bool processDirtyRoot = RootRef?.IsDirty == true;
+            if (processDirtyRoot)
             {
                 Commit(new NodeCommitInfo(RootRef), skipSelf: skipRoot);
-                RootRef!.ResolveKey(TrieStore, true);
             }
 
             while (_currentCommit.TryDequeue(out NodeCommitInfo node))
             {
                 if (_logger.IsTrace) _logger.Trace($"Committing {node} in {blockNumber}");
-                TrieStore.CommitNode(blockNumber, GetStateRootHash(), node, writeFlags: writeFlags);
+                TrieStore.CommitNode(blockNumber, node, writeFlags: writeFlags);
             }
 
-            if (processCommits)
+            if (processDirtyRoot)
             {
-                //RootRef!.ResolveKey(TrieStore, true);
-
+                RootRef!.ResolveKey(TrieStore, true);
                 //resetting root reference for instances without cache will 'unresolve' root node, freeing TrieNode instances
                 //otherwise block commit sets will retain references to TrieNodes and not free them during e.g. snap sync
                 SetRootHash(RootRef.Keccak!, true);
             }
 
-            TrieStore.FinishBlockCommit(TrieType, blockNumber, RootRef, GetStateRootHash(), writeFlags);
+            TrieStore.FinishBlockCommit(TrieType, blockNumber, RootRef, writeFlags);
+            if (TrieStore.Capability == TrieNodeResolverCapability.Path && TrieType == TrieType.State)
+                ParentStateRootHash = RootHash;
             _uncommitedPaths = new Bloom();
             ClearedBySelfDestruct = false;
             if (_logger.IsDebug) _logger.Debug($"Finished committing block {blockNumber}");
@@ -375,7 +376,6 @@ namespace Nethermind.Trie
             else if (resetObjects)
             {
                 RootRef = TrieStore.FindCachedOrUnknown(_rootHash, Array.Empty<byte>(), StoreNibblePathPrefix);
-                //TrieStore.ClearCacheAfter(value);
             }
         }
 
@@ -431,26 +431,26 @@ namespace Nethermind.Trie
         public virtual byte[]? Get(ReadOnlySpan<byte> rawKey, Keccak? rootHash = null)
         {
             //for diagnostics
-            //if (Capability == TrieNodeResolverCapability.Path)
-            //{
-            //    byte[] pathValue = TrieStore.CanAccessByPath() ? GetByPath(rawKey, rootHash) : GetInternal(rawKey, rootHash);
-            //    byte[] internalValue = GetInternal(rawKey, rootHash);
-            //    if (!Bytes.EqualityComparer.Equals(internalValue, pathValue))
-            //        if (_logger.IsWarn) _logger.Warn($"Difference for key: {rawKey.ToHexString()} | ST prefix: {StoreNibblePathPrefix?.ToHexString()} | internal: {internalValue?.ToHexString()} | path value: {pathValue?.ToHexString()}");
-            //    return pathValue;
-            //}
-            //return GetInternal(rawKey, rootHash);
-            return Capability switch
+            if (Capability == TrieNodeResolverCapability.Path)
             {
-                TrieNodeResolverCapability.Hash => GetInternal(rawKey, rootHash),
-                TrieNodeResolverCapability.Path => TrieStore.CanAccessByPath() ? GetByPath(rawKey, rootHash) : GetInternal(rawKey, rootHash),
-                _ => throw new ArgumentOutOfRangeException()
-            };
+                byte[] pathValue = TrieStore.CanAccessByPath() ? GetByPath(rawKey, rootHash) : GetInternal(rawKey, rootHash);
+                byte[] internalValue = GetInternal(rawKey, rootHash);
+                if (!Bytes.EqualityComparer.Equals(internalValue, pathValue))
+                    if (_logger.IsWarn) _logger.Warn($"Difference for key: {rawKey.ToHexString()} | ST prefix: {StoreNibblePathPrefix?.ToHexString()} | internal: {internalValue?.ToHexString()} | path value: {pathValue?.ToHexString()}");
+                return pathValue;
+            }
+            return GetInternal(rawKey, rootHash);
+            //return Capability switch
+            //{
+            //    TrieNodeResolverCapability.Hash => GetInternal(rawKey, rootHash),
+            //    TrieNodeResolverCapability.Path => TrieStore.CanAccessByPath() ? GetByPath(rawKey, rootHash) : GetInternal(rawKey, rootHash),
+            //    _ => throw new ArgumentOutOfRangeException()
+            //};
         }
 
         private byte[]? GetByPath(ReadOnlySpan<byte> rawKey, Keccak? rootHash = null)
         {
-            Keccak cacheProbeRoot = rootHash;
+            //Keccak cacheProbeRoot = rootHash;
             if (rootHash is null)
             {
                 if (RootRef is null) return null;
@@ -462,32 +462,20 @@ namespace Nethermind.Trie
                 else
                 {
                     //is it possible outside of unit tests?
-                    if (RootRef.Keccak is null)
-                    {
-                        RootRef.ResolveNode(TrieStore);
-                        RootRef.ResolveKey(TrieStore, true);
-                    }
-                    cacheProbeRoot = RootRef.Keccak;
+                    //if (RootRef.Keccak is null)
+                    //{
+                    //    RootRef.ResolveNode(TrieStore);
+                    //    RootRef.ResolveKey(TrieStore, true);
+                    //}
+                    //cacheProbeRoot = RootRef.Keccak;
                 }
             }
-
-            if (TrieType == TrieType.Storage)
-                cacheProbeRoot = GetStateRootHash();
 
             // try and get cached nodes
             Span<byte> nibbleBytes = stackalloc byte[StoreNibblePathPrefix.Length + rawKey.Length * 2];
             StoreNibblePathPrefix.CopyTo(nibbleBytes);
             Nibbles.BytesToNibbleBytes(rawKey, nibbleBytes[StoreNibblePathPrefix.Length..]);
-            TrieNode? node = TrieStore.FindCachedOrUnknown(nibbleBytes[StoreNibblePathPrefix.Length..], StoreNibblePathPrefix, cacheProbeRoot);
-            if (cacheProbeRoot is null)
-            {
-                TrieNode? node2 = TrieStore.FindCachedOrUnknown(nibbleBytes[StoreNibblePathPrefix.Length..], StoreNibblePathPrefix, RootHash);
-                if (node2.NodeType != node.NodeType)
-                {
-                    int a = 10;
-                    a++;
-                }
-            }
+            TrieNode? node = TrieStore.FindCachedOrUnknown(nibbleBytes[StoreNibblePathPrefix.Length..], StoreNibblePathPrefix, ParentStateRootHash);
 
             if (node is null)
                 return null;
@@ -1482,11 +1470,6 @@ namespace Nethermind.Trie
         private static void ThrowMissingTrieNodeException(in TraverseContext traverseContext, TrieNodeException e)
         {
             throw new MissingTrieNodeException(e.Message, e, traverseContext.UpdatePath.ToArray(), traverseContext.CurrentIndex);
-        }
-
-        public virtual Keccak GetStateRootHash()
-        {
-            return RootRef?.Keccak ?? Keccak.EmptyTreeHash;
         }
     }
 }

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -921,7 +921,7 @@ namespace Nethermind.Trie
                         return null;
                     }
 
-                    if(Capability == TrieNodeResolverCapability.Path) _deleteNodes?.Enqueue(node.CloneNodeForDeletion());
+                    if (Capability == TrieNodeResolverCapability.Path) _deleteNodes?.Enqueue(node.CloneNodeForDeletion());
                     ConnectNodes(null, in traverseContext);
                 }
                 else if (Bytes.AreEqual(traverseContext.UpdateValue, node.Value))
@@ -1025,7 +1025,7 @@ namespace Nethermind.Trie
 
                 if (traverseContext.IsDelete)
                 {
-                    if(Capability == TrieNodeResolverCapability.Path) _deleteNodes?.Enqueue(node.CloneNodeForDeletion());
+                    if (Capability == TrieNodeResolverCapability.Path) _deleteNodes?.Enqueue(node.CloneNodeForDeletion());
                     ConnectNodes(null, in traverseContext);
                     return traverseContext.UpdateValue;
                 }

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -475,7 +475,7 @@ namespace Nethermind.Trie
             Span<byte> nibbleBytes = stackalloc byte[StoreNibblePathPrefix.Length + rawKey.Length * 2];
             StoreNibblePathPrefix.CopyTo(nibbleBytes);
             Nibbles.BytesToNibbleBytes(rawKey, nibbleBytes[StoreNibblePathPrefix.Length..]);
-            TrieNode? node = TrieStore.FindCachedOrUnknown(nibbleBytes[StoreNibblePathPrefix.Length..], StoreNibblePathPrefix, ParentStateRootHash);
+            TrieNode? node = TrieStore.FindCachedOrUnknown(nibbleBytes[StoreNibblePathPrefix.Length..], StoreNibblePathPrefix, rootHash ?? ParentStateRootHash);
 
             if (node is null)
                 return null;

--- a/src/Nethermind/Nethermind.Trie/Pruning/ITrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ITrieStore.cs
@@ -9,9 +9,11 @@ namespace Nethermind.Trie.Pruning
 {
     public interface ITrieStore : ITrieNodeResolver, IDisposable
     {
+        void SetContext(Keccak keccak);
         void CommitNode(long blockNumber, NodeCommitInfo nodeCommitInfo, WriteFlags writeFlags = WriteFlags.None);
+        void CommitNode(long blockNumber, Keccak rootHash, NodeCommitInfo nodeCommitInfo, WriteFlags writeFlags = WriteFlags.None);
 
-        void FinishBlockCommit(TrieType trieType, long blockNumber, TrieNode? root, WriteFlags writeFlags = WriteFlags.None);
+        void FinishBlockCommit(TrieType trieType, long blockNumber, TrieNode? root, Keccak stateRootHash = null, WriteFlags writeFlags = WriteFlags.None);
 
         bool IsPersisted(in ValueKeccak keccak);
 

--- a/src/Nethermind/Nethermind.Trie/Pruning/ITrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ITrieStore.cs
@@ -11,9 +11,8 @@ namespace Nethermind.Trie.Pruning
     {
         void OpenContext(Keccak keccak);
         void CommitNode(long blockNumber, NodeCommitInfo nodeCommitInfo, WriteFlags writeFlags = WriteFlags.None);
-        void CommitNode(long blockNumber, Keccak rootHash, NodeCommitInfo nodeCommitInfo, WriteFlags writeFlags = WriteFlags.None);
 
-        void FinishBlockCommit(TrieType trieType, long blockNumber, TrieNode? root, Keccak stateRootHash = null, WriteFlags writeFlags = WriteFlags.None);
+        void FinishBlockCommit(TrieType trieType, long blockNumber, TrieNode? root, WriteFlags writeFlags = WriteFlags.None);
 
         bool IsPersisted(in ValueKeccak keccak);
 
@@ -27,7 +26,7 @@ namespace Nethermind.Trie.Pruning
 
         public void ClearCache();
 
-        void MarkPrefixDeleted(long blockNumber, Keccak rootHash, ReadOnlySpan<byte> keyPrefix);
+        void MarkPrefixDeleted(long blockNumber, ReadOnlySpan<byte> keyPrefix);
         void DeleteByRange(Span<byte> startKey, Span<byte> endKey);
 
         bool CanAccessByPath();

--- a/src/Nethermind/Nethermind.Trie/Pruning/ITrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ITrieStore.cs
@@ -9,7 +9,7 @@ namespace Nethermind.Trie.Pruning
 {
     public interface ITrieStore : ITrieNodeResolver, IDisposable
     {
-        void OpenContext(Keccak keccak);
+        void OpenContext(long blockNumber, Keccak keccak);
         void CommitNode(long blockNumber, NodeCommitInfo nodeCommitInfo, WriteFlags writeFlags = WriteFlags.None);
 
         void FinishBlockCommit(TrieType trieType, long blockNumber, TrieNode? root, WriteFlags writeFlags = WriteFlags.None);

--- a/src/Nethermind/Nethermind.Trie/Pruning/ITrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ITrieStore.cs
@@ -9,7 +9,7 @@ namespace Nethermind.Trie.Pruning
 {
     public interface ITrieStore : ITrieNodeResolver, IDisposable
     {
-        void SetContext(Keccak keccak);
+        void OpenContext(Keccak keccak);
         void CommitNode(long blockNumber, NodeCommitInfo nodeCommitInfo, WriteFlags writeFlags = WriteFlags.None);
         void CommitNode(long blockNumber, Keccak rootHash, NodeCommitInfo nodeCommitInfo, WriteFlags writeFlags = WriteFlags.None);
 
@@ -27,7 +27,7 @@ namespace Nethermind.Trie.Pruning
 
         public void ClearCache();
 
-        void MarkPrefixDeleted(long blockNumber, ReadOnlySpan<byte> keyPrefix);
+        void MarkPrefixDeleted(long blockNumber, Keccak rootHash, ReadOnlySpan<byte> keyPrefix);
         void DeleteByRange(Span<byte> startKey, Span<byte> endKey);
 
         bool CanAccessByPath();

--- a/src/Nethermind/Nethermind.Trie/Pruning/ITrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ITrieStore.cs
@@ -22,7 +22,8 @@ namespace Nethermind.Trie.Pruning
 
         IKeyValueStore AsKeyValueStore();
 
-        void SaveNodeDirectly(long blockNumber, TrieNode trieNode, IKeyValueStore? batch = null, bool withDelete = false, WriteFlags writeFlags = WriteFlags.None);
+        void PersistNode(TrieNode trieNode, IKeyValueStore? batch = null, bool withDelete = false, WriteFlags writeFlags = WriteFlags.None);
+        void PersistNodeData(Span<byte> fullPath, int pathToNodeLength, byte[]? rlpData, IKeyValueStore? keyValueStore = null, WriteFlags writeFlags = WriteFlags.None);
 
         public void ClearCache();
 

--- a/src/Nethermind/Nethermind.Trie/Pruning/NullTrieNodeResolver.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/NullTrieNodeResolver.cs
@@ -20,7 +20,7 @@ namespace Nethermind.Trie.Pruning
         public TrieNodeResolverCapability Capability => TrieNodeResolverCapability.Hash;
 
         public TrieNode FindCachedOrUnknown(Keccak hash) => new(NodeType.Unknown, hash);
-        public TrieNode FindCachedOrUnknown(Keccak hash, Span<byte> nodePath, Span<byte> storagePrefix) => new(NodeType.Unknown, nodePath, hash){StoreNibblePathPrefix = storagePrefix.ToArray()};
+        public TrieNode FindCachedOrUnknown(Keccak hash, Span<byte> nodePath, Span<byte> storagePrefix) => new(NodeType.Unknown, nodePath, hash) { StoreNibblePathPrefix = storagePrefix.ToArray() };
 
         public TrieNode? FindCachedOrUnknown(Span<byte> nodePath, byte[] storagePrefix, Keccak? rootHash)
         {

--- a/src/Nethermind/Nethermind.Trie/Pruning/NullTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/NullTrieStore.cs
@@ -15,7 +15,7 @@ namespace Nethermind.Trie.Pruning
 
         public void CommitNode(long blockNumber, NodeCommitInfo nodeCommitInfo, WriteFlags flags = WriteFlags.None) { }
 
-        public void FinishBlockCommit(TrieType trieType, long blockNumber, TrieNode? root, Keccak stateRootHash = null, WriteFlags flags = WriteFlags.None) { }
+        public void FinishBlockCommit(TrieType trieType, long blockNumber, TrieNode? root, WriteFlags flags = WriteFlags.None) { }
 
         public void HackPersistOnShutdown() { }
 
@@ -69,7 +69,7 @@ namespace Nethermind.Trie.Pruning
         public bool ExistsInDB(Keccak hash, byte[] nodePathNibbles) => false;
 
         public void DeleteByRange(Span<byte> startKey, Span<byte> endKey) { }
-        public void MarkPrefixDeleted(long blockNumber, Keccak stateRoot, ReadOnlySpan<byte> keyPrefix)
+        public void MarkPrefixDeleted(long blockNumber, ReadOnlySpan<byte> keyPrefix)
         {
             throw new NotImplementedException();
         }

--- a/src/Nethermind/Nethermind.Trie/Pruning/NullTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/NullTrieStore.cs
@@ -90,7 +90,7 @@ namespace Nethermind.Trie.Pruning
             throw new NotImplementedException();
         }
 
-        public void OpenContext(Keccak keccak)
+        public void OpenContext(long blockNumber, Keccak keccak)
         {
             throw new NotImplementedException();
         }

--- a/src/Nethermind/Nethermind.Trie/Pruning/NullTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/NullTrieStore.cs
@@ -39,7 +39,7 @@ namespace Nethermind.Trie.Pruning
 
         public TrieNode FindCachedOrUnknown(Keccak hash, Span<byte> nodePath, Span<byte> storagePrefix)
         {
-            return new(NodeType.Unknown, nodePath, hash){StoreNibblePathPrefix = storagePrefix.ToArray()};
+            return new(NodeType.Unknown, nodePath, hash) { StoreNibblePathPrefix = storagePrefix.ToArray() };
         }
 
         public TrieNode FindCachedOrUnknown(Span<byte> nodePath, byte[] storagePrefix, Keccak rootHash)

--- a/src/Nethermind/Nethermind.Trie/Pruning/NullTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/NullTrieStore.cs
@@ -69,7 +69,7 @@ namespace Nethermind.Trie.Pruning
         public bool ExistsInDB(Keccak hash, byte[] nodePathNibbles) => false;
 
         public void DeleteByRange(Span<byte> startKey, Span<byte> endKey) { }
-        public void MarkPrefixDeleted(long blockNumber, ReadOnlySpan<byte> keyPrefix)
+        public void MarkPrefixDeleted(long blockNumber, Keccak stateRoot, ReadOnlySpan<byte> keyPrefix)
         {
             throw new NotImplementedException();
         }
@@ -89,7 +89,7 @@ namespace Nethermind.Trie.Pruning
             throw new NotImplementedException();
         }
 
-        public void SetContext(Keccak keccak)
+        public void OpenContext(Keccak keccak)
         {
             throw new NotImplementedException();
         }

--- a/src/Nethermind/Nethermind.Trie/Pruning/NullTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/NullTrieStore.cs
@@ -61,7 +61,8 @@ namespace Nethermind.Trie.Pruning
             return Array.Empty<byte>();
         }
 
-        public void SaveNodeDirectly(long blockNumber, TrieNode trieNode, IKeyValueStore? keyValueStore = null, bool withDelete = false, WriteFlags writeFlags = WriteFlags.None) { }
+        public void PersistNode(TrieNode trieNode, IKeyValueStore? keyValueStore = null, bool withDelete = false, WriteFlags writeFlags = WriteFlags.None) { }
+        public void PersistNodeData(Span<byte> fullPath, int pathToNodeLength, byte[]? rlpData, IKeyValueStore? keyValueStore = null, WriteFlags writeFlags = WriteFlags.None) { }
 
         public void ClearCache() { }
         public void ClearCacheAfter(Keccak rootHash) { }

--- a/src/Nethermind/Nethermind.Trie/Pruning/NullTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/NullTrieStore.cs
@@ -15,7 +15,7 @@ namespace Nethermind.Trie.Pruning
 
         public void CommitNode(long blockNumber, NodeCommitInfo nodeCommitInfo, WriteFlags flags = WriteFlags.None) { }
 
-        public void FinishBlockCommit(TrieType trieType, long blockNumber, TrieNode? root, WriteFlags flags = WriteFlags.None) { }
+        public void FinishBlockCommit(TrieType trieType, long blockNumber, TrieNode? root, Keccak stateRootHash = null, WriteFlags flags = WriteFlags.None) { }
 
         public void HackPersistOnShutdown() { }
 
@@ -64,6 +64,7 @@ namespace Nethermind.Trie.Pruning
         public void SaveNodeDirectly(long blockNumber, TrieNode trieNode, IKeyValueStore? keyValueStore = null, bool withDelete = false, WriteFlags writeFlags = WriteFlags.None) { }
 
         public void ClearCache() { }
+        public void ClearCacheAfter(Keccak rootHash) { }
 
         public bool ExistsInDB(Keccak hash, byte[] nodePathNibbles) => false;
 
@@ -79,6 +80,16 @@ namespace Nethermind.Trie.Pruning
         }
 
         public byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void CommitNode(long blockNumber, Keccak rootHash, NodeCommitInfo nodeCommitInfo, WriteFlags writeFlags = WriteFlags.None)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SetContext(Keccak keccak)
         {
             throw new NotImplementedException();
         }

--- a/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStore.cs
@@ -50,7 +50,7 @@ namespace Nethermind.Trie.Pruning
 
         public void CommitNode(long blockNumber, NodeCommitInfo nodeCommitInfo, WriteFlags flags = WriteFlags.None) { }
 
-        public void FinishBlockCommit(TrieType trieType, long blockNumber, TrieNode? root, Keccak stateRootHash = null, WriteFlags flags = WriteFlags.None) { }
+        public void FinishBlockCommit(TrieType trieType, long blockNumber, TrieNode? root, WriteFlags flags = WriteFlags.None) { }
 
         public event EventHandler<ReorgBoundaryReached> ReorgBoundaryReached
         {
@@ -84,7 +84,7 @@ namespace Nethermind.Trie.Pruning
         public void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None) { }
 
         public bool CanAccessByPath() => _trieStore.CanAccessByPath();
-        public void MarkPrefixDeleted(long blockNumber, Keccak stateRoot, ReadOnlySpan<byte> keyPrefix)
+        public void MarkPrefixDeleted(long blockNumber, ReadOnlySpan<byte> keyPrefix)
         {
             throw new NotImplementedException();
         }

--- a/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStore.cs
@@ -50,7 +50,7 @@ namespace Nethermind.Trie.Pruning
 
         public void CommitNode(long blockNumber, NodeCommitInfo nodeCommitInfo, WriteFlags flags = WriteFlags.None) { }
 
-        public void FinishBlockCommit(TrieType trieType, long blockNumber, TrieNode? root, WriteFlags flags = WriteFlags.None) { }
+        public void FinishBlockCommit(TrieType trieType, long blockNumber, TrieNode? root, Keccak stateRootHash = null, WriteFlags flags = WriteFlags.None) { }
 
         public event EventHandler<ReorgBoundaryReached> ReorgBoundaryReached
         {
@@ -76,6 +76,8 @@ namespace Nethermind.Trie.Pruning
             _trieStore.ClearCache();
         }
 
+        public void ClearCacheAfter(Keccak rootHash) { }
+
         public bool ExistsInDB(Keccak hash, byte[] nodePathNibbles) => _trieStore.ExistsInDB(hash, nodePathNibbles);
 
         public byte[]? this[ReadOnlySpan<byte> key] => _trieStore[key];
@@ -88,6 +90,16 @@ namespace Nethermind.Trie.Pruning
         }
 
         public void DeleteByRange(Span<byte> startKey, Span<byte> endKey) { }
+
+        public void CommitNode(long blockNumber, Keccak rootHash, NodeCommitInfo nodeCommitInfo, WriteFlags writeFlags = WriteFlags.None)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SetContext(Keccak keccak)
+        {
+            throw new NotImplementedException();
+        }
 
         private class ReadOnlyValueStore : IKeyValueStore
         {

--- a/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStore.cs
@@ -95,7 +95,7 @@ namespace Nethermind.Trie.Pruning
             throw new NotImplementedException();
         }
 
-        public void OpenContext(Keccak keccak)
+        public void OpenContext(long blockNumber, Keccak keccak)
         {
             throw new NotImplementedException();
         }

--- a/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStore.cs
@@ -67,10 +67,9 @@ namespace Nethermind.Trie.Pruning
             throw new NotImplementedException();
         }
 
-        public void SaveNodeDirectly(long blockNumber, TrieNode trieNode, IKeyValueStore? keyValueStore, bool withDelete = false, WriteFlags writeFlags = WriteFlags.None)
-        {
-            throw new NotImplementedException();
-        }
+        public void PersistNode(TrieNode trieNode, IKeyValueStore? keyValueStore, bool withDelete = false, WriteFlags writeFlags = WriteFlags.None) { }
+        public void PersistNodeData(Span<byte> fullPath, int pathToNodeLength, byte[]? rlpData, IKeyValueStore? keyValueStore = null, WriteFlags writeFlags = WriteFlags.None) { }
+
         public void ClearCache()
         {
             _trieStore.ClearCache();

--- a/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStore.cs
@@ -84,7 +84,7 @@ namespace Nethermind.Trie.Pruning
         public void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None) { }
 
         public bool CanAccessByPath() => _trieStore.CanAccessByPath();
-        public void MarkPrefixDeleted(long blockNumber, ReadOnlySpan<byte> keyPrefix)
+        public void MarkPrefixDeleted(long blockNumber, Keccak stateRoot, ReadOnlySpan<byte> keyPrefix)
         {
             throw new NotImplementedException();
         }
@@ -96,7 +96,7 @@ namespace Nethermind.Trie.Pruning
             throw new NotImplementedException();
         }
 
-        public void SetContext(Keccak keccak)
+        public void OpenContext(Keccak keccak)
         {
             throw new NotImplementedException();
         }

--- a/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStoreByPath.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStoreByPath.cs
@@ -68,7 +68,9 @@ namespace Nethermind.Trie.Pruning
             return _trieStore.LoadRlp(nodePath, rootHash);
         }
 
-        public void SaveNodeDirectly(long blockNumber, TrieNode trieNode, IKeyValueStore? keyValueStore = null, bool withDelete = false, WriteFlags writeFlags = WriteFlags.None) { }
+        public void PersistNode(TrieNode trieNode, IKeyValueStore? keyValueStore = null, bool withDelete = false, WriteFlags writeFlags = WriteFlags.None) { }
+        public void PersistNodeData(Span<byte> fullPath, int pathToNodeLength, byte[]? rlpData, IKeyValueStore? keyValueStore = null, WriteFlags writeFlags = WriteFlags.None) { }
+
         public void ClearCache() => _trieStore.ClearCache();
         public void ClearCacheAfter(Keccak rootHash) { }
 

--- a/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStoreByPath.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStoreByPath.cs
@@ -52,7 +52,7 @@ namespace Nethermind.Trie.Pruning
 
         public void CommitNode(long blockNumber, NodeCommitInfo nodeCommitInfo, WriteFlags writeFlags = WriteFlags.None) { }
 
-        public void FinishBlockCommit(TrieType trieType, long blockNumber, TrieNode? root, WriteFlags writeFlags = WriteFlags.None) { }
+        public void FinishBlockCommit(TrieType trieType, long blockNumber, TrieNode? root, Keccak stateRootHash = null, WriteFlags writeFlags = WriteFlags.None) { }
 
         public void HackPersistOnShutdown() { }
 
@@ -70,6 +70,7 @@ namespace Nethermind.Trie.Pruning
 
         public void SaveNodeDirectly(long blockNumber, TrieNode trieNode, IKeyValueStore? keyValueStore = null, bool withDelete = false, WriteFlags writeFlags = WriteFlags.None) { }
         public void ClearCache() => _trieStore.ClearCache();
+        public void ClearCacheAfter(Keccak rootHash) { }
 
         public bool ExistsInDB(Keccak hash, byte[] nodePathNibbles) => _trieStore.ExistsInDB(hash, nodePathNibbles);
 
@@ -83,6 +84,16 @@ namespace Nethermind.Trie.Pruning
         public byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags) => _trieStore.Get(key, flags);
 
         public IKeyValueStore AsKeyValueStore() => _publicStore;
+
+        public void CommitNode(long blockNumber, Keccak rootHash, NodeCommitInfo nodeCommitInfo, WriteFlags writeFlags = WriteFlags.None)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SetContext(Keccak keccak)
+        {
+            throw new NotImplementedException();
+        }
 
         private class ReadOnlyValueStore : IKeyValueStore
         {

--- a/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStoreByPath.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStoreByPath.cs
@@ -87,15 +87,9 @@ namespace Nethermind.Trie.Pruning
 
         public IKeyValueStore AsKeyValueStore() => _publicStore;
 
-        public void CommitNode(long blockNumber, Keccak rootHash, NodeCommitInfo nodeCommitInfo, WriteFlags writeFlags = WriteFlags.None)
-        {
-            throw new NotImplementedException();
-        }
+        public void CommitNode(long blockNumber, Keccak rootHash, NodeCommitInfo nodeCommitInfo, WriteFlags writeFlags = WriteFlags.None) { }
 
-        public void OpenContext(long blockNumber, Keccak keccak)
-        {
-            throw new NotImplementedException();
-        }
+        public void OpenContext(long blockNumber, Keccak keccak) { }
 
         private class ReadOnlyValueStore : IKeyValueStore
         {

--- a/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStoreByPath.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStoreByPath.cs
@@ -52,7 +52,7 @@ namespace Nethermind.Trie.Pruning
 
         public void CommitNode(long blockNumber, NodeCommitInfo nodeCommitInfo, WriteFlags writeFlags = WriteFlags.None) { }
 
-        public void FinishBlockCommit(TrieType trieType, long blockNumber, TrieNode? root, Keccak stateRootHash = null, WriteFlags writeFlags = WriteFlags.None) { }
+        public void FinishBlockCommit(TrieType trieType, long blockNumber, TrieNode? root, WriteFlags writeFlags = WriteFlags.None) { }
 
         public void HackPersistOnShutdown() { }
 
@@ -75,7 +75,7 @@ namespace Nethermind.Trie.Pruning
         public bool ExistsInDB(Keccak hash, byte[] nodePathNibbles) => _trieStore.ExistsInDB(hash, nodePathNibbles);
 
         public void DeleteByRange(Span<byte> startKey, Span<byte> endKey) { }
-        public void MarkPrefixDeleted(long blockNumber, Keccak stateRoot, ReadOnlySpan<byte> keyPrefix) { }
+        public void MarkPrefixDeleted(long blockNumber, ReadOnlySpan<byte> keyPrefix) { }
 
         public bool CanAccessByPath() => _trieStore.CanAccessByPath();
 

--- a/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStoreByPath.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStoreByPath.cs
@@ -92,7 +92,7 @@ namespace Nethermind.Trie.Pruning
             throw new NotImplementedException();
         }
 
-        public void OpenContext(Keccak keccak)
+        public void OpenContext(long blockNumber, Keccak keccak)
         {
             throw new NotImplementedException();
         }

--- a/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStoreByPath.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStoreByPath.cs
@@ -75,7 +75,7 @@ namespace Nethermind.Trie.Pruning
         public bool ExistsInDB(Keccak hash, byte[] nodePathNibbles) => _trieStore.ExistsInDB(hash, nodePathNibbles);
 
         public void DeleteByRange(Span<byte> startKey, Span<byte> endKey) { }
-        public void MarkPrefixDeleted(long blockNumber, ReadOnlySpan<byte> keyPrefix) { }
+        public void MarkPrefixDeleted(long blockNumber, Keccak stateRoot, ReadOnlySpan<byte> keyPrefix) { }
 
         public bool CanAccessByPath() => _trieStore.CanAccessByPath();
 
@@ -90,7 +90,7 @@ namespace Nethermind.Trie.Pruning
             throw new NotImplementedException();
         }
 
-        public void SetContext(Keccak keccak)
+        public void OpenContext(Keccak keccak)
         {
             throw new NotImplementedException();
         }

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -276,7 +276,7 @@ namespace Nethermind.Trie.Pruning
             return node;
         }
 
-        public void FinishBlockCommit(TrieType trieType, long blockNumber, TrieNode? root, Keccak stateRootHash = null, WriteFlags writeFlags = WriteFlags.None)
+        public void FinishBlockCommit(TrieType trieType, long blockNumber, TrieNode? root, WriteFlags writeFlags = WriteFlags.None)
         {
             if (blockNumber < 0) throw new ArgumentOutOfRangeException(nameof(blockNumber));
             EnsureCommitSetExistsForBlock(blockNumber);
@@ -876,7 +876,7 @@ namespace Nethermind.Trie.Pruning
             _keyValueStore.DeleteByRange(startKey, endKey);
         }
 
-        public void MarkPrefixDeleted(long blockNumber, Keccak stateRoot, ReadOnlySpan<byte> keyPrefix)
+        public void MarkPrefixDeleted(long blockNumber, ReadOnlySpan<byte> keyPrefix)
         {
             throw new NotImplementedException();
         }

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -844,10 +844,15 @@ namespace Nethermind.Trie.Pruning
             throw new NotImplementedException();
         }
 
-        public void SaveNodeDirectly(long blockNumber, TrieNode trieNode, IKeyValueStore? keyValueStore = null, bool withDelete = false, WriteFlags writeFlags = WriteFlags.None)
+        public void PersistNode(TrieNode trieNode, IKeyValueStore? keyValueStore = null, bool withDelete = false, WriteFlags writeFlags = WriteFlags.None)
         {
             keyValueStore ??= _keyValueStore;
             keyValueStore.Set(trieNode.Keccak.Bytes, trieNode.Value.ToArray(), writeFlags);
+        }
+
+        public void PersistNodeData(Span<byte> fullPath, int pathToNodeLength, byte[]? rlpData, IKeyValueStore? keyValueStore = null, WriteFlags writeFlags = WriteFlags.None)
+        {
+            throw new NotImplementedException();
         }
 
         public bool ExistsInDB(Keccak hash, byte[] nodePathNibbles)

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -276,7 +276,7 @@ namespace Nethermind.Trie.Pruning
             return node;
         }
 
-        public void FinishBlockCommit(TrieType trieType, long blockNumber, TrieNode? root, WriteFlags writeFlags = WriteFlags.None)
+        public void FinishBlockCommit(TrieType trieType, long blockNumber, TrieNode? root, Keccak stateRootHash = null, WriteFlags writeFlags = WriteFlags.None)
         {
             if (blockNumber < 0) throw new ArgumentOutOfRangeException(nameof(blockNumber));
             EnsureCommitSetExistsForBlock(blockNumber);
@@ -555,6 +555,11 @@ namespace Nethermind.Trie.Pruning
         /// This method is here to support testing.
         /// </summary>
         public void ClearCache() => _dirtyNodes.Clear();
+
+        public void ClearCacheAfter(Keccak rootHash)
+        {
+            throw new NotImplementedException();
+        }
 
         public void Dispose()
         {
@@ -882,6 +887,15 @@ namespace Nethermind.Trie.Pruning
         }
 
         public IKeyValueStore AsKeyValueStore() => _publicStore;
+
+        public void CommitNode(long blockNumber, Keccak rootHash, NodeCommitInfo nodeCommitInfo, WriteFlags writeFlags = WriteFlags.None)
+        {
+            CommitNode(blockNumber, nodeCommitInfo, writeFlags);
+        }
+
+        public void SetContext(Keccak keccak)
+        {
+        }
 
         private class TrieKeyValueStore : IKeyValueStore
         {

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -876,7 +876,7 @@ namespace Nethermind.Trie.Pruning
             _keyValueStore.DeleteByRange(startKey, endKey);
         }
 
-        public void MarkPrefixDeleted(long blockNumber, ReadOnlySpan<byte> keyPrefix)
+        public void MarkPrefixDeleted(long blockNumber, Keccak stateRoot, ReadOnlySpan<byte> keyPrefix)
         {
             throw new NotImplementedException();
         }
@@ -893,7 +893,7 @@ namespace Nethermind.Trie.Pruning
             CommitNode(blockNumber, nodeCommitInfo, writeFlags);
         }
 
-        public void SetContext(Keccak keccak)
+        public void OpenContext(Keccak keccak)
         {
         }
 

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -898,9 +898,7 @@ namespace Nethermind.Trie.Pruning
             CommitNode(blockNumber, nodeCommitInfo, writeFlags);
         }
 
-        public void OpenContext(Keccak keccak)
-        {
-        }
+        public void OpenContext(long blockNumber, Keccak keccak) { }
 
         private class TrieKeyValueStore : IKeyValueStore
         {

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStoreByPath.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStoreByPath.cs
@@ -688,7 +688,7 @@ namespace Nethermind.Trie.Pruning
             if (prefix.Length % 2 != 0)
                 throw new ArgumentException("Only even length prefixes supported");
 
-            Span<byte> fromKey = new (GC.AllocateUninitializedArray<byte>(prefix.Length));
+            Span<byte> fromKey = new(GC.AllocateUninitializedArray<byte>(prefix.Length));
             prefix.CopyTo(fromKey);
             Span<byte> toKey = new(GC.AllocateUninitializedArray<byte>(prefix.Length));
             prefix.CopyTo(toKey);
@@ -843,7 +843,7 @@ namespace Nethermind.Trie.Pruning
                     keyRanges[3] = EncodePathWithEnforcedOddity(childPathTo, fullKeyLength, 1, 0xff);
                 }
 
-                for (int i = 0; i < 4; i+=2)
+                for (int i = 0; i < 4; i += 2)
                 {
                     if (_logger.IsTrace) _logger.Trace($"Branch deletion for {branchNode.FullPath.ToHexString()} | from: {keyRanges[i].ToHexString()} to: {keyRanges[i + 1].ToHexString()}");
                     _pathStateDb?.EnqueueDeleteRange(fullKeyLength == 66 ? StateColumns.Storage : StateColumns.State, keyRanges[i], keyRanges[i + 1]);

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStoreByPath.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStoreByPath.cs
@@ -472,14 +472,14 @@ namespace Nethermind.Trie.Pruning
                     if (_logger.IsTrace) _logger.Trace($"Persist target {persistUntilBlock} | persisting {frontSet.BlockNumber} / {frontSet.Root?.Keccak}");
                 }
 
-                LastPersistedBlockNumber = frontSet.BlockNumber;
-
                 foreach (StateColumns column in Enum.GetValues(typeof(StateColumns)))
                 {
                     _currentBatches[column] ??= _stateDb.GetColumnDb(column).StartBatch();
                     //_committedNodes[column].PersistUntilBlock(persistUntilBlock, _currentBatches[column]);
-                    _committedNodes[column].PersistUntilBlock(persistUntilBlock, stateRoot, _currentBatches[column]);
+                    _committedNodes[column].PersistUntilBlock(persistUntilBlock, frontSet?.Root?.Keccak ?? Keccak.EmptyTreeHash, _currentBatches[column]);
                 }
+
+                LastPersistedBlockNumber = frontSet.BlockNumber;
 
                 stopwatch.Stop();
                 Metrics.SnapshotPersistenceTime = stopwatch.ElapsedMilliseconds;

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStoreByPath.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStoreByPath.cs
@@ -383,6 +383,10 @@ namespace Nethermind.Trie.Pruning
             {
                 Stopwatch stopwatch = Stopwatch.StartNew();
 
+                int noOfBlocks = _commitSetQueue.ToList().Count((b) => b.BlockNumber == persistUntilBlock);
+                if (noOfBlocks > 1)
+                    throw new InvalidOperationException("Multiple blocks with same number - can't persist!");
+
                 BlockCommitSet frontSet = null;
                 while (_commitSetQueue.TryPeek(out BlockCommitSet peekSet) && peekSet.BlockNumber <= persistUntilBlock)
                 {
@@ -408,7 +412,7 @@ namespace Nethermind.Trie.Pruning
                 // Generally hanging nodes are not a problem in the DB but anything missing from the DB is.
                 foreach (StateColumns column in Enum.GetValues(typeof(StateColumns)))
                 {
-                    _currentBatches[column].Dispose();
+                    _currentBatches[column]?.Dispose();
                     _currentBatches[column] = null;
                 }
             }

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStoreByPath.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStoreByPath.cs
@@ -940,10 +940,10 @@ namespace Nethermind.Trie.Pruning
 
         public IKeyValueStore AsKeyValueStore() => _publicStore;
 
-        public void OpenContext(Keccak keccak)
+        public void OpenContext(long blockNumber, Keccak keccak)
         {
-            _committedNodes[StateColumns.State].OpenContext(keccak);
-            _committedNodes[StateColumns.Storage].OpenContext(keccak);
+            _committedNodes[StateColumns.State].OpenContext(blockNumber, keccak);
+            _committedNodes[StateColumns.Storage].OpenContext(blockNumber, keccak);
         }
 
         private class TrieKeyValueStore : IKeyValueStore

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
@@ -33,7 +33,7 @@ namespace Nethermind.Trie
                 }
 
                 if (tree.Capability == TrieNodeResolverCapability.Path) item.ResolveNode(tree);
-                
+
                 return item.NodeType switch
                 {
                     NodeType.Branch => RlpEncodeBranch(tree, item, bufferPool),

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Visitor.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Visitor.cs
@@ -287,7 +287,7 @@ namespace Nethermind.Trie
                                     trieVisitContext.Level++;
                                     trieVisitContext.BranchChildIndex = null;
 
-                                    using (trieVisitContext.AbsolutePathNext(new byte[]{8,0}))
+                                    using (trieVisitContext.AbsolutePathNext(new byte[] { 8, 0 }))
                                     {
                                         ITrieNodeResolver storageNodeResolver = trieVisitContext.StorageTrieNodeResolver ?? nodeResolver;
                                         if (TryResolveStorageRoot(storageNodeResolver, CollectionsMarshal.AsSpan(trieVisitContext.AbsolutePathNibbles), out TrieNode? storageRoot))

--- a/src/Nethermind/Nethermind.Trie/TrieNode.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.cs
@@ -1097,12 +1097,12 @@ namespace Nethermind.Trie
                                         child = tree.FindCachedOrUnknown(keccak!);
                                         break;
                                     case TrieNodeResolverCapability.Path:
-                                    {
-                                        Span<byte> childPath = stackalloc byte[GetChildPathLength()];
-                                        GetChildPath(i, childPath);
-                                        child = tree.FindCachedOrUnknown(keccak!, childPath, StoreNibblePathPrefix);
-                                        break;
-                                    }
+                                        {
+                                            Span<byte> childPath = stackalloc byte[GetChildPathLength()];
+                                            GetChildPath(i, childPath);
+                                            child = tree.FindCachedOrUnknown(keccak!, childPath, StoreNibblePathPrefix);
+                                            break;
+                                        }
                                     default:
                                         throw new ArgumentOutOfRangeException($"tree capability cannot be {tree.Capability}");
                                 }

--- a/src/Nethermind/Nethermind.Trie/VisitContext.cs
+++ b/src/Nethermind/Nethermind.Trie/VisitContext.cs
@@ -63,7 +63,7 @@ namespace Nethermind.Trie
         public TrieVisitContext Clone()
         {
             TrieVisitContext cloned = (TrieVisitContext)MemberwiseClone();
-            if (_absolutePathNibbles is not null) 
+            if (_absolutePathNibbles is not null)
                 cloned._absolutePathNibbles = new List<byte>(_absolutePathNibbles);
             return cloned;
         }


### PR DESCRIPTION
## Changes

Introduces a modified version of path based cache which tracks blocks relationship to better handle reorgs as well as block processing without head updates. The cache is still based on path first, then block, but no longer stores TrieNode instances.
- history for a given path stored in a sorted set
- single cache instance stores multiple paths using a dictionary
- single cache instance aggregates changes across multiple blocks - represents a single branch until a branching point

In order to read values from the cache an appropriate state root needs to be provided. This is tracked within `PatriciaTree`using `ParentStateRootHash` property.

Additional change to `TreeSync` to handle inlinded nodes of branches.

Will require further changes and adjusting to:
- #6214
- #6232
and then with: #6260 

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No