### PR TITLE
Remove syncing check from ReviewBlockTree step

### DIFF
--- a/src/Nethermind/Nethermind.Init/Steps/ReviewBlockTree.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/ReviewBlockTree.cs
@@ -39,10 +39,6 @@ namespace Nethermind.Init.Steps
         private async Task RunBlockTreeInitTasks(CancellationToken cancellationToken)
         {
             ISyncConfig syncConfig = _api.Config<ISyncConfig>();
-            if (!syncConfig.SynchronizationEnabled)
-            {
-                return;
-            }
 
             if (_api.BlockTree is null) throw new StepDependencyException(nameof(_api.BlockTree));
 


### PR DESCRIPTION
Right now because of in-memory pruning, after client restarts there is a gap between the last state root from which we have state in the database and the latest processed block (for which we should have state) according to block tree. This gap is fixed at startup by reviewing the block tree and reprocessing the blocks in the gap, however if networking or synchronization are disabled in config this reprocessing won't happen, causing issues later in the pipeline because of missing state.

## Changes

- Reprocess blocks in the gap regardless of whether synchronization/networking are enabled or not.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No