### PR TITLE
Halve Discovery MaxOutgoingMessagePerSecond

### DIFF
--- a/src/Nethermind/Nethermind.Network.Discovery/IDiscoveryConfig.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/IDiscoveryConfig.cs
@@ -112,6 +112,6 @@ public interface IDiscoveryConfig : IConfig
     [ConfigItem(DefaultValue = "0.05")]
     float DropFullBucketNodeProbability { get; set; }
 
-    [ConfigItem(Description = "Limit number of outgoing discovery message per second.", DefaultValue = "100", HiddenFromDocs = true)]
+    [ConfigItem(Description = "Limit number of outgoing discovery message per second.", DefaultValue = "50", HiddenFromDocs = true)]
     int MaxOutgoingMessagePerSecond { get; set; }
 }


### PR DESCRIPTION
## Changes

- In #6354 I fixed in advertent over allocation and addition throttling from CPU burn; however this may have increased the rate of `MaxOutgoingMessagePerSecond` (to its stated number). This looks like it has caused additional network instability and bandwidth usage, so halve the rate here.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [ ] Yes
- [x] No
