### PR TITLE
Add mgaspersec to metrics reported to grafana

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Metrics.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Metrics.cs
@@ -15,6 +15,10 @@ namespace Nethermind.Blockchain
         [Description("Total MGas processed")]
         public static double Mgas { get; set; }
 
+        [GaugeMetric]
+        [Description("MGas processed per second")]
+        public static double MgasPerSec { get; set; }
+
         [CounterMetric]
         [Description("Total number of transactions processed")]
         public static long Transactions { get; set; }

--- a/src/Nethermind/Nethermind.Consensus/Processing/ProcessingStats.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ProcessingStats.cs
@@ -129,6 +129,8 @@ namespace Nethermind.Consensus.Processing
                     string blockGas = Evm.Metrics.BlockMinGasPrice != float.MaxValue ? $"⛽ Gas gwei: {Evm.Metrics.BlockMinGasPrice:N2} .. {whiteText}{Math.Max(Evm.Metrics.BlockMinGasPrice, Evm.Metrics.BlockEstMedianGasPrice):N2}{resetColor} ({Evm.Metrics.BlockAveGasPrice:N2}) .. {Evm.Metrics.BlockMaxGasPrice:N2}" : "";
                     string mgasColor = whiteText;
 
+                    Metrics.MgasPerSec = mgasPerSecond;
+
                     if (chunkBlocks > 1)
                     {
                         _logger.Info($"Processed   {block.Number - chunkBlocks + 1,9}...{block.Number,9} | {chunkMs,9:N2} ms  |  slot    {runMs,7:N0} ms |{blockGas}");

--- a/src/Nethermind/Nethermind.Evm/Metrics.cs
+++ b/src/Nethermind/Nethermind.Evm/Metrics.cs
@@ -16,7 +16,6 @@ public class Metrics
     [Description("Number of EVM exceptions thrown by contracts.")]
     public static long EvmExceptions { get; set; }
 
-    [CounterMetric]
     [Description("Number of SELFDESTRUCT calls.")]
     public static long SelfDestructs { get; set; }
 
@@ -32,61 +31,50 @@ public class Metrics
     [Description("Number of SSTORE opcodes executed.")]
     public static long SstoreOpcode { get; set; }
 
-    [CounterMetric]
     [Description("Number of TLOAD opcodes executed.")]
     public static long TloadOpcode { get; set; }
 
-    [CounterMetric]
     [Description("Number of TSTORE opcodes executed.")]
     public static long TstoreOpcode { get; set; }
 
-    [CounterMetric]
     [Description("Number of MCOPY opcodes executed.")]
     public static long MCopyOpcode { get; set; }
 
-    [CounterMetric]
     [Description("Number of MODEXP precompiles executed.")]
     public static long ModExpOpcode { get; set; }
 
-    [CounterMetric]
     [Description("Number of BLOCKHASH opcodes executed.")]
     public static long BlockhashOpcode { get; set; }
 
-    [CounterMetric]
     [Description("Number of BN254_MUL precompile calls.")]
     public static long Bn254MulPrecompile { get; set; }
 
-    [CounterMetric]
     [Description("Number of BN254_ADD precompile calls.")]
     public static long Bn254AddPrecompile { get; set; }
 
-    [CounterMetric]
     [Description("Number of BN254_PAIRING precompile calls.")]
     public static long Bn254PairingPrecompile { get; set; }
 
-    [CounterMetric]
     [Description("Number of EC_RECOVERY precompile calls.")]
     public static long EcRecoverPrecompile { get; set; }
 
-    [CounterMetric]
     [Description("Number of MODEXP precompile calls.")]
     public static long ModExpPrecompile { get; set; }
 
-    [CounterMetric]
     [Description("Number of RIPEMD160 precompile calls.")]
     public static long Ripemd160Precompile { get; set; }
 
-    [CounterMetric]
     [Description("Number of SHA256 precompile calls.")]
     public static long Sha256Precompile { get; set; }
 
-    [CounterMetric]
     [Description("Number of Point Evaluation precompile calls.")]
     public static long PointEvaluationPrecompile { get; set; }
 
+    [CounterMetric]
     [Description("Number of calls made to addresses without code.")]
     public static long EmptyCalls { get; set; }
 
+    [CounterMetric]
     [Description("Number of contract create calls.")]
     public static long Creates { get; set; }
     internal static long Transactions { get; set; }


### PR DESCRIPTION
With vibes around MGas/s as metric, should be reporting it to grafana

<img width="989" alt="image" src="https://github.com/NethermindEth/nethermind/assets/1142958/eab5f813-f21e-4d12-a8e3-0a3afc89fc17">


## Changes

- Add `MgasPerSec` to metrics reported to grafana
- Add some very fine grained opcodes to reporting
    - EmptyCalls (sends between EOAs)
    - Creates
- Remove some very fine grained opcodes from being reported
    - SelfDestructs (not as interesting as before deprciation)
    - TloadOpcode
    - TstoreOpcode
    - MCopyOpcode
    - ModExpOpcode
    - BlockhashOpcode
    - Bn254MulPrecompile
    - Bn254AddPrecompile
    - Bn254PairingPrecompile
    - EcRecoverPrecompile
    - ModExpPrecompile
    - Ripemd160Precompile
    - Sha256Precompile

## Types of changes

#### What types of changes does your code introduce?

- [x] New feature (a non-breaking change that adds functionality)
- [x] Breaking change (a change that causes existing functionality not to work as expected)

## Testing

#### Requires testing

- [X] No
