### PR TITLE
Fix ShaMerkleTree for multithreaded access

### DIFF
--- a/src/Nethermind/Nethermind.Merkleization/ShaMerkleTree.cs
+++ b/src/Nethermind/Nethermind.Merkleization/ShaMerkleTree.cs
@@ -12,7 +12,8 @@ namespace Nethermind.Merkleization;
 public class ShaMerkleTree : MerkleTree
 {
     private static readonly Bytes32[] _zeroHashes = new Bytes32[32];
-    private static readonly HashAlgorithm _hashAlgorithm = SHA256.Create();
+    [ThreadStatic]
+    private static HashAlgorithm? _hashAlgorithm;
 
     static ShaMerkleTree()
     {
@@ -41,7 +42,7 @@ public class ShaMerkleTree : MerkleTree
         a.CopyTo(combined);
         b.CopyTo(combined[a.Length..]);
 
-        _hashAlgorithm.TryComputeHash(combined, target, out int bytesWritten);
+        (_hashAlgorithm ??= SHA256.Create()).TryComputeHash(combined, target, out int bytesWritten);
     }
 
     protected override Bytes32[] ZeroHashesInternal => _zeroHashes;


### PR DESCRIPTION
Resolves #6684

## Changes

- Use different HashAlgorithm instance per thread

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No
