### PR TITLE
More patricia tree benchmarks

### DIFF
--- a/src/Nethermind/Nethermind.Benchmark/Store/PatriciaTreeBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Store/PatriciaTreeBenchmarks.cs
@@ -2,11 +2,17 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using BenchmarkDotNet.Attributes;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Db;
+using Nethermind.Int256;
+using Nethermind.Logging;
 using Nethermind.State;
+using Nethermind.Trie.Pruning;
 
 namespace Nethermind.Benchmarks.Store
 {
@@ -19,6 +25,17 @@ namespace Nethermind.Benchmarks.Store
         private static readonly Account _account3 = Build.An.Account.WithBalance(4).TestObject;
 
         private StateTree _tree;
+
+        // Just the backing KV. Used for benchmarking that include deserialization overhead.
+        private MemDb _backingMemory;
+
+        // Full uncommitted tree with in memory node. Node should be fully deserialized.
+        private StateTree _fullTree;
+
+        // All entries
+        private const int _entryCount = 1024;
+        private (Hash256, Account)[] _entries;
+        private (Hash256, Account)[] _entriesShuffled;
 
         private (string Name, Action<StateTree> Action)[] _scenarios = new (string, Action<StateTree>)[]
         {
@@ -198,10 +215,38 @@ namespace Nethermind.Benchmarks.Store
         public void Setup()
         {
             _tree = new StateTree();
+
+            _entries = new (Hash256, Account)[_entryCount];
+            for (int i = 0; i < _entryCount; i++)
+            {
+                _entries[i] = (Keccak.Compute(i.ToBigEndianByteArray()), new Account((UInt256)i));
+            }
+
+            _entriesShuffled = new (Hash256, Account)[_entryCount];
+            for (int i = 0; i < _entryCount; i++)
+            {
+                _entriesShuffled[i] = _entries[i];
+            }
+            new Random(0).Shuffle(_entriesShuffled);
+
+            _backingMemory = new MemDb();
+            StateTree tempTree = new StateTree(new TrieStore(_backingMemory, NullLogManager.Instance), LimboLogs.Instance);
+            for (int i = 0; i < _entryCount; i++)
+            {
+                tempTree.Set(_entries[i].Item1, _entries[i].Item2);
+            }
+            tempTree.Commit(0);
+
+            // Don't commit this time
+            _fullTree = new StateTree();
+            for (int i = 0; i < _entryCount; i++)
+            {
+                _fullTree.Set(_entries[i].Item1, _entries[i].Item2);
+            }
         }
 
         [Benchmark]
-        public void Improved()
+        public void Scenarios()
         {
             for (int i = 0; i < 19; i++)
             {
@@ -210,11 +255,43 @@ namespace Nethermind.Benchmarks.Store
         }
 
         [Benchmark]
-        public void Current()
+        public void InsertAndHash()
         {
-            for (int i = 0; i < 19; i++)
+            StateTree tempTree = new StateTree();
+            for (int i = 0; i < _entryCount; i++)
             {
-                _scenarios[i].Action(_tree);
+                tempTree.Set(_entries[i].Item1, _entries[i].Item2);
+            }
+            tempTree.UpdateRootHash();
+        }
+
+        [Benchmark]
+        public void Insert()
+        {
+            StateTree tempTree = new StateTree(new TrieStore(new MemDb(), NullLogManager.Instance), LimboLogs.Instance);
+            for (int i = 0; i < _entryCount; i++)
+            {
+                tempTree.Set(_entries[i].Item1, _entries[i].Item2);
+            }
+            tempTree.Commit(0);
+        }
+
+        [Benchmark]
+        public void ReadWithFullTree()
+        {
+            for (int i = 0; i < _entryCount; i++)
+            {
+                _fullTree.Get(_entriesShuffled[i].Item1);
+            }
+        }
+
+        [Benchmark]
+        public void ReadAndDeserialize()
+        {
+            StateTree tempTree = new StateTree(new TrieStore(_backingMemory, NullLogManager.Instance), LimboLogs.Instance);
+            for (int i = 0; i < _entryCount; i++)
+            {
+                tempTree.Get(_entriesShuffled[i].Item1);
             }
         }
     }

--- a/src/Nethermind/Nethermind.Benchmark/Store/PatriciaTreeBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Store/PatriciaTreeBenchmarks.cs
@@ -16,6 +16,8 @@ using Nethermind.Trie.Pruning;
 
 namespace Nethermind.Benchmarks.Store
 {
+
+    [MemoryDiagnoser]
     public class PatriciaTreeBenchmarks
     {
         private static readonly Account _empty = Build.An.Account.WithBalance(0).TestObject;

--- a/src/Nethermind/Nethermind.Benchmark/Store/PatriciaTreeBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Store/PatriciaTreeBenchmarks.cs
@@ -26,6 +26,8 @@ namespace Nethermind.Benchmarks.Store
 
         private StateTree _tree;
 
+        private Hash256 _rootHash;
+
         // Just the backing KV. Used for benchmarking that include deserialization overhead.
         private MemDb _backingMemory;
 
@@ -238,6 +240,7 @@ namespace Nethermind.Benchmarks.Store
                 tempTree.Set(_entries[i].Item1, _entries[i].Item2);
             }
             tempTree.Commit(0);
+            _rootHash = tempTree.RootHash;
 
             _fullTree = new StateTree();
             for (int i = 0; i < _entryCount; i++)
@@ -306,6 +309,7 @@ namespace Nethermind.Benchmarks.Store
         public void ReadAndDeserialize()
         {
             StateTree tempTree = new StateTree(new TrieStore(_backingMemory, NullLogManager.Instance), NullLogManager.Instance);
+            tempTree.RootHash = _rootHash;
             for (int i = 0; i < _entryCount; i++)
             {
                 tempTree.Get(_entriesShuffled[i].Item1);


### PR DESCRIPTION
- No functional change, just add more benchmarks for PatriciaTree.
- Here are my result:

| Method                      | Mean       | Error     | StdDev    | Median     | Gen0     | Gen1     | Gen2    | Allocated  |
|---------------------------- |-----------:|----------:|----------:|-----------:|---------:|---------:|--------:|-----------:|
| Scenarios                   |   111.0 us |   2.21 us |   3.81 us |   109.3 us |   8.7891 |   2.1973 |       - |  144.77 KB |
| InsertAndHash               | 3,062.2 us |  60.02 us | 115.64 us | 3,025.6 us | 218.7500 | 128.9063 |       - | 3593.14 KB |
| InsertAndCommit             | 5,734.0 us | 114.43 us | 315.16 us | 5,769.8 us | 437.5000 | 382.8125 | 93.7500 | 5879.76 KB |
| ReadWithFullTree            | 2,734.2 us |  34.77 us |  29.03 us | 2,726.2 us | 320.3125 |        - |       - |  5277.6 KB |
| ReadWithUncommittedFullTree |   493.9 us |   6.62 us |   6.19 us |   490.9 us |  23.4375 |        - |       - |     384 KB |
| ReadAndDeserialize          | 2,806.2 us |  52.81 us |  46.81 us | 2,796.2 us | 320.3125 |   3.9063 |       - | 5280.61 KB |

## Types of changes

#### What types of changes does your code introduce?

- [X] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [ ] Yes
- [X] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No
