### PR TITLE
Refactor/minor worldstate cleanup

### DIFF
--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -166,7 +166,7 @@ public class InitializeNetwork : IStep
         _api.DisposeStack.Push(_api.Synchronizer);
 
         ISyncServer syncServer = _api.SyncServer = new SyncServer(
-            _api.TrieStore!.GetByHashKeyValueStore(),
+            _api.TrieStore!.TrieNodeRlpStore,
             _api.DbProvider.CodeDb,
             _api.BlockTree,
             _api.ReceiptStorage!,

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -166,7 +166,7 @@ public class InitializeNetwork : IStep
         _api.DisposeStack.Push(_api.Synchronizer);
 
         ISyncServer syncServer = _api.SyncServer = new SyncServer(
-            _api.TrieStore!.AsKeyValueStore(),
+            _api.TrieStore!.GetByHashKeyValueStore(),
             _api.DbProvider.CodeDb,
             _api.BlockTree,
             _api.ReceiptStorage!,

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
@@ -176,13 +176,11 @@ public partial class EthRpcModule : IEthRpcModule
         }
 
         BlockHeader? header = searchResult.Object;
-        Account account = _stateReader.GetAccount(header!.StateRoot!, address);
-        if (account is null)
+        byte[] storage = _stateReader.GetStorage(header!.StateRoot!, address, positionIndex);
+        if (storage is null)
         {
             return ResultWrapper<byte[]>.Success(Array.Empty<byte>());
         }
-
-        byte[] storage = _stateReader.GetStorage(account.StorageRoot, positionIndex);
         return ResultWrapper<byte[]>.Success(storage!.PadLeft(32));
     }
 

--- a/src/Nethermind/Nethermind.State.Test/StateReaderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StateReaderTests.cs
@@ -148,9 +148,7 @@ namespace Nethermind.Store.Test
 
             StateReader reader =
                 new(new TrieStore(stateDb, LimboLogs.Instance), Substitute.For<IDb>(), Logger);
-            Hash256 storageRoot = reader.GetStorageRoot(stateRoot0, _address1);
-            reader.GetStorage(storageRoot, storageCell.Index + 1).Should().BeEquivalentTo(new byte[] { 0 });
-            reader.GetStorage(Keccak.EmptyTreeHash, storageCell.Index + 1).Should().BeEquivalentTo(new byte[] { 0 });
+            reader.GetStorage(stateRoot0, _address1, storageCell.Index + 1).Should().BeEquivalentTo(new byte[] { 0 });
         }
 
         private Task StartTask(StateReader reader, Hash256 stateRoot, UInt256 value)
@@ -173,8 +171,7 @@ namespace Nethermind.Store.Test
                 {
                     for (int i = 0; i < 1000; i++)
                     {
-                        Hash256 storageRoot = reader.GetStorageRoot(stateRoot, storageCell.Address);
-                        byte[] result = reader.GetStorage(storageRoot, storageCell.Index);
+                        byte[] result = reader.GetStorage(stateRoot, storageCell.Address, storageCell.Index);
                         result.Should().BeEquivalentTo(value);
                     }
                 });
@@ -206,8 +203,7 @@ namespace Nethermind.Store.Test
             StateReader reader = new(
                 new TrieStore(dbProvider.StateDb, LimboLogs.Instance), dbProvider.CodeDb, Logger);
 
-            var account = reader.GetAccount(state.StateRoot, _address1);
-            var retrieved = reader.GetStorage(account.StorageRoot, storageCell.Index);
+            var retrieved = reader.GetStorage(state.StateRoot, _address1, storageCell.Index);
             retrieved.Should().BeEquivalentTo(initialValue);
 
             /* at this stage we set the value in storage to 1,2,3 at the tested storage cell */
@@ -230,7 +226,7 @@ namespace Nethermind.Store.Test
                We will try to retrieve the value by taking the state root from the processor.*/
 
             retrieved =
-                reader.GetStorage(processorStateProvider.GetStorageRoot(storageCell.Address), storageCell.Index);
+                reader.GetStorage(processorStateProvider.StateRoot, storageCell.Address, storageCell.Index);
             retrieved.Should().BeEquivalentTo(newValue);
 
             /* If it failed then it means that the blockchain bridge cached the previous call value */

--- a/src/Nethermind/Nethermind.State/IStateReader.cs
+++ b/src/Nethermind/Nethermind.State/IStateReader.cs
@@ -12,7 +12,7 @@ namespace Nethermind.State
     {
         Account? GetAccount(Hash256 stateRoot, Address address);
 
-        byte[]? GetStorage(Hash256 storageRoot, in UInt256 index);
+        byte[]? GetStorage(Hash256 stateRoot, Address address, in UInt256 index);
 
         byte[]? GetCode(Hash256 codeHash);
 

--- a/src/Nethermind/Nethermind.State/StateReader.cs
+++ b/src/Nethermind/Nethermind.State/StateReader.cs
@@ -33,8 +33,12 @@ namespace Nethermind.State
             return GetState(stateRoot, address);
         }
 
-        public byte[] GetStorage(Hash256 storageRoot, in UInt256 index)
+        public byte[] GetStorage(Hash256 stateRoot, Address address, in UInt256 index)
         {
+            Account? account = GetAccount(stateRoot, address);
+            if (account == null) return null;
+
+            Hash256 storageRoot = account.StorageRoot;
             if (storageRoot == Keccak.EmptyTreeHash)
             {
                 return new byte[] { 0 };

--- a/src/Nethermind/Nethermind.Synchronization.Test/OldStyleFullSynchronizerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/OldStyleFullSynchronizerTests.cs
@@ -85,7 +85,7 @@ namespace Nethermind.Synchronization.Test
                 stateReader,
                 LimboLogs.Instance);
             _syncServer = new SyncServer(
-                trieStore.AsKeyValueStore(),
+                trieStore.GetByHashKeyValueStore(),
                 _codeDb,
                 _blockTree,
                 _receiptStorage,

--- a/src/Nethermind/Nethermind.Synchronization.Test/OldStyleFullSynchronizerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/OldStyleFullSynchronizerTests.cs
@@ -85,7 +85,7 @@ namespace Nethermind.Synchronization.Test
                 stateReader,
                 LimboLogs.Instance);
             _syncServer = new SyncServer(
-                trieStore.GetByHashKeyValueStore(),
+                trieStore.TrieNodeRlpStore,
                 _codeDb,
                 _blockTree,
                 _receiptStorage,

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncServerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncServerTests.cs
@@ -645,7 +645,7 @@ namespace Nethermind.Synchronization.Test
             MemDb stateDb = new();
             TrieStore trieStore = new(stateDb, Prune.WhenCacheReaches(10.MB()), NoPersistence.Instance, LimboLogs.Instance);
             ctx.SyncServer = new SyncServer(
-                trieStore.AsKeyValueStore(),
+                trieStore.GetByHashKeyValueStore(),
                 new MemDb(),
                 localBlockTree,
                 NullReceiptStorage.Instance,

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncServerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncServerTests.cs
@@ -645,7 +645,7 @@ namespace Nethermind.Synchronization.Test
             MemDb stateDb = new();
             TrieStore trieStore = new(stateDb, Prune.WhenCacheReaches(10.MB()), NoPersistence.Instance, LimboLogs.Instance);
             ctx.SyncServer = new SyncServer(
-                trieStore.GetByHashKeyValueStore(),
+                trieStore.TrieNodeRlpStore,
                 new MemDb(),
                 localBlockTree,
                 NullReceiptStorage.Instance,

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncThreadTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncThreadTests.cs
@@ -367,7 +367,7 @@ namespace Nethermind.Synchronization.Test
 
             ISyncModeSelector selector = synchronizer.SyncModeSelector;
             SyncServer syncServer = new(
-                trieStore.GetByHashKeyValueStore(),
+                trieStore.TrieNodeRlpStore,
                 codeDb,
                 tree,
                 receiptStorage,

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncThreadTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncThreadTests.cs
@@ -367,7 +367,7 @@ namespace Nethermind.Synchronization.Test
 
             ISyncModeSelector selector = synchronizer.SyncModeSelector;
             SyncServer syncServer = new(
-                trieStore.AsKeyValueStore(),
+                trieStore.GetByHashKeyValueStore(),
                 codeDb,
                 tree,
                 receiptStorage,

--- a/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
@@ -401,7 +401,7 @@ namespace Nethermind.Synchronization.Test
                 }
 
                 SyncServer = new SyncServer(
-                    trieStore.GetByHashKeyValueStore(),
+                    trieStore.TrieNodeRlpStore,
                     codeDb,
                     BlockTree,
                     NullReceiptStorage.Instance,

--- a/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
@@ -401,7 +401,7 @@ namespace Nethermind.Synchronization.Test
                 }
 
                 SyncServer = new SyncServer(
-                    trieStore.AsKeyValueStore(),
+                    trieStore.GetByHashKeyValueStore(),
                     codeDb,
                     BlockTree,
                     NullReceiptStorage.Instance,

--- a/src/Nethermind/Nethermind.Synchronization.Test/Trie/HealingTreeTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/Trie/HealingTreeTests.cs
@@ -95,7 +95,7 @@ public class HealingTreeTests
         if (isMainThread && successfullyRecovered)
         {
             action.Should().NotThrow();
-            db.KeyWasWritten(kvp => Bytes.AreEqual(kvp.Item1, ValueKeccak.Compute(_rlp).Bytes) && Bytes.AreEqual(kvp.Item2, _rlp));
+            trieStore.Received().Set(ValueKeccak.Compute(_rlp), _rlp);
         }
         else
         {

--- a/src/Nethermind/Nethermind.Synchronization.Test/Trie/HealingTreeTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/Trie/HealingTreeTests.cs
@@ -83,7 +83,7 @@ public class HealingTreeTests
             k => throw new MissingTrieNodeException("", new TrieNodeException("", _key), path, 1),
             k => new TrieNode(NodeType.Leaf) { Key = path });
         TestMemDb db = new();
-        trieStore.AsKeyValueStore().Returns(db);
+        trieStore.GetByHashKeyValueStore().Returns(db);
 
         ITrieNodeRecovery<GetTrieNodesRequest> recovery = Substitute.For<ITrieNodeRecovery<GetTrieNodesRequest>>();
         recovery.CanRecover.Returns(isMainThread);

--- a/src/Nethermind/Nethermind.Synchronization.Test/Trie/HealingTreeTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/Trie/HealingTreeTests.cs
@@ -83,7 +83,7 @@ public class HealingTreeTests
             k => throw new MissingTrieNodeException("", new TrieNodeException("", _key), path, 1),
             k => new TrieNode(NodeType.Leaf) { Key = path });
         TestMemDb db = new();
-        trieStore.GetByHashKeyValueStore().Returns(db);
+        trieStore.TrieNodeRlpStore.Returns(db);
 
         ITrieNodeRecovery<GetTrieNodesRequest> recovery = Substitute.For<ITrieNodeRecovery<GetTrieNodesRequest>>();
         recovery.CanRecover.Returns(isMainThread);

--- a/src/Nethermind/Nethermind.Synchronization/Trie/HealingStateTree.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Trie/HealingStateTree.cs
@@ -82,7 +82,7 @@ public class HealingStateTree : StateTree
             byte[]? rlp = _recovery.Recover(rlpHash, request).GetAwaiter().GetResult();
             if (rlp is not null)
             {
-                TrieStore.AsKeyValueStore().Set(rlpHash.Bytes, rlp);
+                TrieStore.Set(rlpHash, rlp);
                 return true;
             }
         }

--- a/src/Nethermind/Nethermind.Synchronization/Trie/HealingStorageTree.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Trie/HealingStorageTree.cs
@@ -81,7 +81,7 @@ public class HealingStorageTree : StorageTree
             byte[]? rlp = _recovery.Recover(rlpHash, request).GetAwaiter().GetResult();
             if (rlp is not null)
             {
-                TrieStore.AsKeyValueStore().Set(rlpHash.Bytes, rlp);
+                TrieStore.Set(rlpHash, rlp);
                 return true;
             }
         }

--- a/src/Nethermind/Nethermind.Trie/Pruning/ITrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ITrieStore.cs
@@ -20,7 +20,7 @@ namespace Nethermind.Trie.Pruning
         event EventHandler<ReorgBoundaryReached>? ReorgBoundaryReached;
 
         // Used for serving via hash
-        IReadOnlyKeyValueStore GetByHashKeyValueStore();
+        IReadOnlyKeyValueStore TrieNodeRlpStore { get; }
 
         // Used by healing
         void Set(in ValueHash256 hash, byte[] rlp);

--- a/src/Nethermind/Nethermind.Trie/Pruning/ITrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ITrieStore.cs
@@ -19,6 +19,10 @@ namespace Nethermind.Trie.Pruning
 
         event EventHandler<ReorgBoundaryReached>? ReorgBoundaryReached;
 
-        IKeyValueStore AsKeyValueStore();
+        // Used for serving via hash
+        IReadOnlyKeyValueStore GetByHashKeyValueStore();
+
+        // Used by healing
+        void Set(in ValueHash256 hash, byte[] rlp);
     }
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/NullTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/NullTrieStore.cs
@@ -17,8 +17,6 @@ namespace Nethermind.Trie.Pruning
 
         public void FinishBlockCommit(TrieType trieType, long blockNumber, TrieNode? root, WriteFlags flags = WriteFlags.None) { }
 
-        public static void HackPersistOnShutdown() { }
-
         public IReadOnlyTrieStore AsReadOnly(IKeyValueStore keyValueStore) => this;
 
         public event EventHandler<ReorgBoundaryReached> ReorgBoundaryReached
@@ -27,7 +25,7 @@ namespace Nethermind.Trie.Pruning
             remove { }
         }
 
-        public IKeyValueStore AsKeyValueStore() => null!;
+        public IReadOnlyKeyValueStore GetByHashKeyValueStore() => null!;
 
         public TrieNode FindCachedOrUnknown(Hash256 hash) => new(NodeType.Unknown, hash);
 
@@ -37,6 +35,8 @@ namespace Nethermind.Trie.Pruning
 
         public void Dispose() { }
 
-        public static byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None) => null;
+        public void Set(in ValueHash256 hash, byte[] rlp)
+        {
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/NullTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/NullTrieStore.cs
@@ -25,7 +25,7 @@ namespace Nethermind.Trie.Pruning
             remove { }
         }
 
-        public IReadOnlyKeyValueStore GetByHashKeyValueStore() => null!;
+        public IReadOnlyKeyValueStore TrieNodeRlpStore => null!;
 
         public TrieNode FindCachedOrUnknown(Hash256 hash) => new(NodeType.Unknown, hash);
 

--- a/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStore.cs
@@ -14,13 +14,13 @@ namespace Nethermind.Trie.Pruning
     {
         private readonly TrieStore _trieStore;
         private readonly IKeyValueStore? _readOnlyStore;
-        private readonly ReadOnlyValueStore _publicStore;
+        private readonly IReadOnlyKeyValueStore _publicStore;
 
         public ReadOnlyTrieStore(TrieStore trieStore, IKeyValueStore? readOnlyStore)
         {
             _trieStore = trieStore ?? throw new ArgumentNullException(nameof(trieStore));
             _readOnlyStore = readOnlyStore;
-            _publicStore = new ReadOnlyValueStore(_trieStore.AsKeyValueStore());
+            _publicStore = _trieStore.GetByHashKeyValueStore();
         }
 
         public TrieNode FindCachedOrUnknown(Hash256 hash) =>
@@ -45,24 +45,11 @@ namespace Nethermind.Trie.Pruning
             remove { }
         }
 
-        public IKeyValueStore AsKeyValueStore() => _publicStore;
+        public IReadOnlyKeyValueStore GetByHashKeyValueStore() => _publicStore;
+        public void Set(in ValueHash256 hash, byte[] rlp)
+        {
+        }
 
         public void Dispose() { }
-
-        public static void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None) { }
-
-        private class ReadOnlyValueStore : IKeyValueStore
-        {
-            private readonly IKeyValueStore _keyValueStore;
-
-            public ReadOnlyValueStore(IKeyValueStore keyValueStore)
-            {
-                _keyValueStore = keyValueStore;
-            }
-
-            public byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None) => _keyValueStore.Get(key, flags);
-
-            public void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None) { }
-        }
     }
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStore.cs
@@ -20,7 +20,7 @@ namespace Nethermind.Trie.Pruning
         {
             _trieStore = trieStore ?? throw new ArgumentNullException(nameof(trieStore));
             _readOnlyStore = readOnlyStore;
-            _publicStore = _trieStore.GetByHashKeyValueStore();
+            _publicStore = _trieStore.TrieNodeRlpStore;
         }
 
         public TrieNode FindCachedOrUnknown(Hash256 hash) =>
@@ -45,7 +45,8 @@ namespace Nethermind.Trie.Pruning
             remove { }
         }
 
-        public IReadOnlyKeyValueStore GetByHashKeyValueStore() => _publicStore;
+        public IReadOnlyKeyValueStore TrieNodeRlpStore => _publicStore;
+
         public void Set(in ValueHash256 hash, byte[] rlp)
         {
         }

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -823,7 +823,8 @@ namespace Nethermind.Trie.Pruning
                 : _keyValueStore.Get(key, flags);
         }
 
-        public IReadOnlyKeyValueStore GetByHashKeyValueStore() => _publicStore;
+        public IReadOnlyKeyValueStore TrieNodeRlpStore => _publicStore;
+
         public void Set(in ValueHash256 hash, byte[] rlp)
         {
             _keyValueStore.Set(hash, rlp);

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -812,7 +812,7 @@ namespace Nethermind.Trie.Pruning
             });
         }
 
-        private byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)
+        private byte[]? GetByHash(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)
         {
             return _pruningStrategy.PruningEnabled
                    && _dirtyNodes.AllNodes.TryGetValue(new ValueHash256(key), out TrieNode? trieNode)
@@ -823,9 +823,13 @@ namespace Nethermind.Trie.Pruning
                 : _keyValueStore.Get(key, flags);
         }
 
-        public IKeyValueStore AsKeyValueStore() => _publicStore;
+        public IReadOnlyKeyValueStore GetByHashKeyValueStore() => _publicStore;
+        public void Set(in ValueHash256 hash, byte[] rlp)
+        {
+            _keyValueStore.Set(hash, rlp);
+        }
 
-        private class TrieKeyValueStore : IKeyValueStore
+        private class TrieKeyValueStore : IReadOnlyKeyValueStore
         {
             private readonly TrieStore _trieStore;
 
@@ -834,10 +838,7 @@ namespace Nethermind.Trie.Pruning
                 _trieStore = trieStore;
             }
 
-            public byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None) => _trieStore.Get(key, flags);
-
-            public void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None)
-                => _trieStore._keyValueStore.Set(key, value, flags);
+            public byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None) => _trieStore.GetByHash(key, flags);
         }
     }
 }


### PR DESCRIPTION
- Minor state code cleanup to reduce the size of #6331 a little bit.

## Changes

- `IStateReader.GetStorage` now accept (stateRoot, address), instead storageRoot as flat based layout cannot address storage by storage hash.
- `ITrieStore.AsKeyValueStore()` -> `ITrieStore.GetByHashKeyValueStore` to make it clear it is being used for serving by hash. Setter now use a dedicated method.

## Types of changes

#### What types of changes does your code introduce?

- [X] Refactoring

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

- Seems to work.