### PR TITLE
Self-recovery of TxPool max capacity

### DIFF
--- a/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
@@ -311,6 +311,15 @@ namespace Nethermind.TxPool.Collections
                     if (_cacheMap.Count > _capacity)
                     {
                         RemoveLast(out removed);
+
+                        // Self-recovery in case of exceeding collection's max capacity.
+                        // If capacity is exceeded by more than 1 (1 is normal situation), then remove one more item.
+                        // Every time when we will add 1 item, we will remove 2, until we will drop below max cap.
+                        if (_cacheMap.Count > _capacity)
+                        {
+                            RemoveLast(out removed);
+                        }
+
                         return true;
                     }
 


### PR DESCRIPTION
## Changes

- if TxPool/BlobPool capacity is exceeded, remove 2 worst txs instead of 1 (when inserting new tx)

It will not be used in normal workflow - only if TxPool/BlobPool capacity will be exceeded, which is not expected, but rarely observed on devnet nodes

## Types of changes

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No