### PR TITLE
Enable caching store / db for path based layout.

### DIFF
--- a/src/Nethermind/Nethermind.Api/IApiWithBlockchain.cs
+++ b/src/Nethermind/Nethermind.Api/IApiWithBlockchain.cs
@@ -15,6 +15,7 @@ using Nethermind.Consensus.Producers;
 using Nethermind.Consensus.Rewards;
 using Nethermind.Consensus.Validators;
 using Nethermind.Core;
+using Nethermind.Db.ByPathState;
 using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Facade;
 using Nethermind.Facade.Eth;
@@ -63,6 +64,7 @@ namespace Nethermind.Api
         /// </remarks>
         IWorldState? WorldState { get; set; }
         IKeyValueStoreWithBatching? MainStateDbWithCache { get; set; }
+        IByPathStateDb? MainPathStateDbWithCache { get; set; }
         IReadOnlyStateProvider? ChainHeadStateProvider { get; set; }
         IStateReader? StateReader { get; set; }
         ITransactionProcessor? TransactionProcessor { get; set; }

--- a/src/Nethermind/Nethermind.Api/NethermindApi.cs
+++ b/src/Nethermind/Nethermind.Api/NethermindApi.cs
@@ -55,6 +55,7 @@ using Nethermind.Wallet;
 using Nethermind.Sockets;
 using Nethermind.Synchronization.SnapSync;
 using System;
+using Nethermind.Db.ByPathState;
 
 namespace Nethermind.Api
 {
@@ -142,6 +143,7 @@ namespace Nethermind.Api
         public ILogFinder? LogFinder { get; set; }
         public ILogManager LogManager { get; set; }
         public IKeyValueStoreWithBatching? MainStateDbWithCache { get; set; }
+        public IByPathStateDb? MainPathStateDbWithCache { get; set; }
         public IMessageSerializationService MessageSerializationService { get; } = new MessageSerializationService();
         public IGossipPolicy GossipPolicy { get; set; } = Policy.FullGossip;
         public IMonitoringService MonitoringService { get; set; } = NullMonitoringService.Instance;

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
@@ -26,6 +26,7 @@ using FluentAssertions;
 using Nethermind.Consensus.Processing;
 using Nethermind.Consensus.Rewards;
 using Nethermind.Core.Test.Blockchain;
+using Nethermind.Db.ByPathState;
 using Nethermind.Evm.TransactionProcessing;
 
 namespace Nethermind.Blockchain.Test
@@ -67,7 +68,7 @@ namespace Nethermind.Blockchain.Test
         {
             MemColumnsDb<StateColumns> stateDb = new();
             IDb codeDb = new MemDb();
-            TrieStoreByPath trieStore = new TrieStoreByPath(stateDb, LimboLogs.Instance);
+            TrieStoreByPath trieStore = new(new ByPathStateDb(stateDb, LimboLogs.Instance), LimboLogs.Instance);
 
             IWorldState stateProvider = new WorldState(trieStore, codeDb, LimboLogs.Instance);
             ITransactionProcessor transactionProcessor = Substitute.For<ITransactionProcessor>();

--- a/src/Nethermind/Nethermind.Blockchain.Test/Producers/DevBlockproducerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Producers/DevBlockproducerTests.cs
@@ -15,6 +15,7 @@ using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
 using Nethermind.Db.Blooms;
+using Nethermind.Db.ByPathState;
 using Nethermind.Evm;
 using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Logging;
@@ -46,7 +47,7 @@ namespace Nethermind.Blockchain.Test.Producers
                 .WithoutSettingHead
                 .TestObject;
 
-            TrieStoreByPath trieStore = new(dbProvider.GetColumnDb<StateColumns>(DbNames.PathState), LimboLogs.Instance);
+            TrieStoreByPath trieStore = new(new ByPathStateDb(dbProvider.GetColumnDb<StateColumns>(DbNames.PathState), LimboLogs.Instance), LimboLogs.Instance);
 
             WorldState stateProvider = new(
                 trieStore,

--- a/src/Nethermind/Nethermind.Blockchain.Test/Visitors/StartupTreeFixerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Visitors/StartupTreeFixerTests.cs
@@ -14,6 +14,7 @@ using Nethermind.Logging;
 using Nethermind.Specs;
 using Nethermind.State.Repositories;
 using Nethermind.Db.Blooms;
+using Nethermind.Db.ByPathState;
 using Nethermind.JsonRpc.Test.Modules;
 using NUnit.Framework;
 using Nethermind.Trie.Pruning;
@@ -73,7 +74,7 @@ namespace Nethermind.Blockchain.Test.Visitors
                 .WithDatabaseFrom(builder)
                 .TestObject;
 
-            TrieStoreByPath trieStore = new TrieStoreByPath(new MemColumnsDb<StateColumns>(), LimboLogs.Instance);
+            TrieStoreByPath trieStore = new(new ByPathStateDb(new MemColumnsDb<StateColumns>(), LimboLogs.Instance), LimboLogs.Instance);
             StartupBlockTreeFixer fixer = new(new SyncConfig(), tree, trieStore, LimboNoErrorLogger.Instance);
             await tree.Accept(fixer, CancellationToken.None);
 
@@ -147,7 +148,7 @@ namespace Nethermind.Blockchain.Test.Visitors
 
             // we create a new empty db for stateDb so we shouldn't suggest new blocks
             IColumnsDb<StateColumns> stateDb = new MemColumnsDb<StateColumns>();
-            TrieStoreByPath trieStore = new TrieStoreByPath(stateDb, LimboLogs.Instance);
+            TrieStoreByPath trieStore = new(new ByPathStateDb(stateDb, LimboLogs.Instance), LimboLogs.Instance);
             IBlockTreeVisitor fixer = new StartupBlockTreeFixer(new SyncConfig(), tree, trieStore, LimboNoErrorLogger.Instance, 5);
             BlockVisitOutcome result = await fixer.VisitBlock(tree.Head!, CancellationToken.None);
 
@@ -169,7 +170,7 @@ namespace Nethermind.Blockchain.Test.Visitors
             newBlockchainProcessor.Start();
             testRpc.BlockchainProcessor = newBlockchainProcessor;
 
-            TrieStoreByPath trieStore = new TrieStoreByPath(testRpc.DbProvider.PathStateDb, LimboLogs.Instance);
+            TrieStoreByPath trieStore = new(new ByPathStateDb(testRpc.DbProvider.PathStateDb, LimboLogs.Instance), LimboLogs.Instance);
             IBlockTreeVisitor fixer = new StartupBlockTreeFixer(new SyncConfig(), tree, trieStore, LimboNoErrorLogger.Instance, 5);
             BlockVisitOutcome result = await fixer.VisitBlock(null!, CancellationToken.None);
 
@@ -218,7 +219,7 @@ namespace Nethermind.Blockchain.Test.Visitors
             tree.UpdateMainChain(block2);
 
             IColumnsDb<StateColumns> stateDb = new MemColumnsDb<StateColumns>();
-            TrieStoreByPath trieStore = new TrieStoreByPath(stateDb, LimboLogs.Instance);
+            TrieStoreByPath trieStore = new(new ByPathStateDb(stateDb, LimboLogs.Instance), LimboLogs.Instance);
             StartupBlockTreeFixer fixer = new(new SyncConfig(), tree, trieStore, LimboNoErrorLogger.Instance);
             await tree.Accept(fixer, CancellationToken.None);
 

--- a/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
@@ -24,6 +24,7 @@ using Nethermind.Core.Test.Builders;
 using Nethermind.Crypto;
 using Nethermind.Db;
 using Nethermind.Db.Blooms;
+using Nethermind.Db.ByPathState;
 using Nethermind.Evm;
 using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Int256;
@@ -116,7 +117,7 @@ public class TestBlockchain : IDisposable
         SpecProvider = CreateSpecProvider(specProvider ?? MainnetSpecProvider.Instance);
         EthereumEcdsa = new EthereumEcdsa(SpecProvider.ChainId, LogManager);
         DbProvider = await CreateDbProvider();
-        TrieStore = usePathStateDb ? new TrieStoreByPath(PathStateDb, LogManager) : new TrieStore(StateDb, LogManager);
+        TrieStore = usePathStateDb ? new TrieStoreByPath(new ByPathStateDb(PathStateDb, LogManager), LogManager) : new TrieStore(StateDb, LogManager);
 
         State = new WorldState(TrieStore, DbProvider.CodeDb, LogManager);
 

--- a/src/Nethermind/Nethermind.Core.Test/Builders/TestItem.Tree.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Builders/TestItem.Tree.cs
@@ -5,6 +5,7 @@
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Db;
+using Nethermind.Db.ByPathState;
 using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
 using Nethermind.State;
@@ -60,7 +61,7 @@ namespace Nethermind.Core.Test.Builders
 
             public static StateTreeByPath GetStateTreeByPath(ITrieStore? store)
             {
-                store ??= new TrieStoreByPath(new MemColumnsDb<StateColumns>(), LimboLogs.Instance);
+                store ??= new TrieStoreByPath(new ByPathStateDb(new MemColumnsDb<StateColumns>(), LimboLogs.Instance), LimboLogs.Instance);
 
                 var stateTree = new StateTreeByPath(store, LimboLogs.Instance);
 
@@ -105,7 +106,7 @@ namespace Nethermind.Core.Test.Builders
 
             public static (StateTreeByPath stateTree, StorageTree storageTree) GetTreesByPath(ITrieStore? store)
             {
-                store ??= new TrieStoreByPath(new MemColumnsDb<StateColumns>(), LimboLogs.Instance);
+                store ??= new TrieStoreByPath(new ByPathStateDb(new MemColumnsDb<StateColumns>(), LimboLogs.Instance), LimboLogs.Instance);
 
                 var storageTree = new StorageTree(store, LimboLogs.Instance, AccountAddress0);
 

--- a/src/Nethermind/Nethermind.Db/ByPathState/ByPathStateDb.cs
+++ b/src/Nethermind/Nethermind.Db/ByPathState/ByPathStateDb.cs
@@ -2,29 +2,19 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
-using System.Runtime;
-using System.Text;
-using System.Threading.Tasks;
-using Nethermind.Core;
 using Nethermind.Logging;
 
 namespace Nethermind.Db.ByPathState;
+
 public class ByPathStateDb : IByPathStateDb
 {
-    private readonly RocksDbSettings _settings;
-    private readonly IRocksDbFactory _dbFactory;
+    private readonly IColumnsDb<StateColumns> _currentDb;
+    private readonly Dictionary<StateColumns, ByPathStateDbPrunner> _prunners;
 
-    private IColumnsDb<StateColumns> _currentDb;
-    private Dictionary<StateColumns, ByPathStateDbPrunner> _prunners;
-
-    public ByPathStateDb(RocksDbSettings settings, IRocksDbFactory dbFactory, ILogManager logManager)
+    public ByPathStateDb(IColumnsDb<StateColumns> currentDb, ILogManager logManager)
     {
-        _settings = settings;
-        _dbFactory = dbFactory;
-        _currentDb = _dbFactory.CreateColumnsDb<StateColumns>(_settings);
+        _currentDb = currentDb;
         _prunners = new Dictionary<StateColumns, ByPathStateDbPrunner>()
         {
             { StateColumns.State, new ByPathStateDbPrunner(_currentDb.GetColumnDb(StateColumns.State), logManager)},

--- a/src/Nethermind/Nethermind.Db/StandardDbInitializer.cs
+++ b/src/Nethermind/Nethermind.Db/StandardDbInitializer.cs
@@ -54,11 +54,7 @@ namespace Nethermind.Db
                     ? new FullPruningInnerDbFactory(RocksDbFactory, _fileSystem, stateDbSettings.DbPath)
                     : new MemDbFactoryToRocksDbAdapter(MemDbFactory),
                 () => Interlocked.Increment(ref Metrics.StateDbInPruningWrites)));
-
-            RocksDbSettings pathStateDbSettings = BuildRocksDbSettings(DbNames.PathState, () => Metrics.StateDbReads++, () => Metrics.StateDbWrites++);
-            RegisterCustomColumnDb(DbNames.PathState, () => new ByPathStateDb(
-                pathStateDbSettings,
-                PersistedDb ? RocksDbFactory : new MemDbFactoryToRocksDbAdapter(MemDbFactory), _logManager));
+            RegisterColumnsDb<StateColumns>(BuildRocksDbSettings(DbNames.PathState, () => Metrics.StateDbReads++, () => Metrics.StateDbWrites++));
 
             RegisterDb(BuildRocksDbSettings(DbNames.Code, () => Metrics.CodeDbReads++, () => Metrics.CodeDbWrites++));
             RegisterDb(BuildRocksDbSettings(DbNames.Bloom, () => Metrics.BloomDbReads++, () => Metrics.BloomDbWrites++));

--- a/src/Nethermind/Nethermind.Evm.Test/TransactionProcessorFeeTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/TransactionProcessorFeeTests.cs
@@ -9,6 +9,7 @@ using Nethermind.Core.Extensions;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Crypto;
 using Nethermind.Db;
+using Nethermind.Db.ByPathState;
 using Nethermind.Evm.Tracing;
 using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Logging;
@@ -35,7 +36,7 @@ public class TransactionProcessorFeeTests
         _spec = new(London.Instance);
         _specProvider = new TestSpecProvider(_spec);
 
-        TrieStoreByPath trieStore = new(new MemColumnsDb<StateColumns>(), LimboLogs.Instance);
+        TrieStoreByPath trieStore = new(new ByPathStateDb(new MemColumnsDb<StateColumns>(), LimboLogs.Instance), LimboLogs.Instance);
 
         _stateProvider = new WorldState(trieStore, new MemDb(), LimboLogs.Instance);
         _stateProvider.CreateAccount(TestItem.AddressA, 1.Ether());

--- a/src/Nethermind/Nethermind.Facade.Test/BlockchainBridgeTests.cs
+++ b/src/Nethermind/Nethermind.Facade.Test/BlockchainBridgeTests.cs
@@ -28,6 +28,7 @@ using Nethermind.TxPool;
 using NSubstitute;
 using NUnit.Framework;
 using Nethermind.Config;
+using Nethermind.Db.ByPathState;
 using Nethermind.Evm;
 
 namespace Nethermind.Facade.Test
@@ -62,7 +63,7 @@ namespace Nethermind.Facade.Test
 
             ReadOnlyTxProcessingEnv processingEnv = new(
                 new ReadOnlyDbProvider(_dbProvider, false),
-                new TrieStoreByPath(_dbProvider.PathStateDb, LimboLogs.Instance).AsReadOnly(),
+                new TrieStoreByPath(new ByPathStateDb(_dbProvider.PathStateDb, LimboLogs.Instance), LimboLogs.Instance).AsReadOnly(),
                 new ReadOnlyBlockTree(_blockTree),
                 _specProvider,
                 LimboLogs.Instance);
@@ -206,7 +207,7 @@ namespace Nethermind.Facade.Test
         {
             ReadOnlyTxProcessingEnv processingEnv = new(
                 new ReadOnlyDbProvider(_dbProvider, false),
-                new TrieStoreByPath(_dbProvider.PathStateDb, LimboLogs.Instance).AsReadOnly(),
+                new TrieStoreByPath(new ByPathStateDb(_dbProvider.PathStateDb, LimboLogs.Instance), LimboLogs.Instance).AsReadOnly(),
                 new ReadOnlyBlockTree(_blockTree),
                 _specProvider,
                 LimboLogs.Instance);

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -159,7 +159,8 @@ public class InitializeNetwork : IStep
                 _api.ReadOnlyTrieStore!,
                 _api.BetterPeerStrategy,
                 _api.ChainSpec,
-                _api.LogManager);
+                _api.LogManager,
+                _api.MainPathStateDbWithCache);
         }
 
         _api.SyncModeSelector = _api.Synchronizer.SyncModeSelector;

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Proof/ProofRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Proof/ProofRpcModuleTests.cs
@@ -27,6 +27,7 @@ using Nethermind.TxPool;
 using NUnit.Framework;
 using System.Threading.Tasks;
 using Nethermind.Consensus.Processing;
+using Nethermind.Db.ByPathState;
 using Nethermind.State.Tracing;
 using NSubstitute;
 
@@ -62,7 +63,7 @@ namespace Nethermind.JsonRpc.Test.Modules.Proof
             ProofModuleFactory moduleFactory = new(
                 _dbProvider,
                 _blockTree,
-                new TrieStoreByPath(_dbProvider.PathStateDb, LimboLogs.Instance).AsReadOnly(),
+                new TrieStoreByPath(new ByPathStateDb(_dbProvider.PathStateDb, LimboLogs.Instance), LimboLogs.Instance).AsReadOnly(),
                 new CompositeBlockPreprocessorStep(new RecoverSignatures(new EthereumEcdsa(TestBlockchainIds.ChainId, LimboLogs.Instance), NullTxPool.Instance, _specProvider, LimboLogs.Instance)),
                 receiptStorage,
                 _specProvider,
@@ -207,7 +208,7 @@ namespace Nethermind.JsonRpc.Test.Modules.Proof
             ProofModuleFactory moduleFactory = new ProofModuleFactory(
                 _dbProvider,
                 _blockTree,
-                new TrieStoreByPath(_dbProvider.PathStateDb, LimboLogs.Instance).AsReadOnly(),
+                new TrieStoreByPath(new ByPathStateDb(_dbProvider.PathStateDb, LimboLogs.Instance), LimboLogs.Instance).AsReadOnly(),
                 new CompositeBlockPreprocessorStep(new RecoverSignatures(new EthereumEcdsa(TestBlockchainIds.ChainId, LimboLogs.Instance), NullTxPool.Instance, _specProvider, LimboLogs.Instance)),
                 _receiptFinder,
                 _specProvider,
@@ -871,7 +872,7 @@ namespace Nethermind.JsonRpc.Test.Modules.Proof
         private WorldState CreateInitialState(byte[]? code)
         {
             //WorldState stateProvider = new(new TrieStore(_dbProvider.StateDb, LimboLogs.Instance), _dbProvider.CodeDb, LimboLogs.Instance);
-            WorldState stateProvider = new(new TrieStoreByPath(_dbProvider.PathStateDb, LimboLogs.Instance), _dbProvider.CodeDb, LimboLogs.Instance);
+            WorldState stateProvider = new(new TrieStoreByPath(new ByPathStateDb(_dbProvider.PathStateDb, LimboLogs.Instance), LimboLogs.Instance), _dbProvider.CodeDb, LimboLogs.Instance);
             AddAccount(stateProvider, TestItem.AddressA, 1.Ether());
             AddAccount(stateProvider, TestItem.AddressB, 1.Ether());
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
@@ -437,7 +437,8 @@ public partial class MergePlugin : IConsensusWrapperPlugin, ISynchronizationPlug
                 _api.BetterPeerStrategy,
                 _api.ChainSpec,
                 _beaconSync,
-                _api.LogManager
+                _api.LogManager,
+                _api.MainPathStateDbWithCache!
             );
             _api.Synchronizer = synchronizer;
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeSynchronizer.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeSynchronizer.cs
@@ -8,6 +8,7 @@ using Nethermind.Config;
 using Nethermind.Consensus;
 using Nethermind.Core.Specs;
 using Nethermind.Db;
+using Nethermind.Db.ByPathState;
 using Nethermind.Logging;
 using Nethermind.Merge.Plugin.InvalidChainTracker;
 using Nethermind.Specs.ChainSpecStyle;
@@ -18,9 +19,6 @@ using Nethermind.Synchronization.FastBlocks;
 using Nethermind.Synchronization.ParallelSync;
 using Nethermind.Synchronization.Peers;
 using Nethermind.Trie.Pruning;
-using Nethermind.Synchronization.Reporting;
-using Nethermind.Synchronization.SnapSync;
-using Nethermind.Trie.ByPath;
 
 namespace Nethermind.Merge.Plugin.Synchronization;
 
@@ -58,7 +56,8 @@ public class MergeSynchronizer : Synchronizer
         IBetterPeerStrategy betterPeerStrategy,
         ChainSpec chainSpec,
         IBeaconSyncStrategy beaconSync,
-        ILogManager logManager)
+        ILogManager logManager,
+        IByPathStateDb? pathStateDb = null)
         : base(
             dbProvider,
             specProvider,
@@ -73,7 +72,8 @@ public class MergeSynchronizer : Synchronizer
             readOnlyTrieStore,
             betterPeerStrategy,
             chainSpec,
-            logManager)
+            logManager,
+            pathStateDb)
     {
         _invalidChainTracker = invalidChainTracker;
         _poSSwitcher = poSSwitcher;

--- a/src/Nethermind/Nethermind.State.Test/PatriciaTreeTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/PatriciaTreeTests.cs
@@ -7,6 +7,7 @@ using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
+using Nethermind.Db.ByPathState;
 using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
@@ -94,7 +95,7 @@ namespace Nethermind.Store.Test
             ITrieStore trieStore = _resolverCapability switch
             {
                 TrieNodeResolverCapability.Hash => new TrieStore(new MemDb(), LimboLogs.Instance),
-                TrieNodeResolverCapability.Path => new TrieStoreByPath(new MemColumnsDb<StateColumns>(), LimboLogs.Instance),
+                TrieNodeResolverCapability.Path => new TrieStoreByPath(new ByPathStateDb(new MemColumnsDb<StateColumns>(), LimboLogs.Instance), LimboLogs.Instance),
                 _ => throw new Exception()
             };
             Account account = new(1);

--- a/src/Nethermind/Nethermind.State.Test/SnapSync/RecreateStateFromAccountRangesTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/SnapSync/RecreateStateFromAccountRangesTests.cs
@@ -272,7 +272,7 @@ namespace Nethermind.Store.Test.SnapSync
             ProgressTracker progressTracker = resolverCapability switch
             {
                 TrieNodeResolverCapability.Hash => new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance),
-                TrieNodeResolverCapability.Path => new(null, dbProvider.GetDb<IDb>(DbNames.PathState), LimboLogs.Instance),
+                TrieNodeResolverCapability.Path => new(null, dbProvider.GetColumnDb<StateColumns>(DbNames.PathState).GetColumnDb(StateColumns.State), LimboLogs.Instance),
                 _ => throw new ArgumentOutOfRangeException()
             };
 

--- a/src/Nethermind/Nethermind.State.Test/StateProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StateProviderTests.cs
@@ -19,6 +19,7 @@ using Nethermind.Trie.Pruning;
 using NSubstitute;
 using NUnit.Framework;
 using System.Threading;
+using Nethermind.Db.ByPathState;
 
 namespace Nethermind.Store.Test
 {
@@ -44,11 +45,11 @@ namespace Nethermind.Store.Test
         public static (string Name, ITrieStore TrieStore)[] InitVariants()
         {
             TrieStore ts = new TrieStore(new MemDb(), Logger);
-            MemColumnsDb<StateColumns> memDb = new MemColumnsDb<StateColumns>();
+            MemColumnsDb<StateColumns> memDb = new();
             return new (string, ITrieStore)[]
             {
                 ("Keccak Store", ts),
-                ("Path Store", new TrieStoreByPath(memDb, Logger))
+                ("Path Store", new TrieStoreByPath(new ByPathStateDb(memDb, Logger), Logger))
             };
         }
 

--- a/src/Nethermind/Nethermind.State.Test/StateReaderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StateReaderTests.cs
@@ -17,6 +17,7 @@ using NSubstitute;
 using NUnit.Framework;
 using Nethermind.Core.Test;
 using System.Collections;
+using Nethermind.Db.ByPathState;
 
 namespace Nethermind.Store.Test
 {
@@ -240,7 +241,7 @@ namespace Nethermind.Store.Test
                 get
                 {
                     yield return new TestCaseData("Keccak Store", new TrieStore(new MemDb(), Logger));
-                    yield return new TestCaseData("Path Store", new TrieStoreByPath(new MemColumnsDb<StateColumns>(), ByPathPersist.IfBlockOlderThan(128), Logger));
+                    yield return new TestCaseData("Path Store", new TrieStoreByPath(new ByPathStateDb(new MemColumnsDb<StateColumns>(), Logger), ByPathPersist.IfBlockOlderThan(128), Logger));
                 }
             }
 

--- a/src/Nethermind/Nethermind.State.Test/StateTreeByPathTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StateTreeByPathTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.IO;
 using System.Linq;
 using FluentAssertions;
 using Nethermind.Core;
@@ -9,6 +10,7 @@ using Nethermind.Core.Crypto;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
+using Nethermind.Db.ByPathState;
 using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.State;
@@ -39,7 +41,7 @@ namespace Nethermind.Store.Test
         {
             MemColumnsDb<StateColumns> stateDb = new();
             MemDb db = (MemDb)stateDb.GetColumnDb(StateColumns.State);
-            StateTreeByPath tree = new(new TrieStoreByPath(stateDb, LimboLogs.Instance), LimboLogs.Instance);
+            StateTreeByPath tree = new(new TrieStoreByPath(new ByPathStateDb(stateDb, LimboLogs.Instance), LimboLogs.Instance), LimboLogs.Instance);
             tree.Set(TestItem.AddressA, _account0);
             tree.Set(TestItem.AddressB, _account0);
             tree.Set(TestItem.AddressC, _account0);
@@ -52,7 +54,7 @@ namespace Nethermind.Store.Test
         {
             MemColumnsDb<StateColumns> stateDb = new();
             MemDb db = (MemDb)stateDb.GetColumnDb(StateColumns.State);
-            StateTreeByPath tree = new(new TrieStoreByPath(stateDb, LimboLogs.Instance), LimboLogs.Instance);
+            StateTreeByPath tree = new(new TrieStoreByPath(new ByPathStateDb(stateDb, LimboLogs.Instance), LimboLogs.Instance), LimboLogs.Instance);
             tree.Set(TestItem.AddressA, _account0);
             tree.Set(TestItem.AddressB, _account0);
             tree.Set(TestItem.AddressC, _account0);
@@ -65,7 +67,7 @@ namespace Nethermind.Store.Test
         {
             MemColumnsDb<StateColumns> stateDb = new();
             MemDb db = (MemDb)stateDb.GetColumnDb(StateColumns.State);
-            StateTreeByPath tree = new(new TrieStoreByPath(stateDb, LimboLogs.Instance), LimboLogs.Instance);
+            StateTreeByPath tree = new(new TrieStoreByPath(new ByPathStateDb(stateDb, LimboLogs.Instance), LimboLogs.Instance), LimboLogs.Instance);
             tree.Set(new Hash256("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb00000000"), _account0);
             tree.Set(new Hash256("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb1eeeeeb0"), _account0);
             tree.Set(new Hash256("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb1eeeeeb1"), _account0);
@@ -84,7 +86,7 @@ namespace Nethermind.Store.Test
         {
             MemColumnsDb<StateColumns> stateDb = new();
             MemDb db = (MemDb)stateDb.GetColumnDb(StateColumns.State);
-            StateTreeByPath tree = new(new TrieStoreByPath(stateDb, LimboLogs.Instance), LimboLogs.Instance);
+            StateTreeByPath tree = new(new TrieStoreByPath(new ByPathStateDb(stateDb, LimboLogs.Instance), LimboLogs.Instance), LimboLogs.Instance);
             tree.Set(new Hash256("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb00000000"), _account0);
             tree.Set(new Hash256("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb1eeeeeb0"), _account0);
             tree.Set(new Hash256("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb1eeeeeb1"), _account0);
@@ -100,7 +102,7 @@ namespace Nethermind.Store.Test
         {
             MemColumnsDb<StateColumns> stateDb = new();
             MemDb db = (MemDb)stateDb.GetColumnDb(StateColumns.State);
-            StateTreeByPath tree = new(new TrieStoreByPath(stateDb, LimboLogs.Instance), LimboLogs.Instance);
+            StateTreeByPath tree = new(new TrieStoreByPath(new ByPathStateDb(stateDb, LimboLogs.Instance), LimboLogs.Instance), LimboLogs.Instance);
             tree.Set(new Hash256("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb00000000"), _account0);
             tree.Set(new Hash256("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb1eeeeeb0"), _account0);
             tree.Set(new Hash256("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb1eeeeeb1"), _account0);
@@ -117,7 +119,7 @@ namespace Nethermind.Store.Test
         {
             MemColumnsDb<StateColumns> stateDb = new();
             MemDb db = (MemDb)stateDb.GetColumnDb(StateColumns.State);
-            StateTreeByPath tree = new(new TrieStoreByPath(stateDb, LimboLogs.Instance), LimboLogs.Instance);
+            StateTreeByPath tree = new(new TrieStoreByPath(new ByPathStateDb(stateDb, LimboLogs.Instance), LimboLogs.Instance), LimboLogs.Instance);
             tree.Set(new Hash256("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb00000000"), _account0);
             tree.Set(new Hash256("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb1eeeeeb0"), _account0);
             tree.Set(new Hash256("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb1eeeeeb1"), _account0);
@@ -135,7 +137,7 @@ namespace Nethermind.Store.Test
         {
             MemColumnsDb<StateColumns> stateDb = new();
             MemDb db = (MemDb)stateDb.GetColumnDb(StateColumns.State);
-            StateTreeByPath tree = new(new TrieStoreByPath(stateDb, LimboLogs.Instance), LimboLogs.Instance);
+            StateTreeByPath tree = new(new TrieStoreByPath(new ByPathStateDb(stateDb, LimboLogs.Instance), LimboLogs.Instance), LimboLogs.Instance);
             tree.Set(new Hash256("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb00000000"), _account0);
             tree.Set(new Hash256("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb11111111"), _account1);
             Account account = tree.Get(new Hash256("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb11111111"));
@@ -151,8 +153,8 @@ namespace Nethermind.Store.Test
         [Test]
         public void Scenario_traverse_extension_read_missing()
         {
-            MemColumnsDb<StateColumns> db = new MemColumnsDb<StateColumns>();
-            StateTreeByPath tree = new(new TrieStoreByPath(db, LimboLogs.Instance), LimboLogs.Instance);
+            MemColumnsDb<StateColumns> stateDb = new();
+            StateTreeByPath tree = new(new TrieStoreByPath(new ByPathStateDb(stateDb, LimboLogs.Instance), LimboLogs.Instance), LimboLogs.Instance);
             tree.Set(new Hash256("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb00000000"), _account0);
             tree.Set(new Hash256("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb11111111"), _account1);
             Account account = tree.Get(new Hash256("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeedddddddddddddddddddddddd"));
@@ -167,8 +169,8 @@ namespace Nethermind.Store.Test
         [Test]
         public void Scenario_traverse_extension_new_branching()
         {
-            MemColumnsDb<StateColumns> db = new MemColumnsDb<StateColumns>();
-            StateTreeByPath tree = new(new TrieStoreByPath(db, LimboLogs.Instance), LimboLogs.Instance);
+            MemColumnsDb<StateColumns> stateDb = new MemColumnsDb<StateColumns>();
+            StateTreeByPath tree = new(new TrieStoreByPath(new ByPathStateDb(stateDb, LimboLogs.Instance), LimboLogs.Instance), LimboLogs.Instance);
             tree.Set(new Hash256("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb00000000"), _account0);
             tree.Set(new Hash256("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb11111111"), _account1);
             tree.Set(new Hash256("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeedddddddddddddddddddddddd"), _account2);
@@ -184,7 +186,7 @@ namespace Nethermind.Store.Test
         {
             MemColumnsDb<StateColumns> stateDb = new();
             MemDb db = (MemDb)stateDb.GetColumnDb(StateColumns.State);
-            StateTreeByPath tree = new(new TrieStoreByPath(stateDb, LimboLogs.Instance), LimboLogs.Instance);
+            StateTreeByPath tree = new(new TrieStoreByPath(new ByPathStateDb(stateDb, LimboLogs.Instance), LimboLogs.Instance), LimboLogs.Instance);
             tree.Set(new Hash256("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb00000000"), _account0);
             tree.Set(new Hash256("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb11111111"), _account1);
             tree.Set(new Hash256("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeddddddddddddddddddddddddd"), null);
@@ -201,7 +203,7 @@ namespace Nethermind.Store.Test
         {
             MemColumnsDb<StateColumns> stateDb = new();
             MemDb db = (MemDb)stateDb.GetColumnDb(StateColumns.State);
-            StateTreeByPath tree = new(new TrieStoreByPath(stateDb, LimboLogs.Instance), LimboLogs.Instance);
+            StateTreeByPath tree = new(new TrieStoreByPath(new ByPathStateDb(stateDb, LimboLogs.Instance), LimboLogs.Instance), LimboLogs.Instance);
             tree.Set(new Hash256("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb00000000"), _account0);
             tree.Set(new Hash256("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb11111111"), _account1);
             tree.Set(new Hash256("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeaaaaaaaaaaaaaaaab00000000"), _account2);
@@ -217,8 +219,8 @@ namespace Nethermind.Store.Test
         [Test]
         public void Scenario_traverse_leaf_update_new_value()
         {
-            MemColumnsDb<StateColumns> db = new MemColumnsDb<StateColumns>();
-            StateTreeByPath tree = new(new TrieStoreByPath(db, LimboLogs.Instance), LimboLogs.Instance);
+            MemColumnsDb<StateColumns> stateDb = new();
+            StateTreeByPath tree = new(new TrieStoreByPath(new ByPathStateDb(stateDb, LimboLogs.Instance), LimboLogs.Instance), LimboLogs.Instance);
             tree.Set(new Hash256("1111111111111111111111111111111111111111111111111111111111111111"), _account0);
             tree.Set(new Hash256("1111111111111111111111111111111111111111111111111111111111111111"), _account1);
             tree.UpdateRootHash();
@@ -231,8 +233,8 @@ namespace Nethermind.Store.Test
         [Test]
         public void Scenario_traverse_leaf_update_no_change()
         {
-            MemColumnsDb<StateColumns> db = new MemColumnsDb<StateColumns>();
-            StateTreeByPath tree = new(new TrieStoreByPath(db, LimboLogs.Instance), LimboLogs.Instance);
+            MemColumnsDb<StateColumns> stateDb = new();
+            StateTreeByPath tree = new(new TrieStoreByPath(new ByPathStateDb(stateDb, LimboLogs.Instance), LimboLogs.Instance), LimboLogs.Instance);
             tree.Set(new Hash256("1111111111111111111111111111111111111111111111111111111111111111"), _account0);
             tree.Set(new Hash256("1111111111111111111111111111111111111111111111111111111111111111"), _account0);
             tree.UpdateRootHash();
@@ -245,8 +247,8 @@ namespace Nethermind.Store.Test
         [Test]
         public void Scenario_traverse_leaf_read_matching_leaf()
         {
-            MemColumnsDb<StateColumns> db = new MemColumnsDb<StateColumns>();
-            StateTreeByPath tree = new(new TrieStoreByPath(db, LimboLogs.Instance), LimboLogs.Instance);
+            MemColumnsDb<StateColumns> stateDb = new();
+            StateTreeByPath tree = new(new TrieStoreByPath(new ByPathStateDb(stateDb, LimboLogs.Instance), LimboLogs.Instance), LimboLogs.Instance);
             tree.Set(new Hash256("1111111111111111111111111111111111111111111111111111111111111111"), _account0);
             tree.Set(new Hash256("1111111111111111111111111111111111111111111111111111111111111111"), null);
             tree.UpdateRootHash();
@@ -259,8 +261,8 @@ namespace Nethermind.Store.Test
         [Test]
         public void Scenario_traverse_leaf_delete_missing()
         {
-            MemColumnsDb<StateColumns> db = new MemColumnsDb<StateColumns>();
-            StateTreeByPath tree = new(new TrieStoreByPath(db, LimboLogs.Instance), LimboLogs.Instance);
+            MemColumnsDb<StateColumns> stateDb = new();
+            StateTreeByPath tree = new(new TrieStoreByPath(new ByPathStateDb(stateDb, LimboLogs.Instance), LimboLogs.Instance), LimboLogs.Instance);
             tree.Set(new Hash256("1111111111111111111111111111111111111111111111111111111111111111"), _account0);
             tree.Set(new Hash256("1111111111111111111111111111111ddddddddddddddddddddddddddddddddd"), null);
             tree.UpdateRootHash();
@@ -273,8 +275,8 @@ namespace Nethermind.Store.Test
         [Test]
         public void Scenario_traverse_leaf_update_with_extension()
         {
-            MemColumnsDb<StateColumns> db = new MemColumnsDb<StateColumns>();
-            StateTreeByPath tree = new(new TrieStoreByPath(db, LimboLogs.Instance), LimboLogs.Instance);
+            MemColumnsDb<StateColumns> stateDb = new();
+            StateTreeByPath tree = new(new TrieStoreByPath(new ByPathStateDb(stateDb, LimboLogs.Instance), LimboLogs.Instance), LimboLogs.Instance);
             tree.Set(new Hash256("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb11111111111111111111111111111111"), _account0);
             tree.Set(new Hash256("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb00000000000000000000000000000000"), _account1);
             tree.UpdateRootHash();
@@ -287,8 +289,8 @@ namespace Nethermind.Store.Test
         [Test]
         public void Scenario_traverse_leaf_delete_matching_leaf()
         {
-            MemColumnsDb<StateColumns> db = new MemColumnsDb<StateColumns>();
-            StateTreeByPath tree = new(new TrieStoreByPath(db, LimboLogs.Instance), LimboLogs.Instance);
+            MemColumnsDb<StateColumns> stateDb = new();
+            StateTreeByPath tree = new(new TrieStoreByPath(new ByPathStateDb(stateDb, LimboLogs.Instance), LimboLogs.Instance), LimboLogs.Instance);
             tree.Set(new Hash256("1111111111111111111111111111111111111111111111111111111111111111"), _account0);
             Account account = tree.Get(new Hash256("1111111111111111111111111111111111111111111111111111111111111111"));
             Assert.NotNull(account);
@@ -302,8 +304,8 @@ namespace Nethermind.Store.Test
         [Test]
         public void Scenario_traverse_leaf_read_missing()
         {
-            MemColumnsDb<StateColumns> db = new MemColumnsDb<StateColumns>();
-            StateTreeByPath tree = new(new TrieStoreByPath(db, LimboLogs.Instance), LimboLogs.Instance);
+            MemColumnsDb<StateColumns> stateDb = new();
+            StateTreeByPath tree = new(new TrieStoreByPath(new ByPathStateDb(stateDb, LimboLogs.Instance), LimboLogs.Instance), LimboLogs.Instance);
             tree.Set(new Hash256("1111111111111111111111111111111111111111111111111111111111111111"), _account0);
             Account account = tree.Get(new Hash256("111111111111111111111111111111111111111111111111111111111ddddddd"));
             Assert.Null(account);
@@ -317,8 +319,8 @@ namespace Nethermind.Store.Test
         [Test]
         public void Scenario_traverse_branch_update_missing()
         {
-            MemColumnsDb<StateColumns> db = new MemColumnsDb<StateColumns>();
-            StateTreeByPath tree = new(new TrieStoreByPath(db, LimboLogs.Instance), LimboLogs.Instance);
+            MemColumnsDb<StateColumns> stateDb = new();
+            StateTreeByPath tree = new(new TrieStoreByPath(new ByPathStateDb(stateDb, LimboLogs.Instance), LimboLogs.Instance), LimboLogs.Instance);
             tree.Set(new Hash256("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb00000"), _account0);
             tree.Set(new Hash256("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb11111"), _account1);
             tree.Set(new Hash256("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb22222"), _account2);
@@ -332,8 +334,8 @@ namespace Nethermind.Store.Test
         [Test]
         public void Scenario_traverse_branch_read_missing()
         {
-            MemColumnsDb<StateColumns> db = new MemColumnsDb<StateColumns>();
-            StateTreeByPath tree = new(new TrieStoreByPath(db, LimboLogs.Instance), LimboLogs.Instance);
+            MemColumnsDb<StateColumns> stateDb = new();
+            StateTreeByPath tree = new(new TrieStoreByPath(new ByPathStateDb(stateDb, LimboLogs.Instance), LimboLogs.Instance), LimboLogs.Instance);
             tree.Set(new Hash256("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb00000"), _account0);
             tree.Set(new Hash256("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb11111"), _account1);
             Account account = tree.Get(new Hash256("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb22222"));
@@ -348,8 +350,8 @@ namespace Nethermind.Store.Test
         [Test]
         public void Scenario_traverse_branch_delete_missing()
         {
-            MemColumnsDb<StateColumns> db = new MemColumnsDb<StateColumns>();
-            StateTreeByPath tree = new(new TrieStoreByPath(db, LimboLogs.Instance), LimboLogs.Instance);
+            MemColumnsDb<StateColumns> stateDb = new();
+            StateTreeByPath tree = new(new TrieStoreByPath(new ByPathStateDb(stateDb, LimboLogs.Instance), LimboLogs.Instance), LimboLogs.Instance);
             tree.Set(new Hash256("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb00000"), _account0);
             tree.Set(new Hash256("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb11111"), _account1);
             tree.Set(new Hash256("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb22222"), null);
@@ -363,8 +365,8 @@ namespace Nethermind.Store.Test
         [Test]
         public void Minimal_hashes_when_setting_on_empty()
         {
-            MemColumnsDb<StateColumns> db = new MemColumnsDb<StateColumns>();
-            StateTreeByPath tree = new(new TrieStoreByPath(db, LimboLogs.Instance), LimboLogs.Instance);
+            MemColumnsDb<StateColumns> stateDb = new();
+            StateTreeByPath tree = new(new TrieStoreByPath(new ByPathStateDb(stateDb, LimboLogs.Instance), LimboLogs.Instance), LimboLogs.Instance);
             //StateTreeByPath tree = new(new TrieStoreByPath(db, LimboLogs.Instance), LimboLogs.Instance);
             tree.Set(TestItem.AddressA, _account0);
             tree.Set(TestItem.AddressB, _account0);
@@ -379,8 +381,8 @@ namespace Nethermind.Store.Test
         [Test]
         public void Minimal_encodings_when_setting_on_empty()
         {
-            MemColumnsDb<StateColumns> db = new MemColumnsDb<StateColumns>();
-            StateTreeByPath tree = new(new TrieStoreByPath(db, LimboLogs.Instance), LimboLogs.Instance);
+            MemColumnsDb<StateColumns> stateDb = new();
+            StateTreeByPath tree = new(new TrieStoreByPath(new ByPathStateDb(stateDb, LimboLogs.Instance), LimboLogs.Instance), LimboLogs.Instance);
             tree.Set(TestItem.AddressA, _account0);
             tree.Set(TestItem.AddressB, _account0);
             tree.Set(TestItem.AddressC, _account0);
@@ -391,8 +393,8 @@ namespace Nethermind.Store.Test
         [Test]
         public void Zero_decodings_when_setting_on_empty()
         {
-            MemColumnsDb<StateColumns> db = new MemColumnsDb<StateColumns>();
-            StateTreeByPath tree = new(new TrieStoreByPath(db, LimboLogs.Instance), LimboLogs.Instance);
+            MemColumnsDb<StateColumns> stateDb = new();
+            StateTreeByPath tree = new(new TrieStoreByPath(new ByPathStateDb(stateDb, LimboLogs.Instance), LimboLogs.Instance), LimboLogs.Instance);
             tree.Set(TestItem.AddressA, _account0);
             tree.Set(TestItem.AddressB, _account0);
             tree.Set(TestItem.AddressC, _account0);
@@ -417,9 +419,9 @@ namespace Nethermind.Store.Test
         [Test]
         public void No_writes_on_reverted_update()
         {
-            MemColumnsDb<StateColumns> db = new MemColumnsDb<StateColumns>();
-            MemDb stateColumn = db.GetColumnDb(StateColumns.State) as MemDb;
-            StateTreeByPath tree = new(new TrieStoreByPath(db, LimboLogs.Instance), LimboLogs.Instance);
+            MemColumnsDb<StateColumns> stateDb = new();
+            MemDb stateColumn = stateDb.GetColumnDb(StateColumns.State) as MemDb;
+            StateTreeByPath tree = new(new TrieStoreByPath(new ByPathStateDb(stateDb, LimboLogs.Instance), LimboLogs.Instance), LimboLogs.Instance);
             tree.Set(TestItem.AddressA, _account0);
             tree.Commit(0);
             Assert.That(stateColumn.WritesCount, Is.EqualTo(1), "writes before"); // extension, branch, two leaves
@@ -432,9 +434,9 @@ namespace Nethermind.Store.Test
         [Test]
         public void No_writes_without_commit()
         {
-            MemColumnsDb<StateColumns> db = new MemColumnsDb<StateColumns>();
-            MemDb stateColumn = db.GetColumnDb(StateColumns.State) as MemDb;
-            StateTreeByPath tree = new(new TrieStoreByPath(db, LimboLogs.Instance), LimboLogs.Instance);
+            MemColumnsDb<StateColumns> stateDb = new MemColumnsDb<StateColumns>();
+            MemDb stateColumn = stateDb.GetColumnDb(StateColumns.State) as MemDb;
+            StateTreeByPath tree = new(new TrieStoreByPath(new ByPathStateDb(stateDb, LimboLogs.Instance), LimboLogs.Instance), LimboLogs.Instance);
             tree.Set(TestItem.AddressA, _account0);
             Assert.That(stateColumn.WritesCount, Is.EqualTo(0), "writes");
         }
@@ -442,8 +444,8 @@ namespace Nethermind.Store.Test
         [Test]
         public void Can_ask_about_root_hash_without_commiting()
         {
-            MemColumnsDb<StateColumns> db = new MemColumnsDb<StateColumns>();
-            StateTreeByPath tree = new(new TrieStoreByPath(db, LimboLogs.Instance), LimboLogs.Instance);
+            MemColumnsDb<StateColumns> stateDb = new MemColumnsDb<StateColumns>();
+            StateTreeByPath tree = new(new TrieStoreByPath(new ByPathStateDb(stateDb, LimboLogs.Instance), LimboLogs.Instance), LimboLogs.Instance);
             tree.Set(TestItem.AddressA, _account0);
             tree.UpdateRootHash();
             Assert.That(tree.RootHash.ToString(true), Is.EqualTo("0x545a417202afcb10925b2afddb70a698710bb1cf4ab32942c42e9f019d564fdc"));
@@ -452,8 +454,8 @@ namespace Nethermind.Store.Test
         [Test]
         public void Can_ask_about_root_hash_without_when_emptied()
         {
-            MemColumnsDb<StateColumns> db = new MemColumnsDb<StateColumns>();
-            StateTreeByPath tree = new(new TrieStoreByPath(db, LimboLogs.Instance), LimboLogs.Instance);
+            MemColumnsDb<StateColumns> stateDb = new();
+            StateTreeByPath tree = new(new TrieStoreByPath(new ByPathStateDb(stateDb, LimboLogs.Instance), LimboLogs.Instance), LimboLogs.Instance);
             tree.Set(new Hash256("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeb00000000"), _account0);
             tree.UpdateRootHash();
             Assert.That(tree.RootHash, Is.Not.EqualTo(PatriciaTree.EmptyTreeHash));
@@ -479,8 +481,8 @@ namespace Nethermind.Store.Test
         [Test]
         public void hash_empty_tree_root_hash_initially()
         {
-            MemColumnsDb<StateColumns> db = new MemColumnsDb<StateColumns>();
-            StateTreeByPath tree = new(new TrieStoreByPath(db, LimboLogs.Instance), LimboLogs.Instance);
+            MemColumnsDb<StateColumns> stateDb = new();
+            StateTreeByPath tree = new(new TrieStoreByPath(new ByPathStateDb(stateDb, LimboLogs.Instance), LimboLogs.Instance), LimboLogs.Instance);
             Assert.That(tree.RootHash, Is.EqualTo(PatriciaTree.EmptyTreeHash));
         }
 
@@ -493,16 +495,16 @@ namespace Nethermind.Store.Test
             var d = Nibbles.ToEncodedStorageBytes(new byte[] { 5, 3, 0, 12 });
             var e = Nibbles.ToEncodedStorageBytes(new byte[] { 5, 3, 0, 12, 7 });
 
-            MemColumnsDb<StateColumns> db = new MemColumnsDb<StateColumns>();
-            StateTreeByPath tree = new(new TrieStoreByPath(db, LimboLogs.Instance), LimboLogs.Instance);
+            MemColumnsDb<StateColumns> stateDb = new();
+            StateTreeByPath tree = new(new TrieStoreByPath(new ByPathStateDb(stateDb, LimboLogs.Instance), LimboLogs.Instance), LimboLogs.Instance);
             tree.Set(TestItem.AddressA, null);
         }
 
         [Test]
         public void History_update_one_block()
         {
-            MemColumnsDb<StateColumns> db = new MemColumnsDb<StateColumns>();
-            StateTreeByPath tree = new(new TrieStoreByPath(db, ByPathPersist.IfBlockOlderThan(10), LimboLogs.Instance), LimboLogs.Instance);
+            MemColumnsDb<StateColumns> stateDb = new();
+            StateTreeByPath tree = new(new TrieStoreByPath(new ByPathStateDb(stateDb, LimboLogs.Instance), ByPathPersist.IfBlockOlderThan(10), LimboLogs.Instance), LimboLogs.Instance);
             tree.Set(TestItem.AddressA, _account0);
             tree.Commit(0);
             Hash256 root0 = tree.RootHash;
@@ -519,8 +521,8 @@ namespace Nethermind.Store.Test
         [Test]
         public void History_update_one_block_before_null()
         {
-            MemColumnsDb<StateColumns> db = new MemColumnsDb<StateColumns>();
-            StateTreeByPath tree = new(new TrieStoreByPath(db, ByPathPersist.IfBlockOlderThan(10), LimboLogs.Instance), LimboLogs.Instance);
+            MemColumnsDb<StateColumns> stateDb = new();
+            StateTreeByPath tree = new(new TrieStoreByPath(new ByPathStateDb(stateDb, LimboLogs.Instance), ByPathPersist.IfBlockOlderThan(10), LimboLogs.Instance), LimboLogs.Instance);
             tree.Set(TestItem.AddressB, _account0);
             tree.Commit(0);
             Hash256 root0 = tree.RootHash;
@@ -541,8 +543,8 @@ namespace Nethermind.Store.Test
         [Test]
         public void History_update_non_continous_blocks()
         {
-            MemColumnsDb<StateColumns> db = new MemColumnsDb<StateColumns>();
-            StateTreeByPath tree = new(new TrieStoreByPath(db, ByPathPersist.IfBlockOlderThan(10), LimboLogs.Instance), LimboLogs.Instance);
+            MemColumnsDb<StateColumns> stateDb = new();
+            StateTreeByPath tree = new(new TrieStoreByPath(new ByPathStateDb(stateDb, LimboLogs.Instance), ByPathPersist.IfBlockOlderThan(10), LimboLogs.Instance), LimboLogs.Instance);
             tree.Set(TestItem.AddressA, _account0);
             tree.Commit(0);
             Hash256 root0 = tree.RootHash;
@@ -568,8 +570,8 @@ namespace Nethermind.Store.Test
         [Test]
         public void History_get_cached_from_root_with_no_changes()
         {
-            MemColumnsDb<StateColumns> db = new MemColumnsDb<StateColumns>();
-            StateTreeByPath tree = new(new TrieStoreByPath(db, ByPathPersist.IfBlockOlderThan(5), LimboLogs.Instance), LimboLogs.Instance);
+            MemColumnsDb<StateColumns> stateDb = new();
+            StateTreeByPath tree = new(new TrieStoreByPath(new ByPathStateDb(stateDb, LimboLogs.Instance), ByPathPersist.IfBlockOlderThan(10), LimboLogs.Instance), LimboLogs.Instance);
             tree.Set(TestItem.AddressA, _account0);
             tree.Set(TestItem.AddressB, _account1);
             tree.Set(TestItem.AddressC, _account2);
@@ -596,8 +598,8 @@ namespace Nethermind.Store.Test
         [Test]
         public void History_get_on_block_when_account_not_existed()
         {
-            MemColumnsDb<StateColumns> db = new MemColumnsDb<StateColumns>();
-            StateTreeByPath tree = new(new TrieStoreByPath(db, ByPathPersist.IfBlockOlderThan(10), LimboLogs.Instance), LimboLogs.Instance);
+            MemColumnsDb<StateColumns> stateDb = new();
+            StateTreeByPath tree = new(new TrieStoreByPath(new ByPathStateDb(stateDb, LimboLogs.Instance), ByPathPersist.IfBlockOlderThan(10), LimboLogs.Instance), LimboLogs.Instance);
             tree.Set(TestItem.AddressA, _account0);
             tree.Commit(0);
             Hash256 root0 = tree.RootHash;
@@ -618,8 +620,8 @@ namespace Nethermind.Store.Test
         [Test]
         public void History_delete_when_max_number_blocks_exceeded()
         {
-            MemColumnsDb<StateColumns> db = new MemColumnsDb<StateColumns>();
-            StateTreeByPath tree = new(new TrieStoreByPath(db, ByPathPersist.IfBlockOlderThan(10), LimboLogs.Instance), LimboLogs.Instance);
+            MemColumnsDb<StateColumns> stateDb = new MemColumnsDb<StateColumns>();
+            StateTreeByPath tree = new(new TrieStoreByPath(new ByPathStateDb(stateDb, LimboLogs.Instance), ByPathPersist.IfBlockOlderThan(10), LimboLogs.Instance), LimboLogs.Instance);
             tree.Set(TestItem.AddressA, _account0);
             tree.Commit(0);
             Hash256 root0 = tree.RootHash;
@@ -646,8 +648,8 @@ namespace Nethermind.Store.Test
             ILogManager logManager = new NUnitLogManager(LogLevel.Warn);
             ILogger logger = logManager.GetLogger("");
 
-            MemColumnsDb<StateColumns> db = new MemColumnsDb<StateColumns>();
-            StateTreeByPath tree = new(new TrieStoreByPath(db, LimboLogs.Instance), LimboLogs.Instance);
+            MemColumnsDb<StateColumns> stateDb = new();
+            StateTreeByPath tree = new(new TrieStoreByPath(new ByPathStateDb(stateDb, LimboLogs.Instance), LimboLogs.Instance), LimboLogs.Instance);
 
             int numberOfAccounts = 10000;
 
@@ -679,16 +681,16 @@ namespace Nethermind.Store.Test
 
             Hash256 rootEnd = tree.RootHash;
 
-            MemDb stateDb = (MemDb)db.GetColumnDb(StateColumns.State);
-            Assert.That(stateDb.GetAllValues().All(b => b is null), Is.True);
+            MemDb stateColumns = (MemDb)stateDb.GetColumnDb(StateColumns.State);
+            Assert.That(stateColumns.GetAllValues().All(b => b is null), Is.True);
             //Assert.That(rootEnd, Is.EqualTo(Keccak.EmptyTreeHash));
         }
 
         [Test]
         public void CopyStateTest()
         {
-            MemColumnsDb<StateColumns> db = new MemColumnsDb<StateColumns>();
-            StateTreeByPath tree = new(new TrieStoreByPath(db, LimboLogs.Instance), LimboLogs.Instance);
+            MemColumnsDb<StateColumns> stateDb = new();
+            StateTreeByPath tree = new(new TrieStoreByPath(new ByPathStateDb(stateDb, LimboLogs.Instance), LimboLogs.Instance), LimboLogs.Instance);
 
             tree.Set(TestItem.AddressA, _account1);
             tree.Set(TestItem.AddressB, _account1);
@@ -708,8 +710,8 @@ namespace Nethermind.Store.Test
             ILogManager logManager = new NUnitLogManager(LogLevel.Warn);
             ILogger logger = logManager.GetLogger("");
 
-            MemColumnsDb<StateColumns> pathDb = new MemColumnsDb<StateColumns>();
-            TrieStoreByPath pathStore = new(pathDb, ByPathPersist.IfBlockOlderThan(10), LimboLogs.Instance);
+            MemColumnsDb<StateColumns> pathDb = new();
+            TrieStoreByPath pathStore = new(new ByPathStateDb(pathDb, LimboLogs.Instance), ByPathPersist.IfBlockOlderThan(10), LimboLogs.Instance);
             StateTreeByPath tree = new(pathStore, LimboLogs.Instance);
 
             MemDb db = new MemDb();
@@ -789,8 +791,8 @@ namespace Nethermind.Store.Test
             ILogManager logManager = new NUnitLogManager(LogLevel.Warn);
             ILogger logger = logManager.GetLogger("");
 
-            MemColumnsDb<StateColumns> pathDb = new MemColumnsDb<StateColumns>();
-            TrieStoreByPath pathStore = new(pathDb, ByPathPersist.IfBlockOlderThan(2), logManager);
+            MemColumnsDb<StateColumns> pathDb = new();
+            TrieStoreByPath pathStore = new(new ByPathStateDb(pathDb, LimboLogs.Instance), ByPathPersist.IfBlockOlderThan(2), logManager);
             StateTreeByPath tree = new(pathStore, LimboLogs.Instance);
             MemDb innerStateDb = (MemDb)pathDb.GetColumnDb(StateColumns.State);
 
@@ -820,8 +822,8 @@ namespace Nethermind.Store.Test
             ILogManager logManager = new NUnitLogManager(LogLevel.Warn);
             ILogger logger = logManager.GetLogger("");
 
-            MemColumnsDb<StateColumns> pathDb = new MemColumnsDb<StateColumns>();
-            TrieStoreByPath pathStore = new(pathDb, ByPathPersist.IfBlockOlderThan(2), logManager);
+            MemColumnsDb<StateColumns> pathDb = new();
+            TrieStoreByPath pathStore = new(new ByPathStateDb(pathDb, LimboLogs.Instance), ByPathPersist.IfBlockOlderThan(2), logManager);
             StateTreeByPath tree = new(pathStore, LimboLogs.Instance);
             MemDb innerStateDb = (MemDb)pathDb.GetColumnDb(StateColumns.State);
 
@@ -861,8 +863,8 @@ namespace Nethermind.Store.Test
             ILogManager logManager = new NUnitLogManager(LogLevel.Warn);
             ILogger logger = logManager.GetLogger("");
 
-            MemColumnsDb<StateColumns> pathDb = new MemColumnsDb<StateColumns>();
-            TrieStoreByPath pathStore = new(pathDb, ByPathPersist.IfBlockOlderThan(4), logManager);
+            MemColumnsDb<StateColumns> pathDb = new();
+            TrieStoreByPath pathStore = new(new ByPathStateDb(pathDb, logManager), ByPathPersist.IfBlockOlderThan(4), logManager);
             StateTreeByPath tree = new(pathStore, LimboLogs.Instance);
             MemDb innerStateDb = (MemDb)pathDb.GetColumnDb(StateColumns.State);
 

--- a/src/Nethermind/Nethermind.State/StateTreeByPath.cs
+++ b/src/Nethermind/Nethermind.State/StateTreeByPath.cs
@@ -9,6 +9,7 @@ using Nethermind.Core.Buffers;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Db;
+using Nethermind.Db.ByPathState;
 using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
@@ -44,7 +45,7 @@ namespace Nethermind.State
 
         [DebuggerStepThrough]
         public StateTreeByPath(ICappedArrayPool? bufferPool = null)
-            : base(new TrieStoreByPath(new MemColumnsDb<StateColumns>(), NullLogManager.Instance), Keccak.EmptyTreeHash, true, true, NullLogManager.Instance, bufferPool)
+            : base(new TrieStoreByPath(new ByPathStateDb(new MemColumnsDb<StateColumns>(), NullLogManager.Instance), NullLogManager.Instance), Keccak.EmptyTreeHash, true, true, NullLogManager.Instance, bufferPool)
         {
             TrieType = TrieType.State;
         }

--- a/src/Nethermind/Nethermind.State/TrieNodeResolverCapabilityStateExtension.cs
+++ b/src/Nethermind/Nethermind.State/TrieNodeResolverCapabilityStateExtension.cs
@@ -4,6 +4,7 @@
 using System;
 using Nethermind.Core;
 using Nethermind.Db;
+using Nethermind.Db.ByPathState;
 using Nethermind.Logging;
 using Nethermind.Trie.Pruning;
 
@@ -33,6 +34,6 @@ public static class TrieNodeResolverCapabilityStateExtension
 
     public static IStateTree CreateStateStore(this TrieNodeResolverCapability capability, IColumnsDb<StateColumns>? db, ILogManager? logManager)
     {
-        return new StateTreeByPath(new TrieStoreByPath(db, ByPathPersist.IfBlockOlderThan(128), logManager), logManager);
+        return new StateTreeByPath(new TrieStoreByPath(new ByPathStateDb(db, logManager), ByPathPersist.IfBlockOlderThan(128), logManager), logManager);
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/RecreateStateFromAccountRangesTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/RecreateStateFromAccountRangesTests.cs
@@ -11,6 +11,7 @@ using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
+using Nethermind.Db.ByPathState;
 using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.State;
@@ -331,7 +332,7 @@ namespace Nethermind.Synchronization.Test.SnapSync
             byte[][] lastProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[1].Path.Bytes);
             byte[][] proofs = firstProof.Concat(lastProof).ToArray();
 
-            StateTreeByPath newTree = new(new TrieStoreByPath(new MemColumnsDb<StateColumns>(), LimboLogs.Instance), LimboLogs.Instance);
+            StateTreeByPath newTree = new(new TrieStoreByPath(new ByPathStateDb(new MemColumnsDb<StateColumns>(), LimboLogs.Instance), LimboLogs.Instance), LimboLogs.Instance);
 
             PathWithAccount[] receiptAccounts = TestItem.Tree.AccountsWithPaths[0..2];
 
@@ -361,7 +362,7 @@ namespace Nethermind.Synchronization.Test.SnapSync
         [Test]
         public void CorrectlyDetermineMaxKeccakExist()
         {
-            StateTreeByPath tree = new StateTreeByPath(new TrieStoreByPath(new MemColumnsDb<StateColumns>(), LimboLogs.Instance), LimboLogs.Instance);
+            StateTreeByPath tree = new(new TrieStoreByPath(new ByPathStateDb(new MemColumnsDb<StateColumns>(), LimboLogs.Instance), LimboLogs.Instance), LimboLogs.Instance);
 
             PathWithAccount ac1 = new PathWithAccount(Keccak.Zero, Build.An.Account.WithBalance(1).TestObject);
             PathWithAccount ac2 = new PathWithAccount(Keccak.Compute("anything"), Build.An.Account.WithBalance(2).TestObject);
@@ -385,7 +386,7 @@ namespace Nethermind.Synchronization.Test.SnapSync
             byte[][] lastProof = CreateProofForPath(ac2.Path.Bytes, tree);
             byte[][] proofs = firstProof.Concat(lastProof).ToArray();
 
-            StateTreeByPath newTree = new(new TrieStoreByPath(new MemColumnsDb<StateColumns>(), LimboLogs.Instance), LimboLogs.Instance);
+            StateTreeByPath newTree = new(new TrieStoreByPath(new ByPathStateDb(new MemColumnsDb<StateColumns>(), LimboLogs.Instance), LimboLogs.Instance), LimboLogs.Instance);
 
             PathWithAccount[] receiptAccounts = { ac1, ac2 };
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/RecreateStateFromStorageRangesTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/RecreateStateFromStorageRangesTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
+using Nethermind.Db.ByPathState;
 using Nethermind.Logging;
 using Nethermind.State;
 using Nethermind.State.Proofs;
@@ -40,7 +41,7 @@ namespace Nethermind.Synchronization.Test.SnapSync
             _store = _resolverCapability switch
             {
                 TrieNodeResolverCapability.Hash => new TrieStore(new MemDb(), LimboLogs.Instance),
-                TrieNodeResolverCapability.Path => new TrieStoreByPath(new MemColumnsDb<StateColumns>(), LimboLogs.Instance),
+                TrieNodeResolverCapability.Path => new TrieStoreByPath(new ByPathStateDb(new MemColumnsDb<StateColumns>(), LimboLogs.Instance), LimboLogs.Instance),
                 _ => throw new Exception()
             };
             if (_resolverCapability == TrieNodeResolverCapability.Hash)

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProvider.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProvider.cs
@@ -12,6 +12,7 @@ using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Db;
+using Nethermind.Db.ByPathState;
 using Nethermind.Logging;
 using Nethermind.State;
 using Nethermind.State.Snap;
@@ -373,7 +374,7 @@ namespace Nethermind.Synchronization.SnapSync
             public ITrieStore Create()
             {
                 //no in memory caching
-                return new TrieStoreByPath(_stateDb, _logManager);
+                return new TrieStoreByPath(new ByPathStateDb(_stateDb, _logManager), _logManager);
             }
 
             public bool Return(ITrieStore obj)

--- a/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
@@ -87,6 +87,7 @@ namespace Nethermind.Synchronization
             _logManager);
 
         private readonly IReadOnlyTrieStore _readOnlyTrieStore;
+        private readonly IByPathStateDb _byPathStateDb;
 
 
         protected ISyncModeSelector? _syncModeSelector;
@@ -113,7 +114,8 @@ namespace Nethermind.Synchronization
             IReadOnlyTrieStore readOnlyTrieStore,
             IBetterPeerStrategy betterPeerStrategy,
             ChainSpec chainSpec,
-            ILogManager logManager)
+            ILogManager logManager,
+            IByPathStateDb? pathStateDb = null)
         {
             _dbProvider = dbProvider ?? throw new ArgumentNullException(nameof(dbProvider));
             _logger = logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
@@ -130,6 +132,7 @@ namespace Nethermind.Synchronization
             _betterPeerStrategy = betterPeerStrategy ?? throw new ArgumentNullException(nameof(betterPeerStrategy));
             _chainSpec = chainSpec ?? throw new ArgumentNullException(nameof(chainSpec));
             _readOnlyTrieStore = readOnlyTrieStore ?? throw new ArgumentNullException(nameof(readOnlyTrieStore));
+            _byPathStateDb = pathStateDb;
 
             _syncReport = new SyncReport(_syncPeerPool!, nodeStatsManager!, _syncConfig, _pivot, logManager);
 
@@ -272,7 +275,7 @@ namespace Nethermind.Synchronization
 
         private void StartStateSyncComponents()
         {
-            TreeSync treeSync = new(SyncMode.StateNodes, _dbProvider.CodeDb, _dbProvider.PathStateDb as ByPathStateDb, _blockTree, _logManager);
+            TreeSync treeSync = new(SyncMode.StateNodes, _dbProvider.CodeDb, _byPathStateDb, _blockTree, _logManager);
             _stateSyncFeed = new StateSyncFeed(treeSync, _logManager);
             SyncDispatcher<StateSyncBatch> stateSyncDispatcher = CreateDispatcher(
                 _stateSyncFeed,

--- a/src/Nethermind/Nethermind.Trie.Test/PathCacheTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/PathCacheTests.cs
@@ -12,6 +12,7 @@ using Nethermind.Core.Extensions;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
+using Nethermind.Db.ByPathState;
 using Nethermind.Logging;
 using Nethermind.Trie.ByPath;
 using Nethermind.Trie.Pruning;
@@ -23,7 +24,7 @@ namespace Nethermind.Trie.Test;
 public class PathCacheTests
 {
     private static readonly ILogManager Logger = NUnitLogManager.Instance;
-    private static readonly ITrieStore _trieStore = new TrieStoreByPath(new MemColumnsDb<StateColumns>(), Logger);
+    private static readonly ITrieStore _trieStore = new TrieStoreByPath(new ByPathStateDb(new MemColumnsDb<StateColumns>(), Logger), Logger);
     //private static readonly int CacheSize = 5;
 
     [TestCaseSource(typeof(Instances))]

--- a/src/Nethermind/Nethermind.Trie.Test/PathDataCacheTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/PathDataCacheTests.cs
@@ -7,6 +7,7 @@ using Nethermind.Core.Extensions;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
+using Nethermind.Db.ByPathState;
 using Nethermind.Logging;
 using Nethermind.Trie.ByPath;
 using Nethermind.Trie.Pruning;
@@ -22,7 +23,7 @@ public class PathDataCacheTests
     [Test()]
     public void Get_node_latest_version()
     {
-        PathDataCache cache = new PathDataCache(new TrieStoreByPath(new MemColumnsDb<StateColumns>(), Logger), Logger);
+        PathDataCache cache = new(new TrieStoreByPath(new ByPathStateDb(new MemColumnsDb<StateColumns>(), Logger), Logger), Logger);
 
         byte[] path1 = Nibbles.BytesToNibbleBytes(Bytes.FromHexString("0x0000000000000000000000000000000000000000000000000000000000001234"));
         TrieNode node = CreateResolvedLeaf(path1, 160.ToByteArray(), 60);
@@ -40,7 +41,7 @@ public class PathDataCacheTests
     [Test()]
     public void Get_node_using_path_and_keccak()
     {
-        PathDataCache cache = new PathDataCache(new TrieStoreByPath(new MemColumnsDb<StateColumns>(), Logger), Logger);
+        PathDataCache cache = new(new TrieStoreByPath(new ByPathStateDb(new MemColumnsDb<StateColumns>(), Logger), Logger), Logger);
 
         byte[] path1 = Nibbles.BytesToNibbleBytes(Bytes.FromHexString("0x0000000000000000000000000000000000000000000000000000000000001234"));
         TrieNode node = CreateResolvedLeaf(path1, 160.ToByteArray(), 60);
@@ -65,7 +66,7 @@ public class PathDataCacheTests
     [Test()]
     public void Get_node_using_root_hash()
     {
-        PathDataCache cache = new PathDataCache(new TrieStoreByPath(new MemColumnsDb<StateColumns>(), Logger), Logger);
+        PathDataCache cache = new(new TrieStoreByPath(new ByPathStateDb(new MemColumnsDb<StateColumns>(), Logger), Logger), Logger);
 
         byte[] path1 = Nibbles.BytesToNibbleBytes(Bytes.FromHexString("0x0000000000000000000000000000000000000000000000000000000000001234"));
 
@@ -92,7 +93,7 @@ public class PathDataCacheTests
     [Test()]
     public void Add_deleted_prefix_get_node()
     {
-        PathDataCache cache = new(new TrieStoreByPath(new MemColumnsDb<StateColumns>(), Logger), Logger, 4);
+        PathDataCache cache = new(new TrieStoreByPath(new ByPathStateDb(new MemColumnsDb<StateColumns>(), Logger), Logger), Logger, 4);
 
         byte[] path1 = Nibbles.BytesToNibbleBytes(Bytes.FromHexString("0x1acf000000000000000000000000000000000000000000000000000000091234"));
         byte[] path2 = Nibbles.BytesToNibbleBytes(Bytes.FromHexString("0x1acf100000000000000000000000000000000000000000000000000000091234"));
@@ -123,7 +124,7 @@ public class PathDataCacheTests
     [Test()]
     public void Add_deleted_prefix_persist_get_node()
     {
-        ITrieStore trieStore = new TrieStoreByPath(new MemColumnsDb<StateColumns>(), Logger);
+        ITrieStore trieStore = new TrieStoreByPath(new ByPathStateDb(new MemColumnsDb<StateColumns>(), Logger), Logger);
         PathDataCache cache = new(trieStore, Logger, 4);
 
         byte[] path1 = Nibbles.BytesToNibbleBytes(Bytes.FromHexString("0x1acf000000000000000000000000000000000000000000000000000000091234"));
@@ -159,7 +160,7 @@ public class PathDataCacheTests
     [Test()]
     public void Add_deleted_prefix_persist_get_node_2()
     {
-        PathDataCache cache = new(new TrieStoreByPath(new MemColumnsDb<StateColumns>(), Logger), Logger, 4);
+        PathDataCache cache = new(new TrieStoreByPath(new ByPathStateDb(new MemColumnsDb<StateColumns>(), Logger), Logger), Logger, 4);
 
         byte[] path1 = Nibbles.BytesToNibbleBytes(Bytes.FromHexString("0x1acf000000000000000000000000000000000000000000000000000000091234"));
         byte[] path2 = Nibbles.BytesToNibbleBytes(Bytes.FromHexString("0x1acf100000000000000000000000000000000000000000000000000000091234"));
@@ -208,8 +209,8 @@ public class PathDataCacheTests
     [Test()]
     public void Test_persist_until_block_1()
     {
-        ITrieStore trieStore = new TrieStoreByPath(new MemColumnsDb<StateColumns>(), Logger);
-        PathDataCache cache = new(trieStore, Logger);
+        ITrieStore trieStore = new TrieStoreByPath(new ByPathStateDb(new MemColumnsDb<StateColumns>(), Logger), Logger);
+        PathDataCache cache = new(trieStore, Logger, 4);
 
         byte[] path1 = Nibbles.BytesToNibbleBytes(Bytes.FromHexString("0x1ac0000000000000000000000000000000000000000000000000000000091234"));
         byte[] path2 = Nibbles.BytesToNibbleBytes(Bytes.FromHexString("0x1ac1000000000000000000000000000000000000000000000000000000091234"));
@@ -237,7 +238,7 @@ public class PathDataCacheTests
     [Test()]
     public void Test_persist_until_block_2()
     {
-        ITrieStore trieStore = new TrieStoreByPath(new MemColumnsDb<StateColumns>(), Logger);
+        ITrieStore trieStore = new TrieStoreByPath(new ByPathStateDb(new MemColumnsDb<StateColumns>(), Logger), Logger);
         PathDataCache cache = new(trieStore, Logger);
 
         byte[] path1 = Nibbles.BytesToNibbleBytes(Bytes.FromHexString("0x1ac0000000000000000000000000000000000000000000000000000000091234"));
@@ -268,7 +269,7 @@ public class PathDataCacheTests
     [Test()]
     public void Test_persist_until_block_3()
     {
-        PathDataCache cache = new(new TrieStoreByPath(new MemColumnsDb<StateColumns>(), Logger), Logger, 4);
+        PathDataCache cache = new(new TrieStoreByPath(new ByPathStateDb(new MemColumnsDb<StateColumns>(), Logger), Logger), Logger, 4);
 
         byte[] path1 = Nibbles.BytesToNibbleBytes(Bytes.FromHexString("0x1ac0000000000000000000000000000000000000000000000000000000091234"));
 

--- a/src/Nethermind/Nethermind.Trie.Test/TrieByPathFuzzTesting.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieByPathFuzzTesting.cs
@@ -11,6 +11,7 @@ using Nethermind.Core.Extensions;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
+using Nethermind.Db.ByPathState;
 using Nethermind.Db.Rocks;
 using Nethermind.Db.Rocks.Config;
 using Nethermind.Int256;
@@ -98,7 +99,7 @@ public class TrieByPathFuzzTesting
 
         var codeDb = new MemDb();
         TestPathPersistanceStrategy strategy = new(lookupLimit, lookupLimit / 2);
-        using TrieStoreByPath pathTrieStore = new(memDb, strategy, _logManager);
+        using TrieStoreByPath pathTrieStore = new(new ByPathStateDb(memDb, _logManager), strategy, _logManager);
         WorldState pathStateProvider = new(pathTrieStore, new MemDb(), _logManager);
 
         using TrieStore trieStore = new(new MemDb(), No.Pruning, Persist.IfBlockOlderThan(lookupLimit), _logManager);

--- a/src/Nethermind/Nethermind.Trie.Test/TrieByPathTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieByPathTests.cs
@@ -11,6 +11,7 @@ using Nethermind.Core.Extensions;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
+using Nethermind.Db.ByPathState;
 using Nethermind.Db.Rocks;
 using Nethermind.Db.Rocks.Config;
 using Nethermind.Int256;
@@ -71,7 +72,7 @@ public class TrieByPathTests
     public void Single_leaf()
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager);
         patriciaTree.Set(_keyAccountA, _longLeaf1);
         patriciaTree.Commit(0);
@@ -84,7 +85,7 @@ public class TrieByPathTests
     public void Single_leaf_update_same_block()
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
         PatriciaTree patriciaTree = new PatriciaTree(trieStore, _logManager);
         patriciaTree.Set(_keyAccountA, _longLeaf1);
         patriciaTree.Set(_keyAccountA, _longLeaf2);
@@ -102,7 +103,7 @@ public class TrieByPathTests
     public void Single_leaf_update_next_blocks()
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager);
         patriciaTree.Set(_keyAccountA, _longLeaf1);
         patriciaTree.Commit(0);
@@ -124,7 +125,7 @@ public class TrieByPathTests
     public void Single_leaf_delete_same_block()
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager);
         patriciaTree.Set(_keyAccountA, _longLeaf1);
         patriciaTree.Set(_keyAccountA, Array.Empty<byte>());
@@ -141,7 +142,7 @@ public class TrieByPathTests
     public void Single_leaf_delete_next_block()
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager);
         patriciaTree.Set(_keyAccountA, _longLeaf1);
         patriciaTree.Commit(0);
@@ -160,7 +161,7 @@ public class TrieByPathTests
     public void Single_leaf_and_keep_for_multiple_dispatches_then_delete()
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, LimboLogs.Instance);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), LimboLogs.Instance);
         PatriciaTree patriciaTree = new(trieStore, _logManager);
         patriciaTree.Commit(0);
         patriciaTree.Commit(1);
@@ -194,7 +195,7 @@ public class TrieByPathTests
     public void Branch_with_branch_and_leaf()
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager);
         patriciaTree.Set(_keyAccountA, _longLeaf1);
         patriciaTree.Set(_keyAccountB, _longLeaf1);
@@ -225,7 +226,7 @@ public class TrieByPathTests
     public void Branch_with_branch_and_leaf_then_deleted()
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager);
         patriciaTree.Set(_keyAccountA, _longLeaf1);
         patriciaTree.Set(_keyAccountB, _longLeaf1);
@@ -248,7 +249,7 @@ public class TrieByPathTests
     public void Test_add_many(int i)
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
         PatriciaTree patriciaTree = new(trieStore, Keccak.EmptyTreeHash, true, true, _logManager);
 
         for (int j = 0; j < i; j++)
@@ -273,7 +274,7 @@ public class TrieByPathTests
     public void Test_try_delete_and_read_missing_nodes(int i)
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
         PatriciaTree patriciaTree = new(trieStore, Keccak.EmptyTreeHash, true, true, _logManager);
 
         for (int j = 0; j < i; j++)
@@ -314,7 +315,7 @@ public class TrieByPathTests
     public void Test_update_many(int i)
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager);
 
         for (int j = 0; j < i; j++)
@@ -346,7 +347,7 @@ public class TrieByPathTests
     public void Test_update_many_next_block(int i)
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager);
 
         for (int j = 0; j < i; j++)
@@ -383,7 +384,7 @@ public class TrieByPathTests
     public void Test_add_and_delete_many_same_block(int i)
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager);
 
         for (int j = 0; j < i; j++)
@@ -415,7 +416,7 @@ public class TrieByPathTests
     public void Test_add_and_delete_many_next_block(int i)
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager);
 
         for (int j = 0; j < i; j++)
@@ -466,7 +467,7 @@ public class TrieByPathTests
     public void Two_branches_exactly_same_leaf()
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager);
         patriciaTree.Set(_keyAccountA, _longLeaf1);
         patriciaTree.Set(_keyAccountB, _longLeaf1);
@@ -487,7 +488,7 @@ public class TrieByPathTests
     public void Two_branches_exactly_same_leaf_then_one_removed()
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, LimboLogs.Instance);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), LimboLogs.Instance);
 
         PatriciaTree patriciaTree = new StateTree(trieStore, _logManager);
 
@@ -522,7 +523,7 @@ public class TrieByPathTests
 
     private static PatriciaTree CreateCheckTree(IColumnsDb<StateColumns> memDb, Hash256 root, ILogManager logManager)
     {
-        PatriciaTree checkTree = new(new TrieStoreByPath(memDb, logManager), logManager);
+        PatriciaTree checkTree = new(new TrieStoreByPath(new ByPathStateDb(memDb, logManager), logManager), logManager);
         checkTree.RootHash = root;
         return checkTree;
     }
@@ -531,7 +532,7 @@ public class TrieByPathTests
     public void Extension_with_branch_with_two_different_children()
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager);
         patriciaTree.Set(_keyAccountA, _longLeaf1);
         patriciaTree.Set(_keyAccountB, _longLeaf2);
@@ -546,7 +547,7 @@ public class TrieByPathTests
     public void Extension_with_branch_with_two_same_children()
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager);
         patriciaTree.Set(_keyAccountA, _longLeaf1);
         patriciaTree.Set(_keyAccountB, _longLeaf1);
@@ -561,7 +562,7 @@ public class TrieByPathTests
     public void When_branch_with_two_different_children_change_one_and_change_back_next_block()
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager);
         patriciaTree.Set(_keyAccountA, _longLeaf1);
         patriciaTree.Set(_keyAccountB, _longLeaf2);
@@ -582,7 +583,7 @@ public class TrieByPathTests
     public void When_branch_with_two_same_children_change_one_and_change_back_next_block()
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager);
         patriciaTree.Set(_keyAccountA, _longLeaf1);
         patriciaTree.Set(_keyAccountB, _longLeaf1);
@@ -615,7 +616,7 @@ public class TrieByPathTests
         byte[] key3 = Bytes.FromHexString("000000200000000cc").PadLeft(32);
 
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager);
         patriciaTree.Set(key1, _longLeaf1);
         patriciaTree.Set(key2, _longLeaf1);
@@ -663,7 +664,7 @@ public class TrieByPathTests
         byte[] key3 = Bytes.FromHexString("000000200000000cc").PadLeft(32);
 
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager);
         patriciaTree.Set(key1, _longLeaf1);
         patriciaTree.Set(key2, _longLeaf1);
@@ -685,7 +686,7 @@ public class TrieByPathTests
     public void When_two_branches_with_two_same_children_change_one_and_change_back_next_block()
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager);
         patriciaTree.Set(_keyAccountA, _longLeaf1);
         patriciaTree.Set(_keyAccountB, _longLeaf1);
@@ -710,7 +711,7 @@ public class TrieByPathTests
     public void Persist_inlined_node()
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager);
 
         byte[] smallLeafValue = Bytes.FromHexString("00000010000000aa");
@@ -746,7 +747,7 @@ public class TrieByPathTests
     public void Request_deletion_for_leaf()
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
 
         Span<byte> fullPathNibbles = stackalloc byte[64];
         Nibbles.BytesToNibbleBytes(Bytes.FromHexString("0x12345600000033333333333333300ee000000555555555555555550000abcdef"), fullPathNibbles);
@@ -759,7 +760,7 @@ public class TrieByPathTests
     public void Request_deletion_for_extension()
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
 
         Span<byte> fullPathNibbles = stackalloc byte[5] { 3, 13, 3, 2, 13 };
         Span<byte> extensionKey = stackalloc byte[2] { 7, 10 };
@@ -791,8 +792,7 @@ public class TrieByPathTests
         Queue<Hash256> rootQueue = new();
 
         MemColumnsDb<StateColumns> memDb = new();
-
-        using TrieStoreByPath trieStore = new(memDb, ByPathPersist.IfBlockOlderThan(lookupLimit), _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), ByPathPersist.IfBlockOlderThan(lookupLimit), _logManager);
         StateTreeByPath patriciaTree = new(trieStore, _logManager);
 
         byte[][] accounts = new byte[accountsCount][];
@@ -926,7 +926,7 @@ public class TrieByPathTests
         TestPathPersistanceStrategy strategy = new(lookupLimit, lookupLimit / 2);
 
         Reorganization.MaxDepth = 1;
-        using TrieStoreByPath trieStore = new(memDb, strategy, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), strategy, _logManager);
         trieStore.ReorgBoundaryReached += (object? sender, ReorgBoundaryReached e) =>
         {
             strategy.LastPersistedBlockNumber = e.BlockNumber;
@@ -1083,7 +1083,7 @@ public class TrieByPathTests
 
         TestPathPersistanceStrategy strategy = new(lookupLimit, lookupLimit / 2);
 
-        using TrieStoreByPath trieStore = new(memDb, strategy, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), strategy, _logManager);
 
         WorldState stateProvider = new(trieStore, new MemDb(), _logManager);
 
@@ -1223,7 +1223,7 @@ public class TrieByPathTests
         var dirInfo = Directory.CreateTempSubdirectory();
         using ColumnsDb<StateColumns> stateDb = new(dirInfo.FullName, new RocksDbSettings("pathState", Path.Combine(dirInfo.FullName, "pathState")), new DbConfig(), _logManager, new StateColumns[] { StateColumns.State, StateColumns.Storage });
 
-        using TrieStoreByPath pathTrieStore = new(stateDb, ByPathPersist.IfBlockOlderThan(2), _logManager);
+        using TrieStoreByPath pathTrieStore = new(new ByPathStateDb(stateDb, _logManager), ByPathPersist.IfBlockOlderThan(2), _logManager);
         WorldState pathStateProvider = new(pathTrieStore, new MemDb(), _logManager);
 
         pathStateProvider.CreateAccount(TestItem.AddressA, 100);

--- a/src/Nethermind/Nethermind.Trie.Test/TrieByPathWithPrefixTest.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieByPathWithPrefixTest.cs
@@ -8,6 +8,7 @@ using Nethermind.Core.Extensions;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
+using Nethermind.Db.ByPathState;
 using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
@@ -64,7 +65,7 @@ public class TrieByPathWithPrefixTest
     public void Single_leaf()
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager)
         {
             StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
@@ -80,7 +81,7 @@ public class TrieByPathWithPrefixTest
     public void Single_leaf_update_same_block()
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
         PatriciaTree patriciaTree = new PatriciaTree(trieStore, _logManager)
         {
             StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
@@ -101,7 +102,7 @@ public class TrieByPathWithPrefixTest
     public void Single_leaf_update_next_blocks()
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager)
         {
             StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
@@ -126,7 +127,7 @@ public class TrieByPathWithPrefixTest
     public void Single_leaf_delete_same_block()
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager)
         {
             StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
@@ -146,7 +147,7 @@ public class TrieByPathWithPrefixTest
     public void Single_leaf_delete_next_block()
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager)
         {
             StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
@@ -168,7 +169,7 @@ public class TrieByPathWithPrefixTest
     public void Single_leaf_and_keep_for_multiple_dispatches_then_delete()
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, LimboLogs.Instance);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager)
         {
             StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
@@ -205,7 +206,7 @@ public class TrieByPathWithPrefixTest
     public void Branch_with_branch_and_leaf()
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager)
         {
             StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
@@ -239,7 +240,7 @@ public class TrieByPathWithPrefixTest
     public void Branch_with_branch_and_leaf_then_deleted()
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager)
         {
             StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
@@ -265,7 +266,7 @@ public class TrieByPathWithPrefixTest
     public void Test_add_many(int i)
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
         PatriciaTree patriciaTree = new(trieStore, Keccak.EmptyTreeHash, true, true, _logManager)
         {
             StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
@@ -293,7 +294,7 @@ public class TrieByPathWithPrefixTest
     public void Test_try_delete_and_read_missing_nodes(int i)
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
         PatriciaTree patriciaTree = new(trieStore, Keccak.EmptyTreeHash, true, true, _logManager)
         {
             StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
@@ -337,7 +338,7 @@ public class TrieByPathWithPrefixTest
     public void Test_update_many(int i)
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager)
         {
             StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
@@ -372,7 +373,7 @@ public class TrieByPathWithPrefixTest
     private void Test_update_many_next_block(int i)
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager)
         {
             StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
@@ -412,7 +413,7 @@ public class TrieByPathWithPrefixTest
     public void Test_add_and_delete_many_same_block(int i)
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager)
         {
             StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
@@ -447,7 +448,7 @@ public class TrieByPathWithPrefixTest
     public void Test_add_and_delete_many_next_block(int i)
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager)
         {
             StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
@@ -500,7 +501,7 @@ public class TrieByPathWithPrefixTest
     public void Two_branches_exactly_same_leaf()
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager)
         {
             StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
@@ -524,7 +525,7 @@ public class TrieByPathWithPrefixTest
     public void Two_branches_exactly_same_leaf_then_one_removed()
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new TrieStoreByPath(memDb, LimboLogs.Instance);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), LimboLogs.Instance);
 
         PatriciaTree patriciaTree = new PatriciaTree(trieStore, Keccak.EmptyTreeHash, true, true, _logManager)
         {
@@ -563,7 +564,7 @@ public class TrieByPathWithPrefixTest
 
     private static PatriciaTree CreateCheckTree(IColumnsDb<StateColumns> memDb, PatriciaTree tree, ILogManager logManager)
     {
-        PatriciaTree checkTree = new(new TrieStoreByPath(memDb, logManager), logManager)
+        PatriciaTree checkTree = new(new TrieStoreByPath(new ByPathStateDb(memDb, logManager), logManager), logManager)
         {
             StorageBytePathPrefix = Nibbles.ToBytes(tree.StoreNibblePathPrefix),
             RootHash = tree.RootHash,
@@ -575,7 +576,7 @@ public class TrieByPathWithPrefixTest
     public void Extension_with_branch_with_two_different_children()
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager)
         {
             StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
@@ -593,7 +594,7 @@ public class TrieByPathWithPrefixTest
     public void Extension_with_branch_with_two_same_children()
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager)
         {
             StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
@@ -611,7 +612,7 @@ public class TrieByPathWithPrefixTest
     public void When_branch_with_two_different_children_change_one_and_change_back_next_block()
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager)
         {
             StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
@@ -635,7 +636,7 @@ public class TrieByPathWithPrefixTest
     public void When_branch_with_two_same_children_change_one_and_change_back_next_block()
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager)
         {
             StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
@@ -671,7 +672,7 @@ public class TrieByPathWithPrefixTest
         byte[] key3 = Bytes.FromHexString("000000200000000cc").PadLeft(32);
 
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager)
         {
             StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
@@ -722,7 +723,7 @@ public class TrieByPathWithPrefixTest
         byte[] key3 = Bytes.FromHexString("000000200000000cc").PadLeft(32);
 
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager)
         {
             StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
@@ -747,7 +748,7 @@ public class TrieByPathWithPrefixTest
     public void When_two_branches_with_two_same_children_change_one_and_change_back_next_block()
     {
         MemColumnsDb<StateColumns> memDb = new();
-        using TrieStoreByPath trieStore = new(memDb, _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager)
         {
             StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()
@@ -794,8 +795,7 @@ public class TrieByPathWithPrefixTest
         Queue<Hash256> rootQueue = new();
 
         MemColumnsDb<StateColumns> memDb = new();
-
-        using TrieStoreByPath trieStore = new(memDb, ByPathPersist.IfBlockOlderThan(lookupLimit), _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), ByPathPersist.IfBlockOlderThan(lookupLimit), _logManager);
         StateTreeByPath patriciaTree = new(trieStore, _logManager);
 
         byte[][] accounts = new byte[accountsCount][];
@@ -919,8 +919,7 @@ public class TrieByPathWithPrefixTest
         Stack<Hash256> rootStack = new();
 
         MemColumnsDb<StateColumns> memDb = new();
-
-        using TrieStoreByPath trieStore = new(memDb, ByPathPersist.IfBlockOlderThan(lookupLimit), _logManager);
+        using TrieStoreByPath trieStore = new(new ByPathStateDb(memDb, _logManager), ByPathPersist.IfBlockOlderThan(lookupLimit), _logManager);
         PatriciaTree patriciaTree = new(trieStore, _logManager)
         {
             StorageBytePathPrefix = _keyAccountA.Concat(new[] { (byte)128 }).ToArray()

--- a/src/Nethermind/Nethermind.Trie/ByPath/PathDataCache.cs
+++ b/src/Nethermind/Nethermind.Trie/ByPath/PathDataCache.cs
@@ -218,7 +218,7 @@ internal class PathDataCacheInstance
     {
         if (IsOpened && !_isDirty)
         {
-            _lastState = _lastState.ParentBlock;
+            _lastState = _lastState?.ParentBlock;
         }
     }
 

--- a/src/Nethermind/Nethermind.Trie/CachingStore.cs
+++ b/src/Nethermind/Nethermind.Trie/CachingStore.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Nethermind.Core;
 using Nethermind.Core.Caching;
 using Nethermind.Core.Extensions;
+using Nethermind.Db;
 
 namespace Nethermind.Trie
 {
@@ -89,5 +90,77 @@ namespace Nethermind.Trie
         {
             _wrappedStore.DeleteByRange(startKey, endKey);
         }
+    }
+
+    public class CachingDb : IDb
+    {
+        private readonly IDb _wrappedDb;
+
+        public CachingDb(IDb wrappedDb, int maxCapacity)
+        {
+            _wrappedDb = wrappedDb ?? throw new ArgumentNullException(nameof(_wrappedDb));
+            _cache = new SpanLruCache<byte, byte[]>(maxCapacity, 0, "RLP Cache", Bytes.SpanEqualityComparer);
+        }
+
+        public bool PreferWriteByArray => true;
+        private readonly SpanLruCache<byte, byte[]> _cache;
+
+        public byte[]? this[ReadOnlySpan<byte> key]
+        {
+            get
+            {
+                return Get(key);
+            }
+            set
+            {
+                Set(key, value);
+            }
+        }
+
+        public byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)
+        {
+            if ((flags & ReadFlags.HintCacheMiss) == ReadFlags.HintCacheMiss)
+            {
+                return _wrappedDb.Get(key, flags);
+            }
+
+            if (!_cache.TryGet(key, out byte[] value))
+            {
+                value = _wrappedDb.Get(key, flags);
+                _cache.Set(key, value);
+            }
+            else
+            {
+                // TODO: a hack assuming that we cache only one thing, accepted unanimously by Lukasz, Marek, and Tomasz
+                Pruning.Metrics.LoadedFromRlpCacheNodesCount++;
+            }
+
+            return value;
+        }
+
+        public void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None)
+        {
+            _cache.Set(key, value);
+            _wrappedDb.Set(key, value, flags);
+        }
+
+        public IWriteBatch StartWriteBatch() => _wrappedDb.StartWriteBatch();
+
+        public void DeleteByRange(Span<byte> startKey, Span<byte> endKey)
+        {
+            //should put the effort to iterate over cache?
+            _cache.Clear();
+            _wrappedDb.DeleteByRange(startKey, endKey);
+        }
+
+        public void Dispose() => _wrappedDb.Dispose();
+
+        public string Name => _wrappedDb.Name;
+
+        public KeyValuePair<byte[], byte[]?>[] this[byte[][] keys] => _wrappedDb[keys];
+
+        public IEnumerable<KeyValuePair<byte[], byte[]?>> GetAll(bool ordered = false) => _wrappedDb.GetAll(ordered);
+
+        public IEnumerable<byte[]> GetAllValues(bool ordered = false) => _wrappedDb.GetAllValues(ordered);
     }
 }

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -20,6 +20,7 @@ using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Crypto;
 using Nethermind.Db;
+using Nethermind.Db.ByPathState;
 using Nethermind.Evm;
 using Nethermind.Int256;
 using Nethermind.Logging;
@@ -52,7 +53,7 @@ namespace Nethermind.TxPool.Test
             _logManager = LimboLogs.Instance;
             _specProvider = MainnetSpecProvider.Instance;
             _ethereumEcdsa = new EthereumEcdsa(_specProvider.ChainId, _logManager);
-            var trieStore = new TrieStoreByPath(new MemColumnsDb<StateColumns>(), _logManager);
+            var trieStore = new TrieStoreByPath(new ByPathStateDb(new MemColumnsDb<StateColumns>(), _logManager), _logManager);
             var codeDb = new MemDb();
             _stateProvider = new WorldState(trieStore, codeDb, _logManager);
             _blockTree = Substitute.For<IBlockTree>();


### PR DESCRIPTION
Fixes Closes Resolves #

## Changes
Add a caching layer on top of DB similar to `CachingStore `for `IKeyValueStore`, but at `ColumnsDb `level to align with path based DB layout.

- New class `CachingDb` will wrap up `ColumnDb `in `ColumnsDb` using same functionality as CachingStore
- `ByPathStateDb `will aggregate `IColumnsDb` instead of derive from `ColumnsDb`. This way it can wrap both a cached and non-cached version of `IColumnsDb`

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing