### PR TITLE
Fix negative gas cost in debug_traceTransaction traces

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeTxMemoryTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeTxMemoryTracerTests.cs
@@ -16,13 +16,36 @@ namespace Nethermind.Evm.Test.Tracing;
 public class GethLikeTxMemoryTracerTests : VirtualMachineTestsBase
 {
     [Test]
-    public void Can_trace_gas()
+    public void Can_trace_gas_halt_with_stop()
     {
         byte[] code = Prepare.EvmCode
             .PushData("0x1")
             .PushData("0x2")
             .Op(Instruction.ADD)
             .Op(Instruction.STOP)
+            .Done;
+
+        int[] gasCosts = new int[] { 3, 3, 3, 0 };
+
+        GethLikeTxTrace trace = ExecuteAndTrace(code);
+
+        int gasTotal = 0;
+        for (int i = 0; i < gasCosts.Length; i++)
+        {
+            Assert.That(trace.Entries[i].Gas, Is.EqualTo(79000 - gasTotal), $"gas[{i}]");
+            Assert.That(trace.Entries[i].GasCost, Is.EqualTo(gasCosts[i]), $"gasCost[{i}]");
+            gasTotal += gasCosts[i];
+        }
+    }
+
+    [Test]
+    public void Can_trace_gas_halt_with_return()
+    {
+        byte[] code = Prepare.EvmCode
+            .PushData("0x1")
+            .PushData("0x2")
+            .Op(Instruction.ADD)
+            .Op(Instruction.RETURN)
             .Done;
 
         int[] gasCosts = new int[] { 3, 3, 3, 0 };


### PR DESCRIPTION
Fixes #6669, #6810

## Changes

- Adds a check to ensure that the GasCost trace entry is not overwritten after the `STOP` or `RETURN` opcodes are executed and the gas cost is properly recorded in the trace entry
- This approach is based on the way that [ParityLikeTxTracer](https://github.com/NethermindEth/nethermind/blob/master/src/Nethermind/Nethermind.Evm/Tracing/ParityStyle/ParityLikeTxTracer.cs#L278-L297) handles this situation

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No