### PR TITLE
Dont skip tests Nethermind.JsonRpc.Test 

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
@@ -41,7 +41,6 @@ namespace Nethermind.JsonRpc.Test.Modules.Eth;
 
 [Parallelizable(ParallelScope.All)]
 [TestFixture]
-[Culture("en-US")]
 public partial class EthRpcModuleTests
 {
     [TestCase("earliest", "0x3635c9adc5dea00000")]

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
@@ -41,6 +41,7 @@ namespace Nethermind.JsonRpc.Test.Modules.Eth;
 
 [Parallelizable(ParallelScope.All)]
 [TestFixture]
+[SetCulture("en-US")]
 public partial class EthRpcModuleTests
 {
     [TestCase("earliest", "0x3635c9adc5dea00000")]

--- a/src/Nethermind/Nethermind.Serialization.Json/DoubleConverter.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/DoubleConverter.cs
@@ -6,6 +6,7 @@ using System;
 namespace Nethermind.Serialization.Json
 {
     using Nethermind.Core.Collections;
+    using System.Globalization;
     using System.Runtime.CompilerServices;
     using System.Text.Json;
     using System.Text.Json.Serialization;
@@ -26,7 +27,7 @@ namespace Nethermind.Serialization.Json
             double value,
             JsonSerializerOptions options)
         {
-            writer.WriteRawValue(value.ToString("0.0#########"), skipInputValidation: true);
+            writer.WriteRawValue(value.ToString("0.0#########", CultureInfo.InvariantCulture), skipInputValidation: true);
         }
     }
 
@@ -73,7 +74,7 @@ namespace Nethermind.Serialization.Json
             writer.WriteStartArray();
             foreach (double value in values)
             {
-                writer.WriteRawValue(value.ToString("0.0#########"), skipInputValidation: true);
+                writer.WriteRawValue(value.ToString("0.0#########", CultureInfo.InvariantCulture), skipInputValidation: true);
             }
             writer.WriteEndArray();
         }


### PR DESCRIPTION
Fixes many tests currently being skipped in `Nethermind.JsonRpc.Test`

Depending on #6859 since it will fix currently broken tests.

Sets `Invariant` culture on Json converter to avoid `,` in json output