### PR TITLE
Fix/disconnect p2p message

### DIFF
--- a/src/Nethermind/Nethermind.Network.Stats/Model/DisconnectReason.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/Model/DisconnectReason.cs
@@ -21,6 +21,7 @@ public enum DisconnectReason : byte
     SessionAlreadyExist,
     ReplacingSessionWithOppositeDirection,
     OppositeDirectionCleanup,
+    Exception,
 
     // Non sync, non connection related disconnect
     SnapServerNotImplemented,

--- a/src/Nethermind/Nethermind.Network.Test/Rlpx/ZeroNettyP2PHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/Rlpx/ZeroNettyP2PHandlerTests.cs
@@ -21,19 +21,6 @@ namespace Nethermind.Network.Test.Rlpx;
 
 public class ZeroNettyP2PHandlerTests
 {
-
-    [Test]
-    public async Task When_exception_is_thrown__then_disconnect_session()
-    {
-        ISession session = Substitute.For<ISession>();
-        IChannelHandlerContext channelHandlerContext = Substitute.For<IChannelHandlerContext>();
-        ZeroNettyP2PHandler handler = new ZeroNettyP2PHandler(session, LimboLogs.Instance);
-
-        handler.ExceptionCaught(channelHandlerContext, new Exception());
-
-        await channelHandlerContext.Received().DisconnectAsync();
-    }
-
     [Test]
     public void When_exception_is_thrown_send_disconnect_message()
     {

--- a/src/Nethermind/Nethermind.Network.Test/Rlpx/ZeroNettyP2PHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/Rlpx/ZeroNettyP2PHandlerTests.cs
@@ -13,6 +13,7 @@ using Nethermind.Network.P2P;
 using Nethermind.Network.P2P.ProtocolHandlers;
 using Nethermind.Network.Rlpx;
 using Nethermind.Serialization.Rlp;
+using Nethermind.Stats.Model;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -34,6 +35,18 @@ public class ZeroNettyP2PHandlerTests
     }
 
     [Test]
+    public void When_exception_is_thrown_send_disconnect_message()
+    {
+        ISession session = Substitute.For<ISession>();
+        IChannelHandlerContext channelHandlerContext = Substitute.For<IChannelHandlerContext>();
+        ZeroNettyP2PHandler handler = new ZeroNettyP2PHandler(session, LimboLogs.Instance);
+
+        handler.ExceptionCaught(channelHandlerContext, new Exception());
+
+        session.Received().InitiateDisconnect(Arg.Any<DisconnectReason>(), Arg.Any<string>());
+    }
+
+    [Test]
     public async Task When_internal_nethermind_exception_is_thrown__then_do_not_disconnect_session()
     {
         ISession session = Substitute.For<ISession>();
@@ -44,6 +57,7 @@ public class ZeroNettyP2PHandlerTests
 
         await channelHandlerContext.DidNotReceive().DisconnectAsync();
     }
+
 
     [Test]
     public void When_not_a_snappy_encoded_data_then_pass_data_directly()

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroNettyP2PHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroNettyP2PHandler.cs
@@ -113,7 +113,6 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
             {
                 if (_logger.IsDebug) _logger.Debug($"Error in communication with {clientId}: {exception}");
             }
-            _logger.Info($"Exception caught: " + exception.GetType().Name);
 
             if (exception is IInternalNethermindException)
             {
@@ -121,13 +120,11 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
             }
             else if (_session?.Node?.IsStatic != true)
             {
-                _session.InitiateDisconnect(DisconnectReason.Other, exception.Message);
+                _session.InitiateDisconnect(DisconnectReason.Other, $"Peer caused exception: {exception.GetType().Name} with message: {exception.Message}");
                 context.DisconnectAsync().ContinueWith(x =>
                 {
                     if (x.IsFaulted && _logger.IsTrace)
                         _logger.Trace($"Error while disconnecting on context on {this} : {x.Exception}");
-                    else
-                        _logger.Warn("Disconnected from " + context.Name);
 
                 });
             }

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroNettyP2PHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroNettyP2PHandler.cs
@@ -113,6 +113,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
             {
                 if (_logger.IsDebug) _logger.Debug($"Error in communication with {clientId}: {exception}");
             }
+            _logger.Info($"Exception caught: " + exception.GetType().Name);
 
             if (exception is IInternalNethermindException)
             {

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroNettyP2PHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroNettyP2PHandler.cs
@@ -120,12 +120,6 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
             else if (_session?.Node?.IsStatic != true)
             {
                 _session.InitiateDisconnect(DisconnectReason.Exception, $"Exception in connection: {exception.GetType().Name} with message: {exception.Message}");
-                context.DisconnectAsync().ContinueWith(x =>
-                {
-                    if (x.IsFaulted && _logger.IsTrace)
-                        _logger.Trace($"Error while disconnecting on context on {this} : {x.Exception}");
-
-                });
             }
             else
             {

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroNettyP2PHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroNettyP2PHandler.cs
@@ -10,6 +10,7 @@ using DotNetty.Transport.Channels;
 using Nethermind.Core.Exceptions;
 using Nethermind.Logging;
 using Nethermind.Network.Rlpx;
+using Nethermind.Serialization.Rlp;
 using Nethermind.Stats.Model;
 using Snappy;
 
@@ -117,7 +118,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
             {
                 // Do nothing as we don't want to drop peer for internal issue.
             }
-            else if (_session?.Node?.IsStatic != true)
+            else if (exception is RlpException || _session?.Node?.IsStatic != true)
             {
                 context.DisconnectAsync().ContinueWith(x =>
                 {

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroNettyP2PHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroNettyP2PHandler.cs
@@ -10,7 +10,6 @@ using DotNetty.Transport.Channels;
 using Nethermind.Core.Exceptions;
 using Nethermind.Logging;
 using Nethermind.Network.Rlpx;
-using Nethermind.Serialization.Rlp;
 using Nethermind.Stats.Model;
 using Snappy;
 

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroNettyP2PHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroNettyP2PHandler.cs
@@ -119,7 +119,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
             }
             else if (_session?.Node?.IsStatic != true)
             {
-                _session.InitiateDisconnect(DisconnectReason.Other, $"Peer caused exception: {exception.GetType().Name} with message: {exception.Message}");
+                _session.InitiateDisconnect(DisconnectReason.Other, $"Exception in connection: {exception.GetType().Name} with message: {exception.Message}");
                 context.DisconnectAsync().ContinueWith(x =>
                 {
                     if (x.IsFaulted && _logger.IsTrace)

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroNettyP2PHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroNettyP2PHandler.cs
@@ -121,6 +121,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
             }
             else if (_session?.Node?.IsStatic != true)
             {
+                _session.InitiateDisconnect(DisconnectReason.Other, exception.Message);
                 context.DisconnectAsync().ContinueWith(x =>
                 {
                     if (x.IsFaulted && _logger.IsTrace)

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroNettyP2PHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroNettyP2PHandler.cs
@@ -119,7 +119,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
             }
             else if (_session?.Node?.IsStatic != true)
             {
-                _session.InitiateDisconnect(DisconnectReason.Other, $"Exception in connection: {exception.GetType().Name} with message: {exception.Message}");
+                _session.InitiateDisconnect(DisconnectReason.Exception, $"Exception in connection: {exception.GetType().Name} with message: {exception.Message}");
                 context.DisconnectAsync().ContinueWith(x =>
                 {
                     if (x.IsFaulted && _logger.IsTrace)

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroNettyP2PHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroNettyP2PHandler.cs
@@ -119,12 +119,15 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
             {
                 // Do nothing as we don't want to drop peer for internal issue.
             }
-            else if (exception is RlpException || _session?.Node?.IsStatic != true)
+            else if (_session?.Node?.IsStatic != true)
             {
                 context.DisconnectAsync().ContinueWith(x =>
                 {
                     if (x.IsFaulted && _logger.IsTrace)
                         _logger.Trace($"Error while disconnecting on context on {this} : {x.Exception}");
+                    else
+                        _logger.Warn("Disconnected from " + context.Name);
+
                 });
             }
             else


### PR DESCRIPTION
Fixes ##6565 TestMaliciousStatus

We disconnect the channel without sending the disconnect package to the peer. 

## Changes

Send a disc connect message before calling the disconnect method.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No
