### PR TITLE
Fix trie exception when killed after memory pruning before next block

### DIFF
--- a/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
@@ -876,7 +876,7 @@ namespace Nethermind.Trie.Test.Pruning
 
                 if (i > 4)
                 {
-                    Assert.That(() => reorgBoundary, Is.EqualTo(i-3).After(1000, 1));
+                    Assert.That(() => reorgBoundary, Is.EqualTo(i - 3).After(1000, 1));
                 }
                 else
                 {

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -610,6 +610,8 @@ namespace Nethermind.Trie.Pruning
                     {
                         if (_logger.IsError) _logger.Error("Pruning failed with exception.", e);
                     }
+
+                    AnnounceReorgBoundaries();
                 });
             }
         }

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -610,8 +610,6 @@ namespace Nethermind.Trie.Pruning
                     {
                         if (_logger.IsError) _logger.Error("Pruning failed with exception.", e);
                     }
-
-                    AnnounceReorgBoundaries();
                 });
             }
         }
@@ -672,6 +670,7 @@ namespace Nethermind.Trie.Pruning
                 Task deleteTask = Task.Run(() => RemovePastKeys(persistedHashes));
 
                 writeBatch.Dispose();
+                AnnounceReorgBoundaries();
                 deleteTask.Wait();
 
                 foreach (KeyValuePair<HashAndTinyPathAndHash, long> keyValuePair in _persistedLastSeens)


### PR DESCRIPTION
- Fix trie exception when killed after memory pruning but before next block.
- This is because last persisted state is not saved after memory pruning.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

