### PR TITLE
Perf/Live Pruning

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/FullPruning/PruningTriggerPersistenceStrategy.cs
+++ b/src/Nethermind/Nethermind.Blockchain/FullPruning/PruningTriggerPersistenceStrategy.cs
@@ -67,6 +67,8 @@ public class PruningTriggerPersistenceStrategy : IPersistenceStrategy, IDisposab
         return inPruning;
     }
 
+    public bool IsFullPruning => _inPruning != 0;
+
     /// <inheritdoc/>
     public void Dispose()
     {

--- a/src/Nethermind/Nethermind.Db/IPruningConfig.cs
+++ b/src/Nethermind/Nethermind.Db/IPruningConfig.cs
@@ -92,4 +92,7 @@ public interface IPruningConfig : IConfig
 
     [ConfigItem(Description = "Whether to enables available disk space check.", DefaultValue = "true")]
     bool AvailableSpaceCheckEnabled { get; set; }
+
+    [ConfigItem(Description = "[TECHNICAL] Number of past persisted keys to keep track off for possible pruning.", DefaultValue = "1000000")]
+    int TrackedPastKeyCount { get; set; }
 }

--- a/src/Nethermind/Nethermind.Db/MemDb.cs
+++ b/src/Nethermind/Nethermind.Db/MemDb.cs
@@ -141,6 +141,11 @@ namespace Nethermind.Db
             }
 
             WritesCount++;
+            if (value == null)
+            {
+                _db.TryRemove(key, out _);
+                return;
+            }
             _db[key] = value;
         }
     }

--- a/src/Nethermind/Nethermind.Db/PruningConfig.cs
+++ b/src/Nethermind/Nethermind.Db/PruningConfig.cs
@@ -32,5 +32,6 @@ namespace Nethermind.Db
         public int FullPruningMinimumDelayHours { get; set; } = 240;
         public FullPruningCompletionBehavior FullPruningCompletionBehavior { get; set; } = FullPruningCompletionBehavior.None;
         public bool AvailableSpaceCheckEnabled { get; set; } = true;
+        public int TrackedPastKeyCount { get; set; } = 1000000;
     }
 }

--- a/src/Nethermind/Nethermind.Init/InitializeStateDb.cs
+++ b/src/Nethermind/Nethermind.Init/InitializeStateDb.cs
@@ -90,7 +90,8 @@ public class InitializeStateDb : IStep
                 persistenceStrategy = persistenceStrategy.Or(triggerPersistenceStrategy);
             }
 
-            pruningStrategy = Prune.WhenCacheReaches(pruningConfig.CacheMb.MB()); // TODO: memory hint should define this
+            pruningStrategy = Prune.WhenCacheReaches(pruningConfig.CacheMb.MB()) // TODO: memory hint should define this
+                .TrackingPastKeys(pruningConfig.TrackedPastKeyCount);
         }
         else
         {

--- a/src/Nethermind/Nethermind.Trie.Test/Pruning/TestPruningStrategy.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/Pruning/TestPruningStrategy.cs
@@ -8,10 +8,13 @@ namespace Nethermind.Trie.Test.Pruning
     public class TestPruningStrategy : IPruningStrategy
     {
         private readonly bool _pruningEnabled;
-        public TestPruningStrategy(bool pruningEnabled, bool shouldPrune = false)
+        private readonly int _trackedPastKeyCount;
+
+        public TestPruningStrategy(bool pruningEnabled, bool shouldPrune = false, int trackedPastKeyCount = 0)
         {
             _pruningEnabled = pruningEnabled;
             ShouldPruneEnabled = shouldPrune;
+            _trackedPastKeyCount = trackedPastKeyCount;
         }
 
         public bool PruningEnabled => _pruningEnabled;
@@ -27,5 +30,7 @@ namespace Nethermind.Trie.Test.Pruning
 
             return false;
         }
+
+        public int TrackedPastKeyCount => _trackedPastKeyCount;
     }
 }

--- a/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
@@ -35,12 +35,22 @@ namespace Nethermind.Trie.Test.Pruning
             _scheme = scheme;
         }
 
-        public TrieStore CreateTrieStore(IPruningStrategy? pruningStrategy = null, IKeyValueStoreWithBatching? kvStore = null, IPersistenceStrategy? persistenceStrategy = null)
+        private TrieStore CreateTrieStore(
+            IPruningStrategy? pruningStrategy = null,
+            IKeyValueStoreWithBatching? kvStore = null,
+            IPersistenceStrategy? persistenceStrategy = null,
+            long? reorgDepthOverride = null
+        )
         {
             pruningStrategy ??= No.Pruning;
             kvStore ??= new TestMemDb();
             persistenceStrategy ??= No.Persistence;
-            return new(new NodeStorage(kvStore, _scheme, requirePath: _scheme == INodeStorage.KeyScheme.HalfPath), pruningStrategy, persistenceStrategy, _logManager);
+            return new(
+                new NodeStorage(kvStore, _scheme, requirePath: _scheme == INodeStorage.KeyScheme.HalfPath),
+                pruningStrategy,
+                persistenceStrategy,
+                _logManager,
+                reorgDepthOverride: reorgDepthOverride);
         }
 
         [SetUp]
@@ -810,6 +820,65 @@ namespace Nethermind.Trie.Test.Pruning
             stateTree.Set(TestItem.AddressA, account);
             stateTree.Commit(0);
             trieStore.HasRoot(stateTree.RootHash).Should().BeTrue();
+        }
+
+        public async Task Will_RemovePastKeys_OnSnapshot()
+        {
+            MemDb memDb = new();
+
+            using TrieStore fullTrieStore = CreateTrieStore(
+                kvStore: memDb,
+                pruningStrategy: new TestPruningStrategy(true, true, 100000),
+                persistenceStrategy: No.Persistence,
+                reorgDepthOverride: 2);
+
+            IScopedTrieStore trieStore = fullTrieStore.GetTrieStore(null);
+
+            for (int i = 0; i < 64; i++)
+            {
+                TrieNode node = new(NodeType.Leaf, TestItem.Keccaks[i], new byte[2]);
+                trieStore.CommitNode(i, new NodeCommitInfo(node, TreePath.Empty));
+                trieStore.FinishBlockCommit(TrieType.State, i, node);
+
+                // Pruning is done in background
+                await Task.Delay(TimeSpan.FromMilliseconds(10));
+            }
+
+            if (_scheme == INodeStorage.KeyScheme.Hash)
+            {
+                memDb.Count.Should().NotBe(1);
+            }
+            else
+            {
+                memDb.Count.Should().Be(1);
+            }
+        }
+
+        [Test]
+        public async Task Will_NotRemove_ReCommittedNode()
+        {
+            MemDb memDb = new();
+
+            using TrieStore fullTrieStore = CreateTrieStore(
+                kvStore: memDb,
+                pruningStrategy: new TestPruningStrategy(true, true, 100000),
+                persistenceStrategy: No.Persistence,
+                reorgDepthOverride: 2);
+
+            IScopedTrieStore trieStore = fullTrieStore.GetTrieStore(null);
+
+            for (int i = 0; i < 64; i++)
+            {
+                TrieNode node = new(NodeType.Leaf, TestItem.Keccaks[i % 4], new byte[2]);
+                trieStore.CommitNode(i, new NodeCommitInfo(node, TreePath.Empty));
+                node = trieStore.FindCachedOrUnknown(TreePath.Empty, node.Keccak);
+                trieStore.FinishBlockCommit(TrieType.State, i, node);
+
+                // Pruning is done in background
+                await Task.Delay(TimeSpan.FromMilliseconds(10));
+            }
+
+            memDb.Count.Should().Be(4);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Trie.Test/TinyTreePathTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TinyTreePathTests.cs
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using FluentAssertions;
+using Nethermind.Core.Crypto;
+using NUnit.Framework;
+
+namespace Nethermind.Trie.Test;
+
+public class TinyTreePathTests
+{
+    [Test]
+    public void Should_ConvertFromAndToTreePath()
+    {
+        TreePath path = new TreePath(new ValueHash256("0123456789abcd00000000000000000000000000000000000000000000000000"), 14);
+
+        TinyTreePath tinyPath = new TinyTreePath(path);
+
+        tinyPath.ToTreePath().Should().Be(path);
+    }
+
+    [Test]
+    public void When_PathIsTooLong_Should_Throw()
+    {
+        TreePath path = new TreePath(new ValueHash256("0123456789000000000000000000000000000000000000000000000000000000"), 15);
+
+        Action act = () => new TinyTreePath(path);
+        act.Should().Throw<InvalidOperationException>();
+    }
+}
+

--- a/src/Nethermind/Nethermind.Trie/INodeStorage.cs
+++ b/src/Nethermind/Nethermind.Trie/INodeStorage.cs
@@ -44,5 +44,6 @@ public interface INodeStorage
     public interface WriteBatch : IDisposable
     {
         void Set(Hash256? address, in TreePath path, in ValueHash256 currentNodeKeccak, byte[] toArray, WriteFlags writeFlags);
+        void Remove(Hash256? address, in TreePath path, in ValueHash256 currentNodeKeccak);
     }
 }

--- a/src/Nethermind/Nethermind.Trie/NodeStorage.cs
+++ b/src/Nethermind/Nethermind.Trie/NodeStorage.cs
@@ -220,5 +220,11 @@ public class NodeStorage : INodeStorage
 
             _writeBatch.Set(_nodeStorage.GetExpectedPath(stackalloc byte[StoragePathLength], address, path, keccak), toArray, writeFlags);
         }
+
+        public void Remove(Hash256? address, in TreePath path, in ValueHash256 keccak)
+        {
+            // Only delete half path key. DO NOT delete hash based key.
+            _writeBatch.Remove(GetHalfPathNodeStoragePathSpan(stackalloc byte[StoragePathLength], address, path, keccak));
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/Archive.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/Archive.cs
@@ -13,5 +13,7 @@ namespace Nethermind.Trie.Pruning
         {
             return true;
         }
+
+        public bool IsFullPruning => false;
     }
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/CompositePersistenceStrategy.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/CompositePersistenceStrategy.cs
@@ -22,4 +22,5 @@ public class CompositePersistenceStrategy : IPersistenceStrategy
     }
 
     public bool ShouldPersist(long blockNumber) => _strategies.Any(strategy => strategy.ShouldPersist(blockNumber));
+    public bool IsFullPruning => _strategies.Any(strategy => strategy.IsFullPruning);
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/IPersistenceStrategy.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/IPersistenceStrategy.cs
@@ -6,5 +6,6 @@ namespace Nethermind.Trie.Pruning
     public interface IPersistenceStrategy
     {
         bool ShouldPersist(long blockNumber);
+        bool IsFullPruning { get; }
     }
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/ISnapshotStrategy.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ISnapshotStrategy.cs
@@ -7,5 +7,6 @@ namespace Nethermind.Trie.Pruning
     {
         bool PruningEnabled { get; }
         bool ShouldPrune(in long currentMemory);
+        int TrackedPastKeyCount { get; }
     }
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/IntervalSnapshotting.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/IntervalSnapshotting.cs
@@ -16,5 +16,7 @@ namespace Nethermind.Trie.Pruning
         {
             return blockNumber % _snapshotInterval == 0;
         }
+
+        public bool IsFullPruning => false;
     }
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/MemoryLimit.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/MemoryLimit.cs
@@ -21,5 +21,7 @@ namespace Nethermind.Trie.Pruning
         {
             return PruningEnabled && currentMemory >= _memoryLimit;
         }
+
+        public int TrackedPastKeyCount => 0;
     }
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/NoPersistence.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/NoPersistence.cs
@@ -13,5 +13,7 @@ namespace Nethermind.Trie.Pruning
         {
             return false;
         }
+
+        public bool IsFullPruning => false;
     }
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/NoPruning.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/NoPruning.cs
@@ -15,5 +15,7 @@ namespace Nethermind.Trie.Pruning
         {
             return false;
         }
+
+        public int TrackedPastKeyCount => 0;
     }
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/Prune.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/Prune.cs
@@ -7,5 +7,10 @@ namespace Nethermind.Trie.Pruning
     {
         public static IPruningStrategy WhenCacheReaches(long sizeInBytes)
             => new MemoryLimit(sizeInBytes);
+
+        public static IPruningStrategy TrackingPastKeys(this IPruningStrategy baseStrategy, int trackedPastKeyCount)
+            => trackedPastKeyCount <= 0
+                ? baseStrategy
+                : new TrackedPastKeyCountStrategy(baseStrategy, trackedPastKeyCount);
     }
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/TinyTreePath.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TinyTreePath.cs
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Nethermind.Core.Crypto;
+
+namespace Nethermind.Trie;
+
+/// <summary>
+/// Like TreePath, but tiny. Fit in 8 byte, like a long. Can only represent 14 nibble.
+/// </summary>
+public struct TinyTreePath
+{
+    public const int MaxNibbleLength = 14;
+
+    long _data;
+
+    // Eh.. readonly?
+    private Span<byte> AsSpan => MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref _data, 1));
+
+    public TinyTreePath(in TreePath path)
+    {
+        if (path.Length > MaxNibbleLength) throw new InvalidOperationException("Unable to represent more than 14 nibble");
+        Span<byte> pathSpan = path.Path.BytesAsSpan;
+        Span<byte> selfSpan = AsSpan;
+        pathSpan[..7].CopyTo(selfSpan);
+        selfSpan[7] = (byte)path.Length;
+    }
+
+    public int Length => AsSpan[7];
+
+    public TreePath ToTreePath()
+    {
+        ValueHash256 rawPath = Keccak.Zero;
+        Span<byte> pathSpan = rawPath.BytesAsSpan;
+        Span<byte> selfSpan = AsSpan;
+        selfSpan[..7].CopyTo(pathSpan);
+
+        return new TreePath(rawPath, selfSpan[7]);
+    }
+}

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrackedPastKeyCountStrategy.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrackedPastKeyCountStrategy.cs
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.Trie.Pruning;
+
+public class TrackedPastKeyCountStrategy : IPruningStrategy
+{
+    private IPruningStrategy _baseStrategy;
+    private readonly int _trackedPastKeyCount;
+    public bool PruningEnabled => _baseStrategy.PruningEnabled;
+
+    public TrackedPastKeyCountStrategy(IPruningStrategy baseStrategy, int trackedPastKeyCount)
+    {
+        _baseStrategy = baseStrategy;
+        _trackedPastKeyCount = trackedPastKeyCount;
+    }
+
+    public bool ShouldPrune(in long currentMemory)
+    {
+        return _baseStrategy.ShouldPrune(in currentMemory);
+    }
+
+    public int TrackedPastKeyCount => _trackedPastKeyCount;
+}

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Core;
+using Nethermind.Core.Caching;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
@@ -247,9 +248,19 @@ namespace Nethermind.Trie.Pruning
 
         private readonly DirtyNodesCache _dirtyNodes;
 
+        // Track some of the persisted path hash. Used to be able to remove keys when it is replaced.
+        // If null, disable removing key.
+        private LruCache<(Hash256?, TinyTreePath), ValueHash256>? _pastPathHash;
+
+        // Track ALL of the recently re-committed persisted nodes. This is so that we don't accidentally remove
+        // recommitted persisted nodes (which will not get re-persisted).
+        private ConcurrentDictionary<(Hash256?, TinyTreePath, ValueHash256), long> _persistedLastSeens = new();
+
         private bool _lastPersistedReachedReorgBoundary;
         private Task _pruningTask = Task.CompletedTask;
         private readonly CancellationTokenSource _pruningTaskCancellationTokenSource = new();
+
+        private long _reorgDepth = Reorganization.MaxDepth;
 
         public TrieStore(IKeyValueStoreWithBatching? keyValueStore, ILogManager? logManager)
             : this(keyValueStore, No.Pruning, Pruning.Persist.EveryBlock, logManager)
@@ -273,7 +284,8 @@ namespace Nethermind.Trie.Pruning
             INodeStorage? nodeStorage,
             IPruningStrategy? pruningStrategy,
             IPersistenceStrategy? persistenceStrategy,
-            ILogManager? logManager)
+            ILogManager? logManager,
+            long? reorgDepthOverride = null)
         {
             _logger = logManager?.GetClassLogger<TrieStore>() ?? throw new ArgumentNullException(nameof(logManager));
             _nodeStorage = nodeStorage ?? throw new ArgumentNullException(nameof(nodeStorage));
@@ -281,6 +293,17 @@ namespace Nethermind.Trie.Pruning
             _persistenceStrategy = persistenceStrategy ?? throw new ArgumentNullException(nameof(persistenceStrategy));
             _dirtyNodes = new DirtyNodesCache(this);
             _publicStore = new TrieKeyValueStore(this);
+
+            if (reorgDepthOverride != null) _reorgDepth = reorgDepthOverride.Value;
+
+            if (pruningStrategy.TrackedPastKeyCount > 0 && nodeStorage.RequirePath)
+            {
+                _pastPathHash = new(pruningStrategy.TrackedPastKeyCount, "");
+            }
+            else
+            {
+                _pastPathHash = null;
+            }
         }
 
         public IScopedTrieStore GetTrieStore(Hash256? address)
@@ -437,7 +460,7 @@ namespace Nethermind.Trie.Pruning
                         _currentBatch ??= _nodeStorage.StartWriteBatch();
                         try
                         {
-                            PersistBlockCommitSet(address, set, _currentBatch, writeFlags);
+                            PersistBlockCommitSet(address, set, _currentBatch, writeFlags: writeFlags);
                             PruneCurrentSet();
                         }
                         finally
@@ -592,7 +615,7 @@ namespace Nethermind.Trie.Pruning
                 using ArrayPoolList<BlockCommitSet> candidateSets = new(_commitSetQueue.Count);
                 while (_commitSetQueue.TryDequeue(out BlockCommitSet frontSet))
                 {
-                    if (frontSet!.BlockNumber >= LatestCommittedBlockNumber - Reorganization.MaxDepth)
+                    if (frontSet!.BlockNumber >= LatestCommittedBlockNumber - _reorgDepth)
                     {
                         toAddBack.Add(frontSet);
                     }
@@ -613,12 +636,28 @@ namespace Nethermind.Trie.Pruning
                     _commitSetQueue.Enqueue(toAddBack[index]);
                 }
 
+                Dictionary<(Hash256?, TinyTreePath), Hash256?>? persistedHashes =
+                    // If its a reorg, we can't remove node as persisted node may not be canonical
+                    _pastPathHash != null && candidateSets.Count == 1
+                    ? new Dictionary<(Hash256?, TinyTreePath), Hash256?>()
+                    : null;
+
                 INodeStorage.WriteBatch writeBatch = _nodeStorage.StartWriteBatch();
                 for (int index = 0; index < candidateSets.Count; index++)
                 {
                     BlockCommitSet blockCommitSet = candidateSets[index];
                     if (_logger.IsDebug) _logger.Debug($"Elevated pruning for candidate {blockCommitSet.BlockNumber}");
-                    PersistBlockCommitSet(null, blockCommitSet, writeBatch);
+                    PersistBlockCommitSet(null, blockCommitSet, writeBatch, persistedHashes: persistedHashes);
+                }
+
+                RemovePastKeys(persistedHashes);
+
+                foreach (KeyValuePair<(Hash256, TinyTreePath, ValueHash256), long> keyValuePair in _persistedLastSeens)
+                {
+                    if (IsNoLongerNeeded(keyValuePair.Value))
+                    {
+                        _persistedLastSeens.Remove(keyValuePair.Key, out _);
+                    }
                 }
                 writeBatch.Dispose();
 
@@ -628,10 +667,49 @@ namespace Nethermind.Trie.Pruning
                 }
 
                 _commitSetQueue.TryPeek(out BlockCommitSet? uselessFrontSet);
-                if (_logger.IsDebug) _logger.Debug($"Found no candidate for elevated pruning (sets: {_commitSetQueue.Count}, earliest: {uselessFrontSet?.BlockNumber}, newest kept: {LatestCommittedBlockNumber}, reorg depth {Reorganization.MaxDepth})");
+                if (_logger.IsDebug) _logger.Debug($"Found no candidate for elevated pruning (sets: {_commitSetQueue.Count}, earliest: {uselessFrontSet?.BlockNumber}, newest kept: {LatestCommittedBlockNumber}, reorg depth {_reorgDepth})");
             }
 
             return false;
+        }
+
+        private void RemovePastKeys(Dictionary<(Hash256, TinyTreePath), Hash256?>? persistedHashes)
+        {
+            if (persistedHashes == null) return;
+
+            bool CanRemove(Hash256? address, TinyTreePath path, TreePath fullPath, ValueHash256 keccak, Hash256? currentlyPersistingKeccak)
+            {
+                // Multiple current hash that we don't keep track for simplicity. Just ignore this case.
+                if (currentlyPersistingKeccak == null) return false;
+
+                // The persisted hash is the same as currently persisting hash. Do nothing.
+                if (currentlyPersistingKeccak == keccak) return false;
+
+                // We have is in cache and it is still needed.
+                if (_dirtyNodes.TryGetValue(new DirtyNodesCache.Key(address, fullPath, keccak.ToCommitment()), out TrieNode node) &&
+                    !IsNoLongerNeeded(node)) return false;
+
+                // We don't have it in cache, but we know it was re-committed, so if it is still needed, don't remove
+                if (_persistedLastSeens.TryGetValue((address, path, keccak), out long commitBlock) &&
+                    !IsNoLongerNeeded(commitBlock)) return false;
+
+                return true;
+            }
+
+            using INodeStorage.WriteBatch deleteNodeBatch = _nodeStorage.StartWriteBatch();
+            foreach (KeyValuePair<(Hash256?, TinyTreePath), Hash256> keyValuePair in persistedHashes)
+            {
+                (Hash256? addr, TinyTreePath path) key = keyValuePair.Key;
+                if (key.path.Length > TinyTreePath.MaxNibbleLength) continue;
+                if (_pastPathHash.TryGet((key.addr, key.path), out ValueHash256 prevHash))
+                {
+                    TreePath fullPath = key.path.ToTreePath(); // Micro op to reduce double convert
+                    if (CanRemove(key.addr, key.path, fullPath, prevHash, keyValuePair.Value))
+                    {
+                        deleteNodeBatch.Remove(key.addr, fullPath, prevHash);
+                    }
+                }
+            }
         }
 
         /// <summary>
@@ -668,6 +746,9 @@ namespace Nethermind.Trie.Pruning
                 if (node.IsPersisted)
                 {
                     if (_logger.IsTrace) _logger.Trace($"Removing persisted {node} from memory.");
+
+                    TrackPrunedPersistedNodes(key, node);
+
                     Hash256? keccak = node.Keccak;
                     if (keccak is null)
                     {
@@ -702,12 +783,34 @@ namespace Nethermind.Trie.Pruning
                 }
             }
 
-            MemoryUsedByDirtyCache = newMemory;
+            MemoryUsedByDirtyCache = newMemory + _persistedLastSeens.Count * 48;
             Metrics.CachedNodesCount = _dirtyNodes.Count;
 
             stopwatch.Stop();
             Metrics.PruningTime = stopwatch.ElapsedMilliseconds;
             if (_logger.IsDebug) _logger.Debug($"Finished pruning nodes in {stopwatch.ElapsedMilliseconds}ms {MemoryUsedByDirtyCache / 1.MB()} MB, last persisted block: {LastPersistedBlockNumber} current: {LatestCommittedBlockNumber}.");
+        }
+
+        private void TrackPrunedPersistedNodes(in DirtyNodesCache.Key key, TrieNode node)
+        {
+            if (key.Path.Length > TinyTreePath.MaxNibbleLength) return;
+            if (_pastPathHash == null) return;
+
+            TinyTreePath treePath = new TinyTreePath(key.Path);
+            // Persisted node with LastSeen is a node that has been re-committed, likely due to processing
+            // recalculated to the same hash.
+            if (node.LastSeen != null)
+            {
+                // Update _persistedLastSeen to later value.
+                if (!_persistedLastSeens.TryGetValue((key.Address, treePath, key.Keccak), out long currentLastSeen) || currentLastSeen < node.LastSeen.Value)
+                {
+                    _persistedLastSeens[(key.Address, treePath, key.Keccak)] = node.LastSeen.Value;
+                }
+            }
+
+            // This persisted node is being removed from cache. Keep it in mind in case of an update to the same
+            // path.
+            _pastPathHash.Set((key.Address, treePath), key.Keccak);
         }
 
         /// <summary>
@@ -775,10 +878,37 @@ namespace Nethermind.Trie.Pruning
         /// Already persisted nodes are skipped. After this action we are sure that the full state is available
         /// for the block represented by this commit set.
         /// </summary>
+        /// <param name="address"></param>
         /// <param name="commitSet">A commit set of a block which root is to be persisted.</param>
-        private void PersistBlockCommitSet(Hash256? address, BlockCommitSet commitSet, INodeStorage.WriteBatch writeBatch, WriteFlags writeFlags = WriteFlags.None)
+        /// <param name="writeBatch">The write batch to write to</param>
+        /// <param name="persistedHashes">Track persisted hashes in this dictionary if not null</param>
+        /// <param name="writeFlags"></param>
+        private void PersistBlockCommitSet(
+            Hash256? address,
+            BlockCommitSet commitSet,
+            INodeStorage.WriteBatch writeBatch,
+            Dictionary<(Hash256?, TinyTreePath), Hash256?>? persistedHashes = null,
+            WriteFlags writeFlags = WriteFlags.None
+        )
         {
-            void PersistNode(TrieNode tn, Hash256? address2, TreePath path) => this.PersistNode(address2, path, tn, commitSet.BlockNumber, writeFlags, writeBatch);
+            void PersistNode(TrieNode tn, Hash256? address2, TreePath path)
+            {
+                if (persistedHashes != null && path.Length <= TinyTreePath.MaxNibbleLength)
+                {
+                    (Hash256 address2, TinyTreePath path) key = (address2, new TinyTreePath(path));
+                    if (persistedHashes.ContainsKey(key))
+                    {
+                        // Null mark that there are multiple saved hash for this path. So we don't attempt to remove anything.
+                        // Otherwise this would have to be a list, which is such a rare case that its not worth it to have a list.
+                        persistedHashes[key] = null;
+                    }
+                    else
+                    {
+                        persistedHashes[key] = tn.Keccak;
+                    }
+                }
+                this.PersistNode(address2, path, tn, commitSet.BlockNumber, writeFlags, writeBatch);
+            }
 
             if (_logger.IsDebug) _logger.Debug($"Persisting from root {commitSet.Root} in {commitSet.BlockNumber}");
 
@@ -822,18 +952,23 @@ namespace Nethermind.Trie.Pruning
 
         private bool IsNoLongerNeeded(TrieNode node)
         {
-            Debug.Assert(node.LastSeen.HasValue, $"Any node that is cache should have {nameof(TrieNode.LastSeen)} set.");
-            return node.LastSeen < LastPersistedBlockNumber
-                   && node.LastSeen < LatestCommittedBlockNumber - Reorganization.MaxDepth;
+            return IsNoLongerNeeded(node.LastSeen);
+        }
+
+        private bool IsNoLongerNeeded(long? lastSeen)
+        {
+            Debug.Assert(lastSeen.HasValue, $"Any node that is cache should have {nameof(TrieNode.LastSeen)} set.");
+            return lastSeen < LastPersistedBlockNumber
+                   && lastSeen < LatestCommittedBlockNumber - _reorgDepth;
         }
 
         private void DequeueOldCommitSets()
         {
             while (_commitSetQueue.TryPeek(out BlockCommitSet blockCommitSet))
             {
-                if (blockCommitSet.BlockNumber < LatestCommittedBlockNumber - Reorganization.MaxDepth - 1)
+                if (blockCommitSet.BlockNumber < LatestCommittedBlockNumber - _reorgDepth - 1)
                 {
-                    if (_logger.IsDebug) _logger.Debug($"Removing historical ({_commitSetQueue.Count}) {blockCommitSet.BlockNumber} < {LatestCommittedBlockNumber} - {Reorganization.MaxDepth}");
+                    if (_logger.IsDebug) _logger.Debug($"Removing historical ({_commitSetQueue.Count}) {blockCommitSet.BlockNumber} < {LatestCommittedBlockNumber} - {_reorgDepth}");
                     _commitSetQueue.TryDequeue(out _);
                 }
                 else
@@ -882,7 +1017,7 @@ namespace Nethermind.Trie.Pruning
             {
                 // even after we persist a block we do not really remember it as a safe checkpoint
                 // until max reorgs blocks after
-                if (LatestCommittedBlockNumber >= LastPersistedBlockNumber + Reorganization.MaxDepth)
+                if (LatestCommittedBlockNumber >= LastPersistedBlockNumber + _reorgDepth)
                 {
                     shouldAnnounceReorgBoundary = true;
                 }
@@ -906,11 +1041,11 @@ namespace Nethermind.Trie.Pruning
                 using ArrayPoolList<BlockCommitSet> candidateSets = new(_commitSetQueue.Count);
                 while (_commitSetQueue.TryDequeue(out BlockCommitSet frontSet))
                 {
-                    if (candidateSets.Count == 0 || candidateSets[0].BlockNumber == frontSet!.BlockNumber)
+                    if (!frontSet.IsSealed || candidateSets.Count == 0 || candidateSets[0].BlockNumber == frontSet!.BlockNumber)
                     {
                         candidateSets.Add(frontSet);
                     }
-                    else if (frontSet!.BlockNumber < LatestCommittedBlockNumber - Reorganization.MaxDepth
+                    else if (frontSet!.BlockNumber < LatestCommittedBlockNumber - _reorgDepth
                              && frontSet!.BlockNumber > candidateSets[0].BlockNumber)
                     {
                         candidateSets.Clear();

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -636,9 +636,16 @@ namespace Nethermind.Trie.Pruning
                     _commitSetQueue.Enqueue(toAddBack[index]);
                 }
 
+                bool shouldDeletePersistedNode =
+                    // Its disabled
+                    _pastPathHash != null &&
+                    // Full pruning need to visit all node, so can't delete anything.
+                    !_persistenceStrategy.IsFullPruning &&
+                    // If more than one candidate set, its a reorg, we can't remove node as persisted node may not be canonical
+                    candidateSets.Count == 1;
+
                 Dictionary<(Hash256?, TinyTreePath), Hash256?>? persistedHashes =
-                    // If its a reorg, we can't remove node as persisted node may not be canonical
-                    _pastPathHash != null && candidateSets.Count == 1
+                    shouldDeletePersistedNode
                     ? new Dictionary<(Hash256?, TinyTreePath), Hash256?>()
                     : null;
 


### PR DESCRIPTION
- We have seen #6331 reduces database growth by about 50% likely due to improved compression. Branch that change only one child that sits next to previously unchanged branch probably get compressed really well.
- BUT WAIT THERE'S MORE!
- Since different path no longer share hashes we can approximately keep track of what is currently in the database, and on persist of a canonical block, we remove the old value.
- This work suprisingly well, where 90% (95% for state, 82% for storage) of the about to be persisted key have a match in the LRU for tracking persisted node.
- This does require additional memory with an LRU of 2 million nodes. This should take about 2Mil * 48 byte of memory at best case, with an additional 0.5Mil * 48 byte to keep track of recommitted nodes to prevent them from being deleted. Only path of nibble length <= 14 is tracked to save space. 
- Note, this does mean that for storage it will need to keep the full 32 byte address for the key, to prevent two storage from accidentally sharing the same (key, hash) tuple, which is unlikely but a vector for attack. This increase disk space use by about 2GB. Block processing time is much harder to notice any difference, but there could be other overhead that is not obvious right now.

- In a test run, running blocks from Oct 9 to Oct 21 the database does grow slower but only by half.

  | Size before (GB) | Size after (GB) | Increase (GB) | Increase (%)
-- | -- | -- | -- | --
HalfPath | 143.7 | 157.7 | 14 | 9.74%
HalfPath with improved pruning | 143.7 | 151.4 | 7.7 | 5.36%

- However, looking deeper and scanning the database shows that the uncompressed database size only grow by 1.28% instead of 14.62% under normal case. This is likely due to how rocksdb works where deletion is not performed until the SST file is merged/compacted with lower level SST file.

  | Uncompressed Size GB (Before) | Uncompressed Size GB | Increase (GB) | Increase
-- | -- | -- | -- | --
HalfPath | 217 | 253.780 | 37.095 | 14.62%
HalfPath with improved pruning | 217 | 219.499 | 2.814 | 1.28%

- On a longer run, with block spanning from 9 Oct to about 20 Jan (about 3 month), state db size grew from 143GB to 164GB.
- You can also see that the delete command saturated enough of the database after about 2 week.
![Screenshot_2024-01-20_22-14-58](https://github.com/NethermindEth/nethermind/assets/1841324/525424c2-00c7-495c-81c3-860155785d69)

- Halfpath without node removal grew from 143GB to 262GB.
![Screenshot_2024-01-20_22-15-23](https://github.com/NethermindEth/nethermind/assets/1841324/10c86629-7c42-419d-a7f1-d7fd6da9de6a)

- On master (hash layout), state db grew from 174GB to 428GB.
![Screenshot_2024-01-21_07-04-35](https://github.com/NethermindEth/nethermind/assets/1841324/76e5ae41-94fb-4034-9ea1-d43302999eee)

## Changes

- _List the changes_

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [ ] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
