### PR TITLE
Fix reference assemblies package path

### DIFF
--- a/src/Nethermind/Nethermind.ReferenceAssemblies/Nethermind.ReferenceAssemblies.csproj
+++ b/src/Nethermind/Nethermind.ReferenceAssemblies/Nethermind.ReferenceAssemblies.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include="ref/**/*.dll" Pack="true" PackagePath="ref/$(TFM)">
+    <Content Include="ref/**/*.dll" Pack="true" PackagePath="ref/$(TargetFramework)">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>


### PR DESCRIPTION
## Changes

Fixed Nethermind.ReferenceAssemblies package path modified during .NET 8 migration.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
