### PR TITLE
Use column db for verkle kv db

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
@@ -248,7 +248,7 @@ public partial class BlockProcessor : IBlockProcessor
         for (var i = 0; i < Math.Min(256, current); i++)
         {
             // an extract check - dont think it is needed
-            if(header.IsGenesis) break;
+            if (header.IsGenesis) break;
             _blockHashInStateHandlerHandler.AddParentBlockHashToState(header, spec, stateProvider, NullBlockTracer.Instance);
             header = _blockTree.FindParentHeader(currentBlock, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
             if (header is null)
@@ -299,7 +299,7 @@ public partial class BlockProcessor : IBlockProcessor
 
         _beaconBlockRootHandler.ApplyContractStateChanges(block, spec, worldState);
 
-        if (spec.IsEip2935Enabled )
+        if (spec.IsEip2935Enabled)
         {
             // TODO: find a better way to handle this - no need to have this check everytime
             //      this would just be true on the fork block

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -152,21 +152,20 @@ public class ColumnDb : IDb
 
     public IEnumerable<KeyValuePair<byte[], byte[]?>> GetIterator()
     {
-        using Iterator iterator = _mainDb.CreateIterator(true, _columnFamily);
+        Iterator iterator = _mainDb.CreateIterator(true, _columnFamily);
         return _mainDb.GetAllCore(iterator);
     }
 
     public IEnumerable<KeyValuePair<byte[], byte[]?>> GetIterator(byte[] start)
     {
-        using Iterator iterator = _mainDb.CreateIterator(true, _columnFamily);
-        iterator.Seek(start);
-        return _mainDb.GetAllCore(iterator);
+        Iterator iterator = _mainDb.CreateIterator(start, true, _columnFamily);
+        return _mainDb.WrapInEnumerable(iterator);
     }
 
     public IEnumerable<KeyValuePair<byte[], byte[]?>> GetIterator(byte[] start, byte[] end)
     {
-        using Iterator iterator = _mainDb.CreateIterator(true, _columnFamily);
-        iterator.Seek(start);
-        return _mainDb.GetAllCore(iterator);
+        // TODO: Do this properly?
+        return GetIterator(start)
+            .TakeWhile((kv) => kv.Key.AsSpan().SequenceCompareTo(end.AsSpan()) <= 0);
     }
 }

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -6,7 +6,9 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions;
+using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Threading;
 using ConcurrentCollections;
 using Nethermind.Config;
@@ -20,6 +22,7 @@ using Nethermind.Int256;
 using Nethermind.Logging;
 using RocksDbSharp;
 using IWriteBatch = Nethermind.Core.IWriteBatch;
+using MemoryExtensions = Nethermind.Core.Extensions.MemoryExtensions;
 
 namespace Nethermind.Db.Rocks;
 
@@ -813,31 +816,24 @@ public class DbOnTheRocks : IDb, ITunableDb
 
     protected internal Iterator CreateIterator(bool ordered = false, ColumnFamilyHandle? ch = null)
     {
-        ReadOptions readOptions = new();
-        readOptions.SetTailing(!ordered);
-
-        try
-        {
-            return _db.NewIterator(ch, readOptions);
-        }
-        catch (RocksDbSharpException e)
-        {
-            CreateMarkerIfCorrupt(e);
-            throw;
-        }
+        return CreateIterator(null, ordered, ch);
     }
 
-    private Iterator CreateIterator(byte[] start, byte[] end, bool ordered = false, ColumnFamilyHandle? ch = null)
+    protected internal Iterator CreateIterator(byte[]? start, bool ordered = false, ColumnFamilyHandle? ch = null)
     {
         ReadOptions readOptions = new();
         readOptions.SetTailing(!ordered);
-        // TODO: does not work with SetIterateLowerBound (use seek instead) - have to figure out the reason behind this?
-        // readOptions.SetIterateLowerBound(start);
-        readOptions.SetIterateUpperBound(end);
         try
         {
             Iterator? iterator = _db.NewIterator(ch, readOptions);
-            iterator.Seek(start);
+            if (start != null)
+            {
+                iterator.Seek(start);
+            }
+            else
+            {
+                iterator.SeekToFirst();
+            }
             return iterator;
         }
         catch (RocksDbSharpException e)
@@ -882,24 +878,21 @@ public class DbOnTheRocks : IDb, ITunableDb
 
     public IEnumerable<KeyValuePair<byte[], byte[]?>> GetIterator()
     {
-        Iterator iterator = CreateIterator(true);
+        Iterator iterator = CreateIterator(null, true, null);
         return GetAllCore(iterator);
     }
 
     public IEnumerable<KeyValuePair<byte[], byte[]?>> GetIterator(byte[] start)
     {
-        Iterator iterator = CreateIterator(true);
-        iterator.Seek(start);
-        return GetAllCoreBounded(iterator);
+        Iterator iterator = CreateIterator(start, true, null);
+        return WrapInEnumerable(iterator);
     }
 
     public IEnumerable<KeyValuePair<byte[], byte[]?>> GetIterator(byte[] start, byte[] end)
     {
-        // TODO: another work around for rocksDb not having inclusive range.
-        UInt256 x = new(end, true);
-        if (x == UInt256.MaxValue) return GetIterator(start);
-        Iterator iterator = CreateIterator(start, x.ToBigEndian(), true);
-        return GetAllCoreBounded(iterator);
+        // TODO: Do this properly?
+        return GetIterator(start)
+            .TakeWhile((kv) => kv.Key.AsSpan().SequenceCompareTo(end.AsSpan()) <= 0);
     }
 
     public IEnumerable<byte[]> GetAllKeys(bool ordered = false)
@@ -1005,21 +998,11 @@ public class DbOnTheRocks : IDb, ITunableDb
         }
     }
 
-    public IEnumerable<KeyValuePair<byte[], byte[]?>> GetAllCore(Iterator iterator)
+    internal IEnumerable<KeyValuePair<byte[], byte[]?>> WrapInEnumerable(Iterator iterator)
     {
         try
         {
             ObjectDisposedException.ThrowIf(_isDisposing, this);
-
-            try
-            {
-                iterator.SeekToFirst();
-            }
-            catch (RocksDbSharpException e)
-            {
-                CreateMarkerIfCorrupt(e);
-                throw;
-            }
 
             while (iterator.Valid())
             {
@@ -1048,6 +1031,21 @@ public class DbOnTheRocks : IDb, ITunableDb
                 throw;
             }
         }
+    }
+
+    public IEnumerable<KeyValuePair<byte[], byte[]?>> GetAllCore(Iterator iterator)
+    {
+        try
+        {
+            iterator.SeekToFirst();
+        }
+        catch (RocksDbSharpException e)
+        {
+            CreateMarkerIfCorrupt(e);
+            throw;
+        }
+
+        return WrapInEnumerable(iterator);
     }
 
     public bool KeyExists(ReadOnlySpan<byte> key)

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -843,39 +843,6 @@ public class DbOnTheRocks : IDb, ITunableDb
         }
     }
 
-    private IEnumerable<KeyValuePair<byte[], byte[]?>> GetAllCoreBounded(Iterator iterator)
-    {
-        if (_isDisposing)
-        {
-            throw new ObjectDisposedException($"Attempted to read form a disposed database {Name}");
-        }
-
-        while (iterator.Valid())
-        {
-            yield return new KeyValuePair<byte[], byte[]?>(iterator.Key(), iterator.Value());
-
-            try
-            {
-                iterator.Next();
-            }
-            catch (RocksDbSharpException e)
-            {
-                CreateMarkerIfCorrupt(e);
-                throw;
-            }
-        }
-
-        try
-        {
-            iterator.Dispose();
-        }
-        catch (RocksDbSharpException e)
-        {
-            CreateMarkerIfCorrupt(e);
-            throw;
-        }
-    }
-
     public IEnumerable<KeyValuePair<byte[], byte[]?>> GetIterator()
     {
         Iterator iterator = CreateIterator(null, true, null);

--- a/src/Nethermind/Nethermind.Db/DbNames.cs
+++ b/src/Nethermind/Nethermind.Db/DbNames.cs
@@ -19,12 +19,11 @@ namespace Nethermind.Db
         public const string CHT = "canonicalHashTrie";
         public const string Metadata = "metadata";
         public const string BlobTransactions = "blobTransactions";
-        public const string Leaf = "leaf";
-        public const string InternalNodes = "internalNodes";
         public const string ForwardDiff = "forwardDiff";
         public const string ReverseDiff = "reverseDiff";
         public const string Preimages = "preimages";
         public const string StateRootToBlock = "stateRoots";
         public const string HistoryOfAccounts = "historyOfAccounts";
+        public const string VerkleState = "verkleState";
     }
 }

--- a/src/Nethermind/Nethermind.Db/IDbProvider.cs
+++ b/src/Nethermind/Nethermind.Db/IDbProvider.cs
@@ -36,9 +36,6 @@ namespace Nethermind.Db
         void RegisterColumnDb<T>(string dbName, IColumnsDb<T> db);
         IEnumerable<KeyValuePair<string, IDbMeta>> GetAllDbMeta();
 
-        public IDb LeafDb => GetDb<IDb>(DbNames.Leaf);
-        public IDb InternalNodesDb => GetDb<IDb>(DbNames.InternalNodes);
-
         public IDb ForwardDiff => GetDb<IDb>(DbNames.ForwardDiff);
         public IDb ReverseDiff => GetDb<IDb>(DbNames.ReverseDiff);
         public IDb StateRootToBlocks => GetDb<IDb>(DbNames.StateRootToBlock);

--- a/src/Nethermind/Nethermind.Db/MemColumnsDb.cs
+++ b/src/Nethermind/Nethermind.Db/MemColumnsDb.cs
@@ -10,20 +10,26 @@ namespace Nethermind.Db
     public class MemColumnsDb<TKey> : IColumnsDb<TKey> where TKey : struct, Enum
     {
         private readonly IDictionary<TKey, IDb> _columnDbs = new Dictionary<TKey, IDb>();
+        private readonly bool _sorted = false;
 
         public MemColumnsDb(string _) : this(Enum.GetValues<TKey>())
         {
         }
 
-        public MemColumnsDb(params TKey[] keys)
+        public MemColumnsDb(params TKey[] keys) : this(false, keys)
         {
+        }
+
+        public MemColumnsDb(bool sorted, params TKey[] keys)
+        {
+            _sorted = sorted;
             foreach (var key in keys)
             {
                 GetColumnDb(key);
             }
         }
 
-        public IDb GetColumnDb(TKey key) => !_columnDbs.TryGetValue(key, out var db) ? _columnDbs[key] = new MemDb() : db;
+        public IDb GetColumnDb(TKey key) => !_columnDbs.TryGetValue(key, out var db) ? _columnDbs[key] = new MemDb(_sorted) : db;
         public IEnumerable<TKey> ColumnKeys => _columnDbs.Keys;
 
         public IReadOnlyColumnDb<TKey> CreateReadOnly(bool createInMemWriteStore)

--- a/src/Nethermind/Nethermind.Db/MemDb.cs
+++ b/src/Nethermind/Nethermind.Db/MemDb.cs
@@ -109,7 +109,9 @@ namespace Nethermind.Db
         public virtual IEnumerable<KeyValuePair<byte[], byte[]?>> GetIterator(byte[] start, byte[] end)
         {
             if (_sortedKeys is null) throw new ArgumentException($"cannot get ordered data");
+
             if (Bytes.BytesComparer.Compare(start, end) > 0) yield break;
+
             using SortedSet<byte[]>.Enumerator keyEnumerator = _sortedKeys
                 .GetViewBetween(start, end)
                 .GetEnumerator();

--- a/src/Nethermind/Nethermind.Db/MemDbFactory.cs
+++ b/src/Nethermind/Nethermind.Db/MemDbFactory.cs
@@ -16,7 +16,7 @@ namespace Nethermind.Db
 
         public IColumnsDb<T> CreateColumnsDb<T>(DbSettings dbSettings) where T : struct, Enum
         {
-            return new MemColumnsDb<T>(dbSettings.DbName);
+            return new MemColumnsDb<T>(true);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Db/StandardDbInitializer.cs
+++ b/src/Nethermind/Nethermind.Db/StandardDbInitializer.cs
@@ -6,7 +6,6 @@ using System.IO.Abstractions;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Db.FullPruning;
-using Nethermind.Verkle.Tree.VerkleDb;
 
 namespace Nethermind.Db
 {

--- a/src/Nethermind/Nethermind.Db/StandardDbInitializer.cs
+++ b/src/Nethermind/Nethermind.Db/StandardDbInitializer.cs
@@ -6,6 +6,7 @@ using System.IO.Abstractions;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Db.FullPruning;
+using Nethermind.Verkle.Tree.VerkleDb;
 
 namespace Nethermind.Db
 {
@@ -67,8 +68,7 @@ namespace Nethermind.Db
             {
                 RegisterColumnsDb<BlobTxsColumns>(BuildDbSettings(DbNames.BlobTransactions));
             }
-            RegisterDb(BuildDbSettings(DbNames.Leaf));
-            RegisterDb(BuildDbSettings(DbNames.InternalNodes));
+            RegisterColumnsDb<VerkleDbColumns>(BuildDbSettings(DbNames.VerkleState));
 
             RegisterDb(BuildDbSettings(DbNames.ForwardDiff));
             RegisterDb(BuildDbSettings(DbNames.ReverseDiff));

--- a/src/Nethermind/Nethermind.Db/VerkleDbColumns.cs
+++ b/src/Nethermind/Nethermind.Db/VerkleDbColumns.cs
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.Verkle.Tree.VerkleDb;
+
+public enum VerkleDbColumns
+{
+    InternalNodes,
+    Leaf
+}

--- a/src/Nethermind/Nethermind.Db/VerkleDbColumns.cs
+++ b/src/Nethermind/Nethermind.Db/VerkleDbColumns.cs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-namespace Nethermind.Verkle.Tree.VerkleDb;
+namespace Nethermind.Db;
 
 public enum VerkleDbColumns
 {

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
@@ -109,7 +109,7 @@ public partial class EngineModuleTests
             new NewPayloadHandler(
                 chain.BlockValidator,
                 chain.BlockTree,
-                new InitConfig(){StatelessProcessingEnabled = statelessProcessingEnabled},
+                new InitConfig() { StatelessProcessingEnabled = statelessProcessingEnabled },
                 synchronizationConfig,
                 chain.PoSSwitcher,
                 chain.BeaconSync,

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V2.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V2.cs
@@ -426,16 +426,16 @@ public partial class EngineModuleTests
         Block block2 = chain.BlockTree.FindBlock(2)!;
         await chain2.BlockTree.SuggestBlockAsync(block2, BlockTreeSuggestOptions.ForceSetAsMain);
 
-        Block block3  = chain.BlockTree.FindBlock(3)!;
+        Block block3 = chain.BlockTree.FindBlock(3)!;
         await chain2.BlockTree.SuggestBlockAsync(block3, BlockTreeSuggestOptions.ForceSetAsMain);
 
-        Block block4  = chain.BlockTree.FindBlock(4)!;
+        Block block4 = chain.BlockTree.FindBlock(4)!;
         await chain2.BlockTree.SuggestBlockAsync(block4, BlockTreeSuggestOptions.ForceSetAsMain);
 
-        Block block5  = chain.BlockTree.FindBlock(5)!;
+        Block block5 = chain.BlockTree.FindBlock(5)!;
         await chain2.BlockTree.SuggestBlockAsync(block5, BlockTreeSuggestOptions.ForceSetAsMain);
 
-        Block block6  = chain.BlockTree.FindBlock(6)!;
+        Block block6 = chain.BlockTree.FindBlock(6)!;
         await chain2.BlockTree.SuggestBlockAsync(block6, BlockTreeSuggestOptions.ForceSetAsMain);
 
         ResultWrapper<PayloadStatusV1> executePayloadResult =

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Verkle/VerkleProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Verkle/VerkleProtocolHandler.cs
@@ -26,6 +26,7 @@ using Nethermind.Verkle.Tree;
 using Nethermind.Verkle.Tree.Serializers;
 using Nethermind.Verkle.Tree.Sync;
 using Nethermind.Verkle.Tree.TreeStore;
+using Nethermind.Verkle.Tree.VerkleDb;
 
 namespace Nethermind.Network.P2P.Subprotocols.Verkle;
 
@@ -248,7 +249,7 @@ public class VerkleProtocolHandler : ZeroProtocolHandlerBase, IVerkleSyncPeer
         subTreeRangeMessageSerializer.Serialize(buffer, response);
         SubTreeRangeMessage? decode = subTreeRangeMessageSerializer.Deserialize(buffer);
 
-        var stateStore = new VerkleTreeStore<PersistEveryBlock>(new MemDb(), new MemDb(), new MemDb(), LimboLogs.Instance);
+        var stateStore = new VerkleTreeStore<PersistEveryBlock>(new MemColumnsDb<VerkleDbColumns>(), new MemDb(), LimboLogs.Instance);
         var localTree = new VerkleTree(stateStore, LimboLogs.Instance);
         var isCorrect = localTree.CreateStatelessTreeFromRange(
             verkleProofSerializer.Decode(new RlpStream(decode.Proofs)), rootPoint, startingStem,

--- a/src/Nethermind/Nethermind.State/VerkleStateTree.cs
+++ b/src/Nethermind/Nethermind.State/VerkleStateTree.cs
@@ -16,6 +16,7 @@ using Nethermind.Verkle.Curve;
 using Nethermind.Verkle.Tree;
 using Nethermind.Verkle.Tree.TreeStore;
 using Nethermind.Verkle.Tree.Utils;
+using Nethermind.Verkle.Tree.VerkleDb;
 
 namespace Nethermind.State;
 
@@ -78,7 +79,7 @@ public class VerkleStateTree(IVerkleTreeStore stateStore, ILogManager logManager
 
     public static VerkleStateTree CreateStatelessTreeFromExecutionWitness(ExecutionWitness? execWitness, Banderwagon root, ILogManager logManager)
     {
-        VerkleTreeStore<PersistEveryBlock>? stateStore = new(new MemDb(), new MemDb(), new MemDb(), logManager);
+        VerkleTreeStore<PersistEveryBlock>? stateStore = new(new MemColumnsDb<VerkleDbColumns>(), new MemDb(), logManager);
         VerkleStateTree? tree = new(stateStore, logManager);
         if (!tree.InsertIntoStatelessTree(execWitness, root))
         {

--- a/src/Nethermind/Nethermind.Synchronization.Test/VerkleSync/VerkleProgressTrackerTest.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/VerkleSync/VerkleProgressTrackerTest.cs
@@ -7,6 +7,7 @@ using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
 using Nethermind.Logging;
 using Nethermind.Synchronization.VerkleSync;
+using Nethermind.Verkle.Tree.VerkleDb;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -17,9 +18,9 @@ public class VerkleProgressTrackerTest
     [Test]
     public void Will_create_multiple_get_address_range_request()
     {
-        var database = new MemDb();
+        var database = new MemColumnsDb<VerkleDbColumns>();
         IDbProvider dbProvider = Substitute.For<IDbProvider>();
-        dbProvider.InternalNodesDb.Returns(database);
+        dbProvider.GetColumnDb<VerkleDbColumns>(DbNames.VerkleState).Returns(database);
         BlockTree blockTree = Build.A.BlockTree().WithBlocks(Build.A.Block.TestObject).TestObject;
         VerkleProgressTracker progressTracker = new(blockTree, dbProvider, LimboLogs.Instance, 4);
 

--- a/src/Nethermind/Nethermind.Synchronization/VerkleSync/VerkleProgressTracker.cs
+++ b/src/Nethermind/Nethermind.Synchronization/VerkleSync/VerkleProgressTracker.cs
@@ -17,6 +17,7 @@ using Nethermind.Verkle.Tree.Serializers;
 using Nethermind.Verkle.Tree.Sync;
 using Nethermind.Verkle.Tree.TreeNodes;
 using Nethermind.Verkle.Tree.TreeStore;
+using Nethermind.Verkle.Tree.VerkleDb;
 
 namespace Nethermind.Synchronization.VerkleSync;
 
@@ -53,7 +54,7 @@ public class VerkleProgressTracker : IRangeProgressTracker<VerkleSyncBatch>
     public VerkleProgressTracker(IBlockTree blockTree, IDbProvider dbProvider, ILogManager logManager, int subTreeRangePartitionCount = 8)
     {
         _logger = logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
-        _db = dbProvider.InternalNodesDb ?? throw new ArgumentNullException(nameof(dbProvider));
+        _db = dbProvider.GetColumnDb<VerkleDbColumns>(DbNames.VerkleState).GetColumnDb(VerkleDbColumns.InternalNodes) ?? throw new ArgumentNullException(nameof(dbProvider));
         _verkleStore = new VerkleTreeStore<PersistEveryBlock>(dbProvider, logManager);
         _pivot = new RangeSync.Pivot(blockTree, logManager);
 

--- a/src/Nethermind/Nethermind.Synchronization/VerkleSync/VerkleSyncProvider.cs
+++ b/src/Nethermind/Nethermind.Synchronization/VerkleSync/VerkleSyncProvider.cs
@@ -14,6 +14,7 @@ using Nethermind.Verkle.Tree;
 using Nethermind.Verkle.Tree.Serializers;
 using Nethermind.Verkle.Tree.Sync;
 using Nethermind.Verkle.Tree.TreeStore;
+using Nethermind.Verkle.Tree.VerkleDb;
 using ILogger = Nethermind.Logging.ILogger;
 
 namespace Nethermind.Synchronization.VerkleSync;
@@ -75,7 +76,7 @@ public class VerkleSyncProvider : IVerkleSyncProvider
             VerkleProof vProof = ser.Decode(new RlpStream(proofs!));
             try
             {
-                var stateStore = new VerkleTreeStore<PersistEveryBlock>(new MemDb(), new MemDb(), new MemDb(), _logManager);
+                var stateStore = new VerkleTreeStore<PersistEveryBlock>(new MemColumnsDb<VerkleDbColumns>(), new MemDb(), _logManager);
                 var localTree = new VerkleTree(stateStore, LimboLogs.Instance);
                 var isCorrect = localTree.CreateStatelessTreeFromRange(vProof, rootPoint, startingStem, subTrees[^1].Path, subTrees);
                 if (!isCorrect)

--- a/src/Nethermind/Nethermind.Synchronization/VerkleSync/VerkleSyncServer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/VerkleSync/VerkleSyncServer.cs
@@ -12,6 +12,7 @@ using Nethermind.Verkle.Curve;
 using Nethermind.Verkle.Tree;
 using Nethermind.Verkle.Tree.Sync;
 using Nethermind.Verkle.Tree.TreeStore;
+using Nethermind.Verkle.Tree.VerkleDb;
 
 namespace Nethermind.Synchronization.VerkleSync;
 
@@ -47,7 +48,7 @@ public class VerkleSyncServer
 
     private void TestIsGeneratedProofValid(VerkleProof vProof, Banderwagon rootPoint, Stem startingStem, PathWithSubTree[] nodes)
     {
-        VerkleTreeStore<PersistEveryBlock>? stateStore = new(new MemDb(), new MemDb(), new MemDb(), LimboLogs.Instance);
+        VerkleTreeStore<PersistEveryBlock>? stateStore = new(new MemColumnsDb<VerkleDbColumns>(), new MemDb(), LimboLogs.Instance);
         VerkleTree localTree = new VerkleTree(stateStore, LimboLogs.Instance);
         var isCorrect = localTree.CreateStatelessTreeFromRange(vProof, rootPoint, startingStem, nodes[^1].Path, nodes);
         _logger.Info(!isCorrect

--- a/src/Nethermind/Nethermind.Verkle.Tree.Test/GenesisTestBench.cs
+++ b/src/Nethermind/Nethermind.Verkle.Tree.Test/GenesisTestBench.cs
@@ -30,7 +30,7 @@ public class GenesisTestBench
     [TestCase(DbMode.PersistantDb)]
     public void TestInsertKey0Value0(DbMode dbMode)
     {
-        using var reader = new StreamReader("/home/eurus/nethermind/src/Nethermind/Nethermind.Verkle.Tree.Test/genesis.csv");
+        using var reader = new StreamReader(typeof(GenesisTestBench).Assembly.GetManifestResourceStream("Nethermind.Verkle.Tree.Test.genesis.csv"));
         var listA = new List<Hash256>();
         var listB = new List<byte[]>();
         while (!reader.EndOfStream)

--- a/src/Nethermind/Nethermind.Verkle.Tree.Test/Nethermind.Verkle.Tree.Test.csproj
+++ b/src/Nethermind/Nethermind.Verkle.Tree.Test/Nethermind.Verkle.Tree.Test.csproj
@@ -22,4 +22,9 @@
     <ProjectReference Include="..\Nethermind.Verkle.Tree\Nethermind.Verkle.Tree.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Remove="genesis.csv" />
+    <EmbeddedResource Include="genesis.csv" />
+  </ItemGroup>
+
 </Project>

--- a/src/Nethermind/Nethermind.Verkle.Tree.Test/TestSyncRangesInAHugeVerkleTree.cs
+++ b/src/Nethermind/Nethermind.Verkle.Tree.Test/TestSyncRangesInAHugeVerkleTree.cs
@@ -24,6 +24,7 @@ using Nethermind.Verkle.Curve;
 using Nethermind.Verkle.Tree.Serializers;
 using Nethermind.Verkle.Tree.Sync;
 using Nethermind.Verkle.Tree.TreeStore;
+using Nethermind.Verkle.Tree.VerkleDb;
 
 namespace Nethermind.Verkle.Tree.Test;
 
@@ -205,7 +206,7 @@ public class TestSyncRangesInAHugeVerkleTree
         Stem endStem = range[^1].Path;
 
         VerkleProof proof = tree.CreateVerkleRangeProof(startStem, endStem, out Banderwagon root, stateRootToUse);
-        var stateStore = new VerkleTreeStore<PersistEveryBlock>(new MemDb(), new MemDb(), new MemDb(), LimboLogs.Instance);
+        var stateStore = new VerkleTreeStore<PersistEveryBlock>(new MemColumnsDb<VerkleDbColumns>(), new MemDb(), LimboLogs.Instance);
         var tempTree = new VerkleTree(stateStore, LimboLogs.Instance);
         bool isTrue = tempTree.CreateStatelessTreeFromRange(proof, root, startStem, endStem, range);
         Assert.IsTrue(isTrue);
@@ -426,7 +427,7 @@ public class TestSyncRangesInAHugeVerkleTree
         VerkleProof newProof = TestProofSerialization(proof);
         SubTreeRangeMessage? newMessage = TestSubTreeRangeSerializer(message);
         var newStore =
-            new VerkleTreeStore<PersistEveryBlock>(new MemDb(), new MemDb(), new MemDb(), LimboLogs.Instance);
+            new VerkleTreeStore<PersistEveryBlock>(new MemColumnsDb<VerkleDbColumns>(), new MemDb(), LimboLogs.Instance);
 
         var localTree = new VerkleTree(newStore, LimboLogs.Instance);
         bool isTrue = localTree.CreateStatelessTreeFromRange(newProof, root, startingStem, endStem, newMessage.PathsWithSubTrees);

--- a/src/Nethermind/Nethermind.Verkle.Tree/TreeStore/VerkleTreeStore.cs
+++ b/src/Nethermind/Nethermind.Verkle.Tree/TreeStore/VerkleTreeStore.cs
@@ -40,13 +40,12 @@ public partial class VerkleTreeStore<TPersistence> : IVerkleTreeStore
     }
 
     public VerkleTreeStore(
-        IDb leafDb,
-        IDb internalDb,
+        IColumnsDb<VerkleDbColumns> verkleColumnDb,
         IDb stateRootToBlocks,
         ILogManager? logManager)
     {
         _logger = logManager?.GetClassLogger<VerkleTreeStore<TPersistence>>() ?? throw new ArgumentNullException(nameof(logManager));
-        Storage = new VerkleKeyValueDb(internalDb, leafDb);
+        Storage = new VerkleKeyValueDb(verkleColumnDb);
         _stateRootToBlocks = new StateRootToBlockMap(stateRootToBlocks);
         if (TPersistence.IsUsingCache)
         {


### PR DESCRIPTION
Resolves #6700 

- Leaf and internal nodes now in the same column db and saved atomically.
- Not sure about `StateRootToBlock` or other db. So I just leave it.

## Types of changes

#### What types of changes does your code introduce?

- [X] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

- [x] Unit test for the verkle package passed.
- [x] Kurtosis can start it.