### PR TITLE
Further optimize Rpl.LengthOf(...)

### DIFF
--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -1574,13 +1574,17 @@ namespace Nethermind.Serialization.Rlp
                 value = item.u1;
                 size = 8;
             }
+            else if (item.u0 < 128)
+            {
+                return 1;
+            }
             else
             {
                 value = item.u0;
                 size = 0;
             }
 
-            return LengthOf((long)value) + size;
+            return  1 + sizeof(ulong) - (BitOperations.LeadingZeroCount((ulong)value) / 8) + size;
         }
 
         public static int LengthOf(byte[][]? arrays)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -1557,15 +1557,30 @@ namespace Nethermind.Serialization.Rlp
 
         public static int LengthOf(UInt256 item)
         {
-            if (item < 128UL)
+            ulong value;
+            int size;
+            if (item.u3 > 0)
             {
-                return 1;
+                value = item.u3;
+                size = 24;
+            }
+            else if (item.u2 > 0)
+            {
+                value = item.u2;
+                size = 16;
+            }
+            else if (item.u1 > 0)
+            {
+                value = item.u1;
+                size = 8;
+            }
+            else
+            {
+                value = item.u0;
+                size = 0;
             }
 
-            Span<byte> bytes = stackalloc byte[32];
-            item.ToBigEndian(bytes);
-            int length = bytes.WithoutLeadingZeros().Length;
-            return length + 1;
+            return LengthOf((long)value) + size;
         }
 
         public static int LengthOf(byte[][]? arrays)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -1555,7 +1555,7 @@ namespace Nethermind.Serialization.Rlp
             return item is null ? LengthOfNull : LengthOf(item.Value);
         }
 
-        public static int LengthOf(UInt256 item)
+        public static int LengthOf(in UInt256 item)
         {
             ulong value;
             int size;

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -1584,7 +1584,7 @@ namespace Nethermind.Serialization.Rlp
                 size = 0;
             }
 
-            return  1 + sizeof(ulong) - (BitOperations.LeadingZeroCount((ulong)value) / 8) + size;
+            return 1 + sizeof(ulong) - (BitOperations.LeadingZeroCount((ulong)value) / 8) + size;
         }
 
         public static int LengthOf(byte[][]? arrays)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -1601,22 +1601,7 @@ namespace Nethermind.Serialization.Rlp
             }
         }
 
-        public static int LengthOf(int value)
-        {
-            if (value < 0)
-            {
-                return 9; // will be a sign extended long -> ulong
-            }
-            if ((uint)value < 128)
-            {
-                return 1;
-            }
-            else
-            {
-                // everything has a length prefix
-                return 1 + sizeof(uint) - (BitOperations.LeadingZeroCount((uint)value) / 8);
-            }
-        }
+        public static int LengthOf(int value) => LengthOf((long)value);
 
         public static int LengthOf(Hash256? item)
         {

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -1562,17 +1562,17 @@ namespace Nethermind.Serialization.Rlp
             if (item.u3 > 0)
             {
                 value = item.u3;
-                size = 24;
+                size = 1 + sizeof(ulong) * 4;
             }
             else if (item.u2 > 0)
             {
                 value = item.u2;
-                size = 16;
+                size = 1 + sizeof(ulong) * 3;
             }
             else if (item.u1 > 0)
             {
                 value = item.u1;
-                size = 8;
+                size = 1 + sizeof(ulong) * 2;
             }
             else if (item.u0 < 128)
             {
@@ -1581,10 +1581,10 @@ namespace Nethermind.Serialization.Rlp
             else
             {
                 value = item.u0;
-                size = 0;
+                size = 1 + sizeof(ulong);
             }
 
-            return 1 + sizeof(ulong) - (BitOperations.LeadingZeroCount((ulong)value) / 8) + size;
+            return size - (BitOperations.LeadingZeroCount(value) / 8);
         }
 
         public static int LengthOf(byte[][]? arrays)


### PR DESCRIPTION
## Changes

- Forward Rpl.LengthOf(int) to LengthOf(long)  from https://github.com/NethermindEth/nethermind/pull/6729#discussion_r1491325971 by @PaulusParssinen
- Use quick checks for UInt256 and forward to LengthOf(long); drop stackalloc, span, coversion to bigendien etc

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
