### PR TITLE
Cleanup rocksdb config and metrics

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Blocks/BlockStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Blocks/BlockStore.cs
@@ -42,7 +42,7 @@ public class BlockStore : IBlockStore
 
     private void TruncateToMaxSize()
     {
-        int toDelete = (int)(_blockDb.GetSize() - _maxSize!);
+        int toDelete = (int)(_blockDb.GatherMetric().Size - _maxSize!);
         if (toDelete > 0)
         {
             foreach (var blockToDelete in GetAll().Take(toDelete))

--- a/src/Nethermind/Nethermind.Core/Attributes/Metrics.cs
+++ b/src/Nethermind/Nethermind.Core/Attributes/Metrics.cs
@@ -23,10 +23,10 @@ public sealed class GaugeMetricAttribute : Attribute { }
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
 public sealed class KeyIsLabelAttribute : Attribute
 {
-    public string LabelName { get; }
+    public string[] LabelNames { get; }
 
-    public KeyIsLabelAttribute(string labelName)
+    public KeyIsLabelAttribute(params string[] labelNames)
     {
-        LabelName = labelName;
+        LabelNames = labelNames;
     }
 }

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -142,7 +142,7 @@ public class ColumnDb : IDb
     /// <exception cref="NotSupportedException"></exception>
     public void Clear() { throw new NotSupportedException(); }
     public long GetSize() => _mainDb.GetSize();
-    public long GetCacheSize() => _mainDb.GetCacheSize();
+    public long GetCacheSize(bool includeSharedCache) => _mainDb.GetCacheSize(includeSharedCache);
     public long GetIndexSize() => _mainDb.GetIndexSize();
     public long GetMemtableSize() => _mainDb.GetMemtableSize();
 

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -141,10 +141,9 @@ public class ColumnDb : IDb
     /// </summary>
     /// <exception cref="NotSupportedException"></exception>
     public void Clear() { throw new NotSupportedException(); }
-    public long GetSize() => _mainDb.GetSize();
-    public long GetCacheSize(bool includeSharedCache) => _mainDb.GetCacheSize(includeSharedCache);
-    public long GetIndexSize() => _mainDb.GetIndexSize();
-    public long GetMemtableSize() => _mainDb.GetMemtableSize();
+
+    // Maybe it should be column specific metric?
+    public IDbMeta.DbMetric GatherMetric(bool includeSharedCache = false) => _mainDb.GatherMetric();
 
     public void DangerousReleaseMemory(in ReadOnlySpan<byte> span)
     {

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -121,7 +121,10 @@ public class ColumnDb : IDb
         _rocksDb.Remove(key, _columnFamily, _mainDb.WriteOptions);
     }
 
-    public bool KeyExists(ReadOnlySpan<byte> key) => _rocksDb.Get(key, _columnFamily) is not null;
+    public bool KeyExists(ReadOnlySpan<byte> key)
+    {
+        return _mainDb.KeyExistsWithColumn(key, _columnFamily);
+    }
 
     public void Flush()
     {

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -143,7 +143,7 @@ public class ColumnDb : IDb
     public void Clear() { throw new NotSupportedException(); }
 
     // Maybe it should be column specific metric?
-    public IDbMeta.DbMetric GatherMetric(bool includeSharedCache = false) => _mainDb.GatherMetric();
+    public IDbMeta.DbMetric GatherMetric(bool includeSharedCache = false) => _mainDb.GatherMetric(includeSharedCache);
 
     public void DangerousReleaseMemory(in ReadOnlySpan<byte> span)
     {

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnsDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnsDb.cs
@@ -28,6 +28,21 @@ public class ColumnsDb<T> : DbOnTheRocks, IColumnsDb<T> where T : struct, Enum
         }
     }
 
+    protected override long FetchTotalPropertyValue(string propertyName)
+    {
+        long total = 0;
+        foreach (KeyValuePair<T, ColumnDb> kv in _columnDbs)
+        {
+            long value = long.TryParse(_db.GetProperty(propertyName, kv.Value._columnFamily), out long parsedValue)
+                ? parsedValue
+                : 0;
+
+            total += value;
+        }
+
+        return total;
+    }
+
     public override void Compact()
     {
         foreach (T key in ColumnKeys)

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
@@ -29,6 +29,20 @@ public class DbConfig : IDbConfig
     public ulong? MaxBytesForLevelBase { get; set; } = (ulong)256.MiB();
     public ulong TargetFileSizeBase { get; set; } = (ulong)64.MiB();
     public int TargetFileSizeMultiplier { get; set; } = 1;
+    public bool UseTwoLevelIndex { get; set; } = true;
+    public bool UseHashIndex { get; set; } = false;
+    public ulong? PrefixExtractorLength { get; set; } = null;
+    public bool AllowMmapReads { get; set; } = false;
+    public bool VerifyChecksum { get; set; } = true;
+    public double MaxBytesForLevelMultiplier { get; set; } = 10;
+    public ulong? MaxCompactionBytes { get; set; } = null;
+    public int MinWriteBufferNumberToMerge { get; set; } = 1;
+    public ulong? RowCacheSize { get; set; } = null;
+    public bool OptimizeFiltersForHits { get; set; } = true;
+    public bool OnlyCompressLastLevel { get; set; } = false;
+    public long? MaxWriteBufferSizeToMaintain { get; set; } = null;
+    public bool UseHashSkipListMemtable { get; set; } = false;
+    public int BlockRestartInterval { get; set; } = 16;
 
     public ulong ReceiptsDbWriteBufferSize { get; set; } = (ulong)8.MiB();
     public uint ReceiptsDbWriteBufferNumber { get; set; } = 4;
@@ -174,6 +188,20 @@ public class DbConfig : IDbConfig
     public ulong? StateDbCompactionReadAhead { get; set; }
     public bool? StateDbDisableCompression { get; set; } = false;
     public int StateDbTargetFileSizeMultiplier { get; set; } = 2;
+    public bool StateDbEnableTwoLevelIndex { get; set; } = true;
+    public bool StateDbEnableHashIndex { get; set; } = false;
+    public ulong? StateDbPrefixExtractorLength { get; set; } = null;
+    public bool StateDbAllowMmapReads { get; set; } = false;
+    public bool StateDbVerifyChecksum { get; set; } = true;
+    public double StateDbMaxBytesForLevelMultiplier { get; set; } = 10;
+    public ulong? StateDbMaxCompactionBytes { get; set; } = null;
+    public int StateDbMinWriteBufferNumberToMerge { get; set; } = 1;
+    public ulong? StateDbRowCacheSize { get; set; } = null;
+    public bool StateDbOptimizeFiltersForHits { get; set; } = true;
+    public bool StateDbOnlyCompressLastLevel { get; set; } = false;
+    public long? StateDbMaxWriteBufferSizeToMaintain { get; set; } = null;
+    public bool StateDbUseHashSkipListMemtable { get; set; } = false;
+    public int StateDbBlockRestartInterval { get; set; } = 16;
     public IDictionary<string, string>? StateDbAdditionalRocksDbOptions { get; set; }
 
     public uint RecycleLogFileNum { get; set; } = 0;

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
@@ -188,8 +188,8 @@ public class DbConfig : IDbConfig
     public ulong? StateDbCompactionReadAhead { get; set; }
     public bool? StateDbDisableCompression { get; set; } = false;
     public int StateDbTargetFileSizeMultiplier { get; set; } = 2;
-    public bool StateDbEnableTwoLevelIndex { get; set; } = true;
-    public bool StateDbEnableHashIndex { get; set; } = false;
+    public bool StateDbUseTwoLevelIndex { get; set; } = true;
+    public bool StateDbUseHashIndex { get; set; } = false;
     public ulong? StateDbPrefixExtractorLength { get; set; } = null;
     public bool StateDbAllowMmapReads { get; set; } = false;
     public bool StateDbVerifyChecksum { get; set; } = true;

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/IDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/IDbConfig.cs
@@ -188,8 +188,8 @@ public interface IDbConfig : IConfig
     ulong? StateDbCompactionReadAhead { get; set; }
     bool? StateDbDisableCompression { get; set; }
     int StateDbTargetFileSizeMultiplier { get; set; }
-    bool StateDbEnableTwoLevelIndex { get; set; }
-    bool StateDbEnableHashIndex { get; set; }
+    bool StateDbUseTwoLevelIndex { get; set; }
+    bool StateDbUseHashIndex { get; set; }
     ulong? StateDbPrefixExtractorLength { get; set; }
     bool StateDbAllowMmapReads { get; set; }
     bool StateDbVerifyChecksum { get; set; }

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/IDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/IDbConfig.cs
@@ -30,6 +30,20 @@ public interface IDbConfig : IConfig
     ulong? MaxBytesForLevelBase { get; set; }
     ulong TargetFileSizeBase { get; set; }
     int TargetFileSizeMultiplier { get; set; }
+    bool UseTwoLevelIndex { get; set; }
+    bool UseHashIndex { get; set; }
+    ulong? PrefixExtractorLength { get; set; }
+    bool AllowMmapReads { get; set; }
+    bool VerifyChecksum { get; set; }
+    double MaxBytesForLevelMultiplier { get; set; }
+    ulong? MaxCompactionBytes { get; set; }
+    int MinWriteBufferNumberToMerge { get; set; }
+    ulong? RowCacheSize { get; set; }
+    bool OptimizeFiltersForHits { get; set; }
+    bool OnlyCompressLastLevel { get; set; }
+    long? MaxWriteBufferSizeToMaintain { get; set; }
+    bool UseHashSkipListMemtable { get; set; }
+    int BlockRestartInterval { get; set; }
 
     ulong ReceiptsDbWriteBufferSize { get; set; }
     uint ReceiptsDbWriteBufferNumber { get; set; }
@@ -174,6 +188,20 @@ public interface IDbConfig : IConfig
     ulong? StateDbCompactionReadAhead { get; set; }
     bool? StateDbDisableCompression { get; set; }
     int StateDbTargetFileSizeMultiplier { get; set; }
+    bool StateDbEnableTwoLevelIndex { get; set; }
+    bool StateDbEnableHashIndex { get; set; }
+    ulong? StateDbPrefixExtractorLength { get; set; }
+    bool StateDbAllowMmapReads { get; set; }
+    bool StateDbVerifyChecksum { get; set; }
+    double StateDbMaxBytesForLevelMultiplier { get; set; }
+    ulong? StateDbMaxCompactionBytes { get; set; }
+    int StateDbMinWriteBufferNumberToMerge { get; set; }
+    ulong? StateDbRowCacheSize { get; set; }
+    bool StateDbOptimizeFiltersForHits { get; set; }
+    bool StateDbOnlyCompressLastLevel { get; set; }
+    long? StateDbMaxWriteBufferSizeToMaintain { get; set; }
+    bool StateDbUseHashSkipListMemtable { get; set; }
+    int StateDbBlockRestartInterval { get; set; }
     IDictionary<string, string>? StateDbAdditionalRocksDbOptions { get; set; }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/PerTableDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/PerTableDbConfig.cs
@@ -51,6 +51,20 @@ public class PerTableDbConfig
     public ulong MaxBytesForLevelBase => ReadConfig<ulong>(nameof(MaxBytesForLevelBase));
     public ulong TargetFileSizeBase => ReadConfig<ulong>(nameof(TargetFileSizeBase));
     public int TargetFileSizeMultiplier => ReadConfig<int>(nameof(TargetFileSizeMultiplier));
+    public bool UseTwoLevelIndex => ReadConfig<bool>(nameof(UseTwoLevelIndex));
+    public bool UseHashIndex => ReadConfig<bool>(nameof(UseHashIndex));
+    public ulong? PrefixExtractorLength => ReadConfig<ulong?>(nameof(PrefixExtractorLength));
+    public bool AllowMmapReads => ReadConfig<bool>(nameof(AllowMmapReads));
+    public bool VerifyChecksum => ReadConfig<bool>(nameof(VerifyChecksum));
+    public double MaxBytesForLevelMultiplier => ReadConfig<double>(nameof(MaxBytesForLevelMultiplier));
+    public ulong? MaxCompactionBytes => ReadConfig<ulong?>(nameof(MaxCompactionBytes));
+    public int MinWriteBufferNumberToMerge => ReadConfig<int>(nameof(MinWriteBufferNumberToMerge));
+    public ulong? RowCacheSize => ReadConfig<ulong?>(nameof(RowCacheSize));
+    public bool OptimizeFiltersForHits => ReadConfig<bool>(nameof(OptimizeFiltersForHits));
+    public bool OnlyCompressLastLevel => ReadConfig<bool>(nameof(OnlyCompressLastLevel));
+    public long? MaxWriteBufferSizeToMaintain => ReadConfig<long?>(nameof(MaxWriteBufferSizeToMaintain));
+    public bool UseHashSkipListMemtable => ReadConfig<bool>(nameof(UseHashSkipListMemtable));
+    public int BlockRestartInterval => ReadConfig<int>(nameof(BlockRestartInterval));
 
     private T? ReadConfig<T>(string propertyName)
     {

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -147,7 +147,12 @@ public class DbOnTheRocks : IDb, ITunableDb
                     if (columnFamily == "Default") columnFamily = "default";
 
                     ColumnFamilyOptions options = new();
-                    BuildOptions(new PerTableDbConfig(dbConfig, _settings, columnFamily), options, sharedCache);
+                    IntPtr? cacheForColumn = sharedCache;
+                    if (_cache != null)
+                    {
+                        cacheForColumn = _cache;
+                    }
+                    BuildOptions(new PerTableDbConfig(dbConfig, _settings, columnFamily), options, cacheForColumn);
                     columnFamilies.Add(columnFamily, options);
                 }
             }

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -427,7 +427,7 @@ public class DbOnTheRocks : IDb, ITunableDb
             // So the bottommost level is about 80-90% of the database. So it may make sense to only compress that
             // part, which make the top level faster, and/or mmap-able.
             options.SetCompression(Compression.No);
-            _rocksDbNative.rocksdb_options_get_bottommost_compression(0x1); // 0x1 is snappy.
+            _rocksDbNative.rocksdb_options_set_bottommost_compression(options.Handle, 0x1); // 0x1 is snappy.
         }
 
         // Target size of each SST file. Increase to reduce number of file. Default is 64MB.

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -1303,14 +1303,14 @@ public class DbOnTheRocks : IDb, ITunableDb
             case ITunableDb.TuneType.HeavyWrite:
                 // Compaction spikes are clear at this point. Will definitely affect attestation performance.
                 // Its unclear if it improve or slow down sync time. Seems to be the sweet spot.
-                ApplyOptions(GetHeavyWriteOptions((ulong) 4.GiB()));
+                ApplyOptions(GetHeavyWriteOptions((ulong)4.GiB()));
                 break;
             case ITunableDb.TuneType.AggressiveHeavyWrite:
                 // For when, you are desperate, but don't wanna disable compaction completely, because you don't want
                 // peers to drop. Tend to be faster than disabling compaction completely, except if your ratelimit
                 // is a bit low and your compaction is lagging behind, which will trigger slowdown, so sync will hang
                 // intermittently, but at least peer count is stable.
-                ApplyOptions(GetHeavyWriteOptions((ulong) 16.GiB()));
+                ApplyOptions(GetHeavyWriteOptions((ulong)16.GiB()));
                 break;
             case ITunableDb.TuneType.DisableCompaction:
                 // Completely disable compaction. On mainnet, max num of l0 files for state seems to be about 10800.
@@ -1426,7 +1426,7 @@ public class DbOnTheRocks : IDb, ITunableDb
 
     private IDictionary<string, string> GetDisableCompactionOptions()
     {
-        IDictionary<string, string> heavyWriteOption = GetHeavyWriteOptions((ulong) 32.GiB());
+        IDictionary<string, string> heavyWriteOption = GetHeavyWriteOptions((ulong)32.GiB());
 
         heavyWriteOption["disable_auto_compactions"] = "true";
         // Increase the size of the write buffer, which reduces the number of l0 file by 4x. This does slows down

--- a/src/Nethermind/Nethermind.Db.Rocks/RocksDbExtensions.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/RocksDbExtensions.cs
@@ -21,9 +21,11 @@ internal static class RocksDbExtensions
         RocksDbNative.Instance.rocksdb_free(intPtr);
     }
 
-    internal static unsafe Span<byte> GetSpan(this RocksDb db, ReadOnlySpan<byte> key, ColumnFamilyHandle? cf = null)
+    internal static unsafe Span<byte> GetSpan(this RocksDb db, ReadOnlySpan<byte> key, ColumnFamilyHandle? cf = null, ReadOptions? readOptionObj = null)
     {
         var readOptions = _defaultReadOptions.Handle;
+        if (readOptionObj is not null) readOptions = readOptionObj.Handle;
+
         var keyLength = (long)key.Length;
 
         if (keyLength == 0)

--- a/src/Nethermind/Nethermind.Db.Rocks/Statistics/DbMetricsUpdater.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Statistics/DbMetricsUpdater.cs
@@ -11,7 +11,7 @@ using RocksDbSharp;
 
 namespace Nethermind.Db.Rocks.Statistics;
 
-public partial class DbMetricsUpdater<T>: IDisposable where T : Options<T>
+public partial class DbMetricsUpdater<T> : IDisposable where T : Options<T>
 {
     private readonly string _dbName;
     private readonly Options<T> _dbOptions;

--- a/src/Nethermind/Nethermind.Db.Rocks/Statistics/DbMetricsUpdater.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Statistics/DbMetricsUpdater.cs
@@ -72,7 +72,7 @@ public partial class DbMetricsUpdater<T> : IDisposable where T : Options<T>
     {
         foreach ((string Name, IDictionary<string, double> SubMetric) value in ExtractStatsFromStatisticString(dbStatsString))
         {
-            // The metric can be of several time, usually just a counter, but sometime its a histogram,
+            // The metric can be of several type, usually just a counter, but sometime its a histogram,
             // in which case we take both the sum and count.
             if (value.SubMetric.TryGetValue("SUM", out var valueSum))
             {

--- a/src/Nethermind/Nethermind.Db.Rocks/Statistics/DbMetricsUpdater.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Statistics/DbMetricsUpdater.cs
@@ -76,12 +76,12 @@ public partial class DbMetricsUpdater<T> : IDisposable where T : Options<T>
             // in which case we take both the sum and count.
             if (value.SubMetric.TryGetValue("SUM", out var valueSum))
             {
-                Metrics.DbStats[(_dbName + "Db", value.Name + ".sum")] = valueSum;
-                Metrics.DbStats[(_dbName + "Db", value.Name + ".count")] = value.SubMetric["COUNT"];
+                Metrics.DbStats[($"{_dbName}Db", $"{value.Name}.sum")] = valueSum;
+                Metrics.DbStats[($"{_dbName}Db", $"{value.Name}.count")] = value.SubMetric["COUNT"];
             }
             else
             {
-                Metrics.DbStats[(_dbName + "Db", value.Name)] = value.SubMetric["COUNT"];
+                Metrics.DbStats[($"{_dbName}Db", value.Name)] = value.SubMetric["COUNT"];
             }
         }
     }
@@ -126,7 +126,7 @@ public partial class DbMetricsUpdater<T> : IDisposable where T : Options<T>
         {
             foreach (var stat in stats)
             {
-                Metrics.DbStats[(_dbName + "Db", stat.Name)] = stat.Value;
+                Metrics.DbStats[($"{_dbName}Db", stat.Name)] = stat.Value;
             }
         }
     }

--- a/src/Nethermind/Nethermind.Db.Rocks/Statistics/DbMetricsUpdater.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Statistics/DbMetricsUpdater.cs
@@ -11,17 +11,17 @@ using RocksDbSharp;
 
 namespace Nethermind.Db.Rocks.Statistics;
 
-public partial class DbMetricsUpdater
+public partial class DbMetricsUpdater<T>: IDisposable where T : Options<T>
 {
     private readonly string _dbName;
-    private readonly DbOptions _dbOptions;
+    private readonly Options<T> _dbOptions;
     private readonly RocksDb _db;
     private readonly IDbConfig _dbConfig;
     private readonly ILogger _logger;
     private readonly ColumnFamilyHandle? _columnFamilyHandle;
     private Timer? _timer;
 
-    public DbMetricsUpdater(string dbName, DbOptions dbOptions, RocksDb db, ColumnFamilyHandle? cf, IDbConfig dbConfig, ILogger logger)
+    public DbMetricsUpdater(string dbName, Options<T> dbOptions, RocksDb db, ColumnFamilyHandle? cf, IDbConfig dbConfig, ILogger logger)
     {
         _dbName = dbName;
         _dbOptions = dbOptions;
@@ -57,6 +57,7 @@ public partial class DbMetricsUpdater
             if (_dbConfig.EnableDbStatistics)
             {
                 var dbStatsString = _dbOptions.GetStatisticsString();
+                ProcessStatisticsString(dbStatsString);
                 // Currently we don't extract any DB statistics but we can do it here
             }
         }
@@ -64,6 +65,42 @@ public partial class DbMetricsUpdater
         {
             _logger.Error($"Error when updating metrics for {_dbName} database.", exc);
             // Maybe we would like to stop the _timer here to avoid logging the same error all over again?
+        }
+    }
+
+    public void ProcessStatisticsString(string dbStatsString)
+    {
+        foreach ((string Name, IDictionary<string, double> SubMetric) value in ExtractStatsFromStatisticString(dbStatsString))
+        {
+            // The metric can be of several time, usually just a counter, but sometime its a histogram,
+            // in which case we take both the sum and count.
+            if (value.SubMetric.TryGetValue("SUM", out var valueSum))
+            {
+                Metrics.DbStats[(_dbName + "Db", value.Name + ".sum")] = valueSum;
+                Metrics.DbStats[(_dbName + "Db", value.Name + ".count")] = value.SubMetric["COUNT"];
+            }
+            else
+            {
+                Metrics.DbStats[(_dbName + "Db", value.Name)] = value.SubMetric["COUNT"];
+            }
+        }
+    }
+
+    private static IEnumerable<(string Name, IDictionary<string, double> Value)> ExtractStatsFromStatisticString(string statsStr)
+    {
+        var matches = ExtractStatsRegex2().Matches(statsStr);
+
+        foreach (Match match in matches)
+        {
+            string statName = match.Groups[1].Value;
+
+            IDictionary<string, double> metricDictionary = new Dictionary<string, double>();
+            foreach (Match metricMatch in ExtractSubStatsRegex().Matches(match.Groups[2].Value))
+            {
+                metricDictionary[metricMatch.Groups[1].Value] = double.Parse(metricMatch.Groups[2].Value);
+            }
+
+            yield return (statName, metricDictionary);
         }
     }
 
@@ -83,13 +120,13 @@ public partial class DbMetricsUpdater
         }
     }
 
-    private void UpdateMetricsFromList(List<(string Name, long Value)> levelStats)
+    private void UpdateMetricsFromList(List<(string Name, long Value)> stats)
     {
-        if (levelStats is not null)
+        if (stats is not null)
         {
-            foreach (var stat in levelStats)
+            foreach (var stat in stats)
             {
-                Metrics.DbStats[$"{_dbName}Db{stat.Name}"] = stat.Value;
+                Metrics.DbStats[(_dbName + "Db", stat.Name)] = stat.Value;
             }
         }
     }
@@ -153,6 +190,12 @@ public partial class DbMetricsUpdater
 
     [GeneratedRegex("^Interval compaction: (\\d+)\\.\\d+.*GB write.*\\s+(\\d+)\\.\\d+.*MB\\/s write.*\\s+(\\d+)\\.\\d+.*GB read.*\\s+(\\d+)\\.\\d+.*MB\\/s read.*\\s+(\\d+)\\.\\d+.*seconds.*$", RegexOptions.Multiline)]
     private static partial Regex ExtractIntervalRegex();
+
+    [GeneratedRegex("^(\\S+)(.*)$", RegexOptions.Multiline)]
+    private static partial Regex ExtractStatsRegex2();
+
+    [GeneratedRegex("(\\S+) \\: (\\S+)", RegexOptions.Multiline)]
+    private static partial Regex ExtractSubStatsRegex();
 
     public void Dispose()
     {

--- a/src/Nethermind/Nethermind.Db.Test/ColumnsDbTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/ColumnsDbTests.cs
@@ -76,7 +76,7 @@ public class ColumnsDbTests
         colA.Set(TestItem.KeccakA, TestItem.KeccakA.BytesToArray());
         colB.Set(TestItem.KeccakA, TestItem.KeccakB.BytesToArray());
 
-        _db.GetMemtableSize().Should().Be(22544);
+        _db.GatherMetric().MemtableSize.Should().Be(22544);
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Db.Test/ColumnsDbTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/ColumnsDbTests.cs
@@ -68,6 +68,18 @@ public class ColumnsDbTests
     }
 
     [Test]
+    public void SmokeTestMemtableSize()
+    {
+        IDb colA = _db.GetColumnDb(TestColumns.ColumnA);
+        IDb colB = _db.GetColumnDb(TestColumns.ColumnB);
+
+        colA.Set(TestItem.KeccakA, TestItem.KeccakA.BytesToArray());
+        colB.Set(TestItem.KeccakA, TestItem.KeccakB.BytesToArray());
+
+        _db.GetMemtableSize().Should().Be(22544);
+    }
+
+    [Test]
     public void SmokeTestDefaultColumn()
     {
         IDb defaultCol = _db.GetColumnDb(TestColumns.Default);

--- a/src/Nethermind/Nethermind.Db.Test/DbMetricsUpdaterTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/DbMetricsUpdaterTests.cs
@@ -1,11 +1,13 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.IO;
 using Nethermind.Db.Rocks.Statistics;
 using NUnit.Framework;
 using NSubstitute;
 using Nethermind.Logging;
+using RocksDbSharp;
 
 namespace Nethermind.Db.Test
 {
@@ -25,20 +27,38 @@ namespace Nethermind.Db.Test
             InterfaceLogger logger = Substitute.For<InterfaceLogger>();
 
             string testDump = File.ReadAllText(@"InputFiles/CompactionStatsExample_AllData.txt");
-            new DbMetricsUpdater("Test", null, null, null, null, new(logger)).ProcessCompactionStats(testDump);
+            new DbMetricsUpdater<DbOptions>("Test", null, null, null, null, new(logger)).ProcessCompactionStats(testDump);
+
+            var theStas = Metrics.DbStats;
+            Console.Out.WriteLine($"The stats {theStas}");
 
             Assert.That(Metrics.DbStats.Count, Is.EqualTo(11));
-            Assert.That(Metrics.DbStats["TestDbLevel0Files"], Is.EqualTo(2));
-            Assert.That(Metrics.DbStats["TestDbLevel0FilesCompacted"], Is.EqualTo(0));
-            Assert.That(Metrics.DbStats["TestDbLevel1Files"], Is.EqualTo(4));
-            Assert.That(Metrics.DbStats["TestDbLevel1FilesCompacted"], Is.EqualTo(2));
-            Assert.That(Metrics.DbStats["TestDbLevel2Files"], Is.EqualTo(3));
-            Assert.That(Metrics.DbStats["TestDbLevel2FilesCompacted"], Is.EqualTo(1));
-            Assert.That(Metrics.DbStats["TestDbIntervalCompactionGBWrite"], Is.EqualTo(10));
-            Assert.That(Metrics.DbStats["TestDbIntervalCompactionMBPerSecWrite"], Is.EqualTo(2));
-            Assert.That(Metrics.DbStats["TestDbIntervalCompactionGBRead"], Is.EqualTo(123));
-            Assert.That(Metrics.DbStats["TestDbIntervalCompactionMBPerSecRead"], Is.EqualTo(0));
-            Assert.That(Metrics.DbStats["TestDbIntervalCompactionSeconds"], Is.EqualTo(111));
+            Assert.That(Metrics.DbStats[("TestDb", "Level0Files")], Is.EqualTo(2));
+            Assert.That(Metrics.DbStats[("TestDb", "Level0FilesCompacted")], Is.EqualTo(0));
+            Assert.That(Metrics.DbStats[("TestDb", "Level1Files")], Is.EqualTo(4));
+            Assert.That(Metrics.DbStats[("TestDb", "Level1FilesCompacted")], Is.EqualTo(2));
+            Assert.That(Metrics.DbStats[("TestDb", "Level2Files")], Is.EqualTo(3));
+            Assert.That(Metrics.DbStats[("TestDb", "Level2FilesCompacted")], Is.EqualTo(1));
+            Assert.That(Metrics.DbStats[("TestDb", "IntervalCompactionGBWrite")], Is.EqualTo(10));
+            Assert.That(Metrics.DbStats[("TestDb", "IntervalCompactionMBPerSecWrite")], Is.EqualTo(2));
+            Assert.That(Metrics.DbStats[("TestDb", "IntervalCompactionGBRead")], Is.EqualTo(123));
+            Assert.That(Metrics.DbStats[("TestDb", "IntervalCompactionMBPerSecRead")], Is.EqualTo(0));
+            Assert.That(Metrics.DbStats[("TestDb", "IntervalCompactionSeconds")], Is.EqualTo(111));
+        }
+
+        [Test]
+        public void ProcessStats_AllDataExist()
+        {
+            InterfaceLogger logger = Substitute.For<InterfaceLogger>();
+
+            string testDump = File.ReadAllText(@"InputFiles/SampleStats.txt");
+            new DbMetricsUpdater<DbOptions>("Test", null, null, null, null, new(logger)).ProcessStatisticsString(testDump);
+
+            Assert.That(Metrics.DbStats[("TestDb", "rocksdb.prefetch.bytes")], Is.EqualTo(1));
+            Assert.That(Metrics.DbStats[("TestDb", "rocksdb.prefetch.bytes.useful")], Is.EqualTo(2));
+            Assert.That(Metrics.DbStats[("TestDb", "rocksdb.prefetch.hits")], Is.EqualTo(3));
+            Assert.That(Metrics.DbStats[("TestDb", "rocksdb.db.get.micros.count")], Is.EqualTo(4));
+            Assert.That(Metrics.DbStats[("TestDb", "rocksdb.db.get.micros.sum")], Is.EqualTo(5));
         }
 
         [Test]
@@ -47,14 +67,14 @@ namespace Nethermind.Db.Test
             InterfaceLogger logger = Substitute.For<InterfaceLogger>();
 
             string testDump = File.ReadAllText(@"InputFiles/CompactionStatsExample_MissingLevels.txt");
-            new DbMetricsUpdater("Test", null, null, null, null, new(logger)).ProcessCompactionStats(testDump);
+            new DbMetricsUpdater<DbOptions>("Test", null, null, null, null, new(logger)).ProcessCompactionStats(testDump);
 
             Assert.That(Metrics.DbStats.Count, Is.EqualTo(5));
-            Assert.That(Metrics.DbStats["TestDbIntervalCompactionGBWrite"], Is.EqualTo(10));
-            Assert.That(Metrics.DbStats["TestDbIntervalCompactionMBPerSecWrite"], Is.EqualTo(2));
-            Assert.That(Metrics.DbStats["TestDbIntervalCompactionGBRead"], Is.EqualTo(123));
-            Assert.That(Metrics.DbStats["TestDbIntervalCompactionMBPerSecRead"], Is.EqualTo(0));
-            Assert.That(Metrics.DbStats["TestDbIntervalCompactionSeconds"], Is.EqualTo(111));
+            Assert.That(Metrics.DbStats[("TestDb", "IntervalCompactionGBWrite")], Is.EqualTo(10));
+            Assert.That(Metrics.DbStats[("TestDb", "IntervalCompactionMBPerSecWrite")], Is.EqualTo(2));
+            Assert.That(Metrics.DbStats[("TestDb", "IntervalCompactionGBRead")], Is.EqualTo(123));
+            Assert.That(Metrics.DbStats[("TestDb", "IntervalCompactionMBPerSecRead")], Is.EqualTo(0));
+            Assert.That(Metrics.DbStats[("TestDb", "IntervalCompactionSeconds")], Is.EqualTo(111));
         }
 
         [Test]
@@ -64,15 +84,15 @@ namespace Nethermind.Db.Test
             logger.IsWarn.Returns(true);
 
             string testDump = File.ReadAllText(@"InputFiles/CompactionStatsExample_MissingIntervalCompaction.txt");
-            new DbMetricsUpdater("Test", null, null, null, null, new(logger)).ProcessCompactionStats(testDump);
+            new DbMetricsUpdater<DbOptions>("Test", null, null, null, null, new(logger)).ProcessCompactionStats(testDump);
 
             Assert.That(Metrics.DbStats.Count, Is.EqualTo(6));
-            Assert.That(Metrics.DbStats["TestDbLevel0Files"], Is.EqualTo(2));
-            Assert.That(Metrics.DbStats["TestDbLevel0FilesCompacted"], Is.EqualTo(0));
-            Assert.That(Metrics.DbStats["TestDbLevel1Files"], Is.EqualTo(4));
-            Assert.That(Metrics.DbStats["TestDbLevel1FilesCompacted"], Is.EqualTo(2));
-            Assert.That(Metrics.DbStats["TestDbLevel2Files"], Is.EqualTo(3));
-            Assert.That(Metrics.DbStats["TestDbLevel2FilesCompacted"], Is.EqualTo(1));
+            Assert.That(Metrics.DbStats[("TestDb", "Level0Files")], Is.EqualTo(2));
+            Assert.That(Metrics.DbStats[("TestDb", "Level0FilesCompacted")], Is.EqualTo(0));
+            Assert.That(Metrics.DbStats[("TestDb", "Level1Files")], Is.EqualTo(4));
+            Assert.That(Metrics.DbStats[("TestDb", "Level1FilesCompacted")], Is.EqualTo(2));
+            Assert.That(Metrics.DbStats[("TestDb", "Level2Files")], Is.EqualTo(3));
+            Assert.That(Metrics.DbStats[("TestDb", "Level2FilesCompacted")], Is.EqualTo(1));
 
             logger.Received().Warn(Arg.Is<string>(s => s.StartsWith("Cannot find 'Interval compaction' stats for Test database")));
         }
@@ -84,7 +104,7 @@ namespace Nethermind.Db.Test
             logger.IsWarn.Returns(true);
 
             string testDump = string.Empty;
-            new DbMetricsUpdater("Test", null, null, null, null, new(logger)).ProcessCompactionStats(testDump);
+            new DbMetricsUpdater<DbOptions>("Test", null, null, null, null, new(logger)).ProcessCompactionStats(testDump);
 
             Assert.That(Metrics.DbStats.Count, Is.EqualTo(0));
 
@@ -98,7 +118,7 @@ namespace Nethermind.Db.Test
             logger.IsWarn.Returns(true);
 
             string testDump = null;
-            new DbMetricsUpdater("Test", null, null, null, null, new(logger)).ProcessCompactionStats(testDump);
+            new DbMetricsUpdater<DbOptions>("Test", null, null, null, null, new(logger)).ProcessCompactionStats(testDump);
 
             Assert.That(Metrics.DbStats.Count, Is.EqualTo(0));
 

--- a/src/Nethermind/Nethermind.Db.Test/DbMetricsUpdaterTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/DbMetricsUpdaterTests.cs
@@ -29,9 +29,6 @@ namespace Nethermind.Db.Test
             string testDump = File.ReadAllText(@"InputFiles/CompactionStatsExample_AllData.txt");
             new DbMetricsUpdater<DbOptions>("Test", null, null, null, null, new(logger)).ProcessCompactionStats(testDump);
 
-            var theStas = Metrics.DbStats;
-            Console.Out.WriteLine($"The stats {theStas}");
-
             Assert.That(Metrics.DbStats.Count, Is.EqualTo(11));
             Assert.That(Metrics.DbStats[("TestDb", "Level0Files")], Is.EqualTo(2));
             Assert.That(Metrics.DbStats[("TestDb", "Level0FilesCompacted")], Is.EqualTo(0));

--- a/src/Nethermind/Nethermind.Db.Test/InputFiles/SampleStats.txt
+++ b/src/Nethermind/Nethermind.Db.Test/InputFiles/SampleStats.txt
@@ -1,0 +1,6 @@
+rocksdb.prefetch.bytes COUNT : 1
+rocksdb.prefetch.bytes.useful COUNT : 2
+rocksdb.prefetch.hits COUNT : 3
+rocksdb.db.get.micros P50 : 0.000000 P95 : 0.000000 P99 : 0.000000 P100 : 0.000000 COUNT : 4 SUM : 5
+rocksdb.db.write.micros P50 : 0.000000 P95 : 0.000000 P99 : 0.000000 P100 : 0.000000 COUNT : 0 SUM : 0
+rocksdb.subcompaction.setup.times.micros P50 : 0.000000 P95 : 0.000000 P99 : 0.000000 P100 : 0.000000 COUNT : 0 SUM : 0

--- a/src/Nethermind/Nethermind.Db.Test/Nethermind.Db.Test.csproj
+++ b/src/Nethermind/Nethermind.Db.Test/Nethermind.Db.Test.csproj
@@ -33,5 +33,8 @@
     <None Update="InputFiles\CompactionStatsExample_AllData.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="InputFiles\SampleStats.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/src/Nethermind/Nethermind.Db.Test/RocksDbSettingsTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/RocksDbSettingsTests.cs
@@ -15,8 +15,6 @@ namespace Nethermind.Db.Test
             DbSettings settings = new("name", "path")
             {
                 BlockCacheSize = 1,
-                UpdateReadMetrics = () => { },
-                UpdateWriteMetrics = () => { },
                 WriteBufferNumber = 5,
                 WriteBufferSize = 10,
                 CacheIndexAndFilterBlocks = true

--- a/src/Nethermind/Nethermind.Db/CompressingDb.cs
+++ b/src/Nethermind/Nethermind.Db/CompressingDb.cs
@@ -143,7 +143,7 @@ namespace Nethermind.Db
 
             public long GetSize() => _wrapped.GetSize();
 
-            public long GetCacheSize() => _wrapped.GetCacheSize();
+            public long GetCacheSize(bool includeCacheSize) => _wrapped.GetCacheSize(includeCacheSize);
 
             public long GetIndexSize() => _wrapped.GetIndexSize();
 

--- a/src/Nethermind/Nethermind.Db/CompressingDb.cs
+++ b/src/Nethermind/Nethermind.Db/CompressingDb.cs
@@ -141,13 +141,7 @@ namespace Nethermind.Db
 
             public void Clear() => _wrapped.Clear();
 
-            public long GetSize() => _wrapped.GetSize();
-
-            public long GetCacheSize(bool includeCacheSize) => _wrapped.GetCacheSize(includeCacheSize);
-
-            public long GetIndexSize() => _wrapped.GetIndexSize();
-
-            public long GetMemtableSize() => _wrapped.GetMemtableSize();
+            public IDbMeta.DbMetric GatherMetric(bool includeSharedCache = false) => _wrapped.GatherMetric(includeSharedCache);
 
             public void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None)
                 => _wrapped.Set(key, Compress(value), flags);

--- a/src/Nethermind/Nethermind.Db/DbProvider.cs
+++ b/src/Nethermind/Nethermind.Db/DbProvider.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
+using Nethermind.Core;
 
 namespace Nethermind.Db
 {
@@ -76,6 +77,19 @@ namespace Nethermind.Db
             }
 
             _registeredColumnDbs.TryAdd(dbName, db);
+        }
+
+        public IEnumerable<KeyValuePair<string, IDbMeta>> GetAllDbMeta()
+        {
+            foreach (KeyValuePair<string, IDb> kv in _registeredDbs)
+            {
+                yield return new KeyValuePair<string, IDbMeta>(kv.Key, kv.Value);
+            }
+
+            foreach (KeyValuePair<string, object> kv in _registeredColumnDbs)
+            {
+                yield return new KeyValuePair<string, IDbMeta>(kv.Key, (IDbMeta)kv.Value);
+            }
         }
     }
 }

--- a/src/Nethermind/Nethermind.Db/FullPruning/FullPruningDb.cs
+++ b/src/Nethermind/Nethermind.Db/FullPruning/FullPruningDb.cs
@@ -115,10 +115,10 @@ namespace Nethermind.Db.FullPruning
             _pruningContext?.CloningDb.Dispose();
         }
 
-        public long GetSize() => _currentDb.GetSize() + (_pruningContext?.CloningDb.GetSize() ?? 0);
-        public long GetCacheSize(bool includeSharedCache) => _currentDb.GetCacheSize(includeSharedCache) + (_pruningContext?.CloningDb.GetCacheSize() ?? 0);
-        public long GetIndexSize() => _currentDb.GetIndexSize() + (_pruningContext?.CloningDb.GetIndexSize() ?? 0);
-        public long GetMemtableSize() => _currentDb.GetMemtableSize() + (_pruningContext?.CloningDb.GetMemtableSize() ?? 0);
+        public IDbMeta.DbMetric GatherMetric(bool includeSharedCache = false)
+        {
+            return _currentDb.GatherMetric(includeSharedCache);
+        }
 
         public string Name => _settings.DbName;
 

--- a/src/Nethermind/Nethermind.Db/FullPruning/FullPruningDb.cs
+++ b/src/Nethermind/Nethermind.Db/FullPruning/FullPruningDb.cs
@@ -116,7 +116,7 @@ namespace Nethermind.Db.FullPruning
         }
 
         public long GetSize() => _currentDb.GetSize() + (_pruningContext?.CloningDb.GetSize() ?? 0);
-        public long GetCacheSize() => _currentDb.GetCacheSize() + (_pruningContext?.CloningDb.GetCacheSize() ?? 0);
+        public long GetCacheSize(bool includeSharedCache) => _currentDb.GetCacheSize(includeSharedCache) + (_pruningContext?.CloningDb.GetCacheSize() ?? 0);
         public long GetIndexSize() => _currentDb.GetIndexSize() + (_pruningContext?.CloningDb.GetIndexSize() ?? 0);
         public long GetMemtableSize() => _currentDb.GetMemtableSize() + (_pruningContext?.CloningDb.GetMemtableSize() ?? 0);
 

--- a/src/Nethermind/Nethermind.Db/IDb.cs
+++ b/src/Nethermind/Nethermind.Db/IDb.cs
@@ -21,13 +21,20 @@ namespace Nethermind.Db
     // Some metadata options
     public interface IDbMeta
     {
-        long GetSize() => 0;
-        long GetCacheSize(bool includeSharedCache = false) => 0;
-        long GetIndexSize() => 0;
-        long GetMemtableSize() => 0;
+        DbMetric GatherMetric(bool includeSharedCache = false) => new DbMetric();
 
         void Flush() { }
         void Clear() { }
         void Compact() { }
+
+        struct DbMetric
+        {
+            public long Size { get; init; }
+            public long CacheSize { get; init; }
+            public long IndexSize { get; init; }
+            public long MemtableSize { get; init; }
+            public long TotalReads { get; init; }
+            public long TotalWrites { get; init; }
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Db/IDb.cs
+++ b/src/Nethermind/Nethermind.Db/IDb.cs
@@ -22,7 +22,7 @@ namespace Nethermind.Db
     public interface IDbMeta
     {
         long GetSize() => 0;
-        long GetCacheSize() => 0;
+        long GetCacheSize(bool includeSharedCache = false) => 0;
         long GetIndexSize() => 0;
         long GetMemtableSize() => 0;
 

--- a/src/Nethermind/Nethermind.Db/IDbProvider.cs
+++ b/src/Nethermind/Nethermind.Db/IDbProvider.cs
@@ -34,5 +34,6 @@ namespace Nethermind.Db
 
         void RegisterDb<T>(string dbName, T db) where T : class, IDb;
         void RegisterColumnDb<T>(string dbName, IColumnsDb<T> db);
+        public IEnumerable<KeyValuePair<string, IDbMeta>> GetAllDbMeta();
     }
 }

--- a/src/Nethermind/Nethermind.Db/IDbProvider.cs
+++ b/src/Nethermind/Nethermind.Db/IDbProvider.cs
@@ -34,6 +34,6 @@ namespace Nethermind.Db
 
         void RegisterDb<T>(string dbName, T db) where T : class, IDb;
         void RegisterColumnDb<T>(string dbName, IColumnsDb<T> db);
-        public IEnumerable<KeyValuePair<string, IDbMeta>> GetAllDbMeta();
+        IEnumerable<KeyValuePair<string, IDbMeta>> GetAllDbMeta();
     }
 }

--- a/src/Nethermind/Nethermind.Db/MemDb.cs
+++ b/src/Nethermind/Nethermind.Db/MemDb.cs
@@ -103,7 +103,7 @@ namespace Nethermind.Db
         public int Count => _db.Count;
 
         public long GetSize() => 0;
-        public long GetCacheSize() => 0;
+        public long GetCacheSize(bool includeCacheSize) => 0;
         public long GetIndexSize() => 0;
         public long GetMemtableSize() => 0;
 

--- a/src/Nethermind/Nethermind.Db/Metrics.cs
+++ b/src/Nethermind/Nethermind.Db/Metrics.cs
@@ -11,71 +11,71 @@ namespace Nethermind.Db
     public static class Metrics
     {
         [CounterMetric]
-        [Description("Number of Bloom DB reads.")]
+        [Description("[DEPRECATED] Number of Bloom DB reads.")]
         public static long BloomDbReads { get; set; }
 
         [CounterMetric]
-        [Description("Number of Bloom DB writes.")]
+        [Description("[DEPRECATED] Number of Bloom DB writes.")]
         public static long BloomDbWrites { get; set; }
 
         [CounterMetric]
-        [Description("Number of CHT DB reads.")]
+        [Description("[DEPRECATED] Number of CHT DB reads.")]
         public static long CHTDbReads { get; set; }
 
         [CounterMetric]
-        [Description("Number of CHT DB writes.")]
+        [Description("[DEPRECATED] Number of CHT DB writes.")]
         public static long CHTDbWrites { get; set; }
 
         [CounterMetric]
-        [Description("Number of Blocks DB reads.")]
+        [Description("[DEPRECATED] Number of Blocks DB reads.")]
         public static long BlocksDbReads { get; set; }
 
         [CounterMetric]
-        [Description("Number of Blocks DB writes.")]
+        [Description("[DEPRECATED] Number of Blocks DB writes.")]
         public static long BlocksDbWrites { get; set; }
 
         [CounterMetric]
-        [Description("Number of Code DB cache reads.")]
+        [Description("[DEPRECATED] Number of Code DB cache reads.")]
         public static long CodeDbCache { get; set; }
 
         [CounterMetric]
-        [Description("Number of Code DB reads.")]
+        [Description("[DEPRECATED] Number of Code DB reads.")]
         public static long CodeDbReads { get; set; }
 
         [CounterMetric]
-        [Description("Number of Code DB writes.")]
+        [Description("[DEPRECATED] Number of Code DB writes.")]
         public static long CodeDbWrites { get; set; }
 
         [CounterMetric]
-        [Description("Number of Receipts DB reads.")]
+        [Description("[DEPRECATED] Number of Receipts DB reads.")]
         public static long ReceiptsDbReads { get; set; }
 
         [CounterMetric]
-        [Description("Number of Receipts DB writes.")]
+        [Description("[DEPRECATED] Number of Receipts DB writes.")]
         public static long ReceiptsDbWrites { get; set; }
 
         [CounterMetric]
-        [Description("Number of Block Infos DB reads.")]
+        [Description("[DEPRECATED] Number of Block Infos DB reads.")]
         public static long BlockInfosDbReads { get; set; }
 
         [CounterMetric]
-        [Description("Number of Block Infos DB writes.")]
+        [Description("[DEPRECATED] Number of Block Infos DB writes.")]
         public static long BlockInfosDbWrites { get; set; }
 
         [CounterMetric]
-        [Description("Number of State Trie reads.")]
+        [Description("[DEPRECATED] Number of State Trie reads.")]
         public static long StateTreeReads { get; set; }
 
         [CounterMetric]
-        [Description("Number of Blocks Trie writes.")]
+        [Description("[DEPRECATED] Number of Blocks Trie writes.")]
         public static long StateTreeWrites { get; set; }
 
         [CounterMetric]
-        [Description("Number of State DB reads.")]
+        [Description("[DEPRECATED] Number of State DB reads.")]
         public static long StateDbReads { get; set; }
 
         [CounterMetric]
-        [Description("Number of State DB writes.")]
+        [Description("[DEPRECATED] Number of State DB writes.")]
         public static long StateDbWrites { get; set; }
 
         [CounterMetric]
@@ -83,148 +83,158 @@ namespace Nethermind.Db
         public static int StateDbInPruningWrites;
 
         [CounterMetric]
-        [Description("Number of storage trie reads.")]
+        [Description("[DEPRECATED] Number of storage trie reads.")]
         public static long StorageTreeReads { get; set; }
 
         [CounterMetric]
-        [Description("Number of storage trie writes.")]
+        [Description("[DEPRECATED] Number of storage trie writes.")]
         public static long StorageTreeWrites { get; set; }
 
         [CounterMetric]
-        [Description("Number of other DB reads.")]
+        [Description("[DEPRECATED] Number of other DB reads.")]
         public static long OtherDbReads { get; set; }
 
         [CounterMetric]
-        [Description("Number of other DB writes.")]
+        [Description("[DEPRECATED] Number of other DB writes.")]
         public static long OtherDbWrites { get; set; }
 
         [CounterMetric]
-        [Description("Number of Headers DB reads.")]
+        [Description("[DEPRECATED] Number of Headers DB reads.")]
         public static long HeaderDbReads { get; set; }
 
         [CounterMetric]
-        [Description("Number of Headers DB writes.")]
+        [Description("[DEPRECATED] Number of Headers DB writes.")]
         public static long HeaderDbWrites { get; set; }
 
         [CounterMetric]
-        [Description("Number of BlockNumbers DB reads.")]
+        [Description("[DEPRECATED] Number of BlockNumbers DB reads.")]
         public static long BlockNumberDbReads { get; set; }
 
         [CounterMetric]
-        [Description("Number of BlockNumbers DB writes.")]
+        [Description("[DEPRECATED] Number of BlockNumbers DB writes.")]
         public static long BlockNumberDbWrites { get; set; }
 
         [CounterMetric]
-        [Description("Number of Witness DB reads.")]
+        [Description("[DEPRECATED] Number of Witness DB reads.")]
         public static long WitnessDbReads { get; set; }
 
         [CounterMetric]
-        [Description("Number of Witness DB writes.")]
+        [Description("[DEPRECATED] Number of Witness DB writes.")]
         public static long WitnessDbWrites { get; set; }
 
         [CounterMetric]
-        [Description("Number of Metadata DB reads.")]
+        [Description("[DEPRECATED] Number of Metadata DB reads.")]
         public static long MetadataDbReads { get; set; }
 
         [CounterMetric]
-        [Description("Number of Metadata DB writes.")]
+        [Description("[DEPRECATED] Number of Metadata DB writes.")]
         public static long MetadataDbWrites { get; set; }
 
         [CounterMetric]
-        [Description("Number of BadBlocks DB writes.")]
+        [Description("[DEPRECATED] Number of BadBlocks DB writes.")]
         public static long BadBlocksDbWrites { get; set; }
 
         [CounterMetric]
-        [Description("Number of BadBlocks DB reads.")]
+        [Description("[DEPRECATED] Number of BadBlocks DB reads.")]
         public static long BadBlocksDbReads { get; set; }
 
         [CounterMetric]
-        [Description("Number of BlobTransactions DB reads.")]
+        [Description("[DEPRECATED] Number of BlobTransactions DB reads.")]
         public static long BlobTransactionsDbReads { get; set; }
 
         [CounterMetric]
-        [Description("Number of BlobTransactions DB writes.")]
+        [Description("[DEPRECATED] Number of BlobTransactions DB writes.")]
         public static long BlobTransactionsDbWrites { get; set; }
 
         [GaugeMetric]
-        [Description("Indicator if StadeDb is being pruned.")]
+        [Description("[DEPRECATED] Indicator if StadeDb is being pruned.")]
         public static int StateDbPruning { get; set; }
 
         [GaugeMetric]
-        [Description("Size of state DB in bytes")]
+        [Description("[DEPRECATED] Size of state DB in bytes")]
         public static long StateDbSize { get; set; }
 
         [GaugeMetric]
-        [Description("Size of receipts DB in bytes")]
+        [Description("[DEPRECATED] Size of receipts DB in bytes")]
         public static long ReceiptsDbSize { get; set; }
 
         [GaugeMetric]
-        [Description("Size of headers DB in bytes")]
+        [Description("[DEPRECATED] Size of headers DB in bytes")]
         public static long HeadersDbSize { get; set; }
 
         [GaugeMetric]
-        [Description("Size of blocks DB in bytes")]
+        [Description("[DEPRECATED] Size of blocks DB in bytes")]
         public static long BlocksDbSize { get; set; }
 
         [GaugeMetric]
-        [Description("Size of bloom DB in bytes")]
+        [Description("[DEPRECATED] Size of bloom DB in bytes")]
         public static long BloomDbSize { get; set; }
 
         [GaugeMetric]
-        [Description("Size of code DB in bytes")]
+        [Description("[DEPRECATED] Size of code DB in bytes")]
         public static long CodeDbSize { get; set; }
 
         [GaugeMetric]
-        [Description("Size of blockInfos DB in bytes")]
+        [Description("[DEPRECATED] Size of blockInfos DB in bytes")]
         public static long BlockInfosDbSize { get; set; }
 
         [GaugeMetric]
-        [Description("Size of cht DB in bytes")]
+        [Description("[DEPRECATED] Size of cht DB in bytes")]
         public static long ChtDbSize { get; set; }
 
         [GaugeMetric]
-        [Description("Size of metadata DB in bytes")]
+        [Description("[DEPRECATED] Size of metadata DB in bytes")]
         public static long MetadataDbSize { get; set; }
 
         [GaugeMetric]
-        [Description("Size of witness DB in bytes")]
+        [Description("[DEPRECATED] Size of witness DB in bytes")]
         public static long WitnessDbSize { get; set; }
 
         [GaugeMetric]
-        [Description("Size of unmanaged memory for DB block caches in bytes")]
+        [Description("[DEPRECATED] Size of unmanaged memory for DB block caches in bytes")]
         public static long DbBlockCacheMemorySize { get; set; }
 
         [GaugeMetric]
-        [Description("Size of unmanaged memory for DB indexes and filters in bytes")]
+        [Description("[DEPRECATED] Size of unmanaged memory for DB indexes and filters in bytes")]
         public static long DbIndexFilterMemorySize { get; set; }
 
         [GaugeMetric]
-        [Description("Size of unmanaged memory for DB memtables in bytes")]
+        [Description("[DEPRECATED] Size of unmanaged memory for DB memtables in bytes")]
         public static long DbMemtableMemorySize { get; set; }
 
         [GaugeMetric]
-        [Description("Size of total unmanaged memory for DB in bytes")]
+        [Description("[DEPRECATED] Size of total unmanaged memory for DB in bytes")]
         public static long DbTotalMemorySize { get; set; }
+
+        [GaugeMetric]
+        [Description("Database reads per database")]
+        [KeyIsLabel("db")]
+        public static IDictionary<string, long> DbReads { get; set; } = new ConcurrentDictionary<string, long>();
+
+        [GaugeMetric]
+        [Description("Database writes per database")]
+        [KeyIsLabel("db")]
+        public static IDictionary<string, long> DbWrites { get; set; } = new ConcurrentDictionary<string, long>();
 
         [GaugeMetric]
         [Description("Database size per database")]
         [KeyIsLabel("db")]
-        public static IDictionary<string, double> DbSize { get; set; } = new ConcurrentDictionary<string, double>();
+        public static IDictionary<string, long> DbSize { get; set; } = new ConcurrentDictionary<string, long>();
 
         [GaugeMetric]
         [Description("Database memtable per database")]
         [KeyIsLabel("db")]
-        public static IDictionary<string, double> MemtableSize { get; set; } = new ConcurrentDictionary<string, double>();
+        public static IDictionary<string, long> MemtableSize { get; set; } = new ConcurrentDictionary<string, long>();
 
         [GaugeMetric]
         [Description("Database block cache size per database")]
         [KeyIsLabel("db")]
-        public static IDictionary<string, double> BlockCacheSize { get; set; } = new ConcurrentDictionary<string, double>();
+        public static IDictionary<string, long> BlockCacheSize { get; set; } = new ConcurrentDictionary<string, long>();
 
         [GaugeMetric]
         [Description("Database index and filter size per database")]
         [KeyIsLabel("db")]
-        public static IDictionary<string, double> IndexFilterSize { get; set; } = new ConcurrentDictionary<string, double>();
+        public static IDictionary<string, long> IndexFilterSize { get; set; } = new ConcurrentDictionary<string, long>();
 
         [Description("Metrics extracted from RocksDB Compaction Stats and DB Statistics")]
         [KeyIsLabel("db", "metric")]

--- a/src/Nethermind/Nethermind.Db/Metrics.cs
+++ b/src/Nethermind/Nethermind.Db/Metrics.cs
@@ -206,8 +206,28 @@ namespace Nethermind.Db
         [Description("Size of total unmanaged memory for DB in bytes")]
         public static long DbTotalMemorySize { get; set; }
 
+        [GaugeMetric]
+        [Description("Database size per database")]
+        [KeyIsLabel("db")]
+        public static IDictionary<string, double> DbSize { get; set; } = new ConcurrentDictionary<string, double>();
+
+        [GaugeMetric]
+        [Description("Database memtable per database")]
+        [KeyIsLabel("db")]
+        public static IDictionary<string, double> MemtableSize { get; set; } = new ConcurrentDictionary<string, double>();
+
+        [GaugeMetric]
+        [Description("Database block cache size per database")]
+        [KeyIsLabel("db")]
+        public static IDictionary<string, double> BlockCacheSize { get; set; } = new ConcurrentDictionary<string, double>();
+
+        [GaugeMetric]
+        [Description("Database index and filter size per database")]
+        [KeyIsLabel("db")]
+        public static IDictionary<string, double> IndexFilterSize { get; set; } = new ConcurrentDictionary<string, double>();
+
         [Description("Metrics extracted from RocksDB Compaction Stats and DB Statistics")]
-        [KeyIsLabel("dbName", "metric")]
+        [KeyIsLabel("db", "metric")]
         public static IDictionary<(string, string), double> DbStats { get; set; } = new ConcurrentDictionary<(string, string), double>();
     }
 }

--- a/src/Nethermind/Nethermind.Db/Metrics.cs
+++ b/src/Nethermind/Nethermind.Db/Metrics.cs
@@ -207,6 +207,7 @@ namespace Nethermind.Db
         public static long DbTotalMemorySize { get; set; }
 
         [Description("Metrics extracted from RocksDB Compaction Stats and DB Statistics")]
-        public static IDictionary<string, long> DbStats { get; set; } = new ConcurrentDictionary<string, long>();
+        [KeyIsLabel("dbName", "metric")]
+        public static IDictionary<(string, string), double> DbStats { get; set; } = new ConcurrentDictionary<(string, string), double>();
     }
 }

--- a/src/Nethermind/Nethermind.Db/Metrics.cs
+++ b/src/Nethermind/Nethermind.Db/Metrics.cs
@@ -224,17 +224,17 @@ namespace Nethermind.Db
         [GaugeMetric]
         [Description("Database memtable per database")]
         [KeyIsLabel("db")]
-        public static IDictionary<string, long> MemtableSize { get; set; } = new ConcurrentDictionary<string, long>();
+        public static IDictionary<string, long> DbMemtableSize { get; set; } = new ConcurrentDictionary<string, long>();
 
         [GaugeMetric]
         [Description("Database block cache size per database")]
         [KeyIsLabel("db")]
-        public static IDictionary<string, long> BlockCacheSize { get; set; } = new ConcurrentDictionary<string, long>();
+        public static IDictionary<string, long> DbBlockCacheSize { get; set; } = new ConcurrentDictionary<string, long>();
 
         [GaugeMetric]
         [Description("Database index and filter size per database")]
         [KeyIsLabel("db")]
-        public static IDictionary<string, long> IndexFilterSize { get; set; } = new ConcurrentDictionary<string, long>();
+        public static IDictionary<string, long> DbIndexFilterSize { get; set; } = new ConcurrentDictionary<string, long>();
 
         [Description("Metrics extracted from RocksDB Compaction Stats and DB Statistics")]
         [KeyIsLabel("db", "metric")]

--- a/src/Nethermind/Nethermind.Db/Metrics.cs
+++ b/src/Nethermind/Nethermind.Db/Metrics.cs
@@ -11,71 +11,71 @@ namespace Nethermind.Db
     public static class Metrics
     {
         [CounterMetric]
-        [Description("[DEPRECATED] Number of Bloom DB reads.")]
+        [Description("_Deprecated._ Number of Bloom DB reads.")]
         public static long BloomDbReads { get; set; }
 
         [CounterMetric]
-        [Description("[DEPRECATED] Number of Bloom DB writes.")]
+        [Description("_Deprecated._ Number of Bloom DB writes.")]
         public static long BloomDbWrites { get; set; }
 
         [CounterMetric]
-        [Description("[DEPRECATED] Number of CHT DB reads.")]
+        [Description("_Deprecated._ Number of CHT DB reads.")]
         public static long CHTDbReads { get; set; }
 
         [CounterMetric]
-        [Description("[DEPRECATED] Number of CHT DB writes.")]
+        [Description("_Deprecated._ Number of CHT DB writes.")]
         public static long CHTDbWrites { get; set; }
 
         [CounterMetric]
-        [Description("[DEPRECATED] Number of Blocks DB reads.")]
+        [Description("_Deprecated._ Number of Blocks DB reads.")]
         public static long BlocksDbReads { get; set; }
 
         [CounterMetric]
-        [Description("[DEPRECATED] Number of Blocks DB writes.")]
+        [Description("_Deprecated._ Number of Blocks DB writes.")]
         public static long BlocksDbWrites { get; set; }
 
         [CounterMetric]
-        [Description("[DEPRECATED] Number of Code DB cache reads.")]
+        [Description("_Deprecated._ Number of Code DB cache reads.")]
         public static long CodeDbCache { get; set; }
 
         [CounterMetric]
-        [Description("[DEPRECATED] Number of Code DB reads.")]
+        [Description("_Deprecated._ Number of Code DB reads.")]
         public static long CodeDbReads { get; set; }
 
         [CounterMetric]
-        [Description("[DEPRECATED] Number of Code DB writes.")]
+        [Description("_Deprecated._ Number of Code DB writes.")]
         public static long CodeDbWrites { get; set; }
 
         [CounterMetric]
-        [Description("[DEPRECATED] Number of Receipts DB reads.")]
+        [Description("_Deprecated._ Number of Receipts DB reads.")]
         public static long ReceiptsDbReads { get; set; }
 
         [CounterMetric]
-        [Description("[DEPRECATED] Number of Receipts DB writes.")]
+        [Description("_Deprecated._ Number of Receipts DB writes.")]
         public static long ReceiptsDbWrites { get; set; }
 
         [CounterMetric]
-        [Description("[DEPRECATED] Number of Block Infos DB reads.")]
+        [Description("_Deprecated._ Number of Block Infos DB reads.")]
         public static long BlockInfosDbReads { get; set; }
 
         [CounterMetric]
-        [Description("[DEPRECATED] Number of Block Infos DB writes.")]
+        [Description("_Deprecated._ Number of Block Infos DB writes.")]
         public static long BlockInfosDbWrites { get; set; }
 
         [CounterMetric]
-        [Description("[DEPRECATED] Number of State Trie reads.")]
+        [Description("_Deprecated._ Number of State Trie reads.")]
         public static long StateTreeReads { get; set; }
 
         [CounterMetric]
-        [Description("[DEPRECATED] Number of Blocks Trie writes.")]
+        [Description("_Deprecated._ Number of Blocks Trie writes.")]
         public static long StateTreeWrites { get; set; }
 
         [CounterMetric]
-        [Description("[DEPRECATED] Number of State DB reads.")]
+        [Description("_Deprecated._ Number of State DB reads.")]
         public static long StateDbReads { get; set; }
 
         [CounterMetric]
-        [Description("[DEPRECATED] Number of State DB writes.")]
+        [Description("_Deprecated._ Number of State DB writes.")]
         public static long StateDbWrites { get; set; }
 
         [CounterMetric]
@@ -83,127 +83,127 @@ namespace Nethermind.Db
         public static int StateDbInPruningWrites;
 
         [CounterMetric]
-        [Description("[DEPRECATED] Number of storage trie reads.")]
+        [Description("_Deprecated._ Number of storage trie reads.")]
         public static long StorageTreeReads { get; set; }
 
         [CounterMetric]
-        [Description("[DEPRECATED] Number of storage trie writes.")]
+        [Description("_Deprecated._ Number of storage trie writes.")]
         public static long StorageTreeWrites { get; set; }
 
         [CounterMetric]
-        [Description("[DEPRECATED] Number of other DB reads.")]
+        [Description("_Deprecated._ Number of other DB reads.")]
         public static long OtherDbReads { get; set; }
 
         [CounterMetric]
-        [Description("[DEPRECATED] Number of other DB writes.")]
+        [Description("_Deprecated._ Number of other DB writes.")]
         public static long OtherDbWrites { get; set; }
 
         [CounterMetric]
-        [Description("[DEPRECATED] Number of Headers DB reads.")]
+        [Description("_Deprecated._ Number of Headers DB reads.")]
         public static long HeaderDbReads { get; set; }
 
         [CounterMetric]
-        [Description("[DEPRECATED] Number of Headers DB writes.")]
+        [Description("_Deprecated._ Number of Headers DB writes.")]
         public static long HeaderDbWrites { get; set; }
 
         [CounterMetric]
-        [Description("[DEPRECATED] Number of BlockNumbers DB reads.")]
+        [Description("_Deprecated._ Number of BlockNumbers DB reads.")]
         public static long BlockNumberDbReads { get; set; }
 
         [CounterMetric]
-        [Description("[DEPRECATED] Number of BlockNumbers DB writes.")]
+        [Description("_Deprecated._ Number of BlockNumbers DB writes.")]
         public static long BlockNumberDbWrites { get; set; }
 
         [CounterMetric]
-        [Description("[DEPRECATED] Number of Witness DB reads.")]
+        [Description("_Deprecated._ Number of Witness DB reads.")]
         public static long WitnessDbReads { get; set; }
 
         [CounterMetric]
-        [Description("[DEPRECATED] Number of Witness DB writes.")]
+        [Description("_Deprecated._ Number of Witness DB writes.")]
         public static long WitnessDbWrites { get; set; }
 
         [CounterMetric]
-        [Description("[DEPRECATED] Number of Metadata DB reads.")]
+        [Description("_Deprecated._ Number of Metadata DB reads.")]
         public static long MetadataDbReads { get; set; }
 
         [CounterMetric]
-        [Description("[DEPRECATED] Number of Metadata DB writes.")]
+        [Description("_Deprecated._ Number of Metadata DB writes.")]
         public static long MetadataDbWrites { get; set; }
 
         [CounterMetric]
-        [Description("[DEPRECATED] Number of BadBlocks DB writes.")]
+        [Description("_Deprecated._ Number of BadBlocks DB writes.")]
         public static long BadBlocksDbWrites { get; set; }
 
         [CounterMetric]
-        [Description("[DEPRECATED] Number of BadBlocks DB reads.")]
+        [Description("_Deprecated._ Number of BadBlocks DB reads.")]
         public static long BadBlocksDbReads { get; set; }
 
         [CounterMetric]
-        [Description("[DEPRECATED] Number of BlobTransactions DB reads.")]
+        [Description("_Deprecated._ Number of BlobTransactions DB reads.")]
         public static long BlobTransactionsDbReads { get; set; }
 
         [CounterMetric]
-        [Description("[DEPRECATED] Number of BlobTransactions DB writes.")]
+        [Description("_Deprecated._ Number of BlobTransactions DB writes.")]
         public static long BlobTransactionsDbWrites { get; set; }
 
         [GaugeMetric]
-        [Description("[DEPRECATED] Indicator if StadeDb is being pruned.")]
+        [Description("_Deprecated._ Indicator if StadeDb is being pruned.")]
         public static int StateDbPruning { get; set; }
 
         [GaugeMetric]
-        [Description("[DEPRECATED] Size of state DB in bytes")]
+        [Description("_Deprecated._ Size of state DB in bytes")]
         public static long StateDbSize { get; set; }
 
         [GaugeMetric]
-        [Description("[DEPRECATED] Size of receipts DB in bytes")]
+        [Description("_Deprecated._ Size of receipts DB in bytes")]
         public static long ReceiptsDbSize { get; set; }
 
         [GaugeMetric]
-        [Description("[DEPRECATED] Size of headers DB in bytes")]
+        [Description("_Deprecated._ Size of headers DB in bytes")]
         public static long HeadersDbSize { get; set; }
 
         [GaugeMetric]
-        [Description("[DEPRECATED] Size of blocks DB in bytes")]
+        [Description("_Deprecated._ Size of blocks DB in bytes")]
         public static long BlocksDbSize { get; set; }
 
         [GaugeMetric]
-        [Description("[DEPRECATED] Size of bloom DB in bytes")]
+        [Description("_Deprecated._ Size of bloom DB in bytes")]
         public static long BloomDbSize { get; set; }
 
         [GaugeMetric]
-        [Description("[DEPRECATED] Size of code DB in bytes")]
+        [Description("_Deprecated._ Size of code DB in bytes")]
         public static long CodeDbSize { get; set; }
 
         [GaugeMetric]
-        [Description("[DEPRECATED] Size of blockInfos DB in bytes")]
+        [Description("_Deprecated._ Size of blockInfos DB in bytes")]
         public static long BlockInfosDbSize { get; set; }
 
         [GaugeMetric]
-        [Description("[DEPRECATED] Size of cht DB in bytes")]
+        [Description("_Deprecated._ Size of cht DB in bytes")]
         public static long ChtDbSize { get; set; }
 
         [GaugeMetric]
-        [Description("[DEPRECATED] Size of metadata DB in bytes")]
+        [Description("_Deprecated._ Size of metadata DB in bytes")]
         public static long MetadataDbSize { get; set; }
 
         [GaugeMetric]
-        [Description("[DEPRECATED] Size of witness DB in bytes")]
+        [Description("_Deprecated._ Size of witness DB in bytes")]
         public static long WitnessDbSize { get; set; }
 
         [GaugeMetric]
-        [Description("[DEPRECATED] Size of unmanaged memory for DB block caches in bytes")]
+        [Description("_Deprecated._ Size of unmanaged memory for DB block caches in bytes")]
         public static long DbBlockCacheMemorySize { get; set; }
 
         [GaugeMetric]
-        [Description("[DEPRECATED] Size of unmanaged memory for DB indexes and filters in bytes")]
+        [Description("_Deprecated._ Size of unmanaged memory for DB indexes and filters in bytes")]
         public static long DbIndexFilterMemorySize { get; set; }
 
         [GaugeMetric]
-        [Description("[DEPRECATED] Size of unmanaged memory for DB memtables in bytes")]
+        [Description("_Deprecated._ Size of unmanaged memory for DB memtables in bytes")]
         public static long DbMemtableMemorySize { get; set; }
 
         [GaugeMetric]
-        [Description("[DEPRECATED] Size of total unmanaged memory for DB in bytes")]
+        [Description("_Deprecated._ Size of total unmanaged memory for DB in bytes")]
         public static long DbTotalMemorySize { get; set; }
 
         [GaugeMetric]

--- a/src/Nethermind/Nethermind.Db/NullDb.cs
+++ b/src/Nethermind/Nethermind.Db/NullDb.cs
@@ -43,12 +43,6 @@ namespace Nethermind.Db
             return false;
         }
 
-        public long GetSize() => 0;
-        public long GetCacheSize(bool includeSharedCache) => 0;
-        public long GetIndexSize() => 0;
-        public long GetMemtableSize() => 0;
-
-        public IDb Innermost => this;
         public void Flush() { }
         public void Clear() { }
 

--- a/src/Nethermind/Nethermind.Db/NullDb.cs
+++ b/src/Nethermind/Nethermind.Db/NullDb.cs
@@ -44,7 +44,7 @@ namespace Nethermind.Db
         }
 
         public long GetSize() => 0;
-        public long GetCacheSize() => 0;
+        public long GetCacheSize(bool includeSharedCache) => 0;
         public long GetIndexSize() => 0;
         public long GetMemtableSize() => 0;
 

--- a/src/Nethermind/Nethermind.Db/ReadOnlyDb.cs
+++ b/src/Nethermind/Nethermind.Db/ReadOnlyDb.cs
@@ -73,7 +73,7 @@ namespace Nethermind.Db
         }
 
         public long GetSize() => _wrappedDb.GetSize();
-        public long GetCacheSize() => _wrappedDb.GetCacheSize();
+        public long GetCacheSize(bool includeSharedCache) => _wrappedDb.GetCacheSize(includeSharedCache);
         public long GetIndexSize() => _wrappedDb.GetIndexSize();
         public long GetMemtableSize() => _wrappedDb.GetMemtableSize();
 

--- a/src/Nethermind/Nethermind.Db/ReadOnlyDb.cs
+++ b/src/Nethermind/Nethermind.Db/ReadOnlyDb.cs
@@ -72,10 +72,7 @@ namespace Nethermind.Db
             return this.LikeABatch();
         }
 
-        public long GetSize() => _wrappedDb.GetSize();
-        public long GetCacheSize(bool includeSharedCache) => _wrappedDb.GetCacheSize(includeSharedCache);
-        public long GetIndexSize() => _wrappedDb.GetIndexSize();
-        public long GetMemtableSize() => _wrappedDb.GetMemtableSize();
+        public IDbMeta.DbMetric GatherMetric(bool includeSharedCache = false) => _wrappedDb.GatherMetric(includeSharedCache);
 
         public void Remove(ReadOnlySpan<byte> key) { }
 

--- a/src/Nethermind/Nethermind.Db/ReadOnlyDbProvider.cs
+++ b/src/Nethermind/Nethermind.Db/ReadOnlyDbProvider.cs
@@ -66,5 +66,10 @@ namespace Nethermind.Db
         {
             _wrappedProvider.RegisterColumnDb(dbName, db);
         }
+
+        public IEnumerable<KeyValuePair<string, IDbMeta>> GetAllDbMeta()
+        {
+            return _wrappedProvider.GetAllDbMeta();
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Db/RocksDbSettings.cs
+++ b/src/Nethermind/Nethermind.Db/RocksDbSettings.cs
@@ -16,9 +16,6 @@ namespace Nethermind.Db
         public string DbName { get; private set; }
         public string DbPath { get; private set; }
 
-        public Action? UpdateReadMetrics { get; init; }
-        public Action? UpdateWriteMetrics { get; init; }
-
         public ulong? WriteBufferSize { get; init; }
         public uint? WriteBufferNumber { get; init; }
         public ulong? BlockCacheSize { get; init; }

--- a/src/Nethermind/Nethermind.Db/SimpleFilePublicKeyDb.cs
+++ b/src/Nethermind/Nethermind.Db/SimpleFilePublicKeyDb.cs
@@ -85,12 +85,6 @@ namespace Nethermind.Db
             return _cache.ContainsKey(key);
         }
 
-        public long GetSize() => 0;
-        public long GetCacheSize(bool includeSharedCache) => 0;
-        public long GetIndexSize() => 0;
-        public long GetMemtableSize() => 0;
-
-        public IDb Innermost => this;
         public void Flush() { }
         public void Clear()
         {

--- a/src/Nethermind/Nethermind.Db/SimpleFilePublicKeyDb.cs
+++ b/src/Nethermind/Nethermind.Db/SimpleFilePublicKeyDb.cs
@@ -86,7 +86,7 @@ namespace Nethermind.Db
         }
 
         public long GetSize() => 0;
-        public long GetCacheSize() => 0;
+        public long GetCacheSize(bool includeSharedCache) => 0;
         public long GetIndexSize() => 0;
         public long GetMemtableSize() => 0;
 

--- a/src/Nethermind/Nethermind.Db/StandardDbInitializer.cs
+++ b/src/Nethermind/Nethermind.Db/StandardDbInitializer.cs
@@ -36,13 +36,13 @@ namespace Nethermind.Db
 
         private void RegisterAll(bool useReceiptsDb, bool useBlobsDb)
         {
-            RegisterDb(BuildDbSettings(DbNames.Blocks, () => Metrics.BlocksDbReads++, () => Metrics.BlocksDbWrites++));
-            RegisterDb(BuildDbSettings(DbNames.Headers, () => Metrics.HeaderDbReads++, () => Metrics.HeaderDbWrites++));
-            RegisterDb(BuildDbSettings(DbNames.BlockNumbers, () => Metrics.BlockNumberDbReads++, () => Metrics.BlockNumberDbWrites++));
-            RegisterDb(BuildDbSettings(DbNames.BlockInfos, () => Metrics.BlockInfosDbReads++, () => Metrics.BlockInfosDbWrites++));
-            RegisterDb(BuildDbSettings(DbNames.BadBlocks, () => Metrics.BadBlocksDbReads++, () => Metrics.BadBlocksDbWrites++));
+            RegisterDb(BuildDbSettings(DbNames.Blocks));
+            RegisterDb(BuildDbSettings(DbNames.Headers));
+            RegisterDb(BuildDbSettings(DbNames.BlockNumbers));
+            RegisterDb(BuildDbSettings(DbNames.BlockInfos));
+            RegisterDb(BuildDbSettings(DbNames.BadBlocks));
 
-            DbSettings stateDbSettings = BuildDbSettings(DbNames.State, () => Metrics.StateDbReads++, () => Metrics.StateDbWrites++);
+            DbSettings stateDbSettings = BuildDbSettings(DbNames.State);
             RegisterCustomDb(DbNames.State, () => new FullPruningDb(
                 stateDbSettings,
                 DbFactory is not MemDbFactory
@@ -50,31 +50,29 @@ namespace Nethermind.Db
                     : DbFactory,
                 () => Interlocked.Increment(ref Metrics.StateDbInPruningWrites)));
 
-            RegisterDb(BuildDbSettings(DbNames.Code, () => Metrics.CodeDbReads++, () => Metrics.CodeDbWrites++));
-            RegisterDb(BuildDbSettings(DbNames.Bloom, () => Metrics.BloomDbReads++, () => Metrics.BloomDbWrites++));
-            RegisterDb(BuildDbSettings(DbNames.CHT, () => Metrics.CHTDbReads++, () => Metrics.CHTDbWrites++));
-            RegisterDb(BuildDbSettings(DbNames.Witness, () => Metrics.WitnessDbReads++, () => Metrics.WitnessDbWrites++));
+            RegisterDb(BuildDbSettings(DbNames.Code));
+            RegisterDb(BuildDbSettings(DbNames.Bloom));
+            RegisterDb(BuildDbSettings(DbNames.CHT));
+            RegisterDb(BuildDbSettings(DbNames.Witness));
             if (useReceiptsDb)
             {
-                RegisterColumnsDb<ReceiptsColumns>(BuildDbSettings(DbNames.Receipts, () => Metrics.ReceiptsDbReads++, () => Metrics.ReceiptsDbWrites++));
+                RegisterColumnsDb<ReceiptsColumns>(BuildDbSettings(DbNames.Receipts));
             }
             else
             {
                 RegisterCustomColumnDb(DbNames.Receipts, () => new ReadOnlyColumnsDb<ReceiptsColumns>(new MemColumnsDb<ReceiptsColumns>(), false));
             }
-            RegisterDb(BuildDbSettings(DbNames.Metadata, () => Metrics.MetadataDbReads++, () => Metrics.MetadataDbWrites++));
+            RegisterDb(BuildDbSettings(DbNames.Metadata));
             if (useBlobsDb)
             {
-                RegisterColumnsDb<BlobTxsColumns>(BuildDbSettings(DbNames.BlobTransactions, () => Metrics.BlobTransactionsDbReads++, () => Metrics.BlobTransactionsDbWrites++));
+                RegisterColumnsDb<BlobTxsColumns>(BuildDbSettings(DbNames.BlobTransactions));
             }
         }
 
-        private static DbSettings BuildDbSettings(string dbName, Action updateReadsMetrics, Action updateWriteMetrics, bool deleteOnStart = false)
+        private static DbSettings BuildDbSettings(string dbName, bool deleteOnStart = false)
         {
             return new(GetTitleDbName(dbName), dbName)
             {
-                UpdateReadMetrics = updateReadsMetrics,
-                UpdateWriteMetrics = updateWriteMetrics,
                 DeleteOnStart = deleteOnStart
             };
         }

--- a/src/Nethermind/Nethermind.Init/Steps/StartMonitoring.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/StartMonitoring.cs
@@ -101,9 +101,9 @@ public class StartMonitoring : IStep
                     // Note: At the moment, the metric for a columns db is combined across column.
                     IDbMeta.DbMetric dbMetric = kv.Value.GatherMetric(includeSharedCache: kv.Key == DbNames.State); // Only include shared cache if state db
                     Db.Metrics.DbSize[kv.Key] = dbMetric.Size;
-                    Db.Metrics.BlockCacheSize[kv.Key] = dbMetric.CacheSize;
-                    Db.Metrics.MemtableSize[kv.Key] = dbMetric.MemtableSize;
-                    Db.Metrics.IndexFilterSize[kv.Key] = dbMetric.IndexSize;
+                    Db.Metrics.DbBlockCacheSize[kv.Key] = dbMetric.CacheSize;
+                    Db.Metrics.DbMemtableSize[kv.Key] = dbMetric.MemtableSize;
+                    Db.Metrics.DbIndexFilterSize[kv.Key] = dbMetric.IndexSize;
                     Db.Metrics.DbReads[kv.Key] = dbMetric.TotalReads;
                     Db.Metrics.DbWrites[kv.Key] = dbMetric.TotalWrites;
 

--- a/src/Nethermind/Nethermind.Init/Steps/StartMonitoring.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/StartMonitoring.cs
@@ -91,6 +91,15 @@ public class StartMonitoring : IStep
                     return;
                 }
 
+                foreach (KeyValuePair<string,IDbMeta> kv in dbProvider.GetAllDbMeta())
+                {
+                    Db.Metrics.DbSize[kv.Key] = kv.Value.GetSize();
+                    Db.Metrics.BlockCacheSize[kv.Key] = kv.Value.GetCacheSize(includeSharedCache: kv.Key == DbNames.State); // Only include shared cache if state db
+                    Db.Metrics.MemtableSize[kv.Key] = kv.Value.GetMemtableSize();
+                    Db.Metrics.IndexFilterSize[kv.Key] = kv.Value.GetIndexSize();
+                }
+
+                // Please don't use these anymore. Just use label...
                 Db.Metrics.StateDbSize = dbProvider.StateDb.GetSize();
                 Db.Metrics.ReceiptsDbSize = dbProvider.ReceiptsDb.GetSize();
                 Db.Metrics.HeadersDbSize = dbProvider.HeadersDb.GetSize();
@@ -138,6 +147,7 @@ public class StartMonitoring : IStep
                 Db.Metrics.DbTotalMemorySize = Db.Metrics.DbBlockCacheMemorySize
                                                 + Db.Metrics.DbIndexFilterMemorySize
                                                 + Db.Metrics.DbMemtableMemorySize;
+
             });
         }
 

--- a/src/Nethermind/Nethermind.Init/Steps/StartMonitoring.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/StartMonitoring.cs
@@ -102,17 +102,16 @@ public class StartMonitoring : IStep
                 Db.Metrics.MetadataDbSize = dbProvider.MetadataDb.GetSize();
                 Db.Metrics.WitnessDbSize = dbProvider.WitnessDb.GetSize();
 
-                Db.Metrics.DbBlockCacheMemorySize = dbProvider.StateDb.GetCacheSize()
-                                                    + dbProvider.BlockInfosDb.GetCacheSize()
-                                                    + dbProvider.HeadersDb.GetCacheSize()
-                                                    + dbProvider.BlocksDb.GetCacheSize()
-                                                    + dbProvider.ReceiptsDb.GetCacheSize();
-                // Share same cache with StateDb
-                // + dbProvider.ChtDb.GetCacheSize()
-                // + dbProvider.MetadataDb.GetCacheSize()
-                // + dbProvider.WitnessDb.GetCacheSize()
-                // + dbProvider.CodeDb.GetCacheSize()
-                // + dbProvider.BloomDb.GetCacheSize()
+                Db.Metrics.DbBlockCacheMemorySize = dbProvider.StateDb.GetCacheSize(includeSharedCache: true)
+                                                    + dbProvider.ReceiptsDb.GetIndexSize()
+                                                    + dbProvider.HeadersDb.GetIndexSize()
+                                                    + dbProvider.BlocksDb.GetIndexSize()
+                                                    + dbProvider.BloomDb.GetIndexSize()
+                                                    + dbProvider.CodeDb.GetIndexSize()
+                                                    + dbProvider.BlockInfosDb.GetIndexSize()
+                                                    + dbProvider.ChtDb.GetIndexSize()
+                                                    + dbProvider.MetadataDb.GetIndexSize()
+                                                    + dbProvider.WitnessDb.GetIndexSize();
 
                 Db.Metrics.DbIndexFilterMemorySize = dbProvider.StateDb.GetIndexSize()
                                                     + dbProvider.ReceiptsDb.GetIndexSize()

--- a/src/Nethermind/Nethermind.Init/Steps/StartMonitoring.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/StartMonitoring.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -134,7 +135,15 @@ public class StartMonitoring : IStep
                 IDbMeta.DbMetric chtDbMetric = dbProvider.ChtDb.GatherMetric();
                 IDbMeta.DbMetric metadataDbMetric = dbProvider.MetadataDb.GatherMetric();
                 IDbMeta.DbMetric witnessDbMetric = dbProvider.WitnessDb.GatherMetric();
-                IDbMeta.DbMetric blobTransactionDbMetric = dbProvider.BlobTransactionsDb.GatherMetric();
+                IDbMeta.DbMetric blobTransactionDbMetric = new IDbMeta.DbMetric();
+                try
+                {
+                    blobTransactionDbMetric = dbProvider.BlobTransactionsDb.GatherMetric();
+                }
+                catch (ArgumentException)
+                {
+                    // Sometime its not registered.
+                }
 
                 Db.Metrics.StateDbSize = stateDbMetric.Size;
                 Db.Metrics.StateDbReads = stateDbMetric.TotalReads;

--- a/src/Nethermind/Nethermind.Init/Steps/StartMonitoring.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/StartMonitoring.cs
@@ -91,63 +91,102 @@ public class StartMonitoring : IStep
                     return;
                 }
 
+                long totalBlockCacheMemorySize = 0;
+                long totalIndexAndFilterMemorySize = 0;
+                long totalMemtableMemorySize = 0;
+
                 foreach (KeyValuePair<string,IDbMeta> kv in dbProvider.GetAllDbMeta())
                 {
-                    Db.Metrics.DbSize[kv.Key] = kv.Value.GetSize();
-                    Db.Metrics.BlockCacheSize[kv.Key] = kv.Value.GetCacheSize(includeSharedCache: kv.Key == DbNames.State); // Only include shared cache if state db
-                    Db.Metrics.MemtableSize[kv.Key] = kv.Value.GetMemtableSize();
-                    Db.Metrics.IndexFilterSize[kv.Key] = kv.Value.GetIndexSize();
+                    // Note: At the moment, the metric for a columns db is combined across column.
+                    IDbMeta.DbMetric dbMetric = kv.Value.GatherMetric(includeSharedCache: kv.Key == DbNames.State); // Only include shared cache if state db
+                    Db.Metrics.DbSize[kv.Key] = dbMetric.Size;
+                    Db.Metrics.BlockCacheSize[kv.Key] = dbMetric.CacheSize;
+                    Db.Metrics.MemtableSize[kv.Key] = dbMetric.MemtableSize;
+                    Db.Metrics.IndexFilterSize[kv.Key] = dbMetric.IndexSize;
+                    Db.Metrics.DbReads[kv.Key] = dbMetric.TotalReads;
+                    Db.Metrics.DbWrites[kv.Key] = dbMetric.TotalWrites;
+
+                    totalBlockCacheMemorySize += dbMetric.CacheSize;
+                    totalIndexAndFilterMemorySize += dbMetric.IndexSize;
+                    totalMemtableMemorySize += dbMetric.MemtableSize;
                 }
 
-                // Please don't use these anymore. Just use label...
-                Db.Metrics.StateDbSize = dbProvider.StateDb.GetSize();
-                Db.Metrics.ReceiptsDbSize = dbProvider.ReceiptsDb.GetSize();
-                Db.Metrics.HeadersDbSize = dbProvider.HeadersDb.GetSize();
-                Db.Metrics.BlocksDbSize = dbProvider.BlocksDb.GetSize();
-                Db.Metrics.BloomDbSize = dbProvider.BloomDb.GetSize();
-                Db.Metrics.CodeDbSize = dbProvider.CodeDb.GetSize();
-                Db.Metrics.BlockInfosDbSize = dbProvider.BlockInfosDb.GetSize();
-                Db.Metrics.ChtDbSize = dbProvider.ChtDb.GetSize();
-                Db.Metrics.MetadataDbSize = dbProvider.MetadataDb.GetSize();
-                Db.Metrics.WitnessDbSize = dbProvider.WitnessDb.GetSize();
-
-                Db.Metrics.DbBlockCacheMemorySize = dbProvider.StateDb.GetCacheSize(includeSharedCache: true)
-                                                    + dbProvider.ReceiptsDb.GetIndexSize()
-                                                    + dbProvider.HeadersDb.GetIndexSize()
-                                                    + dbProvider.BlocksDb.GetIndexSize()
-                                                    + dbProvider.BloomDb.GetIndexSize()
-                                                    + dbProvider.CodeDb.GetIndexSize()
-                                                    + dbProvider.BlockInfosDb.GetIndexSize()
-                                                    + dbProvider.ChtDb.GetIndexSize()
-                                                    + dbProvider.MetadataDb.GetIndexSize()
-                                                    + dbProvider.WitnessDb.GetIndexSize();
-
-                Db.Metrics.DbIndexFilterMemorySize = dbProvider.StateDb.GetIndexSize()
-                                                    + dbProvider.ReceiptsDb.GetIndexSize()
-                                                    + dbProvider.HeadersDb.GetIndexSize()
-                                                    + dbProvider.BlocksDb.GetIndexSize()
-                                                    + dbProvider.BloomDb.GetIndexSize()
-                                                    + dbProvider.CodeDb.GetIndexSize()
-                                                    + dbProvider.BlockInfosDb.GetIndexSize()
-                                                    + dbProvider.ChtDb.GetIndexSize()
-                                                    + dbProvider.MetadataDb.GetIndexSize()
-                                                    + dbProvider.WitnessDb.GetIndexSize();
-
-                Db.Metrics.DbMemtableMemorySize = dbProvider.StateDb.GetMemtableSize()
-                                                    + dbProvider.ReceiptsDb.GetMemtableSize()
-                                                    + dbProvider.HeadersDb.GetMemtableSize()
-                                                    + dbProvider.BlocksDb.GetMemtableSize()
-                                                    + dbProvider.BloomDb.GetMemtableSize()
-                                                    + dbProvider.CodeDb.GetMemtableSize()
-                                                    + dbProvider.BlockInfosDb.GetMemtableSize()
-                                                    + dbProvider.ChtDb.GetMemtableSize()
-                                                    + dbProvider.MetadataDb.GetMemtableSize()
-                                                    + dbProvider.WitnessDb.GetMemtableSize();
-
+                // You dont need this, just use `sum` in prometheus, this is what happen when you don't use label.
+                Db.Metrics.DbBlockCacheMemorySize = totalBlockCacheMemorySize;
+                Db.Metrics.DbIndexFilterMemorySize = totalIndexAndFilterMemorySize;
+                Db.Metrics.DbMemtableMemorySize = totalMemtableMemorySize;
                 Db.Metrics.DbTotalMemorySize = Db.Metrics.DbBlockCacheMemorySize
                                                 + Db.Metrics.DbIndexFilterMemorySize
                                                 + Db.Metrics.DbMemtableMemorySize;
 
+
+                // Please don't use these anymore. Just use label... I'm just adding it here to not break existing dashboard.
+                // TODO: Remove this... please
+                IDbMeta.DbMetric stateDbMetric = dbProvider.StateDb.GatherMetric(includeSharedCache: true);
+                IDbMeta.DbMetric receiptDbMetric = dbProvider.ReceiptsDb.GatherMetric();
+                IDbMeta.DbMetric headerDbMetric = dbProvider.HeadersDb.GatherMetric();
+                IDbMeta.DbMetric blocksDbMetric = dbProvider.BlocksDb.GatherMetric();
+                IDbMeta.DbMetric blockNumberDbMetric = dbProvider.BlockNumbersDb.GatherMetric();
+                IDbMeta.DbMetric badBlockDbMetric = dbProvider.BadBlocksDb.GatherMetric();
+                IDbMeta.DbMetric bloomDbMetric = dbProvider.BloomDb.GatherMetric();
+                IDbMeta.DbMetric codeDbMetric = dbProvider.CodeDb.GatherMetric();
+                IDbMeta.DbMetric blockInfoDbMetric = dbProvider.BlockInfosDb.GatherMetric();
+                IDbMeta.DbMetric chtDbMetric = dbProvider.ChtDb.GatherMetric();
+                IDbMeta.DbMetric metadataDbMetric = dbProvider.MetadataDb.GatherMetric();
+                IDbMeta.DbMetric witnessDbMetric = dbProvider.WitnessDb.GatherMetric();
+                IDbMeta.DbMetric blobTransactionDbMetric = dbProvider.BlobTransactionsDb.GatherMetric();
+
+                Db.Metrics.StateDbSize = stateDbMetric.Size;
+                Db.Metrics.StateDbReads = stateDbMetric.TotalReads;
+                Db.Metrics.StateDbWrites = stateDbMetric.TotalWrites;
+
+                Db.Metrics.ReceiptsDbSize = receiptDbMetric.Size;
+                Db.Metrics.ReceiptsDbReads = receiptDbMetric.TotalReads;
+                Db.Metrics.ReceiptsDbWrites = receiptDbMetric.TotalWrites;
+
+                // Look at what just happen, one metric have `s`, two other dont. Just use label.
+                Db.Metrics.HeadersDbSize = headerDbMetric.Size;
+                Db.Metrics.HeaderDbReads = headerDbMetric.TotalReads;
+                Db.Metrics.HeaderDbWrites = headerDbMetric.TotalWrites;
+
+                Db.Metrics.BlocksDbSize = blocksDbMetric.Size;
+                Db.Metrics.BlocksDbReads = blocksDbMetric.TotalReads;
+                Db.Metrics.BlocksDbWrites = blocksDbMetric.TotalWrites;
+
+                // Guess what? this one does not have db size and stuff.
+                Db.Metrics.BlockNumberDbReads = blockNumberDbMetric.TotalReads;
+                Db.Metrics.BlockNumberDbReads = blockNumberDbMetric.TotalWrites;
+
+                Db.Metrics.BadBlocksDbReads = badBlockDbMetric.TotalReads;
+                Db.Metrics.BadBlocksDbWrites = badBlockDbMetric.TotalWrites;
+
+                Db.Metrics.BloomDbSize = bloomDbMetric.Size;
+                Db.Metrics.BloomDbReads = bloomDbMetric.TotalReads;
+                Db.Metrics.BloomDbWrites = bloomDbMetric.TotalWrites;
+
+                Db.Metrics.CodeDbSize = codeDbMetric.Size;
+                Db.Metrics.CodeDbReads = codeDbMetric.TotalReads;
+                Db.Metrics.CodeDbWrites = codeDbMetric.TotalWrites;
+
+                Db.Metrics.BlockInfosDbSize = blockInfoDbMetric.Size;
+                Db.Metrics.BlockInfosDbReads = blockInfoDbMetric.TotalReads;
+                Db.Metrics.BlockInfosDbWrites = blockInfoDbMetric.TotalWrites;
+
+                // Ooo look! One is capitalized differently. **snap a picture like in a zoo**
+                Db.Metrics.ChtDbSize = chtDbMetric.Size;
+                Db.Metrics.CHTDbReads = chtDbMetric.TotalReads;
+                Db.Metrics.CHTDbWrites = chtDbMetric.TotalWrites;
+
+                Db.Metrics.MetadataDbSize = metadataDbMetric.Size;
+                Db.Metrics.MetadataDbReads = metadataDbMetric.TotalReads;
+                Db.Metrics.MetadataDbWrites = metadataDbMetric.TotalWrites;
+
+                Db.Metrics.WitnessDbSize = witnessDbMetric.Size;
+                Db.Metrics.WitnessDbReads = witnessDbMetric.TotalReads;
+                Db.Metrics.WitnessDbReads = witnessDbMetric.TotalWrites;
+
+                Db.Metrics.BlobTransactionsDbReads = blobTransactionDbMetric.TotalReads;
+                Db.Metrics.BlobTransactionsDbWrites = blobTransactionDbMetric.TotalWrites;
             });
         }
 

--- a/src/Nethermind/Nethermind.Init/Steps/StartMonitoring.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/StartMonitoring.cs
@@ -95,7 +95,7 @@ public class StartMonitoring : IStep
                 long totalIndexAndFilterMemorySize = 0;
                 long totalMemtableMemorySize = 0;
 
-                foreach (KeyValuePair<string,IDbMeta> kv in dbProvider.GetAllDbMeta())
+                foreach (KeyValuePair<string, IDbMeta> kv in dbProvider.GetAllDbMeta())
                 {
                     // Note: At the moment, the metric for a columns db is combined across column.
                     IDbMeta.DbMetric dbMetric = kv.Value.GatherMetric(includeSharedCache: kv.Key == DbNames.State); // Only include shared cache if state db

--- a/src/Nethermind/Nethermind.Monitoring/Metrics/MetricsController.cs
+++ b/src/Nethermind/Nethermind.Monitoring/Metrics/MetricsController.cs
@@ -8,6 +8,7 @@ using System.ComponentModel;
 using System.Diagnostics.Metrics;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -36,7 +37,7 @@ namespace Nethermind.Monitoring.Metrics
         {
             internal MemberInfo MemberInfo;
             internal string DictionaryName;
-            internal string LabelName;
+            internal string[] LabelNames;
             internal string GaugeName;
             internal IDictionary Dictionary;
         }
@@ -63,8 +64,8 @@ namespace Nethermind.Monitoring.Metrics
 
             foreach (DictionaryMetricInfo info in _dictionaryCache[type])
             {
-                if (info.LabelName is null) continue; // Old behaviour creates new metric as it is created
-                _gauges[info.GaugeName] = CreateMemberInfoMetricsGauge(info.MemberInfo, info.LabelName);
+                if (info.LabelNames is null || info.LabelNames.Length == 0) continue; // Old behaviour creates new metric as it is created
+                _gauges[info.GaugeName] = CreateMemberInfoMetricsGauge(info.MemberInfo, info.LabelNames);
             }
         }
 
@@ -167,7 +168,7 @@ namespace Nethermind.Monitoring.Metrics
                     {
                         MemberInfo = p,
                         DictionaryName = p.Name,
-                        LabelName = p.GetCustomAttribute<KeyIsLabelAttribute>()?.LabelName,
+                        LabelNames = p.GetCustomAttribute<KeyIsLabelAttribute>()?.LabelNames,
                         GaugeName = GetGaugeNameKey(type.Name, p.Name),
                         Dictionary = (IDictionary)p.GetValue(null)
                     })
@@ -224,7 +225,7 @@ namespace Nethermind.Monitoring.Metrics
 
             foreach (DictionaryMetricInfo info in _dictionaryCache[type])
             {
-                if (info.LabelName is null)
+                if (info.LabelNames is null)
                 {
                     IDictionary dict = info.Dictionary;
                     // Its fine that the key here need to call `ToString()`. Better here then in the metrics, where it might
@@ -251,7 +252,20 @@ namespace Nethermind.Monitoring.Metrics
                     foreach (object key in dict.Keys)
                     {
                         double value = Convert.ToDouble(dict[key]);
-                        ReplaceValueIfChanged(value, gaugeName, key.ToString());
+                        if (key is ITuple keyAsTuple)
+                        {
+                            string[] labels = new string[keyAsTuple.Length];
+                            for (int i = 0; i < keyAsTuple.Length; i++)
+                            {
+                                labels[i] = keyAsTuple[i].ToString();
+                            }
+
+                            ReplaceValueIfChanged(value, gaugeName, labels);
+                        }
+                        else
+                        {
+                            ReplaceValueIfChanged(value, gaugeName, key.ToString());
+                        }
                     }
                 }
             }

--- a/src/Nethermind/Nethermind.Runner/Nethermind.Runner.csproj
+++ b/src/Nethermind/Nethermind.Runner/Nethermind.Runner.csproj
@@ -119,4 +119,8 @@
     </ItemGroup>
   </Target>
 
+  <PropertyGroup>
+    <NoWarn>$(NoWarn);AD0001</NoWarn>
+  </PropertyGroup>
+
 </Project>

--- a/src/Nethermind/Nethermind.Runner/Nethermind.Runner.csproj
+++ b/src/Nethermind/Nethermind.Runner/Nethermind.Runner.csproj
@@ -119,8 +119,4 @@
     </ItemGroup>
   </Target>
 
-  <PropertyGroup>
-    <NoWarn>$(NoWarn);AD0001</NoWarn>
-  </PropertyGroup>
-
 </Project>


### PR DESCRIPTION
Fixes #6574 

## Changes

- Exposes more rocksdb config and added comments on them. No config is actually changed.
- Change the estimate measurement for heavywrite tune from l0 file num to l0 layer size. No config actually changed, just how its calculated.
- Exposes rocksdb statistics as metrics. This metrics contain things such as cache hit, bloom usefulness, read bytes, blob file read bytes, etc... there is quite a lot in it actually. Of course, it is not served by default.
- Fix database size, cache size and other db size not working properly for column db.
- Fix column db not using same cache as main column in the same column db.
- Use label instead of separate metric for each separate db so that we don't miss db metric anymore.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)
- [X] New feature (a non-breaking change that adds functionality)
- [X] Refactoring

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Seems to work. 
- [X] Db block cache size
- [X] Db memtable size
- [X] Db index filter size
- [X] Db size
- [X] Db read
- [X] Db write

## Remarks

- Please use label. No need to sum at application level. Prometheus/grafana can sum by label, node, etcs.