### PR TITLE
Failures > 4 for ping message alerts

### DIFF
--- a/src/Nethermind/Nethermind.Network/SessionMonitor.cs
+++ b/src/Nethermind/Nethermind.Network/SessionMonitor.cs
@@ -94,7 +94,7 @@ namespace Nethermind.Network
                             if (failures > 4 && failures > tasks.Length / 3)
                             {
                                 decimal percentage = (decimal)failures / tasksLength;
-                                if (_logger.IsInfo) _logger.Info($"{percentage:P0} of nodes did not respond to a Ping message - {failures}/{tasksLength}");
+                                if (_logger.IsInfo) _logger.Info($"{failures} of {tasksLength} checked nodes did not respond to a Ping message - {percentage:P0}");
                             }
                         }
                     }

--- a/src/Nethermind/Nethermind.Network/SessionMonitor.cs
+++ b/src/Nethermind/Nethermind.Network/SessionMonitor.cs
@@ -91,7 +91,7 @@ namespace Nethermind.Network
                             int successes = tasks.Count(x => x);
                             int failures = tasksLength - successes;
                             if (_logger.IsTrace) _logger.Trace($"Sent ping messages to {tasksLength} peers. Received {successes} pongs.");
-                            if (failures > tasks.Length / 3)
+                            if (failures > 4 && failures > tasks.Length / 3)
                             {
                                 decimal percentage = (decimal)failures / tasksLength;
                                 if (_logger.IsInfo) _logger.Info($"{percentage:P0} of nodes did not respond to a Ping message - {failures}/{tasksLength}");


### PR DESCRIPTION
## Changes

- I get the message `100 % of nodes did not respond to a Ping message - 1/1` frequently which seems a bit alarmist. We already don't alert when its less that 33% of the batch contacted, so also have a lower absolute limit on this.

e.g. 100% of nodes, followed by 49 connected

![image](https://github.com/NethermindEth/nethermind/assets/1142958/0d3c9ae1-0644-4a6d-8ace-b8626105e1a8)



## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No
