### PR TITLE
Allow CL client to reorg the canonical chain

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
@@ -200,8 +200,16 @@ public class ForkchoiceUpdatedHandler : IForkchoiceUpdatedHandler
 
         if (_blockTree.IsOnMainChainBehindHead(newHeadBlock))
         {
-            if (_logger.IsInfo) _logger.Info($"Valid. ForkChoiceUpdated ignored - already in canonical chain. Request: {requestStr}.");
-            return ForkchoiceUpdatedV1Result.Valid(null, forkchoiceState.HeadBlockHash);
+            if (payloadAttributes is null)
+            {
+                if (_logger.IsInfo)
+                    _logger.Info($"Valid. ForkChoiceUpdated ignored - already in canonical chain. Request: {requestStr}.");
+                return ForkchoiceUpdatedV1Result.Valid(null, forkchoiceState.HeadBlockHash);
+            }
+            else if (_logger.IsWarn)
+            {
+                _logger.Warn($"Building on top of old head. Possible reorg. Request: {requestStr}.");
+            }
         }
 
         bool newHeadTheSameAsCurrentHead = _blockTree.Head!.Hash == newHeadBlock.Hash;


### PR DESCRIPTION
Arguably CL client should be in control of what's the canonical chain, as long as it's not inconsistent with past request, for example as long as it's not trying to reorg a finalized block.

This will probably never happen on mainnet. However in Op Stack chains, the block building process is used not only to produce new blocks (reorg the chain) but also to derive blocks from the information stored in the L1.

## Changes

- If CL is trying to build on top of an old head block, don't ignore it, let it reorg the chain if it wishes to do so.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### Notes on testing

Running a validator with this PR would be very good to make sure no regressions are introduced.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No