### PR TITLE
HTTP/2 & HTTP/3 (Partial)

### DIFF
--- a/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
+++ b/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
@@ -57,6 +57,10 @@ namespace Nethermind.Runner.JsonRpc
             {
                 options.Limits.MaxRequestBodySize = jsonRpcConfig.MaxRequestBodySize;
                 options.ConfigureHttpsDefaults(co => co.SslProtocols |= SslProtocols.Tls13);
+                options.ConfigureEndpointDefaults(listenOptions =>
+                {
+                    listenOptions.Protocols = HttpProtocols.Http1AndHttp2AndHttp3;
+                });
             });
             Bootstrap.Instance.RegisterJsonRpcServices(services);
 
@@ -144,7 +148,7 @@ namespace Nethermind.Runner.JsonRpc
             {
                 if (ctx.Request.Method == "GET")
                 {
-                    await ctx.Response.WriteAsync("Nethermind JSON RPC");
+                    await ctx.Response.WriteAsync("Nethermind JSON RPC " + ctx.Request.Protocol);
                 }
 
                 if (ctx.Request.Method == "POST" &&


### PR DESCRIPTION
Contributes to #1934

## Changes

- Enables HTTP/2 & HTTP/3

Notes
- HTTP/2 & HTTP/3 also need http**s** set up which I don't think we have any docs on or easy way to setup)
- HTTP/3 on linux also needs install of `libmsquic`
- So sorta 😅

## Types of changes

#### What types of changes does your code introduce?

- [x] New feature (a non-breaking change that adds functionality)