### PR TITLE
Use FrozenDictionary for StorageTree key cache

### DIFF
--- a/src/Nethermind/Nethermind.State/StorageTree.cs
+++ b/src/Nethermind/Nethermind.State/StorageTree.cs
@@ -24,15 +24,15 @@ namespace Nethermind.State
         private static FrozenDictionary<UInt256, byte[]> CreateLookup()
         {
             Span<byte> buffer = stackalloc byte[32];
-            Dictionary<UInt256, byte[]> cache = new Dictionary<UInt256, byte[]>(LookupSize);
+            Dictionary<UInt256, byte[]> lookup = new Dictionary<UInt256, byte[]>(LookupSize);
             for (int i = 0; i < LookupSize; i++)
             {
                 UInt256 index = (UInt256)i;
                 index.ToBigEndian(buffer);
-                cache[index] = Keccak.Compute(buffer).BytesToArray();
+                lookup[index] = Keccak.Compute(buffer).BytesToArray();
             }
 
-            return cache.ToFrozenDictionary();
+            return lookup.ToFrozenDictionary();
         }
 
         public StorageTree(IScopedTrieStore? trieStore, ILogManager? logManager)

--- a/src/Nethermind/Nethermind.State/StorageTree.cs
+++ b/src/Nethermind/Nethermind.State/StorageTree.cs
@@ -17,18 +17,15 @@ namespace Nethermind.State
 {
     public class StorageTree : PatriciaTree
     {
-        private static readonly UInt256 CacheSize = 1024;
-
-        private static readonly int CacheSizeInt = (int)CacheSize;
-
-        private static readonly FrozenDictionary<UInt256, byte[]> Cache = CreateCache();
+        private static readonly int LookupSize = 1024;
+        private static readonly FrozenDictionary<UInt256, byte[]> Lookup = CreateLookup();
         private static readonly byte[] _emptyBytes = { 0 };
 
-        private static FrozenDictionary<UInt256, byte[]> CreateCache()
+        private static FrozenDictionary<UInt256, byte[]> CreateLookup()
         {
             Span<byte> buffer = stackalloc byte[32];
-            Dictionary<UInt256, byte[]> cache = new Dictionary<UInt256, byte[]>(CacheSizeInt);
-            for (int i = 0; i < CacheSizeInt; i++)
+            Dictionary<UInt256, byte[]> cache = new Dictionary<UInt256, byte[]>(LookupSize);
+            for (int i = 0; i < LookupSize; i++)
             {
                 UInt256 index = (UInt256)i;
                 index.ToBigEndian(buffer);
@@ -51,9 +48,9 @@ namespace Nethermind.State
 
         private static void GetKey(in UInt256 index, ref Span<byte> key)
         {
-            if (index < CacheSizeInt)
+            if (index < LookupSize)
             {
-                key = Cache[index];
+                key = Lookup[index];
                 return;
             }
 


### PR DESCRIPTION
## Changes

- Use FrozenDictionary for StorageTree 1024 key hash lookup
- Skip `.CopyTo` when lookup hit and use value directly from lookup

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
