### PR TITLE
Logs: Line wrap peers summary

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeersReport.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeersReport.cs
@@ -115,21 +115,6 @@ namespace Nethermind.Synchronization.Peers
                 activeContexts.AppendTo(_stringBuilder, "None");
                 _stringBuilder.Append(" | Sleeping: ");
                 sleepingContexts.AppendTo(_stringBuilder, activeContexts.Total != activeContexts.None ? "None" : "All");
-                _stringBuilder.Append(" |");
-
-                isFirst = true;
-                foreach (var peerGroup in peerGroups.OrderByDescending(x => x.Count()))
-                {
-                    if (isFirst)
-                    {
-                        isFirst = false;
-                    }
-                    else
-                    {
-                        _stringBuilder.Append(',');
-                    }
-                    _stringBuilder.Append($" {peerGroup.Key} ({peerGroup.Count() / sum,3:P0})");
-                }
 
                 string result = _stringBuilder.ToString();
                 _stringBuilder.Clear();
@@ -152,6 +137,35 @@ namespace Nethermind.Synchronization.Peers
                 contextCounts.State += contexts.HasFlag(AllocationContexts.State) ? 1 : 0;
                 contextCounts.Witness += contexts.HasFlag(AllocationContexts.Witness) ? 1 : 0;
                 contextCounts.Snap += contexts.HasFlag(AllocationContexts.Snap) ? 1 : 0;
+            }
+        }
+
+        internal string? MakeDiversityReportForPeers(IEnumerable<PeerInfo> peers, string header)
+        {
+            lock (_writeLock)
+            {
+                IEnumerable<IGrouping<NodeClientType, PeerInfo>> peerGroups = peers.GroupBy(peerInfo => peerInfo.SyncPeer.ClientType);
+                float sum = peerGroups.Sum(x => x.Count());
+
+                _stringBuilder.Append(header);
+
+                bool isFirst = true;
+                foreach (var peerGroup in peerGroups.OrderByDescending(x => x.Count()))
+                {
+                    if (isFirst)
+                    {
+                        isFirst = false;
+                    }
+                    else
+                    {
+                        _stringBuilder.Append(',');
+                    }
+                    _stringBuilder.Append($" {peerGroup.Key} ({peerGroup.Count() / sum,3:P0})");
+                }
+
+                string result = _stringBuilder.ToString();
+                _stringBuilder.Clear();
+                return result;
             }
         }
 

--- a/src/Nethermind/Nethermind.Synchronization/Reporting/SyncReport.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Reporting/SyncReport.cs
@@ -176,6 +176,7 @@ namespace Nethermind.Synchronization.Reporting
                 if (_reportId % PeerCountFrequency == 0)
                 {
                     _logger.Info(_syncPeersReport.MakeSummaryReportForPeers(_syncPeerPool.InitializedPeers, $"Peers | with best block: {_syncPeerPool.InitializedPeersCount} | all: {_syncPeerPool.PeerCount}"));
+                    _logger.Info(_syncPeersReport.MakeDiversityReportForPeers(_syncPeerPool.InitializedPeers, $"Peers | node diversity : "));
                 }
             }
 


### PR DESCRIPTION
## Changes

- Maintain peers summary within rest of logs rather than word wrapping

Before

<img width="710" alt="image" src="https://github.com/NethermindEth/nethermind/assets/1142958/43360c36-2d0e-40ed-a05a-818aaae7affe">


After


<img width="593" alt="image" src="https://github.com/NethermindEth/nethermind/assets/1142958/9385105b-21a9-4eee-ad35-79e7b0e5a04a">


## Types of changes

#### What types of changes does your code introduce?

- [x] Refactoring
- [x] Documentation update

## Testing

#### Requires testing

- [x] No
