### PR TITLE
Use Avx512Vbmi for endianness swapping

### DIFF
--- a/src/Nethermind/Nethermind.Evm/EvmStack.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmStack.cs
@@ -252,7 +252,7 @@ public ref struct EvmStack<TTracing>
                 7, 6, 5, 4, 3, 2, 1, 0);
             if (Avx512Vbmi.VL.IsSupported)
             {
-                Word convert =  Avx512Vbmi.VL.PermuteVar32x8(data, shuffle);
+                Word convert = Avx512Vbmi.VL.PermuteVar32x8(data, shuffle);
                 result = Unsafe.As<Word, UInt256>(ref convert);
             }
             else

--- a/src/Nethermind/Nethermind.Evm/EvmStack.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmStack.cs
@@ -166,15 +166,23 @@ public ref struct EvmStack<TTracing>
 
         if (Avx2.IsSupported)
         {
-            Vector256<ulong> permute = Unsafe.As<UInt256, Vector256<ulong>>(ref Unsafe.AsRef(in value));
-            Vector256<ulong> convert = Avx2.Permute4x64(permute, 0b_01_00_11_10);
             Word shuffle = Vector256.Create(
                 (byte)
                 31, 30, 29, 28, 27, 26, 25, 24,
                 23, 22, 21, 20, 19, 18, 17, 16,
                 15, 14, 13, 12, 11, 10, 9, 8,
                 7, 6, 5, 4, 3, 2, 1, 0);
-            Unsafe.WriteUnaligned(ref bytes, Avx2.Shuffle(Unsafe.As<Vector256<ulong>, Word>(ref convert), shuffle));
+            if (Avx512Vbmi.VL.IsSupported)
+            {
+                Word data = Unsafe.As<UInt256, Word>(ref Unsafe.AsRef(in value));
+                Unsafe.WriteUnaligned(ref bytes, Avx512Vbmi.VL.PermuteVar32x8(data, shuffle));
+            }
+            else if (Avx2.IsSupported)
+            {
+                Vector256<ulong> permute = Unsafe.As<UInt256, Vector256<ulong>>(ref Unsafe.AsRef(in value));
+                Vector256<ulong> convert = Avx2.Permute4x64(permute, 0b_01_00_11_10);
+                Unsafe.WriteUnaligned(ref bytes, Avx2.Shuffle(Unsafe.As<Vector256<ulong>, Word>(ref convert), shuffle));
+            }
         }
         else
         {
@@ -242,9 +250,17 @@ public ref struct EvmStack<TTracing>
                 23, 22, 21, 20, 19, 18, 17, 16,
                 15, 14, 13, 12, 11, 10, 9, 8,
                 7, 6, 5, 4, 3, 2, 1, 0);
-            Word convert = Avx2.Shuffle(data, shuffle);
-            Vector256<ulong> permute = Avx2.Permute4x64(Unsafe.As<Word, Vector256<ulong>>(ref convert), 0b_01_00_11_10);
-            result = Unsafe.As<Vector256<ulong>, UInt256>(ref permute);
+            if (Avx512Vbmi.VL.IsSupported)
+            {
+                Word convert =  Avx512Vbmi.VL.PermuteVar32x8(data, shuffle);
+                result = Unsafe.As<Word, UInt256>(ref convert);
+            }
+            else
+            {
+                Word convert = Avx2.Shuffle(data, shuffle);
+                Vector256<ulong> permute = Avx2.Permute4x64(Unsafe.As<Word, Vector256<ulong>>(ref convert), 0b_01_00_11_10);
+                result = Unsafe.As<Vector256<ulong>, UInt256>(ref permute);
+            }
         }
         else
         {


### PR DESCRIPTION
## Changes

- Use Avx512Vbmi for endianness swapping, is 1 instruction rather than 2

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
