### PR TITLE
Fix base config & migrate op to V2 methods

### DIFF
--- a/src/Nethermind/Nethermind.Optimism/IOptimismEngineRpcModule.cs
+++ b/src/Nethermind/Nethermind.Optimism/IOptimismEngineRpcModule.cs
@@ -30,4 +30,22 @@ public interface IOptimismEngineRpcModule : IRpcModule
         IsSharable = true,
         IsImplemented = true)]
     Task<ResultWrapper<PayloadStatusV1>> engine_newPayloadV1(ExecutionPayload executionPayload);
+
+    [JsonRpcMethod(
+        Description = "Verifies the payload according to the execution environment rules and returns the verification status and hash of the last valid block.",
+        IsSharable = true,
+        IsImplemented = true)]
+    Task<ResultWrapper<ForkchoiceUpdatedV1Result>> engine_forkchoiceUpdatedV2(ForkchoiceStateV1 forkchoiceState, OptimismPayloadAttributes? payloadAttributes = null);
+
+    [JsonRpcMethod(
+        Description = "Returns the most recent version of an execution payload with respect to the transaction set contained by the mempool.",
+        IsSharable = true,
+        IsImplemented = true)]
+    Task<ResultWrapper<GetPayloadV2Result?>> engine_getPayloadV2(byte[] payloadId);
+
+    [JsonRpcMethod(
+        Description = "Verifies the payload according to the execution environment rules and returns the verification status and hash of the last valid block.",
+        IsSharable = true,
+        IsImplemented = true)]
+    Task<ResultWrapper<PayloadStatusV1>> engine_newPayloadV2(ExecutionPayload executionPayload);
 }

--- a/src/Nethermind/Nethermind.Optimism/OptimismEngineRpcModule.cs
+++ b/src/Nethermind/Nethermind.Optimism/OptimismEngineRpcModule.cs
@@ -28,6 +28,21 @@ public class OptimismEngineRpcModule : IOptimismEngineRpcModule
         return _engineRpcModule.engine_newPayloadV1(executionPayload);
     }
 
+    public async Task<ResultWrapper<ForkchoiceUpdatedV1Result>> engine_forkchoiceUpdatedV2(ForkchoiceStateV1 forkchoiceState, OptimismPayloadAttributes? payloadAttributes = null)
+    {
+        return await _engineRpcModule.engine_forkchoiceUpdatedV2(forkchoiceState, payloadAttributes);
+    }
+
+    public Task<ResultWrapper<GetPayloadV2Result?>> engine_getPayloadV2(byte[] payloadId)
+    {
+        return _engineRpcModule.engine_getPayloadV2(payloadId);
+    }
+
+    public Task<ResultWrapper<PayloadStatusV1>> engine_newPayloadV2(ExecutionPayload executionPayload)
+    {
+        return _engineRpcModule.engine_newPayloadV2(executionPayload);
+    }
+
     public OptimismEngineRpcModule(IEngineRpcModule engineRpcModule)
     {
         _engineRpcModule = engineRpcModule;

--- a/src/Nethermind/Nethermind.Runner/configs/base-mainnet.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/base-mainnet.cfg
@@ -3,7 +3,8 @@
         "ChainSpecPath" : "chainspec/base-mainnet.json",
         "GenesisHash" : "0xf712aa9241cc24369b143cf6dce85f0902a9731e70d66818a3a5845b296c73dd",
         "BaseDbPath" : "nethermind_db/base-mainnet",
-        "LogFileName" : "base-mainnet.logs.txt"
+        "LogFileName" : "base-mainnet.logs.txt",
+        "DisableGcOnNewPayload": false
     },
     "JsonRpc" : {
         "Enabled" : true,


### PR DESCRIPTION
Fixes Closes Resolves #
Latest version of op node calls V2 engine methods instead of V1

## Changes

- Migrate to V2
- Fix base config

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_


