### PR TITLE
Reduce allocations of Gossip filter closures

### DIFF
--- a/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
@@ -26,6 +26,7 @@ namespace Nethermind.TxPool
         private readonly ITxPoolConfig _txPoolConfig;
         private readonly IChainHeadInfoProvider _headInfo;
         private readonly ITxGossipPolicy _txGossipPolicy;
+        private readonly Func<Transaction, bool> _gossipFilter;
 
         /// <summary>
         /// Timer for rebroadcasting pending own transactions.
@@ -78,6 +79,8 @@ namespace Nethermind.TxPool
             _txPoolConfig = txPoolConfig;
             _headInfo = chainHeadInfoProvider;
             _txGossipPolicy = transactionsGossipPolicy ?? ShouldGossip.Instance;
+            // Allocate closure once
+            _gossipFilter = t => _txGossipPolicy.ShouldGossipTransaction(t);
             _logger = logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
             _persistentTxs = new TxDistinctSortedPool(MemoryAllowance.MemPoolSize, comparer, logManager);
             _accumulatedTemporaryTxs = new ResettableList<Transaction>(512, 4);
@@ -311,7 +314,7 @@ namespace Nethermind.TxPool
             {
                 try
                 {
-                    peer.SendNewTransactions(txs.Where(t => _txGossipPolicy.ShouldGossipTransaction(t)), sendFullTx);
+                    peer.SendNewTransactions(txs.Where(_gossipFilter), sendFullTx);
                     if (_logger.IsTrace) _logger.Trace($"Notified {peer} about transactions.");
                 }
                 catch (Exception e)


### PR DESCRIPTION
## Changes

- Only allocate the closure once

<img width="791" alt="image" src="https://github.com/NethermindEth/nethermind/assets/1142958/09e4bd45-af5f-4e82-8e64-b1e0d5ce565c">


## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No
