### PR TITLE
Put clique block producer on dispose stack

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.Clique/CliquePlugin.cs
+++ b/src/Nethermind/Nethermind.Consensus.Clique/CliquePlugin.cs
@@ -151,6 +151,11 @@ namespace Nethermind.Consensus.Clique
                 _cliqueConfig!,
                 getFromApi.LogManager);
 
+            if (blockProducer is IDisposable disposable)
+            {
+                getFromApi.DisposeStack.Push(disposable);
+            }
+
             return Task.FromResult(blockProducer);
         }
 

--- a/src/Nethermind/Nethermind.Consensus.Clique/CliquePlugin.cs
+++ b/src/Nethermind/Nethermind.Consensus.Clique/CliquePlugin.cs
@@ -153,7 +153,7 @@ namespace Nethermind.Consensus.Clique
 
             getFromApi.DisposeStack.Push(blockProducer);
 
-            return Task.FromResult(blockProducer);
+            return Task.FromResult((IBlockProducer)blockProducer);
         }
 
         public Task InitNetworkProtocol()

--- a/src/Nethermind/Nethermind.Consensus.Clique/CliquePlugin.cs
+++ b/src/Nethermind/Nethermind.Consensus.Clique/CliquePlugin.cs
@@ -137,7 +137,7 @@ namespace Nethermind.Consensus.Clique
 
             IGasLimitCalculator gasLimitCalculator = setInApi.GasLimitCalculator = new TargetAdjustedGasLimitCalculator(getFromApi.SpecProvider, _blocksConfig);
 
-            IBlockProducer blockProducer = new CliqueBlockProducer(
+            CliqueBlockProducer blockProducer = new (
                 additionalTxSource.Then(txPoolTxSource),
                 chainProcessor,
                 producerEnv.StateProvider,
@@ -151,10 +151,7 @@ namespace Nethermind.Consensus.Clique
                 _cliqueConfig!,
                 getFromApi.LogManager);
 
-            if (blockProducer is IDisposable disposable)
-            {
-                getFromApi.DisposeStack.Push(disposable);
-            }
+            getFromApi.DisposeStack.Push(blockProducer);
 
             return Task.FromResult(blockProducer);
         }

--- a/src/Nethermind/Nethermind.Consensus.Clique/CliquePlugin.cs
+++ b/src/Nethermind/Nethermind.Consensus.Clique/CliquePlugin.cs
@@ -137,7 +137,7 @@ namespace Nethermind.Consensus.Clique
 
             IGasLimitCalculator gasLimitCalculator = setInApi.GasLimitCalculator = new TargetAdjustedGasLimitCalculator(getFromApi.SpecProvider, _blocksConfig);
 
-            CliqueBlockProducer blockProducer = new (
+            CliqueBlockProducer blockProducer = new(
                 additionalTxSource.Then(txPoolTxSource),
                 chainProcessor,
                 producerEnv.StateProvider,


### PR DESCRIPTION
Bug:
`CliqueBlockProducer` will throw `ObjectDisposedException` during shutdown. 

Fix:
Put `CliqueBlockProducer` on the dispose stack. 