### PR TITLE
Allow retrieving memory traces that are unconstrained in size

### DIFF
--- a/src/Nethermind/Nethermind.Evm/Tracing/TraceMemory.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/TraceMemory.cs
@@ -46,7 +46,7 @@ public readonly struct TraceMemory
     }
 
     private const int MemoryPadLimit = 1024 * 1024;
-    public ReadOnlySpan<byte> Slice(int start, int length)
+    public ReadOnlySpan<byte> Slice(int start, int length, bool limit = true)
     {
         ArgumentOutOfRangeException.ThrowIfNegative(start, nameof(start));
         ArgumentOutOfRangeException.ThrowIfNegative(length, nameof(length));
@@ -55,8 +55,11 @@ public readonly struct TraceMemory
 
         if (start + length > span.Length)
         {
-            int paddingNeeded = start + length - span.Length;
-            if (paddingNeeded > MemoryPadLimit) throw new InvalidOperationException($"reached limit for padding memory slice: {paddingNeeded}");
+            if (limit)
+            {
+                int paddingNeeded = start + length - span.Length;
+                if (paddingNeeded > MemoryPadLimit) throw new InvalidOperationException($"reached limit for padding memory slice: {paddingNeeded}");
+            }
             byte[] result = new byte[length];
             int overlap = span.Length - start;
             if (overlap > 0)


### PR DESCRIPTION
## Changes

Adds a `bool` parameter to `TraceMemory Slice()`, which is `true` by default.
If `true`, an exception is thrown if the `ReadOnlySpan<byte>` to be returned from the function exceeds `MemoryPadLimit`.
If `false`, no size constraint is imposed on the return value. This is useful for retrieving the *verbatim* memory contents.

## Types of changes

#### What types of changes does your code introduce?

- [x] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
