### PR TITLE
Fix double write during full pruning

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/CopyTreeVisitorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/CopyTreeVisitorTests.cs
@@ -53,6 +53,7 @@ namespace Nethermind.Blockchain.Test.FullPruning
             clonedDb.Values.Should().BeEquivalentTo(values);
 
             clonedDb.KeyWasWrittenWithFlags(keys[0], WriteFlags.LowPriority);
+            trieDb.KeyWasReadWithFlags(keys[0], ReadFlags.SkipDuplicateRead | ReadFlags.HintCacheMiss);
         }
 
         [Test, Timeout(Timeout.MaxTestTime)]

--- a/src/Nethermind/Nethermind.Blockchain/FullPruning/CopyTreeVisitor.cs
+++ b/src/Nethermind/Nethermind.Blockchain/FullPruning/CopyTreeVisitor.cs
@@ -43,6 +43,9 @@ namespace Nethermind.Blockchain.FullPruning
         }
 
         public bool IsFullDbScan => true;
+
+        public ReadFlags ExtraReadFlag => ReadFlags.SkipDuplicateRead;
+
         public bool ShouldVisit(Hash256 nextNode) => !_cancellationToken.IsCancellationRequested;
 
         public void VisitTree(Hash256 rootHash, TrieVisitContext trieVisitContext)

--- a/src/Nethermind/Nethermind.Core/IKeyValueStore.cs
+++ b/src/Nethermind/Nethermind.Core/IKeyValueStore.cs
@@ -70,6 +70,9 @@ namespace Nethermind.Core
 
         // Hint that the workload is likely to need the next value in the sequence and should prefetch it.
         HintReadAhead = 2,
+
+        // Used for full pruning db to skip duplicate read
+        SkipDuplicateRead = 4,
     }
 
     [Flags]

--- a/src/Nethermind/Nethermind.Db/FullPruning/FullPruningDb.cs
+++ b/src/Nethermind/Nethermind.Db/FullPruning/FullPruningDb.cs
@@ -52,7 +52,7 @@ namespace Nethermind.Db.FullPruning
         public byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)
         {
             byte[]? value = _currentDb.Get(key, flags); // we are reading from the main DB
-            if (_pruningContext?.DuplicateReads == true)
+            if (_pruningContext?.DuplicateReads == true && (flags & ReadFlags.SkipDuplicateRead) == 0)
             {
                 Duplicate(_pruningContext.CloningDb, key, value, WriteFlags.None);
             }
@@ -63,7 +63,7 @@ namespace Nethermind.Db.FullPruning
         public Span<byte> GetSpan(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)
         {
             Span<byte> value = _currentDb.GetSpan(key, flags); // we are reading from the main DB
-            if (!value.IsNull() && _pruningContext?.DuplicateReads == true)
+            if (!value.IsNull() && _pruningContext?.DuplicateReads == true && (flags & ReadFlags.SkipDuplicateRead) == 0)
             {
                 Duplicate(_pruningContext.CloningDb, key, value, WriteFlags.None);
             }

--- a/src/Nethermind/Nethermind.Db/FullPruning/FullPruningDb.cs
+++ b/src/Nethermind/Nethermind.Db/FullPruning/FullPruningDb.cs
@@ -52,7 +52,7 @@ namespace Nethermind.Db.FullPruning
         public byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)
         {
             byte[]? value = _currentDb.Get(key, flags); // we are reading from the main DB
-            if (_pruningContext?.DuplicateReads == true && (flags & ReadFlags.SkipDuplicateRead) == 0)
+            if (value != null && _pruningContext?.DuplicateReads == true && (flags & ReadFlags.SkipDuplicateRead) == 0)
             {
                 Duplicate(_pruningContext.CloningDb, key, value, WriteFlags.None);
             }

--- a/src/Nethermind/Nethermind.Trie/ITreeVisitor.cs
+++ b/src/Nethermind/Nethermind.Trie/ITreeVisitor.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using Nethermind.Core;
 using Nethermind.Core.Crypto;
 
 namespace Nethermind.Trie
@@ -11,6 +12,8 @@ namespace Nethermind.Trie
         /// Specify that this is a full table scan and should optimize for it.
         /// </summary>
         public bool IsFullDbScan { get; }
+
+        ReadFlags ExtraReadFlag => ReadFlags.None;
 
         bool ShouldVisit(Hash256 nextNode);
 

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -1088,10 +1088,16 @@ namespace Nethermind.Trie
                 }
             }
 
-            ITrieNodeResolver resolver = TrieStore;
+            ReadFlags flags = visitor.ExtraReadFlag;
             if (visitor.IsFullDbScan)
             {
-                resolver = new TrieNodeResolverWithReadFlags(TrieStore, ReadFlags.HintCacheMiss);
+                flags |= ReadFlags.HintCacheMiss;
+            }
+
+            ITrieNodeResolver resolver = TrieStore;
+            if (flags != ReadFlags.None)
+            {
+                resolver = new TrieNodeResolverWithReadFlags(TrieStore, flags);
             }
 
             visitor.VisitTree(rootHash, trieVisitContext);


### PR DESCRIPTION
- Not sure when do this happen, but it turns out, during full pruning, and in memory pruning at the same time, all read is duplicated causing duplicated writes.
- This add a flag to skip it if the read come from CopyTreeVisitor.
- Seems to increase maximum throughput 5x.
![Screenshot_2023-12-23_20-24-12](https://github.com/NethermindEth/nethermind/assets/1841324/2bc2d201-84ec-4690-914d-e50749e3f25a)

## Changes

- Add a flag `SkipDuplicateRead`.
- Pass it.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)
- [X] Optimization

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Full pruning completed successfully
