### PR TITLE
Use async run for migration

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Events/WaitForEventTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Events/WaitForEventTests.cs
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Nethermind.Core.Events;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Core.Test.Events;
+
+public class WaitForEventTests
+{
+
+    [Test]
+    public async Task Test_WaitForEvent()
+    {
+        ITestObj stubObj = Substitute.For<ITestObj>();
+
+        bool condCalled = false;
+
+        Task awaitingEvent = Wait.ForEventCondition<bool>(
+            CancellationToken.None,
+            (e) => stubObj.TestEvent += e,
+            (e) => stubObj.TestEvent -= e,
+            (cond) =>
+            {
+                condCalled = true;
+                return cond;
+            });
+
+        await Task.Delay(100);
+        awaitingEvent.IsCompleted.Should().BeFalse();
+        condCalled.Should().BeFalse();
+
+        stubObj.TestEvent += Raise.Event<EventHandler<bool>>(this, false);
+
+        condCalled.Should().BeTrue();
+        await Task.Delay(100);
+        awaitingEvent.IsCompleted.Should().BeFalse();
+
+        stubObj.TestEvent += Raise.Event<EventHandler<bool>>(this, true);
+        await Task.Delay(100);
+        awaitingEvent.IsCompleted.Should().BeTrue();
+    }
+
+
+    [Test]
+    public async Task Test_WaitForEvent_Cancelled()
+    {
+        ITestObj stubObj = Substitute.For<ITestObj>();
+
+        CancellationTokenSource cts = new CancellationTokenSource();
+        Task awaitingEvent = Wait.ForEventCondition<bool>(
+            cts.Token,
+            (e) => stubObj.TestEvent += e,
+            (e) => stubObj.TestEvent -= e,
+            (cond) => cond);
+
+        await Task.Delay(100);
+        awaitingEvent.IsCompleted.Should().BeFalse();
+
+        cts.Cancel();
+
+        await Task.Delay(100);
+        awaitingEvent.IsCanceled.Should().BeTrue();
+    }
+
+    public interface ITestObj
+    {
+        public event EventHandler<bool> TestEvent;
+    }
+}

--- a/src/Nethermind/Nethermind.Core/Events/WaitForEvent.cs
+++ b/src/Nethermind/Nethermind.Core/Events/WaitForEvent.cs
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nethermind.Core.Events;
+
+public static class Wait
+{
+    public static async Task ForEventCondition<T>(
+        CancellationToken cancellationToken,
+        Action<EventHandler<T>> register,
+        Action<EventHandler<T>> unregister,
+        Func<T, bool> condition)
+    {
+        TaskCompletionSource completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        EventHandler<T> handler = (sender, t) =>
+        {
+            if (condition(t))
+            {
+                completion.SetResult();
+            }
+        };
+
+        register(handler);
+
+        try
+        {
+            cancellationToken.Register(() => completion.SetCanceled(cancellationToken));
+            await completion.Task;
+        }
+        finally
+        {
+            unregister(handler);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Init/Steps/DatabaseMigrations.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/DatabaseMigrations.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -20,14 +21,12 @@ namespace Nethermind.Init.Steps
             _api = api;
         }
 
-        public Task Execute(CancellationToken cancellationToken)
+        public async Task Execute(CancellationToken cancellationToken)
         {
             foreach (IDatabaseMigration migration in CreateMigrations())
             {
-                migration.Run();
+                await migration.Run(cancellationToken);
             }
-
-            return Task.CompletedTask;
         }
 
         private IEnumerable<IDatabaseMigration> CreateMigrations()

--- a/src/Nethermind/Nethermind.Init/Steps/Migrations/IDatabaseMigration.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/Migrations/IDatabaseMigration.cs
@@ -2,11 +2,13 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Nethermind.Init.Steps.Migrations
 {
-    public interface IDatabaseMigration : IAsyncDisposable
+    public interface IDatabaseMigration
     {
-        void Run();
+        Task Run(CancellationToken cancellationToken);
     }
 }

--- a/src/Nethermind/Nethermind.Init/Steps/Migrations/ReceiptMigration.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/Migrations/ReceiptMigration.cs
@@ -14,6 +14,7 @@ using Nethermind.Blockchain;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Events;
 using Nethermind.Core.Extensions;
 using Nethermind.Db;
 using Nethermind.Int256;
@@ -39,15 +40,11 @@ namespace Nethermind.Init.Steps.Migrations
         [NotNull]
         private readonly IReceiptStorage? _receiptStorage;
         [NotNull]
-        private readonly DisposableStack? _disposeStack;
-        [NotNull]
         private readonly IBlockTree? _blockTree;
         [NotNull]
         private readonly ISyncModeSelector? _syncModeSelector;
         [NotNull]
         private readonly IChainLevelInfoRepository? _chainLevelInfoRepository;
-
-        private readonly ReceiptArrayStorageDecoder _storageDecoder;
 
         private readonly IReceiptConfig _receiptConfig;
         private readonly IColumnsDb<ReceiptsColumns> _receiptsDb;
@@ -57,7 +54,6 @@ namespace Nethermind.Init.Steps.Migrations
 
         public ReceiptMigration(IApiWithNetwork api) : this(
             api.ReceiptStorage!,
-            api.DisposeStack,
             api.BlockTree!,
             api.SyncModeSelector!,
             api.ChainLevelInfoRepository!,
@@ -71,7 +67,6 @@ namespace Nethermind.Init.Steps.Migrations
 
         public ReceiptMigration(
             IReceiptStorage receiptStorage,
-            DisposableStack disposeStack,
             IBlockTree blockTree,
             ISyncModeSelector syncModeSelector,
             IChainLevelInfoRepository chainLevelInfoRepository,
@@ -82,7 +77,6 @@ namespace Nethermind.Init.Steps.Migrations
         )
         {
             _receiptStorage = receiptStorage ?? throw new StepDependencyException(nameof(receiptStorage));
-            _disposeStack = disposeStack ?? throw new StepDependencyException(nameof(disposeStack));
             _blockTree = blockTree ?? throw new StepDependencyException(nameof(blockTree));
             _syncModeSelector = syncModeSelector ?? throw new StepDependencyException(nameof(syncModeSelector));
             _chainLevelInfoRepository = chainLevelInfoRepository ?? throw new StepDependencyException(nameof(chainLevelInfoRepository));
@@ -92,90 +86,72 @@ namespace Nethermind.Init.Steps.Migrations
             _txIndexDb = _receiptsDb.GetColumnDb(ReceiptsColumns.Transactions);
             _recovery = recovery;
             _logger = logManager.GetClassLogger();
-            _storageDecoder = new ReceiptArrayStorageDecoder(); // it just need to detect the type of the storage
-        }
-
-        public async ValueTask DisposeAsync()
-        {
-            _cancellationTokenSource?.Cancel();
-            await (_migrationTask ?? Task.CompletedTask);
         }
 
         public async Task<bool> Run(long blockNumber)
         {
             _cancellationTokenSource?.Cancel();
             await (_migrationTask ?? Task.CompletedTask);
+            _cancellationTokenSource = new CancellationTokenSource();
             _receiptStorage.MigratedBlockNumber = Math.Min(Math.Max(_receiptStorage.MigratedBlockNumber, blockNumber), (_blockTree.Head?.Number ?? 0) + 1);
-            DoRun();
+            _migrationTask = DoRun(_cancellationTokenSource.Token);
             return _receiptConfig.StoreReceipts && _receiptConfig.ReceiptsMigration;
         }
-
-        public void Run()
+        public async Task Run(CancellationToken cancellationToken)
         {
             if (_receiptConfig.StoreReceipts)
             {
                 if (_receiptConfig.ReceiptsMigration)
                 {
                     ResetMigrationIndexIfNeeded();
-                    DoRun();
+                    await DoRun(cancellationToken);
                 }
             }
         }
 
-        private void DoRun()
+        private async Task DoRun(CancellationToken cancellationToken)
         {
             if (_receiptConfig.StoreReceipts)
             {
-                if (CanMigrate(_syncModeSelector.Current))
+                if (!CanMigrate(_syncModeSelector.Current))
                 {
-                    RunMigration();
+                    await Wait.ForEventCondition<SyncModeChangedEventArgs>(
+                        cancellationToken,
+                        (e) => _syncModeSelector.Changed += e,
+                        (e) => _syncModeSelector.Changed -= e,
+                        (arg) => CanMigrate(arg.Current));
                 }
-                else
-                {
-                    _syncModeSelector.Changed -= OnSyncModeChanged;
-                    _syncModeSelector.Changed += OnSyncModeChanged;
-                    if (_logger.IsInfo) _logger.Info($"ReceiptsDb migration will start after switching to full sync.");
-                }
+
+                RunIfNeeded(cancellationToken);
             }
         }
 
         private static bool CanMigrate(SyncMode syncMode) => syncMode.NotSyncing();
 
-        private void OnSyncModeChanged(object? sender, SyncModeChangedEventArgs e)
-        {
-            if (CanMigrate(e.Current))
-            {
-                RunMigration();
-                _syncModeSelector.Changed -= OnSyncModeChanged;
-            }
-        }
-
-        private void RunMigration()
+        private void RunIfNeeded(CancellationToken cancellationToken)
         {
             // Note, it start in decreasing order from this high number.
             long migrateToBlockNumber = _receiptStorage.MigratedBlockNumber == long.MaxValue
-                    ? _syncModeSelector.Current.NotSyncing()
-                        ? _blockTree.Head?.Number ?? 0
-                        : _blockTree.BestKnownNumber
-                    : _receiptStorage.MigratedBlockNumber - 1;
+                ? _syncModeSelector.Current.NotSyncing()
+                    ? _blockTree.Head?.Number ?? 0
+                    : _blockTree.BestKnownNumber
+                : _receiptStorage.MigratedBlockNumber - 1;
             _toBlock = migrateToBlockNumber;
 
             _logger.Warn($"Running migration to {_toBlock}");
 
             if (_toBlock > 0)
             {
-                _cancellationTokenSource = new CancellationTokenSource();
-                _disposeStack.Push(this);
                 _stopwatch = Stopwatch.StartNew();
-                _migrationTask = Task.Run(() => RunMigration(_cancellationTokenSource.Token))
-                    .ContinueWith(x =>
-                    {
-                        if (x.IsFaulted && _logger.IsError)
-                        {
-                            _stopwatch.Stop();
-                            _logger.Error(GetLogMessage("failed", $"Error: {x.Exception}"), x.Exception);
-                        }
-                    });
+                try
+                {
+                    RunMigration(cancellationToken);
+                }
+                catch (Exception e)
+                {
+                    _stopwatch.Stop();
+                    _logger.Error(GetLogMessage("failed", $"Error: {e}"), e);
+                }
             }
             else
             {

--- a/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/Migrations/TotalDifficultyFixMigrationTest.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/Migrations/TotalDifficultyFixMigrationTest.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Synchronization;
@@ -25,7 +26,7 @@ public class TotalDifficultyFixMigrationTest
     [TestCase(3, 3, 10)]
     [TestCase(3, 4, -1)]
     [TestCase(4, 1, -1)]
-    public void Should_fix_td_when_broken(long? lastBlock, long brokenLevel, long expectedTd)
+    public async Task Should_fix_td_when_broken(long? lastBlock, long brokenLevel, long expectedTd)
     {
         long numberOfBlocks = 10;
         long firstBlock = 3;
@@ -71,8 +72,7 @@ public class TotalDifficultyFixMigrationTest
         levels[brokenLevel].BlockInfos[0].TotalDifficulty = 9999;
 
         // Run
-        migration.Run();
-        Thread.Sleep(300);
+        await migration.Run(CancellationToken.None);
 
         // Check level fixed
         for (long i = 0; i < numberOfBlocks; ++i)
@@ -89,7 +89,7 @@ public class TotalDifficultyFixMigrationTest
     }
 
     [Test]
-    public void should_fix_non_canonical()
+    public async Task should_fix_non_canonical()
     {
         Dictionary<Hash256, BlockHeader> hashesToHeaders = new();
         BlockHeader g = Core.Test.Builders.Build.A.BlockHeader.WithDifficulty(1).TestObject;
@@ -146,8 +146,7 @@ public class TotalDifficultyFixMigrationTest
         TotalDifficultyFixMigration migration = new(chainLevelInfoRepository, blockTree, syncConfig, new TestLogManager());
 
         // Run
-        migration.Run();
-        Thread.Sleep(3000);
+        await migration.Run(CancellationToken.None);
 
         persistedLevels[0].Should().BeNull();
         persistedLevels[1].Should().BeNull();


### PR DESCRIPTION
- "Why!?... just... even if..." ***takes a deep breath*** 
- Refactor database migration to run async and takes the cancellation token from step's run.

## Changes

- Use `Task Run(CancellationToken)` instead. The cancellation token is same as application wide.
- No need to manually make one and pass oneself to dispose stack.

## Types of changes

#### What types of changes does your code introduce?

- [X] Refactoring

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- IReceipt migration can run and continue
