### PR TITLE
Make aura dependencies move only one way

### DIFF
--- a/src/Nethermind/Nethermind.AuRa.Test/AuRaSealValidatorTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/AuRaSealValidatorTests.cs
@@ -57,10 +57,8 @@ namespace Nethermind.AuRa.Test
                 Substitute.For<IValidatorStore>(),
                 _validSealerStrategy,
                 _ethereumEcdsa,
-                _logManager)
-            {
-                ReportingValidator = _reportingValidator
-            };
+                _reportingValidator,
+                _logManager);
         }
 
         public enum Repeat

--- a/src/Nethermind/Nethermind.AuRa.Test/AuraBlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/AuraBlockProcessorTests.cs
@@ -160,6 +160,7 @@ namespace Nethermind.AuRa.Test
                 LimboLogs.Instance,
                 Substitute.For<IBlockTree>(),
                 new WithdrawalProcessor(stateProvider, LimboLogs.Instance),
+                null,
                 txFilter,
                 contractRewriter: contractRewriter);
 

--- a/src/Nethermind/Nethermind.AuRa.Test/Contract/AuRaContractGasLimitOverrideTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/Contract/AuRaContractGasLimitOverrideTests.cs
@@ -100,6 +100,7 @@ public class AuRaContractGasLimitOverrideTests
                 BlockTree,
                 NullWithdrawalProcessor.Instance,
                 null,
+                null,
                 GasLimitCalculator as AuRaContractGasLimitOverride);
         }
 

--- a/src/Nethermind/Nethermind.AuRa.Test/Transactions/TxCertifierFilterTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/Transactions/TxCertifierFilterTests.cs
@@ -155,7 +155,8 @@ public class TxCertifierFilterTests
                 ReceiptStorage,
                 LimboLogs.Instance,
                 BlockTree,
-                NullWithdrawalProcessor.Instance);
+                NullWithdrawalProcessor.Instance,
+                null);
         }
 
         protected override Task AddBlocksOnStart() => Task.CompletedTask;

--- a/src/Nethermind/Nethermind.AuRa.Test/Transactions/TxPermissionFilterTest.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/Transactions/TxPermissionFilterTest.cs
@@ -297,6 +297,7 @@ public class TxPermissionFilterTest
                 LimboLogs.Instance,
                 BlockTree,
                 NullWithdrawalProcessor.Instance,
+                null,
                 PermissionBasedTxFilter);
         }
 

--- a/src/Nethermind/Nethermind.Consensus.AuRa/AuRaBlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/AuRaBlockProcessor.cs
@@ -29,7 +29,6 @@ namespace Nethermind.Consensus.AuRa
         private readonly ContractRewriter? _contractRewriter;
         private readonly ITxFilter _txFilter;
         private readonly ILogger _logger;
-        private IAuRaValidator? _auRaValidator;
 
         public AuRaBlockProcessor(
             ISpecProvider specProvider,
@@ -60,7 +59,7 @@ namespace Nethermind.Consensus.AuRa
             _blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
             _logger = logManager?.GetClassLogger<AuRaBlockProcessor>() ?? throw new ArgumentNullException(nameof(logManager));
             _txFilter = txFilter ?? NullTxFilter.Instance;
-            _auRaValidator = auRaValidator;
+            AuRaValidator = auRaValidator ?? new NullAuRaValidator();
             _gasLimitOverride = gasLimitOverride;
             _contractRewriter = contractRewriter;
             if (blockTransactionsExecutor is IBlockProductionTransactionsExecutor produceBlockTransactionsStrategy)
@@ -69,10 +68,7 @@ namespace Nethermind.Consensus.AuRa
             }
         }
 
-        private IAuRaValidator AuRaValidator
-        {
-            get => _auRaValidator ?? new NullAuRaValidator();
-        }
+        private IAuRaValidator AuRaValidator { get; }
 
         protected override TxReceipt[] ProcessBlock(Block block, IBlockTracer blockTracer, ProcessingOptions options)
         {

--- a/src/Nethermind/Nethermind.Consensus.AuRa/AuRaBlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/AuRaBlockProcessor.cs
@@ -41,6 +41,7 @@ namespace Nethermind.Consensus.AuRa
             ILogManager logManager,
             IBlockTree blockTree,
             IWithdrawalProcessor withdrawalProcessor,
+            IAuRaValidator? auRaValidator,
             ITxFilter? txFilter = null,
             AuRaContractGasLimitOverride? gasLimitOverride = null,
             ContractRewriter? contractRewriter = null)
@@ -59,6 +60,7 @@ namespace Nethermind.Consensus.AuRa
             _blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
             _logger = logManager?.GetClassLogger<AuRaBlockProcessor>() ?? throw new ArgumentNullException(nameof(logManager));
             _txFilter = txFilter ?? NullTxFilter.Instance;
+            _auRaValidator = auRaValidator;
             _gasLimitOverride = gasLimitOverride;
             _contractRewriter = contractRewriter;
             if (blockTransactionsExecutor is IBlockProductionTransactionsExecutor produceBlockTransactionsStrategy)
@@ -67,10 +69,9 @@ namespace Nethermind.Consensus.AuRa
             }
         }
 
-        public IAuRaValidator AuRaValidator
+        private IAuRaValidator AuRaValidator
         {
             get => _auRaValidator ?? new NullAuRaValidator();
-            set => _auRaValidator = value;
         }
 
         protected override TxReceipt[] ProcessBlock(Block block, IBlockTracer blockTracer, ProcessingOptions options)

--- a/src/Nethermind/Nethermind.Consensus.AuRa/AuRaSealValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/AuRaSealValidator.cs
@@ -24,8 +24,9 @@ namespace Nethermind.Consensus.AuRa
         private readonly IEthereumEcdsa _ecdsa;
         private readonly ILogger _logger;
         private readonly ReceivedSteps _receivedSteps = new ReceivedSteps();
+        private IReportingValidator ReportingValidator { get; }
 
-        public AuRaSealValidator(AuRaParameters parameters, IAuRaStepCalculator stepCalculator, IBlockTree blockTree, IValidatorStore validatorStore, IValidSealerStrategy validSealerStrategy, IEthereumEcdsa ecdsa, ILogManager logManager)
+        public AuRaSealValidator(AuRaParameters parameters, IAuRaStepCalculator stepCalculator, IBlockTree blockTree, IValidatorStore validatorStore, IValidSealerStrategy validSealerStrategy, IEthereumEcdsa ecdsa, IReportingValidator reportingValidator, ILogManager logManager)
         {
             _parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
             _stepCalculator = stepCalculator ?? throw new ArgumentNullException(nameof(stepCalculator));
@@ -33,10 +34,9 @@ namespace Nethermind.Consensus.AuRa
             _validatorStore = validatorStore ?? throw new ArgumentNullException(nameof(validatorStore));
             _validSealerStrategy = validSealerStrategy ?? throw new ArgumentNullException(nameof(validSealerStrategy));
             _ecdsa = ecdsa ?? throw new ArgumentNullException(nameof(ecdsa));
+            ReportingValidator = reportingValidator ?? throw new ArgumentNullException(nameof(reportingValidator));;
             _logger = logManager.GetClassLogger<AuRaSealValidator>() ?? throw new ArgumentNullException(nameof(logManager));
         }
-
-        public IReportingValidator ReportingValidator { get; set; } = NullReportingValidator.Instance;
 
         public bool ValidateParams(BlockHeader parent, BlockHeader header, bool isUncle = false)
         {

--- a/src/Nethermind/Nethermind.Consensus.AuRa/AuRaSealValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/AuRaSealValidator.cs
@@ -26,7 +26,7 @@ namespace Nethermind.Consensus.AuRa
         private readonly ReceivedSteps _receivedSteps = new ReceivedSteps();
         private IReportingValidator ReportingValidator { get; }
 
-        public AuRaSealValidator(AuRaParameters parameters, IAuRaStepCalculator stepCalculator, IBlockTree blockTree, IValidatorStore validatorStore, IValidSealerStrategy validSealerStrategy, IEthereumEcdsa ecdsa, IReportingValidator reportingValidator, ILogManager logManager)
+        public AuRaSealValidator(AuRaParameters parameters, IAuRaStepCalculator stepCalculator, IBlockTree blockTree, IValidatorStore validatorStore, IValidSealerStrategy validSealerStrategy, IEthereumEcdsa ecdsa, IReportingValidator? reportingValidator, ILogManager logManager)
         {
             _parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
             _stepCalculator = stepCalculator ?? throw new ArgumentNullException(nameof(stepCalculator));
@@ -34,7 +34,7 @@ namespace Nethermind.Consensus.AuRa
             _validatorStore = validatorStore ?? throw new ArgumentNullException(nameof(validatorStore));
             _validSealerStrategy = validSealerStrategy ?? throw new ArgumentNullException(nameof(validSealerStrategy));
             _ecdsa = ecdsa ?? throw new ArgumentNullException(nameof(ecdsa));
-            ReportingValidator = reportingValidator ?? throw new ArgumentNullException(nameof(reportingValidator));;
+            ReportingValidator = reportingValidator ?? NullReportingValidator.Instance;
             _logger = logManager.GetClassLogger<AuRaSealValidator>() ?? throw new ArgumentNullException(nameof(logManager));
         }
 

--- a/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/StartBlockProducerAuRa.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/StartBlockProducerAuRa.cs
@@ -159,12 +159,10 @@ public class StartBlockProducerAuRa
             _api.LogManager,
             changeableTxProcessingEnv.BlockTree,
             NullWithdrawalProcessor.Instance,
+            _validator,
             auRaTxFilter,
             CreateGasLimitCalculator(constantContractTxProcessingEnv) as AuRaContractGasLimitOverride,
-            contractRewriter)
-        {
-            AuRaValidator = _validator
-        };
+            contractRewriter);
     }
 
     internal TxPoolTxSource CreateTxPoolTxSource(ReadOnlyTxProcessingEnv processingEnv, IReadOnlyTxProcessorSource readOnlyTxProcessorSource)

--- a/src/Nethermind/Nethermind.Merge.AuRa/AuRaMergeBlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa/AuRaMergeBlockProcessor.cs
@@ -4,6 +4,7 @@
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Consensus.AuRa;
+using Nethermind.Consensus.AuRa.Validators;
 using Nethermind.Consensus.Processing;
 using Nethermind.Consensus.Rewards;
 using Nethermind.Consensus.Transactions;
@@ -29,6 +30,7 @@ public class AuRaMergeBlockProcessor : AuRaBlockProcessor
         ILogManager logManager,
         IBlockTree blockTree,
         IWithdrawalProcessor withdrawalProcessor,
+        IAuRaValidator? auRaValidator,
         ITxFilter? txFilter = null,
         AuRaContractGasLimitOverride? gasLimitOverride = null,
         ContractRewriter? contractRewriter = null
@@ -42,6 +44,7 @@ public class AuRaMergeBlockProcessor : AuRaBlockProcessor
             logManager,
             blockTree,
             withdrawalProcessor,
+            auRaValidator,
             txFilter,
             gasLimitOverride,
             contractRewriter

--- a/src/Nethermind/Nethermind.Merge.AuRa/AuRaMergeBlockProducerEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa/AuRaMergeBlockProducerEnvFactory.cs
@@ -1,9 +1,11 @@
 // SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using Nethermind.Api;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Config;
+using Nethermind.Consensus.AuRa;
 using Nethermind.Consensus.AuRa.Config;
 using Nethermind.Consensus.AuRa.InitializationSteps;
 using Nethermind.Consensus.Comparers;
@@ -83,7 +85,9 @@ public class AuRaMergeBlockProducerEnvFactory : BlockProducerEnvFactory
                     withdrawalContractFactory.Create(readOnlyTxProcessingEnv.TransactionProcessor),
                     logManager
                     )
-                ));
+                ),
+            null
+            );
     }
 
     protected override TxPoolTxSource CreateTxPoolTxSource(

--- a/src/Nethermind/Nethermind.Merge.AuRa/InitializationSteps/InitializeBlockchainAuRaMerge.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa/InitializationSteps/InitializeBlockchainAuRaMerge.cs
@@ -22,7 +22,7 @@ namespace Nethermind.Merge.AuRa.InitializationSteps
             _api = api;
         }
 
-        protected override BlockProcessor NewBlockProcessor(AuRaNethermindApi api, ITxFilter txFilter, IAuRaValidator auRaValidator, ContractRewriter contractRewriter)
+        protected override AuRaMergeBlockProcessor NewAuRaBlockProcessor(ITxFilter txFilter, IAuRaValidator auRaValidator, ContractRewriter contractRewriter)
         {
             WithdrawalContractFactory withdrawalContractFactory = new WithdrawalContractFactory(_api.ChainSpec!.AuRa, _api.AbiEncoder);
             IWorldState worldState = _api.WorldState!;

--- a/src/Nethermind/Nethermind.Merge.AuRa/InitializationSteps/InitializeBlockchainAuRaMerge.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa/InitializationSteps/InitializeBlockchainAuRaMerge.cs
@@ -3,6 +3,7 @@
 
 using Nethermind.Consensus.AuRa;
 using Nethermind.Consensus.AuRa.InitializationSteps;
+using Nethermind.Consensus.AuRa.Validators;
 using Nethermind.Consensus.Processing;
 using Nethermind.Consensus.Transactions;
 using Nethermind.Evm.TransactionProcessing;
@@ -21,7 +22,7 @@ namespace Nethermind.Merge.AuRa.InitializationSteps
             _api = api;
         }
 
-        protected override BlockProcessor NewBlockProcessor(AuRaNethermindApi api, ITxFilter txFilter, ContractRewriter contractRewriter)
+        protected override BlockProcessor NewBlockProcessor(AuRaNethermindApi api, ITxFilter txFilter, IAuRaValidator auRaValidator, ContractRewriter contractRewriter)
         {
             WithdrawalContractFactory withdrawalContractFactory = new WithdrawalContractFactory(_api.ChainSpec!.AuRa, _api.AbiEncoder);
             IWorldState worldState = _api.WorldState!;
@@ -38,6 +39,7 @@ namespace Nethermind.Merge.AuRa.InitializationSteps
                 _api.BlockTree!,
                 new AuraWithdrawalProcessor(
                     withdrawalContractFactory.Create(transactionProcessor!), _api.LogManager),
+                auRaValidator,
                 txFilter,
                 GetGasLimitCalculator(),
                 contractRewriter


### PR DESCRIPTION
- Some dependencies in AuRA is added later instead of via constructor.
- This makes it very hard to follow.

## Changes

- Pass `IAuraValidator` and `IReportingValidator` via constructor.

## Types of changes

#### What types of changes does your code introduce?

- [X] Refactoring

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

- No idea how to test this.