### PR TITLE
Better disposable of JSON RPC batches

### DIFF
--- a/src/Nethermind/Nethermind.AccountAbstraction/Subscribe/NewPendingUserOpsSubscription.cs
+++ b/src/Nethermind/Nethermind.AccountAbstraction/Subscribe/NewPendingUserOpsSubscription.cs
@@ -62,8 +62,7 @@ namespace Nethermind.AccountAbstraction.Subscribe
         {
             ScheduleAction(async () =>
             {
-                JsonRpcResult result;
-                result = _includeUserOperations
+                using JsonRpcResult result = _includeUserOperations
                     ? CreateSubscriptionMessage(new { UserOperation = new UserOperationRpc(e.UserOperation), e.EntryPoint })
                     : CreateSubscriptionMessage(new { UserOperation = e.UserOperation.RequestId, e.EntryPoint });
                 await JsonRpcDuplexClient.SendJsonRpcResult(result);

--- a/src/Nethermind/Nethermind.AccountAbstraction/Subscribe/NewReceivedUserOpsSubscription.cs
+++ b/src/Nethermind/Nethermind.AccountAbstraction/Subscribe/NewReceivedUserOpsSubscription.cs
@@ -62,10 +62,9 @@ namespace Nethermind.AccountAbstraction.Subscribe
         {
             ScheduleAction(async () =>
             {
-                JsonRpcResult result;
-                result = _includeUserOperations
-                    ? CreateSubscriptionMessage(new { UserOperation = new UserOperationRpc(e.UserOperation), e.EntryPoint })
-                    : CreateSubscriptionMessage(new { UserOperation = e.UserOperation.RequestId, e.EntryPoint });
+                using JsonRpcResult result = _includeUserOperations
+                   ? CreateSubscriptionMessage(new { UserOperation = new UserOperationRpc(e.UserOperation), e.EntryPoint })
+                   : CreateSubscriptionMessage(new { UserOperation = e.UserOperation.RequestId, e.EntryPoint });
                 await JsonRpcDuplexClient.SendJsonRpcResult(result);
                 if (_logger.IsTrace) _logger.Trace($"newReceivedUserOperations subscription {Id} printed hash of newReceivedUserOperations.");
             });

--- a/src/Nethermind/Nethermind.Core/Extensions/DisposableExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/DisposableExtensions.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Nethermind.Core.Extensions;
@@ -16,6 +17,34 @@ public static class DisposableExtensions
         }
     }
 
-    public static ValueTask TryDisposeAsync<T>(this T item) =>
-        item is IAsyncDisposable d ? d.DisposeAsync() : default;
+    public static void DisposeItems<T>(this IEnumerable<T> item) where T : IDisposable
+    {
+        foreach (T disposable in item)
+        {
+            disposable.Dispose();
+        }
+    }
+
+    public static async ValueTask DisposeItemsAsync<T>(this IEnumerable<T> item) where T : IAsyncDisposable
+    {
+        foreach (T disposable in item)
+        {
+            await disposable.DisposeAsync();
+        }
+    }
+
+
+    public static ValueTask TryDisposeAsync<T>(this T item)
+    {
+        switch (item)
+        {
+            case IAsyncDisposable d1:
+                return d1.DisposeAsync();
+            case IDisposable d2:
+                d2.Dispose();
+                break;
+        }
+
+        return default;
+    }
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcProcessorTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcProcessorTests.cs
@@ -10,6 +10,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Nethermind.Core.Extensions;
 using Nethermind.Logging;
 using Nethermind.Serialization.Json;
 using Nethermind.JsonRpc.Modules;
@@ -67,6 +68,7 @@ public class JsonRpcProcessorTests
         IList<JsonRpcResult> result = await ProcessAsync("{\"id\":12345678901234567890,\"jsonrpc\":\"2.0\",\"method\":\"eth_getTransactionCount\",\"params\":[\"0x7f01d9b227593e033bf8d6fc86e634d27aa85568\",\"0x668c24\"]}");
         result.Should().HaveCount(1);
         Assert.That(result[0].Response!.Id, Is.EqualTo(decimal.Parse("12345678901234567890")));
+        await result.TryDisposeAsync();
     }
 
     [Test]
@@ -75,6 +77,7 @@ public class JsonRpcProcessorTests
         IList<JsonRpcResult> result = await ProcessAsync("{\"id\":\"0xa1aa12434\",\"jsonrpc\":\"2.0\",\"method\":\"eth_getTransactionCount\",\"params\":[\"0x7f01d9b227593e033bf8d6fc86e634d27aa85568\",\"0x668c24\"]}");
         result.Should().HaveCount(1);
         Assert.That(result[0].Response!.Id, Is.EqualTo("0xa1aa12434"));
+        await result.TryDisposeAsync();
     }
 
     [Test]
@@ -83,6 +86,7 @@ public class JsonRpcProcessorTests
         IList<JsonRpcResult> result = await ProcessAsync("{\"id\":67,\"jsonrpc\":\"2.0\",\"method\":\"eth_getTransactionCount\",\"params\":[\"0x7f01d9b227593e033bf8d6fc86e634d27aa85568\",\"0x668c24\"]}");
         result.Should().HaveCount(1);
         Assert.That(result[0].Response!.Id, Is.EqualTo(67));
+        await result.TryDisposeAsync();
     }
 
     [Test]
@@ -99,6 +103,7 @@ public class JsonRpcProcessorTests
         {
             result[0].Response.Should().BeOfType<JsonRpcSuccessResponse>();
         }
+        await result.TryDisposeAsync();
     }
 
 
@@ -108,6 +113,7 @@ public class JsonRpcProcessorTests
         IList<JsonRpcResult> result = await ProcessAsync("{\"id\":9223372036854775807,\"jsonrpc\":\"2.0\",\"method\":\"eth_getTransactionCount\",\"params\":[\"0x7f01d9b227593e033bf8d6fc86e634d27aa85568\",\"0x668c24\"]}");
         result.Should().HaveCount(1);
         Assert.That(result[0].Response!.Id, Is.EqualTo(long.MaxValue));
+        await result.TryDisposeAsync();
     }
 
     [Test]
@@ -116,6 +122,7 @@ public class JsonRpcProcessorTests
         IList<JsonRpcResult> result = await ProcessAsync("{\"id\":\";\\\\\\\"\",\"jsonrpc\":\"2.0\",\"method\":\"eth_getTransactionCount\",\"params\":[\"0x7f01d9b227593e033bf8d6fc86e634d27aa85568\",\"0x668c24\"]}");
         result.Should().HaveCount(1);
         Assert.That(result[0].Response!.Id, Is.EqualTo(";\\\""));
+        await result.TryDisposeAsync();
     }
 
     [Test]
@@ -124,6 +131,7 @@ public class JsonRpcProcessorTests
         IList<JsonRpcResult> result = await ProcessAsync("{\"id\":null,\"jsonrpc\":\"2.0\",\"method\":\"eth_getTransactionCount\",\"params\":[\"0x7f01d9b227593e033bf8d6fc86e634d27aa85568\",\"0x668c24\"]}");
         result.Should().HaveCount(1);
         Assert.That(result[0].Response!.Id, Is.EqualTo(null));
+        await result.TryDisposeAsync();
     }
 
     [Test]
@@ -140,6 +148,7 @@ public class JsonRpcProcessorTests
         {
             (await result[0].BatchedResponses!.Select(r => r.Response).ToListAsync()).Should().AllBeOfType<JsonRpcSuccessResponse>();
         }
+        await result.TryDisposeAsync();
     }
 
     [Test]
@@ -156,6 +165,7 @@ public class JsonRpcProcessorTests
         {
             (await result[0].BatchedResponses!.Select(r => r.Response).ToListAsync()).Should().AllBeOfType<JsonRpcSuccessResponse>();
         }
+        await result.TryDisposeAsync();
     }
 
     [Test]
@@ -165,6 +175,7 @@ public class JsonRpcProcessorTests
         result.Should().HaveCount(1);
         result[0].Response.Should().NotBeNull();
         result[0].Response.Should().BeOfType<JsonRpcErrorResponse>();
+        await result.TryDisposeAsync();
     }
 
     [Test]
@@ -177,6 +188,7 @@ public class JsonRpcProcessorTests
         var resultList = await result[0].BatchedResponses!.ToListAsync();
         resultList.Should().HaveCount(2);
         Assert.IsTrue(resultList.All(r => r.Response != _errorResponse));
+        await result.TryDisposeAsync();
     }
 
     [Test]
@@ -186,6 +198,7 @@ public class JsonRpcProcessorTests
         result.Should().HaveCount(1);
         result[0].BatchedResponses.Should().NotBeNull();
         result[0].Response.Should().BeNull();
+        await result.TryDisposeAsync();
     }
 
     [Test]
@@ -195,6 +208,7 @@ public class JsonRpcProcessorTests
         result.Should().HaveCount(1);
         result[0].BatchedResponses.Should().NotBeNull();
         result[0].Response.Should().BeNull();
+        await result.TryDisposeAsync();
     }
 
     [Test]
@@ -208,6 +222,7 @@ public class JsonRpcProcessorTests
         result[1].Response.Should().NotBeNull();
         result[1].BatchedResponses.Should().BeNull();
         result[1].Response.Should().NotBeSameAs(_errorResponse);
+        await result.TryDisposeAsync();
     }
 
     [Test]
@@ -223,6 +238,7 @@ public class JsonRpcProcessorTests
         List<JsonRpcResult.Entry> resultList = await result[1].BatchedResponses!.ToListAsync();
         resultList.Should().HaveCount(2);
         Assert.IsTrue(resultList.All(r => r.Response != _errorResponse));
+        await result.TryDisposeAsync();
     }
 
     [Test]
@@ -236,6 +252,7 @@ public class JsonRpcProcessorTests
         result[1].Response.Should().NotBeNull();
         result[1].BatchedResponses.Should().BeNull();
         result[1].Response.Should().BeSameAs(_errorResponse);
+        await result.TryDisposeAsync();
     }
 
     [Test]
@@ -247,6 +264,7 @@ public class JsonRpcProcessorTests
         result[0].BatchedResponses.Should().BeNull();
         result[1].Response.Should().BeSameAs(_errorResponse);
         result[1].BatchedResponses.Should().BeNull();
+        await result.TryDisposeAsync();
     }
 
     [Test]
@@ -266,6 +284,7 @@ public class JsonRpcProcessorTests
         IList<JsonRpcResult> result = await ProcessAsync(request.ToString());
         result.Should().HaveCount(1);
         result[0].Response.Should().BeAssignableTo<JsonRpcErrorResponse>();
+        await result.TryDisposeAsync();
     }
 
     [Test]
@@ -291,6 +310,7 @@ public class JsonRpcProcessorTests
         batchedResults.Should().AllSatisfy(rpcResult =>
             rpcResult.Response.Should().BeOfType(_returnErrors ? typeof(JsonRpcErrorResponse) : typeof(JsonRpcSuccessResponse))
         );
+        await result.TryDisposeAsync();
     }
 
     [Test]
@@ -322,6 +342,7 @@ public class JsonRpcProcessorTests
         }
 
         (await enumerator.MoveNextAsync()).Should().BeFalse();
+        await result.TryDisposeAsync();
     }
 
     [Test]
@@ -330,6 +351,7 @@ public class JsonRpcProcessorTests
         IList<JsonRpcResult> result = await ProcessAsync("invalid");
         result.Should().HaveCount(1);
         result[0].Response.Should().BeSameAs(_errorResponse);
+        await result.TryDisposeAsync();
     }
 
     [Test]
@@ -340,6 +362,7 @@ public class JsonRpcProcessorTests
         result[0].Response.Should().BeNull();
         result[0].BatchedResponses.Should().NotBeNull();
         Assert.IsTrue((await result[0].BatchedResponses!.ToListAsync()).All(r => r.Response != _errorResponse));
+        await result.TryDisposeAsync();
     }
 
     [Test]
@@ -350,6 +373,7 @@ public class JsonRpcProcessorTests
         result[0].Response.Should().NotBeNull();
         result[0].BatchedResponses.Should().BeNull();
         result[0].Response.Should().NotBeSameAs(_errorResponse);
+        await result.TryDisposeAsync();
     }
 
     [Test]
@@ -362,6 +386,7 @@ public class JsonRpcProcessorTests
         IList<JsonRpcResult.Entry> resultList = (await result[0].BatchedResponses!.ToListAsync());
         resultList.Should().HaveCount(3);
         Assert.IsTrue(resultList.All(r => r.Response != _errorResponse));
+        await result.TryDisposeAsync();
     }
 
     [Test]
@@ -372,6 +397,7 @@ public class JsonRpcProcessorTests
         result[0].Response.Should().NotBeNull();
         result[0].BatchedResponses.Should().BeNull();
         result[0].Response.Should().BeSameAs(_errorResponse);
+        await result.TryDisposeAsync();
     }
 
     [Test]
@@ -382,6 +408,7 @@ public class JsonRpcProcessorTests
         result[0].Response.Should().NotBeNull();
         result[0].BatchedResponses.Should().BeNull();
         result[0].Response.Should().BeSameAs(_errorResponse);
+        await result.TryDisposeAsync();
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcSocketsClientTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcSocketsClientTests.cs
@@ -51,7 +51,7 @@ public class JsonRpcSocketsClientTests
                     jsonRpcLocalStats: new NullJsonRpcLocalStats(),
                     jsonSerializer: new EthereumJsonSerializer()
                 );
-                JsonRpcResult result = JsonRpcResult.Single(bigObject, default);
+                using JsonRpcResult result = JsonRpcResult.Single(bigObject, default);
 
                 return await client.SendJsonRpcResult(result);
             });
@@ -122,7 +122,7 @@ public class JsonRpcSocketsClientTests
 
                 for (int i = 0; i < messageCount; i++)
                 {
-                    JsonRpcResult result = JsonRpcResult.Single(RandomSuccessResponse(1_000, () => disposeCount++), default);
+                    using JsonRpcResult result = JsonRpcResult.Single(RandomSuccessResponse(1_000, () => disposeCount++), default);
                     await client.SendJsonRpcResult(result);
                     await Task.Delay(100);
                 }
@@ -291,7 +291,7 @@ public class JsonRpcSocketsClientTests
                     jsonRpcLocalStats: new NullJsonRpcLocalStats(),
                     jsonSerializer: new EthereumJsonSerializer()
                 );
-                JsonRpcResult result = JsonRpcResult.Single(RandomSuccessResponse(1_000), default);
+                using JsonRpcResult result = JsonRpcResult.Single(RandomSuccessResponse(1_000), default);
 
                 for (int i = 0; i < messageCount; i++)
                 {
@@ -335,7 +335,7 @@ public class JsonRpcSocketsClientTests
                     jsonRpcLocalStats: new NullJsonRpcLocalStats(),
                     jsonSerializer: new EthereumJsonSerializer()
                 );
-                JsonRpcResult result = JsonRpcResult.Collection(RandomBatchResult(10, 100));
+                using JsonRpcResult result = JsonRpcResult.Collection(RandomBatchResult(10, 100));
 
                 await client.SendJsonRpcResult(result);
 
@@ -375,7 +375,7 @@ public class JsonRpcSocketsClientTests
                     jsonSerializer: new EthereumJsonSerializer(),
                     maxBatchResponseBodySize: maxByteCount
                 );
-                JsonRpcResult result = JsonRpcResult.Collection(RandomBatchResult(10, 100));
+                using JsonRpcResult result = JsonRpcResult.Collection(RandomBatchResult(10, 100));
 
                 int sent = await client.SendJsonRpcResult(result);
 

--- a/src/Nethermind/Nethermind.JsonRpc/IJsonRpcBatchResult.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/IJsonRpcBatchResult.cs
@@ -10,7 +10,7 @@ namespace Nethermind.JsonRpc;
 
 /// <summary>Exposes an enumerator that provides asynchronous iteration over values of a specified type.</summary>
 /// <typeparam name="T">The type of values to enumerate.</typeparam>
-public interface IJsonRpcBatchResult : IAsyncEnumerable<JsonRpcResult.Entry>
+public interface IJsonRpcBatchResult : IAsyncEnumerable<JsonRpcResult.Entry>, IDisposable
 {
     /// <summary>Returns an enumerator that iterates asynchronously through the collection.</summary>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> that may be used to cancel the asynchronous iteration.</param>

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcResponse.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcResponse.cs
@@ -16,24 +16,17 @@ namespace Nethermind.JsonRpc
     [JsonDerivedType(typeof(JsonRpcSuccessResponse))]
     [JsonDerivedType(typeof(JsonRpcErrorResponse))]
     [JsonDerivedType(typeof(JsonRpcSubscriptionResponse))]
-    public class JsonRpcResponse : IDisposable
+    public class JsonRpcResponse(Action? action = null) : IDisposable
     {
-        private Action? _disposableAction;
-
-        public JsonRpcResponse(Action? disposableAction = null)
-        {
-            _disposableAction = disposableAction;
-        }
-
         public void AddDisposable(Action disposableAction)
         {
-            if (_disposableAction is null)
+            if (action is null)
             {
-                _disposableAction = disposableAction;
+                action = disposableAction;
             }
             else
             {
-                _disposableAction += disposableAction;
+                action += disposableAction;
             }
         }
 
@@ -52,8 +45,8 @@ namespace Nethermind.JsonRpc
 
         public virtual void Dispose()
         {
-            _disposableAction?.Invoke();
-            _disposableAction = null;
+            action?.Invoke();
+            action = null;
         }
     }
 

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcResult.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcResult.cs
@@ -6,7 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Nethermind.JsonRpc
 {
-    public readonly struct JsonRpcResult
+    public readonly struct JsonRpcResult : IDisposable
     {
         [MemberNotNullWhen(true, nameof(BatchedResponses))]
         [MemberNotNullWhen(false, nameof(SingleResponse))]
@@ -54,6 +54,12 @@ namespace Nethermind.JsonRpc
             {
                 Response?.Dispose();
             }
+        }
+
+        public void Dispose()
+        {
+            SingleResponse?.Dispose();
+            BatchedResponses?.Dispose();
         }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/DroppedPendingTransactionsSubscription.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/DroppedPendingTransactionsSubscription.cs
@@ -28,7 +28,7 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
         {
             ScheduleAction(async () =>
             {
-                JsonRpcResult result = CreateSubscriptionMessage(e.Transaction.Hash);
+                using JsonRpcResult result = CreateSubscriptionMessage(e.Transaction.Hash);
                 await JsonRpcDuplexClient.SendJsonRpcResult(result);
                 if (_logger.IsTrace)
                     _logger.Trace(

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/LogsSubscription.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/LogsSubscription.cs
@@ -80,7 +80,7 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
 
                 foreach (var filterLog in filterLogs)
                 {
-                    JsonRpcResult result = CreateSubscriptionMessage(filterLog);
+                    using JsonRpcResult result = CreateSubscriptionMessage(filterLog);
                     await JsonRpcDuplexClient.SendJsonRpcResult(result);
                     if (_logger.IsTrace) _logger.Trace($"Logs subscription {Id} printed new log.");
                 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/NewHeadSubscription.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/NewHeadSubscription.cs
@@ -38,8 +38,7 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
         {
             ScheduleAction(async () =>
             {
-                JsonRpcResult result = CreateSubscriptionMessage(new BlockForRpc(e.Block, _includeTransactions, _specProvider));
-
+                using JsonRpcResult result = CreateSubscriptionMessage(new BlockForRpc(e.Block, _includeTransactions, _specProvider));
                 await JsonRpcDuplexClient.SendJsonRpcResult(result);
                 if (_logger.IsTrace) _logger.Trace($"NewHeads subscription {Id} printed new block");
             });

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/NewPendingTransactionsSubscription.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/NewPendingTransactionsSubscription.cs
@@ -34,7 +34,7 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
         {
             ScheduleAction(async () =>
             {
-                JsonRpcResult result = CreateSubscriptionMessage(_includeTransactions ? new TransactionForRpc(e.Transaction) : e.Transaction.Hash);
+                using JsonRpcResult result = CreateSubscriptionMessage(_includeTransactions ? new TransactionForRpc(e.Transaction) : e.Transaction.Hash);
                 await JsonRpcDuplexClient.SendJsonRpcResult(result);
                 if (_logger.IsTrace) _logger.Trace($"NewPendingTransactions subscription {Id} printed hash of NewPendingTransaction.");
             });

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/SyncingSubscription.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/SyncingSubscription.cs
@@ -80,8 +80,11 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
                     });
                 }
 
+                using (result)
+                {
+                    await JsonRpcDuplexClient.SendJsonRpcResult(result);
+                }
 
-                await JsonRpcDuplexClient.SendJsonRpcResult(result);
                 _logger.Trace($"Syncing subscription {Id} printed SyncingResult object.");
             });
         }

--- a/src/Nethermind/Nethermind.JsonRpc/WebSockets/JsonRpcSocketsClient.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/WebSockets/JsonRpcSocketsClient.cs
@@ -63,22 +63,26 @@ public class JsonRpcSocketsClient<TStream> : SocketClient<TStream>, IJsonRpcDupl
 
         await foreach (JsonRpcResult result in _jsonRpcProcessor.ProcessAsync(request, _jsonRpcContext))
         {
-            stopwatch.Restart();
-
-            int singleResponseSize = await SendJsonRpcResult(result);
-            allResponsesSize += singleResponseSize;
-
-            if (result.IsCollection)
+            using (result)
             {
-                long handlingTimeMicroseconds = stopwatch.ElapsedMicroseconds();
-                _ = _jsonRpcLocalStats.ReportCall(new RpcReport("# collection serialization #", handlingTimeMicroseconds, true), handlingTimeMicroseconds, singleResponseSize);
+                stopwatch.Restart();
+
+                int singleResponseSize = await SendJsonRpcResult(result);
+                allResponsesSize += singleResponseSize;
+
+                if (result.IsCollection)
+                {
+                    long handlingTimeMicroseconds = stopwatch.ElapsedMicroseconds();
+                    _ = _jsonRpcLocalStats.ReportCall(new RpcReport("# collection serialization #", handlingTimeMicroseconds, true), handlingTimeMicroseconds, singleResponseSize);
+                }
+                else
+                {
+                    long handlingTimeMicroseconds = stopwatch.ElapsedMicroseconds();
+                    _ = _jsonRpcLocalStats.ReportCall(result.Report!.Value, handlingTimeMicroseconds, singleResponseSize);
+                }
+
+                stopwatch.Restart();
             }
-            else
-            {
-                long handlingTimeMicroseconds = stopwatch.ElapsedMicroseconds();
-                _ = _jsonRpcLocalStats.ReportCall(result.Report!.Value, handlingTimeMicroseconds, singleResponseSize);
-            }
-            stopwatch.Restart();
         }
 
         IncrementBytesSentMetric(allResponsesSize);
@@ -120,34 +124,27 @@ public class JsonRpcSocketsClient<TStream> : SocketClient<TStream>, IJsonRpcDupl
                 int responseSize = 1;
                 bool isFirst = true;
                 await _stream.WriteAsync(_jsonOpeningBracket);
-                JsonRpcBatchResultAsyncEnumerator enumerator = result.BatchedResponses!.GetAsyncEnumerator(CancellationToken.None);
-                try
+                await using JsonRpcBatchResultAsyncEnumerator enumerator = result.BatchedResponses!.GetAsyncEnumerator(CancellationToken.None);
+                while (await enumerator.MoveNextAsync())
                 {
-                    while (await enumerator.MoveNextAsync())
+                    JsonRpcResult.Entry entry = enumerator.Current;
+                    using (entry)
                     {
-                        JsonRpcResult.Entry entry = enumerator.Current;
-                        using (entry)
+                        if (!isFirst)
                         {
-                            if (!isFirst)
-                            {
-                                await _stream.WriteAsync(_jsonComma);
-                                responseSize += 1;
-                            }
-                            isFirst = false;
-                            responseSize += (int)await _jsonSerializer.SerializeAsync(_stream, result.Response, indented: false);
-                            _ = _jsonRpcLocalStats.ReportCall(entry.Report);
+                            await _stream.WriteAsync(_jsonComma);
+                            responseSize += 1;
+                        }
+                        isFirst = false;
+                        responseSize += (int)await _jsonSerializer.SerializeAsync(_stream, result.Response, indented: false);
+                        _ = _jsonRpcLocalStats.ReportCall(entry.Report);
 
-                            // We reached the limit and don't want to responded to more request in the batch
-                            if (!_jsonRpcContext.IsAuthenticated && responseSize > _maxBatchResponseBodySize)
-                            {
-                                enumerator.IsStopped = true;
-                            }
+                        // We reached the limit and don't want to responded to more request in the batch
+                        if (!_jsonRpcContext.IsAuthenticated && responseSize > _maxBatchResponseBodySize)
+                        {
+                            enumerator.IsStopped = true;
                         }
                     }
-                }
-                finally
-                {
-                    await enumerator.DisposeAsync();
                 }
 
                 await _stream.WriteAsync(_jsonClosingBracket);
@@ -159,13 +156,9 @@ public class JsonRpcSocketsClient<TStream> : SocketClient<TStream>, IJsonRpcDupl
             }
             else
             {
-                using (result.Response)
-                {
-                    int responseSize = (int)await _jsonSerializer.SerializeAsync(_stream, result.Response, indented: false);
-                    responseSize += await _stream.WriteEndOfMessageAsync();
-
-                    return responseSize;
-                }
+                int responseSize = (int)await _jsonSerializer.SerializeAsync(_stream, result.Response, indented: false);
+                responseSize += await _stream.WriteEndOfMessageAsync();
+                return responseSize;
             }
         }
         finally


### PR DESCRIPTION
## Changes

- Better disposable of JSON RPC batches
- Make dispose of `JsonRpcResult` at the caller

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No