### PR TITLE
Disable networking on OpStack configs

### DIFF
--- a/src/Nethermind/Nethermind.Runner/configs/base-goerli.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/base-goerli.cfg
@@ -5,6 +5,9 @@
         "BaseDbPath" : "nethermind_db/base-goerli",
         "LogFileName" : "base-goerli.logs.txt"
     },
+    "Sync": {
+        "NetworkingEnabled": false
+    },
     "JsonRpc" : {
         "Enabled" : true,
         "Port" : 8545,

--- a/src/Nethermind/Nethermind.Runner/configs/base-mainnet.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/base-mainnet.cfg
@@ -6,6 +6,9 @@
         "LogFileName" : "base-mainnet.logs.txt",
         "DisableGcOnNewPayload": false
     },
+    "Sync": {
+      "NetworkingEnabled": false
+    },
     "JsonRpc" : {
         "Enabled" : true,
         "Port" : 8545,

--- a/src/Nethermind/Nethermind.Runner/configs/op-goerli.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/op-goerli.cfg
@@ -8,14 +8,7 @@
     "DisableGcOnNewPayload": false
   },
   "Sync": {
-    "FastSync": true,
-    "SnapSync": true,
-    "PivotNumber": 4061224,
-    "PivotHash": "0x0f783549ea4313b784eadd9b8e8a69913b368b7366363ea814d7707ac505175f",
-    "PivotTotalDifficulty": "8122447",
-    "FastBlocks": true,
-    "FastSyncCatchUpHeightDelta": "10000000000",
-    "MaxAttemptsToUpdatePivot": 0
+    "NetworkingEnabled": false
   },
   "JsonRpc": {
     "Enabled": true,

--- a/src/Nethermind/Nethermind.Runner/configs/op-mainnet.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/op-mainnet.cfg
@@ -8,14 +8,7 @@
     "DisableGcOnNewPayload": false
   },
   "Sync": {
-    "FastSync": true,
-    "SnapSync": true,
-    "PivotNumber": 105235063,
-    "PivotHash": "0xdbf6a80fef073de06add9b0d14026d6e5a86c85f6d102c36d3d8e9cf89c2afd3",
-    "PivotTotalDifficulty": "210470125",
-    "FastBlocks": true,
-    "FastSyncCatchUpHeightDelta": "10000000000",
-    "MaxAttemptsToUpdatePivot": 0
+    "NetworkingEnabled": false
   },
   "JsonRpc": {
     "Enabled": true,


### PR DESCRIPTION
## Changes

- Disables networking and synchronization in OpStack chains

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: Config

## Testing

#### Requires testing

- [ ] Yes
- [x] No


#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

P2P Networking is now disabled by default in OP Stack configs.