### PR TITLE
Devritualize Dictionary/Hashset

### DIFF
--- a/src/Nethermind/Nethermind.AccountAbstraction/Broadcaster/PeerInfo.cs
+++ b/src/Nethermind/Nethermind.AccountAbstraction/Broadcaster/PeerInfo.cs
@@ -12,7 +12,7 @@ namespace Nethermind.AccountAbstraction.Broadcaster
     {
         private IUserOperationPoolPeer Peer { get; }
 
-        private LruKeyCache<Hash256> NotifiedUserOperations { get; } = new(MemoryAllowance.MemPoolSize, "notifiedUserOperations");
+        private LruKeyCache<Hash256AsKey> NotifiedUserOperations { get; } = new(MemoryAllowance.MemPoolSize, "notifiedUserOperations");
 
         public PeerInfo(IUserOperationPoolPeer peer)
         {

--- a/src/Nethermind/Nethermind.AuRa.Test/Transactions/PermissionTxComparerTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/Transactions/PermissionTxComparerTests.cs
@@ -269,9 +269,9 @@ namespace Nethermind.AuRa.Test.Transactions
                 .ThenBy(defaultComparer);
 
 
-            Dictionary<Address?, Transaction[]> txBySender = transactions.GroupBy(t => t.SenderAddress)
+            Dictionary<AddressAsKey, Transaction[]> txBySender = transactions.GroupBy(t => t.SenderAddress)
                 .ToDictionary(
-                    g => g.Key,
+                    g => (AddressAsKey)g.Key,
                     g => g.OrderBy(t => t,
                         // to simulate order coming from TxPool
                         comparer.GetPoolUniqueTxComparerByNonce()).ToArray());

--- a/src/Nethermind/Nethermind.Blockchain.Test/Builders/FilterBuilder.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Builders/FilterBuilder.cs
@@ -125,7 +125,7 @@ namespace Nethermind.Blockchain.Test.Builders
 
         public FilterBuilder WithAddresses(params Address[] addresses)
         {
-            _address = new AddressFilter(addresses.ToHashSet());
+            _address = new AddressFilter(addresses.Select(a => new AddressAsKey(a)).ToHashSet());
 
             return this;
         }

--- a/src/Nethermind/Nethermind.Blockchain.Test/Filters/AddressFilterTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Filters/AddressFilterTests.cs
@@ -74,7 +74,7 @@ public class AddressFilterTests
     [Test]
     public void Accepts_any_address_when_set_is_empty()
     {
-        HashSet<Address> addresses = new();
+        HashSet<AddressAsKey> addresses = new();
         AddressFilter filter = new AddressFilter(addresses);
 
         filter.Accepts(TestItem.AddressA).Should().BeTrue();
@@ -85,7 +85,7 @@ public class AddressFilterTests
     [Test]
     public void Accepts_any_address_when_set_is_empty_by_ref()
     {
-        HashSet<Address> addresses = new();
+        HashSet<AddressAsKey> addresses = new();
         AddressFilter filter = new AddressFilter(addresses);
 
         AddressStructRef addressARef = TestItem.AddressA.ToStructRef();
@@ -99,7 +99,7 @@ public class AddressFilterTests
     [Test]
     public void Accepts_only_addresses_in_a_set()
     {
-        HashSet<Address> addresses = new()
+        HashSet<AddressAsKey> addresses = new()
         {
             TestItem.AddressA, TestItem.AddressC
         };
@@ -113,7 +113,7 @@ public class AddressFilterTests
     [Test]
     public void Accepts_only_addresses_in_a_set_by_ref()
     {
-        HashSet<Address> addresses = new()
+        HashSet<AddressAsKey> addresses = new()
         {
             TestItem.AddressA, TestItem.AddressC
         };
@@ -188,7 +188,7 @@ public class AddressFilterTests
     [Test]
     public void Matches_any_bloom_when_set_is_empty()
     {
-        HashSet<Address> addresses = new();
+        HashSet<AddressAsKey> addresses = new();
         AddressFilter filter = new AddressFilter(addresses);
 
         filter.Matches(BloomFromAddress(TestItem.AddressA)).Should().BeTrue();
@@ -199,7 +199,7 @@ public class AddressFilterTests
     [Test]
     public void Matches_any_bloom_when_set_is_empty_by_ref()
     {
-        HashSet<Address> addresses = new();
+        HashSet<AddressAsKey> addresses = new();
         AddressFilter filter = new AddressFilter(addresses);
 
         BloomStructRef bloomARef = BloomFromAddress(TestItem.AddressA).ToStructRef();
@@ -236,7 +236,7 @@ public class AddressFilterTests
     [Test]
     public void Matches_any_bloom_using_addresses_set()
     {
-        HashSet<Address> addresses = new()
+        HashSet<AddressAsKey> addresses = new()
         {
             TestItem.AddressA, TestItem.AddressC
         };
@@ -250,7 +250,7 @@ public class AddressFilterTests
     [Test]
     public void Matches_any_bloom_using_addresses_set_by_ref()
     {
-        HashSet<Address> addresses = new()
+        HashSet<AddressAsKey> addresses = new()
         {
             TestItem.AddressA, TestItem.AddressC
         };

--- a/src/Nethermind/Nethermind.Blockchain.Test/Filters/FilterStoreTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Filters/FilterStoreTests.cs
@@ -102,7 +102,7 @@ namespace Nethermind.Blockchain.Test.Filters
                 yield return new TestCaseData(null, AddressFilter.AnyAddress);
                 yield return new TestCaseData(TestItem.AddressA.ToString(), new AddressFilter(TestItem.AddressA));
                 yield return new TestCaseData(new[] { TestItem.AddressA.ToString(), TestItem.AddressB.ToString() },
-                    new AddressFilter(new HashSet<Address>() { TestItem.AddressA, TestItem.AddressB }));
+                    new AddressFilter(new HashSet<AddressAsKey>() { TestItem.AddressA, TestItem.AddressB }));
             }
         }
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionSelectorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionSelectorTests.cs
@@ -230,17 +230,17 @@ namespace Nethermind.Blockchain.Test
             IComparer<Transaction> defaultComparer = transactionComparerProvider.GetDefaultComparer();
             IComparer<Transaction> comparer = CompareTxByNonce.Instance.ThenBy(defaultComparer);
 
-            Dictionary<Address, Transaction[]> GroupTransactions(bool supportBlobs) =>
+            Dictionary<AddressAsKey, Transaction[]> GroupTransactions(bool supportBlobs) =>
                 testCase.Transactions
                     .Where(t => t.SenderAddress is not null)
                     .Where(t => t.SupportsBlobs == supportBlobs)
                     .GroupBy(t => t.SenderAddress)
                     .ToDictionary(
-                        g => g.Key!,
+                        g => new AddressAsKey(g.Key!),
                         g => g.OrderBy(t => t, comparer).ToArray());
 
-            Dictionary<Address, Transaction[]> transactions = GroupTransactions(false);
-            Dictionary<Address, Transaction[]> blobTransactions = GroupTransactions(true);
+            Dictionary<AddressAsKey, Transaction[]> transactions = GroupTransactions(false);
+            Dictionary<AddressAsKey, Transaction[]> blobTransactions = GroupTransactions(true);
             transactionPool.GetPendingTransactionsBySender().Returns(transactions);
             transactionPool.GetPendingLightBlobTransactionsBySender().Returns(blobTransactions);
             foreach (Transaction blobTx in blobTransactions.SelectMany(kvp => kvp.Value))

--- a/src/Nethermind/Nethermind.Blockchain.Test/TxPoolSourceTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TxPoolSourceTests.cs
@@ -25,10 +25,10 @@ public class TxPoolSourceTests
         TransactionComparerProvider transactionComparerProvider = new(specProvider, Build.A.BlockTree().TestObject);
 
         ITxPool txPool = Substitute.For<ITxPool>();
-        Dictionary<Address, Transaction[]> transactionsWithBlobs = blobCountPerTx
+        Dictionary<AddressAsKey, Transaction[]> transactionsWithBlobs = blobCountPerTx
             .Select((blobsCount, index) => (blobCount: blobsCount, index))
             .ToDictionary(
-                pair => new Address((new byte[19]).Concat(new byte[] { (byte)pair.index }).ToArray()),
+                pair => new AddressAsKey(new Address((new byte[19]).Concat(new byte[] { (byte)pair.index }).ToArray())),
                 pair => new Transaction[] { Build.A.Transaction.WithShardBlobTxTypeAndFields(pair.blobCount).TestObject });
         txPool.GetPendingTransactions().Returns(new Transaction[0]);
         txPool.GetPendingLightBlobTransactionsBySender().Returns(transactionsWithBlobs);

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/InMemoryReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/InMemoryReceiptStorage.cs
@@ -12,9 +12,9 @@ namespace Nethermind.Blockchain.Receipts
     {
         private readonly bool _allowReceiptIterator;
         private readonly IBlockTree? _blockTree;
-        private readonly ConcurrentDictionary<Hash256, TxReceipt[]> _receipts = new();
+        private readonly ConcurrentDictionary<Hash256AsKey, TxReceipt[]> _receipts = new();
 
-        private readonly ConcurrentDictionary<Hash256, TxReceipt> _transactions = new();
+        private readonly ConcurrentDictionary<Hash256AsKey, TxReceipt> _transactions = new();
 
 #pragma warning disable CS0067
         public event EventHandler<BlockReplacementEventArgs> ReceiptsInserted;

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
@@ -372,10 +372,10 @@ namespace Nethermind.Blockchain.Receipts
 
         private void RemoveBlockTx(Block block, Block? exceptBlock = null)
         {
-            HashSet<Hash256> newTxs = null;
+            HashSet<Hash256AsKey> newTxs = null;
             if (exceptBlock is not null)
             {
-                newTxs = new HashSet<Hash256>(exceptBlock.Transactions.Select((tx) => tx.Hash));
+                newTxs = new HashSet<Hash256AsKey>(exceptBlock.Transactions.Select((tx) => new Hash256AsKey(tx.Hash)));
             }
 
             using IWriteBatch writeBatch = _transactionDb.StartWriteBatch();

--- a/src/Nethermind/Nethermind.Consensus.AuRa/Transactions/TxPriorityTxSource.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/Transactions/TxPriorityTxSource.cs
@@ -46,7 +46,7 @@ namespace Nethermind.Consensus.AuRa.Transactions
 
         public override string ToString() => $"{nameof(TxPriorityTxSource)}";
 
-        protected override IEnumerable<Transaction> GetOrderedTransactions(IDictionary<Address, Transaction[]> pendingTransactions, IComparer<Transaction> comparer)
+        protected override IEnumerable<Transaction> GetOrderedTransactions(Dictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparer)
         {
             if (_logger.IsTrace)
             {

--- a/src/Nethermind/Nethermind.Consensus.AuRa/Transactions/TxPriorityTxSource.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/Transactions/TxPriorityTxSource.cs
@@ -46,7 +46,7 @@ namespace Nethermind.Consensus.AuRa.Transactions
 
         public override string ToString() => $"{nameof(TxPriorityTxSource)}";
 
-        protected override IEnumerable<Transaction> GetOrderedTransactions(Dictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparer)
+        protected override IEnumerable<Transaction> GetOrderedTransactions(IDictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparer)
         {
             if (_logger.IsTrace)
             {

--- a/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
@@ -51,8 +51,8 @@ namespace Nethermind.Consensus.Producers
             long blockNumber = parent.Number + 1;
             IReleaseSpec spec = _specProvider.GetSpec(parent);
             UInt256 baseFee = BaseFeeCalculator.Calculate(parent, spec);
-            Dictionary<AddressAsKey, Transaction[]> pendingTransactions = _transactionPool.GetPendingTransactionsBySender();
-            Dictionary<AddressAsKey, Transaction[]> pendingBlobTransactionsEquivalences = _transactionPool.GetPendingLightBlobTransactionsBySender();
+            IDictionary<AddressAsKey, Transaction[]> pendingTransactions = _transactionPool.GetPendingTransactionsBySender();
+            IDictionary<AddressAsKey, Transaction[]> pendingBlobTransactionsEquivalences = _transactionPool.GetPendingLightBlobTransactionsBySender();
             IComparer<Transaction> comparer = GetComparer(parent, new BlockPreparationContext(baseFee, blockNumber))
                 .ThenBy(ByHashTxComparer.Instance); // in order to sort properly and not lose transactions we need to differentiate on their identity which provided comparer might not be doing
 
@@ -206,13 +206,13 @@ namespace Nethermind.Consensus.Producers
             return true;
         }
 
-        protected virtual IEnumerable<Transaction> GetOrderedTransactions(Dictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparer) =>
+        protected virtual IEnumerable<Transaction> GetOrderedTransactions(IDictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparer) =>
             Order(pendingTransactions, comparer);
 
         protected virtual IComparer<Transaction> GetComparer(BlockHeader parent, BlockPreparationContext blockPreparationContext)
             => _transactionComparerProvider.GetDefaultProducerComparer(blockPreparationContext);
 
-        internal static IEnumerable<Transaction> Order(Dictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparerWithIdentity)
+        internal static IEnumerable<Transaction> Order(IDictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparerWithIdentity)
         {
             IEnumerator<Transaction>[] bySenderEnumerators = pendingTransactions
                 .Select<KeyValuePair<AddressAsKey, Transaction[]>, IEnumerable<Transaction>>(g => g.Value)

--- a/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
@@ -51,8 +51,8 @@ namespace Nethermind.Consensus.Producers
             long blockNumber = parent.Number + 1;
             IReleaseSpec spec = _specProvider.GetSpec(parent);
             UInt256 baseFee = BaseFeeCalculator.Calculate(parent, spec);
-            IDictionary<Address, Transaction[]> pendingTransactions = _transactionPool.GetPendingTransactionsBySender();
-            IDictionary<Address, Transaction[]> pendingBlobTransactionsEquivalences = _transactionPool.GetPendingLightBlobTransactionsBySender();
+            Dictionary<AddressAsKey, Transaction[]> pendingTransactions = _transactionPool.GetPendingTransactionsBySender();
+            Dictionary<AddressAsKey, Transaction[]> pendingBlobTransactionsEquivalences = _transactionPool.GetPendingLightBlobTransactionsBySender();
             IComparer<Transaction> comparer = GetComparer(parent, new BlockPreparationContext(baseFee, blockNumber))
                 .ThenBy(ByHashTxComparer.Instance); // in order to sort properly and not lose transactions we need to differentiate on their identity which provided comparer might not be doing
 
@@ -206,16 +206,16 @@ namespace Nethermind.Consensus.Producers
             return true;
         }
 
-        protected virtual IEnumerable<Transaction> GetOrderedTransactions(IDictionary<Address, Transaction[]> pendingTransactions, IComparer<Transaction> comparer) =>
+        protected virtual IEnumerable<Transaction> GetOrderedTransactions(Dictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparer) =>
             Order(pendingTransactions, comparer);
 
         protected virtual IComparer<Transaction> GetComparer(BlockHeader parent, BlockPreparationContext blockPreparationContext)
             => _transactionComparerProvider.GetDefaultProducerComparer(blockPreparationContext);
 
-        internal static IEnumerable<Transaction> Order(IDictionary<Address, Transaction[]> pendingTransactions, IComparer<Transaction> comparerWithIdentity)
+        internal static IEnumerable<Transaction> Order(Dictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparerWithIdentity)
         {
             IEnumerator<Transaction>[] bySenderEnumerators = pendingTransactions
-                .Select<KeyValuePair<Address, Transaction[]>, IEnumerable<Transaction>>(g => g.Value)
+                .Select<KeyValuePair<AddressAsKey, Transaction[]>, IEnumerable<Transaction>>(g => g.Value)
                 .Select(g => g.GetEnumerator())
                 .ToArray();
 

--- a/src/Nethermind/Nethermind.Core/Address.cs
+++ b/src/Nethermind/Nethermind.Core/Address.cs
@@ -4,6 +4,7 @@
 using System;
 using System.ComponentModel;
 using System.Globalization;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text.Json.Serialization;
@@ -19,6 +20,11 @@ namespace Nethermind.Core
     [TypeConverter(typeof(AddressTypeConverter))]
     public class Address : IEquatable<Address>, IComparable<Address>
     {
+        // Ensure that hashes are different for every run of the node and every node, so if are any hash collisions on
+        // one node they will not be the same on another node or across a restart so hash collision cannot be used to degrade
+        // the performance of the network as a whole.
+        private static readonly uint s_instanceRandom = (uint)System.Security.Cryptography.RandomNumberGenerator.GetInt32(int.MinValue, int.MaxValue);
+
         public const int Size = 20;
         private const int HexCharsCount = 2 * Size; // 5a4eab120fb44eb6684e5e32785702ff45ea344d
         private const int PrefixedHexCharsCount = 2 + HexCharsCount; // 0x5a4eab120fb44eb6684e5e32785702ff45ea344d
@@ -188,11 +194,11 @@ namespace Nethermind.Core
 
         public override int GetHashCode()
         {
-            long l0 = Unsafe.ReadUnaligned<long>(ref MemoryMarshal.GetArrayDataReference(Bytes));
-            long l1 = Unsafe.ReadUnaligned<long>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Bytes), sizeof(long)));
-            int i2 = Unsafe.ReadUnaligned<int>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Bytes), sizeof(long) * 2));
-            l0 ^= l1 ^ i2;
-            return (int)(l0 ^ (l0 >> 32));
+            uint hash = s_instanceRandom;
+            hash = BitOperations.Crc32C(hash, Unsafe.ReadUnaligned<ulong>(ref MemoryMarshal.GetArrayDataReference(Bytes)));
+            hash = BitOperations.Crc32C(hash, Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Bytes), sizeof(ulong))));
+            hash = BitOperations.Crc32C(hash, Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Bytes), sizeof(long) * 2)));
+            return (int)hash;
         }
 
         public static bool operator ==(Address? a, Address? b)
@@ -227,6 +233,18 @@ namespace Nethermind.Core
             public override bool CanConvertTo(ITypeDescriptorContext? context, Type? destinationType) =>
                 destinationType == typeof(string) || base.CanConvertTo(context, destinationType);
         }
+    }
+
+    public readonly struct AddressAsKey(Address key) : IEquatable<AddressAsKey>
+    {
+        private readonly Address _key = key;
+        public Address Value => _key;
+
+        public static implicit operator Address(AddressAsKey key) => key._key;
+        public static implicit operator AddressAsKey(Address key) => new(key);
+
+        public bool Equals(AddressAsKey other) => _key.Equals(other._key);
+        public override int GetHashCode() => _key.GetHashCode();
     }
 
     public ref struct AddressStructRef

--- a/src/Nethermind/Nethermind.Core/Crypto/Hash256.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/Hash256.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
@@ -18,6 +19,11 @@ namespace Nethermind.Core.Crypto
     [JsonConverter(typeof(ValueHash256Converter))]
     public readonly struct ValueHash256 : IEquatable<ValueHash256>, IComparable<ValueHash256>, IEquatable<Hash256>
     {
+        // Ensure that hashes are different for every run of the node and every node, so if are any hash collisions on
+        // one node they will not be the same on another node or across a restart so hash collision cannot be used to degrade
+        // the performance of the network as a whole.
+        private static readonly uint s_instanceRandom = (uint)System.Security.Cryptography.RandomNumberGenerator.GetInt32(int.MinValue, int.MaxValue);
+
         private readonly Vector256<byte> _bytes;
 
         public const int MemorySize = 32;
@@ -62,15 +68,12 @@ namespace Nethermind.Core.Crypto
 
         public override int GetHashCode()
         {
-            long v0 = Unsafe.As<Vector256<byte>, long>(ref Unsafe.AsRef(in _bytes));
-            long v1 = Unsafe.Add(ref Unsafe.As<Vector256<byte>, long>(ref Unsafe.AsRef(in _bytes)), 1);
-            long v2 = Unsafe.Add(ref Unsafe.As<Vector256<byte>, long>(ref Unsafe.AsRef(in _bytes)), 2);
-            long v3 = Unsafe.Add(ref Unsafe.As<Vector256<byte>, long>(ref Unsafe.AsRef(in _bytes)), 3);
-            v0 ^= v1;
-            v2 ^= v3;
-            v0 ^= v2;
-
-            return (int)v0 ^ (int)(v0 >> 32);
+            uint hash = s_instanceRandom;
+            hash = BitOperations.Crc32C(hash, Unsafe.As<Vector256<byte>, ulong>(ref Unsafe.AsRef(in _bytes)));
+            hash = BitOperations.Crc32C(hash, Unsafe.Add(ref Unsafe.As<Vector256<byte>, ulong>(ref Unsafe.AsRef(in _bytes)), 1));
+            hash = BitOperations.Crc32C(hash, Unsafe.Add(ref Unsafe.As<Vector256<byte>, ulong>(ref Unsafe.AsRef(in _bytes)), 2));
+            hash = BitOperations.Crc32C(hash, Unsafe.Add(ref Unsafe.As<Vector256<byte>, ulong>(ref Unsafe.AsRef(in _bytes)), 3));
+            return (int)hash;
         }
 
         public int CompareTo(ValueHash256 other)
@@ -116,6 +119,18 @@ namespace Nethermind.Core.Crypto
         public static bool operator <(in ValueHash256 left, in ValueHash256 right) => left.CompareTo(in right) < 0;
         public static bool operator >=(in ValueHash256 left, in ValueHash256 right) => left.CompareTo(in right) >= 0;
         public static bool operator <=(in ValueHash256 left, in ValueHash256 right) => left.CompareTo(in right) <= 0;
+    }
+
+    public readonly struct Hash256AsKey(Hash256 key) : IEquatable<Hash256AsKey>
+    {
+        private readonly Hash256 _key = key;
+        public Hash256 Value => _key;
+
+        public static implicit operator Hash256(Hash256AsKey key) => key._key;
+        public static implicit operator Hash256AsKey(Hash256 key) => new(key);
+
+        public bool Equals(Hash256AsKey other) => _key.Equals(other._key);
+        public override int GetHashCode() => _key.GetHashCode();
     }
 
     [JsonConverter(typeof(Hash256Converter))]

--- a/src/Nethermind/Nethermind.Core/StorageCell.cs
+++ b/src/Nethermind/Nethermind.Core/StorageCell.cs
@@ -3,8 +3,8 @@
 
 using System;
 using System.Diagnostics;
+using System.Numerics;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using Nethermind.Core.Crypto;
 using Nethermind.Int256;
 
@@ -57,10 +57,12 @@ namespace Nethermind.Core
 
         public override int GetHashCode()
         {
-            unchecked
-            {
-                return (Address.GetHashCode() * 397) ^ Index.GetHashCode();
-            }
+            uint hash = (uint)Address.GetHashCode();
+            hash = BitOperations.Crc32C(hash, _index.u0);
+            hash = BitOperations.Crc32C(hash, _index.u1);
+            hash = BitOperations.Crc32C(hash, _index.u2);
+            hash = BitOperations.Crc32C(hash, _index.u3);
+            return (int)hash;
         }
 
         public override string ToString()

--- a/src/Nethermind/Nethermind.Evm/EvmState.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmState.cs
@@ -104,7 +104,7 @@ namespace Nethermind.Evm
         // As we can add here from VM, we need it as ICollection
         public ICollection<Address> DestroyList => _destroyList;
         // As we can add here from VM, we need it as ICollection
-        public ICollection<Address> CreateList => _createList;
+        public ICollection<AddressAsKey> CreateList => _createList;
         // As we can add here from VM, we need it as ICollection
         public ICollection<LogEntry> Logs => _logs;
 
@@ -112,7 +112,7 @@ namespace Nethermind.Evm
         private readonly JournalSet<StorageCell> _accessedStorageCells;
         private readonly JournalCollection<LogEntry> _logs;
         private readonly JournalSet<Address> _destroyList;
-        private readonly HashSet<Address> _createList;
+        private readonly HashSet<AddressAsKey> _createList;
         private readonly int _accessedAddressesSnapshot;
         private readonly int _accessedStorageKeysSnapshot;
         private readonly int _destroyListSnapshot;
@@ -190,7 +190,7 @@ namespace Nethermind.Evm
                 _accessedAddresses = new JournalSet<Address>();
                 _accessedStorageCells = new JournalSet<StorageCell>();
                 _destroyList = new JournalSet<Address>();
-                _createList = new HashSet<Address>();
+                _createList = new HashSet<AddressAsKey>();
                 _logs = new JournalCollection<LogEntry>();
             }
             if (executionType.IsAnyCreate())

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -42,7 +42,7 @@ using Int256;
 public class VirtualMachine : IVirtualMachine
 {
     public const int MaxCallDepth = 1024;
-    internal static FrozenDictionary<Address, CodeInfo> PrecompileCode { get; } = InitializePrecompiledContracts();
+    internal static FrozenDictionary<AddressAsKey, CodeInfo> PrecompileCode { get; } = InitializePrecompiledContracts();
     internal static LruCache<ValueHash256, CodeInfo> CodeCache { get; } = new(MemoryAllowance.CodeCacheSize, MemoryAllowance.CodeCacheSize, "VM bytecodes");
 
     private readonly static UInt256 P255Int = (UInt256)System.Numerics.BigInteger.Pow(2, 255);
@@ -98,9 +98,9 @@ public class VirtualMachine : IVirtualMachine
         where TTracingActions : struct, IIsTracing
         => _evm.Run<TTracingActions>(state, worldState, txTracer);
 
-    private static FrozenDictionary<Address, CodeInfo> InitializePrecompiledContracts()
+    private static FrozenDictionary<AddressAsKey, CodeInfo> InitializePrecompiledContracts()
     {
-        return new Dictionary<Address, CodeInfo>
+        return new Dictionary<AddressAsKey, CodeInfo>
         {
             [EcRecoverPrecompile.Address] = new(EcRecoverPrecompile.Instance),
             [Sha256Precompile.Address] = new(Sha256Precompile.Instance),

--- a/src/Nethermind/Nethermind.Facade/Filters/AddressFilter.cs
+++ b/src/Nethermind/Nethermind.Facade/Filters/AddressFilter.cs
@@ -9,7 +9,7 @@ namespace Nethermind.Blockchain.Filters
 {
     public class AddressFilter
     {
-        public static readonly AddressFilter AnyAddress = new(addresses: new HashSet<Address>());
+        public static readonly AddressFilter AnyAddress = new(addresses: new HashSet<AddressAsKey>());
 
         private Bloom.BloomExtract[]? _addressesBloomIndexes;
         private Bloom.BloomExtract? _addressBloomExtract;
@@ -19,13 +19,13 @@ namespace Nethermind.Blockchain.Filters
             Address = address;
         }
 
-        public AddressFilter(HashSet<Address> addresses)
+        public AddressFilter(HashSet<AddressAsKey> addresses)
         {
             Addresses = addresses;
         }
 
         public Address? Address { get; }
-        public HashSet<Address>? Addresses { get; }
+        public HashSet<AddressAsKey>? Addresses { get; }
         private Bloom.BloomExtract[] AddressesBloomExtracts => _addressesBloomIndexes ??= CalculateBloomExtracts();
         private Bloom.BloomExtract AddressBloomExtract => _addressBloomExtract ??= Bloom.GetExtract(Address);
 
@@ -102,6 +102,6 @@ namespace Nethermind.Blockchain.Filters
             return bloom.Matches(AddressBloomExtract);
         }
 
-        private Bloom.BloomExtract[] CalculateBloomExtracts() => Addresses.Select(Bloom.GetExtract).ToArray();
+        private Bloom.BloomExtract[] CalculateBloomExtracts() => Addresses.Select(a => Bloom.GetExtract(a)).ToArray();
     }
 }

--- a/src/Nethermind/Nethermind.Facade/Filters/FilterStore.cs
+++ b/src/Nethermind/Nethermind.Facade/Filters/FilterStore.cs
@@ -171,7 +171,7 @@ namespace Nethermind.Blockchain.Filters
 
             if (address is IEnumerable<string> e)
             {
-                return new AddressFilter(e.Select(a => new Address(a)).ToHashSet());
+                return new AddressFilter(e.Select(a => new AddressAsKey(new Address(a))).ToHashSet());
             }
 
             throw new InvalidDataException("Invalid address filter format");

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/AdminModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/AdminModuleTests.cs
@@ -38,7 +38,7 @@ public class AdminModuleTests
         _blockTree = Build.A.BlockTree().OfChainLength(5).TestObject;
         _networkConfig = new NetworkConfig();
         IPeerPool peerPool = Substitute.For<IPeerPool>();
-        ConcurrentDictionary<PublicKey, Peer> dict = new();
+        ConcurrentDictionary<PublicKeyAsKey, Peer> dict = new();
         dict.TryAdd(TestItem.PublicKeyA, new Peer(new Node(TestItem.PublicKeyA, "127.0.0.1", 30303, true)));
         peerPool.ActivePeers.Returns(dict);
 

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/TxPool/TransactionPoolContent.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/TxPool/TransactionPoolContent.cs
@@ -17,7 +17,7 @@ namespace Nethermind.JsonRpc.Modules.TxPool
             Queued = info.Queued.ToDictionary(k => k.Key, k => k.Value.ToDictionary(v => v.Key, v => new TransactionForRpc(null, null, null, v.Value)));
         }
 
-        public IDictionary<Address, Dictionary<ulong, TransactionForRpc>> Pending { get; set; }
-        public IDictionary<Address, Dictionary<ulong, TransactionForRpc>> Queued { get; set; }
+        public Dictionary<AddressAsKey, Dictionary<ulong, TransactionForRpc>> Pending { get; set; }
+        public Dictionary<AddressAsKey, Dictionary<ulong, TransactionForRpc>> Queued { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/TxPool/TransactionPoolInspection.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/TxPool/TransactionPoolInspection.cs
@@ -16,8 +16,8 @@ namespace Nethermind.JsonRpc.Modules.TxPool
             Queued = info.Queued.ToDictionary(k => k.Key, k => k.Value.ToDictionary(v => v.Key, v => GetTransactionSummary(v.Value)));
         }
 
-        public IDictionary<Address, Dictionary<ulong, string>> Pending { get; set; }
-        public IDictionary<Address, Dictionary<ulong, string>> Queued { get; set; }
+        public Dictionary<AddressAsKey, Dictionary<ulong, string>> Pending { get; set; }
+        public Dictionary<AddressAsKey, Dictionary<ulong, string>> Queued { get; set; }
 
         private static string GetTransactionSummary(Transaction tx)
             => $"{tx.SenderAddress}: {tx.Value} wei + {tx.GasLimit} × {tx.GasPrice} gas";

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/BlockCacheService.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/BlockCacheService.cs
@@ -9,6 +9,6 @@ namespace Nethermind.Merge.Plugin.Handlers;
 
 public class BlockCacheService : IBlockCacheService
 {
-    public ConcurrentDictionary<Hash256, Block> BlockCache { get; } = new();
+    public ConcurrentDictionary<Hash256AsKey, Block> BlockCache { get; } = new();
     public Hash256? FinalizedHash { get; set; }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/IBlockCacheService.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/IBlockCacheService.cs
@@ -9,6 +9,6 @@ namespace Nethermind.Merge.Plugin.Handlers;
 
 public interface IBlockCacheService
 {
-    public ConcurrentDictionary<Hash256, Block> BlockCache { get; }
+    public ConcurrentDictionary<Hash256AsKey, Block> BlockCache { get; }
     Hash256? FinalizedHash { get; set; }
 }

--- a/src/Nethermind/Nethermind.Network/IPeerPool.cs
+++ b/src/Nethermind/Nethermind.Network/IPeerPool.cs
@@ -14,8 +14,8 @@ namespace Nethermind.Network;
 
 public interface IPeerPool
 {
-    ConcurrentDictionary<PublicKey, Peer> Peers { get; }
-    ConcurrentDictionary<PublicKey, Peer> ActivePeers { get; }
+    ConcurrentDictionary<PublicKeyAsKey, Peer> Peers { get; }
+    ConcurrentDictionary<PublicKeyAsKey, Peer> ActivePeers { get; }
 
     IEnumerable<Peer> StaticPeers { get; }
     IEnumerable<Peer> NonStaticPeers { get; }

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
@@ -73,7 +73,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
             initialRequestSize: 4
         );
 
-        protected LruKeyCache<Hash256> NotifiedTransactions { get; } = new(2 * MemoryAllowance.MemPoolSize, "notifiedTransactions");
+        protected LruKeyCache<Hash256AsKey> NotifiedTransactions { get; } = new(2 * MemoryAllowance.MemPoolSize, "notifiedTransactions");
 
         protected SyncPeerProtocolHandlerBase(ISession session,
             IMessageSerializationService serializer,

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandler.cs
@@ -33,7 +33,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
         protected readonly ITxPool _txPool;
         private readonly IGossipPolicy _gossipPolicy;
         private readonly ITxGossipPolicy _txGossipPolicy;
-        private readonly LruKeyCache<Hash256> _lastBlockNotificationCache = new(10, "LastBlockNotificationCache");
+        private readonly LruKeyCache<Hash256AsKey> _lastBlockNotificationCache = new(10, "LastBlockNotificationCache");
 
         public Eth62ProtocolHandler(ISession session,
             IMessageSerializationService serializer,

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -297,7 +297,7 @@ namespace Nethermind.Network
 
                     if (_logger.IsTrace || (_logger.IsDebug && _logCounter % 5 == 0))
                     {
-                        KeyValuePair<PublicKey, Peer>[] activePeers = _peerPool.ActivePeers.ToArray();
+                        KeyValuePair<PublicKeyAsKey, Peer>[] activePeers = _peerPool.ActivePeers.ToArray();
                         int activePeersCount = activePeers.Length;
                         if (activePeersCount != previousActivePeersCount)
                         {
@@ -733,7 +733,7 @@ namespace Nethermind.Network
             if (!session.Node.IsStatic && _peerPool.ActivePeers.Count >= MaxActivePeers)
             {
                 int initCount = 0;
-                foreach (KeyValuePair<PublicKey, Peer> pair in _peerPool.ActivePeers)
+                foreach (KeyValuePair<PublicKeyAsKey, Peer> pair in _peerPool.ActivePeers)
                 {
                     // we need to count initialized as we may have a list of active peers that is just being initialized
                     // and we do not know yet whether they are fine or not

--- a/src/Nethermind/Nethermind.Network/PeerPool.cs
+++ b/src/Nethermind/Nethermind.Network/PeerPool.cs
@@ -29,9 +29,9 @@ namespace Nethermind.Network
         private readonly INetworkConfig _networkConfig;
         private readonly ILogger _logger;
 
-        public ConcurrentDictionary<PublicKey, Peer> ActivePeers { get; } = new();
-        public ConcurrentDictionary<PublicKey, Peer> Peers { get; } = new();
-        private readonly ConcurrentDictionary<PublicKey, Peer> _staticPeers = new();
+        public ConcurrentDictionary<PublicKeyAsKey, Peer> ActivePeers { get; } = new();
+        public ConcurrentDictionary<PublicKeyAsKey, Peer> Peers { get; } = new();
+        private readonly ConcurrentDictionary<PublicKeyAsKey, Peer> _staticPeers = new();
 
         public IEnumerable<Peer> NonStaticPeers => Peers.Values.Where(p => !p.Node.IsStatic);
         public IEnumerable<Peer> StaticPeers => _staticPeers.Values;
@@ -42,8 +42,8 @@ namespace Nethermind.Network
 
         private readonly CancellationTokenSource _cancellationTokenSource = new();
 
-        readonly Func<PublicKey, (Node Node, ConcurrentDictionary<PublicKey, Peer> Statics), Peer> _createNewNodePeer;
-        readonly Func<PublicKey, (NetworkNode Node, ConcurrentDictionary<PublicKey, Peer> Statics), Peer> _createNewNetworkNodePeer;
+        readonly Func<PublicKeyAsKey, (Node Node, ConcurrentDictionary<PublicKeyAsKey, Peer> Statics), Peer> _createNewNodePeer;
+        readonly Func<PublicKeyAsKey, (NetworkNode Node, ConcurrentDictionary<PublicKeyAsKey, Peer> Statics), Peer> _createNewNetworkNodePeer;
 
         public PeerPool(
             INodeSource nodeSource,
@@ -88,7 +88,7 @@ namespace Nethermind.Network
             return Peers.GetOrAdd(node.NodeId, valueFactory: _createNewNetworkNodePeer, (node, _staticPeers));
         }
 
-        private Peer CreateNew(PublicKey key, (Node Node, ConcurrentDictionary<PublicKey, Peer> Statics) arg)
+        private Peer CreateNew(PublicKeyAsKey key, (Node Node, ConcurrentDictionary<PublicKeyAsKey, Peer> Statics) arg)
         {
             if (arg.Node.IsBootnode || arg.Node.IsStatic)
             {
@@ -105,7 +105,7 @@ namespace Nethermind.Network
             return peer;
         }
 
-        private Peer CreateNew(PublicKey key, (NetworkNode Node, ConcurrentDictionary<PublicKey, Peer> Statics) arg)
+        private Peer CreateNew(PublicKeyAsKey key, (NetworkNode Node, ConcurrentDictionary<PublicKeyAsKey, Peer> Statics) arg)
         {
             Node node = new(arg.Node);
             Peer peer = new(node, _stats.GetOrAdd(node));

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -24,7 +24,7 @@ namespace Nethermind.State
         private readonly StateProvider _stateProvider;
         private readonly ILogManager? _logManager;
         internal readonly IStorageTreeFactory _storageTreeFactory;
-        private readonly ResettableDictionary<Address, StorageTree> _storages = new();
+        private readonly ResettableDictionary<AddressAsKey, StorageTree> _storages = new();
 
         /// <summary>
         /// EIP-1283
@@ -211,7 +211,7 @@ namespace Nethermind.State
         public void CommitTrees(long blockNumber)
         {
             // _logger.Warn($"Storage block commit {blockNumber}");
-            foreach (KeyValuePair<Address, StorageTree> storage in _storages)
+            foreach (KeyValuePair<AddressAsKey, StorageTree> storage in _storages)
             {
                 storage.Value.Commit(blockNumber);
             }

--- a/src/Nethermind/Nethermind.State/StateProvider.cs
+++ b/src/Nethermind/Nethermind.State/StateProvider.cs
@@ -24,14 +24,14 @@ namespace Nethermind.State
     internal class StateProvider
     {
         private const int StartCapacity = Resettable.StartCapacity;
-        private readonly ResettableDictionary<Address, Stack<int>> _intraBlockCache = new();
-        private readonly ResettableHashSet<Address> _committedThisRound = new();
-        private readonly HashSet<Address> _nullAccountReads = new();
+        private readonly ResettableDictionary<AddressAsKey, Stack<int>> _intraBlockCache = new();
+        private readonly ResettableHashSet<AddressAsKey> _committedThisRound = new();
+        private readonly HashSet<AddressAsKey> _nullAccountReads = new();
         // Only guarding against hot duplicates so filter doesn't need to be too big
         // Note:
         // False negatives are fine as they will just result in a overwrite set
         // False positives would be problematic as the code _must_ be persisted
-        private readonly LruKeyCache<Hash256> _codeInsertFilter = new(2048, "Code Insert Filter");
+        private readonly LruKeyCache<Hash256AsKey> _codeInsertFilter = new(2048, "Code Insert Filter");
 
         private readonly List<Change> _keptInCache = new();
         private readonly ILogger _logger;
@@ -482,10 +482,10 @@ namespace Nethermind.State
             }
 
             bool isTracing = stateTracer.IsTracingState;
-            Dictionary<Address, ChangeTrace> trace = null;
+            Dictionary<AddressAsKey, ChangeTrace> trace = null;
             if (isTracing)
             {
-                trace = new Dictionary<Address, ChangeTrace>();
+                trace = new Dictionary<AddressAsKey, ChangeTrace>();
             }
 
             for (int i = 0; i <= _currentPosition; i++)
@@ -616,7 +616,7 @@ namespace Nethermind.State
             }
         }
 
-        private void ReportChanges(IStateTracer stateTracer, Dictionary<Address, ChangeTrace> trace)
+        private void ReportChanges(IStateTracer stateTracer, Dictionary<AddressAsKey, ChangeTrace> trace)
         {
             foreach ((Address address, ChangeTrace change) in trace)
             {

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
@@ -65,10 +65,10 @@ namespace Nethermind.Synchronization.FastSync
         // concurrent request handling with the read lock.
         private readonly ReaderWriterLockSlim _syncStateLock = new();
         private readonly ConcurrentDictionary<StateSyncBatch, object?> _pendingRequests = new();
-        private Dictionary<Hash256, HashSet<DependentItem>> _dependencies = new();
-        private readonly LruKeyCache<Hash256> _alreadySavedNode = new(AlreadySavedCapacity, "saved nodes");
-        private readonly LruKeyCache<Hash256> _alreadySavedCode = new(AlreadySavedCapacity, "saved nodes");
-        private readonly HashSet<Hash256> _codesSameAsNodes = new();
+        private Dictionary<Hash256AsKey, HashSet<DependentItem>> _dependencies = new();
+        private readonly LruKeyCache<Hash256AsKey> _alreadySavedNode = new(AlreadySavedCapacity, "saved nodes");
+        private readonly LruKeyCache<Hash256AsKey> _alreadySavedCode = new(AlreadySavedCapacity, "saved nodes");
+        private readonly HashSet<Hash256AsKey> _codesSameAsNodes = new();
 
         private BranchProgress _branchProgress;
         private int _hintsToResetRoot;
@@ -508,7 +508,7 @@ namespace Nethermind.Synchronization.FastSync
                     _branchProgress.ReportSynced(syncItem, NodeProgressState.Requested);
                 }
 
-                LruKeyCache<Hash256> alreadySavedCache =
+                LruKeyCache<Hash256AsKey> alreadySavedCache =
                     syncItem.NodeDataType == NodeDataType.Code ? _alreadySavedCode : _alreadySavedNode;
                 if (alreadySavedCache.Get(syncItem.Hash))
                 {
@@ -712,7 +712,7 @@ namespace Nethermind.Synchronization.FastSync
                     if (_logger.IsError) _logger.Error($"POSSIBLE FAST SYNC CORRUPTION | Dependencies hanging after the root node saved - count: {_dependencies.Count}, first: {_dependencies.Keys.First()}");
                 }
 
-                _dependencies = new Dictionary<Hash256, HashSet<DependentItem>>();
+                _dependencies = new Dictionary<Hash256AsKey, HashSet<DependentItem>>();
                 // _alreadySaved = new LruKeyCache<Keccak>(AlreadySavedCapacity, "saved nodes");
             }
 

--- a/src/Nethermind/Nethermind.TxPool.Test/Collections/SortedPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/Collections/SortedPoolTests.cs
@@ -24,7 +24,7 @@ namespace Nethermind.TxPool.Test.Collections
     {
         private const int Capacity = 16;
 
-        private SortedPool<ValueHash256, Transaction, Address> _sortedPool;
+        private SortedPool<ValueHash256, Transaction, AddressAsKey> _sortedPool;
 
         private readonly Transaction[] _transactions = new Transaction[Capacity * 8];
 

--- a/src/Nethermind/Nethermind.TxPool.Test/TransactionPoolInfoProviderTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TransactionPoolInfoProviderTests.cs
@@ -37,7 +37,7 @@ namespace Nethermind.TxPool.Test
             var transactions = GetTransactions();
 
             _txPool.GetPendingTransactionsBySender()
-                .Returns(new Dictionary<Address, Transaction[]> { { _address, transactions } });
+                .Returns(new Dictionary<AddressAsKey, Transaction[]> { { _address, transactions } });
             var info = _infoProvider.GetInfo();
 
             info.Pending.Count.Should().Be(1);

--- a/src/Nethermind/Nethermind.TxPool.Test/TransactionPoolInfoProviderTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TransactionPoolInfoProviderTests.cs
@@ -44,14 +44,14 @@ namespace Nethermind.TxPool.Test
             info.Queued.Count.Should().Be(1);
 
             var pending = info.Pending.First();
-            pending.Key.Should().Be(_address);
+            pending.Key.Value.Should().Be(_address);
             pending.Value.Count.Should().Be(3);
             VerifyNonceAndTransactions(pending.Value, 3);
             VerifyNonceAndTransactions(pending.Value, 4);
             VerifyNonceAndTransactions(pending.Value, 5);
 
             var queued = info.Queued.First();
-            queued.Key.Should().Be(_address);
+            queued.Key.Value.Should().Be(_address);
             queued.Value.Count.Should().Be(4);
             VerifyNonceAndTransactions(queued.Value, 1);
             VerifyNonceAndTransactions(queued.Value, 2);

--- a/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
@@ -98,7 +98,7 @@ namespace Nethermind.TxPool.Collections
         /// <summary>
         /// Gets all items in groups in supplied comparer order in groups.
         /// </summary>
-        public IDictionary<TGroupKey, TValue[]> GetBucketSnapshot(Predicate<TGroupKey>? where = null)
+        public Dictionary<TGroupKey, TValue[]> GetBucketSnapshot(Predicate<TGroupKey>? where = null)
         {
             using var lockRelease = Lock.Acquire();
 

--- a/src/Nethermind/Nethermind.TxPool/Collections/TxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/TxDistinctSortedPool.cs
@@ -16,7 +16,7 @@ using Nethermind.TxPool.Comparison;
 
 namespace Nethermind.TxPool.Collections
 {
-    public class TxDistinctSortedPool : DistinctValueSortedPool<ValueHash256, Transaction, Address>
+    public class TxDistinctSortedPool : DistinctValueSortedPool<ValueHash256, Transaction, AddressAsKey>
     {
         private readonly List<Transaction> _transactionsToRemove = new();
         protected int _poolCapacity;
@@ -34,10 +34,10 @@ namespace Nethermind.TxPool.Collections
         protected override IComparer<Transaction> GetGroupComparer(IComparer<Transaction> comparer) => comparer.GetPoolUniqueTxComparerByNonce();
         protected override IComparer<Transaction> GetReplacementComparer(IComparer<Transaction> comparer) => comparer.GetReplacementComparer();
 
-        protected override Address MapToGroup(Transaction value) => value.MapTxToGroup() ?? throw new ArgumentException("MapTxToGroup() returned null!");
+        protected override AddressAsKey MapToGroup(Transaction value) => value.MapTxToGroup() ?? throw new ArgumentException("MapTxToGroup() returned null!");
         protected override ValueHash256 GetKey(Transaction value) => value.Hash!;
 
-        protected override void UpdateGroup(Address groupKey, EnhancedSortedSet<Transaction> bucket, Func<Address, IReadOnlySortedSet<Transaction>, IEnumerable<(Transaction Tx, Action<Transaction>? Change)>> changingElements)
+        protected override void UpdateGroup(AddressAsKey groupKey, EnhancedSortedSet<Transaction> bucket, Func<AddressAsKey, IReadOnlySortedSet<Transaction>, IEnumerable<(Transaction Tx, Action<Transaction>? Change)>> changingElements)
         {
             _transactionsToRemove.Clear();
             Transaction? lastElement = bucket.Max;
@@ -76,7 +76,7 @@ namespace Nethermind.TxPool.Collections
             using var lockRelease = Lock.Acquire();
 
             VerifyCapacity();
-            foreach ((Address address, EnhancedSortedSet<Transaction> bucket) in _buckets)
+            foreach ((AddressAsKey address, EnhancedSortedSet<Transaction> bucket) in _buckets)
             {
                 Debug.Assert(bucket.Count > 0);
 

--- a/src/Nethermind/Nethermind.TxPool/HashCache.cs
+++ b/src/Nethermind/Nethermind.TxPool/HashCache.cs
@@ -23,12 +23,12 @@ namespace Nethermind.TxPool
     {
         private const int SafeCapacity = 1024 * 16;
 
-        private readonly LruKeyCache<ValueHash256> _longTermCache = new(
+        private readonly LruKeyCache<Hash256AsKey> _longTermCache = new(
             MemoryAllowance.TxHashCacheSize,
             Math.Min(SafeCapacity, MemoryAllowance.TxHashCacheSize),
             "long term hash cache");
 
-        private readonly LruKeyCache<ValueHash256> _currentBlockCache = new(
+        private readonly LruKeyCache<Hash256AsKey> _currentBlockCache = new(
             SafeCapacity,
             Math.Min(SafeCapacity, MemoryAllowance.TxHashCacheSize),
             "current block hash cache");

--- a/src/Nethermind/Nethermind.TxPool/ITxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxPool.cs
@@ -20,13 +20,13 @@ namespace Nethermind.TxPool
         /// Non-blob txs grouped by sender address, sorted by nonce and later tx pool sorting
         /// </summary>
         /// <returns></returns>
-        Dictionary<AddressAsKey, Transaction[]> GetPendingTransactionsBySender();
+        IDictionary<AddressAsKey, Transaction[]> GetPendingTransactionsBySender();
 
         /// <summary>
         /// Blob txs light equivalences grouped by sender address, sorted by nonce and later tx pool sorting
         /// </summary>
         /// <returns></returns>
-        Dictionary<AddressAsKey, Transaction[]> GetPendingLightBlobTransactionsBySender();
+        IDictionary<AddressAsKey, Transaction[]> GetPendingLightBlobTransactionsBySender();
 
         /// <summary>
         /// from a specific sender, sorted by nonce and later tx pool sorting

--- a/src/Nethermind/Nethermind.TxPool/ITxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxPool.cs
@@ -20,13 +20,13 @@ namespace Nethermind.TxPool
         /// Non-blob txs grouped by sender address, sorted by nonce and later tx pool sorting
         /// </summary>
         /// <returns></returns>
-        IDictionary<Address, Transaction[]> GetPendingTransactionsBySender();
+        Dictionary<AddressAsKey, Transaction[]> GetPendingTransactionsBySender();
 
         /// <summary>
         /// Blob txs light equivalences grouped by sender address, sorted by nonce and later tx pool sorting
         /// </summary>
         /// <returns></returns>
-        IDictionary<Address, Transaction[]> GetPendingLightBlobTransactionsBySender();
+        Dictionary<AddressAsKey, Transaction[]> GetPendingLightBlobTransactionsBySender();
 
         /// <summary>
         /// from a specific sender, sorted by nonce and later tx pool sorting

--- a/src/Nethermind/Nethermind.TxPool/NonceManager.cs
+++ b/src/Nethermind/Nethermind.TxPool/NonceManager.cs
@@ -11,7 +11,7 @@ namespace Nethermind.TxPool;
 
 public class NonceManager : INonceManager
 {
-    private readonly ConcurrentDictionary<Address, AddressNonceManager> _addressNonceManagers = new();
+    private readonly ConcurrentDictionary<AddressAsKey, AddressNonceManager> _addressNonceManagers = new();
     private readonly IAccountStateProvider _accounts;
 
     public NonceManager(IAccountStateProvider accounts)

--- a/src/Nethermind/Nethermind.TxPool/NullTxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/NullTxPool.cs
@@ -22,10 +22,10 @@ namespace Nethermind.TxPool
 
         public Transaction[] GetPendingTransactionsBySender(Address address) => Array.Empty<Transaction>();
 
-        public Dictionary<AddressAsKey, Transaction[]> GetPendingTransactionsBySender()
+        public IDictionary<AddressAsKey, Transaction[]> GetPendingTransactionsBySender()
             => new Dictionary<AddressAsKey, Transaction[]>();
 
-        public Dictionary<AddressAsKey, Transaction[]> GetPendingLightBlobTransactionsBySender()
+        public IDictionary<AddressAsKey, Transaction[]> GetPendingLightBlobTransactionsBySender()
             => new Dictionary<AddressAsKey, Transaction[]>();
 
         public static IEnumerable<Transaction> GetPendingBlobTransactions() => Array.Empty<Transaction>();

--- a/src/Nethermind/Nethermind.TxPool/NullTxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/NullTxPool.cs
@@ -22,11 +22,11 @@ namespace Nethermind.TxPool
 
         public Transaction[] GetPendingTransactionsBySender(Address address) => Array.Empty<Transaction>();
 
-        public IDictionary<Address, Transaction[]> GetPendingTransactionsBySender()
-            => new Dictionary<Address, Transaction[]>();
+        public Dictionary<AddressAsKey, Transaction[]> GetPendingTransactionsBySender()
+            => new Dictionary<AddressAsKey, Transaction[]>();
 
-        public IDictionary<Address, Transaction[]> GetPendingLightBlobTransactionsBySender()
-            => new Dictionary<Address, Transaction[]>();
+        public Dictionary<AddressAsKey, Transaction[]> GetPendingLightBlobTransactionsBySender()
+            => new Dictionary<AddressAsKey, Transaction[]>();
 
         public static IEnumerable<Transaction> GetPendingBlobTransactions() => Array.Empty<Transaction>();
 

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -160,10 +160,10 @@ namespace Nethermind.TxPool
 
         public int GetPendingTransactionsCount() => _transactions.Count;
 
-        public IDictionary<Address, Transaction[]> GetPendingTransactionsBySender() =>
+        public Dictionary<AddressAsKey, Transaction[]> GetPendingTransactionsBySender() =>
             _transactions.GetBucketSnapshot();
 
-        public IDictionary<Address, Transaction[]> GetPendingLightBlobTransactionsBySender() =>
+        public Dictionary<AddressAsKey, Transaction[]> GetPendingLightBlobTransactionsBySender() =>
             _blobTransactions.GetBucketSnapshot();
 
         public Transaction[] GetPendingTransactionsBySender(Address address) =>
@@ -729,7 +729,7 @@ namespace Nethermind.TxPool
         private static void AddNodeInfoEntryForTxPool()
         {
             ThisNodeInfo.AddInfo("Mem est tx   :",
-                $"{(LruCache<ValueHash256, object>.CalculateMemorySize(32, MemoryAllowance.TxHashCacheSize) + LruCache<Hash256, Transaction>.CalculateMemorySize(4096, MemoryAllowance.MemPoolSize)) / 1000 / 1000} MB"
+                $"{(LruCache<ValueHash256, object>.CalculateMemorySize(32, MemoryAllowance.TxHashCacheSize) + LruCache<Hash256AsKey, Transaction>.CalculateMemorySize(4096, MemoryAllowance.MemPoolSize)) / 1000 / 1000} MB"
                     .PadLeft(8));
         }
 

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -160,10 +160,10 @@ namespace Nethermind.TxPool
 
         public int GetPendingTransactionsCount() => _transactions.Count;
 
-        public Dictionary<AddressAsKey, Transaction[]> GetPendingTransactionsBySender() =>
+        public IDictionary<AddressAsKey, Transaction[]> GetPendingTransactionsBySender() =>
             _transactions.GetBucketSnapshot();
 
-        public Dictionary<AddressAsKey, Transaction[]> GetPendingLightBlobTransactionsBySender() =>
+        public IDictionary<AddressAsKey, Transaction[]> GetPendingLightBlobTransactionsBySender() =>
             _blobTransactions.GetBucketSnapshot();
 
         public Transaction[] GetPendingTransactionsBySender(Address address) =>

--- a/src/Nethermind/Nethermind.TxPool/TxPoolInfo.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPoolInfo.cs
@@ -8,11 +8,11 @@ namespace Nethermind.TxPool
 {
     public class TxPoolInfo
     {
-        public IDictionary<Address, IDictionary<ulong, Transaction>> Pending { get; }
-        public IDictionary<Address, IDictionary<ulong, Transaction>> Queued { get; }
+        public Dictionary<AddressAsKey, IDictionary<ulong, Transaction>> Pending { get; }
+        public Dictionary<AddressAsKey, IDictionary<ulong, Transaction>> Queued { get; }
 
-        public TxPoolInfo(IDictionary<Address, IDictionary<ulong, Transaction>> pending,
-            IDictionary<Address, IDictionary<ulong, Transaction>> queued)
+        public TxPoolInfo(Dictionary<AddressAsKey, IDictionary<ulong, Transaction>> pending,
+            Dictionary<AddressAsKey, IDictionary<ulong, Transaction>> queued)
         {
             Pending = pending;
             Queued = queued;

--- a/src/Nethermind/Nethermind.TxPool/TxPoolInfoProvider.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPoolInfoProvider.cs
@@ -24,9 +24,9 @@ namespace Nethermind.TxPool
             // only std txs are picked here. Should we add blobs?
             // BTW this class should be rewritten or removed - a lot of unnecessary allocations
             var groupedTransactions = _txPool.GetPendingTransactionsBySender();
-            var pendingTransactions = new Dictionary<Address, IDictionary<ulong, Transaction>>();
-            var queuedTransactions = new Dictionary<Address, IDictionary<ulong, Transaction>>();
-            foreach (KeyValuePair<Address, Transaction[]> group in groupedTransactions)
+            var pendingTransactions = new Dictionary<AddressAsKey, IDictionary<ulong, Transaction>>();
+            var queuedTransactions = new Dictionary<AddressAsKey, IDictionary<ulong, Transaction>>();
+            foreach (KeyValuePair<AddressAsKey, Transaction[]> group in groupedTransactions)
             {
                 Address address = group.Key;
                 var accountNonce = _stateReader.GetAccount(address).Nonce;


### PR DESCRIPTION
## Changes

- Wrap `Hash256`, `Address` and `PrivateKey` in a `struct` wrapper when used as a `ConcurrentDictionary`, `Dictionary` or `HashSet` key. This uses the same space (single pointer), but the struct wrapper causes the implementation of these generics to collapse to a concrete type that can then inline and make direct calls to `.Equals` and `.GetHashCode` rather than interface calls via a shared implementation.
- Change some `IDictionary` returns/fields to their concreate type `Dictionary`
- Reimplement `.GetHashCode`s to use `BitOperations.Crc32C` which is hardware accelerated and fast (3 cycle latency, 1 cycle throughput)
- Seed the GetHashCode with a crypto random value created on process start, so any performance determintal hashcode collisions will be isolated to one run and one node, rather than be shared by all nodes.

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No

#### If yes, did you write tests?

- [x] No