### PR TITLE
Fix nethtest handing of `_info`

### DIFF
--- a/src/Nethermind/Ethereum.Test.Base/EthereumTestResult.cs
+++ b/src/Nethermind/Ethereum.Test.Base/EthereumTestResult.cs
@@ -34,7 +34,7 @@ namespace Ethereum.Test.Base
         public bool Pass { get; set; }
         public string Fork { get; set; }
 
-        [JsonIgnore] public int TimeInMs { get; set; }
+        public double TimeInMs { get; set; }
 
         public Hash256 StateRoot { get; set; } = Keccak.EmptyTreeHash;
     }

--- a/src/Nethermind/Ethereum.Test.Base/GeneralStateTestInfoJson.cs
+++ b/src/Nethermind/Ethereum.Test.Base/GeneralStateTestInfoJson.cs
@@ -1,12 +1,49 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Ethereum.Test.Base
 {
+    [JsonConverter(typeof(GeneralStateTestInfoConverter))]
     public class GeneralStateTestInfoJson
     {
         public Dictionary<string, string>? Labels { get; set; }
+    }
+
+
+    public class GeneralStateTestInfoConverter : JsonConverter<GeneralStateTestInfoJson>
+    {
+        public override GeneralStateTestInfoJson? Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options)
+        {
+            Dictionary<string, string>? labels = null;
+            if (reader.TokenType == JsonTokenType.String || reader.TokenType == JsonTokenType.Number)
+            {
+                labels = new Dictionary<string, string>
+                {
+                    ["0"] = reader.GetString()
+                };
+            }
+            else
+            {
+                labels = JsonSerializer.Deserialize<Dictionary<string, string>>(ref reader, options);
+            }
+
+            return new GeneralStateTestInfoJson { Labels = labels };
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            GeneralStateTestInfoJson info,
+            JsonSerializerOptions options)
+        {
+            JsonSerializer.Serialize(writer, info, options);
+        }
     }
 }

--- a/src/Nethermind/Ethereum.Test.Base/GeneralStateTestInfoJson.cs
+++ b/src/Nethermind/Ethereum.Test.Base/GeneralStateTestInfoJson.cs
@@ -14,7 +14,6 @@ namespace Ethereum.Test.Base
         public Dictionary<string, string>? Labels { get; set; }
     }
 
-
     public class GeneralStateTestInfoConverter : JsonConverter<GeneralStateTestInfoJson>
     {
         public override GeneralStateTestInfoJson? Read(

--- a/src/Nethermind/Ethereum.Test.Base/GeneralStateTestInfoJson.cs
+++ b/src/Nethermind/Ethereum.Test.Base/GeneralStateTestInfoJson.cs
@@ -22,16 +22,25 @@ namespace Ethereum.Test.Base
             JsonSerializerOptions options)
         {
             Dictionary<string, string>? labels = null;
-            if (reader.TokenType == JsonTokenType.String || reader.TokenType == JsonTokenType.Number)
+            if (reader.TokenType == JsonTokenType.StartObject)
             {
-                labels = new Dictionary<string, string>
+                var depth = reader.CurrentDepth;
+                while (reader.Read())
                 {
-                    ["0"] = reader.GetString()
-                };
-            }
-            else
-            {
-                labels = JsonSerializer.Deserialize<Dictionary<string, string>>(ref reader, options);
+                    if (reader.TokenType == JsonTokenType.EndObject && reader.CurrentDepth == depth)
+                    {
+                        break;
+                    }
+                    if (reader.TokenType == JsonTokenType.PropertyName && reader.ValueTextEquals("labels"u8))
+                    {
+                        reader.Read();
+                        labels = JsonSerializer.Deserialize<Dictionary<string, string>>(ref reader, options);
+                    }
+                    else
+                    {
+                        reader.Skip();
+                    }
+                }
             }
 
             return new GeneralStateTestInfoJson { Labels = labels };

--- a/src/Nethermind/Ethereum.Test.Base/GeneralTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/GeneralTestBase.cs
@@ -140,7 +140,7 @@ namespace Ethereum.Test.Base
 
             List<string> differences = RunAssertions(test, stateProvider);
             EthereumTestResult testResult = new(test.Name, test.ForkName, differences.Count == 0);
-            testResult.TimeInMs = (int)stopwatch.Elapsed.TotalMilliseconds;
+            testResult.TimeInMs = stopwatch.Elapsed.TotalMilliseconds;
             testResult.StateRoot = stateProvider.StateRoot;
 
             //            Assert.Zero(differences.Count, "differences");

--- a/src/Nethermind/Ethereum.Test.Base/JsonToEthereumTest.cs
+++ b/src/Nethermind/Ethereum.Test.Base/JsonToEthereumTest.cs
@@ -209,7 +209,6 @@ namespace Ethereum.Test.Base
             foreach (KeyValuePair<string, PostStateJson[]> postStateBySpec in testJson.Post)
             {
                 int iterationNumber = 0;
-                int testIndex = testJson.Info?.Labels?.Select(x => System.Convert.ToInt32(x.Key)).FirstOrDefault() ?? 0;
                 foreach (PostStateJson stateJson in postStateBySpec.Value)
                 {
                     GeneralStateTest test = new();

--- a/src/Nethermind/Ethereum.Test.Base/JsonToEthereumTest.cs
+++ b/src/Nethermind/Ethereum.Test.Base/JsonToEthereumTest.cs
@@ -219,10 +219,6 @@ namespace Ethereum.Test.Base
                     {
                         test.Name += testJson.Info?.Labels?[iterationNumber.ToString()]?.Replace(":label ", string.Empty);
                     }
-                    else
-                    {
-                        test.Name += string.Empty;
-                    }
 
                     test.ForkName = postStateBySpec.Key;
                     test.Fork = ParseSpec(postStateBySpec.Key);

--- a/src/Nethermind/Nethermind.Blockchain.Test.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test.Runner/Program.cs
@@ -14,7 +14,7 @@ namespace Nethermind.Blockchain.Test.Runner
     internal class Program
     {
         private static readonly List<string> AllFailingTests = new List<string>();
-        private static long _totalMs;
+        private static double _totalMs;
 
         public static async Task Main(params string[] args)
         {
@@ -79,7 +79,7 @@ namespace Nethermind.Blockchain.Test.Runner
             var result = stateTest.RunTests().ToList();
             var failedTestsInCategory = result.Where(r => !r.Pass).Select(t => t.Name + " " + t.LoadFailure).ToArray();
             AllFailingTests.AddRange(failedTestsInCategory);
-            long categoryTimeInMs = result.Sum(t => t.TimeInMs);
+            long categoryTimeInMs = (long)result.Sum(t => t.TimeInMs);
             _totalMs += result.Sum(t => t.TimeInMs);
 
             if (result.Any())
@@ -96,7 +96,7 @@ namespace Nethermind.Blockchain.Test.Runner
 
             var failedTestsInCategory = testResults.Where(r => !r.Pass).Select(t => t.Name + " " + t.LoadFailure).ToArray();
             AllFailingTests.AddRange(failedTestsInCategory);
-            long categoryTimeInMs = testResults.Sum(t => t.TimeInMs);
+            long categoryTimeInMs = (long)testResults.Sum(t => t.TimeInMs);
             _totalMs += testResults.Sum(t => t.TimeInMs);
 
             if (testResults.Any())

--- a/src/Nethermind/Nethermind.Test.Runner/StateTestRunner.cs
+++ b/src/Nethermind/Nethermind.Test.Runner/StateTestRunner.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Threading;
+using System.Threading.Tasks;
 
 using Ethereum.Test.Base;
 using Ethereum.Test.Base.Interfaces;
@@ -69,10 +70,10 @@ namespace Nethermind.Test.Runner
                 if (_whenTrace != WhenTrace.Always)
                 {
                     // Warm up
-                    for (int i = 0; i < 25; i++)
+                    Parallel.For(0, 30, (i, s) =>
                     {
                         _ = RunTest(test, NullTxTracer.Instance);
-                    }
+                    });
 
                     // Give time to Jit optimized version
                     Thread.Sleep(20);

--- a/src/Nethermind/Nethermind.Test.Runner/StateTestRunner.cs
+++ b/src/Nethermind/Nethermind.Test.Runner/StateTestRunner.cs
@@ -76,6 +76,7 @@ namespace Nethermind.Test.Runner
 
                     // Give time to Jit optimized version
                     Thread.Sleep(20);
+                    GC.Collect(GC.MaxGeneration);
                     result = RunTest(test, NullTxTracer.Instance);
                 }
 

--- a/src/Nethermind/Nethermind.Test.Runner/StateTestRunner.cs
+++ b/src/Nethermind/Nethermind.Test.Runner/StateTestRunner.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
+using System.Threading;
+
 using Ethereum.Test.Base;
 using Ethereum.Test.Base.Interfaces;
 using Nethermind.Evm;
@@ -62,9 +64,20 @@ namespace Nethermind.Test.Runner
             {
                 if (_filter is not null && !Regex.Match(test.Name, $"^({_filter})").Success)
                     continue;
+
                 EthereumTestResult result = null;
                 if (_whenTrace != WhenTrace.Always)
+                {
+                    // Warm up
+                    for (int i = 0; i < 25; i++)
+                    {
+                        _ = RunTest(test, NullTxTracer.Instance);
+                    }
+
+                    // Give time to Jit optimized version
+                    Thread.Sleep(20);
                     result = RunTest(test, NullTxTracer.Instance);
+                }
 
                 if (_whenTrace != WhenTrace.Never && !(result?.Pass ?? false))
                 {

--- a/src/Nethermind/Nethermind.Test.Runner/StateTestTxTraceResult.cs
+++ b/src/Nethermind/Nethermind.Test.Runner/StateTestTxTraceResult.cs
@@ -14,7 +14,7 @@ namespace Nethermind.Test.Runner
         public long GasUsed { get; set; }
 
         [JsonPropertyName("time")]
-        public int Time { get; set; }
+        public double Time { get; set; }
 
         [JsonPropertyName("error")]
         public string Error { get; set; }


### PR DESCRIPTION
## Changes

- Previously were more flexible in handling of `_info` restore that flexibility
- Include the `timeInMs` in the Json output for successful tests not just failed trace time
- Pre-warm Jit to determine that time
e.g.
```
❯ .\nethtest.exe -n -i E:\slow.json
[
  {
    "name": "jd_attack_london_10MGas_JUMPDEST_250M_d0g0v0_",
    "pass": false,
    "fork": "Shanghai",
    "timeInMs": 140.2537,
    "stateRoot": "0xb477153913f9f4214202f0eda1fa4afe153f937dee736e6284bd188e71a63ae6"
  }
]
```

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_
