### PR TITLE
Fix metric not working

### DIFF
--- a/src/Nethermind/Nethermind.Monitoring/NethermindKestrelMetricServer.cs
+++ b/src/Nethermind/Nethermind.Monitoring/NethermindKestrelMetricServer.cs
@@ -114,9 +114,9 @@ public sealed class NethermindKestrelMetricServer : MetricHandler
         }
 
         var webHost = builder.Build();
-        webHost.Start();
 
         // This is what changed
+        // webHost.Start();
         // return webHost.WaitForShutdownAsync(cancel);
 
         return webHost.RunAsync(cancel);


### PR DESCRIPTION
- I was so occupied at checking exit code that I forgot to check that the metric still works.
- That was embarressing.
- The exception that was silenced is server already started.

## Changes

- Fix metric not being served.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

- It serve it now.