### PR TITLE
Revert "Replace caching store with row cache (#6405)"

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
@@ -175,7 +175,6 @@ public class DbConfig : IDbConfig
     public bool? StateDbDisableCompression { get; set; } = false;
     public int StateDbTargetFileSizeMultiplier { get; set; } = 2;
     public IDictionary<string, string>? StateDbAdditionalRocksDbOptions { get; set; }
-    public ulong? StateDbRowCacheSize { get; set; }
 
     public uint RecycleLogFileNum { get; set; } = 0;
     public bool WriteAheadLogSync { get; set; } = false;

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/IDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/IDbConfig.cs
@@ -174,7 +174,6 @@ public interface IDbConfig : IConfig
     ulong? StateDbCompactionReadAhead { get; set; }
     bool? StateDbDisableCompression { get; set; }
     int StateDbTargetFileSizeMultiplier { get; set; }
-    ulong? StateDbRowCacheSize { get; set; }
     IDictionary<string, string>? StateDbAdditionalRocksDbOptions { get; set; }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/PerTableDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/PerTableDbConfig.cs
@@ -51,7 +51,6 @@ public class PerTableDbConfig
     public ulong MaxBytesForLevelBase => ReadConfig<ulong>(nameof(MaxBytesForLevelBase));
     public ulong TargetFileSizeBase => ReadConfig<ulong>(nameof(TargetFileSizeBase));
     public int TargetFileSizeMultiplier => ReadConfig<int>(nameof(TargetFileSizeMultiplier));
-    public ulong? RowCacheSize => ReadConfig<ulong?>(nameof(RowCacheSize));
 
     private T? ReadConfig<T>(string propertyName)
     {

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -53,7 +53,6 @@ public class DbOnTheRocks : IDb, ITunableDb
     private long _maxThisDbSize;
 
     protected IntPtr? _cache = null;
-    protected IntPtr? _rowCache = null;
 
     private readonly DbSettings _settings;
 
@@ -357,12 +356,6 @@ public class DbOnTheRocks : IDb, ITunableDb
 
         options.SetCreateIfMissing();
         options.SetAdviseRandomOnOpen(true);
-
-        if (dbConfig.RowCacheSize > 0)
-        {
-            _rowCache = RocksDbSharp.Native.Instance.rocksdb_cache_create_lru(new UIntPtr(dbConfig.RowCacheSize.Value));
-            _rocksDbNative.rocksdb_options_set_row_cache(options.Handle, _rowCache.Value);
-        }
 
         /*
          * Multi-Threaded Compactions
@@ -1056,11 +1049,6 @@ public class DbOnTheRocks : IDb, ITunableDb
         if (_cache.HasValue)
         {
             _rocksDbNative.rocksdb_cache_destroy(_cache.Value);
-        }
-
-        if (_rowCache.HasValue)
-        {
-            _rocksDbNative.rocksdb_cache_destroy(_rowCache.Value);
         }
 
         if (_rateLimiter.HasValue)

--- a/src/Nethermind/Nethermind.Init/InitializeStateDb.cs
+++ b/src/Nethermind/Nethermind.Init/InitializeStateDb.cs
@@ -76,10 +76,12 @@ public class InitializeStateDb : IStep
             setApi.WitnessRepository = NullWitnessCollector.Instance;
         }
 
+        CachingStore cachedStateDb = getApi.DbProvider.StateDb
+            .Cached(Trie.MemoryAllowance.TrieNodeCacheCount);
         IKeyValueStore codeDb = getApi.DbProvider.CodeDb
             .WitnessedBy(witnessCollector);
 
-        IKeyValueStoreWithBatching stateWitnessedBy = getApi.DbProvider.StateDb.WitnessedBy(witnessCollector);
+        IKeyValueStoreWithBatching stateWitnessedBy = cachedStateDb.WitnessedBy(witnessCollector);
         IPersistenceStrategy persistenceStrategy;
         IPruningStrategy pruningStrategy;
         if (pruningConfig.Mode.IsMemory())
@@ -130,6 +132,7 @@ public class InitializeStateDb : IStep
             IFullPruningDb fullPruningDb = (IFullPruningDb)getApi.DbProvider!.StateDb;
             fullPruningDb.PruningStarted += (_, args) =>
             {
+                cachedStateDb.PersistCache(args.Context);
                 trieStore.PersistCache(args.Context, args.Context.CancellationTokenSource.Token);
             };
         }

--- a/src/Nethermind/Nethermind.Init/MemoryHintMan.cs
+++ b/src/Nethermind/Nethermind.Init/MemoryHintMan.cs
@@ -64,7 +64,7 @@ namespace Nethermind.Init
                 AssignFastBlocksMemory(syncConfig);
                 _remainingMemory -= FastBlocksMemory;
                 if (_logger.IsInfo) _logger.Info($"  Fast blocks memory: {FastBlocksMemory / 1000 / 1000,5} MB");
-                AssignTrieCacheMemory(dbConfig);
+                AssignTrieCacheMemory();
                 _remainingMemory -= TrieCacheMemory;
                 if (_logger.IsInfo) _logger.Info($"  Trie memory:        {TrieCacheMemory / 1000 / 1000,5} MB");
                 UpdateDbConfig(cpuCount, syncConfig, dbConfig, initConfig);
@@ -104,10 +104,10 @@ namespace Nethermind.Init
         public long PeersMemory { get; private set; }
         public long TrieCacheMemory { get; private set; }
 
-        private void AssignTrieCacheMemory(IDbConfig dbConfig)
+        private void AssignTrieCacheMemory()
         {
             TrieCacheMemory = (long)(0.2 * _remainingMemory);
-            dbConfig.StateDbRowCacheSize = (ulong)TrieCacheMemory;
+            Trie.MemoryAllowance.TrieNodeCacheMemory = TrieCacheMemory;
         }
 
         private void AssignPeersMemory(INetworkConfig networkConfig)

--- a/src/Nethermind/Nethermind.Runner.Test/MemoryHintManTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/MemoryHintManTests.cs
@@ -168,7 +168,7 @@ namespace Nethermind.Runner.Test
         {
             _initConfig.MemoryHint = memoryHint;
             SetMemoryAllowances(1);
-            _dbConfig.StateDbRowCacheSize.Should().BeGreaterThan(0);
+            Trie.MemoryAllowance.TrieNodeCacheCount.Should().BeGreaterThan(0);
         }
 
         [TestCase(true)]

--- a/src/Nethermind/Nethermind.State.Test/CachingStoreTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/CachingStoreTests.cs
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+using Nethermind.Core.Test;
+using Nethermind.Trie;
+using NUnit.Framework;
+
+namespace Nethermind.Store.Test
+{
+    [Parallelizable(ParallelScope.All)]
+    public class CachingStoreTests
+    {
+        [Test]
+        public void When_setting_values_stores_them_in_the_cache()
+        {
+            Context ctx = new(2);
+            ctx.Database[Key1] = Value1;
+            _ = ctx.Database[Key1];
+            ctx.Wrapped.KeyWasWritten(Key3, 0);
+        }
+
+        [Test]
+        public void When_reading_values_stores_them_in_the_cache()
+        {
+            Context ctx = new(2);
+            ctx.Wrapped.ReadFunc = (key) => Value1;
+            _ = ctx.Database[Key1];
+            _ = ctx.Database[Key1];
+            ctx.Wrapped.KeyWasRead(Key1);
+        }
+
+        [Test]
+        public void When_reading_values_with_flags_forward_the_flags()
+        {
+            Context ctx = new(2);
+            ctx.Wrapped.ReadFunc = (key) => Value1;
+            _ = ctx.Database.Get(Key1, ReadFlags.HintReadAhead);
+            ctx.Wrapped.KeyWasReadWithFlags(Key1, ReadFlags.HintReadAhead);
+        }
+
+        [Test]
+        public void Uses_lru_strategy_when_caching_on_reads()
+        {
+            Context ctx = new(2);
+            ctx.Wrapped.ReadFunc = (key) => Value1;
+            _ = ctx.Database[Key1];
+            _ = ctx.Database[Key2];
+            _ = ctx.Database[Key3];
+            _ = ctx.Database[Key3];
+            _ = ctx.Database[Key2];
+            _ = ctx.Database[Key1];
+            ctx.Wrapped.KeyWasRead(Key1, 2);
+            ctx.Wrapped.KeyWasRead(Key2, 1);
+            ctx.Wrapped.KeyWasRead(Key3, 1);
+        }
+
+        [Test]
+        public void Uses_lru_strategy_when_caching_on_writes()
+        {
+            Context ctx = new(2);
+            ctx.Wrapped.ReadFunc = (key) => Value1;
+            ctx.Database[Key1] = Value1;
+            ctx.Database[Key2] = Value1;
+            ctx.Database[Key3] = Value1;
+            _ = ctx.Database[Key3];
+            _ = ctx.Database[Key2];
+            _ = ctx.Database[Key1];
+            ctx.Wrapped.KeyWasRead(Key1, 1);
+            ctx.Wrapped.KeyWasRead(Key2, 0);
+            ctx.Wrapped.KeyWasRead(Key3, 0);
+        }
+
+        private class Context
+        {
+            public TestMemDb Wrapped { get; set; } = new();
+
+            public CachingStore Database { get; set; }
+
+            public Context(int size)
+            {
+                Database = new CachingStore(Wrapped, size);
+            }
+        }
+
+        private static readonly byte[] Key1 = { 1 };
+
+        private static readonly byte[] Key2 = { 2 };
+
+        private static readonly byte[] Key3 = { 3 };
+
+        private static readonly byte[] Value1 = { 1 };
+
+        private static readonly byte[] Value2 = { 2 };
+
+        private static readonly byte[] Value3 = { 3 };
+    }
+}

--- a/src/Nethermind/Nethermind.State.Test/Witnesses/WitnessingStoreTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/Witnesses/WitnessingStoreTests.cs
@@ -40,9 +40,9 @@ namespace Nethermind.Store.Test.Witnesses
         }
 
         [Test]
-        public void Collects_on_reads_2()
+        public void Collects_on_reads_when_cached_underneath()
         {
-            Context context = new();
+            Context context = new(2);
             context.Wrapped[Key1] = Value1;
             context.Wrapped[Key2] = Value2;
             context.Wrapped[Key3] = Value3;
@@ -63,9 +63,9 @@ namespace Nethermind.Store.Test.Witnesses
         }
 
         [Test]
-        public void Collects_on_reads_and_previously_populated()
+        public void Collects_on_reads_when_cached_underneath_and_previously_populated()
         {
-            Context context = new();
+            Context context = new(3);
 
             using IDisposable tracker = context.WitnessCollector.TrackOnThisThread();
             context.Database[Key1] = Value1;
@@ -112,6 +112,12 @@ namespace Nethermind.Store.Test.Witnesses
             {
                 WitnessCollector = new WitnessCollector(new MemDb(), LimboLogs.Instance);
                 Database = new WitnessingStore(Wrapped, WitnessCollector);
+            }
+
+            public Context(int cacheSize)
+            {
+                WitnessCollector = new WitnessCollector(new MemDb(), LimboLogs.Instance);
+                Database = new WitnessingStore(new CachingStore(Wrapped, cacheSize), WitnessCollector);
             }
         }
 

--- a/src/Nethermind/Nethermind.Trie/CachingStore.cs
+++ b/src/Nethermind/Nethermind.Trie/CachingStore.cs
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Nethermind.Core;
+using Nethermind.Core.Caching;
+using Nethermind.Core.Extensions;
+
+namespace Nethermind.Trie
+{
+    public static class KeyValueStoreWithBatchingExtensions
+    {
+        public static CachingStore Cached(this IKeyValueStoreWithBatching @this, int maxCapacity)
+        {
+            return new CachingStore(@this, maxCapacity);
+        }
+    }
+
+    public class CachingStore : IKeyValueStoreWithBatching
+    {
+        private readonly IKeyValueStoreWithBatching _wrappedStore;
+
+        public CachingStore(IKeyValueStoreWithBatching wrappedStore, int maxCapacity)
+        {
+            _wrappedStore = wrappedStore ?? throw new ArgumentNullException(nameof(wrappedStore));
+            _cache = new SpanLruCache<byte, byte[]>(maxCapacity, 0, "RLP Cache", Bytes.SpanEqualityComparer);
+        }
+
+        public bool PreferWriteByArray => true;
+        private readonly SpanLruCache<byte, byte[]> _cache;
+
+        public byte[]? this[ReadOnlySpan<byte> key]
+        {
+            get
+            {
+                return Get(key);
+            }
+            set
+            {
+                Set(key, value);
+            }
+        }
+
+        public byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)
+        {
+            if ((flags & ReadFlags.HintCacheMiss) == ReadFlags.HintCacheMiss)
+            {
+                return _wrappedStore.Get(key, flags);
+            }
+
+            if (!_cache.TryGet(key, out byte[] value))
+            {
+                value = _wrappedStore.Get(key, flags);
+                _cache.Set(key, value);
+            }
+            else
+            {
+                // TODO: a hack assuming that we cache only one thing, accepted unanimously by Lukasz, Marek, and Tomasz
+                Pruning.Metrics.LoadedFromRlpCacheNodesCount++;
+            }
+
+            return value;
+        }
+
+        public void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None)
+        {
+            _cache.Set(key, value);
+            _wrappedStore.Set(key, value, flags);
+        }
+
+
+        public IWriteBatch StartWriteBatch() => _wrappedStore.StartWriteBatch();
+
+        public void PersistCache(IKeyValueStore pruningContext)
+        {
+            KeyValuePair<byte[], byte[]>[] clone = _cache.ToArray();
+            Task.Run(() =>
+            {
+                foreach (KeyValuePair<byte[], byte[]> kvp in clone)
+                {
+                    pruningContext[kvp.Key] = kvp.Value;
+                }
+            });
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Trie/MemoryAllowance.cs
+++ b/src/Nethermind/Nethermind.Trie/MemoryAllowance.cs
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core.Extensions;
+
+namespace Nethermind.Trie
+{
+    public static class MemoryAllowance
+    {
+        public static long TrieNodeCacheMemory { get; set; } = 128.MB();
+
+        public static int TrieNodeCacheCount => (int)(TrieNodeCacheMemory / PatriciaTree.OneNodeAvgMemoryEstimate);
+    }
+}


### PR DESCRIPTION
This reverts commit 9d1b4f66ee9abe131e1f32555f4bfd7235291c69.

- Full pruning with in memory pruning does not work reliably without caching store.
- Also means we are kinda running on luck here.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [ ] Yes
- [X] No

#### Steps to reproduce

- Rerun an old database, turn on pruning, restart and run verify trie.

### Remarks

- Still trying to find solutions, but still can't find a reliable one.