### PR TITLE
Reduce memory for GetPayloadBodiesByRangeV1 and GetPayloadBodiesByHashV1

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetPayloadBodiesByHashV1Handler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetPayloadBodiesByHashV1Handler.cs
@@ -35,16 +35,18 @@ public class GetPayloadBodiesByHashV1Handler : IAsyncHandler<IList<Hash256>, IEn
             return ResultWrapper<IEnumerable<ExecutionPayloadBodyV1Result?>>.Fail(error, MergeErrorCodes.TooLargeRequest);
         }
 
-        var payloadBodies = new ExecutionPayloadBodyV1Result?[blockHashes.Count];
+        return Task.FromResult(ResultWrapper<IEnumerable<ExecutionPayloadBodyV1Result?>>.Success(GetRequests(blockHashes)));
+    }
+
+    private IEnumerable<ExecutionPayloadBodyV1Result?> GetRequests(IList<Hash256> blockHashes)
+    {
         for (int i = 0; i < blockHashes.Count; i++)
         {
             Block? block = _blockTree.FindBlock(blockHashes[i]);
 
-            payloadBodies[i] = block is null
-                ? null
-                : new ExecutionPayloadBodyV1Result(block.Transactions, block.Withdrawals);
+            yield return (block is null ? null : new ExecutionPayloadBodyV1Result(block.Transactions, block.Withdrawals));
         }
 
-        return Task.FromResult(ResultWrapper<IEnumerable<ExecutionPayloadBodyV1Result?>>.Success(payloadBodies));
+        yield break;
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetPayloadBodiesByRangeV1Handler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetPayloadBodiesByRangeV1Handler.cs
@@ -44,16 +44,20 @@ public class GetPayloadBodiesByRangeV1Handler : IGetPayloadBodiesByRangeV1Handle
             return ResultWrapper<IEnumerable<ExecutionPayloadBodyV1Result?>>.Fail(error, MergeErrorCodes.TooLargeRequest);
         }
 
+        return ResultWrapper<IEnumerable<ExecutionPayloadBodyV1Result?>>.Success(GetRequests(start, count));
+    }
+
+    private IEnumerable<ExecutionPayloadBodyV1Result?> GetRequests(long start, long count)
+    {
         var headNumber = _blockTree.Head?.Number ?? 0;
-        var payloadBodies = new List<ExecutionPayloadBodyV1Result?>((int)count);
 
         for (long i = start, c = Math.Min(start + count - 1, headNumber); i <= c; i++)
         {
             var block = _blockTree.FindBlock(i);
 
-            payloadBodies.Add(block is null ? null : new(block.Transactions, block.Withdrawals));
+            yield return (block is null ? null : new ExecutionPayloadBodyV1Result(block.Transactions, block.Withdrawals));
         }
 
-        return ResultWrapper<IEnumerable<ExecutionPayloadBodyV1Result?>>.Success(payloadBodies);
+        yield break;
     }
 }


### PR DESCRIPTION
## Changes

- Use full enumerator rather than building List for block bodies

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No