### PR TITLE
Feature/exit on blocknumber

### DIFF
--- a/src/Nethermind/Nethermind.Api/IInitConfig.cs
+++ b/src/Nethermind/Nethermind.Api/IInitConfig.cs
@@ -79,6 +79,9 @@ public interface IInitConfig : IConfig
 
     [ConfigItem(Description = "[TECHNICAL] Disable setting malloc options. Set to true if using different memory allocator or manually setting malloc opts.", DefaultValue = "false", HiddenFromDocs = true)]
     bool DisableMallocOpts { get; set; }
+
+    [ConfigItem(Description = "[TECHNICAL] Exit when block number is reached. Useful for scripting and testing.", DefaultValue = "null", HiddenFromDocs = true)]
+    long? ExitOnBlockNumber { get; set; }
 }
 
 public enum DiagnosticMode

--- a/src/Nethermind/Nethermind.Api/InitConfig.cs
+++ b/src/Nethermind/Nethermind.Api/InitConfig.cs
@@ -33,6 +33,7 @@ namespace Nethermind.Api
         public long? MemoryHint { get; set; }
         public bool DisableGcOnNewPayload { get; set; } = true;
         public bool DisableMallocOpts { get; set; } = false;
+        public long? ExitOnBlockNumber { get; set; } = null;
 
         [Obsolete("Use DiagnosticMode with MemDb instead")]
         public bool UseMemDb

--- a/src/Nethermind/Nethermind.Blockchain.Test/ExitOnBlocknumberHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/ExitOnBlocknumberHandlerTests.cs
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Config;
+using Nethermind.Core;
+using Nethermind.Core.Test.Builders;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Blockchain.Test;
+
+public class ExitOnBlocknumberHandlerTests
+{
+    [TestCase(10, false)]
+    [TestCase(99, false)]
+    [TestCase(100, true)]
+    [TestCase(101, true)]
+    public void Will_Exit_When_BlockReached(long blockNumber, bool exitReceived)
+    {
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        IProcessExitSource processExitSource = Substitute.For<IProcessExitSource>();
+        new ExitOnBlockNumberHandler(blockTree, processExitSource, 100);
+
+        blockTree.BlockAddedToMain += Raise.EventWith(
+            new BlockReplacementEventArgs(Build.A.Block.WithNumber(blockNumber).TestObject));
+
+        if (exitReceived)
+        {
+            processExitSource.Received().Exit(0);
+        }
+        else
+        {
+            processExitSource.DidNotReceive().Exit(0);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Blockchain.Test/ExitOnBlocknumberHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/ExitOnBlocknumberHandlerTests.cs
@@ -4,6 +4,7 @@
 using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Logging;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -19,7 +20,7 @@ public class ExitOnBlocknumberHandlerTests
     {
         IBlockTree blockTree = Substitute.For<IBlockTree>();
         IProcessExitSource processExitSource = Substitute.For<IProcessExitSource>();
-        new ExitOnBlockNumberHandler(blockTree, processExitSource, 100);
+        new ExitOnBlockNumberHandler(blockTree, processExitSource, 100, LimboLogs.Instance);
 
         blockTree.BlockAddedToMain += Raise.EventWith(
             new BlockReplacementEventArgs(Build.A.Block.WithNumber(blockNumber).TestObject));

--- a/src/Nethermind/Nethermind.Blockchain/ExitOnBlockNumberHandler.cs
+++ b/src/Nethermind/Nethermind.Blockchain/ExitOnBlockNumberHandler.cs
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Config;
+
+namespace Nethermind.Blockchain;
+
+/// <summary>
+/// Just call exit if blocktree report added block is more than a specific number.
+/// </summary>
+public class ExitOnBlockNumberHandler
+{
+    public ExitOnBlockNumberHandler(IBlockTree blockTree, IProcessExitSource processExitSource, long? initConfigExitOnBlockNumber)
+    {
+        blockTree.BlockAddedToMain += (sender, args) =>
+        {
+            if (args.Block.Number >= initConfigExitOnBlockNumber)
+            {
+                processExitSource.Exit(0);
+            }
+        };
+    }
+}

--- a/src/Nethermind/Nethermind.Blockchain/ExitOnBlockNumberHandler.cs
+++ b/src/Nethermind/Nethermind.Blockchain/ExitOnBlockNumberHandler.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Nethermind.Config;
+using Nethermind.Logging;
 
 namespace Nethermind.Blockchain;
 
@@ -10,12 +11,19 @@ namespace Nethermind.Blockchain;
 /// </summary>
 public class ExitOnBlockNumberHandler
 {
-    public ExitOnBlockNumberHandler(IBlockTree blockTree, IProcessExitSource processExitSource, long? initConfigExitOnBlockNumber)
+    public ExitOnBlockNumberHandler(
+        IBlockTree blockTree,
+        IProcessExitSource processExitSource,
+        long initConfigExitOnBlockNumber,
+        ILogManager logManager)
     {
+        ILogger logger = logManager.GetClassLogger();
+
         blockTree.BlockAddedToMain += (sender, args) =>
         {
             if (args.Block.Number >= initConfigExitOnBlockNumber)
             {
+                logger.Info($"Block {args.Block.Number} reached. Exiting.");
                 processExitSource.Exit(0);
             }
         };

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeBlockTree.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeBlockTree.cs
@@ -102,6 +102,11 @@ namespace Nethermind.Init.Steps
 
             _set.LogFinder = logFinder;
 
+            if (initConfig.ExitOnBlockNumber != null)
+            {
+                new ExitOnBlockNumberHandler(blockTree, _get.ProcessExit!, initConfig.ExitOnBlockNumber);
+            }
+
             return Task.CompletedTask;
         }
     }

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeBlockTree.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeBlockTree.cs
@@ -104,7 +104,7 @@ namespace Nethermind.Init.Steps
 
             if (initConfig.ExitOnBlockNumber != null)
             {
-                new ExitOnBlockNumberHandler(blockTree, _get.ProcessExit!, initConfig.ExitOnBlockNumber);
+                new ExitOnBlockNumberHandler(blockTree, _get.ProcessExit!, initConfig.ExitOnBlockNumber.Value, _get.LogManager);
             }
 
             return Task.CompletedTask;

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTests.cs
@@ -28,7 +28,7 @@ namespace Nethermind.Synchronization.Test.FastSync
     [TestFixture(1, 100)]
     [TestFixture(4, 0)]
     [TestFixture(4, 100)]
-    [Parallelizable(ParallelScope.Children)]
+    [Parallelizable(ParallelScope.All)]
     public class StateSyncFeedTests : StateSyncFeedTestsBase
     {
         // Useful for set and forget run. But this test is taking a long time to have it set to other than 1.


### PR DESCRIPTION
- Minor flag to exit when a certain block number was reached.
- Useful for things like measuring how much do the database size increase on full sync.

## Changes

- Added a flag to exit when a certain block number was reached.

## Types of changes

#### What types of changes does your code introduce?

- [X] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

[X] Will not exit when not specified.
[X] Exit early when specifying block number higher than current block number.
[X] Exit when starting with older block number but then reach the specified block number.

## Documentation

#### Requires documentation update

- [X] No: Internal flag.

#### Requires explanation in Release Notes

- [X] No

