### PR TITLE
Fix silent backgrount task failure.

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Scheduler/BackgroundTaskScheduler.cs
+++ b/src/Nethermind/Nethermind.Consensus/Scheduler/BackgroundTaskScheduler.cs
@@ -106,7 +106,7 @@ public class BackgroundTaskScheduler : IBackgroundTaskScheduler, IAsyncDisposabl
             }
             catch (Exception e)
             {
-                if (_logger.IsDebug) _logger.Debug($"Error processing background task {e}.");
+                if (_logger.IsError) _logger.Error($"Error processing background task {e}.");
             }
         }
     }

--- a/src/Nethermind/Nethermind.Consensus/Scheduler/BackgroundTaskScheduler.cs
+++ b/src/Nethermind/Nethermind.Consensus/Scheduler/BackgroundTaskScheduler.cs
@@ -22,6 +22,7 @@ namespace Nethermind.Consensus.Scheduler;
 /// - Task will not run if block processing is happening and it still have some time left.
 ///   It is up to the task to determine what happen if cancelled, maybe it will reschedule for later, or resume later, but
 ///   preferably, stop execution immediately. Don't hang BTW. Other background task need to cancel too.
+/// - A failure at this level is considered unexpected and loud. Exception should be handled at handler level.
 ///
 /// Note: Yes, I know there is a built in TaskScheduler that can do some magical stuff that stop execution on async
 /// and stuff, but that is complicated and I don't wanna explain why you need `async Task.Yield()` in the middle of a loop,

--- a/src/Nethermind/Nethermind.Core/Collections/ArrayPoolList.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/ArrayPoolList.cs
@@ -103,7 +103,14 @@ public sealed class ArrayPoolList<T> : IList<T>, IList, IReadOnlyList<T>, IDispo
         Array.Copy(_array, 0, array!, index, _count);
     }
 
-    public int Count => _count;
+    public int Count
+    {
+        get
+        {
+            GuardDispose();
+            return _count;
+        }
+    }
 
     public int Capacity => _capacity;
 

--- a/src/Nethermind/Nethermind.Network.Stats/Model/DisconnectReason.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/Model/DisconnectReason.cs
@@ -21,6 +21,7 @@ public enum DisconnectReason : byte
     SessionAlreadyExist,
     ReplacingSessionWithOppositeDirection,
     OppositeDirectionCleanup,
+    BackgroundTaskFailure,
     Exception,
 
     // Non sync, non connection related disconnect

--- a/src/Nethermind/Nethermind.Network.Test/P2P/PacketSenderTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/PacketSenderTests.cs
@@ -89,7 +89,7 @@ namespace Nethermind.Network.Test.P2P
             await context.Received(1).WriteAndFlushAsync(Arg.Any<IByteBuffer>());
         }
 
-        private class TestMessage: P2PMessage
+        private class TestMessage : P2PMessage
         {
             public override int PacketType { get; } = 0;
             public override string Protocol { get; } = "";

--- a/src/Nethermind/Nethermind.Network.Test/P2P/PacketSenderTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/PacketSenderTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using DotNetty.Buffers;
 using DotNetty.Common.Utilities;
 using DotNetty.Transport.Channels;
+using FluentAssertions;
 using Nethermind.Logging;
 using Nethermind.Network.P2P;
 using Nethermind.Network.P2P.Messages;
@@ -23,8 +24,11 @@ namespace Nethermind.Network.Test.P2P
         {
             IByteBuffer serialized = UnpooledByteBufferAllocator.Default.Buffer(2);
             var serializer = Substitute.For<IMessageSerializationService>();
-            serializer.ZeroSerialize(PingMessage.Instance).Returns(serialized);
+
+            TestMessage testMessage = new TestMessage();
+            serializer.ZeroSerialize(testMessage).Returns(serialized);
             serialized.SafeRelease();
+
             IChannelHandlerContext context = Substitute.For<IChannelHandlerContext>();
             IChannel channel = Substitute.For<IChannel>();
             channel.IsWritable.Returns(true);
@@ -33,7 +37,8 @@ namespace Nethermind.Network.Test.P2P
 
             PacketSender packetSender = new(serializer, LimboLogs.Instance, TimeSpan.Zero);
             packetSender.HandlerAdded(context);
-            packetSender.Enqueue(PingMessage.Instance);
+            packetSender.Enqueue(testMessage);
+            testMessage.WasDisposed.Should().BeTrue();
 
             context.Received(1).WriteAndFlushAsync(Arg.Any<IByteBuffer>());
         }
@@ -82,6 +87,19 @@ namespace Nethermind.Network.Test.P2P
             await Task.Delay(delay * 3);
 
             await context.Received(1).WriteAndFlushAsync(Arg.Any<IByteBuffer>());
+        }
+
+        private class TestMessage: P2PMessage
+        {
+            public override int PacketType { get; } = 0;
+            public override string Protocol { get; } = "";
+
+            public bool WasDisposed { get; set; }
+            public override void Dispose()
+            {
+                base.Dispose();
+                WasDisposed = true;
+            }
         }
     }
 }

--- a/src/Nethermind/Nethermind.Network/P2P/Messages/P2PMessage.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Messages/P2PMessage.cs
@@ -1,14 +1,20 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
+
 namespace Nethermind.Network.P2P.Messages
 {
-    public abstract class P2PMessage : MessageBase
+    public abstract class P2PMessage : MessageBase, IDisposable
     {
         public abstract int PacketType { get; }
 
         public int AdaptivePacketType { get; set; }
 
         public abstract string Protocol { get; }
+
+        public virtual void Dispose()
+        {
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Network/P2P/PacketSender.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/PacketSender.cs
@@ -33,6 +33,7 @@ namespace Nethermind.Network.P2P
             }
 
             IByteBuffer buffer = _messageSerializationService.ZeroSerialize(message);
+            message.Dispose();
             int length = buffer.ReadableBytes;
 
             // Running in background

--- a/src/Nethermind/Nethermind.Network/P2P/PacketSender.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/PacketSender.cs
@@ -27,13 +27,20 @@ namespace Nethermind.Network.P2P
 
         public int Enqueue<T>(T message) where T : P2PMessage
         {
-            if (!_context.Channel.IsWritable || !_context.Channel.Active)
+            IByteBuffer buffer;
+            try
             {
-                return 0;
-            }
+                if (!_context.Channel.IsWritable || !_context.Channel.Active)
+                {
+                    return 0;
+                }
 
-            IByteBuffer buffer = _messageSerializationService.ZeroSerialize(message);
-            message.Dispose();
+                buffer = _messageSerializationService.ZeroSerialize(message);
+            }
+            finally
+            {
+                message.Dispose();
+            }
             int length = buffer.ReadableBytes;
 
             // Running in background

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ProtocolHandlerBase.cs
@@ -22,7 +22,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
         public bool IsPriority { get; set; }
         protected INodeStatsManager StatsManager { get; }
         private readonly IMessageSerializationService _serializer;
-        protected ISession Session { get; }
+        protected internal ISession Session { get; }
         protected long Counter;
 
         private readonly TaskCompletionSource<MessageBase> _initCompletionSource;
@@ -37,7 +37,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
             _initCompletionSource = new TaskCompletionSource<MessageBase>();
         }
 
-        protected ILogger Logger { get; }
+        protected internal ILogger Logger { get; }
 
         protected abstract TimeSpan InitTimeout { get; }
 
@@ -77,7 +77,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
             }
         }
 
-        protected void Send<T>(T message) where T : P2PMessage
+        protected internal void Send<T>(T message) where T : P2PMessage
         {
             Interlocked.Increment(ref Counter);
             if (Logger.IsTrace) Logger.Trace($"{Counter} Sending {typeof(T).Name}");

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
@@ -241,7 +241,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
         protected virtual void SendNewTransactionsCore(IEnumerable<Transaction> txs, bool sendFullTx)
         {
             int packetSizeLeft = TransactionsMessage.MaxPacketSize;
-            using ArrayPoolList<Transaction> txsToSend = new(1024);
+            ArrayPoolList<Transaction> txsToSend = new(1024);
 
             foreach (Transaction tx in txs)
             {
@@ -265,6 +265,10 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
             if (txsToSend.Count > 0)
             {
                 SendMessage(txsToSend);
+            }
+            else
+            {
+                txsToSend.Dispose();
             }
         }
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/HashesMessage.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/HashesMessage.cs
@@ -21,5 +21,11 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth
         {
             return $"{GetType().Name}({Hashes.Count})";
         }
+
+        public override void Dispose()
+        {
+            base.Dispose();
+            if (Hashes is IDisposable disposable) disposable.Dispose();
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/PooledTxsRequestor.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/PooledTxsRequestor.cs
@@ -58,7 +58,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth
                         if (hashesToRequest.Count % MaxNumberOfTxsInOneMsg == 0 && hashesToRequest.Count > 0)
                         {
                             RequestPooledTransactionsEth66(send, hashesToRequest);
-                            hashesToRequest.Clear();
+                            hashesToRequest = new(MaxNumberOfTxsInOneMsg);
                         }
 
                         hashesToRequest.Add(discoveredTxHashes[i]);
@@ -90,7 +90,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth
                     if (txSize > packetSizeLeft && hashesToRequest.Count > 0)
                     {
                         RequestPooledTransactionsEth66(send, hashesToRequest);
-                        hashesToRequest.Clear();
+                        hashesToRequest = new ArrayPoolList<Hash256>(discoveredTxHashesAndSizes.Count);
                         packetSizeLeft = TransactionsMessage.MaxPacketSize;
                     }
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/PooledTxsRequestor.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/PooledTxsRequestor.cs
@@ -30,7 +30,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth
 
         public void RequestTransactions(Action<GetPooledTransactionsMessage> send, IReadOnlyList<Hash256> hashes)
         {
-            using ArrayPoolList<Hash256> discoveredTxHashes = new(hashes.Count);
+            ArrayPoolList<Hash256> discoveredTxHashes = new(hashes.Count);
             AddMarkUnknownHashes(hashes, discoveredTxHashes);
 
             if (discoveredTxHashes.Count != 0)
@@ -41,7 +41,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth
 
         public void RequestTransactionsEth66(Action<V66.Messages.GetPooledTransactionsMessage> send, IReadOnlyList<Hash256> hashes)
         {
-            using ArrayPoolList<Hash256> discoveredTxHashes = new(hashes.Count);
+            ArrayPoolList<Hash256> discoveredTxHashes = new(hashes.Count);
             AddMarkUnknownHashes(hashes, discoveredTxHashes);
 
             if (discoveredTxHashes.Count != 0)
@@ -52,7 +52,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth
                 }
                 else
                 {
-                    using ArrayPoolList<Hash256> hashesToRequest = new(MaxNumberOfTxsInOneMsg);
+                    ArrayPoolList<Hash256> hashesToRequest = new(MaxNumberOfTxsInOneMsg);
                     for (int i = 0; i < discoveredTxHashes.Count; i++)
                     {
                         if (hashesToRequest.Count % MaxNumberOfTxsInOneMsg == 0 && hashesToRequest.Count > 0)
@@ -80,7 +80,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth
             if (discoveredTxHashesAndSizes.Count != 0)
             {
                 int packetSizeLeft = TransactionsMessage.MaxPacketSize;
-                using ArrayPoolList<Hash256> hashesToRequest = new(discoveredTxHashesAndSizes.Count);
+                ArrayPoolList<Hash256> hashesToRequest = new(discoveredTxHashesAndSizes.Count);
 
                 for (int i = 0; i < discoveredTxHashesAndSizes.Count; i++)
                 {

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandler.cs
@@ -185,7 +185,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
                     GetBlockHeadersMessage getBlockHeadersMessage
                         = Deserialize<GetBlockHeadersMessage>(message.Content);
                     ReportIn(getBlockHeadersMessage, size);
-                    ScheduleSyncServe(getBlockHeadersMessage, Handle);
+                    BackgroundTaskScheduler.ScheduleSyncServe(getBlockHeadersMessage, Handle);
                     break;
                 case Eth62MessageCode.BlockHeaders:
                     BlockHeadersMessage headersMsg = Deserialize<BlockHeadersMessage>(message.Content);
@@ -195,7 +195,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
                 case Eth62MessageCode.GetBlockBodies:
                     GetBlockBodiesMessage getBodiesMsg = Deserialize<GetBlockBodiesMessage>(message.Content);
                     ReportIn(getBodiesMsg, size);
-                    ScheduleSyncServe(getBodiesMsg, Handle);
+                    BackgroundTaskScheduler.ScheduleSyncServe(getBodiesMsg, Handle);
                     break;
                 case Eth62MessageCode.BlockBodies:
                     BlockBodiesMessage bodiesMsg = Deserialize<BlockBodiesMessage>(message.Content);
@@ -261,7 +261,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
         {
             IList<Transaction> iList = msg.Transactions;
 
-            BackgroundTaskScheduler.ScheduleTask((iList, 0), HandleSlow);
+            BackgroundTaskScheduler.ScheduleBackgroundTask((iList, 0), HandleSlow);
         }
 
         private Task HandleSlow((IList<Transaction> txs, int startIndex) request, CancellationToken cancellationToken)
@@ -276,7 +276,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
                 if (cancellationToken.IsCancellationRequested)
                 {
                     // Reschedule and with different start index
-                    BackgroundTaskScheduler.ScheduleTask((transactions, i), HandleSlow);
+                    BackgroundTaskScheduler.ScheduleBackgroundTask((transactions, i), HandleSlow);
                     return Task.CompletedTask;
                 }
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandler.cs
@@ -264,7 +264,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
             BackgroundTaskScheduler.ScheduleBackgroundTask((iList, 0), HandleSlow);
         }
 
-        private Task HandleSlow((IList<Transaction> txs, int startIndex) request, CancellationToken cancellationToken)
+        private ValueTask HandleSlow((IList<Transaction> txs, int startIndex) request, CancellationToken cancellationToken)
         {
             IList<Transaction> transactions = request.txs;
             int startIdx = request.startIndex;
@@ -277,12 +277,12 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
                 {
                     // Reschedule and with different start index
                     BackgroundTaskScheduler.ScheduleBackgroundTask((transactions, i), HandleSlow);
-                    return Task.CompletedTask;
+                    return ValueTask.CompletedTask;
                 }
 
                 PrepareAndSubmitTransaction(transactions[i], isTrace);
             }
-            return Task.CompletedTask;
+            return ValueTask.CompletedTask;
         }
 
         private void PrepareAndSubmitTransaction(Transaction tx, bool isTrace)

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Messages/TransactionsMessage.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Messages/TransactionsMessage.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Collections.Generic;
 using Nethermind.Core;
 using Nethermind.Network.P2P.Messages;
@@ -23,5 +24,11 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages
         }
 
         public override string ToString() => $"{nameof(TransactionsMessage)}({Transactions?.Count})";
+
+        public override void Dispose()
+        {
+            base.Dispose();
+            if (Transactions is IDisposable disposable) disposable.Dispose();
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V63/Eth63ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V63/Eth63ProtocolHandler.cs
@@ -73,7 +73,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V63
                 case Eth63MessageCode.GetReceipts:
                     GetReceiptsMessage getReceiptsMessage = Deserialize<GetReceiptsMessage>(message.Content);
                     ReportIn(getReceiptsMessage, size);
-                    ScheduleSyncServe(getReceiptsMessage, Handle);
+                    BackgroundTaskScheduler.ScheduleSyncServe(getReceiptsMessage, Handle);
                     break;
                 case Eth63MessageCode.Receipts:
                     ReceiptsMessage receiptsMessage = Deserialize<ReceiptsMessage>(message.Content);
@@ -83,7 +83,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V63
                 case Eth63MessageCode.GetNodeData:
                     GetNodeDataMessage getNodeDataMessage = Deserialize<GetNodeDataMessage>(message.Content);
                     ReportIn(getNodeDataMessage, size);
-                    ScheduleSyncServe(getNodeDataMessage, Handle);
+                    BackgroundTaskScheduler.ScheduleSyncServe(getNodeDataMessage, Handle);
                     break;
                 case Eth63MessageCode.NodeData:
                     NodeDataMessage nodeDataMessage = Deserialize<NodeDataMessage>(message.Content);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandler.cs
@@ -135,7 +135,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V65
 
         internal Task<PooledTransactionsMessage> FulfillPooledTransactionsRequest(GetPooledTransactionsMessage msg, CancellationToken cancellationToken)
         {
-            using ArrayPoolList<Transaction> txsToSend = new(msg.Hashes.Count);
+            ArrayPoolList<Transaction> txsToSend = new(msg.Hashes.Count);
 
             int packetSizeLeft = TransactionsMessage.MaxPacketSize;
             for (int i = 0; i < msg.Hashes.Count; i++)
@@ -168,7 +168,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V65
                 return;
             }
 
-            using ArrayPoolList<Hash256> hashes = new(NewPooledTransactionHashesMessage.MaxCount);
+            ArrayPoolList<Hash256> hashes = new(NewPooledTransactionHashesMessage.MaxCount);
 
             foreach (Transaction tx in txs)
             {
@@ -188,6 +188,10 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V65
             if (hashes.Count > 0)
             {
                 SendMessage(hashes);
+            }
+            else
+            {
+                hashes.Dispose();
             }
         }
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandler.cs
@@ -121,7 +121,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V65
             }
         }
 
-        private async Task Handle(GetPooledTransactionsMessage msg, CancellationToken cancellationToken)
+        private async ValueTask Handle(GetPooledTransactionsMessage msg, CancellationToken cancellationToken)
         {
             Metrics.Eth65GetPooledTransactionsReceived++;
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandler.cs
@@ -76,7 +76,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V65
                     GetPooledTransactionsMessage getPooledTxMsg
                         = Deserialize<GetPooledTransactionsMessage>(message.Content);
                     ReportIn(getPooledTxMsg, size);
-                    BackgroundTaskScheduler.ScheduleTask(getPooledTxMsg, Handle);
+                    BackgroundTaskScheduler.ScheduleBackgroundTask(getPooledTxMsg, Handle);
                     break;
                 case Eth65MessageCode.NewPooledTransactionHashes:
                     if (CanReceiveTransactions)

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandler.cs
@@ -73,7 +73,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
                         = Deserialize<GetBlockHeadersMessage>(message.Content);
                     Metrics.Eth66GetBlockHeadersReceived++;
                     ReportIn(getBlockHeadersMessage, size);
-                    ScheduleSyncServe(getBlockHeadersMessage, Handle);
+                    BackgroundTaskScheduler.ScheduleSyncServe(getBlockHeadersMessage, Handle);
                     break;
                 case Eth66MessageCode.BlockHeaders:
                     BlockHeadersMessage headersMsg = Deserialize<BlockHeadersMessage>(message.Content);
@@ -85,7 +85,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
                     GetBlockBodiesMessage getBodiesMsg = Deserialize<GetBlockBodiesMessage>(message.Content);
                     Metrics.Eth66GetBlockBodiesReceived++;
                     ReportIn(getBodiesMsg, size);
-                    ScheduleSyncServe(getBodiesMsg, Handle);
+                    BackgroundTaskScheduler.ScheduleSyncServe(getBodiesMsg, Handle);
                     break;
                 case Eth66MessageCode.BlockBodies:
                     BlockBodiesMessage bodiesMsg = Deserialize<BlockBodiesMessage>(message.Content);
@@ -98,7 +98,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
                         = Deserialize<GetPooledTransactionsMessage>(message.Content);
                     Metrics.Eth66GetPooledTransactionsReceived++;
                     ReportIn(getPooledTxMsg, size);
-                    ScheduleSyncServe(getPooledTxMsg, Handle);
+                    BackgroundTaskScheduler.ScheduleSyncServe(getPooledTxMsg, Handle);
                     break;
                 case Eth66MessageCode.PooledTransactions:
                     if (CanReceiveTransactions)
@@ -120,7 +120,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
                     GetReceiptsMessage getReceiptsMessage = Deserialize<GetReceiptsMessage>(message.Content);
                     Metrics.Eth66GetReceiptsReceived++;
                     ReportIn(getReceiptsMessage, size);
-                    ScheduleSyncServe(getReceiptsMessage, Handle);
+                    BackgroundTaskScheduler.ScheduleSyncServe(getReceiptsMessage, Handle);
                     break;
                 case Eth66MessageCode.Receipts:
                     ReceiptsMessage receiptsMessage = Deserialize<ReceiptsMessage>(message.Content);
@@ -132,7 +132,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
                     GetNodeDataMessage getNodeDataMessage = Deserialize<GetNodeDataMessage>(message.Content);
                     Metrics.Eth66GetNodeDataReceived++;
                     ReportIn(getNodeDataMessage, size);
-                    ScheduleSyncServe(getNodeDataMessage, Handle);
+                    BackgroundTaskScheduler.ScheduleSyncServe(getNodeDataMessage, Handle);
                     break;
                 case Eth66MessageCode.NodeData:
                     NodeDataMessage nodeDataMessage = Deserialize<NodeDataMessage>(message.Content);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Messages/Eth66Message.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Messages/Eth66Message.cs
@@ -24,5 +24,11 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66.Messages
 
         public override string ToString()
             => $"{GetType().Name}Eth66({RequestId},{EthMessage})";
+
+        public override void Dispose()
+        {
+            base.Dispose();
+            EthMessage.Dispose();
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
@@ -132,9 +132,9 @@ public class Eth68ProtocolHandler : Eth67ProtocolHandler
             if (hashes.Count == NewPooledTransactionHashesMessage68.MaxCount)
             {
                 SendMessage(types, sizes, hashes);
-                types.Clear();
-                sizes.Clear();
-                hashes.Clear();
+                types = new(NewPooledTransactionHashesMessage68.MaxCount);
+                sizes = new(NewPooledTransactionHashesMessage68.MaxCount);
+                hashes = new(NewPooledTransactionHashesMessage68.MaxCount);
             }
 
             if (tx.Hash is not null)
@@ -149,6 +149,12 @@ public class Eth68ProtocolHandler : Eth67ProtocolHandler
         if (hashes.Count != 0)
         {
             SendMessage(types, sizes, hashes);
+        }
+        else
+        {
+            types.Dispose();
+            sizes.Dispose();
+            hashes.Dispose();
         }
     }
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
@@ -123,9 +123,9 @@ public class Eth68ProtocolHandler : Eth67ProtocolHandler
             return;
         }
 
-        using ArrayPoolList<byte> types = new(NewPooledTransactionHashesMessage68.MaxCount);
-        using ArrayPoolList<int> sizes = new(NewPooledTransactionHashesMessage68.MaxCount);
-        using ArrayPoolList<Hash256> hashes = new(NewPooledTransactionHashesMessage68.MaxCount);
+        ArrayPoolList<byte> types = new(NewPooledTransactionHashesMessage68.MaxCount);
+        ArrayPoolList<int> sizes = new(NewPooledTransactionHashesMessage68.MaxCount);
+        ArrayPoolList<Hash256> hashes = new(NewPooledTransactionHashesMessage68.MaxCount);
 
         foreach (Transaction tx in txs)
         {

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Messages/NewPooledTransactionHashesMessage68.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Messages/NewPooledTransactionHashesMessage68.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Collections.Generic;
 using Nethermind.Core.Crypto;
 using Nethermind.Network.P2P.Messages;
@@ -28,5 +29,13 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V68.Messages
         }
 
         public override string ToString() => $"{nameof(NewPooledTransactionHashesMessage68)}({Hashes.Count})";
+
+        public override void Dispose()
+        {
+            base.Dispose();
+            if (Types is IDisposable disposable) disposable.Dispose();
+            if (Sizes is IDisposable disposable2) disposable2.Dispose();
+            if (Hashes is IDisposable disposable3) disposable3.Dispose();
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Les/LesProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Les/LesProtocolHandler.cs
@@ -124,27 +124,27 @@ namespace Nethermind.Network.P2P.Subprotocols.Les
                 case LesMessageCode.GetBlockHeaders:
                     GetBlockHeadersMessage getBlockHeadersMessage = Deserialize<GetBlockHeadersMessage>(message.Content);
                     if (NetworkDiagTracer.IsEnabled) NetworkDiagTracer.ReportIncomingMessage(Session.Node.Address, Name, getBlockHeadersMessage.ToString(), size);
-                    ScheduleSyncServe(getBlockHeadersMessage, Handle);
+                    BackgroundTaskScheduler.ScheduleSyncServe(getBlockHeadersMessage, Handle);
                     break;
                 case LesMessageCode.GetBlockBodies:
                     GetBlockBodiesMessage getBlockBodiesMessage = Deserialize<GetBlockBodiesMessage>(message.Content);
                     if (NetworkDiagTracer.IsEnabled) NetworkDiagTracer.ReportIncomingMessage(Session.Node.Address, Name, getBlockBodiesMessage.ToString(), size);
-                    ScheduleSyncServe(getBlockBodiesMessage, Handle);
+                    BackgroundTaskScheduler.ScheduleSyncServe(getBlockBodiesMessage, Handle);
                     break;
                 case LesMessageCode.GetReceipts:
                     GetReceiptsMessage getReceiptsMessage = Deserialize<GetReceiptsMessage>(message.Content);
                     if (NetworkDiagTracer.IsEnabled) NetworkDiagTracer.ReportIncomingMessage(Session.Node.Address, Name, getReceiptsMessage.ToString(), size);
-                    ScheduleSyncServe(getReceiptsMessage, Handle);
+                    BackgroundTaskScheduler.ScheduleSyncServe(getReceiptsMessage, Handle);
                     break;
                 case LesMessageCode.GetContractCodes:
                     GetContractCodesMessage getContractCodesMessage = Deserialize<GetContractCodesMessage>(message.Content);
                     if (NetworkDiagTracer.IsEnabled) NetworkDiagTracer.ReportIncomingMessage(Session.Node.Address, Name, getContractCodesMessage.ToString(), size);
-                    ScheduleSyncServe(getContractCodesMessage, Handle);
+                    BackgroundTaskScheduler.ScheduleSyncServe(getContractCodesMessage, Handle);
                     break;
                 case LesMessageCode.GetHelperTrieProofs:
                     GetHelperTrieProofsMessage getHelperTrieProofsMessage = Deserialize<GetHelperTrieProofsMessage>(message.Content);
                     if (NetworkDiagTracer.IsEnabled) NetworkDiagTracer.ReportIncomingMessage(Session.Node.Address, Name, getHelperTrieProofsMessage.ToString(), size);
-                    ScheduleSyncServe(getHelperTrieProofsMessage, Handle);
+                    BackgroundTaskScheduler.ScheduleSyncServe(getHelperTrieProofsMessage, Handle);
                     break;
             }
         }

--- a/src/Nethermind/Nethermind.Network/P2P/Utils/BackgroundTaskSchedulerWrapper.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Utils/BackgroundTaskSchedulerWrapper.cs
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Nethermind.Consensus.Scheduler;
+using Nethermind.Network.P2P.Messages;
+using Nethermind.Network.P2P.ProtocolHandlers;
+using Nethermind.Stats.Model;
+using Nethermind.Synchronization;
+
+namespace Nethermind.Network.P2P.Utils;
+
+/// <summary>
+/// Some utility function for interacting with BackgroundTaskScheduler. Notably, disconnect and/or log on failure.
+/// </summary>
+/// <param name="handler"></param>
+/// <param name="backgroundTaskScheduler"></param>
+public class BackgroundTaskSchedulerWrapper(ProtocolHandlerBase handler, IBackgroundTaskScheduler backgroundTaskScheduler)
+{
+    internal void ScheduleSyncServe<TReq, TRes>(TReq request, Func<TReq, CancellationToken, Task<TRes>> fulfillFunc) where TRes : P2PMessage
+    {
+        ScheduleBackgroundTask((request, fulfillFunc), BackgroundSyncSender);
+    }
+
+    internal void ScheduleSyncServe<TReq, TRes>(TReq request, Func<TReq, CancellationToken, ValueTask<TRes>> fulfillFunc) where TRes : P2PMessage
+    {
+        ScheduleBackgroundTask((request, fulfillFunc), BackgroundSyncSenderValueTask);
+    }
+
+    internal void ScheduleBackgroundTask<TReq>(TReq request, Func<TReq, CancellationToken, Task> fulfillFunc)
+    {
+        backgroundTaskScheduler.ScheduleTask((request, fulfillFunc), BackgroundTaskFailureHandler);
+    }
+
+    internal void ScheduleBackgroundTask<TReq>(TReq request, Func<TReq, CancellationToken, ValueTask> fulfillFunc)
+    {
+        backgroundTaskScheduler.ScheduleTask((request, fulfillFunc), BackgroundTaskFailureHandlerValueTask);
+    }
+
+    // I just don't want to create a closure.. so this happens.
+    private async Task BackgroundSyncSender<TReq, TRes>(
+        (TReq Request, Func<TReq, CancellationToken, Task<TRes>> FullfillFunc) input, CancellationToken cancellationToken) where TRes : P2PMessage
+    {
+        try
+        {
+            TRes response = await input.FullfillFunc.Invoke(input.Request, cancellationToken);
+            handler.Send(response);
+        }
+        catch (EthSyncException e)
+        {
+            handler.Session.InitiateDisconnect(DisconnectReason.EthSyncException, e.Message);
+        }
+    }
+
+    private async Task BackgroundSyncSenderValueTask<TReq, TRes>(
+        (TReq Request, Func<TReq, CancellationToken, ValueTask<TRes>> FullfillFunc) input, CancellationToken cancellationToken) where TRes : P2PMessage
+    {
+        try
+        {
+            TRes response = await input.FullfillFunc.Invoke(input.Request, cancellationToken);
+            handler.Send(response);
+        }
+        catch (EthSyncException e)
+        {
+            handler.Session.InitiateDisconnect(DisconnectReason.EthSyncException, e.Message);
+        }
+    }
+
+    // Yes, I do feels like... am I overcomplicating this?
+    private async Task BackgroundTaskFailureHandler<TReq>((TReq Request, Func<TReq, CancellationToken, Task> BackgroundTask) input, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await input.BackgroundTask.Invoke(input.Request, cancellationToken);
+        }
+        catch (Exception e)
+        {
+            handler.Session.InitiateDisconnect(DisconnectReason.BackgroundTaskFailure, e.Message);
+            if (handler.Logger.IsDebug) handler.Logger.Debug($"Failure running background task on session {handler.Session}, {e}");
+        }
+    }
+
+    private async Task BackgroundTaskFailureHandlerValueTask<TReq>((TReq Request, Func<TReq, CancellationToken, ValueTask> BackgroundTask) input, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await input.BackgroundTask.Invoke(input.Request, cancellationToken);
+        }
+        catch (Exception e)
+        {
+            handler.Session.InitiateDisconnect(DisconnectReason.BackgroundTaskFailure, e.Message);
+            if (handler.Logger.IsDebug) handler.Logger.Debug($"Failure running background task on session {handler.Session}, {e}");
+        }
+    }
+}


### PR DESCRIPTION
- Fix silent background task failure causing transaction to not be able to sent out due to ArrayPoolList being disposed before serialization.

## Changes

- Log error on unhandled exception at BackgroundTaskScheduler level.
- Disconnect and log debug on unhandled exception at p2p handler level.
- Add IDisposable to P2PMessage and dispose after serialization in PacketSender.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

