### PR TITLE
Use TryGetValue to halve Dictionary lookups

### DIFF
--- a/src/Nethermind/Nethermind.Cli/Modules/CliModuleLoader.cs
+++ b/src/Nethermind/Nethermind.Cli/Modules/CliModuleLoader.cs
@@ -93,14 +93,15 @@ namespace Nethermind.Cli.Modules
                 }
 
                 ObjectInstance instance;
-                if (!_objects.ContainsKey(objectName))
+                if (!_objects.TryGetValue(objectName, out ObjectInstance? value))
                 {
                     instance = _engine.JintEngine.Object.Construct(Arguments.Empty);
                     _engine.JintEngine.SetValue(objectName, instance);
-                    _objects[objectName] = instance;
+                    value = instance;
+                    _objects[objectName] = value;
                 }
 
-                instance = _objects[objectName];
+                instance = value;
                 var @delegate = CreateDelegate(methodInfo, module);
                 DelegateWrapper nativeDelegate = new DelegateWrapper(_engine.JintEngine, @delegate);
 

--- a/src/Nethermind/Nethermind.Cli/NodeManager.cs
+++ b/src/Nethermind/Nethermind.Cli/NodeManager.cs
@@ -44,12 +44,13 @@ namespace Nethermind.Cli
         public void SwitchUri(Uri uri)
         {
             CurrentUri = uri.ToString();
-            if (!_clients.ContainsKey(uri))
+            if (!_clients.TryGetValue(uri, out IJsonRpcClient? value))
             {
-                _clients[uri] = new BasicJsonRpcClient(uri, _serializer, _logManager);
+                value = new BasicJsonRpcClient(uri, _serializer, _logManager);
+                _clients[uri] = value;
             }
 
-            _currentClient = _clients[uri];
+            _currentClient = value;
         }
 
         public void SwitchClient(IJsonRpcClient client)

--- a/src/Nethermind/Nethermind.Cli/NodeManager.cs
+++ b/src/Nethermind/Nethermind.Cli/NodeManager.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net.Http;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Jint.Native;
 using Jint.Native.Json;
@@ -44,10 +45,10 @@ namespace Nethermind.Cli
         public void SwitchUri(Uri uri)
         {
             CurrentUri = uri.ToString();
-            if (!_clients.TryGetValue(uri, out IJsonRpcClient? value))
+            ref IJsonRpcClient? value = ref CollectionsMarshal.GetValueRefOrAddDefault(_clients, uri, out bool exists);
+            if (!exists)
             {
                 value = new BasicJsonRpcClient(uri, _serializer, _logManager);
-                _clients[uri] = value;
             }
 
             _currentClient = value;

--- a/src/Nethermind/Nethermind.Consensus.Clique/SnapshotManager.cs
+++ b/src/Nethermind/Nethermind.Consensus.Clique/SnapshotManager.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using Nethermind.Blockchain;
 using Nethermind.Core;
@@ -353,10 +354,10 @@ namespace Nethermind.Consensus.Clique
 
         private bool Cast(Snapshot snapshot, Address address, bool authorize)
         {
-            if (!snapshot.Tally.TryGetValue(address, out Tally? value))
+            ref Tally? value = ref CollectionsMarshal.GetValueRefOrAddDefault(snapshot.Tally, address, out bool exists);
+            if (!exists)
             {
                 value = new Tally(authorize);
-                snapshot.Tally[address] = value;
             }
 
             // Ensure the vote is meaningful

--- a/src/Nethermind/Nethermind.Consensus.Clique/SnapshotManager.cs
+++ b/src/Nethermind/Nethermind.Consensus.Clique/SnapshotManager.cs
@@ -274,8 +274,8 @@ namespace Nethermind.Consensus.Clique
 
                 // Resolve the authorization key and check against signers
                 Address signer = header.Author;
-                if (!snapshot.Signers.ContainsKey(signer)) throw new InvalidOperationException("Unauthorized signer");
-                if (HasSignedRecently(snapshot, number, signer)) throw new InvalidOperationException($"Recently signed (trying to sign {number} when last signed {snapshot.Signers[signer]} with {snapshot.Signers.Count} signers)");
+                if (!snapshot.Signers.TryGetValue(signer, out var value)) throw new InvalidOperationException("Unauthorized signer");
+                if (HasSignedRecently(snapshot, number, signer)) throw new InvalidOperationException($"Recently signed (trying to sign {number} when last signed {value} with {snapshot.Signers.Count} signers)");
 
                 snapshot.Signers[signer] = number;
 
@@ -353,25 +353,24 @@ namespace Nethermind.Consensus.Clique
 
         private bool Cast(Snapshot snapshot, Address address, bool authorize)
         {
-            if (!snapshot.Tally.ContainsKey(address))
+            if (!snapshot.Tally.TryGetValue(address, out Tally? value))
             {
-                snapshot.Tally[address] = new Tally(authorize);
+                value = new Tally(authorize);
+                snapshot.Tally[address] = value;
             }
 
             // Ensure the vote is meaningful
             if (!IsValidVote(snapshot, address, authorize)) return false;
-
-            // Cast the vote into tally
-            snapshot.Tally[address].Votes++;
+            value.Votes++;
             return true;
         }
 
         private bool Uncast(Snapshot snapshot, Address address, bool authorize)
         {
             // If there's no tally, it's a dangling vote, just drop
-            if (!snapshot.Tally.ContainsKey(address)) return true;
+            if (!snapshot.Tally.TryGetValue(address, out Tally? value)) return true;
 
-            Tally tally = snapshot.Tally[address];
+            Tally tally = value;
             // Ensure we only revert counted votes
             if (tally.Authorize != authorize) return false;
 

--- a/src/Nethermind/Nethermind.Consensus.Clique/SnapshotManager.cs
+++ b/src/Nethermind/Nethermind.Consensus.Clique/SnapshotManager.cs
@@ -362,6 +362,8 @@ namespace Nethermind.Consensus.Clique
 
             // Ensure the vote is meaningful
             if (!IsValidVote(snapshot, address, authorize)) return false;
+
+            // Cast the vote into tally ref
             value.Votes++;
             return true;
         }

--- a/src/Nethermind/Nethermind.Consensus.Ethash/HintBasedCache.cs
+++ b/src/Nethermind/Nethermind.Consensus.Ethash/HintBasedCache.cs
@@ -55,12 +55,13 @@ namespace Nethermind.Consensus.Ethash
                 throw new InvalidOperationException("Hint too wide");
             }
 
-            if (!_epochsPerGuid.ContainsKey(guid))
+            if (!_epochsPerGuid.TryGetValue(guid, out HashSet<uint>? value))
             {
-                _epochsPerGuid[guid] = new HashSet<uint>();
+                value = new HashSet<uint>();
+                _epochsPerGuid[guid] = value;
             }
 
-            HashSet<uint> epochForGuid = _epochsPerGuid[guid];
+            HashSet<uint> epochForGuid = value;
             uint currentMin = uint.MaxValue;
             uint currentMax = 0;
             foreach (uint alreadyCachedEpoch in epochForGuid.ToList())
@@ -78,12 +79,12 @@ namespace Nethermind.Consensus.Ethash
                 if (alreadyCachedEpoch < startEpoch || alreadyCachedEpoch > endEpoch)
                 {
                     epochForGuid.Remove(alreadyCachedEpoch);
-                    if (!_epochRefs.ContainsKey(alreadyCachedEpoch))
+                    if (!_epochRefs.TryGetValue(alreadyCachedEpoch, out var value))
                     {
                         throw new InvalidAsynchronousStateException("Epoch ref missing");
                     }
 
-                    _epochRefs[alreadyCachedEpoch] = _epochRefs[alreadyCachedEpoch] - 1;
+                    _epochRefs[alreadyCachedEpoch] = value - 1;
                     if (_epochRefs[alreadyCachedEpoch] == 0)
                     {
                         // _logger.Warn($"Removing data set for epoch {alreadyCachedEpoch}");
@@ -102,12 +103,13 @@ namespace Nethermind.Consensus.Ethash
                     if (!epochForGuid.Contains(epoch))
                     {
                         epochForGuid.Add(epoch);
-                        if (!_epochRefs.ContainsKey(epoch))
+                        if (!_epochRefs.TryGetValue(epoch, out var value))
                         {
-                            _epochRefs[epoch] = 0;
+                            value = 0;
+                            _epochRefs[epoch] = value;
                         }
 
-                        _epochRefs[epoch] = _epochRefs[epoch] + 1;
+                        _epochRefs[epoch] = value + 1;
                         if (_epochRefs[epoch] == 1)
                         {
                             // _logger.Warn($"Building data set for epoch {epoch}");

--- a/src/Nethermind/Nethermind.Consensus.Ethash/HintBasedCache.cs
+++ b/src/Nethermind/Nethermind.Consensus.Ethash/HintBasedCache.cs
@@ -79,12 +79,12 @@ namespace Nethermind.Consensus.Ethash
                 if (alreadyCachedEpoch < startEpoch || alreadyCachedEpoch > endEpoch)
                 {
                     epochForGuid.Remove(alreadyCachedEpoch);
-                    if (!_epochRefs.TryGetValue(alreadyCachedEpoch, out var value))
+                    if (!_epochRefs.TryGetValue(alreadyCachedEpoch, out var epochValue))
                     {
                         throw new InvalidAsynchronousStateException("Epoch ref missing");
                     }
 
-                    _epochRefs[alreadyCachedEpoch] = value - 1;
+                    _epochRefs[alreadyCachedEpoch] = epochValue - 1;
                     if (_epochRefs[alreadyCachedEpoch] == 0)
                     {
                         // _logger.Warn($"Removing data set for epoch {alreadyCachedEpoch}");
@@ -100,16 +100,15 @@ namespace Nethermind.Consensus.Ethash
                 for (long i = startEpoch; i <= endEpoch; i++)
                 {
                     uint epoch = (uint)i;
-                    if (!epochForGuid.Contains(epoch))
+                    if (epochForGuid.Add(epoch))
                     {
-                        epochForGuid.Add(epoch);
-                        if (!_epochRefs.TryGetValue(epoch, out var value))
+                        if (!_epochRefs.TryGetValue(epoch, out var epochValue))
                         {
-                            value = 0;
-                            _epochRefs[epoch] = value;
+                            epochValue = 0;
+                            _epochRefs[epoch] = epochValue;
                         }
 
-                        _epochRefs[epoch] = value + 1;
+                        _epochRefs[epoch] = epochValue + 1;
                         if (_epochRefs[epoch] == 1)
                         {
                             // _logger.Warn($"Building data set for epoch {epoch}");

--- a/src/Nethermind/Nethermind.Consensus.Ethash/HintBasedCache.cs
+++ b/src/Nethermind/Nethermind.Consensus.Ethash/HintBasedCache.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Logging;
@@ -55,10 +56,10 @@ namespace Nethermind.Consensus.Ethash
                 throw new InvalidOperationException("Hint too wide");
             }
 
-            if (!_epochsPerGuid.TryGetValue(guid, out HashSet<uint>? value))
+            ref HashSet<uint>? value = ref CollectionsMarshal.GetValueRefOrAddDefault(_epochsPerGuid, guid, out bool exists);
+            if (!exists)
             {
                 value = new HashSet<uint>();
-                _epochsPerGuid[guid] = value;
             }
 
             HashSet<uint> epochForGuid = value;

--- a/src/Nethermind/Nethermind.Core/Collections/LinkedHashSet.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/LinkedHashSet.cs
@@ -10,7 +10,7 @@ namespace Nethermind.Core.Collections
 {
     public class LinkedHashSet<T> : ISet<T>, IReadOnlySet<T> where T : notnull
     {
-        private readonly IDictionary<T, LinkedListNode<T>> _dict;
+        private readonly Dictionary<T, LinkedListNode<T>> _dict;
         private readonly LinkedList<T> _list;
 
         public LinkedHashSet(int initialCapacity)
@@ -71,7 +71,7 @@ namespace Nethermind.Core.Collections
 
             T[] ts = new T[Count];
             CopyTo(ts, 0);
-            ISet<T> set = other.ToHashSet();
+            HashSet<T> set = other.ToHashSet();
             foreach (T t in this.ToArray())
             {
                 if (!set.Contains(t))
@@ -106,7 +106,7 @@ namespace Nethermind.Core.Collections
         {
             if (other is null) throw new ArgumentNullException(nameof(other));
 
-            ISet<T> set = other.ToHashSet();
+            HashSet<T> set = other.ToHashSet();
             int otherCount = set.Count;
             if (Count > otherCount)
             {
@@ -134,7 +134,7 @@ namespace Nethermind.Core.Collections
         {
             if (other is null) throw new ArgumentNullException(nameof(other));
 
-            ISet<T> set = other.ToHashSet();
+            HashSet<T> set = other.ToHashSet();
             return this.All(t => set.Contains(t));
         }
 
@@ -167,7 +167,7 @@ namespace Nethermind.Core.Collections
             T[] ts = new T[Count];
             CopyTo(ts, 0);
 
-            ISet<T> set = other.ToHashSet();
+            HashSet<T> set = other.ToHashSet();
             for (int index = 0; index < ts.Length; index++)
             {
                 T t = ts[index];

--- a/src/Nethermind/Nethermind.Core/Collections/LinkedHashSet.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/LinkedHashSet.cs
@@ -201,7 +201,7 @@ namespace Nethermind.Core.Collections
 
         public int Count => _dict.Count;
 
-        public bool IsReadOnly => _dict.IsReadOnly;
+        public bool IsReadOnly => false;
 
         void ICollection<T>.Add(T item)
         {

--- a/src/Nethermind/Nethermind.Core/Resettables/ResettableDictionary.cs
+++ b/src/Nethermind/Nethermind.Core/Resettables/ResettableDictionary.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 
 namespace Nethermind.Core.Resettables
 {
@@ -94,6 +95,11 @@ namespace Nethermind.Core.Resettables
             // fixed C# 9
             return _wrapped.TryGetValue(key, out value);
 #pragma warning restore 8601
+        }
+
+        public ref TValue? GetValueRefOrAddDefault(TKey key, out bool exists)
+        {
+            return ref CollectionsMarshal.GetValueRefOrAddDefault(_wrapped, key, out exists);
         }
 
         public TValue this[TKey key]

--- a/src/Nethermind/Nethermind.Evm/Tracing/ParityStyle/ParityLikeTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/ParityStyle/ParityLikeTxTracer.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
@@ -320,16 +321,17 @@ namespace Nethermind.Evm.Tracing.ParityStyle
                 throw new InvalidOperationException($"{nameof(ParityLikeTxTracer)} did not expect state change report.");
             }
 
-            if (!_trace.StateChanges.TryGetValue(address, out ParityAccountStateChange? value))
+            ref ParityAccountStateChange? value = ref CollectionsMarshal.GetValueRefOrAddDefault(_trace.StateChanges, address, out bool exists);
+            if (!exists)
             {
-                _trace.StateChanges[address] = new ParityAccountStateChange();
+                value = new ParityAccountStateChange();
             }
             else
             {
                 before = value.Balance?.Before ?? before;
             }
 
-            _trace.StateChanges[address].Balance = new ParityStateChange<UInt256?>(before, after);
+            value.Balance = new ParityStateChange<UInt256?>(before, after);
         }
 
         public override void ReportCodeChange(Address address, byte[] before, byte[] after)
@@ -353,34 +355,35 @@ namespace Nethermind.Evm.Tracing.ParityStyle
 
         public override void ReportNonceChange(Address address, UInt256? before, UInt256? after)
         {
-            if (!_trace.StateChanges!.TryGetValue(address, out ParityAccountStateChange? value))
+            ref ParityAccountStateChange? value = ref CollectionsMarshal.GetValueRefOrAddDefault(_trace.StateChanges, address, out bool exists);
+            if (!exists)
             {
-                _trace.StateChanges[address] = new ParityAccountStateChange();
+                value = new ParityAccountStateChange();
             }
             else
             {
                 before = value.Nonce?.Before ?? before;
             }
 
-            _trace.StateChanges[address].Nonce = new ParityStateChange<UInt256?>(before, after);
+            value.Nonce = new ParityStateChange<UInt256?>(before, after);
         }
 
         public override void ReportStorageChange(in StorageCell storageCell, byte[] before, byte[] after)
         {
-            if (!_trace.StateChanges!.TryGetValue(storageCell.Address, out ParityAccountStateChange? value))
+            ref ParityAccountStateChange? value = ref CollectionsMarshal.GetValueRefOrAddDefault(_trace.StateChanges, storageCell.Address, out bool exists);
+            if (!exists)
             {
                 value = new ParityAccountStateChange();
-                _trace.StateChanges[storageCell.Address] = value;
             }
 
-            Dictionary<UInt256, ParityStateChange<byte[]>> storage = value.Storage ?? (value.Storage = new Dictionary<UInt256, ParityStateChange<byte[]>>());
-
-            if (storage.TryGetValue(storageCell.Index, out ParityStateChange<byte[]> change))
+            Dictionary<UInt256, ParityStateChange<byte[]>> storage = value.Storage ??= [];
+            ref ParityStateChange<byte[]>? change = ref CollectionsMarshal.GetValueRefOrAddDefault(storage, storageCell.Index, out exists);
+            if (exists)
             {
                 before = change.Before ?? before;
             }
 
-            storage[storageCell.Index] = new ParityStateChange<byte[]>(before, after);
+            change = new ParityStateChange<byte[]>(before, after);
         }
 
         public override void ReportAction(long gas, UInt256 value, Address from, Address to, ReadOnlyMemory<byte> input, ExecutionType callType, bool isPrecompileCall = false)

--- a/src/Nethermind/Nethermind.Evm/Tracing/ParityStyle/ParityLikeTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/ParityStyle/ParityLikeTxTracer.cs
@@ -341,16 +341,17 @@ namespace Nethermind.Evm.Tracing.ParityStyle
                 throw new InvalidOperationException($"{nameof(ParityLikeTxTracer)} did not expect state change report.");
             }
 
-            if (!_trace.StateChanges.TryGetValue(address, out ParityAccountStateChange? value))
+            ref ParityAccountStateChange? value = ref CollectionsMarshal.GetValueRefOrAddDefault(_trace.StateChanges, address, out bool exists);
+            if (!exists)
             {
-                _trace.StateChanges[address] = new ParityAccountStateChange();
+                value = new ParityAccountStateChange();
             }
             else
             {
                 before = value.Code?.Before ?? before;
             }
 
-            _trace.StateChanges[address].Code = new ParityStateChange<byte[]>(before, after);
+            value.Code = new ParityStateChange<byte[]>(before, after);
         }
 
         public override void ReportNonceChange(Address address, UInt256? before, UInt256? after)

--- a/src/Nethermind/Nethermind.Evm/Tracing/ParityStyle/ParityLikeTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/ParityStyle/ParityLikeTxTracer.cs
@@ -320,13 +320,13 @@ namespace Nethermind.Evm.Tracing.ParityStyle
                 throw new InvalidOperationException($"{nameof(ParityLikeTxTracer)} did not expect state change report.");
             }
 
-            if (!_trace.StateChanges.ContainsKey(address))
+            if (!_trace.StateChanges.TryGetValue(address, out ParityAccountStateChange? value))
             {
                 _trace.StateChanges[address] = new ParityAccountStateChange();
             }
             else
             {
-                before = _trace.StateChanges[address].Balance?.Before ?? before;
+                before = value.Balance?.Before ?? before;
             }
 
             _trace.StateChanges[address].Balance = new ParityStateChange<UInt256?>(before, after);
@@ -339,13 +339,13 @@ namespace Nethermind.Evm.Tracing.ParityStyle
                 throw new InvalidOperationException($"{nameof(ParityLikeTxTracer)} did not expect state change report.");
             }
 
-            if (!_trace.StateChanges.ContainsKey(address))
+            if (!_trace.StateChanges.TryGetValue(address, out ParityAccountStateChange? value))
             {
                 _trace.StateChanges[address] = new ParityAccountStateChange();
             }
             else
             {
-                before = _trace.StateChanges[address].Code?.Before ?? before;
+                before = value.Code?.Before ?? before;
             }
 
             _trace.StateChanges[address].Code = new ParityStateChange<byte[]>(before, after);
@@ -353,13 +353,13 @@ namespace Nethermind.Evm.Tracing.ParityStyle
 
         public override void ReportNonceChange(Address address, UInt256? before, UInt256? after)
         {
-            if (!_trace.StateChanges!.ContainsKey(address))
+            if (!_trace.StateChanges!.TryGetValue(address, out ParityAccountStateChange? value))
             {
                 _trace.StateChanges[address] = new ParityAccountStateChange();
             }
             else
             {
-                before = _trace.StateChanges[address].Nonce?.Before ?? before;
+                before = value.Nonce?.Before ?? before;
             }
 
             _trace.StateChanges[address].Nonce = new ParityStateChange<UInt256?>(before, after);
@@ -367,17 +367,17 @@ namespace Nethermind.Evm.Tracing.ParityStyle
 
         public override void ReportStorageChange(in StorageCell storageCell, byte[] before, byte[] after)
         {
-            if (!_trace.StateChanges!.ContainsKey(storageCell.Address))
+            if (!_trace.StateChanges!.TryGetValue(storageCell.Address, out ParityAccountStateChange? value))
             {
-                _trace.StateChanges[storageCell.Address] = new ParityAccountStateChange();
+                value = new ParityAccountStateChange();
+                _trace.StateChanges[storageCell.Address] = value;
             }
 
-            Dictionary<UInt256, ParityStateChange<byte[]>> storage =
-                _trace.StateChanges[storageCell.Address].Storage ?? (_trace.StateChanges[storageCell.Address].Storage = new Dictionary<UInt256, ParityStateChange<byte[]>>());
+            Dictionary<UInt256, ParityStateChange<byte[]>> storage = value.Storage ?? (value.Storage = new Dictionary<UInt256, ParityStateChange<byte[]>>());
 
-            if (storage.TryGetValue(storageCell.Index, out ParityStateChange<byte[]> value))
+            if (storage.TryGetValue(storageCell.Index, out ParityStateChange<byte[]> change))
             {
-                before = value.Before ?? before;
+                before = change.Before ?? before;
             }
 
             storage[storageCell.Index] = new ParityStateChange<byte[]>(before, after);

--- a/src/Nethermind/Nethermind.Network/P2P/Session.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Session.cs
@@ -572,12 +572,13 @@ namespace Nethermind.Network.P2P
         private AdaptiveCodeResolver GetOrCreateResolver()
         {
             string key = string.Join(":", _protocols.Select(p => p.Key).OrderBy(x => x).ToArray());
-            if (!_resolvers.ContainsKey(key))
+            if (!_resolvers.TryGetValue(key, out AdaptiveCodeResolver? value))
             {
-                _resolvers[key] = new AdaptiveCodeResolver(_protocols);
+                value = new AdaptiveCodeResolver(_protocols);
+                _resolvers[key] = value;
             }
 
-            return _resolvers[key];
+            return value;
         }
 
         public override string ToString()

--- a/src/Nethermind/Nethermind.Overseer.Test/Framework/TestBuilder.cs
+++ b/src/Nethermind/Nethermind.Overseer.Test/Framework/TestBuilder.cs
@@ -209,7 +209,7 @@ namespace Nethermind.Overseer.Test.Framework
 
         private NethermindProcessWrapper GetOrCreateNode(string name, string baseConfigFile, string key)
         {
-            if (!Nodes.ContainsKey(name))
+            if (!Nodes.TryGetValue(name, out NethermindProcessWrapper value))
             {
                 string bootnodes = string.Empty;
                 foreach ((_, NethermindProcessWrapper process) in Nodes)
@@ -227,11 +227,12 @@ namespace Nethermind.Overseer.Test.Framework
                 int p2pPort = _startPort + _nodeCounter;
                 int httpPort = _startHttpPort + _nodeCounter;
                 TestContext.WriteLine($"Creating {name} at {p2pPort}, http://localhost:{httpPort}");
-                Nodes[name] = _processBuilder.Create(name, _runnerDir, configPath, dbDir, httpPort, p2pPort, nodeKey, bootnodes);
+                value = _processBuilder.Create(name, _runnerDir, configPath, dbDir, httpPort, p2pPort, nodeKey, bootnodes);
+                Nodes[name] = value;
                 _nodeCounter++;
             }
 
-            return Nodes[name];
+            return value;
         }
 
         private string GetNodeKey(string key)

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -70,7 +70,7 @@ namespace Nethermind.State
         /// <returns></returns>
         public byte[] GetOriginal(in StorageCell storageCell)
         {
-            if (!_originalValues.ContainsKey(storageCell))
+            if (!_originalValues.TryGetValue(storageCell, out var value))
             {
                 throw new InvalidOperationException("Get original should only be called after get within the same caching round");
             }
@@ -86,7 +86,7 @@ namespace Nethermind.State
                 }
             }
 
-            return _originalValues[storageCell];
+            return value;
         }
 
 
@@ -224,13 +224,13 @@ namespace Nethermind.State
 
         private StorageTree GetOrCreateStorage(Address address)
         {
-            if (!_storages.ContainsKey(address))
+            if (!_storages.TryGetValue(address, out StorageTree? value))
             {
                 StorageTree storageTree = _storageTreeFactory.Create(address, _trieStore, _stateProvider.GetStorageRoot(address), StateRoot, _logManager);
                 return _storages[address] = storageTree;
             }
 
-            return _storages[address];
+            return value;
         }
 
         private byte[] LoadFromTree(in StorageCell storageCell)

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -224,10 +224,11 @@ namespace Nethermind.State
 
         private StorageTree GetOrCreateStorage(Address address)
         {
-            if (!_storages.TryGetValue(address, out StorageTree? value))
+            ref StorageTree? value = ref _storages.GetValueRefOrAddDefault(address, out bool exists);
+            if (!exists)
             {
-                StorageTree storageTree = _storageTreeFactory.Create(address, _trieStore, _stateProvider.GetStorageRoot(address), StateRoot, _logManager);
-                return _storages[address] = storageTree;
+                value = _storageTreeFactory.Create(address, _trieStore, _stateProvider.GetStorageRoot(address), StateRoot, _logManager);
+                return value;
             }
 
             return value;

--- a/src/Nethermind/Nethermind.State/Proofs/AccountProofCollector.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/AccountProofCollector.cs
@@ -4,8 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using Nethermind.Core;
-using Nethermind.Core.Buffers;
 using Nethermind.Core.Crypto;
 using Nethermind.Int256;
 using Nethermind.Serialization.Rlp;
@@ -181,10 +181,10 @@ namespace Nethermind.State.Proofs
                     }
                     else
                     {
-                        if (!_storageNodeInfos.TryGetValue(childHash, out StorageNodeInfo? value))
+                        ref StorageNodeInfo? value = ref CollectionsMarshal.GetValueRefOrAddDefault(_storageNodeInfos, childHash, out bool exists);
+                        if (!exists)
                         {
                             value = new StorageNodeInfo();
-                            _storageNodeInfos[childHash] = value;
                         }
 
                         if (!bumpedIndexes.Contains((byte)childIndex))

--- a/src/Nethermind/Nethermind.State/Proofs/AccountProofCollector.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/AccountProofCollector.cs
@@ -181,18 +181,19 @@ namespace Nethermind.State.Proofs
                     }
                     else
                     {
-                        if (!_storageNodeInfos.ContainsKey(childHash))
+                        if (!_storageNodeInfos.TryGetValue(childHash, out StorageNodeInfo? value))
                         {
-                            _storageNodeInfos[childHash] = new StorageNodeInfo();
+                            value = new StorageNodeInfo();
+                            _storageNodeInfos[childHash] = value;
                         }
 
                         if (!bumpedIndexes.Contains((byte)childIndex))
                         {
                             bumpedIndexes.Add((byte)childIndex);
-                            _storageNodeInfos[childHash].PathIndex = _pathTraversalIndex + 1;
+                            value.PathIndex = _pathTraversalIndex + 1;
                         }
 
-                        _storageNodeInfos[childHash].StorageIndices.Add(storageIndex);
+                        value.StorageIndices.Add(storageIndex);
                         _nodeToVisitFilter.Add(childHash);
                     }
                 }

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
@@ -25,7 +25,7 @@ namespace Nethermind.Synchronization.FastBlocks
 {
     public class HeadersSyncFeed : ActivatedSyncFeed<HeadersSyncBatch?>
     {
-        private readonly IDictionary<ulong, IDictionary<long, ulong>> _historicalOverrides = new Dictionary<ulong, IDictionary<long, ulong>>()
+        private readonly Dictionary<ulong, IDictionary<long, ulong>> _historicalOverrides = new Dictionary<ulong, IDictionary<long, ulong>>()
         {
             // Kovan has some wrong difficulty in early blocks before using proper AuRa difficulty calculation
             // In order to support that we need to support another pivot

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
@@ -973,12 +973,13 @@ namespace Nethermind.Synchronization.FastSync
         {
             lock (_dependencies)
             {
-                if (!_dependencies.ContainsKey(dependency))
+                if (!_dependencies.TryGetValue(dependency, out HashSet<DependentItem>? value))
                 {
-                    _dependencies[dependency] = new HashSet<DependentItem>(DependentItemComparer.Instance);
+                    value = new HashSet<DependentItem>(DependentItemComparer.Instance);
+                    _dependencies[dependency] = value;
                 }
 
-                _dependencies[dependency].Add(dependentItem);
+                value.Add(dependentItem);
             }
         }
 

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
@@ -6,11 +6,11 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Blockchain;
 using Nethermind.Core;
-using Nethermind.Core.Buffers;
 using Nethermind.Core.Caching;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
@@ -973,10 +973,10 @@ namespace Nethermind.Synchronization.FastSync
         {
             lock (_dependencies)
             {
-                if (!_dependencies.TryGetValue(dependency, out HashSet<DependentItem>? value))
+                ref HashSet<DependentItem>? value = ref CollectionsMarshal.GetValueRefOrAddDefault(_dependencies, dependency, out bool exists);
+                if (!exists)
                 {
                     value = new HashSet<DependentItem>(DependentItemComparer.Instance);
-                    _dependencies[dependency] = value;
                 }
 
                 value.Add(dependentItem);

--- a/src/Nethermind/Nethermind.Wallet/DevKeyStoreWallet.cs
+++ b/src/Nethermind/Nethermind.Wallet/DevKeyStoreWallet.cs
@@ -89,9 +89,9 @@ namespace Nethermind.Wallet
         public Signature Sign(Hash256 message, Address address, SecureString passphrase)
         {
             PrivateKey key;
-            if (_unlockedAccounts.ContainsKey(address))
+            if (_unlockedAccounts.TryGetValue(address, out PrivateKey value))
             {
-                key = _unlockedAccounts[address];
+                key = value;
             }
             else
             {
@@ -107,9 +107,9 @@ namespace Nethermind.Wallet
         public Signature Sign(Hash256 message, Address address)
         {
             PrivateKey key;
-            if (_unlockedAccounts.ContainsKey(address))
+            if (_unlockedAccounts.TryGetValue(address, out PrivateKey value))
             {
-                key = _unlockedAccounts[address];
+                key = value;
             }
             else
             {

--- a/src/Nethermind/Nethermind.Wallet/DevWallet.cs
+++ b/src/Nethermind/Nethermind.Wallet/DevWallet.cs
@@ -101,9 +101,9 @@ namespace Nethermind.Wallet
         }
         public Signature Sign(Hash256 message, Address address, SecureString passphrase)
         {
-            if (!_isUnlocked.ContainsKey(address)) throw new SecurityException("Account does not exist.");
+            if (!_isUnlocked.TryGetValue(address, out var value)) throw new SecurityException("Account does not exist.");
 
-            if (!_isUnlocked[address] && !CheckPassword(address, passphrase)) throw new SecurityException("Cannot sign without password or unlocked account.");
+            if (_isUnlocked[address] = !value && !CheckPassword(address, passphrase)) throw new SecurityException("Cannot sign without password or unlocked account.");
 
             return Sign(message, address);
         }

--- a/src/Nethermind/Nethermind.Wallet/DevWallet.cs
+++ b/src/Nethermind/Nethermind.Wallet/DevWallet.cs
@@ -103,7 +103,7 @@ namespace Nethermind.Wallet
         {
             if (!_isUnlocked.TryGetValue(address, out var value)) throw new SecurityException("Account does not exist.");
 
-            if (_isUnlocked[address] = !value && !CheckPassword(address, passphrase)) throw new SecurityException("Cannot sign without password or unlocked account.");
+            if (!value && !CheckPassword(address, passphrase)) throw new SecurityException("Cannot sign without password or unlocked account.");
 
             return Sign(message, address);
         }


### PR DESCRIPTION
## Changes

- Use `TryGetValue` rather than guard with `Contains` and then a lookup of value
- Or `CollectionsMarshal.GetValueRefOrAddDefault` when appropriate

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No
