### PR TITLE
Propagate pooled arrays to RlpStream

### DIFF
--- a/src/Nethermind/Nethermind.AccountAbstraction/Data/UserOperationDecoder.cs
+++ b/src/Nethermind/Nethermind.AccountAbstraction/Data/UserOperationDecoder.cs
@@ -18,7 +18,7 @@ namespace Nethermind.AccountAbstraction.Data
 
             RlpStream rlpStream = new(GetLength(item, rlpBehaviors));
             Encode(rlpStream, item, rlpBehaviors);
-            return new Rlp(rlpStream.Data!);
+            return new Rlp(rlpStream.Data.ToArray()!);
 
         }
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/Receipts/KeccaksIteratorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Receipts/KeccaksIteratorTests.cs
@@ -64,7 +64,7 @@ public class KeccaksIteratorTests
         }
 
         Span<byte> buffer = stackalloc byte[32];
-        KeccaksIterator iterator = new(rlpStream.Data, buffer);
+        KeccaksIterator iterator = new(rlpStream.Data.AsSpan(), buffer);
 
         List<Hash256> decoded = new();
         while (iterator.TryGetNext(out Hash256StructRef kec))
@@ -92,7 +92,7 @@ public class KeccaksIteratorTests
         }
 
         Span<byte> buffer = stackalloc byte[32];
-        KeccaksIterator iterator = new(rlpStream.Data, buffer);
+        KeccaksIterator iterator = new(rlpStream.Data.AsSpan(), buffer);
 
         List<Hash256> decoded = new();
         while (iterator.TryGetNext(out Hash256StructRef kec))

--- a/src/Nethermind/Nethermind.Consensus.AuRa/Validators/PendingValidatorsDecoder.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/Validators/PendingValidatorsDecoder.cs
@@ -52,7 +52,7 @@ namespace Nethermind.Consensus.AuRa.Validators
 
             RlpStream rlpStream = new RlpStream(GetLength(item, rlpBehaviors));
             Encode(rlpStream, item, rlpBehaviors);
-            return new Rlp(rlpStream.Data);
+            return new Rlp(rlpStream.Data.ToArray());
         }
 
         public void Encode(RlpStream rlpStream, PendingValidators item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)

--- a/src/Nethermind/Nethermind.Consensus.AuRa/Validators/ValidatorInfoDecoder.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/Validators/ValidatorInfoDecoder.cs
@@ -44,7 +44,7 @@ namespace Nethermind.Consensus.AuRa.Validators
 
             RlpStream rlpStream = new(GetLength(item, rlpBehaviors));
             Encode(rlpStream, item, rlpBehaviors);
-            return new Rlp(rlpStream.Data);
+            return new Rlp(rlpStream.Data.ToArray());
         }
 
         public void Encode(RlpStream stream, ValidatorInfo? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)

--- a/src/Nethermind/Nethermind.Consensus.Clique/CliqueBlockProducer.cs
+++ b/src/Nethermind/Nethermind.Consensus.Clique/CliqueBlockProducer.cs
@@ -447,7 +447,7 @@ public class CliqueBlockProducer : ICliqueBlockProducer, IDisposable
             Array.Empty<BlockHeader>(),
             spec.WithdrawalsEnabled ? Enumerable.Empty<Withdrawal>() : null
             );
-        header.TxRoot = new TxTrie(block.Transactions).RootHash;
+        header.TxRoot = TxTrie.CalculateRoot(block.Transactions);
         block.Header.Author = _sealer.Address;
         return block;
     }

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockExtensions.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockExtensions.cs
@@ -28,7 +28,7 @@ namespace Nethermind.Consensus.Processing
 
         public static bool TrySetTransactions(this Block block, Transaction[] transactions)
         {
-            block.Header.TxRoot = new TxTrie(transactions).RootHash;
+            block.Header.TxRoot = TxTrie.CalculateRoot(transactions);
 
             if (block is BlockToProduce blockToProduce)
             {

--- a/src/Nethermind/Nethermind.Consensus/Validators/BlockValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/BlockValidator.cs
@@ -317,7 +317,7 @@ public class BlockValidator : IBlockValidator
     }
     public static bool ValidateTxRootMatchesTxs(BlockHeader header, BlockBody body, out Hash256 txRoot)
     {
-        txRoot = new TxTrie(body.Transactions).RootHash;
+        txRoot = TxTrie.CalculateRoot(body.Transactions);
         return txRoot == header.TxRoot;
     }
 

--- a/src/Nethermind/Nethermind.Core.Test/Builders/BlockBuilder.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Builders/BlockBuilder.cs
@@ -95,9 +95,8 @@ namespace Nethermind.Core.Test.Builders
             }
 
             BlockBuilder result = WithTransactions(txs);
-            ReceiptTrie receiptTrie = new(specProvider.GetSpec(TestObjectInternal.Header), receipts);
-            receiptTrie.UpdateRootHash();
-            TestObjectInternal.Header.ReceiptsRoot = receiptTrie.RootHash;
+            Hash256 receiptHash = ReceiptTrie.CalculateRoot(specProvider.GetSpec(TestObjectInternal.Header), receipts);
+            TestObjectInternal.Header.ReceiptsRoot = receiptHash;
             return result;
         }
 
@@ -105,10 +104,8 @@ namespace Nethermind.Core.Test.Builders
         {
             TestObjectInternal = TestObjectInternal.WithReplacedBody(
                 TestObjectInternal.Body.WithChangedTransactions(transactions));
-            TxTrie trie = new(transactions);
-            trie.UpdateRootHash();
 
-            TestObjectInternal.Header.TxRoot = trie.RootHash;
+            TestObjectInternal.Header.TxRoot = TxTrie.CalculateRoot(transactions);
             return this;
         }
 

--- a/src/Nethermind/Nethermind.Core.Test/Builders/BlockTreeBuilder.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Builders/BlockTreeBuilder.cs
@@ -285,9 +285,9 @@ namespace Nethermind.Core.Test.Builders
                     currentBlock.Bloom!.Add(receipt.Logs);
                 }
 
-                currentBlock.Header.TxRoot = new TxTrie(currentBlock.Transactions).RootHash;
+                currentBlock.Header.TxRoot = TxTrie.CalculateRoot(currentBlock.Transactions);
                 TxReceipt[] txReceipts = receipts.ToArray();
-                currentBlock.Header.ReceiptsRoot = new ReceiptTrie(_specProvider.GetSpec(currentBlock.Header), txReceipts).RootHash;
+                currentBlock.Header.ReceiptsRoot = ReceiptTrie.CalculateRoot(_specProvider.GetSpec(currentBlock.Header), txReceipts);
                 currentBlock.Header.Hash = currentBlock.CalculateHash();
                 foreach (TxReceipt txReceipt in txReceipts)
                 {

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/AccessListDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/AccessListDecoderTests.cs
@@ -108,7 +108,7 @@ namespace Nethermind.Core.Test.Encoding
             RlpStream rlpStream = new(10000);
             _decoder.Encode(rlpStream, testCase.AccessList);
             rlpStream.Position = 0;
-            Rlp.ValueDecoderContext ctx = rlpStream.Data.AsRlpValueContext();
+            Rlp.ValueDecoderContext ctx = rlpStream.Data.AsSpan().AsRlpValueContext();
             AccessList decoded = _decoder.Decode(ref ctx)!;
             if (testCase.AccessList is null)
             {

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/BlockInfoDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/BlockInfoDecoderTests.cs
@@ -102,7 +102,7 @@ namespace Nethermind.Core.Test.Encoding
                 stream.Encode(item.IsFinalized);
             }
 
-            return new Rlp(stream.Data!);
+            return new Rlp(stream.Data.ToArray()!);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/TxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/TxDecoderTests.cs
@@ -126,7 +126,7 @@ namespace Nethermind.Core.Test.Encoding
             RlpStream rlpStream = new(10000);
             _txDecoder.Encode(rlpStream, testCase.Tx);
 
-            Rlp.ValueDecoderContext decoderContext = new(rlpStream.Data, true);
+            Rlp.ValueDecoderContext decoderContext = new(rlpStream.Data.ToArray(), true);
             rlpStream.Position = 0;
             Transaction? decoded = _txDecoder.Decode(ref decoderContext);
             decoded!.SenderAddress =
@@ -143,7 +143,7 @@ namespace Nethermind.Core.Test.Encoding
             RlpStream rlpStream = new(10000);
             _txDecoder.Encode(rlpStream, testCase.Tx);
 
-            Rlp.ValueDecoderContext decoderContext = new(rlpStream.Data, true);
+            Rlp.ValueDecoderContext decoderContext = new(rlpStream.Data.ToArray(), true);
             rlpStream.Position = 0;
             Transaction? decoded = _txDecoder.Decode(ref decoderContext);
 

--- a/src/Nethermind/Nethermind.Core.Test/RlpTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/RlpTests.cs
@@ -259,7 +259,7 @@ namespace Nethermind.Core.Test
             stream.Encode(randomBytes);
             stream.Encode(randomBytes);
 
-            Memory<byte> memory = stream.Data;
+            Memory<byte> memory = stream.Data.ToArray();
             Rlp.ValueDecoderContext context = new Rlp.ValueDecoderContext(memory, sliceValue);
 
             for (int i = 0; i < 3; i++)

--- a/src/Nethermind/Nethermind.Core/Buffers/CappedArray.cs
+++ b/src/Nethermind/Nethermind.Core/Buffers/CappedArray.cs
@@ -13,8 +13,13 @@ namespace Nethermind.Core.Buffers;
 /// </summary>
 public readonly struct CappedArray<T>
 {
-    private readonly T[]? _array = null;
-    private readonly int _length = 0;
+    private readonly static CappedArray<T> _null = default;
+    private readonly static CappedArray<T> _empty = new CappedArray<T>(Array.Empty<T>());
+    public static ref readonly CappedArray<T> Null => ref _null;
+    public static ref readonly CappedArray<T> Empty => ref _empty;
+
+    private readonly T[]? _array;
+    private readonly int _length;
 
     public CappedArray(T[]? array, int length)
     {
@@ -31,27 +36,48 @@ public readonly struct CappedArray<T>
         }
     }
 
-    public static implicit operator ReadOnlySpan<T>(CappedArray<T> array)
+    public static implicit operator ReadOnlySpan<T>(in CappedArray<T> array)
     {
         return array.AsSpan();
     }
 
     public static implicit operator CappedArray<T>(T[]? array)
     {
-        if (array == null) return new CappedArray<T>(null);
+        if (array == null) return default;
         return new CappedArray<T>(array);
     }
 
-    public readonly int Length => _length;
+    public T this[int index]
+    {
+        get
+        {
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, _length);
+            return _array![index];
+        }
+        set
+        {
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, _length);
+            _array![index] = value;
+        }
+    }
 
-    public readonly T[]? Array => _array;
+    public readonly int Length => _length;
+    public readonly int UnderlyingLength => _array?.Length ?? 0;
+
+    public readonly T[]? UnderlyingArray => _array;
     public readonly bool IsUncapped => _length == _array?.Length;
     public readonly bool IsNull => _array is null;
     public readonly bool IsNotNull => _array is not null;
+    public readonly bool IsNotNullOrEmpty => _length > 0;
 
     public readonly Span<T> AsSpan()
     {
-        return _array.AsSpan()[..Length];
+        return _array.AsSpan(0, _length);
+    }
+
+    public readonly Span<T> AsSpan(int start, int length)
+    {
+        return _array.AsSpan(start, length);
     }
 
     public readonly T[]? ToArray()

--- a/src/Nethermind/Nethermind.Core/Buffers/ICappedArrayPool.cs
+++ b/src/Nethermind/Nethermind.Core/Buffers/ICappedArrayPool.cs
@@ -7,7 +7,7 @@ public interface ICappedArrayPool
 {
     CappedArray<byte> Rent(int size);
 
-    void Return(CappedArray<byte> buffer);
+    void Return(in CappedArray<byte> buffer);
 }
 
 public static class BufferPoolExtensions
@@ -18,7 +18,7 @@ public static class BufferPoolExtensions
         return pool.Rent(size);
     }
 
-    public static void SafeReturnBuffer(this ICappedArrayPool? pool, CappedArray<byte> buffer)
+    public static void SafeReturnBuffer(this ICappedArrayPool? pool, in CappedArray<byte> buffer)
     {
         pool?.Return(buffer);
     }

--- a/src/Nethermind/Nethermind.Core/KeyValueStoreExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/KeyValueStoreExtensions.cs
@@ -104,7 +104,7 @@ namespace Nethermind.Core
             db.PutSpan(key.Bytes, value, writeFlags);
         }
 
-        public static void Set(this IWriteOnlyKeyValueStore db, Hash256 key, CappedArray<byte> value, WriteFlags writeFlags = WriteFlags.None)
+        public static void Set(this IWriteOnlyKeyValueStore db, Hash256 key, in CappedArray<byte> value, WriteFlags writeFlags = WriteFlags.None)
         {
             if (value.IsUncapped && db.PreferWriteByArray)
             {
@@ -112,7 +112,7 @@ namespace Nethermind.Core
                 return;
             }
 
-            db.PutSpan(key.Bytes, value, writeFlags);
+            db.PutSpan(key.Bytes, value.AsSpan(), writeFlags);
         }
 
         public static void Set(this IWriteOnlyKeyValueStore db, long blockNumber, Hash256 key, ReadOnlySpan<byte> value, WriteFlags writeFlags = WriteFlags.None)

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugBridge.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugBridge.cs
@@ -102,9 +102,8 @@ public class DebugBridge : IDebugBridge
         }
 
         Block block = searchResult.Object;
-        ReceiptTrie receiptTrie = new(_specProvider.GetSpec(block.Header), txReceipts);
-        receiptTrie.UpdateRootHash();
-        if (block.ReceiptsRoot != receiptTrie.RootHash)
+        Hash256 receiptHash = ReceiptTrie.CalculateRoot(_specProvider.GetSpec(block.Header), txReceipts);
+        if (block.ReceiptsRoot != receiptHash)
         {
             throw new InvalidDataException("Receipts root mismatch");
         }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Proof/ProofRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Proof/ProofRpcModule.cs
@@ -200,12 +200,12 @@ namespace Nethermind.JsonRpc.Modules.Proof
 
         private static byte[][] BuildTxProofs(Transaction[] txs, IReleaseSpec releaseSpec, int index)
         {
-            return new TxTrie(txs, true).BuildProof(index);
+            return TxTrie.CalculateProof(txs, index);
         }
 
         private byte[][] BuildReceiptProofs(BlockHeader blockHeader, TxReceipt[] receipts, int index)
         {
-            return new ReceiptTrie(_specProvider.GetSpec(blockHeader), receipts, true).BuildProof(index);
+            return ReceiptTrie.CalculateReceiptProofs(_specProvider.GetSpec(blockHeader), receipts, index);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayload.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayload.cs
@@ -145,7 +145,7 @@ public class ExecutionPayload : IForkValidator, IExecutionPayloadParams
                 Author = FeeRecipient,
                 IsPostMerge = true,
                 TotalDifficulty = totalDifficulty,
-                TxRoot = new TxTrie(transactions).RootHash,
+                TxRoot = TxTrie.CalculateRoot(transactions),
                 WithdrawalsRoot = Withdrawals is null ? null : new WithdrawalTrie(Withdrawals).RootHash,
             };
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/PivotUpdator.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/PivotUpdator.cs
@@ -234,7 +234,7 @@ public class PivotUpdator
             RlpStream pivotData = new(38); //1 byte (prefix) + 4 bytes (long) + 1 byte (prefix) + 32 bytes (Keccak)
             pivotData.Encode(finalizedBlockNumber);
             pivotData.Encode(finalizedBlockHash);
-            _metadataDb.Set(MetadataDbKeys.UpdatedPivotData, pivotData.Data!);
+            _metadataDb.Set(MetadataDbKeys.UpdatedPivotData, pivotData.Data.ToArray()!);
 
             if (_logger.IsInfo) _logger.Info($"New pivot block has been set based on ForkChoiceUpdate from CL. Pivot block number: {finalizedBlockNumber}, hash: {finalizedBlockHash}");
             return true;

--- a/src/Nethermind/Nethermind.Network.Enr/NodeRecord.cs
+++ b/src/Nethermind/Nethermind.Network.Enr/NodeRecord.cs
@@ -201,7 +201,7 @@ public class NodeRecord
         int totalLength = Rlp.LengthOfSequence(contentLength);
         RlpStream rlpStream = new(totalLength);
         Encode(rlpStream);
-        return rlpStream.Data!.ToHexString();
+        return rlpStream.Data.AsSpan().ToHexString();
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Network.Enr/NodeRecordSigner.cs
+++ b/src/Nethermind/Nethermind.Network.Enr/NodeRecordSigner.cs
@@ -105,7 +105,7 @@ public class NodeRecordSigner : INodeRecordSigner
             originalContentStream.StartSequence(noSigContentLength);
             originalContentStream.Write(rlpStream.Read(noSigContentLength));
             rlpStream.Position = startPosition;
-            nodeRecord.OriginalContentRlp = originalContentStream.Data!;
+            nodeRecord.OriginalContentRlp = originalContentStream.Data.ToArray()!;
         }
 
         nodeRecord.EnrSequence = enrSequence;

--- a/src/Nethermind/Nethermind.Network/NetworkNodeDecoder.cs
+++ b/src/Nethermind/Nethermind.Network/NetworkNodeDecoder.cs
@@ -60,7 +60,7 @@ namespace Nethermind.Network
             stream.Encode(item.Port);
             stream.Encode(string.Empty);
             stream.Encode(item.Reputation);
-            return new Rlp(stream.Data);
+            return new Rlp(stream.Data.ToArray());
         }
 
         public void Encode(MemoryStream stream, NetworkNode item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/AccountDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/AccountDecoder.cs
@@ -82,7 +82,7 @@ namespace Nethermind.Serialization.Rlp
 
             Encode(item, rlpStream, contentLength);
 
-            return new Rlp(rlpStream.Data);
+            return new Rlp(rlpStream.Data.ToArray());
         }
 
         public void Encode(Account account, RlpStream rlpStream, int? contentLength = null)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/BlockDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/BlockDecoder.cs
@@ -224,7 +224,7 @@ namespace Nethermind.Serialization.Rlp
 
             RlpStream rlpStream = new(GetLength(item, rlpBehaviors));
             Encode(rlpStream, item, rlpBehaviors);
-            return new(rlpStream.Data);
+            return new(rlpStream.Data.ToArray());
         }
 
         public void Encode(RlpStream stream, Block? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/ByteArrayExtensions.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/ByteArrayExtensions.cs
@@ -13,9 +13,9 @@ namespace Nethermind.Serialization.Rlp
             return new(bytes ?? Array.Empty<byte>());
         }
 
-        public static RlpStream AsRlpStream(this CappedArray<byte> bytes)
+        public static RlpStream AsRlpStream(in this CappedArray<byte> bytes)
         {
-            return new(bytes.Array ?? Array.Empty<byte>());
+            return new(in bytes.IsNotNull ? ref bytes : ref CappedArray<byte>.Empty);
         }
 
         public static Rlp.ValueDecoderContext AsRlpValueContext(this byte[]? bytes)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/CompactReceiptStorageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/CompactReceiptStorageDecoder.cs
@@ -167,7 +167,7 @@ namespace Nethermind.Serialization.Rlp
         {
             RlpStream rlpStream = new(GetLength(item, rlpBehaviors));
             Encode(rlpStream, item, rlpBehaviors);
-            return new Rlp(rlpStream.Data);
+            return new Rlp(rlpStream.Data.ToArray());
         }
 
         public void Encode(RlpStream rlpStream, TxReceipt? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/HeaderDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/HeaderDecoder.cs
@@ -257,7 +257,7 @@ namespace Nethermind.Serialization.Rlp
             RlpStream rlpStream = new(GetLength(item, rlpBehaviors));
             Encode(rlpStream, item, rlpBehaviors);
 
-            return new Rlp(rlpStream.Data);
+            return new Rlp(rlpStream.Data.ToArray());
         }
 
         private static int GetContentLength(BlockHeader? item, RlpBehaviors rlpBehaviors)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/LogEntryDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/LogEntryDecoder.cs
@@ -63,7 +63,7 @@ namespace Nethermind.Serialization.Rlp
 
             RlpStream rlpStream = new(GetLength(item, rlpBehaviors));
             Encode(rlpStream, item, rlpBehaviors);
-            return new Rlp(rlpStream.Data);
+            return new Rlp(rlpStream.Data.ToArray());
         }
 
         public void Encode(RlpStream rlpStream, LogEntry? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptMessageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptMessageDecoder.cs
@@ -138,7 +138,7 @@ namespace Nethermind.Serialization.Rlp
             int length = GetLength(item, rlpBehaviors);
             RlpStream stream = new(length);
             Encode(stream, item, rlpBehaviors);
-            return stream.Data;
+            return stream.Data.ToArray();
         }
 
         public void Encode(RlpStream rlpStream, TxReceipt item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptStorageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptStorageDecoder.cs
@@ -175,7 +175,7 @@ namespace Nethermind.Serialization.Rlp
         {
             RlpStream rlpStream = new(GetLength(item, rlpBehaviors));
             Encode(rlpStream, item, rlpBehaviors);
-            return new Rlp(rlpStream.Data);
+            return new Rlp(rlpStream.Data.ToArray());
         }
 
         public void Encode(RlpStream rlpStream, TxReceipt? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -183,7 +183,7 @@ namespace Nethermind.Serialization.Rlp
             if (item is Rlp rlp)
             {
                 RlpStream stream = new(LengthOfSequence(rlp.Length));
-                return new(stream.Data);
+                return new(stream.Data.ToArray());
             }
 
             IRlpStreamDecoder<T>? rlpStreamDecoder = GetStreamDecoder<T>();
@@ -192,7 +192,7 @@ namespace Nethermind.Serialization.Rlp
                 int totalLength = rlpStreamDecoder.GetLength(item, behaviors);
                 RlpStream stream = new(totalLength);
                 rlpStreamDecoder.Encode(stream, item, behaviors);
-                return new Rlp(stream.Data);
+                return new Rlp(stream.Data.ToArray());
             }
 
             IRlpObjectDecoder<T>? rlpDecoder = GetObjectDecoder<T>();
@@ -212,7 +212,7 @@ namespace Nethermind.Serialization.Rlp
                 int totalLength = rlpStreamDecoder.GetLength(items, behaviors);
                 RlpStream stream = new(totalLength);
                 rlpStreamDecoder.Encode(stream, items, behaviors);
-                return new Rlp(stream.Data);
+                return new Rlp(stream.Data.ToArray());
             }
 
             IRlpObjectDecoder<T> rlpDecoder = GetObjectDecoder<T>();

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpStream.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpStream.cs
@@ -10,6 +10,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using Nethermind.Core;
+using Nethermind.Core.Buffers;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Int256;
@@ -26,6 +27,8 @@ namespace Nethermind.Serialization.Rlp
         private static readonly WithdrawalDecoder _withdrawalDecoder = new();
         private static readonly LogEntryDecoder _logEntryDecoder = LogEntryDecoder.Instance;
 
+        private CappedArray<byte> _data;
+
         protected RlpStream()
         {
         }
@@ -36,12 +39,17 @@ namespace Nethermind.Serialization.Rlp
 
         public RlpStream(int length)
         {
-            Data = new byte[length];
+            _data = new byte[length];
         }
 
         public RlpStream(byte[] data)
         {
-            Data = data;
+            _data = data;
+        }
+
+        public RlpStream(in CappedArray<byte> data)
+        {
+            _data = data;
         }
 
         public void Encode(Block value)
@@ -165,15 +173,15 @@ namespace Nethermind.Serialization.Rlp
         {
             for (int i = 0; i < bytesToWrite.Count; ++i)
             {
-                Data![_position + i] = bytesToWrite[i];
+                Data[_position + i] = bytesToWrite[i];
             }
             Position += bytesToWrite.Count;
         }
 
         protected virtual string Description =>
-            Data?.Slice(0, Math.Min(Rlp.DebugMessageContentLength, Length)).ToHexString() ?? "0x";
+            Data.AsSpan(0, Math.Min(Rlp.DebugMessageContentLength, Length)).ToHexString() ?? "0x";
 
-        public byte[]? Data { get; }
+        public ref readonly CappedArray<byte> Data => ref _data;
 
         private int _position = 0;
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoder.cs
@@ -590,7 +590,7 @@ namespace Nethermind.Serialization.Rlp
         {
             RlpStream rlpStream = new(GetLength(item, rlpBehaviors));
             Encode(rlpStream, item, rlpBehaviors);
-            return new Rlp(rlpStream.Data);
+            return new Rlp(rlpStream.Data.ToArray());
         }
 
         public void Encode(RlpStream stream, T? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
@@ -603,7 +603,7 @@ namespace Nethermind.Serialization.Rlp
         {
             RlpStream rlpStream = new(GetTxLength(item, rlpBehaviors, forSigning, isEip155Enabled, chainId));
             EncodeTx(rlpStream, item, rlpBehaviors, forSigning, isEip155Enabled, chainId);
-            return new Rlp(rlpStream.Data);
+            return new Rlp(rlpStream.Data.ToArray());
         }
 
         private void EncodeTx(RlpStream stream, T? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None,

--- a/src/Nethermind/Nethermind.Serialization.Rlp/WithdrawalDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/WithdrawalDecoder.cs
@@ -70,7 +70,7 @@ public class WithdrawalDecoder : IRlpStreamDecoder<Withdrawal>, IRlpValueDecoder
 
         Encode(stream, item, rlpBehaviors);
 
-        return new(stream.Data);
+        return new(stream.Data.ToArray());
     }
 
     private static int GetContentLength(Withdrawal item) =>

--- a/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
@@ -1329,7 +1329,7 @@ namespace Nethermind.Synchronization.Test
 
                     _headers[blockHashes[i]].ReceiptsRoot = flags.HasFlag(Response.IncorrectReceiptRoot)
                         ? Keccak.EmptyTreeHash
-                        : new ReceiptTrie(MainnetSpecProvider.Instance.GetSpec((ForkActivation)_headers[blockHashes[i]].Number), receipts[i]).RootHash;
+                        : ReceiptTrie.CalculateRoot(MainnetSpecProvider.Instance.GetSpec((ForkActivation)_headers[blockHashes[i]].Number), receipts[i]);
                 }
 
                 ReceiptsMessage message = new(receipts);

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloadContext.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloadContext.cs
@@ -125,7 +125,7 @@ namespace Nethermind.Synchronization.Blocks
 
         private void ValidateReceipts(Block block, TxReceipt[] blockReceipts)
         {
-            Hash256 receiptsRoot = new ReceiptTrie(_specProvider.GetSpec(block.Header), blockReceipts).RootHash;
+            Hash256 receiptsRoot = ReceiptTrie.CalculateRoot(_specProvider.GetSpec(block.Header), blockReceipts);
 
             if (receiptsRoot != block.ReceiptsRoot)
             {

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/DetailedProgress.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/DetailedProgress.cs
@@ -152,7 +152,7 @@ namespace Nethermind.Synchronization.FastSync
             {
                 stream.Encode(entry);
             }
-            return stream.Data;
+            return stream.Data.ToArray()!;
         }
 
         private static int GetLength(Span<long> progress)

--- a/src/Nethermind/Nethermind.Synchronization/LesSync/CanonicalHashTrie.cs
+++ b/src/Nethermind/Nethermind.Synchronization/LesSync/CanonicalHashTrie.cs
@@ -136,7 +136,7 @@ namespace Nethermind.Synchronization.LesSync
             (Hash256? Hash, UInt256 Value) item = (header.Hash, header.TotalDifficulty.Value);
             RlpStream stream = new(_decoder.GetLength(item, RlpBehaviors.None));
             _decoder.Encode(stream, item);
-            return new Rlp(stream.Data);
+            return new Rlp(stream.Data.ToArray());
         }
     }
 }

--- a/src/Nethermind/Nethermind.Trie.Test/TrackingCappedArrayPoolTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrackingCappedArrayPoolTests.cs
@@ -29,7 +29,7 @@ public class TrackingCappedArrayPoolTests
         pool.Return(sample);
         arrayPool.Received(0).Return(Arg.Any<byte[]>());
 
-        pool.ReturnAll();
+        pool.Dispose();
         arrayPool.Received(4).Return(Arg.Any<byte[]>());
     }
 }

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -385,7 +385,7 @@ namespace Nethermind.Trie
                     [..nibblesCount]; // Slice to exact size;
 
                 Nibbles.BytesToNibbleBytes(rawKey, nibbles);
-                var result = Run(nibbles, nibblesCount, new CappedArray<byte>(Array.Empty<byte>()), false, startRootHash: rootHash).ToArray();
+                var result = Run(nibbles, nibblesCount, in CappedArray<byte>.Empty, isUpdate: false, startRootHash: rootHash).ToArray();
                 if (array is not null) ArrayPool<byte>.Shared.Return(array);
 
                 return result;
@@ -426,7 +426,7 @@ namespace Nethermind.Trie
 
         [SkipLocalsInit]
         [DebuggerStepThrough]
-        public virtual void Set(ReadOnlySpan<byte> rawKey, CappedArray<byte> value)
+        public virtual void Set(ReadOnlySpan<byte> rawKey, in CappedArray<byte> value)
         {
             if (_isTrace) Trace(in rawKey, in value);
 
@@ -438,7 +438,7 @@ namespace Nethermind.Trie
                 [..nibblesCount]; // Slice to exact size
 
             Nibbles.BytesToNibbleBytes(rawKey, nibbles);
-            Run(nibbles, nibblesCount, value, true);
+            Run(nibbles, nibblesCount, in value, isUpdate: true);
 
             if (array is not null) ArrayPool<byte>.Shared.Return(array);
 
@@ -457,7 +457,7 @@ namespace Nethermind.Trie
         private CappedArray<byte> Run(
             Span<byte> updatePath,
             int nibblesCount,
-            CappedArray<byte> updateValue,
+            in CappedArray<byte> updateValue,
             bool isUpdate,
             bool ignoreMissingDelete = true,
             Hash256? startRootHash = null)

--- a/src/Nethermind/Nethermind.Trie/TrackingCappedArrayPool.cs
+++ b/src/Nethermind/Nethermind.Trie/TrackingCappedArrayPool.cs
@@ -4,17 +4,18 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
 using Nethermind.Core.Buffers;
-using Nethermind.Trie.Pruning;
 
 namespace Nethermind.Trie;
 
 /// <summary>
 /// Track every rented CappedArray<byte> and return them all at once
 /// </summary>
-public class TrackingCappedArrayPool : ICappedArrayPool
+public class TrackingCappedArrayPool : ICappedArrayPool, IDisposable
 {
-    private readonly List<CappedArray<byte>> _rentedBuffers;
+    private readonly List<byte[]> _rentedBuffers;
     private readonly ArrayPool<byte> _arrayPool;
 
     public TrackingCappedArrayPool() : this(0)
@@ -23,7 +24,7 @@ public class TrackingCappedArrayPool : ICappedArrayPool
 
     public TrackingCappedArrayPool(int initialCapacity, ArrayPool<byte> arrayPool = null)
     {
-        _rentedBuffers = new List<CappedArray<byte>>(initialCapacity);
+        _rentedBuffers = new List<byte[]>(initialCapacity);
         _arrayPool = arrayPool ?? ArrayPool<byte>.Shared;
     }
 
@@ -31,26 +32,25 @@ public class TrackingCappedArrayPool : ICappedArrayPool
     {
         if (size == 0)
         {
-            return new CappedArray<byte>(Array.Empty<byte>());
+            return CappedArray<byte>.Empty;
         }
 
-        CappedArray<byte> rented = new CappedArray<byte>(_arrayPool.Rent(size), size);
-        rented.AsSpan().Clear();
-        _rentedBuffers.Add(rented);
+        byte[] array = _arrayPool.Rent(size);
+        CappedArray<byte> rented = new CappedArray<byte>(array, size);
+        array.AsSpan().Clear();
+        _rentedBuffers.Add(array);
         return rented;
     }
 
-    public void Return(CappedArray<byte> buffer)
+    public void Return(in CappedArray<byte> buffer)
     {
     }
 
-    public void ReturnAll()
+    public void Dispose()
     {
-        foreach (CappedArray<byte> rentedBuffer in _rentedBuffers)
+        foreach (byte[] rentedBuffer in CollectionsMarshal.AsSpan(_rentedBuffers))
         {
-            if (rentedBuffer.IsNotNull && rentedBuffer.Array.Length != 0)
-                _arrayPool.Return(rentedBuffer.Array);
+            _arrayPool.Return(rentedBuffer);
         }
-        _rentedBuffers.Clear();
     }
 }

--- a/src/Nethermind/Nethermind.Trie/TrieNode.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.cs
@@ -107,7 +107,7 @@ namespace Nethermind.Trie
 
                     if (obj is null)
                     {
-                        return new CappedArray<byte>(null);
+                        return CappedArray<byte>.Null;
                     }
 
                     if (obj is byte[] asBytes)
@@ -121,7 +121,7 @@ namespace Nethermind.Trie
                 if (!AllowBranchValues)
                 {
                     // branches that we use for state will never have value set as all the keys are equal length
-                    return new CappedArray<byte>(Array.Empty<byte>());
+                    return CappedArray<byte>.Empty;
                 }
 
                 obj = _data![BranchesCount];
@@ -130,7 +130,7 @@ namespace Nethermind.Trie
                     if (_rlpStream is null)
                     {
                         _data[BranchesCount] = Array.Empty<byte>();
-                        return new CappedArray<byte>(Array.Empty<byte>());
+                        return CappedArray<byte>.Empty;
                     }
                     else
                     {
@@ -172,7 +172,7 @@ namespace Nethermind.Trie
                 if (value.IsUncapped)
                 {
                     // Store array directly if possible to reduce memory
-                    _data![IsLeaf ? 1 : BranchesCount] = value.Array;
+                    _data![IsLeaf ? 1 : BranchesCount] = value.UnderlyingArray;
                     return;
                 }
 
@@ -230,7 +230,7 @@ namespace Nethermind.Trie
             }
         }
 
-        public TrieNode(NodeType nodeType, CappedArray<byte> rlp, bool isDirty = false)
+        public TrieNode(NodeType nodeType, in CappedArray<byte> rlp, bool isDirty = false)
         {
             NodeType = nodeType;
             FullRlp = rlp;
@@ -248,7 +248,7 @@ namespace Nethermind.Trie
         {
         }
 
-        public TrieNode(NodeType nodeType, Hash256 keccak, CappedArray<byte> rlp)
+        public TrieNode(NodeType nodeType, Hash256 keccak, in CappedArray<byte> rlp)
             : this(nodeType, rlp)
         {
             Keccak = keccak;
@@ -494,7 +494,7 @@ namespace Nethermind.Trie
             {
                 CappedArray<byte> oldRlp = FullRlp;
                 FullRlp = RlpEncode(tree, bufferPool);
-                if (oldRlp.IsNotNull)
+                if (oldRlp.IsNotNullOrEmpty)
                 {
                     bufferPool.SafeReturnBuffer(oldRlp);
                 }
@@ -729,10 +729,10 @@ namespace Nethermind.Trie
                     : MemorySizes.RefSize + Hash256.MemorySize;
             long fullRlpSize =
                 MemorySizes.RefSize +
-                (FullRlp.IsNull ? 0 : MemorySizes.Align(FullRlp.Array.Length + MemorySizes.ArrayOverhead));
+                (FullRlp.IsNull ? 0 : MemorySizes.Align(FullRlp.UnderlyingLength + MemorySizes.ArrayOverhead));
             long rlpStreamSize =
                 MemorySizes.RefSize + (_rlpStream?.MemorySize ?? 0)
-                - (FullRlp.IsNull ? 0 : MemorySizes.Align(FullRlp.Array.Length + MemorySizes.ArrayOverhead));
+                - (FullRlp.IsNull ? 0 : MemorySizes.Align(FullRlp.UnderlyingLength + MemorySizes.ArrayOverhead));
             long dataSize =
                 MemorySizes.RefSize +
                 (_data is null
@@ -762,7 +762,7 @@ namespace Nethermind.Trie
 
                 if (_data![i] is CappedArray<byte> cappedArray)
                 {
-                    dataSize += MemorySizes.ArrayOverhead + (cappedArray.Array?.Length ?? 0) + MemorySizes.SmallObjectOverhead;
+                    dataSize += MemorySizes.ArrayOverhead + cappedArray.UnderlyingLength + MemorySizes.SmallObjectOverhead;
                 }
 
                 if (recursive)
@@ -813,14 +813,14 @@ namespace Nethermind.Trie
             return trieNode;
         }
 
-        public TrieNode CloneWithChangedValue(CappedArray<byte> changedValue)
+        public TrieNode CloneWithChangedValue(in CappedArray<byte> changedValue)
         {
             TrieNode trieNode = Clone();
             trieNode.Value = changedValue;
             return trieNode;
         }
 
-        public TrieNode CloneWithChangedKeyAndValue(byte[] key, CappedArray<byte> changedValue)
+        public TrieNode CloneWithChangedKeyAndValue(byte[] key, in CappedArray<byte> changedValue)
         {
             TrieNode trieNode = Clone();
             trieNode.Key = key;
@@ -965,9 +965,16 @@ namespace Nethermind.Trie
             return hasStorage;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void InitData()
         {
             if (_data is null)
+            {
+                Initialize();
+            }
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            void Initialize()
             {
                 switch (NodeType)
                 {

--- a/src/Nethermind/Nethermind.Trie/TrieNodeFactory.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNodeFactory.cs
@@ -13,7 +13,7 @@ namespace Nethermind.Trie
             return node;
         }
 
-        public static TrieNode CreateLeaf(byte[] path, CappedArray<byte> value)
+        public static TrieNode CreateLeaf(byte[] path, in CappedArray<byte> value)
         {
             TrieNode node = new(NodeType.Leaf);
             node.Key = path;

--- a/src/Nethermind/Nethermind.TxPool/LightTxDecoder.cs
+++ b/src/Nethermind/Nethermind.TxPool/LightTxDecoder.cs
@@ -42,7 +42,7 @@ public class LightTxDecoder : TxDecoder<Transaction>
         rlpStream.Encode(tx.PoolIndex);
         rlpStream.Encode(tx.GetLength());
 
-        return rlpStream.Data!;
+        return rlpStream.Data.ToArray()!;
     }
 
     public static LightTransaction Decode(byte[] data)


### PR DESCRIPTION
Follow up to Perf/poolable triestore #6022

## Changes

- Propagate pooled arrays to `RlpStream`, by having is backing storage be `CappedArray<byte>`; rather than have it create an array if the pooled array is not same size as data.
- Pre-generate encoded array for numeric keys 0 to 1024 and reuse those rather than regenerating each time.
- Enclose the temp trie methods `TxTrie.CalculateRoot`, `ReceiptTrie.CalculateProof`, `TxTrie.CalculateRoot`, `ReceiptTrie.CalculateProof` in static method using the pooling and switch everything over to use them; rather than multistep unpooled.

Left before, right after

![image](https://github.com/NethermindEth/nethermind/assets/1142958/aaacca76-bf2a-4f51-9e23-351c60386188)


## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No