### PR TITLE
Fix rpc module not returned on arbitrary error

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
@@ -68,11 +68,6 @@ public class JsonRpcService : IJsonRpcService
                 if (_logger.IsError) _logger.Error($"Error during method execution, request: {rpcRequest}", ex);
                 return GetErrorResponse(rpcRequest.Method, ErrorCodes.ModuleTimeout, "Timeout", ex.ToString(), rpcRequest.Id);
             }
-            catch (Exception ex)
-            {
-                if (_logger.IsError) _logger.Error($"Error during method execution, request: {rpcRequest}", ex);
-                return GetErrorResponse(rpcRequest.Method, ErrorCodes.InternalError, "Internal error", ex.ToString(), rpcRequest.Id);
-            }
         }
         catch (Exception ex)
         {
@@ -202,6 +197,11 @@ public class JsonRpcService : IJsonRpcService
         catch (Exception e) when (e.InnerException is InsufficientBalanceException)
         {
             return GetErrorResponse(methodName, ErrorCodes.InvalidInput, e.InnerException.Message, e.ToString(), request.Id, returnAction);
+        }
+        catch (Exception ex)
+        {
+            if (_logger.IsError) _logger.Error($"Error during method execution, request: {request}", ex);
+            return GetErrorResponse(methodName, ErrorCodes.InternalError, "Internal error", ex.ToString(), request.Id, returnAction);
         }
         finally
         {

--- a/src/Nethermind/Nethermind.JsonRpc/WebSockets/JsonRpcSocketsClient.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/WebSockets/JsonRpcSocketsClient.cs
@@ -159,10 +159,13 @@ public class JsonRpcSocketsClient<TStream> : SocketClient<TStream>, IJsonRpcDupl
             }
             else
             {
-                int responseSize = (int)await _jsonSerializer.SerializeAsync(_stream, result.Response, indented: false);
-                responseSize += await _stream.WriteEndOfMessageAsync();
+                using (result.Response)
+                {
+                    int responseSize = (int)await _jsonSerializer.SerializeAsync(_stream, result.Response, indented: false);
+                    responseSize += await _stream.WriteEndOfMessageAsync();
 
-                return responseSize;
+                    return responseSize;
+                }
             }
         }
         finally


### PR DESCRIPTION
## Fix #6724

- On `eth_getLogs` which is a special case, when it throws of any arbitrary error, the module is not returned.
- Not sure what is the actual error that causes this problem for user.
- Also fix response not disposed on websocket.

## Changes

- Fix

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Reproducable by randomly throwing error in eth_getLogs.
- Websocket is reproducable by turning on websocket with nimbus.