### PR TITLE
Increase Trie robustness for multi-readers

### DIFF
--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpStream.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpStream.cs
@@ -27,7 +27,7 @@ namespace Nethermind.Serialization.Rlp
         private static readonly WithdrawalDecoder _withdrawalDecoder = new();
         private static readonly LogEntryDecoder _logEntryDecoder = LogEntryDecoder.Instance;
 
-        private CappedArray<byte> _data;
+        private readonly CappedArray<byte> _data;
 
         protected RlpStream()
         {
@@ -50,6 +50,11 @@ namespace Nethermind.Serialization.Rlp
         public RlpStream(in CappedArray<byte> data)
         {
             _data = data;
+        }
+
+        public RlpStream Clone()
+        {
+            return new(_data);
         }
 
         public void Encode(Block value)

--- a/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
@@ -673,7 +673,7 @@ namespace Nethermind.Trie.Test.Pruning
             readOnlyNode.Should().NotBe(originalNode);
             readOnlyNode.Should().BeEquivalentTo(originalNode,
                 eq => eq.Including(t => t.Keccak)
-                    .Including(t => t.FullRlp)
+                    .Including(t => t.RlpStream)
                     .Including(t => t.NodeType));
 
             readOnlyNode.Key?.ToString().Should().Be(originalNode.Key?.ToString());

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -51,6 +51,8 @@ namespace Nethermind.Trie
         private readonly bool _isTrace;
         private readonly bool _isDebug;
 
+        private int _isWriteInProgress;
+
         private Hash256 _rootHash = Keccak.EmptyTreeHash;
 
         public TrieNode? RootRef { get; set; }
@@ -415,21 +417,42 @@ namespace Nethermind.Trie
         {
             if (_isTrace) Trace(in rawKey, in value);
 
-            int nibblesCount = 2 * rawKey.Length;
-            byte[] array = null;
-            Span<byte> nibbles = (rawKey.Length <= MaxKeyStackAlloc
-                    ? stackalloc byte[MaxKeyStackAlloc] // Fixed size stack allocation
-                    : array = ArrayPool<byte>.Shared.Rent(nibblesCount))
-                [..nibblesCount]; // Slice to exact size
+            if (Interlocked.CompareExchange(ref _isWriteInProgress, 1, 0) != 0)
+            {
+                ThrowNonConcurrentWrites();
+            }
 
-            Nibbles.BytesToNibbleBytes(rawKey, nibbles);
-            Run(nibbles, nibblesCount, in value, isUpdate: true);
+            try
+            {
+                int nibblesCount = 2 * rawKey.Length;
+                byte[] array = null;
+                Span<byte> nibbles = (rawKey.Length <= MaxKeyStackAlloc
+                        ? stackalloc byte[MaxKeyStackAlloc] // Fixed size stack allocation
+                        : array = ArrayPool<byte>.Shared.Rent(nibblesCount))
+                    [..nibblesCount]; // Slice to exact size
 
-            if (array is not null) ArrayPool<byte>.Shared.Return(array);
+                Nibbles.BytesToNibbleBytes(rawKey, nibbles);
+                // lazy stack cleaning after the previous update
+                ClearNodeStack();
+                Run(nibbles, nibblesCount, in value, isUpdate: true);
+
+                if (array is not null) ArrayPool<byte>.Shared.Return(array);
+            }
+            finally
+            {
+                Volatile.Write(ref _isWriteInProgress, 0);
+            }
 
             void Trace(in ReadOnlySpan<byte> rawKey, in CappedArray<byte> value)
             {
                 _logger.Trace($"{(value.Length == 0 ? $"Deleting {rawKey.ToHexString()}" : $"Setting {rawKey.ToHexString()} = {value.AsSpan().ToHexString()}")}");
+            }
+
+            [DoesNotReturn]
+            [StackTraceHidden]
+            static void ThrowNonConcurrentWrites()
+            {
+                throw new InvalidOperationException("Only reads can be done in parallel on the Patricia tree");
             }
         }
 
@@ -447,26 +470,14 @@ namespace Nethermind.Trie
             bool ignoreMissingDelete = true,
             Hash256? startRootHash = null)
         {
-            if (isUpdate && startRootHash is not null)
-            {
-                ThrowNonConcurrentWrites();
-            }
-
 #if DEBUG
             if (nibblesCount != updatePath.Length)
             {
                 throw new Exception("Does it ever happen?");
             }
 #endif
-
             TraverseContext traverseContext =
                 new(updatePath[..nibblesCount], updateValue, isUpdate, ignoreMissingDelete);
-
-            // lazy stack cleaning after the previous update
-            if (traverseContext.IsUpdate)
-            {
-                ClearNodeStack();
-            }
 
             CappedArray<byte> result;
             if (startRootHash is not null)
@@ -500,13 +511,6 @@ namespace Nethermind.Trie
             }
 
             return result;
-
-            [DoesNotReturn]
-            [StackTraceHidden]
-            static void ThrowNonConcurrentWrites()
-            {
-                throw new InvalidOperationException("Only reads can be done in parallel on the Patricia tree");
-            }
 
             void TraceStart(Hash256 startRootHash, in TraverseContext traverseContext)
             {

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
@@ -177,12 +177,13 @@ namespace Nethermind.Trie
             {
                 int totalLength = 0;
                 item.InitData();
-                item.SeekChild(0);
+                RlpStream? rlpStream = item.RlpStream;
+                item.SeekChild(rlpStream, 0);
                 for (int i = 0; i < BranchesCount; i++)
                 {
-                    if (item._rlpStream is not null && item._data![i] is null)
+                    if (rlpStream is not null && item._data![i] is null)
                     {
-                        (int prefixLength, int contentLength) = item._rlpStream.PeekPrefixAndContentLength();
+                        (int prefixLength, int contentLength) = rlpStream.PeekPrefixAndContentLength();
                         totalLength += prefixLength + contentLength;
                     }
                     else
@@ -203,7 +204,7 @@ namespace Nethermind.Trie
                         }
                     }
 
-                    item._rlpStream?.SkipItem();
+                    rlpStream?.SkipItem();
                 }
 
                 return totalLength;
@@ -212,9 +213,9 @@ namespace Nethermind.Trie
             private static void WriteChildrenRlp(ITrieNodeResolver tree, TrieNode item, Span<byte> destination, ICappedArrayPool? bufferPool)
             {
                 int position = 0;
-                RlpStream rlpStream = item._rlpStream;
                 item.InitData();
-                item.SeekChild(0);
+                RlpStream? rlpStream = item.RlpStream;
+                item.SeekChild(rlpStream, 0);
                 for (int i = 0; i < BranchesCount; i++)
                 {
                     if (rlpStream is not null && item._data![i] is null)


### PR DESCRIPTION
## Changes

- Use `RlpStream` as the backing for `FullRlp` removing one field, but also having atomic writes vs the struct
- Take all fields to method locals when operating on them, so any check (like null check) remains valid for the method.
- Always **(_and this is the important one_)** take a clone of the `RlpStream` when operating on it; as otherwise multiple readers with adjust each others positions in the stream.
- Use an atomic barrier to prevent concurrent writers; rather than just checking params
- Move some things (like the barrier) that only apply to writes into the `Set` rather than having in shared `Run`
- Atomically set `IsDirty` and use same flag for `IsDirty` and `IsSealed`
- Atomically set the `_data` backing array

Common symptoms of this are Rlp error with invalid encoding exceptions; likely more on txPool than block production since it is single threaded (at the moment)

With these changes I'm happily running TxPool and BlockProduction on the same StateTree; and might be able to remove `StateReader` and it's trie. Though for a follow up PR.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No

#### Notes

* Lukasz will ask if the cloned RlpStreams can be structs 😉