### PR TITLE
Fix arraylength check on null parameters

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
@@ -126,7 +126,7 @@ public class JsonRpcService : IJsonRpcService
                     // if the null is the default parameter it could be passed in an explicit way as "" or null
                     // or we can treat null as a missing parameter. Two tests for this cases:
                     // Eth_call_is_working_with_implicit_null_as_the_last_argument and Eth_call_is_working_with_explicit_null_as_the_last_argument
-                    bool isExplicit = providedParameters.GetArrayLength() >= parameterIndex + 1;
+                    bool isExplicit = providedParametersLength >= parameterIndex + 1;
                     if (nullable && isExplicit)
                     {
                         explicitNullableParamsCount += 1;


### PR DESCRIPTION
Fixes

![image](https://github.com/NethermindEth/nethermind/assets/1142958/e375572c-7e87-4dd2-8661-79e376ec4402)

## Changes

- Use `providedParametersLength` which has already taken into account `null` parameters rather than rechecking `.GetArrayLength()`

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No