### PR TITLE
McsLock fast-paths

### DIFF
--- a/src/Nethermind/Nethermind.Core/Threading/McsLock.cs
+++ b/src/Nethermind/Nethermind.Core/Threading/McsLock.cs
@@ -26,7 +26,7 @@ public class McsLock
     /// </summary>
     private volatile ThreadNode? _tail;
 
-    internal volatile ThreadNode? currentLockHolder = null;
+    internal volatile ThreadNode? _currentLockHolder = null;
 
     /// <summary>
     /// Acquires the lock. If the lock is already held, the calling thread is placed into a queue and
@@ -37,7 +37,7 @@ public class McsLock
         ThreadNode node = _node.Value!;
 
         // Check for reentrancy.
-        if (ReferenceEquals(node, currentLockHolder))
+        if (ReferenceEquals(node, _currentLockHolder))
             ThrowInvalidOperationException();
 
         node.State = (nuint)LockState.Waiting;
@@ -49,7 +49,7 @@ public class McsLock
         }
 
         // Set current lock holder.
-        currentLockHolder = node;
+        _currentLockHolder = node;
 
         return new Disposable(this);
 
@@ -136,7 +136,7 @@ public class McsLock
                 if (Interlocked.CompareExchange(ref _lock._tail, null, node) == node)
                 {
                     // Clear current lock holder.
-                    _lock.currentLockHolder = null;
+                    _lock._currentLockHolder = null;
                     return;
                 }
 
@@ -148,7 +148,7 @@ public class McsLock
 
             ThreadNode next = node.Next!;
             // Clear current lock holder.
-            _lock.currentLockHolder = null;
+            _lock._currentLockHolder = null;
             // Pass the lock to the next thread by setting its 'Locked' flag to false.
             next.State = (nuint)LockState.ReadyToAcquire;
 

--- a/src/Nethermind/Nethermind.Core/Threading/McsPriorityLock.cs
+++ b/src/Nethermind/Nethermind.Core/Threading/McsPriorityLock.cs
@@ -43,7 +43,7 @@ public class McsPriorityLock
     public McsLock.Disposable Acquire()
     {
         // Check for reentrancy.
-        if (Thread.CurrentThread == _coreLock.currentLockHolder)
+        if (_coreLock._node.Value == _coreLock.currentLockHolder)
             ThrowInvalidOperationException();
 
         var isPriority = Thread.CurrentThread.Priority > ThreadPriority.Normal;

--- a/src/Nethermind/Nethermind.Core/Threading/McsPriorityLock.cs
+++ b/src/Nethermind/Nethermind.Core/Threading/McsPriorityLock.cs
@@ -43,7 +43,7 @@ public class McsPriorityLock
     public McsLock.Disposable Acquire()
     {
         // Check for reentrancy.
-        if (_coreLock._node.Value == _coreLock.currentLockHolder)
+        if (_coreLock._node.Value == _coreLock._currentLockHolder)
             ThrowInvalidOperationException();
 
         var isPriority = Thread.CurrentThread.Priority > ThreadPriority.Normal;


### PR DESCRIPTION
## Changes

Spend less time on lock management, so less likely to encounter contention.
- Use `ThreadNode` rather than `Thread.CurrentThread` to check for reenterncy
- Change spin `State` size from `bool` to `nuint` so is natural machine word size
- Move `SpinWait` stack reservations out of the uncontended path
- Move `Monitor`/`lock` signalling out of the fast-path (reducing fast path size and associated `try`/`finally`s)
- After aquiring lock to signal, check if waiting thread has already picked up the signal before Monitor singalling
- Fast-paths with mild contention will not use `lock` at all

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization
- [x] Refactoring

## Testing

#### Requires testing

- [x] No
