### PR TITLE
Reduce allocations in StorageRangesMessageSerializer

### DIFF
--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/StorageRangesMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/StorageRangesMessageSerializer.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using DotNetty.Buffers;
 using Nethermind.Core.Crypto;
 using Nethermind.Serialization.Rlp;
@@ -8,8 +9,18 @@ using Nethermind.State.Snap;
 
 namespace Nethermind.Network.P2P.Subprotocols.Snap.Messages
 {
-    public class StorageRangesMessageSerializer : IZeroMessageSerializer<StorageRangeMessage>
+    public sealed class StorageRangesMessageSerializer : IZeroMessageSerializer<StorageRangeMessage>
     {
+        private readonly Func<RlpStream, PathWithStorageSlot> _decodeSlot;
+        private readonly Func<RlpStream, PathWithStorageSlot[]> _decodeSlotArray;
+
+        public StorageRangesMessageSerializer()
+        {
+            // Capture closures once
+            _decodeSlot = DecodeSlot;
+            _decodeSlotArray = s => s.DecodeArray(_decodeSlot);
+        }
+
         public void Serialize(IByteBuffer byteBuffer, StorageRangeMessage message)
         {
             (int contentLength, int allSlotsLength, int[] accountSlotsLengths, int proofsLength) = CalculateLengths(message);
@@ -71,7 +82,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap.Messages
             stream.ReadSequenceLength();
 
             message.RequestId = stream.DecodeLong();
-            message.Slots = stream.DecodeArray(s => s.DecodeArray(DecodeSlot));
+            message.Slots = stream.DecodeArray(_decodeSlotArray);
             message.Proofs = stream.DecodeArray(s => s.DecodeByteArray());
 
             return message;

--- a/src/Nethermind/Nethermind.State/Snap/PathWithStorageSlot.cs
+++ b/src/Nethermind/Nethermind.State/Snap/PathWithStorageSlot.cs
@@ -1,19 +1,31 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
+using System.Numerics;
 using Nethermind.Core.Crypto;
 
 namespace Nethermind.State.Snap
 {
-    public readonly struct PathWithStorageSlot
+    public readonly struct PathWithStorageSlot(ValueHash256 keyHash, byte[] slotRlpValue)
+        : IEquatable<PathWithStorageSlot>, IEqualityOperators<PathWithStorageSlot, PathWithStorageSlot, bool>
     {
-        public PathWithStorageSlot(ValueHash256 keyHash, byte[] slotRlpValue)
+        public ValueHash256 Path { get; } = keyHash;
+        public byte[] SlotRlpValue { get; } = slotRlpValue;
+
+        public bool Equals(in PathWithStorageSlot other)
         {
-            Path = keyHash;
-            SlotRlpValue = slotRlpValue;
+            return Path == other.Path && SlotRlpValue.AsSpan().SequenceEqual(other.SlotRlpValue);
         }
 
-        public ValueHash256 Path { get; }
-        public byte[] SlotRlpValue { get; }
+        public bool Equals(PathWithStorageSlot other) => Equals(in other);
+
+        public static bool operator ==(PathWithStorageSlot left, PathWithStorageSlot right) => left.Equals(in right);
+
+        public static bool operator !=(PathWithStorageSlot left, PathWithStorageSlot right) => !left.Equals(in right);
+
+        public override bool Equals(object obj) => obj is PathWithStorageSlot pws && Equals(in pws);
+
+        public override int GetHashCode() => throw new NotImplementedException();
     }
 }

--- a/src/Nethermind/Nethermind.State/Snap/PathWithStorageSlot.cs
+++ b/src/Nethermind/Nethermind.State/Snap/PathWithStorageSlot.cs
@@ -5,7 +5,7 @@ using Nethermind.Core.Crypto;
 
 namespace Nethermind.State.Snap
 {
-    public class PathWithStorageSlot
+    public readonly struct PathWithStorageSlot
     {
         public PathWithStorageSlot(ValueHash256 keyHash, byte[] slotRlpValue)
         {
@@ -13,7 +13,7 @@ namespace Nethermind.State.Snap
             SlotRlpValue = slotRlpValue;
         }
 
-        public ValueHash256 Path { get; set; }
-        public byte[] SlotRlpValue { get; set; }
+        public ValueHash256 Path { get; }
+        public byte[] SlotRlpValue { get; }
     }
 }


### PR DESCRIPTION
## Changes

- Capture closures once per class rather than once per invocation
- Change `PathWithStorageSlot` from class to `readonly struct`

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No
