### PR TITLE
Change the default of ExposeHost to + due to backward compatibility

### DIFF
--- a/src/Nethermind/Nethermind.Monitoring/Config/IMetricsConfig.cs
+++ b/src/Nethermind/Nethermind.Monitoring/Config/IMetricsConfig.cs
@@ -8,7 +8,7 @@ namespace Nethermind.Monitoring.Config;
 [ConfigCategory(Description = "Configuration of the metrics provided by a Nethermind node for both, the Prometheus and the dotnet-counters.")]
 public interface IMetricsConfig : IConfig
 {
-    [ConfigItem(Description = "The IP address to expose Prometheus metrics at.", DefaultValue = "+")]
+    [ConfigItem(Description = "The IP address to expose Prometheus metrics at. \"+\" means listening on all available hostnames. Setting this to \"localhost\" prevents remote access.", DefaultValue = "+")]
     string ExposeHost { get; }
 
     [ConfigItem(Description = "The port to expose Prometheus metrics at.", DefaultValue = "null")]

--- a/src/Nethermind/Nethermind.Monitoring/Config/IMetricsConfig.cs
+++ b/src/Nethermind/Nethermind.Monitoring/Config/IMetricsConfig.cs
@@ -8,7 +8,7 @@ namespace Nethermind.Monitoring.Config;
 [ConfigCategory(Description = "Configuration of the metrics provided by a Nethermind node for both, the Prometheus and the dotnet-counters.")]
 public interface IMetricsConfig : IConfig
 {
-    [ConfigItem(Description = "The IP address to expose Prometheus metrics at.", DefaultValue = "0.0.0.0")]
+    [ConfigItem(Description = "The IP address to expose Prometheus metrics at.", DefaultValue = "+")]
     string ExposeHost { get; }
 
     [ConfigItem(Description = "The port to expose Prometheus metrics at.", DefaultValue = "null")]

--- a/src/Nethermind/Nethermind.Monitoring/Config/IMetricsConfig.cs
+++ b/src/Nethermind/Nethermind.Monitoring/Config/IMetricsConfig.cs
@@ -8,7 +8,7 @@ namespace Nethermind.Monitoring.Config;
 [ConfigCategory(Description = "Configuration of the metrics provided by a Nethermind node for both, the Prometheus and the dotnet-counters.")]
 public interface IMetricsConfig : IConfig
 {
-    [ConfigItem(Description = "The IP address to expose Prometheus metrics at.", DefaultValue = "127.0.0.1")]
+    [ConfigItem(Description = "The IP address to expose Prometheus metrics at.", DefaultValue = "0.0.0.0")]
     string ExposeHost { get; }
 
     [ConfigItem(Description = "The port to expose Prometheus metrics at.", DefaultValue = "null")]

--- a/src/Nethermind/Nethermind.Monitoring/Config/IMetricsConfig.cs
+++ b/src/Nethermind/Nethermind.Monitoring/Config/IMetricsConfig.cs
@@ -8,7 +8,7 @@ namespace Nethermind.Monitoring.Config;
 [ConfigCategory(Description = "Configuration of the metrics provided by a Nethermind node for both, the Prometheus and the dotnet-counters.")]
 public interface IMetricsConfig : IConfig
 {
-    [ConfigItem(Description = "The IP address to expose Prometheus metrics at. \"+\" means listening on all available hostnames. Setting this to \"localhost\" prevents remote access.", DefaultValue = "+")]
+    [ConfigItem(Description = "The IP address to expose Prometheus metrics at. The value of `+` means listening on all available hostnames. Setting this to `localhost` prevents remote access.", DefaultValue = "+")]
     string ExposeHost { get; }
 
     [ConfigItem(Description = "The port to expose Prometheus metrics at.", DefaultValue = "null")]

--- a/src/Nethermind/Nethermind.Monitoring/Config/MetricsConfig.cs
+++ b/src/Nethermind/Nethermind.Monitoring/Config/MetricsConfig.cs
@@ -5,7 +5,7 @@ namespace Nethermind.Monitoring.Config
 {
     public class MetricsConfig : IMetricsConfig
     {
-        public string ExposeHost { get; set; } = "0.0.0.0";
+        public string ExposeHost { get; set; } = "+";
         public int? ExposePort { get; set; } = null;
         public bool Enabled { get; set; } = false;
         public bool CountersEnabled { get; set; } = false;

--- a/src/Nethermind/Nethermind.Monitoring/Config/MetricsConfig.cs
+++ b/src/Nethermind/Nethermind.Monitoring/Config/MetricsConfig.cs
@@ -5,7 +5,7 @@ namespace Nethermind.Monitoring.Config
 {
     public class MetricsConfig : IMetricsConfig
     {
-        public string ExposeHost { get; set; } = "127.0.0.1";
+        public string ExposeHost { get; set; } = "0.0.0.0";
         public int? ExposePort { get; set; } = null;
         public bool Enabled { get; set; } = false;
         public bool CountersEnabled { get; set; } = false;


### PR DESCRIPTION
## Changes

Revert the default for ExposeHost for metrics

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [ ] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
