### PR TITLE
Fix TotalDifficulty for post-merge networks in genesis

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Synchronization.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Synchronization.cs
@@ -77,6 +77,8 @@ public partial class EngineModuleTests
         chain.BeaconSync.IsBeaconSyncHeadersFinished().Should().BeFalse();
         chain.BeaconSync.IsBeaconSyncFinished(chain.BlockTree.FindBlock(block.Hash!)?.Header).Should().BeFalse();
         AssertBeaconPivotValues(chain.BeaconPivot, block.Header);
+
+        block.Header.TotalDifficulty = 0;
         pointers.LowestInsertedBeaconHeader = block.Header;
         pointers.BestKnownBeaconBlock = block.Number;
         pointers.LowestInsertedHeader = block.Header;
@@ -151,6 +153,7 @@ public partial class EngineModuleTests
         chain.BeaconSync.IsBeaconSyncFinished(chain.BlockTree.FindBlock(block.Hash!)?.Header).Should().BeFalse();
         AssertBeaconPivotValues(chain.BeaconPivot, block.Header);
 
+        block.Header.TotalDifficulty = 0;
         pointers.LowestInsertedBeaconHeader = block.Header;
         pointers.BestKnownBeaconBlock = block.Number;
         pointers.LowestInsertedHeader = block.Header;
@@ -167,6 +170,7 @@ public partial class EngineModuleTests
         chain.BeaconSync.IsBeaconSyncFinished(chain.BlockTree.FindBlock(nextUnconnectedBlock.Hash!)?.Header).Should().BeFalse();
         AssertBeaconPivotValues(chain.BeaconPivot, nextUnconnectedBlock.Header);
 
+        nextUnconnectedBlock.Header.TotalDifficulty = 0;
         pointers.LowestInsertedBeaconHeader = nextUnconnectedBlock.Header;
         pointers.BestKnownBeaconBlock = nextUnconnectedBlock.Number;
         AssertBlockTreePointers(chain.BlockTree, pointers);
@@ -967,7 +971,7 @@ public partial class EngineModuleTests
         beaconPivot.BeaconPivotExists().Should().BeTrue();
         beaconPivot.PivotNumber.Should().Be(blockHeader.Number);
         beaconPivot.PivotHash.Should().Be(blockHeader.Hash ?? blockHeader.CalculateHash());
-        beaconPivot.PivotTotalDifficulty.Should().Be(null);
+        beaconPivot.PivotTotalDifficulty.Should().Be((UInt256)0);
     }
 
     private class BlockTreePointers

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/PoSSwitcherTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/PoSSwitcherTests.cs
@@ -255,7 +255,7 @@ namespace Nethermind.Merge.Plugin.Test
             if (pivotTotalDifficulty != null)
                 syncConfig = new SyncConfig() { PivotTotalDifficulty = $"{(UInt256)pivotTotalDifficulty}" };
             PoSSwitcher poSSwitcher = new PoSSwitcher(new MergeConfig(), syncConfig, new MemDb(), blockTree, specProvider, LimboLogs.Instance);
-            if (expectedFinalTotalDifficulty!=null)
+            if (expectedFinalTotalDifficulty != null)
                 poSSwitcher.FinalTotalDifficulty.Should().Be((UInt256)expectedFinalTotalDifficulty);
             else
                 poSSwitcher.FinalTotalDifficulty.Should().BeNull();

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/PoSSwitcherTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/PoSSwitcherTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.IO;
+using FluentAssertions;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core;
@@ -221,6 +222,45 @@ namespace Nethermind.Merge.Plugin.Test
             Assert.That(newSpecProvider.MergeBlockNumber?.BlockNumber, Is.EqualTo(terminalBlock + 1));
             Assert.That(newPoSSwitcher.HasEverReachedTerminalBlock(), Is.EqualTo(true));
         }
+
+        [Test]
+        public void No_final_difficulty_if_conditions_are_not_met()
+        {
+            AssertFinalTotalDifficulty(10005, 10000, 10000, null);
+        }
+
+        [TestCase(0, 1)]
+        [TestCase(0, 0)]
+        [TestCase(5000, 6000)]
+        public void Can_set_final_total_difficulty_for_post_merge_networks(long ttd, long genesisDifficulty)
+        {
+            AssertFinalTotalDifficulty(ttd, genesisDifficulty, null, genesisDifficulty);
+        }
+
+        [TestCase(0, 1)]
+        [TestCase(0, 0)]
+        [TestCase(5000, 6000)]
+        public void Can_set_final_total_difficulty_based_on_sync_pivot(long ttd, long pivotTotalDifficulty)
+        {
+            AssertFinalTotalDifficulty(ttd, 0, pivotTotalDifficulty, pivotTotalDifficulty);
+        }
+
+        private void AssertFinalTotalDifficulty(long ttd, long genesisDifficulty, long? pivotTotalDifficulty, long? expectedFinalTotalDifficulty)
+        {
+            TestSpecProvider specProvider = new(London.Instance);
+            specProvider.TerminalTotalDifficulty = (UInt256)ttd;
+            Block genesisBlock = Build.A.Block.WithNumber(0).WithDifficulty((UInt256)genesisDifficulty).TestObject;
+            BlockTree blockTree = Build.A.BlockTree(genesisBlock, specProvider).OfChainLength(4).TestObject;
+            SyncConfig syncConfig = new();
+            if (pivotTotalDifficulty != null)
+                syncConfig = new SyncConfig() { PivotTotalDifficulty = $"{(UInt256)pivotTotalDifficulty}" };
+            PoSSwitcher poSSwitcher = new PoSSwitcher(new MergeConfig(), syncConfig, new MemDb(), blockTree, specProvider, LimboLogs.Instance);
+            if (expectedFinalTotalDifficulty!=null)
+                poSSwitcher.FinalTotalDifficulty.Should().Be((UInt256)expectedFinalTotalDifficulty);
+            else
+                poSSwitcher.FinalTotalDifficulty.Should().BeNull();
+        }
+
 
         private static PoSSwitcher CreatePosSwitcher(IBlockTree blockTree, IDb? db = null, ISpecProvider? specProvider = null)
         {

--- a/src/Nethermind/Nethermind.Merge.Plugin/PoSSwitcher.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/PoSSwitcher.cs
@@ -88,10 +88,21 @@ namespace Nethermind.Merge.Plugin
         {
             _finalTotalDifficulty = _mergeConfig.FinalTotalDifficultyParsed;
 
+            if (TerminalTotalDifficulty is null)
+                return;
+
             // pivot post TTD, so we know FinalTotalDifficulty
-            if (_syncConfig.PivotTotalDifficultyParsed != 0 && TerminalTotalDifficulty is not null && _syncConfig.PivotTotalDifficultyParsed >= TerminalTotalDifficulty)
+            if (_syncConfig.PivotTotalDifficultyParsed != 0 && _syncConfig.PivotTotalDifficultyParsed >= TerminalTotalDifficulty)
             {
                 _finalTotalDifficulty = _syncConfig.PivotTotalDifficultyParsed;
+            }
+            else
+            {
+                UInt256 genesisDifficulty = _blockTree.Genesis?.Difficulty ?? 0;
+                if (genesisDifficulty >= TerminalTotalDifficulty) // networks with the merge in genesis
+                {
+                    _finalTotalDifficulty = genesisDifficulty;
+                }
             }
         }
 

--- a/src/Nethermind/Nethermind.Runner/configs/holesky.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/holesky.cfg
@@ -26,7 +26,6 @@
         "EngineEnabledModules": "net,eth,subscribe,engine,web3,client"
     },
     "Merge": {
-        "Enabled": true,
-        "FinalTotalDifficulty": "1"
+        "Enabled": true
     }
 }

--- a/src/Nethermind/Nethermind.Runner/configs/holesky_archive.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/holesky_archive.cfg
@@ -27,7 +27,6 @@
         "EngineEnabledModules": "net,eth,subscribe,engine,web3,client"
     },
     "Merge": {
-        "Enabled": true,
-        "FinalTotalDifficulty": "1"
+        "Enabled": true
     }
 }


### PR DESCRIPTION
## Changes

Ready for review, but please don't merge yet. I am going to test it more.

If genesis.Difficulty is greater than or equal to TTD, then we have a merge in the genesis.
This pull request:
- Removes the need for setting FinalTotalDifficulty for holesky.
- It will help with post-merge devnet edge cases and the calculation of total difficulty on them.
- Additionally, I added some missing tests for a similar trick but with a sync pivot.


## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
