### PR TITLE
TxPool autorecover

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/KnownChainSizesTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/KnownChainSizesTests.cs
@@ -15,8 +15,8 @@ public class KnownChainSizesTests
     {
         // Pruning size have to be updated frequently
         ChainSizes.CreateChainSizeInfo(BlockchainIds.Mainnet).PruningSize.Should().BeLessThan(210.GB());
-        ChainSizes.CreateChainSizeInfo(BlockchainIds.Goerli).PruningSize.Should().BeLessThan(90.GB());
-        ChainSizes.CreateChainSizeInfo(BlockchainIds.Sepolia).PruningSize.Should().BeLessThan(15.GB());
+        ChainSizes.CreateChainSizeInfo(BlockchainIds.Goerli).PruningSize.Should().BeLessThan(95.GB());
+        ChainSizes.CreateChainSizeInfo(BlockchainIds.Sepolia).PruningSize.Should().BeLessThan(18.GB());
 
         ChainSizes.CreateChainSizeInfo(BlockchainIds.Chiado).PruningSize.Should().Be(null);
         ChainSizes.CreateChainSizeInfo(BlockchainIds.Gnosis).PruningSize.Should().Be(null);

--- a/src/Nethermind/Nethermind.Runner.Test/ConfigFilesTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/ConfigFilesTests.cs
@@ -169,10 +169,9 @@ namespace Nethermind.Runner.Test
             Test<IMetricsConfig, string>(configWildcard, c => c.PushGatewayUrl, "");
         }
 
-        [TestCase("^mainnet ^spaceneth ^volta", 50)]
+        [TestCase("^spaceneth ^volta", 50)]
         [TestCase("spaceneth", 4)]
         [TestCase("volta", 25)]
-        [TestCase("mainnet", 50)]
         public void Network_defaults_are_correct(string configWildcard, int activePeers = 50)
         {
             Test<INetworkConfig, int>(configWildcard, c => c.DiscoveryPort, 30303);

--- a/src/Nethermind/Nethermind.Runner.Test/ConfigFilesTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/ConfigFilesTests.cs
@@ -172,7 +172,7 @@ namespace Nethermind.Runner.Test
         [TestCase("^mainnet ^spaceneth ^volta", 50)]
         [TestCase("spaceneth", 4)]
         [TestCase("volta", 25)]
-        [TestCase("mainnet", 100)]
+        [TestCase("mainnet", 50)]
         public void Network_defaults_are_correct(string configWildcard, int activePeers = 50)
         {
             Test<INetworkConfig, int>(configWildcard, c => c.DiscoveryPort, 30303);

--- a/src/Nethermind/Nethermind.Runner/configs/mainnet_archive.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/mainnet_archive.cfg
@@ -6,9 +6,6 @@
     "LogFileName": "mainnet_archive.logs.txt",
     "MemoryHint": 4096000000
   },
-  "Network": {
-    "ActivePeersMaxCount": 100
-  },
   "Sync": {
     "DownloadBodiesInFastSync": false,
     "DownloadReceiptsInFastSync": false

--- a/src/Nethermind/Nethermind.TxPool.Test/Collections/DistinctValueSortedPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/Collections/DistinctValueSortedPoolTests.cs
@@ -205,13 +205,13 @@ namespace Nethermind.TxPool.Test.Collections
             pool.Count.Should().Be(Capacity);
         }
 
-        [TestCase(0,16)]
-        [TestCase(1,15)]
-        [TestCase(2,14)]
-        [TestCase(6,10)]
-        [TestCase(10,6)]
-        [TestCase(11,6)]
-        [TestCase(13,6)]
+        [TestCase(0, 16)]
+        [TestCase(1, 15)]
+        [TestCase(2, 14)]
+        [TestCase(6, 10)]
+        [TestCase(10, 6)]
+        [TestCase(11, 6)]
+        [TestCase(13, 6)]
         public void Capacity_can_shrink_to_given_value(int shrinkValue, int expectedCapacity)
         {
             var pool = new ShrinkableDistinctPool(Capacity, _comparer, new WithFinalizerComparer(), LimboLogs.Instance);

--- a/src/Nethermind/Nethermind.TxPool/Collections/BlobTxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/BlobTxDistinctSortedPool.cs
@@ -22,11 +22,7 @@ public class BlobTxDistinctSortedPool : TxDistinctSortedPool
     protected override IComparer<Transaction> GetReplacementComparer(IComparer<Transaction> comparer)
         => comparer.GetBlobReplacementComparer();
 
-    public override void VerifyCapacity()
-    {
-        if (_logger.IsWarn && Count > _poolCapacity)
-            _logger.Warn($"Blob pool exceeds the config size {Count}/{_poolCapacity}");
-    }
+    protected override string ShortPoolName => "BlobPool";
 
     /// <summary>
     /// For tests only - to test sorting

--- a/src/Nethermind/Nethermind.TxPool/Collections/DistinctValueSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/DistinctValueSortedPool.cs
@@ -35,7 +35,7 @@ namespace Nethermind.TxPool.Collections
             IComparer<TValue> comparer,
             IEqualityComparer<TValue> distinctComparer,
             ILogManager logManager)
-            : base(capacity, comparer)
+            : base(capacity, comparer, logManager)
         {
             // ReSharper disable once VirtualMemberCallInConstructor
             _comparer = GetReplacementComparer(comparer ?? throw new ArgumentNullException(nameof(comparer)));

--- a/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
@@ -94,12 +94,4 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool
         _blobTxStorage.Delete(hash, tx.Timestamp);
         return base.Remove(hash, tx);
     }
-
-    public override void VerifyCapacity()
-    {
-        base.VerifyCapacity();
-
-        if (_logger.IsDebug && Count == _poolCapacity)
-            _logger.Debug($"Blob persistent storage has reached max size of {_poolCapacity}, blob txs can be evicted now");
-    }
 }

--- a/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
@@ -316,7 +316,7 @@ namespace Nethermind.TxPool.Collections
                         if (!RemoveLast(out removed) || _cacheMap.Count > _capacity)
                         {
                             if (_cacheMap.Count > _capacity && _logger.IsWarn)
-                                _logger.Warn($"(TryInsert) Failed to remove the last item from the pool, the current state is {Count}/{_capacity}. {GetInfoAboutWorstValues}");
+                                _logger.Warn($"Capacity exceeded or failed to remove the last item from the pool, the current state is {Count}/{_capacity}. {GetInfoAboutWorstValues}");
                             UpdateWorstValue();
                             RemoveLast(out removed);
                         }

--- a/src/Nethermind/Nethermind.TxPool/Collections/TxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/TxDistinctSortedPool.cs
@@ -75,7 +75,7 @@ namespace Nethermind.TxPool.Collections
         {
             using var lockRelease = Lock.Acquire();
 
-            VerifyCapacity();
+            EnsureCapacity();
             foreach ((Address address, EnhancedSortedSet<Transaction> bucket) in _buckets)
             {
                 Debug.Assert(bucket.Count > 0);
@@ -133,10 +133,6 @@ namespace Nethermind.TxPool.Collections
             }
         }
 
-        public virtual void VerifyCapacity()
-        {
-            if (_logger.IsWarn && Count > _poolCapacity)
-                _logger.Warn($"TxPool exceeds the config size {Count}/{_poolCapacity}");
-        }
+        protected override string ShortPoolName => "TxPool";
     }
 }


### PR DESCRIPTION
## Changes

TxPool autorecover - experiments

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

For now I am experimenting

## Documentation

#### Requires documentation update

- [ ] Yes
- [ ] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
