### PR TITLE
Reduce readonly CALL allocations by 64 bytes

### DIFF
--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -871,9 +871,8 @@ namespace Nethermind.Trie
             }
 
             ResolveNode(childNode, in traverseContext);
-            TrieNode nextNode = childNode;
 
-            return TraverseNext(in traverseContext, 1, nextNode);
+            return TraverseNext(in traverseContext, 1, childNode);
         }
 
         private CappedArray<byte> TraverseLeaf(TrieNode node, in TraverseContext traverseContext)

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -288,7 +288,7 @@ namespace Nethermind.Trie
             }
 
             void ClearExceptions() => _commitExceptions?.Clear();
-            bool WereExceptions() => !(_commitExceptions?.IsEmpty ?? true);
+            bool WereExceptions() => _commitExceptions?.IsEmpty == false;
 
             void AddException(Exception value)
             {

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -872,7 +872,7 @@ namespace Nethermind.Trie
 
             ResolveNode(childNode, in traverseContext);
 
-            return TraverseNext(in traverseContext, 1, childNode);
+            return TraverseNext(childNode, in traverseContext, 1);
         }
 
         private CappedArray<byte> TraverseLeaf(TrieNode node, in TraverseContext traverseContext)
@@ -1004,7 +1004,7 @@ namespace Nethermind.Trie
 
                 ResolveNode(next, in traverseContext);
 
-                return TraverseNext(in traverseContext, extensionLength, next);
+                return TraverseNext(next, in traverseContext, extensionLength);
             }
 
             if (traverseContext.IsRead)
@@ -1065,7 +1065,7 @@ namespace Nethermind.Trie
             return traverseContext.UpdateValue;
         }
 
-        private CappedArray<byte> TraverseNext(in TraverseContext traverseContext, int extensionLength, TrieNode next)
+        private CappedArray<byte> TraverseNext(TrieNode next, in TraverseContext traverseContext, int extensionLength)
         {
             // Move large struct creation out of flow so doesn't force additional stack space
             // in calling method even if not used

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -5,11 +5,11 @@ using System;
 using System.Buffers;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Core;
 using Nethermind.Core.Buffers;
@@ -36,15 +36,10 @@ namespace Nethermind.Trie
 
         public TrieType TrieType { get; init; }
 
-        /// <summary>
-        /// To save allocations this used to be static but this caused one of the hardest to reproduce issues
-        /// when we decided to run some of the tree operations in parallel.
-        /// </summary>
-        private readonly Stack<StackedNode> _nodeStack = new();
+        private Stack<StackedNode>? _nodeStack;
 
-        private readonly ConcurrentQueue<Exception>? _commitExceptions;
-
-        private readonly ConcurrentQueue<NodeCommitInfo>? _currentCommit;
+        private ConcurrentQueue<Exception>? _commitExceptions;
+        private ConcurrentQueue<NodeCommitInfo>? _currentCommit;
 
         public ITrieStore TrieStore { get; }
         public ICappedArrayPool? _bufferPool;
@@ -129,31 +124,20 @@ namespace Nethermind.Trie
             // TODO: cannot do that without knowing whether the owning account is persisted or not
             // RootRef?.MarkPersistedRecursively(_logger);
 
-            if (_allowCommits)
-            {
-                _currentCommit = new ConcurrentQueue<NodeCommitInfo>();
-                _commitExceptions = new ConcurrentQueue<Exception>();
-            }
-
             _bufferPool = bufferPool;
         }
 
         public void Commit(long blockNumber, bool skipRoot = false, WriteFlags writeFlags = WriteFlags.None)
         {
-            if (_currentCommit is null)
-            {
-                ThrowInvalidAsynchronousStateException();
-            }
-
             if (!_allowCommits)
             {
-                ThrowTrieException();
+                ThrowReadOnlyTrieException();
             }
 
             if (RootRef is not null && RootRef.IsDirty)
             {
                 Commit(new NodeCommitInfo(RootRef), skipSelf: skipRoot);
-                while (_currentCommit.TryDequeue(out NodeCommitInfo node))
+                while (TryDequeueCommit(out NodeCommitInfo node))
                 {
                     if (_isTrace) Trace(blockNumber, node);
                     TrieStore.CommitNode(blockNumber, node, writeFlags: writeFlags);
@@ -168,6 +152,12 @@ namespace Nethermind.Trie
 
             if (_isDebug) Debug(blockNumber);
 
+            bool TryDequeueCommit(out NodeCommitInfo value)
+            {
+                Unsafe.SkipInit(out value);
+                return _currentCommit?.TryDequeue(out value) ?? false;
+            }
+
             [MethodImpl(MethodImplOptions.NoInlining)]
             void Trace(long blockNumber, in NodeCommitInfo node)
             {
@@ -179,32 +169,13 @@ namespace Nethermind.Trie
             {
                 _logger.Debug($"Finished committing block {blockNumber}");
             }
-
-            [DoesNotReturn]
-            [StackTraceHidden]
-            static void ThrowInvalidAsynchronousStateException()
-            {
-                throw new InvalidAsynchronousStateException($"{nameof(_currentCommit)} is NULL when calling {nameof(Commit)}");
-            }
-
-            [DoesNotReturn]
-            [StackTraceHidden]
-            static void ThrowTrieException()
-            {
-                throw new TrieException("Commits are not allowed on this trie.");
-            }
         }
 
         private void Commit(NodeCommitInfo nodeCommitInfo, bool skipSelf = false)
         {
-            if (_currentCommit is null)
+            if (!_allowCommits)
             {
-                ThrowInvalidAsynchronousStateException(nameof(_currentCommit));
-            }
-
-            if (_commitExceptions is null)
-            {
-                ThrowInvalidAsynchronousStateException(nameof(_commitExceptions));
+                ThrowReadOnlyTrieException();
             }
 
             TrieNode node = nodeCommitInfo.Node;
@@ -248,7 +219,7 @@ namespace Nethermind.Trie
 
                     if (nodesToCommit.Count >= 4)
                     {
-                        _commitExceptions.Clear();
+                        ClearExceptions();
                         Parallel.For(0, nodesToCommit.Count, i =>
                         {
                             try
@@ -257,11 +228,11 @@ namespace Nethermind.Trie
                             }
                             catch (Exception e)
                             {
-                                _commitExceptions!.Enqueue(e);
+                                AddException(e);
                             }
                         });
 
-                        if (!_commitExceptions.IsEmpty)
+                        if (WereExceptions())
                         {
                             ThrowAggregateExceptions();
                         }
@@ -300,7 +271,7 @@ namespace Nethermind.Trie
             {
                 if (!skipSelf)
                 {
-                    _currentCommit.Enqueue(nodeCommitInfo);
+                    EnqueueCommit(nodeCommitInfo);
                 }
             }
             else
@@ -308,26 +279,48 @@ namespace Nethermind.Trie
                 if (_isTrace) TraceSkipInlineNode(node);
             }
 
-            [DoesNotReturn]
-            [StackTraceHidden]
-            void ThrowAggregateExceptions()
+            void EnqueueCommit(in NodeCommitInfo value)
             {
-                throw new AggregateException(_commitExceptions);
+                ConcurrentQueue<NodeCommitInfo> queue = Volatile.Read(ref _currentCommit);
+                // Allocate queue if first commit made
+                queue ??= CreateQueue();
+                queue.Enqueue(value);
+
+                [MethodImpl(MethodImplOptions.NoInlining)]
+                ConcurrentQueue<NodeCommitInfo> CreateQueue()
+                {
+                    ConcurrentQueue<NodeCommitInfo> queue = new();
+                    ConcurrentQueue<NodeCommitInfo> current = Interlocked.CompareExchange(ref _currentCommit, queue, null);
+                    return (current is null) ? queue : current;
+                }
+            }
+
+            void ClearExceptions() => _commitExceptions?.Clear();
+            bool WereExceptions() => !(_commitExceptions?.IsEmpty ?? true);
+
+            void AddException(Exception value)
+            {
+                ConcurrentQueue<Exception> queue = Volatile.Read(ref _commitExceptions);
+                // Allocate queue if first exception thrown
+                queue ??= CreateQueue();
+                queue.Enqueue(value);
+
+                [MethodImpl(MethodImplOptions.NoInlining)]
+                ConcurrentQueue<Exception> CreateQueue()
+                {
+                    ConcurrentQueue<Exception> queue = new();
+                    ConcurrentQueue<Exception> current = Interlocked.CompareExchange(ref _commitExceptions, queue, null);
+                    return (current is null) ? queue : current;
+                }
             }
 
             [DoesNotReturn]
             [StackTraceHidden]
-            static void ThrowInvalidExtension()
-            {
-                throw new InvalidOperationException("An attempt to store an extension without a child.");
-            }
+            void ThrowAggregateExceptions() => throw new AggregateException(_commitExceptions);
 
             [DoesNotReturn]
             [StackTraceHidden]
-            static void ThrowInvalidAsynchronousStateException(string param)
-            {
-                throw new InvalidAsynchronousStateException($"{param} is NULL when calling {nameof(Commit)}");
-            }
+            static void ThrowInvalidExtension() => throw new InvalidOperationException("An attempt to store an extension without a child.");
 
             [MethodImpl(MethodImplOptions.NoInlining)]
             void Trace(TrieNode node, int i)
@@ -480,7 +473,7 @@ namespace Nethermind.Trie
             // lazy stack cleaning after the previous update
             if (traverseContext.IsUpdate)
             {
-                _nodeStack.Clear();
+                ClearNodeStack();
             }
 
             CappedArray<byte> result;
@@ -592,15 +585,15 @@ namespace Nethermind.Trie
 
         private void ConnectNodes(TrieNode? node, in TraverseContext traverseContext)
         {
-            bool isRoot = _nodeStack.Count == 0;
+            bool isRoot = IsNodeStackEmpty();
             TrieNode nextNode = node;
 
             while (!isRoot)
             {
-                StackedNode parentOnStack = _nodeStack.Pop();
+                StackedNode parentOnStack = PopFromNodeStack();
                 node = parentOnStack.Node;
 
-                isRoot = _nodeStack.Count == 0;
+                isRoot = IsNodeStackEmpty();
 
                 if (node.IsLeaf)
                 {
@@ -848,7 +841,7 @@ namespace Nethermind.Trie
             TrieNode childNode = node.GetChild(TrieStore, traverseContext.UpdatePath[traverseContext.CurrentIndex]);
             if (traverseContext.IsUpdate)
             {
-                _nodeStack.Push(new StackedNode(node, traverseContext.UpdatePath[traverseContext.CurrentIndex]));
+                PushToNodeStack(new StackedNode(node, traverseContext.UpdatePath[traverseContext.CurrentIndex]));
             }
 
             if (childNode is null)
@@ -961,7 +954,7 @@ namespace Nethermind.Trie
             {
                 ReadOnlySpan<byte> extensionPath = longerPath[..extensionLength];
                 TrieNode extension = TrieNodeFactory.CreateExtension(extensionPath.ToArray());
-                _nodeStack.Push(new StackedNode(extension, 0));
+                PushToNodeStack(new StackedNode(extension, 0));
             }
 
             TrieNode branch = TrieNodeFactory.CreateBranch();
@@ -980,7 +973,7 @@ namespace Nethermind.Trie
             TrieNode withUpdatedKeyAndValue = node.CloneWithChangedKeyAndValue(
                 leafPath.ToArray(), longerPathValue);
 
-            _nodeStack.Push(new StackedNode(branch, longerPath[extensionLength]));
+            PushToNodeStack(new StackedNode(branch, longerPath[extensionLength]));
             ConnectNodes(withUpdatedKeyAndValue, in traverseContext);
 
             return traverseContext.UpdateValue;
@@ -1001,7 +994,7 @@ namespace Nethermind.Trie
             {
                 if (traverseContext.IsUpdate)
                 {
-                    _nodeStack.Push(new StackedNode(node, 0));
+                    PushToNodeStack(new StackedNode(node, 0));
                 }
 
                 TrieNode next = node.GetChild(TrieStore, 0);
@@ -1035,7 +1028,7 @@ namespace Nethermind.Trie
             {
                 byte[] extensionPath = node.Key.Slice(0, extensionLength);
                 node = node.CloneWithChangedKey(extensionPath);
-                _nodeStack.Push(new StackedNode(node, 0));
+                PushToNodeStack(new StackedNode(node, 0));
             }
 
             TrieNode branch = TrieNodeFactory.CreateBranch();
@@ -1198,6 +1191,41 @@ namespace Nethermind.Trie
                 rootRef?.Accept(visitor, resolver, trieVisitContext);
             }
         }
+
+        bool IsNodeStackEmpty()
+        {
+            Stack<StackedNode> nodeStack = _nodeStack;
+            if (nodeStack is null) return true;
+            return nodeStack.Count == 0;
+        }
+
+        void ClearNodeStack() => _nodeStack?.Clear();
+
+        void PushToNodeStack(in StackedNode value)
+        {
+            // Allocated the _nodeStack if first push
+            _nodeStack ??= new();
+            _nodeStack.Push(value);
+        }
+
+        StackedNode PopFromNodeStack()
+        {
+            Stack<StackedNode> stackedNodes = _nodeStack;
+            if (stackedNodes is null)
+            {
+                Throw();
+            }
+
+            return stackedNodes.Pop();
+
+            [DoesNotReturn]
+            [StackTraceHidden]
+            static void Throw() => throw new InvalidOperationException($"Nothing on {nameof(_nodeStack)}");
+        }
+
+        [DoesNotReturn]
+        [StackTraceHidden]
+        static void ThrowReadOnlyTrieException() => throw new TrieException("Commits are not allowed on this trie.");
 
         [DoesNotReturn]
         [StackTraceHidden]


### PR DESCRIPTION
## Changes

- Delay allocation of the two `ConcurrentQueue<T>` and one `Stack<StackedNode>` until a change is written to the `PatriciaTree`.
- This means smart contracts that either only proxy, forward or just read values (no `sstore`s) to return don't need to perform these allocations.

```
Type layout for 'ConcurrentQueue`1'
Size: 24 bytes. Paddings: 0 bytes (%0 of empty space)
|=================================================|
| Object Header (8 bytes)                         |
|-------------------------------------------------|
| Method Table Ptr (8 bytes)                      |
|=================================================|
|   0-7: Object _crossSegmentLock (8 bytes)       |
|-------------------------------------------------|
|  8-15: ConcurrentQueueSegment`1 _tail (8 bytes) |
|-------------------------------------------------|
| 16-23: ConcurrentQueueSegment`1 _head (8 bytes) |
|=================================================|


Type layout for 'ConcurrentQueue`1'
Size: 24 bytes. Paddings: 0 bytes (%0 of empty space)
|=================================================|
| Object Header (8 bytes)                         |
|-------------------------------------------------|
| Method Table Ptr (8 bytes)                      |
|=================================================|
|   0-7: Object _crossSegmentLock (8 bytes)       |
|-------------------------------------------------|
|  8-15: ConcurrentQueueSegment`1 _tail (8 bytes) |
|-------------------------------------------------|
| 16-23: ConcurrentQueueSegment`1 _head (8 bytes) |
|=================================================|


Type layout for 'Stack`1'
Size: 16 bytes. Paddings: 0 bytes (%0 of empty space)
|=======================================|
| Object Header (8 bytes)               |
|---------------------------------------|
| Method Table Ptr (8 bytes)            |
|=======================================|
|   0-7: StackedNode[] _array (8 bytes) |
|---------------------------------------|
|  8-11: Int32 _size (4 bytes)          |
|---------------------------------------|
| 12-15: Int32 _version (4 bytes)       |
|=======================================|
```

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No