### PR TITLE
Gas price estimation as 4 byte float rather than 16 byte decimal

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Processing/ProcessingStats.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ProcessingStats.cs
@@ -124,7 +124,7 @@ namespace Nethermind.Consensus.Processing
                     decimal bps = chunkMicroseconds == 0 ? -1 : chunkBlocks / chunkMicroseconds * 1000 * 1000;
                     decimal chunkMs = (chunkMicroseconds == 0 ? -1 : chunkMicroseconds / 1000);
                     decimal runMs = (runMicroseconds == 0 ? -1 : runMicroseconds / 1000);
-                    string blockGas = Evm.Metrics.BlockMinGasPrice != decimal.MaxValue ? $" Gas gwei: {Evm.Metrics.BlockMinGasPrice:N2} .. {whiteText}{Math.Max(Evm.Metrics.BlockMinGasPrice, Evm.Metrics.BlockEstMedianGasPrice):N2}{resetColor} ({Evm.Metrics.BlockAveGasPrice:N2}) .. {Evm.Metrics.BlockMaxGasPrice:N2}" : "";
+                    string blockGas = Evm.Metrics.BlockMinGasPrice != float.MaxValue ? $" Gas gwei: {Evm.Metrics.BlockMinGasPrice:N2} .. {whiteText}{Math.Max(Evm.Metrics.BlockMinGasPrice, Evm.Metrics.BlockEstMedianGasPrice):N2}{resetColor} ({Evm.Metrics.BlockAveGasPrice:N2}) .. {Evm.Metrics.BlockMaxGasPrice:N2}" : "";
                     if (chunkBlocks > 1)
                     {
                         _logger.Info($"Processed   {block.Number - chunkBlocks + 1,9}...{block.Number,9} | {chunkMs,9:N2} ms  |  slot    {runMs,7:N0} ms |{blockGas}");

--- a/src/Nethermind/Nethermind.Evm/Metrics.cs
+++ b/src/Nethermind/Nethermind.Evm/Metrics.cs
@@ -90,23 +90,23 @@ public class Metrics
     [Description("Number of contract create calls.")]
     public static long Creates { get; set; }
     internal static long Transactions { get; set; }
-    internal static decimal AveGasPrice { get; set; }
-    internal static decimal MinGasPrice { get; set; } = decimal.MaxValue;
-    internal static decimal MaxGasPrice { get; set; }
-    internal static decimal EstMedianGasPrice { get; set; }
+    internal static float AveGasPrice { get; set; }
+    internal static float MinGasPrice { get; set; } = float.MaxValue;
+    internal static float MaxGasPrice { get; set; }
+    internal static float EstMedianGasPrice { get; set; }
 
     internal static long BlockTransactions { get; set; }
-    internal static decimal BlockAveGasPrice { get; set; }
-    internal static decimal BlockMinGasPrice { get; set; } = decimal.MaxValue;
-    internal static decimal BlockMaxGasPrice { get; set; }
-    internal static decimal BlockEstMedianGasPrice { get; set; }
+    internal static float BlockAveGasPrice { get; set; }
+    internal static float BlockMinGasPrice { get; set; } = float.MaxValue;
+    internal static float BlockMaxGasPrice { get; set; }
+    internal static float BlockEstMedianGasPrice { get; set; }
 
     public static void ResetBlockStats()
     {
         BlockTransactions = 0;
-        BlockAveGasPrice = 0m;
-        BlockMaxGasPrice = 0m;
-        BlockEstMedianGasPrice = 0m;
-        BlockMinGasPrice = decimal.MaxValue;
+        BlockAveGasPrice = 0.0f;
+        BlockMaxGasPrice = 0.0f;
+        BlockEstMedianGasPrice = 0.0f;
+        BlockMinGasPrice = float.MaxValue;
     }
 }

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -117,7 +117,7 @@ namespace Nethermind.Evm.TransactionProcessing
 
             if (opts == ExecutionOptions.Commit || opts == ExecutionOptions.None)
             {
-                decimal gasPrice = (decimal)effectiveGasPrice / 1_000_000_000m;
+                float gasPrice = (float)((double)effectiveGasPrice / 1_000_000_000.0);
                 Metrics.MinGasPrice = Math.Min(gasPrice, Metrics.MinGasPrice);
                 Metrics.MaxGasPrice = Math.Max(gasPrice, Metrics.MaxGasPrice);
 
@@ -125,11 +125,11 @@ namespace Nethermind.Evm.TransactionProcessing
                 Metrics.BlockMaxGasPrice = Math.Max(gasPrice, Metrics.BlockMaxGasPrice);
 
                 Metrics.AveGasPrice = (Metrics.AveGasPrice * Metrics.Transactions + gasPrice) / (Metrics.Transactions + 1);
-                Metrics.EstMedianGasPrice += Metrics.AveGasPrice * 0.01m * decimal.Sign(gasPrice - Metrics.EstMedianGasPrice);
+                Metrics.EstMedianGasPrice += Metrics.AveGasPrice * 0.01f * float.Sign(gasPrice - Metrics.EstMedianGasPrice);
                 Metrics.Transactions++;
 
                 Metrics.BlockAveGasPrice = (Metrics.BlockAveGasPrice * Metrics.BlockTransactions + gasPrice) / (Metrics.BlockTransactions + 1);
-                Metrics.BlockEstMedianGasPrice += Metrics.BlockAveGasPrice * 0.01m * decimal.Sign(gasPrice - Metrics.BlockEstMedianGasPrice);
+                Metrics.BlockEstMedianGasPrice += Metrics.BlockAveGasPrice * 0.01f * float.Sign(gasPrice - Metrics.BlockEstMedianGasPrice);
                 Metrics.BlockTransactions++;
             }
 


### PR DESCRIPTION
## Changes

- Gas price in gwei is between ~0.001 and ~4000; in practice between 8 and 300 and given in 2 decimal places. Using a 4 byte float accurately covers this range without needing to resort to the precision of a 16 byte decimal.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No
