### PR TITLE
Optimize RLP length calculation

### DIFF
--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -1594,74 +1594,28 @@ namespace Nethermind.Serialization.Rlp
 
         public static int LengthOf(long value)
         {
-            // everything has a length prefix
-            if (value < 0)
+            if ((ulong)value < 128)
             {
-                return 9;
+                return 1;
             }
-
-            if (value < 256L * 256L * 256L * 256L * 256L * 256L * 256L)
+            else
             {
-                if (value < 256L * 256L * 256L * 256L * 256L * 256L)
-                {
-                    if (value < 256L * 256L * 256L * 256L * 256L)
-                    {
-                        if (value < 256L * 256L * 256L * 256L)
-                        {
-                            if (value < 256 * 256 * 256)
-                            {
-                                if (value < 256 * 256)
-                                {
-                                    if (value < 128)
-                                    {
-                                        return 1;
-                                    }
-
-                                    return value < 256 ? 2 : 3;
-                                }
-
-                                return 4;
-                            }
-
-                            return 5;
-                        }
-
-                        return 6;
-                    }
-
-                    return 7;
-                }
-
-                return 8;
+                // everything has a length prefix
+                return 1 + sizeof(ulong) - (BitOperations.LeadingZeroCount((ulong)(value | 1)) / 8);
             }
-
-            return 9;
         }
 
         public static int LengthOf(int value)
         {
-            // everything has a length prefix
-            if (value < 0)
+            if ((uint)value < 128)
             {
-                return 9; // we cast it to long now
+                return 1;
             }
-
-            if (value < 256 * 256 * 256)
+            else
             {
-                if (value < 256 * 256)
-                {
-                    if (value < 128)
-                    {
-                        return 1;
-                    }
-
-                    return value < 256 ? 2 : 3;
-                }
-
-                return 4;
+                // everything has a length prefix
+                return 1 + sizeof(uint) - (BitOperations.LeadingZeroCount((uint)value | 1) / 8);
             }
-
-            return 5;
         }
 
         public static int LengthOf(Hash256? item)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -407,7 +407,7 @@ namespace Nethermind.Serialization.Rlp
 
             if (value < 1 << 16)
             {
-                BinaryPrimitives.WriteInt16BigEndian(buffer.Slice(position), (short)value);
+                BinaryPrimitives.WriteUInt16BigEndian(buffer.Slice(position), (ushort)value);
                 return position + 2;
             }
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -1603,6 +1603,10 @@ namespace Nethermind.Serialization.Rlp
 
         public static int LengthOf(int value)
         {
+            if (value < 0)
+            {
+                return 9; // will be a sign extended long -> ulong
+            }
             if ((uint)value < 128)
             {
                 return 1;

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -1597,7 +1597,7 @@ namespace Nethermind.Serialization.Rlp
             else
             {
                 // everything has a length prefix
-                return 1 + sizeof(ulong) - (BitOperations.LeadingZeroCount((ulong)(value | 1)) / 8);
+                return 1 + sizeof(ulong) - (BitOperations.LeadingZeroCount((ulong)value) / 8);
             }
         }
 
@@ -1610,7 +1610,7 @@ namespace Nethermind.Serialization.Rlp
             else
             {
                 // everything has a length prefix
-                return 1 + sizeof(uint) - (BitOperations.LeadingZeroCount((uint)value | 1) / 8);
+                return 1 + sizeof(uint) - (BitOperations.LeadingZeroCount((uint)value) / 8);
             }
         }
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -407,8 +407,7 @@ namespace Nethermind.Serialization.Rlp
 
             if (value < 1 << 16)
             {
-                buffer[position] = (byte)(value >> 8);
-                buffer[position + 1] = ((byte)value);
+                BinaryPrimitives.WriteInt16BigEndian(buffer.Slice(position), (short)value);
                 return position + 2;
             }
 
@@ -420,10 +419,7 @@ namespace Nethermind.Serialization.Rlp
                 return position + 3;
             }
 
-            buffer[position] = (byte)(value >> 24);
-            buffer[position + 1] = (byte)(value >> 16);
-            buffer[position + 2] = (byte)(value >> 8);
-            buffer[position + 3] = (byte)value;
+            BinaryPrimitives.WriteInt32BigEndian(buffer.Slice(position), value);
             return position + 4;
         }
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -429,22 +429,8 @@ namespace Nethermind.Serialization.Rlp
 
         public static int LengthOfLength(int value)
         {
-            if (value < 1 << 8)
-            {
-                return 1;
-            }
-
-            if (value < 1 << 16)
-            {
-                return 2;
-            }
-
-            if (value < 1 << 24)
-            {
-                return 3;
-            }
-
-            return 4;
+            int bits = 32 - BitOperations.LeadingZeroCount((uint)value | 1);
+            return (bits + 7) / 8;
         }
 
         public static byte[] SerializeLength(int value)


### PR DESCRIPTION
## Changes

* [Make Rlp.LengthOfLength branchless](https://github.com/NethermindEth/nethermind/commit/befbda17376d37d3e7df3c0e6c12785bf0c9935d)
  * This is just calculating the amount of bytes required the represent the value, we can CLZ it. This makes the method inlineable for the JIT thanks to much tighter IL (and codegen).
  * [SharpLab](https://sharplab.io/#v2:EYLgxg9gTgpgtADwGwBYA0AXEBDAzgWwB8ABABgAJiBGAOgDkBXfGKASzFwG4BYAKGIDMlAEzkAwuQDefcrMpDqScqwB2GcgBkYKgOYYAFgHkAZlt0GAFKvUA3bABsGMAJQy503nK/K15YKwxccgBecgFROHIAIQDDAAcWbAxWCBVcGi1sABNVHQAtFggxCAY1CwsGa2c7RxhyQnIqZx5Pb1liAHZyC39A8gBqcg7ncgB6cgAOFq8AXz4ZoA)
* [Make Rlp.LengthOf almost branchless](https://github.com/NethermindEth/nethermind/commit/ef66b02310e5a01893871330ad325f5e93dc78f1)
  * We can use similar bit tricks here. Wasn't able to get rid of the branch that handles the `0 < value < 128` special case, should still be friendlier to the branch prediction and to the JIT.
  * [SharpLab](https://sharplab.io/#v2:EYLgxg9gTgpgtADwGwBYA0AXEBDAzgWwB8ABABgAJiBGAOgDkBXfGKASzFwG4BYAKD+IBmSgCZyAYXJ8A3n3LzKw6knKsAdhnIAZGGoDmGABYB5AGaoAFABsI+8gDdsVhjACUchbN4Kfq0+QsLBht9V0dnGHIAHnIqEQAOd29feS8UlOIAdlieZJSAXw8UmCtcGCLfNPSfAHoa8hh7FgBPI3U9ckM8cmxyK10DQ3IAB1hTVgQK6qzY8gBqclxWAC8YCFMgkL1XcjgAgCFWDGNhlmwMVltcGh1sABN2gC0WCHEIBg1A4Ntt8Jcd+qJXLVQp5cignxCShUFTqTQ6fRGMyCEQWOEOJz/CpVFKsfxfOFhTGRGJxRJTTwUjLZKicKRgnwQ9IlMr06o46rkOoNJpQVqGdqdbq9fqIoajGDjSYM9IzKjzRYrNYbBiE3YHI4nM4XK43GD3J4vN4fDAEjREiIA8hAqngipM+RQ5SqDTaAZI8woAD6+zwJXUMGsPwxlr4AEgvGGw9zGi02nYurgen13eKxhNw2G8QE/iTyKQklHI1GZgBOXJR0FhzPZiy56LkEQAViQWnIACpGy2253m62O13+73uwO+z3B1pCxHM1n8fWYmPRyPh0OJ0vV2Op9PeFGo7X52uV+PF0f15OZ9vd3u58SGyfDw/NxfL1fZznbwuW+v11vd8XX/uH6Dj+z5FqB17vhEDZkr+V7/q+YZyhWCFhlW4GIdkB59uQAD8jbkCA5CCMhr5oTuCEzCgJG7mRFHZE21GoeGz4zEg1G0buMyZCRHEYdayEcWWFYOoo0Kwq6CKDMiIg+n6VgBmirq5kkPgcrU9Sxny8YdImyaioMIzptK1SAVBMQFraamytk5ZcvUADukRgHgmhHOQGAQH0wZqBA9m2iJtqmS4d5fiuIEyqkto+EFebYSuKmcpFEWcjF0EJAliWqVFmVIdlBQVHlvgzFhX54WIhHEYVAXJZC2RUf5BXJTMDH2nw+RAA)
* [Use BinaryPrimitives in Rlp.SerializeLength](https://github.com/NethermindEth/nethermind/commit/879a9af8ae4bd037d34b0f9eb05b2864f1d77618)
  * Little bit better codegen. We get `bswap` for 32-bit case and reduce remove few bounds-checks. We could also reduce bounds-checks for the 24-bit case but I thought this change more as a refactor to utilize the "new" built-in APIs.
## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No

#### Notes on testing

All tests green locally. 
