### PR TITLE
Refactor/refactor protocol handler registrations

### DIFF
--- a/src/Nethermind/Nethermind.AccountAbstraction/AccountAbstractionPlugin.cs
+++ b/src/Nethermind/Nethermind.AccountAbstraction/AccountAbstractionPlugin.cs
@@ -266,9 +266,8 @@ public class AccountAbstractionPlugin : IConsensusWrapperPlugin
             AccountAbstractionPeerManager peerManager = new(_userOperationPools, UserOperationBroadcaster, _accountAbstractionConfig.AaPriorityPeersMaxCount, _logger);
 
             serializer.Register(new UserOperationsMessageSerializer());
-            protocolsManager.AddProtocol(Protocol.AA,
-                session => new AaProtocolHandler(session, serializer, stats, _userOperationPools, peerManager, logManager));
-            protocolsManager.AddSupportedCapability(new Capability(Protocol.AA, 0));
+            protocolsManager.AddProtocol(Protocol.AA, 0,
+                new AaProtocolHandlerFactory(serializer, stats, _userOperationPools, peerManager, logManager));
 
             if (_logger.IsInfo) _logger.Info("Initialized Account Abstraction network protocol");
         }

--- a/src/Nethermind/Nethermind.AccountAbstraction/Network/AaProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.AccountAbstraction/Network/AaProtocolHandler.cs
@@ -50,7 +50,7 @@ namespace Nethermind.AccountAbstraction.Network
 
         public override string ProtocolCode => Protocol.AA;
 
-        public override int MessageIdSpaceSize => 4;
+        public override int MessageIdSpaceSize => ProtocolMessageIdSpaces.AA;
 
         public override string Name => "aa";
 

--- a/src/Nethermind/Nethermind.AccountAbstraction/Network/AaProtocolHandlerFactory.cs
+++ b/src/Nethermind/Nethermind.AccountAbstraction/Network/AaProtocolHandlerFactory.cs
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Generic;
+using Nethermind.AccountAbstraction.Source;
+using Nethermind.Core;
+using Nethermind.Logging;
+using Nethermind.Network;
+using Nethermind.Network.P2P;
+using Nethermind.Network.P2P.ProtocolHandlers;
+using Nethermind.Stats;
+
+namespace Nethermind.AccountAbstraction.Network;
+
+public class AaProtocolHandlerFactory: IProtocolHandlerFactory
+{
+    private readonly IMessageSerializationService _serializer;
+    private readonly INodeStatsManager _nodeStatsManager;
+    private readonly IDictionary<Address, IUserOperationPool> _userOperationPools;
+    private readonly IAccountAbstractionPeerManager _peerManager;
+    private readonly ILogManager _logManager;
+    public int ProtocolPriority => ProtocolPriorities.Satellite;
+    public int MessageIdSpaceSize => ProtocolMessageIdSpaces.Wit;
+
+    public AaProtocolHandlerFactory(
+        IMessageSerializationService serializer,
+        INodeStatsManager nodeStatsManager,
+        IDictionary<Address, IUserOperationPool> userOperationPools,
+        IAccountAbstractionPeerManager peerManager,
+        ILogManager logManager)
+    {
+        _serializer = serializer;
+        _nodeStatsManager = nodeStatsManager;
+        _userOperationPools = userOperationPools;
+        _peerManager = peerManager;
+        _logManager = logManager;
+    }
+
+    public IProtocolHandler Create(ISession session)
+    {
+        return new AaProtocolHandler(session, _serializer, _nodeStatsManager, _userOperationPools, _peerManager, _logManager);
+    }
+}

--- a/src/Nethermind/Nethermind.Network.Test/P2P/SessionTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/SessionTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using DotNetty.Transport.Channels;
 using FluentAssertions;
@@ -451,6 +452,7 @@ namespace Nethermind.Network.Test.P2P
             session.AddProtocolHandler(aaa);
             session.AddProtocolHandler(bbb);
             session.AddProtocolHandler(ccc);
+            session.RegisterProtocolMessageSpace(new Dictionary<string, int>());
 
             _packetSender.Enqueue(PingMessage.Instance).Returns(10);
             session.DeliverMessage(PingMessage.Instance);
@@ -537,6 +539,7 @@ namespace Nethermind.Network.Test.P2P
 
             IProtocolHandler p2p = BuildHandler("p2p", 10);
             session.AddProtocolHandler(p2p);
+            session.RegisterProtocolMessageSpace(new Dictionary<string, int>());
 
             p2p.When(it => it.DisconnectProtocol(Arg.Any<DisconnectReason>(), Arg.Any<string>()))
                 .Do((_) =>
@@ -569,6 +572,7 @@ namespace Nethermind.Network.Test.P2P
             session.AddProtocolHandler(aaa);
             session.AddProtocolHandler(bbb);
             session.AddProtocolHandler(ccc);
+            session.RegisterProtocolMessageSpace(new Dictionary<string, int>());
 
             byte[] data = new byte[10];
             session.ReceiveMessage(new Packet("---", 3, data));

--- a/src/Nethermind/Nethermind.Network.Test/ProtocolsManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/ProtocolsManagerTests.cs
@@ -100,6 +100,7 @@ namespace Nethermind.Network.Test
                 _protocolValidator = new ProtocolValidator(_nodeStatsManager, _blockTree, forkInfo, LimboLogs.Instance);
                 _peerStorage = Substitute.For<INetworkStorage>();
                 _syncPeerPool = Substitute.For<ISyncPeerPool>();
+                _syncPeerPool.TryAddPeer(Arg.Any<ISyncPeer>()).Returns(true);
                 _gossipPolicy = Substitute.For<IGossipPolicy>();
                 _manager = new ProtocolsManager(
                     _syncPeerPool,

--- a/src/Nethermind/Nethermind.Network/IProtocolsManager.cs
+++ b/src/Nethermind/Nethermind.Network/IProtocolsManager.cs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using Nethermind.Network.P2P;
-using Nethermind.Network.P2P.EventArg;
 using Nethermind.Network.P2P.ProtocolHandlers;
 using Nethermind.Stats.Model;
 
@@ -14,7 +12,6 @@ namespace Nethermind.Network
         void AddSupportedCapability(Capability capability);
         void RemoveSupportedCapability(Capability capability);
         void SendNewCapability(Capability capability);
-        void AddProtocol(string code, Func<ISession, IProtocolHandler> factory);
-        event EventHandler<ProtocolInitializedEventArgs> P2PProtocolInitialized;
+        void AddProtocol(string code, int version, IProtocolHandlerFactory factory);
     }
 }

--- a/src/Nethermind/Nethermind.Network/P2P/EventArg/ProtocolEventArgs.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/EventArg/ProtocolEventArgs.cs
@@ -1,18 +1,17 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Collections.Generic;
+
 namespace Nethermind.Network.P2P.EventArg
 {
     public class ProtocolEventArgs : System.EventArgs
     {
-        public int Version { get; }
+        public IList<(string ProtocolCode, int Version)> Protocols { get; }
 
-        public string ProtocolCode { get; }
-
-        public ProtocolEventArgs(string protocolCode, int version)
+        public ProtocolEventArgs(IList<(string ProtocolCode, int Version)> protocols)
         {
-            Version = version;
-            ProtocolCode = protocolCode;
+            Protocols = protocols;
         }
     }
 }

--- a/src/Nethermind/Nethermind.Network/P2P/ISession.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ISession.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using DotNetty.Transport.Channels;
 using Nethermind.Core.Crypto;
 using Nethermind.Network.P2P.EventArg;
@@ -40,6 +41,10 @@ namespace Nethermind.Network.P2P
         IPingSender PingSender { get; set; }
 
         void AddProtocolHandler(IProtocolHandler handler);
+
+        // Before the protocol is added, some protocol may need to send message, during which the adaptive id must be
+        // correct
+        void RegisterProtocolMessageSpace(IDictionary<string, int> protocolMessageSpace);
 
         bool TryGetProtocolHandler(string protocolCode, out IProtocolHandler handler);
 

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/IProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/IProtocolHandler.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using Nethermind.Network.Contract.P2P;
 using Nethermind.Network.P2P.EventArg;
 using Nethermind.Network.Rlpx;
 using Nethermind.Stats.Model;
@@ -19,5 +20,19 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
         void DisconnectProtocol(DisconnectReason disconnectReason, string details);
         event EventHandler<ProtocolInitializedEventArgs> ProtocolInitialized;
         event EventHandler<ProtocolEventArgs> SubprotocolRequested;
+    }
+
+    public interface IProtocolHandlerFactory
+    {
+        int ProtocolPriority { get; }
+        int MessageIdSpaceSize { get; }
+        IProtocolHandler Create(ISession session);
+    }
+
+    public static class ProtocolPriorities
+    {
+        public const int P2P = 1;
+        public const int Sync = 10;
+        public const int Satellite = 100;
     }
 }

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandlerFactory.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandlerFactory.cs
@@ -1,0 +1,126 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Text.RegularExpressions;
+using Nethermind.Logging;
+using Nethermind.Network.Config;
+using Nethermind.Network.Contract.P2P;
+using Nethermind.Network.P2P.EventArg;
+using Nethermind.Network.Rlpx;
+using Nethermind.Stats;
+using Nethermind.Stats.Model;
+
+namespace Nethermind.Network.P2P.ProtocolHandlers;
+
+public class P2PProtocolHandlerFactory: IProtocolHandlerFactory
+{
+    private readonly IRlpxHost _rlpxHost;
+    private readonly IMessageSerializationService _serializer;
+    private readonly Regex? _clientIdPattern;
+    private readonly IDiscoveryApp _discoveryApp;
+    private readonly IProtocolValidator _protocolValidator;
+    private readonly INodeStatsManager _stats;
+    private readonly ILogManager _logManager;
+    private readonly ILogger _logger;
+
+    public int ProtocolPriority => ProtocolPriorities.P2P;
+    public int MessageIdSpaceSize => ProtocolMessageIdSpaces.P2P;
+    public static int MessageSpace => 0x10;
+
+    public P2PProtocolHandlerFactory(
+        IRlpxHost rlpxHost,
+        IMessageSerializationService serializer,
+        INetworkConfig networkConfig,
+        IDiscoveryApp discoveryApp,
+        IProtocolValidator protocolValidator,
+        INodeStatsManager stats,
+        ILogManager logManager
+    )
+    {
+        _discoveryApp = discoveryApp;
+        _protocolValidator = protocolValidator;
+        _stats = stats;
+
+        if (networkConfig.ClientIdMatcher is not null)
+        {
+            _clientIdPattern = new Regex(networkConfig.ClientIdMatcher, RegexOptions.Compiled);
+        }
+
+        _rlpxHost = rlpxHost;
+        _serializer = serializer;
+        _logManager = logManager;
+        _logger = logManager.GetClassLogger<P2PProtocolHandlerFactory>();
+    }
+
+    public IProtocolHandler Create(ISession session)
+    {
+        P2PProtocolHandler handler = new(session, _rlpxHost.LocalNodeId, _stats, _serializer, _clientIdPattern, _logManager);
+        InitP2PProtocol(session, handler);
+        return handler;
+    }
+
+    private void InitP2PProtocol(ISession session, P2PProtocolHandler handler)
+    {
+        session.PingSender = handler;
+        handler.ProtocolInitialized += (sender, args) =>
+        {
+            P2PProtocolInitializedEventArgs typedArgs = (P2PProtocolInitializedEventArgs)args;
+            if (!RunBasicChecks(session, Protocol.P2P, handler.ProtocolVersion)) return;
+
+            if (handler.ProtocolVersion >= 5)
+            {
+                if (_logger.IsTrace) _logger.Trace($"{handler.ProtocolCode}.{handler.ProtocolVersion} established on {session} - enabling snappy");
+                session.EnableSnappy();
+            }
+            else
+            {
+                if (_logger.IsTrace) _logger.Trace($"{handler.ProtocolCode}.{handler.ProtocolVersion} established on {session} - disabling snappy");
+            }
+
+            _stats.ReportP2PInitializationEvent(session.Node, new P2PNodeDetails
+            {
+                ClientId = typedArgs.ClientId,
+                Capabilities = typedArgs.Capabilities.ToArray(),
+                P2PVersion = typedArgs.P2PVersion,
+                ListenPort = typedArgs.ListenPort
+            });
+
+            AddNodeToDiscovery(session, typedArgs);
+
+            _protocolValidator.DisconnectOnInvalid(Protocol.P2P, session, args);
+        };
+    }
+
+    /// <summary>
+    /// In case of IN connection we don't know what is the port node is listening on until we receive the Hello message
+    /// </summary>
+    private void AddNodeToDiscovery(ISession session, P2PProtocolInitializedEventArgs eventArgs)
+    {
+        if (eventArgs.ListenPort == 0)
+        {
+            if (_logger.IsTrace) _logger.Trace($"Listen port is 0, node is not listening: {session}");
+            return;
+        }
+
+        if (session.Node.Port != eventArgs.ListenPort)
+        {
+            if (_logger.IsDebug) _logger.Debug($"Updating listen port for {session:s} to: {eventArgs.ListenPort}");
+            session.Node.Port = eventArgs.ListenPort;
+        }
+
+        //In case peer was initiated outside of discovery and discovery is enabled, we are adding it to discovery for future use (e.g. trusted peer)
+        _discoveryApp.AddNodeToDiscovery(session.Node);
+    }
+
+    private bool RunBasicChecks(ISession session, string protocolCode, int protocolVersion)
+    {
+        if (session.IsClosing)
+        {
+            if (_logger.IsDebug) _logger.Debug($"|NetworkTrace| {protocolCode}.{protocolVersion} initialized in {session}");
+            return false;
+        }
+
+        if (_logger.IsTrace) _logger.Trace($"|NetworkTrace| {protocolCode}.{protocolVersion} initialized in {session}");
+        return true;
+    }
+}

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SatelliteProtocolHandlerFactory.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SatelliteProtocolHandlerFactory.cs
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Logging;
+using Nethermind.Synchronization.Peers;
+
+namespace Nethermind.Network.P2P.ProtocolHandlers;
+
+public abstract class SatelliteProtocolHandlerFactory: IProtocolHandlerFactory
+{
+    private readonly ILogger _logger;
+    private readonly IProtocolValidator _protocolValidator;
+    private readonly ISyncPeerPool _syncPool;
+
+    protected SatelliteProtocolHandlerFactory(
+        IProtocolValidator protocolValidator,
+        ISyncPeerPool syncPool,
+        ILogManager logManager)
+    {
+        _protocolValidator = protocolValidator;
+        _syncPool = syncPool;
+        _logger = logManager.GetClassLogger<SyncProtocolHandlerFactory>();
+    }
+
+
+    public int ProtocolPriority => ProtocolPriorities.Satellite;
+    public abstract int MessageIdSpaceSize { get; }
+    public abstract ProtocolHandlerBase CreateSatelliteProtocol(ISession session);
+
+    public IProtocolHandler Create(ISession session)
+    {
+        ProtocolHandlerBase satelliteProtocol = CreateSatelliteProtocol(session);
+        InitSatelliteProtocol(session, satelliteProtocol);
+        return satelliteProtocol;
+    }
+
+
+    private void InitSatelliteProtocol(ISession session, ProtocolHandlerBase handler)
+    {
+        session.Node.EthDetails = handler.Name;
+        handler.ProtocolInitialized += (sender, args) =>
+        {
+            if (!RunBasicChecks(session, handler.ProtocolCode, handler.ProtocolVersion)) return;
+            // SyncPeerProtocolInitializedEventArgs typedArgs = (SyncPeerProtocolInitializedEventArgs)args;
+            // _stats.ReportSyncPeerInitializeEvent(handler.ProtocolCode, session.Node, new SyncPeerNodeDetails
+            // {
+            //     NetworkId = typedArgs.NetworkId,
+            //     BestHash = typedArgs.BestHash,
+            //     GenesisHash = typedArgs.GenesisHash,
+            //     ProtocolVersion = typedArgs.ProtocolVersion,
+            //     TotalDifficulty = (BigInteger)typedArgs.TotalDifficulty
+            // });
+            bool isValid = _protocolValidator.DisconnectOnInvalid(handler.ProtocolCode, session, args);
+            if (isValid)
+            {
+                var peer = _syncPool.GetPeer(session.Node)!;
+                peer.SyncPeer.RegisterSatelliteProtocol(handler.ProtocolCode, handler);
+                if (handler.IsPriority) _syncPool.SetPeerPriority(session.Node.Id);
+                if (_logger.IsDebug) _logger.Debug($"{handler.ProtocolCode} satellite protocol registered for sync peer {session}.");
+
+                if (_logger.IsTrace) _logger.Trace($"Finalized {handler.ProtocolCode.ToUpper()} protocol initialization on {session} - adding sync peer {session.Node:s}");
+            }
+            else
+            {
+                if (_logger.IsTrace) _logger.Trace($"|NetworkTrace| {handler.ProtocolCode}{handler.ProtocolVersion} is invalid on {session}");
+            }
+        };
+    }
+
+    private bool RunBasicChecks(ISession session, string protocolCode, int protocolVersion)
+    {
+        if (session.IsClosing)
+        {
+            if (_logger.IsDebug) _logger.Debug($"|NetworkTrace| {protocolCode}.{protocolVersion} initialized in {session}");
+            return false;
+        }
+
+        if (_logger.IsTrace) _logger.Trace($"|NetworkTrace| {protocolCode}.{protocolVersion} initialized in {session}");
+        return true;
+    }
+}

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncProtocolHandlerFactory.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncProtocolHandlerFactory.cs
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using Nethermind.Config;
+using Nethermind.Logging;
+using Nethermind.Network.P2P.EventArg;
+using Nethermind.Stats;
+using Nethermind.Stats.Model;
+using Nethermind.Synchronization.Peers;
+using Nethermind.TxPool;
+
+namespace Nethermind.Network.P2P.ProtocolHandlers;
+
+public abstract class SyncProtocolHandlerFactory: IProtocolHandlerFactory
+{
+    private readonly IProtocolValidator _protocolValidator;
+    private readonly INetworkStorage _peerStorage;
+    private readonly ISyncPeerPool _syncPool;
+    protected readonly ITxPool _txPool;
+    protected readonly INodeStatsManager _stats;
+    private readonly ILogger _logger;
+
+    protected SyncProtocolHandlerFactory(
+        IProtocolValidator protocolValidator,
+        INetworkStorage peerStorage,
+        ISyncPeerPool syncPool,
+        ITxPool txPool,
+        INodeStatsManager stats,
+        ILogManager logManager)
+    {
+        _protocolValidator = protocolValidator;
+        _peerStorage = peerStorage;
+        _syncPool = syncPool;
+        _txPool = txPool;
+        _stats = stats;
+        _logger = logManager.GetClassLogger<SyncProtocolHandlerFactory>();
+    }
+
+    public int ProtocolPriority => ProtocolPriorities.Sync;
+    public abstract int MessageIdSpaceSize { get; }
+
+    protected abstract SyncPeerProtocolHandlerBase CreateSyncProtocolHandler(ISession session);
+
+    public IProtocolHandler Create(ISession session)
+    {
+        SyncPeerProtocolHandlerBase handler = CreateSyncProtocolHandler(session);
+        InitSyncPeerProtocol(session, handler);
+        return handler;
+    }
+
+    private void InitSyncPeerProtocol(ISession session, SyncPeerProtocolHandlerBase handler)
+    {
+        session.Node.EthDetails = handler.Name;
+        handler.ProtocolInitialized += (sender, args) =>
+        {
+            if (!RunBasicChecks(session, handler.ProtocolCode, handler.ProtocolVersion)) return;
+            SyncPeerProtocolInitializedEventArgs typedArgs = (SyncPeerProtocolInitializedEventArgs)args;
+            // TODO: Does not need to be here
+            _stats.ReportSyncPeerInitializeEvent(handler.ProtocolCode, session.Node, new SyncPeerNodeDetails
+            {
+                NetworkId = typedArgs.NetworkId,
+                BestHash = typedArgs.BestHash,
+                GenesisHash = typedArgs.GenesisHash,
+                ProtocolVersion = typedArgs.ProtocolVersion,
+                TotalDifficulty = (BigInteger)typedArgs.TotalDifficulty
+            });
+            bool isValid = _protocolValidator.DisconnectOnInvalid(handler.ProtocolCode, session, args);
+            if (isValid)
+            {
+                // TODO: Disconnect if pool already have peer
+                // if (_logger.IsTrace) _logger.Trace($"Not able to add a sync peer on {session} for {session.Node:s}");
+                // session.InitiateDisconnect(DisconnectReason.SessionIdAlreadyExists, "sync peer");
+                _syncPool.AddPeer(handler);
+                if (handler.IncludeInTxPool) _txPool.AddPeer(handler);
+                if (_logger.IsDebug) _logger.Debug($"{handler.ClientId} sync peer {session} created.");
+
+                session.Disconnected += (o, e) =>
+                {
+                    _syncPool.RemovePeer(handler);
+                    _txPool.RemovePeer(session.Node.Id);
+                    if (session.BestStateReached == SessionState.Initialized)
+                    {
+                        if (_logger.IsDebug)
+                            _logger.Debug(
+                                $"{session.Direction} {session.Node:s} disconnected {e.DisconnectType} {e.DisconnectReason} {e.Details}");
+                    }
+                };
+
+                if (_logger.IsTrace) _logger.Trace($"Finalized {handler.ProtocolCode.ToUpper()} protocol initialization on {session} - adding sync peer {session.Node:s}");
+
+                //Add/Update peer to the storage and to sync manager
+                _peerStorage.UpdateNode(new NetworkNode(session.Node.Id, session.Node.Host, session.Node.Port, _stats.GetOrAdd(session.Node).NewPersistedNodeReputation(DateTime.UtcNow)));
+            }
+            else
+            {
+                if (_logger.IsTrace) _logger.Trace($"|NetworkTrace| {handler.ProtocolCode}{handler.ProtocolVersion} is invalid on {session}");
+            }
+        };
+    }
+
+    private bool RunBasicChecks(ISession session, string protocolCode, int protocolVersion)
+    {
+        if (session.IsClosing)
+        {
+            if (_logger.IsDebug) _logger.Debug($"|NetworkTrace| {protocolCode}.{protocolVersion} initialized in {session}");
+            return false;
+        }
+
+        if (_logger.IsTrace) _logger.Trace($"|NetworkTrace| {protocolCode}.{protocolVersion} initialized in {session}");
+        return true;
+    }
+}

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncProtocolHandlerFactory.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncProtocolHandlerFactory.cs
@@ -70,10 +70,12 @@ public abstract class SyncProtocolHandlerFactory: IProtocolHandlerFactory
             bool isValid = _protocolValidator.DisconnectOnInvalid(handler.ProtocolCode, session, args);
             if (isValid)
             {
-                // TODO: Disconnect if pool already have peer
-                // if (_logger.IsTrace) _logger.Trace($"Not able to add a sync peer on {session} for {session.Node:s}");
-                // session.InitiateDisconnect(DisconnectReason.SessionIdAlreadyExists, "sync peer");
-                _syncPool.AddPeer(handler);
+                if (!_syncPool.TryAddPeer(handler))
+                {
+                    if (_logger.IsTrace) _logger.Trace($"Not able to add a sync peer on {session} for {session.Node:s}");
+                    session.InitiateDisconnect(DisconnectReason.SessionIdAlreadyExists, "sync peer");
+                }
+
                 if (handler.IncludeInTxPool) _txPool.AddPeer(handler);
                 if (_logger.IsDebug) _logger.Debug($"{handler.ClientId} sync peer {session} created.");
 

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolMessageIdSpaces.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolMessageIdSpaces.cs
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.Network.P2P;
+
+public static class ProtocolMessageIdSpaces
+{
+    public const int AA = 4;
+    public const int P2P = 16;
+    public const int Eth62 = 8;
+    public const int Eth63 = 17;
+    public const int Eth66 = Eth63;
+    public const int Eth67 = Eth66;
+    public const int Eth68 = Eth67;
+    public const int Les = 23;
+    public const int NodeData = 2;
+    public const int Snap = 8;
+    public const int Wit = 3;
+}

--- a/src/Nethermind/Nethermind.Network/P2P/Session.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Session.cs
@@ -578,8 +578,9 @@ namespace Nethermind.Network.P2P
         {
             // Combine with already initialized protocols
             // Note: Devp2p does not specify add or remove capability in the spec, so what actually happen if a protocol
-            // is removed is not really know, or what happen if a message with the wrong adaptive id happens to be send
-            // in between and such.
+            // is removed is not really defined, or what happen if a message with the wrong adaptive id happens to be send
+            // in between and such, so we'll assume that protocol space is never removed, but this is not really correct
+            // as newly added protocol can go in between other protocol.
             protocols = protocols
                 .Concat(_protocols.Select((p) => KeyValuePair.Create(p.Key, p.Value.MessageIdSpaceSize)))
                 .ToDictionary();

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandler.cs
@@ -61,7 +61,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
 
         public override byte ProtocolVersion => EthVersions.Eth62;
         public override string ProtocolCode => Protocol.Eth;
-        public override int MessageIdSpaceSize => 8;
+        public override int MessageIdSpaceSize => ProtocolMessageIdSpaces.Eth62;
         public override string Name => "eth62";
         protected override TimeSpan InitTimeout => Timeouts.Eth62Status;
         protected bool CanReceiveTransactions => _txGossipPolicy.ShouldListenToGossipedTransactions;

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V63/Eth63ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V63/Eth63ProtocolHandler.cs
@@ -61,7 +61,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V63
 
         public override byte ProtocolVersion => EthVersions.Eth63;
 
-        public override int MessageIdSpaceSize => 17; // magic number here following Go
+        public override int MessageIdSpaceSize => ProtocolMessageIdSpaces.Eth63;
 
         public override void HandleMessage(ZeroPacket message)
         {

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandlerFactory.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandlerFactory.cs
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Consensus;
+using Nethermind.Consensus.Scheduler;
+using Nethermind.Logging;
+using Nethermind.Network.P2P.ProtocolHandlers;
+using Nethermind.Stats;
+using Nethermind.Synchronization;
+using Nethermind.Synchronization.Peers;
+using Nethermind.TxPool;
+
+namespace Nethermind.Network.P2P.Subprotocols.Eth.V66;
+
+public class Eth66ProtocolHandlerFactory: SyncProtocolHandlerFactory
+{
+    private readonly IMessageSerializationService _serializer;
+    private readonly ISyncServer _syncServer;
+    private readonly IBackgroundTaskScheduler _backgroundTaskScheduler;
+    private readonly IPooledTxsRequestor _pooledTxsRequestor;
+    private readonly IGossipPolicy _gossipPolicy;
+    private readonly ForkInfo _forkInfo;
+    private readonly ILogManager _logManager;
+    private readonly ITxGossipPolicy? _txGossipPolicy;
+
+    public Eth66ProtocolHandlerFactory(
+        IProtocolValidator protocolValidator,
+        INetworkStorage peerStorage,
+        ISyncPeerPool syncPool,
+        IMessageSerializationService serializer,
+        INodeStatsManager stats,
+        ISyncServer syncServer,
+        IBackgroundTaskScheduler backgroundTaskScheduler,
+        ITxPool txPool,
+        IPooledTxsRequestor pooledTxsRequestor,
+        IGossipPolicy gossipPolicy,
+        ForkInfo forkInfo,
+        ILogManager logManager,
+        ITxGossipPolicy txGossipPolicy
+    ) :
+        base(
+            protocolValidator,
+            peerStorage,
+            syncPool,
+            txPool,
+            stats,
+            logManager)
+    {
+        _serializer = serializer;
+        _syncServer = syncServer;
+        _backgroundTaskScheduler = backgroundTaskScheduler;
+        _pooledTxsRequestor = pooledTxsRequestor;
+        _gossipPolicy = gossipPolicy;
+        _forkInfo = forkInfo;
+        _logManager = logManager;
+        _txGossipPolicy = txGossipPolicy;
+    }
+
+    public override int MessageIdSpaceSize => ProtocolMessageIdSpaces.Eth66;
+
+    protected override SyncPeerProtocolHandlerBase CreateSyncProtocolHandler(ISession session)
+    {
+        return new Eth66ProtocolHandler(
+            session,
+            _serializer,
+            _stats,
+            _syncServer,
+            _backgroundTaskScheduler,
+            _txPool,
+            _pooledTxsRequestor,
+            _gossipPolicy,
+            _forkInfo,
+            _logManager,
+            _txGossipPolicy);
+    }
+
+}

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V67/Eth67ProtocolHandlerFactory.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V67/Eth67ProtocolHandlerFactory.cs
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Consensus;
+using Nethermind.Consensus.Scheduler;
+using Nethermind.Logging;
+using Nethermind.Network.P2P.ProtocolHandlers;
+using Nethermind.Network.P2P.Subprotocols.Eth.V67;
+using Nethermind.Stats;
+using Nethermind.Synchronization;
+using Nethermind.Synchronization.Peers;
+using Nethermind.TxPool;
+
+namespace Nethermind.Network.P2P.Subprotocols.Eth.V67;
+
+public class Eth67ProtocolHandlerFactory: SyncProtocolHandlerFactory
+{
+    private readonly IMessageSerializationService _serializer;
+    private readonly ISyncServer _syncServer;
+    private readonly IBackgroundTaskScheduler _backgroundTaskScheduler;
+    private readonly IPooledTxsRequestor _pooledTxsRequestor;
+    private readonly IGossipPolicy _gossipPolicy;
+    private readonly ForkInfo _forkInfo;
+    private readonly ILogManager _logManager;
+    private readonly ITxGossipPolicy? _txGossipPolicy;
+
+    public override int MessageIdSpaceSize => ProtocolMessageIdSpaces.Eth67;
+
+    public Eth67ProtocolHandlerFactory(
+        IProtocolValidator protocolValidator,
+        INetworkStorage peerStorage,
+        ISyncPeerPool syncPool,
+        IMessageSerializationService serializer,
+        INodeStatsManager stats,
+        ISyncServer syncServer,
+        IBackgroundTaskScheduler backgroundTaskScheduler,
+        ITxPool txPool,
+        IPooledTxsRequestor pooledTxsRequestor,
+        IGossipPolicy gossipPolicy,
+        ForkInfo forkInfo,
+        ILogManager logManager,
+        ITxGossipPolicy txGossipPolicy
+    ) :
+        base(
+            protocolValidator,
+            peerStorage,
+            syncPool,
+            txPool,
+            stats,
+            logManager)
+    {
+        _serializer = serializer;
+        _syncServer = syncServer;
+        _backgroundTaskScheduler = backgroundTaskScheduler;
+        _pooledTxsRequestor = pooledTxsRequestor;
+        _gossipPolicy = gossipPolicy;
+        _forkInfo = forkInfo;
+        _logManager = logManager;
+        _txGossipPolicy = txGossipPolicy;
+    }
+
+    protected override SyncPeerProtocolHandlerBase CreateSyncProtocolHandler(ISession session)
+    {
+        return new Eth67ProtocolHandler(
+            session,
+            _serializer,
+            _stats,
+            _syncServer,
+            _backgroundTaskScheduler,
+            _txPool,
+            _pooledTxsRequestor,
+            _gossipPolicy,
+            _forkInfo,
+            _logManager,
+            _txGossipPolicy);
+    }
+
+}

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth67ProtocolHandlerFactory.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth67ProtocolHandlerFactory.cs
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Consensus;
+using Nethermind.Consensus.Scheduler;
+using Nethermind.Logging;
+using Nethermind.Network.P2P.ProtocolHandlers;
+using Nethermind.Stats;
+using Nethermind.Synchronization;
+using Nethermind.Synchronization.Peers;
+using Nethermind.TxPool;
+
+namespace Nethermind.Network.P2P.Subprotocols.Eth.V68;
+
+public class Eth68ProtocolHandlerFactory: SyncProtocolHandlerFactory
+{
+    private readonly IMessageSerializationService _serializer;
+    private readonly ISyncServer _syncServer;
+    private readonly IBackgroundTaskScheduler _backgroundTaskScheduler;
+    private readonly IPooledTxsRequestor _pooledTxsRequestor;
+    private readonly IGossipPolicy _gossipPolicy;
+    private readonly ForkInfo _forkInfo;
+    private readonly ILogManager _logManager;
+    private readonly ITxGossipPolicy? _txGossipPolicy;
+
+    public Eth68ProtocolHandlerFactory(
+        IProtocolValidator protocolValidator,
+        INetworkStorage peerStorage,
+        ISyncPeerPool syncPool,
+        IMessageSerializationService serializer,
+        INodeStatsManager stats,
+        ISyncServer syncServer,
+        IBackgroundTaskScheduler backgroundTaskScheduler,
+        ITxPool txPool,
+        IPooledTxsRequestor pooledTxsRequestor,
+        IGossipPolicy gossipPolicy,
+        ForkInfo forkInfo,
+        ILogManager logManager,
+        ITxGossipPolicy txGossipPolicy
+    ) :
+        base(
+            protocolValidator,
+            peerStorage,
+            syncPool,
+            txPool,
+            stats,
+            logManager)
+    {
+        _serializer = serializer;
+        _syncServer = syncServer;
+        _backgroundTaskScheduler = backgroundTaskScheduler;
+        _pooledTxsRequestor = pooledTxsRequestor;
+        _gossipPolicy = gossipPolicy;
+        _forkInfo = forkInfo;
+        _logManager = logManager;
+        _txGossipPolicy = txGossipPolicy;
+    }
+
+    public override int MessageIdSpaceSize => ProtocolMessageIdSpaces.Eth68;
+
+    protected override SyncPeerProtocolHandlerBase CreateSyncProtocolHandler(ISession session)
+    {
+        return new Eth68ProtocolHandler(
+            session,
+            _serializer,
+            _stats,
+            _syncServer,
+            _backgroundTaskScheduler,
+            _txPool,
+            _pooledTxsRequestor,
+            _gossipPolicy,
+            _forkInfo,
+            _logManager,
+            _txGossipPolicy);
+    }
+
+}

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Les/LesProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Les/LesProtocolHandler.cs
@@ -91,7 +91,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Les
 
         public override string ProtocolCode => Protocol.Les;
 
-        public override int MessageIdSpaceSize => 23;
+        public override int MessageIdSpaceSize => ProtocolMessageIdSpaces.Les;
 
         protected override TimeSpan InitTimeout => Timeouts.Les3Status;
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Les/LesProtocolHandlerFactory.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Les/LesProtocolHandlerFactory.cs
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Consensus.Scheduler;
+using Nethermind.Logging;
+using Nethermind.Network.P2P.ProtocolHandlers;
+using Nethermind.Stats;
+using Nethermind.Synchronization;
+using Nethermind.Synchronization.Peers;
+using Nethermind.TxPool;
+
+namespace Nethermind.Network.P2P.Subprotocols.Les;
+
+public class LesProtocolHandlerFactory: SyncProtocolHandlerFactory
+{
+    private readonly IMessageSerializationService _serializer;
+    private readonly IBackgroundTaskScheduler _backgroundTaskScheduler;
+    private readonly ISyncServer _syncServer;
+    private readonly ILogManager _logManager;
+
+    public LesProtocolHandlerFactory(
+        IProtocolValidator protocolValidator,
+        INetworkStorage peerStorage,
+        ISyncPeerPool syncPool,
+        ITxPool txPool,
+        IMessageSerializationService serializer,
+        INodeStatsManager stats,
+        ISyncServer syncServer,
+        IBackgroundTaskScheduler backgroundTaskScheduler,
+        ILogManager logManager)
+        : base(protocolValidator, peerStorage, syncPool, txPool, stats, logManager)
+    {
+        _serializer = serializer;
+        _syncServer = syncServer;
+        _backgroundTaskScheduler = backgroundTaskScheduler;
+        _logManager = logManager;
+    }
+
+    public override int MessageIdSpaceSize => ProtocolMessageIdSpaces.Les;
+
+    protected override SyncPeerProtocolHandlerBase CreateSyncProtocolHandler(ISession session)
+    {
+        return new LesProtocolHandler(session, _serializer, _stats, _syncServer, _backgroundTaskScheduler, _logManager);
+    }
+}

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/NodeData/NodeDataProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/NodeData/NodeDataProtocolHandler.cs
@@ -31,7 +31,7 @@ public class NodeDataProtocolHandler : ZeroProtocolHandlerBase, INodeDataPeer
     protected override TimeSpan InitTimeout => Timeouts.Eth;
     public override byte ProtocolVersion => 1;
     public override string ProtocolCode => Protocol.NodeData;
-    public override int MessageIdSpaceSize => 2;
+    public override int MessageIdSpaceSize => ProtocolMessageIdSpaces.NodeData;
 
     public NodeDataProtocolHandler(ISession session,
         IMessageSerializationService serializer,

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/NodeData/NodeDataProtocolHandlerFactory.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/NodeData/NodeDataProtocolHandlerFactory.cs
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Consensus.Scheduler;
+using Nethermind.Logging;
+using Nethermind.Network.P2P.ProtocolHandlers;
+using Nethermind.Stats;
+using Nethermind.Synchronization;
+using Nethermind.Synchronization.Peers;
+
+namespace Nethermind.Network.P2P.Subprotocols.NodeData;
+
+public class NodeDataProtocolHandlerFactory: SatelliteProtocolHandlerFactory
+{
+    private readonly IMessageSerializationService _serializer;
+    private readonly INodeStatsManager _stats;
+    private readonly ISyncServer _syncServer;
+    private readonly IBackgroundTaskScheduler _backgroundTaskScheduler;
+    private readonly ILogManager _logManager;
+
+    public override int MessageIdSpaceSize => 2;
+
+    public NodeDataProtocolHandlerFactory(
+        IProtocolValidator protocolValidator,
+        ISyncPeerPool syncPool,
+        IMessageSerializationService serializer,
+        INodeStatsManager stats,
+        ISyncServer syncServer,
+        IBackgroundTaskScheduler backgroundTaskScheduler,
+        ILogManager logManager
+    ) : base(protocolValidator, syncPool, logManager)
+    {
+        _serializer = serializer;
+        _stats = stats;
+        _syncServer = syncServer;
+        _backgroundTaskScheduler = backgroundTaskScheduler;
+        _logManager = logManager;
+    }
+
+    public override ProtocolHandlerBase CreateSatelliteProtocol(ISession session)
+    {
+        return new NodeDataProtocolHandler(session, _serializer, _stats, _syncServer, _backgroundTaskScheduler,
+            _logManager);
+    }
+}

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/SnapProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/SnapProtocolHandler.cs
@@ -37,7 +37,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap
 
         public override byte ProtocolVersion => 1;
         public override string ProtocolCode => Protocol.Snap;
-        public override int MessageIdSpaceSize => 8;
+        public override int MessageIdSpaceSize => ProtocolMessageIdSpaces.Snap;
 
         private const string DisconnectMessage = "Serving snap data in not implemented in this node.";
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/SnapProtocolHandlerFactory.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/SnapProtocolHandlerFactory.cs
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Logging;
+using Nethermind.Network.P2P.ProtocolHandlers;
+using Nethermind.Stats;
+using Nethermind.Synchronization.Peers;
+
+namespace Nethermind.Network.P2P.Subprotocols.Snap;
+
+public class SnapProtocolHandlerFactory: SatelliteProtocolHandlerFactory
+{
+    private readonly INodeStatsManager _stats;
+    private readonly IMessageSerializationService _serializer;
+    private readonly ILogManager _logManager;
+
+    public SnapProtocolHandlerFactory(
+        IProtocolValidator protocolValidator,
+        ISyncPeerPool syncPool,
+        INodeStatsManager stats,
+        IMessageSerializationService serializer,
+        ILogManager logManager) : base(protocolValidator, syncPool, logManager)
+    {
+        _stats = stats;
+        _serializer = serializer;
+        _logManager = logManager;
+    }
+
+    public override int MessageIdSpaceSize => ProtocolMessageIdSpaces.Snap;
+
+    public override ProtocolHandlerBase CreateSatelliteProtocol(ISession session)
+    {
+        return new SnapProtocolHandler(session, _stats, _serializer, _logManager);
+    }
+}

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Wit/WitProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Wit/WitProtocolHandler.cs
@@ -16,6 +16,7 @@ using Nethermind.Stats;
 using Nethermind.Stats.Model;
 using Nethermind.Synchronization;
 
+
 namespace Nethermind.Network.P2P.Subprotocols.Wit
 {
     public class WitProtocolHandler : ZeroProtocolHandlerBase, IWitnessPeer
@@ -38,7 +39,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Wit
 
         public override string ProtocolCode => Protocol.Wit;
 
-        public override int MessageIdSpaceSize => 3;
+        public override int MessageIdSpaceSize => ProtocolMessageIdSpaces.Wit;
 
         public override string Name => "wit0";
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Wit/WitProtocolHandlerFactory.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Wit/WitProtocolHandlerFactory.cs
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Logging;
+using Nethermind.Network.P2P.ProtocolHandlers;
+using Nethermind.Stats;
+using Nethermind.Synchronization;
+using Nethermind.Synchronization.Peers;
+
+namespace Nethermind.Network.P2P.Subprotocols.Wit;
+
+public class WitProtocolHandlerFactory: SatelliteProtocolHandlerFactory
+{
+    private readonly INodeStatsManager _stats;
+    private readonly IMessageSerializationService _serializer;
+    private readonly ISyncServer _syncServer;
+    private readonly ILogManager _logManager;
+
+    public WitProtocolHandlerFactory(
+        IProtocolValidator protocolValidator,
+        ISyncPeerPool syncPool,
+        INodeStatsManager stats,
+        ISyncServer syncServer,
+        IMessageSerializationService serializer,
+        ILogManager logManager) : base(protocolValidator, syncPool, logManager)
+    {
+        _stats = stats;
+        _serializer = serializer;
+        _syncServer = syncServer;
+        _logManager = logManager;
+    }
+
+    public override int MessageIdSpaceSize => ProtocolMessageIdSpaces.Wit;
+
+    public override ProtocolHandlerBase CreateSatelliteProtocol(ISession session)
+    {
+        return new WitProtocolHandler(session, _serializer, _stats, _syncServer, _logManager);
+    }
+}

--- a/src/Nethermind/Nethermind.Network/ProtocolsManager.cs
+++ b/src/Nethermind/Nethermind.Network/ProtocolsManager.cs
@@ -4,9 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Numerics;
-using System.Text.RegularExpressions;
-using Nethermind.Config;
+using System.Linq;
 using Nethermind.Consensus;
 using Nethermind.Consensus.Scheduler;
 using Nethermind.Logging;
@@ -36,10 +34,7 @@ namespace Nethermind.Network
 {
     public class ProtocolsManager : IProtocolsManager
     {
-        private readonly ConcurrentDictionary<Guid, SyncPeerProtocolHandlerBase> _syncPeers = new();
-
-        private readonly ConcurrentDictionary<Node, ConcurrentDictionary<Guid, ProtocolHandlerBase>> _hangingSatelliteProtocols =
-            new();
+        public const int AnyVersion = -1;
 
         private readonly ConcurrentDictionary<Guid, ISession> _sessions = new();
         private readonly ISyncPeerPool _syncPool;
@@ -58,11 +53,9 @@ namespace Nethermind.Network
         private readonly INetworkConfig _networkConfig;
         private readonly ILogManager _logManager;
         private readonly ILogger _logger;
-        private readonly IDictionary<string, Func<ISession, int, IProtocolHandler>> _protocolFactories;
+        private readonly IDictionary<(string, int), IProtocolHandlerFactory> _protocolFactories;
         private readonly HashSet<Capability> _capabilities = new();
-        private readonly Regex? _clientIdPattern;
         private readonly IBackgroundTaskScheduler _backgroundTaskScheduler;
-        public event EventHandler<ProtocolInitializedEventArgs>? P2PProtocolInitialized;
 
         public ProtocolsManager(
             ISyncPeerPool syncPeerPool,
@@ -100,11 +93,6 @@ namespace Nethermind.Network
             _networkConfig = networkConfig ?? throw new ArgumentNullException(nameof(networkConfig));
             _logger = _logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
 
-            if (networkConfig.ClientIdMatcher is not null)
-            {
-                _clientIdPattern = new Regex(networkConfig.ClientIdMatcher, RegexOptions.Compiled);
-            }
-
             _protocolFactories = GetProtocolFactories();
             rlpxHost.SessionCreated += SessionCreated;
         }
@@ -121,28 +109,13 @@ namespace Nethermind.Network
             ISession session = (ISession)sender;
             session.Initialized -= SessionInitialized;
             session.Disconnected -= SessionDisconnected;
-
-            if (_syncPeers.TryRemove(session.SessionId, out var removed))
-            {
-                _syncPool.RemovePeer(removed);
-                _txPool.RemovePeer(removed.Node.Id);
-                if (session.BestStateReached == SessionState.Initialized)
-                {
-                    if (_logger.IsDebug) _logger.Debug($"{session.Direction} {session.Node:s} disconnected {e.DisconnectType} {e.DisconnectReason} {e.Details}");
-                }
-            }
-
-            if (_hangingSatelliteProtocols.TryGetValue(session.Node, out var registrations))
-            {
-                registrations.TryRemove(session.SessionId, out _);
-            }
-
             _sessions.TryRemove(session.SessionId, out session);
         }
 
         private void SessionInitialized(object sender, EventArgs e)
         {
             ISession session = (ISession)sender;
+            session.RegisterProtocolMessageSpace(new Dictionary<string, int> { { Protocol.P2P, P2PProtocolHandlerFactory.MessageSpace } });
             InitProtocol(session, Protocol.P2P, session.P2PVersion, true);
         }
 
@@ -158,14 +131,34 @@ namespace Nethermind.Network
                 return;
             }
 
-            string code = protocolCode.ToLowerInvariant();
-            if (!_protocolFactories.TryGetValue(code, out Func<ISession, int, IProtocolHandler> protocolFactory))
+            IProtocolHandlerFactory? factory = GetProtocolHandlerFactory(protocolCode, version);
+            if (factory == null)
             {
-                throw new NotSupportedException($"Protocol {code} {version} is not supported");
+                throw new NotSupportedException($"Protocol {protocolCode} {version} is not supported");
             }
 
-            IProtocolHandler protocolHandler = protocolFactory(session, version);
-            protocolHandler.SubprotocolRequested += (s, e) => InitProtocol(session, e.ProtocolCode, e.Version);
+            IProtocolHandler protocolHandler = factory.Create(session);
+            protocolHandler.SubprotocolRequested += (s, e) =>
+            {
+                // Select only protocol with factory and order by factory priority so that they are executed in the
+                // correct order.
+                var protocolAndMessageIdSpace = e.Protocols
+                    .Select((p) => (p, GetProtocolHandlerFactory(p.ProtocolCode, p.Version)))
+                    .Where((p) => p.Item2 != null)
+                    .OrderBy(p => p.Item2.ProtocolPriority)
+                    .Select((p => (p.Item1, p.Item2.MessageIdSpaceSize)))
+                    .ToList();
+
+                var protocols = protocolAndMessageIdSpace.Select((p) => p.Item1).ToList();
+                var messageIdSpaceSize = protocolAndMessageIdSpace.ToDictionary(p => p.Item1.ProtocolCode, p => p.MessageIdSpaceSize);
+                session.RegisterProtocolMessageSpace(messageIdSpaceSize);
+
+                for (var i = 0; i < protocols.Count; i++)
+                {
+                    InitProtocol(session, protocols[i].ProtocolCode, protocols[i].Version);
+                }
+            };
+
             session.AddProtocolHandler(protocolHandler);
             if (addCapabilities)
             {
@@ -178,247 +171,45 @@ namespace Nethermind.Network
             protocolHandler.Init();
         }
 
-        public void AddProtocol(string code, Func<ISession, IProtocolHandler> factory)
+        private IProtocolHandlerFactory? GetProtocolHandlerFactory(string protocolCode, int version)
         {
-            if (_protocolFactories.ContainsKey(code))
+            protocolCode = protocolCode.ToLowerInvariant();
+
+            if (_protocolFactories.TryGetValue((protocolCode, version), out IProtocolHandlerFactory? handlerFactory))
+            {
+                return handlerFactory;
+            }
+
+            if (_protocolFactories.TryGetValue((protocolCode, AnyVersion), out handlerFactory))
+            {
+                return handlerFactory;
+            }
+
+            return null;
+        }
+
+        public void AddProtocol(string code, int version, IProtocolHandlerFactory factory)
+        {
+            if (_protocolFactories.ContainsKey((code, version)))
             {
                 throw new InvalidOperationException($"Protocol {code} was already added.");
             }
 
-            _protocolFactories[code] = (session, _) => factory(session);
+            _protocolFactories[(code, version)] = factory;
         }
 
-        private IDictionary<string, Func<ISession, int, IProtocolHandler>> GetProtocolFactories()
-            => new Dictionary<string, Func<ISession, int, IProtocolHandler>>
+        private IDictionary<(string, int), IProtocolHandlerFactory> GetProtocolFactories()
+            => new Dictionary<(string, int), IProtocolHandlerFactory>
             {
-                [Protocol.P2P] = (session, _) =>
-                {
-                    P2PProtocolHandler handler = new(session, _rlpxHost.LocalNodeId, _stats, _serializer, _clientIdPattern, _logManager);
-                    session.PingSender = handler;
-                    InitP2PProtocol(session, handler);
-
-                    return handler;
-                },
-                [Protocol.Eth] = (session, version) =>
-                {
-                    var ethHandler = version switch
-                    {
-                        66 => new Eth66ProtocolHandler(session, _serializer, _stats, _syncServer, _backgroundTaskScheduler, _txPool, _pooledTxsRequestor, _gossipPolicy, _forkInfo, _logManager, _txGossipPolicy),
-                        67 => new Eth67ProtocolHandler(session, _serializer, _stats, _syncServer, _backgroundTaskScheduler, _txPool, _pooledTxsRequestor, _gossipPolicy, _forkInfo, _logManager, _txGossipPolicy),
-                        68 => new Eth68ProtocolHandler(session, _serializer, _stats, _syncServer, _backgroundTaskScheduler, _txPool, _pooledTxsRequestor, _gossipPolicy, _forkInfo, _logManager, _txGossipPolicy),
-                        _ => throw new NotSupportedException($"Eth protocol version {version} is not supported.")
-                    };
-
-                    InitSyncPeerProtocol(session, ethHandler);
-                    return ethHandler;
-                },
-                [Protocol.Snap] = (session, version) =>
-                {
-                    var handler = version switch
-                    {
-                        1 => new SnapProtocolHandler(session, _stats, _serializer, _logManager),
-                        _ => throw new NotSupportedException($"{Protocol.Snap}.{version} is not supported.")
-                    };
-                    InitSatelliteProtocol(session, handler);
-
-                    return handler;
-                },
-                [Protocol.NodeData] = (session, version) =>
-                {
-                    var handler = version switch
-                    {
-                        1 => new NodeDataProtocolHandler(session, _serializer, _stats, _syncServer, _backgroundTaskScheduler, _logManager),
-                        _ => throw new NotSupportedException($"{Protocol.NodeData}.{version} is not supported.")
-                    };
-                    InitSatelliteProtocol(session, handler);
-
-                    return handler;
-                },
-                [Protocol.Wit] = (session, version) =>
-                {
-                    var handler = version switch
-                    {
-                        0 => new WitProtocolHandler(session, _serializer, _stats, _syncServer, _logManager),
-                        _ => throw new NotSupportedException($"{Protocol.Wit}.{version} is not supported.")
-                    };
-                    InitSatelliteProtocol(session, handler);
-
-                    return handler;
-                },
-                [Protocol.Les] = (session, version) =>
-                {
-                    LesProtocolHandler handler = new(session, _serializer, _stats, _syncServer, _backgroundTaskScheduler, _logManager);
-                    InitSyncPeerProtocol(session, handler);
-
-                    return handler;
-                }
+                [(Protocol.P2P, AnyVersion)] = new P2PProtocolHandlerFactory(_rlpxHost, _serializer, _networkConfig, _discoveryApp, _protocolValidator, _stats, _logManager),
+                [(Protocol.Eth, 66)] = new Eth66ProtocolHandlerFactory(_protocolValidator, _peerStorage, _syncPool, _serializer, _stats, _syncServer, _backgroundTaskScheduler, _txPool, _pooledTxsRequestor, _gossipPolicy, _forkInfo, _logManager, _txGossipPolicy),
+                [(Protocol.Eth, 67)] = new Eth67ProtocolHandlerFactory(_protocolValidator, _peerStorage, _syncPool, _serializer, _stats, _syncServer, _backgroundTaskScheduler, _txPool, _pooledTxsRequestor, _gossipPolicy, _forkInfo, _logManager, _txGossipPolicy),
+                [(Protocol.Eth, 68)] = new Eth68ProtocolHandlerFactory(_protocolValidator, _peerStorage, _syncPool, _serializer, _stats, _syncServer, _backgroundTaskScheduler, _txPool, _pooledTxsRequestor, _gossipPolicy, _forkInfo, _logManager, _txGossipPolicy),
+                [(Protocol.Snap, 1)] = new SnapProtocolHandlerFactory(_protocolValidator, _syncPool, _stats, _serializer, _logManager),
+                [(Protocol.NodeData, 1)] = new NodeDataProtocolHandlerFactory(_protocolValidator, _syncPool, _serializer, _stats, _syncServer, _backgroundTaskScheduler, _logManager),
+                [(Protocol.Wit, 0)] = new WitProtocolHandlerFactory(_protocolValidator, _syncPool, _stats, _syncServer, _serializer, _logManager),
+                [(Protocol.Les, 0)] = new LesProtocolHandlerFactory(_protocolValidator, _peerStorage, _syncPool, _txPool, _serializer, _stats, _syncServer, _backgroundTaskScheduler, _logManager)
             };
-
-        private void InitSatelliteProtocol(ISession session, ProtocolHandlerBase handler)
-        {
-            session.Node.EthDetails = handler.Name;
-            handler.ProtocolInitialized += (sender, args) =>
-            {
-                if (!RunBasicChecks(session, handler.ProtocolCode, handler.ProtocolVersion)) return;
-                // SyncPeerProtocolInitializedEventArgs typedArgs = (SyncPeerProtocolInitializedEventArgs)args;
-                // _stats.ReportSyncPeerInitializeEvent(handler.ProtocolCode, session.Node, new SyncPeerNodeDetails
-                // {
-                //     NetworkId = typedArgs.NetworkId,
-                //     BestHash = typedArgs.BestHash,
-                //     GenesisHash = typedArgs.GenesisHash,
-                //     ProtocolVersion = typedArgs.ProtocolVersion,
-                //     TotalDifficulty = (BigInteger)typedArgs.TotalDifficulty
-                // });
-                bool isValid = _protocolValidator.DisconnectOnInvalid(handler.ProtocolCode, session, args);
-                if (isValid)
-                {
-                    var peer = _syncPool.GetPeer(session.Node);
-                    if (peer is not null)
-                    {
-                        peer.SyncPeer.RegisterSatelliteProtocol(handler.ProtocolCode, handler);
-                        if (handler.IsPriority) _syncPool.SetPeerPriority(session.Node.Id);
-                        if (_logger.IsDebug) _logger.Debug($"{handler.ProtocolCode} satellite protocol registered for sync peer {session}.");
-                    }
-                    else
-                    {
-                        _hangingSatelliteProtocols.AddOrUpdate(session.Node,
-                            new ConcurrentDictionary<Guid, ProtocolHandlerBase>(new[] { new KeyValuePair<Guid, ProtocolHandlerBase>(session.SessionId, handler) }),
-                            (node, dict) =>
-                        {
-                            dict[session.SessionId] = handler;
-                            return dict;
-                        });
-
-                        if (_logger.IsTrace) _logger.Trace($"{handler.ProtocolCode} satellite protocol sync peer {session} not found.");
-                    }
-
-                    if (_logger.IsTrace) _logger.Trace($"Finalized {handler.ProtocolCode.ToUpper()} protocol initialization on {session} - adding sync peer {session.Node:s}");
-                }
-                else
-                {
-                    if (_logger.IsTrace) _logger.Trace($"|NetworkTrace| {handler.ProtocolCode}{handler.ProtocolVersion} is invalid on {session}");
-                }
-            };
-        }
-
-        private void InitP2PProtocol(ISession session, P2PProtocolHandler handler)
-        {
-            handler.ProtocolInitialized += (sender, args) =>
-            {
-                P2PProtocolInitializedEventArgs typedArgs = (P2PProtocolInitializedEventArgs)args;
-                if (!RunBasicChecks(session, Protocol.P2P, handler.ProtocolVersion)) return;
-
-                if (handler.ProtocolVersion >= 5)
-                {
-                    if (_logger.IsTrace) _logger.Trace($"{handler.ProtocolCode}.{handler.ProtocolVersion} established on {session} - enabling snappy");
-                    session.EnableSnappy();
-                }
-                else
-                {
-                    if (_logger.IsTrace) _logger.Trace($"{handler.ProtocolCode}.{handler.ProtocolVersion} established on {session} - disabling snappy");
-                }
-
-                _stats.ReportP2PInitializationEvent(session.Node, new P2PNodeDetails
-                {
-                    ClientId = typedArgs.ClientId,
-                    Capabilities = typedArgs.Capabilities.ToArray(),
-                    P2PVersion = typedArgs.P2PVersion,
-                    ListenPort = typedArgs.ListenPort
-                });
-
-                AddNodeToDiscovery(session, typedArgs);
-
-                _protocolValidator.DisconnectOnInvalid(Protocol.P2P, session, args);
-
-                if (_logger.IsTrace) _logger.Trace($"Finalized P2P protocol initialization on {session}");
-                P2PProtocolInitialized?.Invoke(this, typedArgs);
-            };
-        }
-
-        private void InitSyncPeerProtocol(ISession session, SyncPeerProtocolHandlerBase handler)
-        {
-            session.Node.EthDetails = handler.Name;
-            handler.ProtocolInitialized += (sender, args) =>
-            {
-                if (!RunBasicChecks(session, handler.ProtocolCode, handler.ProtocolVersion)) return;
-                SyncPeerProtocolInitializedEventArgs typedArgs = (SyncPeerProtocolInitializedEventArgs)args;
-                _stats.ReportSyncPeerInitializeEvent(handler.ProtocolCode, session.Node, new SyncPeerNodeDetails
-                {
-                    NetworkId = typedArgs.NetworkId,
-                    BestHash = typedArgs.BestHash,
-                    GenesisHash = typedArgs.GenesisHash,
-                    ProtocolVersion = typedArgs.ProtocolVersion,
-                    TotalDifficulty = (BigInteger)typedArgs.TotalDifficulty
-                });
-                bool isValid = _protocolValidator.DisconnectOnInvalid(handler.ProtocolCode, session, args);
-                if (isValid)
-                {
-                    if (_syncPeers.TryAdd(session.SessionId, handler))
-                    {
-                        if (_hangingSatelliteProtocols.TryGetValue(handler.Node, out var handlerDictionary))
-                        {
-                            foreach (KeyValuePair<Guid, ProtocolHandlerBase> registration in handlerDictionary)
-                            {
-                                handler.RegisterSatelliteProtocol(registration.Value);
-                                if (registration.Value.IsPriority) handler.IsPriority = true;
-                                if (_logger.IsDebug) _logger.Debug($"{handler.ProtocolCode} satellite protocol registered for sync peer {session}. Sync peer has priority: {handler.IsPriority}");
-                            }
-                        }
-
-                        _syncPool.AddPeer(handler);
-                        if (handler.IncludeInTxPool) _txPool.AddPeer(handler);
-                        if (_logger.IsDebug) _logger.Debug($"{handler.ClientId} sync peer {session} created.");
-                    }
-                    else
-                    {
-                        if (_logger.IsTrace) _logger.Trace($"Not able to add a sync peer on {session} for {session.Node:s}");
-                        session.InitiateDisconnect(DisconnectReason.SessionIdAlreadyExists, "sync peer");
-                    }
-
-                    if (_logger.IsTrace) _logger.Trace($"Finalized {handler.ProtocolCode.ToUpper()} protocol initialization on {session} - adding sync peer {session.Node:s}");
-
-                    //Add/Update peer to the storage and to sync manager
-                    _peerStorage.UpdateNode(new NetworkNode(session.Node.Id, session.Node.Host, session.Node.Port, _stats.GetOrAdd(session.Node).NewPersistedNodeReputation(DateTime.UtcNow)));
-                }
-                else
-                {
-                    if (_logger.IsTrace) _logger.Trace($"|NetworkTrace| {handler.ProtocolCode}{handler.ProtocolVersion} is invalid on {session}");
-                }
-            };
-        }
-
-        private bool RunBasicChecks(ISession session, string protocolCode, int protocolVersion)
-        {
-            if (session.IsClosing)
-            {
-                if (_logger.IsDebug) _logger.Debug($"|NetworkTrace| {protocolCode}.{protocolVersion} initialized in {session}");
-                return false;
-            }
-
-            if (_logger.IsTrace) _logger.Trace($"|NetworkTrace| {protocolCode}.{protocolVersion} initialized in {session}");
-            return true;
-        }
-
-        /// <summary>
-        /// In case of IN connection we don't know what is the port node is listening on until we receive the Hello message
-        /// </summary>
-        private void AddNodeToDiscovery(ISession session, P2PProtocolInitializedEventArgs eventArgs)
-        {
-            if (eventArgs.ListenPort == 0)
-            {
-                if (_logger.IsTrace) _logger.Trace($"Listen port is 0, node is not listening: {session}");
-                return;
-            }
-
-            if (session.Node.Port != eventArgs.ListenPort)
-            {
-                if (_logger.IsDebug) _logger.Debug($"Updating listen port for {session:s} to: {eventArgs.ListenPort}");
-                session.Node.Port = eventArgs.ListenPort;
-            }
-
-            //In case peer was initiated outside of discovery and discovery is enabled, we are adding it to discovery for future use (e.g. trusted peer)
-            _discoveryApp.AddNodeToDiscovery(session.Node);
-        }
 
         public void AddSupportedCapability(Capability capability)
         {

--- a/src/Nethermind/Nethermind.Network/ProtocolsManager.cs
+++ b/src/Nethermind/Nethermind.Network/ProtocolsManager.cs
@@ -196,6 +196,7 @@ namespace Nethermind.Network
             }
 
             _protocolFactories[(code, version)] = factory;
+            AddSupportedCapability(new Capability(code, version));
         }
 
         private IDictionary<(string, int), IProtocolHandlerFactory> GetProtocolFactories()

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/SnapProtocolTests/StateSyncDispatcherTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/SnapProtocolTests/StateSyncDispatcherTests.cs
@@ -64,7 +64,7 @@ public class StateSyncDispatcherTests
         peer.ProtocolVersion.Returns((byte)66);
         peer.IsInitialized.Returns(true);
         peer.TotalDifficulty.Returns(new Int256.UInt256(1_000_000_000));
-        _pool.AddPeer(peer);
+        _pool.TryAddPeer(peer);
 
         StateSyncBatch batch = new(
             Keccak.OfAnEmptyString,
@@ -91,7 +91,7 @@ public class StateSyncDispatcherTests
                 x[1] = snapPeer;
                 return true;
             });
-        _pool.AddPeer(peer);
+        _pool.TryAddPeer(peer);
 
         StateSyncItem item01 = new(Keccak.EmptyTreeHash, null, new byte[] { 3 }, NodeDataType.State);
         StateSyncItem item02 = new(Keccak.EmptyTreeHash, new byte[] { 11 }, new byte[] { 2 }, NodeDataType.State);

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTestsBase.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTestsBase.cs
@@ -105,7 +105,7 @@ namespace Nethermind.Synchronization.Test.FastSync
 
             foreach (ISyncPeer syncPeer in syncPeers)
             {
-                ctx.Pool.AddPeer(syncPeer);
+                ctx.Pool.TryAddPeer(syncPeer);
             }
 
             ctx.TreeFeed = new(SyncMode.StateNodes, dbContext.LocalCodeDb, dbContext.LocalStateDb, blockTree, _logManager);

--- a/src/Nethermind/Nethermind.Synchronization.Test/OldStyleFullSynchronizerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/OldStyleFullSynchronizerTests.cs
@@ -131,7 +131,7 @@ namespace Nethermind.Synchronization.Test
             };
             _pool.Start();
             _synchronizer.Start();
-            _pool.AddPeer(peer);
+            _pool.TryAddPeer(peer);
 
             resetEvent.WaitOne(_standardTimeoutUnit);
             Assert.That(_blockTree.BestSuggestedHeader!.Number, Is.EqualTo(SyncBatchSize.Max * 2 - 1));
@@ -145,7 +145,7 @@ namespace Nethermind.Synchronization.Test
 
             _pool.Start();
             _synchronizer.Start();
-            _pool.AddPeer(peer);
+            _pool.TryAddPeer(peer);
 
             Assert.That(_blockTree.BestSuggestedHeader!.Number, Is.EqualTo(0));
         }
@@ -161,7 +161,7 @@ namespace Nethermind.Synchronization.Test
             _synchronizer.SyncEvent += (_, _) => { resetEvent.Set(); };
             _pool.Start();
             _synchronizer.Start();
-            _pool.AddPeer(peer);
+            _pool.TryAddPeer(peer);
 
             resetEvent.WaitOne(_standardTimeoutUnit);
             Assert.That(_blockTree.BestSuggestedHeader!.Number, Is.EqualTo(SyncBatchSize.Max * 2 - 1));
@@ -181,7 +181,7 @@ namespace Nethermind.Synchronization.Test
             };
             _pool.Start();
             _synchronizer.Start();
-            _pool.AddPeer(peer);
+            _pool.TryAddPeer(peer);
 
             BlockTreeBuilder.ExtendTree(_remoteBlockTree, SyncBatchSize.Max * 2);
             _syncServer.AddNewBlock(_remoteBlockTree.RetrieveHeadBlock()!, peer);
@@ -208,7 +208,7 @@ namespace Nethermind.Synchronization.Test
 
             _pool.Start();
             _synchronizer.Start();
-            _pool.AddPeer(peer);
+            _pool.TryAddPeer(peer);
 
             Block block = Build.A.Block
                 .WithParent(_remoteBlockTree.Head!)
@@ -235,7 +235,7 @@ namespace Nethermind.Synchronization.Test
 
             _pool.Start();
             _synchronizer.Start();
-            _pool.AddPeer(miner1);
+            _pool.TryAddPeer(miner1);
 
             resetEvent.WaitOne(_standardTimeoutUnit);
 
@@ -277,7 +277,7 @@ namespace Nethermind.Synchronization.Test
 
             _pool.Start();
             _synchronizer.Start();
-            _pool.AddPeer(miner1);
+            _pool.TryAddPeer(miner1);
 
             resetEvent.WaitOne(_standardTimeoutUnit);
 
@@ -311,7 +311,7 @@ namespace Nethermind.Synchronization.Test
 
             _pool.Start();
             _synchronizer.Start();
-            _pool.AddPeer(miner1);
+            _pool.TryAddPeer(miner1);
             resetEvent.WaitOne(_standardTimeoutUnit);
 
             Assert.That(_blockTree.BestSuggestedHeader!.Hash, Is.EqualTo(minerTree.BestSuggestedHeader!.Hash), "client agrees with miner before split");
@@ -328,7 +328,7 @@ namespace Nethermind.Synchronization.Test
 
             _pool.Start();
             _synchronizer.Start();
-            _pool.AddPeer(miner2);
+            _pool.TryAddPeer(miner2);
             resetEvent.WaitOne(_standardTimeoutUnit);
 
             await miner2.Received().GetBlockHeaders(6, 1, 0, default);
@@ -349,7 +349,7 @@ namespace Nethermind.Synchronization.Test
 
             _pool.Start();
             _synchronizer.Start();
-            _pool.AddPeer(miner1);
+            _pool.TryAddPeer(miner1);
             resetEvent.WaitOne(_standardTimeoutUnit);
 
             Assert.That(_blockTree.BestSuggestedHeader!.Hash, Is.EqualTo(minerTree.BestSuggestedHeader!.Hash), "client agrees with miner before split");
@@ -366,7 +366,7 @@ namespace Nethermind.Synchronization.Test
 
             _pool.Start();
             _synchronizer.Start();
-            _pool.AddPeer(miner2);
+            _pool.TryAddPeer(miner2);
             resetEvent.WaitOne(_standardTimeoutUnit);
 
             await miner2.Received().GetBlockHeaders(6, 1, 0, default);

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
@@ -85,8 +85,9 @@ namespace Nethermind.Synchronization.Test.ParallelSync
             public int InitializedPeersCount { get; } = 0;
             public int PeerMaxCount { get; } = 0;
 
-            public void AddPeer(ISyncPeer syncPeer)
+            public bool TryAddPeer(ISyncPeer syncPeer)
             {
+                return false;
             }
 
             public void RemovePeer(ISyncPeer syncPeer)

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerPoolTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerPoolTests.cs
@@ -167,7 +167,7 @@ namespace Nethermind.Synchronization.Test
             for (int i = 0; i < 3; i++)
             {
                 Assert.That(ctx.Pool.PeerCount, Is.EqualTo(0));
-                ctx.Pool.AddPeer(new SimpleSyncPeerMock(TestItem.PublicKeys[i]));
+                ctx.Pool.TryAddPeer(new SimpleSyncPeerMock(TestItem.PublicKeys[i]));
             }
         }
 
@@ -246,7 +246,7 @@ namespace Nethermind.Synchronization.Test
 
             SimpleSyncPeerMock peer = new(TestItem.PublicKeyA) { IsPriority = true };
             ctx.Pool.Start();
-            ctx.Pool.AddPeer(peer);
+            ctx.Pool.TryAddPeer(peer);
             await WaitForPeersInitialization(ctx);
             ctx.Pool.PriorityPeerCount.Should().Be(1);
 
@@ -264,7 +264,7 @@ namespace Nethermind.Synchronization.Test
 
             SimpleSyncPeerMock peer = new(TestItem.PublicKeyA) { IsPriority = false };
             ctx.Pool.Start();
-            ctx.Pool.AddPeer(peer);
+            ctx.Pool.TryAddPeer(peer);
             await WaitForPeersInitialization(ctx);
             ctx.Pool.PriorityPeerCount.Should().Be(0);
 
@@ -281,7 +281,7 @@ namespace Nethermind.Synchronization.Test
             for (int i = 0; i < 3; i++)
             {
                 syncPeers[i] = new SimpleSyncPeerMock(TestItem.PublicKeys[i]);
-                ctx.Pool.AddPeer(syncPeers[i]);
+                ctx.Pool.TryAddPeer(syncPeers[i]);
             }
 
             await ctx.Pool.StopAsync();
@@ -301,7 +301,7 @@ namespace Nethermind.Synchronization.Test
             for (int i = 0; i < 3; i++)
             {
                 Assert.That(ctx.Pool.PeerCount, Is.EqualTo(i));
-                ctx.Pool.AddPeer(new SimpleSyncPeerMock(TestItem.PublicKeys[i]));
+                ctx.Pool.TryAddPeer(new SimpleSyncPeerMock(TestItem.PublicKeys[i]));
             }
         }
 
@@ -310,8 +310,8 @@ namespace Nethermind.Synchronization.Test
         {
             await using Context ctx = new();
             ctx.Pool.Start();
-            ctx.Pool.AddPeer(new SimpleSyncPeerMock(TestItem.PublicKeyA));
-            ctx.Pool.AddPeer(new SimpleSyncPeerMock(TestItem.PublicKeyA));
+            ctx.Pool.TryAddPeer(new SimpleSyncPeerMock(TestItem.PublicKeyA));
+            ctx.Pool.TryAddPeer(new SimpleSyncPeerMock(TestItem.PublicKeyA));
 
             Assert.That(ctx.Pool.PeerCount, Is.EqualTo(1));
         }
@@ -334,7 +334,7 @@ namespace Nethermind.Synchronization.Test
             for (int i = 0; i < 3; i++)
             {
                 syncPeers[i] = new SimpleSyncPeerMock(TestItem.PublicKeys[i]);
-                ctx.Pool.AddPeer(syncPeers[i]);
+                ctx.Pool.TryAddPeer(syncPeers[i]);
             }
 
             for (int i = 3; i > 0; i--)
@@ -366,7 +366,7 @@ namespace Nethermind.Synchronization.Test
             ctx.Pool.Start();
             ISyncPeer? syncPeer = Substitute.For<ISyncPeer>();
             syncPeer.Node.Returns(new Node(TestItem.PublicKeyA, "127.0.0.1", 30303));
-            ctx.Pool.AddPeer(syncPeer);
+            ctx.Pool.TryAddPeer(syncPeer);
             ctx.Pool.RefreshTotalDifficulty(syncPeer, Keccak.Zero);
             await Task.Delay(100);
 
@@ -394,12 +394,12 @@ namespace Nethermind.Synchronization.Test
             SetupSpeedStats(ctx, TestItem.PublicKeyB, 100);
 
             ctx.Pool.Start();
-            ctx.Pool.AddPeer(new SimpleSyncPeerMock(TestItem.PublicKeyA, "A"));
+            ctx.Pool.TryAddPeer(new SimpleSyncPeerMock(TestItem.PublicKeyA, "A"));
             await WaitForPeersInitialization(ctx);
             SyncPeerAllocation allocation = await ctx.Pool.Allocate(new BlocksSyncPeerAllocationStrategy(null));
             bool replaced = false;
             allocation.Replaced += (_, _) => replaced = true;
-            ctx.Pool.AddPeer(new SimpleSyncPeerMock(TestItem.PublicKeyB, "B"));
+            ctx.Pool.TryAddPeer(new SimpleSyncPeerMock(TestItem.PublicKeyB, "B"));
 
             await WaitFor(() => replaced);
             Assert.True(replaced);
@@ -413,12 +413,12 @@ namespace Nethermind.Synchronization.Test
             SetupSpeedStats(ctx, TestItem.PublicKeyB, 100);
 
             ctx.Pool.Start();
-            ctx.Pool.AddPeer(new SimpleSyncPeerMock(TestItem.PublicKeyA));
+            ctx.Pool.TryAddPeer(new SimpleSyncPeerMock(TestItem.PublicKeyA));
             await WaitForPeersInitialization(ctx);
             SyncPeerAllocation allocation = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
             bool replaced = false;
             allocation.Replaced += (_, _) => replaced = true;
-            ctx.Pool.AddPeer(new SimpleSyncPeerMock(TestItem.PublicKeyB));
+            ctx.Pool.TryAddPeer(new SimpleSyncPeerMock(TestItem.PublicKeyB));
             await WaitForPeersInitialization(ctx);
 
             Assert.False(replaced);
@@ -432,12 +432,12 @@ namespace Nethermind.Synchronization.Test
             SetupSpeedStats(ctx, TestItem.PublicKeyB, 100);
 
             ctx.Pool.Start();
-            ctx.Pool.AddPeer(new SimpleSyncPeerMock(TestItem.PublicKeyA));
+            ctx.Pool.TryAddPeer(new SimpleSyncPeerMock(TestItem.PublicKeyA));
             await WaitForPeersInitialization(ctx);
             SyncPeerAllocation allocation = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
             bool replaced = false;
             allocation.Replaced += (_, _) => replaced = true;
-            ctx.Pool.AddPeer(new SimpleSyncPeerMock(TestItem.PublicKeyB));
+            ctx.Pool.TryAddPeer(new SimpleSyncPeerMock(TestItem.PublicKeyB));
             await WaitForPeersInitialization(ctx);
 
             Assert.False(replaced);
@@ -451,12 +451,12 @@ namespace Nethermind.Synchronization.Test
             SetupSpeedStats(ctx, TestItem.PublicKeyB, 4);
 
             ctx.Pool.Start();
-            ctx.Pool.AddPeer(new SimpleSyncPeerMock(TestItem.PublicKeyA));
+            ctx.Pool.TryAddPeer(new SimpleSyncPeerMock(TestItem.PublicKeyA));
             await WaitForPeersInitialization(ctx);
             SyncPeerAllocation allocation = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
             bool replaced = false;
             allocation.Replaced += (_, _) => replaced = true;
-            ctx.Pool.AddPeer(new SimpleSyncPeerMock(TestItem.PublicKeyB));
+            ctx.Pool.TryAddPeer(new SimpleSyncPeerMock(TestItem.PublicKeyB));
             await WaitForPeersInitialization(ctx);
 
             Assert.False(replaced);
@@ -470,12 +470,12 @@ namespace Nethermind.Synchronization.Test
             SetupSpeedStats(ctx, TestItem.PublicKeyB, 100);
 
             ctx.Pool.Start();
-            ctx.Pool.AddPeer(new SimpleSyncPeerMock(TestItem.PublicKeyA));
+            ctx.Pool.TryAddPeer(new SimpleSyncPeerMock(TestItem.PublicKeyA));
             await WaitForPeersInitialization(ctx);
             SyncPeerAllocation allocation = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
             bool replaced = false;
             allocation.Replaced += (_, _) => replaced = true;
-            ctx.Pool.AddPeer(new SimpleSyncPeerMock(TestItem.PublicKeyB));
+            ctx.Pool.TryAddPeer(new SimpleSyncPeerMock(TestItem.PublicKeyB));
             await WaitForPeersInitialization(ctx);
             Assert.False(replaced);
         }
@@ -627,7 +627,7 @@ namespace Nethermind.Synchronization.Test
             SimpleSyncPeerMock peer = new SimpleSyncPeerMock(TestItem.PublicKeyA);
             peer.SetHeaderResponseTime(int.MaxValue);
             ctx.Pool.Start();
-            ctx.Pool.AddPeer(peer);
+            ctx.Pool.TryAddPeer(peer);
 
             await WaitFor(() => peer.DisconnectRequested);
             Assert.True(peer.DisconnectRequested);
@@ -640,7 +640,7 @@ namespace Nethermind.Synchronization.Test
             SimpleSyncPeerMock peer = new SimpleSyncPeerMock(TestItem.PublicKeyA);
             peer.SetHeaderResponseTime(500);
             ctx.Pool.Start();
-            ctx.Pool.AddPeer(peer);
+            ctx.Pool.TryAddPeer(peer);
 
             SyncPeerAllocation allocation = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
             ctx.Pool.RemovePeer(peer);
@@ -656,7 +656,7 @@ namespace Nethermind.Synchronization.Test
             SimpleSyncPeerMock peer = new SimpleSyncPeerMock(TestItem.PublicKeyA);
             peer.SetHeaderFailure(true);
             ctx.Pool.Start();
-            ctx.Pool.AddPeer(peer);
+            ctx.Pool.TryAddPeer(peer);
             await WaitForPeersInitialization(ctx);
 
             SyncPeerAllocation allocation = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
@@ -813,7 +813,7 @@ namespace Nethermind.Synchronization.Test
 
             for (int i = 0; i < count; i++)
             {
-                ctx.Pool.AddPeer(peers[i]);
+                ctx.Pool.TryAddPeer(peers[i]);
             }
 
             await WaitForPeersInitialization(ctx);

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncThreadTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncThreadTests.cs
@@ -105,7 +105,7 @@ namespace Nethermind.Synchronization.Test
                     }
 
                     SyncTestContext remotePeer = _peers[remoteIndex];
-                    localPeer.PeerPool!.AddPeer(new SyncPeerMock(remotePeer.Tree, TestItem.PublicKeys[localIndex],
+                    localPeer.PeerPool!.TryAddPeer(new SyncPeerMock(remotePeer.Tree, TestItem.PublicKeys[localIndex],
                         $"PEER{localIndex}", remotePeer.SyncServer, TestItem.PublicKeys[remoteIndex],
                         $"PEER{remoteIndex}"));
                 }

--- a/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
@@ -533,7 +533,7 @@ namespace Nethermind.Synchronization.Test
 
                 _logger.Info($"PEER ADDED {syncPeer.ClientId}");
                 _peers.TryAdd(syncPeer.ClientId, syncPeer);
-                SyncPeerPool.AddPeer(syncPeer);
+                SyncPeerPool.TryAddPeer(syncPeer);
                 return this;
             }
 

--- a/src/Nethermind/Nethermind.Synchronization/Peers/ISyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/ISyncPeerPool.cs
@@ -63,7 +63,7 @@ namespace Nethermind.Synchronization.Peers
         /// Invoked when a new connection is established and ETH subprotocol handshake is finished - this node is ready to sync.
         /// </summary>
         /// <param name="syncPeer"></param>
-        void AddPeer(ISyncPeer syncPeer);
+        bool TryAddPeer(ISyncPeer syncPeer);
 
         /// <summary>
         /// Invoked after a session / connection is closed.


### PR DESCRIPTION
- Currently its hard not to add a satellite protocol without modifying ProtocolManager.
- This is because ProtocolManager have some logic that is needed in order for the satellite protocol to be initialized after sync/eth protocol.
- This PR adds a `IProtocolHandlerFactory` which is responsible to create protocol handler. It has a Priority field which allow specifying the order of initialization. 
- This allow moving some initialization code outside of ProtocolManager into subclass of `IProtocolHandlerFactory`.
- This unfortunately is not enough, as the adaptive message id must be sorted in order of protocol name. So more change is needed for that.

## Changes

- _List the changes_

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [X] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [ ] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
