### PR TITLE
Fix/snap server throwing error on some case

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Utils/LastNStateRootTracker.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Utils/LastNStateRootTracker.cs
@@ -79,9 +79,8 @@ public class LastNStateRootTracker : ILastNStateRootTracker, IDisposable
             parent = _blockTree.FindParentHeader(parent, BlockTreeLookupOptions.All);
         }
 
-        stateRoots.Reverse();
         _availableStateRoots = newStateRootSet;
-        _stateRootQueue = new Queue<Hash256>(stateRoots);
+        _stateRootQueue = new Queue<Hash256>(stateRoots.Reverse());
         _lastQueuedStateRoot = newHead.StateRoot;
     }
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/PooledTxsRequestor.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/PooledTxsRequestor.cs
@@ -52,13 +52,13 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth
                 }
                 else
                 {
-                    using ArrayPoolList<Hash256> hashesToRequest = new(MaxNumberOfTxsInOneMsg);
+                    ArrayPoolList<Hash256> hashesToRequest = new(MaxNumberOfTxsInOneMsg);
                     for (int i = 0; i < discoveredTxHashes.Count; i++)
                     {
                         if (hashesToRequest.Count % MaxNumberOfTxsInOneMsg == 0 && hashesToRequest.Count > 0)
                         {
                             RequestPooledTransactionsEth66(send, hashesToRequest);
-                            hashesToRequest.Clear();
+                            hashesToRequest = new(MaxNumberOfTxsInOneMsg);
                         }
 
                         hashesToRequest.Add(discoveredTxHashes[i]);
@@ -80,7 +80,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth
             if (discoveredTxHashesAndSizes.Count != 0)
             {
                 int packetSizeLeft = TransactionsMessage.MaxPacketSize;
-                using ArrayPoolList<Hash256> hashesToRequest = new(discoveredTxHashesAndSizes.Count);
+                ArrayPoolList<Hash256> hashesToRequest = new(discoveredTxHashesAndSizes.Count);
 
                 for (int i = 0; i < discoveredTxHashesAndSizes.Count; i++)
                 {
@@ -90,7 +90,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth
                     if (txSize > packetSizeLeft && hashesToRequest.Count > 0)
                     {
                         RequestPooledTransactionsEth66(send, hashesToRequest);
-                        hashesToRequest.Clear();
+                        hashesToRequest = new ArrayPoolList<Hash256>(discoveredTxHashesAndSizes.Count);
                         packetSizeLeft = TransactionsMessage.MaxPacketSize;
                     }
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/RangeQueryVisitorTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/RangeQueryVisitorTests.cs
@@ -83,6 +83,26 @@ public class RangeQueryVisitorTests
         nodes.ContainsKey(new Hash256("0400000000000000000000000000000000000000000000000000000000000000")).Should().BeTrue();
     }
 
+    [Test]
+    public void AccountRangeFetch_AfterTree()
+    {
+        StateTree tree = new StateTree();
+        tree.Set(new Hash256("0400000000000000000000000000000000000000000000000000000000000000"), TestItem.GenerateRandomAccount());
+        tree.Set(new Hash256("0500000000000000000000000000000000000000000000000000000000000000"), TestItem.GenerateRandomAccount());
+        tree.UpdateRootHash();
+
+        var startHash = new Hash256("0510000000000000000000000000000000000000000000000000000000000000");
+        var limitHash = new Hash256("0600000000000000000000000000000000000000000000000000000000000000");
+
+        using RangeQueryVisitor visitor = new(startHash, limitHash, false);
+        tree.Accept(visitor, tree.RootHash, CreateVisitingOptions());
+        (IDictionary<ValueHash256, byte[]> nodes, long _) = visitor.GetNodesAndSize();
+
+        nodes.Count.Should().Be(0);
+        Action act = () => visitor.GetProofs();
+        act.Should().NotThrow();
+    }
+
     private static VisitingOptions CreateVisitingOptions() => new() { ExpectAccounts = false };
 
     [Test]

--- a/src/Nethermind/Nethermind.Trie/RangeQueryVisitor.cs
+++ b/src/Nethermind/Nethermind.Trie/RangeQueryVisitor.cs
@@ -147,15 +147,18 @@ public class RangeQueryVisitor : ITreeVisitor<TreePathContext>, IDisposable
         }
 
         TreePath rightmostPath = _rightmostLeafPath;
-        for (int i = 64; i >= 0; i--)
+        if (rightmostPath.Length != 0)
         {
-            if (!_rightmostNodes[i].HasValue) continue;
+            for (int i = 64; i >= 0; i--)
+            {
+                if (!_rightmostNodes[i].HasValue) continue;
 
-            (TreePath path, TrieNode node) = _rightmostNodes[i].Value;
-            rightmostPath.TruncateMut(i);
-            if (rightmostPath != path) continue;
+                (TreePath path, TrieNode node) = _rightmostNodes[i].Value;
+                rightmostPath.TruncateMut(i);
+                if (rightmostPath != path) continue;
 
-            proofs.Add(node.FullRlp.ToArray());
+                proofs.Add(node.FullRlp.ToArray());
+            }
         }
 
         return proofs.ToArray();

--- a/src/Nethermind/Nethermind.Trie/RangeQueryVisitor.cs
+++ b/src/Nethermind/Nethermind.Trie/RangeQueryVisitor.cs
@@ -171,6 +171,7 @@ public class RangeQueryVisitor : ITreeVisitor<TreePathContext>, IDisposable
 
     public void VisitMissingNode(in TreePathContext ctx, Hash256 nodeHash, TrieVisitContext trieVisitContext)
     {
+        throw new TrieException($"Missing node {ctx.Path} {nodeHash}");
     }
 
     public void VisitBranch(in TreePathContext ctx, TrieNode node, TrieVisitContext trieVisitContext)


### PR DESCRIPTION
- Randomly, could be after 5 minute, could be after 2 hour, snap syncing node syncing will hang due to an error in RangeQueryVisitor when the requesting a range where the start hash is after the last node in a storage trie.
- Why does it request a range after the last node? No idea.

## Changes

- Fix bug.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Can sync