### PR TITLE
Remove contention from KeccakHash during Sync

### DIFF
--- a/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.cs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
@@ -642,32 +642,36 @@ namespace Nethermind.Core.Crypto
 
         private static class Pool
         {
-            private const int MaxPooled = 24;
-            private static readonly ConcurrentQueue<byte[]> s_remainderCache = new();
-            public static byte[] RentRemainder() => s_remainderCache.TryDequeue(out byte[]? remainder) ? remainder : new byte[STATE_SIZE];
+            private const int MaxPooledPerThread = 4;
+            [ThreadStatic]
+            private static Queue<byte[]>? s_remainderCache;
+            public static byte[] RentRemainder() => s_remainderCache?.TryDequeue(out byte[]? remainder) ?? false ? remainder : new byte[STATE_SIZE];
             public static void ReturnRemainder(ref byte[] remainder)
             {
                 if (remainder.Length == 0) return;
 
-                if (s_remainderCache.Count <= MaxPooled)
+                var cache = (s_remainderCache ??= new());
+                if (cache.Count <= MaxPooledPerThread)
                 {
                     remainder.AsSpan().Clear();
-                    s_remainderCache.Enqueue(remainder);
+                    cache.Enqueue(remainder);
                 }
 
                 remainder = Array.Empty<byte>();
             }
 
-            private static readonly ConcurrentQueue<ulong[]> s_stateCache = new();
-            public static ulong[] RentState() => s_stateCache.TryDequeue(out ulong[]? state) ? state : new ulong[STATE_SIZE / sizeof(ulong)];
+            [ThreadStatic]
+            private static Queue<ulong[]>? s_stateCache;
+            public static ulong[] RentState() => s_stateCache?.TryDequeue(out ulong[]? state) ?? false ? state : new ulong[STATE_SIZE / sizeof(ulong)];
             public static void ReturnState(ref ulong[] state)
             {
                 if (state.Length == 0) return;
 
-                if (s_stateCache.Count <= MaxPooled)
+                var cache = (s_stateCache ??= new());
+                if (cache.Count <= MaxPooledPerThread)
                 {
                     state.AsSpan().Clear();
-                    s_stateCache.Enqueue(state);
+                    cache.Enqueue(state);
                 }
 
                 state = Array.Empty<ulong>();


### PR DESCRIPTION
## Changes

- Use `ThreadStatic`s for the pooled buffers rather than a `ConcurrentQueue` as their is lots of contention in very high multi thtreaded Keccaking

Before Left, After Right

![image](https://github.com/NethermindEth/nethermind/assets/1142958/bdf96294-4017-4321-90f4-197572cabab7)

During sync, before it spends more time contended on getting the buffer than it does hashing; after all the time is on the Keccak

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
