### PR TITLE
Feature: Exposing Prometheus metrics to user-defined interface

### DIFF
--- a/src/Nethermind/Nethermind.Monitoring/Config/IMetricsConfig.cs
+++ b/src/Nethermind/Nethermind.Monitoring/Config/IMetricsConfig.cs
@@ -8,6 +8,9 @@ namespace Nethermind.Monitoring.Config;
 [ConfigCategory(Description = "Configuration of the metrics provided by a Nethermind node for both, the Prometheus and the dotnet-counters.")]
 public interface IMetricsConfig : IConfig
 {
+    [ConfigItem(Description = "The ip at which to expose Prometheus metrics.", DefaultValue = "127.0.0.1")]
+    string ExposeHost { get; }
+
     [ConfigItem(Description = "The port to expose Prometheus metrics at.", DefaultValue = "null")]
     int? ExposePort { get; }
 

--- a/src/Nethermind/Nethermind.Monitoring/Config/MetricsConfig.cs
+++ b/src/Nethermind/Nethermind.Monitoring/Config/MetricsConfig.cs
@@ -5,6 +5,7 @@ namespace Nethermind.Monitoring.Config
 {
     public class MetricsConfig : IMetricsConfig
     {
+        public string ExposeHost { get; set; } = "127.0.0.1";
         public int? ExposePort { get; set; } = null;
         public bool Enabled { get; set; } = false;
         public bool CountersEnabled { get; set; } = false;

--- a/src/Nethermind/Nethermind.Monitoring/MonitoringService.cs
+++ b/src/Nethermind/Nethermind.Monitoring/MonitoringService.cs
@@ -19,6 +19,7 @@ namespace Nethermind.Monitoring
         private readonly ILogger _logger;
         private readonly Options _options;
 
+        private readonly string _exposeHost;
         private readonly int? _exposePort;
         private readonly string _nodeName;
         private readonly bool _pushEnabled;
@@ -29,12 +30,14 @@ namespace Nethermind.Monitoring
         {
             _metricsController = metricsController ?? throw new ArgumentNullException(nameof(metricsController));
 
+            string exposeHost = metricsConfig.ExposeHost;
             int? exposePort = metricsConfig.ExposePort;
             string nodeName = metricsConfig.NodeName;
             string pushGatewayUrl = metricsConfig.PushGatewayUrl;
             bool pushEnabled = metricsConfig.Enabled;
             int intervalSeconds = metricsConfig.IntervalSeconds;
 
+            _exposeHost = exposeHost;
             _exposePort = exposePort;
             _nodeName = string.IsNullOrWhiteSpace(nodeName)
                 ? throw new ArgumentNullException(nameof(nodeName))
@@ -81,7 +84,7 @@ namespace Nethermind.Monitoring
             }
             if (_exposePort is not null)
             {
-                new NethermindKestrelMetricServer(_exposePort.Value).Start();
+                new NethermindKestrelMetricServer(_exposeHost, _exposePort.Value).Start();
             }
             await Task.Factory.StartNew(() => _metricsController.StartUpdating(), TaskCreationOptions.LongRunning);
             if (_logger.IsInfo) _logger.Info($"Started monitoring for the group: {_options.Group}, instance: {_options.Instance}");


### PR DESCRIPTION
## Changes

- Add `--Metrics.ExposeHost` option and pass that to NethermindKestrelMetricServer so a hostname other than localhost can be exposed. Defaults to `127.0.0.1` since this is the current default behavior without an option.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [X] Yes
- [ ] No

_I have only compiled this on my dev laptop and not run this on my production node yet. Therefore I am looking for early feedback to my commits until that can be completed. It would be good to verify the passed address matches what is printed in the logs (instead of 127.0.0.1, as it currently shows). as well as, ensuring that the hostname:port can be accessed, i.e. from dev laptop curl_

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

_Built Nethermind.Runner, correcting all errors and verified the new CLI option was available (when spelled correctly)_

## Documentation

#### Requires documentation update

- [X] Yes
- [ ] No

_Metrics documentation is already marked for needing update_

#### Requires explanation in Release Notes

- [X] Yes
- [ ] No

_Add `Metrics.ExposeHost` configuration option. Defaults to `127.0.0.1`. Allows Prometheus metrics to be exposed on an interface other than localhost._


