### PR TITLE
Fix logging in SortedPool

### DIFF
--- a/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
@@ -316,7 +316,7 @@ namespace Nethermind.TxPool.Collections
                         if (!RemoveLast(out removed) || _cacheMap.Count > _capacity)
                         {
                             if (_cacheMap.Count > _capacity && _logger.IsWarn)
-                                _logger.Warn($"Capacity exceeded or failed to remove the last item from the pool, the current state is {Count}/{_capacity}. {GetInfoAboutWorstValues}");
+                                _logger.Warn($"Capacity exceeded or failed to remove the last item from the pool, the current state is {Count}/{_capacity}. {GetInfoAboutWorstValues()}");
                             UpdateWorstValue();
                             RemoveLast(out removed);
                         }
@@ -477,12 +477,12 @@ namespace Nethermind.TxPool.Collections
                 if (RemoveLast(out TValue? removed))
                 {
                     if (_logger.IsInfo)
-                        _logger.Info($"Removed the last item {removed} from the pool, the current state is {Count}/{expectedCapacity}. {GetInfoAboutWorstValues}");
+                        _logger.Info($"Removed the last item {removed} from the pool, the current state is {Count}/{expectedCapacity}. {GetInfoAboutWorstValues()}");
                 }
                 else
                 {
                     if (_logger.IsWarn)
-                        _logger.Warn($"Failed to remove the last item from the pool, the current state is {Count}/{expectedCapacity}. {GetInfoAboutWorstValues}");
+                        _logger.Warn($"Failed to remove the last item from the pool, the current state is {Count}/{expectedCapacity}. {GetInfoAboutWorstValues()}");
                     UpdateWorstValue();
                 }
 
@@ -494,8 +494,7 @@ namespace Nethermind.TxPool.Collections
         {
             TKey? key = _worstValue.GetValueOrDefault().Value;
             var isWorstValueInPool = _cacheMap.TryGetValue(key, out TValue? value) && value != null;
-            return
-                $"Worst value {_worstValue}, items in worstSortedValues {_worstSortedValues.Count}, GetVakye: {_worstValue.GetValueOrDefault()} current max in worst values {_worstSortedValues.Max}, IsWorstValueInPool {isWorstValueInPool}";
+            return $"Number of items in worstSortedValues: {_worstSortedValues.Count}; IsWorstValueInPool: {isWorstValueInPool}; Worst value: {_worstValue}; GetValue: {_worstValue.GetValueOrDefault()}; Current max in worstSortedValues: {_worstSortedValues.Max};";
         }
 
         public void UpdatePool(Func<TGroupKey, IReadOnlySortedSet<TValue>, IEnumerable<(TValue Tx, Action<TValue>? Change)>> changingElements)


### PR DESCRIPTION
## Changes

- Fix logging to have expected items instead of e.g. `Failed to remove the last item from the pool, the current state is 8366/2048. System.Func1[System.String]`

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### Notes on testing

Tested on local node - after changes logging as expected

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No