### PR TITLE
Reduce overflow exceptions in TransactionSubstate

### DIFF
--- a/src/Nethermind/Nethermind.Evm/TransactionSubstate.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionSubstate.cs
@@ -131,10 +131,16 @@ public class TransactionSubstate
         {
             if (span.Length < WordSize * 2) { return null; }
 
-            int start = (int)new UInt256(span.Slice(0, WordSize), isBigEndian: true);
+            UInt256 startRaw = new UInt256(span.Slice(0, WordSize), isBigEndian: true);
+            if (startRaw > int.MaxValue) { return null; }
+
+            int start = (int)startRaw;
             if (checked(start + WordSize) > span.Length) { return null; }
 
-            int length = (int)new UInt256(span.Slice(start, WordSize), isBigEndian: true);
+            UInt256 lengthRaw = new UInt256(span.Slice(start, WordSize), isBigEndian: true);
+            if (lengthRaw > int.MaxValue) { return null; }
+
+            int length = (int)lengthRaw;
             if (checked(start + WordSize + length) != span.Length) { return null; }
 
             return span.Slice(start + WordSize, length).ToHexString(true);


### PR DESCRIPTION
## Changes

- If UInt256 value cannot be converted to int, earily return `null` rather than throw catch and return `null`

Only seen a couple though

<img width="281" alt="image" src="https://github.com/NethermindEth/nethermind/assets/1142958/b25bd4d6-0591-4685-9dfe-59be9f5c1f09">


## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No