### PR TITLE
Features/unified p2p message metrics

### DIFF
--- a/src/Nethermind/Nethermind.Core/Metric/IMetricLabels.cs
+++ b/src/Nethermind/Nethermind.Core/Metric/IMetricLabels.cs
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.Core.Metric;
+
+/// <summary>
+/// Used by MetricController to provide labels. Useful in high performance scenario where you don't want to set a string
+/// on the metric dictionary as key and/or you don't want to use tuple.
+/// </summary>
+public interface IMetricLabels
+{
+    string[] Labels { get; }
+}

--- a/src/Nethermind/Nethermind.Init/Steps/StartMonitoring.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/StartMonitoring.cs
@@ -204,10 +204,7 @@ public class StartMonitoring : IStep
             Synchronization.Metrics.SyncTime = (long?)_api.EthSyncingInfo?.UpdateAndGetSyncTime().TotalSeconds ?? 0;
         });
 
-        monitoringService.AddMetricsUpdateAction(() =>
-        {
-            Network.Metrics.UpdateP2PMetrics();
-        });
+        monitoringService.AddMetricsUpdateAction(Network.Metrics.UpdateP2PMetrics);
     }
 
     private void PrepareProductInfoMetrics()

--- a/src/Nethermind/Nethermind.Init/Steps/StartMonitoring.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/StartMonitoring.cs
@@ -203,8 +203,6 @@ public class StartMonitoring : IStep
         {
             Synchronization.Metrics.SyncTime = (long?)_api.EthSyncingInfo?.UpdateAndGetSyncTime().TotalSeconds ?? 0;
         });
-
-        monitoringService.AddMetricsUpdateAction(Network.Metrics.UpdateP2PMetrics);
     }
 
     private void PrepareProductInfoMetrics()

--- a/src/Nethermind/Nethermind.Init/Steps/StartMonitoring.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/StartMonitoring.cs
@@ -203,6 +203,11 @@ public class StartMonitoring : IStep
         {
             Synchronization.Metrics.SyncTime = (long?)_api.EthSyncingInfo?.UpdateAndGetSyncTime().TotalSeconds ?? 0;
         });
+
+        monitoringService.AddMetricsUpdateAction(() =>
+        {
+            Network.Metrics.UpdateP2PMetrics();
+        });
     }
 
     private void PrepareProductInfoMetrics()

--- a/src/Nethermind/Nethermind.Monitoring.Test/MetricsTests.cs
+++ b/src/Nethermind/Nethermind.Monitoring.Test/MetricsTests.cs
@@ -47,7 +47,7 @@ public class MetricsTests
         Option2,
     }
 
-    public struct CustomLabelType(int num1, int num2, int num3): IMetricLabels
+    public struct CustomLabelType(int num1, int num2, int num3) : IMetricLabels
     {
         public string[] Labels => [num1.ToString(), num2.ToString(), num3.ToString()];
     }

--- a/src/Nethermind/Nethermind.Monitoring/Metrics/MetricsController.cs
+++ b/src/Nethermind/Nethermind.Monitoring/Metrics/MetricsController.cs
@@ -259,16 +259,16 @@ namespace Nethermind.Monitoring.Metrics
                                 ReplaceValueIfChanged(value, gaugeName, label.Labels);
                                 break;
                             case ITuple keyAsTuple:
-                            {
-                                string[] labels = new string[keyAsTuple.Length];
-                                for (int i = 0; i < keyAsTuple.Length; i++)
                                 {
-                                    labels[i] = keyAsTuple[i].ToString();
-                                }
+                                    string[] labels = new string[keyAsTuple.Length];
+                                    for (int i = 0; i < keyAsTuple.Length; i++)
+                                    {
+                                        labels[i] = keyAsTuple[i].ToString();
+                                    }
 
-                                ReplaceValueIfChanged(value, gaugeName, labels);
-                                break;
-                            }
+                                    ReplaceValueIfChanged(value, gaugeName, labels);
+                                    break;
+                                }
                             default:
                                 ReplaceValueIfChanged(value, gaugeName, key.ToString());
                                 break;

--- a/src/Nethermind/Nethermind.Monitoring/Metrics/MetricsController.cs
+++ b/src/Nethermind/Nethermind.Monitoring/Metrics/MetricsController.cs
@@ -15,6 +15,7 @@ using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Attributes;
 using Nethermind.Core.Collections;
+using Nethermind.Core.Metric;
 using Nethermind.Monitoring.Config;
 using Prometheus;
 
@@ -252,19 +253,25 @@ namespace Nethermind.Monitoring.Metrics
                     foreach (object key in dict.Keys)
                     {
                         double value = Convert.ToDouble(dict[key]);
-                        if (key is ITuple keyAsTuple)
+                        switch (key)
                         {
-                            string[] labels = new string[keyAsTuple.Length];
-                            for (int i = 0; i < keyAsTuple.Length; i++)
+                            case IMetricLabels label:
+                                ReplaceValueIfChanged(value, gaugeName, label.Labels);
+                                break;
+                            case ITuple keyAsTuple:
                             {
-                                labels[i] = keyAsTuple[i].ToString();
-                            }
+                                string[] labels = new string[keyAsTuple.Length];
+                                for (int i = 0; i < keyAsTuple.Length; i++)
+                                {
+                                    labels[i] = keyAsTuple[i].ToString();
+                                }
 
-                            ReplaceValueIfChanged(value, gaugeName, labels);
-                        }
-                        else
-                        {
-                            ReplaceValueIfChanged(value, gaugeName, key.ToString());
+                                ReplaceValueIfChanged(value, gaugeName, labels);
+                                break;
+                            }
+                            default:
+                                ReplaceValueIfChanged(value, gaugeName, key.ToString());
+                                break;
                         }
                     }
                 }

--- a/src/Nethermind/Nethermind.Network.Test/P2P/SessionTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/SessionTests.cs
@@ -13,6 +13,7 @@ using Nethermind.Network.P2P.Messages;
 using Nethermind.Network.P2P.ProtocolHandlers;
 using Nethermind.Network.Rlpx;
 using Nethermind.Stats.Model;
+using NonBlocking;
 using NSubstitute;
 using NSubstitute.ReceivedExtensions;
 using NUnit.Framework;
@@ -618,6 +619,15 @@ namespace Nethermind.Network.Test.P2P
             afterRemote = Network.Metrics.OtherDisconnects;
             Assert.That(afterLocal, Is.EqualTo(beforeLocal));
             Assert.That(afterRemote, Is.EqualTo(beforeRemote + 1));
+        }
+
+        [Test]
+        public void UpdateMetric()
+        {
+            Session.IncomingP2PMessages.Clear();
+            Session.IncomingP2PMessages.TryAdd(("snap0", 0), 111);
+            Metrics.UpdateP2PMetrics();
+            Metrics.IncomingP2PMessages[("snap0", "GetAccountRange")].Should().Be(111);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Network.Test/P2P/SessionTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/SessionTests.cs
@@ -625,9 +625,9 @@ namespace Nethermind.Network.Test.P2P
         public void UpdateMetric()
         {
             Session.IncomingP2PMessages.Clear();
-            Session.IncomingP2PMessages.TryAdd(("p2p", 0, 0), 111);
+            Session.IncomingP2PMessages.TryAdd(("p2p", 5, 0), 111);
             Metrics.UpdateP2PMetrics();
-            Metrics.IncomingP2PMessages[("p2p0", "Hello")].Should().Be(111);
+            Metrics.IncomingP2PMessages[("p2p5", "Hello")].Should().Be(111);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Network.Test/P2P/SessionTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/SessionTests.cs
@@ -625,9 +625,9 @@ namespace Nethermind.Network.Test.P2P
         public void UpdateMetric()
         {
             Session.IncomingP2PMessages.Clear();
-            Session.IncomingP2PMessages.TryAdd(("snap0", 0), 111);
+            Session.IncomingP2PMessages.TryAdd(("p2p", 0, 0), 111);
             Metrics.UpdateP2PMetrics();
-            Metrics.IncomingP2PMessages[("snap0", "GetAccountRange")].Should().Be(111);
+            Metrics.IncomingP2PMessages[("p2p0", "Hello")].Should().Be(111);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Network.Test/P2P/SessionTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/SessionTests.cs
@@ -620,14 +620,5 @@ namespace Nethermind.Network.Test.P2P
             Assert.That(afterLocal, Is.EqualTo(beforeLocal));
             Assert.That(afterRemote, Is.EqualTo(beforeRemote + 1));
         }
-
-        [Test]
-        public void UpdateMetric()
-        {
-            Session.IncomingP2PMessages.Clear();
-            Session.IncomingP2PMessages.TryAdd(("p2p", 5, 0), 111);
-            Metrics.UpdateP2PMetrics();
-            Metrics.IncomingP2PMessages[("p2p5", "Hello")].Should().Be(111);
-        }
     }
 }

--- a/src/Nethermind/Nethermind.Network/Metrics.cs
+++ b/src/Nethermind/Nethermind.Network/Metrics.cs
@@ -11,7 +11,15 @@ using System.Reflection;
 using System.Runtime.Serialization;
 using Nethermind.Core.Attributes;
 using Nethermind.Network.P2P;
+using Nethermind.Network.P2P.Subprotocols.Eth.V62;
+using Nethermind.Network.P2P.Subprotocols.Eth.V63;
+using Nethermind.Network.P2P.Subprotocols.Eth.V65;
+using Nethermind.Network.P2P.Subprotocols.Eth.V66;
+using Nethermind.Network.P2P.Subprotocols.Eth.V68;
+using Nethermind.Network.P2P.Subprotocols.Les;
+using Nethermind.Network.P2P.Subprotocols.NodeData;
 using Nethermind.Network.P2P.Subprotocols.Snap;
+using Nethermind.Network.P2P.Subprotocols.Wit;
 using Nethermind.Stats.Model;
 
 namespace Nethermind.Network
@@ -409,7 +417,8 @@ namespace Nethermind.Network
 #if DEBUG
                     throw new NotImplementedException($"Message name for protocol {kv.Key.Item1} message id {kv.Key.Item2} not set.");
 #endif
-                    messageName = kv.Key.Item2.ToString(); // Just use the integer directly then
+
+                    messageName = kv.Key.Item3.ToString(); // Just use the integer directly then
                 }
 
                 to[(kv.Key.Item1 + kv.Key.Item2, messageName)] = kv.Value;
@@ -418,8 +427,30 @@ namespace Nethermind.Network
 
         // Should this be in a different place? Maybe. Still not sure.
         private static FrozenDictionary<(string, byte, int), string> MessageNames =
-            FromMessageCodeClass("p2p", 0, typeof(P2PMessageCode))
-                .Concat(FromMessageCodeClass("snap", 0, typeof(SnapMessageCode)))
+            FromMessageCodeClass("p2p", 5, typeof(P2PMessageCode))
+
+                .Concat(FromMessageCodeClass("eth", 66, typeof(Eth62MessageCode)))
+                .Concat(FromMessageCodeClass("eth", 66, typeof(Eth63MessageCode)))
+                .Concat(FromMessageCodeClass("eth", 66, typeof(Eth65MessageCode)))
+                .Concat(FromMessageCodeClass("eth", 66, typeof(Eth66MessageCode)))
+
+                .Concat(FromMessageCodeClass("eth", 67, typeof(Eth62MessageCode)))
+                .Concat(FromMessageCodeClass("eth", 67, typeof(Eth63MessageCode)))
+                .Concat(FromMessageCodeClass("eth", 67, typeof(Eth65MessageCode)))
+                .Concat(FromMessageCodeClass("eth", 67, typeof(Eth66MessageCode)))
+
+                .Concat(FromMessageCodeClass("eth", 68, typeof(Eth62MessageCode)))
+                .Concat(FromMessageCodeClass("eth", 68, typeof(Eth63MessageCode)))
+                .Concat(FromMessageCodeClass("eth", 68, typeof(Eth65MessageCode)))
+                .Concat(FromMessageCodeClass("eth", 68, typeof(Eth66MessageCode)))
+                .Concat(FromMessageCodeClass("eth", 68, typeof(Eth68MessageCode)))
+
+                .Concat(FromMessageCodeClass("nodedata", 1, typeof(NodeDataMessageCode)))
+                .Concat(FromMessageCodeClass("wit", 0, typeof(WitMessageCode)))
+                .Concat(FromMessageCodeClass("les", 0, typeof(LesMessageCode)))
+
+                .Concat(FromMessageCodeClass("snap", 1, typeof(SnapMessageCode)))
+
                 .ToFrozenDictionary();
 
         static IEnumerable<KeyValuePair<(string, byte, int), string>> FromMessageCodeClass(string protocol, byte version, Type classType)

--- a/src/Nethermind/Nethermind.Network/Metrics.cs
+++ b/src/Nethermind/Nethermind.Network/Metrics.cs
@@ -1,10 +1,14 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Collections.Concurrent;
+using System.Collections.Frozen;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.Serialization;
 using Nethermind.Core.Attributes;
+using Nethermind.Network.P2P;
 using Nethermind.Stats.Model;
 
 namespace Nethermind.Network
@@ -37,27 +41,27 @@ namespace Nethermind.Network
         public static long HandshakeTimeouts { get; set; }
 
         [CounterMetric]
-        [Description("Number of devp2p hello messages received")]
+        [Description("_Deprecated._ Number of devp2p hello messages received")]
         public static long HellosReceived { get; set; }
 
         [CounterMetric]
-        [Description("Number of devp2p hello messages sent")]
+        [Description("_Deprecated._ Number of devp2p hello messages sent")]
         public static long HellosSent { get; set; }
 
         [CounterMetric]
-        [Description("Number of eth status messages received")]
+        [Description("_Deprecated._ Number of eth status messages received")]
         public static long StatusesReceived { get; set; }
 
         [CounterMetric]
-        [Description("Number of eth status messages sent")]
+        [Description("_Deprecated._ Number of eth status messages sent")]
         public static long StatusesSent { get; set; }
 
         [CounterMetric]
-        [Description("Number of les status messages received")]
+        [Description("_Deprecated._ Number of les status messages received")]
         public static long LesStatusesReceived { get; set; }
 
         [CounterMetric]
-        [Description("Number of les status messages sent")]
+        [Description("_Deprecated._ Number of les status messages sent")]
         public static long LesStatusesSent { get; set; }
 
         [CounterMetric]
@@ -165,183 +169,183 @@ namespace Nethermind.Network
         public static long LocalTcpSubsystemErrorDisconnects { get; set; }
 
         [CounterMetric]
-        [Description("Number of eth.62 NewBlockHashes messages received")]
+        [Description("_Deprecated._ Number of eth.62 NewBlockHashes messages received")]
         public static long Eth62NewBlockHashesReceived { get; set; }
 
         [CounterMetric]
-        [Description("Number of eth.62 Transactions messages received")]
+        [Description("_Deprecated._ Number of eth.62 Transactions messages received")]
         public static long Eth62TransactionsReceived { get; set; }
 
         [CounterMetric]
-        [Description("Number of eth.62 GetBlockHeaders messages received")]
+        [Description("_Deprecated._ Number of eth.62 GetBlockHeaders messages received")]
         public static long Eth62GetBlockHeadersReceived { get; set; }
 
         [CounterMetric]
-        [Description("Number of eth.62 BlockHeaders messages received")]
+        [Description("_Deprecated._ Number of eth.62 BlockHeaders messages received")]
         public static long Eth62BlockHeadersReceived { get; set; }
 
         [CounterMetric]
-        [Description("Number of eth.62 GetBlockBodies messages received")]
+        [Description("_Deprecated._ Number of eth.62 GetBlockBodies messages received")]
         public static long Eth62GetBlockBodiesReceived { get; set; }
 
         [CounterMetric]
-        [Description("Number of eth.62 BlockBodies messages received")]
+        [Description("_Deprecated._ Number of eth.62 BlockBodies messages received")]
         public static long Eth62BlockBodiesReceived { get; set; }
 
         [CounterMetric]
-        [Description("Number of eth.62 NewBlock messages received")]
+        [Description("_Deprecated._ Number of eth.62 NewBlock messages received")]
         public static long Eth62NewBlockReceived { get; set; }
 
         [CounterMetric]
-        [Description("Number of eth.63 GetReceipts messages received")]
+        [Description("_Deprecated._ Number of eth.63 GetReceipts messages received")]
         public static long Eth63GetReceiptsReceived { get; set; }
 
         [CounterMetric]
-        [Description("Number of eth.63 Receipts messages received")]
+        [Description("_Deprecated._ Number of eth.63 Receipts messages received")]
         public static long Eth63ReceiptsReceived { get; set; }
 
         [CounterMetric]
-        [Description("Number of eth.63 GetNodeData messages received")]
+        [Description("_Deprecated._ Number of eth.63 GetNodeData messages received")]
         public static long Eth63GetNodeDataReceived { get; set; }
 
         [CounterMetric]
-        [Description("Number of eth.63 NodeData messages received")]
+        [Description("_Deprecated._ Number of eth.63 NodeData messages received")]
         public static long Eth63NodeDataReceived { get; set; }
 
         [CounterMetric]
-        [Description("Number of eth.65 NewPooledTransactionHashes messages received")]
+        [Description("_Deprecated._ Number of eth.65 NewPooledTransactionHashes messages received")]
         public static long Eth65NewPooledTransactionHashesReceived { get; set; }
 
         [CounterMetric]
-        [Description("Number of eth.65 NewPooledTransactionHashes messages sent")]
+        [Description("_Deprecated._ Number of eth.65 NewPooledTransactionHashes messages sent")]
         public static long Eth65NewPooledTransactionHashesSent { get; set; }
 
         [CounterMetric]
-        [Description("Number of eth.68 NewPooledTransactionHashes messages received")]
+        [Description("_Deprecated._ Number of eth.68 NewPooledTransactionHashes messages received")]
         public static long Eth68NewPooledTransactionHashesReceived { get; set; }
 
         [CounterMetric]
-        [Description("Number of eth.68 NewPooledTransactionHashes messages sent")]
+        [Description("_Deprecated._ Number of eth.68 NewPooledTransactionHashes messages sent")]
         public static long Eth68NewPooledTransactionHashesSent { get; set; }
 
         [CounterMetric]
-        [Description("Number of eth.65 GetPooledTransactions messages received")]
+        [Description("_Deprecated._ Number of eth.65 GetPooledTransactions messages received")]
         public static long Eth65GetPooledTransactionsReceived { get; set; }
 
         [CounterMetric]
-        [Description("Number of eth.65 GetPooledTransactions messages sent")]
+        [Description("_Deprecated._ Number of eth.65 GetPooledTransactions messages sent")]
         public static long Eth65GetPooledTransactionsRequested { get; set; }
 
         [CounterMetric]
-        [Description("Number of eth.65 PooledTransactions messages received")]
+        [Description("_Deprecated._ Number of eth.65 PooledTransactions messages received")]
         public static long Eth65PooledTransactionsReceived { get; set; }
 
         [CounterMetric]
-        [Description("Number of eth.66 GetBlockHeaders messages received")]
+        [Description("_Deprecated._ Number of eth.66 GetBlockHeaders messages received")]
         public static long Eth66GetBlockHeadersReceived { get; set; }
 
         [CounterMetric]
-        [Description("Number of eth.66 BlockHeaders messages received")]
+        [Description("_Deprecated._ Number of eth.66 BlockHeaders messages received")]
         public static long Eth66BlockHeadersReceived { get; set; }
 
         [CounterMetric]
-        [Description("Number of eth.66 GetBlockBodies messages received")]
+        [Description("_Deprecated._ Number of eth.66 GetBlockBodies messages received")]
         public static long Eth66GetBlockBodiesReceived { get; set; }
 
         [CounterMetric]
-        [Description("Number of eth.66 BlockBodies messages received")]
+        [Description("_Deprecated._ Number of eth.66 BlockBodies messages received")]
         public static long Eth66BlockBodiesReceived { get; set; }
 
         [CounterMetric]
-        [Description("Number of eth.66 GetNodeData messages received")]
+        [Description("_Deprecated._ Number of eth.66 GetNodeData messages received")]
         public static long Eth66GetNodeDataReceived { get; set; }
 
         [CounterMetric]
-        [Description("Number of eth.66 NodeData messages received")]
+        [Description("_Deprecated._ Number of eth.66 NodeData messages received")]
         public static long Eth66NodeDataReceived { get; set; }
 
         [CounterMetric]
-        [Description("Number of eth.66 GetReceipts messages received")]
+        [Description("_Deprecated._ Number of eth.66 GetReceipts messages received")]
         public static long Eth66GetReceiptsReceived { get; set; }
 
         [CounterMetric]
-        [Description("Number of eth.66 Receipts messages received")]
+        [Description("_Deprecated._ Number of eth.66 Receipts messages received")]
         public static long Eth66ReceiptsReceived { get; set; }
 
         [CounterMetric]
-        [Description("Number of eth.66 GetPooledTransactions messages received")]
+        [Description("_Deprecated._ Number of eth.66 GetPooledTransactions messages received")]
         public static long Eth66GetPooledTransactionsReceived { get; set; }
 
         [CounterMetric]
-        [Description("Number of eth.66 GetPooledTransactions messages sent")]
+        [Description("_Deprecated._ Number of eth.66 GetPooledTransactions messages sent")]
         public static long Eth66GetPooledTransactionsRequested { get; set; }
 
         [CounterMetric]
-        [Description("Number of eth.66 PooledTransactions messages received")]
+        [Description("_Deprecated._ Number of eth.66 PooledTransactions messages received")]
         public static long Eth66PooledTransactionsReceived { get; set; }
 
         [CounterMetric]
-        [Description("Number of SNAP GetAccountRange messages received")]
+        [Description("_Deprecated._ Number of SNAP GetAccountRange messages received")]
         public static long SnapGetAccountRangeReceived { get; set; }
 
         [CounterMetric]
-        [Description("Number of SNAP GetAccountRange messages sent")]
+        [Description("_Deprecated._ Number of SNAP GetAccountRange messages sent")]
         public static long SnapGetAccountRangeSent { get; set; }
 
         [CounterMetric]
-        [Description("Number of SNAP AccountRange messages received")]
+        [Description("_Deprecated._ Number of SNAP AccountRange messages received")]
         public static long SnapAccountRangeReceived { get; set; }
 
         [CounterMetric]
-        [Description("Number of SNAP GetStorageRanges messages received")]
+        [Description("_Deprecated._ Number of SNAP GetStorageRanges messages received")]
         public static long SnapGetStorageRangesReceived { get; set; }
 
         [CounterMetric]
-        [Description("Number of SNAP GetStorageRanges messages sent")]
+        [Description("_Deprecated._ Number of SNAP GetStorageRanges messages sent")]
         public static long SnapGetStorageRangesSent { get; set; }
 
         [CounterMetric]
-        [Description("Number of SNAP StorageRanges messages received")]
+        [Description("_Deprecated._ Number of SNAP StorageRanges messages received")]
         public static long SnapStorageRangesReceived { get; set; }
 
         [CounterMetric]
-        [Description("Number of SNAP GetByteCodes messages received")]
+        [Description("_Deprecated._ Number of SNAP GetByteCodes messages received")]
         public static long SnapGetByteCodesReceived { get; set; }
 
         [CounterMetric]
-        [Description("Number of SNAP GetByteCodes messages sent")]
+        [Description("_Deprecated._ Number of SNAP GetByteCodes messages sent")]
         public static long SnapGetByteCodesSent { get; set; }
 
         [CounterMetric]
-        [Description("Number of SNAP ByteCodes messages received")]
+        [Description("_Deprecated._ Number of SNAP ByteCodes messages received")]
         public static long SnapByteCodesReceived { get; set; }
 
         [CounterMetric]
-        [Description("Number of SNAP GetTrieNodes messages received")]
+        [Description("_Deprecated._ Number of SNAP GetTrieNodes messages received")]
         public static long SnapGetTrieNodesReceived { get; set; }
 
         [CounterMetric]
-        [Description("Number of SNAP GetTrieNodes messages sent")]
+        [Description("_Deprecated._ Number of SNAP GetTrieNodes messages sent")]
         public static long SnapGetTrieNodesSent { get; set; }
 
         [CounterMetric]
-        [Description("Number of SNAP TrieNodes messages received")]
+        [Description("_Deprecated._ Number of SNAP TrieNodes messages received")]
         public static long SnapTrieNodesReceived { get; set; }
 
         [CounterMetric]
-        [Description("Number of GetNodeData messages received via NodeData protocol")]
+        [Description("_Deprecated._ Number of GetNodeData messages received via NodeData protocol")]
         public static long GetNodeDataReceived { get; set; }
 
         [CounterMetric]
-        [Description("Number of NodeData messages received via NodeData protocol")]
+        [Description("_Deprecated._ Number of NodeData messages received via NodeData protocol")]
         public static long NodeDataReceived { get; set; }
 
         [CounterMetric]
-        [Description("Number of bytes sent through P2P (TCP).")]
+        [Description("_Deprecated._ Number of bytes sent through P2P (TCP).")]
         public static long P2PBytesSent;
 
         [CounterMetric]
-        [Description("Number of bytes received through P2P (TCP).")]
+        [Description("_Deprecated._ Number of bytes received through P2P (TCP).")]
         public static long P2PBytesReceived;
 
         [CounterMetric]
@@ -364,5 +368,56 @@ namespace Nethermind.Network
         [Description("The maximum number of peers this node allows to connect.")]
         [DataMember(Name = "ethereum_peer_limit")]
         public static long PeerLimit { get; set; }
+
+        [CounterMetric]
+        [Description("Number of outgoing p2p packets.")]
+        [KeyIsLabel("protocol", "message")]
+        public static NonBlocking.ConcurrentDictionary<(string, string), long> OutgoingP2PMessages = new();
+
+        [CounterMetric]
+        [Description("Bytes of outgoing p2p packets.")]
+        [KeyIsLabel("protocol", "message")]
+        public static NonBlocking.ConcurrentDictionary<(string, string), long> OutgoingP2PMessageBytes = new();
+
+        [CounterMetric]
+        [Description("Number of incoming p2p packets.")]
+        [KeyIsLabel("protocol", "message")]
+        public static NonBlocking.ConcurrentDictionary<(string, string), long> IncomingP2PMessages = new();
+
+        [CounterMetric]
+        [Description("Bytes of incoming p2p packets.")]
+        [KeyIsLabel("protocol", "message")]
+        public static NonBlocking.ConcurrentDictionary<(string, string), long> IncomingP2PMessageBytes = new();
+
+        public static void UpdateP2PMetrics()
+        {
+            TranslateFromMessageNumberToName(Session.OutgoingP2PMessages, OutgoingP2PMessages);
+            TranslateFromMessageNumberToName(Session.OutgoingP2PMessageBytes, OutgoingP2PMessageBytes);
+            TranslateFromMessageNumberToName(Session.IncomingP2PMessages, IncomingP2PMessages);
+            TranslateFromMessageNumberToName(Session.IncomingP2PMessageBytes, IncomingP2PMessageBytes);
+        }
+
+        static void TranslateFromMessageNumberToName(NonBlocking.ConcurrentDictionary<(string, int), long> from, NonBlocking.ConcurrentDictionary<(string, string), long> to)
+        {
+            foreach (KeyValuePair<(string, int),long> kv in from)
+            {
+                if (!MessageNames.TryGetValue(kv.Key, out string messageName))
+                {
+#if DEBUG
+                    throw new NotImplementedException($"Message name for protocol {kv.Key.Item1} message id {kv.Key.Item2} not set.");
+#endif
+
+                    messageName = kv.Key.Item2.ToString(); // Just use the integer directly then
+                }
+
+                to[(kv.Key.Item1, messageName)] = kv.Value;
+            }
+        }
+
+        // Should this be in a different place? Maybe. Still not sure.
+        private static FrozenDictionary<(string, int), string> MessageNames = new Dictionary<(string, int), string>()
+        {
+
+        }.ToFrozenDictionary();
     }
 }

--- a/src/Nethermind/Nethermind.Network/Metrics.cs
+++ b/src/Nethermind/Nethermind.Network/Metrics.cs
@@ -420,9 +420,10 @@ namespace Nethermind.Network
                 {
 #if DEBUG
                     throw new NotImplementedException($"Message name for protocol {kv.Key.Item1} message id {kv.Key.Item3} not set.");
+#else
+                    messageName = kv.Key.Item3.ToString(); // Just use the integer directly then
 #endif
 
-                    messageName = kv.Key.Item3.ToString(); // Just use the integer directly then
                 }
 
                 to[(kv.Key.Item1 + kv.Key.Item2, messageName)] = kv.Value;

--- a/src/Nethermind/Nethermind.Network/Metrics.cs
+++ b/src/Nethermind/Nethermind.Network/Metrics.cs
@@ -419,7 +419,7 @@ namespace Nethermind.Network
                 if (!MessageNames.TryGetValue((kv.Key.Item1, kv.Key.Item3), out string messageName))
                 {
 #if DEBUG
-                    throw new NotImplementedException($"Message name for protocol {kv.Key.Item1} message id {kv.Key.Item2} not set.");
+                    throw new NotImplementedException($"Message name for protocol {kv.Key.Item1} message id {kv.Key.Item3} not set.");
 #endif
 
                     messageName = kv.Key.Item3.ToString(); // Just use the integer directly then

--- a/src/Nethermind/Nethermind.Network/Metrics.cs
+++ b/src/Nethermind/Nethermind.Network/Metrics.cs
@@ -414,7 +414,7 @@ namespace Nethermind.Network
 
         static void TranslateFromMessageNumberToName(NonBlocking.ConcurrentDictionary<(string, byte, int), long> from, NonBlocking.ConcurrentDictionary<(string, string), long> to)
         {
-            foreach (KeyValuePair<(string, byte, int),long> kv in from)
+            foreach (KeyValuePair<(string, byte, int), long> kv in from)
             {
                 if (!MessageNames.TryGetValue((kv.Key.Item1, kv.Key.Item3), out string messageName))
                 {
@@ -454,5 +454,5 @@ namespace Nethermind.Network
                 .Where((field) => field.FieldType.IsAssignableTo(typeof(int)))
                 .Select((field) => KeyValuePair.Create((protocol, (int)field.GetValue(null)), field.Name));
         }
-     }
+    }
 }

--- a/src/Nethermind/Nethermind.Network/Metrics.cs
+++ b/src/Nethermind/Nethermind.Network/Metrics.cs
@@ -384,76 +384,24 @@ namespace Nethermind.Network
         [DataMember(Name = "nethermind_outgoing_p2p_messages")]
         [Description("Number of outgoing p2p packets.")]
         [KeyIsLabel("protocol", "message")]
-        public static NonBlocking.ConcurrentDictionary<(string, string), long> OutgoingP2PMessages { get; } = new();
+        public static NonBlocking.ConcurrentDictionary<P2PMessageKey, long> OutgoingP2PMessages { get; } = new();
 
         [CounterMetric]
         [DataMember(Name = "nethermind_outgoing_p2p_message_bytes")]
         [Description("Bytes of outgoing p2p packets.")]
         [KeyIsLabel("protocol", "message")]
-        public static NonBlocking.ConcurrentDictionary<(string, string), long> OutgoingP2PMessageBytes { get; } = new();
+        public static NonBlocking.ConcurrentDictionary<P2PMessageKey, long> OutgoingP2PMessageBytes { get; } = new();
 
         [CounterMetric]
         [DataMember(Name = "nethermind_incoming_p2p_messages")]
         [Description("Number of incoming p2p packets.")]
         [KeyIsLabel("protocol", "message")]
-        public static NonBlocking.ConcurrentDictionary<(string, string), long> IncomingP2PMessages { get; } = new();
+        public static NonBlocking.ConcurrentDictionary<P2PMessageKey, long> IncomingP2PMessages { get; } = new();
 
         [CounterMetric]
         [DataMember(Name = "nethermind_incoming_p2p_message_bytes")]
         [Description("Bytes of incoming p2p packets.")]
         [KeyIsLabel("protocol", "message")]
-        public static NonBlocking.ConcurrentDictionary<(string, string), long> IncomingP2PMessageBytes { get; } = new();
-
-        public static void UpdateP2PMetrics()
-        {
-            TranslateFromMessageNumberToName(Session.OutgoingP2PMessages, OutgoingP2PMessages);
-            TranslateFromMessageNumberToName(Session.OutgoingP2PMessageBytes, OutgoingP2PMessageBytes);
-            TranslateFromMessageNumberToName(Session.IncomingP2PMessages, IncomingP2PMessages);
-            TranslateFromMessageNumberToName(Session.IncomingP2PMessageBytes, IncomingP2PMessageBytes);
-        }
-
-        static void TranslateFromMessageNumberToName(NonBlocking.ConcurrentDictionary<(string, byte, int), long> from, NonBlocking.ConcurrentDictionary<(string, string), long> to)
-        {
-            foreach (KeyValuePair<(string, byte, int), long> kv in from)
-            {
-                if (!MessageNames.TryGetValue((kv.Key.Item1, kv.Key.Item3), out string messageName))
-                {
-#if DEBUG
-                    throw new NotImplementedException($"Message name for protocol {kv.Key.Item1} message id {kv.Key.Item3} not set.");
-#else
-                    messageName = kv.Key.Item3.ToString(); // Just use the integer directly then
-#endif
-
-                }
-
-                to[(kv.Key.Item1 + kv.Key.Item2, messageName)] = kv.Value;
-            }
-        }
-
-        // Should this be in a different place? Maybe. Still not sure.
-        private static FrozenDictionary<(string, int), string> MessageNames =
-            FromMessageCodeClass("p2p", typeof(P2PMessageCode))
-
-                .Concat(FromMessageCodeClass("eth", typeof(Eth62MessageCode)))
-                .Concat(FromMessageCodeClass("eth", typeof(Eth63MessageCode)))
-                .Concat(FromMessageCodeClass("eth", typeof(Eth65MessageCode)))
-                .Concat(FromMessageCodeClass("eth", typeof(Eth66MessageCode)))
-                .Concat(FromMessageCodeClass("eth", typeof(Eth68MessageCode)))
-
-                .Concat(FromMessageCodeClass("nodedata", typeof(NodeDataMessageCode)))
-                .Concat(FromMessageCodeClass("wit", typeof(WitMessageCode)))
-                .Concat(FromMessageCodeClass("les", typeof(LesMessageCode)))
-
-                .Concat(FromMessageCodeClass("snap", typeof(SnapMessageCode)))
-
-                .ToFrozenDictionary();
-
-        static IEnumerable<KeyValuePair<(string, int), string>> FromMessageCodeClass(string protocol, Type classType)
-        {
-            return classType.GetFields(
-                    BindingFlags.Public | BindingFlags.Static)
-                .Where((field) => field.FieldType.IsAssignableTo(typeof(int)))
-                .Select((field) => KeyValuePair.Create((protocol, (int)field.GetValue(null)), field.Name));
-        }
+        public static NonBlocking.ConcurrentDictionary<P2PMessageKey, long> IncomingP2PMessageBytes { get; } = new();
     }
 }

--- a/src/Nethermind/Nethermind.Network/P2P/P2PMessageKey.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/P2PMessageKey.cs
@@ -21,7 +21,7 @@ namespace Nethermind.Network.P2P;
 
 public readonly record struct VersionedProtocol(string Protocol, byte Version);
 
-public record struct P2PMessageKey(VersionedProtocol Protocol, int PacketType): IMetricLabels
+public record struct P2PMessageKey(VersionedProtocol Protocol, int PacketType) : IMetricLabels
 {
     private static readonly FrozenDictionary<(string, int), string> MessageNames =
         FromMessageCodeClass(Contract.P2P.Protocol.P2P, typeof(P2PMessageCode))

--- a/src/Nethermind/Nethermind.Network/P2P/P2PMessageKey.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/P2PMessageKey.cs
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Nethermind.Network.P2P.Subprotocols.Eth.V62;
+using Nethermind.Network.P2P.Subprotocols.Eth.V63;
+using Nethermind.Network.P2P.Subprotocols.Eth.V65;
+using Nethermind.Network.P2P.Subprotocols.Eth.V66;
+using Nethermind.Network.P2P.Subprotocols.Eth.V68;
+using Nethermind.Network.P2P.Subprotocols.Les;
+using Nethermind.Network.P2P.Subprotocols.NodeData;
+using Nethermind.Network.P2P.Subprotocols.Snap;
+using Nethermind.Network.P2P.Subprotocols.Wit;
+
+namespace Nethermind.Network.P2P;
+
+public readonly record struct VersionedProtocol(string Protocol, byte Version);
+
+public record struct P2PMessageKey(VersionedProtocol Protocol, int PacketType)
+{
+    private static readonly FrozenDictionary<(string, int), string> MessageNames =
+        FromMessageCodeClass(Contract.P2P.Protocol.P2P, typeof(P2PMessageCode))
+
+            .Concat(FromMessageCodeClass(Contract.P2P.Protocol.Eth, typeof(Eth62MessageCode)))
+            .Concat(FromMessageCodeClass(Contract.P2P.Protocol.Eth, typeof(Eth63MessageCode)))
+            .Concat(FromMessageCodeClass(Contract.P2P.Protocol.Eth, typeof(Eth65MessageCode)))
+            .Concat(FromMessageCodeClass(Contract.P2P.Protocol.Eth, typeof(Eth66MessageCode)))
+            .Concat(FromMessageCodeClass(Contract.P2P.Protocol.Eth, typeof(Eth68MessageCode)))
+
+            .Concat(FromMessageCodeClass(Contract.P2P.Protocol.NodeData, typeof(NodeDataMessageCode)))
+            .Concat(FromMessageCodeClass(Contract.P2P.Protocol.Wit, typeof(WitMessageCode)))
+            .Concat(FromMessageCodeClass(Contract.P2P.Protocol.Les, typeof(LesMessageCode)))
+
+            .Concat(FromMessageCodeClass(Contract.P2P.Protocol.Snap, typeof(SnapMessageCode)))
+
+            .ToFrozenDictionary();
+
+    private static IEnumerable<KeyValuePair<(string, int), string>> FromMessageCodeClass(string protocol, Type classType) =>
+        classType.GetFields(
+                BindingFlags.Public | BindingFlags.Static)
+            .Where(field => field.FieldType.IsAssignableTo(typeof(int)))
+            .Select(field => KeyValuePair.Create((protocol, (int)field.GetValue(null)), field.Name));
+
+    private string? _name = null;
+
+    public override string ToString()
+    {
+        if (_name is null)
+        {
+            if (!MessageNames.TryGetValue((Protocol.Protocol, PacketType), out _name))
+            {
+#if DEBUG
+                throw new NotImplementedException($"Message name for protocol {Protocol.Protocol} message id {PacketType} not set.");
+#else
+                _name = PacketType.ToString(); // Just use the integer directly then
+#endif
+            }
+        }
+
+        return _name!;
+    }
+}

--- a/src/Nethermind/Nethermind.Network/P2P/Session.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Session.cs
@@ -674,6 +674,7 @@ namespace Nethermind.Network.P2P
 
         private void RecordIncomingMessageMetric(string protocol, int packetType, int size)
         {
+            if (protocol == null) return;
             byte version = _protocols.TryGetValue(protocol, out IProtocolHandler? handler)
                 ? handler!.ProtocolVersion
                 : (byte)0;

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Eth62MessageCode.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Eth62MessageCode.cs
@@ -13,21 +13,5 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
         public const int GetBlockBodies = 0x05;
         public const int BlockBodies = 0x06;
         public const int NewBlock = 0x07;
-
-        public static string GetDescription(int code)
-        {
-            return code switch
-            {
-                Status => nameof(Status),
-                NewBlockHashes => nameof(NewBlockHashes),
-                Transactions => nameof(Transactions),
-                GetBlockHeaders => nameof(GetBlockHeaders),
-                BlockHeaders => nameof(BlockHeaders),
-                GetBlockBodies => nameof(GetBlockBodies),
-                BlockBodies => nameof(BlockBodies),
-                NewBlock => nameof(NewBlock),
-                _ => $"Unknown({code.ToString()})"
-            };
-        }
     }
 }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandler.cs
@@ -139,8 +139,6 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
                 throw new SubprotocolException($"No {nameof(StatusMessage)} received prior to communication with {Node:c}.");
             }
 
-            if (Logger.IsTrace) Logger.Trace($"{Counter:D5} {Eth62MessageCode.GetDescription(packetType)} from {Node:c}");
-
             switch (packetType)
             {
                 case Eth62MessageCode.Status:


### PR DESCRIPTION
- As requested, metrics for all p2p messages. 
- Automatically have metrics for all p2p message type, incoming and outgoing, count and bytes. Dashboard would look like this:
![Screenshot_2024-03-16_03-42-32](https://github.com/NethermindEth/nethermind/assets/1841324/c36b9280-be09-4e3b-8061-40bda6d95049)

- Uses four metric with two label each. Example `rate(nethermind_incoming_p2p_messages{protocol="snap1",message="GetAccountRange"}[$__rate_interval])`
  - nethermind_incoming_p2p_messages
  - nethermind_incoming_p2p_message_bytes
  - nethermind_outgoing_p2p_messages
  - nethermind_outgoing_p2p_message_bytes.
- Like any other labeled metric, can sum them by protocol or message. 
- Actually, should `message` be `message_type`? or `type`? No sure. Let me know if anyone have any preference.
- Deprecate a bunch of metrics that is now redundant.

## Changes

- Add four new metrics that is labeled with the protocol and message type.

## Types of changes

#### What types of changes does your code introduce?

- [X] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Seems to work.

## Documentation

#### Requires documentation update

- [ ] Yes
- [X] No

#### Requires explanation in Release Notes

- [X] Yes
- [ ] No

```
- Deprecated per message type p2p metric in favour of unified metric for all p2p message. These metrics will be removed on next release.
  - `nethermind_*_sent`
  - `nethermind_*_received`.
Please use:
 - `nethermind_incoming_p2p_messages`
 - `nethermind_outgoing_p2p_messages`.
```