### PR TITLE
Fix Network.DiagTracerEnabled object disposed 

### DIFF
--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandler.cs
@@ -303,9 +303,10 @@ public class P2PProtocolHandler(
         if (Logger.IsTrace)
             Logger.Trace($"Sending disconnect {disconnectReason} ({details}) to {Session.Node:s}");
         DisconnectMessage message = new(disconnectReason.ToEthDisconnectReason());
-        Send(message);
         if (NetworkDiagTracer.IsEnabled)
             NetworkDiagTracer.ReportDisconnect(Session.Node.Address, $"Local {disconnectReason} {details}");
+        Send(message);
+
     }
 
     private void SendHello()

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ProtocolHandlerBase.cs
@@ -81,8 +81,8 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
         {
             Interlocked.Increment(ref Counter);
             if (Logger.IsTrace) Logger.Trace($"{Counter} Sending {typeof(T).Name}");
-            int size = Session.DeliverMessage(message);
             if (NetworkDiagTracer.IsEnabled) NetworkDiagTracer.ReportOutgoingMessage(Session.Node?.Address, Name, message.ToString(), size);
+            int size = Session.DeliverMessage(message);
         }
 
         protected async Task CheckProtocolInitTimeout()

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ProtocolHandlerBase.cs
@@ -81,8 +81,14 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
         {
             Interlocked.Increment(ref Counter);
             if (Logger.IsTrace) Logger.Trace($"{Counter} Sending {typeof(T).Name}");
-            if (NetworkDiagTracer.IsEnabled) NetworkDiagTracer.ReportOutgoingMessage(Session.Node?.Address, Name, message.ToString(), size);
-            int size = Session.DeliverMessage(message);
+            if (NetworkDiagTracer.IsEnabled)
+            {
+                string messageString = message.ToString();
+                int size = Session.DeliverMessage(message);
+                NetworkDiagTracer.ReportOutgoingMessage(Session.Node?.Address, Name, messageString, size);
+            }
+            else
+                Session.DeliverMessage(message);
         }
 
         protected async Task CheckProtocolInitTimeout()


### PR DESCRIPTION
Network.DiagTracerEnabled throws `ObjectDisposedException`

Write to log before the dispose happens. 

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_


