### PR TITLE
Only lookup from dirty nodes once

### DIFF
--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -405,9 +405,9 @@ namespace Nethermind.Trie.Pruning
             if (_pruningStrategy.PruningEnabled)
             {
                 DirtyNodesCache.Key key = new DirtyNodesCache.Key(address, nodeCommitInfo.Path, node.Keccak);
-                if (IsNodeCached(key))
+                if (_dirtyNodes.TryGetValue(in key, out TrieNode cachedNodeCopy))
                 {
-                    TrieNode cachedNodeCopy = FindCachedOrUnknown(key, false);
+                    Metrics.LoadedFromCacheNodesCount++;
                     if (!ReferenceEquals(cachedNodeCopy, node))
                     {
                         if (_logger.IsTrace) _logger.Trace($"Replacing {node} with its cached copy {cachedNodeCopy}.");


### PR DESCRIPTION
## Changes

- Only lookup from dirty nodes once, rather than looking up if exists, then relooking up value (i.e. twice)

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
