### PR TITLE
TxPool autorecover

### DIFF
--- a/src/Nethermind/Nethermind.Runner.Test/ConfigFilesTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/ConfigFilesTests.cs
@@ -171,10 +171,9 @@ namespace Nethermind.Runner.Test
             Test<IMetricsConfig, string>(configWildcard, c => c.PushGatewayUrl, "");
         }
 
-        [TestCase("^mainnet ^spaceneth ^volta", 50)]
+        [TestCase("^spaceneth ^volta", 50)]
         [TestCase("spaceneth", 4)]
         [TestCase("volta", 25)]
-        [TestCase("mainnet", 50)]
         public void Network_defaults_are_correct(string configWildcard, int activePeers = 50)
         {
             Test<INetworkConfig, int>(configWildcard, c => c.DiscoveryPort, 30303);

--- a/src/Nethermind/Nethermind.TxPool.Test/Collections/DistinctValueSortedPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/Collections/DistinctValueSortedPoolTests.cs
@@ -140,6 +140,19 @@ namespace Nethermind.TxPool.Test.Collections
             }
         }
 
+        private class ShrinkableDistinctPool : WithFinalizerDistinctPool
+        {
+            public ShrinkableDistinctPool(int capacity, IComparer<WithFinalizer> comparer, IEqualityComparer<WithFinalizer> distinctComparer, ILogManager logManager)
+                : base(capacity, comparer, distinctComparer, logManager)
+            {
+            }
+
+            public void Shrink(int capacity)
+            {
+                EnsureCapacity(capacity);
+            }
+        }
+
         private class WithFinalizerDistinctPool : DistinctValueSortedPool<int, WithFinalizer, int>
         {
             public WithFinalizerDistinctPool(int capacity, IComparer<WithFinalizer> comparer, IEqualityComparer<WithFinalizer> distinctComparer, ILogManager logManager)
@@ -155,23 +168,23 @@ namespace Nethermind.TxPool.Test.Collections
             protected override int GetKey(WithFinalizer value) => value.Index;
         }
 
+        IComparer<WithFinalizer> _comparer = Comparer<WithFinalizer>.Create((t1, t2) =>
+        {
+            int t1Oddity = t1.Index % 2;
+            int t2Oddity = t2.Index % 2;
+
+            if (t1Oddity.CompareTo(t2Oddity) != 0)
+            {
+                return t1Oddity.CompareTo(t2Oddity);
+            }
+
+            return t1.Index.CompareTo(t2.Index);
+        });
+
         [Test]
         public void Capacity_is_never_exceeded()
         {
-            IComparer<WithFinalizer> comparer = Comparer<WithFinalizer>.Create((t1, t2) =>
-            {
-                int t1Oddity = t1.Index % 2;
-                int t2Oddity = t2.Index % 2;
-
-                if (t1Oddity.CompareTo(t2Oddity) != 0)
-                {
-                    return t1Oddity.CompareTo(t2Oddity);
-                }
-
-                return t1.Index.CompareTo(t2.Index);
-            });
-
-            var pool = new WithFinalizerDistinctPool(Capacity, comparer, new WithFinalizerComparer(), LimboLogs.Instance);
+            var pool = new WithFinalizerDistinctPool(Capacity, _comparer, new WithFinalizerComparer(), LimboLogs.Instance);
 
             int capacityMultiplier = 10;
             int expectedAllCount = Capacity * capacityMultiplier;
@@ -192,23 +205,39 @@ namespace Nethermind.TxPool.Test.Collections
             pool.Count.Should().Be(Capacity);
         }
 
+        [TestCase(0, 16)]
+        [TestCase(1, 15)]
+        [TestCase(2, 14)]
+        [TestCase(6, 10)]
+        [TestCase(10, 6)]
+        [TestCase(11, 6)]
+        [TestCase(13, 6)]
+        public void Capacity_can_shrink_to_given_value(int shrinkValue, int expectedCapacity)
+        {
+            var pool = new ShrinkableDistinctPool(Capacity, _comparer, new WithFinalizerComparer(), LimboLogs.Instance);
+
+            int capacityMultiplier = 10;
+            int expectedAllCount = Capacity * capacityMultiplier;
+
+            WithFinalizer newOne;
+            for (int i = 0; i < expectedAllCount; i++)
+            {
+                newOne = new WithFinalizer();
+                pool.TryInsert(newOne.Index, newOne);
+            }
+
+            newOne = null;
+
+            CollectAndFinalize();
+
+            pool.Shrink(Capacity - shrinkValue);
+            pool.Count.Should().Be(expectedCapacity);
+        }
+
         [Test]
         public void Capacity_is_never_exceeded_when_there_are_duplicates()
         {
-            Comparer<WithFinalizer> comparer = Comparer<WithFinalizer>.Create((t1, t2) =>
-            {
-                int t1Oddity = t1.Index % 2;
-                int t2Oddity = t2.Index % 2;
-
-                if (t1Oddity.CompareTo(t2Oddity) != 0)
-                {
-                    return t1Oddity.CompareTo(t2Oddity);
-                }
-
-                return t1.Index.CompareTo(t2.Index);
-            });
-
-            var pool = new WithFinalizerDistinctPool(Capacity, comparer, new WithFinalizerComparer(), LimboLogs.Instance);
+            var pool = new WithFinalizerDistinctPool(Capacity, _comparer, new WithFinalizerComparer(), LimboLogs.Instance);
 
             int capacityMultiplier = 10;
 
@@ -232,20 +261,7 @@ namespace Nethermind.TxPool.Test.Collections
             _finalizedCount.Should().Be(0);
             _allCount.Should().Be(0);
 
-            IComparer<WithFinalizer> comparer = Comparer<WithFinalizer>.Create((t1, t2) =>
-            {
-                int t1Oddity = t1.Index % 2;
-                int t2Oddity = t2.Index % 2;
-
-                if (t1Oddity.CompareTo(t2Oddity) != 0)
-                {
-                    return t1Oddity.CompareTo(t2Oddity);
-                }
-
-                return t1.Index.CompareTo(t2.Index);
-            });
-
-            var pool = new WithFinalizerDistinctPool(Capacity, comparer, new WithFinalizerComparer(), LimboLogs.Instance);
+            var pool = new WithFinalizerDistinctPool(Capacity, _comparer, new WithFinalizerComparer(), LimboLogs.Instance);
 
             void KeepGoing(int iterations)
             {

--- a/src/Nethermind/Nethermind.TxPool/Collections/BlobTxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/BlobTxDistinctSortedPool.cs
@@ -22,11 +22,7 @@ public class BlobTxDistinctSortedPool : TxDistinctSortedPool
     protected override IComparer<Transaction> GetReplacementComparer(IComparer<Transaction> comparer)
         => comparer.GetBlobReplacementComparer();
 
-    public override void VerifyCapacity()
-    {
-        if (_logger.IsWarn && Count > _poolCapacity)
-            _logger.Warn($"Blob pool exceeds the config size {Count}/{_poolCapacity}");
-    }
+    protected override string ShortPoolName => "BlobPool";
 
     /// <summary>
     /// For tests only - to test sorting

--- a/src/Nethermind/Nethermind.TxPool/Collections/DistinctValueSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/DistinctValueSortedPool.cs
@@ -35,7 +35,7 @@ namespace Nethermind.TxPool.Collections
             IComparer<TValue> comparer,
             IEqualityComparer<TValue> distinctComparer,
             ILogManager logManager)
-            : base(capacity, comparer)
+            : base(capacity, comparer, logManager)
         {
             // ReSharper disable once VirtualMemberCallInConstructor
             _comparer = GetReplacementComparer(comparer ?? throw new ArgumentNullException(nameof(comparer)));

--- a/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
@@ -94,12 +94,4 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool
         _blobTxStorage.Delete(hash, tx.Timestamp);
         return base.Remove(hash, tx);
     }
-
-    public override void VerifyCapacity()
-    {
-        base.VerifyCapacity();
-
-        if (_logger.IsDebug && Count == _poolCapacity)
-            _logger.Debug($"Blob persistent storage has reached max size of {_poolCapacity}, blob txs can be evicted now");
-    }
 }

--- a/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Threading;
+using Nethermind.Logging;
 
 namespace Nethermind.TxPool.Collections
 {
@@ -25,6 +26,7 @@ namespace Nethermind.TxPool.Collections
         protected McsPriorityLock Lock { get; } = new();
 
         private readonly int _capacity;
+        private readonly ILogger _logger;
 
         // comparer for a bucket
         private readonly IComparer<TValue> _groupComparer;
@@ -48,7 +50,7 @@ namespace Nethermind.TxPool.Collections
         /// </summary>
         /// <param name="capacity">Max capacity, after surpassing it elements will be removed based on last by <see cref="comparer"/>.</param>
         /// <param name="comparer">Comparer to sort items.</param>
-        protected SortedPool(int capacity, IComparer<TValue> comparer)
+        protected SortedPool(int capacity, IComparer<TValue> comparer, ILogManager logManager)
         {
             _capacity = capacity;
             // ReSharper disable VirtualMemberCallInConstructor
@@ -57,6 +59,7 @@ namespace Nethermind.TxPool.Collections
             _cacheMap = new Dictionary<TKey, TValue>(); // do not initialize it at the full capacity
             _buckets = new Dictionary<TGroupKey, EnhancedSortedSet<TValue>>();
             _worstSortedValues = new DictionarySortedSet<TValue, TKey>(_sortedComparer);
+            _logger = logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
         }
 
         /// <summary>
@@ -312,6 +315,8 @@ namespace Nethermind.TxPool.Collections
                     {
                         if (!RemoveLast(out removed) || _cacheMap.Count > _capacity)
                         {
+                            if (_cacheMap.Count > _capacity && _logger.IsWarn)
+                                _logger.Warn($"Capacity exceeded or failed to remove the last item from the pool, the current state is {Count}/{_capacity}. {GetInfoAboutWorstValues}");
                             UpdateWorstValue();
                             RemoveLast(out removed);
                         }
@@ -453,6 +458,46 @@ namespace Nethermind.TxPool.Collections
             return false;
         }
 
+        protected void EnsureCapacity(int? expectedCapacity = null)
+        {
+            expectedCapacity ??= _capacity; // expectedCapacity is added for testing purpose. null should be used in production code
+            if (Count <= expectedCapacity)
+                return;
+
+            if (_logger.IsWarn)
+                _logger.Warn($"{ShortPoolName} exceeds the config size {Count}/{expectedCapacity}. Trying to repair the pool");
+
+            // Trying to auto-recover TxPool. If this code is executed, it means that something is wrong with our TxPool logic.
+            // However, auto-recover mitigates bad consequences of such bugs.
+            int maxIterations = 10; // We don't want to add an infinite loop, so we can break after a few iterations.
+            int iterations = 0;
+            while (Count > expectedCapacity)
+            {
+                ++iterations;
+                if (RemoveLast(out TValue? removed))
+                {
+                    if (_logger.IsInfo)
+                        _logger.Info($"Removed the last item {removed} from the pool, the current state is {Count}/{expectedCapacity}. {GetInfoAboutWorstValues}");
+                }
+                else
+                {
+                    if (_logger.IsWarn)
+                        _logger.Warn($"Failed to remove the last item from the pool, the current state is {Count}/{expectedCapacity}. {GetInfoAboutWorstValues}");
+                    UpdateWorstValue();
+                }
+
+                if (iterations >= maxIterations) break;
+            }
+        }
+
+        private string GetInfoAboutWorstValues()
+        {
+            TKey? key = _worstValue.GetValueOrDefault().Value;
+            var isWorstValueInPool = _cacheMap.TryGetValue(key, out TValue? value) && value != null;
+            return
+                $"Worst value {_worstValue}, items in worstSortedValues {_worstSortedValues.Count}, GetVakye: {_worstValue.GetValueOrDefault()} current max in worst values {_worstSortedValues.Max}, IsWorstValueInPool {isWorstValueInPool}";
+        }
+
         public void UpdatePool(Func<TGroupKey, IReadOnlySortedSet<TValue>, IEnumerable<(TValue Tx, Action<TValue>? Change)>> changingElements)
         {
             using var lockRelease = Lock.Acquire();
@@ -485,5 +530,7 @@ namespace Nethermind.TxPool.Collections
                 change?.Invoke(value);
             }
         }
+
+        protected virtual string ShortPoolName => "SortedPool";
     }
 }

--- a/src/Nethermind/Nethermind.TxPool/Collections/TxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/TxDistinctSortedPool.cs
@@ -75,7 +75,7 @@ namespace Nethermind.TxPool.Collections
         {
             using var lockRelease = Lock.Acquire();
 
-            VerifyCapacity();
+            EnsureCapacity();
             foreach ((AddressAsKey address, EnhancedSortedSet<Transaction> bucket) in _buckets)
             {
                 Debug.Assert(bucket.Count > 0);
@@ -133,10 +133,6 @@ namespace Nethermind.TxPool.Collections
             }
         }
 
-        public virtual void VerifyCapacity()
-        {
-            if (_logger.IsWarn && Count > _poolCapacity)
-                _logger.Warn($"TxPool exceeds the config size {Count}/{_poolCapacity}");
-        }
+        protected override string ShortPoolName => "TxPool";
     }
 }


### PR DESCRIPTION
## Changes

TxPool autorecovering if it exceeded capacity

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [] No

#### Notes on testing

For now I am experimenting

## Documentation

#### Requires documentation update

- [ ] Yes
- [ ] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
