### PR TITLE
Perf/fetch blockheader from peer on FCU if block so that it start beacon header sync.

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Reactive.Subjects;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Api;

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Reactive.Subjects;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Api;
@@ -37,6 +38,7 @@ using Nethermind.Specs.ChainSpecStyle;
 using Nethermind.Specs.Forks;
 using Nethermind.State;
 using Nethermind.Synchronization.ParallelSync;
+using Nethermind.Synchronization.Peers;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -119,6 +121,7 @@ public partial class EngineModuleTests
                 chain.BeaconPivot,
                 peerRefresher,
                 chain.SpecProvider,
+                chain.SyncPeerPool,
                 chain.LogManager,
                 new BlocksConfig().SecondsPerSlot),
             new GetPayloadBodiesByHashV1Handler(chain.BlockTree, chain.LogManager),
@@ -146,6 +149,8 @@ public partial class EngineModuleTests
 
         public IWithdrawalProcessor? WithdrawalProcessor { get; set; }
 
+        public ISyncPeerPool SyncPeerPool { get; set; }
+
         protected int _blockProcessingThrottle = 0;
 
         public MergeTestBlockchain ThrottleBlockProcessor(int delayMs)
@@ -163,6 +168,7 @@ public partial class EngineModuleTests
             GenesisBlockBuilder = Core.Test.Builders.Build.A.Block.Genesis.Genesis.WithTimestamp(1UL);
             MergeConfig = mergeConfig ?? new MergeConfig() { TerminalTotalDifficulty = "0" };
             PayloadPreparationService = mockedPayloadPreparationService;
+            SyncPeerPool = Substitute.For<ISyncPeerPool>();
             LogManager = logManager ?? LogManager;
         }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Synchronization.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Synchronization.cs
@@ -118,7 +118,7 @@ public partial class EngineModuleTests
             .GetBlockHeaders(Arg.Any<Hash256>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(new BlockHeader[1] { block.Header }));
         SyncPeerAllocation alloc = new SyncPeerAllocation(new PeerInfo(syncPeer), AllocationContexts.All);
-        alloc.AllocateBestPeer(new []{new PeerInfo(syncPeer)}, Substitute.For<INodeStatsManager>(), Substitute.For<IBlockTree>());
+        alloc.AllocateBestPeer(new[] { new PeerInfo(syncPeer) }, Substitute.For<INodeStatsManager>(), Substitute.For<IBlockTree>());
         chain.SyncPeerPool
             .Allocate(
                 Arg.Any<IPeerAllocationStrategy>(),

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
@@ -121,6 +121,7 @@ public class ForkchoiceUpdatedHandler : IForkchoiceUpdatedHandler
 
             if (headBlockHeader == null)
             {
+                if (_logger.IsDebug) _logger.Debug($"Attempting to fetch header from peer: {simpleRequestStr}.");
                 headBlockHeader = await FetchHeaderFromPeer(forkchoiceState);
             }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Find;
+using Nethermind.Blockchain.Synchronization;
 using Nethermind.Consensus;
 using Nethermind.Consensus.Processing;
 using Nethermind.Consensus.Producers;
@@ -21,6 +22,8 @@ using Nethermind.Merge.Plugin.BlockProduction;
 using Nethermind.Merge.Plugin.Data;
 using Nethermind.Merge.Plugin.InvalidChainTracker;
 using Nethermind.Merge.Plugin.Synchronization;
+using Nethermind.Synchronization.Peers;
+using Nethermind.Synchronization.Peers.AllocationStrategies;
 
 namespace Nethermind.Merge.Plugin.Handlers;
 
@@ -48,6 +51,7 @@ public class ForkchoiceUpdatedHandler : IForkchoiceUpdatedHandler
     private readonly ISpecProvider _specProvider;
     private readonly bool _simulateBlockProduction;
     private readonly ulong _secondsPerSlot;
+    private readonly ISyncPeerPool _syncPeerPool;
 
     public ForkchoiceUpdatedHandler(
         IBlockTree blockTree,
@@ -61,6 +65,7 @@ public class ForkchoiceUpdatedHandler : IForkchoiceUpdatedHandler
         IBeaconPivot beaconPivot,
         IPeerRefresher peerRefresher,
         ISpecProvider specProvider,
+        ISyncPeerPool syncPeerPool,
         ILogManager logManager,
         ulong secondsPerSlot,
         bool simulateBlockProduction = false)
@@ -76,23 +81,23 @@ public class ForkchoiceUpdatedHandler : IForkchoiceUpdatedHandler
         _beaconPivot = beaconPivot;
         _peerRefresher = peerRefresher;
         _specProvider = specProvider;
+        _syncPeerPool = syncPeerPool;
         _simulateBlockProduction = simulateBlockProduction;
         _secondsPerSlot = secondsPerSlot;
         _logger = logManager.GetClassLogger();
     }
 
-    public Task<ResultWrapper<ForkchoiceUpdatedV1Result>> Handle(ForkchoiceStateV1 forkchoiceState, PayloadAttributes? payloadAttributes, int version)
+    public async Task<ResultWrapper<ForkchoiceUpdatedV1Result>> Handle(ForkchoiceStateV1 forkchoiceState, PayloadAttributes? payloadAttributes, int version)
     {
         Block? newHeadBlock = GetBlock(forkchoiceState.HeadBlockHash);
-        ResultWrapper<ForkchoiceUpdatedV1Result>? payloadUpdateResult = ApplyForkchoiceUpdate(newHeadBlock, forkchoiceState, payloadAttributes);
-        return Task.FromResult(
+        ResultWrapper<ForkchoiceUpdatedV1Result>? payloadUpdateResult = await ApplyForkchoiceUpdate(newHeadBlock, forkchoiceState, payloadAttributes);
+        return
             ValidateAttributes(payloadAttributes, version) ??
             payloadUpdateResult ??
-            StartBuildingPayload(newHeadBlock!, forkchoiceState, payloadAttributes)
-        );
+            StartBuildingPayload(newHeadBlock!, forkchoiceState, payloadAttributes);
     }
 
-    private ResultWrapper<ForkchoiceUpdatedV1Result>? ApplyForkchoiceUpdate(Block? newHeadBlock, ForkchoiceStateV1 forkchoiceState, PayloadAttributes? payloadAttributes)
+    private async Task<ResultWrapper<ForkchoiceUpdatedV1Result>?> ApplyForkchoiceUpdate(Block? newHeadBlock, ForkchoiceStateV1 forkchoiceState, PayloadAttributes? payloadAttributes)
     {
         using var handle = Thread.CurrentThread.BoostPriority();
 
@@ -107,15 +112,25 @@ public class ForkchoiceUpdatedHandler : IForkchoiceUpdatedHandler
             string simpleRequestStr = payloadAttributes is null ? forkchoiceState.ToString() : $"{forkchoiceState} {payloadAttributes}";
             if (_logger.IsInfo) _logger.Info($"Received {simpleRequestStr}");
 
+            BlockHeader? headBlockHeader = null;
+
             if (_blockCacheService.BlockCache.TryGetValue(forkchoiceState.HeadBlockHash, out Block? block))
             {
-                StartNewBeaconHeaderSync(forkchoiceState, block, $"{simpleRequestStr}");
-            }
-            else if (_logger.IsInfo)
-            {
-                _logger.Info($"Syncing Unknown ForkChoiceState head hash Request: {simpleRequestStr}.");
+                headBlockHeader = block.Header;
             }
 
+            if (headBlockHeader == null)
+            {
+                headBlockHeader = await FetchHeaderFromPeer(forkchoiceState);
+            }
+
+            if (headBlockHeader != null)
+            {
+                StartNewBeaconHeaderSync(forkchoiceState, headBlockHeader, simpleRequestStr);
+                return ForkchoiceUpdatedV1Result.Syncing;
+            }
+
+            if (_logger.IsInfo) _logger.Info($"Syncing Unknown ForkChoiceState head hash Request: {simpleRequestStr}.");
             return ForkchoiceUpdatedV1Result.Syncing;
         }
 
@@ -141,7 +156,7 @@ public class ForkchoiceUpdatedHandler : IForkchoiceUpdatedHandler
             {
                 if (_logger.IsInfo) _logger.Info($"Parent of block {newHeadBlock} not available. Starting new beacon header. sync.");
 
-                StartNewBeaconHeaderSync(forkchoiceState, newHeadBlock!, requestStr);
+                StartNewBeaconHeaderSync(forkchoiceState, newHeadBlock!.Header, requestStr);
 
                 return ForkchoiceUpdatedV1Result.Syncing;
             }
@@ -150,7 +165,7 @@ public class ForkchoiceUpdatedHandler : IForkchoiceUpdatedHandler
             {
                 if (_logger.IsInfo) _logger.Info("Force starting new sync.");
 
-                StartNewBeaconHeaderSync(forkchoiceState, newHeadBlock!, requestStr);
+                StartNewBeaconHeaderSync(forkchoiceState, newHeadBlock!.Header, requestStr);
 
                 return ForkchoiceUpdatedV1Result.Syncing;
             }
@@ -250,6 +265,29 @@ public class ForkchoiceUpdatedHandler : IForkchoiceUpdatedHandler
         return null;
     }
 
+    private async Task<BlockHeader?> FetchHeaderFromPeer(ForkchoiceStateV1 forkchoiceState)
+    {
+        using CancellationTokenSource cts = new CancellationTokenSource();
+        cts.CancelAfter(TimeSpan.FromSeconds(2));
+
+        BlockHeader[]? headers = null;
+        try
+        {
+            headers = await _syncPeerPool.AllocateAndRun(
+                peer => peer.GetBlockHeaders(forkchoiceState.HeadBlockHash, 1, 0, cts.Token),
+                BySpeedStrategy.FastestHeader,
+                AllocationContexts.Headers,
+                cts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            // Timeout or no peer.
+            return null;
+        }
+
+        return headers?.Length == 1 ? headers[0] : null;
+    }
+
     private ResultWrapper<ForkchoiceUpdatedV1Result> StartBuildingPayload(Block newHeadBlock, ForkchoiceStateV1 forkchoiceState, PayloadAttributes? payloadAttributes)
     {
         string? payloadId = null;
@@ -297,11 +335,11 @@ public class ForkchoiceUpdatedHandler : IForkchoiceUpdatedHandler
         };
     }
 
-    private void StartNewBeaconHeaderSync(ForkchoiceStateV1 forkchoiceState, Block block, string requestStr)
+    private void StartNewBeaconHeaderSync(ForkchoiceStateV1 forkchoiceState, BlockHeader blockHeader, string requestStr)
     {
-        _mergeSyncController.InitBeaconHeaderSync(block.Header);
-        _beaconPivot.ProcessDestination = block.Header;
-        _peerRefresher.RefreshPeers(block.Hash!, block.ParentHash!, forkchoiceState.FinalizedBlockHash);
+        _mergeSyncController.InitBeaconHeaderSync(blockHeader);
+        _beaconPivot.ProcessDestination = blockHeader;
+        _peerRefresher.RefreshPeers(blockHeader.Hash!, blockHeader.ParentHash!, forkchoiceState.FinalizedBlockHash);
         _blockCacheService.FinalizedHash = forkchoiceState.FinalizedBlockHash;
 
         if (_logger.IsInfo) _logger.Info($"Start a new sync process, Request: {requestStr}.");

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
@@ -336,6 +336,7 @@ public partial class MergePlugin : IConsensusWrapperPlugin, ISynchronizationPlug
                     _beaconPivot,
                     _peerRefresher,
                     _api.SpecProvider,
+                    _api.SyncPeerPool!,
                     _api.LogManager,
                     _api.Config<IBlocksConfig>().SecondsPerSlot,
                     _api.Config<IMergeConfig>().SimulateBlockProduction),

--- a/src/Nethermind/Nethermind.Optimism/OptimismPlugin.cs
+++ b/src/Nethermind/Nethermind.Optimism/OptimismPlugin.cs
@@ -241,6 +241,7 @@ public class OptimismPlugin : IConsensusPlugin, ISynchronizationPlugin, IInitial
                 _beaconPivot,
                 _peerRefresher,
                 _api.SpecProvider,
+                _api.SyncPeerPool!,
                 _api.LogManager,
                 _api.Config<IBlocksConfig>().SecondsPerSlot,
                 _api.Config<IMergeConfig>().SimulateBlockProduction),

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
@@ -43,7 +43,7 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                 IPeerAllocationStrategy peerAllocationStrategy,
                 AllocationContexts contexts,
                 int timeoutMilliseconds = 0,
-                CancellationToken? cancellationToken = null)
+                CancellationToken cancellationToken = default)
             {
                 await _peerSemaphore.WaitAsync();
                 ISyncPeer syncPeer = Substitute.For<ISyncPeer>();
@@ -55,12 +55,6 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                     Substitute.For<INodeStatsManager>(),
                     Substitute.For<IBlockTree>());
                 return allocation;
-            }
-
-            public Task<T> AllocateAndRun<T>(Func<ISyncPeer, Task<T>> func, IPeerAllocationStrategy peerAllocationStrategy, AllocationContexts allocationContexts,
-                CancellationToken cancellationToken)
-            {
-                throw new NotImplementedException();
             }
 
             public void Free(SyncPeerAllocation syncPeerAllocation)

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
@@ -39,7 +39,11 @@ namespace Nethermind.Synchronization.Test.ParallelSync
             {
             }
 
-            public async Task<SyncPeerAllocation> Allocate(IPeerAllocationStrategy peerAllocationStrategy, AllocationContexts contexts, int timeoutMilliseconds = 0)
+            public async Task<SyncPeerAllocation> Allocate(
+                IPeerAllocationStrategy peerAllocationStrategy,
+                AllocationContexts contexts,
+                int timeoutMilliseconds = 0,
+                CancellationToken? cancellationToken = null)
             {
                 await _peerSemaphore.WaitAsync();
                 ISyncPeer syncPeer = Substitute.For<ISyncPeer>();
@@ -51,6 +55,12 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                     Substitute.For<INodeStatsManager>(),
                     Substitute.For<IBlockTree>());
                 return allocation;
+            }
+
+            public Task<T> AllocateAndRun<T>(Func<ISyncPeer, Task<T>> func, IPeerAllocationStrategy peerAllocationStrategy, AllocationContexts allocationContexts,
+                CancellationToken cancellationToken)
+            {
+                throw new NotImplementedException();
             }
 
             public void Free(SyncPeerAllocation syncPeerAllocation)

--- a/src/Nethermind/Nethermind.Synchronization/Peers/AllocationStrategies/BySpeedStrategy.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/AllocationStrategies/BySpeedStrategy.cs
@@ -11,6 +11,8 @@ namespace Nethermind.Synchronization.Peers.AllocationStrategies
 {
     public class BySpeedStrategy : IPeerAllocationStrategy
     {
+        public static BySpeedStrategy FastestHeader = new BySpeedStrategy(TransferSpeedType.Headers, true);
+
         private readonly TransferSpeedType _speedType;
         private readonly bool _priority;
         private readonly decimal _minDiffPercentageForSpeedSwitch;

--- a/src/Nethermind/Nethermind.Synchronization/Peers/ISyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/ISyncPeerPool.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core.Crypto;
@@ -13,7 +14,17 @@ namespace Nethermind.Synchronization.Peers
 {
     public interface ISyncPeerPool : IDisposable
     {
-        Task<SyncPeerAllocation> Allocate(IPeerAllocationStrategy peerAllocationStrategy, AllocationContexts allocationContexts, int timeoutMilliseconds = 0);
+        Task<SyncPeerAllocation> Allocate(
+            IPeerAllocationStrategy peerAllocationStrategy,
+            AllocationContexts allocationContexts,
+            int timeoutMilliseconds = 0,
+            CancellationToken? cancellationToken = null);
+
+        Task<T> AllocateAndRun<T>(
+            Func<ISyncPeer, Task<T>> func,
+            IPeerAllocationStrategy peerAllocationStrategy,
+            AllocationContexts allocationContexts,
+            CancellationToken cancellationToken);
 
         void Free(SyncPeerAllocation syncPeerAllocation);
 

--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
@@ -318,13 +318,12 @@ namespace Nethermind.Synchronization.Peers
             IPeerAllocationStrategy peerAllocationStrategy,
             AllocationContexts allocationContexts = AllocationContexts.All,
             int timeoutMilliseconds = 0,
-            CancellationToken? cancellationToken = null)
+            CancellationToken cancellationToken = default)
         {
             int tryCount = 1;
             DateTime startTime = DateTime.UtcNow;
 
-            if (cancellationToken == null) cancellationToken = CancellationToken.None;
-            using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken.Value, _refreshLoopCancellation.Token);
+            using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _refreshLoopCancellation.Token);
 
             SyncPeerAllocation allocation = new(peerAllocationStrategy, allocationContexts);
             while (true)
@@ -348,20 +347,6 @@ namespace Nethermind.Synchronization.Peers
                         _signals.Reset(); // without this we have no delay
                     }
                 }
-            }
-        }
-
-        public async Task<T> AllocateAndRun<T>(Func<ISyncPeer, Task<T>> func, IPeerAllocationStrategy peerAllocationStrategy, AllocationContexts allocationContexts,
-            CancellationToken cancellationToken)
-        {
-            SyncPeerAllocation allocation = await Allocate(peerAllocationStrategy, allocationContexts, cancellationToken: cancellationToken);
-            try
-            {
-                return await func(allocation.Current!.SyncPeer);
-            }
-            finally
-            {
-                Free(allocation);
             }
         }
 


### PR DESCRIPTION
Address #6596 

- At least with lighthouse, after a long shutdown, it does not send new payload until it finishes catching up to head. It does send FCU however. 
- This means that Nethermind does not start catching up until lighthouse send new payload message.
- This changes that so that nethermind will attempt to get header from p2p if the block is not known allowing it to sart catching up.

#### Before
```
======================== Nethermind initialization completed ========================
This node    : enode://290dabe192600a6a939ef463258325e58e577291542684eb96cc0cde4d4dc4470e90c9433693bd2727936bfbaa0aa2bf216478f92e0bcf90cd25c61893dabdd7@45.133.181.46:30303
RPC modules  : Admin
Node address : 0x6f1e3c3464737eec2a548476a755f6cad5023d4e (do not use as an account)
Mem est tx   :    82 MB
Mem est DB   :     5 MB
JSON RPC     : http://127.0.0.1:8545 ; http://localhost:8551
Genesis hash : 0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3
External IP  : 45.133.181.46
Ethereum     : tcp://45.133.181.46:30303
Discovery    : udp://45.133.181.46:30303
Client id    : Nethermind/v1.26.0-unstable+0f627b59/linux-x64/dotnet8.0.0
Chainspec    : chainspec/foundation.json
Chain head   : 19132943 (0xb2322a...8d0017)
Chain ID     : Mainnet
===================================================================================== 
2024-02-02 17:27:51.4426|INFO|Merge.Plugin.Handlers.ForkchoiceUpdatedHandler|207|Syncing, Block 0x11e58f468460027536349b4a4d2feb229807d492ebd77e0974c2c2a3eee1c454 not found. 
2024-02-02 17:27:51.4442|INFO|Merge.Plugin.Handlers.ForkchoiceUpdatedHandler|207|Received ForkChoice: 0x11e58f...e1c454, Safe: 0x47520b...207eb0, Finalized: 0xf3ee8c...7a5d89 
2024-02-02 17:27:51.4456|INFO|Merge.Plugin.Handlers.ForkchoiceUpdatedHandler|22|Syncing Unknown ForkChoiceState head hash Request: ForkChoice: 0x11e58f...e1c454, Safe: 0x47520b...207eb0, Finalized: 0xf3ee8c...7a5d89. 
2024-02-02 17:27:51.4456|INFO|Merge.Plugin.Handlers.ForkchoiceUpdatedHandler|196|Syncing, Block 0x11e58f468460027536349b4a4d2feb229807d492ebd77e0974c2c2a3eee1c454 not found. 
2024-02-02 17:27:51.4456|INFO|Merge.Plugin.Handlers.ForkchoiceUpdatedHandler|196|Received ForkChoice: 0x11e58f...e1c454, Safe: 0x47520b...207eb0, Finalized: 0xf3ee8c...7a5d89 
# it waits until CL catches up near to head
2024-02-02 17:43:23.9696|INFO|Merge.Plugin.Handlers.ForkchoiceUpdatedHandler|235|Received ForkChoice: 0x727b45...45710f, Safe: 0x16bfb9...0887d3, Finalized: 0x96a68a...8b533d 
2024-02-02 17:43:23.9708|INFO|Merge.Plugin.Handlers.ForkchoiceUpdatedHandler|207|Syncing Unknown ForkChoiceState head hash Request: ForkChoice: 0x727b45...45710f, Safe: 0x16bfb9...0887d3, Finalized: 0x96a68a...8b533d. 
2024-02-02 17:43:33.3438|INFO|Merge.Plugin.Handlers.ForkchoiceUpdatedHandler|22|Syncing, Block 0x160fa2707fa64b1998dfe5a9ca683ec165dbd94ef74631555fe58b7ccad44bda not found. 
2024-02-02 17:43:33.3438|INFO|Merge.Plugin.Handlers.ForkchoiceUpdatedHandler|22|Received ForkChoice: 0x160fa2...d44bda, Safe: 0xe99a4b...d0af30, Finalized: 0x727b45...45710f 
2024-02-02 17:43:33.3449|INFO|Merge.Plugin.Handlers.ForkchoiceUpdatedHandler|213|Syncing Unknown ForkChoiceState head hash Request: ForkChoice: 0x160fa2...d44bda, Safe: 0xe99a4b...d0af30, Finalized: 0x727b45...45710f. 
# CL finally send some new payload
2024-02-02 17:43:37.9346|INFO|Merge.Plugin.Handlers.NewPayloadHandler|22|Received New Block:  19139845 (0xb8c135...138379) 
2024-02-02 17:43:37.9365|INFO|Merge.Plugin.Handlers.NewPayloadHandler|22|Insert block into cache without parent 19139845 (0xb8c135...138379) 
2024-02-02 17:43:38.0005|INFO|Merge.Plugin.Handlers.NewPayloadHandler|22|Received New Block:  19139846 (0x88d3b5...dde5a5) 
2024-02-02 17:43:43.0350|INFO|Merge.Plugin.Handlers.NewPayloadHandler|211|Insert block into cache without parent 19139892 (0xd71372...8269f4) 
2024-02-02 17:43:43.1116|INFO|Merge.Plugin.Handlers.NewPayloadHandler|218|Received New Block:  19139893 (0x9e7923...94474e) 
2024-02-02 17:43:43.1128|INFO|Merge.Plugin.Handlers.NewPayloadHandler|218|Insert block into cache without parent 19139893 (0x9e7923...94474e) 
2024-02-02 17:43:44.0708|INFO|Merge.Plugin.Handlers.ForkchoiceUpdatedHandler|220|Syncing, Block 0x9e7923a860574769358188f71ec44fe945872d6456c30bea4aeffd0eae94474e not found. 
2024-02-02 17:43:44.0708|INFO|Merge.Plugin.Handlers.ForkchoiceUpdatedHandler|220|Received ForkChoice: 0x9e7923...94474e, Safe: 0x160fa2...d44bda, Finalized: 0xe99a4b...d0af30 
2024-02-02 17:43:44.0730|INFO|Merge.Plugin.Synchronization.BeaconPivot|220|New beacon pivot: 19139893 (0x9e7923a860574769358188f71ec44fe945872d6456c30bea4aeffd0eae94474e) 
2024-02-02 17:43:44.0776|INFO|Merge.Plugin.Handlers.ForkchoiceUpdatedHandler|220|Start a new sync process, Request: ForkChoice: 0x9e7923...94474e, Safe: 0x160fa2...d44bda, Finalized: 0xe99a4b...d0af30. 
# And now we start processing block
2024-02-02 17:44:08.2524|INFO|Consensus.Processing.BlockchainProcessor|29|Processed    19133005... 19133010 |    933.85 ms  |  slot    1,022,480 ms |⛽ Gas gwei: 18.02 .. 18.21 (19.70) .. 51.71 
2024-02-02 17:44:08.2524|INFO|Consensus.Processing.BlockchainProcessor|29|- Blocks 6           87.17 MGas   |  1,139    txs |  calls  4,417 (179) | sload  14,004 | sstore  4,047 | create   6 
2024-02-02 17:44:08.2524|INFO|Consensus.Processing.BlockchainProcessor|29|- Block throughput   93.35 MGas/s |   1219.68 t/s |          6.42 Blk/s | recv        0 | proc       30 
# After some time NOW it catches up to head
2024-02-02 17:58:36.3142|INFO|Consensus.Processing.BlockchainProcessor|29|Processed            19139968     |    124.03 ms  |  slot      5,607 ms |⛽ Gas gwei: 26.69 .. 26.76 (29.79) .. 116.69 
2024-02-02 17:58:36.3142|INFO|Consensus.Processing.BlockchainProcessor|29|- Block              13.99 MGas   |    154    txs |  calls    637 ( 16) | sload   2,059 | sstore    598 | create   2( -1) 
2024-02-02 17:58:36.3142|INFO|Consensus.Processing.BlockchainProcessor|29|- Block throughput  112.76 MGas/s |   1241.65 t/s |          8.06 Blk/s | recv        0 | proc        0 
2024-02-02 17:58:36.3169|INFO|Merge.Plugin.Handlers.ForkchoiceUpdatedHandler|21|Received ForkChoice: 19139967 (0x4798ae...1f08cf), Safe: 19139906 (0x0f9c8e...e92b03), Finalized: 19139875 (0xb79050...af72f8) 
2024-02-02 17:58:36.4317|INFO|Merge.Plugin.Handlers.ForkchoiceUpdatedHandler|21|Synced Chain Head to 19139968 (0xc98e12...94043b) 
2024-02-02 17:58:46.5158|INFO|Merge.Plugin.Handlers.ForkchoiceUpdatedHandler|250|Received ForkChoice: 19139968 (0xc98e12...94043b), Safe: 19139938 (0x4bd3e3...f1c516), Finalized: 19139906 (0x0f9c8e...e92b03) 
2024-02-02 17:58:49.3558|INFO|Merge.Plugin.Handlers.NewPayloadHandler|10|Received New Block:  19139969 (0xe60f96...dfb901) 
2024-02-02 17:58:49.4341|INFO|Consensus.Processing.BlockchainProcessor|29|Processed            19139969     |     75.05 ms  |  slot     13,120 ms |⛽ Gas gwei: 26.47 .. 26.51 (28.44) .. 54.03 
2024-02-02 17:58:49.4341|INFO|Consensus.Processing.BlockchainProcessor|29|- Block              13.05 MGas   |    133    txs |  calls    687 ( 25) | sload   1,992 | sstore    706 | create   0 
2024-02-02 17:58:49.4341|INFO|Consensus.Processing.BlockchainProcessor|29|- Block throughput  173.84 MGas/s |   1772.22 t/s |         13.32 Blk/s | recv        0 | proc        0 
2024-02-02 17:58:50.7495|INFO|Merge.Plugin.Handlers.ForkchoiceUpdatedHandler|218|Received ForkChoice: 19139969 (0xe60f96...dfb901), Safe: 19139938 (0x4bd3e3...f1c516), Finalized: 19139906 (0x0f9c8e...e92b03) 
2024-02-02 17:58:50.7511|INFO|Merge.Plugin.Handlers.ForkchoiceUpdatedHandler|218|Synced Chain Head to 19139969 (0xe60f96...dfb901) 
2024-02-02 17:59:00.8616|INFO|Merge.Plugin.Handlers.NewPayloadHandler|17|Received New Block:  19139970 (0x035555...56ec36) 
2024-02-02 17:59:00.9592|INFO|Consensus.Processing.BlockchainProcessor|29|Processed            19139970     |     94.47 ms  |  slot     11,525 ms |⛽ Gas gwei: 26.04 .. 26.04 (29.86) .. 127.04 
2024-02-02 17:59:00.9592|INFO|Consensus.Processing.BlockchainProcessor|29|- Block              12.81 MGas   |    149    txs |  calls    792 ( 12) | sload   2,410 | sstore    705 | create   1 
2024-02-02 17:59:00.9592|INFO|Consensus.Processing.BlockchainProcessor|29|- Block throughput  135.59 MGas/s |   1577.22 t/s |         10.59 Blk/s | recv        0 | proc        0 

```

### After

```
======================== Nethermind initialization completed ========================
This node    : enode://290dabe192600a6a939ef463258325e58e577291542684eb96cc0cde4d4dc4470e90c9433693bd2727936bfbaa0aa2bf216478f92e0bcf90cd25c61893dabdd7@45.133.181.46:30303
RPC modules  : Admin
Node address : 0x6f1e3c3464737eec2a548476a755f6cad5023d4e (do not use as an account)
Mem est tx   :    82 MB
Mem est DB   :     2 MB
JSON RPC     : http://127.0.0.1:8545 ; http://localhost:8551
Genesis hash : 0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3
External IP  : 45.133.181.46
Ethereum     : tcp://45.133.181.46:30303
Discovery    : udp://45.133.181.46:30303
Client id    : Nethermind/v1.26.0-unstable+0f627b59/linux-x64/dotnet8.0.0
Chainspec    : chainspec/foundation.json
Chain head   : 19132943 (0xb2322a...8d0017)
Chain ID     : Mainnet
===================================================================================== 
2024-02-02 18:01:21.3963|INFO|Merge.Plugin.Handlers.ForkchoiceUpdatedHandler|203|Syncing, Block 0x11e58f468460027536349b4a4d2feb229807d492ebd77e0974c2c2a3eee1c454 not found. 
2024-02-02 18:01:21.3985|INFO|Merge.Plugin.Handlers.ForkchoiceUpdatedHandler|203|Received ForkChoice: 0x11e58f...e1c454, Safe: 0x47520b...207eb0, Finalized: 0xf3ee8c...7a5d89 
2024-02-02 18:01:21.3985|WARN|Merge.Plugin.Handlers.ForkchoiceUpdatedHandler|203|Attempting to fetch header from peer: ForkChoice: 0x11e58f...e1c454, Safe: 0x47520b...207eb0, Finalized: 0xf3ee8c...7a5d89. 
2024-02-02 18:01:21.4048|WARN|Merge.Plugin.Handlers.ForkchoiceUpdatedHandler|20|Got header: 19134276. 
2024-02-02 18:01:21.4065|INFO|Merge.Plugin.Synchronization.BeaconPivot|20|New beacon pivot: 19134276 (0x11e58f468460027536349b4a4d2feb229807d492ebd77e0974c2c2a3eee1c454) 
2024-02-02 18:01:21.4094|INFO|Merge.Plugin.Handlers.ForkchoiceUpdatedHandler|20|Start a new sync process, Request: ForkChoice: 0x11e58f...e1c454, Safe: 0x47520b...207eb0, Finalized: 0xf3ee8c...7a5d89. 
2024-02-02 18:01:21.4101|INFO|Merge.Plugin.Handlers.ForkchoiceUpdatedHandler|16|Syncing, Block 0x11e58f468460027536349b4a4d2feb229807d492ebd77e0974c2c2a3eee1c454 not found. 
2024-02-02 18:01:21.4101|INFO|Merge.Plugin.Handlers.ForkchoiceUpdatedHandler|16|Received ForkChoice: 0x11e58f...e1c454, Safe: 0x47520b...207eb0, Finalized: 0xf3ee8c...7a5d89 
2024-02-02 18:01:21.4101|WARN|Merge.Plugin.Handlers.ForkchoiceUpdatedHandler|16|Attempting to fetch header from peer: ForkChoice: 0x11e58f...e1c454, Safe: 0x47520b...207eb0, Finalized: 0xf3ee8c...7a5d89. 
2024-02-02 18:01:21.4107|WARN|Merge.Plugin.Handlers.ForkchoiceUpdatedHandler|16|Got header: 19134276. 
# It started header sync without having a newpayload before it.
2024-02-02 18:01:21.4107|INFO|Merge.Plugin.Handlers.ForkchoiceUpdatedHandler|16|Start a new sync process, Request: ForkChoice: 0x11e58f...e1c454, Safe: 0x47520b...207eb0, Finalized: 0xf3ee8c...7a5d89. 
2024-02-02 18:01:21.8950|INFO|Synchronization.ParallelSync.MultiSyncModeSelector|20|Changing state WaitingForBlock to BeaconHeaders at processed: 19133009 | state: 19133009 | block: 19133009 | header: 19133009 | target block: 19134276 | peer block: 19139981 
2024-02-02 18:01:21.8950|INFO|Synchronization.Reporting.SyncReport|20|Sync mode changed from WaitingForBlock to BeaconHeaders 
2024-02-02 18:01:21.8967|INFO|Merge.Plugin.Synchronization.BeaconHeadersSyncFeed|20|Initialized beacon headers sync. lowestRequestedHeaderNumber: 19134276,lowestInsertedBlockHeader: 19134276 (0x11e58f468460027536349b4a4d2feb229807d492ebd77e0974c2c2a3eee1c454), pivotNumber: 19134275, pivotDestination: 19132946 
2024-02-02 18:01:23.8942|INFO|Synchronization.ParallelSync.MultiSyncModeSelector|254|Changing state BeaconHeaders to Full at processed: 19133009 | state: 19133009 | block: 19133009 | header: 19133009 | target block: 19134276 | peer block: 19139981 
2024-02-02 18:01:23.8948|INFO|Network.SnapCapabilitySwitcher|254|State sync finished. Disabled snap capability. 
2024-02-02 18:01:23.8948|INFO|Synchronization.Reporting.SyncReport|254|Sync mode changed from BeaconHeaders to Full 
# So it start block processing early
2024-02-02 18:01:26.9417|INFO|Consensus.Processing.BlockchainProcessor|28|Processed    19133006... 19133010 |    764.58 ms  |  slot     56,969 ms |⛽ Gas gwei: 18.02 .. 18.21 (19.70) .. 51.71 
2024-02-02 18:01:26.9417|INFO|Consensus.Processing.BlockchainProcessor|28|- Blocks 5           72.29 MGas   |    960    txs |  calls  3,561 (144) | sload  11,539 | sstore  3,222 | create   3 
2024-02-02 18:01:26.9417|INFO|Consensus.Processing.BlockchainProcessor|28|- Block throughput   94.55 MGas/s |   1255.58 t/s |          6.54 Blk/s | recv        0 | proc       30 
2024-02-02 18:01:27.9931|INFO|Consensus.Processing.BlockchainProcessor|28|Processed    19133011... 19133017 |  1,050.80 ms  |  slot      1,051 ms |⛽ Gas gwei: 16.58 .. 16.95 (17.69) .. 70.00 
2024-02-02 18:01:27.9931|INFO|Consensus.Processing.BlockchainProcessor|28|- Blocks 7          100.25 MGas   |  1,305    txs |  calls  4,526 (205) | sload  15,137 | sstore  4,336 | create   0 
2024-02-02 18:01:27.9931|INFO|Consensus.Processing.BlockchainProcessor|28|- Block throughput   95.40 MGas/s |   1241.91 t/s |          6.66 Blk/s | recv        0 | proc       23 
2024-02-02 18:02:00.8279|INFO|Consensus.Processing.BlockchainProcessor|28|- Block throughput  114.83 MGas/s |   1177.05 t/s |          7.68 Blk/s | recv        0 | proc      540 
2024-02-02 18:02:00.8852|INFO|Synchronization.Reporting.SyncReport|193|Downloaded   19,133,803 / 19,134,276 (100.00 %) | current           36 Blk/s | total            8 Blk/s 
2024-02-02 18:02:01.1616|INFO|Merge.Plugin.Handlers.ForkchoiceUpdatedHandler|254|Syncing, Block 0xbf0c679b77261d1c8e4a8bfd08e141060144515544dd3606c6eb953194cfc884 not found. 
2024-02-02 18:02:01.1616|INFO|Merge.Plugin.Handlers.ForkchoiceUpdatedHandler|254|Received ForkChoice: 0xbf0c67...cfc884, Safe: 0x52e333...c3a0e4, Finalized: 0x5fae07...208ea4 
2024-02-02 18:02:01.1616|WARN|Merge.Plugin.Handlers.ForkchoiceUpdatedHandler|254|Attempting to fetch header from peer: ForkChoice: 0xbf0c67...cfc884, Safe: 0x52e333...c3a0e4, Finalized: 0x5fae07...208ea4. 
# Lighthouse seems to give another FCU after every 64 block.
2024-02-02 18:02:01.1626|WARN|Merge.Plugin.Handlers.ForkchoiceUpdatedHandler|254|Got header: 19134329. 
2024-02-02 18:02:01.1626|INFO|Merge.Plugin.Synchronization.BeaconPivot|254|New beacon pivot: 19134329 (0xbf0c679b77261d1c8e4a8bfd08e141060144515544dd3606c6eb953194cfc884) 
2024-02-02 18:02:01.1635|INFO|Merge.Plugin.Handlers.ForkchoiceUpdatedHandler|254|Start a new sync process, Request: ForkChoice: 0xbf0c67...cfc884, Safe: 0x52e333...c3a0e4, Finalized: 0x5fae07...208ea4. 
2024-02-02 18:02:01.8778|INFO|Consensus.Processing.BlockchainProcessor|28|Processed    19133264... 19133270 |  1,049.26 ms  |  slot      1,050 ms |⛽ Gas gwei: 21.27 .. 21.27 (22.77) .. 281.39 
# Finally  get the new payload
2024-02-02 18:20:47.2037|INFO|Merge.Plugin.Handlers.NewPayloadHandler|197|Received New Block:  19140034 (0x491da9...6c85d6) 
2024-02-02 18:20:47.2079|INFO|Merge.Plugin.Handlers.NewPayloadHandler|197|Syncing... Inserting block 19140034 (0x491da9...6c85d6). 
2024-02-02 18:20:52.2258|INFO|Consensus.Processing.BlockchainProcessor|28|Processed    19139987... 19139996 |  1,060.90 ms  |  slot      1,062 ms |⛽ Gas gwei: 25.36 .. 25.62 (27.23) .. 42.36 
2024-02-02 18:20:52.2258|INFO|Consensus.Processing.BlockchainProcessor|28|- Blocks 10         154.95 MGas   |  1,330    txs |  calls  6,888 (225) | sload  23,857 | sstore  8,070 | create   7( -3) 
# After some time it catches up to head
2024-02-02 18:21:01.3325|INFO|Consensus.Processing.BlockchainProcessor|28|Processed    19140078... 19140079 |    158.11 ms  |  slot      1,186 ms |⛽ Gas gwei: 21.66 .. 21.66 (23.63) .. 57.29 
2024-02-02 18:21:01.3325|INFO|Consensus.Processing.BlockchainProcessor|28|- Blocks 2           24.50 MGas   |    274    txs |  calls  1,156 ( 18) | sload   4,071 | sstore  1,316 | create   1( -1) 
2024-02-02 18:21:01.3325|INFO|Consensus.Processing.BlockchainProcessor|28|- Block throughput  154.96 MGas/s |   1732.97 t/s |         12.65 Blk/s | recv        0 | proc        0 
2024-02-02 18:21:01.3353|INFO|Merge.Plugin.Handlers.ForkchoiceUpdatedHandler|204|Received ForkChoice: 19140078 (0x946741...91f89c), Safe: 19140033 (0x751f49...6e00ab), Finalized: 19140001 (0x9e3519...2ea394) 
2024-02-02 18:21:01.4419|INFO|Merge.Plugin.Handlers.ForkchoiceUpdatedHandler|204|Received ForkChoice: 19140079 (0x3fc4cb...007a89), Safe: 19140033 (0x751f49...6e00ab), Finalized: 19140001 (0x9e3519...2ea394) 
2024-02-02 18:21:01.4431|INFO|Merge.Plugin.Handlers.ForkchoiceUpdatedHandler|204|Synced Chain Head to 19140079 (0x3fc4cb...007a89) 

```

### Graph

- Before, after. Note that CL is slower than max block processing rate, so it looks like it slow down. Also CL can sometimes lose peer and hang for some reason.
![Screenshot_2024-02-02_18-25-51](https://github.com/NethermindEth/nethermind/assets/1841324/4c37c59a-7d9d-4445-9e53-5cbbcc4faa5e)

- Two more after run. CL does not hang this time.
![Screenshot_2024-02-02_20-20-07](https://github.com/NethermindEth/nethermind/assets/1841324/23f3d605-3615-43b6-a70e-f8acfb92b18b)

## Changes

- Try to fetch header from p2p on FCU if block is not in block cache.

## Types of changes

#### What types of changes does your code introduce?

- [X] New feature (a non-breaking change that adds functionality)
- [X] Optimization

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Tested with a backup of nethermind and lighthouse db from yesterday.

## Documentation

#### Requires documentation update

- [ ] Yes
- [X] No

#### Requires explanation in Release Notes

- [X] Yes

- Improves catch up to head after long CL shutdown.

