### PR TITLE
Parse BlockParameter correctly for eth_call

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Find/BlockParameter.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Find/BlockParameter.cs
@@ -49,6 +49,8 @@ namespace Nethermind.Blockchain.Find
 
         public BlockParameter(Hash256 blockHash, bool requireCanonical = false)
         {
+            ArgumentNullException.ThrowIfNull(blockHash);
+
             Type = BlockParameterType.BlockHash;
             BlockHash = blockHash;
             RequireCanonical = requireCanonical;
@@ -151,10 +153,17 @@ namespace Nethermind.JsonRpc.Data
             if (tokenType == JsonTokenType.StartObject)
             {
                 bool requireCanonical = false;
+                bool readEndObject = false;
                 Hash256 blockHash = null;
                 for (int i = 0; i < 2; i++)
                 {
                     reader.Read();
+                    if (reader.TokenType == JsonTokenType.EndObject)
+                    {
+                        readEndObject = true;
+                        break;
+                    }
+
                     if (reader.ValueTextEquals("requireCanonical"u8))
                     {
                         reader.Read();
@@ -168,7 +177,7 @@ namespace Nethermind.JsonRpc.Data
 
                 BlockParameter parameter = new(blockHash, requireCanonical);
 
-                if (!reader.Read() || reader.TokenType != JsonTokenType.EndObject)
+                if ((!readEndObject && !reader.Read()) || reader.TokenType != JsonTokenType.EndObject)
                 {
                     ThrowInvalidFormatting();
                 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EthCall.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EthCall.cs
@@ -138,6 +138,19 @@ public partial class EthRpcModuleTests
     }
 
     [Test]
+    public async Task Eth_call_with_blockhash_ok()
+    {
+        using Context ctx = await Context.Create();
+        TransactionForRpc transaction = new(Keccak.Zero, 1L, 1, new Transaction());
+        transaction.From = TestItem.AddressA;
+        transaction.To = TestItem.AddressB;
+
+        string serialized =
+            await ctx.Test.TestEthRpc("eth_call", ctx.Test.JsonSerializer.Serialize(transaction), "{\"blockHash\":\"0xf0b3f69cbd4e1e8d9b0ef02ff5d1384d18e19d251a4052f5f90bab190c5e8937\"}");
+        Assert.That(serialized, Is.EqualTo("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32001,\"message\":\"0xf0b3f69cbd4e1e8d9b0ef02ff5d1384d18e19d251a4052f5f90bab190c5e8937 could not be found\"},\"id\":67}"));
+    }
+
+    [Test]
     public async Task Eth_call_create_tx_with_empty_data()
     {
         using Context ctx = await Context.Create();


### PR DESCRIPTION
## Changes

- Should parse `blockHash` when `requireCanonical` is not present

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No
