### PR TITLE
Added support for ChainSpec.json file larger than 1GB

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/GenesisLoaderTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/GenesisLoaderTests.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.IO;
@@ -71,9 +71,11 @@ public class GenesisLoaderTests
 
     private static ChainSpec LoadChainSpec(string path)
     {
-        string data = File.ReadAllText(path);
-        ChainSpecLoader chainSpecLoader = new(new EthereumJsonSerializer());
-        ChainSpec chainSpec = chainSpecLoader.Load(data);
-        return chainSpec;
+        using (Stream stream = File.OpenRead(path))
+        {
+            ChainSpecLoader chainSpecLoader = new(new EthereumJsonSerializer());
+            ChainSpec chainSpec = chainSpecLoader.Load(stream);
+            return chainSpec;
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecBasedSpecProviderTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecBasedSpecProviderTests.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
@@ -487,7 +487,10 @@ public class ChainSpecBasedSpecProviderTests
     {
         ChainSpecLoader loader = new(new EthereumJsonSerializer());
         string path = Path.Combine(TestContext.CurrentContext.WorkDirectory, $"../../../../Chains/{chain}.json");
-        return loader.Load(File.ReadAllText(path));
+        using (FileStream stream = File.OpenRead(path))
+        {
+            return loader.Load(stream);
+        }
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecLoaderTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecLoaderTests.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Collections.Generic;
@@ -112,10 +112,12 @@ public class ChainSpecLoaderTests
 
     private static ChainSpec LoadChainSpec(string path)
     {
-        var data = File.ReadAllText(path);
-        ChainSpecLoader chainSpecLoader = new(new EthereumJsonSerializer());
-        ChainSpec chainSpec = chainSpecLoader.Load(data);
-        return chainSpec;
+        using (Stream stream = File.OpenRead(path))
+        {
+            ChainSpecLoader chainSpecLoader = new(new EthereumJsonSerializer());
+            ChainSpec chainSpec = chainSpecLoader.Load(stream);
+            return chainSpec;
+        }
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoaderExtensions.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoaderExtensions.cs
@@ -84,15 +84,7 @@ public static class ChainSpecLoaderExtensions
             throw new FileNotFoundException(missingChainspecFileMessage.ToString());
         }
         if (logger.IsInfo) logger.Info($"Loading chainspec from file: {filePath}");
-        FileInfo fileInfo = new(filePath);
-        if (fileInfo.Length >= 1024 * 1024 * 1024)//1GB
-        {
-            using FileStream fileStream = new(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
-            return chainSpecLoader.Load(fileStream);
-        }
-        else
-        {
-            return chainSpecLoader.Load(File.ReadAllText(filePath));
-        }
+        using FileStream fileStream = new(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+        return chainSpecLoader.Load(fileStream);
     }
 }

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoaderExtensions.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoaderExtensions.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
@@ -84,6 +84,15 @@ public static class ChainSpecLoaderExtensions
             throw new FileNotFoundException(missingChainspecFileMessage.ToString());
         }
         if (logger.IsInfo) logger.Info($"Loading chainspec from file: {filePath}");
-        return chainSpecLoader.Load(File.ReadAllText(filePath));
+        FileInfo fileInfo = new(filePath);
+        if (fileInfo.Length >= 1024 * 1024 * 1024)//1GB
+        {
+            using FileStream fileStream = new(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            return chainSpecLoader.Load(fileStream);
+        }
+        else
+        {
+            return chainSpecLoader.Load(File.ReadAllText(filePath));
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/IChainSpecLoader.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/IChainSpecLoader.cs
@@ -1,5 +1,7 @@
-// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
+
+using System.IO;
 
 namespace Nethermind.Specs.ChainSpecStyle
 {
@@ -7,5 +9,6 @@ namespace Nethermind.Specs.ChainSpecStyle
     {
         ChainSpec Load(byte[] data);
         ChainSpec Load(string jsonData);
+        ChainSpec Load(Stream streamData);
     }
 }


### PR DESCRIPTION
This commit addresses `System.OutOfMemoryException` errors in the C# API when reading files ≥1GB using `File.ReadAllText(filePath)`. It introduces a file size check and switches to C#’s stream-based API for large file handling.


## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] No

## Documentation

#### Requires documentation update

- [X] No

## Remarks

### Background:
Our custom evm network is currently being upgraded. 
After this, we will use the current Ethereum protocol as our main network protocol. 
We're using the genesis.json file to store the state of our old network to make sure it works well with all clients. 
This means our new network will have a very large genesis.json file. 
We've already made most clients (EL+CL) work steadily on our internal devnet.
EL clients like Geth, Besu, Erigon, and Reth are working.
But Nethermind has a problem because it uses the C# `File.ReadAllText` API, and this causes a `System.OutOfMemoryException`.

### Purpose:
This submission aims to fix the Nethermind error. 
By doing this, we can use Geth, Nethermind, and Besu, each with a 33% share, for our network’s early staking nodes. 
If we don't merge to upstream here, we will have to keep updating a Nethermind version with small changes, or we might have to use Erigon or Reth instead(This is risky because they are still in the 'preview' or 'alpha' stage of development).

It's important to know that our current chainspec.json file is almost 1GB. We can make it smaller than 1GB by removing extra spaces, but we think this fix won't cause any other problems, even if we don't really need it.

### Points for Discussion:
From a performance point of view, I think using Stream is better. 
Big JSON files, even those smaller than 1GB, need a lot of memory to be read. Using Stream can greatly reduce this memory need. 
I’ve also compared the wall-clock time (`chainSpecLoader.Load(fileStream)` vs `chainSpecLoader.Load(File.ReadAllText(filePath))`) and found that using Stream is faster for processing 1GB files. 
So, if it's okay, I’d like to append a commit to this pull request to entirely switch from using String to Stream for loading the chainspec.json file. Is this a good idea?
