### PR TITLE
Unify js types, use typed arrays everywhere + long for slice parameters

### DIFF
--- a/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/JavaScript/Context.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/JavaScript/Context.cs
@@ -13,12 +13,12 @@ namespace Nethermind.Evm.Tracing.GethStyle.JavaScript;
 
 public class Context
 {
-    private IList? _blockHashConverted;
-    private IList? _txHashConverted;
-    private IList? _inputConverted;
-    private IList? _fromConverted;
-    private IList? _toConverted;
-    private IList? _outputConverted;
+    private ITypedArray<byte>? _blockHashConverted;
+    private ITypedArray<byte>? _txHashConverted;
+    private ITypedArray<byte>? _inputConverted;
+    private ITypedArray<byte>? _fromConverted;
+    private ITypedArray<byte>? _toConverted;
+    private ITypedArray<byte>? _outputConverted;
     private dynamic? _valueConverted;
     private dynamic? _gasPriceConverted;
     private Address? _from;
@@ -111,17 +111,17 @@ public class Context
     }
 
     public string type { get; set; } = null!;
-    public IList? from => _fromConverted ??= From?.Bytes.ToUnTypedScriptArray();
-    public IList? to => _toConverted ??= To?.Bytes.ToUnTypedScriptArray();
-    public IList? input => _inputConverted ??= Input.ToArray().ToUnTypedScriptArray();
+    public ITypedArray<byte>? from => _fromConverted ??= From?.Bytes.ToTypedScriptArray();
+    public ITypedArray<byte>? to => _toConverted ??= To?.Bytes.ToTypedScriptArray();
+    public ITypedArray<byte>? input => _inputConverted ??= Input.ToArray().ToTypedScriptArray();
     public long gas { get; set; }
     public long gasUsed { get; set; }
     public IJavaScriptObject gasPrice => _gasPriceConverted ??= GasPrice.ToBigInteger();
     public IJavaScriptObject value => _valueConverted ??= Value.ToBigInteger();
     public long block { get; set; }
-    public IList? output => _outputConverted ??= Output?.ToUnTypedScriptArray();
-    public IList? blockHash => _blockHashConverted ??= BlockHash?.BytesToArray().ToUnTypedScriptArray();
+    public ITypedArray<byte>? output => _outputConverted ??= Output?.ToTypedScriptArray();
+    public ITypedArray<byte>? blockHash => _blockHashConverted ??= BlockHash?.BytesToArray().ToTypedScriptArray();
     public int? txIndex { get; set; }
-    public IList? txHash => _txHashConverted ??= TxHash?.BytesToArray().ToUnTypedScriptArray();
+    public ITypedArray<byte>? txHash => _txHashConverted ??= TxHash?.BytesToArray().ToTypedScriptArray();
     public dynamic? error { get; set; } = Undefined.Value;
 }

--- a/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/JavaScript/Engine.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/JavaScript/Engine.cs
@@ -33,7 +33,6 @@ public class Engine : IDisposable
 
     private readonly IReleaseSpec _spec;
 
-    private readonly dynamic _createUntypedArray;
     private dynamic _bigInteger;
     private dynamic _createUint8Array;
 
@@ -89,7 +88,7 @@ public class Engine : IDisposable
         Func<object?, string> toHex = ToHex;
         Func<object, ITypedArray<byte>> toAddress = ToAddress;
         Func<object, bool> isPrecompiled = IsPrecompiled;
-        Func<object, int, int, ITypedArray<byte>> slice = Slice;
+        Func<object, long, long, ITypedArray<byte>> slice = Slice;
         Func<object, ulong, ITypedArray<byte>> toContract = ToContract;
         Func<object, string, object, ITypedArray<byte>> toContract2 = ToContract2;
 
@@ -100,7 +99,6 @@ public class Engine : IDisposable
         V8Engine.AddHostObject(nameof(slice), slice);
         V8Engine.AddHostObject(nameof(toContract), toContract);
         V8Engine.AddHostObject(nameof(toContract2), toContract2);
-        _createUntypedArray = V8Engine.Script.Array.from;
 
         if (!IsDebugging)
         {
@@ -134,7 +132,7 @@ public class Engine : IDisposable
     /// <summary>
     /// Returns a slice of input
     /// </summary>
-    private ITypedArray<byte> Slice(object input, int start, int end)
+    private ITypedArray<byte> Slice(object input, long start, long end)
     {
         if (input == null)
         {
@@ -146,7 +144,7 @@ public class Engine : IDisposable
             throw new ArgumentOutOfRangeException(nameof(start), $"tracer accessed out of bound memory: offset {start}, end {end}");
         }
 
-        return input.ToBytes().Slice(start, end - start).ToTypedScriptArray();
+        return input.ToBytes().Slice((int)start, (int)(end - start)).ToTypedScriptArray();
     }
 
     /// <summary>
@@ -170,11 +168,6 @@ public class Engine : IDisposable
     /// Creates a JavaScript V8Engine typed byte array
     /// </summary>
     public ITypedArray<byte> CreateUint8Array(byte[] buffer) => _createUint8Array(buffer);
-
-    /// <summary>
-    /// Creates a JavaScript V8Engine untyped array with number values
-    /// </summary>
-    public IList CreateUntypedArray(byte[] buffer) => _createUntypedArray(buffer);
 
     /// <summary>
     /// Creates a JavaScript BigInteger object

--- a/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/JavaScript/JavaScriptConverter.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/JavaScript/JavaScriptConverter.cs
@@ -49,8 +49,6 @@ public static class JavaScriptConverter
 
     public static ITypedArray<byte> ToTypedScriptArray(this ReadOnlyMemory<byte> memory) => memory.ToArray().ToTypedScriptArray();
 
-    public static IList ToUnTypedScriptArray(this byte[] array) => CurrentEngine.CreateUntypedArray(array);
-
     public static IJavaScriptObject ToBigInteger(this BigInteger bigInteger) => CurrentEngine.CreateBigInteger(bigInteger);
     public static IJavaScriptObject ToBigInteger(this UInt256 bigInteger) => CurrentEngine.CreateBigInteger((BigInteger)bigInteger);
 


### PR DESCRIPTION
## Changes

Initially Geth had some different types used, they unified them after our feedback here: https://github.com/ethereum/go-ethereum/pull/28488 this makes same changes in Nethermind.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Run some smoke test comparisions

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No