### PR TITLE
Use state reader for trie visitor

### DIFF
--- a/src/Nethermind/Nethermind.Init/InitializeStateDb.cs
+++ b/src/Nethermind/Nethermind.Init/InitializeStateDb.cs
@@ -150,9 +150,8 @@ public class InitializeStateDb : IStep
                 try
                 {
                     _logger!.Info("Collecting trie stats and verifying that no nodes are missing...");
-                    IWorldState diagStateProvider = stateManager.GlobalWorldState;
-                    diagStateProvider.StateRoot = getApi.BlockTree!.Head?.StateRoot ?? Keccak.EmptyTreeHash;
-                    TrieStats stats = diagStateProvider.CollectStats(getApi.DbProvider.CodeDb, _api.LogManager);
+                    Hash256 stateRoot = getApi.BlockTree!.Head?.StateRoot ?? Keccak.EmptyTreeHash;
+                    TrieStats stats = stateManager.GlobalStateReader.CollectStats(stateRoot, getApi.DbProvider.CodeDb, _api.LogManager);
                     _logger.Info($"Starting from {getApi.BlockTree.Head?.Number} {getApi.BlockTree.Head?.StateRoot}{Environment.NewLine}" + stats);
                 }
                 catch (Exception ex)

--- a/src/Nethermind/Nethermind.State.Test/StateProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StateProviderTests.cs
@@ -88,18 +88,6 @@ namespace Nethermind.Store.Test
         }
 
         [Test]
-        public void Can_collect_stats()
-        {
-            WorldState provider = new(new TrieStore(new MemDb(), Logger), _codeDb, Logger);
-            provider.CreateAccount(TestItem.AddressA, 1.Ether());
-            provider.Commit(MuirGlacier.Instance);
-            provider.CommitTree(0);
-
-            var stats = provider.CollectStats(_codeDb, Logger);
-            stats.AccountCount.Should().Be(1);
-        }
-
-        [Test]
         public void Can_accepts_visitors()
         {
             WorldState provider = new(new TrieStore(new MemDb(), Logger), Substitute.For<IDb>(), Logger);

--- a/src/Nethermind/Nethermind.State/IWorldStateExtensions.cs
+++ b/src/Nethermind/Nethermind.State/IWorldStateExtensions.cs
@@ -31,16 +31,5 @@ namespace Nethermind.State
             stateProvider.Accept(dumper, stateProvider.StateRoot);
             return dumper.ToString();
         }
-
-        public static TrieStats CollectStats(this IWorldState stateProvider, IKeyValueStore codeStorage, ILogManager logManager)
-        {
-            TrieStatsCollector collector = new(codeStorage, logManager);
-            stateProvider.Accept(collector, stateProvider.StateRoot, new VisitingOptions
-            {
-                MaxDegreeOfParallelism = Environment.ProcessorCount,
-                FullScanMemoryBudget = 16.GiB(), // Gonna guess that if you are running this, you have a decent setup.
-            });
-            return collector.Stats;
-        }
     }
 }


### PR DESCRIPTION
- Use StateReader for VerifyTrie instead of WorldState.
- Its faster as it does not modify dirty cache.. Probably a mistake before when it use WorldState.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)
- [X] Optimization

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

- I've literally always change this. 