### PR TITLE
Exclude Tx Hashes when serving Blocks & apply network back pressure

### DIFF
--- a/src/Nethermind/Nethermind.AccountAbstraction/Network/UserOperationsMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.AccountAbstraction/Network/UserOperationsMessageSerializer.cs
@@ -15,7 +15,7 @@ namespace Nethermind.AccountAbstraction.Network
         public void Serialize(IByteBuffer byteBuffer, UserOperationsMessage message)
         {
             int length = GetLength(message, out int contentLength);
-            byteBuffer.EnsureWritable(length, true);
+            byteBuffer.EnsureWritable(length);
             NettyRlpStream nettyRlpStream = new(byteBuffer);
 
             nettyRlpStream.StartSequence(contentLength);

--- a/src/Nethermind/Nethermind.Blockchain.Test/Blocks/BlockStoreTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Blocks/BlockStoreTests.cs
@@ -26,12 +26,12 @@ public class BlockStoreTests
         Block block = Build.A.Block.WithNumber(1).TestObject;
         store.Insert(block);
 
-        Block? retrieved = store.Get(block.Number, block.Hash!, cached);
+        Block? retrieved = store.Get(block.Number, block.Hash!, RlpBehaviors.None, cached);
         retrieved.Should().BeEquivalentTo(block);
 
         store.Delete(block.Number, block.Hash!);
 
-        store.Get(block.Number, block.Hash!, cached).Should().BeNull();
+        store.Get(block.Number, block.Hash!, RlpBehaviors.None, cached).Should().BeNull();
     }
 
     [Test]
@@ -57,7 +57,7 @@ public class BlockStoreTests
         Block block = Build.A.Block.WithNumber(1).TestObject;
         db[block.Hash!.Bytes] = (new BlockDecoder()).Encode(block).Bytes;
 
-        Block? retrieved = store.Get(block.Number, block.Hash!, cached);
+        Block? retrieved = store.Get(block.Number, block.Hash!, RlpBehaviors.None, cached);
         retrieved.Should().BeEquivalentTo(block);
     }
 
@@ -83,12 +83,12 @@ public class BlockStoreTests
         Block block = Build.A.Block.WithNumber(1).TestObject;
         store.Insert(block);
 
-        Block? retrieved = store.Get(block.Number, block.Hash!, true);
+        Block? retrieved = store.Get(block.Number, block.Hash!, RlpBehaviors.None, true);
         retrieved.Should().BeEquivalentTo(block);
 
         db.Clear();
 
-        retrieved = store.Get(block.Number, block.Hash!, true);
+        retrieved = store.Get(block.Number, block.Hash!, RlpBehaviors.None, true);
         retrieved.Should().BeEquivalentTo(block);
     }
 

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -1301,7 +1301,11 @@ namespace Nethermind.Blockchain
             blockNumber ??= _headerStore.GetBlockNumber(blockHash);
             if (blockNumber is not null)
             {
-                block = _blockStore.Get(blockNumber.Value, blockHash, shouldCache: false);
+                block = _blockStore.Get(
+                    blockNumber.Value,
+                    blockHash,
+                    (options & BlockTreeLookupOptions.ExcludeTxHashes) != 0 ? RlpBehaviors.ExcludeHashes : RlpBehaviors.None,
+                    shouldCache: false);
             }
 
             if (block is null)

--- a/src/Nethermind/Nethermind.Blockchain/BlockTreeMethodOptions.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTreeMethodOptions.cs
@@ -13,7 +13,8 @@ public enum BlockTreeLookupOptions
     RequireCanonical = 2,
     DoNotCreateLevelIfMissing = 4,
     AllowInvalid = 8,
-    All = 15
+    ExcludeTxHashes = 16,
+    All = 31
 }
 
 [Flags]

--- a/src/Nethermind/Nethermind.Blockchain/Blocks/BlockStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Blocks/BlockStore.cs
@@ -84,11 +84,11 @@ public class BlockStore : IBlockStore
         _blockDb.Remove(blockHash.Bytes);
     }
 
-    public Block? Get(long blockNumber, Hash256 blockHash, bool shouldCache = false)
+    public Block? Get(long blockNumber, Hash256 blockHash, RlpBehaviors rlpBehaviors = RlpBehaviors.None, bool shouldCache = false)
     {
-        Block? b = _blockDb.Get(blockNumber, blockHash, _blockDecoder, _blockCache, shouldCache);
+        Block? b = _blockDb.Get(blockNumber, blockHash, _blockDecoder, _blockCache, rlpBehaviors, shouldCache);
         if (b is not null) return b;
-        return _blockDb.Get(blockHash, _blockDecoder, _blockCache, shouldCache);
+        return _blockDb.Get(blockHash, _blockDecoder, _blockCache, rlpBehaviors, shouldCache);
     }
 
     public ReceiptRecoveryBlock? GetReceiptRecoveryBlock(long blockNumber, Hash256 blockHash)

--- a/src/Nethermind/Nethermind.Blockchain/Blocks/IBlockStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Blocks/IBlockStore.cs
@@ -16,7 +16,7 @@ public interface IBlockStore
 {
     void Insert(Block block, WriteFlags writeFlags = WriteFlags.None);
     void Delete(long blockNumber, Hash256 blockHash);
-    Block? Get(long blockNumber, Hash256 blockHash, bool shouldCache = true);
+    Block? Get(long blockNumber, Hash256 blockHash, RlpBehaviors rlpBehaviors = RlpBehaviors.None, bool shouldCache = true);
     IEnumerable<Block> GetAll();
     ReceiptRecoveryBlock? GetReceiptRecoveryBlock(long blockNumber, Hash256 blockHash);
     void Cache(Block block);

--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayload.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayload.cs
@@ -171,7 +171,7 @@ public class ExecutionPayload : IForkValidator, IExecutionPayloadParams
         {
             try
             {
-                return Rlp.Decode<Transaction>(t, RlpBehaviors.SkipTypedWrapping);
+                return Rlp.Decode<Transaction>(t, RlpBehaviors.SkipTypedWrapping | RlpBehaviors.ExcludeHashes);
             }
             catch (RlpException e)
             {

--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayload.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayload.cs
@@ -171,7 +171,7 @@ public class ExecutionPayload : IForkValidator, IExecutionPayloadParams
         {
             try
             {
-                return Rlp.Decode<Transaction>(t, RlpBehaviors.SkipTypedWrapping | RlpBehaviors.ExcludeHashes);
+                return Rlp.Decode<Transaction>(t, RlpBehaviors.SkipTypedWrapping);
             }
             catch (RlpException e)
             {

--- a/src/Nethermind/Nethermind.Merge.Plugin/IMergeConfig.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/IMergeConfig.cs
@@ -60,7 +60,7 @@ public interface IMergeConfig : IConfig
             - A positive number to release memory after that many Engine API calls
 
 
-            """, DefaultValue = "75")]
+            """, DefaultValue = "25")]
     public int CollectionsPerDecommit { get; set; }
 
     [ConfigItem(Description = "The timeout, in seconds, for the `engine_newPayload` method.", DefaultValue = "7", HiddenFromDocs = true)]

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergeConfig.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergeConfig.cs
@@ -29,7 +29,7 @@ namespace Nethermind.Merge.Plugin
 
         public GcCompaction CompactMemory { get; set; } = GcCompaction.Yes;
 
-        public int CollectionsPerDecommit { get; set; } = 75;
+        public int CollectionsPerDecommit { get; set; } = 25;
 
         public int NewPayloadTimeout { get; set; } = 7;
 

--- a/src/Nethermind/Nethermind.Network.Test/P2P/PacketSenderTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/PacketSenderTests.cs
@@ -27,6 +27,7 @@ namespace Nethermind.Network.Test.P2P
             serialized.SafeRelease();
             IChannelHandlerContext context = Substitute.For<IChannelHandlerContext>();
             IChannel channel = Substitute.For<IChannel>();
+            channel.IsWritable.Returns(true);
             channel.Active.Returns(true);
             context.Channel.Returns(channel);
 
@@ -46,6 +47,7 @@ namespace Nethermind.Network.Test.P2P
             serialized.SafeRelease();
             IChannelHandlerContext context = Substitute.For<IChannelHandlerContext>();
             IChannel channel = Substitute.For<IChannel>();
+            channel.IsWritable.Returns(true);
             channel.Active.Returns(false);
             context.Channel.Returns(channel);
 
@@ -65,6 +67,7 @@ namespace Nethermind.Network.Test.P2P
             serialized.SafeRelease();
             IChannelHandlerContext context = Substitute.For<IChannelHandlerContext>();
             IChannel channel = Substitute.For<IChannel>();
+            channel.IsWritable.Returns(true);
             channel.Active.Returns(true);
             context.Channel.Returns(channel);
 

--- a/src/Nethermind/Nethermind.Network/P2P/Messages/AddCapabilityMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Messages/AddCapabilityMessageSerializer.cs
@@ -15,7 +15,7 @@ namespace Nethermind.Network.P2P.Messages
         public void Serialize(IByteBuffer byteBuffer, AddCapabilityMessage msg)
         {
             int totalLength = GetLength(msg, out int contentLength);
-            byteBuffer.EnsureWritable(totalLength, true);
+            byteBuffer.EnsureWritable(totalLength);
 
             NettyRlpStream stream = new(byteBuffer);
             stream.StartSequence(contentLength);

--- a/src/Nethermind/Nethermind.Network/P2P/Messages/DisconnectMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Messages/DisconnectMessageSerializer.cs
@@ -13,7 +13,7 @@ namespace Nethermind.Network.P2P.Messages
         public void Serialize(IByteBuffer byteBuffer, DisconnectMessage msg)
         {
             int length = GetLength(msg, out int contentLength);
-            byteBuffer.EnsureWritable(length);
+            byteBuffer.EnsureWritable(length, force: true);
             NettyRlpStream rlpStream = new(byteBuffer);
 
             rlpStream.StartSequence(contentLength);

--- a/src/Nethermind/Nethermind.Network/P2P/Messages/HelloMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Messages/HelloMessageSerializer.cs
@@ -15,7 +15,7 @@ namespace Nethermind.Network.P2P.Messages
         public void Serialize(IByteBuffer byteBuffer, HelloMessage msg)
         {
             (int totalLength, int innerLength) length = GetLength(msg);
-            byteBuffer.EnsureWritable(Rlp.LengthOfSequence(length.totalLength), true);
+            byteBuffer.EnsureWritable(Rlp.LengthOfSequence(length.totalLength), force: true);
             NettyRlpStream stream = new(byteBuffer);
             stream.StartSequence(length.totalLength);
             stream.Encode(msg.P2PVersion);

--- a/src/Nethermind/Nethermind.Network/P2P/PacketSender.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/PacketSender.cs
@@ -27,7 +27,7 @@ namespace Nethermind.Network.P2P
 
         public int Enqueue<T>(T message) where T : P2PMessage
         {
-            if (!_context.Channel.Active)
+            if (!_context.Channel.IsWritable || !_context.Channel.Active)
             {
                 return 0;
             }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/HashesMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/HashesMessageSerializer.cs
@@ -24,7 +24,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth
         public void Serialize(IByteBuffer byteBuffer, T message)
         {
             int length = GetLength(message, out int contentLength);
-            byteBuffer.EnsureWritable(length, true);
+            byteBuffer.EnsureWritable(length);
             RlpStream rlpStream = new NettyRlpStream(byteBuffer);
 
             rlpStream.StartSequence(contentLength);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Messages/BlockBodiesMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Messages/BlockBodiesMessageSerializer.cs
@@ -16,7 +16,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages
         public void Serialize(IByteBuffer byteBuffer, BlockBodiesMessage message)
         {
             int totalLength = GetLength(message, out int contentLength);
-            byteBuffer.EnsureWritable(totalLength, true);
+            byteBuffer.EnsureWritable(totalLength);
             NettyRlpStream stream = new(byteBuffer);
             stream.StartSequence(contentLength);
             foreach (BlockBody? body in message.Bodies.Bodies)

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Messages/BlockHeadersMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Messages/BlockHeadersMessageSerializer.cs
@@ -14,7 +14,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages
         public void Serialize(IByteBuffer byteBuffer, BlockHeadersMessage message)
         {
             int length = GetLength(message, out int contentLength);
-            byteBuffer.EnsureWritable(length, true);
+            byteBuffer.EnsureWritable(length);
             RlpStream rlpStream = new NettyRlpStream(byteBuffer);
 
             rlpStream.StartSequence(contentLength);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Messages/GetBlockBodiesMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Messages/GetBlockBodiesMessageSerializer.cs
@@ -12,7 +12,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages
         public void Serialize(IByteBuffer byteBuffer, GetBlockBodiesMessage message)
         {
             int length = GetLength(message, out int contentLength);
-            byteBuffer.EnsureWritable(length, true);
+            byteBuffer.EnsureWritable(length);
             NettyRlpStream nettyRlpStream = new(byteBuffer);
 
             nettyRlpStream.StartSequence(contentLength);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Messages/GetBlockHeadersMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Messages/GetBlockHeadersMessageSerializer.cs
@@ -33,7 +33,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages
         public void Serialize(IByteBuffer byteBuffer, GetBlockHeadersMessage message)
         {
             int length = GetLength(message, out int contentLength);
-            byteBuffer.EnsureWritable(length, true);
+            byteBuffer.EnsureWritable(length);
             RlpStream rlpStream = new NettyRlpStream(byteBuffer);
 
             rlpStream.StartSequence(contentLength);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Messages/NewBlockHashesMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Messages/NewBlockHashesMessageSerializer.cs
@@ -12,7 +12,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages
         public void Serialize(IByteBuffer byteBuffer, NewBlockHashesMessage message)
         {
             int length = GetLength(message, out int contentLength);
-            byteBuffer.EnsureWritable(length, true);
+            byteBuffer.EnsureWritable(length);
             NettyRlpStream nettyRlpStream = new(byteBuffer);
 
             nettyRlpStream.StartSequence(contentLength);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Messages/NewBlockMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Messages/NewBlockMessageSerializer.cs
@@ -14,7 +14,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages
         public void Serialize(IByteBuffer byteBuffer, NewBlockMessage message)
         {
             int length = GetLength(message, out int contentLength);
-            byteBuffer.EnsureWritable(length, true);
+            byteBuffer.EnsureWritable(length);
             RlpStream rlpStream = new NettyRlpStream(byteBuffer);
 
             rlpStream.StartSequence(contentLength);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Messages/TransactionsMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Messages/TransactionsMessageSerializer.cs
@@ -14,7 +14,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages
         public void Serialize(IByteBuffer byteBuffer, TransactionsMessage message)
         {
             int length = GetLength(message, out int contentLength);
-            byteBuffer.EnsureWritable(length, true);
+            byteBuffer.EnsureWritable(length);
             NettyRlpStream nettyRlpStream = new(byteBuffer);
 
             nettyRlpStream.StartSequence(contentLength);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V63/Messages/NodeDataMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V63/Messages/NodeDataMessageSerializer.cs
@@ -11,7 +11,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V63.Messages
         public void Serialize(IByteBuffer byteBuffer, NodeDataMessage message)
         {
             int length = GetLength(message, out int contentLength);
-            byteBuffer.EnsureWritable(length, true);
+            byteBuffer.EnsureWritable(length);
             RlpStream rlpStream = new NettyRlpStream(byteBuffer);
 
             rlpStream.StartSequence(contentLength);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V63/Messages/ReceiptsMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V63/Messages/ReceiptsMessageSerializer.cs
@@ -25,7 +25,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V63.Messages
         {
             int totalLength = GetLength(message, out int contentLength);
 
-            byteBuffer.EnsureWritable(totalLength, true);
+            byteBuffer.EnsureWritable(totalLength);
             NettyRlpStream stream = new(byteBuffer);
             stream.StartSequence(contentLength);
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Messages/Eth66MessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Messages/Eth66MessageSerializer.cs
@@ -21,7 +21,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66.Messages
         public void Serialize(IByteBuffer byteBuffer, TEth66Message message)
         {
             int length = GetLength(message, out int contentLength);
-            byteBuffer.EnsureWritable(length, true);
+            byteBuffer.EnsureWritable(length);
             RlpStream rlpStream = new NettyRlpStream(byteBuffer);
             rlpStream.StartSequence(contentLength);
             rlpStream.Encode(message.RequestId);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Messages/NewPooledTransactionHashesMessageSerializer68.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Messages/NewPooledTransactionHashesMessageSerializer68.cs
@@ -36,7 +36,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V68.Messages
 
             int totalSize = Rlp.LengthOf(message.Types) + Rlp.LengthOfSequence(sizesLength) + Rlp.LengthOfSequence(hashesLength);
 
-            byteBuffer.EnsureWritable(totalSize, true);
+            byteBuffer.EnsureWritable(totalSize);
 
             RlpStream rlpStream = new NettyRlpStream(byteBuffer);
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Les/Messages/BlockHeadersMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Les/Messages/BlockHeadersMessageSerializer.cs
@@ -20,7 +20,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Les.Messages
             int totalLength = Rlp.LengthOfSequence(contentLength);
 
             RlpStream rlpStream = new NettyRlpStream(byteBuffer);
-            byteBuffer.EnsureWritable(totalLength, true);
+            byteBuffer.EnsureWritable(totalLength);
 
             rlpStream.StartSequence(contentLength);
             rlpStream.Encode(message.RequestId);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Les/Messages/GetBlockHeadersMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Les/Messages/GetBlockHeadersMessageSerializer.cs
@@ -17,7 +17,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Les.Messages
             int totalLength = Rlp.LengthOfSequence(contentLength);
 
             RlpStream rlpStream = new NettyRlpStream(byteBuffer);
-            byteBuffer.EnsureWritable(totalLength, true);
+            byteBuffer.EnsureWritable(totalLength);
 
             rlpStream.StartSequence(contentLength);
             rlpStream.Encode(message.RequestId);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/NodeData/Messages/NodeDataMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/NodeData/Messages/NodeDataMessageSerializer.cs
@@ -11,7 +11,7 @@ public class NodeDataMessageSerializer : IZeroInnerMessageSerializer<NodeDataMes
     public void Serialize(IByteBuffer byteBuffer, NodeDataMessage message)
     {
         int length = GetLength(message, out int contentLength);
-        byteBuffer.EnsureWritable(length, true);
+        byteBuffer.EnsureWritable(length);
         RlpStream rlpStream = new NettyRlpStream(byteBuffer);
 
         rlpStream.StartSequence(contentLength);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/AccountRangeMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/AccountRangeMessageSerializer.cs
@@ -15,7 +15,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap.Messages
         {
             (int contentLength, int pwasLength, int proofsLength) = GetLength(message);
 
-            byteBuffer.EnsureWritable(Rlp.LengthOfSequence(contentLength), true);
+            byteBuffer.EnsureWritable(Rlp.LengthOfSequence(contentLength));
 
             NettyRlpStream stream = new(byteBuffer);
             stream.StartSequence(contentLength);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/ByteCodesMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/ByteCodesMessageSerializer.cs
@@ -11,7 +11,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap.Messages
         public void Serialize(IByteBuffer byteBuffer, ByteCodesMessage message)
         {
             (int contentLength, int codesLength) = GetLength(message);
-            byteBuffer.EnsureWritable(Rlp.LengthOfSequence(contentLength), true);
+            byteBuffer.EnsureWritable(Rlp.LengthOfSequence(contentLength));
             RlpStream rlpStream = new NettyRlpStream(byteBuffer);
 
             rlpStream.StartSequence(contentLength);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/GetTrieNodesMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/GetTrieNodesMessageSerializer.cs
@@ -13,7 +13,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap.Messages
         {
             (int contentLength, int allPathsLength, int[] pathsLengths) = CalculateLengths(message);
 
-            byteBuffer.EnsureWritable(Rlp.LengthOfSequence(contentLength), true);
+            byteBuffer.EnsureWritable(Rlp.LengthOfSequence(contentLength));
             NettyRlpStream stream = new(byteBuffer);
 
             stream.StartSequence(contentLength);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/SnapSerializerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/SnapSerializerBase.cs
@@ -15,7 +15,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap.Messages
         protected NettyRlpStream GetRlpStreamAndStartSequence(IByteBuffer byteBuffer, T msg)
         {
             int totalLength = GetLength(msg, out int contentLength);
-            byteBuffer.EnsureWritable(totalLength, true);
+            byteBuffer.EnsureWritable(totalLength);
             NettyRlpStream stream = new(byteBuffer);
             stream.StartSequence(contentLength);
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/StorageRangesMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/StorageRangesMessageSerializer.cs
@@ -25,7 +25,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap.Messages
         {
             (int contentLength, int allSlotsLength, int[] accountSlotsLengths, int proofsLength) = CalculateLengths(message);
 
-            byteBuffer.EnsureWritable(Rlp.LengthOfSequence(contentLength), true);
+            byteBuffer.EnsureWritable(Rlp.LengthOfSequence(contentLength));
             NettyRlpStream stream = new(byteBuffer);
 
             stream.StartSequence(contentLength);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/TrieNodesMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/TrieNodesMessageSerializer.cs
@@ -12,7 +12,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap.Messages
         {
             (int contentLength, int nodesLength) = GetLength(message);
 
-            byteBuffer.EnsureWritable(Rlp.LengthOfSequence(contentLength), true);
+            byteBuffer.EnsureWritable(Rlp.LengthOfSequence(contentLength));
 
             NettyRlpStream rlpStream = new(byteBuffer);
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Wit/Messages/BlockWitnessHashesMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Wit/Messages/BlockWitnessHashesMessageSerializer.cs
@@ -15,7 +15,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Wit.Messages
 
             int contentLength = GetLength(message, out int totalLength);
 
-            byteBuffer.EnsureWritable(totalLength, true);
+            byteBuffer.EnsureWritable(totalLength);
             nettyRlpStream.StartSequence(contentLength);
             nettyRlpStream.Encode(message.RequestId);
             if (message.Hashes is null)

--- a/src/Nethermind/Nethermind.Network/Rlpx/Handshake/AckEip8MessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/Handshake/AckEip8MessageSerializer.cs
@@ -28,7 +28,7 @@ namespace Nethermind.Network.Rlpx.Handshake
             totalLength += Rlp.LengthOf(msg.Nonce);
             totalLength += Rlp.LengthOf(msg.Version);
 
-            byteBuffer.EnsureWritable(Rlp.LengthOfSequence(totalLength), true);
+            byteBuffer.EnsureWritable(Rlp.LengthOfSequence(totalLength));
             NettyRlpStream stream = new(byteBuffer);
             stream.StartSequence(totalLength);
             stream.Encode(msg.EphemeralPublicKey.Bytes);

--- a/src/Nethermind/Nethermind.Network/Rlpx/Handshake/AuthEip8MessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/Handshake/AuthEip8MessageSerializer.cs
@@ -22,7 +22,7 @@ namespace Nethermind.Network.Rlpx.Handshake
         {
             int totalLength = GetLength(msg);
             // TODO: Account for the padding
-            byteBuffer.EnsureWritable(Rlp.LengthOfSequence(totalLength), true);
+            byteBuffer.EnsureWritable(Rlp.LengthOfSequence(totalLength));
             NettyRlpStream stream = new(byteBuffer);
             stream.StartSequence(totalLength);
             stream.Encode(Bytes.Concat(msg.Signature.Bytes, msg.Signature.RecoveryId));

--- a/src/Nethermind/Nethermind.Network/Rlpx/Handshake/AuthMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/Handshake/AuthMessageSerializer.cs
@@ -37,7 +37,7 @@ namespace Nethermind.Network.Rlpx.Handshake
 
         public void Serialize(IByteBuffer byteBuffer, AuthMessage msg)
         {
-            byteBuffer.EnsureWritable(Length, true);
+            byteBuffer.EnsureWritable(Length);
             byteBuffer.WriteBytes(msg.Signature.Bytes);
             byteBuffer.WriteByte(msg.Signature.RecoveryId);
             byteBuffer.WriteBytes(msg.EphemeralPublicHash.Bytes);

--- a/src/Nethermind/Nethermind.Network/Rlpx/RlpxHost.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/RlpxHost.cs
@@ -116,7 +116,7 @@ namespace Nethermind.Network.Rlpx
                     .ChildOption(ChannelOption.TcpNodelay, true)
                     .ChildOption(ChannelOption.SoTimeout, (int)_connectTimeout.TotalMilliseconds)
                     .ChildOption(ChannelOption.SoKeepalive, true)
-                    .ChildOption(ChannelOption.WriteBufferHighWaterMark, (int)(3.MB() + 1.MB() / 2))
+                    .ChildOption(ChannelOption.WriteBufferHighWaterMark, (int)3.MB())
                     .ChildOption(ChannelOption.WriteBufferLowWaterMark, (int)1.MB())
                     .Handler(new LoggingHandler("BOSS", LogLevel.TRACE))
                     .ChildHandler(new ActionChannelInitializer<ISocketChannel>(ch =>
@@ -176,7 +176,7 @@ namespace Nethermind.Network.Rlpx
                 .Option(ChannelOption.TcpNodelay, true)
                 .Option(ChannelOption.SoTimeout, (int)_connectTimeout.TotalMilliseconds)
                 .Option(ChannelOption.SoKeepalive, true)
-                .Option(ChannelOption.WriteBufferHighWaterMark, (int)(3.MB() + 1.MB() / 2))
+                .Option(ChannelOption.WriteBufferHighWaterMark, (int)3.MB())
                 .Option(ChannelOption.WriteBufferLowWaterMark, (int)1.MB())
                 .Option(ChannelOption.MessageSizeEstimator, DefaultMessageSizeEstimator.Default)
                 .Option(ChannelOption.ConnectTimeout, _connectTimeout);

--- a/src/Nethermind/Nethermind.Network/Rlpx/RlpxHost.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/RlpxHost.cs
@@ -12,6 +12,7 @@ using DotNetty.Transport.Bootstrapping;
 using DotNetty.Transport.Channels;
 using DotNetty.Transport.Channels.Sockets;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
 using Nethermind.Logging;
 using Nethermind.Network.Config;
 using Nethermind.Network.P2P;
@@ -112,6 +113,11 @@ namespace Nethermind.Network.Rlpx
                     .Group(_bossGroup, _workerGroup)
                     .Channel<TcpServerSocketChannel>()
                     .ChildOption(ChannelOption.SoBacklog, 100)
+                    .ChildOption(ChannelOption.TcpNodelay, true)
+                    .ChildOption(ChannelOption.SoTimeout, (int)_connectTimeout.TotalMilliseconds)
+                    .ChildOption(ChannelOption.SoKeepalive, true)
+                    .ChildOption(ChannelOption.WriteBufferHighWaterMark, (int)4.MB())
+                    .ChildOption(ChannelOption.WriteBufferLowWaterMark, (int)1.MB())
                     .Handler(new LoggingHandler("BOSS", LogLevel.TRACE))
                     .ChildHandler(new ActionChannelInitializer<ISocketChannel>(ch =>
                     {
@@ -164,11 +170,16 @@ namespace Nethermind.Network.Rlpx
             if (_logger.IsTrace) _logger.Trace($"|NetworkTrace| {node:s} initiating OUT connection");
 
             Bootstrap clientBootstrap = new();
-            clientBootstrap.Group(_workerGroup);
-            clientBootstrap.Channel<TcpSocketChannel>();
-            clientBootstrap.Option(ChannelOption.TcpNodelay, true);
-            clientBootstrap.Option(ChannelOption.MessageSizeEstimator, DefaultMessageSizeEstimator.Default);
-            clientBootstrap.Option(ChannelOption.ConnectTimeout, _connectTimeout);
+            clientBootstrap
+                .Group(_workerGroup)
+                .Channel<TcpSocketChannel>()
+                .Option(ChannelOption.TcpNodelay, true)
+                .Option(ChannelOption.SoTimeout, (int)_connectTimeout.TotalMilliseconds)
+                .Option(ChannelOption.SoKeepalive, true)
+                .Option(ChannelOption.WriteBufferHighWaterMark, (int)4.MB())
+                .Option(ChannelOption.WriteBufferLowWaterMark, (int)1.MB())
+                .Option(ChannelOption.MessageSizeEstimator, DefaultMessageSizeEstimator.Default)
+                .Option(ChannelOption.ConnectTimeout, _connectTimeout);
             clientBootstrap.Handler(new ActionChannelInitializer<ISocketChannel>(ch =>
             {
                 Session session = new(LocalPort, node, ch, _disconnectsAnalyzer, _logManager);

--- a/src/Nethermind/Nethermind.Network/Rlpx/RlpxHost.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/RlpxHost.cs
@@ -116,7 +116,7 @@ namespace Nethermind.Network.Rlpx
                     .ChildOption(ChannelOption.TcpNodelay, true)
                     .ChildOption(ChannelOption.SoTimeout, (int)_connectTimeout.TotalMilliseconds)
                     .ChildOption(ChannelOption.SoKeepalive, true)
-                    .ChildOption(ChannelOption.WriteBufferHighWaterMark, (int)4.MB())
+                    .ChildOption(ChannelOption.WriteBufferHighWaterMark, (int)(3.MB() + 1.MB() / 2))
                     .ChildOption(ChannelOption.WriteBufferLowWaterMark, (int)1.MB())
                     .Handler(new LoggingHandler("BOSS", LogLevel.TRACE))
                     .ChildHandler(new ActionChannelInitializer<ISocketChannel>(ch =>
@@ -176,7 +176,7 @@ namespace Nethermind.Network.Rlpx
                 .Option(ChannelOption.TcpNodelay, true)
                 .Option(ChannelOption.SoTimeout, (int)_connectTimeout.TotalMilliseconds)
                 .Option(ChannelOption.SoKeepalive, true)
-                .Option(ChannelOption.WriteBufferHighWaterMark, (int)4.MB())
+                .Option(ChannelOption.WriteBufferHighWaterMark, (int)(3.MB() + 1.MB() / 2))
                 .Option(ChannelOption.WriteBufferLowWaterMark, (int)1.MB())
                 .Option(ChannelOption.MessageSizeEstimator, DefaultMessageSizeEstimator.Default)
                 .Option(ChannelOption.ConnectTimeout, _connectTimeout);

--- a/src/Nethermind/Nethermind.Network/Rlpx/ZeroFrameEncoder.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/ZeroFrameEncoder.cs
@@ -38,11 +38,7 @@ namespace Nethermind.Network.Rlpx
 
                 FrameHeaderReader.FrameInfo frame = _headerReader.ReadFrameHeader(input);
 
-                // 0 if the buffer has enough writable bytes, and its capacity is unchanged.
-                // 1 if the buffer does not have enough bytes, and its capacity is unchanged.
-                // 2 if the buffer has enough writable bytes, and its capacity has been increased.
-                // 3 if the buffer does not have enough bytes, but its capacity has been increased to its maximum.
-                _ = output.EnsureWritable(Frame.HeaderSize + Frame.MacSize + frame.PayloadSize + Frame.MacSize, true);
+                output.EnsureWritable(Frame.HeaderSize + Frame.MacSize + frame.PayloadSize + Frame.MacSize);
 
                 WriteHeader(output);
                 WriteHeaderMac(output);

--- a/src/Nethermind/Nethermind.Network/Rlpx/ZeroPacketSplitter.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/ZeroPacketSplitter.cs
@@ -46,7 +46,7 @@ namespace Nethermind.Network.Rlpx
                 int totalPayloadOffset = MaxFrameSize * i;
                 int framePayloadSize = Math.Min(MaxFrameSize, totalPayloadSize - totalPayloadOffset);
                 int paddingSize = i == framesCount - 1 ? Frame.CalculatePadding(totalPayloadSize) : 0;
-                output.EnsureWritable(Frame.HeaderSize + framePayloadSize + paddingSize, true);
+                output.EnsureWritable(Frame.HeaderSize + framePayloadSize + paddingSize);
 
                 // 000 - 016 | header
                 // 016 - 01x | packet type

--- a/src/Nethermind/Nethermind.Network/Rlpx/ZeroSnappyEncoder.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/ZeroSnappyEncoder.cs
@@ -23,10 +23,11 @@ namespace Nethermind.Network.Rlpx
         {
             byte packetType = input.ReadByte();
 
-            output.EnsureWritable(1, true);
+            output.EnsureWritable(1);
             output.WriteByte(packetType);
 
-            output.EnsureWritable(SnappyCodec.GetMaxCompressedLength(input.ReadableBytes), true);
+            output.EnsureWritable(SnappyCodec.GetMaxCompressedLength(input.ReadableBytes));
+
             if (_logger.IsTrace) _logger.Trace($"Compressing with Snappy a message of length {input.ReadableBytes}");
             int length = SnappyCodec.Compress(
                 input.Array,

--- a/src/Nethermind/Nethermind.Network/Rlpx/ZeroSnappyEncoder.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/ZeroSnappyEncoder.cs
@@ -23,10 +23,8 @@ namespace Nethermind.Network.Rlpx
         {
             byte packetType = input.ReadByte();
 
-            output.EnsureWritable(1);
+            output.EnsureWritable(1 + SnappyCodec.GetMaxCompressedLength(input.ReadableBytes));
             output.WriteByte(packetType);
-
-            output.EnsureWritable(SnappyCodec.GetMaxCompressedLength(input.ReadableBytes));
 
             if (_logger.IsTrace) _logger.Trace($"Compressing with Snappy a message of length {input.ReadableBytes}");
             int length = SnappyCodec.Compress(

--- a/src/Nethermind/Nethermind.Serialization.Rlp/BlockDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/BlockDecoder.cs
@@ -176,7 +176,7 @@ namespace Nethermind.Serialization.Rlp
             List<Transaction> transactions = new();
             while (decoderContext.Position < transactionsCheck)
             {
-                transactions.Add(Rlp.Decode<Transaction>(ref decoderContext));
+                transactions.Add(Rlp.Decode<Transaction>(ref decoderContext, rlpBehaviors));
             }
 
             decoderContext.Check(transactionsCheck);

--- a/src/Nethermind/Nethermind.Serialization.Rlp/BlockDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/BlockDecoder.cs
@@ -37,7 +37,7 @@ namespace Nethermind.Serialization.Rlp
             List<Transaction> transactions = new();
             while (rlpStream.Position < transactionsCheck)
             {
-                transactions.Add(Rlp.Decode<Transaction>(rlpStream));
+                transactions.Add(Rlp.Decode<Transaction>(rlpStream, rlpBehaviors));
             }
 
             rlpStream.Check(transactionsCheck);

--- a/src/Nethermind/Nethermind.Serialization.Rlp/KeyValueStoreRlpExtensions.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/KeyValueStoreRlpExtensions.cs
@@ -15,22 +15,22 @@ public static class KeyValueStoreRlpExtensions
 {
     [SkipLocalsInit]
     public static TItem? Get<TItem>(this IReadOnlyKeyValueStore db, long blockNumber, ValueHash256 hash, IRlpStreamDecoder<TItem> decoder,
-        LruCache<ValueHash256, TItem> cache = null, bool shouldCache = true) where TItem : class
+        LruCache<ValueHash256, TItem> cache = null, RlpBehaviors rlpBehaviors = RlpBehaviors.None, bool shouldCache = true) where TItem : class
     {
         Span<byte> dbKey = stackalloc byte[40];
         KeyValueStoreExtensions.GetBlockNumPrefixedKey(blockNumber, hash, dbKey);
-        return Get(db, hash, dbKey, decoder, cache, shouldCache);
+        return Get(db, hash, dbKey, decoder, cache, rlpBehaviors, shouldCache);
     }
 
-    public static TItem? Get<TItem>(this IReadOnlyKeyValueStore db, ValueHash256 key, IRlpStreamDecoder<TItem> decoder, LruCache<ValueHash256, TItem> cache = null, bool shouldCache = true) where TItem : class
+    public static TItem? Get<TItem>(this IReadOnlyKeyValueStore db, ValueHash256 key, IRlpStreamDecoder<TItem> decoder, LruCache<ValueHash256, TItem> cache = null, RlpBehaviors rlpBehaviors = RlpBehaviors.None, bool shouldCache = true) where TItem : class
     {
-        return Get(db, key, key.Bytes, decoder, cache, shouldCache);
+        return Get(db, key, key.Bytes, decoder, cache, rlpBehaviors, shouldCache);
     }
 
-    public static TItem? Get<TItem>(this IReadOnlyKeyValueStore db, long key, IRlpStreamDecoder<TItem>? decoder, LruCache<long, TItem>? cache = null, bool shouldCache = true) where TItem : class
+    public static TItem? Get<TItem>(this IReadOnlyKeyValueStore db, long key, IRlpStreamDecoder<TItem>? decoder, LruCache<long, TItem>? cache = null, RlpBehaviors rlpBehaviors = RlpBehaviors.None, bool shouldCache = true) where TItem : class
     {
         byte[] keyDb = key.ToBigEndianByteArrayWithoutLeadingZeros();
-        return Get(db, key, keyDb, decoder, cache, shouldCache);
+        return Get(db, key, keyDb, decoder, cache, rlpBehaviors, shouldCache);
     }
 
     public static TItem? Get<TCacheKey, TItem>(
@@ -39,6 +39,7 @@ public static class KeyValueStoreRlpExtensions
         ReadOnlySpan<byte> key,
         IRlpStreamDecoder<TItem> decoder,
         LruCache<TCacheKey, TItem> cache = null,
+        RlpBehaviors rlpBehaviors = RlpBehaviors.None,
         bool shouldCache = true
     ) where TItem : class
     {
@@ -61,7 +62,7 @@ public static class KeyValueStoreRlpExtensions
                     }
 
                     var rlpValueContext = data.AsRlpValueContext();
-                    item = valueDecoder.Decode(ref rlpValueContext, RlpBehaviors.AllowExtraBytes);
+                    item = valueDecoder.Decode(ref rlpValueContext, rlpBehaviors | RlpBehaviors.AllowExtraBytes);
                 }
                 finally
                 {
@@ -82,7 +83,7 @@ public static class KeyValueStoreRlpExtensions
 
                 using NettyRlpStream nettyRlpStream = new NettyRlpStream(buff);
 
-                item = decoder.Decode(nettyRlpStream, RlpBehaviors.AllowExtraBytes);
+                item = decoder.Decode(nettyRlpStream, rlpBehaviors | RlpBehaviors.AllowExtraBytes);
             }
         }
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/NettyRlpStream.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/NettyRlpStream.cs
@@ -22,7 +22,7 @@ namespace Nethermind.Serialization.Rlp
 
         public override void Write(ReadOnlySpan<byte> bytesToWrite)
         {
-            _buffer.EnsureWritable(bytesToWrite.Length, true);
+            _buffer.EnsureWritable(bytesToWrite.Length);
 
             Span<byte> target =
                 _buffer.Array.AsSpan(_buffer.ArrayOffset + _buffer.WriterIndex, bytesToWrite.Length);
@@ -34,7 +34,7 @@ namespace Nethermind.Serialization.Rlp
 
         public override void Write(IReadOnlyList<byte> bytesToWrite)
         {
-            _buffer.EnsureWritable(bytesToWrite.Count, true);
+            _buffer.EnsureWritable(bytesToWrite.Count);
             Span<byte> target =
                 _buffer.Array.AsSpan(_buffer.ArrayOffset + _buffer.WriterIndex, bytesToWrite.Count);
             for (int i = 0; i < bytesToWrite.Count; ++i)
@@ -48,13 +48,13 @@ namespace Nethermind.Serialization.Rlp
 
         public override void WriteByte(byte byteToWrite)
         {
-            _buffer.EnsureWritable(1, true);
+            _buffer.EnsureWritable(1);
             _buffer.WriteByte(byteToWrite);
         }
 
         protected override void WriteZero(int length)
         {
-            _buffer.EnsureWritable(length, true);
+            _buffer.EnsureWritable(length);
             _buffer.WriteZero(length);
         }
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpBehaviors.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpBehaviors.cs
@@ -30,5 +30,6 @@ public enum RlpBehaviors
     /// See https://eips.ethereum.org/EIPS/eip-4844#networking
     /// </summary>
     InMempoolForm = 64,
-    All = AllowExtraBytes | ForSealing | Storage | Eip658Receipts | AllowUnsigned | SkipTypedWrapping | InMempoolForm
+    ExcludeHashes = 128,
+    All = AllowExtraBytes | ForSealing | Storage | Eip658Receipts | AllowUnsigned | SkipTypedWrapping | InMempoolForm | ExcludeHashes,
 }

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncServerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncServerTests.cs
@@ -77,7 +77,7 @@ namespace Nethermind.Synchronization.Test
         {
             Context ctx = new();
             ctx.SyncServer.Find(TestItem.KeccakA);
-            ctx.BlockTree.Received().FindBlock(Arg.Any<Hash256>(), BlockTreeLookupOptions.TotalDifficultyNotNeeded);
+            ctx.BlockTree.Received().FindBlock(Arg.Any<Hash256>(), BlockTreeLookupOptions.TotalDifficultyNotNeeded | BlockTreeLookupOptions.ExcludeTxHashes);
         }
 
         [TestCase(true, true, true)]

--- a/src/Nethermind/Nethermind.Synchronization/SyncServer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SyncServer.cs
@@ -414,7 +414,7 @@ namespace Nethermind.Synchronization
             return _blockTree.FindLowestCommonAncestor(firstDescendant, secondDescendant, Sync.MaxReorgLength);
         }
 
-        public Block Find(Hash256 hash) => _blockTree.FindBlock(hash, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
+        public Block Find(Hash256 hash) => _blockTree.FindBlock(hash, BlockTreeLookupOptions.TotalDifficultyNotNeeded | BlockTreeLookupOptions.ExcludeTxHashes);
 
         public Hash256? FindHash(long number)
         {


### PR DESCRIPTION
Resolves #6556
Resolves #6559
Resolves #6558
Resolves #4625
Resolves #4802

Previous

<img width="604" alt="image" src="https://github.com/NethermindEth/nethermind/assets/1142958/afbde342-ebce-43d9-b5f5-91057183f302">

After

<img width="659" alt="image" src="https://github.com/NethermindEth/nethermind/assets/1142958/040c90c4-e449-49eb-b757-61abeb705c7a">

Previous
<img width="636" alt="image" src="https://github.com/NethermindEth/nethermind/assets/1142958/6d8509fd-dadc-4ceb-8dbb-cbf754fdc291">


After
<img width="634" alt="image" src="https://github.com/NethermindEth/nethermind/assets/1142958/9641c6ab-29b8-4fa9-869d-4ea6cb9abb5e">

Previous
<img width="635" alt="image" src="https://github.com/NethermindEth/nethermind/assets/1142958/e2765cc6-b453-487c-bf3c-3f90d8093ece">

After
<img width="637" alt="image" src="https://github.com/NethermindEth/nethermind/assets/1142958/682fa731-1b89-4b52-8bf0-9b2c293dbb4b">


## Changes

- Don't generate Tx hashes or allocate transactionSequence for sync requests as they are never sent.
- Calcuate the tx hashes in the background while generating blocks to release the memory from the transactionSequence (saved for hash generation).
- Apply better defaults for p2p networking and enforce.
- Don't send packets to non writable channels
- Large GC collect more frequently

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] Optimization

## Testing

#### Requires testing

- [ ] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No