### PR TITLE
Revise validation errors

### DIFF
--- a/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
@@ -212,7 +212,7 @@ namespace Ethereum.Test.Base
                 {
                     // TODO: mimic the actual behaviour where block goes through validating sync manager?
                     correctRlp[i].Block.Header.IsPostMerge = correctRlp[i].Block.Difficulty == 0;
-                    if (!test.SealEngineUsed || blockValidator.ValidateSuggestedBlock(correctRlp[i].Block))
+                    if (!test.SealEngineUsed || blockValidator.ValidateSuggestedBlock(correctRlp[i].Block, out _))
                     {
                         blockTree.SuggestBlock(correctRlp[i].Block);
                     }

--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/BlockValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/BlockValidatorTests.cs
@@ -171,7 +171,7 @@ namespace Nethermind.Blockchain.Test.Validators
             Substitute.For<ISpecProvider>(),
             "InvalidUnclesHash");
 
-            yield return new TestCaseData(   
+            yield return new TestCaseData(
             Build.A.Block.WithHeader(Build.A.BlockHeader.WithTransactionsRoot(Keccak.Zero).TestObject).TestObject,
             Substitute.For<ISpecProvider>(),
             "InvalidTxRoot");
@@ -191,9 +191,9 @@ namespace Nethermind.Blockchain.Test.Validators
         }
 
         [TestCaseSource(nameof(BadSuggestedBlocks))]
-        public void ValidateSuggestedBlock_SuggestedBlockIsInvalid_CorrectErrorIsSet(Block suggestedBlock, ISpecProvider specProvider,string expectedError)
+        public void ValidateSuggestedBlock_SuggestedBlockIsInvalid_CorrectErrorIsSet(Block suggestedBlock, ISpecProvider specProvider, string expectedError)
         {
-            TxValidator txValidator = new(TestBlockchainIds.ChainId);            
+            TxValidator txValidator = new(TestBlockchainIds.ChainId);
             BlockValidator sut = new(txValidator, Always.Valid, Always.Valid, specProvider, LimboLogs.Instance);
             string? error;
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/BlockValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/BlockValidatorTests.cs
@@ -1,16 +1,22 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using Nethermind.Consensus.Messages;
 using Nethermind.Consensus.Validators;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Evm;
 using Nethermind.Logging;
 using Nethermind.Specs;
+using Nethermind.Specs.Forks;
 using Nethermind.Specs.Test;
 using NSubstitute;
 using NUnit.Framework;
+using System;
+using System.Collections;
+using System.Collections.Generic;
 
 namespace Nethermind.Blockchain.Test.Validators
 {
@@ -87,6 +93,121 @@ namespace Nethermind.Blockchain.Test.Validators
             Assert.That(
                 BlockValidator.ValidateBodyAgainstHeader(block.Header, block.Body),
                 Is.False);
+        }
+
+        [Test]
+        public void ValidateProcessedBlock_HashesAreTheSame_ReturnsTrue()
+        {
+            TxValidator txValidator = new(TestBlockchainIds.ChainId);
+            ISpecProvider specProvider = Substitute.For<ISpecProvider>();
+            BlockValidator sut = new(txValidator, Always.Valid, Always.Valid, specProvider, LimboLogs.Instance);
+            Block suggestedBlock = Build.A.Block.TestObject;
+            Block processedBlock = Build.A.Block.TestObject;
+
+            Assert.That(sut.ValidateProcessedBlock(
+                suggestedBlock,
+                Array.Empty<TxReceipt>(),
+                processedBlock), Is.True);
+        }
+
+        [Test]
+        public void ValidateProcessedBlock_HashesAreTheSame_ErrorIsNull()
+        {
+            TxValidator txValidator = new(TestBlockchainIds.ChainId);
+            ISpecProvider specProvider = Substitute.For<ISpecProvider>();
+            BlockValidator sut = new(txValidator, Always.Valid, Always.Valid, specProvider, LimboLogs.Instance);
+            Block suggestedBlock = Build.A.Block.TestObject;
+            Block processedBlock = Build.A.Block.TestObject;
+            string? error;
+
+            sut.ValidateProcessedBlock(
+                suggestedBlock,
+                Array.Empty<TxReceipt>(),
+                processedBlock, out error);
+
+            Assert.That(error, Is.Null);
+        }
+
+        [Test]
+        public void ValidateProcessedBlock_StateRootIsWrong_ReturnsFalse()
+        {
+            TxValidator txValidator = new(TestBlockchainIds.ChainId);
+            ISpecProvider specProvider = Substitute.For<ISpecProvider>();
+            BlockValidator sut = new(txValidator, Always.Valid, Always.Valid, specProvider, LimboLogs.Instance);
+            Block suggestedBlock = Build.A.Block.TestObject;
+            Block processedBlock = Build.A.Block.WithStateRoot(Keccak.Zero).TestObject;
+
+            Assert.That(sut.ValidateProcessedBlock(
+                suggestedBlock,
+                Array.Empty<TxReceipt>(),
+                processedBlock), Is.False);
+        }
+
+        [Test]
+        public void ValidateProcessedBlock_StateRootIsWrong_ErrorIsSet()
+        {
+            TxValidator txValidator = new(TestBlockchainIds.ChainId);
+            ISpecProvider specProvider = Substitute.For<ISpecProvider>();
+            BlockValidator sut = new(txValidator, Always.Valid, Always.Valid, specProvider, LimboLogs.Instance);
+            Block suggestedBlock = Build.A.Block.TestObject;
+            Block processedBlock = Build.A.Block.WithStateRoot(Keccak.Zero).TestObject;
+            string? error;
+
+            sut.ValidateProcessedBlock(
+                suggestedBlock,
+                Array.Empty<TxReceipt>(),
+                processedBlock, out error);
+
+            Assert.That(error, Does.StartWith("InvalidStateRoot"));
+        }
+
+        [Test]
+        public void ValidateSuggestedBlock_UncleHashIsWrong_ErrorIsSet()
+        {
+            TxValidator txValidator = new(TestBlockchainIds.ChainId);
+            ISpecProvider specProvider = Substitute.For<ISpecProvider>();
+            BlockValidator sut = new(txValidator, Always.Valid, Always.Valid, specProvider, LimboLogs.Instance);
+            Block suggestedBlock = Build.A.Block.WithHeader(Build.A.BlockHeader.WithUnclesHash(Keccak.Zero).TestObject).TestObject;
+            string? error;
+
+            sut.ValidateSuggestedBlock(
+                suggestedBlock, out error);
+
+            Assert.That(error, Does.StartWith("InvalidUnclesHash"));
+        }
+
+        [Test]
+        public void ValidateSuggestedBlock_TxRootHashIsWrong_ErrorIsSet()
+        {
+            TxValidator txValidator = new(TestBlockchainIds.ChainId);
+            ISpecProvider specProvider = Substitute.For<ISpecProvider>();
+            BlockValidator sut = new(txValidator, Always.Valid, Always.Valid, specProvider, LimboLogs.Instance);
+            Block suggestedBlock = Build.A.Block.WithHeader(Build.A.BlockHeader.WithTransactionsRoot(Keccak.Zero).TestObject).TestObject;
+            string? error;
+
+            sut.ValidateSuggestedBlock(
+                suggestedBlock, out error);
+
+            Assert.That(error, Does.StartWith("InvalidTxRoot"));
+        }
+
+        [Test]
+        public void ValidateSuggestedBlock_MaxFeePerBlobGasIsTooLow_ErrorIsSet()
+        {
+            TxValidator txValidator = new(TestBlockchainIds.ChainId);
+            ISpecProvider specProvider = new CustomSpecProvider(((ForkActivation)0, Cancun.Instance));
+            BlockValidator sut = new(txValidator, Always.Valid, Always.Valid, specProvider, LimboLogs.Instance);
+            Block suggestedBlock = Build.A.Block.WithBlobGasUsed(131072).WithExcessBlobGas(1).WithTransactions(Build.A.Transaction.WithShardBlobTxTypeAndFields(1)
+                                                                                     .WithMaxFeePerBlobGas(0)
+                                                                                     .WithMaxFeePerGas(1000000)
+                                                                                     .Signed()
+                                                                                     .TestObject).TestObject;
+            string? error;
+
+            sut.ValidateSuggestedBlock(
+                suggestedBlock, out error);
+
+            Assert.That(error, Does.StartWith("InsufficientMaxFeePerBlobGas"));
         }
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/HeaderValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/HeaderValidatorTests.cs
@@ -17,6 +17,7 @@ using Nethermind.Logging;
 using Nethermind.Specs;
 using Nethermind.Specs.Forks;
 using Nethermind.Specs.Test;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Nethermind.Blockchain.Test.Validators
@@ -318,6 +319,17 @@ namespace Nethermind.Blockchain.Test.Validators
 
             bool result = _validator.Validate(_block.Header);
             Assert.False(result);
+        }
+
+        [Test]
+        public void Validate_HashIsWrong_ErrorMessageIsSet()
+        {
+            HeaderValidator sut = new HeaderValidator(_blockTree, Always.Valid, Substitute.For<ISpecProvider>(), new OneLoggerLogManager(new(_testLogger)));
+            _block.Header.Hash = Keccak.Zero;
+            string? error;
+            sut.Validate(_block.Header, false, out error);
+
+            Assert.That(error, Does.StartWith("InvalidHeaderHash"));
         }
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/TestBlockValidator.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/TestBlockValidator.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Nethermind.Consensus.Validators;
 using Nethermind.Core;
 
@@ -34,8 +35,20 @@ public class TestBlockValidator : IBlockValidator
         return _alwaysSameResultForSuggested ?? _suggestedValidationResults.Dequeue();
     }
 
+    public bool Validate(BlockHeader header, BlockHeader? parent, bool isUncle, [NotNullWhen(false)] out string? error)
+    {
+        var result = _alwaysSameResultForSuggested ?? _suggestedValidationResults.Dequeue();
+        error = result ? null : "";
+        return result;
+    }
+
     public bool Validate(BlockHeader header, bool isUncle)
     {
+        return _alwaysSameResultForSuggested ?? _suggestedValidationResults.Dequeue();
+    }
+    public bool Validate(BlockHeader header, bool isUncle, [NotNullWhen(false)] out string? error)
+    {
+        error = null;
         return _alwaysSameResultForSuggested ?? _suggestedValidationResults.Dequeue();
     }
 
@@ -43,9 +56,18 @@ public class TestBlockValidator : IBlockValidator
     {
         return _alwaysSameResultForSuggested ?? _suggestedValidationResults.Dequeue();
     }
-
+    public bool ValidateSuggestedBlock(Block block, [NotNullWhen(false)] out string? error)
+    {
+        error = null;
+        return _alwaysSameResultForSuggested ?? _suggestedValidationResults.Dequeue();
+    }
     public bool ValidateProcessedBlock(Block processedBlock, TxReceipt[] receipts, Block suggestedBlock)
     {
+        return _alwaysSameResultForProcessed ?? _processedValidationResults.Dequeue();
+    }
+    public bool ValidateProcessedBlock(Block processedBlock, TxReceipt[] receipts, Block suggestedBlock, [NotNullWhen(false)] out string? error)
+    {
+        error = null;
         return _alwaysSameResultForProcessed ?? _processedValidationResults.Dequeue();
     }
 
@@ -56,9 +78,11 @@ public class TestBlockValidator : IBlockValidator
         return _alwaysSameResultForSuggested ?? _suggestedValidationResults.Dequeue();
     }
 
-    public bool ValidateOrphanedBlock(Block block, out string? error)
+    public bool ValidateOrphanedBlock(Block block, [NotNullWhen(false)] out string? error)
     {
         error = null;
         return _alwaysSameResultForSuggested ?? _suggestedValidationResults.Dequeue();
     }
+
+
 }

--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/TestTransactionValidator.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/TestTransactionValidator.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
 using Nethermind.TxPool;
@@ -28,6 +29,11 @@ namespace Nethermind.Blockchain.Test.Validators
 
         public bool IsWellFormed(Transaction transaction, IReleaseSpec releaseSpec)
         {
+            return _alwaysSameResult ?? _validationResults.Dequeue();
+        }
+        public bool IsWellFormed(Transaction transaction, IReleaseSpec releaseSpec, [NotNullWhen(false)] out string? errorMessage)
+        {
+            errorMessage = null;
             return _alwaysSameResult ?? _validationResults.Dequeue();
         }
     }

--- a/src/Nethermind/Nethermind.Blockchain/InvalidBlockException.cs
+++ b/src/Nethermind/Nethermind.Blockchain/InvalidBlockException.cs
@@ -9,10 +9,10 @@ namespace Nethermind.Blockchain;
 public class InvalidBlockException : BlockchainException
 {
     public InvalidBlockException(Block block, string message, Exception? innerException = null)
-        : base($"Invalid block: {block} : {message}", innerException) => InvalidBlock = block.Header;
+        : base(message, innerException) => InvalidBlock = block.Header;
 
     public InvalidBlockException(BlockHeader block, string message, Exception? innerException = null)
-        : base($"Invalid block: {block} : {message}", innerException) => InvalidBlock = block;
+        : base(message, innerException) => InvalidBlock = block;
 
     public BlockHeader InvalidBlock { get; }
 }

--- a/src/Nethermind/Nethermind.Consensus.AuRa/AuRaHeaderValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/AuRaHeaderValidator.cs
@@ -27,7 +27,7 @@ namespace Nethermind.Consensus.AuRa
             _blockGasLimitContractTransitions = blockGasLimitContractTransitions ?? throw new ArgumentNullException(nameof(blockGasLimitContractTransitions));
         }
 
-        protected override bool ValidateGasLimitRange(BlockHeader header, BlockHeader parent, IReleaseSpec spec) =>
-            _blockGasLimitContractTransitions.TryGetForBlock(header.Number, out _) || base.ValidateGasLimitRange(header, parent, spec);
+        protected override bool ValidateGasLimitRange(BlockHeader header, BlockHeader parent, IReleaseSpec spec, ref string error) =>
+            _blockGasLimitContractTransitions.TryGetForBlock(header.Number, out _) || base.ValidateGasLimitRange(header, parent, spec, ref error);
     }
 }

--- a/src/Nethermind/Nethermind.Consensus/Messages/BlockErrorMessages.cs
+++ b/src/Nethermind/Nethermind.Consensus/Messages/BlockErrorMessages.cs
@@ -95,7 +95,7 @@ public static class BlockErrorMessages
         "HeaderGasUsedMismatch: Gas used in header does not match calculated.";
 
     //Block's blob gas used in header is above the limit.
-    public static string BlobGasUsedAboveBlockLimit() =>
+    public static readonly string BlobGasUsedAboveBlockLimit =
         $"BlockBlobGasExceeded: A block cannot have more than {Eip4844Constants.MaxBlobGasPerBlock} blob gas.";
 
     //Block's excess blob gas in header is incorrect.

--- a/src/Nethermind/Nethermind.Consensus/Messages/BlockErrorMessages.cs
+++ b/src/Nethermind/Nethermind.Consensus/Messages/BlockErrorMessages.cs
@@ -107,4 +107,13 @@ public static class BlockErrorMessages
 
     public const string InvalidTimestamp =
         "InvalidTimestamp: Timestamp in header cannot be lower than ancestor.";
+
+    public const string NegativeBlockNumber =
+        "NegativeBlockNumber: Block number cannot be negative.";
+
+    public const string NegativeGasLimit =
+        "NegativeGasLimit: Gas limit cannot be negative.";
+
+    public const string NegativeGasUsed =
+        "NegativeGasUsed: Cannot be negative.";
 }

--- a/src/Nethermind/Nethermind.Consensus/Messages/BlockErrorMessages.cs
+++ b/src/Nethermind/Nethermind.Consensus/Messages/BlockErrorMessages.cs
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+using Nethermind.Crypto;
+
+namespace Nethermind.Consensus.Messages;
+public static class BlockErrorMessages
+{
+    public static string ExceededUncleLimit(int maxUncleCount) =>
+        $"ExceededUncleLimit: Cannot have more than {maxUncleCount}.";
+
+    public const string InsufficientMaxFeePerBlobGas =
+        "InsufficientMaxFeePerBlobGas: Not enough to cover blob gas fee.";
+
+    public const string InvalidLogsBloom =
+        "InvalidLogsBloom: Logs bloom in header does not match.";
+
+    public static string InvalidTxRoot(Core.Crypto.Hash256 expected, Core.Crypto.Hash256 actual) =>
+        $"InvalidTxRoot: Expected {expected}, got {actual}";
+
+    public const string InvalidUncle =
+        "InvalidUncle: Uncle could not be validated.";
+
+    public const string InvalidUnclesHash =
+        "InvalidUnclesHash: Uncle header hash does not match.";
+
+    public static string InvalidWithdrawalsRoot(Core.Crypto.Hash256 expected, Core.Crypto.Hash256 actual) =>
+        $"InvalidWithdrawalsRoot: expected {expected}, got {actual}";
+
+    public const string MissingWithdrawals =
+        "MissingWithdrawals: Block body is missing withdrawals.";
+
+    public const string WithdrawalsNotEnabled =
+        "WithdrawalsNotEnabled: Block body cannot have withdrawals.";
+
+    public const string InvalidReceiptsRoot =
+        "InvalidReceiptsRoot: Receipts root in header does not match.";
+
+    public const string InvalidStateRoot =
+        "InvalidStateRoot: State root in header does not match.";
+
+    public const string InvalidParentBeaconBlockRoot =
+        "InvalidParentBeaconBlockRoot: Beacon block root in header does not match.";
+
+    public const string BlobGasPriceOverflow =
+        "BlobGasPriceOverflow: Overflow in excess blob gas.";
+
+    public const string InvalidHeaderHash =
+        "InvalidHeaderHash: Header hash does not match.";
+
+    public const string InvalidExtraData =
+        "InvalidExtraData: Extra data in header is not valid.";
+
+    public const string InvalidGenesisBlock =
+        "InvalidGenesisBlock: Genesis block could not be validated.";
+
+    public const string InvalidAncestor =
+        "InvalidAncestor: No valid ancestors could be found.";
+
+    public const string InvalidTotalDifficulty =
+        "InvalidTotalDifficulty: Could not be validated.";
+
+    public const string InvalidSealParameters =
+        "InvalidSealParameters: Could not be validated.";
+
+    public const string ExceededGasLimit =
+        "ExceededGasLimit: Gas used exceeds gas limit.";
+
+    public const string InvalidGasLimit =
+        "InvalidGasLimit: Gas limit is not correct.";
+
+    public const string InvalidBlockNumber =
+        "InvalidBlockNumber: Block number does not match the parent.";
+
+    public const string InvalidBaseFeePerGas =
+        "InvalidBaseFeePerGas: Does not match calculated.";
+
+    public const string NotAllowedBlobGasUsed =
+        "NotAllowedBlobGasUsed: Cannot be set.";
+
+    public const string NotAllowedExcessBlobGas =
+        "NotAllowedExcessBlobGas: Cannot be set.";
+
+    public const string MissingBlobGasUsed =
+        "MissingBlobGasUsed: Must be set in header.";
+
+    public const string MissingExcessBlobGas =
+        "MissingExcessBlobGas: Must be set in header.";
+
+    public static string InvalidTxInBlock(int i) =>
+        $"InvalidTxInBlock: Tx at index {i} in body.";
+
+    public const string HeaderGasUsedMismatch =
+        "HeaderGasUsedMismatch: Gas used in header does not match calculated.";
+
+    //Block's blob gas used in header is above the limit.
+    public static string BlobGasUsedAboveBlockLimit() =>
+        $"BlockBlobGasExceeded: A block cannot have more than {Eip4844Constants.MaxBlobGasPerBlock} blob gas.";
+
+    //Block's excess blob gas in header is incorrect.
+    public const string IncorrectExcessBlobGas =
+        "HeaderExcessBlobGasMismatch: Excess blob gas in header does not match calculated.";
+
+    public const string HeaderBlobGasMismatch =
+        "HeaderBlobGasMismatch: Blob gas in header does not match calculated.";
+
+    public const string InvalidTimestamp =
+        "InvalidTimestamp: Timestamp in header cannot be lower than ancestor.";
+}

--- a/src/Nethermind/Nethermind.Consensus/Messages/TxErrorMessages.cs
+++ b/src/Nethermind/Nethermind.Consensus/Messages/TxErrorMessages.cs
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+using Nethermind.Crypto;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Nethermind.Consensus.Messages;
+public static class TxErrorMessages
+{
+    public static string InvalidTxType(string name) =>
+        $"InvalidTxType: Transaction type in {name} is not supported.";
+    public const string IntrinsicGasTooLow =
+        "IntrinsicGasTooLow: Gas limit is too low.";
+
+    public const string InvalidTxSignature =
+        "InvalidTxSignature: Signature is invalid.";
+    public static string InvalidTxChainId(ulong expected, ulong? actual) =>
+        $"InvalidTxChainId: Expected {expected}, got {actual}.";
+
+    public const string InvalidMaxPriorityFeePerGas =
+        "InvalidMaxPriorityFeePerGas: Cannot be higher than maxFeePerGas.";
+
+    public const string ContractSizeTooBig =
+        "ContractSizeTooBig: Max initcode size exceeded.";
+
+    public const string NotAllowedMaxFeePerBlobGas =
+        "NotAllowedMaxFeePerBlobGas: Cannot be set.";
+
+    public const string NotAllowedBlobVersionedHashes =
+        "NotAllowedBlobVersionedHashes: Cannot be set.";
+
+    public const string InvalidTransaction =
+        $"InvalidTransaction: Cannot be {nameof(ShardBlobNetworkWrapper)}.";
+
+    public const string TxMissingTo =
+        "TxMissingTo: Must be set.";
+
+    public const string BlobTxMissingMaxFeePerBlobGas =
+        "BlobTxMissingMaxFeePerBlobGas: Must be set.";
+
+    public const string BlobTxMissingBlobVersionedHashes =
+        "BlobTxMissingBlobVersionedHashes: Must be set.";
+
+    public static string BlobTxGasLimitExceeded =>
+        $"BlobTxGasLimitExceeded: Transaction exceeded {Eip4844Constants.MaxBlobGasPerTransaction}.";
+
+    public const string BlobTxMissingBlobs =
+        "BlobTxMissingBlobs: Blob transaction must have blobs.";
+
+    public const string MissingBlobVersionedHash =
+        "MissingBlobVersionedHash: Must be set.";
+
+    public static string InvalidBlobVersionedHashSize =>
+        $"InvalidBlobVersionedHashSize: Cannot exceed {KzgPolynomialCommitments.BytesPerBlobVersionedHash}.";
+
+    public const string InvalidBlobVersionedHashVersion =
+        "InvalidBlobVersionedHashVersion: Blob version not supported.";
+
+    public static string ExceededBlobSize =>
+        $"ExceededBlobSize: Cannot be more than {Ckzg.Ckzg.BytesPerBlob}.";
+
+    public static string ExceededBlobCommitmentSize =>
+        $"ExceededBlobCommitmentSize: Cannot be more than {Ckzg.Ckzg.BytesPerCommitment}.";
+
+    public static string InvalidBlobProofSize =>
+        $"InvalidBlobProofSize: Cannot be more than {Ckzg.Ckzg.BytesPerProof}.";
+
+    public const string InvalidBlobCommitmentHash =
+        "InvalidBlobCommitmentHash: Commitment hash does not match.";
+
+    public const string InvalidBlobProof =
+        "InvalidBlobProof: Proof does not match.";
+
+    public const string InvalidBlobData
+        = "InvalidTxBlobData: Number of blobs, hashes, commitments and proofs must match.";
+}

--- a/src/Nethermind/Nethermind.Consensus/Messages/TxErrorMessages.cs
+++ b/src/Nethermind/Nethermind.Consensus/Messages/TxErrorMessages.cs
@@ -61,7 +61,7 @@ public static class TxErrorMessages
     public const string InvalidBlobVersionedHashVersion =
         "InvalidBlobVersionedHashVersion: Blob version not supported.";
 
-    public static string ExceededBlobSize =>
+    public static readonly string ExceededBlobSize =
         $"ExceededBlobSize: Cannot be more than {Ckzg.Ckzg.BytesPerBlob}.";
 
     public static readonly string ExceededBlobCommitmentSize =

--- a/src/Nethermind/Nethermind.Consensus/Messages/TxErrorMessages.cs
+++ b/src/Nethermind/Nethermind.Consensus/Messages/TxErrorMessages.cs
@@ -64,7 +64,7 @@ public static class TxErrorMessages
     public static string ExceededBlobSize =>
         $"ExceededBlobSize: Cannot be more than {Ckzg.Ckzg.BytesPerBlob}.";
 
-    public static string ExceededBlobCommitmentSize =>
+    public static readonly string ExceededBlobCommitmentSize =
         $"ExceededBlobCommitmentSize: Cannot be more than {Ckzg.Ckzg.BytesPerCommitment}.";
 
     public static readonly string InvalidBlobProofSize =

--- a/src/Nethermind/Nethermind.Consensus/Messages/TxErrorMessages.cs
+++ b/src/Nethermind/Nethermind.Consensus/Messages/TxErrorMessages.cs
@@ -55,7 +55,7 @@ public static class TxErrorMessages
     public const string MissingBlobVersionedHash =
         "MissingBlobVersionedHash: Must be set.";
 
-    public static string InvalidBlobVersionedHashSize =>
+    public static readonly string InvalidBlobVersionedHashSize =
         $"InvalidBlobVersionedHashSize: Cannot exceed {KzgPolynomialCommitments.BytesPerBlobVersionedHash}.";
 
     public const string InvalidBlobVersionedHashVersion =

--- a/src/Nethermind/Nethermind.Consensus/Messages/TxErrorMessages.cs
+++ b/src/Nethermind/Nethermind.Consensus/Messages/TxErrorMessages.cs
@@ -67,7 +67,7 @@ public static class TxErrorMessages
     public static string ExceededBlobCommitmentSize =>
         $"ExceededBlobCommitmentSize: Cannot be more than {Ckzg.Ckzg.BytesPerCommitment}.";
 
-    public static string InvalidBlobProofSize =>
+    public static readonly string InvalidBlobProofSize =
         $"InvalidBlobProofSize: Cannot be more than {Ckzg.Ckzg.BytesPerProof}.";
 
     public const string InvalidBlobCommitmentHash =

--- a/src/Nethermind/Nethermind.Consensus/Messages/TxErrorMessages.cs
+++ b/src/Nethermind/Nethermind.Consensus/Messages/TxErrorMessages.cs
@@ -46,7 +46,7 @@ public static class TxErrorMessages
     public const string BlobTxMissingBlobVersionedHashes =
         "BlobTxMissingBlobVersionedHashes: Must be set.";
 
-    public static string BlobTxGasLimitExceeded =>
+    public static readonly string BlobTxGasLimitExceeded =
         $"BlobTxGasLimitExceeded: Transaction exceeded {Eip4844Constants.MaxBlobGasPerTransaction}.";
 
     public const string BlobTxMissingBlobs =

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
@@ -213,11 +213,11 @@ public partial class BlockProcessor : IBlockProcessor
     // TODO: block processor pipeline
     private void ValidateProcessedBlock(Block suggestedBlock, ProcessingOptions options, Block block, TxReceipt[] receipts)
     {
-        if (!options.ContainsFlag(ProcessingOptions.NoValidation) && !_blockValidator.ValidateProcessedBlock(block, receipts, suggestedBlock))
+        if (!options.ContainsFlag(ProcessingOptions.NoValidation) && !_blockValidator.ValidateProcessedBlock(block, receipts, suggestedBlock, out string? error))
         {
-            if (_logger.IsWarn) _logger.Warn($"Processed block is not valid {suggestedBlock.ToString(Block.Format.FullHashAndNumber)}");
-            if (_logger.IsWarn) _logger.Warn($"Suggested block TD: {suggestedBlock.TotalDifficulty}, Suggested block IsPostMerge {suggestedBlock.IsPostMerge}, Block TD: {block.TotalDifficulty}, Block IsPostMerge {block.IsPostMerge}");
-            throw new InvalidBlockException(suggestedBlock, "invalid hash after block processing");
+            if (_logger.IsError) _logger.Error($"Processed block is not valid {suggestedBlock.ToString(Block.Format.FullHashAndNumber)}");
+            if (_logger.IsError) _logger.Error($"Suggested block TD: {suggestedBlock.TotalDifficulty}, Suggested block IsPostMerge {suggestedBlock.IsPostMerge}, Block TD: {block.TotalDifficulty}, Block IsPostMerge {block.IsPostMerge}");
+            throw new InvalidBlockException(suggestedBlock, error);
         }
     }
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
@@ -215,8 +215,8 @@ public partial class BlockProcessor : IBlockProcessor
     {
         if (!options.ContainsFlag(ProcessingOptions.NoValidation) && !_blockValidator.ValidateProcessedBlock(block, receipts, suggestedBlock, out string? error))
         {
-            if (_logger.IsError) _logger.Error($"Processed block is not valid {suggestedBlock.ToString(Block.Format.FullHashAndNumber)}");
-            if (_logger.IsError) _logger.Error($"Suggested block TD: {suggestedBlock.TotalDifficulty}, Suggested block IsPostMerge {suggestedBlock.IsPostMerge}, Block TD: {block.TotalDifficulty}, Block IsPostMerge {block.IsPostMerge}");
+            if (_logger.IsWarn) _logger.Warn($"Processed block is not valid {suggestedBlock.ToString(Block.Format.FullHashAndNumber)} - {error}");
+            if (_logger.IsWarn) _logger.Warn($"Suggested block TD: {suggestedBlock.TotalDifficulty}, Suggested block IsPostMerge {suggestedBlock.IsPostMerge}, Block TD: {block.TotalDifficulty}, Block IsPostMerge {block.IsPostMerge}");
             throw new InvalidBlockException(suggestedBlock, error);
         }
     }

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockRemovedEventArgs.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockRemovedEventArgs.cs
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Core.Crypto;
+
+namespace Nethermind.Consensus.Processing;
+
+public class BlockRemovedEventArgs : BlockHashEventArgs
+{
+    public string? Message { get; }
+
+    public BlockRemovedEventArgs(Hash256 blockHash, ProcessingResult processingResult, string? message = null) : base(blockHash, processingResult)
+    {
+        Message = message;
+    }
+
+    public BlockRemovedEventArgs(Hash256 blockHash, ProcessingResult processingResult, Exception exception) : base(blockHash, processingResult, exception)
+    {
+    }
+}

--- a/src/Nethermind/Nethermind.Consensus/Processing/IBlockProcessingQueue.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/IBlockProcessingQueue.cs
@@ -25,7 +25,7 @@ namespace Nethermind.Consensus.Processing
         /// </summary>
         event EventHandler ProcessingQueueEmpty;
 
-        event EventHandler<BlockHashEventArgs> BlockRemoved;
+        event EventHandler<BlockRemovedEventArgs> BlockRemoved;
 
         /// <summary>
         /// Number of blocks in the processing queue.

--- a/src/Nethermind/Nethermind.Consensus/Validators/AlwaysValid.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/AlwaysValid.cs
@@ -39,11 +39,21 @@ public class Always : IBlockValidator, ISealValidator, IUnclesValidator, ITxVali
         return _result;
     }
 
+    public bool Validate(BlockHeader header, BlockHeader? parent, bool isUncle, out string? error)
+    {
+        error = null;
+        return _result;
+    }
+
     public bool Validate(BlockHeader header, bool isUncle = false)
     {
         return _result;
     }
-
+    public bool Validate(BlockHeader header, bool isUncle, out string? error)
+    {
+        error = null;
+        return _result;
+    }
     public bool ValidateSuggestedBlock(Block block)
     {
         return _result;
@@ -73,6 +83,11 @@ public class Always : IBlockValidator, ISealValidator, IUnclesValidator, ITxVali
     {
         return _result;
     }
+    public bool IsWellFormed(Transaction transaction, IReleaseSpec releaseSpec, out string? errorMessage)
+    {
+        errorMessage = null;
+        return _result;
+    }
 
     public bool ValidateWithdrawals(Block block, out string? error)
     {
@@ -86,4 +101,17 @@ public class Always : IBlockValidator, ISealValidator, IUnclesValidator, ITxVali
         error = null;
         return _result;
     }
+
+    public bool ValidateSuggestedBlock(Block block, out string? error)
+    {
+        error = null;
+        return _result;
+    }
+
+    public bool ValidateProcessedBlock(Block processedBlock, TxReceipt[] receipts, Block suggestedBlock, out string? error)
+    {
+        error = null;
+        return _result;
+    }
+
 }

--- a/src/Nethermind/Nethermind.Consensus/Validators/BlockValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/BlockValidator.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Text;
 using Nethermind.Blockchain;
+using Nethermind.Consensus.Messages;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
@@ -40,12 +41,22 @@ public class BlockValidator : IBlockValidator
 
     public bool Validate(BlockHeader header, BlockHeader? parent, bool isUncle)
     {
-        return _headerValidator.Validate(header, parent, isUncle);
+        return _headerValidator.Validate(header, parent, isUncle, out _);
+    }
+
+    public bool Validate(BlockHeader header, BlockHeader? parent, bool isUncle, out string? error)
+    {
+        return _headerValidator.Validate(header, parent, isUncle, out error);
     }
 
     public bool Validate(BlockHeader header, bool isUncle)
     {
-        return _headerValidator.Validate(header, isUncle);
+        return _headerValidator.Validate(header, isUncle, out _);
+    }
+
+    public bool Validate(BlockHeader header, bool isUncle, out string? error)
+    {
+        return _headerValidator.Validate(header, isUncle, out error);
     }
 
     /// <summary>
@@ -75,33 +86,48 @@ public class BlockValidator : IBlockValidator
     /// </returns>
     public bool ValidateSuggestedBlock(Block block)
     {
+        return ValidateSuggestedBlock(block, out _);
+    }
+    /// <summary>
+    /// Suggested block validation runs basic checks that can be executed before going through the expensive EVM processing.
+    /// </summary>
+    /// <param name="block">A block to validate</param>
+    /// <param name="errorMessage">Message detailing a validation failure.</param>
+    /// <returns>
+    /// <c>true</c> if the <paramref name="block"/> is valid; otherwise, <c>false</c>.
+    /// </returns>
+    public bool ValidateSuggestedBlock(Block block, out string? errorMessage)
+    {
         IReleaseSpec spec = _specProvider.GetSpec(block.Header);
 
-        if (!ValidateTransactions(block, spec))
+        if (!ValidateTransactions(block, spec, out errorMessage))
             return false;
 
-        if (!ValidateEip4844Fields(block, spec, out _))
+        if (!ValidateEip4844Fields(block, spec, out errorMessage))
             return false;
 
         if (spec.MaximumUncleCount < block.Uncles.Length)
         {
             if (_logger.IsDebug) _logger.Debug($"{Invalid(block)} Uncle count of {block.Uncles.Length} exceeds the max limit of {spec.MaximumUncleCount}");
+            errorMessage = BlockErrorMessages.ExceededUncleLimit(spec.MaximumUncleCount);
             return false;
         }
 
         if (!ValidateUnclesHashMatches(block, out Hash256 unclesHash))
         {
             if (_logger.IsDebug) _logger.Debug($"{Invalid(block)} Uncles hash mismatch: expected {block.Header.UnclesHash}, got {unclesHash}");
+            errorMessage = BlockErrorMessages.InvalidUnclesHash;
             return false;
         }
 
         if (!_unclesValidator.Validate(block.Header, block.Uncles))
         {
             if (_logger.IsDebug) _logger.Debug($"{Invalid(block)} Invalid uncles");
+            errorMessage = BlockErrorMessages.InvalidUncle;
             return false;
         }
 
-        bool blockHeaderValid = _headerValidator.Validate(block.Header);
+        bool blockHeaderValid = _headerValidator.Validate(block.Header, false, out errorMessage);
         if (!blockHeaderValid)
         {
             if (_logger.IsDebug) _logger.Debug($"{Invalid(block)} Invalid header");
@@ -111,10 +137,11 @@ public class BlockValidator : IBlockValidator
         if (!ValidateTxRootMatchesTxs(block, out Hash256 txRoot))
         {
             if (_logger.IsDebug) _logger.Debug($"{Invalid(block)} Transaction root hash mismatch: expected {block.Header.TxRoot}, got {txRoot}");
+            errorMessage = BlockErrorMessages.InvalidTxRoot(block.Header.TxRoot, txRoot);
             return false;
         }
 
-        if (!ValidateWithdrawals(block, spec, out _))
+        if (!ValidateWithdrawals(block, spec, out errorMessage))
             return false;
 
         return true;
@@ -130,61 +157,84 @@ public class BlockValidator : IBlockValidator
     /// <returns><c>true</c> if the <paramref name="processedBlock"/> is valid; otherwise, <c>false</c>.</returns>
     public bool ValidateProcessedBlock(Block processedBlock, TxReceipt[] receipts, Block suggestedBlock)
     {
+        return ValidateProcessedBlock(processedBlock, receipts, suggestedBlock, out _);
+    }
+
+    /// <summary>
+    /// Processed block validation is comparing the block hashes (which include all other results).
+    /// We only make exact checks on what is invalid if the hash is different.
+    /// </summary>
+    /// <param name="processedBlock">This should be the block processing result (after going through the EVM processing)</param>
+    /// <param name="receipts">List of tx receipts from the processed block (required only for better diagnostics when the receipt root is invalid).</param>
+    /// <param name="suggestedBlock">Block received from the network - unchanged.</param>
+    /// <param name="error">Detailed error message if validation fails otherwise <value>null</value>.</param>
+    /// <returns><c>true</c> if the <paramref name="processedBlock"/> is valid; otherwise, <c>false</c>.</returns>
+    public bool ValidateProcessedBlock(Block processedBlock, TxReceipt[] receipts, Block suggestedBlock, out string? error)
+    {
         bool isValid = processedBlock.Header.Hash == suggestedBlock.Header.Hash;
-        if (!isValid && _logger.IsWarn)
+
+        if (isValid)
         {
-            _logger.Warn($"Processed block {processedBlock.ToString(Block.Format.Short)} is invalid:");
-            _logger.Warn($"- hash: expected {suggestedBlock.Hash}, got {processedBlock.Hash}");
-
-            if (processedBlock.Header.GasUsed != suggestedBlock.Header.GasUsed)
-            {
-                _logger.Warn($"- gas used: expected {suggestedBlock.Header.GasUsed}, got {processedBlock.Header.GasUsed} (diff: {processedBlock.Header.GasUsed - suggestedBlock.Header.GasUsed})");
-            }
-
-            if (processedBlock.Header.Bloom != suggestedBlock.Header.Bloom)
-            {
-                _logger.Warn($"- bloom: expected {suggestedBlock.Header.Bloom}, got {processedBlock.Header.Bloom}");
-            }
-
-            if (processedBlock.Header.ReceiptsRoot != suggestedBlock.Header.ReceiptsRoot)
-            {
-                _logger.Warn($"- receipts root: expected {suggestedBlock.Header.ReceiptsRoot}, got {processedBlock.Header.ReceiptsRoot}");
-            }
-
-            if (processedBlock.Header.StateRoot != suggestedBlock.Header.StateRoot)
-            {
-                _logger.Warn($"- state root: expected {suggestedBlock.Header.StateRoot}, got {processedBlock.Header.StateRoot}");
-            }
-
-            if (processedBlock.Header.BlobGasUsed != suggestedBlock.Header.BlobGasUsed)
-            {
-                _logger.Warn($"- blob gas used: expected {suggestedBlock.Header.BlobGasUsed}, got {processedBlock.Header.BlobGasUsed}");
-            }
-
-            if (processedBlock.Header.ExcessBlobGas != suggestedBlock.Header.ExcessBlobGas)
-            {
-                _logger.Warn($"- excess blob gas: expected {suggestedBlock.Header.ExcessBlobGas}, got {processedBlock.Header.ExcessBlobGas}");
-            }
-
-            if (processedBlock.Header.ParentBeaconBlockRoot != suggestedBlock.Header.ParentBeaconBlockRoot)
-            {
-                _logger.Warn($"- parent beacon block root : expected {suggestedBlock.Header.ParentBeaconBlockRoot}, got {processedBlock.Header.ParentBeaconBlockRoot}");
-            }
-
-            for (int i = 0; i < processedBlock.Transactions.Length; i++)
-            {
-                if (receipts[i].Error is not null && receipts[i].GasUsed == 0 && receipts[i].Error == "invalid")
-                {
-                    _logger.Warn($"- invalid transaction {i}");
-                }
-            }
-
-            if (suggestedBlock.ExtraData is not null)
-            {
-                _logger.Warn($"- block extra data : {suggestedBlock.ExtraData.ToHexString()}, UTF8: {Encoding.UTF8.GetString(suggestedBlock.ExtraData)}");
-            }
+            error = null;
+            return true;
+        }
+        if (_logger.IsError) _logger.Error($"Processed block {processedBlock.ToString(Block.Format.Short)} is invalid:");
+        if (_logger.IsError) _logger.Error($"- hash: expected {suggestedBlock.Hash}, got {processedBlock.Hash}");
+        error = null;
+        if (processedBlock.Header.GasUsed != suggestedBlock.Header.GasUsed)
+        {
+            if (_logger.IsError) _logger.Error($"- gas used: expected {suggestedBlock.Header.GasUsed}, got {processedBlock.Header.GasUsed} (diff: {processedBlock.Header.GasUsed - suggestedBlock.Header.GasUsed})");
+            error = error ?? BlockErrorMessages.HeaderGasUsedMismatch;
         }
 
+        if (processedBlock.Header.Bloom != suggestedBlock.Header.Bloom)
+        {
+            if (_logger.IsError) _logger.Error($"- bloom: expected {suggestedBlock.Header.Bloom}, got {processedBlock.Header.Bloom}");
+            error = error ?? BlockErrorMessages.InvalidLogsBloom;
+        }
+
+        if (processedBlock.Header.ReceiptsRoot != suggestedBlock.Header.ReceiptsRoot)
+        {
+            if (_logger.IsError) _logger.Error($"- receipts root: expected {suggestedBlock.Header.ReceiptsRoot}, got {processedBlock.Header.ReceiptsRoot}");
+            error = error ?? BlockErrorMessages.InvalidReceiptsRoot;
+        }
+
+        if (processedBlock.Header.StateRoot != suggestedBlock.Header.StateRoot)
+        {
+            if (_logger.IsError) _logger.Error($"- state root: expected {suggestedBlock.Header.StateRoot}, got {processedBlock.Header.StateRoot}");
+            error = error ?? BlockErrorMessages.InvalidStateRoot;
+        }
+
+        if (processedBlock.Header.BlobGasUsed != suggestedBlock.Header.BlobGasUsed)
+        {
+            if (_logger.IsError) _logger.Error($"- blob gas used: expected {suggestedBlock.Header.BlobGasUsed}, got {processedBlock.Header.BlobGasUsed}");
+            error = error ?? BlockErrorMessages.HeaderBlobGasMismatch;
+        }
+
+        if (processedBlock.Header.ExcessBlobGas != suggestedBlock.Header.ExcessBlobGas)
+        {
+            if (_logger.IsError) _logger.Error($"- excess blob gas: expected {suggestedBlock.Header.ExcessBlobGas}, got {processedBlock.Header.ExcessBlobGas}");
+            error = error ?? BlockErrorMessages.IncorrectExcessBlobGas;
+        }
+
+        if (processedBlock.Header.ParentBeaconBlockRoot != suggestedBlock.Header.ParentBeaconBlockRoot)
+        {
+            if (_logger.IsError) _logger.Error($"- parent beacon block root : expected {suggestedBlock.Header.ParentBeaconBlockRoot}, got {processedBlock.Header.ParentBeaconBlockRoot}");
+            error = error ?? BlockErrorMessages.InvalidParentBeaconBlockRoot;
+        }
+
+        for (int i = 0; i < processedBlock.Transactions.Length; i++)
+        {
+            if (receipts[i].Error is not null && receipts[i].GasUsed == 0 && receipts[i].Error == "invalid")
+            {
+                if (_logger.IsError) _logger.Error($"- invalid transaction {i}");
+                error = error ?? BlockErrorMessages.InvalidTxInBlock(i);
+            }
+        }
+        if (suggestedBlock.ExtraData is not null)
+        {
+            if (_logger.IsError) _logger.Error($"- block extra data : {suggestedBlock.ExtraData.ToHexString()}, UTF8: {Encoding.UTF8.GetString(suggestedBlock.ExtraData)}");
+        }
         return isValid;
     }
 
@@ -195,18 +245,18 @@ public class BlockValidator : IBlockValidator
     {
         if (spec.WithdrawalsEnabled && block.Withdrawals is null)
         {
-            error = $"Withdrawals cannot be null in block {block.Hash} when EIP-4895 activated.";
+            error = BlockErrorMessages.MissingWithdrawals;
 
-            if (_logger.IsWarn) _logger.Warn(error);
+            if (_logger.IsWarn) _logger.Warn($"Withdrawals cannot be null in block {block.Hash} when EIP-4895 activated.");
 
             return false;
         }
 
         if (!spec.WithdrawalsEnabled && block.Withdrawals is not null)
         {
-            error = $"Withdrawals must be null in block {block.Hash} when EIP-4895 not activated.";
+            error = BlockErrorMessages.WithdrawalsNotEnabled;
 
-            if (_logger.IsWarn) _logger.Warn(error);
+            if (_logger.IsWarn) _logger.Warn($"Withdrawals must be null in block {block.Hash} when EIP-4895 not activated.");
 
             return false;
         }
@@ -215,7 +265,7 @@ public class BlockValidator : IBlockValidator
         {
             if (!ValidateWithdrawalsHashMatches(block, out Hash256 withdrawalsRoot))
             {
-                error = $"Withdrawals root hash mismatch in block {block.ToString(Block.Format.FullHashAndNumber)}: expected {block.Header.WithdrawalsRoot}, got {withdrawalsRoot}";
+                error = BlockErrorMessages.InvalidWithdrawalsRoot(block.Header.WithdrawalsRoot, withdrawalsRoot);
                 if (_logger.IsWarn) _logger.Warn($"Withdrawals root hash mismatch in block {block.ToString(Block.Format.FullHashAndNumber)}: expected {block.Header.WithdrawalsRoot}, got {withdrawalsRoot}");
 
                 return false;
@@ -227,7 +277,7 @@ public class BlockValidator : IBlockValidator
         return true;
     }
 
-    private bool ValidateTransactions(Block block, IReleaseSpec spec)
+    private bool ValidateTransactions(Block block, IReleaseSpec spec, out string? errorMessage)
     {
         Transaction[] transactions = block.Transactions;
 
@@ -235,13 +285,13 @@ public class BlockValidator : IBlockValidator
         {
             Transaction transaction = transactions[txIndex];
 
-            if (!_txValidator.IsWellFormed(transaction, spec))
+            if (!_txValidator.IsWellFormed(transaction, spec, out errorMessage))
             {
-                if (_logger.IsDebug) _logger.Debug($"{Invalid(block)} Invalid transaction {transaction.Hash}");
+                if (_logger.IsDebug) _logger.Debug($"{Invalid(block)} Invalid transaction: {errorMessage}");
                 return false;
             }
         }
-
+        errorMessage = null;
         return true;
     }
 
@@ -270,7 +320,7 @@ public class BlockValidator : IBlockValidator
             {
                 if (!BlobGasCalculator.TryCalculateBlobGasPricePerUnit(block.Header, out blobGasPrice))
                 {
-                    error = "{nameof(blobGasPrice)} overflow";
+                    error = BlockErrorMessages.BlobGasPriceOverflow;
                     if (_logger.IsDebug) _logger.Debug($"{Invalid(block)} {error}.");
                     return false;
                 }
@@ -278,8 +328,8 @@ public class BlockValidator : IBlockValidator
 
             if (transaction.MaxFeePerBlobGas < blobGasPrice)
             {
-                error = $"A transaction has unsufficient {nameof(transaction.MaxFeePerBlobGas)} to cover current blob gas fee: {transaction.MaxFeePerBlobGas} < {blobGasPrice}";
-                if (_logger.IsDebug) _logger.Debug($"{Invalid(block)} {error}.");
+                error = BlockErrorMessages.InsufficientMaxFeePerBlobGas;
+                if (_logger.IsDebug) _logger.Debug($"{Invalid(block)} Transaction at index {txIndex} has insufficient {nameof(transaction.MaxFeePerBlobGas)} to cover current blob gas fee: {transaction.MaxFeePerBlobGas} < {blobGasPrice}.");
                 return false;
             }
 
@@ -290,15 +340,15 @@ public class BlockValidator : IBlockValidator
 
         if (blobGasUsed > Eip4844Constants.MaxBlobGasPerBlock)
         {
-            error = $"A block cannot have more than {Eip4844Constants.MaxBlobGasPerBlock} blob gas.";
+            error = BlockErrorMessages.BlobGasUsedAboveBlockLimit();
             if (_logger.IsDebug) _logger.Debug($"{Invalid(block)} {error}.");
             return false;
         }
 
         if (blobGasUsed != block.Header.BlobGasUsed)
         {
-            error = $"{Invalid(block)} {nameof(BlockHeader.BlobGasUsed)} declared in the block header does not match actual blob gas used: {block.Header.BlobGasUsed} != {blobGasUsed}.";
-            if (_logger.IsDebug) _logger.Debug($"{Invalid(block)} {error}.");
+            error = BlockErrorMessages.HeaderBlobGasMismatch;
+            if (_logger.IsDebug) _logger.Debug($"{Invalid(block)} {nameof(BlockHeader.BlobGasUsed)} declared in the block header does not match actual blob gas used: {block.Header.BlobGasUsed} != {blobGasUsed}.");
             return false;
         }
 

--- a/src/Nethermind/Nethermind.Consensus/Validators/BlockValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/BlockValidator.cs
@@ -340,7 +340,7 @@ public class BlockValidator : IBlockValidator
 
         if (blobGasUsed > Eip4844Constants.MaxBlobGasPerBlock)
         {
-            error = BlockErrorMessages.BlobGasUsedAboveBlockLimit();
+            error = BlockErrorMessages.BlobGasUsedAboveBlockLimit;
             if (_logger.IsDebug) _logger.Debug($"{Invalid(block)} {error}.");
             return false;
         }

--- a/src/Nethermind/Nethermind.Consensus/Validators/Extensions.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/Extensions.cs
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Consensus.Validators;
+using Nethermind.Core;
+
+public static class Extensions
+{
+    public static bool Validate(this IHeaderValidator headerValidator, BlockHeader header, BlockHeader? parent, bool isUncle = false)
+    {
+        return headerValidator.Validate(header, parent, isUncle, out _);
+    }
+    public static bool Validate(this IHeaderValidator headerValidator, BlockHeader header, bool isUncle = false)
+    {
+        return headerValidator.Validate(header, isUncle, out _);
+    }
+}

--- a/src/Nethermind/Nethermind.Consensus/Validators/HeaderValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/HeaderValidator.cs
@@ -180,9 +180,9 @@ namespace Nethermind.Consensus.Validators
 
             error = blockHeader switch
             {
-                { Number: < 0 } => "NegativeBlockNumber: Block number cannot be negative.",
-                { GasLimit: < 0 } => "NegativeBlockNumber: Block number cannot be negative.",
-                { GasUsed: < 0 } => "NegativeGasUsed: Cannot be negative.",
+                { Number: < 0 } => BlockErrorMessages.NegativeBlockNumber,
+                { GasLimit: < 0 } => BlockErrorMessages.NegativeGasLimit,
+                { GasUsed: < 0 } => BlockErrorMessages.NegativeGasUsed,
                 _ => null
             };
 

--- a/src/Nethermind/Nethermind.Consensus/Validators/HeaderValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/HeaderValidator.cs
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using Microsoft.Extensions.Options;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Find;
+using Nethermind.Consensus.Messages;
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
@@ -39,131 +41,167 @@ namespace Nethermind.Consensus.Validators
 
         public static bool ValidateHash(BlockHeader header) => header.Hash == header.CalculateHash();
 
-        /// <summary>
-        /// Note that this does not validate seal which is the responsibility of <see cref="ISealValidator"/>>
-        /// </summary>
-        /// <param name="header">BlockHeader to validate</param>
-        /// <param name="parent">BlockHeader which is the parent of <paramref name="header"/></param>
-        /// <param name="isUncle"><value>True</value> if uncle block, otherwise <value>False</value></param>
-        /// <returns></returns>
-        public virtual bool Validate(BlockHeader header, BlockHeader? parent, bool isUncle = false)
+        private bool ValidateHash(BlockHeader header, ref string? error)
         {
-            if (!ValidateFieldLimit(header))
-            {
-                return false;
-            }
-
             bool hashAsExpected = ValidateHash(header);
 
             if (!hashAsExpected)
             {
                 if (_logger.IsWarn) _logger.Warn($"Invalid block header ({header.Hash}) - invalid block hash");
-            }
-
-            IReleaseSpec spec = _specProvider.GetSpec(header);
-            bool extraDataValid = ValidateExtraData(header, parent, spec, isUncle);
-            if (parent is null)
-            {
-                if (header.Number == 0)
-                {
-                    bool isGenesisValid = ValidateGenesis(header);
-                    if (!isGenesisValid)
-                    {
-                        if (_logger.IsWarn) _logger.Warn($"Invalid genesis block header ({header.Hash})");
-                    }
-
-                    return isGenesisValid;
-                }
-
-                if (_logger.IsDebug) _logger.Debug($"Orphan block, could not find parent ({header.ParentHash}) of ({header.Hash})");
-                return false;
-            }
-
-            bool totalDifficultyCorrect = ValidateTotalDifficulty(parent, header);
-
-            bool sealParamsCorrect = _sealValidator.ValidateParams(parent, header, isUncle);
-            if (!sealParamsCorrect)
-            {
-                if (_logger.IsWarn) _logger.Warn($"Invalid block header ({header.Hash}) - seal parameters incorrect");
-            }
-
-            bool gasUsedBelowLimit = header.GasUsed <= header.GasLimit;
-            if (!gasUsedBelowLimit)
-            {
-                if (_logger.IsWarn) _logger.Warn($"Invalid block header ({header.Hash}) - gas used above gas limit");
-            }
-
-            bool gasLimitInRange = ValidateGasLimitRange(header, parent, spec);
-
-            // bool gasLimitAboveAbsoluteMinimum = header.GasLimit >= 125000; // described in the YellowPaper but not followed
-
-            bool timestampValid = ValidateTimestamp(parent, header);
-
-            bool numberIsParentPlusOne = header.Number == parent.Number + 1;
-            if (!numberIsParentPlusOne)
-            {
-                if (_logger.IsWarn) _logger.Warn($"Invalid block header ({header.Hash}) - block number is not parent + 1");
-            }
-
-            if (_logger.IsTrace) _logger.Trace($"Validating block {header.ToString(BlockHeader.Format.Short)}, extraData {header.ExtraData.ToHexString(true)}");
-
-            bool eip1559Valid = true;
-            bool isEip1559Enabled = spec.IsEip1559Enabled;
-            if (isEip1559Enabled)
-            {
-                UInt256? expectedBaseFee = BaseFeeCalculator.Calculate(parent, spec);
-                eip1559Valid = expectedBaseFee == header.BaseFeePerGas;
-
-                if (expectedBaseFee != header.BaseFeePerGas)
-                {
-                    if (_logger.IsWarn) _logger.Warn($"Invalid block header ({header.ToString(BlockHeader.Format.Short)}) incorrect base fee. Expected base fee: {expectedBaseFee}, Current base fee: {header.BaseFeePerGas} ");
-                    eip1559Valid = false;
-                }
-            }
-
-            bool eip4844Valid = ValidateBlobGasFields(header, parent, spec);
-
-            return
-                totalDifficultyCorrect &&
-                gasUsedBelowLimit &&
-                gasLimitInRange &&
-                sealParamsCorrect &&
-                // gasLimitAboveAbsoluteMinimum && // described in the YellowPaper but not followed
-                timestampValid &&
-                numberIsParentPlusOne &&
-                hashAsExpected &&
-                extraDataValid &&
-                eip1559Valid &&
-                eip4844Valid;
-        }
-
-        private bool ValidateFieldLimit(BlockHeader blockHeader)
-        {
-            // Note, these are out of spec. Technically, there could be a block with field with very high value that is
-            // valid when using ulong, but wrapped to negative value when using long. However, switching to ulong
-            // at this point can cause other unexpected error. So we just won't support it for now.
-            if (blockHeader.Number < 0)
-            {
-                if (_logger.IsWarn) _logger.Warn($"Invalid block header ({blockHeader.Hash}) - Block number is negative {blockHeader.Number}");
-                return false;
-            }
-
-            if (blockHeader.GasLimit < 0)
-            {
-                if (_logger.IsWarn) _logger.Warn($"Invalid block header ({blockHeader.Hash}) - Block GasLimit is negative {blockHeader.GasLimit}");
-                return false;
-            }
-
-            if (blockHeader.GasUsed < 0)
-            {
-                if (_logger.IsWarn) _logger.Warn($"Invalid block header ({blockHeader.Hash}) - Block GasUsed is negative {blockHeader.GasUsed}");
+                error = BlockErrorMessages.InvalidHeaderHash;
                 return false;
             }
 
             return true;
         }
 
-        protected virtual bool ValidateExtraData(BlockHeader header, BlockHeader? parent, IReleaseSpec spec, bool isUncle = false)
+        /// <summary>
+        /// Note that this does not validate seal which is the responsibility of <see cref="ISealValidator"/>>
+        /// </summary>
+        /// <param name="header">BlockHeader to validate</param>
+        /// <param name="parent">BlockHeader which is the parent of <paramref name="header"/></param>
+        /// <param name="isUncle"><value>True</value> if uncle block, otherwise <value>False</value></param>
+        /// <returns><value>True</value> if validation succeeds otherwise <value>false</value></returns>
+        public virtual bool Validate(BlockHeader header, BlockHeader? parent, bool isUncle = false)
+        {
+            return Validate(header, parent, isUncle, out _);
+        }
+
+        /// <summary>
+        /// Note that this does not validate seal which is the responsibility of <see cref="ISealValidator"/>>
+        /// </summary>
+        /// <param name="header">BlockHeader to validate</param>
+        /// <param name="parent">BlockHeader which is the parent of <paramref name="header"/></param>
+        /// <param name="isUncle"><value>True</value> if uncle block, otherwise <value>False</value></param>
+        /// <param name="error">Detailed error message if validation fails, otherwise <value>null</value>.</param>
+        /// <returns><value>True</value> if validation succeeds otherwise <value>false</value></returns>
+        public virtual bool Validate(BlockHeader header, BlockHeader? parent, bool isUncle, out string? error)
+        {
+            IReleaseSpec spec;
+            error = null;
+
+            // bool gasLimitAboveAbsoluteMinimum = header.GasLimit >= 125000; // described in the YellowPaper but not followed
+            return ValidateFieldLimit(header, ref error)
+                && ValidateHash(header, ref error)
+                && ValidateExtraData(header, parent, spec = _specProvider.GetSpec(header), isUncle, ref error)
+                && ValidateParent(header, parent, ref error)
+                && ValidateTotalDifficulty(parent!, header, ref error)
+                && ValidateSeal(header, parent, isUncle, ref error)
+                && ValidateGasUsed(header, ref error)
+                && ValidateGasLimitRange(header, parent, spec, ref error)
+                && ValidateTimestamp(header, parent, ref error)
+                && ValidateBlockNumber(header, parent, ref error)
+                && Validate1559(header, parent, spec, ref error)
+                && ValidateBlobGasFields(header, parent, spec, ref error);
+        }
+
+        private bool Validate1559(BlockHeader header, BlockHeader parent, IReleaseSpec spec, ref string? error)
+        {
+            if (spec.IsEip1559Enabled)
+            {
+                UInt256? expectedBaseFee = BaseFeeCalculator.Calculate(parent, spec);
+
+                if (expectedBaseFee != header.BaseFeePerGas)
+                {
+                    if (_logger.IsWarn) _logger.Warn($"Invalid block header ({header.ToString(BlockHeader.Format.Short)}) incorrect base fee. Expected base fee: {expectedBaseFee}, Current base fee: {header.BaseFeePerGas} ");
+                    error = BlockErrorMessages.InvalidBaseFeePerGas;
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private bool ValidateBlockNumber(BlockHeader header, BlockHeader parent, ref string? error)
+        {
+            if (header.Number != parent.Number + 1)
+            {
+                if (_logger.IsWarn) _logger.Warn($"Invalid block header ({header.Hash}) - block number is not parent + 1");
+                error = BlockErrorMessages.InvalidBlockNumber;
+                return false;
+            }
+
+            return true;
+        }
+
+        private bool ValidateGasUsed(BlockHeader header, ref string? error)
+        {
+            if (header.GasUsed > header.GasLimit)
+            {
+                if (_logger.IsWarn) _logger.Warn($"Invalid block header ({header.Hash}) - gas used above gas limit");
+                error = BlockErrorMessages.ExceededGasLimit;
+                return false;
+            }
+
+            return true;
+        }
+
+        private bool ValidateParent(BlockHeader header, BlockHeader? parent, ref string? error)
+        {
+            if (parent is null)
+            {
+                if (header.Number != 0)
+                {
+                    if (_logger.IsDebug) _logger.Debug($"Orphan block, could not find parent ({header.ParentHash}) of ({header.Hash})");
+                    error = BlockErrorMessages.InvalidAncestor;
+                    return false;
+                }
+
+                bool isGenesisValid = ValidateGenesis(header);
+                if (!isGenesisValid)
+                {
+                    if (_logger.IsWarn) _logger.Warn($"Invalid genesis block header ({header.Hash})");
+                    error = BlockErrorMessages.InvalidGenesisBlock;
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private bool ValidateSeal(BlockHeader header, BlockHeader parent, bool isUncle, ref string? error)
+        {
+            bool result = _sealValidator.ValidateParams(parent, header, isUncle);
+
+            if (!result)
+            {
+                if (_logger.IsWarn) _logger.Warn($"Invalid block header ({header.Hash}) - seal parameters incorrect");
+                error = BlockErrorMessages.InvalidSealParameters;
+            }
+
+            return result;
+        }
+
+        private bool ValidateFieldLimit(BlockHeader blockHeader, ref string? error)
+        {
+            // Note, these are out of spec. Technically, there could be a block with field with very high value that is
+            // valid when using ulong, but wrapped to negative value when using long. However, switching to ulong
+            // at this point can cause other unexpected error. So we just won't support it for now.
+
+            error = blockHeader switch
+            {
+                { Number: < 0 } => "NegativeBlockNumber: Block number cannot be negative.",
+                { GasLimit: < 0 } => "NegativeBlockNumber: Block number cannot be negative.",
+                { GasUsed: < 0 } => "NegativeGasUsed: Cannot be negative.",
+                _ => null
+            };
+
+            if (error is null) return true;
+
+            if (_logger.IsWarn)
+                _logger.Warn($"Invalid block header ({blockHeader.Hash}) - {blockHeader switch
+                {
+                    { Number: < 0 } => $"Block number is negative {blockHeader.Number}",
+                    { GasLimit: < 0 } => $"Block GasLimit is negative {blockHeader.GasLimit}",
+                    { GasUsed: < 0 } => $"Block GasUsed is negative {blockHeader.GasUsed}",
+                    _ => error
+                }}");
+
+            return false;
+
+        }
+
+        protected virtual bool ValidateExtraData(BlockHeader header, BlockHeader? parent, IReleaseSpec spec, bool isUncle, ref string? error)
         {
             bool extraDataValid = header.ExtraData.Length <= spec.MaximumExtraDataSize
                                    && (isUncle
@@ -174,35 +212,29 @@ namespace Nethermind.Consensus.Validators
             if (!extraDataValid)
             {
                 if (_logger.IsWarn) _logger.Warn($"Invalid block header ({header.Hash}) - DAO extra data not valid. MaximumExtraDataSize {spec.MaximumExtraDataSize}, ExtraDataLength {header.ExtraData.Length}, DaoBlockNumber: {_daoBlockNumber}");
+                error = BlockErrorMessages.InvalidExtraData;
             }
+
             return extraDataValid;
         }
 
-        protected virtual bool ValidateGasLimitRange(BlockHeader header, BlockHeader parent, IReleaseSpec spec)
+        protected virtual bool ValidateGasLimitRange(BlockHeader header, BlockHeader parent, IReleaseSpec spec, ref string? error)
         {
             long adjustedParentGasLimit = Eip1559GasLimitAdjuster.AdjustGasLimit(spec, parent.GasLimit, header.Number);
             long maxGasLimitDifference = adjustedParentGasLimit / spec.GasLimitBoundDivisor;
 
             long maxNextGasLimit = adjustedParentGasLimit + maxGasLimitDifference;
-            bool gasLimitNotTooHigh;
             bool notToHighWithOverflow = long.MaxValue - maxGasLimitDifference < adjustedParentGasLimit;
-            if (notToHighWithOverflow)
-            {
-                // The edge case used in hive tests. If adjustedParentGasLimit + maxGasLimitDifference >=  long.MaxValue,
-                // we can check for long.MaxValue - maxGasLimitDifference < adjustedParentGasLimit to ensure that we are in range.
-                // In hive we have tests that using long.MaxValue in the genesis block
-                // Even if we add maxGasLimitDifference we don't get header.GasLimit higher than long.MaxValue
-                gasLimitNotTooHigh = true;
-            }
-            else
-            {
-                gasLimitNotTooHigh = header.GasLimit < maxNextGasLimit;
-            }
-
+            // The edge case used in hive tests. If adjustedParentGasLimit + maxGasLimitDifference >=  long.MaxValue,
+            // we can check for long.MaxValue - maxGasLimitDifference < adjustedParentGasLimit to ensure that we are in range.
+            // In hive we have tests that using long.MaxValue in the genesis block
+            // Even if we add maxGasLimitDifference we don't get header.GasLimit higher than long.MaxValue
+            var gasLimitNotTooHigh = notToHighWithOverflow || header.GasLimit < maxNextGasLimit;
 
             if (!gasLimitNotTooHigh)
             {
                 if (_logger.IsWarn) _logger.Warn($"Invalid block header ({header.Hash}) - gas limit too high");
+                error = BlockErrorMessages.InvalidGasLimit;
             }
 
             bool gasLimitNotTooLow = header.GasLimit > adjustedParentGasLimit - maxGasLimitDifference &&
@@ -210,50 +242,48 @@ namespace Nethermind.Consensus.Validators
             if (!gasLimitNotTooLow)
             {
                 if (_logger.IsWarn) _logger.Warn($"Invalid block header ({header.Hash}) - gas limit too low");
+                error = BlockErrorMessages.InvalidGasLimit;
             }
 
             return gasLimitNotTooHigh && gasLimitNotTooLow;
         }
 
-        private bool ValidateTimestamp(BlockHeader parent, BlockHeader header)
+        private bool ValidateTimestamp(BlockHeader header, BlockHeader parent, ref string? error)
         {
             bool timestampMoreThanAtParent = header.Timestamp > parent.Timestamp;
             if (!timestampMoreThanAtParent)
             {
+                error = BlockErrorMessages.InvalidTimestamp;
                 if (_logger.IsWarn) _logger.Warn($"Invalid block header ({header.Hash}) - timestamp before parent");
             }
             return timestampMoreThanAtParent;
         }
 
-        protected virtual bool ValidateTotalDifficulty(BlockHeader parent, BlockHeader header)
+        protected virtual bool ValidateTotalDifficulty(BlockHeader parent, BlockHeader header, ref string? error)
         {
-            if (header.TotalDifficulty is null)
-            {
-                return true;
-            }
+            bool result = true;
 
-            bool totalDifficultyCorrect = true;
-            if (header.TotalDifficulty == 0)
+            if (header.TotalDifficulty is not null)
             {
-                // Same as in BlockTree.SetTotalDifficulty
-                if (!(_blockTree.Genesis!.Difficulty == 0 && _specProvider.TerminalTotalDifficulty == 0))
+                if (header.TotalDifficulty == 0)
                 {
-                    if (_logger.IsDebug)
-                        _logger.Debug($"Invalid block header ({header.Hash}) - zero total difficulty when genesis or ttd is not zero");
-                    totalDifficultyCorrect = false;
+                    // Same as in BlockTree.SetTotalDifficulty
+                    if (!(_blockTree.Genesis!.Difficulty == 0 && _specProvider.TerminalTotalDifficulty == 0))
+                    {
+                        if (_logger.IsDebug) _logger.Debug($"Invalid block header ({header.Hash}) - zero total difficulty when genesis or ttd is not zero");
+                        result = false;
+                        error = BlockErrorMessages.InvalidTotalDifficulty;
+                    }
                 }
-            }
-            else
-            {
-                if (parent.TotalDifficulty + header.Difficulty != header.TotalDifficulty)
+                else if (parent.TotalDifficulty + header.Difficulty != header.TotalDifficulty)
                 {
-                    if (_logger.IsDebug)
-                        _logger.Debug($"Invalid block header ({header.Hash}) - incorrect total difficulty");
-                    totalDifficultyCorrect = false;
+                    if (_logger.IsDebug) _logger.Debug($"Invalid block header ({header.Hash}) - incorrect total difficulty");
+                    result = false;
+                    error = BlockErrorMessages.InvalidTotalDifficulty;
                 }
             }
 
-            return totalDifficultyCorrect;
+            return result;
         }
 
         /// <summary>
@@ -262,61 +292,69 @@ namespace Nethermind.Consensus.Validators
         /// <param name="header">Block header to validate</param>
         /// <param name="isUncle"><value>True</value> if the <paramref name="header"/> is an uncle, otherwise <value>False</value></param>
         /// <returns><value>True</value> if <paramref name="header"/> is valid, otherwise <value>False</value></returns>
-        public virtual bool Validate(BlockHeader header, bool isUncle = false)
-        {
-            BlockHeader parent = _blockTree.FindParentHeader(header, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
-            return Validate(header, parent, isUncle);
-        }
+        public virtual bool Validate(BlockHeader header, bool isUncle = false) => Validate(header, isUncle, out _);
 
-        private bool ValidateGenesis(BlockHeader header)
-        {
-            return
-                header.GasUsed < header.GasLimit &&
-                header.GasLimit > _specProvider.GenesisSpec.MinGasLimit &&
-                header.Timestamp > 0 &&
-                header.Number == 0 &&
-                header.Bloom is not null &&
-                header.ExtraData.Length <= _specProvider.GenesisSpec.MaximumExtraDataSize;
-        }
+        /// <summary>
+        /// Validates all the header elements (usually in relation to parent). Difficulty calculation is validated in <see cref="ISealValidator"/>
+        /// </summary>
+        /// <param name="header">Block header to validate</param>
+        /// <param name="isUncle"><value>True</value> if the <paramref name="header"/> is an uncle, otherwise <value>False</value></param>
+        /// <param name="error">Detailed error message if validation fails, otherwise <value>False</value></param>
+        /// <returns><value>True</value> if <paramref name="header"/> is valid, otherwise <value>False</value></returns>
+        public virtual bool Validate(BlockHeader header, bool isUncle, out string? error) =>
+            Validate(header, _blockTree.FindParentHeader(header, BlockTreeLookupOptions.TotalDifficultyNotNeeded), isUncle, out error);
 
-        private bool ValidateBlobGasFields(BlockHeader header, BlockHeader parentHeader, IReleaseSpec spec)
+        private bool ValidateGenesis(BlockHeader header) =>
+            header.GasUsed < header.GasLimit &&
+            header.GasLimit > _specProvider.GenesisSpec.MinGasLimit &&
+            header.Timestamp > 0 &&
+            header.Number == 0 &&
+            header.Bloom is not null &&
+            header.ExtraData.Length <= _specProvider.GenesisSpec.MaximumExtraDataSize;
+
+        private bool ValidateBlobGasFields(BlockHeader header, BlockHeader parentHeader, IReleaseSpec spec, ref string? error)
         {
-            if (!spec.IsEip4844Enabled)
+            if (spec.IsEip4844Enabled)
+            {
+                if (header.BlobGasUsed is null)
+                {
+                    if (_logger.IsWarn) _logger.Warn("BlobGasUsed field is not set.");
+                    error = BlockErrorMessages.MissingBlobGasUsed;
+                    return false;
+                }
+
+                if (header.ExcessBlobGas is null)
+                {
+                    if (_logger.IsWarn) _logger.Warn("ExcessBlobGas field is not set.");
+                    error = BlockErrorMessages.MissingExcessBlobGas;
+                    return false;
+                }
+
+                ulong? expectedExcessBlobGas = BlobGasCalculator.CalculateExcessBlobGas(parentHeader, spec);
+                if (header.ExcessBlobGas != expectedExcessBlobGas)
+                {
+                    if (_logger.IsWarn) _logger.Warn($"ExcessBlobGas field is incorrect: {header.ExcessBlobGas}, should be {expectedExcessBlobGas}.");
+                    error = BlockErrorMessages.IncorrectExcessBlobGas;
+                    return false;
+                }
+            }
+            else
             {
                 if (header.BlobGasUsed is not null)
                 {
-                    if (_logger.IsWarn) _logger.Warn($"BlobGasUsed field should not have value.");
+                    if (_logger.IsWarn) _logger.Warn("BlobGasUsed field should not have value.");
+                    error = BlockErrorMessages.NotAllowedBlobGasUsed;
                     return false;
                 }
 
                 if (header.ExcessBlobGas is not null)
                 {
-                    if (_logger.IsWarn) _logger.Warn($"ExcessBlobGas field should not have value.");
+                    if (_logger.IsWarn) _logger.Warn("ExcessBlobGas field should not have value.");
+                    error = BlockErrorMessages.NotAllowedExcessBlobGas;
                     return false;
                 }
-
-                return true;
             }
 
-            if (header.BlobGasUsed is null)
-            {
-                if (_logger.IsWarn) _logger.Warn($"BlobGasUsed field is not set.");
-                return false;
-            }
-
-            if (header.ExcessBlobGas is null)
-            {
-                if (_logger.IsWarn) _logger.Warn($"ExcessBlobGas field is not set.");
-                return false;
-            }
-
-            UInt256? expectedExcessBlobGas = BlobGasCalculator.CalculateExcessBlobGas(parentHeader, spec);
-
-            if (header.ExcessBlobGas != expectedExcessBlobGas)
-            {
-                if (_logger.IsWarn) _logger.Warn($"ExcessBlobGas field is incorrect: {header.ExcessBlobGas}, should be {expectedExcessBlobGas}.");
-                return false;
-            }
             return true;
         }
     }

--- a/src/Nethermind/Nethermind.Consensus/Validators/IBlockValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/IBlockValidator.cs
@@ -2,15 +2,13 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Nethermind.Core;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Nethermind.Consensus.Validators;
 
 public interface IBlockValidator : IHeaderValidator, IWithdrawalValidator
 {
-    bool ValidateOrphanedBlock(Block block, out string? error);
-
-    bool ValidateSuggestedBlock(Block block);
-
-    bool ValidateProcessedBlock(Block processedBlock, TxReceipt[] receipts, Block suggestedBlock);
-
+    bool ValidateOrphanedBlock(Block block, [NotNullWhen(false)] out string? error);
+    bool ValidateSuggestedBlock(Block block, [NotNullWhen(false)] out string? error);
+    bool ValidateProcessedBlock(Block processedBlock, TxReceipt[] receipts, Block suggestedBlock, [NotNullWhen(false)] out string? error);
 }

--- a/src/Nethermind/Nethermind.Consensus/Validators/IHeaderValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/IHeaderValidator.cs
@@ -2,12 +2,14 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Nethermind.Core;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Nethermind.Consensus.Validators
 {
     public interface IHeaderValidator
     {
-        bool Validate(BlockHeader header, BlockHeader? parent, bool isUncle = false);
-        bool Validate(BlockHeader header, bool isUncle = false);
+
+        bool Validate(BlockHeader header, BlockHeader? parent, bool isUncle, [NotNullWhen(false)] out string? error);
+        bool Validate(BlockHeader header, bool isUncle, [NotNullWhen(false)] out string? error);
     }
 }

--- a/src/Nethermind/Nethermind.Consensus/Validators/NeverValidBlockValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/NeverValidBlockValidator.cs
@@ -16,9 +16,20 @@ namespace Nethermind.Consensus.Validators
         {
             return false;
         }
+        public bool Validate(BlockHeader header, BlockHeader? parent, bool isUncle, out string? error)
+        {
+            error = null;
+            return false;
+        }
 
         public bool Validate(BlockHeader header, bool isUncle)
         {
+            return false;
+        }
+
+        public bool Validate(BlockHeader header, bool isUncle, out string? error)
+        {
+            error = null;
             return false;
         }
 
@@ -43,5 +54,18 @@ namespace Nethermind.Consensus.Validators
             error = null;
             return false;
         }
+
+        public bool ValidateSuggestedBlock(Block block, out string? error)
+        {
+            error = null;
+            return false;
+        }
+
+        public bool ValidateProcessedBlock(Block processedBlock, TxReceipt[] receipts, Block suggestedBlock, out string? error)
+        {
+            error = null;
+            return false;
+        }
+
     }
 }

--- a/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
@@ -194,19 +194,19 @@ namespace Nethermind.Consensus.Validators
                 return false;
             }
 
-            ulong totalDataGas = BlobGasCalculator.CalculateBlobGas(transaction.BlobVersionedHashes!.Length);
+            int blobCount = transaction.BlobVersionedHashes.Length;
+            ulong totalDataGas = BlobGasCalculator.CalculateBlobGas(blobCount);
             if (totalDataGas > Eip4844Constants.MaxBlobGasPerTransaction)
             {
                 error = TxErrorMessages.BlobTxGasLimitExceeded;
                 return false;
             }
-            if (transaction.BlobVersionedHashes!.Length < Eip4844Constants.MinBlobsPerTransaction)
+
+            if (blobCount < Eip4844Constants.MinBlobsPerTransaction)
             {
                 error = TxErrorMessages.BlobTxMissingBlobs;
                 return false;
             }
-
-            int blobCount = transaction.BlobVersionedHashes.Length;
 
             for (int i = 0; i < blobCount; i++)
             {
@@ -215,13 +215,14 @@ namespace Nethermind.Consensus.Validators
                     error = TxErrorMessages.MissingBlobVersionedHash;
                     return false;
                 }
-                if (transaction.BlobVersionedHashes![i].Length !=
-                KzgPolynomialCommitments.BytesPerBlobVersionedHash)
+
+                if (transaction.BlobVersionedHashes[i].Length != KzgPolynomialCommitments.BytesPerBlobVersionedHash)
                 {
                     error = TxErrorMessages.InvalidBlobVersionedHashSize;
                     return false;
                 }
-                if (transaction.BlobVersionedHashes![i][0] != KzgPolynomialCommitments.KzgBlobHashVersionV1)
+
+                if (transaction.BlobVersionedHashes[i][0] != KzgPolynomialCommitments.KzgBlobHashVersionV1)
                 {
                     error = TxErrorMessages.InvalidBlobVersionedHashVersion;
                     return false;
@@ -236,11 +237,13 @@ namespace Nethermind.Consensus.Validators
                     error = TxErrorMessages.InvalidBlobData;
                     return false;
                 }
+
                 if (wrapper.Commitments.Length != blobCount)
                 {
                     error = TxErrorMessages.InvalidBlobData;
                     return false;
                 }
+
                 if (wrapper.Proofs.Length != blobCount)
                 {
                     error = TxErrorMessages.InvalidBlobData;
@@ -278,8 +281,7 @@ namespace Nethermind.Consensus.Validators
                     }
                 }
 
-                if (!KzgPolynomialCommitments.AreProofsValid(wrapper.Blobs,
-                    wrapper.Commitments, wrapper.Proofs))
+                if (!KzgPolynomialCommitments.AreProofsValid(wrapper.Blobs, wrapper.Commitments, wrapper.Proofs))
                 {
                     error = TxErrorMessages.InvalidBlobProof;
                     return false;

--- a/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
@@ -194,7 +194,7 @@ namespace Nethermind.Consensus.Validators
                 return false;
             }
 
-            var totalDataGas = BlobGasCalculator.CalculateBlobGas(transaction.BlobVersionedHashes!.Length);
+            ulong totalDataGas = BlobGasCalculator.CalculateBlobGas(transaction.BlobVersionedHashes!.Length);
             if (totalDataGas > Eip4844Constants.MaxBlobGasPerTransaction)
             {
                 error = TxErrorMessages.BlobTxGasLimitExceeded;

--- a/src/Nethermind/Nethermind.Consensus/Validators/UnclesValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/UnclesValidator.cs
@@ -42,7 +42,7 @@ namespace Nethermind.Consensus.Validators
             for (int i = 0; i < uncles.Length; i++)
             {
                 BlockHeader uncle = uncles[i];
-                if (!_headerValidator.Validate(uncle, true))
+                if (!_headerValidator.Validate(uncle, true, out _))
                 {
                     _logger.Info($"Invalid block ({header.ToString(BlockHeader.Format.Full)}) - uncle's header invalid");
                     return false;

--- a/src/Nethermind/Nethermind.Core.Test/Builders/BlockValidatorBuilder.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Builders/BlockValidatorBuilder.cs
@@ -35,8 +35,8 @@ namespace Nethermind.Core.Test.Builders
 
         protected override void BeforeReturn()
         {
-            TestObjectInternal.ValidateSuggestedBlock(Arg.Any<Block>()).Returns(_alwaysTrue);
-            TestObjectInternal.ValidateProcessedBlock(Arg.Any<Block>(), Arg.Any<TxReceipt[]>(), Arg.Any<Block>()).Returns(_alwaysTrue);
+            TestObjectInternal.ValidateSuggestedBlock(Arg.Any<Block>(), out _).Returns(_alwaysTrue);
+            TestObjectInternal.ValidateProcessedBlock(Arg.Any<Block>(), Arg.Any<TxReceipt[]>(), Arg.Any<Block>(), out _).Returns(_alwaysTrue);
             base.BeforeReturn();
         }
     }

--- a/src/Nethermind/Nethermind.Core.Test/Builders/TransactionValidatorBuilder.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Builders/TransactionValidatorBuilder.cs
@@ -36,8 +36,8 @@ namespace Nethermind.Core.Test.Builders
 
         protected override void BeforeReturn()
         {
-            TestObjectInternal.IsWellFormed(Arg.Any<Transaction>(), Arg.Any<IReleaseSpec>()).Returns(_alwaysTrue);
-            TestObjectInternal.IsWellFormed(Arg.Any<Transaction>(), Arg.Any<IReleaseSpec>()).Returns(_alwaysTrue);
+            TestObjectInternal.IsWellFormed(Arg.Any<Transaction>(), Arg.Any<IReleaseSpec>(), out _).Returns(_alwaysTrue);
+            TestObjectInternal.IsWellFormed(Arg.Any<Transaction>(), Arg.Any<IReleaseSpec>(), out _).Returns(_alwaysTrue);
             base.BeforeReturn();
         }
     }

--- a/src/Nethermind/Nethermind.Evm.Test/TransactionSubstateTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/TransactionSubstateTests.cs
@@ -136,7 +136,7 @@ namespace Nethermind.Evm.Test
                 "Reverted unknown panic code (0xff)");
 
             // Invalid case
-            yield return (new byte[] { 0x4e, 0x48, 0x7b, 0x71 }, "Reverted NH{q");
+            yield return (new byte[] { 0xf0, 0x28, 0x8c, 0x28 }, "Reverted 0xf0288c28");
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Evm.Test/TransactionSubstateTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/TransactionSubstateTests.cs
@@ -136,7 +136,7 @@ namespace Nethermind.Evm.Test
                 "Reverted unknown panic code (0xff)");
 
             // Invalid case
-            yield return (new byte[] { 0xf0, 0x28, 0x8c, 0x28 }, "Reverted 0xf0288c28");
+            yield return (new byte[] { 0x4e, 0x48, 0x7b, 0x71 }, "Reverted NH{q");
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -127,7 +127,7 @@ namespace Nethermind.Evm.TransactionProcessing
 
             if (commit) WorldState.Commit(spec, tracer.IsTracingState ? tracer : NullTxTracer.Instance);
 
-            ExecutionEnvironment env = BuildExecutionEnvironment(tx, blCtx, spec, effectiveGasPrice);
+            ExecutionEnvironment env = BuildExecutionEnvironment(tx, in blCtx, spec, effectiveGasPrice);
 
             long gasAvailable = tx.GasLimit - intrinsicGas;
             ExecuteEvmCall(tx, header, spec, tracer, opts, gasAvailable, env, out TransactionSubstate? substate, out long spentGas, out byte statusCode);
@@ -182,7 +182,7 @@ namespace Nethermind.Evm.TransactionProcessing
 
         private static void UpdateMetrics(ExecutionOptions opts, UInt256 effectiveGasPrice)
         {
-            if (opts == ExecutionOptions.Commit || opts == ExecutionOptions.None)
+            if (opts is ExecutionOptions.Commit or ExecutionOptions.None)
             {
                 float gasPrice = (float)((double)effectiveGasPrice / 1_000_000_000.0);
                 Metrics.MinGasPrice = Math.Min(gasPrice, Metrics.MinGasPrice);
@@ -396,7 +396,7 @@ namespace Nethermind.Evm.TransactionProcessing
             return TransactionResult.Ok;
         }
 
-        protected virtual ExecutionEnvironment BuildExecutionEnvironment(
+        protected ExecutionEnvironment BuildExecutionEnvironment(
             Transaction tx,
             in BlockExecutionContext blCtx,
             IReleaseSpec spec,
@@ -407,7 +407,8 @@ namespace Nethermind.Evm.TransactionProcessing
 
             TxExecutionContext executionContext = new(in blCtx, tx.SenderAddress, effectiveGasPrice, tx.BlobVersionedHashes);
 
-            CodeInfo codeInfo = tx.IsContractCreation ? new(tx.Data?.AsArray() ?? Array.Empty<byte>())
+            CodeInfo codeInfo = tx.IsContractCreation
+                ? new(tx.Data ?? Memory<byte>.Empty)
                 : VirtualMachine.GetCachedCodeInfo(WorldState, recipient, spec);
 
             byte[] inputData = tx.IsMessageCall ? tx.Data.AsArray() ?? Array.Empty<byte>() : Array.Empty<byte>();

--- a/src/Nethermind/Nethermind.Hive/HiveRunner.cs
+++ b/src/Nethermind/Nethermind.Hive/HiveRunner.cs
@@ -201,7 +201,7 @@ namespace Nethermind.Hive
                 // Start of block processing, setting flag BlockSuggested to default value: false
                 BlockSuggested = false;
 
-                if (!_blockValidator.ValidateSuggestedBlock(block))
+                if (!_blockValidator.ValidateSuggestedBlock(block, out _))
                 {
                     if (_logger.IsInfo) _logger.Info($"Invalid block {block}");
                     return;

--- a/src/Nethermind/Nethermind.Logging/ILogger.cs
+++ b/src/Nethermind/Nethermind.Logging/ILogger.cs
@@ -34,11 +34,11 @@ public readonly struct ILogger
         if (logger.IsError) _value |= LogLevel.Error;
     }
 
-    public bool IsTrace => (_value & LogLevel.Trace) != 0;
-    public bool IsDebug => (_value & LogLevel.Debug) != 0;
-    public bool IsInfo => (_value & LogLevel.Info) != 0;
-    public bool IsWarn => (_value & LogLevel.Warn) != 0;
-    public bool IsError => (_value & LogLevel.Error) != 0;
+    public readonly bool IsTrace => (_value & LogLevel.Trace) != 0;
+    public readonly bool IsDebug => (_value & LogLevel.Debug) != 0;
+    public readonly bool IsInfo => (_value & LogLevel.Info) != 0;
+    public readonly bool IsWarn => (_value & LogLevel.Warn) != 0;
+    public readonly bool IsError => (_value & LogLevel.Error) != 0;
 
 #if DEBUG
     public void SetDebugMode() => _value |= LogLevel.Debug;
@@ -50,35 +50,35 @@ public readonly struct ILogger
     // otherwise they will be executing code to build error strings to pass etc, so we don't want to
     // inline the code for a second check.
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public void Debug(string text)
+    public readonly void Debug(string text)
     {
         if (IsDebug)
             _logger.Debug(text);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public void Error(string text, Exception ex = null)
+    public readonly void Error(string text, Exception ex = null)
     {
         if (IsError)
             _logger.Error(text, ex);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public void Info(string text)
+    public readonly void Info(string text)
     {
         if (IsInfo)
             _logger.Info(text);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public void Trace(string text)
+    public readonly void Trace(string text)
     {
         if (IsTrace)
             _logger.Trace(text);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public void Warn(string text)
+    public readonly void Warn(string text)
     {
         if (IsWarn)
             _logger.Warn(text);

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/InvalidChainTracker/InvalidBlockInterceptorTest.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/InvalidChainTracker/InvalidBlockInterceptorTest.cs
@@ -43,7 +43,7 @@ public class InvalidBlockInterceptorTest
     public void TestValidateSuggestedBlock(bool baseReturnValue, bool isInvalidBlockReported)
     {
         Block block = Build.A.Block.TestObject;
-        _baseValidator.ValidateSuggestedBlock(block).Returns(baseReturnValue);
+        _baseValidator.ValidateSuggestedBlock(block, out string? error).Returns(baseReturnValue);
         _invalidBlockInterceptor.ValidateSuggestedBlock(block);
 
         _tracker.Received().SetChildParent(block.GetOrCalculateHash(), block.ParentHash!);
@@ -64,7 +64,7 @@ public class InvalidBlockInterceptorTest
         Block block = Build.A.Block.TestObject;
         Block suggestedBlock = Build.A.Block.WithExtraData(new byte[] { 1 }).TestObject;
         TxReceipt[] txs = { };
-        _baseValidator.ValidateProcessedBlock(block, txs, suggestedBlock).Returns(baseReturnValue);
+        _baseValidator.ValidateProcessedBlock(block, txs, suggestedBlock, out string? error).Returns(baseReturnValue);
         _invalidBlockInterceptor.ValidateProcessedBlock(block, txs, suggestedBlock);
 
         _tracker.Received().SetChildParent(suggestedBlock.GetOrCalculateHash(), suggestedBlock.ParentHash!);
@@ -84,8 +84,8 @@ public class InvalidBlockInterceptorTest
         Block block = Build.A.Block.TestObject;
         block.Header.StateRoot = Keccak.Zero;
 
-        _baseValidator.ValidateSuggestedBlock(block).Returns(false);
-        _invalidBlockInterceptor.ValidateSuggestedBlock(block);
+        _baseValidator.ValidateSuggestedBlock(block, out _).Returns(false);
+        _invalidBlockInterceptor.ValidateSuggestedBlock(block, out _);
 
         _tracker.DidNotReceive().SetChildParent(block.GetOrCalculateHash(), block.ParentHash!);
         _tracker.DidNotReceive().OnInvalidBlock(block.GetOrCalculateHash(), block.ParentHash);
@@ -102,7 +102,7 @@ public class InvalidBlockInterceptorTest
             block.Transactions.Take(9).ToArray()
         ));
 
-        _baseValidator.ValidateSuggestedBlock(block).Returns(false);
+        _baseValidator.ValidateSuggestedBlock(block, out _).Returns(false);
         _invalidBlockInterceptor.ValidateSuggestedBlock(block);
 
         _tracker.DidNotReceive().SetChildParent(block.GetOrCalculateHash(), block.ParentHash!);
@@ -120,7 +120,7 @@ public class InvalidBlockInterceptorTest
             block.Withdrawals!.Take(8).ToArray()
         ));
 
-        _baseValidator.ValidateSuggestedBlock(block).Returns(false);
+        _baseValidator.ValidateSuggestedBlock(block, out _).Returns(false);
         _invalidBlockInterceptor.ValidateSuggestedBlock(block);
 
         _tracker.DidNotReceive().SetChildParent(block.GetOrCalculateHash(), block.ParentHash!);

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/InvalidChainTracker/InvalidHeaderInterceptorTest.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/InvalidChainTracker/InvalidHeaderInterceptorTest.cs
@@ -41,7 +41,7 @@ public class InvalidHeaderInterceptorTest
     public void TestValidateHeader(bool baseReturnValue, bool isInvalidBlockReported)
     {
         BlockHeader header = Build.A.BlockHeader.TestObject;
-        _baseValidator.Validate(header, false).Returns(baseReturnValue);
+        _baseValidator.Validate(header, false, out string? error).Returns(baseReturnValue);
         _invalidHeaderInterceptor.Validate(header, false);
 
         _tracker.Received().SetChildParent(header.GetOrCalculateHash(), header.ParentHash!);
@@ -63,8 +63,7 @@ public class InvalidHeaderInterceptorTest
         BlockHeader header = Build.A.BlockHeader
             .WithParent(parent)
             .TestObject;
-
-        _baseValidator.Validate(header, parent, false).Returns(baseReturnValue);
+        _baseValidator.Validate(header, parent, false, out string? error).Returns(baseReturnValue);
         _invalidHeaderInterceptor.Validate(header, parent, false);
 
         _tracker.Received().SetChildParent(header.GetOrCalculateHash(), header.ParentHash!);

--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/NewPayloadV1Result.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/NewPayloadV1Result.cs
@@ -3,6 +3,7 @@
 
 using Nethermind.Core.Crypto;
 using Nethermind.JsonRpc;
+using System;
 
 namespace Nethermind.Merge.Plugin.Data;
 
@@ -15,6 +16,12 @@ public static class NewPayloadV1Result
 
     public static ResultWrapper<PayloadStatusV1> Accepted = ResultWrapper<PayloadStatusV1>.Success(PayloadStatusV1.Accepted);
 
+    public static ResultWrapper<PayloadStatusV1> Invalid(string validationError)
+    {
+        if (string.IsNullOrEmpty(validationError))
+            throw new ArgumentException("Must have a message set.", nameof(validationError));
+        return Invalid(null, validationError);
+    }
     public static ResultWrapper<PayloadStatusV1> Invalid(Hash256? latestValidHash, string? validationError = null)
     {
         return ResultWrapper<PayloadStatusV1>.Success(new PayloadStatusV1() { Status = PayloadStatus.Invalid, LatestValidHash = latestValidHash, ValidationError = validationError });

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/NewPayloadHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/NewPayloadHandler.cs
@@ -42,7 +42,7 @@ public class NewPayloadHandler : IAsyncHandler<ExecutionPayload, PayloadStatusV1
     private readonly IMergeSyncController _mergeSyncController;
     private readonly IInvalidChainTracker _invalidChainTracker;
     private readonly ILogger _logger;
-    private readonly LruCache<ValueHash256, bool>? _latestBlocks;
+    private readonly LruCache<ValueHash256, (bool valid, string? message)>? _latestBlocks;
     private readonly ProcessingOptions _defaultProcessingOptions;
     private readonly TimeSpan _timeout;
 
@@ -154,10 +154,10 @@ public class NewPayloadHandler : IAsyncHandler<ExecutionPayload, PayloadStatusV1
 
         if (!ShouldProcessBlock(block, parentHeader, out ProcessingOptions processingOptions)) // we shouldn't process block
         {
-            if (!_blockValidator.ValidateSuggestedBlock(block))
+            if (!_blockValidator.ValidateSuggestedBlock(block, out string? error))
             {
                 if (_logger.IsInfo) _logger.Info($"Rejecting invalid block received during the sync, block: {block}");
-                return NewPayloadV1Result.Invalid(null);
+                return NewPayloadV1Result.Invalid(error);
             }
 
             BlockTreeInsertHeaderOptions insertHeaderOptions = BlockTreeInsertHeaderOptions.BeaconBlockInsert;
@@ -183,17 +183,18 @@ public class NewPayloadHandler : IAsyncHandler<ExecutionPayload, PayloadStatusV1
 
         if (_poSSwitcher.MisconfiguredTerminalTotalDifficulty())
         {
-            if (_logger.IsWarn) _logger.Warn($"Misconfigured terminal total difficulty.");
-
-            return NewPayloadV1Result.Invalid(Keccak.Zero);
+            const string errorMessage = "Misconfigured terminal total difficulty.";
+            if (_logger.IsWarn) _logger.Warn(errorMessage);
+            return NewPayloadV1Result.Invalid(Keccak.Zero, errorMessage);
         }
 
         if ((block.TotalDifficulty ?? 0) != 0 && _poSSwitcher.BlockBeforeTerminalTotalDifficulty(parentHeader))
         {
-            if (_logger.IsWarn) _logger.Warn($"Invalid terminal block. Nethermind TTD {_poSSwitcher.TerminalTotalDifficulty}, Parent TD: {parentHeader.TotalDifficulty}. Request: {requestStr}.");
+            string errorMessage = $"Invalid terminal block. Nethermind TTD {_poSSwitcher.TerminalTotalDifficulty}, Parent TD: {parentHeader.TotalDifficulty}. Request: {requestStr}.";
+            if (_logger.IsWarn) _logger.Warn(errorMessage);
 
             // {status: INVALID, latestValidHash: 0x0000000000000000000000000000000000000000000000000000000000000000, validationError: errorMessage | null} if terminal block conditions are not satisfied
-            return NewPayloadV1Result.Invalid(Keccak.Zero);
+            return NewPayloadV1Result.Invalid(Keccak.Zero, errorMessage);
         }
 
         // Otherwise, we can just process this block and we don't need to do BeaconSync anymore.
@@ -272,40 +273,39 @@ public class NewPayloadHandler : IAsyncHandler<ExecutionPayload, PayloadStatusV1
 
     private async Task<(ValidationResult, string?)> ValidateBlockAndProcess(Block block, BlockHeader parent, ProcessingOptions processingOptions)
     {
-        ValidationResult TryCacheResult(ValidationResult result)
+        ValidationResult TryCacheResult(ValidationResult result, string? errorMessage)
         {
             // notice that it is not correct to add information to the cache
             // if we return SYNCING for example, and don't know yet whether
             // the block is valid or invalid because we haven't processed it yet
             if (result == ValidationResult.Valid || result == ValidationResult.Invalid)
-                _latestBlocks?.Set(block.GetOrCalculateHash(), result == ValidationResult.Valid);
+                _latestBlocks?.Set(block.GetOrCalculateHash(), (result == ValidationResult.Valid, errorMessage));
             return result;
         }
 
         (ValidationResult? result, string? validationMessage) = (null, null);
 
         // If duplicate, reuse results
-        if (_latestBlocks is not null && _latestBlocks.TryGet(block.Hash!, out bool isValid))
+        if (_latestBlocks is not null && _latestBlocks.TryGet(block.Hash!, out (bool valid, string? message) cachedResult))
         {
+            (bool isValid, string? message) = cachedResult;
             if (!isValid)
             {
-                validationMessage = "Invalid block found in latestBlock cache.";
-                if (_logger.IsWarn) _logger.Warn(validationMessage);
+                if (_logger.IsWarn) _logger.Warn("Invalid block found in latestBlock cache.");
             }
-
-            return (isValid ? ValidationResult.Valid : ValidationResult.Invalid, validationMessage);
+            return (isValid ? ValidationResult.Valid : ValidationResult.Invalid, message);
         }
 
         // Validate
-        if (!ValidateWithBlockValidator(block, parent))
+        if (!ValidateWithBlockValidator(block, parent, out validationMessage))
         {
-            return (TryCacheResult(ValidationResult.Invalid), string.Empty);
+            return (TryCacheResult(ValidationResult.Invalid, validationMessage), validationMessage);
         }
 
         TaskCompletionSource<ValidationResult?> blockProcessedTaskCompletionSource = new();
         Task<ValidationResult?> blockProcessed = blockProcessedTaskCompletionSource.Task;
 
-        void GetProcessingQueueOnBlockRemoved(object? o, BlockHashEventArgs e)
+        void GetProcessingQueueOnBlockRemoved(object? o, BlockRemovedEventArgs e)
         {
             if (e.BlockHash == block.Hash)
             {
@@ -329,7 +329,7 @@ public class NewPayloadHandler : IAsyncHandler<ExecutionPayload, PayloadStatusV1
                 {
                     ProcessingResult.QueueException => "Block cannot be added to processing queue.",
                     ProcessingResult.MissingBlock => "Block wasn't found in tree.",
-                    ProcessingResult.ProcessingError => "Block processing failed.",
+                    ProcessingResult.ProcessingError => e.Message ?? "Block processing failed.",
                     _ => null
                 };
 
@@ -387,14 +387,14 @@ public class NewPayloadHandler : IAsyncHandler<ExecutionPayload, PayloadStatusV1
             _processingQueue.BlockRemoved -= GetProcessingQueueOnBlockRemoved;
         }
 
-        return (TryCacheResult(result ?? ValidationResult.Syncing), validationMessage);
+        return (TryCacheResult(result ?? ValidationResult.Syncing, validationMessage), validationMessage);
     }
 
-    private bool ValidateWithBlockValidator(Block block, BlockHeader parent)
+    private bool ValidateWithBlockValidator(Block block, BlockHeader parent, out string? error)
     {
         block.Header.TotalDifficulty ??= parent.TotalDifficulty + block.Difficulty;
         block.Header.IsPostMerge = true; // I think we don't need to set it again here.
-        bool isValid = _blockValidator.ValidateSuggestedBlock(block);
+        bool isValid = _blockValidator.ValidateSuggestedBlock(block, out error);
         if (!isValid && _logger.IsWarn) _logger.Warn($"Block validator rejected the block {block.ToString(Block.Format.FullHashAndNumber)}.");
         return isValid;
     }

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergeHeaderValidator.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergeHeaderValidator.cs
@@ -4,6 +4,7 @@
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Find;
 using Nethermind.Consensus;
+using Nethermind.Consensus.Messages;
 using Nethermind.Consensus.Validators;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
@@ -40,16 +41,24 @@ namespace Nethermind.Merge.Plugin
 
         public override bool Validate(BlockHeader header, BlockHeader? parent, bool isUncle = false)
         {
-            return _poSSwitcher.IsPostMerge(header)
-                ? ValidateTheMergeChecks(header) && base.Validate(header, parent, isUncle)
-                : ValidatePoWTotalDifficulty(header) && _preMergeHeaderValidator.Validate(header, parent, isUncle);
+            return Validate(header, parent, isUncle, out _);
         }
+        public override bool Validate(BlockHeader header, BlockHeader? parent, bool isUncle, out string? error)
+        {
+            error = null;
+            return _poSSwitcher.IsPostMerge(header)
+                ? ValidateTheMergeChecks(header) && base.Validate(header, parent, isUncle, out error)
+                : ValidatePoWTotalDifficulty(header) && _preMergeHeaderValidator.Validate(header, parent, isUncle, out error);
+        }
+
+        public override bool Validate(BlockHeader header, bool isUncle, out string? error) =>
+            Validate(header, _blockTree.FindParentHeader(header, BlockTreeLookupOptions.None), isUncle, out error);
 
         public override bool Validate(BlockHeader header, bool isUncle = false) =>
             Validate(header, _blockTree.FindParentHeader(header, BlockTreeLookupOptions.None), isUncle);
 
-        protected override bool ValidateTotalDifficulty(BlockHeader parent, BlockHeader header) =>
-            _poSSwitcher.IsPostMerge(header) || base.ValidateTotalDifficulty(parent, header);
+        protected override bool ValidateTotalDifficulty(BlockHeader parent, BlockHeader header, ref string? error) =>
+            _poSSwitcher.IsPostMerge(header) || base.ValidateTotalDifficulty(parent, header, ref error);
 
         private bool ValidatePoWTotalDifficulty(BlockHeader header)
         {
@@ -64,36 +73,31 @@ namespace Nethermind.Merge.Plugin
 
         private bool ValidateTheMergeChecks(BlockHeader header)
         {
-            bool validDifficulty = true, validNonce = true, validUncles = true;
             (bool IsTerminal, bool IsPostMerge) switchInfo = _poSSwitcher.GetBlockConsensusInfo(header);
             bool terminalTotalDifficultyChecks = ValidateTerminalTotalDifficultyChecks(header, switchInfo.IsTerminal);
-            if (switchInfo.IsPostMerge)
-            {
-                validDifficulty = ValidateHeaderField(header, header.Difficulty, UInt256.Zero, nameof(header.Difficulty));
-                validNonce = ValidateHeaderField(header, header.Nonce, 0u, nameof(header.Nonce));
-                validUncles = ValidateHeaderField(header, header.UnclesHash, Keccak.OfAnEmptySequenceRlp, nameof(header.UnclesHash));
-            }
+            bool valid = !switchInfo.IsPostMerge ||
+                        ValidateHeaderField(header, header.Difficulty, UInt256.Zero, nameof(header.Difficulty))
+                        && ValidateHeaderField(header, header.Nonce, 0u, nameof(header.Nonce))
+                        && ValidateHeaderField(header, header.UnclesHash, Keccak.OfAnEmptySequenceRlp, nameof(header.UnclesHash));
 
-            return terminalTotalDifficultyChecks
-                   && validDifficulty
-                   && validNonce
-                   && validUncles;
+            return terminalTotalDifficultyChecks && valid;
         }
 
-        protected override bool ValidateExtraData(BlockHeader header, BlockHeader? parent, IReleaseSpec spec, bool isUncle = false)
+        protected override bool ValidateExtraData(BlockHeader header, BlockHeader? parent, IReleaseSpec spec, bool isUncle, ref string? error)
         {
             if (_poSSwitcher.IsPostMerge(header))
             {
                 if (header.ExtraData.Length > MaxExtraDataBytes)
                 {
                     if (_logger.IsWarn) _logger.Warn($"Invalid block header {header.ToString(BlockHeader.Format.Short)} - the {nameof(header.ExtraData)} exceeded max length of {MaxExtraDataBytes}.");
+                    error = BlockErrorMessages.InvalidExtraData;
                     return false;
                 }
 
                 return true;
             }
 
-            return base.ValidateExtraData(header, parent, spec, isUncle);
+            return base.ValidateExtraData(header, parent, spec, isUncle, ref error);
         }
 
         private bool ValidateTerminalTotalDifficultyChecks(BlockHeader header, bool isTerminal)

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeBlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/MergeBlockDownloader.cs
@@ -216,7 +216,7 @@ namespace Nethermind.Merge.Plugin.Synchronization
                     }
 
                     // can move this to block tree now?
-                    if (!_blockValidator.ValidateSuggestedBlock(currentBlock))
+                    if (!_blockValidator.ValidateSuggestedBlock(currentBlock, out _))
                     {
                         string message = $"{bestPeer} sent an invalid block {currentBlock.ToString(Block.Format.Short)}.";
                         if (_logger.IsWarn) _logger.Warn(message);

--- a/src/Nethermind/Nethermind.Mev/Source/BundlePool.cs
+++ b/src/Nethermind/Nethermind.Mev/Source/BundlePool.cs
@@ -240,7 +240,7 @@ namespace Nethermind.Mev.Source
                 BundleTransaction tx = bundle.Transactions[i];
                 if (!tx.CanRevert)
                 {
-                    if (!_txValidator.IsWellFormed(tx, spec))
+                    if (!_txValidator.IsWellFormed(tx, spec, out _))
                     {
                         return false;
                     }

--- a/src/Nethermind/Nethermind.Optimism/OptimismHeaderValidator.cs
+++ b/src/Nethermind/Nethermind.Optimism/OptimismHeaderValidator.cs
@@ -16,5 +16,5 @@ public class OptimismHeaderValidator : HeaderValidator
     {
     }
 
-    protected override bool ValidateGasLimitRange(BlockHeader header, BlockHeader parent, IReleaseSpec spec) => true;
+    protected override bool ValidateGasLimitRange(BlockHeader header, BlockHeader parent, IReleaseSpec spec, ref string? error) => true;
 }

--- a/src/Nethermind/Nethermind.Optimism/OptimismTxValidator.cs
+++ b/src/Nethermind/Nethermind.Optimism/OptimismTxValidator.cs
@@ -4,6 +4,7 @@
 using Nethermind.Core;
 using Nethermind.Core.Specs;
 using Nethermind.TxPool;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Nethermind.Optimism;
 
@@ -17,5 +18,11 @@ public class OptimismTxValidator : ITxValidator
     }
 
     public bool IsWellFormed(Transaction transaction, IReleaseSpec releaseSpec) =>
-        transaction.Type == TxType.DepositTx || _txValidator.IsWellFormed(transaction, releaseSpec);
+        IsWellFormed(transaction, releaseSpec, out _);
+    public bool IsWellFormed(Transaction transaction, IReleaseSpec releaseSpec, [NotNullWhen(false)] out string? error)
+    {
+        error = null;
+        return transaction.Type == TxType.DepositTx || _txValidator.IsWellFormed(transaction, releaseSpec, out error);
+    }
+
 }

--- a/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
@@ -42,6 +42,7 @@ using Nethermind.Trie.Pruning;
 using NSubstitute;
 using NUnit.Framework;
 using BlockTree = Nethermind.Blockchain.BlockTree;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Nethermind.Synchronization.Test
 {
@@ -485,7 +486,35 @@ namespace Nethermind.Synchronization.Test
                 return true;
             }
 
-            public bool ValidateOrphanedBlock(Block block, out string? error)
+            public bool ValidateOrphanedBlock(Block block, [NotNullWhen(false)] out string? error)
+            {
+                Thread.Sleep(1000);
+                error = null;
+                return true;
+            }
+
+            public bool ValidateSuggestedBlock(Block block, [NotNullWhen(false)] out string? error)
+            {
+                Thread.Sleep(1000);
+                error = null;
+                return true;
+            }
+
+            public bool ValidateProcessedBlock(Block processedBlock, TxReceipt[] receipts, Block suggestedBlock, [NotNullWhen(false)] out string? error)
+            {
+                Thread.Sleep(1000);
+                error = null;
+                return true;
+            }
+
+            public bool Validate(BlockHeader header, BlockHeader? parent, bool isUncle, [NotNullWhen(false)] out string? error)
+            {
+                Thread.Sleep(1000);
+                error = null;
+                return true;
+            }
+
+            public bool Validate(BlockHeader header, bool isUncle, [NotNullWhen(false)] out string? error)
             {
                 Thread.Sleep(1000);
                 error = null;

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/BlockDownloader.cs
@@ -341,7 +341,7 @@ namespace Nethermind.Synchronization.Blocks
                     }
 
                     // can move this to block tree now?
-                    if (!_blockValidator.ValidateSuggestedBlock(currentBlock))
+                    if (!_blockValidator.ValidateSuggestedBlock(currentBlock, out _))
                     {
                         throw new EthSyncException($"{bestPeer} sent an invalid block {currentBlock.ToString(Block.Format.Short)}.");
                     }

--- a/src/Nethermind/Nethermind.Synchronization/SyncServer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SyncServer.cs
@@ -196,7 +196,7 @@ namespace Nethermind.Synchronization
 
                     // Recalculate total difficulty as we don't trust total difficulty from gossip
                     block.Header.TotalDifficulty = parent.TotalDifficulty + block.Header.Difficulty;
-                    if (!_blockValidator.ValidateSuggestedBlock(block))
+                    if (!_blockValidator.ValidateSuggestedBlock(block, out _))
                     {
                         ThrowOnInvalidBlock(block, nodeWhoSentTheBlock);
                     }

--- a/src/Nethermind/Nethermind.TxPool/Filters/MalformedTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/MalformedTxFilter.cs
@@ -26,7 +26,7 @@ namespace Nethermind.TxPool.Filters
         public AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions txHandlingOptions)
         {
             IReleaseSpec spec = _specProvider.GetCurrentHeadSpec();
-            if (!_txValidator.IsWellFormed(tx, spec))
+            if (!_txValidator.IsWellFormed(tx, spec, out _))
             {
                 Metrics.PendingTransactionsMalformed++;
                 // It may happen that other nodes send us transactions that were signed for another chain or don't have enough gas.

--- a/src/Nethermind/Nethermind.TxPool/ITxValidator.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxValidator.cs
@@ -3,11 +3,12 @@
 
 using Nethermind.Core;
 using Nethermind.Core.Specs;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Nethermind.TxPool
 {
     public interface ITxValidator
     {
-        bool IsWellFormed(Transaction transaction, IReleaseSpec releaseSpec);
+        bool IsWellFormed(Transaction transaction, IReleaseSpec releaseSpec, [NotNullWhen(false)] out string? error);
     }
 }

--- a/tools/HiveConsensusWorkflowGenerator/Program.cs
+++ b/tools/HiveConsensusWorkflowGenerator/Program.cs
@@ -56,7 +56,7 @@ public static class Program
         .ToList();
 
         string jsonString = JsonSerializer.Serialize(jsonGroups, new JsonSerializerOptions { WriteIndented = true });
-        
+
         File.WriteAllText("matrix.json", jsonString);
     }
 

--- a/tools/SendBlobs/SetupCli.cs
+++ b/tools/SendBlobs/SetupCli.cs
@@ -55,7 +55,7 @@ internal static class SetupCli
                 ulong.TryParse(maxFeePerBlobGasOption.Value(), out ulong shortMaxFeePerBlobGas);
                 maxFeePerBlobGas = shortMaxFeePerBlobGas;
             }
-            else if(maxFeePerDataGasOptionObsolete.HasValue())
+            else if (maxFeePerDataGasOptionObsolete.HasValue())
             {
                 ulong.TryParse(maxFeePerDataGasOptionObsolete.Value(), out ulong shortMaxFeePerBlobGas);
                 maxFeePerBlobGas = shortMaxFeePerBlobGas;
@@ -249,7 +249,8 @@ internal static class SetupCli
                     ulong.TryParse(feeMultiplierOption.Value(), out feeMultiplier);
 
                 UInt256? maxPriorityFeeGas = null;
-                if (maxPriorityFeeGasOption.HasValue() && UInt256.TryParse(maxPriorityFeeGasOption.Value(), out UInt256 maxPriorityFeeGasParsed)){
+                if (maxPriorityFeeGasOption.HasValue() && UInt256.TryParse(maxPriorityFeeGasOption.Value(), out UInt256 maxPriorityFeeGasParsed))
+                {
                     maxPriorityFeeGas = maxPriorityFeeGasParsed;
                 }
 

--- a/tools/docgen/ConfigGenerator.cs
+++ b/tools/docgen/ConfigGenerator.cs
@@ -22,7 +22,7 @@ internal static class ConfigGenerator
             .Where(t => t.IsInterface && typeof(IConfig).IsAssignableFrom(t) &&
                 !excluded.Any(x => t.FullName?.Contains(x, StringComparison.Ordinal) ?? false))
             .OrderBy(t => t.Name);
-        
+
         File.Delete($"~{fileName}");
 
         using var readStream = new StreamReader(File.OpenRead(fileName));


### PR DESCRIPTION
## Changes

This will set error messages primarily for engine RPC endpoints, which is used in some hive test to test for correctness.

Format for error messages is two segments divided with ':'
- first segment is machine parseable and can be used for verification
- second part is a human readable error description
Example: 
`"InvalidAncestor: No valid ancestors could be found."`
`"InvalidBaseFeePerGas: Does not match calculated."`

This is meant to serve as a temporary solution until there is a common standard for Json RPC error codes.

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No
