### PR TITLE
Use Kestrel on Windows for metrics

### DIFF
--- a/src/Nethermind/Nethermind.Monitoring/MonitoringService.cs
+++ b/src/Nethermind/Nethermind.Monitoring/MonitoringService.cs
@@ -9,6 +9,7 @@ using Nethermind.Monitoring.Metrics;
 using Nethermind.Monitoring.Config;
 using System.Net.Sockets;
 using Prometheus;
+using System.Runtime.InteropServices;
 
 namespace Nethermind.Monitoring
 {
@@ -81,7 +82,9 @@ namespace Nethermind.Monitoring
             if (_exposePort is not null)
             {
                 // KestrelMetricServer intercept SIGTERM causing exitcode to be incorrect
-                IMetricServer metricServer = new MetricServer(_exposePort.Value);
+                IMetricServer metricServer = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
+                    new KestrelMetricServer(_exposePort.Value) :
+                    new MetricServer(_exposePort.Value);
                 metricServer.Start();
             }
             await Task.Factory.StartNew(() => _metricsController.StartUpdating(), TaskCreationOptions.LongRunning);


### PR DESCRIPTION
Resolves #6299

## Changes

- HttpListerner needs explicit permissions to listen to a port on Windows or be run in Admin mode, so revert to previous Kestrel listener on Windows

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No