### PR TITLE
Reduce string allocs by networking

### DIFF
--- a/src/Nethermind/Nethermind.Network.Discovery/Lifecycle/NodeLifecycleManager.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Lifecycle/NodeLifecycleManager.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Net;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
@@ -16,6 +17,7 @@ namespace Nethermind.Network.Discovery.Lifecycle;
 
 public class NodeLifecycleManager : INodeLifecycleManager
 {
+    private readonly static IPAddress _localhost = IPAddress.Parse("127.0.0.1");
     private readonly IDiscoveryManager _discoveryManager;
     private readonly INodeTable _nodeTable;
     private readonly ILogger _logger;
@@ -190,7 +192,7 @@ public class NodeLifecycleManager : INodeLifecycleManager
 
         foreach (Node node in msg.Nodes)
         {
-            if (node.Address.Address.ToString().Contains("127.0.0.1"))
+            if (node.Address.Address == _localhost)
             {
                 if (_logger.IsTrace)
                     _logger.Trace($"Received localhost as node address from: {msg.FarPublicKey}, node: {node}");

--- a/src/Nethermind/Nethermind.Network.Enr/EnrContentKey.cs
+++ b/src/Nethermind/Nethermind.Network.Enr/EnrContentKey.cs
@@ -12,45 +12,54 @@ namespace Nethermind.Network.Enr
         /// ETH info
         /// </summary>
         public const string Eth = "eth";
+        public static ReadOnlySpan<byte> EthU8 => "eth"u8;
 
         /// <summary>
         /// Name of identity scheme, e.g. "v4"
         /// </summary>
         public const string Id = "id";
+        public static ReadOnlySpan<byte> IdU8 => "id"u8;
 
         /// <summary>
         /// IPv4 address, 4 bytes
         /// </summary>
         public const string Ip = "ip";
+        public static ReadOnlySpan<byte> IpU8 => "ip"u8;
 
         /// <summary>
         /// IPv6 address, 16 bytes
         /// </summary>
         public const string Ip6 = "ip6";
+        public static ReadOnlySpan<byte> Ip6U8 => "ip6"u8;
 
         /// <summary>
         /// Compressed secp256k1 public key, 33 bytes
         /// </summary>
         public const string Secp256K1 = "secp256k1";
+        public static ReadOnlySpan<byte> Secp256K1U8 => "secp256k1"u8;
 
         /// <summary>
         /// TCP port, big endian integer
         /// </summary>
         public const string Tcp = "tcp";
+        public static ReadOnlySpan<byte> TcpU8 => "tcp"u8;
 
         /// <summary>
         /// IPv6-specific TCP port, big endian integer
         /// </summary>
         public const string Tcp6 = "tcp6";
+        public static ReadOnlySpan<byte> Tcp6U8 => "tcp6"u8;
 
         /// <summary>
         /// UDP port, big endian integer
         /// </summary>
         public const string Udp = "udp";
+        public static ReadOnlySpan<byte> UdpU8 => "udp"u8;
 
         /// <summary>
         /// IPv6-specific UDP port, big endian integer
         /// </summary>
         public const string Udp6 = "udp6";
+        public static ReadOnlySpan<byte> Udp6U8 => "udp6"u8;
     }
 }


### PR DESCRIPTION
## Changes

- Use `IPAddress` comparision rather than string comparision
- Use ReadOnlySpan<byte> Utf8 comparision rather than materializing string
- Lazy create `Host`, `Port` strings in `Node`
- Pre-calucate common `Port` strings

Bunch of unnessary strings being created

<img width="984" alt="image" src="https://github.com/NethermindEth/nethermind/assets/1142958/fe53653e-5f0c-407c-a850-c5963989a6d2">

<img width="700" alt="image" src="https://github.com/NethermindEth/nethermind/assets/1142958/b4715c5b-72e3-452d-8f9d-b37c6d9616c1">


## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
