### PR TITLE
Leaf value collector

### DIFF
--- a/src/Nethermind/Nethermind.Core/Collections/IOwnedReadOnlyList.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/IOwnedReadOnlyList.cs
@@ -20,3 +20,16 @@ public interface IOwnedReadOnlyList<T> : IReadOnlyList<T>, IDisposable
 {
     ReadOnlySpan<T> AsSpan();
 }
+
+public static class OwnedReadOnlyListExtensions
+{
+    public static void DisposeRecursive<T>(this IOwnedReadOnlyList<T> list) where T : IDisposable
+    {
+        for (int i = 0; i < list.Count; i++)
+        {
+            list[i]?.Dispose();
+        }
+
+        list.Dispose();
+    }
+}

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/Messages/StorageRangesMessageSerializerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/Messages/StorageRangesMessageSerializerTests.cs
@@ -20,7 +20,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.Messages
         [Test]
         public void Roundtrip_NoSlotsNoProofs()
         {
-            StorageRangeMessage msg = new()
+            using StorageRangeMessage msg = new()
             {
                 RequestId = MessageConstants.Random.NextLong(),
                 Slots = ArrayPoolList<IOwnedReadOnlyList<PathWithStorageSlot>>.Empty(),
@@ -34,7 +34,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.Messages
         [Test]
         public void Roundtrip_OneProof()
         {
-            StorageRangeMessage msg = new()
+            using StorageRangeMessage msg = new()
             {
                 RequestId = MessageConstants.Random.NextLong(),
                 Slots = ArrayPoolList<IOwnedReadOnlyList<PathWithStorageSlot>>.Empty(),
@@ -44,7 +44,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.Messages
             StorageRangesMessageSerializer serializer = new();
 
             var serialized = serializer.Serialize(msg);
-            var deserialized = serializer.Deserialize(serialized);
+            using var deserialized = serializer.Deserialize(serialized);
 
             SerializerTester.TestZero(serializer, msg);
         }
@@ -52,7 +52,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.Messages
         [Test]
         public void Roundtrip_OneSlot()
         {
-            StorageRangeMessage msg = new()
+            using StorageRangeMessage msg = new()
             {
                 RequestId = MessageConstants.Random.NextLong(),
                 Slots = new ArrayPoolList<IOwnedReadOnlyList<PathWithStorageSlot>>(1)
@@ -73,7 +73,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.Messages
         [Test]
         public void Roundtrip_Many()
         {
-            StorageRangeMessage msg = new()
+            using StorageRangeMessage msg = new()
             {
                 RequestId = MessageConstants.Random.NextLong(),
                 Slots = new ArrayPoolList<IOwnedReadOnlyList<PathWithStorageSlot>>(2) {

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/Messages/StorageRangesMessageSerializerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/Messages/StorageRangesMessageSerializerTests.cs
@@ -23,7 +23,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.Messages
             StorageRangeMessage msg = new()
             {
                 RequestId = MessageConstants.Random.NextLong(),
-                Slots = ArrayPoolList<PathWithStorageSlot[]>.Empty(),
+                Slots = ArrayPoolList<IOwnedReadOnlyList<PathWithStorageSlot>>.Empty(),
                 Proofs = ArrayPoolList<byte[]>.Empty()
             };
             StorageRangesMessageSerializer serializer = new();
@@ -37,7 +37,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.Messages
             StorageRangeMessage msg = new()
             {
                 RequestId = MessageConstants.Random.NextLong(),
-                Slots = ArrayPoolList<PathWithStorageSlot[]>.Empty(),
+                Slots = ArrayPoolList<IOwnedReadOnlyList<PathWithStorageSlot>>.Empty(),
                 Proofs = new ArrayPoolList<byte[]>(2) { TestItem.RandomDataA }
             };
 
@@ -55,7 +55,13 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.Messages
             StorageRangeMessage msg = new()
             {
                 RequestId = MessageConstants.Random.NextLong(),
-                Slots = new ArrayPoolList<PathWithStorageSlot[]>(1) { new PathWithStorageSlot[] { new PathWithStorageSlot(new Hash256("0x10d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"), TestItem.RandomDataA) } },
+                Slots = new ArrayPoolList<IOwnedReadOnlyList<PathWithStorageSlot>>(1)
+                {
+                    new ArrayPoolList<PathWithStorageSlot> (1)
+                    {
+                        new PathWithStorageSlot(new Hash256("0x10d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"), TestItem.RandomDataA)
+                    }
+                },
                 Proofs = ArrayPoolList<byte[]>.Empty()
             };
 
@@ -70,12 +76,12 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.Messages
             StorageRangeMessage msg = new()
             {
                 RequestId = MessageConstants.Random.NextLong(),
-                Slots = new ArrayPoolList<PathWithStorageSlot[]>(2) {
-                    new PathWithStorageSlot[] {
+                Slots = new ArrayPoolList<IOwnedReadOnlyList<PathWithStorageSlot>>(2) {
+                    new ArrayPoolList<PathWithStorageSlot>(2) {
                         new PathWithStorageSlot(new Hash256("0x10d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"), Rlp.Encode(TestItem.RandomDataA).Bytes) ,
                         new PathWithStorageSlot(new Hash256("0x12d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"), Rlp.Encode(TestItem.RandomDataB).Bytes)
                     },
-                    new PathWithStorageSlot[] {
+                    new ArrayPoolList<PathWithStorageSlot>(2) {
                         new PathWithStorageSlot(new Hash256("0x21d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"), Rlp.Encode(TestItem.RandomDataB).Bytes) ,
                         new PathWithStorageSlot(new Hash256("0x22d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"), Rlp.Encode(TestItem.RandomDataC).Bytes)
                     }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/StorageRangeMessage.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/StorageRangeMessage.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Data.Common;
 using Nethermind.Core.Collections;
 using Nethermind.State.Snap;
 
@@ -13,7 +14,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap.Messages
         /// <summary>
         /// List of list of consecutive slots from the trie (one list per account)
         /// </summary>
-        public IOwnedReadOnlyList<PathWithStorageSlot[]> Slots { get; set; }
+        public IOwnedReadOnlyList<IOwnedReadOnlyList<PathWithStorageSlot>> Slots { get; set; }
 
         /// <summary>
         /// List of trie nodes proving the slot range
@@ -23,7 +24,15 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap.Messages
         public override void Dispose()
         {
             base.Dispose();
-            Slots?.Dispose();
+            if (Slots != null)
+            {
+                foreach (IOwnedReadOnlyList<PathWithStorageSlot> pathWithStorageSlots in Slots)
+                {
+                    pathWithStorageSlots?.Dispose();
+                }
+
+                Slots.Dispose();
+            }
             Proofs?.Dispose();
         }
     }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/StorageRangeMessage.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/StorageRangeMessage.cs
@@ -24,15 +24,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap.Messages
         public override void Dispose()
         {
             base.Dispose();
-            if (Slots != null)
-            {
-                foreach (IOwnedReadOnlyList<PathWithStorageSlot> pathWithStorageSlots in Slots)
-                {
-                    pathWithStorageSlots?.Dispose();
-                }
-
-                Slots.Dispose();
-            }
+            Slots?.DisposeRecursive();
             Proofs?.Dispose();
         }
     }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/StorageRangesMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/StorageRangesMessageSerializer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using DotNetty.Buffers;
+using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Serialization.Rlp;
 using Nethermind.State.Snap;
@@ -12,13 +13,13 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap.Messages
     public sealed class StorageRangesMessageSerializer : IZeroMessageSerializer<StorageRangeMessage>
     {
         private readonly Func<RlpStream, PathWithStorageSlot> _decodeSlot;
-        private readonly Func<RlpStream, PathWithStorageSlot[]> _decodeSlotArray;
+        private readonly Func<RlpStream, IOwnedReadOnlyList<PathWithStorageSlot>> _decodeSlotArray;
 
         public StorageRangesMessageSerializer()
         {
             // Capture closures once
             _decodeSlot = DecodeSlot;
-            _decodeSlotArray = s => s.DecodeArray(_decodeSlot);
+            _decodeSlotArray = s => s.DecodeArrayPoolList(_decodeSlot);
         }
 
         public void Serialize(IByteBuffer byteBuffer, StorageRangeMessage message)
@@ -44,9 +45,9 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap.Messages
                 {
                     stream.StartSequence(accountSlotsLengths[i]);
 
-                    PathWithStorageSlot[] accountSlots = message.Slots[i];
+                    IOwnedReadOnlyList<PathWithStorageSlot> accountSlots = message.Slots[i];
 
-                    for (int j = 0; j < accountSlots.Length; j++)
+                    for (int j = 0; j < accountSlots.Count; j++)
                     {
                         var slot = accountSlots[j];
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/SnapProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/SnapProtocolHandler.cs
@@ -259,10 +259,10 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap
             if (SyncServer is null) return new StorageRangeMessage()
             {
                 Proofs = ArrayPoolList<byte[]>.Empty(),
-                Slots = ArrayPoolList<PathWithStorageSlot[]>.Empty(),
+                Slots = ArrayPoolList<IOwnedReadOnlyList<PathWithStorageSlot>>.Empty(),
             };
             StorageRange? storageRange = getStorageRangeMessage.StoragetRange;
-            (IOwnedReadOnlyList<PathWithStorageSlot[]>? ranges, IOwnedReadOnlyList<byte[]>? proofs) = SyncServer.GetStorageRanges(storageRange.RootHash, storageRange.Accounts,
+            (IOwnedReadOnlyList<IOwnedReadOnlyList<PathWithStorageSlot>>? ranges, IOwnedReadOnlyList<byte[]>? proofs) = SyncServer.GetStorageRanges(storageRange.RootHash, storageRange.Accounts,
                 storageRange.StartingHash, storageRange.LimitHash, getStorageRangeMessage.ResponseBytes, cancellationToken);
             StorageRangeMessage? response = new() { Proofs = proofs, Slots = ranges };
             return response;

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/SnapProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/SnapProtocolHandler.cs
@@ -262,7 +262,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap
                 Slots = ArrayPoolList<IOwnedReadOnlyList<PathWithStorageSlot>>.Empty(),
             };
             StorageRange? storageRange = getStorageRangeMessage.StoragetRange;
-            (IOwnedReadOnlyList<IOwnedReadOnlyList<PathWithStorageSlot>>? ranges, IOwnedReadOnlyList<byte[]>? proofs) = SyncServer.GetStorageRanges(storageRange.RootHash, storageRange.Accounts,
+            (IOwnedReadOnlyList<IOwnedReadOnlyList<PathWithStorageSlot>>? ranges, IOwnedReadOnlyList<byte[]> proofs) = SyncServer.GetStorageRanges(storageRange.RootHash, storageRange.Accounts,
                 storageRange.StartingHash, storageRange.LimitHash, getStorageRangeMessage.ResponseBytes, cancellationToken);
             StorageRangeMessage? response = new() { Proofs = proofs, Slots = ranges };
             return response;

--- a/src/Nethermind/Nethermind.Serialization.Rlp/AccountDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/AccountDecoder.cs
@@ -14,6 +14,7 @@ namespace Nethermind.Serialization.Rlp
         private readonly bool _slimFormat;
 
         public static AccountDecoder Instance => new();
+        public static AccountDecoder Slim => new(slimFormat: true);
 
         public AccountDecoder() { }
 

--- a/src/Nethermind/Nethermind.State.Test/SnapSync/RecreateStateFromAccountRangesTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/SnapSync/RecreateStateFromAccountRangesTests.cs
@@ -110,7 +110,7 @@ namespace Nethermind.Store.Test
             MemDb db = new();
             DbProvider dbProvider = new();
             dbProvider.RegisterDb(DbNames.State, db);
-            ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
+            using ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
             SnapProvider snapProvider = new(progressTracker, dbProvider, LimboLogs.Instance);
             AddRangeResult result = snapProvider.AddAccountRange(1, rootHash, Keccak.Zero, TestItem.Tree.AccountsWithPaths, firstProof!.Concat(lastProof!).ToArray());
 
@@ -151,7 +151,7 @@ namespace Nethermind.Store.Test
             MemDb db = new();
             DbProvider dbProvider = new();
             dbProvider.RegisterDb(DbNames.State, db);
-            ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
+            using ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
             SnapProvider snapProvider = new(progressTracker, dbProvider, LimboLogs.Instance);
             var result = snapProvider.AddAccountRange(1, rootHash, TestItem.Tree.AccountsWithPaths[0].Path, TestItem.Tree.AccountsWithPaths);
 
@@ -169,7 +169,7 @@ namespace Nethermind.Store.Test
             MemDb db = new();
             DbProvider dbProvider = new();
             dbProvider.RegisterDb(DbNames.State, db);
-            ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
+            using ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
             SnapProvider snapProvider = new(progressTracker, dbProvider, LimboLogs.Instance);
 
             AccountProofCollector accountProofCollector = new(Keccak.Zero.Bytes);
@@ -219,7 +219,7 @@ namespace Nethermind.Store.Test
             MemDb db = new();
             DbProvider dbProvider = new();
             dbProvider.RegisterDb(DbNames.State, db);
-            ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
+            using ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
             SnapProvider snapProvider = new(progressTracker, dbProvider, LimboLogs.Instance);
 
             AccountProofCollector accountProofCollector = new(Keccak.Zero.Bytes);

--- a/src/Nethermind/Nethermind.State.Test/SnapSync/RecreateStateFromStorageRangesTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/SnapSync/RecreateStateFromStorageRangesTests.cs
@@ -51,7 +51,7 @@ namespace Nethermind.Store.Test
             MemDb db = new();
             DbProvider dbProvider = new();
             dbProvider.RegisterDb(DbNames.State, db);
-            ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
+            using ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
             SnapProvider snapProvider = new(progressTracker, dbProvider, LimboLogs.Instance);
             var result = snapProvider.AddStorageRange(1, null, rootHash, Keccak.Zero, TestItem.Tree.SlotsWithPaths, proof!.StorageProofs![0].Proof!.Concat(proof!.StorageProofs![1].Proof!).ToArray());
 
@@ -70,7 +70,7 @@ namespace Nethermind.Store.Test
             MemDb db = new();
             DbProvider dbProvider = new();
             dbProvider.RegisterDb(DbNames.State, db);
-            ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
+            using ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
             SnapProvider snapProvider = new(progressTracker, dbProvider, LimboLogs.Instance);
             var result = snapProvider.AddStorageRange(1, null, rootHash, Keccak.Zero, TestItem.Tree.SlotsWithPaths, proof!.StorageProofs![0].Proof!.Concat(proof!.StorageProofs![1].Proof!).ToArray());
 
@@ -85,7 +85,7 @@ namespace Nethermind.Store.Test
             MemDb db = new MemDb();
             DbProvider dbProvider = new();
             dbProvider.RegisterDb(DbNames.State, db);
-            ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
+            using ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
             SnapProvider snapProvider = new(progressTracker, dbProvider, LimboLogs.Instance);
             var result = snapProvider.AddStorageRange(1, null, rootHash, TestItem.Tree.SlotsWithPaths[0].Path, TestItem.Tree.SlotsWithPaths);
 
@@ -101,7 +101,7 @@ namespace Nethermind.Store.Test
             MemDb db = new MemDb();
             DbProvider dbProvider = new();
             dbProvider.RegisterDb(DbNames.State, db);
-            ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
+            using ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
             SnapProvider snapProvider = new(progressTracker, dbProvider, LimboLogs.Instance);
 
             AccountProofCollector accountProofCollector = new(TestItem.Tree.AccountAddress0.Bytes, new ValueHash256[] { Keccak.Zero, TestItem.Tree.SlotsWithPaths[1].Path });
@@ -136,7 +136,7 @@ namespace Nethermind.Store.Test
             MemDb db = new MemDb();
             DbProvider dbProvider = new();
             dbProvider.RegisterDb(DbNames.State, db);
-            ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
+            using ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
             SnapProvider snapProvider = new(progressTracker, dbProvider, LimboLogs.Instance);
 
             AccountProofCollector accountProofCollector = new(TestItem.Tree.AccountAddress0.Bytes, new ValueHash256[] { Keccak.Zero, TestItem.Tree.SlotsWithPaths[1].Path });

--- a/src/Nethermind/Nethermind.State/Snap/SlotsAndProofs.cs
+++ b/src/Nethermind/Nethermind.State/Snap/SlotsAndProofs.cs
@@ -8,12 +8,19 @@ namespace Nethermind.State.Snap
 {
     public class SlotsAndProofs : IDisposable
     {
-        public IOwnedReadOnlyList<PathWithStorageSlot[]> PathsAndSlots { get; set; }
+        public IOwnedReadOnlyList<IOwnedReadOnlyList<PathWithStorageSlot>> PathsAndSlots { get; set; }
         public IOwnedReadOnlyList<byte[]> Proofs { get; set; }
 
         public void Dispose()
         {
-            PathsAndSlots?.Dispose();
+            if (PathsAndSlots != null)
+            {
+                foreach (IOwnedReadOnlyList<PathWithStorageSlot> pathWithStorageSlots in PathsAndSlots)
+                {
+                    pathWithStorageSlots?.Dispose();
+                }
+                PathsAndSlots?.Dispose();
+            }
             Proofs?.Dispose();
         }
     }

--- a/src/Nethermind/Nethermind.State/Snap/SlotsAndProofs.cs
+++ b/src/Nethermind/Nethermind.State/Snap/SlotsAndProofs.cs
@@ -11,8 +11,12 @@ namespace Nethermind.State.Snap
         public IOwnedReadOnlyList<IOwnedReadOnlyList<PathWithStorageSlot>> PathsAndSlots { get; set; }
         public IOwnedReadOnlyList<byte[]> Proofs { get; set; }
 
+        private bool _disposed = false;
+
         public void Dispose()
         {
+            if (_disposed) return;
+            _disposed = true;
             if (PathsAndSlots != null)
             {
                 foreach (IOwnedReadOnlyList<PathWithStorageSlot> pathWithStorageSlots in PathsAndSlots)

--- a/src/Nethermind/Nethermind.State/Snap/SlotsAndProofs.cs
+++ b/src/Nethermind/Nethermind.State/Snap/SlotsAndProofs.cs
@@ -17,14 +17,7 @@ namespace Nethermind.State.Snap
         {
             if (_disposed) return;
             _disposed = true;
-            if (PathsAndSlots != null)
-            {
-                foreach (IOwnedReadOnlyList<PathWithStorageSlot> pathWithStorageSlots in PathsAndSlots)
-                {
-                    pathWithStorageSlots?.Dispose();
-                }
-                PathsAndSlots?.Dispose();
-            }
+            PathsAndSlots?.DisposeRecursive();
             Proofs?.Dispose();
         }
     }

--- a/src/Nethermind/Nethermind.Synchronization.Test/RangeQueryVisitorTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/RangeQueryVisitorTests.cs
@@ -17,7 +17,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using FluentAssertions;
+using Nethermind.Core;
+using Nethermind.Core.Buffers;
+using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
@@ -46,15 +50,15 @@ public class RangeQueryVisitorTests
         var startHash = new Hash256("0000000000000000000000000000000000000000000000000000000001113456");
         var limitHash = new Hash256("0000000000000000000000000000000000000000000000000000000001123458");
 
-        using RangeQueryVisitor visitor = new(startHash, limitHash, false);
+        RlpCollector leafCollector = new();
+        using RangeQueryVisitor visitor = new(startHash, limitHash, leafCollector);
         _inputTree.Accept(visitor, _inputTree.RootHash, CreateVisitingOptions());
-        (IDictionary<ValueHash256, byte[]> nodes, long _) = visitor.GetNodesAndSize();
 
-        nodes.Count.Should().Be(4);
+        leafCollector.Leafs.Count.Should().Be(4);
 
         int k = 0;
-        nodes.Should().AllSatisfy(pair =>
-            Rlp.Encode(TestItem.Tree.AccountsWithPaths[k++ + 2].Account).Bytes.Should().BeEquivalentTo(pair.Value)
+        leafCollector.Leafs.Should().AllSatisfy(pair =>
+            Rlp.Encode(TestItem.Tree.AccountsWithPaths[k++ + 2].Account).Bytes.Should().BeEquivalentTo(pair.Item2)
         );
     }
 
@@ -72,10 +76,11 @@ public class RangeQueryVisitorTests
         var startHash = new Hash256("0150000000000000000000000000000000000000000000000000000000000000");
         var limitHash = new Hash256("0350000000000000000000000000000000000000000000000000000000000000");
 
-        using RangeQueryVisitor visitor = new(startHash, limitHash, false);
+        RlpCollector leafCollector = new();
+        using RangeQueryVisitor visitor = new(startHash, limitHash, leafCollector);
         tree.Accept(visitor, tree.RootHash, CreateVisitingOptions());
-        (IDictionary<ValueHash256, byte[]> nodes, long _) = visitor.GetNodesAndSize();
 
+        Dictionary<ValueHash256, byte[]?> nodes = leafCollector.Leafs.ToDictionary((it) => it.Item1, (it) => it.Item2);
         nodes.Count.Should().Be(3);
 
         nodes.ContainsKey(new Hash256("0200000000000000000000000000000000000000000000000000000000000000")).Should().BeTrue();
@@ -94,11 +99,11 @@ public class RangeQueryVisitorTests
         var startHash = new Hash256("0510000000000000000000000000000000000000000000000000000000000000");
         var limitHash = new Hash256("0600000000000000000000000000000000000000000000000000000000000000");
 
-        using RangeQueryVisitor visitor = new(startHash, limitHash, false);
+        RlpCollector leafCollector = new();
+        using RangeQueryVisitor visitor = new(startHash, limitHash, leafCollector);
         tree.Accept(visitor, tree.RootHash, CreateVisitingOptions());
-        (IDictionary<ValueHash256, byte[]> nodes, long _) = visitor.GetNodesAndSize();
 
-        nodes.Count.Should().Be(0);
+        leafCollector.Leafs.Count.Should().Be(0);
         Action act = () => visitor.GetProofs();
         act.Should().NotThrow();
     }
@@ -123,9 +128,10 @@ public class RangeQueryVisitorTests
         var startHash = new Hash256("0x3000000000000000000000000000000000000000000000000000000000000000");
         var limitHash = new Hash256("0x4500000000000000000000000000000000000000000000000000000000000000");
 
-        using RangeQueryVisitor visitor = new(startHash, limitHash, false);
+        RlpCollector leafCollector = new();
+        using RangeQueryVisitor visitor = new(startHash, limitHash, leafCollector);
         stateTree.Accept(visitor, stateTree.RootHash, CreateVisitingOptions());
-        visitor.GetNodesAndSize().Item1.Count.Should().Be(3);
+        leafCollector.Leafs.Count.Should().Be(3);
     }
 
     [Test]
@@ -133,12 +139,25 @@ public class RangeQueryVisitorTests
     {
         TrieStore store = new TrieStore(new MemDb(), LimboLogs.Instance);
         (StateTree inputStateTree, StorageTree _, Hash256 account) = TestItem.Tree.GetTrees(store);
-        using RangeQueryVisitor visitor = new(Keccak.Zero, Keccak.MaxValue, false);
+
+        RlpCollector leafCollector = new();
+        using RangeQueryVisitor visitor = new(Keccak.Zero, Keccak.MaxValue, leafCollector);
         inputStateTree.Accept(visitor, inputStateTree.RootHash, CreateVisitingOptions(), storageAddr: account);
-        (Dictionary<ValueHash256, byte[]> nodes, long _) = visitor.GetNodesAndSize();
+        Dictionary<ValueHash256, byte[]?> nodes = leafCollector.Leafs.ToDictionary((it) => it.Item1, (it) => it.Item2);
         nodes.Count.Should().Be(6);
 
         int k = 0;
         nodes.Should().AllSatisfy(pair => pair.Value.Should().BeEquivalentTo(TestItem.Tree.SlotsWithPaths[k++ + 0].SlotRlpValue));
+    }
+
+    public class RlpCollector : RangeQueryVisitor.ILeafValueCollector
+    {
+        public ArrayPoolList<(ValueHash256, byte[]?)> Leafs { get; } = new(0);
+
+        public int Collect(in ValueHash256 path, CappedArray<byte> value)
+        {
+            Leafs.Add((path, value.ToArray()));
+            return 32 + Rlp.LengthOfByteString(value.Length, 0);
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/ProgressTrackerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/ProgressTrackerTests.cs
@@ -24,7 +24,7 @@ public class ProgressTrackerTests
     public async Task Did_not_have_race_issue()
     {
         BlockTree blockTree = Build.A.BlockTree().WithBlocks(Build.A.Block.TestObject).TestObject;
-        ProgressTracker progressTracker = new(blockTree, new MemDb(), LimboLogs.Instance);
+        using ProgressTracker progressTracker = new(blockTree, new MemDb(), LimboLogs.Instance);
         progressTracker.EnqueueStorageRange(new StorageRange()
         {
             Accounts = ArrayPoolList<PathWithAccount>.Empty(),
@@ -57,7 +57,7 @@ public class ProgressTrackerTests
     public void Will_create_multiple_get_address_range_request()
     {
         BlockTree blockTree = Build.A.BlockTree().WithBlocks(Build.A.Block.TestObject).TestObject;
-        ProgressTracker progressTracker = new(blockTree, new MemDb(), LimboLogs.Instance, 4);
+        using ProgressTracker progressTracker = new(blockTree, new MemDb(), LimboLogs.Instance, 4);
 
         bool finished = progressTracker.IsFinished(out SnapSyncBatch? request);
         request!.AccountRangeRequest.Should().NotBeNull();
@@ -96,7 +96,7 @@ public class ProgressTrackerTests
     public void Will_deque_code_request_if_high_even_if_storage_queue_is_not_empty()
     {
         BlockTree blockTree = Build.A.BlockTree().WithBlocks(Build.A.Block.TestObject).TestObject;
-        ProgressTracker progressTracker = new ProgressTracker(blockTree, new MemDb(), LimboLogs.Instance);
+        using ProgressTracker progressTracker = new ProgressTracker(blockTree, new MemDb(), LimboLogs.Instance);
 
         for (int i = 0; i < ProgressTracker.HIGH_STORAGE_QUEUE_SIZE - 1; i++)
         {
@@ -121,7 +121,7 @@ public class ProgressTrackerTests
     public void Will_deque_storage_request_if_high()
     {
         BlockTree blockTree = Build.A.BlockTree().WithBlocks(Build.A.Block.TestObject).TestObject;
-        ProgressTracker progressTracker = new ProgressTracker(blockTree, new MemDb(), LimboLogs.Instance);
+        using ProgressTracker progressTracker = new ProgressTracker(blockTree, new MemDb(), LimboLogs.Instance);
 
         for (int i = 0; i < ProgressTracker.HIGH_STORAGE_QUEUE_SIZE; i++)
         {
@@ -149,7 +149,7 @@ public class ProgressTrackerTests
             .WithStateRoot(Keccak.EmptyTreeHash)
             .TestObject).TestObject;
         TestMemDb memDb = new();
-        ProgressTracker progressTracker = new(blockTree, memDb, LimboLogs.Instance, 1);
+        using ProgressTracker progressTracker = new(blockTree, memDb, LimboLogs.Instance, 1);
 
         progressTracker.IsFinished(out SnapSyncBatch? request);
         request!.AccountRangeRequest.Should().NotBeNull();

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/RecreateStateFromAccountRangesTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/RecreateStateFromAccountRangesTests.cs
@@ -116,7 +116,7 @@ namespace Nethermind.Synchronization.Test.SnapSync
             MemDb db = new();
             DbProvider dbProvider = new();
             dbProvider.RegisterDb(DbNames.State, db);
-            ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
+            using ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
             SnapProvider snapProvider = new(progressTracker, dbProvider, LimboLogs.Instance);
             AddRangeResult result = snapProvider.AddAccountRange(1, rootHash, Keccak.Zero, TestItem.Tree.AccountsWithPaths, firstProof!.Concat(lastProof!).ToArray());
 
@@ -136,7 +136,7 @@ namespace Nethermind.Synchronization.Test.SnapSync
             MemDb db = new();
             DbProvider dbProvider = new();
             dbProvider.RegisterDb(DbNames.State, db);
-            ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
+            using ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
             SnapProvider snapProvider = new(progressTracker, dbProvider, LimboLogs.Instance);
             var result = snapProvider.AddAccountRange(1, rootHash, TestItem.Tree.AccountsWithPaths[0].Path, TestItem.Tree.AccountsWithPaths, firstProof!.Concat(lastProof!).ToArray());
 
@@ -153,7 +153,7 @@ namespace Nethermind.Synchronization.Test.SnapSync
             MemDb db = new();
             DbProvider dbProvider = new();
             dbProvider.RegisterDb(DbNames.State, db);
-            ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
+            using ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
             SnapProvider snapProvider = new(progressTracker, dbProvider, LimboLogs.Instance);
             var result = snapProvider.AddAccountRange(1, rootHash, TestItem.Tree.AccountsWithPaths[0].Path, TestItem.Tree.AccountsWithPaths);
 
@@ -171,7 +171,7 @@ namespace Nethermind.Synchronization.Test.SnapSync
             MemDb db = new();
             DbProvider dbProvider = new();
             dbProvider.RegisterDb(DbNames.State, db);
-            ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
+            using ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
             SnapProvider snapProvider = new(progressTracker, dbProvider, LimboLogs.Instance);
 
             byte[][] firstProof = CreateProofForPath(Keccak.Zero.Bytes);
@@ -209,7 +209,7 @@ namespace Nethermind.Synchronization.Test.SnapSync
             MemDb db = new();
             DbProvider dbProvider = new();
             dbProvider.RegisterDb(DbNames.State, db);
-            ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
+            using ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
             SnapProvider snapProvider = new(progressTracker, dbProvider, LimboLogs.Instance);
 
             byte[][] firstProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[4].Path.Bytes);
@@ -244,7 +244,7 @@ namespace Nethermind.Synchronization.Test.SnapSync
             MemDb db = new();
             DbProvider dbProvider = new();
             dbProvider.RegisterDb(DbNames.State, db);
-            ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
+            using ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
             SnapProvider snapProvider = new(progressTracker, dbProvider, LimboLogs.Instance);
 
             byte[][] firstProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[4].Path.Bytes);
@@ -279,7 +279,7 @@ namespace Nethermind.Synchronization.Test.SnapSync
             MemDb db = new();
             DbProvider dbProvider = new();
             dbProvider.RegisterDb(DbNames.State, db);
-            ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
+            using ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
             SnapProvider snapProvider = new(progressTracker, dbProvider, LimboLogs.Instance);
 
             byte[][] firstProof = CreateProofForPath(Keccak.Zero.Bytes);
@@ -323,7 +323,7 @@ namespace Nethermind.Synchronization.Test.SnapSync
             MemDb db = new();
             DbProvider dbProvider = new();
             dbProvider.RegisterDb(DbNames.State, db);
-            ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
+            using ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
             SnapProvider snapProvider = new(progressTracker, dbProvider, LimboLogs.Instance);
 
             byte[][] firstProof = CreateProofForPath(Keccak.Zero.Bytes);
@@ -377,7 +377,7 @@ namespace Nethermind.Synchronization.Test.SnapSync
             MemDb db = new();
             DbProvider dbProvider = new();
             dbProvider.RegisterDb(DbNames.State, db);
-            ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
+            using ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
             SnapProvider snapProvider = new(progressTracker, dbProvider, LimboLogs.Instance);
 
             byte[][] firstProof = CreateProofForPath(ac1.Path.Bytes, tree);
@@ -416,7 +416,7 @@ namespace Nethermind.Synchronization.Test.SnapSync
             MemDb db = new();
             DbProvider dbProvider = new();
             dbProvider.RegisterDb(DbNames.State, db);
-            ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
+            using ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
             SnapProvider snapProvider = new(progressTracker, dbProvider, LimboLogs.Instance);
 
             byte[][] firstProof = CreateProofForPath(Keccak.Zero.Bytes);

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/RecreateStateFromStorageRangesTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/RecreateStateFromStorageRangesTests.cs
@@ -47,7 +47,7 @@ namespace Nethermind.Synchronization.Test.SnapSync
             MemDb db = new();
             DbProvider dbProvider = new();
             dbProvider.RegisterDb(DbNames.State, db);
-            ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
+            using ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
             SnapProvider snapProvider = new(progressTracker, dbProvider, LimboLogs.Instance);
 
             var result = snapProvider.AddStorageRange(1, null, rootHash, Keccak.Zero, TestItem.Tree.SlotsWithPaths, proof!.StorageProofs![0].Proof!.Concat(proof!.StorageProofs![1].Proof!).ToArray());
@@ -67,7 +67,7 @@ namespace Nethermind.Synchronization.Test.SnapSync
             MemDb db = new();
             DbProvider dbProvider = new();
             dbProvider.RegisterDb(DbNames.State, db);
-            ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
+            using ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
             SnapProvider snapProvider = new(progressTracker, dbProvider, LimboLogs.Instance);
 
             var result = snapProvider.AddStorageRange(1, null, rootHash, Keccak.Zero, TestItem.Tree.SlotsWithPaths, proof!.StorageProofs![0].Proof!.Concat(proof!.StorageProofs![1].Proof!).ToArray());
@@ -83,7 +83,7 @@ namespace Nethermind.Synchronization.Test.SnapSync
             MemDb db = new MemDb();
             DbProvider dbProvider = new();
             dbProvider.RegisterDb(DbNames.State, db);
-            ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
+            using ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
             SnapProvider snapProvider = new(progressTracker, dbProvider, LimboLogs.Instance);
 
             var result = snapProvider.AddStorageRange(1, null, rootHash, TestItem.Tree.SlotsWithPaths[0].Path, TestItem.Tree.SlotsWithPaths);
@@ -100,7 +100,7 @@ namespace Nethermind.Synchronization.Test.SnapSync
             MemDb db = new MemDb();
             DbProvider dbProvider = new();
             dbProvider.RegisterDb(DbNames.State, db);
-            ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
+            using ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
             SnapProvider snapProvider = new(progressTracker, dbProvider, LimboLogs.Instance);
 
             AccountProofCollector accountProofCollector = new(TestItem.Tree.AccountAddress0.Bytes, new ValueHash256[] { Keccak.Zero, TestItem.Tree.SlotsWithPaths[1].Path });
@@ -135,7 +135,7 @@ namespace Nethermind.Synchronization.Test.SnapSync
             MemDb db = new MemDb();
             DbProvider dbProvider = new();
             dbProvider.RegisterDb(DbNames.State, db);
-            ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
+            using ProgressTracker progressTracker = new(null, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance);
             SnapProvider snapProvider = new(progressTracker, dbProvider, LimboLogs.Instance);
 
             AccountProofCollector accountProofCollector = new(TestItem.Tree.AccountAddress0.Bytes, new ValueHash256[] { Keccak.Zero, TestItem.Tree.SlotsWithPaths[1].Path });

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapServerTest.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapServerTest.cs
@@ -9,7 +9,6 @@ using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
-using Nethermind.Evm.Tracing.GethStyle.JavaScript;
 using Nethermind.Logging;
 using Nethermind.State;
 using Nethermind.State.Snap;
@@ -80,7 +79,7 @@ public class SnapServerTest
 
         accounts.Count.Should().Be(0);
 
-        (IOwnedReadOnlyList<PathWithStorageSlot[]> storageSlots, IOwnedReadOnlyList<byte[]>? proofs) =
+        (IOwnedReadOnlyList<IOwnedReadOnlyList<PathWithStorageSlot>> storageSlots, IOwnedReadOnlyList<byte[]>? proofs) =
             context.Server.GetStorageRanges(context.Tree.RootHash, new PathWithAccount[] { TestItem.Tree.AccountsWithPaths[0] },
                 Keccak.Zero, Keccak.MaxValue, 10, CancellationToken.None);
 
@@ -185,7 +184,7 @@ public class SnapServerTest
         ProgressTracker progressTracker = new(null!, dbProviderClient.StateDb, LimboLogs.Instance);
         SnapProvider snapProvider = new(progressTracker, dbProviderClient, LimboLogs.Instance);
 
-        (IOwnedReadOnlyList<PathWithStorageSlot[]> storageSlots, IOwnedReadOnlyList<byte[]>? proofs) =
+        (IOwnedReadOnlyList<IOwnedReadOnlyList<PathWithStorageSlot>> storageSlots, IOwnedReadOnlyList<byte[]>? proofs) =
             server.GetStorageRanges(InputStateTree.RootHash, new PathWithAccount[] { TestItem.Tree.AccountsWithPaths[0] },
                 Keccak.Zero, Keccak.MaxValue, 10, CancellationToken.None);
 
@@ -216,7 +215,7 @@ public class SnapServerTest
         Hash256 startRange = Keccak.Zero;
         while (true)
         {
-            (IOwnedReadOnlyList<PathWithStorageSlot[]> storageSlots, IOwnedReadOnlyList<byte[]>? proofs) =
+            (IOwnedReadOnlyList<IOwnedReadOnlyList<PathWithStorageSlot>> storageSlots, IOwnedReadOnlyList<byte[]>? proofs) =
                 server.GetStorageRanges(InputStateTree.RootHash, new PathWithAccount[] { TestItem.Tree.AccountsWithPaths[0] },
                     startRange, Keccak.MaxValue, 10000, CancellationToken.None);
 
@@ -290,32 +289,32 @@ public class SnapServerTest
 
 
         var accountWithStorageArray = accountWithStorage.ToArray();
-        IOwnedReadOnlyList<PathWithStorageSlot[]> slots;
+        IOwnedReadOnlyList<IOwnedReadOnlyList<PathWithStorageSlot>> slots;
         IOwnedReadOnlyList<byte[]>? proofs;
 
         (slots, proofs) =
             server.GetStorageRanges(stateTree.RootHash, accountWithStorageArray[..1], Keccak.Zero, Keccak.MaxValue, 10, CancellationToken.None);
         slots.Count.Should().Be(1);
-        slots[0].Length.Should().Be(1);
+        slots[0].Count.Should().Be(1);
         proofs.Should().NotBeNull();
 
         (slots, proofs) =
             server.GetStorageRanges(stateTree.RootHash, accountWithStorageArray[..1], Keccak.Zero, Keccak.MaxValue, 1000000, CancellationToken.None);
         slots.Count.Should().Be(1);
-        slots[0].Length.Should().Be(1000);
+        slots[0].Count.Should().Be(1000);
         proofs.Should().BeEmpty();
 
         (slots, proofs) =
             server.GetStorageRanges(stateTree.RootHash, accountWithStorageArray[..2], Keccak.Zero, Keccak.MaxValue, 10, CancellationToken.None);
         slots.Count.Should().Be(1);
-        slots[0].Length.Should().Be(1);
+        slots[0].Count.Should().Be(1);
         proofs.Should().NotBeNull();
 
         (slots, proofs) =
             server.GetStorageRanges(stateTree.RootHash, accountWithStorageArray[..2], Keccak.Zero, Keccak.MaxValue, 100000, CancellationToken.None);
         slots.Count.Should().Be(2);
-        slots[0].Length.Should().Be(1000);
-        slots[1].Length.Should().Be(539);
+        slots[0].Count.Should().Be(1000);
+        slots[1].Count.Should().Be(539);
         proofs.Should().NotBeNull();
 
 
@@ -323,7 +322,7 @@ public class SnapServerTest
         (slots, proofs) =
             server.GetStorageRanges(stateTree.RootHash, accountWithStorageArray, Keccak.Zero, Keccak.MaxValue, 3000000, CancellationToken.None);
         slots.Count.Should().Be(8);
-        slots[^1].Length.Should().BeLessThan(8000);
+        slots[^1].Count.Should().BeLessThan(8000);
         proofs.Should().NotBeEmpty();
     }
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapServerTest.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapServerTest.cs
@@ -40,11 +40,11 @@ public class SnapServerTest
         IDbProvider dbProviderClient = new DbProvider();
         var stateDbClient = new MemDb();
         dbProviderClient.RegisterDb(DbNames.State, stateDbClient);
-        ProgressTracker progressTracker = new(null!, dbProviderClient.StateDb, LimboLogs.Instance);
+        using ProgressTracker progressTracker = new(null!, dbProviderClient.StateDb, LimboLogs.Instance);
 
         SnapProvider snapProvider = new(progressTracker, dbProviderClient, LimboLogs.Instance);
 
-        return new Context()
+        return new Context
         {
             Server = server,
             SnapProvider = snapProvider,
@@ -67,6 +67,8 @@ public class SnapServerTest
 
         result.Should().Be(AddRangeResult.OK);
         context.ClientStateDb.Keys.Count.Should().Be(10);
+        accounts.Dispose();
+        proofs.Dispose();
     }
 
     [Test]
@@ -74,16 +76,21 @@ public class SnapServerTest
     {
         Context context = CreateContext(stateRootTracker: CreateConstantStateRootTracker(false));
 
-        (IOwnedReadOnlyList<PathWithAccount> accounts, IOwnedReadOnlyList<byte[]> _) =
+        (IOwnedReadOnlyList<PathWithAccount> accounts, IOwnedReadOnlyList<byte[]> accountProofs) =
             context.Server.GetAccountRanges(context.Tree.RootHash, Keccak.Zero, Keccak.MaxValue, 4000, CancellationToken.None);
 
         accounts.Count.Should().Be(0);
 
-        (IOwnedReadOnlyList<IOwnedReadOnlyList<PathWithStorageSlot>> storageSlots, IOwnedReadOnlyList<byte[]>? proofs) =
+        (IOwnedReadOnlyList<IOwnedReadOnlyList<PathWithStorageSlot>> storageSlots, IOwnedReadOnlyList<byte[]> proofs) =
             context.Server.GetStorageRanges(context.Tree.RootHash, new PathWithAccount[] { TestItem.Tree.AccountsWithPaths[0] },
                 Keccak.Zero, Keccak.MaxValue, 10, CancellationToken.None);
 
         storageSlots.Count.Should().Be(0);
+
+        accounts.Dispose();
+        accountProofs.Dispose();
+        proofs.Dispose();
+        storageSlots.DisposeRecursive();
     }
 
     [Test]
@@ -98,14 +105,22 @@ public class SnapServerTest
             (IOwnedReadOnlyList<PathWithAccount> accounts, IOwnedReadOnlyList<byte[]> proofs) =
                 context.Server.GetAccountRanges(context.Tree.RootHash, startRange, Keccak.MaxValue, 100, CancellationToken.None);
 
-            AddRangeResult result = context.SnapProvider.AddAccountRange(1, context.Tree.RootHash, startRange,
-                accounts, proofs);
-
-            result.Should().Be(AddRangeResult.OK);
-            startRange = accounts[^1].Path.ToCommitment();
-            if (startRange.Bytes.SequenceEqual(TestItem.Tree.AccountsWithPaths[^1].Path.Bytes))
+            try
             {
-                break;
+                AddRangeResult result = context.SnapProvider.AddAccountRange(1, context.Tree.RootHash, startRange,
+                    accounts, proofs);
+
+                result.Should().Be(AddRangeResult.OK);
+                startRange = accounts[^1].Path.ToCommitment();
+                if (startRange.Bytes.SequenceEqual(TestItem.Tree.AccountsWithPaths[^1].Path.Bytes))
+                {
+                    break;
+                }
+            }
+            finally
+            {
+                accounts.Dispose();
+                proofs.Dispose();
             }
         }
         context.ClientStateDb.Keys.Count.Should().Be(10);
@@ -126,15 +141,24 @@ public class SnapServerTest
             (IOwnedReadOnlyList<PathWithAccount> accounts, IOwnedReadOnlyList<byte[]> proofs) =
                 context.Server.GetAccountRanges(context.Tree.RootHash, startRange, Keccak.MaxValue, byteLimit, CancellationToken.None);
 
-            AddRangeResult result = context.SnapProvider.AddAccountRange(1, context.Tree.RootHash, startRange,
-                accounts, proofs);
-
-            result.Should().Be(AddRangeResult.OK);
-            if (startRange == accounts[^1].Path.ToCommitment())
+            try
             {
-                break;
+                AddRangeResult result = context.SnapProvider.AddAccountRange(1, context.Tree.RootHash, startRange,
+                    accounts, proofs);
+
+                result.Should().Be(AddRangeResult.OK);
+                if (startRange == accounts[^1].Path.ToCommitment())
+                {
+                    break;
+                }
+
+                startRange = accounts[^1].Path.ToCommitment();
             }
-            startRange = accounts[^1].Path.ToCommitment();
+            finally
+            {
+                accounts.Dispose();
+                proofs.Dispose();
+            }
         }
     }
 
@@ -154,15 +178,24 @@ public class SnapServerTest
             (IOwnedReadOnlyList<PathWithAccount> accounts, IOwnedReadOnlyList<byte[]> proofs) = context.Server
                 .GetAccountRanges(context.Tree.RootHash, startRange, limit, byteLimit, CancellationToken.None);
 
-            AddRangeResult result = context.SnapProvider.AddAccountRange(1, context.Tree.RootHash, startRange,
-                accounts, proofs);
-
-            result.Should().Be(AddRangeResult.OK);
-            if (startRange == accounts[^1].Path.ToCommitment())
+            try
             {
-                break;
+                AddRangeResult result = context.SnapProvider.AddAccountRange(1, context.Tree.RootHash, startRange,
+                    accounts, proofs);
+
+                result.Should().Be(AddRangeResult.OK);
+                if (startRange == accounts[^1].Path.ToCommitment())
+                {
+                    break;
+                }
+
+                startRange = accounts[^1].Path.ToCommitment();
             }
-            startRange = accounts[^1].Path.ToCommitment();
+            finally
+            {
+                accounts.Dispose();
+                proofs.Dispose();
+            }
         }
     }
 
@@ -173,7 +206,7 @@ public class SnapServerTest
         MemDb codeDb = new MemDb();
         TrieStore store = new(stateDb, LimboLogs.Instance);
 
-        (StateTree InputStateTree, StorageTree InputStorageTree, Hash256 account) = TestItem.Tree.GetTrees(store);
+        (StateTree inputStateTree, StorageTree inputStorageTree, Hash256 _) = TestItem.Tree.GetTrees(store);
 
         SnapServer server = new(store.AsReadOnly(), codeDb, CreateConstantStateRootTracker(true), LimboLogs.Instance);
 
@@ -181,17 +214,25 @@ public class SnapServerTest
         dbProviderClient.RegisterDb(DbNames.State, new MemDb());
         dbProviderClient.RegisterDb(DbNames.Code, new MemDb());
 
-        ProgressTracker progressTracker = new(null!, dbProviderClient.StateDb, LimboLogs.Instance);
+        using ProgressTracker progressTracker = new(null!, dbProviderClient.StateDb, LimboLogs.Instance);
         SnapProvider snapProvider = new(progressTracker, dbProviderClient, LimboLogs.Instance);
 
-        (IOwnedReadOnlyList<IOwnedReadOnlyList<PathWithStorageSlot>> storageSlots, IOwnedReadOnlyList<byte[]>? proofs) =
-            server.GetStorageRanges(InputStateTree.RootHash, new PathWithAccount[] { TestItem.Tree.AccountsWithPaths[0] },
+        (IOwnedReadOnlyList<IOwnedReadOnlyList<PathWithStorageSlot>> storageSlots, IOwnedReadOnlyList<byte[]> proofs) =
+            server.GetStorageRanges(inputStateTree.RootHash, new[] { TestItem.Tree.AccountsWithPaths[0] },
                 Keccak.Zero, Keccak.MaxValue, 10, CancellationToken.None);
 
-        AddRangeResult result = snapProvider.AddStorageRange(1, TestItem.Tree.AccountsWithPaths[0], InputStorageTree.RootHash, Keccak.Zero,
-            storageSlots[0], proofs);
+        try
+        {
+            AddRangeResult result = snapProvider.AddStorageRange(1, TestItem.Tree.AccountsWithPaths[0], inputStorageTree.RootHash, Keccak.Zero,
+                storageSlots[0], proofs);
 
-        result.Should().Be(AddRangeResult.OK);
+            result.Should().Be(AddRangeResult.OK);
+        }
+        finally
+        {
+            storageSlots.DisposeRecursive();
+            proofs.Dispose();
+        }
     }
 
     [Test]
@@ -201,7 +242,7 @@ public class SnapServerTest
         MemDb codeDb = new MemDb();
         TrieStore store = new(stateDb, LimboLogs.Instance);
 
-        (StateTree InputStateTree, StorageTree InputStorageTree, Hash256 account) = TestItem.Tree.GetTrees(store, 10000);
+        (StateTree inputStateTree, StorageTree inputStorageTree, Hash256 _) = TestItem.Tree.GetTrees(store, 10000);
 
         SnapServer server = new(store.AsReadOnly(), codeDb, CreateConstantStateRootTracker(true), LimboLogs.Instance);
 
@@ -209,25 +250,34 @@ public class SnapServerTest
         dbProviderClient.RegisterDb(DbNames.State, new MemDb());
         dbProviderClient.RegisterDb(DbNames.Code, new MemDb());
 
-        ProgressTracker progressTracker = new(null!, dbProviderClient.StateDb, LimboLogs.Instance);
+        using ProgressTracker progressTracker = new(null!, dbProviderClient.StateDb, LimboLogs.Instance);
         SnapProvider snapProvider = new(progressTracker, dbProviderClient, LimboLogs.Instance);
 
         Hash256 startRange = Keccak.Zero;
         while (true)
         {
-            (IOwnedReadOnlyList<IOwnedReadOnlyList<PathWithStorageSlot>> storageSlots, IOwnedReadOnlyList<byte[]>? proofs) =
-                server.GetStorageRanges(InputStateTree.RootHash, new PathWithAccount[] { TestItem.Tree.AccountsWithPaths[0] },
+            (IOwnedReadOnlyList<IOwnedReadOnlyList<PathWithStorageSlot>> storageSlots, IOwnedReadOnlyList<byte[]> proofs) =
+                server.GetStorageRanges(inputStateTree.RootHash, new PathWithAccount[] { TestItem.Tree.AccountsWithPaths[0] },
                     startRange, Keccak.MaxValue, 10000, CancellationToken.None);
 
-            AddRangeResult result = snapProvider.AddStorageRange(1, TestItem.Tree.AccountsWithPaths[0], InputStorageTree.RootHash, startRange,
-                storageSlots[0], proofs);
-
-            result.Should().Be(AddRangeResult.OK);
-            if (startRange == storageSlots[0][^1].Path.ToCommitment())
+            try
             {
-                break;
+                AddRangeResult result = snapProvider.AddStorageRange(1, TestItem.Tree.AccountsWithPaths[0], inputStorageTree.RootHash, startRange,
+                    storageSlots[0], proofs);
+
+                result.Should().Be(AddRangeResult.OK);
+                if (startRange == storageSlots[0][^1].Path.ToCommitment())
+                {
+                    break;
+                }
+
+                startRange = storageSlots[0][^1].Path.ToCommitment();
             }
-            startRange = storageSlots[0][^1].Path.ToCommitment();
+            finally
+            {
+                storageSlots.DisposeRecursive();
+                proofs.Dispose();
+            }
         }
     }
 
@@ -265,65 +315,83 @@ public class SnapServerTest
 
         SnapServer server = new(store.AsReadOnly(), codeDb, CreateConstantStateRootTracker(true), LimboLogs.Instance);
 
-        IOwnedReadOnlyList<PathWithAccount> accounts;
         // size of one PathWithAccount ranges from 39 -> 72
-        (accounts, _) =
-            server.GetAccountRanges(stateTree.RootHash, Keccak.Zero, Keccak.MaxValue, 10, CancellationToken.None);
+        (IOwnedReadOnlyList<PathWithAccount> accounts, IOwnedReadOnlyList<byte[]> accountProofs)
+            = server.GetAccountRanges(stateTree.RootHash, Keccak.Zero, Keccak.MaxValue, 10, CancellationToken.None);
         accounts.Count.Should().Be(1);
+        accounts.Dispose();
+        accountProofs.Dispose();
 
-        (accounts, _) =
+        (accounts, accountProofs) =
             server.GetAccountRanges(stateTree.RootHash, Keccak.Zero, Keccak.MaxValue, 100, CancellationToken.None);
         accounts.Count.Should().BeGreaterThan(2);
+        accounts.Dispose();
+        accountProofs.Dispose();
 
-        (accounts, _) =
+        (accounts, accountProofs) =
             server.GetAccountRanges(stateTree.RootHash, Keccak.Zero, Keccak.MaxValue, 10000, CancellationToken.None);
         accounts.Count.Should().BeGreaterThan(138);
+        accounts.Dispose();
+        accountProofs.Dispose();
 
         // TODO: Double check the threshold
-        (accounts, _) =
+        (accounts, accountProofs) =
             server.GetAccountRanges(stateTree.RootHash, Keccak.Zero, Keccak.MaxValue, 720000, CancellationToken.None);
         accounts.Count.Should().Be(10009);
-        (accounts, _) =
+
+        accounts.Dispose();
+        accountProofs.Dispose();
+
+        (accounts, accountProofs) =
             server.GetAccountRanges(stateTree.RootHash, Keccak.Zero, Keccak.MaxValue, 10000000, CancellationToken.None);
         accounts.Count.Should().Be(10009);
-
+        accounts.Dispose();
+        accountProofs.Dispose();
 
         var accountWithStorageArray = accountWithStorage.ToArray();
         IOwnedReadOnlyList<IOwnedReadOnlyList<PathWithStorageSlot>> slots;
-        IOwnedReadOnlyList<byte[]>? proofs;
+        IOwnedReadOnlyList<byte[]> proofs;
 
-        (slots, proofs) =
-            server.GetStorageRanges(stateTree.RootHash, accountWithStorageArray[..1], Keccak.Zero, Keccak.MaxValue, 10, CancellationToken.None);
+        (slots, proofs) = server.GetStorageRanges(stateTree.RootHash, accountWithStorageArray[..1], Keccak.Zero, Keccak.MaxValue, 10, CancellationToken.None);
         slots.Count.Should().Be(1);
         slots[0].Count.Should().Be(1);
         proofs.Should().NotBeNull();
 
-        (slots, proofs) =
-            server.GetStorageRanges(stateTree.RootHash, accountWithStorageArray[..1], Keccak.Zero, Keccak.MaxValue, 1000000, CancellationToken.None);
+        slots.DisposeRecursive();
+        proofs.Dispose();
+
+        (slots, proofs) = server.GetStorageRanges(stateTree.RootHash, accountWithStorageArray[..1], Keccak.Zero, Keccak.MaxValue, 1000000, CancellationToken.None);
         slots.Count.Should().Be(1);
         slots[0].Count.Should().Be(1000);
         proofs.Should().BeEmpty();
 
-        (slots, proofs) =
-            server.GetStorageRanges(stateTree.RootHash, accountWithStorageArray[..2], Keccak.Zero, Keccak.MaxValue, 10, CancellationToken.None);
+        slots.DisposeRecursive();
+        proofs.Dispose();
+
+        (slots, proofs) = server.GetStorageRanges(stateTree.RootHash, accountWithStorageArray[..2], Keccak.Zero, Keccak.MaxValue, 10, CancellationToken.None);
         slots.Count.Should().Be(1);
         slots[0].Count.Should().Be(1);
         proofs.Should().NotBeNull();
+        slots.DisposeRecursive();
+        proofs.Dispose();
 
-        (slots, proofs) =
-            server.GetStorageRanges(stateTree.RootHash, accountWithStorageArray[..2], Keccak.Zero, Keccak.MaxValue, 100000, CancellationToken.None);
+        (slots, proofs) = server.GetStorageRanges(stateTree.RootHash, accountWithStorageArray[..2], Keccak.Zero, Keccak.MaxValue, 100000, CancellationToken.None);
         slots.Count.Should().Be(2);
         slots[0].Count.Should().Be(1000);
         slots[1].Count.Should().Be(539);
         proofs.Should().NotBeNull();
+        slots.DisposeRecursive();
+        proofs.Dispose();
 
 
         // incomplete tree will be returned as the hard limit is 2000000
-        (slots, proofs) =
-            server.GetStorageRanges(stateTree.RootHash, accountWithStorageArray, Keccak.Zero, Keccak.MaxValue, 3000000, CancellationToken.None);
+        (slots, proofs) = server.GetStorageRanges(stateTree.RootHash, accountWithStorageArray, Keccak.Zero, Keccak.MaxValue, 3000000, CancellationToken.None);
         slots.Count.Should().Be(8);
         slots[^1].Count.Should().BeLessThan(8000);
         proofs.Should().NotBeEmpty();
+
+        slots.DisposeRecursive();
+        proofs.Dispose();
     }
 
     private ILastNStateRootTracker CreateConstantStateRootTracker(bool available)

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/AccountCollector.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/AccountCollector.cs
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+using Nethermind.Core.Buffers;
+using Nethermind.Core.Collections;
+using Nethermind.Core.Crypto;
+using Nethermind.Serialization.Rlp;
+using Nethermind.State.Snap;
+using Nethermind.Trie;
+
+namespace Nethermind.Synchronization.SnapSync;
+
+public class AccountCollector : RangeQueryVisitor.ILeafValueCollector
+{
+    public ArrayPoolList<PathWithAccount> Accounts { get; } = new(0);
+
+    public int Collect(in ValueHash256 path, CappedArray<byte> value)
+    {
+        if (value.IsNull)
+        {
+            Accounts.Add(new PathWithAccount(path, null));
+            return 32 + 1;
+        }
+
+        Account accnt = AccountDecoder.Instance.Decode(new RlpStream(value));
+        Accounts.Add(new PathWithAccount(path, accnt));
+        return 32 + AccountDecoder.Slim.GetLength(accnt);
+    }
+}
+

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/ISnapServer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/ISnapServer.cs
@@ -35,7 +35,7 @@ public interface ISnapServer
         long byteLimit,
         CancellationToken cancellationToken);
 
-    (IOwnedReadOnlyList<PathWithStorageSlot[]>, IOwnedReadOnlyList<byte[]>?) GetStorageRanges(
+    (IOwnedReadOnlyList<IOwnedReadOnlyList<PathWithStorageSlot>>, IOwnedReadOnlyList<byte[]>?) GetStorageRanges(
         in ValueHash256 rootHash,
         IReadOnlyList<PathWithAccount> accounts,
         in ValueHash256? startingHash,

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/PathWithStorageCollector.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/PathWithStorageCollector.cs
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+using Nethermind.Core.Buffers;
+using Nethermind.Core.Collections;
+using Nethermind.Core.Crypto;
+using Nethermind.State.Snap;
+using Nethermind.Trie;
+
+namespace Nethermind.Synchronization.SnapSync;
+
+public class PathWithStorageCollector : RangeQueryVisitor.ILeafValueCollector
+{
+    public ArrayPoolList<PathWithStorageSlot> Slots { get; } = new(0);
+
+    public int Collect(in ValueHash256 path, CappedArray<byte> value)
+    {
+        Slots.Add(new PathWithStorageSlot(path, value.ToArray()));
+        return 32 + value.Length;
+    }
+}

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
@@ -18,7 +18,7 @@ using Nethermind.State.Snap;
 
 namespace Nethermind.Synchronization.SnapSync
 {
-    public class ProgressTracker
+    public class ProgressTracker : IDisposable
     {
         private const string NO_REQUEST = "Skipped Request";
 
@@ -452,6 +452,14 @@ namespace Nethermind.Synchronization.SnapSync
             public ValueHash256 AccountPathStart { get; set; } = ValueKeccak.Zero; // Not really needed, but useful
             public ValueHash256 AccountPathLimit { get; set; } = ValueKeccak.MaxValue;
             public bool MoreAccountsToRight { get; set; } = true;
+        }
+
+        public void Dispose()
+        {
+            while (NextSlotRange.TryDequeue(out StorageRange? range))
+            {
+                range?.Dispose();
+            }
         }
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProvider.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProvider.cs
@@ -112,7 +112,7 @@ namespace Nethermind.Synchronization.SnapSync
         {
             AddRangeResult result = AddRangeResult.OK;
 
-            IReadOnlyList<PathWithStorageSlot[]> responses = response.PathsAndSlots;
+            IReadOnlyList<IOwnedReadOnlyList<PathWithStorageSlot>> responses = response.PathsAndSlots;
             if (responses.Count == 0 && response.Proofs.Count == 0)
             {
                 _logger.Trace($"SNAP - GetStorageRange - expired BlockNumber:{request.BlockNumber}, RootHash:{request.RootHash}, (Accounts:{request.Accounts.Count}), {request.StartingHash}");
@@ -139,7 +139,7 @@ namespace Nethermind.Synchronization.SnapSync
                     PathWithAccount account = request.Accounts[i];
                     result = AddStorageRange(request.BlockNumber.Value, account, account.Account.StorageRoot, request.StartingHash, responses[i], proofs);
 
-                    slotCount += responses[i].Length;
+                    slotCount += responses[i].Count;
                 }
 
                 if (requestLength > responses.Count)

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapServer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapServer.cs
@@ -249,7 +249,7 @@ public class SnapServer : ISnapServer
         return (responseNodes, ArrayPoolList<byte[]>.Empty());
     }
 
-    private (long, IOwnedReadOnlyList<byte[]>, bool) GetNodesFromTrieVisitor(
+    private (long bytesSize, IOwnedReadOnlyList<byte[]> proofs, bool stoppedEarly) GetNodesFromTrieVisitor(
         in ValueHash256 rootHash,
         in ValueHash256 startingHash,
         in ValueHash256 limitHash,

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapServer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapServer.cs
@@ -170,7 +170,7 @@ public class SnapServer : ISnapServer
         byteLimit = Math.Max(Math.Min(byteLimit, HardResponseByteLimit), 1);
 
         AccountCollector accounts = new AccountCollector();
-        (long _, IOwnedReadOnlyList<byte[]>? proofs, bool stoppedEarly) = GetNodesFromTrieVisitor(
+        (long _, IOwnedReadOnlyList<byte[]> proofs, _) = GetNodesFromTrieVisitor(
             rootHash,
             startingHash,
             limitHash?.ToCommitment() ?? Keccak.MaxValue,
@@ -181,11 +181,10 @@ public class SnapServer : ISnapServer
             cancellationToken);
 
         ArrayPoolList<PathWithAccount> nodes = accounts.Accounts;
-
-        return nodes.Count == 0 ? (nodes, ArrayPoolList<byte[]>.Empty()) : (nodes, proofs);
+        return (nodes, proofs);
     }
 
-    public (IOwnedReadOnlyList<IOwnedReadOnlyList<PathWithStorageSlot>>, IOwnedReadOnlyList<byte[]>?) GetStorageRanges(in ValueHash256 rootHash, IReadOnlyList<PathWithAccount> accounts, in ValueHash256? startingHash, in ValueHash256? limitHash, long byteLimit, CancellationToken cancellationToken)
+    public (IOwnedReadOnlyList<IOwnedReadOnlyList<PathWithStorageSlot>>, IOwnedReadOnlyList<byte[]>) GetStorageRanges(in ValueHash256 rootHash, IReadOnlyList<PathWithAccount> accounts, in ValueHash256? startingHash, in ValueHash256? limitHash, long byteLimit, CancellationToken cancellationToken)
     {
         if (IsRootMissing(rootHash)) return (ArrayPoolList<IOwnedReadOnlyList<PathWithStorageSlot>>.Empty(), ArrayPoolList<byte[]>.Empty());
         byteLimit = Math.Max(Math.Min(byteLimit, HardResponseByteLimit), 1);
@@ -222,7 +221,7 @@ public class SnapServer : ISnapServer
             Hash256? storagePath = accounts[i].Path.ToCommitment();
 
             PathWithStorageCollector pathWithStorageCollector = new PathWithStorageCollector();
-            (long innerResponseSize, IOwnedReadOnlyList<byte[]>? proofs, bool stoppedEarly) = GetNodesFromTrieVisitor(
+            (long innerResponseSize, IOwnedReadOnlyList<byte[]> proofs, bool stoppedEarly) = GetNodesFromTrieVisitor(
                 rootHash,
                 startingHash1,
                 limitHash1,
@@ -242,6 +241,8 @@ public class SnapServer : ISnapServer
             {
                 return (responseNodes, proofs);
             }
+
+            proofs.Dispose();
             responseSize += innerResponseSize;
         }
 

--- a/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
@@ -19,14 +19,14 @@ using Nethermind.Stats;
 using Nethermind.Stats.Model;
 using Nethermind.Synchronization.Blocks;
 using Nethermind.Synchronization.DbTuner;
-using Nethermind.Synchronization.FastBlocks;
+using Nethermind.Synchronization.FastBlocks
+    ;
 using Nethermind.Synchronization.FastSync;
 using Nethermind.Synchronization.ParallelSync;
 using Nethermind.Synchronization.Peers;
 using Nethermind.Synchronization.Reporting;
 using Nethermind.Synchronization.SnapSync;
 using Nethermind.Synchronization.StateSync;
-using Nethermind.Trie.Pruning;
 
 namespace Nethermind.Synchronization
 {
@@ -90,6 +90,7 @@ namespace Nethermind.Synchronization
 
         protected ISyncModeSelector? _syncModeSelector;
         private readonly IStateReader _stateReader;
+        private readonly ProgressTracker _progressTracker;
 
         public virtual ISyncModeSelector SyncModeSelector => _syncModeSelector ??= new MultiSyncModeSelector(
             SyncProgressResolver,
@@ -134,12 +135,12 @@ namespace Nethermind.Synchronization
 
             _syncReport = new SyncReport(_syncPeerPool!, nodeStatsManager!, _syncConfig, _pivot, logManager);
 
-            ProgressTracker progressTracker = new(
+            _progressTracker = new(
                 blockTree,
                 dbProvider.StateDb,
                 logManager,
                 _syncConfig.SnapSyncAccountRangePartitionCount);
-            SnapProvider = new SnapProvider(progressTracker, dbProvider, logManager);
+            SnapProvider = new SnapProvider(_progressTracker, dbProvider, logManager);
         }
 
         public virtual void Start()
@@ -460,6 +461,7 @@ namespace Nethermind.Synchronization
             HeadersSyncFeed?.Dispose();
             BodiesSyncFeed?.Dispose();
             ReceiptsSyncFeed?.Dispose();
+            _progressTracker.Dispose();
         }
     }
 }

--- a/src/Nethermind/Nethermind.Trie/RangeQueryVisitor.cs
+++ b/src/Nethermind/Nethermind.Trie/RangeQueryVisitor.cs
@@ -17,7 +17,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Buffers;
@@ -34,11 +33,10 @@ public class RangeQueryVisitor : ITreeVisitor<TreePathContext>, IDisposable
     private TreePath _startHash;
     private readonly ValueHash256 _limitHash;
 
-    private readonly bool _isAccountVisitor;
-
     private long _currentBytesCount;
+    private long _currentLeafCount;
     private bool _lastNodeFound = false;
-    private readonly Dictionary<ValueHash256, byte[]> _collectedNodes = new();
+    private readonly ILeafValueCollector _valueCollector;
 
     // For determining proofs
     private (TreePath, TrieNode)?[] _leftmostNodes = new (TreePath, TrieNode)?[65];
@@ -51,8 +49,6 @@ public class RangeQueryVisitor : ITreeVisitor<TreePathContext>, IDisposable
 
     public bool StoppedEarly { get; set; } = false;
     public bool IsFullDbScan => false;
-    private readonly AccountDecoder _standardDecoder = new AccountDecoder();
-    private readonly AccountDecoder _slimDecoder = new AccountDecoder(slimFormat: true);
     private readonly CancellationToken _cancellationToken;
 
     public ReadFlags ExtraReadFlag { get; }
@@ -60,7 +56,7 @@ public class RangeQueryVisitor : ITreeVisitor<TreePathContext>, IDisposable
     public RangeQueryVisitor(
         in ValueHash256 startHash,
         in ValueHash256 limitHash,
-        bool isAccountVisitor,
+        ILeafValueCollector valueCollector,
         long byteLimit = 200000,
         int nodeLimit = 10000,
         ReadFlags readFlags = ReadFlags.None,
@@ -73,7 +69,7 @@ public class RangeQueryVisitor : ITreeVisitor<TreePathContext>, IDisposable
             _startHash = new TreePath(startHash, 64);
 
         _cancellationToken = cancellationToken;
-        _isAccountVisitor = isAccountVisitor;
+        _valueCollector = valueCollector;
         _nodeLimit = nodeLimit;
         _byteLimit = byteLimit;
         ExtraReadFlag = readFlags;
@@ -93,7 +89,7 @@ public class RangeQueryVisitor : ITreeVisitor<TreePathContext>, IDisposable
             return false;
         }
 
-        if (_collectedNodes.Count >= _nodeLimit)
+        if (_currentLeafCount >= _nodeLimit)
         {
             StoppedEarly = true;
             return false;
@@ -122,9 +118,9 @@ public class RangeQueryVisitor : ITreeVisitor<TreePathContext>, IDisposable
     }
 
 
-    public (Dictionary<ValueHash256, byte[]>, long) GetNodesAndSize()
+    public long GetBytesSize()
     {
-        return (_collectedNodes, _currentBytesCount);
+        return _currentBytesCount;
     }
 
     public ArrayPoolList<byte[]> GetProofs()
@@ -216,21 +212,21 @@ public class RangeQueryVisitor : ITreeVisitor<TreePathContext>, IDisposable
     {
     }
 
-    private byte[]? ConvertFullToSlimAccount(CappedArray<byte> accountRlp)
-    {
-        return accountRlp.IsNull ? null : _slimDecoder.Encode(_standardDecoder.Decode(new RlpStream(accountRlp))).Bytes;
-    }
-
-    private void CollectNode(TreePath path, CappedArray<byte> value)
+    private void CollectNode(in TreePath path, CappedArray<byte> value)
     {
         _rightmostLeafPath = path;
 
-        byte[]? nodeValue = _isAccountVisitor ? ConvertFullToSlimAccount(value) : value.ToArray();
-        _collectedNodes[path.Path] = nodeValue;
-        _currentBytesCount += 32 + nodeValue!.Length;
+        int encodedSize = _valueCollector.Collect(path.Path, value);
+        _currentBytesCount += encodedSize;
+        _currentLeafCount++;
     }
 
     public void Dispose()
     {
+    }
+
+    public interface ILeafValueCollector
+    {
+        int Collect(in ValueHash256 path, CappedArray<byte> value);
     }
 }


### PR DESCRIPTION
- Collect leaf value to an arraypoollist of the desired types for snap server instead of encoding accounts to bytes first.
- Increase snap server throughput by about 10-20%.
- Total throughput right now + some optimization in halfpath is about 450k nodes writes per sec. 

## Types of changes

#### What types of changes does your code introduce?

- [X] Optimization

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- [ ] Full mainnet snap sync from one nethermind to another.
- [X] Hive tests