### PR TITLE
Add extra docker compose pull to ensure latest image

### DIFF
--- a/.github/workflows/sync-testnets.yml
+++ b/.github/workflows/sync-testnets.yml
@@ -84,6 +84,7 @@ jobs:
           --el-extra-flag JsonRpc.EnabledModules=[Eth,Subscribe,Trace,TxPool,Web3,Personal,Proof,Net,Parity,Health,Rpc,Debug] \
           --checkpoint-sync-url=${{ matrix.checkpoint-sync-url }}
           echo 'Running sedge...'
+          docker compose pull
           docker compose up -d
 
       - name: Wait for ${{ matrix.network }} to sync

--- a/.github/workflows/sync-testnets.yml
+++ b/.github/workflows/sync-testnets.yml
@@ -84,8 +84,7 @@ jobs:
           --el-extra-flag JsonRpc.EnabledModules=[Eth,Subscribe,Trace,TxPool,Web3,Personal,Proof,Net,Parity,Health,Rpc,Debug] \
           --checkpoint-sync-url=${{ matrix.checkpoint-sync-url }}
           echo 'Running sedge...'
-          docker compose pull
-          docker compose up -d
+          ./build/sedge run -p $GITHUB_WORKSPACE/sedge
 
       - name: Wait for ${{ matrix.network }} to sync
         id: wait


### PR DESCRIPTION
Change from `docker compose up -d` to `sedge run` so image is pulled properly.
## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [X] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No