### PR TITLE
Vectorize DataCost

### DIFF
--- a/src/Nethermind/Nethermind.Evm/IntrinsicGasCalculator.cs
+++ b/src/Nethermind/Nethermind.Evm/IntrinsicGasCalculator.cs
@@ -2,12 +2,15 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections.Generic;
 using System.IO;
+using System.Numerics;
 using Nethermind.Core;
 using Nethermind.Core.Eip2930;
 using Nethermind.Core.Specs;
 using Nethermind.Int256;
+using System.Runtime.Intrinsics;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
 
 namespace Nethermind.Evm;
 
@@ -37,16 +40,44 @@ public static class IntrinsicGasCalculator
     {
         long txDataNonZeroGasCost =
             releaseSpec.IsEip2028Enabled ? GasCostOf.TxDataNonZeroEip2028 : GasCostOf.TxDataNonZero;
-        long dataCost = 0;
         Span<byte> data = transaction.Data.GetValueOrDefault().Span;
+
+        var dataCost = transaction.IsContractCreation && releaseSpec.IsEip3860Enabled
+            ? EvmPooledMemory.Div32Ceiling((UInt256)data.Length) * GasCostOf.InitCodeWord
+            : 0;
+
+        if (Vector256.IsHardwareAccelerated && data.Length >= Vector256<byte>.Count)
+        {
+            ref byte bytes = ref MemoryMarshal.GetReference(data);
+            int i = 0;
+            for (; i < data.Length - Vector256<byte>.Count; i += Vector256<byte>.Count)
+            {
+                Vector256<byte> dataVector = Unsafe.ReadUnaligned<Vector256<byte>>(ref Unsafe.Add(ref bytes, i));
+                uint flags = Vector256.Equals(dataVector, default).ExtractMostSignificantBits();
+                var zeros = BitOperations.PopCount(flags);
+                dataCost += zeros * GasCostOf.TxDataZero + (Vector256<byte>.Count - zeros) * txDataNonZeroGasCost;
+            }
+
+            data = data[i..];
+        }
+        if (Vector128.IsHardwareAccelerated && data.Length >= Vector128<byte>.Count)
+        {
+            ref byte bytes = ref MemoryMarshal.GetReference(data);
+            int i = 0;
+            for (; i < data.Length - Vector128<byte>.Count; i += Vector128<byte>.Count)
+            {
+                Vector128<byte> dataVector = Unsafe.ReadUnaligned<Vector128<byte>>(ref Unsafe.Add(ref MemoryMarshal.GetReference(data), i));
+                uint flags = Vector128.Equals(dataVector, default).ExtractMostSignificantBits();
+                var zeros = BitOperations.PopCount(flags);
+                dataCost += zeros * GasCostOf.TxDataZero + (Vector128<byte>.Count - zeros) * txDataNonZeroGasCost;
+            }
+
+            data = data[i..];
+        }
+
         for (int i = 0; i < data.Length; i++)
         {
             dataCost += data[i] == 0 ? GasCostOf.TxDataZero : txDataNonZeroGasCost;
-        }
-
-        if (transaction.IsContractCreation && releaseSpec.IsEip3860Enabled)
-        {
-            dataCost += EvmPooledMemory.Div32Ceiling((UInt256)data.Length) * GasCostOf.InitCodeWord;
         }
 
         return dataCost;

--- a/src/Nethermind/Nethermind.Evm/IntrinsicGasCalculator.cs
+++ b/src/Nethermind/Nethermind.Evm/IntrinsicGasCalculator.cs
@@ -11,6 +11,7 @@ using Nethermind.Int256;
 using System.Runtime.Intrinsics;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
+using Nethermind.Core.Extensions;
 
 namespace Nethermind.Evm;
 
@@ -41,63 +42,16 @@ public static class IntrinsicGasCalculator
         long txDataNonZeroGasCost =
             releaseSpec.IsEip2028Enabled ? GasCostOf.TxDataNonZeroEip2028 : GasCostOf.TxDataNonZero;
         Span<byte> data = transaction.Data.GetValueOrDefault().Span;
-        int dataLength = data.Length;
-        int totalZeros = 0;
-        if (Vector512.IsHardwareAccelerated && data.Length >= Vector512<byte>.Count)
-        {
-            ref byte bytes = ref MemoryMarshal.GetReference(data);
-            int i = 0;
-            for (; i < data.Length - Vector512<byte>.Count; i += Vector512<byte>.Count)
-            {
-                Vector512<byte> dataVector = Unsafe.ReadUnaligned<Vector512<byte>>(ref Unsafe.Add(ref bytes, i));
-                ulong flags = Vector512.Equals(dataVector, default).ExtractMostSignificantBits();
-                totalZeros += BitOperations.PopCount(flags);
-            }
 
-            data = data[i..];
-        }
-        if (Vector256.IsHardwareAccelerated && data.Length >= Vector256<byte>.Count)
-        {
-            ref byte bytes = ref MemoryMarshal.GetReference(data);
-            int i = 0;
-            for (; i < data.Length - Vector256<byte>.Count; i += Vector256<byte>.Count)
-            {
-                Vector256<byte> dataVector = Unsafe.ReadUnaligned<Vector256<byte>>(ref Unsafe.Add(ref bytes, i));
-                uint flags = Vector256.Equals(dataVector, default).ExtractMostSignificantBits();
-                totalZeros += BitOperations.PopCount(flags);
-            }
-
-            data = data[i..];
-        }
-        if (Vector128.IsHardwareAccelerated && data.Length >= Vector128<byte>.Count)
-        {
-            ref byte bytes = ref MemoryMarshal.GetReference(data);
-            int i = 0;
-            for (; i < data.Length - Vector128<byte>.Count; i += Vector128<byte>.Count)
-            {
-                Vector128<byte> dataVector = Unsafe.ReadUnaligned<Vector128<byte>>(ref Unsafe.Add(ref MemoryMarshal.GetReference(data), i));
-                uint flags = Vector128.Equals(dataVector, default).ExtractMostSignificantBits();
-                totalZeros += BitOperations.PopCount(flags);
-            }
-
-            data = data[i..];
-        }
-
-        for (int i = 0; i < data.Length; i++)
-        {
-            if (data[i] == 0)
-            {
-                totalZeros++;
-            }
-        }
+        int totalZeros = data.CountZeros();
 
         var baseDataCost = (transaction.IsContractCreation && releaseSpec.IsEip3860Enabled
-            ? EvmPooledMemory.Div32Ceiling((UInt256)dataLength) * GasCostOf.InitCodeWord
+            ? EvmPooledMemory.Div32Ceiling((UInt256)data.Length) * GasCostOf.InitCodeWord
             : 0);
 
         return baseDataCost +
             totalZeros * GasCostOf.TxDataZero +
-            (dataLength - totalZeros) * txDataNonZeroGasCost;
+            (data.Length - totalZeros) * txDataNonZeroGasCost;
     }
 
     private static long AccessListCost(Transaction transaction, IReleaseSpec releaseSpec)


### PR DESCRIPTION
## Changes

- Cacluate data costs 32 bytes at a time rather than 1

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No