### PR TITLE
Don't dispose Tasks (unless its waithandle is used)

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
@@ -24,7 +24,7 @@ using Metrics = Nethermind.Blockchain.Metrics;
 
 namespace Nethermind.Consensus.Processing;
 
-public class BlockchainProcessor : IBlockchainProcessor, IBlockProcessingQueue
+public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessingQueue
 {
     public int SoftMaxRecoveryQueueSizeInTx = 10000; // adjust based on tx or gas
     public const int MaxProcessingQueueSize = 2000; // adjust based on tx or gas
@@ -749,8 +749,6 @@ public class BlockchainProcessor : IBlockchainProcessor, IBlockProcessingQueue
         _recoveryQueue.Dispose();
         _blockQueue.Dispose();
         _loopCancellationSource?.Dispose();
-        _recoveryTask?.Dispose();
-        _processorTask?.Dispose();
         _blockTree.NewBestSuggestedBlock -= OnNewBestBlock;
         _blockTree.NewHeadBlock -= OnNewHeadBlock;
     }


### PR DESCRIPTION
## Changes

- Remove the Task.Dispose (the cancellation token handles shutting them down)

Saw following errors in CI
```
TearDown failed for test fixture Nethermind.Blockchain.Test.ReorgTests
TearDown : System.InvalidOperationException : A task may only be disposed if it is in a completion state (RanToCompletion, Faulted or Canceled).
StackTrace: --TearDown
   at System.Threading.Tasks.Task.Dispose(Boolean disposing)
   at System.Threading.Tasks.Task.Dispose()
   at Nethermind.Consensus.Processing.BlockchainProcessor.Dispose() in /_/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs:line 752
   at Nethermind.Blockchain.Test.ReorgTests.TearDown() in /_/src/Nethermind/Nethermind.Blockchain.Test/ReorgTests.cs:line 92
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
```

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No
