### PR TITLE
fix(db, rocks): total table size should include blobs

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -236,7 +236,13 @@ public class DbOnTheRocks : IDb, ITunableDb
     {
         try
         {
-            return long.TryParse(_db.GetProperty("rocksdb.total-sst-files-size"), out long size) ? size : 0;
+            long sstSize = long.TryParse(_db.GetProperty("rocksdb.total-sst-files-size"), out long totalSstFilesSize)
+                ? totalSstFilesSize
+                : 0;
+            long blobSize = long.TryParse(_db.GetProperty("rocksdb.total-blob-file-size"), out long totalBlobFileSize)
+                ? totalBlobFileSize
+                : 0;
+            return sstSize + blobSize;
         }
         catch (RocksDbSharpException e)
         {


### PR DESCRIPTION
## Changes

- `DbOnTheRocks.GetSize()` takes RocksDB's blob storage into account via [the corresponding metric](https://github.com/facebook/rocksdb/blob/9202db1867e412e51e72fc04062ca3664deb097b/include/rocksdb/db.h#L1248-L1250)

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### Notes on testing

Mainnet blocks database has the correct value in the Grafana dashboard

<img width="1531" alt="image" src="https://github.com/NethermindEth/nethermind/assets/5773434/ba574611-2778-4a6d-bae0-b4a6e2ffe6f2">


## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
