### PR TITLE
Initialize Precompiles as static FrozenDictionary

### DIFF
--- a/src/Nethermind/Nethermind.Db/Metrics.cs
+++ b/src/Nethermind/Nethermind.Db/Metrics.cs
@@ -35,6 +35,10 @@ namespace Nethermind.Db
         public static long BlocksDbWrites { get; set; }
 
         [CounterMetric]
+        [Description("Number of Code DB cache reads.")]
+        public static long CodeDbCache { get; set; }
+
+        [CounterMetric]
         [Description("Number of Code DB reads.")]
         public static long CodeDbReads { get; set; }
 

--- a/src/Nethermind/Nethermind.Evm/MemoryAllowance.cs
+++ b/src/Nethermind/Nethermind.Evm/MemoryAllowance.cs
@@ -5,6 +5,6 @@ namespace Nethermind.Evm
 {
     public static class MemoryAllowance
     {
-        public static int CodeCacheSize { get; } = 16_384; 
+        public static int CodeCacheSize { get; } = 16_384;
     }
 }

--- a/src/Nethermind/Nethermind.Evm/MemoryAllowance.cs
+++ b/src/Nethermind/Nethermind.Evm/MemoryAllowance.cs
@@ -5,6 +5,6 @@ namespace Nethermind.Evm
 {
     public static class MemoryAllowance
     {
-        public static int CodeCacheSize { get; } = 1 << 13;
+        public static int CodeCacheSize { get; } = 16_384; 
     }
 }

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -553,6 +553,7 @@ internal sealed class VirtualMachine<TLogger> : IVirtualMachine where TLogger : 
         }
         else
         {
+            Db.Metrics.CodeDbCache++;
             // need to touch code so that any collectors that track database access are informed
             worldState.TouchCode(codeHash);
         }


### PR DESCRIPTION
## Changes

- Move statics to non-generic VM so not instantiated per variant
- Initialize Precompiles as static FrozenDictionary
- Make some more things readonly static

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization
- [x] Refactoring

## Testing

#### Requires testing

- [x] No
