### PR TITLE
Optimize Rlp Encoding

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.AuRa/Validators/PendingValidators.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/Validators/PendingValidators.cs
@@ -11,7 +11,7 @@ namespace Nethermind.Consensus.AuRa.Validators
     {
         static PendingValidators()
         {
-            Rlp.Decoders[typeof(PendingValidators)] = new PendingValidatorsDecoder();
+            Rlp.RegisterDecoder(typeof(PendingValidators), new PendingValidatorsDecoder());
         }
 
         public PendingValidators(long blockNumber, Hash256 blockHash, Address[] addresses)

--- a/src/Nethermind/Nethermind.Consensus.AuRa/Validators/ValidatorInfo.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/Validators/ValidatorInfo.cs
@@ -10,7 +10,7 @@ namespace Nethermind.Consensus.AuRa.Validators
     {
         static ValidatorInfo()
         {
-            Rlp.Decoders[typeof(ValidatorInfo)] = new ValidatorInfoDecoder();
+            Rlp.RegisterDecoder(typeof(ValidatorInfo), new ValidatorInfoDecoder());
         }
 
         public ValidatorInfo(long finalizingBlockNumber, long previousFinalizingBlockNumber, Address[] validators)

--- a/src/Nethermind/Nethermind.Network/NetworkNodeDecoder.cs
+++ b/src/Nethermind/Nethermind.Network/NetworkNodeDecoder.cs
@@ -14,7 +14,7 @@ namespace Nethermind.Network
     {
         static NetworkNodeDecoder()
         {
-            Rlp.Decoders[typeof(NetworkNode)] = new NetworkNodeDecoder();
+            Rlp.RegisterDecoder(typeof(NetworkNode), new NetworkNodeDecoder());
         }
 
         public NetworkNode Decode(RlpStream rlpStream, RlpBehaviors rlpBehaviors = RlpBehaviors.None)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/BlockInfoDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/BlockInfoDecoder.cs
@@ -9,6 +9,8 @@ namespace Nethermind.Serialization.Rlp
 {
     public class BlockInfoDecoder : IRlpStreamDecoder<BlockInfo>, IRlpValueDecoder<BlockInfo>
     {
+        public static BlockInfoDecoder Instance { get; } = new();
+
         public BlockInfo? Decode(RlpStream rlpStream, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
         {
             if (rlpStream.IsNextItemNull())

--- a/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptMessageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptMessageDecoder.cs
@@ -13,7 +13,7 @@ namespace Nethermind.Serialization.Rlp
 
         static ReceiptMessageDecoder()
         {
-            Rlp.Decoders[typeof(TxReceipt)] = new ReceiptMessageDecoder();
+            Rlp.RegisterDecoder(typeof(TxReceipt), new ReceiptMessageDecoder());
         }
 
         public TxReceipt Decode(RlpStream rlpStream, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
@@ -171,9 +171,10 @@ namespace Nethermind.Serialization.Rlp
             rlpStream.Encode(item.Bloom);
 
             rlpStream.StartSequence(logsLength);
-            for (var i = 0; i < item.Logs.Length; i++)
+            LogEntry[] logs = item.Logs;
+            for (var i = 0; i < logs.Length; i++)
             {
-                rlpStream.Encode(item.Logs[i]);
+                rlpStream.Encode(logs[i]);
             }
         }
     }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptStorageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptStorageDecoder.cs
@@ -226,9 +226,10 @@ namespace Nethermind.Serialization.Rlp
 
                 rlpStream.StartSequence(logsLength);
 
-                for (int i = 0; i < item.Logs.Length; i++)
+                LogEntry[] logs = item.Logs;
+                for (int i = 0; i < logs.Length; i++)
                 {
-                    rlpStream.Encode(item.Logs[i]);
+                    rlpStream.Encode(logs[i]);
                 }
 
                 if (_supportTxHash)
@@ -246,9 +247,10 @@ namespace Nethermind.Serialization.Rlp
 
                 rlpStream.StartSequence(logsLength);
 
-                for (int i = 0; i < item.Logs.Length; i++)
+                LogEntry[] logs = item.Logs;
+                for (int i = 0; i < logs.Length; i++)
                 {
-                    rlpStream.Encode(item.Logs[i]);
+                    rlpStream.Encode(logs[i]);
                 }
 
                 rlpStream.Encode(item.Error);

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -77,7 +77,7 @@ namespace Nethermind.Serialization.Rlp
 
         private static Dictionary<TypeAsKey, IRlpDecoder> _decoderBuilder = new();
         private static FrozenDictionary<TypeAsKey, IRlpDecoder>? _decoders;
-        public static FrozenDictionary<TypeAsKey, IRlpDecoder> Decoders = _decoders ??= _decoderBuilder.ToFrozenDictionary();
+        public static FrozenDictionary<TypeAsKey, IRlpDecoder> Decoders => _decoders ??= _decoderBuilder.ToFrozenDictionary();
 
         public struct TypeAsKey(Type key) : IEquatable<TypeAsKey>
         {

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -372,6 +372,20 @@ namespace Nethermind.Serialization.Rlp
             return bigInteger == 0 ? OfEmptyByteArray : Encode(bigInteger.ToBigEndianByteArray(outputLength));
         }
 
+        public static Rlp Encode(in UInt256 value, int length = -1)
+        {
+            if (value.IsZero && length == -1)
+            {
+                return OfEmptyByteArray;
+            }
+            else
+            {
+                Span<byte> bytes = stackalloc byte[32];
+                value.ToBigEndian(bytes);
+                return Encode(length != -1 ? bytes.Slice(bytes.Length - length, length) : bytes.WithoutLeadingZeros());
+            }
+        }
+
         public static int Encode(Span<byte> buffer, int position, ReadOnlySpan<byte> input)
         {
             if (input.Length == 1 && input[0] < 128)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -3,12 +3,14 @@
 
 using System;
 using System.Buffers.Binary;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
@@ -73,10 +75,32 @@ namespace Nethermind.Serialization.Rlp
 
         public int Length => Bytes.Length;
 
-        public static readonly Dictionary<Type, IRlpDecoder> Decoders = new();
+        public static FrozenDictionary<TypeAsKey, IRlpDecoder> Decoders = new Dictionary<TypeAsKey, IRlpDecoder>().ToFrozenDictionary();
+
+        public struct TypeAsKey(Type key) : IEquatable<TypeAsKey>
+        {
+            private readonly Type _key = key;
+            public Type Value => _key;
+
+            public static implicit operator Type(TypeAsKey key) => key._key;
+            public static implicit operator TypeAsKey(Type key) => new(key);
+
+            public bool Equals(TypeAsKey other) => _key.Equals(other._key);
+            public override int GetHashCode() => _key.GetHashCode();
+        }
+
+        public static void RegisterDecoder(Type type, IRlpDecoder decoder)
+        {
+            Dictionary<TypeAsKey, IRlpDecoder> dict = new(Decoders)
+            {
+                [type] = decoder
+            };
+            Decoders = dict.ToFrozenDictionary();
+        }
 
         public static void RegisterDecoders(Assembly assembly)
         {
+            Dictionary<TypeAsKey, IRlpDecoder> dict = new(Decoders);
             foreach (Type? type in assembly.GetExportedTypes())
             {
                 if (!type.IsClass || type.IsAbstract || type.IsGenericTypeDefinition)
@@ -107,13 +131,15 @@ namespace Nethermind.Serialization.Rlp
                         }
 
                         Type key = implementedInterface.GenericTypeArguments[0];
-                        if (!Decoders.ContainsKey(key))
+                        if (!dict.ContainsKey(key))
                         {
-                            Decoders[key] = (IRlpDecoder)Activator.CreateInstance(type);
+                            dict[key] = (IRlpDecoder)Activator.CreateInstance(type);
                         }
                     }
                 }
             }
+
+            Decoders = dict.ToFrozenDictionary();
         }
 
         public static T Decode<T>(Rlp oldRlp, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
@@ -130,17 +156,6 @@ namespace Nethermind.Serialization.Rlp
         {
             var valueContext = bytes.AsRlpValueContext();
             return Decode<T>(ref valueContext, rlpBehaviors);
-        }
-
-        public static T[] DecodeArray<T>(RlpStream rlpStream, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
-        {
-            IRlpStreamDecoder<T>? rlpDecoder = GetStreamDecoder<T>();
-            if (rlpDecoder is not null)
-            {
-                return DecodeArray(rlpStream, rlpDecoder, rlpBehaviors);
-            }
-
-            throw new RlpException($"{nameof(Rlp)} does not support decoding {typeof(T).Name}");
         }
 
         public static T[] DecodeArray<T>(RlpStream rlpStream, IRlpStreamDecoder<T>? rlpDecoder, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
@@ -246,6 +261,12 @@ namespace Nethermind.Serialization.Rlp
             return result;
         }
 
+        public static Rlp Encode(Account item, RlpBehaviors behaviors = RlpBehaviors.None)
+            => AccountDecoder.Instance.Encode(item, behaviors);
+
+        public static Rlp Encode(LogEntry item, RlpBehaviors behaviors = RlpBehaviors.None)
+            => LogEntryDecoder.Instance.Encode(item, behaviors);
+
         public static Rlp Encode<T>(T item, RlpBehaviors behaviors = RlpBehaviors.None)
         {
             if (item is Rlp rlp)
@@ -314,8 +335,7 @@ namespace Nethermind.Serialization.Rlp
             bool isEip155Enabled = false,
             ulong chainId = 0)
         {
-            TxDecoder txDecoder = new TxDecoder();
-            return txDecoder.EncodeTx(transaction, RlpBehaviors.SkipTypedWrapping, forSigning, isEip155Enabled,
+            return TxDecoder.Instance.EncodeTx(transaction, RlpBehaviors.SkipTypedWrapping, forSigning, isEip155Enabled,
                 chainId);
         }
 
@@ -352,32 +372,6 @@ namespace Nethermind.Serialization.Rlp
             return bigInteger == 0 ? OfEmptyByteArray : Encode(bigInteger.ToBigEndianByteArray(outputLength));
         }
 
-        public static Rlp Encode(in UInt256 value, int length = -1)
-        {
-            if (value.IsZero && length == -1)
-            {
-                return OfEmptyByteArray;
-            }
-            else
-            {
-                Span<byte> bytes = stackalloc byte[32];
-                value.ToBigEndian(bytes);
-                return Encode(length != -1 ? bytes.Slice(bytes.Length - length, length) : bytes.WithoutLeadingZeros());
-            }
-        }
-
-
-        public static int Encode(Span<byte> buffer, int position, byte[]? input)
-        {
-            if (input is null || input.Length == 0)
-            {
-                buffer[position++] = OfEmptyByteArray.Bytes[0];
-                return position;
-            }
-
-            return Encode(buffer, position, input.AsSpan());
-        }
-
         public static int Encode(Span<byte> buffer, int position, ReadOnlySpan<byte> input)
         {
             if (input.Length == 1 && input[0] < 128)
@@ -403,6 +397,27 @@ namespace Nethermind.Serialization.Rlp
             position += input.Length;
 
             return position;
+        }
+
+        public static int Encode(Span<byte> buffer, int position, Hash256 hash)
+        {
+            Debug.Assert(hash is not null);
+            var newPosition = position + LengthOfKeccakRlp;
+            if ((uint)newPosition > (uint)buffer.Length)
+            {
+                ThrowArgumentOutOfRangeException();
+            }
+
+            Unsafe.Add(ref MemoryMarshal.GetReference(buffer), position) = 160;
+            Unsafe.As<byte, ValueHash256>(ref Unsafe.Add(ref MemoryMarshal.GetReference(buffer), position + 1)) = hash.ValueHash256;
+            return newPosition;
+
+            [DoesNotReturn]
+            [StackTraceHidden]
+            static void ThrowArgumentOutOfRangeException()
+            {
+                throw new ArgumentOutOfRangeException(nameof(buffer));
+            }
         }
 
         public static Rlp Encode(ReadOnlySpan<byte> input)
@@ -528,7 +543,7 @@ namespace Nethermind.Serialization.Rlp
 
             byte[] result = new byte[LengthOfKeccakRlp];
             result[0] = 160;
-            keccak.Bytes.CopyTo(result.AsSpan()[1..]);
+            Unsafe.As<byte, ValueHash256>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(result), 1)) = keccak.ValueHash256;
             return new Rlp(result);
         }
 
@@ -1830,14 +1845,12 @@ namespace Nethermind.Serialization.Rlp
 
         public static int LengthOf(LogEntry item)
         {
-            IRlpDecoder<LogEntry>? rlpDecoder = GetDecoder<LogEntry>();
-            return rlpDecoder?.GetLength(item, RlpBehaviors.None) ?? throw new RlpException($"{nameof(Rlp)} does not support length of {nameof(LogEntry)}");
+            return LogEntryDecoder.Instance.GetLength(item, RlpBehaviors.None);
         }
 
         public static int LengthOf(BlockInfo item)
         {
-            IRlpDecoder<BlockInfo>? rlpDecoder = GetDecoder<BlockInfo>();
-            return rlpDecoder?.GetLength(item, RlpBehaviors.None) ?? throw new RlpException($"{nameof(Rlp)} does not support length of {nameof(BlockInfo)}");
+            return BlockInfoDecoder.Instance.GetLength(item, RlpBehaviors.None);
         }
 
         public class SkipGlobalRegistration : Attribute

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoder.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using FastEnumUtility;
 using Microsoft.Extensions.ObjectPool;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
@@ -11,7 +10,7 @@ using Nethermind.Serialization.Rlp.Eip2930;
 
 namespace Nethermind.Serialization.Rlp
 {
-    public class TxDecoder : TxDecoder<Transaction>
+    public sealed class TxDecoder : TxDecoder<Transaction>
     {
         public const int MaxDelayedHashTxnSize = 32768;
         public static TxDecoder Instance = new TxDecoder();

--- a/src/Nethermind/Nethermind.Serialization.Rlp/ValueRlpStream.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/ValueRlpStream.cs
@@ -279,7 +279,7 @@ public ref struct ValueRlpStream(in CappedArray<byte> data)
         return Data![_position];
     }
 
-    private void SkipBytes(int length)
+    public void SkipBytes(int length)
     {
         _position += length;
     }

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -347,7 +347,7 @@ namespace Nethermind.Trie
         public void UpdateRootHash()
         {
             TreePath path = TreePath.Empty;
-            RootRef?.ResolveKey(TrieStore, ref path, true, bufferPool: _bufferPool);
+            RootRef?.ResolveKey(TrieStore, ref path, isRoot: true, bufferPool: _bufferPool);
             SetRootHash(RootRef?.Keccak ?? EmptyTreeHash, false);
         }
 
@@ -730,7 +730,7 @@ namespace Nethermind.Trie
                                 }
                             }
 
-                            node.AppendChildPathBranch(ref path, childNodeIndex);
+                            path.AppendMut(childNodeIndex);
                             TrieNode childNode = node.GetChildWithChildPath(TrieStore, ref path, childNodeIndex);
                             if (childNode is null)
                             {
@@ -926,7 +926,7 @@ namespace Nethermind.Trie
             }
 
             int childIdx = traverseContext.UpdatePath[traverseContext.CurrentIndex];
-            node.AppendChildPathBranch(ref path, childIdx);
+            path.AppendMut(childIdx);
             TrieNode childNode = node.GetChildWithChildPath(TrieStore, ref path, childIdx);
             if (traverseContext.IsUpdate)
             {

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Buffers;
 using System.Diagnostics;
-using System.IO;
-using System.Linq;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Nethermind.Core.Buffers;
@@ -25,41 +23,11 @@ namespace Nethermind.Trie
 
         private class TrieNodeDecoder
         {
-            public static CappedArray<byte> Encode(ITrieNodeResolver tree, ref TreePath path, TrieNode? item, ICappedArrayPool? bufferPool)
+            [SkipLocalsInit]
+            public static CappedArray<byte> EncodeExtension(TrieNode item, ITrieNodeResolver tree, ref TreePath path, ICappedArrayPool? bufferPool)
             {
                 Metrics.TreeNodeRlpEncodings++;
 
-                if (item is null)
-                {
-                    ThrowNullNode();
-                }
-
-                return item.NodeType switch
-                {
-                    NodeType.Branch => RlpEncodeBranch(tree, ref path, item, bufferPool),
-                    NodeType.Extension => EncodeExtension(tree, ref path, item, bufferPool),
-                    NodeType.Leaf => EncodeLeaf(item, bufferPool),
-                    _ => ThrowUnhandledNodeType(item)
-                };
-
-                [DoesNotReturn]
-                [StackTraceHidden]
-                static void ThrowNullNode()
-                {
-                    throw new TrieException("An attempt was made to RLP encode a null node.");
-                }
-
-                [DoesNotReturn]
-                [StackTraceHidden]
-                static CappedArray<byte> ThrowUnhandledNodeType(TrieNode item)
-                {
-                    throw new TrieException($"An attempt was made to encode a trie node of type {item.NodeType}");
-                }
-            }
-
-            [SkipLocalsInit]
-            private static CappedArray<byte> EncodeExtension(ITrieNodeResolver tree, ref TreePath path, TrieNode item, ICappedArrayPool? bufferPool)
-            {
                 Debug.Assert(item.NodeType == NodeType.Extension,
                     $"Node passed to {nameof(EncodeExtension)} is {item.NodeType}");
                 Debug.Assert(item.Key is not null,
@@ -115,8 +83,10 @@ namespace Nethermind.Trie
             }
 
             [SkipLocalsInit]
-            private static CappedArray<byte> EncodeLeaf(TrieNode node, ICappedArrayPool? pool)
+            public static CappedArray<byte> EncodeLeaf(TrieNode node, ICappedArrayPool? pool)
             {
+                Metrics.TreeNodeRlpEncodings++;
+
                 if (node.Key is null)
                 {
                     ThrowNullKey(node);
@@ -155,8 +125,10 @@ namespace Nethermind.Trie
                 throw new TrieException($"Hex prefix of a leaf node is null at node {node.Keccak}");
             }
 
-            private static CappedArray<byte> RlpEncodeBranch(ITrieNodeResolver tree, ref TreePath path, TrieNode item, ICappedArrayPool? pool)
+            public static CappedArray<byte> RlpEncodeBranch(TrieNode item, ITrieNodeResolver tree, ref TreePath path, ICappedArrayPool? pool)
             {
+                Metrics.TreeNodeRlpEncodings++;
+
                 int valueRlpLength = AllowBranchValues ? Rlp.LengthOf(item.Value.AsSpan()) : 1;
                 int contentLength = valueRlpLength + GetChildrenRlpLengthForBranch(tree, ref path, item, pool);
                 int sequenceLength = Rlp.LengthOfSequence(contentLength);
@@ -179,18 +151,57 @@ namespace Nethermind.Trie
 
             private static int GetChildrenRlpLengthForBranch(ITrieNodeResolver tree, ref TreePath path, TrieNode item, ICappedArrayPool? bufferPool)
             {
-                int totalLength = 0;
                 item.EnsureInitialized();
+                // Tail call optimized.
+                if (item.HasRlp)
+                {
+                    return GetChildrenRlpLengthForBranchRlp(tree, ref path, item, bufferPool);
+                }
+                else
+                {
+                    return GetChildrenRlpLengthForBranchNonRlp(tree, ref path, item, bufferPool);
+                }
+            }
+
+            private static int GetChildrenRlpLengthForBranchNonRlp(ITrieNodeResolver tree, ref TreePath path, TrieNode item, ICappedArrayPool bufferPool)
+            {
+                int totalLength = 0;
+                for (int i = 0; i < BranchesCount; i++)
+                {
+                    object data = item._data[i];
+                    if (ReferenceEquals(data, _nullNode) || data is null)
+                    {
+                        totalLength++;
+                    }
+                    else if (data is Hash256)
+                    {
+                        totalLength += Rlp.LengthOfKeccakRlp;
+                    }
+                    else
+                    {
+                        path.AppendMut(i);
+                        TrieNode childNode = (TrieNode)data;
+                        childNode.ResolveKey(tree, ref path, isRoot: false, bufferPool: bufferPool);
+                        path.TruncateOne();
+                        totalLength += childNode.Keccak is null ? childNode.FullRlp.Length : Rlp.LengthOfKeccakRlp;
+                    }
+                }
+                return totalLength;
+            }
+
+            private static int GetChildrenRlpLengthForBranchRlp(ITrieNodeResolver tree, ref TreePath path, TrieNode item, ICappedArrayPool? bufferPool)
+            {
+                int totalLength = 0;
                 ValueRlpStream rlpStream = item.RlpStream;
                 item.SeekChild(ref rlpStream, 0);
                 for (int i = 0; i < BranchesCount; i++)
                 {
-                    bool isRlp = rlpStream.IsNotNull;
                     object data = item._data[i];
-                    if (rlpStream.IsNotNull && data is null)
+                    if (data is null)
                     {
-                        (int prefixLength, int contentLength) = rlpStream.PeekPrefixAndContentLength();
-                        totalLength += prefixLength + contentLength;
+                        int length = rlpStream.PeekNextRlpLength();
+                        totalLength += length;
+                        rlpStream.SkipBytes(length);
                     }
                     else
                     {
@@ -204,15 +215,16 @@ namespace Nethermind.Trie
                         }
                         else
                         {
-                            TrieNode childNode = (TrieNode)data;
-                            item.AppendChildPathBranch(ref path, i);
-                            childNode!.ResolveKey(tree, ref path, false, bufferPool: bufferPool);
+                            path.AppendMut(i);
+                            Debug.Assert(data is TrieNode, "Data is not TrieNode");
+                            TrieNode childNode = Unsafe.As<TrieNode>(data);
+                            childNode.ResolveKey(tree, ref path, isRoot: false, bufferPool: bufferPool);
                             path.TruncateOne();
                             totalLength += childNode.Keccak is null ? childNode.FullRlp.Length : Rlp.LengthOfKeccakRlp;
                         }
-                    }
 
-                    if (isRlp) rlpStream.SkipItem();
+                        rlpStream.SkipItem();
+                    }
                 }
 
                 return totalLength;
@@ -220,41 +232,91 @@ namespace Nethermind.Trie
 
             private static void WriteChildrenRlpBranch(ITrieNodeResolver tree, ref TreePath path, TrieNode item, Span<byte> destination, ICappedArrayPool? bufferPool)
             {
-                int position = 0;
                 item.EnsureInitialized();
-                ValueRlpStream rlpStream = item.RlpStream;
-                item.SeekChild(ref rlpStream, 0);
+                // Tail call optimized.
+                if (item.HasRlp)
+                {
+                    WriteChildrenRlpBranchRlp(tree, ref path, item, destination, bufferPool);
+                }
+                else
+                {
+                    WriteChildrenRlpBranchNonRlp(tree, ref path, item, destination, bufferPool);
+                }
+            }
+
+            private static void WriteChildrenRlpBranchNonRlp(ITrieNodeResolver tree, ref TreePath path, TrieNode item, Span<byte> destination, ICappedArrayPool? bufferPool)
+            {
+                int position = 0;
                 for (int i = 0; i < BranchesCount; i++)
                 {
-                    bool isRlp = rlpStream.IsNotNull;
                     object data = item._data[i];
-                    if (isRlp && data is null)
+                    if (ReferenceEquals(data, _nullNode) || data is null)
+                    {
+                        destination[position++] = 128;
+                    }
+                    else if (data is Hash256 hash)
+                    {
+                        position = Rlp.Encode(destination, position, hash);
+                    }
+                    else
+                    {
+                        path.AppendMut(i);
+                        Debug.Assert(data is TrieNode, "Data is not TrieNode");
+                        TrieNode childNode = Unsafe.As<TrieNode>(data);
+                        childNode!.ResolveKey(tree, ref path, isRoot: false, bufferPool: bufferPool);
+                        path.TruncateOne();
+
+                        hash = childNode.Keccak;
+                        if (hash is null)
+                        {
+                            Span<byte> fullRlp = childNode.FullRlp!.AsSpan();
+                            fullRlp.CopyTo(destination.Slice(position, fullRlp.Length));
+                            position += fullRlp.Length;
+                        }
+                        else
+                        {
+                            position = Rlp.Encode(destination, position, hash);
+                        }
+                    }
+                }
+            }
+
+            private static void WriteChildrenRlpBranchRlp(ITrieNodeResolver tree, ref TreePath path, TrieNode item, Span<byte> destination, ICappedArrayPool? bufferPool)
+            {
+                ValueRlpStream rlpStream = item.RlpStream;
+                item.SeekChild(ref rlpStream, 0);
+                int position = 0;
+                for (int i = 0; i < BranchesCount; i++)
+                {
+                    object data = item._data[i];
+                    if (data is null)
                     {
                         int length = rlpStream.PeekNextRlpLength();
                         Span<byte> nextItem = rlpStream.Data.AsSpan(rlpStream.Position, length);
                         nextItem.CopyTo(destination.Slice(position, nextItem.Length));
                         position += nextItem.Length;
-                        rlpStream.SkipItem();
+                        rlpStream.SkipBytes(length);
                     }
                     else
                     {
-                        if (isRlp) rlpStream.SkipItem();
                         if (ReferenceEquals(data, _nullNode) || data is null)
                         {
                             destination[position++] = 128;
                         }
-                        else if (data is Hash256)
+                        else if (data is Hash256 hash)
                         {
-                            position = Rlp.Encode(destination, position, (data as Hash256)!.Bytes);
+                            position = Rlp.Encode(destination, position, hash);
                         }
                         else
                         {
-                            TrieNode childNode = (TrieNode)data;
-                            item.AppendChildPathBranch(ref path, i);
-                            childNode!.ResolveKey(tree, ref path, false, bufferPool: bufferPool);
+                            path.AppendMut(i);
+                            Debug.Assert(data is TrieNode, "Data is not TrieNode");
+                            TrieNode childNode = Unsafe.As<TrieNode>(data);
+                            childNode!.ResolveKey(tree, ref path, isRoot: false, bufferPool: bufferPool);
                             path.TruncateOne();
 
-                            if (childNode.Keccak is null)
+                            hash = childNode.Keccak;
+                            if (hash is null)
                             {
                                 Span<byte> fullRlp = childNode.FullRlp!.AsSpan();
                                 fullRlp.CopyTo(destination.Slice(position, fullRlp.Length));
@@ -262,9 +324,11 @@ namespace Nethermind.Trie
                             }
                             else
                             {
-                                position = Rlp.Encode(destination, position, childNode.Keccak.Bytes);
+                                position = Rlp.Encode(destination, position, hash);
                             }
                         }
+
+                        rlpStream.SkipItem();
                     }
                 }
             }

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Visitor.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Visitor.cs
@@ -213,7 +213,7 @@ namespace Nethermind.Trie
                         {
                             TrieNode?[] output = new TrieNode?[16];
                             currentNode.ResolveAllChildBranch(nodeResolver, ref path, output);
-                            currentNode.AppendChildPathBranch(ref path, 0);
+                            path.AppendMut(0);
                             for (int i = 0; i < 16; i++)
                             {
                                 if (output[i] == null) continue;


### PR DESCRIPTION
## Changes

- Use FrozenDictionary for encoder lookup
- Use struct wrapper for `Type` for dicitionary devirtualization
- Use `Instance` decoder for `BlockInfo`, `Account`, `LogInfo` rather than type lookup
- Use `Instance` decoder for `Transaction` rather than instatiating new one each time.
- Use 256bit assignment rather than Span copy for Hash256 encoding
- Seal `TxDecoder` and `TrieNode`
- Split Rlp and Non-Rlp key generation into seperate methods rather than checking on each loop iteration.

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization
- [x] Refactoring

## Testing

#### Requires testing

- [x] No
