### PR TITLE
Migrate snap message to use MessageDictionary

### DIFF
--- a/src/Nethermind/Nethermind.Network.Test/MessageDictionaryTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/MessageDictionaryTests.cs
@@ -18,7 +18,7 @@ namespace Nethermind.Network.Test;
 public class MessageDictionaryTests
 {
     private readonly List<Eth66Message<GetBlockHeadersMessage>> _recordedRequests = new();
-    private MessageDictionary<Eth66Message<GetBlockHeadersMessage>, GetBlockHeadersMessage, BlockHeader[]>
+    private MessageDictionary<Eth66Message<GetBlockHeadersMessage>, BlockHeader[]>
         _testMessageDictionary;
 
     [SetUp]

--- a/src/Nethermind/Nethermind.Network.Test/SnapProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/SnapProtocolHandlerTests.cs
@@ -86,7 +86,8 @@ public class SnapProtocolHandlerTests
 
                         IByteBuffer buffer = MessageSerializationService.ZeroSerialize(new AccountRangeMessage()
                         {
-                            PathsWithAccounts = new ArrayPoolList<PathWithAccount>(1) { new PathWithAccount(Keccak.Zero, Account.TotallyEmpty) }
+                            PathsWithAccounts = new ArrayPoolList<PathWithAccount>(1) { new PathWithAccount(Keccak.Zero, Account.TotallyEmpty) },
+                            RequestId = accountRangeMessage.RequestId,
                         });
                         buffer.ReadByte(); // Need to skip adaptive type
 

--- a/src/Nethermind/Nethermind.Network/P2P/MessageDictionary.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/MessageDictionary.cs
@@ -6,13 +6,12 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Nethermind.Core.Exceptions;
-using Nethermind.Network.P2P.Messages;
 using Nethermind.Network.P2P.Subprotocols;
 using Nethermind.Network.P2P.Subprotocols.Eth.V66.Messages;
 
 namespace Nethermind.Network.P2P;
 
-public class MessageDictionary<T66Msg, TMsg, TData> where T66Msg : Eth66Message<TMsg> where TMsg : P2PMessage
+public class MessageDictionary<T66Msg, TData> where T66Msg : IEth66Message
 {
     private readonly Action<T66Msg> _send;
 
@@ -44,7 +43,7 @@ public class MessageDictionary<T66Msg, TMsg, TData> where T66Msg : Eth66Message<
     {
         if (_requestCount >= MaxConcurrentRequest)
         {
-            throw new ConcurrencyLimitReachedException($"Concurrent request limit reached. Message type: {typeof(TMsg)}");
+            throw new ConcurrencyLimitReachedException($"Concurrent request limit reached. Message type: {typeof(T66Msg)}");
         }
 
         if (_requests.TryAdd(request.Message.RequestId, request))
@@ -93,7 +92,7 @@ public class MessageDictionary<T66Msg, TMsg, TData> where T66Msg : Eth66Message<
         }
         else
         {
-            throw new SubprotocolException($"Received a response to {nameof(TMsg)} that has not been requested");
+            throw new SubprotocolException($"Received a response to {nameof(T66Msg)} that has not been requested");
         }
     }
 }

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroProtocolHandlerBase.cs
@@ -49,7 +49,6 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
             Func<TRequest, string> describeRequestFunc,
             CancellationToken token
         )
-            where TRequest : MessageBase
         {
             Task<TResponse> task = request.CompletionSource.Task;
             using CancellationTokenSource delayCancellation = new();

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandler.cs
@@ -29,10 +29,10 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
     /// </summary>
     public class Eth66ProtocolHandler : Eth65ProtocolHandler
     {
-        private readonly MessageDictionary<GetBlockHeadersMessage, V62.Messages.GetBlockHeadersMessage, IOwnedReadOnlyList<BlockHeader>> _headersRequests66;
-        private readonly MessageDictionary<GetBlockBodiesMessage, V62.Messages.GetBlockBodiesMessage, (OwnedBlockBodies, long)> _bodiesRequests66;
-        private readonly MessageDictionary<GetNodeDataMessage, V63.Messages.GetNodeDataMessage, IOwnedReadOnlyList<byte[]>> _nodeDataRequests66;
-        private readonly MessageDictionary<GetReceiptsMessage, V63.Messages.GetReceiptsMessage, (IOwnedReadOnlyList<TxReceipt[]>, long)> _receiptsRequests66;
+        private readonly MessageDictionary<GetBlockHeadersMessage, IOwnedReadOnlyList<BlockHeader>> _headersRequests66;
+        private readonly MessageDictionary<GetBlockBodiesMessage, (OwnedBlockBodies, long)> _bodiesRequests66;
+        private readonly MessageDictionary<GetNodeDataMessage, IOwnedReadOnlyList<byte[]>> _nodeDataRequests66;
+        private readonly MessageDictionary<GetReceiptsMessage, (IOwnedReadOnlyList<TxReceipt[]>, long)> _receiptsRequests66;
         private readonly IPooledTxsRequestor _pooledTxsRequestor;
         private readonly Action<GetPooledTransactionsMessage> _sendAction;
 
@@ -49,10 +49,10 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
             ITxGossipPolicy? transactionsGossipPolicy = null)
             : base(session, serializer, nodeStatsManager, syncServer, backgroundTaskScheduler, txPool, pooledTxsRequestor, gossipPolicy, forkInfo, logManager, transactionsGossipPolicy)
         {
-            _headersRequests66 = new MessageDictionary<GetBlockHeadersMessage, V62.Messages.GetBlockHeadersMessage, IOwnedReadOnlyList<BlockHeader>>(Send);
-            _bodiesRequests66 = new MessageDictionary<GetBlockBodiesMessage, V62.Messages.GetBlockBodiesMessage, (OwnedBlockBodies, long)>(Send);
-            _nodeDataRequests66 = new MessageDictionary<GetNodeDataMessage, V63.Messages.GetNodeDataMessage, IOwnedReadOnlyList<byte[]>>(Send);
-            _receiptsRequests66 = new MessageDictionary<GetReceiptsMessage, V63.Messages.GetReceiptsMessage, (IOwnedReadOnlyList<TxReceipt[]>, long)>(Send);
+            _headersRequests66 = new MessageDictionary<GetBlockHeadersMessage, IOwnedReadOnlyList<BlockHeader>>(Send);
+            _bodiesRequests66 = new MessageDictionary<GetBlockBodiesMessage, (OwnedBlockBodies, long)>(Send);
+            _nodeDataRequests66 = new MessageDictionary<GetNodeDataMessage, IOwnedReadOnlyList<byte[]>>(Send);
+            _receiptsRequests66 = new MessageDictionary<GetReceiptsMessage, (IOwnedReadOnlyList<TxReceipt[]>, long)>(Send);
             _pooledTxsRequestor = pooledTxsRequestor;
             // Capture Action once rather than per call
             _sendAction = Send;
@@ -288,15 +288,14 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
                 token);
         }
 
-        private async Task<TResponse> SendRequestGenericEth66<T66, TRequest, TResponse>(
-            MessageDictionary<T66, TRequest, TResponse> messageQueue,
+        private async Task<TResponse> SendRequestGenericEth66<T66, TResponse>(
+            MessageDictionary<T66, TResponse> messageQueue,
             T66 message,
             TransferSpeedType speedType,
             Func<T66, string> describeRequestFunc,
             CancellationToken token
         )
-            where T66 : Eth66Message<TRequest>
-            where TRequest : P2PMessage
+            where T66 : IEth66Message
         {
             Request<T66, TResponse> request = new(message);
             messageQueue.Send(request);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Messages/Eth66Message.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Messages/Eth66Message.cs
@@ -5,7 +5,7 @@ using Nethermind.Network.P2P.Messages;
 
 namespace Nethermind.Network.P2P.Subprotocols.Eth.V66.Messages
 {
-    public abstract class Eth66Message<T> : P2PMessage where T : P2PMessage
+    public abstract class Eth66Message<T> : P2PMessage, IEth66Message where T : P2PMessage
     {
         public override int PacketType => EthMessage.PacketType;
         public override string Protocol => EthMessage.Protocol;
@@ -30,5 +30,10 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66.Messages
             base.Dispose();
             EthMessage.Dispose();
         }
+    }
+
+    public interface IEth66Message
+    {
+        long RequestId { get; }
     }
 }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/SnapMessageBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/SnapMessageBase.cs
@@ -13,7 +13,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap.Messages
         /// <summary>
         /// Request ID to match up responses with
         /// </summary>
-        public long RequestId { get; set; }
+        public long RequestId { get; set; } = MessageConstants.Random.NextLong();
 
         protected SnapMessageBase(bool generateRandomRequestId = true)
         {

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/SnapMessageBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/SnapMessageBase.cs
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Nethermind.Network.P2P.Messages;
+using Nethermind.Network.P2P.Subprotocols.Eth.V66.Messages;
 
 namespace Nethermind.Network.P2P.Subprotocols.Snap.Messages
 {
-    public abstract class SnapMessageBase : P2PMessage
+    public abstract class SnapMessageBase : P2PMessage, IEth66Message
     {
         public override string Protocol => Contract.P2P.Protocol.Snap;
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/SnapProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/SnapProtocolHandler.cs
@@ -51,10 +51,10 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap
 
         private const string DisconnectMessage = "Serving snap data in not implemented in this node.";
 
-        private readonly MessageQueue<GetAccountRangeMessage, AccountRangeMessage> _getAccountRangeRequests;
-        private readonly MessageQueue<GetStorageRangeMessage, StorageRangeMessage> _getStorageRangeRequests;
-        private readonly MessageQueue<GetByteCodesMessage, ByteCodesMessage> _getByteCodesRequests;
-        private readonly MessageQueue<GetTrieNodesMessage, TrieNodesMessage> _getTrieNodesRequests;
+        private readonly MessageDictionary<GetAccountRangeMessage, AccountRangeMessage> _getAccountRangeRequests;
+        private readonly MessageDictionary<GetStorageRangeMessage, StorageRangeMessage> _getStorageRangeRequests;
+        private readonly MessageDictionary<GetByteCodesMessage, ByteCodesMessage> _getByteCodesRequests;
+        private readonly MessageDictionary<GetTrieNodesMessage, TrieNodesMessage> _getTrieNodesRequests;
         private static readonly byte[] _emptyBytes = [0];
 
         public SnapProtocolHandler(ISession session,
@@ -171,25 +171,25 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap
         private void Handle(AccountRangeMessage msg, long size)
         {
             Metrics.SnapAccountRangeReceived++;
-            _getAccountRangeRequests.Handle(msg, size);
+            _getAccountRangeRequests.Handle(msg.RequestId, msg, size);
         }
 
         private void Handle(StorageRangeMessage msg, long size)
         {
             Metrics.SnapStorageRangesReceived++;
-            _getStorageRangeRequests.Handle(msg, size);
+            _getStorageRangeRequests.Handle(msg.RequestId, msg, size);
         }
 
         private void Handle(ByteCodesMessage msg, long size)
         {
             Metrics.SnapByteCodesReceived++;
-            _getByteCodesRequests.Handle(msg, size);
+            _getByteCodesRequests.Handle(msg.RequestId, msg, size);
         }
 
         private void Handle(TrieNodesMessage msg, long size)
         {
             Metrics.SnapTrieNodesReceived++;
-            _getTrieNodesRequests.Handle(msg, size);
+            _getTrieNodesRequests.Handle(msg.RequestId, msg, size);
         }
 
         private ValueTask<AccountRangeMessage> Handle(GetAccountRangeMessage getAccountRangeMessage, CancellationToken cancellationToken)
@@ -357,16 +357,14 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap
             return groups;
         }
 
-        private async Task<TOut> SendRequest<TIn, TOut>(TIn msg, MessageQueue<TIn, TOut> requestQueue, CancellationToken token)
+        private async Task<TOut> SendRequest<TIn, TOut>(TIn msg, MessageDictionary<TIn, TOut> messageDictionary, CancellationToken token)
             where TIn : SnapMessageBase
             where TOut : SnapMessageBase
         {
-            return await SendRequestGeneric(
-                requestQueue,
-                msg,
-                TransferSpeedType.SnapRanges,
-                static request => request.ToString(),
-                token);
+            Request<TIn, TOut> request = new(msg);
+            messageDictionary.Send(request);
+
+            return await HandleResponse(request, TransferSpeedType.SnapRanges, static req => req.ToString(), token);
         }
     }
 }


### PR DESCRIPTION
- The MessageDictionary class is the successor to MessageQueue which allow handling of P2P message out of order.
- For some reason, snap protocol handler does not use it, even when it have request id. Wonder why it does not implement it, who missed it when creating the MessageDictionary.. oh wait its me. That makes complete sense.
- This means it can't handle snap request out of order, which will probably just cause peer disconnection.
- Also finally explain why just increasing number of concurrent call does not work improve snap server throughput.

## Changes

- Make it implement it.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)
- [X] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- [x] Mainnet sync.
- [x] Mainnet snap serve.
- [X] Snap hive test