### PR TITLE
Update rocksdb with the loading order fix

### DIFF
--- a/src/Nethermind/Directory.Packages.props
+++ b/src/Nethermind/Directory.Packages.props
@@ -62,7 +62,7 @@
     <PackageVersion Include="Pyroscope" Version="0.8.14" />
     <PackageVersion Include="ReadLine" Version="2.0.1" />
     <PackageVersion Include="RichardSzalay.MockHttp" Version="7.0.0" />
-    <PackageVersion Include="RocksDB" Version="8.3.2.39829" />
+    <PackageVersion Include="RocksDB" Version="8.10.0.45817" />
     <PackageVersion Include="SCrypt" Version="2.0.0.2" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />
     <PackageVersion Include="Snappy.Standard" Version="0.2.0" />

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
@@ -24,7 +24,7 @@ public class DbConfig : IDbConfig
     public bool? UseDirectReads { get; set; } = false;
     public bool? UseDirectIoForFlushAndCompactions { get; set; } = false;
     public bool? DisableCompression { get; set; } = false;
-    public ulong? CompactionReadAhead { get; set; }
+    public ulong? CompactionReadAhead { get; set; } = (ulong) 256.KiB();
     public IDictionary<string, string>? AdditionalRocksDbOptions { get; set; }
     public ulong? MaxBytesForLevelBase { get; set; } = (ulong)256.MiB();
     public ulong TargetFileSizeBase { get; set; } = (ulong)64.MiB();

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
@@ -24,7 +24,7 @@ public class DbConfig : IDbConfig
     public bool? UseDirectReads { get; set; } = false;
     public bool? UseDirectIoForFlushAndCompactions { get; set; } = false;
     public bool? DisableCompression { get; set; } = false;
-    public ulong? CompactionReadAhead { get; set; } = (ulong) 256.KiB();
+    public ulong? CompactionReadAhead { get; set; } = (ulong)256.KiB();
     public IDictionary<string, string>? AdditionalRocksDbOptions { get; set; }
     public ulong? MaxBytesForLevelBase { get; set; } = (ulong)256.MiB();
     public ulong TargetFileSizeBase { get; set; } = (ulong)64.MiB();

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -513,6 +513,8 @@ public class DbOnTheRocks : IDb, ITunableDb
         // This one set the threadpool env, so its actually different from the above two
         options.IncreaseParallelism(Environment.ProcessorCount);
 
+        options.SetLevelCompactionDynamicLevelBytes(false);
+
         // VERY important to reduce stalls. Allow L0->L1 compaction to happen with multiple thread.
         _rocksDbNative.rocksdb_options_set_max_subcompactions(options.Handle, (uint)Environment.ProcessorCount);
 

--- a/src/Nethermind/Nethermind.Db.Test/RocksDbTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/RocksDbTests.cs
@@ -11,5 +11,5 @@ namespace Nethermind.Db.Test;
 internal static class RocksDbTests
 {
     [Test]
-    public static void Should_have_required_version() => DbOnTheRocks.GetRocksDbVersion().Should().Be("8.3.2");
+    public static void Should_have_required_version() => DbOnTheRocks.GetRocksDbVersion().Should().Be("8.10.0");
 }


### PR DESCRIPTION
Fixes #6544 

## Changes

- Update RocksDB with https://github.com/curiosity-ai/rocksdb-sharp/pull/51

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Significant db version change 8.3 -> 8.10

## Documentation

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

When building from source or using ppa, the client does not use system-installed version of rocksdb anymore

