### PR TITLE
Fix Snap Server Hive Tests

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Utils/LastNStateRootTrackerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Utils/LastNStateRootTrackerTests.cs
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using FluentAssertions;
+using Nethermind.Blockchain.Utils;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Test.Builders;
+using NUnit.Framework;
+
+namespace Nethermind.Blockchain.Test.Utils;
+
+public class LastNStateRootTrackerTests
+{
+    [Test]
+    public void Test_trackLastN()
+    {
+        System.Collections.Generic.List<Block> blocks = new();
+        Block currentBlock = Build.A.Block.Genesis.TestObject;
+        blocks.Add(currentBlock);
+        for (int i = 0; i < 20; i++)
+        {
+            currentBlock = Build.A.Block
+                .WithParent(currentBlock)
+                .WithStateRoot(Keccak.Compute(i.ToBigEndianByteArray()))
+                .TestObject;
+            blocks.Add(currentBlock);
+        }
+
+        BlockTree tree = Build.A.BlockTree().WithBlocks(blocks.ToArray()).TestObject;
+
+        LastNStateRootTracker tracker = new LastNStateRootTracker(tree, 10);
+
+        for (int i = 0; i < 30; i++)
+        {
+            tracker.HasStateRoot(Keccak.Compute(i.ToBigEndianByteArray()))
+                .Should().Be(i is >= 10 and < 20);
+        }
+    }
+
+    [Test]
+    public void Test_ContinueTrackingAsWeGetNewHead()
+    {
+        System.Collections.Generic.List<Block> blocks = new();
+        Block currentBlock = Build.A.Block.Genesis.TestObject;
+        blocks.Add(currentBlock);
+        for (int i = 0; i < 20; i++)
+        {
+            currentBlock = Build.A.Block
+                .WithParent(currentBlock)
+                .WithStateRoot(Keccak.Compute(i.ToBigEndianByteArray()))
+                .TestObject;
+            blocks.Add(currentBlock);
+        }
+
+        BlockTree tree = Build.A.BlockTree().WithBlocks(blocks.ToArray()).TestObject;
+
+        LastNStateRootTracker tracker = new LastNStateRootTracker(tree, 10);
+
+        currentBlock = Build.A.Block
+            .WithParent(currentBlock)
+            .WithStateRoot(Keccak.Compute(20.ToBigEndianByteArray()))
+            .TestObject;
+        tree.SuggestBlock(currentBlock);
+        tree.UpdateMainChain(new[] { currentBlock }, true);
+
+        for (int i = 0; i < 30; i++)
+        {
+            tracker.HasStateRoot(Keccak.Compute(i.ToBigEndianByteArray()))
+                .Should().Be(i is >= 11 and < 21);
+        }
+    }
+
+    [Test]
+    public void Test_OnReorg_RebuildSet()
+    {
+        System.Collections.Generic.List<Block> blocks = new();
+        Block currentBlock = Build.A.Block.Genesis.TestObject;
+        blocks.Add(currentBlock);
+        for (int i = 0; i < 20; i++)
+        {
+            currentBlock = Build.A.Block
+                .WithParent(currentBlock)
+                .WithStateRoot(Keccak.Compute(i.ToBigEndianByteArray()))
+                .TestObject;
+            blocks.Add(currentBlock);
+        }
+
+        BlockTree tree = Build.A.BlockTree().WithBlocks(blocks.ToArray()).TestObject;
+
+        LastNStateRootTracker tracker = new LastNStateRootTracker(tree, 10);
+
+        currentBlock = Build.A.Block
+            .WithParent(tree.FindBlock(15, BlockTreeLookupOptions.All)!)
+            .WithStateRoot(Keccak.Compute(100.ToBigEndianByteArray()))
+            .TestObject;
+        tree.SuggestBlock(currentBlock);
+        tree.UpdateMainChain(new[] { currentBlock }, true);
+
+        for (int i = 0; i < 30; i++)
+        {
+            tracker.HasStateRoot(Keccak.Compute(i.ToBigEndianByteArray()))
+                .Should().Be(i is >= 6 and < 15);
+        }
+
+        tracker.HasStateRoot(Keccak.Compute(100.ToBigEndianByteArray())).Should().BeTrue();
+    }
+}

--- a/src/Nethermind/Nethermind.Blockchain/Utils/ILastNStateRootTracker.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Utils/ILastNStateRootTracker.cs
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core.Crypto;
+
+namespace Nethermind.Blockchain.Utils;
+
+public interface ILastNStateRootTracker
+{
+    bool HasStateRoot(Hash256 stateRoot);
+}

--- a/src/Nethermind/Nethermind.Blockchain/Utils/LastNStateRootTracker.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Utils/LastNStateRootTracker.cs
@@ -12,7 +12,7 @@ namespace Nethermind.Blockchain.Utils;
 
 // TODO: Move responsibility to IWorldStateManager? Could be, but if IWorldStateManager store more than 128 blocks
 // of state, that would be out of spec for snap and it would fail hive test.
-public class LastNStateRootTracker: ILastNStateRootTracker, IDisposable
+public class LastNStateRootTracker : ILastNStateRootTracker, IDisposable
 {
     private IBlockTree _blockTree;
     private readonly int _lastN = 0;
@@ -48,14 +48,14 @@ public class LastNStateRootTracker: ILastNStateRootTracker, IDisposable
             _availableStateRoots.AddOrUpdate(
                 newHead.StateRoot,
                 (_) => 1,
-                (_, oldValue) => oldValue+1);
+                (_, oldValue) => oldValue + 1);
             while (_stateRootQueue.Count >= _lastN && _stateRootQueue.TryDequeue(out Hash256 oldStateRoot))
             {
                 int newNum = _availableStateRoots.AddOrUpdate(
                     oldStateRoot,
                     (_) => 0,
                     (_,
-                        oldValue) => oldValue-1);
+                        oldValue) => oldValue - 1);
                 if (newNum == 0) _availableStateRoots.Remove(oldStateRoot, out _);
             }
             _stateRootQueue.Enqueue(newHead.StateRoot);
@@ -73,7 +73,7 @@ public class LastNStateRootTracker: ILastNStateRootTracker, IDisposable
             newStateRootSet.AddOrUpdate(
                 parent.StateRoot,
                 (_) => 1,
-                (_, oldValue) => oldValue+1);
+                (_, oldValue) => oldValue + 1);
             stateRoots.Add(parent.StateRoot);
             parent = _blockTree.FindParentHeader(parent, BlockTreeLookupOptions.All);
         }

--- a/src/Nethermind/Nethermind.Blockchain/Utils/LastNStateRootTracker.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Utils/LastNStateRootTracker.cs
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using Nethermind.Blockchain.Find;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+
+namespace Nethermind.Blockchain.Utils;
+
+// TODO: Move responsibility to IWorldStateManager? Could be, but if IWorldStateManager store more than 128 blocks
+// of state, that would be out of spec for snap and it would fail hive test.
+public class LastNStateRootTracker: ILastNStateRootTracker, IDisposable
+{
+    private IBlockTree _blockTree;
+    private readonly int _lastN = 0;
+
+    private Hash256? _lastQueuedStateRoot = null;
+    private Queue<Hash256> _stateRootQueue = new Queue<Hash256>();
+    private ConcurrentDictionary<Hash256, int> _availableStateRoots = new();
+
+    public LastNStateRootTracker(IBlockTree blockTree, int lastN)
+    {
+        _blockTree = blockTree;
+        _lastN = lastN;
+
+        _blockTree.NewHeadBlock += BlockTreeOnNewHeadBlock;
+        if (_blockTree.Head != null) ResetAvailableStateRoots(_blockTree.Head.Header, true);
+    }
+
+    private void BlockTreeOnNewHeadBlock(object? sender, BlockEventArgs e)
+    {
+        ResetAvailableStateRoots(e.Block.Header, false);
+    }
+
+    private void ResetAvailableStateRoots(BlockHeader? newHead, bool resetQueue)
+    {
+        if (_availableStateRoots.TryGetValue(newHead.StateRoot, out int num) && num > 0) return;
+
+        BlockHeader? parent = _blockTree.FindParentHeader(newHead, BlockTreeLookupOptions.All);
+        if (parent == null) return; // What? I don't wanna know...
+
+        if (!resetQueue && _lastQueuedStateRoot == parent.StateRoot)
+        {
+            // Queue is intact.
+            _availableStateRoots.AddOrUpdate(
+                newHead.StateRoot,
+                (_) => 1,
+                (_, oldValue) => oldValue+1);
+            while (_stateRootQueue.Count >= _lastN && _stateRootQueue.TryDequeue(out Hash256 oldStateRoot))
+            {
+                int newNum = _availableStateRoots.AddOrUpdate(
+                    oldStateRoot,
+                    (_) => 0,
+                    (_,
+                        oldValue) => oldValue-1);
+                if (newNum == 0) _availableStateRoots.Remove(oldStateRoot, out _);
+            }
+            _stateRootQueue.Enqueue(newHead.StateRoot);
+            _lastQueuedStateRoot = newHead.StateRoot;
+            return;
+        }
+
+        List<Hash256> stateRoots = new();
+        ConcurrentDictionary<Hash256, int> newStateRootSet = new();
+        newStateRootSet.TryAdd(newHead.StateRoot, 1);
+        stateRoots.Add(newHead.StateRoot);
+
+        while (parent != null && newStateRootSet.Count < _lastN)
+        {
+            _availableStateRoots.AddOrUpdate(
+                parent.StateRoot,
+                (_) => 1,
+                (_, oldValue) => oldValue+1);
+            stateRoots.Add(parent.StateRoot);
+            parent = _blockTree.FindParentHeader(parent, BlockTreeLookupOptions.All);
+        }
+
+        stateRoots.Reverse();
+        _availableStateRoots = newStateRootSet;
+        _stateRootQueue = new Queue<Hash256>(stateRoots);
+        _lastQueuedStateRoot = newHead.StateRoot;
+    }
+
+    public bool HasStateRoot(Hash256 stateRoot)
+    {
+        return _availableStateRoots.TryGetValue(stateRoot, out int num) && num > 0;
+    }
+
+    public void Dispose()
+    {
+        _blockTree.NewHeadBlock -= BlockTreeOnNewHeadBlock;
+    }
+}

--- a/src/Nethermind/Nethermind.Blockchain/Utils/LastNStateRootTracker.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Utils/LastNStateRootTracker.cs
@@ -26,7 +26,7 @@ public class LastNStateRootTracker: ILastNStateRootTracker, IDisposable
         _blockTree = blockTree;
         _lastN = lastN;
 
-        _blockTree.NewHeadBlock += BlockTreeOnNewHeadBlock;
+        _blockTree.BlockAddedToMain += BlockTreeOnNewHeadBlock;
         if (_blockTree.Head != null) ResetAvailableStateRoots(_blockTree.Head.Header, true);
     }
 
@@ -68,9 +68,9 @@ public class LastNStateRootTracker: ILastNStateRootTracker, IDisposable
         newStateRootSet.TryAdd(newHead.StateRoot, 1);
         stateRoots.Add(newHead.StateRoot);
 
-        while (parent != null && newStateRootSet.Count < _lastN)
+        while (parent != null && stateRoots.Count < _lastN)
         {
-            _availableStateRoots.AddOrUpdate(
+            newStateRootSet.AddOrUpdate(
                 parent.StateRoot,
                 (_) => 1,
                 (_, oldValue) => oldValue+1);
@@ -91,6 +91,6 @@ public class LastNStateRootTracker: ILastNStateRootTracker, IDisposable
 
     public void Dispose()
     {
-        _blockTree.NewHeadBlock -= BlockTreeOnNewHeadBlock;
+        _blockTree.BlockAddedToMain -= BlockTreeOnNewHeadBlock;
     }
 }

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -524,6 +524,7 @@ public class InitializeNetwork : IStep
         ISnapServer? snapServer = null;
         if (_syncConfig.SnapServingEnabled)
         {
+            // TODO: Add a proper config for the state persistence depth.
             snapServer = new SnapServer(_api.TrieStore!.AsReadOnly(), _api.DbProvider.CodeDb, new LastNStateRootTracker(_api.BlockTree, 128), _api.LogManager);
         }
 

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Nethermind.Api;
 using Nethermind.Api.Extensions;
 using Nethermind.Blockchain.Synchronization;
+using Nethermind.Blockchain.Utils;
 using Nethermind.Core;
 using Nethermind.Crypto;
 using Nethermind.Db;
@@ -523,7 +524,7 @@ public class InitializeNetwork : IStep
         ISnapServer? snapServer = null;
         if (_syncConfig.SnapServingEnabled)
         {
-            snapServer = new SnapServer(_api.TrieStore!.AsReadOnly(), _api.DbProvider.CodeDb, _api.LogManager);
+            snapServer = new SnapServer(_api.TrieStore!.AsReadOnly(), _api.DbProvider.CodeDb, new LastNStateRootTracker(_api.BlockTree, 128), _api.LogManager);
         }
 
         _api.ProtocolsManager = new ProtocolsManager(

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/Messages/AccountRangeMessageSerializerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/Messages/AccountRangeMessageSerializerTests.cs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using FluentAssertions;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Network.P2P;
 using Nethermind.Network.P2P.Subprotocols.Snap.Messages;
@@ -16,6 +18,20 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.Messages
     {
         public static readonly byte[] Code0 = { 0, 0 };
         public static readonly byte[] Code1 = { 0, 1 };
+
+        [Test]
+        public void Roundtrip_NoAccountsNoProofs_HasCorrectLength()
+        {
+            AccountRangeMessage msg = new()
+            {
+                RequestId = 1,
+                PathsWithAccounts = System.Array.Empty<PathWithAccount>(),
+                Proofs = Array.Empty<byte[]>()
+            };
+
+            AccountRangeMessageSerializer serializer = new();
+            serializer.Serialize(msg).ToHexString().Should().Be("c301c0c0");
+        }
 
         [Test]
         public void Roundtrip_NoAccountsNoProofs()

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/Messages/TrieNodesMessageSerializerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/Messages/TrieNodesMessageSerializerTests.cs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using FluentAssertions;
+using Nethermind.Core.Extensions;
 using Nethermind.Network.P2P.Subprotocols.Snap.Messages;
 using NUnit.Framework;
 
@@ -19,6 +21,17 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.Messages
             TrieNodesMessageSerializer serializer = new();
 
             SerializerTester.TestZero(serializer, message);
+        }
+
+        [Test]
+        public void RoundtripWithCorrectLength()
+        {
+            byte[][] data = { new byte[] { 0xde, 0xad, 0xc0, 0xde }, new byte[] { 0xfe, 0xed } };
+
+            TrieNodesMessage message = new(data);
+            message.RequestId = 1;
+            TrieNodesMessageSerializer serializer = new();
+            serializer.Serialize(message).ToHexString().Should().Be("ca01c884deadc0de82feed");
         }
     }
 }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/AccountRangeMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/AccountRangeMessageSerializer.cs
@@ -85,7 +85,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap.Messages
             int pwasLength = 0;
             if (message.PathsWithAccounts is null || message.PathsWithAccounts.Length == 0)
             {
-                pwasLength = 1;
+                pwasLength = 0;
             }
             else
             {
@@ -104,7 +104,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap.Messages
             int proofsLength = 0;
             if (message.Proofs is null || message.Proofs.Length == 0)
             {
-                proofsLength = 1;
+                proofsLength = 0;
             }
             else
             {

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/TrieNodesMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/TrieNodesMessageSerializer.cs
@@ -44,7 +44,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap.Messages
                 nodesLength += Rlp.LengthOf(message.Nodes[i]);
             }
 
-            return (nodesLength + Rlp.LengthOf(message.RequestId), nodesLength);
+            return (Rlp.LengthOf(message.RequestId) + Rlp.LengthOfSequence(nodesLength), nodesLength);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/TrieNodesMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/TrieNodesMessageSerializer.cs
@@ -44,7 +44,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap.Messages
                 nodesLength += Rlp.LengthOf(message.Nodes[i]);
             }
 
-            return (Rlp.LengthOf(message.RequestId) + Rlp.LengthOfSequence(nodesLength), nodesLength);
+            return (Rlp.LengthOfSequence(nodesLength) + Rlp.LengthOf(message.RequestId), nodesLength);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization.Test/RangeQueryVisitorTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/RangeQueryVisitorTests.cs
@@ -82,7 +82,7 @@ public class RangeQueryVisitorTests
 
         using RangeQueryVisitor visitor = new(startHash, limitHash, false);
         stateTree.Accept(visitor, stateTree.RootHash, CreateVisitingOptions());
-        visitor.GetNodesAndSize().Item1.Count.Should().Be(2);
+        visitor.GetNodesAndSize().Item1.Count.Should().Be(3);
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Synchronization.Test/RangeQueryVisitorTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/RangeQueryVisitorTests.cs
@@ -17,9 +17,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using FluentAssertions;
-using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;

--- a/src/Nethermind/Nethermind.Synchronization.Test/RangeQueryVisitorTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/RangeQueryVisitorTests.cs
@@ -58,6 +58,31 @@ public class RangeQueryVisitorTests
         );
     }
 
+    [Test]
+    public void AccountRangeFetchWithSparserTree()
+    {
+        StateTree tree = new StateTree();
+        tree.Set(new Hash256("0100000000000000000000000000000000000000000000000000000000000000"), TestItem.GenerateRandomAccount());
+        tree.Set(new Hash256("0200000000000000000000000000000000000000000000000000000000000000"), TestItem.GenerateRandomAccount());
+        tree.Set(new Hash256("0300000000000000000000000000000000000000000000000000000000000000"), TestItem.GenerateRandomAccount());
+        tree.Set(new Hash256("0400000000000000000000000000000000000000000000000000000000000000"), TestItem.GenerateRandomAccount());
+        tree.Set(new Hash256("0500000000000000000000000000000000000000000000000000000000000000"), TestItem.GenerateRandomAccount());
+        tree.UpdateRootHash();
+
+        var startHash = new Hash256("0150000000000000000000000000000000000000000000000000000000000000");
+        var limitHash = new Hash256("0350000000000000000000000000000000000000000000000000000000000000");
+
+        using RangeQueryVisitor visitor = new(startHash, limitHash, false);
+        tree.Accept(visitor, tree.RootHash, CreateVisitingOptions());
+        (IDictionary<ValueHash256, byte[]> nodes, long _) = visitor.GetNodesAndSize();
+
+        nodes.Count.Should().Be(3);
+
+        nodes.ContainsKey(new Hash256("0200000000000000000000000000000000000000000000000000000000000000")).Should().BeTrue();
+        nodes.ContainsKey(new Hash256("0300000000000000000000000000000000000000000000000000000000000000")).Should().BeTrue();
+        nodes.ContainsKey(new Hash256("0400000000000000000000000000000000000000000000000000000000000000")).Should().BeTrue();
+    }
+
     private static VisitingOptions CreateVisitingOptions() => new() { ExpectAccounts = false };
 
     [Test]

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapServer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapServer.cs
@@ -84,7 +84,7 @@ public class SnapServer : ISnapServer
             switch (requestedPath.Length)
             {
                 case 0:
-                    throw new InvalidOperationException("Requested group must have at least one request");
+                    return null;
                 case 1:
                     try
                     {

--- a/src/Nethermind/Nethermind.Trie.Test/TreePathTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TreePathTests.cs
@@ -137,6 +137,22 @@ public class TreePathTests
         if (expectedResult == 1) path1.CompareTo(path2).Should().BeGreaterThan(0);
     }
 
+    [TestCase("0000", 0, "0000", -1)]
+    [TestCase("0000", 2, "0000", 0)]
+    [TestCase("0001", 0, "0001", -1)]
+    [TestCase("0003", 2, "0002", 1)]
+    [TestCase("000101", 2, "000100", -1)]
+    [TestCase("000101", 3, "000100", 1)]
+    public void TestCompareToTruncated(string nibbleHex1, int truncateLength, string nibbleHex2, int expectedResult)
+    {
+        TreePath path1 = TreePath.FromNibble(Bytes.FromHexString(nibbleHex1));
+        TreePath path2 = TreePath.FromNibble(Bytes.FromHexString(nibbleHex2));
+
+        if (expectedResult == -1) path1.CompareToTruncated(path2, truncateLength).Should().BeLessThan(0);
+        if (expectedResult == 0) path1.CompareToTruncated(path2, truncateLength).Should().Be(0);
+        if (expectedResult == 1) path1.CompareToTruncated(path2, truncateLength).Should().BeGreaterThan(0);
+    }
+
     [TestCase]
     public void TestScopedAppend()
     {

--- a/src/Nethermind/Nethermind.Trie/Pruning/TreePath.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TreePath.cs
@@ -300,6 +300,23 @@ public struct TreePath
         return Length.CompareTo(otherTree.Length);
     }
 
+    public readonly int CompareToTruncated(in TreePath otherTree, int length)
+    {
+        int minLength = Math.Min(length, otherTree.Length);
+        int commonByteLength = minLength / 2;
+        int compareByByte =
+            Bytes.BytesComparer.Compare(Span[..commonByteLength], otherTree.Span[..commonByteLength]);
+        if (compareByByte != 0) return compareByByte;
+
+        if (minLength % 2 == 1)
+        {
+            int result = this[minLength - 1].CompareTo(otherTree[minLength - 1]);
+            if (result != 0) return result;
+        }
+
+        return length.CompareTo(otherTree.Length);
+    }
+
     private static ReadOnlySpan<byte> ZeroMasksData => new byte[]
     {
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,

--- a/src/Nethermind/Nethermind.Trie/RangeQueryVisitor.cs
+++ b/src/Nethermind/Nethermind.Trie/RangeQueryVisitor.cs
@@ -48,7 +48,6 @@ public class RangeQueryVisitor : ITreeVisitor<TreePathContext>, IDisposable
 
     private readonly int _nodeLimit;
     private readonly long _byteLimit;
-    private readonly long _hardByteLimit;
 
     public bool StoppedEarly { get; set; } = false;
     public bool IsFullDbScan => false;
@@ -62,8 +61,7 @@ public class RangeQueryVisitor : ITreeVisitor<TreePathContext>, IDisposable
         in ValueHash256 startHash,
         in ValueHash256 limitHash,
         bool isAccountVisitor,
-        long byteLimit = -1,
-        long hardByteLimit = 200000,
+        long byteLimit = 200000,
         int nodeLimit = 10000,
         ReadFlags readFlags = ReadFlags.None,
         CancellationToken cancellationToken = default)
@@ -82,7 +80,6 @@ public class RangeQueryVisitor : ITreeVisitor<TreePathContext>, IDisposable
         _isAccountVisitor = isAccountVisitor;
         _nodeLimit = nodeLimit;
         _byteLimit = byteLimit;
-        _hardByteLimit = hardByteLimit;
         ExtraReadFlag = readFlags;
 
         TreePath startHashPath = new TreePath(startHash, 64);
@@ -108,13 +105,7 @@ public class RangeQueryVisitor : ITreeVisitor<TreePathContext>, IDisposable
             return false;
         }
 
-        if (_byteLimit != -1 && _currentBytesCount >= _byteLimit)
-        {
-            StoppedEarly = true;
-            return false;
-        }
-
-        if (_currentBytesCount >= _hardByteLimit)
+        if (_currentBytesCount >= _byteLimit)
         {
             StoppedEarly = true;
             return false;


### PR DESCRIPTION
- Fix snap server hive tests.
- Need to change the default config to turn on snap serving and snap sync, but otherwise should pass all snap tests.
- Slight performance improvement. Halfpath peaks at 250k nodes per sec now.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Have not test sync yet.