### PR TITLE
Fix unbounded memory growth in DoubleArrayConverter

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Json/DoubleArrayConverterTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Json/DoubleArrayConverterTests.cs
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Text.Json;
+using Nethermind.Serialization.Json;
+
+using NUnit.Framework;
+
+namespace Nethermind.Core.Test.Json;
+
+[TestFixture]
+public class  DoubleArrayConverterTests : ConverterTestBase<double[]>
+{
+    static readonly DoubleArrayConverter converter = new();
+
+    [Test]
+    public void Test_roundtrip()
+    {
+        TestConverter(new double[] { -0.5, 0.5, 1.0, 1.5, 2.0, 2.5 }, (a, b) => a.AsSpan().SequenceEqual(b), converter);
+        TestConverter(new double[] { 1, 1, 1, 1 }, (a, b) => a.AsSpan().SequenceEqual(b), converter);
+        TestConverter(new double[] { 0, 0, 0, 0 }, (a, b) => a.AsSpan().SequenceEqual(b), converter);
+        TestConverter(Array.Empty<double>(), (a, b) => a.AsSpan().SequenceEqual(b), converter);
+    }
+}

--- a/src/Nethermind/Nethermind.Core.Test/Json/DoubleArrayConverterTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Json/DoubleArrayConverterTests.cs
@@ -10,7 +10,7 @@ using NUnit.Framework;
 namespace Nethermind.Core.Test.Json;
 
 [TestFixture]
-public class  DoubleArrayConverterTests : ConverterTestBase<double[]>
+public class DoubleArrayConverterTests : ConverterTestBase<double[]>
 {
     static readonly DoubleArrayConverter converter = new();
 

--- a/src/Nethermind/Nethermind.Serialization.Json/DoubleConverter.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/DoubleConverter.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Nethermind.Serialization.Json
 {
-    using System.Collections.Generic;
+    using Nethermind.Core.Collections;
     using System.Runtime.CompilerServices;
     using System.Text.Json;
     using System.Text.Json.Serialization;
@@ -47,19 +47,21 @@ namespace Nethermind.Serialization.Json
             {
                 throw new JsonException();
             }
-            List<double> values = null;
-            reader.Read();
-            while (reader.TokenType == JsonTokenType.Number)
+            using ArrayPoolList<double> values = new ArrayPoolList<double>(16);
+            while (reader.Read() && reader.TokenType == JsonTokenType.Number)
             {
-                values ??= new List<double>();
                 values.Add(reader.GetDouble());
             }
             if (reader.TokenType != JsonTokenType.EndArray)
             {
                 throw new JsonException();
             }
-            reader.Read();
-            return values?.ToArray() ?? Array.Empty<double>();
+
+            if (values.Count == 0) return Array.Empty<double>();
+
+            double[] result = new double[values.Count];
+            values.CopyTo(result, 0);
+            return result;
         }
 
         [SkipLocalsInit]


### PR DESCRIPTION
## Changes

- Fix unbounded memory growth in DoubleArrayConverter by moving on the reader after reading each element

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No
