### PR TITLE
RateLimiter: Remove unneeded async statemachine

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/RateLimiterTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/RateLimiterTests.cs
@@ -48,7 +48,7 @@ public class RateLimiterTests
         RateLimiter rateLimiter = new(1);
         await rateLimiter.WaitAsync(CancellationToken.None);
         CancellationTokenSource cts = new();
-        ValueTask waitTask = rateLimiter.WaitAsync(cts.Token);
+        Task waitTask = rateLimiter.WaitAsync(cts.Token);
         cts.Cancel();
 
         Func<Task> act = async () => await waitTask;

--- a/src/Nethermind/Nethermind.Core/RateLimiter.cs
+++ b/src/Nethermind/Nethermind.Core/RateLimiter.cs
@@ -48,7 +48,7 @@ public class RateLimiter
         return GetCurrentTick() < _nextSlot;
     }
 
-    public async ValueTask WaitAsync(CancellationToken ctx)
+    public Task WaitAsync(CancellationToken ctx)
     {
         long currentNextSlot = _nextSlot;
         while (true)
@@ -64,8 +64,8 @@ public class RateLimiter
         long now = GetCurrentTick();
         long toWait = currentNextSlot - now;
 
-        if (toWait <= 0) return;
+        if (toWait <= 0) return Task.CompletedTask;
 
-        await Task.Delay(TimeSpan.FromMilliseconds(TickToMs(toWait)), ctx);
+        return Task.Delay(TimeSpan.FromMilliseconds(TickToMs(toWait)), ctx);
     }
 }


### PR DESCRIPTION
## Changes

- Can just return Task from Task.Delay directly rather than awaiting it

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No
