### PR TITLE
Use length checks rather than .Any()

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.Clique/CliqueBlockProducer.cs
+++ b/src/Nethermind/Nethermind.Consensus.Clique/CliqueBlockProducer.cs
@@ -379,7 +379,7 @@ public class CliqueBlockProducer : ICliqueBlockProducer, IDisposable
         // Assemble the voting snapshot to check which votes make sense
         Snapshot snapshot = _snapshotManager.GetOrCreateSnapshot(number - 1, parentHeader.Hash);
         bool isEpochBlock = (ulong)number % 30000 == 0;
-        if (!isEpochBlock && _proposals.Any())
+        if (!isEpochBlock && !_proposals.IsEmpty)
         {
             // Gather all the proposals that make sense voting on
             List<Address> addresses = new();

--- a/src/Nethermind/Nethermind.Core/Extensions/EnumExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/EnumExtensions.cs
@@ -25,7 +25,7 @@ public static class EnumExtensions
         // This bit converts to int[]
         IReadOnlyList<T> values = FastEnum.GetValues<T>();
 
-        if (!typeof(T).GetCustomAttributes(typeof(FlagsAttribute), false).Any())
+        if (typeof(T).GetCustomAttributes(typeof(FlagsAttribute), false).Length == 0)
         {
             // We don't have flags so just return the result of GetValues
             return values;

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -195,7 +195,7 @@ namespace Nethermind.Evm.TransactionProcessing
                 }
                 else
                 {
-                    LogEntry[] logs = substate.Logs.Any() ? substate.Logs.ToArray() : Array.Empty<LogEntry>();
+                    LogEntry[] logs = substate.Logs.Count != 0 ? substate.Logs.ToArray() : Array.Empty<LogEntry>();
                     tracer.MarkAsSuccess(env.ExecutingAccount, spentGas, substate.Output.ToArray(), logs, stateRoot);
                 }
             }

--- a/src/Nethermind/Nethermind.Mev.Test/MevRpcModuleTests.TestMevRpcBlockchain.cs
+++ b/src/Nethermind/Nethermind.Mev.Test/MevRpcModuleTests.TestMevRpcBlockchain.cs
@@ -146,7 +146,7 @@ namespace Nethermind.Mev.Test
                     return new MevBlockProducer.MevBlockProducerInfo(producer, manualTrigger, new BeneficiaryTracer());
                 }
 
-                int megabundleProducerCount = _relayAddresses.Any() ? 1 : 0;
+                int megabundleProducerCount = _relayAddresses.Length != 0 ? 1 : 0;
                 List<MevBlockProducer.MevBlockProducerInfo> blockProducers =
                     new(_maxMergedBundles + megabundleProducerCount + 1);
 

--- a/src/Nethermind/Nethermind.Network.Discovery/DiscoveryApp.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/DiscoveryApp.cs
@@ -227,7 +227,7 @@ public class DiscoveryApp : IDiscoveryApp
 
                 //Check if we were able to communicate with any trusted nodes or persisted nodes
                 //if so no need to replay bootstrapping, we can start discovery process
-                if (_discoveryManager.GetOrAddNodeLifecycleManagers(x => x.State == NodeLifecycleState.Active).Any())
+                if (_discoveryManager.GetOrAddNodeLifecycleManagers(x => x.State == NodeLifecycleState.Active).Count != 0)
                 {
                     break;
                 }
@@ -347,7 +347,7 @@ public class DiscoveryApp : IDiscoveryApp
     private async Task<bool> InitializeBootnodes(CancellationToken cancellationToken)
     {
         NetworkNode[] bootnodes = NetworkNode.ParseNodes(_discoveryConfig.Bootnodes, _logger);
-        if (!bootnodes.Any())
+        if (bootnodes.Length == 0)
         {
             if (_logger.IsWarn) _logger.Warn("No bootnodes specified in configuration");
             return true;
@@ -389,7 +389,7 @@ public class DiscoveryApp : IDiscoveryApp
                 break;
             }
 
-            if (_discoveryManager.GetOrAddNodeLifecycleManagers(x => x.State == NodeLifecycleState.Active).Any())
+            if (_discoveryManager.GetOrAddNodeLifecycleManagers(x => x.State == NodeLifecycleState.Active).Count != 0)
             {
                 if (_logger.IsTrace)
                     _logger.Trace(

--- a/src/Nethermind/Nethermind.Network.Discovery/Messages/NeighborsMsg.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Messages/NeighborsMsg.cs
@@ -23,7 +23,7 @@ public class NeighborsMsg : DiscoveryMsg
 
     public override string ToString()
     {
-        return base.ToString() + $", Nodes: {(Nodes.Any() ? string.Join(",", Nodes.Select(x => x.ToString())) : "empty")}";
+        return base.ToString() + $", Nodes: {(Nodes.Length != 0 ? string.Join(",", Nodes.Select(x => x.ToString())) : "empty")}";
     }
 
     public override MsgType MsgType => MsgType.Neighbors;

--- a/src/Nethermind/Nethermind.Network.Discovery/Serializers/NeighborsMsgSerializer.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Serializers/NeighborsMsgSerializer.cs
@@ -27,7 +27,7 @@ public class NeighborsMsgSerializer : DiscoveryMsgSerializerBase, IZeroInnerMess
         PrepareBufferForSerialization(byteBuffer, totalLength, (byte)msg.MsgType);
         NettyRlpStream stream = new(byteBuffer);
         stream.StartSequence(contentLength);
-        if (msg.Nodes.Any())
+        if (msg.Nodes.Length != 0)
         {
             stream.StartSequence(nodesContentLength);
             for (int i = 0; i < msg.Nodes.Length; i++)
@@ -100,7 +100,7 @@ public class NeighborsMsgSerializer : DiscoveryMsgSerializerBase, IZeroInnerMess
     {
         int nodesContentLength = 0;
         int contentLength = 0;
-        if (msg.Nodes.Any())
+        if (msg.Nodes.Length != 0)
         {
             contentLength += GetNodesLength(msg.Nodes, out nodesContentLength);
         }

--- a/src/Nethermind/Nethermind.Network.Test/Rlpx/HobbitTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/Rlpx/HobbitTests.cs
@@ -179,7 +179,7 @@ namespace Nethermind.Network.Test.Rlpx
                     embeddedChannel.WriteOutbound(packet);
                 }
 
-                while (embeddedChannel.OutboundMessages.Any())
+                while (embeddedChannel.OutboundMessages.Count != 0)
                 {
                     IByteBuffer encodedPacket = embeddedChannel.ReadOutbound<IByteBuffer>();
                     embeddedChannel.WriteInbound(encodedPacket);

--- a/src/Nethermind/Nethermind.Network.Test/Rlpx/TestWrappers/ZeroFrameDecoderTestWrapper.cs
+++ b/src/Nethermind/Nethermind.Network.Test/Rlpx/TestWrappers/ZeroFrameDecoderTestWrapper.cs
@@ -37,7 +37,7 @@ namespace Nethermind.Network.Test.Rlpx.TestWrappers
                 }
             }
 
-            if (result.Any())
+            if (result.Count != 0)
             {
                 return (IByteBuffer)result[0];
             }

--- a/src/Nethermind/Nethermind.Network.Test/Rlpx/TestWrappers/ZeroFrameMergerTestWrapper.cs
+++ b/src/Nethermind/Nethermind.Network.Test/Rlpx/TestWrappers/ZeroFrameMergerTestWrapper.cs
@@ -29,7 +29,7 @@ namespace Nethermind.Network.Test.Rlpx.TestWrappers
                 base.Decode(_context, input, result);
             }
 
-            if (!result.Any())
+            if (result.Count == 0)
             {
                 return null;
             }

--- a/src/Nethermind/Nethermind.Network/NodesLoader.cs
+++ b/src/Nethermind/Nethermind.Network/NodesLoader.cs
@@ -95,7 +95,7 @@ namespace Nethermind.Network
 
         private void LoadConfigPeers(List<Node> peers, string? enodesString, Action<Node> nodeUpdate)
         {
-            if (enodesString is null || !enodesString.Any())
+            if (enodesString is null || enodesString.Length == 0)
             {
                 return;
             }

--- a/src/Nethermind/Nethermind.Network/P2P/Session.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Session.cs
@@ -405,7 +405,7 @@ namespace Nethermind.Network.P2P
 
             if (_logger.IsDebug) _logger.Debug($"{this} initiating disconnect because {disconnectReason}, details: {details}");
             //Trigger disconnect on each protocol handler (if p2p is initialized it will send disconnect message to the peer)
-            if (_protocols.Any())
+            if (!_protocols.IsEmpty)
             {
                 foreach (IProtocolHandler protocolHandler in _protocols.Values)
                 {

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -825,7 +825,7 @@ namespace Nethermind.Network
 
         private string GetIncompatibleDesc(IReadOnlyCollection<Peer> incompatibleNodes)
         {
-            if (!incompatibleNodes.Any())
+            if (incompatibleNodes.Count == 0)
             {
                 return "0";
             }

--- a/src/Nethermind/Nethermind.Sockets.Test/WebSocketExtensionsTests.cs
+++ b/src/Nethermind/Nethermind.Sockets.Test/WebSocketExtensionsTests.cs
@@ -62,7 +62,7 @@ namespace Nethermind.Sockets.Test
                     }
                 }
 
-                if (!_receiveResults.Any() && ReturnTaskWithFaultOnEmptyQueue)
+                if (_receiveResults.Count == 0 && ReturnTaskWithFaultOnEmptyQueue)
                 {
                     Task<WebSocketReceiveResult> a = new Task<WebSocketReceiveResult>(() => throw new Exception());
                     a.Start();

--- a/src/Nethermind/Nethermind.Trie.Test/TrieTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieTests.cs
@@ -910,7 +910,7 @@ namespace Nethermind.Trie.Test
 
             rootQueue.Clear();
             Stack<Hash256> stackCopy = new();
-            while (rootStack.Any())
+            while (rootStack.Count != 0)
             {
                 stackCopy.Push(rootStack.Pop());
             }

--- a/src/Nethermind/Nethermind.TxPool/TxPoolInfoProvider.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPoolInfoProvider.cs
@@ -49,12 +49,12 @@ namespace Nethermind.TxPool
                     }
                 }
 
-                if (pending.Any())
+                if (pending.Count != 0)
                 {
                     pendingTransactions[address] = pending;
                 }
 
-                if (queued.Any())
+                if (queued.Count != 0)
                 {
                     queuedTransactions[address] = queued;
                 }


### PR DESCRIPTION
Fixes Closes Resolves #

_Please choose one of the keywords above to refer to the issue this PR solves followed by the issue number (e.g. Fixes #000). If no issue number, remove the line. Also, remove everything marked optional that is not applicable. Remove this note after reading._

## Changes

- Use direct properties `.Length` or `.IsEmpty` rather than Linq `.Any()` when available

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

