### PR TITLE
TxFilteringState as stack ref struct

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/TxFilterAdapter.cs
+++ b/src/Nethermind/Nethermind.Consensus/TxFilterAdapter.cs
@@ -24,7 +24,7 @@ namespace Nethermind.Consensus
             _blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
         }
 
-        public AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions txHandlingOptions)
+        public AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions txHandlingOptions)
         {
             if (tx is not GeneratedTransaction)
             {

--- a/src/Nethermind/Nethermind.TxPool/Filters/AlreadyKnownTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/AlreadyKnownTxFilter.cs
@@ -25,7 +25,7 @@ namespace Nethermind.TxPool.Filters
             _logger = logger;
         }
 
-        public AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions handlingOptions)
+        public AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions handlingOptions)
         {
             if (_hashCache.Get(tx.Hash!))
             {

--- a/src/Nethermind/Nethermind.TxPool/Filters/BalanceTooLowFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/BalanceTooLowFilter.cs
@@ -24,7 +24,7 @@ namespace Nethermind.TxPool.Filters
             _logger = logger;
         }
 
-        public AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions handlingOptions)
+        public AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions handlingOptions)
         {
             if (tx.IsFree())
             {

--- a/src/Nethermind/Nethermind.TxPool/Filters/BalanceZeroFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/BalanceZeroFilter.cs
@@ -21,7 +21,7 @@ namespace Nethermind.TxPool.Filters
             _logger = logger;
         }
 
-        public AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions handlingOptions)
+        public AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions handlingOptions)
         {
             AccountStruct account = state.SenderAccount;
             UInt256 balance = account.Balance;

--- a/src/Nethermind/Nethermind.TxPool/Filters/DeployedCodeFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/DeployedCodeFilter.cs
@@ -17,7 +17,7 @@ namespace Nethermind.TxPool.Filters
         {
             _specProvider = specProvider;
         }
-        public AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions txHandlingOptions)
+        public AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions txHandlingOptions)
         {
             return _specProvider.GetCurrentHeadSpec().IsEip3607Enabled && state.SenderAccount.HasCode
                 ? AcceptTxResult.SenderIsContract

--- a/src/Nethermind/Nethermind.TxPool/Filters/FeeTooLowFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/FeeTooLowFilter.cs
@@ -32,7 +32,7 @@ namespace Nethermind.TxPool.Filters
             _logger = logger;
         }
 
-        public AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions handlingOptions)
+        public AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions handlingOptions)
         {
             bool isLocal = (handlingOptions & TxHandlingOptions.PersistentBroadcast) != 0;
             if (isLocal)

--- a/src/Nethermind/Nethermind.TxPool/Filters/FutureNonceFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/FutureNonceFilter.cs
@@ -15,7 +15,7 @@ public class FutureNonceFilter : IIncomingTxFilter
         _txPoolConfig = txPoolConfig;
     }
 
-    public AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions txHandlingOptions)
+    public AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions txHandlingOptions)
     {
         int relevantMaxPendingTxsPerSender = (tx.SupportsBlobs
             ? _txPoolConfig.MaxPendingBlobTxsPerSender

--- a/src/Nethermind/Nethermind.TxPool/Filters/GapNonceFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/GapNonceFilter.cs
@@ -25,7 +25,7 @@ namespace Nethermind.TxPool.Filters
             _logger = logger;
         }
 
-        public AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions handlingOptions)
+        public AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions handlingOptions)
         {
             bool isLocal = (handlingOptions & TxHandlingOptions.PersistentBroadcast) != 0;
             bool nonceGapsAllowed = isLocal || !_txs.IsFull();

--- a/src/Nethermind/Nethermind.TxPool/Filters/GasLimitTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/GasLimitTxFilter.cs
@@ -24,7 +24,7 @@ namespace Nethermind.TxPool.Filters
             _configuredGasLimit = txPoolConfig.GasLimit ?? long.MaxValue;
         }
 
-        public AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions handlingOptions)
+        public AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions handlingOptions)
         {
             long gasLimit = Math.Min(_chainHeadInfoProvider.BlockGasLimit ?? long.MaxValue, _configuredGasLimit);
             if (tx.GasLimit > gasLimit)

--- a/src/Nethermind/Nethermind.TxPool/Filters/IIncomingTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/IIncomingTxFilter.cs
@@ -11,6 +11,6 @@ namespace Nethermind.TxPool.Filters
     /// </summary>
     public interface IIncomingTxFilter
     {
-        AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions txHandlingOptions);
+        AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions txHandlingOptions);
     }
 }

--- a/src/Nethermind/Nethermind.TxPool/Filters/LowNonceFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/LowNonceFilter.cs
@@ -19,7 +19,7 @@ namespace Nethermind.TxPool.Filters
             _logger = logger;
         }
 
-        public AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions handlingOptions)
+        public AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions handlingOptions)
         {
             // As we have limited number of transaction that we store in mem pool its fairly easy to fill it up with
             // high-priority garbage transactions. We need to filter them as much as possible to use the tx pool space

--- a/src/Nethermind/Nethermind.TxPool/Filters/MalformedTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/MalformedTxFilter.cs
@@ -23,7 +23,7 @@ namespace Nethermind.TxPool.Filters
             _logger = logger;
         }
 
-        public AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions txHandlingOptions)
+        public AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions txHandlingOptions)
         {
             IReleaseSpec spec = _specProvider.GetCurrentHeadSpec();
             if (!_txValidator.IsWellFormed(tx, spec, out _))

--- a/src/Nethermind/Nethermind.TxPool/Filters/NotSupportedTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/NotSupportedTxFilter.cs
@@ -20,7 +20,7 @@ internal sealed class NotSupportedTxFilter : IIncomingTxFilter
         _logger = logger;
     }
 
-    public AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions txHandlingOptions)
+    public AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions txHandlingOptions)
     {
         if (_txPoolConfig.BlobsSupport.IsDisabled() && tx.SupportsBlobs)
         {

--- a/src/Nethermind/Nethermind.TxPool/Filters/NullHashTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/NullHashTxFilter.cs
@@ -12,7 +12,7 @@ namespace Nethermind.TxPool.Filters
     /// </summary>
     internal sealed class NullHashTxFilter : IIncomingTxFilter
     {
-        public AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions handlingOptions)
+        public AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions handlingOptions)
         {
             if (tx.Hash is null)
             {

--- a/src/Nethermind/Nethermind.TxPool/Filters/NullIncomingTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/NullIncomingTxFilter.cs
@@ -11,7 +11,7 @@ namespace Nethermind.TxPool.Filters
 
         public static IIncomingTxFilter Instance { get; } = new NullIncomingTxFilter();
 
-        public AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions txHandlingOptions)
+        public AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions txHandlingOptions)
         {
             return AcceptTxResult.Accepted;
         }

--- a/src/Nethermind/Nethermind.TxPool/Filters/PriorityFeeTooLowFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/PriorityFeeTooLowFilter.cs
@@ -19,7 +19,7 @@ public class PriorityFeeTooLowFilter : IIncomingTxFilter
         _logger = logger;
     }
 
-    public AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions handlingOptions)
+    public AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions handlingOptions)
     {
         if (tx.SupportsBlobs && tx.MaxPriorityFeePerGas < _minBlobsPriorityFee)
         {

--- a/src/Nethermind/Nethermind.TxPool/Filters/TxTypeTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/TxTypeTxFilter.cs
@@ -20,7 +20,7 @@ public class TxTypeTxFilter : IIncomingTxFilter
         _blobTxs = blobTxs;
     }
 
-    public AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions txHandlingOptions)
+    public AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions txHandlingOptions)
     {
         TxDistinctSortedPool otherTxTypePool = (tx.SupportsBlobs ? _txs : _blobTxs);
         if (otherTxTypePool.ContainsBucket(tx.SenderAddress!)) // as unknownSenderFilter will run before this one

--- a/src/Nethermind/Nethermind.TxPool/Filters/UnknownSenderFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/UnknownSenderFilter.cs
@@ -21,7 +21,7 @@ namespace Nethermind.TxPool.Filters
             _logger = logger;
         }
 
-        public AcceptTxResult Accept(Transaction tx, TxFilteringState state, TxHandlingOptions handlingOptions)
+        public AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions handlingOptions)
         {
             /* We have encountered multiple transactions that do not resolve sender address properly.
              * We need to investigate what these txs are and why the sender address is resolved to null.

--- a/src/Nethermind/Nethermind.TxPool/TxFilteringState.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxFilteringState.cs
@@ -5,7 +5,7 @@ using Nethermind.Core;
 
 namespace Nethermind.TxPool;
 
-public class TxFilteringState(Transaction tx, IAccountStateProvider accounts)
+public ref struct TxFilteringState(Transaction tx, IAccountStateProvider accounts)
 {
     private AccountStruct _senderAccount;
 

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -379,7 +379,7 @@ namespace Nethermind.TxPool
 
             TxFilteringState state = new(tx, _accounts);
 
-            AcceptTxResult accepted = FilterTransactions(tx, handlingOptions, state);
+            AcceptTxResult accepted = FilterTransactions(tx, handlingOptions, ref state);
 
             if (!accepted)
             {
@@ -387,7 +387,7 @@ namespace Nethermind.TxPool
             }
             else
             {
-                accepted = AddCore(tx, state, startBroadcast);
+                accepted = AddCore(tx, ref state, startBroadcast);
                 if (accepted)
                 {
                     // Clear proper snapshot
@@ -401,12 +401,12 @@ namespace Nethermind.TxPool
             return accepted;
         }
 
-        private AcceptTxResult FilterTransactions(Transaction tx, TxHandlingOptions handlingOptions, TxFilteringState state)
+        private AcceptTxResult FilterTransactions(Transaction tx, TxHandlingOptions handlingOptions, ref TxFilteringState state)
         {
             IIncomingTxFilter[] filters = _preHashFilters;
             for (int i = 0; i < filters.Length; i++)
             {
-                AcceptTxResult accepted = filters[i].Accept(tx, state, handlingOptions);
+                AcceptTxResult accepted = filters[i].Accept(tx, ref state, handlingOptions);
 
                 if (!accepted)
                 {
@@ -418,7 +418,7 @@ namespace Nethermind.TxPool
             filters = _postHashFilters;
             for (int i = 0; i < filters.Length; i++)
             {
-                AcceptTxResult accepted = filters[i].Accept(tx, state, handlingOptions);
+                AcceptTxResult accepted = filters[i].Accept(tx, ref state, handlingOptions);
 
                 if (!accepted) return accepted;
             }
@@ -426,7 +426,7 @@ namespace Nethermind.TxPool
             return AcceptTxResult.Accepted;
         }
 
-        private AcceptTxResult AddCore(Transaction tx, TxFilteringState state, bool isPersistentBroadcast)
+        private AcceptTxResult AddCore(Transaction tx, ref TxFilteringState state, bool isPersistentBroadcast)
         {
             bool eip1559Enabled = _specProvider.GetCurrentHeadSpec().IsEip1559Enabled;
             UInt256 effectiveGasPrice = tx.CalculateEffectiveGasPrice(eip1559Enabled, _headInfo.CurrentBaseFee);


### PR DESCRIPTION
## Changes

- TxFilteringState as stack ref struct rather than allocation object per tx added to pool

Number 22 on allocations

<img width="611" alt="image" src="https://github.com/NethermindEth/nethermind/assets/1142958/844b6fd8-74b7-45fd-aa70-4419f713de64">


## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
