### PR TITLE
Increase timeout on sync tests since Sepolia peering is weak

### DIFF
--- a/.github/workflows/sync-testnets.yml
+++ b/.github/workflows/sync-testnets.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Wait for ${{ matrix.network }} to sync
         id: wait
-        timeout-minutes: 90
+        timeout-minutes: 180
         run: |
           set +e
 


### PR DESCRIPTION
Add more time for sepolia to finish since it has a bit less peers discovered for sync nowadays.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [X] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [X] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No
