### PR TITLE
Consistently use DateTime.UtcNow over DateTime.Now

### DIFF
--- a/src/Nethermind/Nethermind.AuRa.Test/AuRaHealthHintServiceTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/AuRaHealthHintServiceTests.cs
@@ -21,7 +21,7 @@ namespace Nethermind.AuRa.Test
             [ValueSource(nameof(BlockProcessorIntervalHintTestCases))]
             BlockProcessorIntervalHint test)
         {
-            ManualTimestamper manualTimestamper = new(DateTime.Now);
+            ManualTimestamper manualTimestamper = new(DateTime.UtcNow);
             AuRaStepCalculator stepCalculator = new(new Dictionary<long, long>() { { 0, test.StepDuration } }, manualTimestamper, LimboLogs.Instance);
             IValidatorStore validatorStore = Substitute.For<IValidatorStore>();
             validatorStore.GetValidators().Returns(new Address[test.ValidatorsCount]);

--- a/src/Nethermind/Nethermind.AuRa.Test/AuRaStepCalculatorTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/AuRaStepCalculatorTests.cs
@@ -19,7 +19,7 @@ namespace Nethermind.AuRa.Test
         [TestCase(1)]
         public void step_increases_after_timeToNextStep(int stepDuration)
         {
-            ManualTimestamper manualTimestamper = new(DateTime.Now);
+            ManualTimestamper manualTimestamper = new(DateTime.UtcNow);
             AuRaStepCalculator calculator = new(GetStepDurationsForSingleStep(stepDuration), manualTimestamper, LimboLogs.Instance);
             long step = calculator.CurrentStep;
             manualTimestamper.Add(calculator.TimeToNextStep);
@@ -30,7 +30,7 @@ namespace Nethermind.AuRa.Test
         [TestCase(1)]
         public void after_waiting_for_next_step_timeToNextStep_should_be_close_to_stepDuration_in_seconds(int stepDuration)
         {
-            ManualTimestamper manualTimestamper = new(DateTime.Now);
+            ManualTimestamper manualTimestamper = new(DateTime.UtcNow);
             AuRaStepCalculator calculator = new(GetStepDurationsForSingleStep(stepDuration), manualTimestamper, LimboLogs.Instance);
             manualTimestamper.Add(calculator.TimeToNextStep);
             calculator.TimeToNextStep.Should().BeCloseTo(TimeSpan.FromSeconds(stepDuration), TimeSpan.FromMilliseconds(200));

--- a/src/Nethermind/Nethermind.Blockchain/Data/FileLocalDataSource.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Data/FileLocalDataSource.cs
@@ -135,7 +135,7 @@ namespace Nethermind.Blockchain.Data
             }
             else if (!Equals(_data, DefaultValue))
             {
-                lastChange = DateTime.Now;
+                lastChange = DateTime.UtcNow;
                 _data = DefaultValue;
             }
 

--- a/src/Nethermind/Nethermind.Blockchain/FullPruning/FullPruner.cs
+++ b/src/Nethermind/Nethermind.Blockchain/FullPruning/FullPruner.cs
@@ -79,7 +79,7 @@ namespace Nethermind.Blockchain.FullPruning
             // Lets assume pruning is in progress
             e.Status = PruningStatus.InProgress;
 
-            if (DateTime.Now - _lastPruning < _minimumPruningDelay)
+            if (DateTime.UtcNow - _lastPruning < _minimumPruningDelay)
             {
                 e.Status = PruningStatus.Delayed;
             }

--- a/src/Nethermind/Nethermind.Consensus.AuRa/TaskExt.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/TaskExt.cs
@@ -20,9 +20,9 @@ namespace Nethermind.Consensus.AuRa
         {
             while (delay > TimeSpan.Zero)
             {
-                var before = DateTimeOffset.Now;
+                var before = DateTimeOffset.UtcNow;
                 await Task.Delay(delay, token);
-                delay -= (DateTimeOffset.Now - before);
+                delay -= (DateTimeOffset.UtcNow - before);
             }
         }
     }

--- a/src/Nethermind/Nethermind.Consensus/Scheduler/BackgroundTaskScheduler.cs
+++ b/src/Nethermind/Nethermind.Consensus/Scheduler/BackgroundTaskScheduler.cs
@@ -86,7 +86,7 @@ public class BackgroundTaskScheduler : IBackgroundTaskScheduler, IAsyncDisposabl
                     // from its deadline, we re-queue it. We do this in case there are some task in the queue that already
                     // reached deadline during block processing in which case, it will need to execute in order to handle
                     // its cancellation.
-                    if (DateTimeOffset.Now < activity.Deadline)
+                    if (DateTimeOffset.UtcNow < activity.Deadline)
                     {
                         await _taskQueue.Writer.WriteAsync(activity, _mainCancellationTokenSource.Token);
                         // Throttle deque to prevent infinite loop.
@@ -114,7 +114,7 @@ public class BackgroundTaskScheduler : IBackgroundTaskScheduler, IAsyncDisposabl
     public void ScheduleTask<TReq>(TReq request, Func<TReq, CancellationToken, Task> fulfillFunc, TimeSpan? timeout = null)
     {
         timeout ??= DefaultTimeout;
-        DateTimeOffset deadline = DateTimeOffset.Now + timeout.Value;
+        DateTimeOffset deadline = DateTimeOffset.UtcNow + timeout.Value;
 
         IActivity activity = new Activity<TReq>()
         {
@@ -149,7 +149,7 @@ public class BackgroundTaskScheduler : IBackgroundTaskScheduler, IAsyncDisposabl
         public async Task Do(CancellationToken cancellationToken)
         {
             using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            DateTimeOffset now = DateTimeOffset.Now;
+            DateTimeOffset now = DateTimeOffset.UtcNow;
             TimeSpan timeToComplete = Deadline - now;
             if (timeToComplete <= TimeSpan.Zero)
             {

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/PeerRefresher.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/PeerRefresher.cs
@@ -39,7 +39,7 @@ public class PeerRefresher : IPeerRefresher, IAsyncDisposable
     public void RefreshPeers(Hash256 headBlockhash, Hash256 headParentBlockhash, Hash256 finalizedBlockhash)
     {
         _lastBlockhashes = (headBlockhash, headParentBlockhash, finalizedBlockhash);
-        TimeSpan timePassed = DateTime.Now - _lastRefresh;
+        TimeSpan timePassed = DateTime.UtcNow - _lastRefresh;
         if (timePassed > _minRefreshDelay)
         {
             Refresh(headBlockhash, headParentBlockhash, finalizedBlockhash);
@@ -58,7 +58,7 @@ public class PeerRefresher : IPeerRefresher, IAsyncDisposable
 
     private void Refresh(Hash256 headBlockhash, Hash256 headParentBlockhash, Hash256 finalizedBlockhash)
     {
-        _lastRefresh = DateTime.Now;
+        _lastRefresh = DateTime.UtcNow;
         foreach (PeerInfo peer in _syncPeerPool.AllPeers)
         {
             _ = StartPeerRefreshTask(peer.SyncPeer, headBlockhash, headParentBlockhash, finalizedBlockhash);

--- a/src/Nethermind/Nethermind.Network.Discovery/RoutingTable/NodeBucket.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/RoutingTable/NodeBucket.cs
@@ -111,7 +111,7 @@ public class NodeBucket
     {
         lock (_nodeBucketLock)
         {
-            NodeBucketItem item = new(nodeToRemove, DateTime.Now);
+            NodeBucketItem item = new(nodeToRemove, DateTime.UtcNow);
             if (_items.Remove(item))
             {
                 AddNode(nodeToAdd);

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -372,9 +372,9 @@ namespace Nethermind.Network
             // Once the connection was established, the active peer count will increase, but it might
             // not pass the handshake and the status check. So we wait for a bit to see if we can get
             // the active peer count to go down within this time window.
-            DateTimeOffset deadline = DateTimeOffset.Now + Timeouts.Handshake +
+            DateTimeOffset deadline = DateTimeOffset.UtcNow + Timeouts.Handshake +
                                       TimeSpan.FromMilliseconds(_networkConfig.ConnectTimeoutMs);
-            while (DateTimeOffset.Now < deadline && (AvailableActivePeersCount - _pending) <= 0)
+            while (DateTimeOffset.UtcNow < deadline && (AvailableActivePeersCount - _pending) <= 0)
             {
                 // The signal is not very reliable. So we just do like a simple pool.
                 _peerUpdateRequested.Reset();

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncPeersReportTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncPeersReportTests.cs
@@ -153,7 +153,7 @@ namespace Nethermind.Synchronization.Test
             syncPeer.TryAllocate(AllocationContexts.All);
 
             PeerInfo syncPeer2 = BuildPeer(true, direction: ConnectionDirection.In);
-            syncPeer2.PutToSleep(AllocationContexts.All, DateTime.Now);
+            syncPeer2.PutToSleep(AllocationContexts.All, DateTime.UtcNow);
 
             PeerInfo[] peers = { syncPeer, syncPeer2 };
 

--- a/src/Nethermind/Nethermind.Synchronization/IProcessExitSourceExtensions.cs
+++ b/src/Nethermind/Nethermind.Synchronization/IProcessExitSourceExtensions.cs
@@ -29,9 +29,9 @@ public static class IProcessExitSourceExtensions
             {
                 if (lastExitConditionTime == DateTime.MaxValue)
                 {
-                    lastExitConditionTime = DateTime.Now;
+                    lastExitConditionTime = DateTime.UtcNow;
                 }
-                else if (DateTime.Now - lastExitConditionTime > exitConditionDuration)
+                else if (DateTime.UtcNow - lastExitConditionTime > exitConditionDuration)
                 {
                     logger.Info($"Sync finished. Exiting....");
                     exitSource.Exit(0);

--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
@@ -156,7 +156,7 @@ namespace Nethermind.Synchronization.Peers
         {
             foreach (var peer in _peers)
             {
-                peer.Value.TryToWakeUp(DateTime.Now, TimeSpan.Zero);
+                peer.Value.TryToWakeUp(DateTime.UtcNow, TimeSpan.Zero);
             }
         }
 

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapServer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapServer.cs
@@ -70,13 +70,13 @@ public class SnapServer : ISnapServer
         // TODO: Before checking missing node cache, actually check StateReader.
         if (_rootWithMissingNode.TryGet(rootHash, out DateTimeOffset missingTime))
         {
-            if (DateTimeOffset.Now - missingTime < TimeSpan.FromSeconds(10))
+            if (DateTimeOffset.UtcNow - missingTime < TimeSpan.FromSeconds(10))
             {
                 return true;
             }
 
             // So, problem is, it could be that the missing root was just not processed, so we can't just not retry
-            // forever. `DateTimeOffset.Now` is probably heavy though.
+            // forever. `DateTimeOffset.UtcNow` is probably heavy though.
             _rootWithMissingNode.Delete(rootHash);
         }
 
@@ -85,7 +85,7 @@ public class SnapServer : ISnapServer
 
     private void TrackTrieNodeException(in ValueHash256 rootHash)
     {
-        _rootWithMissingNode.Set(rootHash, DateTimeOffset.Now);
+        _rootWithMissingNode.Set(rootHash, DateTimeOffset.UtcNow);
     }
 
     public byte[][]? GetTrieNodes(PathGroup[] pathSet, in ValueHash256 rootHash, CancellationToken cancellationToken)

--- a/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
@@ -170,7 +170,7 @@ namespace Nethermind.TxPool
                 return;
             }
 
-            DateTimeOffset now = DateTimeOffset.Now;
+            DateTimeOffset now = DateTimeOffset.UtcNow;
             if (_lastPersistedTxBroadcast + _minTimeBetweenPersistedTxBroadcast > now)
             {
                 if (_logger.IsTrace) _logger.Trace($"Minimum time between persistent tx broadcast not reached.");


### PR DESCRIPTION
Almost always use `DateTime.UtcNow` except in a couple places, which can cause inconsitences with timezones and daily savings changes.

## Changes

- Change any use of `DateTime.Now` to `DateTime.UtcNow` other than in logging output

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No
