### PR TITLE
[Fix]  EthSyncing showing Syncing even when node is fully synced up to old default barrier

### DIFF
--- a/src/Nethermind/Nethermind.AccountAbstraction.Test/UserOperationSubscribeTests.cs
+++ b/src/Nethermind/Nethermind.AccountAbstraction.Test/UserOperationSubscribeTests.cs
@@ -75,7 +75,8 @@ namespace Nethermind.AccountAbstraction.Test
                 _txPool,
                 _receiptCanonicalityMonitor,
                 _filterStore,
-                new EthSyncingInfo(_blockTree, _receiptStorage, _syncConfig, new StaticSelector(SyncMode.All), _logManager),
+                new EthSyncingInfo(_blockTree, _receiptStorage, _syncConfig,
+                new StaticSelector(SyncMode.All), Substitute.For<ISyncProgressResolver>(), _logManager),
                 _specProvider,
                 _jsonSerializer);
 

--- a/src/Nethermind/Nethermind.Facade/Eth/EthSyncingInfo.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/EthSyncingInfo.cs
@@ -18,19 +18,22 @@ namespace Nethermind.Facade.Eth
         private readonly ILogger _logger;
         private readonly IReceiptStorage _receiptStorage;
         private readonly ISyncModeSelector _syncModeSelector;
+        private readonly ISyncProgressResolver _syncProgressResolver;
 
         public EthSyncingInfo(
             IBlockTree blockTree,
             IReceiptStorage receiptStorage,
             ISyncConfig syncConfig,
             ISyncModeSelector syncModeSelector,
+            ISyncProgressResolver syncProgressResolver,
             ILogManager logManager)
         {
             _blockTree = blockTree;
+            _receiptStorage = receiptStorage;
             _syncConfig = syncConfig;
             _syncModeSelector = syncModeSelector;
+            _syncProgressResolver = syncProgressResolver;
             _logger = logManager.GetClassLogger();
-            _receiptStorage = receiptStorage;
         }
 
         public SyncingResult GetFullInfo()
@@ -53,18 +56,13 @@ namespace Nethermind.Facade.Eth
             bool needsToDownloadReceiptsAndBodies = _syncConfig.PivotNumberParsed != 0;
             if (_syncConfig.FastSync && needsToDownloadReceiptsAndBodies)
             {
-                bool isDownloadingReceipts = _receiptStorage.LowestInsertedReceiptBlockNumber is null
-                                             || _receiptStorage.LowestInsertedReceiptBlockNumber > _syncConfig.AncientReceiptsBarrierCalc;
-                if (_syncConfig.DownloadReceiptsInFastSync && isDownloadingReceipts)
+                if (_syncConfig.DownloadReceiptsInFastSync && !_syncProgressResolver.IsFastBlocksReceiptsFinished())
                 {
                     if (_logger.IsTrace) _logger.Trace($"Receipts not finished - EthSyncingInfo - HighestBlock: {bestSuggestedNumber}, CurrentBlock: {headNumberOrZero}, AncientReceiptsBarrier: {_syncConfig.AncientReceiptsBarrierCalc}. LowestInsertedBodyNumber: {_blockTree.LowestInsertedBodyNumber} LowestInsertedReceiptBlockNumber: {_receiptStorage.LowestInsertedReceiptBlockNumber}");
                     return ReturnSyncing(headNumberOrZero, bestSuggestedNumber, syncMode);
                 }
 
-
-                bool isDownloadingBodies = _blockTree.LowestInsertedBodyNumber is null
-                                           || _blockTree.LowestInsertedBodyNumber > _syncConfig.AncientBodiesBarrierCalc;
-                if (_syncConfig.DownloadBodiesInFastSync && isDownloadingBodies)
+                if (_syncConfig.DownloadBodiesInFastSync && !_syncProgressResolver.IsFastBlocksBodiesFinished())
                 {
                     if (_logger.IsTrace) _logger.Trace($"Bodies not finished - EthSyncingInfo - HighestBlock: {bestSuggestedNumber}, CurrentBlock: {headNumberOrZero}, AncientBodiesBarrier: {_syncConfig.AncientBodiesBarrierCalc}. LowestInsertedBodyNumber: {_blockTree.LowestInsertedBodyNumber} LowestInsertedReceiptBlockNumber: {_receiptStorage.LowestInsertedReceiptBlockNumber}");
                     return ReturnSyncing(headNumberOrZero, bestSuggestedNumber, syncMode);

--- a/src/Nethermind/Nethermind.HealthChecks.Test/NodeHealthServiceTests.cs
+++ b/src/Nethermind/Nethermind.HealthChecks.Test/NodeHealthServiceTests.cs
@@ -63,7 +63,7 @@ namespace Nethermind.HealthChecks.Test
                 blockFinder.FindBestSuggestedHeader().Returns(GetBlockHeader(2).TestObject);
             }
 
-            IEthSyncingInfo ethSyncingInfo = new EthSyncingInfo(blockFinder, receiptStorage, syncConfig, Substitute.For<ISyncModeSelector>(), LimboLogs.Instance);
+            IEthSyncingInfo ethSyncingInfo = new EthSyncingInfo(blockFinder, receiptStorage, syncConfig, Substitute.For<ISyncModeSelector>(), Substitute.For<ISyncProgressResolver>(), LimboLogs.Instance);
             NodeHealthService nodeHealthService =
                 new(syncServer, blockchainProcessor, blockProducer, new HealthChecksConfig(),
                     healthHintService, ethSyncingInfo, new EngineRpcCapabilitiesProvider(api.SpecProvider), api, new[] { drive }, test.IsMining);
@@ -130,7 +130,8 @@ namespace Nethermind.HealthChecks.Test
 
             CustomRpcCapabilitiesProvider customProvider =
                 new(test.EnabledCapabilities, test.DisabledCapabilities);
-            IEthSyncingInfo ethSyncingInfo = new EthSyncingInfo(blockFinder, new InMemoryReceiptStorage(), new SyncConfig(), syncModeSelector, new TestLogManager());
+            IEthSyncingInfo ethSyncingInfo = new EthSyncingInfo(blockFinder, new InMemoryReceiptStorage(),
+                new SyncConfig(), syncModeSelector, Substitute.For<ISyncProgressResolver>(), new TestLogManager());
             NodeHealthService nodeHealthService =
                 new(syncServer, blockchainProcessor, blockProducer, new HealthChecksConfig(),
                     healthHintService, ethSyncingInfo, customProvider, api, new[] { drive }, false);

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -159,8 +159,10 @@ public class InitializeNetwork : IStep
         }
 
         _api.SyncModeSelector = _api.Synchronizer.SyncModeSelector;
+        _api.SyncProgressResolver = _api.Synchronizer.SyncProgressResolver;
 
-        _api.EthSyncingInfo = new EthSyncingInfo(_api.BlockTree, _api.ReceiptStorage!, _syncConfig, _api.SyncModeSelector, _api.LogManager);
+        _api.EthSyncingInfo = new EthSyncingInfo(_api.BlockTree, _api.ReceiptStorage!, _syncConfig,
+            _api.SyncModeSelector, _api.SyncProgressResolver, _api.LogManager);
         _api.TxGossipPolicy.Policies.Add(new SyncedTxGossipPolicy(_api.SyncModeSelector));
         _api.DisposeStack.Push(_api.SyncModeSelector);
         _api.DisposeStack.Push(_api.Synchronizer);

--- a/src/Nethermind/Nethermind.JsonRpc.Benchmark/EthModuleBenchmarks.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Benchmark/EthModuleBenchmarks.cs
@@ -143,7 +143,7 @@ namespace Nethermind.JsonRpc.Benchmark
 
             IReceiptStorage receiptStorage = new InMemoryReceiptStorage();
             ISyncConfig syncConfig = new SyncConfig();
-            EthSyncingInfo ethSyncingInfo = new(blockTree, receiptStorage, syncConfig, new StaticSelector(SyncMode.All), LimboLogs.Instance);
+            EthSyncingInfo ethSyncingInfo = new(blockTree, receiptStorage, syncConfig, new StaticSelector(SyncMode.All), null, LimboLogs.Instance);
 
             _ethModule = new EthRpcModule(
                 new JsonRpcConfig(),

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
@@ -52,6 +52,7 @@ namespace Nethermind.JsonRpc.Test.Modules
         private ISpecProvider _specProvider = null!;
         private IReceiptMonitor _receiptCanonicalityMonitor = null!;
         private ISyncConfig _syncConfig = null!;
+        private ISyncProgressResolver _syncProgressResolver = null!;
 
         [SetUp]
         public void Setup()
@@ -66,6 +67,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             _jsonSerializer = new EthereumJsonSerializer();
             _receiptCanonicalityMonitor = new ReceiptCanonicalityMonitor(_receiptStorage, _logManager);
             _syncConfig = new SyncConfig();
+            _syncProgressResolver = Substitute.For<ISyncProgressResolver>();
 
             IJsonSerializer jsonSerializer = new EthereumJsonSerializer();
 
@@ -75,7 +77,8 @@ namespace Nethermind.JsonRpc.Test.Modules
                 _txPool,
                 _receiptCanonicalityMonitor,
                 _filterStore,
-                new EthSyncingInfo(_blockTree, _receiptStorage, _syncConfig, new StaticSelector(SyncMode.All), _logManager),
+                new EthSyncingInfo(_blockTree, _receiptStorage, _syncConfig,
+                new StaticSelector(SyncMode.All), _syncProgressResolver, _logManager),
                 _specProvider,
                 jsonSerializer);
 
@@ -187,7 +190,8 @@ namespace Nethermind.JsonRpc.Test.Modules
             Block block = Build.A.Block.WithNumber(head).TestObject;
             _blockTree.Head.Returns(block);
 
-            EthSyncingInfo ethSyncingInfo = new(_blockTree, _receiptStorage, _syncConfig, new StaticSelector(SyncMode.All), _logManager);
+            EthSyncingInfo ethSyncingInfo = new(_blockTree, _receiptStorage, _syncConfig,
+                new StaticSelector(SyncMode.All), _syncProgressResolver, _logManager);
 
             SyncingSubscription syncingSubscription = new(_jsonRpcDuplexClient, _blockTree, ethSyncingInfo, _logManager);
 

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TestRpcBlockchain.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TestRpcBlockchain.cs
@@ -32,6 +32,7 @@ using Nethermind.Wallet;
 
 using Nethermind.Config;
 using Nethermind.Synchronization.ParallelSync;
+using NSubstitute;
 
 namespace Nethermind.JsonRpc.Test.Modules
 {
@@ -152,7 +153,8 @@ namespace Nethermind.JsonRpc.Test.Modules
                 LimboLogs.Instance,
                 SpecProvider,
                 GasPriceOracle,
-                new EthSyncingInfo(BlockTree, ReceiptStorage, syncConfig, new StaticSelector(SyncMode.All), LogManager),
+                new EthSyncingInfo(BlockTree, ReceiptStorage, syncConfig,
+                    new StaticSelector(SyncMode.All), Substitute.For<ISyncProgressResolver>(), LogManager),
                 FeeHistoryOracle);
 
             return this;

--- a/src/Nethermind/Nethermind.Merge.AuRa.Test/AuRaMergeEngineModuleTests.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa.Test/AuRaMergeEngineModuleTests.cs
@@ -144,7 +144,8 @@ public class AuRaMergeEngineModuleTests : EngineModuleTests
             BlocksConfig blocksConfig = new() { MinGasPrice = 0 };
             ISyncConfig syncConfig = new SyncConfig();
             TargetAdjustedGasLimitCalculator targetAdjustedGasLimitCalculator = new(SpecProvider, blocksConfig);
-            EthSyncingInfo = new EthSyncingInfo(BlockTree, ReceiptStorage, syncConfig, new StaticSelector(SyncMode.All), LogManager);
+            EthSyncingInfo = new EthSyncingInfo(BlockTree, ReceiptStorage, syncConfig,
+                new StaticSelector(SyncMode.All), Substitute.For<ISyncProgressResolver>(), LogManager);
             PostMergeBlockProducerFactory blockProducerFactory = new(
                 SpecProvider,
                 SealEngine,

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
@@ -180,7 +180,8 @@ public partial class EngineModuleTests
             BlocksConfig blocksConfig = new() { MinGasPrice = 0 };
             TargetAdjustedGasLimitCalculator targetAdjustedGasLimitCalculator = new(SpecProvider, blocksConfig);
             ISyncConfig syncConfig = new SyncConfig();
-            EthSyncingInfo = new EthSyncingInfo(BlockTree, ReceiptStorage, syncConfig, new StaticSelector(SyncMode.All), LogManager);
+            EthSyncingInfo = new EthSyncingInfo(BlockTree, ReceiptStorage, syncConfig,
+                new StaticSelector(SyncMode.All), Substitute.For<ISyncProgressResolver>(), LogManager);
             PostMergeBlockProducerFactory? blockProducerFactory = new(
                 SpecProvider,
                 SealEngine,


### PR DESCRIPTION
Fixes #6512

## Changes

- changed to follow same logic utilizing SyncProgressResolver 

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

Fixed a bug with `eth_syncing` returning true when node is fully synced to old bodies and receipt barrier.
