### PR TITLE
Further Improve JumpDestAnalysis (x20 improvement)

### DIFF
--- a/src/Nethermind/Nethermind.AccountAbstraction.Test/AccountAbstractionRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.AccountAbstraction.Test/AccountAbstractionRpcModuleTests.cs
@@ -22,8 +22,7 @@ using Nethermind.Int256;
 using Nethermind.JsonRpc.Data;
 using Nethermind.JsonRpc.Test.Modules;
 using Nethermind.Logging;
-
-using Newtonsoft.Json.Linq;
+using Nethermind.State;
 using NUnit.Framework;
 
 namespace Nethermind.AccountAbstraction.Test;

--- a/src/Nethermind/Nethermind.AccountAbstraction.Test/UserOperationTracerTests.cs
+++ b/src/Nethermind/Nethermind.AccountAbstraction.Test/UserOperationTracerTests.cs
@@ -11,6 +11,7 @@ using Nethermind.Evm;
 using Nethermind.Evm.Test;
 using Nethermind.Logging;
 using Nethermind.Specs;
+using Nethermind.State;
 using NUnit.Framework;
 
 namespace Nethermind.AccountAbstraction.Test

--- a/src/Nethermind/Nethermind.Evm.Test/Eip1014Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip1014Tests.cs
@@ -7,6 +7,7 @@ using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Specs;
+using Nethermind.State;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Evm.Tracing.GethStyle;
 using Nethermind.Trie;

--- a/src/Nethermind/Nethermind.Evm.Test/Eip1052Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip1052Tests.cs
@@ -11,6 +11,7 @@ using Nethermind.Int256;
 using Nethermind.Evm.Precompiles;
 using Nethermind.Specs.Forks;
 using Nethermind.Specs.Test;
+using Nethermind.State;
 using NUnit.Framework;
 
 namespace Nethermind.Evm.Test

--- a/src/Nethermind/Nethermind.Evm.Test/Eip1153Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip1153Tests.cs
@@ -3,6 +3,7 @@
 
 using Nethermind.Core.Extensions;
 using Nethermind.Specs;
+using Nethermind.State;
 using Nethermind.Core.Test.Builders;
 using NUnit.Framework;
 using System.Diagnostics;

--- a/src/Nethermind/Nethermind.Evm.Test/Eip1884Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip1884Tests.cs
@@ -5,6 +5,7 @@ using Nethermind.Core;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Specs;
+using Nethermind.State;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Int256;
 using NUnit.Framework;

--- a/src/Nethermind/Nethermind.Evm.Test/Eip3860Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip3860Tests.cs
@@ -3,6 +3,7 @@
 
 using Nethermind.Core.Extensions;
 using Nethermind.Specs;
+using Nethermind.State;
 using Nethermind.Core.Test.Builders;
 using NUnit.Framework;
 using Nethermind.Core;

--- a/src/Nethermind/Nethermind.Evm.Test/StorageAndSelfDestructTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/StorageAndSelfDestructTests.cs
@@ -11,6 +11,7 @@ using Nethermind.Evm.Tracing.ParityStyle;
 using Nethermind.Logging;
 using Nethermind.Specs;
 using Nethermind.Specs.Forks;
+using Nethermind.State;
 using NUnit.Framework;
 
 namespace Nethermind.Evm.Test

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeJavaScriptTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeJavaScriptTracerTests.cs
@@ -12,9 +12,9 @@ using Nethermind.Specs;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Evm.Tracing.GethStyle.JavaScript;
 using Nethermind.Int256;
-using Nethermind.JsonRpc.Modules.DebugModule;
 using Nethermind.Serialization.Json;
 using Nethermind.Specs.Forks;
+using Nethermind.State;
 
 namespace Nethermind.Evm.Test.Tracing;
 

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeTxMemoryTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeTxMemoryTracerTests.cs
@@ -6,6 +6,7 @@ using Nethermind.Core.Attributes;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Evm.Tracing.GethStyle;
+using Nethermind.State;
 using NUnit.Framework;
 
 namespace Nethermind.Evm.Test.Tracing;

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/ParityLikeTxTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/ParityLikeTxTracerTests.cs
@@ -11,6 +11,7 @@ using Nethermind.Core.Test.Builders;
 using Nethermind.Int256;
 using Nethermind.Evm.Precompiles;
 using Nethermind.Evm.Tracing.ParityStyle;
+using Nethermind.State;
 using NUnit.Framework;
 
 namespace Nethermind.Evm.Test.Tracing

--- a/src/Nethermind/Nethermind.Evm.Test/VmCodeDepositTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/VmCodeDepositTests.cs
@@ -4,6 +4,7 @@
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
 using Nethermind.Specs;
+using Nethermind.State;
 using Nethermind.Core.Test.Builders;
 using NUnit.Framework;
 

--- a/src/Nethermind/Nethermind.Evm/ByteArrayExtensions.cs
+++ b/src/Nethermind/Nethermind.Evm/ByteArrayExtensions.cs
@@ -44,6 +44,16 @@ namespace Nethermind.Evm
             return SliceWithZeroPadding(span, (int)startIndex, length, padDirection);
         }
 
+        public static ZeroPaddedSpan SliceWithZeroPadding(this ReadOnlySpan<byte> span, scoped in UInt256 startIndex, int length, PadDirection padDirection = PadDirection.Right)
+        {
+            if (startIndex >= span.Length || startIndex > int.MaxValue)
+            {
+                return new ZeroPaddedSpan(default, length, PadDirection.Right);
+            }
+
+            return SliceWithZeroPadding(span, (int)startIndex, length, padDirection);
+        }
+
         public static ZeroPaddedSpan SliceWithZeroPadding(this ReadOnlyMemory<byte> bytes, scoped in UInt256 startIndex, int length, PadDirection padDirection = PadDirection.Right)
         {
             if (startIndex >= bytes.Length || startIndex > int.MaxValue)

--- a/src/Nethermind/Nethermind.Evm/ByteArrayExtensions.cs
+++ b/src/Nethermind/Nethermind.Evm/ByteArrayExtensions.cs
@@ -36,32 +36,23 @@ namespace Nethermind.Evm
 
         public static ZeroPaddedSpan SliceWithZeroPadding(this Span<byte> span, scoped in UInt256 startIndex, int length, PadDirection padDirection = PadDirection.Right)
         {
-            if (startIndex >= span.Length || startIndex > int.MaxValue)
-            {
-                return new ZeroPaddedSpan(default, length, PadDirection.Right);
-            }
-
-            return SliceWithZeroPadding(span, (int)startIndex, length, padDirection);
+            return startIndex >= span.Length || startIndex > int.MaxValue
+                ? new ZeroPaddedSpan(default, length, PadDirection.Right)
+                : SliceWithZeroPadding(span, (int)startIndex, length, padDirection);
         }
 
         public static ZeroPaddedSpan SliceWithZeroPadding(this ReadOnlySpan<byte> span, scoped in UInt256 startIndex, int length, PadDirection padDirection = PadDirection.Right)
         {
-            if (startIndex >= span.Length || startIndex > int.MaxValue)
-            {
-                return new ZeroPaddedSpan(default, length, PadDirection.Right);
-            }
-
-            return SliceWithZeroPadding(span, (int)startIndex, length, padDirection);
+            return startIndex >= span.Length || startIndex > int.MaxValue
+                ? new ZeroPaddedSpan(default, length, PadDirection.Right)
+                : SliceWithZeroPadding(span, (int)startIndex, length, padDirection);
         }
 
         public static ZeroPaddedSpan SliceWithZeroPadding(this ReadOnlyMemory<byte> bytes, scoped in UInt256 startIndex, int length, PadDirection padDirection = PadDirection.Right)
         {
-            if (startIndex >= bytes.Length || startIndex > int.MaxValue)
-            {
-                return new ZeroPaddedSpan(default, length, PadDirection.Right);
-            }
-
-            return SliceWithZeroPadding(bytes.Span, (int)startIndex, length, padDirection);
+            return startIndex >= bytes.Length || startIndex > int.MaxValue
+                ? new ZeroPaddedSpan(default, length, PadDirection.Right)
+                : SliceWithZeroPadding(bytes.Span, (int)startIndex, length, padDirection);
         }
 
         public static ZeroPaddedSpan SliceWithZeroPadding(this byte[] bytes, scoped in UInt256 startIndex, int length, PadDirection padDirection = PadDirection.Right) =>

--- a/src/Nethermind/Nethermind.Evm/ByteArrayExtensions.cs
+++ b/src/Nethermind/Nethermind.Evm/ByteArrayExtensions.cs
@@ -34,19 +34,13 @@ namespace Nethermind.Evm
             return new ZeroPaddedSpan(span.Slice(startIndex, copiedLength), length - copiedLength, padDirection);
         }
 
-        public static ZeroPaddedSpan SliceWithZeroPadding(this Span<byte> span, scoped in UInt256 startIndex, int length, PadDirection padDirection = PadDirection.Right)
-        {
-            return startIndex >= span.Length || startIndex > int.MaxValue
+        public static ZeroPaddedSpan SliceWithZeroPadding(this Span<byte> span, scoped in UInt256 startIndex, int length, PadDirection padDirection = PadDirection.Right) => startIndex >= span.Length || startIndex > int.MaxValue
                 ? new ZeroPaddedSpan(default, length, PadDirection.Right)
                 : SliceWithZeroPadding(span, (int)startIndex, length, padDirection);
-        }
 
-        public static ZeroPaddedSpan SliceWithZeroPadding(this ReadOnlySpan<byte> span, scoped in UInt256 startIndex, int length, PadDirection padDirection = PadDirection.Right)
-        {
-            return startIndex >= span.Length || startIndex > int.MaxValue
+        public static ZeroPaddedSpan SliceWithZeroPadding(this ReadOnlySpan<byte> span, scoped in UInt256 startIndex, int length, PadDirection padDirection = PadDirection.Right) => startIndex >= span.Length || startIndex > int.MaxValue
                 ? new ZeroPaddedSpan(default, length, PadDirection.Right)
                 : SliceWithZeroPadding(span, (int)startIndex, length, padDirection);
-        }
 
         public static ZeroPaddedSpan SliceWithZeroPadding(this ReadOnlyMemory<byte> bytes, scoped in UInt256 startIndex, int length, PadDirection padDirection = PadDirection.Right) =>
             startIndex >= bytes.Length || startIndex > int.MaxValue

--- a/src/Nethermind/Nethermind.Evm/ByteArrayExtensions.cs
+++ b/src/Nethermind/Nethermind.Evm/ByteArrayExtensions.cs
@@ -48,12 +48,10 @@ namespace Nethermind.Evm
                 : SliceWithZeroPadding(span, (int)startIndex, length, padDirection);
         }
 
-        public static ZeroPaddedSpan SliceWithZeroPadding(this ReadOnlyMemory<byte> bytes, scoped in UInt256 startIndex, int length, PadDirection padDirection = PadDirection.Right)
-        {
-            return startIndex >= bytes.Length || startIndex > int.MaxValue
+        public static ZeroPaddedSpan SliceWithZeroPadding(this ReadOnlyMemory<byte> bytes, scoped in UInt256 startIndex, int length, PadDirection padDirection = PadDirection.Right) =>
+            startIndex >= bytes.Length || startIndex > int.MaxValue
                 ? new ZeroPaddedSpan(default, length, PadDirection.Right)
                 : SliceWithZeroPadding(bytes.Span, (int)startIndex, length, padDirection);
-        }
 
         public static ZeroPaddedSpan SliceWithZeroPadding(this byte[] bytes, scoped in UInt256 startIndex, int length, PadDirection padDirection = PadDirection.Right) =>
             bytes.AsSpan().SliceWithZeroPadding(startIndex, length, padDirection);

--- a/src/Nethermind/Nethermind.Evm/CodeAnalysis/CodeInfo.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeAnalysis/CodeInfo.cs
@@ -13,6 +13,7 @@ namespace Nethermind.Evm.CodeAnalysis
         public IPrecompile? Precompile { get; set; }
         private readonly JumpDestinationAnalyzer _analyzer;
         private static readonly JumpDestinationAnalyzer _emptyAnalyzer = new(Array.Empty<byte>());
+        public static CodeInfo Empty { get; } = new CodeInfo(Array.Empty<byte>());
 
         public CodeInfo(byte[] code)
         {

--- a/src/Nethermind/Nethermind.Evm/CodeAnalysis/CodeInfo.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeAnalysis/CodeInfo.cs
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Threading;
 
 using Nethermind.Evm.Precompiles;
 
 namespace Nethermind.Evm.CodeAnalysis
 {
-    public class CodeInfo
+    public class CodeInfo : IThreadPoolWorkItem
     {
         public byte[] MachineCode { get; set; }
         public IPrecompile? Precompile { get; set; }
@@ -33,6 +34,11 @@ namespace Nethermind.Evm.CodeAnalysis
         public bool ValidateJump(int destination, bool isSubroutine)
         {
             return _analyzer.ValidateJump(destination, isSubroutine);
+        }
+
+        void IThreadPoolWorkItem.Execute()
+        {
+            _analyzer.Execute();
         }
     }
 }

--- a/src/Nethermind/Nethermind.Evm/CodeAnalysis/CodeInfo.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeAnalysis/CodeInfo.cs
@@ -10,13 +10,19 @@ namespace Nethermind.Evm.CodeAnalysis
 {
     public class CodeInfo : IThreadPoolWorkItem
     {
-        public byte[] MachineCode { get; set; }
+        public ReadOnlyMemory<byte> MachineCode { get; }
         public IPrecompile? Precompile { get; set; }
         private readonly JumpDestinationAnalyzer _analyzer;
         private static readonly JumpDestinationAnalyzer _emptyAnalyzer = new(Array.Empty<byte>());
         public static CodeInfo Empty { get; } = new CodeInfo(Array.Empty<byte>());
 
         public CodeInfo(byte[] code)
+        {
+            MachineCode = code;
+            _analyzer = code.Length == 0 ? _emptyAnalyzer : new JumpDestinationAnalyzer(code);
+        }
+
+        public CodeInfo(ReadOnlyMemory<byte> code)
         {
             MachineCode = code;
             _analyzer = code.Length == 0 ? _emptyAnalyzer : new JumpDestinationAnalyzer(code);

--- a/src/Nethermind/Nethermind.Evm/CodeAnalysis/JumpDestinationAnalyzer.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeAnalysis/JumpDestinationAnalyzer.cs
@@ -1,33 +1,21 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Threading;
 
 namespace Nethermind.Evm.CodeAnalysis
 {
-    public sealed class JumpDestinationAnalyzer : IThreadPoolWorkItem
+    public sealed class JumpDestinationAnalyzer(byte[] code)
     {
         private const int PUSH1 = 0x60;
         private const int PUSH32 = 0x7f;
         private const int JUMPDEST = 0x5b;
         private const int BEGINSUB = 0x5c;
-        private const int BitShiftPerInt32 = 5;
+        private const int BitShiftPerInt64 = 6;
 
-        private int[]? _jumpDestBitmap;
-        public byte[] MachineCode { get; set; }
-
-        public JumpDestinationAnalyzer(byte[] code)
-        {
-            // Store the code refence as the JumpDest analysis is lazy
-            // and not performed until first jump.
-            MachineCode = code;
-
-            // Start generating the JumpDestinationBitmap in background.
-            ThreadPool.UnsafeQueueUserWorkItem(this, preferLocal: false);
-        }
+        private long[]? _jumpDestBitmap;
+        public byte[] MachineCode { get; } = code;
 
         public bool ValidateJump(int destination, bool isSubroutine)
         {
@@ -59,13 +47,13 @@ namespace Nethermind.Evm.CodeAnalysis
 
         /// <summary>
         /// Used for conversion between different representations of bit array.
-        /// Returns (n + (32 - 1)) / 32, rearranged to avoid arithmetic overflow.
+        /// Returns (n + (64 - 1)) / 64, rearranged to avoid arithmetic overflow.
         /// For example, in the bit to int case, the straightforward calc would
-        /// be (n + 31) / 32, but that would cause overflow. So instead it's
-        /// rearranged to ((n - 1) / 32) + 1.
+        /// be (n + 63) / 64, but that would cause overflow. So instead it's
+        /// rearranged to ((n - 1) / 64) + 1.
         /// Due to sign extension, we don't need to special case for n == 0, if we use
-        /// bitwise operations (since ((n - 1) >> 5) + 1 = 0).
-        /// This doesn't hold true for ((n - 1) / 32) + 1, which equals 1.
+        /// bitwise operations (since ((n - 1) >> 6) + 1 = 0).
+        /// This doesn't hold true for ((n - 1) / 64) + 1, which equals 1.
         ///
         /// Usage:
         /// GetInt32ArrayLengthFromBitLength(77): returns how many ints must be
@@ -73,20 +61,21 @@ namespace Nethermind.Evm.CodeAnalysis
         /// </summary>
         /// <param name="n"></param>
         /// <returns>how many ints are required to store n bytes</returns>
-        private static int GetInt32ArrayLengthFromBitLength(int n)
+        private static int GetInt64ArrayLengthFromBitLength(int n)
         {
-            return (int)((uint)(n - 1 + (1 << BitShiftPerInt32)) >> BitShiftPerInt32);
+            return (int)((uint)(n - 1 + (1 << BitShiftPerInt64)) >> BitShiftPerInt64);
         }
 
         /// <summary>
         /// Collects data locations in code.
         /// An unset bit means the byte is an opcode, a set bit means it's data.
         /// </summary>
-        private static int[] CreateJumpDestinationBitmap(byte[] code)
+        private static long[] CreateJumpDestinationBitmap(byte[] code)
         {
-            int[] jumpDestBitmap = new int[GetInt32ArrayLengthFromBitLength(code.Length)];
+            long[] jumpDestBitmap = new long[GetInt64ArrayLengthFromBitLength(code.Length)];
 
             int pc = 0;
+            long flags = 0;
             while (true)
             {
                 // Since we are using a non-standard for loop here;
@@ -97,20 +86,29 @@ namespace Nethermind.Evm.CodeAnalysis
                 // Grab the instruction from the code.
                 int op = code[pc];
 
-                if (op >= PUSH1 && op <= PUSH32)
+                int move = 1;
+                if ((uint)op - JUMPDEST <= BEGINSUB - JUMPDEST)
+                {
+                    // Accumulate JumpDest to register
+                    flags |= 1L << pc;
+                }
+                else if ((uint)op - PUSH1 <= PUSH32 - PUSH1)
                 {
                     // Skip forward amount of data the push represents
                     // don't need to analyse data for JumpDests
-                    pc += op - PUSH1 + 1;
+                    move = op - PUSH1 + 2;
                 }
-                else if (op == JUMPDEST || op == BEGINSUB)
+
+                int next = pc + move;
+                if ((pc & 0x3F) + move > 0x3f || next >= code.Length)
                 {
-                    // Exact type will be checked again by ValidateJump
-                    MarkAsJumpDestination(jumpDestBitmap, pc);
+                    // Moving to next array element (or finishing) assign to array.
+                    MarkJumpDestinations(jumpDestBitmap, pc, flags);
+                    flags = 0;
                 }
 
                 // Next instruction
-                pc++;
+                pc = next;
             }
 
             return jumpDestBitmap;
@@ -119,33 +117,21 @@ namespace Nethermind.Evm.CodeAnalysis
         /// <summary>
         /// Checks if the position is in a code segment.
         /// </summary>
-        private static bool IsJumpDestination(int[] bitvec, int pos)
+        private static bool IsJumpDestination(long[] bitvec, int pos)
         {
-            int vecIndex = pos >> BitShiftPerInt32;
+            int vecIndex = pos >> BitShiftPerInt64;
             // Check if in bounds, Jit will add slightly more expensive exception throwing check if we don't
             if ((uint)vecIndex >= (uint)bitvec.Length) return false;
 
-            return (bitvec[vecIndex] & (1 << pos)) != 0;
+            return (bitvec[vecIndex] & (1L << pos)) != 0;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void MarkAsJumpDestination(int[] bitvec, int pos)
+        private static void MarkJumpDestinations(long[] bitvec, int pos, long flags)
         {
-            int vecIndex = pos >> BitShiftPerInt32;
-            Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(bitvec), vecIndex)
-                |= 1 << pos;
-        }
-
-        void IThreadPoolWorkItem.Execute()
-        {
-            if (_jumpDestBitmap is null)
-            {
-                var jumpDestBitmap = CreateJumpDestinationBitmap(MachineCode);
-                // Atomically assign if still null. Aren't really any thread safety issues here,
-                // as will be same result. Just keep first one we created; as Evm will have started
-                // using it if already created and let this one be Gen0 GC'd.
-                Interlocked.CompareExchange(ref _jumpDestBitmap, jumpDestBitmap, null);
-            }
+            uint offset = (uint)pos >> BitShiftPerInt64;
+            Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(bitvec), offset)
+                |= flags;
         }
     }
 }

--- a/src/Nethermind/Nethermind.Evm/CodeAnalysis/JumpDestinationAnalyzer.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeAnalysis/JumpDestinationAnalyzer.cs
@@ -122,7 +122,7 @@ namespace Nethermind.Evm.CodeAnalysis
                     move = op - PUSH1 + 2;
                 }
 
-                Next:
+            Next:
                 int nextCounter = programCounter + move;
                 // Check if read last item of code; we want to write this out also even if not
                 // at a boundary and then we will return the results.

--- a/src/Nethermind/Nethermind.Evm/CodeAnalysis/JumpDestinationAnalyzer.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeAnalysis/JumpDestinationAnalyzer.cs
@@ -31,7 +31,7 @@ namespace Nethermind.Evm.CodeAnalysis
             // Cast to uint to change negative numbers to very int high numbers
             // Then do length check, this both reduces check by 1 and eliminates the bounds
             // check from accessing the span.
-            if ((uint)destination < (uint)machineCode.Length && IsJumpDestination(_jumpDestBitmap, destination))
+            if ((uint)destination < (uint)machineCode.Length && IsJumpDestination(_jumpDestinationBitmap, destination))
             {
                 // Store byte to int, as less expensive operations at word size
                 int codeByte = machineCode[destination];
@@ -130,7 +130,9 @@ namespace Nethermind.Evm.CodeAnalysis
                 // at a boundary and then we will return the results.
                 bool exit = nextCounter >= code.Length;
                 // Does the move mean we are moving to new segment of the long array?
-                if ((programCounter & 63) + move > 63 || exit)
+                // If we take the current index in flags, and add the move, are we at
+                // a new long segment, i.e. a larger than 64 position move.
+                if ((programCounter & 63) + move >= 64 || exit)
                 {
                     // If so write out the flags (if any are set)
                     if (currentFlags != 0)

--- a/src/Nethermind/Nethermind.Evm/CodeAnalysis/JumpDestinationAnalyzer.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeAnalysis/JumpDestinationAnalyzer.cs
@@ -31,16 +31,11 @@ namespace Nethermind.Evm.CodeAnalysis
             // Cast to uint to change negative numbers to very int high numbers
             // Then do length check, this both reduces check by 1 and eliminates the bounds
             // check from accessing the span.
-            if ((uint)destination < (uint)machineCode.Length)
+            if ((uint)destination < (uint)machineCode.Length && IsJumpDestination(_jumpDestBitmap, destination))
             {
                 // Store byte to int, as less expensive operations at word size
                 int codeByte = machineCode[destination];
-                if (IsJumpDestination(_jumpDestinationBitmap, destination))
-                {
-                    result = isSubroutine ?
-                        codeByte == BEGINSUB :
-                        codeByte == JUMPDEST;
-                }
+                result = isSubroutine ? codeByte == BEGINSUB : codeByte == JUMPDEST;
             }
 
             return result;

--- a/src/Nethermind/Nethermind.Evm/EvmStack.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmStack.cs
@@ -333,7 +333,7 @@ public ref struct EvmStack<TTracing>
         return _bytes[Head * WordSize + WordSize - sizeof(byte)];
     }
 
-    public void PushLeftPaddedBytes(Span<byte> value, int paddingLength)
+    public void PushLeftPaddedBytes(ReadOnlySpan<byte> value, int paddingLength)
     {
         if (typeof(TTracing) == typeof(IsTracing)) _tracer.ReportStackPush(value);
 

--- a/src/Nethermind/Nethermind.Evm/IVirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/IVirtualMachine.cs
@@ -18,6 +18,6 @@ namespace Nethermind.Evm
             where TTracingActions : struct, IIsTracing;
 
         CodeInfo GetCachedCodeInfo(IWorldState worldState, Address codeSource, IReleaseSpec spec);
-        void CacheCodeInfo(Hash256 codeHash, CodeInfo cachedCodeInfo);
+        void InsertCode(byte[] code, Address codeOwner, IReleaseSpec spec);
     }
 }

--- a/src/Nethermind/Nethermind.Evm/IVirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/IVirtualMachine.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Nethermind.Core;
+using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.Evm.CodeAnalysis;
 using Nethermind.Evm.Tracing;
@@ -17,5 +18,6 @@ namespace Nethermind.Evm
             where TTracingActions : struct, IIsTracing;
 
         CodeInfo GetCachedCodeInfo(IWorldState worldState, Address codeSource, IReleaseSpec spec);
+        void CacheCodeInfo(Hash256 codeHash, CodeInfo cachedCodeInfo);
     }
 }

--- a/src/Nethermind/Nethermind.Evm/Tracing/AlwaysCancelTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/AlwaysCancelTxTracer.cs
@@ -89,7 +89,7 @@ public class AlwaysCancelTxTracer : ITxTracer
     public void ReportActionEnd(long gas, Address deploymentAddress, ReadOnlyMemory<byte> deployedCode) => throw new OperationCanceledException(ErrorMessage);
     public void ReportBlockHash(Hash256 blockHash) => throw new OperationCanceledException(ErrorMessage);
 
-    public void ReportByteCode(byte[] byteCode) => throw new OperationCanceledException(ErrorMessage);
+    public void ReportByteCode(ReadOnlyMemory<byte> byteCode) => throw new OperationCanceledException(ErrorMessage);
     public void ReportGasUpdateForVmTrace(long refund, long gasAvailable) => throw new OperationCanceledException(ErrorMessage);
     public void ReportRefund(long refund) => throw new OperationCanceledException(ErrorMessage);
     public void ReportExtraGasPressure(long extraGasPressure) => throw new OperationCanceledException(ErrorMessage);

--- a/src/Nethermind/Nethermind.Evm/Tracing/BlockReceiptsTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/BlockReceiptsTracer.cs
@@ -157,7 +157,7 @@ public class BlockReceiptsTracer : IBlockTracer, ITxTracer, IJournal<int>, ITxTr
     public void ReportActionEnd(long gas, Address deploymentAddress, ReadOnlyMemory<byte> deployedCode) =>
         _currentTxTracer.ReportActionEnd(gas, deploymentAddress, deployedCode);
 
-    public void ReportByteCode(byte[] byteCode) =>
+    public void ReportByteCode(ReadOnlyMemory<byte> byteCode) =>
         _currentTxTracer.ReportByteCode(byteCode);
 
     public void ReportGasUpdateForVmTrace(long refund, long gasAvailable) =>

--- a/src/Nethermind/Nethermind.Evm/Tracing/CancellationTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/CancellationTxTracer.cs
@@ -384,7 +384,7 @@ public class CancellationTxTracer : ITxTracer, ITxTracerWrapper
         }
     }
 
-    public void ReportByteCode(byte[] byteCode)
+    public void ReportByteCode(ReadOnlyMemory<byte> byteCode)
     {
         _token.ThrowIfCancellationRequested();
         if (_innerTracer.IsTracingCode)

--- a/src/Nethermind/Nethermind.Evm/Tracing/CompositeTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/CompositeTxTracer.cs
@@ -413,7 +413,7 @@ public class CompositeTxTracer : ITxTracer
         }
     }
 
-    public void ReportByteCode(byte[] byteCode)
+    public void ReportByteCode(ReadOnlyMemory<byte> byteCode)
     {
         for (int index = 0; index < _txTracers.Count; index++)
         {

--- a/src/Nethermind/Nethermind.Evm/Tracing/Debugger/DebugTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/Debugger/DebugTracer.cs
@@ -239,7 +239,7 @@ public class DebugTracer : ITxTracer, ITxTracerWrapper, IDisposable
     public void ReportBlockHash(Hash256 blockHash)
         => InnerTracer.ReportBlockHash(blockHash);
 
-    public void ReportByteCode(byte[] byteCode)
+    public void ReportByteCode(ReadOnlyMemory<byte> byteCode)
         => InnerTracer.ReportByteCode(byteCode);
 
     public void ReportGasUpdateForVmTrace(long refund, long gasAvailable)

--- a/src/Nethermind/Nethermind.Evm/Tracing/ITxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/ITxTracer.cs
@@ -375,11 +375,11 @@ public interface ITxTracer : IWorldStateTracer, IDisposable
     void ReportBlockHash(Hash256 blockHash);
 
     /// <summary>
-    ///
+    /// 
     /// </summary>
     /// <param name="byteCode"></param>
     /// <remarks>Depends on <see cref="IsTracingCode"/></remarks>
-    void ReportByteCode(byte[] byteCode);
+    void ReportByteCode(ReadOnlyMemory<byte> byteCode);
 
     /// <summary>
     /// Special case for VM trace in Parity but we consider removing support for it

--- a/src/Nethermind/Nethermind.Evm/Tracing/NullTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/NullTxTracer.cs
@@ -93,7 +93,7 @@ public class NullTxTracer : TxTracer
         => ThrowInvalidOperationException();
     public override void ReportBlockHash(Hash256 blockHash)
         => ThrowInvalidOperationException();
-    public override void ReportByteCode(byte[] byteCode)
+    public override void ReportByteCode(ReadOnlyMemory<byte> byteCode)
         => ThrowInvalidOperationException();
 
     public override void ReportGasUpdateForVmTrace(long refund, long gasAvailable)

--- a/src/Nethermind/Nethermind.Evm/Tracing/ParityStyle/ParityLikeTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/ParityStyle/ParityLikeTxTracer.cs
@@ -468,9 +468,10 @@ namespace Nethermind.Evm.Tracing.ParityStyle
             PopAction();
         }
 
-        public override void ReportByteCode(byte[] byteCode)
+        public override void ReportByteCode(ReadOnlyMemory<byte> byteCode)
         {
-            _currentVmTrace.VmTrace.Code = byteCode;
+            // TODO: use memory pool?
+            _currentVmTrace.VmTrace.Code = byteCode.ToArray();
         }
 
         public override void ReportGasUpdateForVmTrace(long refund, long gasAvailable)

--- a/src/Nethermind/Nethermind.Evm/Tracing/TxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/TxTracer.cs
@@ -66,7 +66,7 @@ public class TxTracer : ITxTracer
     public virtual void ReportActionError(EvmExceptionType evmExceptionType) { }
     public virtual void ReportActionEnd(long gas, Address deploymentAddress, ReadOnlyMemory<byte> deployedCode) { }
     public virtual void ReportBlockHash(Hash256 blockHash) { }
-    public virtual void ReportByteCode(byte[] byteCode) { }
+    public virtual void ReportByteCode(ReadOnlyMemory<byte> byteCode) { }
     public virtual void ReportGasUpdateForVmTrace(long refund, long gasAvailable) { }
     public virtual void ReportRefund(long refund) { }
     public virtual void ReportExtraGasPressure(long extraGasPressure) { }

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -552,7 +552,11 @@ namespace Nethermind.Evm.TransactionProcessing
 
                         if (unspentGas >= codeDepositGasCost)
                         {
-                            WorldState.InsertCode(env.ExecutingAccount, substate.Output, spec);
+                            var code = substate.Output.ToArray();
+                            Hash256 codeHash = code.Length == 0 ? Keccak.OfAnEmptyString : Keccak.Compute(code.AsSpan());
+                            WorldState.InsertCode(env.ExecutingAccount, codeHash, code, spec);
+                            VirtualMachine.CacheCodeInfo(codeHash, new CodeInfo(code));
+
                             unspentGas -= codeDepositGasCost;
                         }
                     }

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -555,13 +555,7 @@ namespace Nethermind.Evm.TransactionProcessing
                         if (unspentGas >= codeDepositGasCost)
                         {
                             var code = substate.Output.ToArray();
-                            var codeInfo = new CodeInfo(code);
-                            // Start generating the JumpDestinationBitmap in background.
-                            ThreadPool.UnsafeQueueUserWorkItem(codeInfo, preferLocal: false);
-
-                            Hash256 codeHash = code.Length == 0 ? Keccak.OfAnEmptyString : Keccak.Compute(code.AsSpan());
-                            WorldState.InsertCode(env.ExecutingAccount, codeHash, code, spec);
-                            VirtualMachine.CacheCodeInfo(codeHash, codeInfo);
+                            VirtualMachine.InsertCode(code, env.ExecutingAccount, spec);
 
                             unspentGas -= codeDepositGasCost;
                         }

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -2546,6 +2546,9 @@ internal sealed class VirtualMachine<TLogger> : IVirtualMachine
 
         _state.SubtractFromBalance(env.ExecutingAccount, value, spec);
 
+        // Do not add the initCode to the cache as it is
+        // pointing to data in this tx and will become invalid
+        // for another tx as returned to pool.
         CodeInfo codeInfo = new(initCode);
 
         ExecutionEnvironment callEnv = new

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -498,8 +498,14 @@ internal sealed class VirtualMachine<TLogger> : IVirtualMachine
             return _precompiles[codeSource];
         }
 
+        CodeInfo cachedCodeInfo = null;
         Hash256 codeHash = worldState.GetCodeHash(codeSource);
-        CodeInfo cachedCodeInfo = _codeCache.Get(codeHash);
+        if (ReferenceEquals(codeHash, Keccak.OfAnEmptyString))
+        {
+            cachedCodeInfo = CodeInfo.Empty;
+        }
+
+        cachedCodeInfo ??= _codeCache.Get(codeHash);
         if (cachedCodeInfo is null)
         {
             byte[] code = worldState.GetCode(codeHash);

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
@@ -14,6 +14,7 @@ using Nethermind.JsonRpc.Data;
 using Nethermind.Specs;
 using Nethermind.Specs.Forks;
 using Nethermind.Specs.Test;
+using Nethermind.State;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EthCall.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EthCall.cs
@@ -12,6 +12,7 @@ using Nethermind.JsonRpc.Data;
 using Nethermind.Specs;
 using Nethermind.Specs.Forks;
 using Nethermind.Specs.Test;
+using Nethermind.State;
 using NUnit.Framework;
 
 namespace Nethermind.JsonRpc.Test.Modules.Eth;

--- a/src/Nethermind/Nethermind.State/IWorldState.cs
+++ b/src/Nethermind/Nethermind.State/IWorldState.cs
@@ -83,8 +83,6 @@ public interface IWorldState : IJournal<Snapshot>, IReadOnlyStateProvider
     void CreateAccount(Address address, in UInt256 balance, in UInt256 nonce = default);
     void CreateAccountIfNotExists(Address address, in UInt256 balance, in UInt256 nonce = default);
 
-    void InsertCode(Address address, ReadOnlyMemory<byte> code, IReleaseSpec spec, bool isGenesis = false);
-
     void InsertCode(Address address, Hash256 codeHash, ReadOnlyMemory<byte> code, IReleaseSpec spec, bool isGenesis = false);
 
     void AddToBalance(Address address, in UInt256 balanceChange, IReleaseSpec spec);

--- a/src/Nethermind/Nethermind.State/IWorldState.cs
+++ b/src/Nethermind/Nethermind.State/IWorldState.cs
@@ -85,6 +85,8 @@ public interface IWorldState : IJournal<Snapshot>, IReadOnlyStateProvider
 
     void InsertCode(Address address, ReadOnlyMemory<byte> code, IReleaseSpec spec, bool isGenesis = false);
 
+    void InsertCode(Address address, Hash256 codeHash, ReadOnlyMemory<byte> code, IReleaseSpec spec, bool isGenesis = false);
+
     void AddToBalance(Address address, in UInt256 balanceChange, IReleaseSpec spec);
 
     void AddToBalanceAndCreateIfNotExists(Address address, in UInt256 balanceChange, IReleaseSpec spec);

--- a/src/Nethermind/Nethermind.State/IWorldStateExtensions.cs
+++ b/src/Nethermind/Nethermind.State/IWorldStateExtensions.cs
@@ -3,7 +3,9 @@
 
 using System;
 using Nethermind.Core;
+using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
+using Nethermind.Core.Specs;
 using Nethermind.Logging;
 using Nethermind.Trie;
 
@@ -14,11 +16,13 @@ namespace Nethermind.State
         public static byte[] GetCode(this IWorldState stateProvider, Address address)
         {
             Account account = stateProvider.GetAccount(address);
-            if (!account.HasCode)
-            {
-                return Array.Empty<byte>();
-            }
-            return stateProvider.GetCode(account.CodeHash);
+            return !account.HasCode ? Array.Empty<byte>() : stateProvider.GetCode(account.CodeHash);
+        }
+
+        public static void InsertCode(this IWorldState worldState, Address address, ReadOnlyMemory<byte> code, IReleaseSpec spec, bool isGenesis = false)
+        {
+            Hash256 codeHash = code.Length == 0 ? Keccak.OfAnEmptyString : Keccak.Compute(code.Span);
+            worldState.InsertCode(address, codeHash, code, spec, isGenesis);
         }
 
         public static string DumpState(this IWorldState stateProvider)

--- a/src/Nethermind/Nethermind.State/StateProvider.cs
+++ b/src/Nethermind/Nethermind.State/StateProvider.cs
@@ -146,10 +146,9 @@ namespace Nethermind.State
             return account?.Balance ?? UInt256.Zero;
         }
 
-        public void InsertCode(Address address, ReadOnlyMemory<byte> code, IReleaseSpec spec, bool isGenesis = false)
+        public void InsertCode(Address address, Hash256 codeHash, ReadOnlyMemory<byte> code, IReleaseSpec spec, bool isGenesis = false)
         {
             _needsStateRootUpdate = true;
-            Hash256 codeHash = code.Length == 0 ? Keccak.OfAnEmptyString : Keccak.Compute(code.Span);
 
             // Don't reinsert if already inserted. This can be the case when the same
             // code is used by multiple deployments. Either from factory contracts (e.g. LPs)

--- a/src/Nethermind/Nethermind.State/WorldState.cs
+++ b/src/Nethermind/Nethermind.State/WorldState.cs
@@ -106,11 +106,7 @@ namespace Nethermind.State
         {
             _stateProvider.CreateAccount(address, balance, nonce);
         }
-        public void InsertCode(Address address, ReadOnlyMemory<byte> code, IReleaseSpec spec, bool isGenesis = false)
-        {
-            Hash256 codeHash = code.Length == 0 ? Keccak.OfAnEmptyString : Keccak.Compute(code.Span);
-            InsertCode(address, codeHash, code, spec, isGenesis);
-        }
+
         public void InsertCode(Address address, Hash256 codeHash, ReadOnlyMemory<byte> code, IReleaseSpec spec, bool isGenesis = false)
         {
             _stateProvider.InsertCode(address, codeHash, code, spec, isGenesis);

--- a/src/Nethermind/Nethermind.State/WorldState.cs
+++ b/src/Nethermind/Nethermind.State/WorldState.cs
@@ -108,8 +108,14 @@ namespace Nethermind.State
         }
         public void InsertCode(Address address, ReadOnlyMemory<byte> code, IReleaseSpec spec, bool isGenesis = false)
         {
-            _stateProvider.InsertCode(address, code, spec, isGenesis);
+            Hash256 codeHash = code.Length == 0 ? Keccak.OfAnEmptyString : Keccak.Compute(code.Span);
+            InsertCode(address, codeHash, code, spec, isGenesis);
         }
+        public void InsertCode(Address address, Hash256 codeHash, ReadOnlyMemory<byte> code, IReleaseSpec spec, bool isGenesis = false)
+        {
+            _stateProvider.InsertCode(address, codeHash, code, spec, isGenesis);
+        }
+
         public void AddToBalance(Address address, in UInt256 balanceChange, IReleaseSpec spec)
         {
             _stateProvider.AddToBalance(address, balanceChange, spec);

--- a/src/Nethermind/Nethermind.Test.Runner/StateTestTxTracer.cs
+++ b/src/Nethermind/Nethermind.Test.Runner/StateTestTxTracer.cs
@@ -220,7 +220,7 @@ public class StateTestTxTracer : ITxTracer, IDisposable
         throw new NotImplementedException();
     }
 
-    public void ReportByteCode(byte[] byteCode)
+    public void ReportByteCode(ReadOnlyMemory<byte> byteCode)
     {
         throw new NotSupportedException();
     }


### PR DESCRIPTION
## Changes

- Don't Keccak code on Create until it returns sucessfully and both account and cache are being updated (rather than always keccaking)
- Cache code in Transation processor when inserting code
- Change JumpDest Bitmap to 64bit
- Accumulate the bits in register before writing on array element change
- Use initcode in-place rather than `.ToArray`ing a copy

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No