### PR TITLE
Optimize Tries to Array rather than IEnumerator

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Producers/PayloadAttributes.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/PayloadAttributes.cs
@@ -24,7 +24,7 @@ public class PayloadAttributes
 
     public Address SuggestedFeeRecipient { get; set; }
 
-    public IList<Withdrawal>? Withdrawals { get; set; }
+    public Withdrawal[]? Withdrawals { get; set; }
 
     public Hash256? ParentBeaconBlockRoot { get; set; }
 
@@ -41,7 +41,7 @@ public class PayloadAttributes
 
         if (Withdrawals is not null)
         {
-            sb.Append($", {nameof(Withdrawals)} count: {Withdrawals.Count}");
+            sb.Append($", {nameof(Withdrawals)} count: {Withdrawals.Length}");
         }
 
         if (ParentBeaconBlockRoot is not null)
@@ -99,7 +99,7 @@ public class PayloadAttributes
 
         if (Withdrawals is not null)
         {
-            Hash256 withdrawalsRootHash = Withdrawals.Count == 0
+            Hash256 withdrawalsRootHash = Withdrawals.Length == 0
                 ? PatriciaTree.EmptyTreeHash
                 : new WithdrawalTrie(Withdrawals).RootHash;
             withdrawalsRootHash.Bytes.CopyTo(inputSpan.Slice(position, Keccak.Size));

--- a/src/Nethermind/Nethermind.Merge.AuRa.Test/AuRaMergeEngineModuleTests.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa.Test/AuRaMergeEngineModuleTests.cs
@@ -50,7 +50,7 @@ public class AuRaMergeEngineModuleTests : EngineModuleTests
     [TestCaseSource(nameof(GetWithdrawalValidationValues))]
     public override Task forkchoiceUpdatedV2_should_validate_withdrawals((IReleaseSpec Spec,
         string ErrorMessage,
-        IEnumerable<Withdrawal>? Withdrawals,
+        Withdrawal[]? Withdrawals,
         string BlockHash
         ) input)
         => base.forkchoiceUpdatedV2_should_validate_withdrawals(input);

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.HelperFunctions.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.HelperFunctions.cs
@@ -88,7 +88,7 @@ namespace Nethermind.Merge.Plugin.Test
             };
         }
 
-        private static ExecutionPayload CreateBlockRequest(MergeTestBlockchain chain, ExecutionPayload parent, Address miner, IList<Withdrawal>? withdrawals = null,
+        private static ExecutionPayload CreateBlockRequest(MergeTestBlockchain chain, ExecutionPayload parent, Address miner, Withdrawal[]? withdrawals = null,
                ulong? blobGasUsed = null, ulong? excessBlobGas = null, Transaction[]? transactions = null, Hash256? parentBeaconBlockRoot = null)
         {
             ExecutionPayload blockRequest = CreateBlockRequestInternal<ExecutionPayload>(parent, miner, withdrawals, blobGasUsed, excessBlobGas, transactions: transactions, parentBeaconBlockRoot: parentBeaconBlockRoot);
@@ -107,7 +107,7 @@ namespace Nethermind.Merge.Plugin.Test
             return blockRequest;
         }
 
-        private static ExecutionPayloadV3 CreateBlockRequestV3(MergeTestBlockchain chain, ExecutionPayload parent, Address miner, IList<Withdrawal>? withdrawals = null,
+        private static ExecutionPayloadV3 CreateBlockRequestV3(MergeTestBlockchain chain, ExecutionPayload parent, Address miner, Withdrawal[]? withdrawals = null,
                 ulong? blobGasUsed = null, ulong? excessBlobGas = null, Transaction[]? transactions = null, Hash256? parentBeaconBlockRoot = null)
         {
             ExecutionPayloadV3 blockRequestV3 = CreateBlockRequestInternal<ExecutionPayloadV3>(parent, miner, withdrawals, blobGasUsed, excessBlobGas, transactions: transactions, parentBeaconBlockRoot: parentBeaconBlockRoot);
@@ -127,7 +127,7 @@ namespace Nethermind.Merge.Plugin.Test
             return blockRequestV3;
         }
 
-        private static T CreateBlockRequestInternal<T>(ExecutionPayload parent, Address miner, IList<Withdrawal>? withdrawals = null,
+        private static T CreateBlockRequestInternal<T>(ExecutionPayload parent, Address miner, Withdrawal[]? withdrawals = null,
                 ulong? blobGasUsed = null, ulong? excessBlobGas = null, Transaction[]? transactions = null, Hash256? parentBeaconBlockRoot = null) where T : ExecutionPayload, new()
         {
             T blockRequest = new()

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
@@ -650,7 +650,7 @@ public partial class EngineModuleTests
             Timestamp = (ulong)DateTime.UtcNow.AddDays(5).Ticks,
             PrevRandao = TestItem.KeccakA,
             SuggestedFeeRecipient = Address.Zero,
-            Withdrawals = new List<Withdrawal>() { TestItem.WithdrawalA_1Eth }
+            Withdrawals = [TestItem.WithdrawalA_1Eth]
         };
         Block emptyBlock = blockProducer.PrepareEmptyBlock(chain.BlockTree.Head!.Header, payloadAttributes);
         Task<ResultWrapper<PayloadStatusV1>> result1 = await rpc.engine_newPayloadV2(new ExecutionPayload(emptyBlock));

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V2.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V2.cs
@@ -204,7 +204,7 @@ public partial class EngineModuleTests
     public virtual async Task forkchoiceUpdatedV2_should_validate_withdrawals((
         IReleaseSpec Spec,
         string ErrorMessage,
-        IEnumerable<Withdrawal>? Withdrawals,
+        Withdrawal[]? Withdrawals,
         string BlockHash
         ) input)
     {
@@ -323,7 +323,7 @@ public partial class EngineModuleTests
     [TestCaseSource(nameof(GetPayloadWithdrawalsTestCases))]
     public virtual async Task
         getPayloadBodiesByHashV1_should_return_payload_bodies_in_order_of_request_block_hashes_and_null_for_unknown_hashes(
-            IList<Withdrawal> withdrawals)
+            Withdrawal[] withdrawals)
     {
         using MergeTestBlockchain chain = await CreateBlockchain(Shanghai.Instance);
         IEngineRpcModule rpc = CreateEngineModule(chain);
@@ -350,7 +350,7 @@ public partial class EngineModuleTests
     [TestCaseSource(nameof(GetPayloadWithdrawalsTestCases))]
     public virtual async Task
         getPayloadBodiesByRangeV1_should_return_payload_bodies_in_order_of_request_range_and_null_for_unknown_indexes(
-            IList<Withdrawal> withdrawals)
+            Withdrawal[] withdrawals)
     {
         using MergeTestBlockchain chain = await CreateBlockchain(Shanghai.Instance);
         IEngineRpcModule rpc = CreateEngineModule(chain);
@@ -424,7 +424,7 @@ public partial class EngineModuleTests
     }
 
     [TestCaseSource(nameof(GetPayloadWithdrawalsTestCases))]
-    public virtual async Task getPayloadBodiesByRangeV1_should_return_canonical(IList<Withdrawal> withdrawals)
+    public virtual async Task getPayloadBodiesByRangeV1_should_return_canonical(Withdrawal[] withdrawals)
     {
         using MergeTestBlockchain chain = await CreateBlockchain(Shanghai.Instance);
         IEngineRpcModule rpc = CreateEngineModule(chain);
@@ -553,7 +553,7 @@ public partial class EngineModuleTests
             StateRoot = Keccak.Zero,
             Timestamp = 0,
             Transactions = Array.Empty<byte[]>(),
-            Withdrawals = Enumerable.Empty<Withdrawal>()
+            Withdrawals = Array.Empty<Withdrawal>()
         };
 
         string response = await RpcTest.TestSerializedRequest(rpcModule, "engine_newPayloadV1",
@@ -570,7 +570,7 @@ public partial class EngineModuleTests
     public virtual async Task newPayloadV2_should_validate_withdrawals((
         IReleaseSpec Spec,
         string ErrorMessage,
-        IEnumerable<Withdrawal>? Withdrawals,
+        Withdrawal[]? Withdrawals,
         string BlockHash
         ) input)
     {
@@ -613,7 +613,7 @@ public partial class EngineModuleTests
     protected static IEnumerable<(
         IReleaseSpec spec,
         string ErrorMessage,
-        IEnumerable<Withdrawal>? Withdrawals,
+        Withdrawal[]? Withdrawals,
         string blockHash
         )> GetWithdrawalValidationValues()
     {
@@ -625,7 +625,7 @@ public partial class EngineModuleTests
         yield return (
             London.Instance,
             "{0}V1 expected",
-            Enumerable.Empty<Withdrawal>(),
+            Array.Empty<Withdrawal>(),
             "0xaa4aa15951a28e6adab430a795e36a84649bbafb1257eda23e38b9131cbd3b98");
     }
 
@@ -743,11 +743,11 @@ public partial class EngineModuleTests
         };
 
         attrs.ToString().Should().Be(
-            $"PayloadAttributes {{Timestamp: {attrs.Timestamp}, PrevRandao: {attrs.PrevRandao}, SuggestedFeeRecipient: {attrs.SuggestedFeeRecipient}, Withdrawals count: {attrs.Withdrawals.Count}}}");
+            $"PayloadAttributes {{Timestamp: {attrs.Timestamp}, PrevRandao: {attrs.PrevRandao}, SuggestedFeeRecipient: {attrs.SuggestedFeeRecipient}, Withdrawals count: {attrs.Withdrawals.Length}}}");
     }
 
     [TestCaseSource(nameof(PayloadIdTestCases))]
-    public void Should_compute_payload_id_with_withdrawals((IList<Withdrawal>? Withdrawals, string PayloadId) input)
+    public void Should_compute_payload_id_with_withdrawals((Withdrawal[]? Withdrawals, string PayloadId) input)
     {
         var blockHeader = Build.A.BlockHeader.TestObject;
         var payloadAttributes = new PayloadAttributes
@@ -820,7 +820,7 @@ public partial class EngineModuleTests
         ulong timestamp,
         Hash256 random,
         Address feeRecipient,
-        IList<Withdrawal>? withdrawals,
+        Withdrawal[]? withdrawals,
         bool waitForBlockImprovement = true)
     {
         using SemaphoreSlim blockImprovementLock = new SemaphoreSlim(0);
@@ -856,7 +856,7 @@ public partial class EngineModuleTests
         IEngineRpcModule rpc,
         MergeTestBlockchain chain,
         bool waitForBlockImprovement,
-        IList<Withdrawal>? withdrawals)
+        Withdrawal[]? withdrawals)
     {
         Hash256 head = chain.BlockTree.HeadHash;
         ulong timestamp = Timestamper.UnixTime.Seconds;
@@ -871,7 +871,7 @@ public partial class EngineModuleTests
     }
 
     private async Task<ExecutionPayload> SendNewBlockV2(IEngineRpcModule rpc, MergeTestBlockchain chain,
-        IList<Withdrawal>? withdrawals)
+        Withdrawal[]? withdrawals)
     {
         ExecutionPayload executionPayload = CreateBlockRequest(chain, CreateParentBlockRequestOnHead(chain.BlockTree), TestItem.AddressD, withdrawals);
         ResultWrapper<PayloadStatusV1> executePayloadResult = await rpc.engine_newPayloadV2(executionPayload);
@@ -919,7 +919,7 @@ public partial class EngineModuleTests
     }
 
     protected static IEnumerable<(
-        IList<Withdrawal>? Withdrawals,
+        Withdrawal[]? Withdrawals,
         string payloadId
         )> PayloadIdTestCases()
     {

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V3.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V3.cs
@@ -287,7 +287,7 @@ public partial class EngineModuleTests
             Timestamp = chain.BlockTree.Head!.Timestamp,
             PrevRandao = Keccak.Zero,
             SuggestedFeeRecipient = Address.Zero,
-            Withdrawals = new List<Withdrawal>(),
+            Withdrawals = Array.Empty<Withdrawal>(),
             ParentBeaconBlockRoot = isBeaconRootSet ? Keccak.Zero : null,
         };
 
@@ -399,7 +399,7 @@ public partial class EngineModuleTests
             Timestamp = payload.Timestamp + 1,
             PrevRandao = Keccak.Zero,
             SuggestedFeeRecipient = Address.Zero,
-            Withdrawals = new List<Withdrawal>(),
+            Withdrawals = Array.Empty<Withdrawal>(),
             ParentBeaconBlockRoot = null,
         };
 
@@ -426,7 +426,7 @@ public partial class EngineModuleTests
             Timestamp = payload.Timestamp + 1,
             PrevRandao = Keccak.Zero,
             SuggestedFeeRecipient = Address.Zero,
-            Withdrawals = new List<Withdrawal>(),
+            Withdrawals = Array.Empty<Withdrawal>(),
         };
 
         await rpcModule.engine_newPayloadV3(payload, Array.Empty<byte[]>(), payload.ParentBeaconBlockRoot);
@@ -590,7 +590,7 @@ public partial class EngineModuleTests
         }
     }
 
-    private async Task<ExecutionPayload> SendNewBlockV3(IEngineRpcModule rpc, MergeTestBlockchain chain, IList<Withdrawal>? withdrawals)
+    private async Task<ExecutionPayload> SendNewBlockV3(IEngineRpcModule rpc, MergeTestBlockchain chain, Withdrawal[]? withdrawals)
     {
         ExecutionPayloadV3 executionPayload = CreateBlockRequestV3(
             chain, CreateParentBlockRequestOnHead(chain.BlockTree), TestItem.AddressD, withdrawals, 0, 0, parentBeaconBlockRoot: TestItem.KeccakE);
@@ -612,7 +612,7 @@ public partial class EngineModuleTests
         {
             using SemaphoreSlim blockImprovementLock = new(0);
 
-            ExecutionPayload executionPayload1 = await SendNewBlockV3(rpcModule, chain, new List<Withdrawal>());
+            ExecutionPayload executionPayload1 = await SendNewBlockV3(rpcModule, chain, Array.Empty<Withdrawal>());
             txs = BuildTransactions(chain, executionPayload1.BlockHash, TestItem.PrivateKeyA, TestItem.AddressB, (uint)transactionCount, 0, out _, out _, 1);
             chain.AddTransactions(txs);
 
@@ -628,7 +628,7 @@ public partial class EngineModuleTests
             Timestamp = chain.BlockTree.Head!.Timestamp + 1,
             PrevRandao = TestItem.KeccakH,
             SuggestedFeeRecipient = TestItem.AddressF,
-            Withdrawals = new List<Withdrawal> { TestItem.WithdrawalA_1Eth },
+            Withdrawals = [TestItem.WithdrawalA_1Eth],
             ParentBeaconBlockRoot = spec.IsBeaconBlockRootAvailable ? TestItem.KeccakE : null
         };
         Hash256 currentHeadHash = chain.BlockTree.HeadHash;

--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayload.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayload.cs
@@ -89,7 +89,7 @@ public class ExecutionPayload : IForkValidator, IExecutionPayloadParams
     /// Gets or sets a collection of <see cref="Withdrawal"/> as defined in
     /// <see href="https://eips.ethereum.org/EIPS/eip-4895">EIP-4895</see>.
     /// </summary>
-    public IEnumerable<Withdrawal>? Withdrawals { get; set; }
+    public Withdrawal[]? Withdrawals { get; set; }
 
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Optimism/OptimismPayloadAttributes.cs
+++ b/src/Nethermind/Nethermind.Optimism/OptimismPayloadAttributes.cs
@@ -123,7 +123,7 @@ public class OptimismPayloadAttributes : PayloadAttributes
 
         if (Withdrawals is not null)
         {
-            sb.Append($", {nameof(Withdrawals)} count: {Withdrawals.Count}");
+            sb.Append($", {nameof(Withdrawals)} count: {Withdrawals.Length}");
         }
 
         sb.Append('}');

--- a/src/Nethermind/Nethermind.State/Proofs/PatriciaTrieT.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/PatriciaTrieT.cs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using Nethermind.Core.Buffers;
 using Nethermind.Db;
 using Nethermind.Logging;
@@ -24,12 +22,12 @@ public abstract class PatriciaTrie<T> : PatriciaTree
     /// <c>true</c> to maintain an in-memory database for proof computation;
     /// otherwise, <c>false</c>.
     /// </param>
-    public PatriciaTrie(IEnumerable<T>? list, bool canBuildProof, ICappedArrayPool? bufferPool = null)
+    public PatriciaTrie(T[]? list, bool canBuildProof, ICappedArrayPool? bufferPool = null)
         : base(canBuildProof ? new MemDb() : NullDb.Instance, EmptyTreeHash, false, false, NullLogManager.Instance, bufferPool: bufferPool)
     {
         CanBuildProof = canBuildProof;
 
-        if (list?.Any() ?? false)
+        if (list?.Length > 0)
         {
             Initialize(list);
             UpdateRootHash();
@@ -54,7 +52,7 @@ public abstract class PatriciaTrie<T> : PatriciaTree
         return proofCollector.BuildResult();
     }
 
-    protected abstract void Initialize(IEnumerable<T> list);
+    protected abstract void Initialize(T[] list);
 
     protected virtual bool CanBuildProof { get; }
 }

--- a/src/Nethermind/Nethermind.State/Proofs/ProofVerifier.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/ProofVerifier.cs
@@ -3,7 +3,6 @@
 
 using System.IO;
 using System.Linq;
-using Nethermind.Core.Buffers;
 using Nethermind.Core.Crypto;
 using Nethermind.Serialization.Rlp;
 using Nethermind.Trie;

--- a/src/Nethermind/Nethermind.State/Proofs/ReceiptTrie.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/ReceiptTrie.cs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using Nethermind.Core;
 using Nethermind.Core.Buffers;
 using Nethermind.Core.Crypto;
@@ -23,20 +21,20 @@ public class ReceiptTrie : PatriciaTrie<TxReceipt>
 
     /// <inheritdoc/>
     /// <param name="receipts">The transaction receipts to build the trie of.</param>
-    public ReceiptTrie(IReceiptSpec spec, IEnumerable<TxReceipt> receipts, bool canBuildProof = false, ICappedArrayPool? bufferPool = null)
+    public ReceiptTrie(IReceiptSpec spec, TxReceipt[] receipts, bool canBuildProof = false, ICappedArrayPool? bufferPool = null)
         : base(null, canBuildProof, bufferPool: bufferPool)
     {
         ArgumentNullException.ThrowIfNull(spec);
         ArgumentNullException.ThrowIfNull(receipts);
 
-        if (receipts.Any())
+        if (receipts.Length > 0)
         {
             Initialize(receipts, spec);
             UpdateRootHash();
         }
     }
 
-    private void Initialize(IEnumerable<TxReceipt> receipts, IReceiptSpec spec)
+    private void Initialize(TxReceipt[] receipts, IReceiptSpec spec)
     {
         RlpBehaviors behavior = (spec.IsEip658Enabled ? RlpBehaviors.Eip658Receipts : RlpBehaviors.None)
                                 | RlpBehaviors.SkipTypedWrapping;
@@ -51,7 +49,7 @@ public class ReceiptTrie : PatriciaTrie<TxReceipt>
         }
     }
 
-    protected override void Initialize(IEnumerable<TxReceipt> list) => throw new NotSupportedException();
+    protected override void Initialize(TxReceipt[] list) => throw new NotSupportedException();
 
     public static byte[][] CalculateReceiptProofs(IReleaseSpec spec, TxReceipt[] receipts, int index)
     {
@@ -59,9 +57,9 @@ public class ReceiptTrie : PatriciaTrie<TxReceipt>
         return new ReceiptTrie(spec, receipts, canBuildProof: true, cappedArrayPool).BuildProof(index);
     }
 
-    public static Hash256 CalculateRoot(IReceiptSpec receiptSpec, IList<TxReceipt> txReceipts)
+    public static Hash256 CalculateRoot(IReceiptSpec receiptSpec, TxReceipt[] txReceipts)
     {
-        using TrackingCappedArrayPool cappedArrayPool = new(txReceipts.Count * 4);
+        using TrackingCappedArrayPool cappedArrayPool = new(txReceipts.Length * 4);
         Hash256 receiptsRoot = new ReceiptTrie(receiptSpec, txReceipts, bufferPool: cappedArrayPool).RootHash;
         return receiptsRoot;
     }

--- a/src/Nethermind/Nethermind.State/Proofs/TxTrie.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/TxTrie.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections.Generic;
 using Nethermind.Core;
 using Nethermind.Core.Buffers;
 using Nethermind.Core.Crypto;
@@ -21,10 +20,10 @@ public class TxTrie : PatriciaTrie<Transaction>
 
     /// <inheritdoc/>
     /// <param name="transactions">The transactions to build the trie of.</param>
-    public TxTrie(IEnumerable<Transaction> transactions, bool canBuildProof = false, ICappedArrayPool? bufferPool = null)
+    public TxTrie(Transaction[] transactions, bool canBuildProof = false, ICappedArrayPool? bufferPool = null)
         : base(transactions, canBuildProof, bufferPool: bufferPool) => ArgumentNullException.ThrowIfNull(transactions);
 
-    protected override void Initialize(IEnumerable<Transaction> list)
+    protected override void Initialize(Transaction[] list)
     {
         int key = 0;
 
@@ -37,16 +36,16 @@ public class TxTrie : PatriciaTrie<Transaction>
         }
     }
 
-    public static byte[][] CalculateProof(IList<Transaction> transactions, int index)
+    public static byte[][] CalculateProof(Transaction[] transactions, int index)
     {
-        using TrackingCappedArrayPool cappedArray = new TrackingCappedArrayPool(transactions.Count * 4);
+        using TrackingCappedArrayPool cappedArray = new TrackingCappedArrayPool(transactions.Length * 4);
         byte[][] rootHash = new TxTrie(transactions, canBuildProof: true, bufferPool: cappedArray).BuildProof(index);
         return rootHash;
     }
 
-    public static Hash256 CalculateRoot(IList<Transaction> transactions)
+    public static Hash256 CalculateRoot(Transaction[] transactions)
     {
-        using TrackingCappedArrayPool cappedArray = new TrackingCappedArrayPool(transactions.Count * 4);
+        using TrackingCappedArrayPool cappedArray = new TrackingCappedArrayPool(transactions.Length * 4);
         Hash256 rootHash = new TxTrie(transactions, canBuildProof: false, bufferPool: cappedArray).RootHash;
         return rootHash;
     }

--- a/src/Nethermind/Nethermind.State/Proofs/WithdrawalTrie.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/WithdrawalTrie.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections.Generic;
 using Nethermind.Core;
 using Nethermind.Serialization.Rlp;
 using Nethermind.State.Trie;
@@ -18,10 +17,10 @@ public class WithdrawalTrie : PatriciaTrie<Withdrawal>
 
     /// <inheritdoc/>
     /// <param name="withdrawals">The withdrawals to build the trie of.</param>
-    public WithdrawalTrie(IEnumerable<Withdrawal> withdrawals, bool canBuildProof = false)
+    public WithdrawalTrie(Withdrawal[] withdrawals, bool canBuildProof = false)
         : base(withdrawals, canBuildProof) => ArgumentNullException.ThrowIfNull(withdrawals);
 
-    protected override void Initialize(IEnumerable<Withdrawal> withdrawals)
+    protected override void Initialize(Withdrawal[] withdrawals)
     {
         var key = 0;
 


### PR DESCRIPTION
## Changes

- Change parameters for `Withdrawl`, `TxReceipt` and `Transaction` tries to be arrays rather than IEnumerator. They start as arrays to pass them through as arrays meaning no allocation for the enumerator and faster enumeration.

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
