### PR TITLE
fix the contract creation init gas cost

### DIFF
--- a/src/Nethermind/Nethermind.Verkle.Tree/Utils/VerkleWitness.cs
+++ b/src/Nethermind/Nethermind.Verkle.Tree/Utils/VerkleWitness.cs
@@ -85,10 +85,9 @@ public class VerkleWitness : IVerkleWitness
     {
         var gas = isValueTransfer
             ? AccessAccount(contractAddress,
-                AccountHeaderAccess.Version | AccountHeaderAccess.Nonce | AccountHeaderAccess.Balance |
-                AccountHeaderAccess.CodeHash, true)
+                AccountHeaderAccess.Version | AccountHeaderAccess.Nonce | AccountHeaderAccess.Balance, true)
             : AccessAccount(contractAddress,
-                AccountHeaderAccess.Version | AccountHeaderAccess.Nonce | AccountHeaderAccess.CodeHash, true);
+                AccountHeaderAccess.Version | AccountHeaderAccess.Nonce, true);
         // _logger.Info($"AccessForContractCreationInit: {contractAddress.Bytes.ToHexString()} {isValueTransfer} {gas}");
 
         return gas;


### PR DESCRIPTION
remove codeKeccak key access when charging gas from contract creation initialization
ref: https://eips.ethereum.org/EIPS/eip-4762

## Changes

- remove access event `(contract_address, 0, CODE_KECCAK_LEAF_KEY)` when a contract creation is initialized

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [ ] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
