### PR TITLE
Change from time to status trigger - adjustment for Hive Consensus tests

### DIFF
--- a/scripts/wait-for-workflow-completed.sh
+++ b/scripts/wait-for-workflow-completed.sh
@@ -43,7 +43,7 @@ else
     fi
     run_id=$(echo "$response" | \
       jq -r --arg ref "$(echo "$REF" | sed 's/refs\/heads\///')" --arg current_time "$current_time" \
-      '.workflow_runs[] | select(.head_branch == $ref and .created_at >= $current_time) | .id' | sort -r | head -n 1)
+      '.workflow_runs[] | select(.head_branch == $ref and .status == "in_progress") | .id' | sort -r | head -n 1)
     if [ -n "$run_id" ]; then
       echo "🎉 Workflow triggered! Run ID: $run_id"
       break


### PR DESCRIPTION
Time filter seems like not the best idea especially for Hive Consensus tests which are not triggering a docker creation but seeking for already triggered docker creation action - usually it happens almost at the same time for actions like OneClick but in  case of hive consensus it can start searching for image after few seconds which already violates this check.

Because sorting is applied and workflow_id filter is on place just simple status check for inprogress runs seems to be enough.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [X] Yes
- [ ] No
Tested on OneClick and will test after merge to release branch if it triggers properly now.