### PR TITLE
fix byte length calculation

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/RlpTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/RlpTests.cs
@@ -61,18 +61,26 @@ namespace Nethermind.Core.Test
         }
 
         [Test]
-        public void Length_of_byte()
+        public void single_byte_encoding_decoding()
         {
             byte item = 0;
             for (int i = 0; i < 128; i++)
             {
                 Assert.That(Rlp.LengthOf(item), Is.EqualTo(1));
+                var data = Rlp.Encode(item);
+                var rlp = new RlpStream(data.Bytes);
+                Assert.That(rlp.DecodeByte(), Is.EqualTo(item));
+
                 item += 1;
             }
 
             for (int i = 128; i < 256; i++)
             {
                 Assert.That(Rlp.LengthOf(item), Is.EqualTo(2));
+                var data = Rlp.Encode(item);
+                var rlp = new RlpStream(data.Bytes);
+                Assert.That(rlp.DecodeByte(), Is.EqualTo(item));
+
                 item += 1;
             }
         }

--- a/src/Nethermind/Nethermind.Core.Test/RlpTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/RlpTests.cs
@@ -61,6 +61,23 @@ namespace Nethermind.Core.Test
         }
 
         [Test]
+        public void Length_of_byte()
+        {
+            byte item = 0;
+            for (int i = 0; i < 128; i++)
+            {
+                Assert.That(Rlp.LengthOf(item), Is.EqualTo(1));
+                item += 1;
+            }
+
+            for (int i = 128; i < 256; i++)
+            {
+                Assert.That(Rlp.LengthOf(item), Is.EqualTo(2));
+                item += 1;
+            }
+        }
+
+        [Test]
         public void Long_negative()
         {
             Rlp output = Rlp.Encode(-1L);

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -1706,7 +1706,11 @@ namespace Nethermind.Serialization.Rlp
 
         public static int LengthOf(byte value)
         {
-            return 1;
+            if (value < 128)
+            {
+                return 1;
+            }
+            return 2;
         }
 
         public static int LengthOf(bool value)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -1706,11 +1706,7 @@ namespace Nethermind.Serialization.Rlp
 
         public static int LengthOf(byte value)
         {
-            if (value < 128)
-            {
-                return 1;
-            }
-            return 2;
+            return 1 + value / 128;
         }
 
         public static int LengthOf(bool value)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpStream.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpStream.cs
@@ -1143,12 +1143,19 @@ namespace Nethermind.Serialization.Rlp
                 return byteValue;
             }
 
-            ReadOnlySpan<byte> bytes = DecodeByteArraySpan();
-            return bytes.Length == 0 ? (byte)0
-                : bytes.Length == 1 ? bytes[0] == (byte)128
-                    ? (byte)0
-                    : bytes[0]
-                : bytes[1];
+            if (byteValue == 128)
+            {
+                SkipBytes(1);
+                return 0;
+            }
+
+            if (byteValue == 129)
+            {
+                SkipBytes(1);
+                return ReadByte();
+            }
+
+            throw new RlpException($"Unexpected value while decoding byte {byteValue}");
         }
 
         public int DecodeInt()


### PR DESCRIPTION
There was a mistake in Rlp.LengthOf(byte value) && RlpStream.DecodeByte().
For values > 128, encoded length is 2.

## Changes
- Rlp.LengthOf(byte value)
- RlpStream.DecodeByte()

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
