### PR TITLE
Perf/dont redownload downloaded code

### DIFF
--- a/src/Nethermind/Nethermind.State.Test/SnapSync/RecreateStateFromAccountRangesTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/SnapSync/RecreateStateFromAccountRangesTests.cs
@@ -5,6 +5,8 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using FluentAssertions;
+using Nethermind.Blockchain;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
@@ -12,6 +14,7 @@ using Nethermind.Db;
 using Nethermind.Logging;
 using Nethermind.State;
 using Nethermind.State.Proofs;
+using Nethermind.State.Snap;
 using Nethermind.Synchronization.SnapSync;
 using Nethermind.Trie;
 using Nethermind.Trie.Pruning;
@@ -259,6 +262,53 @@ namespace Nethermind.Store.Test
             Assert.That(result3, Is.EqualTo(AddRangeResult.OK));
             Assert.That(db.Keys.Count, Is.EqualTo(6));
             Assert.IsFalse(db.KeyExists(rootHash));
+        }
+
+        [Test]
+        public void Will_not_redownload_persisted_code()
+        {
+            MemDb db = new();
+            MemDb codeDb = new();
+            DbProvider dbProvider = new();
+            dbProvider.RegisterDb(DbNames.State, db);
+            dbProvider.RegisterDb(DbNames.Code, codeDb);
+
+            BlockTree tree = Build.A.BlockTree().OfChainLength(5).TestObject;
+            using ProgressTracker progressTracker = new(tree, dbProvider.GetDb<IDb>(DbNames.State), LimboLogs.Instance, accountRangePartitionCount: 1);
+            SnapProvider snapProvider = new(progressTracker, dbProvider, LimboLogs.Instance);
+
+            PathWithAccount[] accountsWithPath =
+            [
+                new PathWithAccount(new Hash256("0000000000000000000000000000000000000000000000000000000001112345"),
+                    new Account(0, 0, Keccak.EmptyTreeHash, TestItem.Keccaks[0])),
+                new PathWithAccount(new Hash256("0000000000000000000000000000000000000000000000000000000001113456"),
+                    new Account(0, 0, Keccak.EmptyTreeHash, TestItem.Keccaks[1])),
+                new PathWithAccount(new Hash256("0000000000000000000000000000000000000000000000000000000001114567"),
+                    new Account(0, 0, Keccak.EmptyTreeHash, TestItem.Keccaks[2])),
+                new PathWithAccount(new Hash256("0000000000000000000000000000000000000000000000000000000001123456"),
+                    new Account(0, 0, Keccak.EmptyTreeHash, TestItem.Keccaks[3])),
+                new PathWithAccount(new Hash256("0000000000000000000000000000000000000000000000000000000001123457"),
+                    new Account(0, 0, Keccak.EmptyTreeHash, TestItem.Keccaks[4]))
+            ];
+
+            codeDb[TestItem.Keccaks[1].Bytes] = [1];
+            codeDb[TestItem.Keccaks[2].Bytes] = [1];
+
+            StateTree stateTree = new StateTree();
+            foreach (PathWithAccount pathWithAccount in accountsWithPath)
+            {
+                stateTree.Set(pathWithAccount.Path, pathWithAccount.Account);
+            }
+            stateTree.UpdateRootHash();
+
+            snapProvider.AddAccountRange(1,
+                stateTree.RootHash,
+                accountsWithPath[0].Path,
+                accountsWithPath);
+
+            progressTracker.IsFinished(out SnapSyncBatch nextRequest).Should().BeFalse();
+            progressTracker.IsFinished(out nextRequest).Should().BeFalse();
+            nextRequest.CodesRequest.Count.Should().Be(3);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProvider.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProvider.cs
@@ -29,6 +29,8 @@ namespace Nethermind.Synchronization.SnapSync
         private readonly ILogger _logger;
 
         private readonly ProgressTracker _progressTracker;
+
+        // This is actually close to 97% effective.
         private readonly LruKeyCache<ValueHash256> _codeExistKeyCache = new(1024*16, "");
 
         public SnapProvider(ProgressTracker progressTracker, IDbProvider dbProvider, ILogManager logManager)


### PR DESCRIPTION
- Turns out a large portion of the incoming and outgoing portion of uncompressed snap message traffic are code which are duplicated.
- This add a filter so that persisted codes are not redownloaded.
- This reduces about 30% of uncompressed incoming traffic and about 50% of uncompressed outgoing traffic. Compressed traffic is likely much lower as these codes are largely the same and repeated.
- Overall effect on snap sync is not much, although multiple run shows a slight improvement int statedb write rates.
- Graph is (before, after)X5.
![Screenshot_2024-03-27_22-26-37](https://github.com/NethermindEth/nethermind/assets/1841324/d950e274-8ec1-45e3-85e0-198806cca128)

## Changes

- Check if a code was persisted, if so don't download it again.
- Add an LRU to reduce IO.

## Types of changes

#### What types of changes does your code introduce?

- [X] Optimization

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

