### PR TITLE
Update txPool worst value if removal unsuccessful

### DIFF
--- a/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
@@ -310,13 +310,9 @@ namespace Nethermind.TxPool.Collections
 
                     if (_cacheMap.Count > _capacity)
                     {
-                        RemoveLast(out removed);
-
-                        // Self-recovery in case of exceeding collection's max capacity.
-                        // If capacity is exceeded by more than 1 (1 is normal situation), then remove one more item.
-                        // Every time when we will add 1 item, we will remove 2, until we will drop below max cap.
-                        if (_cacheMap.Count > _capacity)
+                        if (!RemoveLast(out removed) || _cacheMap.Count > _capacity)
                         {
+                            UpdateWorstValue();
                             RemoveLast(out removed);
                         }
 
@@ -334,16 +330,17 @@ namespace Nethermind.TxPool.Collections
 
         public bool TryInsert(TKey key, TValue value) => TryInsert(key, value, out _);
 
-        private void RemoveLast(out TValue? removed)
+        private bool RemoveLast(out TValue? removed)
         {
             TKey? key = _worstValue.GetValueOrDefault().Value;
             if (key is not null)
             {
-                TryRemoveNonLocked(key, true, out removed, out _);
+                return TryRemoveNonLocked(key, true, out removed, out _);
             }
             else
             {
                 removed = default;
+                return false;
             }
         }
 


### PR DESCRIPTION
Resolves #6557

## Changes

- If txPool fails to remove txn due to an out of date worst value; update then remove again

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No
