### PR TITLE
Fix flaky tests `Can_produce_first_block_when_private_chains_allowed` and `TestWillExit`

### DIFF
--- a/src/Nethermind/Nethermind.AuRa.Test/AuRaBlockProducerTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/AuRaBlockProducerTests.cs
@@ -226,10 +226,10 @@ namespace Nethermind.AuRa.Test
             await context.AuRaBlockProducer.Start();
             await processedEvent.WaitOneAsync(context.StepDelay * stepDelayMultiplier * 5, CancellationToken.None);
             context.BlockTree.ClearReceivedCalls();
+            await Task.Delay(context.StepDelay * 3);
 
             try
             {
-                await Task.Delay(context.StepDelay);
                 if (processingQueueEmpty)
                 {
                     context.BlockProcessingQueue.ProcessingQueueEmpty += Raise.Event();
@@ -239,6 +239,7 @@ namespace Nethermind.AuRa.Test
                 {
                     context.BlockTree.NewBestSuggestedBlock += Raise.EventWith(new BlockEventArgs(Build.A.Block.TestObject));
                     context.BlockTree.ClearReceivedCalls();
+                    await Task.Delay(context.StepDelay * 3);
                 }
 
                 await processedEvent.WaitOneAsync(context.StepDelay * stepDelayMultiplier * 5, CancellationToken.None);

--- a/src/Nethermind/Nethermind.AuRa.Test/AuRaBlockProducerTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/AuRaBlockProducerTests.cs
@@ -226,7 +226,8 @@ namespace Nethermind.AuRa.Test
             await context.AuRaBlockProducer.Start();
             await processedEvent.WaitOneAsync(context.StepDelay * stepDelayMultiplier * 5, CancellationToken.None);
             context.BlockTree.ClearReceivedCalls();
-            await Task.Delay(context.StepDelay * 3);
+            await Task.Delay(context.StepDelay);
+            processedEvent.Reset();
 
             try
             {
@@ -239,7 +240,7 @@ namespace Nethermind.AuRa.Test
                 {
                     context.BlockTree.NewBestSuggestedBlock += Raise.EventWith(new BlockEventArgs(Build.A.Block.TestObject));
                     context.BlockTree.ClearReceivedCalls();
-                    await Task.Delay(context.StepDelay * 3);
+                    processedEvent.Reset();
                 }
 
                 await processedEvent.WaitOneAsync(context.StepDelay * stepDelayMultiplier * 5, CancellationToken.None);

--- a/src/Nethermind/Nethermind.Synchronization.Test/ExitOnSyncCompleteTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ExitOnSyncCompleteTests.cs
@@ -2,11 +2,13 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Config;
 using Nethermind.Logging;
 using Nethermind.Synchronization.ParallelSync;
 using NSubstitute;
+using NSubstitute.Core;
 using NUnit.Framework;
 
 namespace Nethermind.Synchronization.Test;
@@ -19,7 +21,7 @@ public class ExitOnSyncCompleteTests
     {
         ISyncModeSelector syncMode = Substitute.For<ISyncModeSelector>();
         IProcessExitSource exitSource = Substitute.For<IProcessExitSource>();
-        TimeSpan exitConditionDuration = TimeSpan.FromMilliseconds(10);
+        TimeSpan exitConditionDuration = TimeSpan.FromMilliseconds(40);
 
         exitSource.WatchForExit(syncMode, LimboLogs.Instance, exitConditionDuration: exitConditionDuration);
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/ExitOnSyncCompleteTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ExitOnSyncCompleteTests.cs
@@ -21,12 +21,12 @@ public class ExitOnSyncCompleteTests
     {
         ISyncModeSelector syncMode = Substitute.For<ISyncModeSelector>();
         IProcessExitSource exitSource = Substitute.For<IProcessExitSource>();
-        TimeSpan exitConditionDuration = TimeSpan.FromMilliseconds(40);
+        TimeSpan exitConditionDuration = TimeSpan.FromMilliseconds(10);
 
         exitSource.WatchForExit(syncMode, LimboLogs.Instance, exitConditionDuration: exitConditionDuration);
 
         syncMode.Changed += Raise.EventWith(this, new SyncModeChangedEventArgs(SyncMode.All, SyncMode.WaitingForBlock));
-        await Task.Delay(exitConditionDuration);
+        await Task.Delay(exitConditionDuration * 3);
         syncMode.Changed += Raise.EventWith(this, new SyncModeChangedEventArgs(SyncMode.All, SyncMode.WaitingForBlock));
 
         exitSource.Received().Exit(0);

--- a/src/Nethermind/Nethermind.Synchronization.Test/ExitOnSyncCompleteTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ExitOnSyncCompleteTests.cs
@@ -26,7 +26,7 @@ public class ExitOnSyncCompleteTests
         exitSource.WatchForExit(syncMode, LimboLogs.Instance, exitConditionDuration: exitConditionDuration);
 
         syncMode.Changed += Raise.EventWith(this, new SyncModeChangedEventArgs(SyncMode.All, SyncMode.WaitingForBlock));
-        await Task.Delay(exitConditionDuration * 3);
+        await Task.Delay(exitConditionDuration * 2);
         syncMode.Changed += Raise.EventWith(this, new SyncModeChangedEventArgs(SyncMode.All, SyncMode.WaitingForBlock));
 
         exitSource.Received().Exit(0);


### PR DESCRIPTION
Fixes #6291

concurrency issue where `processedEvent.Set` happens after `ClearReceivedCalls`
Before the fix I could reproduce the issue within 50 attempts
Screenshot after fix:
![image](https://github.com/NethermindEth/nethermind/assets/33181301/181b22d9-bc2a-4c62-8d3d-d78833e7bdf1)

`TestWillExit` could reproduce the issue easily as well.
Screenshot After fix:
![image](https://github.com/NethermindEth/nethermind/assets/33181301/0a69e84f-79dd-441c-a4c4-d838bc97f6cc)


## Changes

- delay after `ClearReceivedCalls`
- delay between the event raising in `TestWillExit`

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No