### PR TITLE
Add benchmark for reading from memory trie store

### DIFF
--- a/src/Nethermind/Nethermind.Benchmark/Store/PatriciaTreeBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Store/PatriciaTreeBenchmarks.cs
@@ -323,6 +323,17 @@ namespace Nethermind.Benchmarks.Store
         }
 
         [Benchmark]
+        public void ReadWithMemoryTrieStoreReadOnly()
+        {
+            StateTree tempTree = new StateTree(_memoryTrieStore.AsReadOnly(), NullLogManager.Instance);
+            tempTree.RootHash = _rootHash;
+            for (int i = 0; i < _entryCount; i++)
+            {
+                tempTree.Get(_entries[i].Item1);
+            }
+        }
+
+        [Benchmark]
         public void ReadAndDeserialize()
         {
             StateTree tempTree = new StateTree(new TrieStore(_backingMemory, NullLogManager.Instance), NullLogManager.Instance);

--- a/src/Nethermind/Nethermind.Benchmark/Store/PatriciaTreeBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Store/PatriciaTreeBenchmarks.cs
@@ -38,6 +38,8 @@ namespace Nethermind.Benchmarks.Store
 
         private StateTree _fullTree;
 
+        private TrieStore _memoryTrieStore;
+
         // All entries
         private const int _entryCount = 1024 * 4;
         private (Hash256, Account)[] _entries;
@@ -256,6 +258,8 @@ namespace Nethermind.Benchmarks.Store
             {
                 _uncommittedFullTree.Set(_entries[i].Item1, _entries[i].Item2);
             }
+
+            _memoryTrieStore = new TrieStore(_backingMemory, Prune.WhenCacheReaches(1.GB()), No.Persistence, NullLogManager.Instance);
         }
 
         [Benchmark]
@@ -304,6 +308,17 @@ namespace Nethermind.Benchmarks.Store
             for (int i = 0; i < _entryCount; i++)
             {
                 _uncommittedFullTree.Get(_entriesShuffled[i].Item1);
+            }
+        }
+
+        [Benchmark]
+        public void ReadWithMemoryTrieStore()
+        {
+            StateTree tempTree = new StateTree(_memoryTrieStore, NullLogManager.Instance);
+            tempTree.RootHash = _rootHash;
+            for (int i = 0; i < _entryCount; i++)
+            {
+                tempTree.Get(_entries[i].Item1);
             }
         }
 


### PR DESCRIPTION
- No functional change, just add benchmark for when the trie load nodes from in memory trie store.
- Here are current readings:

| Method                          | Mean       | Error     | StdDev    | Gen0     | Gen1     | Gen2    | Allocated  |
|-------------------------------- |-----------:|----------:|----------:|---------:|---------:|--------:|-----------:|
| Scenarios                       |   116.6 us |   2.05 us |   2.36 us |   8.7891 |   2.1973 |       - |  146.77 KB |
| InsertAndHash                   | 3,090.4 us |  58.86 us |  89.88 us | 218.7500 | 128.9063 |       - | 3593.14 KB |
| InsertAndCommit                 | 5,959.6 us | 118.68 us | 312.66 us | 437.5000 | 375.0000 | 93.7500 |  5859.5 KB |
| ReadWithFullTree                | 2,868.6 us |  41.60 us |  32.48 us | 320.3125 |        - |       - |  5277.6 KB |
| ReadWithUncommittedFullTree     |   492.7 us |   7.34 us |   5.73 us |  23.4375 |        - |       - |     384 KB |
| ReadWithMemoryTrieStore         | 1,928.7 us |  37.65 us |  41.85 us |  66.4063 |        - |       - | 1091.95 KB |
| ReadWithMemoryTrieStoreReadOnly | 2,944.7 us |  52.97 us |  65.05 us | 320.3125 |        - |       - | 5278.02 KB |
| ReadAndDeserialize              | 2,766.7 us |  52.45 us |  71.79 us | 320.3125 |   3.9063 |       - | 5280.61 KB |


## Types of changes

#### What types of changes does your code introduce?

- [X] New feature (a non-breaking change that adds functionality)
## Testing

#### Requires testing

- [ ] Yes
- [X] No
