### PR TITLE
Default Configuration to Release

### DIFF
--- a/src/Nethermind/Directory.Build.props
+++ b/src/Nethermind/Directory.Build.props
@@ -1,7 +1,9 @@
 <Project>
 
   <PropertyGroup>
-    <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
+    <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
+    <Configuration Condition="'$(Configuration)' == 'debug'">Debug</Configuration>
+    <Configuration Condition="'$(Configuration)' == 'release'">Release</Configuration>
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
     <LangVersion>latest</LangVersion>
     <TargetFramework>net8.0</TargetFramework>

--- a/src/Nethermind/Directory.Build.props
+++ b/src/Nethermind/Directory.Build.props
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
-    <Configuration Condition="'$(Configuration)' == 'debug'">Debug</Configuration>
-    <Configuration Condition="'$(Configuration)' == 'release'">Release</Configuration>
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
     <LangVersion>latest</LangVersion>
     <TargetFramework>net8.0</TargetFramework>


### PR DESCRIPTION
## Changes

- Default configuration to Release; current cause issues in VS when building Ethereum.Tests solultion as it cannot find reference assembiles (if compiling in Release and no previous Debug build)

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No
