### PR TITLE
Skip unnecessary Hash256->ValueHash256->Hash256 conversions

### DIFF
--- a/src/Nethermind/Nethermind.Trie/BatchedTrieVisitor.cs
+++ b/src/Nethermind/Nethermind.Trie/BatchedTrieVisitor.cs
@@ -129,7 +129,7 @@ public class BatchedTrieVisitor<TNodeContext>
     }
 
     public void Start(
-        ValueHash256 root,
+        Hash256 root,
         TrieVisitContext trieVisitContext)
     {
         // Start with the root
@@ -197,7 +197,7 @@ public class BatchedTrieVisitor<TNodeContext>
                 for (int i = 0; i < _maxBatchSize; i++)
                 {
                     if (!theStack.TryPop(out Job item)) break;
-                    finalBatch.Add((_resolver.FindCachedOrUnknown(item.Key.ToCommitment()), item.NodeContext,
+                    finalBatch.Add((_resolver.FindCachedOrUnknown(item.Key), item.NodeContext,
                         item.Context));
                     Interlocked.Decrement(ref _queuedJobs);
                 }
@@ -231,7 +231,7 @@ public class BatchedTrieVisitor<TNodeContext>
             {
                 Job job = preSort[i];
 
-                TrieNode node = _resolver.FindCachedOrUnknown(job.Key.ToCommitment());
+                TrieNode node = _resolver.FindCachedOrUnknown(job.Key);
                 finalBatch.Add((node, job.NodeContext, job.Context));
             }
 
@@ -268,7 +268,7 @@ public class BatchedTrieVisitor<TNodeContext>
                 continue;
             }
 
-            ValueHash256 keccak = trieNode.Keccak;
+            Hash256 keccak = trieNode.Keccak;
             int partitionIdx = CalculatePartitionIdx(keccak);
             Interlocked.Increment(ref _activeJobs);
             Interlocked.Increment(ref _queuedJobs);
@@ -369,11 +369,11 @@ public class BatchedTrieVisitor<TNodeContext>
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
     private readonly struct Job
     {
-        public readonly ValueHash256 Key;
+        public readonly Hash256 Key;
         public readonly TNodeContext NodeContext;
         public readonly SmallTrieVisitContext Context;
 
-        public Job(ValueHash256 key, TNodeContext nodeContext, SmallTrieVisitContext context)
+        public Job(Hash256 key, TNodeContext nodeContext, SmallTrieVisitContext context)
         {
             Key = key;
             NodeContext = nodeContext;

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -86,9 +86,9 @@ namespace Nethermind.Trie.Pruning
 
             public bool IsNodeCached(Hash256 hash) => _objectsCache.ContainsKey(hash);
 
-            public ConcurrentDictionary<ValueHash256, TrieNode> AllNodes => _objectsCache;
+            public ConcurrentDictionary<Hash256AsKey, TrieNode> AllNodes => _objectsCache;
 
-            private readonly ConcurrentDictionary<ValueHash256, TrieNode> _objectsCache = new();
+            private readonly ConcurrentDictionary<Hash256AsKey, TrieNode> _objectsCache = new();
 
             private int _count = 0;
 
@@ -107,7 +107,7 @@ namespace Nethermind.Trie.Pruning
                 if (_trieStore._logger.IsTrace)
                 {
                     _trieStore._logger.Trace($"Trie node dirty cache ({Count})");
-                    foreach (KeyValuePair<ValueHash256, TrieNode> keyValuePair in _objectsCache)
+                    foreach (KeyValuePair<Hash256AsKey, TrieNode> keyValuePair in _objectsCache)
                     {
                         _trieStore._logger.Trace($"  {keyValuePair.Value}");
                     }
@@ -513,7 +513,7 @@ namespace Nethermind.Trie.Pruning
             Stopwatch stopwatch = Stopwatch.StartNew();
 
             long newMemory = 0;
-            foreach ((ValueHash256 key, TrieNode node) in _dirtyNodes.AllNodes)
+            foreach ((Hash256AsKey key, TrieNode node) in _dirtyNodes.AllNodes)
             {
                 if (node.IsPersisted)
                 {
@@ -829,9 +829,9 @@ namespace Nethermind.Trie.Pruning
 
                     // This should clear most nodes. For some reason, not all.
                     PruneCache();
-                    KeyValuePair<ValueHash256, TrieNode>[] nodesCopy = _dirtyNodes.AllNodes.ToArray();
+                    KeyValuePair<Hash256AsKey, TrieNode>[] nodesCopy = _dirtyNodes.AllNodes.ToArray();
 
-                    ConcurrentDictionary<ValueHash256, bool> wasPersisted = new();
+                    ConcurrentDictionary<Hash256AsKey, bool> wasPersisted = new();
                     void PersistNode(TrieNode n)
                     {
                         Hash256? hash = n.Keccak;
@@ -860,7 +860,7 @@ namespace Nethermind.Trie.Pruning
         private byte[]? GetByHash(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)
         {
             return _pruningStrategy.PruningEnabled
-                   && _dirtyNodes.AllNodes.TryGetValue(new ValueHash256(key), out TrieNode? trieNode)
+                   && _dirtyNodes.AllNodes.TryGetValue(new Hash256(key), out TrieNode? trieNode)
                    && trieNode is not null
                    && trieNode.NodeType != NodeType.Unknown
                    && trieNode.FullRlp.IsNotNull


### PR DESCRIPTION
## Changes

- If already have `Hash256` allocated, don't save to `ValueHash256` to then reallocate `Hash256` with `.ToCommitment()` but use the original `Hash256`
- Also use `Hash256` via `Hash256AsKey` for `ConcurrentDicitionary` keys rather than `ValueHash256` as `ConcurrentDicitionary` is less optimal if its keys cannot be written atomicly (max pointer size)

  See: https://github.com/dotnet/runtime/blob/d06742c2dbf9ded9c1a896c2a6d0ba1e333a906e/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs#L2298

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
