### PR TITLE
Set mainnet peers to 50

### DIFF
--- a/src/Nethermind/Nethermind.Runner.Test/ConfigFilesTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/ConfigFilesTests.cs
@@ -173,7 +173,7 @@ namespace Nethermind.Runner.Test
         [TestCase("^mainnet ^spaceneth ^volta", 50)]
         [TestCase("spaceneth", 4)]
         [TestCase("volta", 25)]
-        [TestCase("mainnet", 100)]
+        [TestCase("mainnet", 50)]
         public void Network_defaults_are_correct(string configWildcard, int activePeers = 50)
         {
             Test<INetworkConfig, int>(configWildcard, c => c.DiscoveryPort, 30303);

--- a/src/Nethermind/Nethermind.Runner/configs/mainnet.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/mainnet.cfg
@@ -7,7 +7,7 @@
     "MemoryHint": 2048000000
   },
   "Network": {
-    "ActivePeersMaxCount": 100
+    "ActivePeersMaxCount": 50
   },
   "Sync": {
     "FastSync": true,

--- a/src/Nethermind/Nethermind.Runner/configs/mainnet.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/mainnet.cfg
@@ -6,9 +6,6 @@
     "LogFileName": "mainnet.logs.txt",
     "MemoryHint": 2048000000
   },
-  "Network": {
-    "ActivePeersMaxCount": 50
-  },
   "Sync": {
     "FastSync": true,
     "SnapSync": true,

--- a/src/Nethermind/Nethermind.Runner/configs/mainnet_archive.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/mainnet_archive.cfg
@@ -6,9 +6,6 @@
     "LogFileName": "mainnet_archive.logs.txt",
     "MemoryHint": 4096000000
   },
-  "Network": {
-    "ActivePeersMaxCount": 50
-  },
   "Sync": {
     "DownloadBodiesInFastSync": false,
     "DownloadReceiptsInFastSync": false

--- a/src/Nethermind/Nethermind.Runner/configs/mainnet_archive.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/mainnet_archive.cfg
@@ -7,7 +7,7 @@
     "MemoryHint": 4096000000
   },
   "Network": {
-    "ActivePeersMaxCount": 100
+    "ActivePeersMaxCount": 50
   },
   "Sync": {
     "DownloadBodiesInFastSync": false,


### PR DESCRIPTION
## Changes

- Set default mainnet peers to 50 rather than 100; this matches docs and geth's defaults

## Types of changes

#### What types of changes does your code introduce?

- [x] Build-related changes

## Testing

#### Requires testing

- [x] No