### PR TITLE
Make sure sedge is always cleared after sync

### DIFF
--- a/.github/workflows/sync-testnets.yml
+++ b/.github/workflows/sync-testnets.yml
@@ -161,6 +161,6 @@ jobs:
           cd sedge
           docker compose stop
           cd ..
-          rm -rf sedge
-          rm -rf $GITHUB_WORKSPACE/sedge
+          sudo rm -rf sedge
+          sudo rm -rf $GITHUB_WORKSPACE/sedge
           docker system prune -a -f --volumes

--- a/.github/workflows/sync-testnets.yml
+++ b/.github/workflows/sync-testnets.yml
@@ -158,5 +158,7 @@ jobs:
       - name: Clean Up
         if: always()
         run: |
-          rm -r sedge
-          rm -r $GITHUB_WORKSPACE/sedge
+          rm -rf sedge
+          rm -rf $GITHUB_WORKSPACE/sedge
+          docker compose stop
+          docker system prune -a -f --volumes

--- a/.github/workflows/sync-testnets.yml
+++ b/.github/workflows/sync-testnets.yml
@@ -153,4 +153,10 @@ jobs:
       - name: Get Consensus Logs
         if: always()
         run: |
-          docker logs sedge-consensus-client
+          docker logs sedge-consensus-client      
+
+      - name: Clean Up
+        if: always()
+        run: |
+          rm -r sedge
+          rm -r $GITHUB_WORKSPACE/sedge

--- a/.github/workflows/sync-testnets.yml
+++ b/.github/workflows/sync-testnets.yml
@@ -158,7 +158,9 @@ jobs:
       - name: Clean Up
         if: always()
         run: |
+          cd sedge
+          docker compose stop
+          cd ..
           rm -rf sedge
           rm -rf $GITHUB_WORKSPACE/sedge
-          docker compose stop
           docker system prune -a -f --volumes


### PR DESCRIPTION
Small change to make sure if there was any previous error on a run, sedge is not leaving any leftovers and won't affect next runs.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No