### PR TITLE
Fix excessive timer allocation in rate limiter

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/RateLimiterTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/RateLimiterTests.cs
@@ -23,14 +23,13 @@ public class RateLimiterTests
     {
         RateLimiter rateLimiter = new(eventPerSec);
 
-        TimeSpan duration = TimeSpan.FromMilliseconds(durationMs);
-        DateTimeOffset startTime = DateTimeOffset.Now;
-        DateTimeOffset deadline = startTime + duration;
+        long startTime = Environment.TickCount64;
+        long deadline = startTime + durationMs;
         long counter = 0;
 
         Task[] tasks = Enumerable.Range(0, concurrency).Select(async (_) =>
         {
-            while (DateTimeOffset.Now < deadline)
+            while (Environment.TickCount64 < deadline)
             {
                 Interlocked.Increment(ref counter);
                 await rateLimiter.WaitAsync(CancellationToken.None);
@@ -39,7 +38,7 @@ public class RateLimiterTests
 
         await Task.WhenAll(tasks);
 
-        int effectivePerSec = (int)(counter / (DateTimeOffset.Now - startTime).TotalSeconds);
+        int effectivePerSec = (int)(counter / ((Environment.TickCount64 - startTime) / 1000.0));
         effectivePerSec.Should().BeInRange((int)(eventPerSec * 0.5), (int)(eventPerSec * 1.1));
     }
 

--- a/src/Nethermind/Nethermind.Core/RateLimiter.cs
+++ b/src/Nethermind/Nethermind.Core/RateLimiter.cs
@@ -50,19 +50,19 @@ public class RateLimiter
 
     public async ValueTask WaitAsync(CancellationToken ctx)
     {
-        long originalNextSlot = _nextSlot;
+        long currentNextSlot = _nextSlot;
         while (true)
         {
-            long nextSlot = Interlocked.CompareExchange(ref _nextSlot, originalNextSlot + _delay, originalNextSlot);
-            if (nextSlot == originalNextSlot)
+            long nextSlot = Interlocked.CompareExchange(ref _nextSlot, currentNextSlot + _delay, currentNextSlot);
+            if (nextSlot == currentNextSlot)
             {
                 break;
             }
-            originalNextSlot = nextSlot;
+            currentNextSlot = nextSlot;
         }
 
         long now = GetCurrentTick();
-        long toWait = originalNextSlot - now;
+        long toWait = currentNextSlot - now;
 
         if (toWait <= 0) return;
 

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/DiscoveryManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/DiscoveryManagerTests.cs
@@ -208,7 +208,7 @@ namespace Nethermind.Network.Discovery.Test
             await _discoveryManager.SendMessageAsync(msg);
             await _discoveryManager.SendMessageAsync(msg);
             await _discoveryManager.SendMessageAsync(msg);
-            sw.Elapsed.Should().BeGreaterOrEqualTo(TimeSpan.FromSeconds(1));
+            sw.Elapsed.Should().BeGreaterOrEqualTo(TimeSpan.FromSeconds(0.9));
         }
     }
 }


### PR DESCRIPTION
## Changes

- Fix excessive timer allocation in RateLimiter

Before left (more allocations than `byte[]`) After right

![image](https://github.com/NethermindEth/nethermind/assets/1142958/d34ea4c0-8b30-46bc-971c-52a3ef872f61)


## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No