### PR TITLE
Use IEquatable+GetHashCode keys for Dictionary

### DIFF
--- a/src/Nethermind/Nethermind.Trie/Pruning/TinyTreePath.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TinyTreePath.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Nethermind.Core.Crypto;
 
@@ -11,20 +10,19 @@ namespace Nethermind.Trie;
 /// <summary>
 /// Like TreePath, but tiny. Fit in 8 byte, like a long. Can only represent 14 nibble.
 /// </summary>
-public struct TinyTreePath
+public readonly struct TinyTreePath : IEquatable<TinyTreePath>
 {
     public const int MaxNibbleLength = 14;
 
-    long _data;
+    private readonly long _data;
 
-    // Eh.. readonly?
-    private Span<byte> AsSpan => MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref _data, 1));
+    private ReadOnlySpan<byte> AsSpan => MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(in _data, 1));
 
     public TinyTreePath(in TreePath path)
     {
         if (path.Length > MaxNibbleLength) throw new InvalidOperationException("Unable to represent more than 14 nibble");
         Span<byte> pathSpan = path.Path.BytesAsSpan;
-        Span<byte> selfSpan = AsSpan;
+        Span<byte> selfSpan = MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref _data, 1));
         pathSpan[..7].CopyTo(selfSpan);
         selfSpan[7] = (byte)path.Length;
     }
@@ -35,9 +33,13 @@ public struct TinyTreePath
     {
         ValueHash256 rawPath = Keccak.Zero;
         Span<byte> pathSpan = rawPath.BytesAsSpan;
-        Span<byte> selfSpan = AsSpan;
+        ReadOnlySpan<byte> selfSpan = AsSpan;
         selfSpan[..7].CopyTo(pathSpan);
 
         return new TreePath(rawPath, selfSpan[7]);
     }
+
+    public bool Equals(TinyTreePath other) => _data == other._data;
+    public override bool Equals(object? obj) => obj is TinyTreePath other && Equals(other);
+    public override int GetHashCode() => _data.GetHashCode();
 }


### PR DESCRIPTION
## Changes

![image](https://github.com/NethermindEth/nethermind/assets/1142958/d3920d7c-c4be-4e40-b2c3-4116a05647e8)


- Using a non IEquatable/ValueTuple as Dictionary key causes huge allocations. Define some structs for these keys with implicit conversions from the ValueTuple

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No