### PR TITLE
Don't use exceptions for flow control during sync

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -1272,7 +1272,7 @@ namespace Nethermind.Blockchain
         /// <returns></returns>
         private bool ShouldCache(long number)
         {
-            return number == 0L || Head is null || number <= Head.Number + 1;
+            return number == 0L || Head is null || number >= Head.Number - HeaderStore.CacheSize;
         }
 
         public ChainLevelInfo? FindLevel(long number)

--- a/src/Nethermind/Nethermind.Blockchain/Headers/HeaderStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Headers/HeaderStore.cs
@@ -15,8 +15,8 @@ namespace Nethermind.Blockchain.Headers;
 
 public class HeaderStore : IHeaderStore
 {
-    // SyncProgressResolver MaxLookupBack is 128, add 16 wiggle room
-    private const int CacheSize = 128 + 16;
+    // SyncProgressResolver MaxLookupBack is 256, add 16 wiggle room
+    public const int CacheSize = 256 + 16;
 
     private readonly IDb _headerDb;
     private readonly IDb _blockNumberDb;

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/DetailedProgress.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/DetailedProgress.cs
@@ -79,7 +79,7 @@ namespace Nethermind.Synchronization.FastSync
                 }
 
                 if (logger.IsInfo) logger.Info(
-                    $"State Sync {TimeSpan.FromSeconds(SecondsInSync):dd\\.hh\\:mm\\:ss} | {dataSizeInfo} | branches: {branchProgress.Progress:P2} | kB/s: {savedKBytesPerSecond,5:F0} | accounts {SavedAccounts} | nodes {SavedNodesCount} | diagnostics: {pendingRequestsCount}.{AverageTimeInHandler:f2}ms");
+                    $"State Sync {TimeSpan.FromSeconds(SecondsInSync):dd\\.hh\\:mm\\:ss} | {dataSizeInfo} | branches: {branchProgress.Progress:P2} | kB/s: {savedKBytesPerSecond,5:F0} | accounts {SavedAccounts} | nodes {SavedNodesCount} | pending: {pendingRequestsCount} | ave: {AverageTimeInHandler:f2}ms");
                 if (logger.IsDebug && DateTime.UtcNow - LastReportTime.full > TimeSpan.FromSeconds(10))
                 {
                     long allChecks = CheckWasInDependencies + CheckWasCached + StateWasThere + StateWasNotThere;

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/DetailedProgress.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/DetailedProgress.cs
@@ -79,7 +79,7 @@ namespace Nethermind.Synchronization.FastSync
                 }
 
                 if (logger.IsInfo) logger.Info(
-                    $"State Sync {TimeSpan.FromSeconds(SecondsInSync):dd\\.hh\\:mm\\:ss} | {dataSizeInfo} | branches: {branchProgress.Progress:P2} | kB/s: {savedKBytesPerSecond,5:F0} | accounts {SavedAccounts} | nodes {SavedNodesCount} | pending: {pendingRequestsCount} | ave: {AverageTimeInHandler:f2}ms");
+                    $"State Sync {TimeSpan.FromSeconds(SecondsInSync):dd\\.hh\\:mm\\:ss} | {dataSizeInfo} | branches: {branchProgress.Progress:P2} | kB/s: {savedKBytesPerSecond,5:F0} | accounts {SavedAccounts} | nodes {SavedNodesCount} | pending: {pendingRequestsCount,3} | ave: {AverageTimeInHandler:f2}ms");
                 if (logger.IsDebug && DateTime.UtcNow - LastReportTime.full > TimeSpan.FromSeconds(10))
                 {
                     long allChecks = CheckWasInDependencies + CheckWasCached + StateWasThere + StateWasNotThere;

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
@@ -308,6 +308,7 @@ namespace Nethermind.Synchronization.FastSync
 
                     _data.DisplayProgressReport(_pendingRequests.Count, _branchProgress, _logger);
 
+                    handleWatch.Stop();
                     long total = handleWatch.ElapsedMilliseconds + _networkWatch.ElapsedMilliseconds;
                     if (total != 0)
                     {
@@ -328,7 +329,7 @@ namespace Nethermind.Synchronization.FastSync
                     _data.LastDbReads = _data.DbChecks;
                     _data.AverageTimeInHandler =
                         (_data.AverageTimeInHandler * (_data.ProcessedRequestsCount - 1) +
-                         _handleWatch) / _data.ProcessedRequestsCount;
+                         handleWatch.ElapsedMilliseconds) / _data.ProcessedRequestsCount;
 
                     Interlocked.Add(ref _data.HandledNodesCount, nonEmptyResponses);
                     return result;

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
@@ -327,9 +327,7 @@ namespace Nethermind.Synchronization.FastSync
 
                     Interlocked.Add(ref _handleWatch, handleWatch.ElapsedMilliseconds);
                     _data.LastDbReads = _data.DbChecks;
-                    _data.AverageTimeInHandler =
-                        (_data.AverageTimeInHandler * (_data.ProcessedRequestsCount - 1) +
-                         handleWatch.ElapsedMilliseconds) / _data.ProcessedRequestsCount;
+                    _data.AverageTimeInHandler = _handleWatch / (decimal)_data.ProcessedRequestsCount;
 
                     Interlocked.Add(ref _data.HandledNodesCount, nonEmptyResponses);
                     return result;

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -1077,11 +1077,7 @@ namespace Nethermind.Trie
             if (!rootHash.Equals(Keccak.EmptyTreeHash))
             {
                 rootRef = RootHash == rootHash ? RootRef : TrieStore.FindCachedOrUnknown(rootHash);
-                try
-                {
-                    rootRef!.ResolveNode(TrieStore);
-                }
-                catch (TrieException)
+                if (!rootRef!.TryResolveNode(TrieStore))
                 {
                     visitor.VisitMissingNode(rootHash, trieVisitContext);
                     return;

--- a/src/Nethermind/Nethermind.Trie/Pruning/ITrieNodeResolver.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ITrieNodeResolver.cs
@@ -23,5 +23,12 @@ namespace Nethermind.Trie.Pruning
         /// <param name="hash"></param>
         /// <returns></returns>
         byte[]? LoadRlp(Hash256 hash, ReadFlags flags = ReadFlags.None);
+
+        /// <summary>
+        /// Loads RLP of the node.
+        /// </summary>
+        /// <param name="hash"></param>
+        /// <returns></returns>
+        byte[]? TryLoadRlp(Hash256 hash, ReadFlags flags = ReadFlags.None);
     }
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/NullTrieNodeResolver.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/NullTrieNodeResolver.cs
@@ -14,5 +14,6 @@ namespace Nethermind.Trie.Pruning
 
         public TrieNode FindCachedOrUnknown(Hash256 hash) => new(NodeType.Unknown, hash);
         public byte[]? LoadRlp(Hash256 hash, ReadFlags flags = ReadFlags.None) => null;
+        public byte[]? TryLoadRlp(Hash256 hash, ReadFlags flags = ReadFlags.None) => null;
     }
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/NullTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/NullTrieStore.cs
@@ -29,6 +29,8 @@ namespace Nethermind.Trie.Pruning
 
         public TrieNode FindCachedOrUnknown(Hash256 hash) => new(NodeType.Unknown, hash);
 
+        public byte[] TryLoadRlp(Hash256 hash, ReadFlags flags = ReadFlags.None) => null;
+
         public byte[] LoadRlp(Hash256 hash, ReadFlags flags = ReadFlags.None) => Array.Empty<byte>();
 
         public bool IsPersisted(in ValueHash256 keccak) => true;

--- a/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStore.cs
@@ -26,6 +26,7 @@ namespace Nethermind.Trie.Pruning
         public TrieNode FindCachedOrUnknown(Hash256 hash) =>
             _trieStore.FindCachedOrUnknown(hash, true);
 
+        public byte[]? TryLoadRlp(Hash256 hash, ReadFlags flags) => _trieStore.TryLoadRlp(hash, _readOnlyStore, flags);
         public byte[] LoadRlp(Hash256 hash, ReadFlags flags) => _trieStore.LoadRlp(hash, _readOnlyStore, flags);
 
         public bool IsPersisted(in ValueHash256 keccak) => _trieStore.IsPersisted(keccak);

--- a/src/Nethermind/Nethermind.Trie/TrieNode.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.cs
@@ -304,44 +304,7 @@ namespace Nethermind.Trie
                     throw new InvalidAsynchronousStateException($"{nameof(_rlpStream)} is null when {nameof(NodeType)} is {NodeType}");
                 }
 
-                Metrics.TreeNodeRlpDecodings++;
-                _rlpStream.ReadSequenceLength();
-
-                // micro optimization to prevent searches beyond 3 items for branches (search up to three)
-                int numberOfItems = _rlpStream.PeekNumberOfItemsRemaining(null, 3);
-
-                if (numberOfItems > 2)
-                {
-                    NodeType = NodeType.Branch;
-                }
-                else if (numberOfItems == 2)
-                {
-                    (byte[] key, bool isLeaf) = HexPrefix.FromBytes(_rlpStream.DecodeByteArraySpan());
-
-                    // a hack to set internally and still verify attempts from the outside
-                    // after the code is ready we should just add proper access control for methods from the outside and inside
-                    bool isDirtyActual = IsDirty;
-                    IsDirty = true;
-
-                    if (isLeaf)
-                    {
-                        NodeType = NodeType.Leaf;
-                        Key = key;
-
-                        ReadOnlySpan<byte> valueSpan = _rlpStream.DecodeByteArraySpan();
-                        CappedArray<byte> buffer = bufferPool.SafeRentBuffer(valueSpan.Length);
-                        valueSpan.CopyTo(buffer.AsSpan());
-                        Value = buffer;
-                    }
-                    else
-                    {
-                        NodeType = NodeType.Extension;
-                        Key = key;
-                    }
-
-                    IsDirty = isDirtyActual;
-                }
-                else
+                if (!DecodeRlp(bufferPool, out int numberOfItems))
                 {
                     throw new TrieNodeException($"Unexpected number of items = {numberOfItems} when decoding a node from RLP ({FullRlp.AsSpan().ToHexString()})", Keccak ?? Nethermind.Core.Crypto.Keccak.Zero);
                 }
@@ -350,6 +313,97 @@ namespace Nethermind.Trie
             {
                 throw new TrieNodeException($"Error when decoding node {Keccak}", Keccak ?? Nethermind.Core.Crypto.Keccak.Zero, rlpException);
             }
+        }
+
+        /// <summary>
+        /// Highly optimized
+        /// </summary>
+        public bool TryResolveNode(ITrieNodeResolver tree, ReadFlags readFlags = ReadFlags.None, ICappedArrayPool? bufferPool = null)
+        {
+            try
+            {
+                if (NodeType == NodeType.Unknown)
+                {
+                    if (FullRlp.IsNull)
+                    {
+                        if (Keccak is null)
+                        {
+                            return false;
+                        }
+
+                        FullRlp = tree.TryLoadRlp(Keccak, readFlags);
+                        IsPersisted = true;
+
+                        if (FullRlp.IsNull)
+                        {
+                            return false;
+                        }
+                    }
+                }
+                else
+                {
+                    return true;
+                }
+
+                _rlpStream = FullRlp.AsRlpStream();
+                if (_rlpStream is null)
+                {
+                    throw new InvalidAsynchronousStateException($"{nameof(_rlpStream)} is null when {nameof(NodeType)} is {NodeType}");
+                }
+
+                return DecodeRlp(bufferPool, out _);
+            }
+            catch (RlpException)
+            {
+                return false;
+            }
+        }
+
+        private bool DecodeRlp(ICappedArrayPool bufferPool, out int itemsCount)
+        {
+            Metrics.TreeNodeRlpDecodings++;
+            _rlpStream.ReadSequenceLength();
+
+            // micro optimization to prevent searches beyond 3 items for branches (search up to three)
+            int numberOfItems = itemsCount = _rlpStream.PeekNumberOfItemsRemaining(null, 3);
+
+            if (numberOfItems > 2)
+            {
+                NodeType = NodeType.Branch;
+            }
+            else if (numberOfItems == 2)
+            {
+                (byte[] key, bool isLeaf) = HexPrefix.FromBytes(_rlpStream.DecodeByteArraySpan());
+
+                // a hack to set internally and still verify attempts from the outside
+                // after the code is ready we should just add proper access control for methods from the outside and inside
+                bool isDirtyActual = IsDirty;
+                IsDirty = true;
+
+                if (isLeaf)
+                {
+                    NodeType = NodeType.Leaf;
+                    Key = key;
+
+                    ReadOnlySpan<byte> valueSpan = _rlpStream.DecodeByteArraySpan();
+                    CappedArray<byte> buffer = bufferPool.SafeRentBuffer(valueSpan.Length);
+                    valueSpan.CopyTo(buffer.AsSpan());
+                    Value = buffer;
+                }
+                else
+                {
+                    NodeType = NodeType.Extension;
+                    Key = key;
+                }
+
+                IsDirty = isDirtyActual;
+            }
+            else
+            {
+                return false;
+            }
+
+            return true;
         }
 
         public void ResolveKey(ITrieNodeResolver tree, bool isRoot, ICappedArrayPool? bufferPool = null)

--- a/src/Nethermind/Nethermind.Trie/TrieNodeResolverWithReadFlags.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNodeResolverWithReadFlags.cs
@@ -23,6 +23,16 @@ public class TrieNodeResolverWithReadFlags : ITrieNodeResolver
         return _baseResolver.FindCachedOrUnknown(hash);
     }
 
+    public byte[]? TryLoadRlp(Hash256 hash, ReadFlags flags = ReadFlags.None)
+    {
+        if (flags != ReadFlags.None)
+        {
+            return _baseResolver.TryLoadRlp(hash, flags | _defaultFlags);
+        }
+
+        return _baseResolver.TryLoadRlp(hash, _defaultFlags);
+    }
+
     public byte[]? LoadRlp(Hash256 hash, ReadFlags flags = ReadFlags.None)
     {
         if (flags != ReadFlags.None)


### PR DESCRIPTION
## Changes

- During regular operation we want to throw exceptions for missing trie nodes, however during sync we should use a non throwing path as its just checking for existence (and otherwise just swallows the exceptions). Exceptions are expensive as they need to capture the stack etc
- 
<img width="571" alt="image" src="https://github.com/NethermindEth/nethermind/assets/1142958/569a5015-4fc7-4b27-80bf-158fba8e7de3">


## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No