### PR TITLE
Avoid boxing in AccessLists

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
@@ -154,7 +154,7 @@ public class TxValidatorTests
             .WithType(txType > TxType.AccessList ? TxType.Legacy : txType)
             .WithChainId(TestBlockchainIds.ChainId)
             .WithAccessList(txType == TxType.AccessList
-                ? AccessList.Empty()
+                ? AccessList.Empty
                 : null)
             .WithSignature(signature).TestObject;
 
@@ -185,7 +185,7 @@ public class TxValidatorTests
             .WithMaxPriorityFeePerGas(txType == TxType.EIP1559 ? 10.GWei() : 5.GWei())
             .WithMaxFeePerGas(txType == TxType.EIP1559 ? 10.GWei() : 5.GWei())
             .WithAccessList(txType == TxType.AccessList || txType == TxType.EIP1559
-                ? AccessList.Empty()
+                ? AccessList.Empty
                 : null)
             .WithSignature(signature).TestObject;
 
@@ -210,7 +210,7 @@ public class TxValidatorTests
         Transaction tx = Build.A.Transaction
             .WithType(txType > TxType.AccessList ? TxType.Legacy : txType)
             .WithAccessList(txType == TxType.AccessList
-                ? AccessList.Empty()
+                ? AccessList.Empty
                 : null)
             .WithSignature(signature).TestObject;
 
@@ -240,7 +240,7 @@ public class TxValidatorTests
             .WithMaxPriorityFeePerGas((UInt256)maxPriorityFeePerGas)
             .WithMaxFeePerGas((UInt256)maxFeePerGas)
             .WithAccessList(txType == TxType.AccessList
-                ? AccessList.Empty()
+                ? AccessList.Empty
                 : null)
             .WithChainId(TestBlockchainIds.ChainId)
             .WithSignature(signature).TestObject;

--- a/src/Nethermind/Nethermind.Consensus.Clique/SnapshotManager.cs
+++ b/src/Nethermind/Nethermind.Consensus.Clique/SnapshotManager.cs
@@ -45,7 +45,7 @@ namespace Nethermind.Consensus.Clique
         public Address GetBlockSealer(BlockHeader header)
         {
             if (header.Author is not null) return header.Author;
-            if (header.Number == UInt256.Zero) return Address.Zero;
+            if (header.Number == 0) return Address.Zero;
             if (_signatures.Get(header.Hash) is not null) return _signatures.Get(header.Hash);
 
             int extraSeal = 65;

--- a/src/Nethermind/Nethermind.Evm/EvmState.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmState.cs
@@ -273,7 +273,7 @@ namespace Nethermind.Evm
 
         public void WarmUp(AccessList? accessList)
         {
-            if (accessList is not null)
+            if (accessList is not null && !accessList.IsEmpty)
             {
                 foreach ((Address address, AccessList.StorageKeysEnumerable storages) in accessList)
                 {

--- a/src/Nethermind/Nethermind.Evm/EvmState.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmState.cs
@@ -273,7 +273,7 @@ namespace Nethermind.Evm
 
         public void WarmUp(AccessList? accessList)
         {
-            if (accessList is not null && !accessList.IsEmpty)
+            if (accessList?.IsEmpty == false)
             {
                 foreach ((Address address, AccessList.StorageKeysEnumerable storages) in accessList)
                 {

--- a/src/Nethermind/Nethermind.Evm/Tracing/Proofs/ProofTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/Proofs/ProofTxTracer.cs
@@ -38,7 +38,7 @@ namespace Nethermind.Evm.Tracing.Proofs
 
         public override void ReportBalanceChange(Address address, UInt256? before, UInt256? after)
         {
-            if (_treatSystemAccountDifferently && Address.SystemUser == address && before is null && (after?.IsZero ?? true))
+            if (_treatSystemAccountDifferently && Address.SystemUser == address && before is null && after?.IsZero != false)
             {
                 return;
             }
@@ -58,7 +58,7 @@ namespace Nethermind.Evm.Tracing.Proofs
 
         public override void ReportNonceChange(Address address, UInt256? before, UInt256? after)
         {
-            if (_treatSystemAccountDifferently && Address.SystemUser == address && before is null && (after?.IsZero ?? true))
+            if (_treatSystemAccountDifferently && Address.SystemUser == address && before is null && after?.IsZero != false)
             {
                 return;
             }

--- a/src/Nethermind/Nethermind.Evm/Tracing/Proofs/ProofTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/Proofs/ProofTxTracer.cs
@@ -38,7 +38,7 @@ namespace Nethermind.Evm.Tracing.Proofs
 
         public override void ReportBalanceChange(Address address, UInt256? before, UInt256? after)
         {
-            if (_treatSystemAccountDifferently && Address.SystemUser == address && before is null && after == UInt256.Zero)
+            if (_treatSystemAccountDifferently && Address.SystemUser == address && before is null && (after?.IsZero ?? true))
             {
                 return;
             }
@@ -58,7 +58,7 @@ namespace Nethermind.Evm.Tracing.Proofs
 
         public override void ReportNonceChange(Address address, UInt256? before, UInt256? after)
         {
-            if (_treatSystemAccountDifferently && Address.SystemUser == address && before is null && after == UInt256.Zero)
+            if (_treatSystemAccountDifferently && Address.SystemUser == address && before is null && (after?.IsZero ?? true))
             {
                 return;
             }

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -299,31 +299,32 @@ namespace Nethermind.Evm.TransactionProcessing
 
             bool deleteCallerAccount = false;
 
-            if (!WorldState.AccountExists(tx.SenderAddress))
+            Address sender = tx.SenderAddress;
+            if (sender is null || !WorldState.AccountExists(sender))
             {
-                if (Logger.IsDebug) Logger.Debug($"TX sender account does not exist {tx.SenderAddress} - trying to recover it");
+                if (Logger.IsDebug) Logger.Debug($"TX sender account does not exist {sender} - trying to recover it");
 
-                Address prevSender = tx.SenderAddress;
                 // hacky fix for the potential recovery issue
                 if (tx.Signature is not null)
                     tx.SenderAddress = Ecdsa.RecoverAddress(tx, !spec.ValidateChainId);
 
-                if (prevSender != tx.SenderAddress)
+                if (sender != tx.SenderAddress)
                 {
                     if (Logger.IsWarn)
-                        Logger.Warn($"TX recovery issue fixed - tx was coming with sender {prevSender} and the now it recovers to {tx.SenderAddress}");
+                        Logger.Warn($"TX recovery issue fixed - tx was coming with sender {sender} and the now it recovers to {tx.SenderAddress}");
+                    sender = tx.SenderAddress;
                 }
                 else
                 {
-                    TraceLogInvalidTx(tx, $"SENDER_ACCOUNT_DOES_NOT_EXIST {tx.SenderAddress}");
-                    if (!commit || noValidation || effectiveGasPrice == UInt256.Zero)
+                    TraceLogInvalidTx(tx, $"SENDER_ACCOUNT_DOES_NOT_EXIST {sender}");
+                    if (!commit || noValidation || effectiveGasPrice.IsZero)
                     {
                         deleteCallerAccount = !commit || restore;
-                        WorldState.CreateAccount(tx.SenderAddress, UInt256.Zero);
+                        WorldState.CreateAccount(sender, in UInt256.Zero);
                     }
                 }
 
-                if (tx.SenderAddress is null)
+                if (sender is null)
                 {
                     throw new InvalidDataException($"Failed to recover sender address on tx {tx.Hash} when previously recovered sender account did not exist.");
                 }

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
@@ -577,7 +577,7 @@ namespace Nethermind.Synchronization.ParallelSync
                    !best.IsInFullSync &&
                    !best.IsInStateSync &&
                    // maybe some more sophisticated heuristic?
-                   best.Peer.TotalDifficulty == UInt256.Zero;
+                   best.Peer.TotalDifficulty.IsZero;
         }
 
         private bool ShouldBeInStateSyncMode(Snapshot best)


### PR DESCRIPTION
## Changes

- Maintain two strongly typed `List<T>` to avoid boxing the `UInt256` keys to `object` (some txs have 6k+)
- Clean up some `UInt256 == 0` to `.IsZero`
- Also long comparision to 0 rather than convert to UInt256 and then compare zero
- Use Span when calcuating DataCost

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
