### PR TITLE
Set eth67 and eth68 as default capabilities

### DIFF
--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -201,17 +201,6 @@ public class InitializeNetwork : IStep
             }
         });
 
-        bool stateSyncFinished = _api.Synchronizer.SyncProgressResolver.FindBestFullState() != 0;
-
-        if (_syncConfig.SnapSync || stateSyncFinished || !_syncConfig.FastSync)
-        {
-            // we can't add eth67 capability as default, because it needs snap protocol for syncing (GetNodeData is
-            // no longer available). Eth67 should be added if snap is enabled OR sync is finished OR in archive nodes (no state sync)
-            _api.ProtocolsManager!.AddSupportedCapability(new Capability(Protocol.Eth, 67));
-            _api.ProtocolsManager!.AddSupportedCapability(new Capability(Protocol.Eth, 68));
-        }
-        else if (_logger.IsDebug) _logger.Debug("Skipped enabling eth67 & eth68 capabilities");
-
         if (_syncConfig.SnapSync)
         {
             if (!_syncConfig.SnapServingEnabled)

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
@@ -695,7 +695,7 @@ public partial class EthRpcModuleTests
     {
         using Context ctx = await Context.Create();
         string serialized = await ctx.Test.TestEthRpc("eth_protocolVersion");
-        Assert.That(serialized, Is.EqualTo("{\"jsonrpc\":\"2.0\",\"result\":\"0x42\",\"id\":67}"));
+        Assert.That(serialized, Is.EqualTo("{\"jsonrpc\":\"2.0\",\"result\":\"0x44\",\"id\":67}"));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Network.Test/P2P/P2PProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/P2PProtocolHandlerTests.cs
@@ -87,7 +87,7 @@ namespace Nethermind.Network.Test.P2P
             p2PProtocolHandler.AddSupportedCapability(new Capability(Protocol.Wit, 0));
             p2PProtocolHandler.Init();
 
-            string[] expectedCapabilities = { "eth66", "nodedata1", "wit0" };
+            string[] expectedCapabilities = { "eth66", "eth67", "eth68", "nodedata1", "wit0" };
             _session.Received(1).DeliverMessage(
                 Arg.Is<HelloMessage>(m => m.Capabilities.Select(c => c.ToString()).SequenceEqual(expectedCapabilities)));
         }

--- a/src/Nethermind/Nethermind.Network.Test/P2P/P2PProtocolInfoProviderTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/P2PProtocolInfoProviderTests.cs
@@ -14,14 +14,14 @@ namespace Nethermind.Network.Test.P2P
         public void GetHighestVersionOfEthProtocol_ReturnExpectedResult()
         {
             int result = P2PProtocolInfoProvider.GetHighestVersionOfEthProtocol();
-            Assert.That(result, Is.EqualTo(66));
+            Assert.That(result, Is.EqualTo(68));
         }
 
         [Test]
         public void DefaultCapabilitiesToString_ReturnExpectedResult()
         {
             string result = P2PProtocolInfoProvider.DefaultCapabilitiesToString();
-            Assert.That(result, Is.EqualTo("eth/66,nodedata/1"));
+            Assert.That(result, Is.EqualTo("eth/68,eth/67,eth/66,nodedata/1"));
         }
     }
 }

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandler.cs
@@ -43,6 +43,8 @@ public class P2PProtocolHandler : ProtocolHandlerBase, IPingSender, IP2PProtocol
     public static readonly IEnumerable<Capability> DefaultCapabilities = new Capability[]
     {
         new(Protocol.Eth, 66),
+        new(Protocol.Eth, 67),
+        new(Protocol.Eth, 68),
         new(Protocol.NodeData, 1)
     };
 


### PR DESCRIPTION
## Changes

- remove eth67 and eth68 conditional enabling, now set both as default capabilities

More context:
We were disabling eth67 and eth68 if node were not synced and didn't support snap sync. This is because `GetNodeData` and `NodeData` messages are not supported in mentioned versions and we needed these messages to be able to fast sync on some networks, e.g. gnosis.
In 1.25.0 we released `NodeDataProtocol` - satellite protocol designed for support of `NodeData` messages. Since then nethermind can serve/receive `NodeData` using sattelite protocol and doesn't need eth66 anymore.
For cooperation with old client versions on some networks (e.g. OE), we keep eth66 as default capability. Nodes will use highest common version (eth66).

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes - adjusted tests
- [ ] No