### PR TITLE
[Fix]{Config] old default barrier being ignoreed in clients upgraded to new versions but were initailly synced with older versions (1.19.3 and below))

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/BodiesSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/BodiesSyncFeedTests.cs
@@ -141,19 +141,19 @@ public class BodiesSyncFeedTests
     }
 
     [TestCase(99, false, null, false)]
-    [TestCase(11052930, false, null, true)]
+    [TestCase(11051474, false, null, true)]
     [TestCase(11052984, false, null, true)]
     [TestCase(11052985, false, null, false)]
     [TestCase(99, false, 11052984, false)]
-    [TestCase(11052930, false, 11052984, true)]
+    [TestCase(11051474, false, 11052984, true)]
     [TestCase(11052984, false, 11052984, true)]
     [TestCase(11052985, false, 11052984, false)]
     [TestCase(99, true, null, false)]
-    [TestCase(11052930, true, null, false)]
+    [TestCase(11051474, true, null, false)]
     [TestCase(11052984, true, null, false)]
     [TestCase(11052985, true, null, false)]
     [TestCase(99, false, 0, false)]
-    [TestCase(11052930, false, 0, false)]
+    [TestCase(11051474, false, 0, false)]
     [TestCase(11052984, false, 0, false)]
     [TestCase(11052985, false, 0, false)]
     public async Task When_finished_sync_with_old_default_barrier_then_finishes_imedietely(

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/ReceiptsSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/ReceiptsSyncFeedTests.cs
@@ -241,19 +241,19 @@ namespace Nethermind.Synchronization.Test.FastBlocks
         }
 
         [TestCase(1024, false, null, false)]
-        [TestCase(11052930, false, null, true)]
+        [TestCase(11051474, false, null, true)]
         [TestCase(11052984, false, null, true)]
         [TestCase(11052985, false, null, false)]
         [TestCase(1024, false, 11052984, false)]
-        [TestCase(11052930, false, 11052984, true)]
+        [TestCase(11051474, false, 11052984, true)]
         [TestCase(11052984, false, 11052984, true)]
         [TestCase(11052985, false, 11052984, false)]
         [TestCase(1024, true, null, false)]
-        [TestCase(11052930, true, null, false)]
+        [TestCase(11051474, true, null, false)]
         [TestCase(11052984, true, null, false)]
         [TestCase(11052985, true, null, false)]
         [TestCase(1024, false, 0, false)]
-        [TestCase(11052930, false, 0, false)]
+        [TestCase(11051474, false, 0, false)]
         [TestCase(11052984, false, 0, false)]
         [TestCase(11052985, false, 0, false)]
         public async Task When_finished_sync_with_old_default_barrier_then_finishes_imedietely(

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/BarrierSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/BarrierSyncFeed.cs
@@ -15,6 +15,8 @@ namespace Nethermind.Synchronization.FastBlocks;
 public abstract class BarrierSyncFeed<T> : ActivatedSyncFeed<T>
 {
     internal const int DepositContractBarrier = 11052984;
+    internal const int OldBarrierDefaultExtraRange = 8192;
+
     protected abstract long? LowestInsertedNumber { get; }
     protected abstract int BarrierWhenStartedMetadataDbKey { get; }
     protected abstract long SyncConfigBarrierCalc { get; }
@@ -32,7 +34,7 @@ public abstract class BarrierSyncFeed<T> : ActivatedSyncFeed<T>
     protected bool WithinOldBarrierDefault => _specProvider.ChainId == BlockchainIds.Mainnet
         && _barrierWhenStarted == DepositContractBarrier
         && LowestInsertedNumber <= DepositContractBarrier
-        && LowestInsertedNumber > DepositContractBarrier - 5_000; // this is intentional. this is a magic number as to the amount of possible blocks that had been synced. We noticed on previous versions that the client synced a bit below the default barrier by more than just the GethRequest limit (128).
+        && LowestInsertedNumber > DepositContractBarrier - OldBarrierDefaultExtraRange; // this is intentional. this is a magic number as to the amount of possible blocks that had been synced. We noticed on previous versions that the client synced a bit below the default barrier by more than just the GethRequest limit (128).
 
     public BarrierSyncFeed(IDb metadataDb, ISpecProvider specProvider, ILogger logger)
     {

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/BarrierSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/BarrierSyncFeed.cs
@@ -32,7 +32,7 @@ public abstract class BarrierSyncFeed<T> : ActivatedSyncFeed<T>
     protected bool WithinOldBarrierDefault => _specProvider.ChainId == BlockchainIds.Mainnet
         && _barrierWhenStarted == DepositContractBarrier
         && LowestInsertedNumber <= DepositContractBarrier
-        && LowestInsertedNumber > DepositContractBarrier - GethSyncLimits.MaxBodyFetch; // this is intentional. using this as an approxamation assuming a minimum of 1 receipt in per block in case of receipts
+        && LowestInsertedNumber > DepositContractBarrier - 5_000; // this is intentional. this is a magic number as to the amount of possible blocks that had been synced. We noticed on previous versions that the client synced a bit below the default barrier by more than just the GethRequest limit (128).
 
     public BarrierSyncFeed(IDb metadataDb, ISpecProvider specProvider, ILogger logger)
     {


### PR DESCRIPTION
## Changes

- put a more lenient number for the amount of blocks the node can continue to sync below the barrier and still be within range of the old default.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Will test on 1.19.3

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
