### PR TITLE
Calculate Tx Hash if fast path not available

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
@@ -357,18 +357,20 @@ namespace Nethermind.Blockchain.Receipts
             if (_receiptConfig.TxLookupLimit != 0 && block.Number <= headNumber - _receiptConfig.TxLookupLimit) return;
             if (_receiptConfig.CompactTxIndex)
             {
+                byte[] blockNumber = Rlp.Encode(block.Number).Bytes;
                 foreach (Transaction tx in block.Transactions)
                 {
                     Hash256 hash = (tx.Hash ??= tx.CalculateHash());
-                    writeBatch[hash.Bytes] = Rlp.Encode(block.Number).Bytes;
+                    writeBatch[hash.Bytes] = blockNumber;
                 }
             }
             else
             {
+                byte[] blockHash = block.Hash.BytesToArray();
                 foreach (Transaction tx in block.Transactions)
                 {
                     Hash256 hash = (tx.Hash ??= tx.CalculateHash());
-                    writeBatch[hash.Bytes] = block.Hash.BytesToArray();
+                    writeBatch[hash.Bytes] = blockHash;
                 }
             }
         }

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/PersistentReceiptStorage.cs
@@ -13,6 +13,7 @@ using Nethermind.Core.Caching;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
+using Nethermind.Crypto;
 using Nethermind.Db;
 using Nethermind.Serialization.Rlp;
 #pragma warning disable 618
@@ -358,14 +359,16 @@ namespace Nethermind.Blockchain.Receipts
             {
                 foreach (Transaction tx in block.Transactions)
                 {
-                    writeBatch[tx.Hash.Bytes] = Rlp.Encode(block.Number).Bytes;
+                    Hash256 hash = (tx.Hash ??= tx.CalculateHash());
+                    writeBatch[hash.Bytes] = Rlp.Encode(block.Number).Bytes;
                 }
             }
             else
             {
                 foreach (Transaction tx in block.Transactions)
                 {
-                    writeBatch[tx.Hash.Bytes] = block.Hash.BytesToArray();
+                    Hash256 hash = (tx.Hash ??= tx.CalculateHash());
+                    writeBatch[hash.Bytes] = block.Hash.BytesToArray();
                 }
             }
         }


### PR DESCRIPTION
Resolves #6663 though would need resync
Resolves #6670

## Changes

- Perform the full Rlp hash if fast path not available

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No