### PR TITLE
Improved single byte Rlp.DecodeByteArray

### DIFF
--- a/src/Nethermind/Nethermind.Core/Buffers/CappedArray.cs
+++ b/src/Nethermind/Nethermind.Core/Buffers/CappedArray.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Nethermind.Core.Buffers;
 
@@ -53,14 +55,31 @@ public readonly struct CappedArray<T>
     {
         get
         {
-            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, _length);
-            return _array![index];
+            T[] array = _array!;
+            if (index >= _length || (uint)index >= (uint)array.Length)
+            {
+                ThrowArgumentOutOfRangeException();
+            }
+
+            return array[index];
         }
         set
         {
-            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, _length);
-            _array![index] = value;
+            T[] array = _array!;
+            if (index >= _length || (uint)index >= (uint)array.Length)
+            {
+                ThrowArgumentOutOfRangeException();
+            }
+
+            array[index] = value;
         }
+    }
+
+    [DoesNotReturn]
+    [StackTraceHidden]
+    private static void ThrowArgumentOutOfRangeException()
+    {
+        throw new ArgumentOutOfRangeException();
     }
 
     public readonly int Length => _length;

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpStream.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpStream.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Runtime.CompilerServices;
@@ -1302,57 +1303,107 @@ namespace Nethermind.Serialization.Rlp
             return bytes.Length == 0 ? 0L : bytes.ReadEthUInt64();
         }
 
-        public byte[] DecodeByteArray() => DecodeByteArraySpan().ToArray();
+        public byte[] DecodeByteArray()
+        {
+            var span = DecodeByteArraySpan();
+            if (span.Length == 0)
+            {
+                return Array.Empty<byte>();
+            }
+
+            if (span.Length == 1)
+            {
+                int value = span[0];
+                var arrays = SingleByteArrays;
+                if ((uint)value < (uint)arrays.Length)
+                {
+                    return arrays[value];
+                }
+            }
+
+            return span.ToArray();
+        }
 
         public ReadOnlySpan<byte> DecodeByteArraySpan()
         {
             int prefix = ReadByte();
-            if (prefix == 0)
+            ReadOnlySpan<byte> span = RlpStream.SingleBytes;
+            if ((uint)prefix < (uint)span.Length)
             {
-                return Bytes.ZeroByte.Span;
-            }
-
-            if (prefix < 128)
-            {
-                return new[] { (byte)prefix };
+                return span.Slice(prefix, 1);
             }
 
             if (prefix == 128)
             {
-                return Array.Empty<byte>();
+                return default;
             }
 
             if (prefix <= 183)
             {
                 int length = prefix - 128;
-                Span<byte> buffer = Read(length);
-                if (length == 1 && buffer[0] < 128)
+                ReadOnlySpan<byte> buffer = Read(length);
+                if (buffer.Length == 1 && buffer[0] < 128)
                 {
-                    throw new RlpException($"Unexpected byte value {buffer[0]}");
+                    ThrowUnexpectedValue(buffer[0]);
                 }
 
                 return buffer;
             }
 
+            return DecodeLargerByteArraySpan(prefix);
+
+            [DoesNotReturn]
+            [StackTraceHidden]
+            static void ThrowUnexpectedValue(int buffer0)
+            {
+                throw new RlpException($"Unexpected byte value {buffer0}");
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private ReadOnlySpan<byte> DecodeLargerByteArraySpan(int prefix)
+        {
             if (prefix < 192)
             {
                 int lengthOfLength = prefix - 183;
                 if (lengthOfLength > 4)
                 {
                     // strange but needed to pass tests - seems that spec gives int64 length and tests int32 length
-                    throw new RlpException("Expected length of length less or equal 4");
+                    ThrowUnexpectedLengthOfLength();
                 }
 
                 int length = DeserializeLength(lengthOfLength);
                 if (length < 56)
                 {
-                    throw new RlpException($"Expected length greater or equal 56 and was {length}");
+                    ThrowUnexpectedLength(length);
                 }
 
                 return Read(length);
             }
 
-            throw new RlpException($"Unexpected prefix value of {prefix} when decoding a byte array.");
+            ThrowUnexpectedPrefix(prefix);
+            return default;
+
+            [DoesNotReturn]
+            [StackTraceHidden]
+            static void ThrowUnexpectedPrefix(int prefix)
+            {
+                throw new RlpException($"Unexpected prefix value of {prefix} when decoding a byte array.");
+            }
+
+            [DoesNotReturn]
+            [StackTraceHidden]
+            static void ThrowUnexpectedLength(int length)
+            {
+                throw new RlpException($"Expected length greater or equal 56 and was {length}");
+            }
+
+            [DoesNotReturn]
+            [StackTraceHidden]
+            static void ThrowUnexpectedLengthOfLength()
+            {
+                throw new RlpException("Expected length of length less or equal 4");
+            }
         }
 
         public void SkipItem()
@@ -1403,5 +1454,8 @@ namespace Nethermind.Serialization.Rlp
 
             return result;
         }
+
+        internal static ReadOnlySpan<byte> SingleBytes => new byte[128] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127 };
+        internal static byte[][] SingleByteArrays = new byte[128][] { [0], [1], [2], [3], [4], [5], [6], [7], [8], [9], [10], [11], [12], [13], [14], [15], [16], [17], [18], [19], [20], [21], [22], [23], [24], [25], [26], [27], [28], [29], [30], [31], [32], [33], [34], [35], [36], [37], [38], [39], [40], [41], [42], [43], [44], [45], [46], [47], [48], [49], [50], [51], [52], [53], [54], [55], [56], [57], [58], [59], [60], [61], [62], [63], [64], [65], [66], [67], [68], [69], [70], [71], [72], [73], [74], [75], [76], [77], [78], [79], [80], [81], [82], [83], [84], [85], [86], [87], [88], [89], [90], [91], [92], [93], [94], [95], [96], [97], [98], [99], [100], [101], [102], [103], [104], [105], [106], [107], [108], [109], [110], [111], [112], [113], [114], [115], [116], [117], [118], [119], [120], [121], [122], [123], [124], [125], [126], [127] };
     }
 }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/ValueRlpStream.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/ValueRlpStream.cs
@@ -103,7 +103,7 @@ public ref struct ValueRlpStream(in CappedArray<byte> data)
         else if (prefix < 192)
         {
             int lengthOfLength = prefix - 183;
-            if (lengthOfLength > 4)
+            if ((uint)lengthOfLength > 4)
             {
                 // strange but needed to pass tests - seems that spec gives int64 length and tests int32 length
                 throw new RlpException("Expected length of length less or equal 4");

--- a/src/Nethermind/Nethermind.Serialization.Rlp/ValueRlpStream.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/ValueRlpStream.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Buffers.Binary;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -340,57 +341,107 @@ public ref struct ValueRlpStream(in CappedArray<byte> data)
         return Data.AsSpan(_position + offset, length);
     }
 
-    public byte[] DecodeByteArray() => DecodeByteArraySpan().ToArray();
+    public byte[] DecodeByteArray()
+    {
+        var span = DecodeByteArraySpan();
+        if (span.Length == 0)
+        {
+            return Array.Empty<byte>();
+        }
+
+        if (span.Length == 1)
+        {
+            int value = span[0];
+            var arrays = RlpStream.SingleByteArrays;
+            if ((uint)value < (uint)arrays.Length)
+            {
+                return arrays[value];
+            }
+        }
+
+        return span.ToArray();
+    }
 
     public ReadOnlySpan<byte> DecodeByteArraySpan()
     {
         int prefix = ReadByte();
-        if (prefix == 0)
+        ReadOnlySpan<byte> span = RlpStream.SingleBytes;
+        if ((uint)prefix < (uint)span.Length)
         {
-            return Bytes.ZeroByte.Span;
-        }
-
-        if (prefix < 128)
-        {
-            return new[] { (byte)prefix };
+            return span.Slice(prefix, 1);
         }
 
         if (prefix == 128)
         {
-            return Array.Empty<byte>();
+            return default;
         }
 
         if (prefix <= 183)
         {
             int length = prefix - 128;
-            Span<byte> buffer = Read(length);
-            if (length == 1 && buffer[0] < 128)
+            ReadOnlySpan<byte> buffer = Read(length);
+            if (buffer.Length == 1 && buffer[0] < 128)
             {
-                throw new RlpException($"Unexpected byte value {buffer[0]}");
+                ThrowUnexpectedValue(buffer[0]);
             }
 
             return buffer;
         }
 
+        return DecodeLargerByteArraySpan(prefix);
+
+        [DoesNotReturn]
+        [StackTraceHidden]
+        static void ThrowUnexpectedValue(int buffer0)
+        {
+            throw new RlpException($"Unexpected byte value {buffer0}");
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private ReadOnlySpan<byte> DecodeLargerByteArraySpan(int prefix)
+    {
         if (prefix < 192)
         {
             int lengthOfLength = prefix - 183;
             if (lengthOfLength > 4)
             {
                 // strange but needed to pass tests - seems that spec gives int64 length and tests int32 length
-                throw new RlpException("Expected length of length less or equal 4");
+                ThrowUnexpectedLengthOfLength();
             }
 
             int length = DeserializeLength(lengthOfLength);
             if (length < 56)
             {
-                throw new RlpException($"Expected length greater or equal 56 and was {length}");
+                ThrowUnexpectedLength(length);
             }
 
             return Read(length);
         }
 
-        throw new RlpException($"Unexpected prefix value of {prefix} when decoding a byte array.");
+        ThrowUnexpectedPrefix(prefix);
+        return default;
+
+        [DoesNotReturn]
+        [StackTraceHidden]
+        static void ThrowUnexpectedPrefix(int prefix)
+        {
+            throw new RlpException($"Unexpected prefix value of {prefix} when decoding a byte array.");
+        }
+
+        [DoesNotReturn]
+        [StackTraceHidden]
+        static void ThrowUnexpectedLength(int length)
+        {
+            throw new RlpException($"Expected length greater or equal 56 and was {length}");
+        }
+
+        [DoesNotReturn]
+        [StackTraceHidden]
+        static void ThrowUnexpectedLengthOfLength()
+        {
+            throw new RlpException("Expected length of length less or equal 4");
+        }
     }
 
     public void SkipItem()


### PR DESCRIPTION
## Changes

- Use preallocated Span for bytes 0-127 and preallocated arrays for bytes 0-127 (and the conversion between them)

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
