### PR TITLE
Use NonBlocking.ConcurrentDictionary

### DIFF
--- a/src/Nethermind/Directory.Packages.props
+++ b/src/Nethermind/Directory.Packages.props
@@ -51,6 +51,7 @@
     <PackageVersion Include="Nito.Collections.Deque" Version="1.2.1" />
     <PackageVersion Include="NLog" Version="5.2.8" />
     <PackageVersion Include="NLog.Targets.Seq" Version="3.1.0" />
+    <PackageVersion Include="NonBlocking" Version="2.1.2" />
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
     <PackageVersion Include="NUnit" Version="3.14.0" />
     <PackageVersion Include="NUnit.Analyzers" Version="3.9.0" />

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/InMemoryReceiptStorage.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/InMemoryReceiptStorage.cs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections.Concurrent;
+using NonBlocking;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 

--- a/src/Nethermind/Nethermind.Config/ConfigProvider.cs
+++ b/src/Nethermind/Nethermind.Config/ConfigProvider.cs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections.Concurrent;
+using NonBlocking;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/src/Nethermind/Nethermind.Config/Nethermind.Config.csproj
+++ b/src/Nethermind/Nethermind.Config/Nethermind.Config.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   
   <ItemGroup>
+    <PackageReference Include="NonBlocking" />
     <PackageReference Include="System.Configuration.ConfigurationManager" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Nethermind/Nethermind.Facade/Filters/FilterManager.cs
+++ b/src/Nethermind/Nethermind.Facade/Filters/FilterManager.cs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections.Concurrent;
+using NonBlocking;
 using System.Collections.Generic;
 using Nethermind.Blockchain.Find;
 using Nethermind.Consensus.Processing;

--- a/src/Nethermind/Nethermind.Facade/Filters/FilterStore.cs
+++ b/src/Nethermind/Nethermind.Facade/Filters/FilterStore.cs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections.Concurrent;
+using NonBlocking;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/Nethermind/Nethermind.Facade/Nethermind.Facade.csproj
+++ b/src/Nethermind/Nethermind.Facade/Nethermind.Facade.csproj
@@ -5,6 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="NonBlocking" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Nethermind.Consensus\Nethermind.Consensus.csproj" />
     <ProjectReference Include="..\Nethermind.Core\Nethermind.Core.csproj" />
     <ProjectReference Include="..\Nethermind.Crypto\Nethermind.Crypto.csproj" />

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/RpcMethodFilter.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/RpcMethodFilter.cs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections.Concurrent;
+using NonBlocking;
 using System.Collections.Generic;
 using System.IO.Abstractions;
 using System.Runtime.CompilerServices;

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
@@ -61,7 +61,7 @@ namespace Nethermind.Synchronization.FastBlocks
         /// <summary>
         /// Responses received from peers but waiting in a queue for some other requests to be handled first
         /// </summary>
-        private readonly ConcurrentDictionary<long, HeadersSyncBatch> _dependencies = new();
+        private readonly NonBlocking.ConcurrentDictionary<long, HeadersSyncBatch> _dependencies = new();
         // Stop gap method to reduce allocations from non-struct enumerator
         // https://github.com/dotnet/runtime/pull/38296
 
@@ -354,7 +354,7 @@ namespace Nethermind.Synchronization.FastBlocks
             {
                 lock (_handlerLock)
                 {
-                    ConcurrentDictionary<long, string> all = new();
+                    Dictionary<long, string> all = new();
                     StringBuilder builder = new();
                     builder.AppendLine($"SENT {_sent.Count} PENDING {_pending.Count} DEPENDENCIES {_dependencies.Count}");
                     foreach (var headerDependency in _dependencies)

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections.Concurrent;
+using NonBlocking;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;

--- a/src/Nethermind/Nethermind.Synchronization/Peers/PeerInfo.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/PeerInfo.cs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections.Concurrent;
+using NonBlocking;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;

--- a/src/Nethermind/Nethermind.Trie/Nethermind.Trie.csproj
+++ b/src/Nethermind/Nethermind.Trie/Nethermind.Trie.csproj
@@ -6,6 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="NonBlocking" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Nethermind.Core\Nethermind.Core.csproj" />
     <ProjectReference Include="..\Nethermind.Serialization.Rlp\Nethermind.Serialization.Rlp.csproj" />
   </ItemGroup>

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -831,7 +831,7 @@ namespace Nethermind.Trie.Pruning
                     PruneCache();
                     KeyValuePair<ValueHash256, TrieNode>[] nodesCopy = _dirtyNodes.AllNodes.ToArray();
 
-                    ConcurrentDictionary<ValueHash256, bool> wasPersisted = new();
+                    NonBlocking.ConcurrentDictionary<ValueHash256, bool> wasPersisted = new();
                     void PersistNode(TrieNode n)
                     {
                         Hash256? hash = n.Keccak;

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -86,9 +86,9 @@ namespace Nethermind.Trie.Pruning
 
             public bool IsNodeCached(Hash256 hash) => _objectsCache.ContainsKey(hash);
 
-            public ConcurrentDictionary<ValueHash256, TrieNode> AllNodes => _objectsCache;
+            public ConcurrentDictionary<Hash256AsKey, TrieNode> AllNodes => _objectsCache;
 
-            private readonly ConcurrentDictionary<ValueHash256, TrieNode> _objectsCache = new();
+            private readonly ConcurrentDictionary<Hash256AsKey, TrieNode> _objectsCache = new();
 
             private int _count = 0;
 
@@ -107,7 +107,7 @@ namespace Nethermind.Trie.Pruning
                 if (_trieStore._logger.IsTrace)
                 {
                     _trieStore._logger.Trace($"Trie node dirty cache ({Count})");
-                    foreach (KeyValuePair<ValueHash256, TrieNode> keyValuePair in _objectsCache)
+                    foreach (KeyValuePair<Hash256AsKey, TrieNode> keyValuePair in _objectsCache)
                     {
                         _trieStore._logger.Trace($"  {keyValuePair.Value}");
                     }
@@ -513,7 +513,7 @@ namespace Nethermind.Trie.Pruning
             Stopwatch stopwatch = Stopwatch.StartNew();
 
             long newMemory = 0;
-            foreach ((ValueHash256 key, TrieNode node) in _dirtyNodes.AllNodes)
+            foreach ((Hash256AsKey key, TrieNode node) in _dirtyNodes.AllNodes)
             {
                 if (node.IsPersisted)
                 {
@@ -829,7 +829,7 @@ namespace Nethermind.Trie.Pruning
 
                     // This should clear most nodes. For some reason, not all.
                     PruneCache();
-                    KeyValuePair<ValueHash256, TrieNode>[] nodesCopy = _dirtyNodes.AllNodes.ToArray();
+                    KeyValuePair<Hash256AsKey, TrieNode>[] nodesCopy = _dirtyNodes.AllNodes.ToArray();
 
                     NonBlocking.ConcurrentDictionary<Hash256AsKey, bool> wasPersisted = new();
                     void PersistNode(TrieNode n)
@@ -860,7 +860,7 @@ namespace Nethermind.Trie.Pruning
         private byte[]? GetByHash(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)
         {
             return _pruningStrategy.PruningEnabled
-                   && _dirtyNodes.AllNodes.TryGetValue(new ValueHash256(key), out TrieNode? trieNode)
+                   && _dirtyNodes.AllNodes.TryGetValue(new Hash256(key), out TrieNode? trieNode)
                    && trieNode is not null
                    && trieNode.NodeType != NodeType.Unknown
                    && trieNode.FullRlp.IsNotNull

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -831,7 +831,7 @@ namespace Nethermind.Trie.Pruning
                     PruneCache();
                     KeyValuePair<ValueHash256, TrieNode>[] nodesCopy = _dirtyNodes.AllNodes.ToArray();
 
-                    NonBlocking.ConcurrentDictionary<ValueHash256, bool> wasPersisted = new();
+                    NonBlocking.ConcurrentDictionary<Hash256AsKey, bool> wasPersisted = new();
                     void PersistNode(TrieNode n)
                     {
                         Hash256? hash = n.Keccak;

--- a/src/Nethermind/Nethermind.TxPool/Nethermind.TxPool.csproj
+++ b/src/Nethermind/Nethermind.TxPool/Nethermind.TxPool.csproj
@@ -5,6 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="NonBlocking" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Nethermind.Config\Nethermind.Config.csproj" />
     <ProjectReference Include="..\Nethermind.Core\Nethermind.Core.csproj" />
     <ProjectReference Include="..\Nethermind.Crypto\Nethermind.Crypto.csproj" />

--- a/src/Nethermind/Nethermind.TxPool/NonceManager.cs
+++ b/src/Nethermind/Nethermind.TxPool/NonceManager.cs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System.Collections.Concurrent;
+using NonBlocking;
 using System.Collections.Generic;
 using System.Threading;
 using Nethermind.Core;

--- a/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections.Concurrent;
+using NonBlocking;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;


### PR DESCRIPTION
## Changes

- Use [`NonBlocking.ConcurrentDictionary`](https://github.com/VSadov/NonBlocking) from @VSadov where appropriate. Can't changes `AllNodes` in `TrieStore` as we also grab all the internal locks at one point.

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
