### PR TITLE
Reduce contention inside RocksDB during OldReceipts

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/ReceiptsSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/ReceiptsSyncFeed.cs
@@ -13,6 +13,7 @@ using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
+using Nethermind.Core.Threading;
 using Nethermind.Db;
 using Nethermind.Logging;
 using Nethermind.Stats.Model;
@@ -41,6 +42,7 @@ namespace Nethermind.Synchronization.FastBlocks
         private readonly ISyncReport _syncReport;
         private readonly IReceiptStorage _receiptStorage;
         private readonly ISyncPeerPool _syncPeerPool;
+        private readonly McsLock _allocatorLock = new();
 
         private SyncStatusList _syncStatusList;
 
@@ -230,7 +232,16 @@ namespace Nethermind.Synchronization.FastBlocks
                     bool isValid = !hasBreachedProtocol && TryPrepareReceipts(blockInfo, receipts, out prepared);
                     if (isValid)
                     {
-                        Block block = _blockTree.FindBlock(blockInfo.BlockHash);
+                        Block? block;
+                        // Although thread-safe, because the blocks are so large it causes a lot of contention
+                        // on the allocator inside RocksDb; which then impacts block processing heavily, especially on Windows.
+                        // We take the lock here instead to reduce contention on the allocator in the db.
+                        // A better solution would be to change the allocator https://github.com/NethermindEth/nethermind/issues/6107
+                        using (var handle = _allocatorLock.Acquire())
+                        {
+                            block = _blockTree.FindBlock(blockInfo.BlockHash);
+                        }
+
                         if (block is null)
                         {
                             if (blockInfo.BlockNumber >= _barrier)


### PR DESCRIPTION
Resolves #4642

## Changes

- Lock around `_blockStore.Get` in `BlockTree` to move the contention outside of the RocksDB allocator (which then heavily hits other RocksDB processing like block processing) and into the calling code (OldReceipts/OldBodies)
- A better soltion would be to change the allocator to tcmalloc or Jemalloc however that is much more complicated especially factoring cross platform (will need to be building RocksDB from source and compiling in the allocator) https://github.com/NethermindEth/nethermind/issues/6107

Before

<img width="838" alt="image" src="https://github.com/NethermindEth/nethermind/assets/1142958/cde960d9-68a2-426c-bb93-dcec14234363">

After

<img width="833" alt="image" src="https://github.com/NethermindEth/nethermind/assets/1142958/53d89c5a-7240-4cdb-b0cb-3d527b71a9fc">


## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No

## Documentation

#### Requires explanation in Release Notes

- [x] Yes

Significantly reduces block processing times

## Remarks

On Windows was seeing block processing times of up to 24seconds, this brings it down to mostly in range with the occasional spike to 2secs
