### PR TITLE
Improve TrieStore Dictionary use and Hashing

### DIFF
--- a/src/Nethermind/Nethermind.Core/Crypto/Hash256.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/Hash256.cs
@@ -68,8 +68,12 @@ namespace Nethermind.Core.Crypto
 
         public override int GetHashCode()
         {
-            uint hash = s_instanceRandom;
-            hash = BitOperations.Crc32C(hash, Unsafe.As<Vector256<byte>, ulong>(ref Unsafe.AsRef(in _bytes)));
+            return GetChainedHashCode(s_instanceRandom);
+        }
+
+        public int GetChainedHashCode(uint previousHash)
+        {
+            uint hash = BitOperations.Crc32C(previousHash, Unsafe.As<Vector256<byte>, ulong>(ref Unsafe.AsRef(in _bytes)));
             hash = BitOperations.Crc32C(hash, Unsafe.Add(ref Unsafe.As<Vector256<byte>, ulong>(ref Unsafe.AsRef(in _bytes)), 1));
             hash = BitOperations.Crc32C(hash, Unsafe.Add(ref Unsafe.As<Vector256<byte>, ulong>(ref Unsafe.AsRef(in _bytes)), 2));
             hash = BitOperations.Crc32C(hash, Unsafe.Add(ref Unsafe.As<Vector256<byte>, ulong>(ref Unsafe.AsRef(in _bytes)), 3));
@@ -135,7 +139,7 @@ namespace Nethermind.Core.Crypto
 
     [JsonConverter(typeof(Hash256Converter))]
     [DebuggerStepThrough]
-    public class Hash256 : IEquatable<Hash256>, IComparable<Hash256>
+    public sealed class Hash256 : IEquatable<Hash256>, IComparable<Hash256>
     {
         public const int Size = 32;
 

--- a/src/Nethermind/Nethermind.Trie/Pruning/ITrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ITrieStore.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Threading;
-using System.Threading.Tasks;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 
@@ -14,7 +13,7 @@ namespace Nethermind.Trie.Pruning
     /// </summary>
     public interface ITrieStore : IDisposable
     {
-        void CommitNode(long blockNumber, Hash256? address, NodeCommitInfo nodeCommitInfo, WriteFlags writeFlags = WriteFlags.None);
+        void CommitNode(long blockNumber, Hash256? address, in NodeCommitInfo nodeCommitInfo, WriteFlags writeFlags = WriteFlags.None);
 
         void FinishBlockCommit(TrieType trieType, long blockNumber, Hash256? address, TrieNode? root, WriteFlags writeFlags = WriteFlags.None);
 

--- a/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ReadOnlyTrieStore.cs
@@ -39,7 +39,7 @@ namespace Nethermind.Trie.Pruning
             return new ReadOnlyTrieStore(_trieStore, nodeStore);
         }
 
-        public void CommitNode(long blockNumber, Hash256? address, NodeCommitInfo nodeCommitInfo, WriteFlags flags = WriteFlags.None) { }
+        public void CommitNode(long blockNumber, Hash256? address, in NodeCommitInfo nodeCommitInfo, WriteFlags flags = WriteFlags.None) { }
 
         public void FinishBlockCommit(TrieType trieType, long blockNumber, Hash256? address, TrieNode? root, WriteFlags flags = WriteFlags.None) { }
 

--- a/src/Nethermind/Nethermind.Trie/Pruning/TreePath.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TreePath.cs
@@ -12,6 +12,7 @@ using System.Runtime.Intrinsics;
 using Nethermind.Core.Attributes;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
+using System.Numerics;
 
 namespace Nethermind.Trie;
 
@@ -255,7 +256,7 @@ public struct TreePath
 
     public readonly bool Equals(in TreePath other)
     {
-        return Path.Equals(other.Path) && Length == other.Length;
+        return Length == other.Length && Path.Equals(in other.Path);
     }
 
     public readonly override bool Equals(object? obj)
@@ -265,7 +266,7 @@ public struct TreePath
 
     public readonly override int GetHashCode()
     {
-        return HashCode.Combine(Path, Length);
+        return (int)BitOperations.Crc32C((uint)Path.GetHashCode(), (uint)Length);
     }
 
     /// <summary>


### PR DESCRIPTION
## Changes

- seal `Hash256`
- Introduce `ValueHash256.GetChainedHashCode(uint previousHash)`; if previous hash is randomised seeded can just use that as input for next hash, rather than starting with randomised seed and then combining at end (saving 2 hash combines)
- `TreePath.Equals` check `Length` first rather than last as simpler compare
- `AddOrUpdate` on ConcurrentDictionary rather than `Contains` + set
- `ref CollectionsMarshal.GetValueRefOrAddDefault` on Dictionary rather than `ContainsKey` + set 
- Reduce some struct copying

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
