### PR TITLE
Skip hash validations when block comes from NewPayload 

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/TestBlockValidator.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/TestBlockValidator.cs
@@ -56,7 +56,7 @@ public class TestBlockValidator : IBlockValidator
     {
         return _alwaysSameResultForSuggested ?? _suggestedValidationResults.Dequeue();
     }
-    public bool ValidateSuggestedBlock(Block block, [NotNullWhen(false)] out string? error)
+    public bool ValidateSuggestedBlock(Block block, [NotNullWhen(false)] out string? error, bool validateHashes = true)
     {
         error = null;
         return _alwaysSameResultForSuggested ?? _suggestedValidationResults.Dequeue();

--- a/src/Nethermind/Nethermind.Consensus/Validators/AlwaysValid.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/AlwaysValid.cs
@@ -102,7 +102,7 @@ public class Always : IBlockValidator, ISealValidator, IUnclesValidator, ITxVali
         return _result;
     }
 
-    public bool ValidateSuggestedBlock(Block block, out string? error)
+    public bool ValidateSuggestedBlock(Block block, out string? error, bool validateHashes = true)
     {
         error = null;
         return _result;

--- a/src/Nethermind/Nethermind.Consensus/Validators/BlockValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/BlockValidator.cs
@@ -88,15 +88,17 @@ public class BlockValidator : IBlockValidator
     {
         return ValidateSuggestedBlock(block, out _);
     }
+
     /// <summary>
     /// Suggested block validation runs basic checks that can be executed before going through the expensive EVM processing.
     /// </summary>
     /// <param name="block">A block to validate</param>
     /// <param name="errorMessage">Message detailing a validation failure.</param>
+    /// <param name="validateHashes"></param>
     /// <returns>
     /// <c>true</c> if the <paramref name="block"/> is valid; otherwise, <c>false</c>.
     /// </returns>
-    public bool ValidateSuggestedBlock(Block block, out string? errorMessage)
+    public bool ValidateSuggestedBlock(Block block, out string? errorMessage, bool validateHashes = true)
     {
         IReleaseSpec spec = _specProvider.GetSpec(block.Header);
 
@@ -113,14 +115,14 @@ public class BlockValidator : IBlockValidator
             return false;
         }
 
-        if (!ValidateUnclesHashMatches(block, out Hash256 unclesHash))
+        if (validateHashes && !ValidateUnclesHashMatches(block, out Hash256 unclesHash))
         {
             if (_logger.IsDebug) _logger.Debug($"{Invalid(block)} Uncles hash mismatch: expected {block.Header.UnclesHash}, got {unclesHash}");
             errorMessage = BlockErrorMessages.InvalidUnclesHash;
             return false;
         }
 
-        if (!_unclesValidator.Validate(block.Header, block.Uncles))
+        if (block.Uncles.Length > 0 && !_unclesValidator.Validate(block.Header, block.Uncles))
         {
             if (_logger.IsDebug) _logger.Debug($"{Invalid(block)} Invalid uncles");
             errorMessage = BlockErrorMessages.InvalidUncle;
@@ -134,15 +136,20 @@ public class BlockValidator : IBlockValidator
             return false;
         }
 
-        if (!ValidateTxRootMatchesTxs(block, out Hash256 txRoot))
+        if (validateHashes)
         {
-            if (_logger.IsDebug) _logger.Debug($"{Invalid(block)} Transaction root hash mismatch: expected {block.Header.TxRoot}, got {txRoot}");
-            errorMessage = BlockErrorMessages.InvalidTxRoot(block.Header.TxRoot, txRoot);
-            return false;
-        }
+            if (!ValidateTxRootMatchesTxs(block, out Hash256 txRoot))
+            {
+                if (_logger.IsDebug) _logger.Debug($"{Invalid(block)} Transaction root hash mismatch: expected {block.Header.TxRoot}, got {txRoot}");
+                errorMessage = BlockErrorMessages.InvalidTxRoot(block.Header.TxRoot!, txRoot);
+                return false;
+            }
 
-        if (!ValidateWithdrawals(block, spec, out errorMessage))
-            return false;
+            if (!ValidateWithdrawals(block, spec, out errorMessage))
+            {
+                return false;
+            }
+        }
 
         return true;
     }

--- a/src/Nethermind/Nethermind.Consensus/Validators/IBlockValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/IBlockValidator.cs
@@ -9,6 +9,6 @@ namespace Nethermind.Consensus.Validators;
 public interface IBlockValidator : IHeaderValidator, IWithdrawalValidator
 {
     bool ValidateOrphanedBlock(Block block, [NotNullWhen(false)] out string? error);
-    bool ValidateSuggestedBlock(Block block, [NotNullWhen(false)] out string? error);
+    bool ValidateSuggestedBlock(Block block, [NotNullWhen(false)] out string? error, bool validateHashes = true);
     bool ValidateProcessedBlock(Block processedBlock, TxReceipt[] receipts, Block suggestedBlock, [NotNullWhen(false)] out string? error);
 }

--- a/src/Nethermind/Nethermind.Consensus/Validators/NeverValidBlockValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/NeverValidBlockValidator.cs
@@ -55,7 +55,7 @@ namespace Nethermind.Consensus.Validators
             return false;
         }
 
-        public bool ValidateSuggestedBlock(Block block, out string? error)
+        public bool ValidateSuggestedBlock(Block block, out string? error, bool validateHashes = true)
         {
             error = null;
             return false;

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/InvalidChainTracker/InvalidBlockInterceptorTest.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/InvalidChainTracker/InvalidBlockInterceptorTest.cs
@@ -43,8 +43,8 @@ public class InvalidBlockInterceptorTest
     public void TestValidateSuggestedBlock(bool baseReturnValue, bool isInvalidBlockReported)
     {
         Block block = Build.A.Block.TestObject;
-        _baseValidator.ValidateSuggestedBlock(block, out string? error).Returns(baseReturnValue);
-        _invalidBlockInterceptor.ValidateSuggestedBlock(block);
+        _baseValidator.ValidateSuggestedBlock(block, out _).Returns(baseReturnValue);
+        _invalidBlockInterceptor.ValidateSuggestedBlock(block, out _);
 
         _tracker.Received().SetChildParent(block.GetOrCalculateHash(), block.ParentHash!);
         if (isInvalidBlockReported)
@@ -103,7 +103,7 @@ public class InvalidBlockInterceptorTest
         ));
 
         _baseValidator.ValidateSuggestedBlock(block, out _).Returns(false);
-        _invalidBlockInterceptor.ValidateSuggestedBlock(block);
+        _invalidBlockInterceptor.ValidateSuggestedBlock(block, out _);
 
         _tracker.DidNotReceive().SetChildParent(block.GetOrCalculateHash(), block.ParentHash!);
         _tracker.DidNotReceive().OnInvalidBlock(block.GetOrCalculateHash(), block.ParentHash);
@@ -121,7 +121,7 @@ public class InvalidBlockInterceptorTest
         ));
 
         _baseValidator.ValidateSuggestedBlock(block, out _).Returns(false);
-        _invalidBlockInterceptor.ValidateSuggestedBlock(block);
+        _invalidBlockInterceptor.ValidateSuggestedBlock(block, out _);
 
         _tracker.DidNotReceive().SetChildParent(block.GetOrCalculateHash(), block.ParentHash!);
         _tracker.DidNotReceive().OnInvalidBlock(block.GetOrCalculateHash(), block.ParentHash);

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/NewPayloadHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/NewPayloadHandler.cs
@@ -154,7 +154,7 @@ public class NewPayloadHandler : IAsyncHandler<ExecutionPayload, PayloadStatusV1
 
         if (!ShouldProcessBlock(block, parentHeader, out ProcessingOptions processingOptions)) // we shouldn't process block
         {
-            if (!_blockValidator.ValidateSuggestedBlock(block, out string? error))
+            if (!_blockValidator.ValidateSuggestedBlock(block, out string? error, validateHashes: false))
             {
                 if (_logger.IsInfo) _logger.Info($"Rejecting invalid block received during the sync, block: {block}");
                 return NewPayloadV1Result.Invalid(error);
@@ -394,7 +394,7 @@ public class NewPayloadHandler : IAsyncHandler<ExecutionPayload, PayloadStatusV1
     {
         block.Header.TotalDifficulty ??= parent.TotalDifficulty + block.Difficulty;
         block.Header.IsPostMerge = true; // I think we don't need to set it again here.
-        bool isValid = _blockValidator.ValidateSuggestedBlock(block, out error);
+        bool isValid = _blockValidator.ValidateSuggestedBlock(block, out error, validateHashes: false);
         if (!isValid && _logger.IsWarn) _logger.Warn($"Block validator rejected the block {block.ToString(Block.Format.FullHashAndNumber)}.");
         return isValid;
     }

--- a/src/Nethermind/Nethermind.Merge.Plugin/InvalidChainTracker/InvalidBlockInterceptor.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/InvalidChainTracker/InvalidBlockInterceptor.cs
@@ -69,13 +69,9 @@ public class InvalidBlockInterceptor : IBlockValidator
         return result;
     }
 
-    public bool ValidateSuggestedBlock(Block block)
+    public bool ValidateSuggestedBlock(Block block, [NotNullWhen(false)] out string? error, bool validateHashes = true)
     {
-        return ValidateSuggestedBlock(block, out _);
-    }
-    public bool ValidateSuggestedBlock(Block block, [NotNullWhen(false)] out string? error)
-    {
-        bool result = _baseValidator.ValidateSuggestedBlock(block, out error);
+        bool result = _baseValidator.ValidateSuggestedBlock(block, out error, validateHashes);
         if (!result)
         {
             if (_logger.IsTrace) _logger.Trace($"Intercepted a bad block {block}");

--- a/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
@@ -489,7 +489,7 @@ namespace Nethermind.Synchronization.Test
                 return true;
             }
 
-            public bool ValidateSuggestedBlock(Block block, [NotNullWhen(false)] out string? error)
+            public bool ValidateSuggestedBlock(Block block, [NotNullWhen(false)] out string? error, bool validateHashes = true)
             {
                 Thread.Sleep(1000);
                 error = null;


### PR DESCRIPTION
## Changes

- If block comes from NewPayload, we calculated those hashes in `TryGetBlock`, no need to calculate them again.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No