### PR TITLE
Fix an issue where the default constructor for `AccountStruct` was used when account was not found

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/SpecificBlockReadOnlyStateProvider.cs
+++ b/src/Nethermind/Nethermind.Blockchain/SpecificBlockReadOnlyStateProvider.cs
@@ -22,7 +22,7 @@ namespace Nethermind.Blockchain
 
         public virtual Hash256 StateRoot { get; }
 
-        public AccountStruct GetAccount(Address address) => _stateReader.GetAccount(StateRoot, address) ?? Account.TotallyEmpty.ToStruct();
+        public AccountStruct GetAccount(Address address) => _stateReader.GetAccount(StateRoot, address) ?? AccountStruct.TotallyEmpty;
 
         public bool IsContract(Address address) => GetAccount(address).IsContract;
 

--- a/src/Nethermind/Nethermind.Blockchain/SpecificBlockReadOnlyStateProvider.cs
+++ b/src/Nethermind/Nethermind.Blockchain/SpecificBlockReadOnlyStateProvider.cs
@@ -22,7 +22,7 @@ namespace Nethermind.Blockchain
 
         public virtual Hash256 StateRoot { get; }
 
-        public AccountStruct GetAccount(Address address) => _stateReader.GetAccount(StateRoot, address) ?? default;
+        public AccountStruct GetAccount(Address address) => _stateReader.GetAccount(StateRoot, address) ?? Account.TotallyEmpty.ToStruct();
 
         public bool IsContract(Address address) => GetAccount(address).IsContract;
 

--- a/src/Nethermind/Nethermind.Core/Account.cs
+++ b/src/Nethermind/Nethermind.Core/Account.cs
@@ -106,6 +106,9 @@ namespace Nethermind.Core
 
     public readonly struct AccountStruct
     {
+        private readonly static AccountStruct _totallyEmpty = Account.TotallyEmpty.ToStruct();
+        public static ref readonly AccountStruct TotallyEmpty => ref _totallyEmpty;
+
         private readonly ValueHash256 _codeHash = Keccak.OfAnEmptyString.ValueHash256;
         private readonly ValueHash256 _storageRoot = Keccak.EmptyTreeHash.ValueHash256;
 


### PR DESCRIPTION
## Changes

- Make `SpecificBlockReadOnlyStateProvider` return `Account.TotallyEmpty` instead of `default` for non-existing accounts.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### Notes on testing

This issue broke posdao-tests, they now pass

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No