### PR TITLE
Add diff mode for prestate tracer

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikePrestateTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikePrestateTracerTests.cs
@@ -18,7 +18,13 @@ namespace Nethermind.Evm.Test.Tracing;
 public class GethLikePrestateTracerTests : VirtualMachineTestsBase
 {
     private static readonly JsonSerializerOptions SerializerOptions = EthereumJsonSerializer.JsonOptionsIndented;
-    private readonly GethTraceOptions _gethTraceOptions = GethTraceOptions.Default with { Tracer = NativePrestateTracer.PrestateTracer };
+    private const string DiffMode = """{"diffMode":true}""";
+
+    private static GethTraceOptions GetGethTraceOptions(string? config = null) => GethTraceOptions.Default with
+    {
+        Tracer = NativePrestateTracer.PrestateTracer,
+        TracerConfig = config is not null ? JsonSerializer.Deserialize<JsonElement>(config) : null
+    };
 
     [Test]
     public void Test_PrestateTrace_SStore()
@@ -27,21 +33,11 @@ public class GethLikePrestateTracerTests : VirtualMachineTestsBase
         StorageCell storageCell = new StorageCell(TestItem.AddressB, 32);
         byte[] storageData = Bytes.FromHexString("123456789abcdef");
         TestState.Set(storageCell, storageData);
-        NativePrestateTracer tracer = new(TestState, _gethTraceOptions, TestItem.AddressA, TestItem.AddressB, Address.Zero);
 
-        byte[] sstoreCode = Prepare.EvmCode
-            .PushData(SampleHexData1.PadLeft(64, '0'))
-            .PushData(0)
-            .Op(Instruction.SSTORE)
-            .PushData(SampleHexData2.PadLeft(64, '0'))
-            .PushData(32)
-            .Op(Instruction.SSTORE)
-            .Op(Instruction.STOP)
-            .Done;
-
+        NativePrestateTracer tracer = new(TestState, GetGethTraceOptions(), TestItem.AddressA, TestItem.AddressB, Address.Zero);
         GethLikeTxTrace prestateTrace = Execute(
                 tracer,
-                sstoreCode,
+                SStore,
                 MainnetSpecProvider.CancunActivation)
             .BuildResult();
         const string expectedPrestateTrace = """
@@ -65,32 +61,75 @@ public class GethLikePrestateTracerTests : VirtualMachineTestsBase
     }
 
     [Test]
-    public void Test_PrestateTrace_NestedCalls()
+    public void Test_PrestateTrace_SStore_DiffMode()
     {
         TestState.CreateAccount(Address.Zero, 100.Ether());
-        NativePrestateTracer tracer = new(TestState, _gethTraceOptions, TestItem.AddressA, TestItem.AddressB, Address.Zero);
+        StorageCell storageCell = new StorageCell(TestItem.AddressB, 32);
+        byte[] storageData = Bytes.FromHexString("123456789abcdef");
+        TestState.Set(storageCell, storageData);
 
+        NativePrestateTracer tracer = new(TestState, GetGethTraceOptions(DiffMode), TestItem.AddressA, TestItem.AddressB, Address.Zero);
+        GethLikeTxTrace prestateTrace = Execute(
+                tracer,
+                SStore,
+                MainnetSpecProvider.CancunActivation)
+            .BuildResult();
+        const string expectedPrestateTrace = """
+{
+  "pre": {
+    "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
+      "balance": "0x0"
+    },
+    "0x942921b14f1b1c385cd7e0cc2ef7abe5598c8358": {
+      "balance": "0x0",
+      "storage": {
+        "0x0000000000000000000000000000000000000000000000000000000000000020": "0x0000000000000000000000000000000000000000000000000123456789abcdef"
+      }
+    }
+  },
+  "post": {
+    "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
+      "balance": "0x56bc75e2d630f440f",
+      "nonce": 1
+    },
+    "0x942921b14f1b1c385cd7e0cc2ef7abe5598c8358": {
+      "balance": "0x56bc75e2d63100001",
+      "code": "0x7f0000000000000000000000000000000000000000000000000000000000a012346000557f0000000000000000000000000000000000000000000000000000000000b1567860205500",
+      "storage": {
+        "0x0000000000000000000000000000000000000000000000000000000000000000": "0x0000000000000000000000000000000000000000000000000000000000a01234",
+        "0x0000000000000000000000000000000000000000000000000000000000000020": "0x0000000000000000000000000000000000000000000000000000000000b15678"
+      }
+    }
+  }
+}
+""";
+        Assert.That(JsonSerializer.Serialize(prestateTrace.CustomTracerResult?.Value, SerializerOptions), Is.EqualTo(expectedPrestateTrace));
+    }
+
+    [Test]
+    public void Test_PrestateTrace_NestedCalls()
+    {
         byte[] deployedCode = new byte[3];
-
         byte[] initCode = Prepare.EvmCode
             .ForInitOf(deployedCode)
             .Done;
-
         byte[] createCode = Prepare.EvmCode
             .Create(initCode, 0)
             .Op(Instruction.STOP)
             .Done;
-
-        TestState.CreateAccount(TestItem.AddressC, 1.Ether());
-        TestState.InsertCode(TestItem.AddressC, createCode, Spec);
-        byte[] code = Prepare.EvmCode
+        byte[] nestedCode = Prepare.EvmCode
             .DelegateCall(TestItem.AddressC, 50000)
             .Op(Instruction.STOP)
             .Done;
 
+        TestState.CreateAccount(Address.Zero, 100.Ether());
+        TestState.CreateAccount(TestItem.AddressC, 1.Ether());
+        TestState.InsertCode(TestItem.AddressC, createCode, Spec);
+
+        NativePrestateTracer tracer = new(TestState, GetGethTraceOptions(), TestItem.AddressA, TestItem.AddressB, Address.Zero);
         GethLikeTxTrace prestateTrace = Execute(
                 tracer,
-                code,
+                nestedCode,
                 MainnetSpecProvider.CancunActivation)
             .BuildResult();
         const string expectedPrestateTrace = """
@@ -117,28 +156,79 @@ public class GethLikePrestateTracerTests : VirtualMachineTestsBase
     }
 
     [Test]
-    public void Test_PrestateTrace_Create2()
+    public void Test_PrestateTrace_NestedCalls_DiffMode()
     {
-        TestState.CreateAccount(Address.Zero, 100.Ether());
-        NativePrestateTracer tracer = new(TestState, _gethTraceOptions, TestItem.AddressA, TestItem.AddressB, Address.Zero);
-
-        byte[] salt = { 4, 5, 6 };
-
-        byte[] deployedCode = { 1, 2, 3 };
-
+        byte[] deployedCode = new byte[3];
         byte[] initCode = Prepare.EvmCode
-            .ForInitOf(deployedCode).Done;
-
+            .ForInitOf(deployedCode)
+            .Done;
         byte[] createCode = Prepare.EvmCode
-            .Create2(initCode, salt, 0).Done;
+            .Create(initCode, 0)
+            .Op(Instruction.STOP)
+            .Done;
+        byte[] nestedCode = Prepare.EvmCode
+            .DelegateCall(TestItem.AddressC, 50000)
+            .Op(Instruction.STOP)
+            .Done;
 
+        TestState.CreateAccount(Address.Zero, 100.Ether());
         TestState.CreateAccount(TestItem.AddressC, 1.Ether());
         TestState.InsertCode(TestItem.AddressC, createCode, Spec);
 
+        NativePrestateTracer tracer = new(TestState, GetGethTraceOptions(DiffMode), TestItem.AddressA, TestItem.AddressB, Address.Zero);
+        GethLikeTxTrace prestateTrace = Execute(
+                tracer,
+                nestedCode,
+                MainnetSpecProvider.CancunActivation)
+            .BuildResult();
+        const string expectedPrestateTrace = """
+{
+  "pre": {
+    "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
+      "balance": "0x0"
+    },
+    "0x942921b14f1b1c385cd7e0cc2ef7abe5598c8358": {
+      "balance": "0x0"
+    }
+  },
+  "post": {
+    "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
+      "balance": "0x56bc75e2d630f242e",
+      "nonce": 1
+    },
+    "0x942921b14f1b1c385cd7e0cc2ef7abe5598c8358": {
+      "balance": "0x56bc75e2d63100001",
+      "nonce": 1,
+      "code": "0x60006000600060007376e68a8696537e4141926f3e528733af9e237d6961c350f400"
+    },
+    "0x89aa9b2ce05aaef815f25b237238c0b4ffff6ae3": {
+      "nonce": 1,
+      "code": "0x000000"
+    }
+  }
+}
+""";
+        Assert.That(JsonSerializer.Serialize(prestateTrace.CustomTracerResult?.Value, SerializerOptions), Is.EqualTo(expectedPrestateTrace));
+    }
+
+    [Test]
+    public void Test_PrestateTrace_Create2()
+    {
+        byte[] salt = { 4, 5, 6 };
+        byte[] deployedCode = { 1, 2, 3 };
+        byte[] initCode = Prepare.EvmCode
+            .ForInitOf(deployedCode).Done;
+        byte[] createCode = Prepare.EvmCode
+            .Create2(initCode, salt, 0).Done;
         byte[] code = Prepare.EvmCode
             .Call(TestItem.AddressC, 50000)
             .Done;
 
+        TestState.CreateAccount(Address.Zero, 100.Ether());
+        TestState.CreateAccount(TestItem.AddressC, 1.Ether());
+        TestState.InsertCode(TestItem.AddressC, createCode, Spec);
+
+        NativePrestateTracer tracer = new(TestState, GetGethTraceOptions(), TestItem.AddressA, TestItem.AddressB, Address.Zero);
         GethLikeTxTrace prestateTrace = Execute(
                 tracer,
                 code,
@@ -168,16 +258,75 @@ public class GethLikePrestateTracerTests : VirtualMachineTestsBase
     }
 
     [Test]
+    public void Test_PrestateTrace_Create2_DiffMode()
+    {
+        byte[] salt = { 4, 5, 6 };
+        byte[] deployedCode = { 1, 2, 3 };
+        byte[] initCode = Prepare.EvmCode
+            .ForInitOf(deployedCode).Done;
+        byte[] createCode = Prepare.EvmCode
+            .Create2(initCode, salt, 0).Done;
+        byte[] code = Prepare.EvmCode
+            .Call(TestItem.AddressC, 50000)
+            .Done;
+
+        TestState.CreateAccount(Address.Zero, 100.Ether());
+        TestState.CreateAccount(TestItem.AddressC, 1.Ether());
+        TestState.InsertCode(TestItem.AddressC, createCode, Spec);
+
+        NativePrestateTracer tracer = new(TestState, GetGethTraceOptions(DiffMode), TestItem.AddressA, TestItem.AddressB, Address.Zero);
+        GethLikeTxTrace prestateTrace = Execute(
+                tracer,
+                code,
+                MainnetSpecProvider.CancunActivation)
+            .BuildResult();
+        const string expectedPrestateTrace = """
+{
+  "pre": {
+    "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
+      "balance": "0x0"
+    },
+    "0x942921b14f1b1c385cd7e0cc2ef7abe5598c8358": {
+      "balance": "0x0"
+    },
+    "0x76e68a8696537e4141926f3e528733af9e237d69": {
+      "balance": "0xde0b6b3a7640000",
+      "code": "0x7f7f010203000000000000000000000000000000000000000000000000000000006000527f0060005260036000f3000000000000000000000000000000000000000000000060205262040506602960006000f5"
+    }
+  },
+  "post": {
+    "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
+      "balance": "0x56bc75e2d630f241c",
+      "nonce": 1
+    },
+    "0x942921b14f1b1c385cd7e0cc2ef7abe5598c8358": {
+      "balance": "0x56bc75e2d63100001",
+      "code": "0x600060006000600060007376e68a8696537e4141926f3e528733af9e237d6961c350f1"
+    },
+    "0x76e68a8696537e4141926f3e528733af9e237d69": {
+      "nonce": 1
+    },
+    "0x02caaf71b895896a4d9159943eae74efb6a58238": {
+      "nonce": 1,
+      "code": "0x010203"
+    }
+  }
+}
+""";
+        Assert.That(JsonSerializer.Serialize(prestateTrace.CustomTracerResult?.Value, SerializerOptions), Is.EqualTo(expectedPrestateTrace));
+    }
+
+    [Test]
     public void Test_PrestateTrace_ExistingAccount()
     {
         TestState.CreateAccount(Address.Zero, 100.Ether());
         TestState.CreateAccount(TestItem.AddressC, 5.Ether());
         TestState.IncrementNonce(TestItem.AddressC);
-        NativePrestateTracer tracer = new(TestState, _gethTraceOptions, TestItem.AddressA, TestItem.AddressB, Address.Zero);
 
+        NativePrestateTracer tracer = new(TestState, GetGethTraceOptions(), TestItem.AddressA, TestItem.AddressB, Address.Zero);
         GethLikeTxTrace prestateTrace = Execute(
                 tracer,
-                Balance(),
+                Balance,
                 MainnetSpecProvider.CancunActivation)
             .BuildResult();
         const string expectedPrestateTrace = """
@@ -201,14 +350,52 @@ public class GethLikePrestateTracerTests : VirtualMachineTestsBase
     }
 
     [Test]
+    public void Test_PrestateTrace_ExistingAccount_DiffMode()
+    {
+        TestState.CreateAccount(Address.Zero, 100.Ether());
+        TestState.CreateAccount(TestItem.AddressC, 5.Ether());
+        TestState.IncrementNonce(TestItem.AddressC);
+
+        NativePrestateTracer tracer = new(TestState, GetGethTraceOptions(DiffMode), TestItem.AddressA, TestItem.AddressB, Address.Zero);
+        GethLikeTxTrace prestateTrace = Execute(
+                tracer,
+                Balance,
+                MainnetSpecProvider.CancunActivation)
+            .BuildResult();
+        const string expectedPrestateTrace = """
+{
+  "pre": {
+    "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
+      "balance": "0x0"
+    },
+    "0x942921b14f1b1c385cd7e0cc2ef7abe5598c8358": {
+      "balance": "0x0"
+    }
+  },
+  "post": {
+    "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
+      "balance": "0x56bc75e2d630fa3cc",
+      "nonce": 1
+    },
+    "0x942921b14f1b1c385cd7e0cc2ef7abe5598c8358": {
+      "balance": "0x56bc75e2d63100001",
+      "code": "0x7f00000000000000000000000076e68a8696537e4141926f3e528733af9e237d693100"
+    }
+  }
+}
+""";
+        Assert.That(JsonSerializer.Serialize(prestateTrace.CustomTracerResult?.Value, SerializerOptions), Is.EqualTo(expectedPrestateTrace));
+    }
+
+    [Test]
     public void Test_PrestateTrace_EmptyTo()
     {
         TestState.CreateAccount(Address.Zero, 100.Ether());
-        NativePrestateTracer tracer = new(TestState, _gethTraceOptions, TestItem.AddressA, null, Address.Zero);
 
+        NativePrestateTracer tracer = new(TestState, GetGethTraceOptions(), TestItem.AddressA, null, Address.Zero);
         GethLikeTxTrace prestateTrace = Execute(
                 tracer,
-                Balance(),
+                Balance,
                 MainnetSpecProvider.CancunActivation)
             .BuildResult();
         const string expectedPrestateTrace = """
@@ -230,12 +417,115 @@ public class GethLikePrestateTracerTests : VirtualMachineTestsBase
         Assert.That(JsonSerializer.Serialize(prestateTrace.CustomTracerResult?.Value, SerializerOptions), Is.EqualTo(expectedPrestateTrace));
     }
 
-    private static byte[] Balance()
+    [Test]
+    public void Test_PrestateTrace_EmptyTo_DiffMode()
     {
-        return Prepare.EvmCode
-            .PushData(TestItem.AddressC.ToString(false, false).PadLeft(64, '0'))
-            .Op(Instruction.BALANCE)
-            .Op(Instruction.STOP)
-            .Done;
+        TestState.CreateAccount(Address.Zero, 100.Ether());
+
+        NativePrestateTracer tracer = new(TestState, GetGethTraceOptions(DiffMode), TestItem.AddressA, null, Address.Zero);
+        GethLikeTxTrace prestateTrace = Execute(
+                tracer,
+                Balance,
+                MainnetSpecProvider.CancunActivation)
+            .BuildResult();
+        const string expectedPrestateTrace = """
+{
+  "pre": {
+    "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
+      "balance": "0x0"
     }
+  },
+  "post": {
+    "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
+      "balance": "0x56bc75e2d630fa3cc",
+      "nonce": 1
+    }
+  }
+}
+""";
+        Assert.That(JsonSerializer.Serialize(prestateTrace.CustomTracerResult?.Value, SerializerOptions), Is.EqualTo(expectedPrestateTrace));
+    }
+
+    [Test]
+    public void Test_PrestateTrace_SelfDestruct()
+    {
+        TestState.CreateAccount(Address.Zero, 100.Ether());
+
+        NativePrestateTracer tracer = new(TestState, GetGethTraceOptions(), TestItem.AddressA, null, Address.Zero);
+        GethLikeTxTrace prestateTrace = Execute(
+                tracer,
+                SelfDestruct,
+                MainnetSpecProvider.CancunActivation)
+            .BuildResult();
+        const string expectedPrestateTrace = """
+{
+  "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
+    "balance": "0x0"
+  },
+  "0x24cd2edba056b7c654a50e8201b619d4f624fdda": {
+    "balance": "0x0"
+  },
+  "0x0000000000000000000000000000000000000000": {
+    "balance": "0x56bc75e2d63100000"
+  },
+  "0x76e68a8696537e4141926f3e528733af9e237d69": {
+    "balance": "0x0"
+  }
+}
+""";
+        Assert.That(JsonSerializer.Serialize(prestateTrace.CustomTracerResult?.Value, SerializerOptions), Is.EqualTo(expectedPrestateTrace));
+    }
+
+    [Test]
+    public void Test_PrestateTrace_SelfDestruct_DiffMode()
+    {
+        TestState.CreateAccount(Address.Zero, 100.Ether());
+
+        NativePrestateTracer tracer = new(TestState, GetGethTraceOptions(DiffMode), TestItem.AddressA, null, Address.Zero);
+        GethLikeTxTrace prestateTrace = Execute(
+                tracer,
+                SelfDestruct,
+                MainnetSpecProvider.CancunActivation)
+            .BuildResult();
+        const string expectedPrestateTrace = """
+{
+  "pre": {
+    "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
+      "balance": "0x0"
+    },
+    "0x76e68a8696537e4141926f3e528733af9e237d69": {
+      "balance": "0x0"
+    }
+  },
+  "post": {
+    "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
+      "balance": "0x56bc75e2d630f2e9c",
+      "nonce": 1
+    }
+  }
+}
+""";
+        Assert.That(JsonSerializer.Serialize(prestateTrace.CustomTracerResult?.Value, SerializerOptions), Is.EqualTo(expectedPrestateTrace));
+    }
+
+    private static byte[] SStore => Prepare.EvmCode
+        .PushData(SampleHexData1.PadLeft(64, '0'))
+        .PushData(0)
+        .Op(Instruction.SSTORE)
+        .PushData(SampleHexData2.PadLeft(64, '0'))
+        .PushData(32)
+        .Op(Instruction.SSTORE)
+        .Op(Instruction.STOP)
+        .Done;
+
+    private static byte[] Balance => Prepare.EvmCode
+        .PushData(TestItem.AddressC.ToString(false, false).PadLeft(64, '0'))
+        .Op(Instruction.BALANCE)
+        .Op(Instruction.STOP)
+        .Done;
+
+    private static byte[] SelfDestruct => Prepare.EvmCode
+        .PushData(TestItem.AddressC.ToString(false, false).PadLeft(64, '0'))
+        .Op(Instruction.SELFDESTRUCT)
+        .Done;
 }

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikePrestateTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikePrestateTracerTests.cs
@@ -19,6 +19,8 @@ public class GethLikePrestateTracerTests : VirtualMachineTestsBase
 {
     private static readonly JsonSerializerOptions SerializerOptions = EthereumJsonSerializer.JsonOptionsIndented;
     private const string DiffMode = """{"diffMode":true}""";
+    private const string PrestateMode = """{"diffMode":false}""";
+    private const string? NoConfig = null;
 
     private static GethTraceOptions GetGethTraceOptions(string? config = null) => GethTraceOptions.Default with
     {
@@ -26,88 +28,126 @@ public class GethLikePrestateTracerTests : VirtualMachineTestsBase
         TracerConfig = config is not null ? JsonSerializer.Deserialize<JsonElement>(config) : null
     };
 
-    [Test]
-    public void Test_PrestateTrace_SStore()
+    private const string ExpectedSStorePrestateTrace = """
+        {
+          "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
+            "balance": "0x0"
+          },
+          "0x942921b14f1b1c385cd7e0cc2ef7abe5598c8358": {
+            "balance": "0x0",
+            "storage": {
+              "0x0000000000000000000000000000000000000000000000000000000000000000": "0x0000000000000000000000000000000000000000000000000000000000000000",
+              "0x0000000000000000000000000000000000000000000000000000000000000020": "0x0000000000000000000000000000000000000000000000000123456789abcdef"
+            }
+          },
+          "0x0000000000000000000000000000000000000000": {
+            "balance": "0x56bc75e2d63100000"
+          }
+        }
+        """;
+
+    private const string ExpectedSStoreDiffModeTrace = """
+        {
+          "pre": {
+            "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
+              "balance": "0x0"
+            },
+            "0x942921b14f1b1c385cd7e0cc2ef7abe5598c8358": {
+              "balance": "0x0",
+              "storage": {
+                "0x0000000000000000000000000000000000000000000000000000000000000020": "0x0000000000000000000000000000000000000000000000000123456789abcdef"
+              }
+            }
+          },
+          "post": {
+            "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
+              "balance": "0x56bc75e2d630f440f",
+              "nonce": 1
+            },
+            "0x942921b14f1b1c385cd7e0cc2ef7abe5598c8358": {
+              "balance": "0x56bc75e2d63100001",
+              "code": "0x7f0000000000000000000000000000000000000000000000000000000000a012346000557f0000000000000000000000000000000000000000000000000000000000b1567860205500",
+              "storage": {
+                "0x0000000000000000000000000000000000000000000000000000000000000000": "0x0000000000000000000000000000000000000000000000000000000000a01234",
+                "0x0000000000000000000000000000000000000000000000000000000000000020": "0x0000000000000000000000000000000000000000000000000000000000b15678"
+              }
+            }
+          }
+        }
+        """;
+
+    [TestCase(NoConfig, ExpectedSStorePrestateTrace)]
+    [TestCase(PrestateMode, ExpectedSStorePrestateTrace)]
+    [TestCase(DiffMode, ExpectedSStoreDiffModeTrace)]
+    public void Test_PrestateTrace_SStore(string? config, string expectedTrace)
     {
         TestState.CreateAccount(Address.Zero, 100.Ether());
         StorageCell storageCell = new StorageCell(TestItem.AddressB, 32);
         byte[] storageData = Bytes.FromHexString("123456789abcdef");
         TestState.Set(storageCell, storageData);
 
-        NativePrestateTracer tracer = new(TestState, GetGethTraceOptions(), TestItem.AddressA, TestItem.AddressB, Address.Zero);
-        GethLikeTxTrace prestateTrace = Execute(
+        NativePrestateTracer tracer = new(TestState, GetGethTraceOptions(config), TestItem.AddressA, TestItem.AddressB, Address.Zero);
+        GethLikeTxTrace trace = Execute(
                 tracer,
                 SStore,
                 MainnetSpecProvider.CancunActivation)
             .BuildResult();
-        const string expectedPrestateTrace = """
-{
-  "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
-    "balance": "0x0"
-  },
-  "0x942921b14f1b1c385cd7e0cc2ef7abe5598c8358": {
-    "balance": "0x0",
-    "storage": {
-      "0x0000000000000000000000000000000000000000000000000000000000000000": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "0x0000000000000000000000000000000000000000000000000000000000000020": "0x0000000000000000000000000000000000000000000000000123456789abcdef"
-    }
-  },
-  "0x0000000000000000000000000000000000000000": {
-    "balance": "0x56bc75e2d63100000"
-  }
-}
-""";
-        Assert.That(JsonSerializer.Serialize(prestateTrace.CustomTracerResult?.Value, SerializerOptions), Is.EqualTo(expectedPrestateTrace));
+        Assert.That(JsonSerializer.Serialize(trace.CustomTracerResult?.Value, SerializerOptions), Is.EqualTo(expectedTrace));
     }
 
-    [Test]
-    public void Test_PrestateTrace_SStore_DiffMode()
-    {
-        TestState.CreateAccount(Address.Zero, 100.Ether());
-        StorageCell storageCell = new StorageCell(TestItem.AddressB, 32);
-        byte[] storageData = Bytes.FromHexString("123456789abcdef");
-        TestState.Set(storageCell, storageData);
+    private const string ExpectedNestedCallsPrestateTrace = """
+        {
+          "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
+            "balance": "0x0"
+          },
+          "0x942921b14f1b1c385cd7e0cc2ef7abe5598c8358": {
+            "balance": "0x0"
+          },
+          "0x0000000000000000000000000000000000000000": {
+            "balance": "0x56bc75e2d63100000"
+          },
+          "0x76e68a8696537e4141926f3e528733af9e237d69": {
+            "balance": "0xde0b6b3a7640000",
+            "code": "0x7f7f000000000000000000000000000000000000000000000000000000000000006000527f0060005260036000f30000000000000000000000000000000000000000000000602052602960006000f000"
+          },
+          "0x89aa9b2ce05aaef815f25b237238c0b4ffff6ae3": {
+            "balance": "0x0"
+          }
+        }
+        """;
 
-        NativePrestateTracer tracer = new(TestState, GetGethTraceOptions(DiffMode), TestItem.AddressA, TestItem.AddressB, Address.Zero);
-        GethLikeTxTrace prestateTrace = Execute(
-                tracer,
-                SStore,
-                MainnetSpecProvider.CancunActivation)
-            .BuildResult();
-        const string expectedPrestateTrace = """
-{
-  "pre": {
-    "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
-      "balance": "0x0"
-    },
-    "0x942921b14f1b1c385cd7e0cc2ef7abe5598c8358": {
-      "balance": "0x0",
-      "storage": {
-        "0x0000000000000000000000000000000000000000000000000000000000000020": "0x0000000000000000000000000000000000000000000000000123456789abcdef"
-      }
-    }
-  },
-  "post": {
-    "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
-      "balance": "0x56bc75e2d630f440f",
-      "nonce": 1
-    },
-    "0x942921b14f1b1c385cd7e0cc2ef7abe5598c8358": {
-      "balance": "0x56bc75e2d63100001",
-      "code": "0x7f0000000000000000000000000000000000000000000000000000000000a012346000557f0000000000000000000000000000000000000000000000000000000000b1567860205500",
-      "storage": {
-        "0x0000000000000000000000000000000000000000000000000000000000000000": "0x0000000000000000000000000000000000000000000000000000000000a01234",
-        "0x0000000000000000000000000000000000000000000000000000000000000020": "0x0000000000000000000000000000000000000000000000000000000000b15678"
-      }
-    }
-  }
-}
-""";
-        Assert.That(JsonSerializer.Serialize(prestateTrace.CustomTracerResult?.Value, SerializerOptions), Is.EqualTo(expectedPrestateTrace));
-    }
+    private const string ExpectedNestedCallsDiffModeTrace = """
+        {
+          "pre": {
+            "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
+              "balance": "0x0"
+            },
+            "0x942921b14f1b1c385cd7e0cc2ef7abe5598c8358": {
+              "balance": "0x0"
+            }
+          },
+          "post": {
+            "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
+              "balance": "0x56bc75e2d630f242e",
+              "nonce": 1
+            },
+            "0x942921b14f1b1c385cd7e0cc2ef7abe5598c8358": {
+              "balance": "0x56bc75e2d63100001",
+              "nonce": 1,
+              "code": "0x60006000600060007376e68a8696537e4141926f3e528733af9e237d6961c350f400"
+            },
+            "0x89aa9b2ce05aaef815f25b237238c0b4ffff6ae3": {
+              "nonce": 1,
+              "code": "0x000000"
+            }
+          }
+        }
+        """;
 
-    [Test]
-    public void Test_PrestateTrace_NestedCalls()
+    [TestCase(NoConfig, ExpectedNestedCallsPrestateTrace)]
+    [TestCase(PrestateMode, ExpectedNestedCallsPrestateTrace)]
+    [TestCase(DiffMode, ExpectedNestedCallsDiffModeTrace)]
+    public void Test_PrestateTrace_NestedCalls(string? config, string expectedTrace)
     {
         byte[] deployedCode = new byte[3];
         byte[] initCode = Prepare.EvmCode
@@ -126,93 +166,75 @@ public class GethLikePrestateTracerTests : VirtualMachineTestsBase
         TestState.CreateAccount(TestItem.AddressC, 1.Ether());
         TestState.InsertCode(TestItem.AddressC, createCode, Spec);
 
-        NativePrestateTracer tracer = new(TestState, GetGethTraceOptions(), TestItem.AddressA, TestItem.AddressB, Address.Zero);
-        GethLikeTxTrace prestateTrace = Execute(
+        NativePrestateTracer tracer = new(TestState, GetGethTraceOptions(config), TestItem.AddressA, TestItem.AddressB, Address.Zero);
+        GethLikeTxTrace trace = Execute(
                 tracer,
                 nestedCode,
                 MainnetSpecProvider.CancunActivation)
             .BuildResult();
-        const string expectedPrestateTrace = """
-{
-  "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
-    "balance": "0x0"
-  },
-  "0x942921b14f1b1c385cd7e0cc2ef7abe5598c8358": {
-    "balance": "0x0"
-  },
-  "0x0000000000000000000000000000000000000000": {
-    "balance": "0x56bc75e2d63100000"
-  },
-  "0x76e68a8696537e4141926f3e528733af9e237d69": {
-    "balance": "0xde0b6b3a7640000",
-    "code": "0x7f7f000000000000000000000000000000000000000000000000000000000000006000527f0060005260036000f30000000000000000000000000000000000000000000000602052602960006000f000"
-  },
-  "0x89aa9b2ce05aaef815f25b237238c0b4ffff6ae3": {
-    "balance": "0x0"
-  }
-}
-""";
-        Assert.That(JsonSerializer.Serialize(prestateTrace.CustomTracerResult?.Value, SerializerOptions), Is.EqualTo(expectedPrestateTrace));
+
+        Assert.That(JsonSerializer.Serialize(trace.CustomTracerResult?.Value, SerializerOptions), Is.EqualTo(expectedTrace));
     }
 
-    [Test]
-    public void Test_PrestateTrace_NestedCalls_DiffMode()
-    {
-        byte[] deployedCode = new byte[3];
-        byte[] initCode = Prepare.EvmCode
-            .ForInitOf(deployedCode)
-            .Done;
-        byte[] createCode = Prepare.EvmCode
-            .Create(initCode, 0)
-            .Op(Instruction.STOP)
-            .Done;
-        byte[] nestedCode = Prepare.EvmCode
-            .DelegateCall(TestItem.AddressC, 50000)
-            .Op(Instruction.STOP)
-            .Done;
+    private const string ExpectedCreate2PrestateTrace = """
+        {
+          "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
+            "balance": "0x0"
+          },
+          "0x942921b14f1b1c385cd7e0cc2ef7abe5598c8358": {
+            "balance": "0x0"
+          },
+          "0x0000000000000000000000000000000000000000": {
+            "balance": "0x56bc75e2d63100000"
+          },
+          "0x76e68a8696537e4141926f3e528733af9e237d69": {
+            "balance": "0xde0b6b3a7640000",
+            "code": "0x7f7f010203000000000000000000000000000000000000000000000000000000006000527f0060005260036000f3000000000000000000000000000000000000000000000060205262040506602960006000f5"
+          },
+          "0x02caaf71b895896a4d9159943eae74efb6a58238": {
+            "balance": "0x0"
+          }
+        }
+        """;
 
-        TestState.CreateAccount(Address.Zero, 100.Ether());
-        TestState.CreateAccount(TestItem.AddressC, 1.Ether());
-        TestState.InsertCode(TestItem.AddressC, createCode, Spec);
+    private const string ExpectedCreate2DiffModeTrace = """
+        {
+          "pre": {
+            "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
+              "balance": "0x0"
+            },
+            "0x942921b14f1b1c385cd7e0cc2ef7abe5598c8358": {
+              "balance": "0x0"
+            },
+            "0x76e68a8696537e4141926f3e528733af9e237d69": {
+              "balance": "0xde0b6b3a7640000",
+              "code": "0x7f7f010203000000000000000000000000000000000000000000000000000000006000527f0060005260036000f3000000000000000000000000000000000000000000000060205262040506602960006000f5"
+            }
+          },
+          "post": {
+            "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
+              "balance": "0x56bc75e2d630f241c",
+              "nonce": 1
+            },
+            "0x942921b14f1b1c385cd7e0cc2ef7abe5598c8358": {
+              "balance": "0x56bc75e2d63100001",
+              "code": "0x600060006000600060007376e68a8696537e4141926f3e528733af9e237d6961c350f1"
+            },
+            "0x76e68a8696537e4141926f3e528733af9e237d69": {
+              "nonce": 1
+            },
+            "0x02caaf71b895896a4d9159943eae74efb6a58238": {
+              "nonce": 1,
+              "code": "0x010203"
+            }
+          }
+        }
+        """;
 
-        NativePrestateTracer tracer = new(TestState, GetGethTraceOptions(DiffMode), TestItem.AddressA, TestItem.AddressB, Address.Zero);
-        GethLikeTxTrace prestateTrace = Execute(
-                tracer,
-                nestedCode,
-                MainnetSpecProvider.CancunActivation)
-            .BuildResult();
-        const string expectedPrestateTrace = """
-{
-  "pre": {
-    "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
-      "balance": "0x0"
-    },
-    "0x942921b14f1b1c385cd7e0cc2ef7abe5598c8358": {
-      "balance": "0x0"
-    }
-  },
-  "post": {
-    "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
-      "balance": "0x56bc75e2d630f242e",
-      "nonce": 1
-    },
-    "0x942921b14f1b1c385cd7e0cc2ef7abe5598c8358": {
-      "balance": "0x56bc75e2d63100001",
-      "nonce": 1,
-      "code": "0x60006000600060007376e68a8696537e4141926f3e528733af9e237d6961c350f400"
-    },
-    "0x89aa9b2ce05aaef815f25b237238c0b4ffff6ae3": {
-      "nonce": 1,
-      "code": "0x000000"
-    }
-  }
-}
-""";
-        Assert.That(JsonSerializer.Serialize(prestateTrace.CustomTracerResult?.Value, SerializerOptions), Is.EqualTo(expectedPrestateTrace));
-    }
-
-    [Test]
-    public void Test_PrestateTrace_Create2()
+    [TestCase(NoConfig, ExpectedCreate2PrestateTrace)]
+    [TestCase(PrestateMode, ExpectedCreate2PrestateTrace)]
+    [TestCase(DiffMode, ExpectedCreate2DiffModeTrace)]
+    public void Test_PrestateTrace_Create2(string? config, string expectedTrace)
     {
         byte[] salt = { 4, 5, 6 };
         byte[] deployedCode = { 1, 2, 3 };
@@ -228,284 +250,177 @@ public class GethLikePrestateTracerTests : VirtualMachineTestsBase
         TestState.CreateAccount(TestItem.AddressC, 1.Ether());
         TestState.InsertCode(TestItem.AddressC, createCode, Spec);
 
-        NativePrestateTracer tracer = new(TestState, GetGethTraceOptions(), TestItem.AddressA, TestItem.AddressB, Address.Zero);
-        GethLikeTxTrace prestateTrace = Execute(
+        NativePrestateTracer tracer = new(TestState, GetGethTraceOptions(config), TestItem.AddressA, TestItem.AddressB, Address.Zero);
+        GethLikeTxTrace trace = Execute(
                 tracer,
                 code,
                 MainnetSpecProvider.CancunActivation)
             .BuildResult();
-        const string expectedPrestateTrace = """
-{
-  "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
-    "balance": "0x0"
-  },
-  "0x942921b14f1b1c385cd7e0cc2ef7abe5598c8358": {
-    "balance": "0x0"
-  },
-  "0x0000000000000000000000000000000000000000": {
-    "balance": "0x56bc75e2d63100000"
-  },
-  "0x76e68a8696537e4141926f3e528733af9e237d69": {
-    "balance": "0xde0b6b3a7640000",
-    "code": "0x7f7f010203000000000000000000000000000000000000000000000000000000006000527f0060005260036000f3000000000000000000000000000000000000000000000060205262040506602960006000f5"
-  },
-  "0x02caaf71b895896a4d9159943eae74efb6a58238": {
-    "balance": "0x0"
-  }
-}
-""";
-        Assert.That(JsonSerializer.Serialize(prestateTrace.CustomTracerResult?.Value, SerializerOptions), Is.EqualTo(expectedPrestateTrace));
+
+        Assert.That(JsonSerializer.Serialize(trace.CustomTracerResult?.Value, SerializerOptions), Is.EqualTo(expectedTrace));
     }
 
-    [Test]
-    public void Test_PrestateTrace_Create2_DiffMode()
-    {
-        byte[] salt = { 4, 5, 6 };
-        byte[] deployedCode = { 1, 2, 3 };
-        byte[] initCode = Prepare.EvmCode
-            .ForInitOf(deployedCode).Done;
-        byte[] createCode = Prepare.EvmCode
-            .Create2(initCode, salt, 0).Done;
-        byte[] code = Prepare.EvmCode
-            .Call(TestItem.AddressC, 50000)
-            .Done;
+    private const string ExpectedExistingAccountPrestateTrace = """
+        {
+          "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
+            "balance": "0x0"
+          },
+          "0x942921b14f1b1c385cd7e0cc2ef7abe5598c8358": {
+            "balance": "0x0"
+          },
+          "0x0000000000000000000000000000000000000000": {
+            "balance": "0x56bc75e2d63100000"
+          },
+          "0x76e68a8696537e4141926f3e528733af9e237d69": {
+            "balance": "0x4563918244f40000",
+            "nonce": 1
+          }
+        }
+        """;
 
-        TestState.CreateAccount(Address.Zero, 100.Ether());
-        TestState.CreateAccount(TestItem.AddressC, 1.Ether());
-        TestState.InsertCode(TestItem.AddressC, createCode, Spec);
+    private const string ExpectedExistingAccountDiffModeTrace = """
+        {
+          "pre": {
+            "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
+              "balance": "0x0"
+            },
+            "0x942921b14f1b1c385cd7e0cc2ef7abe5598c8358": {
+              "balance": "0x0"
+            }
+          },
+          "post": {
+            "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
+              "balance": "0x56bc75e2d630fa3cc",
+              "nonce": 1
+            },
+            "0x942921b14f1b1c385cd7e0cc2ef7abe5598c8358": {
+              "balance": "0x56bc75e2d63100001",
+              "code": "0x7f00000000000000000000000076e68a8696537e4141926f3e528733af9e237d693100"
+            }
+          }
+        }
+        """;
 
-        NativePrestateTracer tracer = new(TestState, GetGethTraceOptions(DiffMode), TestItem.AddressA, TestItem.AddressB, Address.Zero);
-        GethLikeTxTrace prestateTrace = Execute(
-                tracer,
-                code,
-                MainnetSpecProvider.CancunActivation)
-            .BuildResult();
-        const string expectedPrestateTrace = """
-{
-  "pre": {
-    "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
-      "balance": "0x0"
-    },
-    "0x942921b14f1b1c385cd7e0cc2ef7abe5598c8358": {
-      "balance": "0x0"
-    },
-    "0x76e68a8696537e4141926f3e528733af9e237d69": {
-      "balance": "0xde0b6b3a7640000",
-      "code": "0x7f7f010203000000000000000000000000000000000000000000000000000000006000527f0060005260036000f3000000000000000000000000000000000000000000000060205262040506602960006000f5"
-    }
-  },
-  "post": {
-    "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
-      "balance": "0x56bc75e2d630f241c",
-      "nonce": 1
-    },
-    "0x942921b14f1b1c385cd7e0cc2ef7abe5598c8358": {
-      "balance": "0x56bc75e2d63100001",
-      "code": "0x600060006000600060007376e68a8696537e4141926f3e528733af9e237d6961c350f1"
-    },
-    "0x76e68a8696537e4141926f3e528733af9e237d69": {
-      "nonce": 1
-    },
-    "0x02caaf71b895896a4d9159943eae74efb6a58238": {
-      "nonce": 1,
-      "code": "0x010203"
-    }
-  }
-}
-""";
-        Assert.That(JsonSerializer.Serialize(prestateTrace.CustomTracerResult?.Value, SerializerOptions), Is.EqualTo(expectedPrestateTrace));
-    }
-
-    [Test]
-    public void Test_PrestateTrace_ExistingAccount()
+    [TestCase(NoConfig, ExpectedExistingAccountPrestateTrace)]
+    [TestCase(PrestateMode, ExpectedExistingAccountPrestateTrace)]
+    [TestCase(DiffMode, ExpectedExistingAccountDiffModeTrace)]
+    public void Test_PrestateTrace_ExistingAccount(string? config, string expectedTrace)
     {
         TestState.CreateAccount(Address.Zero, 100.Ether());
         TestState.CreateAccount(TestItem.AddressC, 5.Ether());
         TestState.IncrementNonce(TestItem.AddressC);
 
-        NativePrestateTracer tracer = new(TestState, GetGethTraceOptions(), TestItem.AddressA, TestItem.AddressB, Address.Zero);
-        GethLikeTxTrace prestateTrace = Execute(
+        NativePrestateTracer tracer = new(TestState, GetGethTraceOptions(config), TestItem.AddressA, TestItem.AddressB, Address.Zero);
+        GethLikeTxTrace trace = Execute(
                 tracer,
                 Balance,
                 MainnetSpecProvider.CancunActivation)
             .BuildResult();
-        const string expectedPrestateTrace = """
-{
-  "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
-    "balance": "0x0"
-  },
-  "0x942921b14f1b1c385cd7e0cc2ef7abe5598c8358": {
-    "balance": "0x0"
-  },
-  "0x0000000000000000000000000000000000000000": {
-    "balance": "0x56bc75e2d63100000"
-  },
-  "0x76e68a8696537e4141926f3e528733af9e237d69": {
-    "balance": "0x4563918244f40000",
-    "nonce": 1
-  }
-}
-""";
-        Assert.That(JsonSerializer.Serialize(prestateTrace.CustomTracerResult?.Value, SerializerOptions), Is.EqualTo(expectedPrestateTrace));
+
+        Assert.That(JsonSerializer.Serialize(trace.CustomTracerResult?.Value, SerializerOptions), Is.EqualTo(expectedTrace));
     }
 
-    [Test]
-    public void Test_PrestateTrace_ExistingAccount_DiffMode()
+    private const string ExpectedEmptyToPrestateTrace = """
+        {
+          "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
+            "balance": "0x0"
+          },
+          "0x24cd2edba056b7c654a50e8201b619d4f624fdda": {
+            "balance": "0x0"
+          },
+          "0x0000000000000000000000000000000000000000": {
+            "balance": "0x56bc75e2d63100000"
+          },
+          "0x76e68a8696537e4141926f3e528733af9e237d69": {
+            "balance": "0x0"
+          }
+        }
+        """;
+
+    private const string ExpectedEmptyToDiffModeTrace = """
+        {
+          "pre": {
+            "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
+              "balance": "0x0"
+            }
+          },
+          "post": {
+            "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
+              "balance": "0x56bc75e2d630fa3cc",
+              "nonce": 1
+            }
+          }
+        }
+        """;
+
+    [TestCase(NoConfig, ExpectedEmptyToPrestateTrace)]
+    [TestCase(PrestateMode, ExpectedEmptyToPrestateTrace)]
+    [TestCase(DiffMode, ExpectedEmptyToDiffModeTrace)]
+    public void Test_PrestateTrace_EmptyTo(string? config, string expectedTrace)
     {
         TestState.CreateAccount(Address.Zero, 100.Ether());
-        TestState.CreateAccount(TestItem.AddressC, 5.Ether());
-        TestState.IncrementNonce(TestItem.AddressC);
 
-        NativePrestateTracer tracer = new(TestState, GetGethTraceOptions(DiffMode), TestItem.AddressA, TestItem.AddressB, Address.Zero);
-        GethLikeTxTrace prestateTrace = Execute(
+        NativePrestateTracer tracer = new(TestState, GetGethTraceOptions(config), TestItem.AddressA, null, Address.Zero);
+        GethLikeTxTrace trace = Execute(
                 tracer,
                 Balance,
                 MainnetSpecProvider.CancunActivation)
             .BuildResult();
-        const string expectedPrestateTrace = """
-{
-  "pre": {
-    "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
-      "balance": "0x0"
-    },
-    "0x942921b14f1b1c385cd7e0cc2ef7abe5598c8358": {
-      "balance": "0x0"
-    }
-  },
-  "post": {
-    "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
-      "balance": "0x56bc75e2d630fa3cc",
-      "nonce": 1
-    },
-    "0x942921b14f1b1c385cd7e0cc2ef7abe5598c8358": {
-      "balance": "0x56bc75e2d63100001",
-      "code": "0x7f00000000000000000000000076e68a8696537e4141926f3e528733af9e237d693100"
-    }
-  }
-}
-""";
-        Assert.That(JsonSerializer.Serialize(prestateTrace.CustomTracerResult?.Value, SerializerOptions), Is.EqualTo(expectedPrestateTrace));
+
+        Assert.That(JsonSerializer.Serialize(trace.CustomTracerResult?.Value, SerializerOptions), Is.EqualTo(expectedTrace));
     }
 
-    [Test]
-    public void Test_PrestateTrace_EmptyTo()
+    private const string ExpectedSelfDestructPrestateTrace = """
+        {
+          "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
+            "balance": "0x0"
+          },
+          "0x24cd2edba056b7c654a50e8201b619d4f624fdda": {
+            "balance": "0x0"
+          },
+          "0x0000000000000000000000000000000000000000": {
+            "balance": "0x56bc75e2d63100000"
+          },
+          "0x76e68a8696537e4141926f3e528733af9e237d69": {
+            "balance": "0x0"
+          }
+        }
+        """;
+
+    private const string ExpectedSelfDestructDiffModeTrace = """
+        {
+          "pre": {
+            "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
+              "balance": "0x0"
+            },
+            "0x76e68a8696537e4141926f3e528733af9e237d69": {
+              "balance": "0x0"
+            }
+          },
+          "post": {
+            "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
+              "balance": "0x56bc75e2d630f2e9c",
+              "nonce": 1
+            }
+          }
+        }
+        """;
+
+    [TestCase(NoConfig, ExpectedSelfDestructPrestateTrace)]
+    [TestCase(PrestateMode, ExpectedEmptyToPrestateTrace)]
+    [TestCase(DiffMode, ExpectedSelfDestructDiffModeTrace)]
+    public void Test_PrestateTrace_SelfDestruct(string? config, string expectedTrace)
     {
         TestState.CreateAccount(Address.Zero, 100.Ether());
 
-        NativePrestateTracer tracer = new(TestState, GetGethTraceOptions(), TestItem.AddressA, null, Address.Zero);
-        GethLikeTxTrace prestateTrace = Execute(
-                tracer,
-                Balance,
-                MainnetSpecProvider.CancunActivation)
-            .BuildResult();
-        const string expectedPrestateTrace = """
-{
-  "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
-    "balance": "0x0"
-  },
-  "0x24cd2edba056b7c654a50e8201b619d4f624fdda": {
-    "balance": "0x0"
-  },
-  "0x0000000000000000000000000000000000000000": {
-    "balance": "0x56bc75e2d63100000"
-  },
-  "0x76e68a8696537e4141926f3e528733af9e237d69": {
-    "balance": "0x0"
-  }
-}
-""";
-        Assert.That(JsonSerializer.Serialize(prestateTrace.CustomTracerResult?.Value, SerializerOptions), Is.EqualTo(expectedPrestateTrace));
-    }
-
-    [Test]
-    public void Test_PrestateTrace_EmptyTo_DiffMode()
-    {
-        TestState.CreateAccount(Address.Zero, 100.Ether());
-
-        NativePrestateTracer tracer = new(TestState, GetGethTraceOptions(DiffMode), TestItem.AddressA, null, Address.Zero);
-        GethLikeTxTrace prestateTrace = Execute(
-                tracer,
-                Balance,
-                MainnetSpecProvider.CancunActivation)
-            .BuildResult();
-        const string expectedPrestateTrace = """
-{
-  "pre": {
-    "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
-      "balance": "0x0"
-    }
-  },
-  "post": {
-    "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
-      "balance": "0x56bc75e2d630fa3cc",
-      "nonce": 1
-    }
-  }
-}
-""";
-        Assert.That(JsonSerializer.Serialize(prestateTrace.CustomTracerResult?.Value, SerializerOptions), Is.EqualTo(expectedPrestateTrace));
-    }
-
-    [Test]
-    public void Test_PrestateTrace_SelfDestruct()
-    {
-        TestState.CreateAccount(Address.Zero, 100.Ether());
-
-        NativePrestateTracer tracer = new(TestState, GetGethTraceOptions(), TestItem.AddressA, null, Address.Zero);
-        GethLikeTxTrace prestateTrace = Execute(
+        NativePrestateTracer tracer = new(TestState, GetGethTraceOptions(config), TestItem.AddressA, null, Address.Zero);
+        GethLikeTxTrace trace = Execute(
                 tracer,
                 SelfDestruct,
                 MainnetSpecProvider.CancunActivation)
             .BuildResult();
-        const string expectedPrestateTrace = """
-{
-  "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
-    "balance": "0x0"
-  },
-  "0x24cd2edba056b7c654a50e8201b619d4f624fdda": {
-    "balance": "0x0"
-  },
-  "0x0000000000000000000000000000000000000000": {
-    "balance": "0x56bc75e2d63100000"
-  },
-  "0x76e68a8696537e4141926f3e528733af9e237d69": {
-    "balance": "0x0"
-  }
-}
-""";
-        Assert.That(JsonSerializer.Serialize(prestateTrace.CustomTracerResult?.Value, SerializerOptions), Is.EqualTo(expectedPrestateTrace));
-    }
 
-    [Test]
-    public void Test_PrestateTrace_SelfDestruct_DiffMode()
-    {
-        TestState.CreateAccount(Address.Zero, 100.Ether());
-
-        NativePrestateTracer tracer = new(TestState, GetGethTraceOptions(DiffMode), TestItem.AddressA, null, Address.Zero);
-        GethLikeTxTrace prestateTrace = Execute(
-                tracer,
-                SelfDestruct,
-                MainnetSpecProvider.CancunActivation)
-            .BuildResult();
-        const string expectedPrestateTrace = """
-{
-  "pre": {
-    "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
-      "balance": "0x0"
-    },
-    "0x76e68a8696537e4141926f3e528733af9e237d69": {
-      "balance": "0x0"
-    }
-  },
-  "post": {
-    "0xb7705ae4c6f81b66cdb323c65f4e8133690fc099": {
-      "balance": "0x56bc75e2d630f2e9c",
-      "nonce": 1
-    }
-  }
-}
-""";
-        Assert.That(JsonSerializer.Serialize(prestateTrace.CustomTracerResult?.Value, SerializerOptions), Is.EqualTo(expectedPrestateTrace));
+        Assert.That(JsonSerializer.Serialize(trace.CustomTracerResult?.Value, SerializerOptions), Is.EqualTo(expectedTrace));
     }
 
     private static byte[] SStore => Prepare.EvmCode

--- a/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/Custom/Native/Prestate/NativePrestateTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/Custom/Native/Prestate/NativePrestateTracer.cs
@@ -194,7 +194,8 @@ public sealed class NativePrestateTracer : GethLikeNativeTxTracer
             }
             else
             {
-                _prestate.Add(addr, new NativePrestateTracerAccount {
+                _prestate.Add(addr, new NativePrestateTracerAccount
+                {
                     Balance = UInt256.Zero
                 });
             }

--- a/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/Custom/Native/Prestate/NativePrestateTracerAccount.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/Custom/Native/Prestate/NativePrestateTracerAccount.cs
@@ -10,23 +10,20 @@ namespace Nethermind.Evm.Tracing.GethStyle.Custom.Native.Prestate;
 [JsonConverter(typeof(NativePrestateTracerAccountConverter))]
 public class NativePrestateTracerAccount
 {
-    public NativePrestateTracerAccount(UInt256 balance)
-    {
-        Balance = balance;
-    }
+    public NativePrestateTracerAccount() { }
 
-    public NativePrestateTracerAccount(UInt256 balance, UInt256 nonce, byte[]? code)
+    public NativePrestateTracerAccount(UInt256? balance, UInt256 nonce, byte[]? code)
     {
         Balance = balance;
         Nonce = nonce > 0 ? nonce : null;
         Code = code is not null && code.Length > 0 ? code : null;
     }
 
-    public UInt256 Balance { get; }
+    public UInt256? Balance { get; set; }
 
-    public UInt256? Nonce { get; }
+    public UInt256? Nonce { get; set; }
 
-    public byte[]? Code { get; }
+    public byte[]? Code { get; set; }
 
     public Dictionary<UInt256, UInt256>? Storage { get; set; }
 }

--- a/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/Custom/Native/Prestate/NativePrestateTracerAccountConverter.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/Custom/Native/Prestate/NativePrestateTracerAccountConverter.cs
@@ -18,8 +18,11 @@ public class NativePrestateTracerAccountConverter : JsonConverter<NativePrestate
             writer.WriteStartObject();
 
             ForcedNumberConversion.ForcedConversion.Value = NumberConversion.Hex;
-            writer.WritePropertyName("balance"u8);
-            JsonSerializer.Serialize(writer, value.Balance, options);
+            if (value.Balance is not null)
+            {
+                writer.WritePropertyName("balance"u8);
+                JsonSerializer.Serialize(writer, value.Balance, options);
+            }
 
             ForcedNumberConversion.ForcedConversion.Value = NumberConversion.Decimal;
             if (value.Nonce is not null)
@@ -35,7 +38,7 @@ public class NativePrestateTracerAccountConverter : JsonConverter<NativePrestate
             }
 
             ForcedNumberConversion.ForcedConversion.Value = NumberConversion.ZeroPaddedHex;
-            if (value.Storage is not null)
+            if (value.Storage is not null && value.Storage.Count > 0)
             {
                 writer.WritePropertyName("storage"u8);
                 JsonSerializer.Serialize(writer, value.Storage, options);

--- a/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/Custom/Native/Prestate/NativePrestateTracerAccountConverter.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/Custom/Native/Prestate/NativePrestateTracerAccountConverter.cs
@@ -38,7 +38,7 @@ public class NativePrestateTracerAccountConverter : JsonConverter<NativePrestate
             }
 
             ForcedNumberConversion.ForcedConversion.Value = NumberConversion.ZeroPaddedHex;
-            if (value.Storage is not null && value.Storage.Count > 0)
+            if (value.Storage?.Count > 0)
             {
                 writer.WritePropertyName("storage"u8);
                 JsonSerializer.Serialize(writer, value.Storage, options);

--- a/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/Custom/Native/Prestate/NativePrestateTracerConfig.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/Custom/Native/Prestate/NativePrestateTracerConfig.cs
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.Evm.Tracing.GethStyle.Custom.Native.Prestate;
+
+public class NativePrestateTracerConfig
+{
+    public bool DiffMode { get; init; }
+}

--- a/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/Custom/Native/Prestate/NativePrestateTracerDiffMode.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/Custom/Native/Prestate/NativePrestateTracerDiffMode.cs
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Generic;
+using Nethermind.Core;
+namespace Nethermind.Evm.Tracing.GethStyle.Custom.Native.Prestate;
+
+public class NativePrestateTracerDiffMode
+{
+    public Dictionary<AddressAsKey, NativePrestateTracerAccount> pre { get; init; }
+    public Dictionary<AddressAsKey, NativePrestateTracerAccount> post { get; init; }
+}


### PR DESCRIPTION
## Changes

- Adds a `diffMode` tracer config option to enable diff mode for the prestate tracer. In diff mode the result object will contain a pre and a post object showing any modified account fields or created/deleted accounts that occurred during the transaction execution.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No