### PR TITLE
Perf/span deserializer

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
@@ -146,7 +146,7 @@ public class TestBlockchain : IDisposable
         State.Commit(SpecProvider.GenesisSpec);
         State.CommitTree(0);
 
-        ReadOnlyTrieStore = TrieStore.AsReadOnly(StateDb);
+        ReadOnlyTrieStore = TrieStore.AsReadOnly();
         WorldStateManager = new WorldStateManager(State, TrieStore, DbProvider, LimboLogs.Instance);
         StateReader = new StateReader(ReadOnlyTrieStore, CodeDb, LogManager);
 

--- a/src/Nethermind/Nethermind.Core/IKeyValueStore.cs
+++ b/src/Nethermind/Nethermind.Core/IKeyValueStore.cs
@@ -92,6 +92,9 @@ namespace Nethermind.Core
 
         // Used for full pruning db to skip duplicate read
         SkipDuplicateRead = 4,
+
+        // Used for witness collector to skip collecting read
+        SkipWitness = 8,
     }
 
     [Flags]

--- a/src/Nethermind/Nethermind.Core/IKeyValueStore.cs
+++ b/src/Nethermind/Nethermind.Core/IKeyValueStore.cs
@@ -39,6 +39,25 @@ namespace Nethermind.Core
         }
 
         void DangerousReleaseMemory(in ReadOnlySpan<byte> span) { }
+
+        T ReadDeserialize<T, TDeserializer>(TDeserializer deserializer, ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)
+            where TDeserializer: ISpanDeserializer<T>
+        {
+            Span<byte> bytes = GetSpan(key, flags);
+            try
+            {
+                return deserializer.Deserialize(bytes);
+            }
+            finally
+            {
+                DangerousReleaseMemory(bytes);
+            }
+        }
+    }
+
+    public interface ISpanDeserializer<T>
+    {
+        T Deserialize(ReadOnlySpan<byte> span);
     }
 
     public interface IWriteOnlyKeyValueStore

--- a/src/Nethermind/Nethermind.Core/IKeyValueStore.cs
+++ b/src/Nethermind/Nethermind.Core/IKeyValueStore.cs
@@ -95,6 +95,9 @@ namespace Nethermind.Core
 
         // Used for witness collector to skip collecting read
         SkipWitness = 8,
+
+        // Used for trie store to not throw on missing node
+        DontThrowOnMissingNode = 16,
     }
 
     [Flags]

--- a/src/Nethermind/Nethermind.Core/Utils/IsNullOrEmptySpanDeserializer.cs
+++ b/src/Nethermind/Nethermind.Core/Utils/IsNullOrEmptySpanDeserializer.cs
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Core.Extensions;
+
+namespace Nethermind.Core.Utils;
+
+public readonly struct IsNullOrEmptySpanDeserializer: ISpanDeserializer<bool>
+{
+    public static IsNullOrEmptySpanDeserializer Instance = new();
+
+    public bool Deserialize(ReadOnlySpan<byte> span)
+    {
+        return span.IsNullOrEmpty();
+    }
+}

--- a/src/Nethermind/Nethermind.Core/Utils/ToArraySpanDeserializer.cs
+++ b/src/Nethermind/Nethermind.Core/Utils/ToArraySpanDeserializer.cs
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Core.Extensions;
+
+namespace Nethermind.Core.Utils;
+
+public readonly struct ToArraySpanDeserializer: ISpanDeserializer<byte[]?>
+{
+    public static ToArraySpanDeserializer Instance = new();
+
+    public byte[]? Deserialize(ReadOnlySpan<byte> span)
+    {
+        if (span.IsNull()) return null;
+        return span.ToArray();
+    }
+}

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -45,6 +45,11 @@ public class ColumnDb : IDb
         return _mainDb.GetSpanWithColumnFamily(key, _columnFamily, flags);
     }
 
+    public T ReadDeserialize<T, TDeserializer>(TDeserializer deserializer, ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None) where TDeserializer : Core.ISpanDeserializer<T>
+    {
+        return _mainDb.ReadDeserializeWithColumnFamily<T, TDeserializer>(deserializer, key, _columnFamily, _readaheadIterators, flags);
+    }
+
     public void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None)
     {
         _mainDb.SetWithColumnFamily(key, _columnFamily, value, flags);

--- a/src/Nethermind/Nethermind.Db.Test/CompressingStoreTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/CompressingStoreTests.cs
@@ -77,6 +77,23 @@ namespace Nethermind.Store.Test
         }
 
         [Test]
+        public void EOAWithSpanDeserialize()
+        {
+            Context ctx = new();
+
+            Rlp encoded = new AccountDecoder().Encode((Account)new(1));
+            ctx.Compressed.PutSpan(Key, encoded.Bytes);
+
+            CollectionAssert.AreEqual(encoded.Bytes, ctx.Compressed[Key]);
+
+            Account decodedAccount =
+                ctx.Compressed.ReadDeserialize<Account, RlpValueDecoderSpanDeserializer<Account, AccountDecoder>>(
+                    new RlpValueDecoderSpanDeserializer<Account, AccountDecoder>(new AccountDecoder()), Key);
+
+            decodedAccount.Balance.IsOne.Should().BeTrue();
+        }
+
+        [Test]
         public void Backward_compatible_read()
         {
             Context ctx = new();

--- a/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
@@ -15,6 +15,7 @@ using Nethermind.Core.Buffers;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Exceptions;
 using Nethermind.Core.Extensions;
+using Nethermind.Core.Utils;
 using Nethermind.Db.Rocks;
 using Nethermind.Db.Rocks.Config;
 using Nethermind.Logging;
@@ -304,6 +305,16 @@ namespace Nethermind.Db.Test
             AllocatedSpan.Should().Be(1);
             _db.DangerousReleaseMemory(readSpan);
             AllocatedSpan.Should().Be(0);
+        }
+
+        [Test]
+        public void Smoke_test_read_deserialize()
+        {
+            byte[] key = new byte[] { 1, 2, 3 };
+            byte[] value = new byte[] { 4, 5, 6 };
+            _db.PutSpan(key, value);
+            byte[] readValue = _db.ReadDeserialize<byte[]?, ToArraySpanDeserializer>(ToArraySpanDeserializer.Instance, key);
+            Assert.That(readValue, Is.EqualTo(new byte[] { 4, 5, 6 }));
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Serialization.Rlp/IRlpDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/IRlpDecoder.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using Nethermind.Core;
 
 namespace Nethermind.Serialization.Rlp
 {
@@ -28,6 +29,16 @@ namespace Nethermind.Serialization.Rlp
     public interface IRlpValueDecoder<T> : IRlpDecoder<T>
     {
         T Decode(ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None);
+    }
+
+    public readonly struct RlpValueDecoderSpanDeserializer<T, TRlpValueDecoder>(TRlpValueDecoder valueDecoder) : ISpanDeserializer<T>
+        where TRlpValueDecoder : IRlpValueDecoder<T>
+    {
+        public T Deserialize(ReadOnlySpan<byte> span)
+        {
+            var decoderContext = new Rlp.ValueDecoderContext(span);
+            return valueDecoder.Decode(ref decoderContext);
+        }
     }
 
     public static class RlpValueDecoderExtensions

--- a/src/Nethermind/Nethermind.State.Test/PatriciaTreeTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/PatriciaTreeTests.cs
@@ -5,6 +5,7 @@ using FluentAssertions;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Utils;
 using Nethermind.Db;
 using Nethermind.Int256;
 using Nethermind.Logging;
@@ -88,11 +89,11 @@ namespace Nethermind.Store.Test
 
             if (hasRoot)
             {
-                trieStore.LoadRlp(stateRoot).Length.Should().BeGreaterThan(0);
+                trieStore.LoadRlp<byte[], ToArraySpanDeserializer>(ToArraySpanDeserializer.Instance, stateRoot).Length.Should().BeGreaterThan(0);
             }
             else
             {
-                trieStore.Invoking(ts => ts.LoadRlp(stateRoot)).Should().Throw<TrieException>();
+                trieStore.Invoking(ts => ts.LoadRlp<byte[], ToArraySpanDeserializer>(ToArraySpanDeserializer.Instance, stateRoot)).Should().Throw<TrieException>();
             }
         }
     }

--- a/src/Nethermind/Nethermind.State/Witnesses/WitnessingStore.cs
+++ b/src/Nethermind/Nethermind.State/Witnesses/WitnessingStore.cs
@@ -43,7 +43,7 @@ namespace Nethermind.State.Witnesses
                 throw new NotSupportedException($"{nameof(WitnessingStore)} requires 32 bytes long keys.");
             }
 
-            Touch(key);
+            if ((flags & ReadFlags.SkipWitness) == 0) Touch(key);
             return _wrapped.Get(key, flags);
         }
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/Trie/HealingTrieStoreTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/Trie/HealingTrieStoreTests.cs
@@ -11,6 +11,7 @@ using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Utils;
 using Nethermind.Logging;
 using Nethermind.Synchronization.Trie;
 using Nethermind.Trie;
@@ -28,7 +29,7 @@ public class HealingTrieStoreTests
         TestMemDb db = new();
         db[TestItem.KeccakA.Bytes] = new byte[] { 1, 2 };
         HealingTrieStore healingTrieStore = new(db, Nethermind.Trie.Pruning.No.Pruning, Persist.EveryBlock, LimboLogs.Instance);
-        healingTrieStore.LoadRlp(TestItem.KeccakA, ReadFlags.None);
+        healingTrieStore.LoadRlp<byte[]?, ToArraySpanDeserializer>(ToArraySpanDeserializer.Instance, TestItem.KeccakA, ReadFlags.None);
     }
 
     [Test]
@@ -44,7 +45,7 @@ public class HealingTrieStoreTests
             .Returns(successfullyRecovered ? Task.FromResult<byte[]?>(rlp) : Task.FromResult<byte[]?>(null));
 
         healingTrieStore.InitializeNetwork(recovery);
-        Action action = () => healingTrieStore.LoadRlp(key, ReadFlags.None);
+        Action action = () => healingTrieStore.LoadRlp<byte[]?, ToArraySpanDeserializer>(ToArraySpanDeserializer.Instance, key, ReadFlags.None);
         if (isMainThread && successfullyRecovered)
         {
             action.Should().NotThrow();

--- a/src/Nethermind/Nethermind.Synchronization/Trie/HealingTrieStore.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Trie/HealingTrieStore.cs
@@ -33,17 +33,22 @@ public class HealingTrieStore : TrieStore
         _recovery = recovery;
     }
 
-    public override byte[] LoadRlp(Hash256 keccak, ReadFlags readFlags = ReadFlags.None)
+    public override T LoadRlp<T, TDeserializer>(TDeserializer deserializer, Hash256 keccak, ReadFlags flags = ReadFlags.None)
     {
+        if ((flags & ReadFlags.DontThrowOnMissingNode) != 0)
+        {
+            return base.LoadRlp<T, TDeserializer>(deserializer, keccak, flags);
+        }
+
         try
         {
-            return base.LoadRlp(keccak, readFlags);
+            return base.LoadRlp<T, TDeserializer>(deserializer, keccak, flags);
         }
         catch (TrieNodeException)
         {
             if (TryRecover(keccak, out byte[] rlp))
             {
-                return rlp;
+                return deserializer.Deserialize(rlp);
             }
 
             throw;

--- a/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
@@ -585,12 +585,13 @@ namespace Nethermind.Trie.Test.Pruning
 
             MemDb originalStore = new MemDb();
             WitnessCollector witnessCollector = new WitnessCollector(new MemDb(), LimboLogs.Instance);
+            using IDisposable tracker = witnessCollector.TrackOnThisThread();
             IKeyValueStoreWithBatching store = originalStore.WitnessedBy(witnessCollector);
             using TrieStore trieStore = new(store, new TestPruningStrategy(false), No.Persistence, _logManager);
             trieStore.CommitNode(0, new NodeCommitInfo(node));
             trieStore.FinishBlockCommit(TrieType.State, 0, node);
 
-            IReadOnlyTrieStore readOnlyTrieStore = trieStore.AsReadOnly(originalStore);
+            IReadOnlyTrieStore readOnlyTrieStore = trieStore.AsReadOnly();
             readOnlyTrieStore.LoadRlp(node.Keccak);
 
             witnessCollector.Collected.Should().BeEmpty();
@@ -616,7 +617,7 @@ namespace Nethermind.Trie.Test.Pruning
 
             if (beThreadSafe)
             {
-                trieStore = trieStore.AsReadOnly(memDb);
+                trieStore = trieStore.AsReadOnly();
             }
 
             void CheckChildren()

--- a/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
@@ -10,6 +10,7 @@ using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Utils;
 using Nethermind.Db;
 using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
@@ -305,7 +306,7 @@ namespace Nethermind.Trie.Test.Pruning
             memDb[Keccak.Zero.Bytes] = new byte[] { 1, 2, 3 };
 
             using TrieStore trieStore = new(memDb, _logManager);
-            trieStore.LoadRlp(Keccak.Zero).Should().NotBeNull();
+            trieStore.LoadRlp<byte[]?, ToArraySpanDeserializer>(ToArraySpanDeserializer.Instance, Keccak.Zero).Should().NotBeNull();
         }
 
         [Test]
@@ -592,7 +593,7 @@ namespace Nethermind.Trie.Test.Pruning
             trieStore.FinishBlockCommit(TrieType.State, 0, node);
 
             IReadOnlyTrieStore readOnlyTrieStore = trieStore.AsReadOnly();
-            readOnlyTrieStore.LoadRlp(node.Keccak);
+            readOnlyTrieStore.LoadRlp<byte[], ToArraySpanDeserializer>(ToArraySpanDeserializer.Instance, node.Keccak);
 
             witnessCollector.Collected.Should().BeEmpty();
         }

--- a/src/Nethermind/Nethermind.Trie.Test/TrieNodeResolverWithReadFlagsTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieNodeResolverWithReadFlagsTests.cs
@@ -5,6 +5,7 @@ using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Utils;
 using Nethermind.Logging;
 using Nethermind.Trie.Pruning;
 using NUnit.Framework;
@@ -23,7 +24,7 @@ public class TrieNodeResolverWithReadFlagsTests
 
         Hash256 theKeccak = TestItem.KeccakA;
         memDb[theKeccak.Bytes] = TestItem.KeccakA.BytesToArray();
-        resolver.LoadRlp(theKeccak);
+        resolver.LoadRlp<byte[]?, ToArraySpanDeserializer>(ToArraySpanDeserializer.Instance, theKeccak);
 
         memDb.KeyWasReadWithFlags(theKeccak.BytesToArray(), theFlags);
     }
@@ -38,7 +39,7 @@ public class TrieNodeResolverWithReadFlagsTests
 
         Hash256 theKeccak = TestItem.KeccakA;
         memDb[theKeccak.Bytes] = TestItem.KeccakA.BytesToArray();
-        resolver.LoadRlp(theKeccak, ReadFlags.HintReadAhead);
+        resolver.LoadRlp<byte[]?, ToArraySpanDeserializer>(ToArraySpanDeserializer.Instance, theKeccak, ReadFlags.HintReadAhead);
 
         memDb.KeyWasReadWithFlags(theKeccak.BytesToArray(), theFlags | ReadFlags.HintReadAhead);
     }

--- a/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
@@ -65,7 +65,7 @@ namespace Nethermind.Trie.Test
         public void Forward_read_flags_on_resolve()
         {
             ITrieNodeResolver resolver = Substitute.For<ITrieNodeResolver>();
-            resolver.LoadRlp<byte[], ToArraySpanDeserializer>(ToArraySpanDeserializer.Instance, TestItem.KeccakA, ReadFlags.HintReadAhead).Returns((byte[])null);
+            resolver.LoadRlp<CappedArray<byte>, TrieNode.CopyToPooledCappedArray>(new TrieNode.CopyToPooledCappedArray(null), TestItem.KeccakA, ReadFlags.HintReadAhead).Returns((byte[])null);
             TrieNode trieNode = new(NodeType.Unknown, TestItem.KeccakA);
             try
             {
@@ -74,7 +74,7 @@ namespace Nethermind.Trie.Test
             catch (TrieException)
             {
             }
-            resolver.Received().LoadRlp<byte[], ToArraySpanDeserializer>(ToArraySpanDeserializer.Instance, TestItem.KeccakA, ReadFlags.HintReadAhead);
+            resolver.Received().LoadRlp<CappedArray<byte>, TrieNode.CopyToPooledCappedArray>(new TrieNode.CopyToPooledCappedArray(null), TestItem.KeccakA, ReadFlags.HintReadAhead);
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
@@ -11,6 +11,7 @@ using Nethermind.Core.Buffers;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Utils;
 using Nethermind.Db;
 using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
@@ -64,7 +65,7 @@ namespace Nethermind.Trie.Test
         public void Forward_read_flags_on_resolve()
         {
             ITrieNodeResolver resolver = Substitute.For<ITrieNodeResolver>();
-            resolver.LoadRlp(TestItem.KeccakA, ReadFlags.HintReadAhead).Returns((byte[])null);
+            resolver.LoadRlp<byte[], ToArraySpanDeserializer>(ToArraySpanDeserializer.Instance, TestItem.KeccakA, ReadFlags.HintReadAhead).Returns((byte[])null);
             TrieNode trieNode = new(NodeType.Unknown, TestItem.KeccakA);
             try
             {
@@ -73,7 +74,7 @@ namespace Nethermind.Trie.Test
             catch (TrieException)
             {
             }
-            resolver.Received().LoadRlp(TestItem.KeccakA, ReadFlags.HintReadAhead);
+            resolver.Received().LoadRlp<byte[], ToArraySpanDeserializer>(ToArraySpanDeserializer.Instance, TestItem.KeccakA, ReadFlags.HintReadAhead);
         }
 
         [Test]
@@ -834,7 +835,7 @@ namespace Nethermind.Trie.Test
             trieNode.Seal();
 
             ITrieNodeResolver trieStore = Substitute.For<ITrieNodeResolver>();
-            trieStore.LoadRlp(Arg.Any<Hash256>()).Throws(new TrieException());
+            trieStore.LoadRlp<byte[], ToArraySpanDeserializer>(ToArraySpanDeserializer.Instance, Arg.Any<Hash256>()).Throws(new TrieException());
             child.ResolveKey(trieStore, false);
             child.IsPersisted = true;
 

--- a/src/Nethermind/Nethermind.Trie/Pruning/ITrieNodeResolver.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ITrieNodeResolver.cs
@@ -22,13 +22,7 @@ namespace Nethermind.Trie.Pruning
         /// </summary>
         /// <param name="hash"></param>
         /// <returns></returns>
-        byte[]? LoadRlp(Hash256 hash, ReadFlags flags = ReadFlags.None);
-
-        /// <summary>
-        /// Loads RLP of the node.
-        /// </summary>
-        /// <param name="hash"></param>
-        /// <returns></returns>
-        byte[]? TryLoadRlp(Hash256 hash, ReadFlags flags = ReadFlags.None);
+        T LoadRlp<T, TDeserializer>(TDeserializer deserializer, Hash256 hash, ReadFlags flags = ReadFlags.None)
+            where TDeserializer : ISpanDeserializer<T>;
     }
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/ITrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ITrieStore.cs
@@ -17,7 +17,7 @@ namespace Nethermind.Trie.Pruning
 
         bool IsPersisted(in ValueHash256 keccak);
 
-        IReadOnlyTrieStore AsReadOnly(IKeyValueStore? keyValueStore = null);
+        IReadOnlyTrieStore AsReadOnly();
 
         event EventHandler<ReorgBoundaryReached>? ReorgBoundaryReached;
 

--- a/src/Nethermind/Nethermind.Trie/Pruning/NullTrieNodeResolver.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/NullTrieNodeResolver.cs
@@ -13,7 +13,9 @@ namespace Nethermind.Trie.Pruning
         public static readonly NullTrieNodeResolver Instance = new();
 
         public TrieNode FindCachedOrUnknown(Hash256 hash) => new(NodeType.Unknown, hash);
-        public byte[]? LoadRlp(Hash256 hash, ReadFlags flags = ReadFlags.None) => null;
-        public byte[]? TryLoadRlp(Hash256 hash, ReadFlags flags = ReadFlags.None) => null;
+        public T LoadRlp<T, TDeserializer>(TDeserializer deserializer, Hash256 hash, ReadFlags flags = ReadFlags.None) where TDeserializer : ISpanDeserializer<T>
+        {
+            return deserializer.Deserialize(null);
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/NullTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/NullTrieStore.cs
@@ -31,9 +31,10 @@ namespace Nethermind.Trie.Pruning
 
         public TrieNode FindCachedOrUnknown(Hash256 hash) => new(NodeType.Unknown, hash);
 
-        public byte[] TryLoadRlp(Hash256 hash, ReadFlags flags = ReadFlags.None) => null;
-
-        public byte[] LoadRlp(Hash256 hash, ReadFlags flags = ReadFlags.None) => Array.Empty<byte>();
+        public T LoadRlp<T, TDeserializer>(TDeserializer deserializer, Hash256 hash, ReadFlags flags = ReadFlags.None) where TDeserializer : ISpanDeserializer<T>
+        {
+            return deserializer.Deserialize(null);
+        }
 
         public bool IsPersisted(in ValueHash256 keccak) => true;
 

--- a/src/Nethermind/Nethermind.Trie/Pruning/NullTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/NullTrieStore.cs
@@ -19,7 +19,7 @@ namespace Nethermind.Trie.Pruning
 
         public void FinishBlockCommit(TrieType trieType, long blockNumber, TrieNode? root, WriteFlags flags = WriteFlags.None) { }
 
-        public IReadOnlyTrieStore AsReadOnly(IKeyValueStore? keyValueStore = null) => this;
+        public IReadOnlyTrieStore AsReadOnly() => this;
 
         public event EventHandler<ReorgBoundaryReached> ReorgBoundaryReached
         {

--- a/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStore.cs
@@ -15,27 +15,25 @@ namespace Nethermind.Trie.Pruning
     public class ReadOnlyTrieStore : IReadOnlyTrieStore
     {
         private readonly TrieStore _trieStore;
-        private readonly IKeyValueStore? _readOnlyStore;
         private readonly IReadOnlyKeyValueStore _publicStore;
 
-        public ReadOnlyTrieStore(TrieStore trieStore, IKeyValueStore? readOnlyStore)
+        public ReadOnlyTrieStore(TrieStore trieStore)
         {
             _trieStore = trieStore ?? throw new ArgumentNullException(nameof(trieStore));
-            _readOnlyStore = readOnlyStore;
             _publicStore = _trieStore.TrieNodeRlpStore;
         }
 
         public TrieNode FindCachedOrUnknown(Hash256 hash) =>
             _trieStore.FindCachedOrUnknown(hash, true);
 
-        public byte[]? TryLoadRlp(Hash256 hash, ReadFlags flags) => _trieStore.TryLoadRlp(hash, _readOnlyStore, flags);
-        public byte[] LoadRlp(Hash256 hash, ReadFlags flags) => _trieStore.LoadRlp(hash, _readOnlyStore, flags);
+        public byte[]? TryLoadRlp(Hash256 hash, ReadFlags flags) => _trieStore.TryLoadRlp(hash, flags | ReadFlags.SkipWitness);
+        public byte[] LoadRlp(Hash256 hash, ReadFlags flags) => _trieStore.LoadRlp(hash, flags | ReadFlags.SkipWitness);
 
         public bool IsPersisted(in ValueHash256 keccak) => _trieStore.IsPersisted(keccak);
 
-        public IReadOnlyTrieStore AsReadOnly(IKeyValueStore keyValueStore)
+        public IReadOnlyTrieStore AsReadOnly()
         {
-            return new ReadOnlyTrieStore(_trieStore, keyValueStore);
+            return new ReadOnlyTrieStore(_trieStore);
         }
 
         public void CommitNode(long blockNumber, NodeCommitInfo nodeCommitInfo, WriteFlags flags = WriteFlags.None) { }

--- a/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStore.cs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Threading;
-using System.Threading.Tasks;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 
@@ -26,8 +24,10 @@ namespace Nethermind.Trie.Pruning
         public TrieNode FindCachedOrUnknown(Hash256 hash) =>
             _trieStore.FindCachedOrUnknown(hash, true);
 
-        public byte[]? TryLoadRlp(Hash256 hash, ReadFlags flags) => _trieStore.TryLoadRlp(hash, flags | ReadFlags.SkipWitness);
-        public byte[] LoadRlp(Hash256 hash, ReadFlags flags) => _trieStore.LoadRlp(hash, flags | ReadFlags.SkipWitness);
+        public T LoadRlp<T, TDeserializer>(TDeserializer deserializer, Hash256 hash, ReadFlags flags = ReadFlags.None) where TDeserializer : ISpanDeserializer<T>
+        {
+            return _trieStore.LoadRlp<T, TDeserializer>(deserializer, hash, flags | ReadFlags.SkipWitness);
+        }
 
         public bool IsPersisted(in ValueHash256 keccak) => _trieStore.IsPersisted(keccak);
 

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -333,10 +333,9 @@ namespace Nethermind.Trie.Pruning
 
         public event EventHandler<ReorgBoundaryReached>? ReorgBoundaryReached;
 
-        public byte[]? TryLoadRlp(Hash256 keccak, IKeyValueStore? keyValueStore, ReadFlags readFlags = ReadFlags.None)
+        public virtual byte[]? TryLoadRlp(Hash256 keccak, ReadFlags readFlags = ReadFlags.None)
         {
-            keyValueStore ??= _keyValueStore;
-            byte[]? rlp = keyValueStore.Get(keccak.Bytes, readFlags);
+            byte[]? rlp = _keyValueStore.Get(keccak.Bytes, readFlags);
 
             if (rlp is not null)
             {
@@ -346,9 +345,9 @@ namespace Nethermind.Trie.Pruning
             return rlp;
         }
 
-        public byte[] LoadRlp(Hash256 keccak, IKeyValueStore? keyValueStore, ReadFlags readFlags = ReadFlags.None)
+        public virtual byte[] LoadRlp(Hash256 keccak, ReadFlags readFlags = ReadFlags.None)
         {
-            byte[]? rlp = TryLoadRlp(keccak, keyValueStore, readFlags);
+            byte[]? rlp = TryLoadRlp(keccak, readFlags);
             if (rlp is null)
             {
                 throw new TrieNodeException($"Node {keccak} is missing from the DB", keccak);
@@ -356,9 +355,6 @@ namespace Nethermind.Trie.Pruning
 
             return rlp;
         }
-
-        public virtual byte[] LoadRlp(Hash256 keccak, ReadFlags readFlags = ReadFlags.None) => LoadRlp(keccak, null, readFlags);
-        public virtual byte[]? TryLoadRlp(Hash256 keccak, ReadFlags readFlags = ReadFlags.None) => TryLoadRlp(keccak, null, readFlags);
 
         public bool IsPersisted(in ValueHash256 keccak)
         {

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -374,8 +374,8 @@ namespace Nethermind.Trie.Pruning
             return true;
         }
 
-        public IReadOnlyTrieStore AsReadOnly(IKeyValueStore? keyValueStore = null) =>
-            new ReadOnlyTrieStore(this, keyValueStore);
+        public IReadOnlyTrieStore AsReadOnly() =>
+            new ReadOnlyTrieStore(this);
 
         public bool IsNodeCached(Hash256 hash) => _dirtyNodes.IsNodeCached(hash);
 

--- a/src/Nethermind/Nethermind.Trie/TrieNode.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.cs
@@ -10,6 +10,7 @@ using Nethermind.Core;
 using Nethermind.Core.Buffers;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
+using Nethermind.Core.Utils;
 using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
 using Nethermind.Trie.Pruning;
@@ -348,7 +349,9 @@ namespace Nethermind.Trie
                         ThrowMissingKeccak();
                     }
 
-                    CappedArray<byte> fullRlp = tree.LoadRlp(keccak, readFlags);
+                    // TODO: Allocate from bufferPool
+                    CappedArray<byte> fullRlp = new CappedArray<byte>(tree.LoadRlp<byte[]?, ToArraySpanDeserializer>(
+                        ToArraySpanDeserializer.Instance, keccak, readFlags));
 
                     if (fullRlp.IsNull)
                     {
@@ -416,7 +419,7 @@ namespace Nethermind.Trie
                             return false;
                         }
 
-                        var fullRlp = tree.TryLoadRlp(keccak, readFlags);
+                        var fullRlp = tree.LoadRlp<byte[], ToArraySpanDeserializer>(ToArraySpanDeserializer.Instance, keccak, readFlags | ReadFlags.DontThrowOnMissingNode);
 
                         if (fullRlp is null)
                         {

--- a/src/Nethermind/Nethermind.Trie/TrieNodeResolverWithReadFlags.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNodeResolverWithReadFlags.cs
@@ -23,23 +23,10 @@ public class TrieNodeResolverWithReadFlags : ITrieNodeResolver
         return _baseResolver.FindCachedOrUnknown(hash);
     }
 
-    public byte[]? TryLoadRlp(Hash256 hash, ReadFlags flags = ReadFlags.None)
+    public T LoadRlp<T, TDeserializer>(TDeserializer deserializer, Hash256 hash, ReadFlags flags = ReadFlags.None) where TDeserializer : ISpanDeserializer<T>
     {
-        if (flags != ReadFlags.None)
-        {
-            return _baseResolver.TryLoadRlp(hash, flags | _defaultFlags);
-        }
+        flags |= _defaultFlags;
 
-        return _baseResolver.TryLoadRlp(hash, _defaultFlags);
-    }
-
-    public byte[]? LoadRlp(Hash256 hash, ReadFlags flags = ReadFlags.None)
-    {
-        if (flags != ReadFlags.None)
-        {
-            return _baseResolver.LoadRlp(hash, flags | _defaultFlags);
-        }
-
-        return _baseResolver.LoadRlp(hash, _defaultFlags);
+        return _baseResolver.LoadRlp<T, TDeserializer>(deserializer, hash, flags);
     }
 }

--- a/src/Nethermind/Nethermind.Trie/TrieStoreWithReadFlags.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieStoreWithReadFlags.cs
@@ -37,8 +37,8 @@ public class TrieStoreWithReadFlags : TrieNodeResolverWithReadFlags, ITrieStore
         return _baseImplementation.IsPersisted(in keccak);
     }
 
-    public IReadOnlyTrieStore AsReadOnly(IKeyValueStore? keyValueStore = null) =>
-        _baseImplementation.AsReadOnly(keyValueStore);
+    public IReadOnlyTrieStore AsReadOnly() =>
+        _baseImplementation.AsReadOnly();
 
     public event EventHandler<ReorgBoundaryReached>? ReorgBoundaryReached
     {


### PR DESCRIPTION
- As requested, a span deserializer at IKeyValueStore.
- Why? The GetSpan requires a corresponding correct DangerouslyReleaseSpan call which can be dangerous and cause the IKeyValueStore to be hard to wrap.
- This cause EOACompressingStore to be unable to implement GetSpan. 
- Also, GetSpan can't use `ReadAhead` flag as the span is part of the iterator, so it can't do DangerouslyReleaseSpan. The `ReadAhead` flag is vital for batched trie visitor and snap serving on halfpath.

## Before

| Method                          | Mean       | Error     | StdDev    | Gen0     | Gen1     | Gen2    | Allocated   |
|-------------------------------- |-----------:|----------:|----------:|---------:|---------:|--------:|------------:|
| Scenarios                       |   123.9 us |   2.47 us |   5.76 us |   8.7891 |   2.1973 |       - |   144.65 KB |
| InsertAndHash                   | 3,218.0 us |  64.09 us | 158.41 us | 218.7500 | 128.9063 |       - |  3593.14 KB |
| InsertAndCommit                 | 5,570.9 us | 129.28 us | 377.13 us | 406.2500 | 281.2500 | 78.1250 |   5594.4 KB |
| ReadWithFullTree                | 3,621.5 us |  71.95 us | 177.84 us | 640.6250 |        - |       - | 10516.34 KB |
| ReadWithUncommittedFullTree     |   471.6 us |   7.01 us |   5.86 us |  23.4375 |        - |       - |      384 KB |
| ReadWithMemoryTrieStore         | 1,874.2 us |  35.80 us |  46.55 us |  66.4063 |        - |       - |  1091.95 KB |
| ReadWithMemoryTrieStoreReadOnly | 3,766.3 us |  74.38 us | 166.36 us | 640.6250 |   3.9063 |       - | 10517.31 KB |
| ReadAndDeserialize              | 3,623.5 us |  67.21 us | 135.78 us | 640.6250 |   7.8125 |       - | 10519.89 KB |


## After

| Method                          | Mean       | Error     | StdDev    | Gen0     | Gen1     | Gen2    | Allocated  |
|-------------------------------- |-----------:|----------:|----------:|---------:|---------:|--------:|-----------:|
| Scenarios                       |   130.2 us |   2.59 us |   6.55 us |  10.7422 |   2.1973 |       - |  175.77 KB |
| InsertAndHash                   | 3,216.7 us |  63.85 us | 113.49 us | 218.7500 | 128.9063 |       - | 3593.14 KB |
| InsertAndCommit                 | 5,756.3 us | 139.09 us | 396.82 us | 406.2500 | 289.0625 | 78.1250 | 5566.94 KB |
| ReadWithFullTree                | 3,690.5 us |  72.90 us | 121.79 us | 605.4688 |        - |       - | 9941.44 KB |
| ReadWithUncommittedFullTree     |   476.8 us |   9.52 us |  16.92 us |  23.4375 |        - |       - |     384 KB |
| ReadWithMemoryTrieStore         | 1,862.7 us |  36.16 us |  45.74 us |  66.4063 |        - |       - | 1091.95 KB |
| ReadWithMemoryTrieStoreReadOnly | 3,738.6 us |  73.77 us | 119.12 us | 601.5625 |        - |       - | 9942.41 KB |
| ReadAndDeserialize              | 3,806.7 us |  90.85 us | 262.11 us | 605.4688 |   7.8125 |       - |    9945 KB |

Well... that is disappointing.

## Changes

- _List the changes_

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [ ] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
