### PR TITLE
Less allocations for node processing

### DIFF
--- a/src/Nethermind/Nethermind.Core/Collections/ArrayPoolList.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/ArrayPoolList.cs
@@ -5,7 +5,6 @@ using System;
 using System.Buffers;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -121,6 +120,49 @@ public sealed class ArrayPoolList<T> : IList<T>, IList, IOwnedReadOnlyList<T>
     }
 
     public int Count { get; private set; } = 0;
+    public void ReduceCount(int count)
+    {
+        GuardDispose();
+        var oldCount = Count;
+        if (count == oldCount) return;
+
+        if (count > oldCount)
+        {
+            ThrowOnlyReduce(count);
+        }
+
+        Count = count;
+        if (count < _capacity / 2)
+        {
+            // Reduced to less than half of the capacity, resize the array.
+            T[] newArray = _arrayPool.Rent(count);
+            _array.AsSpan(0, count).CopyTo(newArray);
+            T[] oldArray = Interlocked.Exchange(ref _array, newArray);
+            _capacity = newArray.Length;
+            _arrayPool.Return(oldArray);
+        }
+        else if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+        {
+            // Release any references to the objects in the array that are no longer in use.
+            Array.Clear(_array, count, oldCount);
+        }
+
+        void ThrowOnlyReduce(int count)
+        {
+            throw new ArgumentException($"Count can only be reduced. {count} is larger than {Count}", nameof(count));
+        }
+    }
+
+    public void Sort(Comparison<T> comparison)
+    {
+        ArgumentNullException.ThrowIfNull(comparison);
+        GuardDispose();
+
+        if (Count > 1)
+        {
+            _array.AsSpan(0, Count).Sort(comparison);
+        }
+    }
 
     public int Capacity => _capacity;
 

--- a/src/Nethermind/Nethermind.Core/Collections/ArrayPoolList.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/ArrayPoolList.cs
@@ -5,6 +5,7 @@ using System;
 using System.Buffers;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading;

--- a/src/Nethermind/Nethermind.Network.Discovery/Lifecycle/NodeLifecycleManager.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Lifecycle/NodeLifecycleManager.cs
@@ -212,10 +212,16 @@ public class NodeLifecycleManager : INodeLifecycleManager
         NodeStats.AddNodeStatsEvent(NodeStatsEventType.DiscoveryFindNodeIn);
         RefreshNodeContactTime();
 
-        Node[] nodes = _nodeTable
-            .GetClosestNodes(msg.SearchedNodeId)
-            .Take(12) // Otherwise the payload may become too big, which is out of spec.
-            .ToArray();
+        // 12 otherwise the payload may become too big, which is out of spec.
+        var closestNodes = _nodeTable.GetClosestNodes(msg.SearchedNodeId, bucketSize: 12);
+        Node[] nodes = new Node[closestNodes.Count];
+        int count = 0;
+        foreach (Node node in closestNodes)
+        {
+            nodes[count] = node;
+            count++;
+        }
+
         SendNeighbors(nodes);
     }
 

--- a/src/Nethermind/Nethermind.Network.Discovery/RoutingTable/INodeTable.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/RoutingTable/INodeTable.cs
@@ -3,6 +3,7 @@
 
 using Nethermind.Core.Crypto;
 using Nethermind.Stats.Model;
+using static Nethermind.Network.Discovery.RoutingTable.NodeTable;
 
 namespace Nethermind.Network.Discovery.RoutingTable;
 
@@ -18,10 +19,11 @@ public interface INodeTable
     /// <summary>
     /// GetClosestNodes to MasterNode
     /// </summary>
-    IEnumerable<Node> GetClosestNodes();
+    ClosestNodesEnumerator GetClosestNodes();
 
     /// <summary>
     /// GetClosestNodes to provided Node
     /// </summary>
-    IEnumerable<Node> GetClosestNodes(byte[] nodeId);
+    ClosestNodesFromNodeEnumerator GetClosestNodes(byte[] nodeId);
+    ClosestNodesFromNodeEnumerator GetClosestNodes(byte[] nodeId, int bucketSize);
 }

--- a/src/Nethermind/Nethermind.Network.Discovery/RoutingTable/NodeBucket.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/RoutingTable/NodeBucket.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Collections;
 using System.Diagnostics;
 using Nethermind.Stats.Model;
 
@@ -28,26 +29,69 @@ public class NodeBucket
 
     public int BucketSize { get; }
 
-    public IEnumerable<NodeBucketItem> BondedItems
+    public bool AnyBondedItems()
     {
-        get
+        foreach (NodeBucketItem _ in BondedItems)
         {
-            lock (_nodeBucketLock)
+            return true;
+        }
+
+        return false;
+    }
+
+    public BondedItemsEnumerator BondedItems
+        => new(this);
+
+    public struct BondedItemsEnumerator : IEnumerator<NodeBucketItem>, IEnumerable<NodeBucketItem>
+    {
+        private NodeBucket _nodeBucket;
+        private LinkedListNode<NodeBucketItem>? _currentNode;
+        private DateTime _referenceTime;
+
+        public BondedItemsEnumerator(NodeBucket nodeBucket)
+        {
+            _nodeBucket = nodeBucket;
+            _referenceTime = DateTime.UtcNow;
+            lock (_nodeBucket._nodeBucketLock)
             {
-                LinkedListNode<NodeBucketItem>? node = _items.Last;
-                DateTime utcNow = DateTime.UtcNow;
-                while (node is not null)
+                _currentNode = nodeBucket._items.Last;
+            }
+            Current = default!;
+        }
+
+        public NodeBucketItem Current { get; private set; }
+
+        object IEnumerator.Current => Current;
+
+        public bool MoveNext()
+        {
+            lock (_nodeBucket._nodeBucketLock)
+            {
+                while (_currentNode != null)
                 {
-                    if (!node.Value.IsBonded(utcNow))
+                    if (!_currentNode.Value.IsBonded(_referenceTime))
                     {
                         break;
                     }
 
-                    yield return node.Value;
-                    node = node.Previous;
+                    Current = _currentNode.Value;
+                    _currentNode = _currentNode.Previous;
+                    return true;
                 }
             }
+            return false;
         }
+
+        public void Reset() => throw new NotSupportedException();
+
+        public readonly void Dispose() { }
+        public BondedItemsEnumerator GetEnumerator() => this;
+
+        IEnumerator<NodeBucketItem> IEnumerable<NodeBucketItem>.GetEnumerator()
+            => GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator()
+            => GetEnumerator();
     }
 
     public int BondedItemsCount

--- a/src/Nethermind/Nethermind.Network.Discovery/RoutingTable/NodeBucket.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/RoutingTable/NodeBucket.cs
@@ -56,7 +56,7 @@ public class NodeBucket
             {
                 _currentNode = nodeBucket._items.Last;
             }
-            Current = default!;
+            Current = null!;
         }
 
         public NodeBucketItem Current { get; private set; }
@@ -77,6 +77,8 @@ public class NodeBucket
                     }
                 }
             }
+
+            Current = null!;
             return false;
         }
 

--- a/src/Nethermind/Nethermind.Network.Discovery/RoutingTable/NodeBucket.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/RoutingTable/NodeBucket.cs
@@ -67,16 +67,14 @@ public class NodeBucket
         {
             lock (_nodeBucket._nodeBucketLock)
             {
-                while (_currentNode != null)
+                while (_currentNode is not null)
                 {
-                    if (!_currentNode.Value.IsBonded(_referenceTime))
-                    {
-                        break;
-                    }
-
                     Current = _currentNode.Value;
                     _currentNode = _currentNode.Previous;
-                    return true;
+                    if (Current.IsBonded(_referenceTime))
+                    {
+                        return true;
+                    }
                 }
             }
             return false;

--- a/src/Nethermind/Nethermind.Network.Discovery/RoutingTable/NodeBucket.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/RoutingTable/NodeBucket.cs
@@ -77,7 +77,7 @@ public class NodeBucket
             return false;
         }
 
-        public void Reset() => throw new NotSupportedException();
+        void IEnumerator.Reset() => throw new NotSupportedException();
 
         public void Dispose()
         {

--- a/src/Nethermind/Nethermind.Network.Discovery/RoutingTable/NodeTable.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/RoutingTable/NodeTable.cs
@@ -120,12 +120,9 @@ public class NodeTable : INodeTable
                     continue;
                 }
 
-                if (_itemEnumerator.Current.Node is not null)
-                {
-                    Current = _itemEnumerator.Current.Node;
-                    _count++;
-                    return true;
-                }
+                Current = _itemEnumerator.Current.Node!;
+                _count++;
+                return true;
             }
             return false;
         }

--- a/src/Nethermind/Nethermind.Network.Discovery/RoutingTable/NodeTable.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/RoutingTable/NodeTable.cs
@@ -85,7 +85,8 @@ public class NodeTable : INodeTable
     {
         private readonly NodeBucket[] _buckets;
         private readonly int _bucketSize;
-        private BondedItemsEnumerator? _itemEnumerator;
+        private BondedItemsEnumerator _itemEnumerator;
+        private bool _enumeratorSet;
         private int _bucketIndex;
         private int _count;
 
@@ -93,7 +94,6 @@ public class NodeTable : INodeTable
         {
             _buckets = buckets;
             _bucketSize = bucketSize;
-            _itemEnumerator = null;
             Current = null!;
             _bucketIndex = -1;
             _count = 0;
@@ -107,7 +107,7 @@ public class NodeTable : INodeTable
         {
             while (_count < _bucketSize)
             {
-                if (_itemEnumerator == null || !_itemEnumerator.Value.MoveNext())
+                if (!_enumeratorSet || !_itemEnumerator.MoveNext())
                 {
                     _bucketIndex++;
                     if (_bucketIndex >= _buckets.Length)
@@ -116,12 +116,13 @@ public class NodeTable : INodeTable
                     }
 
                     _itemEnumerator = _buckets[_bucketIndex].BondedItems.GetEnumerator();
+                    _enumeratorSet = true;
                     continue;
                 }
 
-                if (_itemEnumerator.Value.Current?.Node is not null)
+                if (_itemEnumerator.Current.Node is not null)
                 {
-                    Current = _itemEnumerator.Value.Current.Node;
+                    Current = _itemEnumerator.Current.Node;
                     _count++;
                     return true;
                 }
@@ -131,10 +132,7 @@ public class NodeTable : INodeTable
 
         public void Reset() => throw new NotSupportedException();
 
-        public void Dispose()
-        {
-            _itemEnumerator?.Dispose();
-        }
+        public void Dispose() { }
 
         public ClosestNodesEnumerator GetEnumerator() => this;
 

--- a/src/Nethermind/Nethermind.Network.Discovery/RoutingTable/NodeTable.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/RoutingTable/NodeTable.cs
@@ -105,28 +105,34 @@ public class NodeTable : INodeTable
 
         public bool MoveNext()
         {
-            while (_count < _bucketSize)
+            try
             {
-                if (!_enumeratorSet || !_itemEnumerator.MoveNext())
+                while (_count < _bucketSize)
                 {
-                    _itemEnumerator.Dispose();
-                    _bucketIndex++;
-                    if (_bucketIndex >= _buckets.Length)
+                    if (!_enumeratorSet || !_itemEnumerator.MoveNext())
                     {
-                        return false;
+                        _itemEnumerator.Dispose();
+                        _bucketIndex++;
+                        if (_bucketIndex >= _buckets.Length)
+                        {
+                            return false;
+                        }
+
+                        _itemEnumerator = _buckets[_bucketIndex].BondedItems.GetEnumerator();
+                        _enumeratorSet = true;
+                        continue;
                     }
 
-                    _itemEnumerator = _buckets[_bucketIndex].BondedItems.GetEnumerator();
-                    _enumeratorSet = true;
-                    continue;
+                    Current = _itemEnumerator.Current.Node!;
+                    _count++;
+                    return true;
                 }
-
-                Current = _itemEnumerator.Current.Node!;
-                _count++;
-                return true;
+            }
+            finally
+            {
+                _itemEnumerator.Dispose();
             }
 
-            _itemEnumerator.Dispose();
             return false;
         }
 

--- a/src/Nethermind/Nethermind.Network.Discovery/RoutingTable/NodeTable.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/RoutingTable/NodeTable.cs
@@ -109,6 +109,7 @@ public class NodeTable : INodeTable
             {
                 if (!_enumeratorSet || !_itemEnumerator.MoveNext())
                 {
+                    _itemEnumerator.Dispose();
                     _bucketIndex++;
                     if (_bucketIndex >= _buckets.Length)
                     {
@@ -124,6 +125,8 @@ public class NodeTable : INodeTable
                 _count++;
                 return true;
             }
+
+            _itemEnumerator.Dispose();
             return false;
         }
 

--- a/src/Nethermind/Nethermind.Network.Discovery/RoutingTable/NodeTable.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/RoutingTable/NodeTable.cs
@@ -136,7 +136,7 @@ public class NodeTable : INodeTable
             return false;
         }
 
-        public void Reset() => throw new NotSupportedException();
+        void IEnumerator.Reset() => throw new NotSupportedException();
 
         public void Dispose() { }
 
@@ -203,7 +203,7 @@ public class NodeTable : INodeTable
             return false;
         }
 
-        public void Reset() => throw new NotSupportedException();
+        void IEnumerator.Reset() => throw new NotSupportedException();
         public void Dispose() { }
 
         public ClosestNodesFromNodeEnumerator GetEnumerator() => this;


### PR DESCRIPTION
## Changes

- Introduce struct enumerators rather than using Linq

Addresses the following allocations
![image](https://github.com/NethermindEth/nethermind/assets/1142958/eab1b5b9-ad5d-497e-952f-f1e9b3453baf)


## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
