### PR TITLE
Enable blob txs support in goerli configs

### DIFF
--- a/src/Nethermind/Nethermind.Runner.Test/ConfigFilesTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/ConfigFilesTests.cs
@@ -323,6 +323,17 @@ namespace Nethermind.Runner.Test
             Test<IInitConfig, string>(configWildcard, c => c.LogFileName, (cf, p) => p.Should().Be(cf.Replace("cfg", "logs.txt"), cf));
         }
 
+        [TestCase("goerli", BlobsSupportMode.StorageWithReorgs)]
+        [TestCase("^goerli", BlobsSupportMode.Disabled)]
+        [TestCase("sepolia", BlobsSupportMode.Disabled)]
+        [TestCase("mainnet", BlobsSupportMode.Disabled)]
+        [TestCase("chiado", BlobsSupportMode.Disabled)]
+        [TestCase("gnosis", BlobsSupportMode.Disabled)]
+        public void Blob_txs_support_is_correct(string configWildcard, BlobsSupportMode blobsSupportMode)
+        {
+            Test<ITxPoolConfig, BlobsSupportMode>(configWildcard, c => c.BlobsSupport, blobsSupportMode);
+        }
+
 
         [TestCase("goerli", new[] { 16, 16, 16, 16 })]
         [TestCase("mainnet")]

--- a/src/Nethermind/Nethermind.Runner/configs/goerli.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/goerli.cfg
@@ -7,7 +7,8 @@
     "MemoryHint": 768000000
   },
   "TxPool": {
-    "Size": 1024
+    "Size": 1024,
+    "BlobsSupport": "StorageWithReorgs"
   },
   "Db": {
     "EnableMetricsUpdater": true

--- a/src/Nethermind/Nethermind.Runner/configs/goerli_archive.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/goerli_archive.cfg
@@ -7,7 +7,8 @@
     "MemoryHint": 768000000
   },
   "TxPool": {
-    "Size": 1024
+    "Size": 1024,
+    "BlobsSupport": "StorageWithReorgs"
   },
   "EthStats": {
     "Server": "wss://stats.goerli.net/api",


### PR DESCRIPTION
## Changes

- setting flag `BlobsSupport` to `StorageWithReorgs` in `goerli.cfg` and `goerli_archive.cfg`. It means that on goerli network 1) blob transactions will be supported and 2) stored in persistent db and 3) processed blob transactions would be stored and readded to the blob pool after chain reorganization
- add test for correct config values of `BlobsSupport` for various networks

## Types of changes

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: config adjustment

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No