### PR TITLE
Don't capture tx in ShouldGossipTransaction closure

### DIFF
--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandlerTests.cs
@@ -69,7 +69,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
             _gossipPolicy.ShouldGossipBlock(Arg.Any<BlockHeader>()).Returns(true);
             _gossipPolicy.ShouldDisconnectGossipingNodes.Returns(false);
             _txGossipPolicy = Substitute.For<ITxGossipPolicy>();
-            _txGossipPolicy.ShouldListenToGossippedTransactions.Returns(true);
+            _txGossipPolicy.ShouldListenToGossipedTransactions.Returns(true);
             _txGossipPolicy.ShouldGossipTransaction(Arg.Any<Transaction>()).Returns(true);
             _handler = new Eth62ProtocolHandler(
                 _session,
@@ -386,7 +386,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
         [Test]
         public void Can_handle_transactions([Values(true, false)] bool canGossipTransactions)
         {
-            _txGossipPolicy.ShouldListenToGossippedTransactions.Returns(canGossipTransactions);
+            _txGossipPolicy.ShouldListenToGossipedTransactions.Returns(canGossipTransactions);
             TransactionsMessage msg = new(new List<Transaction>(Build.A.Transaction.SignedAndResolved().TestObjectNTimes(3)));
 
             HandleIncomingStatusMessage();

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandlerTests.cs
@@ -62,7 +62,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V65
             _syncManager.Genesis.Returns(_genesisBlock.Header);
             ITimerFactory timerFactory = Substitute.For<ITimerFactory>();
             _txGossipPolicy = Substitute.For<ITxGossipPolicy>();
-            _txGossipPolicy.ShouldListenToGossippedTransactions.Returns(true);
+            _txGossipPolicy.ShouldListenToGossipedTransactions.Returns(true);
             _txGossipPolicy.ShouldGossipTransaction(Arg.Any<Transaction>()).Returns(true);
             _handler = new Eth65ProtocolHandler(
                 _session,
@@ -180,7 +180,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V65
         [Test]
         public void should_handle_NewPooledTransactionHashesMessage([Values(true, false)] bool canGossipTransactions)
         {
-            _txGossipPolicy.ShouldListenToGossippedTransactions.Returns(canGossipTransactions);
+            _txGossipPolicy.ShouldListenToGossipedTransactions.Returns(canGossipTransactions);
             NewPooledTransactionHashesMessage msg = new(new[] { TestItem.KeccakA, TestItem.KeccakB });
             IMessageSerializationService serializationService = Build.A.SerializationService().WithEth65().TestObject;
 

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandlerTests.cs
@@ -67,7 +67,7 @@ public class Eth68ProtocolHandlerTests
         _syncManager.Genesis.Returns(_genesisBlock.Header);
         _timerFactory = Substitute.For<ITimerFactory>();
         _txGossipPolicy = Substitute.For<ITxGossipPolicy>();
-        _txGossipPolicy.ShouldListenToGossippedTransactions.Returns(true);
+        _txGossipPolicy.ShouldListenToGossipedTransactions.Returns(true);
         _txGossipPolicy.ShouldGossipTransaction(Arg.Any<Transaction>()).Returns(true);
         _handler = new Eth68ProtocolHandler(
             _session,
@@ -107,7 +107,7 @@ public class Eth68ProtocolHandlerTests
     [Test]
     public void Can_handle_NewPooledTransactions_message([Values(0, 1, 2, 100)] int txCount, [Values(true, false)] bool canGossipTransactions)
     {
-        _txGossipPolicy.ShouldListenToGossippedTransactions.Returns(canGossipTransactions);
+        _txGossipPolicy.ShouldListenToGossipedTransactions.Returns(canGossipTransactions);
 
         GenerateLists(txCount, out List<byte> types, out List<int> sizes, out List<Hash256> hashes);
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandler.cs
@@ -61,7 +61,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
         public override int MessageIdSpaceSize => 8;
         public override string Name => "eth62";
         protected override TimeSpan InitTimeout => Timeouts.Eth62Status;
-        protected bool CanReceiveTransactions => _txGossipPolicy.ShouldListenToGossippedTransactions;
+        protected bool CanReceiveTransactions => _txGossipPolicy.ShouldListenToGossipedTransactions;
 
         public override event EventHandler<ProtocolInitializedEventArgs>? ProtocolInitialized;
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncedTxGossipPolicyTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncedTxGossipPolicyTests.cs
@@ -25,5 +25,5 @@ public class SyncedTxGossipPolicyTests
     [TestCase(SyncMode.Disconnected, ExpectedResult = false)]
     [TestCase(SyncMode.UpdatingPivot, ExpectedResult = false)]
     public bool can_gossip(SyncMode mode) =>
-        ((ITxGossipPolicy)new SyncedTxGossipPolicy(new StaticSelector(mode))).ShouldListenToGossippedTransactions;
+        ((ITxGossipPolicy)new SyncedTxGossipPolicy(new StaticSelector(mode))).ShouldListenToGossipedTransactions;
 }

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncedTxGossipPolicy.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncedTxGossipPolicy.cs
@@ -14,5 +14,5 @@ public class SyncedTxGossipPolicy : ITxGossipPolicy
         _syncModeSelector = syncModeSelector;
     }
 
-    public bool ShouldListenToGossippedTransactions => (_syncModeSelector.Current & SyncMode.WaitingForBlock) != 0;
+    public bool ShouldListenToGossipedTransactions => (_syncModeSelector.Current & SyncMode.WaitingForBlock) != 0;
 }


### PR DESCRIPTION
<img width="809" alt="image" src="https://github.com/NethermindEth/nethermind/assets/1142958/006886d1-7482-4241-a72a-04f491451fd4">

## Changes

- Use for loop rather than Linq to avoid the allocation from capturing `Transaction` in a closure

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
