### PR TITLE
Propagate trie data via readonly refs

### DIFF
--- a/src/Nethermind/Nethermind.Core/Buffers/CappedArray.cs
+++ b/src/Nethermind/Nethermind.Core/Buffers/CappedArray.cs
@@ -84,8 +84,11 @@ public readonly struct CappedArray<T>
 
     public readonly T[]? ToArray()
     {
-        if (_array is null) return null;
-        if (_length == _array?.Length) return _array;
+        T[]? array = _array;
+
+        if (array is null) return null;
+        if (array.Length == 0) return Array.Empty<T>();
+        if (_length == array?.Length) return array;
         return AsSpan().ToArray();
     }
 }

--- a/src/Nethermind/Nethermind.Core/Buffers/CappedArray.cs
+++ b/src/Nethermind/Nethermind.Core/Buffers/CappedArray.cs
@@ -17,6 +17,8 @@ public readonly struct CappedArray<T>
     private readonly static CappedArray<T> _empty = new CappedArray<T>(Array.Empty<T>());
     public static ref readonly CappedArray<T> Null => ref _null;
     public static ref readonly CappedArray<T> Empty => ref _empty;
+    public static object NullBoxed { get; } = _null;
+    public static object EmptyBoxed { get; } = _empty;
 
     private readonly T[]? _array;
     private readonly int _length;

--- a/src/Nethermind/Nethermind.State/PartialStorageProviderBase.cs
+++ b/src/Nethermind/Nethermind.State/PartialStorageProviderBase.cs
@@ -43,7 +43,7 @@ namespace Nethermind.State
         /// <returns>Value at cell</returns>
         public byte[] Get(in StorageCell storageCell)
         {
-            return GetCurrentValue(storageCell);
+            return GetCurrentValue(in storageCell);
         }
 
         /// <summary>


### PR DESCRIPTION
## Changes

- Propagate trie data via readonly refs; allows return via register than via stack and the call stack can get quite deep navigating the trie
 
## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
