### PR TITLE
Set MaxBatchResponseBodySize to 32MB (for Lodestar)

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc/IJsonRpcConfig.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/IJsonRpcConfig.cs
@@ -152,6 +152,6 @@ public interface IJsonRpcConfig : IConfig
     [ConfigItem(Description = "The max number of JSON-RPC requests in a batch.", DefaultValue = "1024")]
     int MaxBatchSize { get; set; }
 
-    [ConfigItem(Description = "The max batch size limit for batched JSON-RPC calls.", DefaultValue = "30000000")]
+    [ConfigItem(Description = "The max batch size limit for batched JSON-RPC calls.", DefaultValue = "33554432")]
     long? MaxBatchResponseBodySize { get; set; }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcConfig.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcConfig.cs
@@ -53,7 +53,7 @@ namespace Nethermind.JsonRpc
         public int? EnginePort { get; set; } = null;
         public string[] EngineEnabledModules { get; set; } = ModuleType.DefaultEngineModules.ToArray();
         public int MaxBatchSize { get; set; } = 1024;
-        public long? MaxBatchResponseBodySize { get; set; } = 32.MB();
+        public long? MaxBatchResponseBodySize { get; set; } = 32.MiB();
     };
 };
 

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcConfig.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcConfig.cs
@@ -53,7 +53,7 @@ namespace Nethermind.JsonRpc
         public int? EnginePort { get; set; } = null;
         public string[] EngineEnabledModules { get; set; } = ModuleType.DefaultEngineModules.ToArray();
         public int MaxBatchSize { get; set; } = 1024;
-        public long? MaxBatchResponseBodySize { get; set; } = 30.MB();
+        public long? MaxBatchResponseBodySize { get; set; } = 32.MB();
     };
 };
 


### PR DESCRIPTION
Resolves #5660

## Changes

- Lodestar makes request via non-auth for non engineapi request and sometimes goes a little above the 30M limit, so increase to 32MB to allow them to suceed.

![image](https://github.com/NethermindEth/nethermind/assets/1142958/964a9ec0-f40d-4345-8a04-c32d541d4cca)


## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] Documentation update

## Testing

#### Requires testing

- [x] No