### PR TITLE
Traverse trie branches in same stack frame

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization/Trie/HealingTrieStore.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Trie/HealingTrieStore.cs
@@ -15,7 +15,7 @@ namespace Nethermind.Synchronization.Trie;
 /// <summary>
 /// Trie store that can recover from network using eth63-eth66 protocol and GetNodeData.
 /// </summary>
-public class HealingTrieStore : TrieStore
+public sealed class HealingTrieStore : TrieStore
 {
     private ITrieNodeRecovery<IReadOnlyList<Hash256>>? _recovery;
 

--- a/src/Nethermind/Nethermind.Trie/Pruning/ScopedTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ScopedTrieStore.cs
@@ -6,7 +6,7 @@ using Nethermind.Core.Crypto;
 
 namespace Nethermind.Trie.Pruning;
 
-public class ScopedTrieStore : IScopedTrieStore
+public sealed class ScopedTrieStore : IScopedTrieStore
 {
     private ITrieStore _trieStoreImplementation;
     private readonly Hash256? _address;


### PR DESCRIPTION
## Changes

- Shrink TraverseBranch(es) method (for smaller loop body) and change to a loop as branches can go quite deep, so branches are all traversed in one method call
  - Less stack spaces setup, returned through, etc
- seal `HealingTrieStore` and `ScopedTrieStore`
- Also makes perf traces easier to evaluate as is less branching at lots of different points

Before

![image](https://github.com/NethermindEth/nethermind/assets/1142958/77b6e787-3b95-4076-8f6f-8c3e3291ebae)

After

![image](https://github.com/NethermindEth/nethermind/assets/1142958/28cb7a05-6e61-4857-9056-46954e797e3b)


Also Before (showing how deep it goes)

![image](https://github.com/NethermindEth/nethermind/assets/1142958/fe47d6ed-fa57-4d1a-9386-b62e9b8d1868)


## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No