### PR TITLE
Fix/estimate gas #6390

### DIFF
--- a/src/Nethermind/Nethermind.Evm/Tracing/GasEstimator.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/GasEstimator.cs
@@ -104,6 +104,7 @@ namespace Nethermind.Evm.Tracing
             }
             public override bool IsTracingReceipt => true;
             public override bool IsTracingInstructions => true;
+            public override bool IsTracingActions => true;
             public bool OutOfGas { get; private set; }
 
             public override void MarkAsSuccess(Address recipient, long gasSpent, byte[] output, LogEntry[] logs, Hash256? stateRoot = null)

--- a/src/Nethermind/Nethermind.Evm/Tracing/GasEstimator.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/GasEstimator.cs
@@ -114,6 +114,11 @@ namespace Nethermind.Evm.Tracing
             {
             }
 
+            public override void ReportActionError(EvmExceptionType error)
+            {
+                OutOfGas |= error == EvmExceptionType.OutOfGas;
+            }
+
             public override void ReportOperationError(EvmExceptionType error)
             {
                 OutOfGas |= error == EvmExceptionType.OutOfGas;


### PR DESCRIPTION
Fixes #6390

In our eth_estimateGas we use a `EstimateGasTracer`, call the EVM and pass it to `GasEstimator`.

Problem is that internally `GasEstimator` uses another tracer that does not fail under certain conditions, like running out of gas on code deploy. 

This means you can pass a tx without gas limit which `EstimateGasTracer` will succeed, and then the internal tracer will incorrectly adjust the gas below out of gas. 

This fix will make the internal tracer also fail correctly. 

Another issue to consider is if the internal tracer should also fail on explicits revert ops?


## Changes

`OutOfGasTracer` checks out of gas revert correctly. 

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

