### PR TITLE
Extra log on memory prune

### DIFF
--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -408,6 +408,7 @@ namespace Nethermind.Trie.Pruning
                         {
                             using (_dirtyNodes.AllNodes.AcquireLock())
                             {
+                                Stopwatch sw = Stopwatch.StartNew();
                                 if (_logger.IsDebug) _logger.Debug($"Locked {nameof(TrieStore)} for pruning.");
 
                                 while (!_pruningTaskCancellationTokenSource.IsCancellationRequested && _pruningStrategy.ShouldPrune(MemoryUsedByDirtyCache))
@@ -419,6 +420,9 @@ namespace Nethermind.Trie.Pruning
                                         break;
                                     }
                                 }
+
+                                Metrics.PruningTime = sw.ElapsedMilliseconds;
+                                if (_logger.IsInfo) _logger.Info($"Executed memory prune. Took {sw.Elapsed}.");
                             }
                         }
 
@@ -555,7 +559,6 @@ namespace Nethermind.Trie.Pruning
             Metrics.CachedNodesCount = _dirtyNodes.Count;
 
             stopwatch.Stop();
-            Metrics.PruningTime = stopwatch.ElapsedMilliseconds;
             if (_logger.IsDebug) _logger.Debug($"Finished pruning nodes in {stopwatch.ElapsedMilliseconds}ms {MemoryUsedByDirtyCache / 1.MB()} MB, last persisted block: {LastPersistedBlockNumber} current: {LatestCommittedBlockNumber}.");
         }
 


### PR DESCRIPTION
- Memory pruning ran about once per hour. 
- Its not clear if a long block is caused by memory pruning.
- Since it does not happen often anyway, I'd like to just log out when it happen.
- Also, change the measurement of pruning duration to include snapshot time and second pruning since that is the whole time that the triestore is blocked.

## Types of changes

#### What types of changes does your code introduce?

- [X] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [ ] Yes
- [X] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

