### PR TITLE
Fully separate block forks from timtestamp ones

### DIFF
--- a/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecBasedSpecProviderTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecBasedSpecProviderTests.cs
@@ -842,6 +842,9 @@ public class ChainSpecBasedSpecProviderTests
     {
         get
         {
+            yield return new TestCaseData(new ForkActivation(1), true, false, false);
+            yield return new TestCaseData(new ForkActivation(2), true, false, false);
+            yield return new TestCaseData(new ForkActivation(3), true, false, false);
             yield return new TestCaseData(new ForkActivation(1, 9), true, false, false);
             yield return new TestCaseData(new ForkActivation(2, 9), true, false, false);
             yield return new TestCaseData(new ForkActivation(2, 10), true, true, false);

--- a/src/Nethermind/Nethermind.Specs.Test/CustomSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/CustomSpecProvider.cs
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
-using System.Collections.Generic;
 using System.Linq;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
@@ -10,51 +8,52 @@ using Nethermind.Int256;
 using Nethermind.Specs.ChainSpecStyle;
 using Nethermind.Specs.Forks;
 
-namespace Nethermind.Specs.Test
+namespace Nethermind.Specs.Test;
+
+public class CustomSpecProvider : SpecProviderBase, ISpecProvider
 {
-    public class CustomSpecProvider : SpecProviderBase, ISpecProvider
+    private ForkActivation? _theMergeBlock = null;
+
+    public ulong NetworkId { get; }
+    public ulong ChainId { get; }
+
+    public CustomSpecProvider(params (ForkActivation Activation, IReleaseSpec Spec)[] transitions) : this(TestBlockchainIds.NetworkId, TestBlockchainIds.ChainId, transitions)
     {
-        private ForkActivation? _theMergeBlock = null;
-
-        public ulong NetworkId { get; }
-        public ulong ChainId { get; }
-
-        public CustomSpecProvider(params (ForkActivation Activation, IReleaseSpec Spec)[] transitions) : this(TestBlockchainIds.NetworkId, TestBlockchainIds.ChainId, transitions)
-        {
-        }
-
-        public CustomSpecProvider(ulong networkId, ulong chainId, params (ForkActivation Activation, IReleaseSpec Spec)[] transitions)
-        {
-            NetworkId = networkId;
-            ChainId = chainId;
-
-            (ForkActivation Activation, IReleaseSpec Spec)[] orderedTransitions = transitions.OrderBy(r => r.Activation).ToArray();
-
-            LoadTransitions(orderedTransitions);
-            TransitionActivations = orderedTransitions.Select(t => t.Activation).ToArray();
-        }
-
-        public void UpdateMergeTransitionInfo(long? blockNumber, UInt256? terminalTotalDifficulty = null)
-        {
-            if (blockNumber is not null)
-                _theMergeBlock = (ForkActivation)blockNumber;
-            if (terminalTotalDifficulty is not null)
-                TerminalTotalDifficulty = terminalTotalDifficulty;
-        }
-
-        public ForkActivation? MergeBlockNumber => _theMergeBlock;
-
-        public ulong TimestampFork { get; set; } = ISpecProvider.TimestampForkNever;
-        public UInt256? TerminalTotalDifficulty { get; set; }
-
-        public long? DaoBlockNumber
-        {
-            get
-            {
-                (ForkActivation forkActivation, IReleaseSpec? daoRelease) = _blockTransitions.SingleOrDefault(t => t.Spec == Dao.Instance);
-                return daoRelease is not null ? forkActivation.BlockNumber : null;
-            }
-        }
-
     }
+
+    public CustomSpecProvider(ulong networkId, ulong chainId, params (ForkActivation Activation, IReleaseSpec Spec)[] transitions)
+    {
+        NetworkId = networkId;
+        ChainId = chainId;
+
+        (ForkActivation Activation, IReleaseSpec Spec)[] orderedTransitions = transitions.OrderBy(r => r.Activation).ToArray();
+
+        LoadTransitions(orderedTransitions);
+
+        TransitionActivations = orderedTransitions.Select(t => t.Activation).ToArray();
+    }
+
+    public void UpdateMergeTransitionInfo(long? blockNumber, UInt256? terminalTotalDifficulty = null)
+    {
+        if (blockNumber is not null)
+            _theMergeBlock = (ForkActivation)blockNumber;
+        if (terminalTotalDifficulty is not null)
+            TerminalTotalDifficulty = terminalTotalDifficulty;
+    }
+
+    public ForkActivation? MergeBlockNumber => _theMergeBlock;
+
+    public ulong TimestampFork { get; set; } = ISpecProvider.TimestampForkNever;
+    public UInt256? TerminalTotalDifficulty { get; set; }
+
+    public long? DaoBlockNumber
+    {
+        get
+        {
+            (ForkActivation forkActivation, IReleaseSpec? daoRelease) = _blockTransitions.SingleOrDefault(t => t.Spec == Dao.Instance);
+            return daoRelease is not null ? forkActivation.BlockNumber : null;
+        }
+    }
+
 }
+

--- a/src/Nethermind/Nethermind.Specs.Test/CustomSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/CustomSpecProvider.cs
@@ -93,7 +93,7 @@ namespace Nethermind.Specs.Test
                 ? transition.Spec
                 : GenesisSpec;
         }
-           
+
 
         private static int CompareTransitionOnBlock(ForkActivation forkActivation, (ForkActivation Activation, IReleaseSpec Spec) transition) =>
             forkActivation.CompareTo(transition.Activation);

--- a/src/Nethermind/Nethermind.Specs.Test/CustomSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/CustomSpecProvider.cs
@@ -2,26 +2,22 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Nethermind.Core;
-using Nethermind.Core.Collections;
 using Nethermind.Core.Specs;
 using Nethermind.Int256;
+using Nethermind.Specs.ChainSpecStyle;
 using Nethermind.Specs.Forks;
 
 namespace Nethermind.Specs.Test
 {
-    public class CustomSpecProvider : ISpecProvider
+    public class CustomSpecProvider : SpecProviderBase, ISpecProvider
     {
         private ForkActivation? _theMergeBlock = null;
-        private readonly (ForkActivation Activation, IReleaseSpec Spec)[] _transitions;
-        private (ForkActivation Activation, IReleaseSpec Spec)[] _timestampOnlyTransitions;
-        private ForkActivation? _firstTimestampActivation;
 
         public ulong NetworkId { get; }
         public ulong ChainId { get; }
-
-        public ForkActivation[] TransitionActivations { get; }
 
         public CustomSpecProvider(params (ForkActivation Activation, IReleaseSpec Spec)[] transitions) : this(TestBlockchainIds.NetworkId, TestBlockchainIds.ChainId, transitions)
         {
@@ -32,21 +28,10 @@ namespace Nethermind.Specs.Test
             NetworkId = networkId;
             ChainId = chainId;
 
-            if (transitions.Length == 0)
-            {
-                throw new ArgumentException($"There must be at least one release specified when instantiating {nameof(CustomSpecProvider)}", $"{nameof(transitions)}");
-            }
+            (ForkActivation Activation, IReleaseSpec Spec)[] orderedTransitions = transitions.OrderBy(r => r.Activation).ToArray();
 
-            _transitions = transitions.OrderBy(r => r.Activation).ToArray();
-            TransitionActivations = _transitions.Select(t => t.Activation).ToArray();
-            _firstTimestampActivation = TransitionActivations.FirstOrDefault(t => t.Timestamp is not null);
-            _timestampOnlyTransitions = _transitions.SkipWhile(t => t.Activation.Timestamp is null).ToArray();
-            _transitions = _transitions.TakeWhile(t => t.Activation.Timestamp is null).ToArray();
-
-            if (transitions[0].Activation.BlockNumber != 0L)
-            {
-                throw new ArgumentException($"First release specified when instantiating {nameof(CustomSpecProvider)} should be at genesis block (0)", $"{nameof(transitions)}");
-            }
+            LoadTransitions(orderedTransitions);
+            TransitionActivations = orderedTransitions.Select(t => t.Activation).ToArray();
         }
 
         public void UpdateMergeTransitionInfo(long? blockNumber, UInt256? terminalTotalDifficulty = null)
@@ -62,47 +47,11 @@ namespace Nethermind.Specs.Test
         public ulong TimestampFork { get; set; } = ISpecProvider.TimestampForkNever;
         public UInt256? TerminalTotalDifficulty { get; set; }
 
-#pragma warning disable CS8602
-#pragma warning disable CS8603
-        public IReleaseSpec GenesisSpec => _transitions.Length == 0 ? null : _transitions[0].Spec;
-#pragma warning restore CS8603
-#pragma warning restore CS8602
-
-        public IReleaseSpec GetSpec(ForkActivation forkActivation)
-        {
-            (ForkActivation Activation, IReleaseSpec Spec)[] consideredTransitions = _transitions;
-
-            // TODO: Is this actually needed? Can this be tricked with invalid activation check if someone would fake timestamp from the future?
-            if (_firstTimestampActivation is not null && forkActivation.Timestamp is not null)
-            {
-                if (_firstTimestampActivation.Value.Timestamp < forkActivation.Timestamp
-                    && _firstTimestampActivation.Value.BlockNumber > forkActivation.BlockNumber)
-                {
-                    throw new Exception($"Chainspec file is misconfigured! Timestamp transition is configured to happen before the last block transition.");
-                }
-
-                if (_firstTimestampActivation.Value.Timestamp <= forkActivation.Timestamp)
-                {
-                    consideredTransitions = _timestampOnlyTransitions;
-                }
-            }
-
-            return consideredTransitions.TryGetSearchedItem(forkActivation,
-                CompareTransitionOnBlock,
-                out (ForkActivation Activation, IReleaseSpec Spec) transition)
-                ? transition.Spec
-                : GenesisSpec;
-        }
-
-
-        private static int CompareTransitionOnBlock(ForkActivation forkActivation, (ForkActivation Activation, IReleaseSpec Spec) transition) =>
-            forkActivation.CompareTo(transition.Activation);
-
         public long? DaoBlockNumber
         {
             get
             {
-                (ForkActivation forkActivation, IReleaseSpec daoRelease) = _transitions.SingleOrDefault(t => t.Spec == Dao.Instance);
+                (ForkActivation forkActivation, IReleaseSpec? daoRelease) = _blockTransitions.SingleOrDefault(t => t.Spec == Dao.Instance);
                 return daoRelease is not null ? forkActivation.BlockNumber : null;
             }
         }

--- a/src/Nethermind/Nethermind.Specs.Test/CustomSpecProviderTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/CustomSpecProviderTests.cs
@@ -21,10 +21,6 @@ namespace Nethermind.Specs.Test
         public void When_first_release_is_not_at_block_zero_then_throws_argument_exception()
         {
             Assert.Throws<ArgumentException>(() => _ = new CustomSpecProvider(((ForkActivation)1, Byzantium.Instance)), "ordered");
-
-            Assert.Throws<ArgumentException>(() => _ = new CustomSpecProvider(
-                ((ForkActivation)1, Byzantium.Instance),
-                ((ForkActivation)0, Frontier.Instance)), "not ordered");
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
@@ -100,6 +100,8 @@ namespace Nethermind.Specs.ChainSpecStyle
             _transitions = CreateTransitions(_chainSpec, transitionBlockNumbers, transitionTimestamps);
             _firstTimestampActivation = TransitionActivations.FirstOrDefault(t => t.Timestamp is not null);
             _timestampOnlyTransitions = _transitions.SkipWhile(t => t.Activation.Timestamp is null).ToArray();
+            _transitions = _transitions.TakeWhile(t => t.Activation.Timestamp is null).ToArray();
+
 
             if (_chainSpec.Parameters.TerminalPoWBlockNumber is not null)
             {

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
@@ -6,26 +6,20 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using System.Reflection;
-using Nethermind.Core.Collections;
 using Nethermind.Core.Specs;
 using Nethermind.Int256;
 using Nethermind.Logging;
 
 namespace Nethermind.Specs.ChainSpecStyle
 {
-    public class ChainSpecBasedSpecProvider : ISpecProvider
+    public class ChainSpecBasedSpecProvider : SpecProviderBase, ISpecProvider
     {
-        private (ForkActivation Activation, ReleaseSpec Spec)[] _transitions;
-        private (ForkActivation Activation, ReleaseSpec Spec)[] _timestampOnlyTransitions;
-        private ForkActivation? _firstTimestampActivation;
-
         private readonly ChainSpec _chainSpec;
-        private readonly ILogger _logger;
 
         public ChainSpecBasedSpecProvider(ChainSpec chainSpec, ILogManager logManager = null)
+            : base(logManager?.GetClassLogger<ChainSpecBasedSpecProvider>() ?? LimboTraceLogger.Instance)
         {
             _chainSpec = chainSpec ?? throw new ArgumentNullException(nameof(chainSpec));
-            _logger = logManager?.GetClassLogger<ChainSpecBasedSpecProvider>() ?? LimboTraceLogger.Instance;
             BuildTransitions();
         }
 
@@ -96,12 +90,12 @@ namespace Nethermind.Specs.ChainSpecStyle
                 transitionBlockNumbers.Add(bombDelay.Key);
             }
 
-            TransitionActivations = CreateTransitionActivations(transitionBlockNumbers, transitionTimestamps);
-            _transitions = CreateTransitions(_chainSpec, transitionBlockNumbers, transitionTimestamps);
-            _firstTimestampActivation = TransitionActivations.FirstOrDefault(t => t.Timestamp is not null);
-            _timestampOnlyTransitions = _transitions.SkipWhile(t => t.Activation.Timestamp is null).ToArray();
-            _transitions = _transitions.TakeWhile(t => t.Activation.Timestamp is null).ToArray();
 
+            (ForkActivation Activation, IReleaseSpec Spec)[] allTransitions = CreateTransitions(_chainSpec, transitionBlockNumbers, transitionTimestamps);
+
+            LoadTransitions(allTransitions);
+
+            TransitionActivations = CreateTransitionActivations(transitionBlockNumbers, transitionTimestamps);
 
             if (_chainSpec.Parameters.TerminalPoWBlockNumber is not null)
             {
@@ -111,12 +105,12 @@ namespace Nethermind.Specs.ChainSpecStyle
             TerminalTotalDifficulty = _chainSpec.Parameters.TerminalTotalDifficulty;
         }
 
-        private static (ForkActivation, ReleaseSpec Spec)[] CreateTransitions(
+        private static (ForkActivation, IReleaseSpec Spec)[] CreateTransitions(
             ChainSpec chainSpec,
             SortedSet<long> transitionBlockNumbers,
             SortedSet<ulong> transitionTimestamps)
         {
-            (ForkActivation Activation, ReleaseSpec Spec)[] transitions = new (ForkActivation, ReleaseSpec Spec)[transitionBlockNumbers.Count + transitionTimestamps.Count];
+            (ForkActivation Activation, IReleaseSpec Spec)[] transitions = new (ForkActivation, IReleaseSpec Spec)[transitionBlockNumbers.Count + transitionTimestamps.Count];
             long biggestBlockTransition = transitionBlockNumbers.Max;
 
             int index = 0;
@@ -268,41 +262,9 @@ namespace Nethermind.Specs.ChainSpecStyle
 
         public UInt256? TerminalTotalDifficulty { get; private set; }
 
-        public IReleaseSpec GenesisSpec => _transitions.Length == 0 ? null : _transitions[0].Spec;
-
-        public IReleaseSpec GetSpec(ForkActivation activation)
-        {
-            (ForkActivation Activation, ReleaseSpec Spec)[] consideredTransitions = _transitions;
-
-            // TODO: Is this actually needed? Can this be tricked with invalid activation check if someone would fake timestamp from the future?
-            if (_firstTimestampActivation is not null && activation.Timestamp is not null)
-            {
-                if (_firstTimestampActivation.Value.Timestamp < activation.Timestamp
-                    && _firstTimestampActivation.Value.BlockNumber > activation.BlockNumber)
-                {
-                    if (_logger.IsWarn) _logger.Warn($"Chainspec file is misconfigured! Timestamp transition is configured to happen before the last block transition.");
-                }
-
-                if (_firstTimestampActivation.Value.Timestamp <= activation.Timestamp)
-                {
-                    consideredTransitions = _timestampOnlyTransitions;
-                }
-            }
-
-            return consideredTransitions.TryGetSearchedItem(activation,
-                CompareTransitionOnActivation,
-                out (ForkActivation Activation, ReleaseSpec Spec) transition)
-                ? transition.Spec
-                : GenesisSpec;
-        }
-
-        private static int CompareTransitionOnActivation(ForkActivation activation, (ForkActivation Activation, ReleaseSpec Spec) transition) =>
-            activation.CompareTo(transition.Activation);
-
         public long? DaoBlockNumber => _chainSpec.DaoForkBlockNumber;
 
         public ulong NetworkId => _chainSpec.NetworkId;
         public ulong ChainId => _chainSpec.ChainId;
-        public ForkActivation[] TransitionActivations { get; private set; }
     }
 }

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
@@ -115,7 +115,7 @@ namespace Nethermind.Specs.ChainSpecStyle
             SortedSet<ulong> transitionTimestamps)
         {
             (ForkActivation Activation, ReleaseSpec Spec)[] transitions = new (ForkActivation, ReleaseSpec Spec)[transitionBlockNumbers.Count + transitionTimestamps.Count];
-            long biggestBlockTransition = transitionBlockNumbers.Max + 1; // We assume first timestamp based transition will happen after last blockNumber based transition (in block numbers)
+            long biggestBlockTransition = transitionBlockNumbers.Max;
 
             int index = 0;
             foreach (long releaseStartBlock in transitionBlockNumbers)
@@ -137,7 +137,7 @@ namespace Nethermind.Specs.ChainSpecStyle
 
         private static ForkActivation[] CreateTransitionActivations(SortedSet<long> transitionBlockNumbers, SortedSet<ulong> transitionTimestamps)
         {
-            long biggestBlockTransition = transitionBlockNumbers.Max + 1;
+            long biggestBlockTransition = transitionBlockNumbers.Max;
 
             ForkActivation[] transitionActivations = new ForkActivation[transitionBlockNumbers.Count - 1 + transitionTimestamps.Count];
 

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/SpecProviderBase.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/SpecProviderBase.cs
@@ -27,6 +27,7 @@ public abstract class SpecProviderBase
         {
             throw new ArgumentException($"There must be at least one release specified when instantiating {GetType()}", $"{nameof(transitions)}");
         }
+
         if (transitions.First().Activation.BlockNumber != 0L)
         {
             throw new ArgumentException($"First release specified when instantiating {GetType()} should be at genesis block (0)", $"{nameof(transitions)}");

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/SpecProviderExtensions.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/SpecProviderExtensions.cs
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core.Collections;
+using Nethermind.Core.Specs;
+using Nethermind.Logging;
+using System;
+using System.Linq;
+
+namespace Nethermind.Specs.ChainSpecStyle;
+
+public abstract class SpecProviderBase
+{
+    protected (ForkActivation Activation, IReleaseSpec Spec)[] _blockTransitions;
+    private (ForkActivation Activation, IReleaseSpec Spec)[] _timestampTransitions;
+    private ForkActivation? _firstTimestampActivation;
+    protected readonly ILogger _logger;
+
+    public SpecProviderBase(ILogger logger = null)
+    {
+        _logger = logger;
+    }
+
+    protected void LoadTransitions((ForkActivation Activation, IReleaseSpec Spec)[] transitions)
+    {
+        if (transitions.Length == 0)
+        {
+            throw new ArgumentException($"There must be at least one release specified when instantiating {GetType()}", $"{nameof(transitions)}");
+        }
+        if (transitions.First().Activation.BlockNumber != 0L)
+        {
+            throw new ArgumentException($"First release specified when instantiating {GetType()} should be at genesis block (0)", $"{nameof(transitions)}");
+        }
+
+        _blockTransitions = transitions.TakeWhile(t => t.Activation.Timestamp is null).ToArray();
+        _timestampTransitions = transitions.SkipWhile(t => t.Activation.Timestamp is null).ToArray();
+        _firstTimestampActivation = _timestampTransitions.Length != 0 ? _timestampTransitions.First().Activation : null;
+        GenesisSpec = transitions.First().Spec;
+    }
+
+    public ForkActivation[] TransitionActivations { get; protected set; }
+
+    public IReleaseSpec GenesisSpec { get; private set; }
+
+    public IReleaseSpec GetSpec(ForkActivation activation)
+    {
+        static int CompareTransitionOnActivation(ForkActivation activation, (ForkActivation Activation, IReleaseSpec Spec) transition) =>
+           activation.CompareTo(transition.Activation);
+
+        (ForkActivation Activation, IReleaseSpec Spec)[] consideredTransitions = _blockTransitions;
+
+        if (_firstTimestampActivation is not null && activation.Timestamp is not null)
+        {
+            if (_firstTimestampActivation.Value.Timestamp < activation.Timestamp
+                && _firstTimestampActivation.Value.BlockNumber > activation.BlockNumber)
+            {
+                if (_logger is not null && _logger.IsWarn) _logger.Warn($"Chainspec file is misconfigured! Timestamp transition is configured to happen before the last block transition.");
+            }
+
+            if (_firstTimestampActivation.Value.Timestamp <= activation.Timestamp)
+                consideredTransitions = _timestampTransitions;
+        }
+
+        return consideredTransitions.TryGetSearchedItem(activation,
+            CompareTransitionOnActivation,
+            out (ForkActivation Activation, IReleaseSpec Spec) transition)
+            ? transition.Spec
+            : GenesisSpec;
+    }
+}


### PR DESCRIPTION
## Changes

- block and timestamp forks are fully separated
- `ChainSpecBasedProvider` and `CustomSpecProvider` now share transition loading and `GetSpec` logic

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No