### PR TITLE
Fixed FinalTotalDifficulty based on genesis

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/BlockTreeTests.cs
@@ -20,6 +20,7 @@ using Nethermind.Logging;
 using Nethermind.Merge.Plugin.Synchronization;
 using Nethermind.Serialization.Rlp;
 using Nethermind.Specs;
+using Nethermind.Specs.ChainSpecStyle;
 using Nethermind.Specs.Forks;
 using Nethermind.Synchronization.Blocks;
 using Nethermind.Synchronization.Peers;
@@ -76,7 +77,7 @@ public partial class BlockTreeTests
             .WithSpecProvider(specProvider)
             .OfChainLength(10)
             .TestObject;
-        PoSSwitcher poSSwitcher = new(new MergeConfig(), new SyncConfig(), new MemDb(), tree, specProvider, LimboLogs.Instance);
+        PoSSwitcher poSSwitcher = new(new MergeConfig(), new SyncConfig(), new MemDb(), tree, specProvider, new ChainSpec(), LimboLogs.Instance);
 
         Block? block8 = tree.FindBlock(8, BlockTreeLookupOptions.None);
         Assert.False(block8!.IsTerminalBlock(specProvider));
@@ -95,7 +96,7 @@ public partial class BlockTreeTests
             .WithSpecProvider(specProvider)
             .OfChainLength(10)
             .TestObject;
-        PoSSwitcher poSSwitcher = new(new MergeConfig(), new SyncConfig(), new MemDb(), tree, specProvider, LimboLogs.Instance);
+        PoSSwitcher poSSwitcher = new(new MergeConfig(), new SyncConfig(), new MemDb(), tree, specProvider, new ChainSpec(), LimboLogs.Instance);
 
         Block? block7 = tree.FindBlock(7, BlockTreeLookupOptions.None);
         Block newTerminalBlock = Build.A.Block
@@ -124,7 +125,7 @@ public partial class BlockTreeTests
             .OfChainLength(10)
             .TestObject;
 
-        PoSSwitcher poSSwitcher = new(new MergeConfig(), new SyncConfig(), new MemDb(), tree, specProvider, LimboLogs.Instance);
+        PoSSwitcher poSSwitcher = new(new MergeConfig(), new SyncConfig(), new MemDb(), tree, specProvider, new ChainSpec(), LimboLogs.Instance);
 
         Block? block8 = tree.FindBlock(8, BlockTreeLookupOptions.None);
         Assert.False(block8!.Header.IsTerminalBlock(specProvider));

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
@@ -33,6 +33,7 @@ using Nethermind.Merge.Plugin.GC;
 using Nethermind.Merge.Plugin.Handlers;
 using Nethermind.Merge.Plugin.Synchronization;
 using Nethermind.Specs;
+using Nethermind.Specs.ChainSpecStyle;
 using Nethermind.Specs.Forks;
 using Nethermind.State;
 using Nethermind.Synchronization.ParallelSync;
@@ -236,7 +237,7 @@ public partial class EngineModuleTests
         protected IBlockValidator CreateBlockValidator()
         {
             IBlockCacheService blockCacheService = new BlockCacheService();
-            PoSSwitcher = new PoSSwitcher(MergeConfig, SyncConfig.Default, new MemDb(), BlockTree, SpecProvider, LogManager);
+            PoSSwitcher = new PoSSwitcher(MergeConfig, SyncConfig.Default, new MemDb(), BlockTree, SpecProvider, new ChainSpec(), LogManager);
             SealValidator = new MergeSealValidator(PoSSwitcher, Always.Valid);
             HeaderValidator preMergeHeaderValidator = new HeaderValidator(BlockTree, SealValidator, SpecProvider, LogManager);
             HeaderValidator = new MergeHeaderValidator(PoSSwitcher, preMergeHeaderValidator, BlockTree, SpecProvider, SealValidator, LogManager);

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
@@ -20,6 +20,7 @@ using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Blockchain;
+using Nethermind.Core.Test.Builders;
 using Nethermind.Core.Timers;
 using Nethermind.Crypto;
 using Nethermind.Db;
@@ -237,7 +238,7 @@ public partial class EngineModuleTests
         protected IBlockValidator CreateBlockValidator()
         {
             IBlockCacheService blockCacheService = new BlockCacheService();
-            PoSSwitcher = new PoSSwitcher(MergeConfig, SyncConfig.Default, new MemDb(), BlockTree, SpecProvider, new ChainSpec(), LogManager);
+            PoSSwitcher = new PoSSwitcher(MergeConfig, SyncConfig.Default, new MemDb(), BlockTree, SpecProvider, new ChainSpec() { Genesis = Core.Test.Builders.Build.A.Block.WithDifficulty(0).TestObject }, LogManager);
             SealValidator = new MergeSealValidator(PoSSwitcher, Always.Valid);
             HeaderValidator preMergeHeaderValidator = new HeaderValidator(BlockTree, SealValidator, SpecProvider, LogManager);
             HeaderValidator = new MergeHeaderValidator(PoSSwitcher, preMergeHeaderValidator, BlockTree, SpecProvider, SealValidator, LogManager);

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/MergeRewardCalculatorTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/MergeRewardCalculatorTests.cs
@@ -10,6 +10,7 @@ using Nethermind.Db;
 using Nethermind.Logging;
 using Nethermind.Merge.Plugin.Handlers;
 using Nethermind.Specs;
+using Nethermind.Specs.ChainSpecStyle;
 using Nethermind.Specs.Forks;
 using NSubstitute;
 using NUnit.Framework;
@@ -156,7 +157,7 @@ namespace Nethermind.Merge.Plugin.Test
             specProvider.TerminalTotalDifficulty = 2;
             MergeConfig? mergeConfig = new() { };
             IBlockCacheService blockCacheService = new BlockCacheService();
-            return new PoSSwitcher(mergeConfig, new SyncConfig(), db, blockTree, specProvider, LimboLogs.Instance);
+            return new PoSSwitcher(mergeConfig, new SyncConfig(), db, blockTree, specProvider, new ChainSpec(), LimboLogs.Instance);
         }
 
     }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/PoSSwitcherTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/PoSSwitcherTests.cs
@@ -30,7 +30,7 @@ namespace Nethermind.Merge.Plugin.Test
         {
             UInt256? expectedTtd = null;
             IBlockTree blockTree = Substitute.For<IBlockTree>();
-            PoSSwitcher poSSwitcher = new(new MergeConfig(), new SyncConfig(), new MemDb(), blockTree, TestSpecProvider.Instance, LimboLogs.Instance);
+            PoSSwitcher poSSwitcher = new(new MergeConfig(), new SyncConfig(), new MemDb(), blockTree, TestSpecProvider.Instance, new ChainSpec(), LimboLogs.Instance);
 
             Assert.That(poSSwitcher.TerminalTotalDifficulty, Is.EqualTo(expectedTtd));
         }
@@ -45,7 +45,7 @@ namespace Nethermind.Merge.Plugin.Test
             ChainSpec chainSpec = loader.Load(File.ReadAllText(path));
 
             ChainSpecBasedSpecProvider specProvider = new(chainSpec);
-            PoSSwitcher poSSwitcher = new(new MergeConfig(), new SyncConfig(), new MemDb(), blockTree, specProvider, LimboLogs.Instance);
+            PoSSwitcher poSSwitcher = new(new MergeConfig(), new SyncConfig(), new MemDb(), blockTree, specProvider, new ChainSpec(), LimboLogs.Instance);
 
             Assert.That(poSSwitcher.TerminalTotalDifficulty, Is.EqualTo(expectedTtd));
             Assert.That(specProvider.MergeBlockNumber?.BlockNumber, Is.EqualTo(101));
@@ -93,7 +93,7 @@ namespace Nethermind.Merge.Plugin.Test
             IBlockTree blockTree = Substitute.For<IBlockTree>();
             TestSpecProvider specProvider = new(London.Instance);
             specProvider.UpdateMergeTransitionInfo(100, 20);
-            PoSSwitcher poSSwitcher = new(new MergeConfig() { TerminalTotalDifficulty = "340", TerminalBlockNumber = 2000 }, new SyncConfig(), new MemDb(), blockTree, specProvider, LimboLogs.Instance);
+            PoSSwitcher poSSwitcher = new(new MergeConfig() { TerminalTotalDifficulty = "340", TerminalBlockNumber = 2000 }, new SyncConfig(), new MemDb(), blockTree, specProvider, new ChainSpec(), LimboLogs.Instance);
 
             Assert.That(poSSwitcher.TerminalTotalDifficulty, Is.EqualTo(expectedTtd));
             Assert.That(specProvider.MergeBlockNumber?.BlockNumber, Is.EqualTo(2001));
@@ -106,7 +106,7 @@ namespace Nethermind.Merge.Plugin.Test
             IBlockTree blockTree = Substitute.For<IBlockTree>();
             TestSpecProvider specProvider = new(London.Instance);
             specProvider.UpdateMergeTransitionInfo(2001, expectedTtd);
-            PoSSwitcher poSSwitcher = new(new MergeConfig() { }, new SyncConfig(), new MemDb(), blockTree, specProvider, LimboLogs.Instance);
+            PoSSwitcher poSSwitcher = new(new MergeConfig() { }, new SyncConfig(), new MemDb(), blockTree, specProvider, new ChainSpec(), LimboLogs.Instance);
 
             Assert.That(poSSwitcher.TerminalTotalDifficulty, Is.EqualTo(expectedTtd));
             Assert.That(specProvider.MergeBlockNumber?.BlockNumber, Is.EqualTo(2001));
@@ -254,7 +254,7 @@ namespace Nethermind.Merge.Plugin.Test
             SyncConfig syncConfig = new();
             if (pivotTotalDifficulty != null)
                 syncConfig = new SyncConfig() { PivotTotalDifficulty = $"{(UInt256)pivotTotalDifficulty}" };
-            PoSSwitcher poSSwitcher = new PoSSwitcher(new MergeConfig(), syncConfig, new MemDb(), blockTree, specProvider, LimboLogs.Instance);
+            PoSSwitcher poSSwitcher = new PoSSwitcher(new MergeConfig(), syncConfig, new MemDb(), blockTree, specProvider, new ChainSpec() { Genesis = genesisBlock }, LimboLogs.Instance);
             if (expectedFinalTotalDifficulty != null)
                 poSSwitcher.FinalTotalDifficulty.Should().Be((UInt256)expectedFinalTotalDifficulty);
             else
@@ -266,7 +266,7 @@ namespace Nethermind.Merge.Plugin.Test
         {
             db ??= new MemDb();
             MergeConfig? mergeConfig = new() { };
-            return new PoSSwitcher(mergeConfig, new SyncConfig(), db, blockTree, specProvider ?? MainnetSpecProvider.Instance, LimboLogs.Instance);
+            return new PoSSwitcher(mergeConfig, new SyncConfig(), db, blockTree, specProvider ?? MainnetSpecProvider.Instance, new ChainSpec(), LimboLogs.Instance);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/BeaconHeadersSyncTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/BeaconHeadersSyncTests.cs
@@ -18,6 +18,7 @@ using Nethermind.Merge.Plugin.Handlers;
 using Nethermind.Merge.Plugin.InvalidChainTracker;
 using Nethermind.Merge.Plugin.Synchronization;
 using Nethermind.Specs;
+using Nethermind.Specs.ChainSpecStyle;
 using Nethermind.State.Repositories;
 using Nethermind.Synchronization;
 using Nethermind.Synchronization.FastBlocks;
@@ -71,7 +72,7 @@ public class BeaconHeadersSyncTests
 
         private PoSSwitcher? _poSSwitcher;
         public PoSSwitcher PoSSwitcher => _poSSwitcher ??= new(MergeConfig, SyncConfig, MetadataDb, BlockTree,
-                MainnetSpecProvider.Instance, LimboLogs.Instance);
+                MainnetSpecProvider.Instance, new ChainSpec(), LimboLogs.Instance);
 
         private IInvalidChainTracker? _invalidChainTracker;
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
@@ -92,6 +92,7 @@ public partial class MergePlugin : IConsensusWrapperPlugin, ISynchronizationPlug
                 _api.DbProvider.GetDb<IDb>(DbNames.Metadata),
                 _api.BlockTree,
                 _api.SpecProvider,
+                _api.ChainSpec,
                 _api.LogManager);
             _invalidChainTracker = new InvalidChainTracker.InvalidChainTracker(
                 _poSSwitcher,

--- a/src/Nethermind/Nethermind.Merge.Plugin/PoSSwitcher.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/PoSSwitcher.cs
@@ -12,6 +12,7 @@ using Nethermind.Core.Specs;
 using Nethermind.Db;
 using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
+using Nethermind.Specs.ChainSpecStyle;
 
 namespace Nethermind.Merge.Plugin
 {
@@ -39,6 +40,7 @@ namespace Nethermind.Merge.Plugin
         private readonly IDb _metadataDb;
         private readonly IBlockTree _blockTree;
         private readonly ISpecProvider _specProvider;
+        private readonly ChainSpec _chainSpec;
         private readonly ILogger _logger;
         private Hash256? _terminalBlockHash;
 
@@ -55,6 +57,7 @@ namespace Nethermind.Merge.Plugin
             IDb metadataDb,
             IBlockTree blockTree,
             ISpecProvider specProvider,
+            ChainSpec chainSpec,
             ILogManager logManager)
         {
             _mergeConfig = mergeConfig;
@@ -62,6 +65,7 @@ namespace Nethermind.Merge.Plugin
             _metadataDb = metadataDb;
             _blockTree = blockTree;
             _specProvider = specProvider;
+            _chainSpec = chainSpec;
             _logger = logManager.GetClassLogger();
 
             Initialize();
@@ -98,7 +102,9 @@ namespace Nethermind.Merge.Plugin
             }
             else
             {
-                UInt256 genesisDifficulty = _blockTree.Genesis?.Difficulty ?? 0;
+                if (_chainSpec?.Genesis == null) return;
+
+                UInt256 genesisDifficulty = _chainSpec.Genesis.Difficulty;
                 if (genesisDifficulty >= TerminalTotalDifficulty) // networks with the merge in genesis
                 {
                     _finalTotalDifficulty = genesisDifficulty;

--- a/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.Merge.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.Merge.cs
@@ -20,6 +20,7 @@ using Nethermind.Merge.Plugin;
 using Nethermind.Merge.Plugin.Synchronization;
 using Nethermind.Merge.Plugin.Test;
 using Nethermind.Specs;
+using Nethermind.Specs.ChainSpecStyle;
 using Nethermind.Stats;
 using Nethermind.Stats.Model;
 using Nethermind.Synchronization.Blocks;
@@ -456,6 +457,7 @@ public partial class BlockDownloaderTests
             MetadataDb,
             BlockTree,
             SpecProvider,
+            new ChainSpec(),
             LimboLogs.Instance);
 
         protected override IBetterPeerStrategy BetterPeerStrategy => _betterPeerStrategy ??=

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncServerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncServerTests.cs
@@ -22,6 +22,7 @@ using Nethermind.Merge.Plugin;
 using Nethermind.Merge.Plugin.Handlers;
 using Nethermind.Merge.Plugin.InvalidChainTracker;
 using Nethermind.Specs;
+using Nethermind.Specs.ChainSpecStyle;
 using Nethermind.Specs.Forks;
 using Nethermind.State;
 using Nethermind.Stats.Model;
@@ -180,6 +181,7 @@ namespace Nethermind.Synchronization.Test
                 new MemDb(),
                 localBlockTree,
                 testSpecProvider,
+                new ChainSpec(),
                 LimboLogs.Instance);
             HeaderValidator headerValidator = new(
                 localBlockTree,
@@ -389,6 +391,7 @@ namespace Nethermind.Synchronization.Test
                 new MemDb(),
                 localBlockTree,
                 testSpecProvider,
+                new ChainSpec(),
                 LimboLogs.Instance);
             MergeSealEngine sealEngine = new(
                 new SealEngine(new NethDevSealEngine(), Always.Valid),

--- a/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
@@ -324,7 +324,7 @@ namespace Nethermind.Synchronization.Test
                 {
                     mergeConfig.TerminalTotalDifficulty = UInt256.MaxValue.ToString(CultureInfo.InvariantCulture);
                 }
-                PoSSwitcher poSSwitcher = new(mergeConfig, syncConfig, dbProvider.MetadataDb, BlockTree,  new TestSingleReleaseSpecProvider(Constantinople.Instance), new ChainSpec(), _logManager);
+                PoSSwitcher poSSwitcher = new(mergeConfig, syncConfig, dbProvider.MetadataDb, BlockTree, new TestSingleReleaseSpecProvider(Constantinople.Instance), new ChainSpec(), _logManager);
                 IBeaconPivot beaconPivot = new BeaconPivot(syncConfig, dbProvider.MetadataDb, BlockTree, _logManager);
 
                 TrieStore trieStore = new(stateDb, LimboLogs.Instance);

--- a/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
@@ -324,7 +324,7 @@ namespace Nethermind.Synchronization.Test
                 {
                     mergeConfig.TerminalTotalDifficulty = UInt256.MaxValue.ToString(CultureInfo.InvariantCulture);
                 }
-                PoSSwitcher poSSwitcher = new(mergeConfig, syncConfig, dbProvider.MetadataDb, BlockTree, new TestSingleReleaseSpecProvider(Constantinople.Instance), _logManager);
+                PoSSwitcher poSSwitcher = new(mergeConfig, syncConfig, dbProvider.MetadataDb, BlockTree,  new TestSingleReleaseSpecProvider(Constantinople.Instance), new ChainSpec(), _logManager);
                 IBeaconPivot beaconPivot = new BeaconPivot(syncConfig, dbProvider.MetadataDb, BlockTree, _logManager);
 
                 TrieStore trieStore = new(stateDb, LimboLogs.Instance);


### PR DESCRIPTION
## Changes

Related PR: https://github.com/NethermindEth/nethermind/pull/6407

BlockTree.Genesis can be null if we haven't processed the block, so it is better to use _chainspec.Genesis.Difficulty

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

