### PR TITLE
Fix JsonRPc Double dispose

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPrunerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPrunerTests.cs
@@ -50,7 +50,7 @@ namespace Nethermind.Blockchain.Test.FullPruning
             test.ShouldCopyAllValues();
         }
 
-        [Timeout(Timeout.MaxTestTime)]
+        [Timeout(Timeout.MaxTestTime * 2)] // this is particular long test
         [TestCase(INodeStorage.KeyScheme.Hash, INodeStorage.KeyScheme.Current, INodeStorage.KeyScheme.Hash)]
         [TestCase(INodeStorage.KeyScheme.HalfPath, INodeStorage.KeyScheme.Current, INodeStorage.KeyScheme.HalfPath)]
         [TestCase(INodeStorage.KeyScheme.Hash, INodeStorage.KeyScheme.HalfPath, INodeStorage.KeyScheme.HalfPath)]
@@ -286,7 +286,7 @@ namespace Nethermind.Blockchain.Test.FullPruning
 
                 try
                 {
-                    Assert.That(() => FullPruningDb.Context, Is.Not.Null.After(5000, 1));
+                    Assert.That(() => FullPruningDb.Context, Is.Not.Null.After(Timeout.MaxTestTime, 1));
                 }
                 finally
                 {

--- a/src/Nethermind/Nethermind.Core.Test/Collections/ArrayPoolListTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Collections/ArrayPoolListTests.cs
@@ -314,6 +314,20 @@ public class ArrayPoolListTests
         list.Count.Should().Be(1);
     }
 
+    [Test]
+    public void Dispose_recursive()
+    {
+        ArrayPoolList<ArrayPoolList<int>> list = new(8)
+        {
+            new ArrayPoolList<int>(8),
+            new ArrayPoolList<int>(8),
+            new ArrayPoolList<int>(8)
+        };
+
+        list.DisposeRecursive();
+        list.DisposeRecursive();
+    }
+
 #if DEBUG
     [Test]
     [Explicit("Crashes the test runner")]

--- a/src/Nethermind/Nethermind.Core/Collections/ArrayPoolList.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/ArrayPoolList.cs
@@ -16,7 +16,6 @@ public sealed class ArrayPoolList<T> : IList<T>, IList, IOwnedReadOnlyList<T>
 {
     private readonly ArrayPool<T> _arrayPool;
     private T[] _array;
-    private int _count = 0;
     private int _capacity;
     private bool _disposed;
 
@@ -41,7 +40,7 @@ public sealed class ArrayPoolList<T> : IList<T>, IList, IOwnedReadOnlyList<T>
         }
         _capacity = _array.Length;
 
-        _count = startingCount;
+        Count = startingCount;
     }
 
     ReadOnlySpan<T> IOwnedReadOnlyList<T>.AsSpan()
@@ -52,7 +51,7 @@ public sealed class ArrayPoolList<T> : IList<T>, IList, IOwnedReadOnlyList<T>
     public IEnumerator<T> GetEnumerator()
     {
         GuardDispose();
-        return new ArrayPoolListEnumerator(_array, _count);
+        return new ArrayPoolListEnumerator(_array, Count);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -75,7 +74,7 @@ public sealed class ArrayPoolList<T> : IList<T>, IList, IOwnedReadOnlyList<T>
     public void Add(T item)
     {
         GuardResize();
-        _array[_count++] = item;
+        _array[Count++] = item;
     }
 
     int IList.Add(object? value)
@@ -90,17 +89,17 @@ public sealed class ArrayPoolList<T> : IList<T>, IList, IOwnedReadOnlyList<T>
     public void AddRange(ReadOnlySpan<T> items)
     {
         GuardResize(items.Length);
-        items.CopyTo(_array.AsSpan(_count, items.Length));
-        _count += items.Length;
+        items.CopyTo(_array.AsSpan(Count, items.Length));
+        Count += items.Length;
     }
 
-    public void Clear() => _count = 0;
+    public void Clear() => Count = 0;
 
     public bool Contains(T item)
     {
         GuardDispose();
         int indexOf = Array.IndexOf(_array, item);
-        return indexOf >= 0 && indexOf < _count;
+        return indexOf >= 0 && indexOf < Count;
     }
 
     bool IList.Contains(object? value) => IsCompatibleObject(value) && Contains((T)value!);
@@ -108,7 +107,7 @@ public sealed class ArrayPoolList<T> : IList<T>, IList, IOwnedReadOnlyList<T>
     public void CopyTo(T[] array, int arrayIndex)
     {
         GuardDispose();
-        _array.AsMemory(0, _count).CopyTo(array.AsMemory(arrayIndex));
+        _array.AsMemory(0, Count).CopyTo(array.AsMemory(arrayIndex));
     }
 
     void ICollection.CopyTo(Array array, int index)
@@ -118,17 +117,10 @@ public sealed class ArrayPoolList<T> : IList<T>, IList, IOwnedReadOnlyList<T>
 
         GuardDispose();
 
-        Array.Copy(_array, 0, array!, index, _count);
+        Array.Copy(_array, 0, array!, index, Count);
     }
 
-    public int Count
-    {
-        get
-        {
-            GuardDispose();
-            return _count;
-        }
-    }
+    public int Count { get; private set; } = 0;
 
     public int Capacity => _capacity;
 
@@ -146,7 +138,7 @@ public sealed class ArrayPoolList<T> : IList<T>, IList, IOwnedReadOnlyList<T>
     {
         GuardDispose();
         int indexOf = Array.IndexOf(_array, item);
-        return indexOf < _count ? indexOf : -1;
+        return indexOf < Count ? indexOf : -1;
     }
 
     int IList.IndexOf(object? value) => IsCompatibleObject(value) ? IndexOf((T)value!) : -1;
@@ -155,9 +147,9 @@ public sealed class ArrayPoolList<T> : IList<T>, IList, IOwnedReadOnlyList<T>
     {
         GuardResize();
         GuardIndex(index, allowEqualToCount: true);
-        _array.AsMemory(index, _count - index).CopyTo(_array.AsMemory(index + 1));
+        _array.AsMemory(index, Count - index).CopyTo(_array.AsMemory(index + 1));
         _array[index] = item;
-        _count++;
+        Count++;
     }
 
     void IList.Insert(int index, object? value)
@@ -170,7 +162,7 @@ public sealed class ArrayPoolList<T> : IList<T>, IList, IOwnedReadOnlyList<T>
     private void GuardResize(int itemsToAdd = 1)
     {
         GuardDispose();
-        int newCount = _count + itemsToAdd;
+        int newCount = Count + itemsToAdd;
         if (_capacity == 0)
         {
             _array = _arrayPool.Rent(newCount);
@@ -208,12 +200,12 @@ public sealed class ArrayPoolList<T> : IList<T>, IList, IOwnedReadOnlyList<T>
         if (isValid)
         {
             int start = index + 1;
-            if (start < _count)
+            if (start < Count)
             {
-                _array.AsMemory(start, _count - index).CopyTo(_array.AsMemory(index));
+                _array.AsMemory(start, Count - index).CopyTo(_array.AsMemory(index));
             }
 
-            _count--;
+            Count--;
         }
 
         return isValid;
@@ -223,7 +215,7 @@ public sealed class ArrayPoolList<T> : IList<T>, IList, IOwnedReadOnlyList<T>
     {
         GuardDispose();
         GuardIndex(newLength, allowEqualToCount: true);
-        _count = newLength;
+        Count = newLength;
     }
 
     public T this[int index]
@@ -254,7 +246,7 @@ public sealed class ArrayPoolList<T> : IList<T>, IList, IOwnedReadOnlyList<T>
     private bool GuardIndex(int index, bool shouldThrow = true, bool allowEqualToCount = false)
     {
         GuardDispose();
-        int count = _count;
+        int count = Count;
         if ((uint)index > (uint)count || (!allowEqualToCount && index == count))
         {
             if (shouldThrow)
@@ -300,6 +292,7 @@ public sealed class ArrayPoolList<T> : IList<T>, IList, IOwnedReadOnlyList<T>
         if (!_disposed)
         {
             _disposed = true;
+            Count = 0;
             T[]? array = _array;
             if (array is not null)
             {
@@ -325,5 +318,5 @@ public sealed class ArrayPoolList<T> : IList<T>, IList, IOwnedReadOnlyList<T>
     }
 #endif
 
-    public Span<T> AsSpan() => _array.AsSpan(0, _count);
+    public Span<T> AsSpan() => _array.AsSpan(0, Count);
 }

--- a/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
+++ b/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
@@ -213,10 +213,7 @@ namespace Nethermind.Runner.JsonRpc
                                     }
                                     else
                                     {
-                                        using (result.Response)
-                                        {
-                                            jsonSerializer.Serialize(resultWriter, result.Response);
-                                        }
+                                        jsonSerializer.Serialize(resultWriter, result.Response);
                                     }
 
                                     if (stream is not null)


### PR DESCRIPTION
## Changes

- Removes unnecessary arraypoollist dispose

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No



## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

maybe Add a property on ArrayPoolList call `isDiposed` to check if object has been disposed.
useful for nested arrayPoolLists. 

Since we usually want to dispose the entire collection from the top
and sometimes we dispose inner collection from somewhere else when they are passed as references.
