### PR TITLE
Vectorize BytesToNibbleBytes

### DIFF
--- a/src/Nethermind/Nethermind.Trie/NibbleExtensions.cs
+++ b/src/Nethermind/Nethermind.Trie/NibbleExtensions.cs
@@ -27,35 +27,53 @@ namespace Nethermind.Trie
 
         public unsafe static void BytesToNibbleBytes(ReadOnlySpan<byte> bytes, Span<byte> nibbles)
         {
+            // Ensure the length of the nibbles span is exactly twice the length of the bytes span.
             if (nibbles.Length != 2 * bytes.Length)
             {
                 ThrowArgumentException();
             }
 
+            // Calculate the length to process using SIMD operations.
             var length = bytes.Length / sizeof(Vector128<byte>) * sizeof(Vector128<byte>);
+            // Check if SIMD hardware acceleration is available and if there is data to process.
+            // This will be branch eliminated the asm if not supported.
             if (Vector128.IsHardwareAccelerated && length > 0)
             {
+                // Cast the byte span to a span of Vector128<byte> for SIMD processing.
                 var input = MemoryMarshal.Cast<byte, Vector128<byte>>(bytes.Slice(0, length));
+                // Cast the nibble span to a reference to first element of Vector128<ushort> as input doubles.
                 ref var output = ref Unsafe.As<byte, Vector128<ushort>>(ref MemoryMarshal.GetReference(nibbles));
 
                 for (int i = 0; i < input.Length; i++)
                 {
+                    // Get the bytes where each byte contains 2 nibbles that we want to move into their own byte.
                     Vector128<byte> value = input[i];
-                    (Vector128<ushort> lower0, Vector128<ushort> upper0) = Vector128.Widen(Vector128.BitwiseAnd(value, Vector128.Create((byte)0xf)));
+
+                    // Mask off lower nibble 0x0f and split each byte into two bytes and store them in two separate vectors.
+                    (Vector128<ushort> lower0, Vector128<ushort> upper0) = Vector128.Widen(Vector128.BitwiseAnd(value, Vector128.Create((byte)0x0f)));
+                    // Arrange the 0x0f nibbles; we use the 1st element to represent 0s, and then order as 0,2,4,6,8,10,12,14th elements.
+                    // This leaves byte holes for the other set of nibbles to fill.
                     lower0 = Vector128.Shuffle(lower0.AsByte(), Vector128.Create((byte)1, 0, 1, 2, 1, 4, 1, 6, 1, 8, 1, 10, 1, 12, 1, 14)).AsUInt16();
                     upper0 = Vector128.Shuffle(upper0.AsByte(), Vector128.Create((byte)1, 0, 1, 2, 1, 4, 1, 6, 1, 8, 1, 10, 1, 12, 1, 14)).AsUInt16();
+                    
+                    // Mask off upper nibble 0xf0 and split each byte into two bytes and store them in two separate vectors.
+                    // Widening from byte -> ushort creates byte sized gaps so the two sets can be combined.
                     (Vector128<ushort> lower1, Vector128<ushort> upper1) = Vector128.Widen(Vector128.BitwiseAnd(value, Vector128.Create((byte)0xf0)));
+                    // Arrange the 0xf0 nibbles they are already in correct place, but need to be shifted down by a nibble (e.g. >> 4)
                     lower1 = Vector128.ShiftRightLogical(lower1.AsByte(), 4).AsUInt16();
                     upper1 = Vector128.ShiftRightLogical(upper1.AsByte(), 4).AsUInt16();
 
+                    // Combine the two sets of nibbles from the original bytes as their own bytes
                     lower0 = Vector128.BitwiseOr(lower0, lower1);
                     upper0 = Vector128.BitwiseOr(upper0, upper1);
 
+                    // Store the combined nibbles into the output span.
                     Unsafe.Add(ref output, i * 2) = lower0;
                     Unsafe.Add(ref output, i * 2 + 1) = upper0;
                 }
             }
 
+            // Process any remaining bytes that were not handled by SIMD.
             for (int i = length; i < bytes.Length; i++)
             {
                 int value = Unsafe.Add(ref MemoryMarshal.GetReference(bytes), i);

--- a/src/Nethermind/Nethermind.Trie/NibbleExtensions.cs
+++ b/src/Nethermind/Nethermind.Trie/NibbleExtensions.cs
@@ -4,6 +4,9 @@
 using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
 
 namespace Nethermind.Trie
 {
@@ -18,26 +21,46 @@ namespace Nethermind.Trie
         public static Nibble[] FromBytes(ReadOnlySpan<byte> bytes)
         {
             Nibble[] nibbles = new Nibble[2 * bytes.Length];
-            for (int i = 0; i < bytes.Length; i++)
-            {
-                nibbles[i * 2] = new Nibble((byte)((bytes[i] & 240) >> 4));
-                nibbles[i * 2 + 1] = new Nibble((byte)(bytes[i] & 15));
-            }
-
+            BytesToNibbleBytes(bytes, MemoryMarshal.AsBytes(nibbles.AsSpan()));
             return nibbles;
         }
 
-        public static void BytesToNibbleBytes(ReadOnlySpan<byte> bytes, Span<byte> nibbles)
+        public unsafe static void BytesToNibbleBytes(ReadOnlySpan<byte> bytes, Span<byte> nibbles)
         {
             if (nibbles.Length != 2 * bytes.Length)
             {
                 ThrowArgumentException();
             }
 
-            for (int i = 0; i < bytes.Length; i++)
+            var length = bytes.Length / sizeof(Vector128<byte>) * sizeof(Vector128<byte>);
+            if (Vector128.IsHardwareAccelerated && length > 0)
             {
-                nibbles[i * 2] = (byte)((bytes[i] & 240) >> 4);
-                nibbles[i * 2 + 1] = (byte)(bytes[i] & 15);
+                var input = MemoryMarshal.Cast<byte, Vector128<byte>>(bytes.Slice(0, length));
+                ref var output = ref Unsafe.As<byte, Vector128<ushort>>(ref MemoryMarshal.GetReference(nibbles));
+
+                for (int i = 0; i < input.Length; i++)
+                {
+                    Vector128<byte> value = input[i];
+                    (Vector128<ushort> lower0, Vector128<ushort> upper0) = Vector128.Widen(Vector128.BitwiseAnd(value, Vector128.Create((byte)0xf)));
+                    lower0 = Vector128.Shuffle(lower0.AsByte(), Vector128.Create((byte)1, 0, 1, 2, 1, 4, 1, 6, 1, 8, 1, 10, 1, 12, 1, 14)).AsUInt16();
+                    upper0 = Vector128.Shuffle(upper0.AsByte(), Vector128.Create((byte)1, 0, 1, 2, 1, 4, 1, 6, 1, 8, 1, 10, 1, 12, 1, 14)).AsUInt16();
+                    (Vector128<ushort> lower1, Vector128<ushort> upper1) = Vector128.Widen(Vector128.BitwiseAnd(value, Vector128.Create((byte)0xf0)));
+                    lower1 = Vector128.ShiftRightLogical(lower1.AsByte(), 4).AsUInt16();
+                    upper1 = Vector128.ShiftRightLogical(upper1.AsByte(), 4).AsUInt16();
+
+                    lower0 = Vector128.BitwiseOr(lower0, lower1);
+                    upper0 = Vector128.BitwiseOr(upper0, upper1);
+
+                    Unsafe.Add(ref output, i * 2) = lower0;
+                    Unsafe.Add(ref output, i * 2 + 1) = upper0;
+                }
+            }
+
+            for (int i = length; i < bytes.Length; i++)
+            {
+                int value = Unsafe.Add(ref MemoryMarshal.GetReference(bytes), i);
+                Unsafe.Add(ref MemoryMarshal.GetReference(nibbles), i * 2) = (byte)(value >> 4);
+                Unsafe.Add(ref MemoryMarshal.GetReference(nibbles), i * 2 + 1) = (byte)(value & 15);
             }
 
             [DoesNotReturn]

--- a/src/Nethermind/Nethermind.Trie/NibbleExtensions.cs
+++ b/src/Nethermind/Nethermind.Trie/NibbleExtensions.cs
@@ -76,6 +76,10 @@ namespace Nethermind.Trie
             // Process any remaining bytes that were not handled by SIMD.
             for (int i = length; i < bytes.Length; i++)
             {
+                // We use Unsafe here as we have verified all the bounds above and also only go to length
+                // However the loop doesn't start a 0 and the nibbles span access is complex (rather than just i)
+                // so the Jit can't work out if the bounds checks and their if+exceptions can be eliminated.
+                // Because of this using regular array style access causes 3 bounds checks to be inserted.
                 int value = Unsafe.Add(ref MemoryMarshal.GetReference(bytes), i);
                 Unsafe.Add(ref MemoryMarshal.GetReference(nibbles), i * 2) = (byte)(value >> 4);
                 Unsafe.Add(ref MemoryMarshal.GetReference(nibbles), i * 2 + 1) = (byte)(value & 15);

--- a/src/Nethermind/Nethermind.Trie/NibbleExtensions.cs
+++ b/src/Nethermind/Nethermind.Trie/NibbleExtensions.cs
@@ -55,7 +55,7 @@ namespace Nethermind.Trie
                     // This leaves byte holes for the other set of nibbles to fill.
                     lower0 = Vector128.Shuffle(lower0.AsByte(), Vector128.Create((byte)1, 0, 1, 2, 1, 4, 1, 6, 1, 8, 1, 10, 1, 12, 1, 14)).AsUInt16();
                     upper0 = Vector128.Shuffle(upper0.AsByte(), Vector128.Create((byte)1, 0, 1, 2, 1, 4, 1, 6, 1, 8, 1, 10, 1, 12, 1, 14)).AsUInt16();
-                    
+
                     // Mask off upper nibble 0xf0 and split each byte into two bytes and store them in two separate vectors.
                     // Widening from byte -> ushort creates byte sized gaps so the two sets can be combined.
                     (Vector128<ushort> lower1, Vector128<ushort> upper1) = Vector128.Widen(Vector128.BitwiseAnd(value, Vector128.Create((byte)0xf0)));


### PR DESCRIPTION
## Changes

- Vectorize `BytesToNibbleBytes` to work in 16 byte chunks rather than 1 byte at a time

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

## Remarks

Originally did it for path storage, then realised it was in master https://github.com/NethermindEth/nethermind/pull/6490
