### PR TITLE
Fix too eager dispose in js block tracing

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Tracing/GethStyleTracer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Tracing/GethStyleTracer.cs
@@ -126,9 +126,10 @@ public class GethStyleTracer : IGethStyleTracer
             _processor.Process(block, ProcessingOptions.Trace, blockTracer.WithCancellation(cancellationToken));
             return blockTracer.BuildResult().SingleOrDefault();
         }
-        finally
+        catch
         {
             blockTracer.TryDispose();
+            throw;
         }
     }
 
@@ -177,9 +178,10 @@ public class GethStyleTracer : IGethStyleTracer
             _processor.Process(block, ProcessingOptions.Trace, tracer.WithCancellation(cancellationToken));
             return tracer.BuildResult().SingleOrDefault();
         }
-        finally
+        catch
         {
             tracer.TryDispose();
+            throw;
         }
     }
 
@@ -212,9 +214,10 @@ public class GethStyleTracer : IGethStyleTracer
             _processor.Process(block, ProcessingOptions.Trace, tracer.WithCancellation(cancellationToken));
             return tracer.BuildResult();
         }
-        finally
+        catch
         {
             tracer.TryDispose();
+            throw;
         }
     }
 

--- a/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/Custom/JavaScript/GethLikeBlockJavaScriptTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/Custom/JavaScript/GethLikeBlockJavaScriptTracer.cs
@@ -20,7 +20,7 @@ public class GethLikeBlockJavaScriptTracer : BlockTracerBase<GethLikeTxTrace, Ge
     private readonly Context _ctx;
     private readonly Db _db;
     private int _index;
-    private ArrayPoolList<IDisposable>? _engines;
+    private List<IDisposable>? _engines;
     private UInt256 _baseFee;
 
     public GethLikeBlockJavaScriptTracer(IWorldState worldState, IReleaseSpec spec, GethTraceOptions options) : base(options.TxHash)
@@ -33,7 +33,7 @@ public class GethLikeBlockJavaScriptTracer : BlockTracerBase<GethLikeTxTrace, Ge
 
     public override void StartNewBlockTrace(Block block)
     {
-        _engines = new ArrayPoolList<IDisposable>(block.Transactions.Length + 1);
+        _engines = new List<IDisposable>(block.Transactions.Length + 1);
         _ctx.block = block.Number;
         _ctx.BlockHash = block.Hash;
         _baseFee = block.BaseFeePerGas;
@@ -75,11 +75,10 @@ public class GethLikeBlockJavaScriptTracer : BlockTracerBase<GethLikeTxTrace, Ge
     protected override GethLikeTxTrace OnEnd(GethLikeJavaScriptTxTracer txTracer) => txTracer.BuildResult();
     public void Dispose()
     {
-        ArrayPoolList<IDisposable>? list = Interlocked.Exchange(ref _engines, null);
+        List<IDisposable>? list = Interlocked.Exchange(ref _engines, null);
         if (list is not null)
         {
             list.ForEach(e => e.Dispose());
-            list.Dispose();
         }
     }
 }

--- a/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/Custom/JavaScript/GethLikeJavaScriptTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/GethStyle/Custom/JavaScript/GethLikeJavaScriptTxTracer.cs
@@ -59,7 +59,7 @@ public sealed class GethLikeJavaScriptTxTracer : GethLikeTxTracer, ITxTracer
     public override GethLikeTxTrace BuildResult()
     {
         GethLikeTxTrace result = base.BuildResult();
-        result.CustomTracerResult = new GethLikeCustomTrace() { Value = _tracer.result(_ctx, _db) };
+        result.CustomTracerResult = new GethLikeCustomTrace { Value = _tracer.result(_ctx, _db) };
         _resultConstructed = true;
         return result;
     }


### PR DESCRIPTION
## Changes

- Makes engine dispose lazy on serialization, fixing the issue it was disposed too eagerly introduced in #6929
- Disposes engines on exception
- Removes ArrayPool as it is hard to dispose it just in the right time

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

@natebeauregard can you test it?