### PR TITLE
Increase regex cache size

### DIFF
--- a/src/Nethermind/Nethermind.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Runner/Program.cs
@@ -11,6 +11,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Loader;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 #if !DEBUG
@@ -56,6 +57,8 @@ public static class Program
 
     public static void Main(string[] args)
     {
+        // Increase regex cache size as more added in log coloring matches
+        Regex.CacheSize = 128;
 #if !DEBUG
         ResourceLeakDetector.Level = ResourceLeakDetector.DetectionLevel.Disabled;
 #endif


### PR DESCRIPTION
## Changes

- Many regexes are used for logging; prometheus etc however the default cache size is only 10 which leads to Regex objects being constantly created as shown in this trace for Gnosis.
- Increase cache size for 10 to 128 to stop this allocation

Before

<img width="654" alt="image" src="https://github.com/NethermindEth/nethermind/assets/1142958/ea6f0a7d-3939-469e-a9e3-663452ee3906">

After this path doesn't show up

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No
