### PR TITLE
Perf/read rpc message to end

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcProcessorExtensions.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcProcessorExtensions.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Pipelines;
@@ -11,6 +12,7 @@ namespace Nethermind.JsonRpc.Test
 {
     public static class JsonRpcProcessorExtensions
     {
-        public static IAsyncEnumerable<JsonRpcResult> ProcessAsync(this IJsonRpcProcessor processor, string request, JsonRpcContext context) => processor.ProcessAsync(PipeReader.Create(new MemoryStream(Encoding.UTF8.GetBytes(request))), context);
+        public static IAsyncEnumerable<JsonRpcResult> ProcessAsync(this IJsonRpcProcessor processor, string request, JsonRpcContext context) =>
+            processor.ProcessAsync(PipeReader.Create(new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes(request))), context);
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
@@ -137,9 +137,7 @@ public class JsonRpcProcessor : IJsonRpcProcessor
         try
         {
             // Asynchronously reads data from the PipeReader.
-            ReadResult readResult = _jsonRpcConfig.MaxRequestBodySize is not null
-                ? await reader.ReadAtLeastAsync((int)_jsonRpcConfig.MaxRequestBodySize.Value)
-                : await reader.ReadToEndAsync();
+            ReadResult readResult = await reader.ReadToEndAsync();
 
             buffer = readResult.Buffer;
             // Placeholder for a result in case of deserialization failure.

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
@@ -364,7 +364,7 @@ public class JsonRpcProcessor : IJsonRpcProcessor
 
     private static bool TryParseJson(ref ReadOnlySequence<byte> buffer, out JsonDocument jsonDocument)
     {
-        Utf8JsonReader reader = new(buffer, isFinalBlock: false, new JsonReaderState(new JsonReaderOptions(){CommentHandling = JsonCommentHandling.Skip}) );
+        Utf8JsonReader reader = new(buffer);
 
         if (JsonDocument.TryParseValue(ref reader, out jsonDocument))
         {

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
@@ -10,6 +10,7 @@ using System.IO.Abstractions;
 using System.IO.Pipelines;
 using System.Linq;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Http;
@@ -119,6 +120,7 @@ public class JsonRpcProcessor : IJsonRpcProcessor
     {
         reader = await RecordRequest(reader);
         Stopwatch stopwatch = Stopwatch.StartNew();
+        CancellationTokenSource timeoutSource = new(_jsonRpcConfig.Timeout);
 
         // Handles general exceptions during parsing and validation.
         // Sends an error response and stops the stopwatch.
@@ -137,7 +139,7 @@ public class JsonRpcProcessor : IJsonRpcProcessor
         try
         {
             // Asynchronously reads data from the PipeReader.
-            ReadResult readResult = await reader.ReadToEndAsync();
+            ReadResult readResult = await reader.ReadToEndAsync(timeoutSource.Token);
 
             buffer = readResult.Buffer;
             // Placeholder for a result in case of deserialization failure.

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
@@ -281,14 +281,9 @@ public class JsonRpcService : IJsonRpcService
 
         if (providedParameter.ValueKind == JsonValueKind.Null || (providedParameter.ValueKind == JsonValueKind.String && providedParameter.ValueEquals(ReadOnlySpan<byte>.Empty)))
         {
-            if (providedParameter.ValueKind == JsonValueKind.Null && expectedParameter.IsNullable)
-            {
-                return null;
-            }
-            else
-            {
-                return Type.Missing;
-            }
+            return providedParameter.ValueKind == JsonValueKind.Null && expectedParameter.IsNullable
+                ? null
+                : Type.Missing;
         }
 
         object? executionParam;
@@ -309,14 +304,9 @@ public class JsonRpcService : IJsonRpcService
             if (providedParameter.ValueKind == JsonValueKind.String)
             {
                 JsonConverter converter = EthereumJsonSerializer.JsonOptions.GetConverter(paramType);
-                if (converter.GetType().FullName.StartsWith("System."))
-                {
-                    executionParam = JsonSerializer.Deserialize(providedParameter.GetString(), paramType, EthereumJsonSerializer.JsonOptions);
-                }
-                else
-                {
-                    executionParam = providedParameter.Deserialize(paramType, EthereumJsonSerializer.JsonOptions);
-                }
+                executionParam = converter.GetType().FullName.StartsWith("System.")
+                    ? JsonSerializer.Deserialize(providedParameter.GetString(), paramType, EthereumJsonSerializer.JsonOptions)
+                    : providedParameter.Deserialize(paramType, EthereumJsonSerializer.JsonOptions);
             }
             else
             {

--- a/src/Nethermind/Nethermind.JsonRpc/PipeReaderExtensions.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/PipeReaderExtensions.cs
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Buffers;
+using System.IO.Pipelines;
+using System.Threading.Tasks;
+
+namespace Nethermind.JsonRpc;
+
+public static class PipeReaderExtensions
+{
+    public static async Task<ReadResult> ReadToEndAsync(this PipeReader reader)
+    {
+        while (true)
+        {
+            ReadResult result = await reader.ReadAsync().ConfigureAwait(false);
+            ReadOnlySequence<byte> buffer = result.Buffer;
+            if (buffer.IsEmpty && result.IsCompleted)
+            {
+                return result;
+            }
+            reader.AdvanceTo(buffer.End);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.JsonRpc/PipeReaderExtensions.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/PipeReaderExtensions.cs
@@ -15,7 +15,7 @@ public static class PipeReaderExtensions
         {
             ReadResult result = await reader.ReadAsync().ConfigureAwait(false);
             ReadOnlySequence<byte> buffer = result.Buffer;
-            if (buffer.IsEmpty && result.IsCompleted)
+            if (result.IsCompleted || result.IsCanceled)
             {
                 return result;
             }

--- a/src/Nethermind/Nethermind.JsonRpc/PipeReaderExtensions.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/PipeReaderExtensions.cs
@@ -19,7 +19,7 @@ public static class PipeReaderExtensions
             {
                 return result;
             }
-            reader.AdvanceTo(buffer.End);
+            reader.AdvanceTo(buffer.Start, buffer.End);
         }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/PipeReaderExtensions.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/PipeReaderExtensions.cs
@@ -3,17 +3,18 @@
 
 using System.Buffers;
 using System.IO.Pipelines;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Nethermind.JsonRpc;
 
 public static class PipeReaderExtensions
 {
-    public static async Task<ReadResult> ReadToEndAsync(this PipeReader reader)
+    public static async Task<ReadResult> ReadToEndAsync(this PipeReader reader, CancellationToken cancellationToken = default)
     {
         while (true)
         {
-            ReadResult result = await reader.ReadAsync().ConfigureAwait(false);
+            ReadResult result = await reader.ReadAsync(cancellationToken).ConfigureAwait(false);
             ReadOnlySequence<byte> buffer = result.Buffer;
             if (result.IsCompleted || result.IsCanceled)
             {


### PR DESCRIPTION
## Changes

- Reads JSON RPC message to end before trying to deserialize it.
- Helps with performance on very long requests (which are fairly rare and less realistic scenarios)

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Would be worth comparing performance on very many batched requests (as many as you can under 30MB request limit) as it might be better or worse than original.

@marcindsobczak Would be worth comparing NewPayload performance with big but reasonable size blocks.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
