### PR TITLE
Fix missed release span on column db

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -14,7 +14,7 @@ namespace Nethermind.Db.Rocks;
 public class ColumnDb : IDb
 {
     private readonly RocksDb _rocksDb;
-    private readonly DbOnTheRocks _mainDb;
+    internal readonly DbOnTheRocks _mainDb;
     internal readonly ColumnFamilyHandle _columnFamily;
 
     private DbOnTheRocks.ManagedIterators _readaheadIterators = new();
@@ -136,4 +136,9 @@ public class ColumnDb : IDb
     public long GetCacheSize() => _mainDb.GetCacheSize();
     public long GetIndexSize() => _mainDb.GetIndexSize();
     public long GetMemtableSize() => _mainDb.GetMemtableSize();
+
+    public void DangerousReleaseMemory(in Span<byte> span)
+    {
+        _mainDb.DangerousReleaseMemory(span);
+    }
 }

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -70,6 +70,8 @@ public class DbOnTheRocks : IDb, ITunableDb
 
     private ManagedIterators _readaheadIterators = new();
 
+    internal long _allocatedSpan = 0;
+
     public DbOnTheRocks(
         string basePath,
         RocksDbSettings rocksDbSettings,
@@ -591,7 +593,10 @@ public class DbOnTheRocks : IDb, ITunableDb
         {
             Span<byte> span = _db.GetSpan(key, cf);
             if (!span.IsNullOrEmpty())
+            {
+                Interlocked.Increment(ref _allocatedSpan);
                 GC.AddMemoryPressure(span.Length);
+            }
             return span;
         }
         catch (RocksDbSharpException e)
@@ -609,7 +614,10 @@ public class DbOnTheRocks : IDb, ITunableDb
     public void DangerousReleaseMemory(in Span<byte> span)
     {
         if (!span.IsNullOrEmpty())
+        {
+            Interlocked.Decrement(ref _allocatedSpan);
             GC.RemoveMemoryPressure(span.Length);
+        }
         _db.DangerousReleaseMemory(span);
     }
 

--- a/src/Nethermind/Nethermind.Db.Rocks/Nethermind.Db.Rocks.csproj
+++ b/src/Nethermind/Nethermind.Db.Rocks/Nethermind.Db.Rocks.csproj
@@ -10,6 +10,10 @@
   <ItemGroup>
     <ProjectReference Include="..\Nethermind.Api\Nethermind.Api.csproj" />
     <ProjectReference Include="..\Nethermind.Db\Nethermind.Db.csproj" />
+
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Nethermind.Db.Test</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 
   <ItemGroup>
@@ -17,5 +21,4 @@
     <PackageReference Include="FastEnum" />
     <PackageReference Include="RocksDB" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
- Fix column db missed `DangerousReleaseMemory` implementation introduced by #6232 .
- Found by adding a custom metrics to count the number of allocation vs deallocation.

## Changes

- Added the implementation. 
- Added extra tests to prevent this from happening again. 

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- confirm reproducable via stressing eth_getLogs.