### PR TITLE
Speed up trie node traversal

### DIFF
--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -53,6 +53,9 @@ namespace Nethermind.Trie
 
         private readonly bool _allowCommits;
 
+        private readonly bool _isTrace;
+        private readonly bool _isDebug;
+
         private Hash256 _rootHash = Keccak.EmptyTreeHash;
 
         public TrieNode? RootRef { get; set; }
@@ -116,6 +119,8 @@ namespace Nethermind.Trie
             ICappedArrayPool? bufferPool = null)
         {
             _logger = logManager?.GetClassLogger<PatriciaTree>() ?? throw new ArgumentNullException(nameof(logManager));
+            _isTrace = _logger.IsTrace;
+            _isDebug = _logger.IsDebug;
             TrieStore = trieStore ?? throw new ArgumentNullException(nameof(trieStore));
             _parallelBranches = parallelBranches;
             _allowCommits = allowCommits;
@@ -137,13 +142,12 @@ namespace Nethermind.Trie
         {
             if (_currentCommit is null)
             {
-                throw new InvalidAsynchronousStateException(
-                    $"{nameof(_currentCommit)} is NULL when calling {nameof(Commit)}");
+                ThrowInvalidAsynchronousStateException();
             }
 
             if (!_allowCommits)
             {
-                throw new TrieException("Commits are not allowed on this trie.");
+                ThrowTrieException();
             }
 
             if (RootRef is not null && RootRef.IsDirty)
@@ -151,7 +155,7 @@ namespace Nethermind.Trie
                 Commit(new NodeCommitInfo(RootRef), skipSelf: skipRoot);
                 while (_currentCommit.TryDequeue(out NodeCommitInfo node))
                 {
-                    if (_logger.IsTrace) _logger.Trace($"Committing {node} in {blockNumber}");
+                    if (_isTrace) Trace(blockNumber, node);
                     TrieStore.CommitNode(blockNumber, node, writeFlags: writeFlags);
                 }
 
@@ -161,21 +165,46 @@ namespace Nethermind.Trie
             }
 
             TrieStore.FinishBlockCommit(TrieType, blockNumber, RootRef, writeFlags);
-            if (_logger.IsDebug) _logger.Debug($"Finished committing block {blockNumber}");
+
+            if (_isDebug) Debug(blockNumber);
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            void Trace(long blockNumber, in NodeCommitInfo node)
+            {
+                _logger.Trace($"Committing {node} in {blockNumber}");
+            }
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            void Debug(long blockNumber)
+            {
+                _logger.Debug($"Finished committing block {blockNumber}");
+            }
+
+            [DoesNotReturn]
+            [StackTraceHidden]
+            static void ThrowInvalidAsynchronousStateException()
+            {
+                throw new InvalidAsynchronousStateException($"{nameof(_currentCommit)} is NULL when calling {nameof(Commit)}");
+            }
+
+            [DoesNotReturn]
+            [StackTraceHidden]
+            static void ThrowTrieException()
+            {
+                throw new TrieException("Commits are not allowed on this trie.");
+            }
         }
 
         private void Commit(NodeCommitInfo nodeCommitInfo, bool skipSelf = false)
         {
             if (_currentCommit is null)
             {
-                throw new InvalidAsynchronousStateException(
-                    $"{nameof(_currentCommit)} is NULL when calling {nameof(Commit)}");
+                ThrowInvalidAsynchronousStateException(nameof(_currentCommit));
             }
 
             if (_commitExceptions is null)
             {
-                throw new InvalidAsynchronousStateException(
-                    $"{nameof(_commitExceptions)} is NULL when calling {nameof(Commit)}");
+                ThrowInvalidAsynchronousStateException(nameof(_commitExceptions));
             }
 
             TrieNode node = nodeCommitInfo.Node;
@@ -192,20 +221,16 @@ namespace Nethermind.Trie
                         }
                         else
                         {
-                            if (_logger.IsTrace)
+                            if (_isTrace)
                             {
-                                TrieNode child = node.GetChild(TrieStore, i);
-                                if (child is not null)
-                                {
-                                    _logger.Trace($"Skipping commit of {child}");
-                                }
+                                Trace(node, i);
                             }
                         }
                     }
                 }
                 else
                 {
-                    List<NodeCommitInfo> nodesToCommit = new();
+                    List<NodeCommitInfo> nodesToCommit = new(16);
                     for (int i = 0; i < 16; i++)
                     {
                         if (node.IsChildDirty(i))
@@ -214,13 +239,9 @@ namespace Nethermind.Trie
                         }
                         else
                         {
-                            if (_logger.IsTrace)
+                            if (_isTrace)
                             {
-                                TrieNode child = node.GetChild(TrieStore, i);
-                                if (child is not null)
-                                {
-                                    _logger.Trace($"Skipping commit of {child}");
-                                }
+                                Trace(node, i);
                             }
                         }
                     }
@@ -242,7 +263,7 @@ namespace Nethermind.Trie
 
                         if (!_commitExceptions.IsEmpty)
                         {
-                            throw new AggregateException(_commitExceptions);
+                            ThrowAggregateExceptions();
                         }
                     }
                     else
@@ -259,7 +280,7 @@ namespace Nethermind.Trie
                 TrieNode extensionChild = node.GetChild(TrieStore, 0);
                 if (extensionChild is null)
                 {
-                    throw new InvalidOperationException("An attempt to store an extension without a child.");
+                    ThrowInvalidExtension();
                 }
 
                 if (extensionChild.IsDirty)
@@ -268,7 +289,7 @@ namespace Nethermind.Trie
                 }
                 else
                 {
-                    if (_logger.IsTrace) _logger.Trace($"Skipping commit of {extensionChild}");
+                    if (_isTrace) TraceExtensionSkip(extensionChild);
                 }
             }
 
@@ -284,7 +305,50 @@ namespace Nethermind.Trie
             }
             else
             {
-                if (_logger.IsTrace) _logger.Trace($"Skipping commit of an inlined {node}");
+                if (_isTrace) TraceSkipInlineNode(node);
+            }
+
+            [DoesNotReturn]
+            [StackTraceHidden]
+            void ThrowAggregateExceptions()
+            {
+                throw new AggregateException(_commitExceptions);
+            }
+
+            [DoesNotReturn]
+            [StackTraceHidden]
+            static void ThrowInvalidExtension()
+            {
+                throw new InvalidOperationException("An attempt to store an extension without a child.");
+            }
+
+            [DoesNotReturn]
+            [StackTraceHidden]
+            static void ThrowInvalidAsynchronousStateException(string param)
+            {
+                throw new InvalidAsynchronousStateException($"{param} is NULL when calling {nameof(Commit)}");
+            }
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            void Trace(TrieNode node, int i)
+            {
+                TrieNode child = node.GetChild(TrieStore, i);
+                if (child is not null)
+                {
+                    _logger.Trace($"Skipping commit of {child}");
+                }
+            }
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            void TraceExtensionSkip(TrieNode extensionChild)
+            {
+                _logger.Trace($"Skipping commit of {extensionChild}");
+            }
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            void TraceSkipInlineNode(TrieNode node)
+            {
+                _logger.Trace($"Skipping commit of an inlined {node}");
             }
         }
 
@@ -320,15 +384,11 @@ namespace Nethermind.Trie
                         : array = ArrayPool<byte>.Shared.Rent(nibblesCount))
                     [..nibblesCount]; // Slice to exact size;
 
-                try
-                {
-                    Nibbles.BytesToNibbleBytes(rawKey, nibbles);
-                    return Run(nibbles, nibblesCount, new CappedArray<byte>(Array.Empty<byte>()), false, startRootHash: rootHash).ToArray();
-                }
-                finally
-                {
-                    if (array is not null) ArrayPool<byte>.Shared.Return(array);
-                }
+                Nibbles.BytesToNibbleBytes(rawKey, nibbles);
+                var result = Run(nibbles, nibblesCount, new CappedArray<byte>(Array.Empty<byte>()), false, startRootHash: rootHash).ToArray();
+                if (array is not null) ArrayPool<byte>.Shared.Return(array);
+
+                return result;
             }
             catch (TrieException e)
             {
@@ -337,6 +397,7 @@ namespace Nethermind.Trie
             }
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void EnhanceException(ReadOnlySpan<byte> rawKey, ValueHash256 rootHash, TrieException baseException)
         {
             static TrieNodeException? GetTrieNodeException(TrieException? exception) =>
@@ -367,8 +428,7 @@ namespace Nethermind.Trie
         [DebuggerStepThrough]
         public virtual void Set(ReadOnlySpan<byte> rawKey, CappedArray<byte> value)
         {
-            if (_logger.IsTrace)
-                _logger.Trace($"{(value.Length == 0 ? $"Deleting {rawKey.ToHexString()}" : $"Setting {rawKey.ToHexString()} = {value.AsSpan().ToHexString()}")}");
+            if (_isTrace) Trace(in rawKey, in value);
 
             int nibblesCount = 2 * rawKey.Length;
             byte[] array = null;
@@ -377,14 +437,14 @@ namespace Nethermind.Trie
                     : array = ArrayPool<byte>.Shared.Rent(nibblesCount))
                 [..nibblesCount]; // Slice to exact size
 
-            try
+            Nibbles.BytesToNibbleBytes(rawKey, nibbles);
+            Run(nibbles, nibblesCount, value, true);
+
+            if (array is not null) ArrayPool<byte>.Shared.Return(array);
+
+            void Trace(in ReadOnlySpan<byte> rawKey, in CappedArray<byte> value)
             {
-                Nibbles.BytesToNibbleBytes(rawKey, nibbles);
-                Run(nibbles, nibblesCount, value, true);
-            }
-            finally
-            {
-                if (array is not null) ArrayPool<byte>.Shared.Return(array);
+                _logger.Trace($"{(value.Length == 0 ? $"Deleting {rawKey.ToHexString()}" : $"Setting {rawKey.ToHexString()} = {value.AsSpan().ToHexString()}")}");
             }
         }
 
@@ -404,7 +464,7 @@ namespace Nethermind.Trie
         {
             if (isUpdate && startRootHash is not null)
             {
-                throw new InvalidOperationException("Only reads can be done in parallel on the Patricia tree");
+                ThrowNonConcurrentWrites();
             }
 
 #if DEBUG
@@ -426,7 +486,7 @@ namespace Nethermind.Trie
             CappedArray<byte> result;
             if (startRootHash is not null)
             {
-                if (_logger.IsTrace) _logger.Trace($"Starting from {startRootHash} - {traverseContext.ToString()}");
+                if (_isTrace) TraceStart(startRootHash, in traverseContext);
                 TrieNode startNode = TrieStore.FindCachedOrUnknown(startRootHash);
                 ResolveNode(startNode, in traverseContext);
                 result = TraverseNode(startNode, in traverseContext);
@@ -438,23 +498,50 @@ namespace Nethermind.Trie
                 {
                     if (traverseContext.UpdateValue.IsNotNull)
                     {
-                        if (_logger.IsTrace) _logger.Trace($"Setting new leaf node with value {traverseContext.UpdateValue}");
+                        if (_isTrace) TraceNewLeaf(in traverseContext);
                         byte[] key = updatePath[..nibblesCount].ToArray();
                         RootRef = TrieNodeFactory.CreateLeaf(key, traverseContext.UpdateValue);
                     }
 
-                    if (_logger.IsTrace) _logger.Trace($"Keeping the root as null in {traverseContext.ToString()}");
+                    if (_isTrace) TraceNull(in traverseContext);
                     result = traverseContext.UpdateValue;
                 }
                 else
                 {
                     ResolveNode(RootRef, in traverseContext);
-                    if (_logger.IsTrace) _logger.Trace($"{traverseContext.ToString()}");
+                    if (_isTrace) TraceNode(in traverseContext);
                     result = TraverseNode(RootRef, in traverseContext);
                 }
             }
 
             return result;
+
+            [DoesNotReturn]
+            [StackTraceHidden]
+            static void ThrowNonConcurrentWrites()
+            {
+                throw new InvalidOperationException("Only reads can be done in parallel on the Patricia tree");
+            }
+
+            void TraceStart(Hash256 startRootHash, in TraverseContext traverseContext)
+            {
+                _logger.Trace($"Starting from {startRootHash} - {traverseContext.ToString()}");
+            }
+
+            void TraceNewLeaf(in TraverseContext traverseContext)
+            {
+                _logger.Trace($"Setting new leaf node with value {traverseContext.UpdateValue}");
+            }
+
+            void TraceNull(in TraverseContext traverseContext)
+            {
+                _logger.Trace($"Keeping the root as null in {traverseContext.ToString()}");
+            }
+
+            void TraceNode(in TraverseContext traverseContext)
+            {
+                _logger.Trace($"{traverseContext.ToString()}");
+            }
         }
 
         private void ResolveNode(TrieNode node, in TraverseContext traverseContext)
@@ -471,20 +558,36 @@ namespace Nethermind.Trie
 
         private CappedArray<byte> TraverseNode(TrieNode node, in TraverseContext traverseContext)
         {
-            if (_logger.IsTrace)
-                _logger.Trace(
-                    $"Traversing {node} to {(traverseContext.IsRead ? "READ" : traverseContext.IsDelete ? "DELETE" : "UPDATE")}");
+            if (_isTrace) Trace(node, traverseContext);
 
             return node.NodeType switch
             {
                 NodeType.Branch => TraverseBranch(node, in traverseContext),
                 NodeType.Extension => TraverseExtension(node, in traverseContext),
                 NodeType.Leaf => TraverseLeaf(node, in traverseContext),
-                NodeType.Unknown => throw new InvalidOperationException(
-                    $"Cannot traverse unresolved node {node.Keccak}"),
-                _ => throw new NotSupportedException(
-                    $"Unknown node type {node.NodeType}")
+                NodeType.Unknown => TraverseUnknown(node),
+                _ => ThrowNotSupported(node)
             };
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            void Trace(TrieNode node, in TraverseContext traverseContext)
+            {
+                _logger.Trace($"Traversing {node} to {(traverseContext.IsRead ? "READ" : traverseContext.IsDelete ? "DELETE" : "UPDATE")}");
+            }
+
+            [DoesNotReturn]
+            [StackTraceHidden]
+            static CappedArray<byte> TraverseUnknown(TrieNode node)
+            {
+                throw new InvalidOperationException($"Cannot traverse unresolved node {node.Keccak}");
+            }
+
+            [DoesNotReturn]
+            [StackTraceHidden]
+            static CappedArray<byte> ThrowNotSupported(TrieNode node)
+            {
+                throw new NotSupportedException($"Unknown node type {node.NodeType}");
+            }
         }
 
         private void ConnectNodes(TrieNode? node, in TraverseContext traverseContext)
@@ -525,7 +628,7 @@ namespace Nethermind.Trie
                             // which is not possible in the Ethereum protocol where keys are of equal lengths
                             // (it is possible in the more general trie definition)
                             TrieNode leafFromBranch = TrieNodeFactory.CreateLeaf(Array.Empty<byte>(), node.Value);
-                            if (_logger.IsTrace) _logger.Trace($"Converting {node} into {leafFromBranch}");
+                            if (_isTrace) _logger.Trace($"Converting {node} into {leafFromBranch}");
                             nextNode = leafFromBranch;
                         }
                         else
@@ -567,7 +670,7 @@ namespace Nethermind.Trie
                             {
                                 TrieNode extensionFromBranch =
                                     TrieNodeFactory.CreateExtension(new[] { (byte)childNodeIndex }, childNode);
-                                if (_logger.IsTrace)
+                                if (_isTrace)
                                     _logger.Trace(
                                         $"Extending child {childNodeIndex} {childNode} of {node} into {extensionFromBranch}");
 
@@ -603,7 +706,7 @@ namespace Nethermind.Trie
                                 byte[] newKey = Bytes.Concat((byte)childNodeIndex, childNode.Key);
 
                                 TrieNode extendedExtension = childNode.CloneWithChangedKey(newKey);
-                                if (_logger.IsTrace)
+                                if (_isTrace)
                                     _logger.Trace(
                                         $"Extending child {childNodeIndex} {childNode} of {node} into {extendedExtension}");
                                 nextNode = extendedExtension;
@@ -613,14 +716,14 @@ namespace Nethermind.Trie
                                 byte[] newKey = Bytes.Concat((byte)childNodeIndex, childNode.Key);
 
                                 TrieNode extendedLeaf = childNode.CloneWithChangedKey(newKey);
-                                if (_logger.IsTrace)
+                                if (_isTrace)
                                     _logger.Trace(
                                         $"Extending branch child {childNodeIndex} {childNode} into {extendedLeaf}");
 
-                                if (_logger.IsTrace) _logger.Trace($"Decrementing ref on a leaf extended up to eat a branch {childNode}");
+                                if (_isTrace) _logger.Trace($"Decrementing ref on a leaf extended up to eat a branch {childNode}");
                                 if (node.IsSealed)
                                 {
-                                    if (_logger.IsTrace) _logger.Trace($"Decrementing ref on a branch replaced by a leaf {node}");
+                                    if (_isTrace) _logger.Trace($"Decrementing ref on a branch replaced by a leaf {node}");
                                 }
 
                                 nextNode = extendedLeaf;
@@ -644,7 +747,7 @@ namespace Nethermind.Trie
                     {
                         byte[] newKey = Bytes.Concat(node.Key, nextNode.Key);
                         TrieNode extendedLeaf = nextNode.CloneWithChangedKey(newKey);
-                        if (_logger.IsTrace)
+                        if (_isTrace)
                             _logger.Trace($"Combining {node} and {nextNode} into {extendedLeaf}");
 
                         nextNode = extendedLeaf;
@@ -678,7 +781,7 @@ namespace Nethermind.Trie
 
                         byte[] newKey = Bytes.Concat(node.Key, nextNode.Key);
                         TrieNode extendedExtension = nextNode.CloneWithChangedKey(newKey);
-                        if (_logger.IsTrace)
+                        if (_isTrace)
                             _logger.Trace($"Combining {node} and {nextNode} into {extendedExtension}");
 
                         nextNode = extendedExtension;
@@ -690,7 +793,7 @@ namespace Nethermind.Trie
                             node = node.Clone();
                         }
 
-                        if (_logger.IsTrace) _logger.Trace($"Connecting {node} with {nextNode}");
+                        if (_isTrace) _logger.Trace($"Connecting {node} with {nextNode}");
                         node.SetChild(0, nextNode);
                         nextNode = node;
                     }
@@ -815,7 +918,7 @@ namespace Nethermind.Trie
                 longerPathValue = node.Value;
             }
 
-            int extensionLength = FindCommonPrefixLength(shorterPath, longerPath);
+            int extensionLength = shorterPath.CommonPrefixLength(longerPath);
             if (extensionLength == shorterPath.Length && extensionLength == longerPath.Length)
             {
                 if (traverseContext.IsRead)
@@ -893,7 +996,7 @@ namespace Nethermind.Trie
             TrieNode originalNode = node;
             ReadOnlySpan<byte> remaining = traverseContext.GetRemainingUpdatePath();
 
-            int extensionLength = FindCommonPrefixLength(remaining, node.Key);
+            int extensionLength = remaining.CommonPrefixLength(node.Key);
             if (extensionLength == node.Key.Length)
             {
                 if (traverseContext.IsUpdate)
@@ -976,18 +1079,6 @@ namespace Nethermind.Trie
             // in calling method even if not used
             TraverseContext newContext = traverseContext.WithNewIndex(traverseContext.CurrentIndex + extensionLength);
             return TraverseNode(next, in newContext);
-        }
-
-        private static int FindCommonPrefixLength(ReadOnlySpan<byte> shorterPath, ReadOnlySpan<byte> longerPath)
-        {
-            int commonPrefixLength = 0;
-            int maxLength = Math.Min(shorterPath.Length, longerPath.Length);
-            for (int i = 0; i < maxLength && shorterPath[i] == longerPath[i]; i++, commonPrefixLength++)
-            {
-                // just finding the common part of the path
-            }
-
-            return commonPrefixLength;
         }
 
         private readonly ref struct TraverseContext

--- a/src/Nethermind/Nethermind.Trie/TrieNode.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.cs
@@ -3,8 +3,9 @@
 
 using System;
 using System.ComponentModel;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
-using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Buffers;
 using Nethermind.Core.Crypto;
@@ -73,13 +74,19 @@ namespace Nethermind.Trie
             {
                 if (IsSealed)
                 {
-                    throw new InvalidOperationException(
-                        $"{nameof(TrieNode)} {this} is already sealed when setting {nameof(Key)}.");
+                    ThrowAlreadySealed();
                 }
 
                 InitData();
                 _data![0] = value;
                 Keccak = null;
+
+                [DoesNotReturn]
+                [StackTraceHidden]
+                void ThrowAlreadySealed()
+                {
+                    throw new InvalidOperationException($"{nameof(TrieNode)} {this} is already sealed when setting {nameof(Key)}.");
+                }
             }
         }
 
@@ -144,8 +151,7 @@ namespace Nethermind.Trie
             {
                 if (IsSealed)
                 {
-                    throw new InvalidOperationException(
-                        $"{nameof(TrieNode)} {this} is already sealed when setting {nameof(Value)}.");
+                    ThrowAlreadySealed();
                 }
 
                 InitData();
@@ -170,6 +176,13 @@ namespace Nethermind.Trie
                 }
 
                 _data![IsLeaf ? 1 : BranchesCount] = value;
+
+                [DoesNotReturn]
+                [StackTraceHidden]
+                void ThrowAlreadySealed()
+                {
+                    throw new InvalidOperationException($"{nameof(TrieNode)} {this} is already sealed when setting {nameof(Value)}.");
+                }
             }
         }
 
@@ -262,10 +275,17 @@ namespace Nethermind.Trie
         {
             if (IsSealed)
             {
-                throw new InvalidOperationException($"{nameof(TrieNode)} {this} is already sealed.");
+                ThrowAlreadySealed();
             }
 
             IsDirty = false;
+
+            [DoesNotReturn]
+            [StackTraceHidden]
+            void ThrowAlreadySealed()
+            {
+                throw new InvalidOperationException($"{nameof(TrieNode)} {this} is already sealed.");
+            }
         }
 
         /// <summary>
@@ -281,7 +301,7 @@ namespace Nethermind.Trie
                     {
                         if (Keccak is null)
                         {
-                            throw new TrieException("Unable to resolve node without Keccak");
+                            ThrowMissingKeccak();
                         }
 
                         FullRlp = tree.LoadRlp(Keccak, readFlags);
@@ -289,7 +309,7 @@ namespace Nethermind.Trie
 
                         if (FullRlp.IsNull)
                         {
-                            throw new TrieException($"Trie returned a NULL RLP for node {Keccak}");
+                            ThrowNullRlp();
                         }
                     }
                 }
@@ -301,15 +321,51 @@ namespace Nethermind.Trie
                 _rlpStream = FullRlp.AsRlpStream();
                 if (_rlpStream is null)
                 {
-                    throw new InvalidAsynchronousStateException($"{nameof(_rlpStream)} is null when {nameof(NodeType)} is {NodeType}");
+                    ThrowInvalidStateException();
+                    return;
                 }
 
                 if (!DecodeRlp(bufferPool, out int numberOfItems))
                 {
-                    throw new TrieNodeException($"Unexpected number of items = {numberOfItems} when decoding a node from RLP ({FullRlp.AsSpan().ToHexString()})", Keccak ?? Nethermind.Core.Crypto.Keccak.Zero);
+                    ThrowUnexpectedNumberOfItems(numberOfItems);
                 }
             }
             catch (RlpException rlpException)
+            {
+                ThrowDecodingError(rlpException);
+            }
+
+            [DoesNotReturn]
+            [StackTraceHidden]
+            static void ThrowMissingKeccak()
+            {
+                throw new TrieException("Unable to resolve node without Keccak");
+            }
+
+            [DoesNotReturn]
+            [StackTraceHidden]
+            void ThrowNullRlp()
+            {
+                throw new TrieException($"Trie returned a NULL RLP for node {Keccak}");
+            }
+
+            [DoesNotReturn]
+            [StackTraceHidden]
+            void ThrowInvalidStateException()
+            {
+                throw new InvalidAsynchronousStateException($"{nameof(_rlpStream)} is null when {nameof(NodeType)} is {NodeType}");
+            }
+
+            [DoesNotReturn]
+            [StackTraceHidden]
+            void ThrowUnexpectedNumberOfItems(int numberOfItems)
+            {
+                throw new TrieNodeException($"Unexpected number of items = {numberOfItems} when decoding a node from RLP ({FullRlp.AsSpan().ToHexString()})", Keccak ?? Nethermind.Core.Crypto.Keccak.Zero);
+            }
+
+            [DoesNotReturn]
+            [StackTraceHidden]
+            void ThrowDecodingError(RlpException rlpException)
             {
                 throw new TrieNodeException($"Error when decoding node {Keccak}", Keccak ?? Nethermind.Core.Crypto.Keccak.Zero, rlpException);
             }
@@ -348,7 +404,7 @@ namespace Nethermind.Trie
                 _rlpStream = FullRlp.AsRlpStream();
                 if (_rlpStream is null)
                 {
-                    throw new InvalidAsynchronousStateException($"{nameof(_rlpStream)} is null when {nameof(NodeType)} is {NodeType}");
+                    ThrowInvalidStateException();
                 }
 
                 return DecodeRlp(bufferPool, out _);
@@ -356,6 +412,13 @@ namespace Nethermind.Trie
             catch (RlpException)
             {
                 return false;
+            }
+
+            [DoesNotReturn]
+            [StackTraceHidden]
+            void ThrowInvalidStateException()
+            {
+                throw new InvalidAsynchronousStateException($"{nameof(_rlpStream)} is null when {nameof(NodeType)} is {NodeType}");
             }
         }
 
@@ -529,8 +592,7 @@ namespace Nethermind.Trie
         {
             if (!IsBranch)
             {
-                throw new TrieException(
-                    "An attempt was made to ask about whether a child is null on a non-branch node.");
+                ThrowNotABranch();
             }
 
             if (_rlpStream is not null && _data?[i] is null)
@@ -540,6 +602,13 @@ namespace Nethermind.Trie
             }
 
             return _data?[i] is null || ReferenceEquals(_data[i], _nullNode);
+
+            [DoesNotReturn]
+            [StackTraceHidden]
+            static void ThrowNotABranch()
+            {
+                throw new TrieException("An attempt was made to ask about whether a child is null on a non-branch node.");
+            }
         }
 
         public bool IsChildDirty(int i)
@@ -598,9 +667,7 @@ namespace Nethermind.Trie
             {
                 // we expect this to happen as a Trie traversal error (please see the stack trace above)
                 // we need to investigate this case when it happens again
-                bool isKeccakCalculated = Keccak is not null && FullRlp.IsNotNull;
-                bool isKeccakCorrect = isKeccakCalculated && Keccak == Nethermind.Core.Crypto.Keccak.Compute(FullRlp.AsSpan());
-                throw new TrieException($"Unexpected type found at position {childIndex} of {this} with {nameof(_data)} of length {_data?.Length}. Expected a {nameof(TrieNode)} or {nameof(Keccak)} but found {childOrRef?.GetType()} with a value of {childOrRef}. Keccak calculated? : {isKeccakCalculated}; Keccak correct? : {isKeccakCorrect}");
+                ThrowUnexpectedTypeException(childIndex, childOrRef);
             }
 
             // pruning trick so we never store long persisted paths
@@ -610,6 +677,15 @@ namespace Nethermind.Trie
             }
 
             return child;
+
+            [DoesNotReturn]
+            [StackTraceHidden]
+            void ThrowUnexpectedTypeException(int childIndex, object childOrRef)
+            {
+                bool isKeccakCalculated = Keccak is not null && FullRlp.IsNotNull;
+                bool isKeccakCorrect = isKeccakCalculated && Keccak == Nethermind.Core.Crypto.Keccak.Compute(FullRlp.AsSpan());
+                throw new TrieException($"Unexpected type found at position {childIndex} of {this} with {nameof(_data)} of length {_data?.Length}. Expected a {nameof(TrieNode)} or {nameof(Keccak)} but found {childOrRef?.GetType()} with a value of {childOrRef}. Keccak calculated? : {isKeccakCalculated}; Keccak correct? : {isKeccakCorrect}");
+            }
         }
 
         public void ReplaceChildRef(int i, TrieNode child)
@@ -628,14 +704,20 @@ namespace Nethermind.Trie
         {
             if (IsSealed)
             {
-                throw new InvalidOperationException(
-                    $"{nameof(TrieNode)} {this} is already sealed when setting a child.");
+                ThrowAlreadySealed();
             }
 
             InitData();
             int index = IsExtension ? i + 1 : i;
             _data![index] = node ?? _nullNode;
             Keccak = null;
+
+            [DoesNotReturn]
+            [StackTraceHidden]
+            void ThrowAlreadySealed()
+            {
+                throw new InvalidOperationException($"{nameof(TrieNode)} {this} is already sealed when setting a child.");
+            }
         }
 
         public long GetMemorySize(bool recursive)
@@ -857,8 +939,6 @@ namespace Nethermind.Trie
             // }
         }
 
-        #region private
-
         private bool TryResolveStorageRoot(ITrieNodeResolver resolver, out TrieNode? storageRoot)
         {
             bool hasStorage = false;
@@ -891,8 +971,8 @@ namespace Nethermind.Trie
                 switch (NodeType)
                 {
                     case NodeType.Unknown:
-                        throw new InvalidOperationException(
-                            $"Cannot resolve children of an {nameof(NodeType.Unknown)} node");
+                        ThrowCannotResolveException();
+                        return;
                     case NodeType.Branch:
                         _data = new object[AllowBranchValues ? BranchesCount + 1 : BranchesCount];
                         break;
@@ -900,6 +980,13 @@ namespace Nethermind.Trie
                         _data = new object[2];
                         break;
                 }
+            }
+
+            [DoesNotReturn]
+            [StackTraceHidden]
+            static void ThrowCannotResolveException()
+            {
+                throw new InvalidOperationException($"Cannot resolve children of an {nameof(NodeType.Unknown)} node");
             }
         }
 
@@ -999,7 +1086,7 @@ namespace Nethermind.Trie
                 {
                     if (!childNode.IsPersisted)
                     {
-                        throw new InvalidOperationException("Cannot unresolve a child that is not persisted yet.");
+                        ThrowNotPersisted();
                     }
                     else if (childNode.Keccak is not null) // if not by value node
                     {
@@ -1007,8 +1094,13 @@ namespace Nethermind.Trie
                     }
                 }
             }
-        }
 
-        #endregion
+            [DoesNotReturn]
+            [StackTraceHidden]
+            static void ThrowNotPersisted()
+            {
+                throw new InvalidOperationException("Cannot unresolve a child that is not persisted yet.");
+            }
+        }
     }
 }


### PR DESCRIPTION
While individually low impact these functions are called a huge amount so it does add up. 

## Changes

- The Jit sees a method as an atomic unit that can't be subdivided, and inlining and optimization choices, variable allocation/reservation are taken at that level, so move infrequent code out to other methods. This also makes the hot code more dense and compact in the cpu caches.
- Move the throws and exception creation out to local functions
- Store the `_logger.IsTrace` and `_logger.IsDebug` in a `bool` field in class so its not always a virtual call to check if is disabled
- Move any tracing or debug logging out to local function.
- Use runtime Span.CommonPrefixLength rather than uninteresting custom implementation
- Don't introduce try/finally just to return ArrayPool.Shared arrays, it will happily just reallocate which will be dwarfed by the cost of the exception being thrown. So no special handling is needed.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No