### PR TITLE
Don't use tracing for non-traced rpc calls

### DIFF
--- a/src/Nethermind/Nethermind.Evm/Tracing/CancellationTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/CancellationTxTracer.cs
@@ -37,6 +37,7 @@ public class CancellationTxTracer : ITxTracer, ITxTracerWrapper
         _token = token;
     }
 
+    public bool IsCancelable => true;
     public bool IsCancelled => _token.IsCancellationRequested;
 
     public bool IsTracingReceipt

--- a/src/Nethermind/Nethermind.Evm/Tracing/CancellationTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/CancellationTxTracer.cs
@@ -37,6 +37,8 @@ public class CancellationTxTracer : ITxTracer, ITxTracerWrapper
         _token = token;
     }
 
+    public bool IsCancelled => _token.IsCancellationRequested;
+
     public bool IsTracingReceipt
     {
         get => _isTracingReceipt || _innerTracer.IsTracingReceipt;

--- a/src/Nethermind/Nethermind.Evm/Tracing/ITxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/ITxTracer.cs
@@ -12,6 +12,7 @@ namespace Nethermind.Evm.Tracing;
 
 public interface ITxTracer : IWorldStateTracer, IDisposable
 {
+    bool IsCancelled => false;
     /// <summary>
     /// Defines whether MarkAsSuccess or MarkAsFailed will be called
     /// </summary>

--- a/src/Nethermind/Nethermind.Evm/Tracing/ITxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/ITxTracer.cs
@@ -12,6 +12,7 @@ namespace Nethermind.Evm.Tracing;
 
 public interface ITxTracer : IWorldStateTracer, IDisposable
 {
+    bool IsCancelable => false;
     bool IsCancelled => false;
     /// <summary>
     /// Defines whether MarkAsSuccess or MarkAsFailed will be called

--- a/src/Nethermind/Nethermind.Evm/Tracing/TracerExtensions.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/TracerExtensions.cs
@@ -7,17 +7,9 @@ namespace Nethermind.Evm.Tracing;
 
 public static class TracerExtensions
 {
-    public static CancellationTxTracer WithCancellation(this ITxTracer txTracer, CancellationToken cancellationToken, bool setDefaultCancellations = true)
+    public static CancellationTxTracer WithCancellation(this ITxTracer txTracer, CancellationToken cancellationToken)
     {
-        return !setDefaultCancellations
-            ? new(txTracer, cancellationToken)
-            : new(txTracer, cancellationToken)
-            {
-                IsTracingActions = txTracer.IsTracingActions,
-                IsTracingOpLevelStorage = txTracer.IsTracingOpLevelStorage,
-                IsTracingInstructions = txTracer.IsTracingInstructions, // a little bit costly but almost all are simple calls
-                IsTracingRefunds = txTracer.IsTracingRefunds
-            };
+        return new(txTracer, cancellationToken);
     }
 
     public static CancellationBlockTracer WithCancellation(this IBlockTracer blockTracer, CancellationToken cancellationToken) =>

--- a/src/Nethermind/Nethermind.Evm/Tracing/TracerExtensions.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/TracerExtensions.cs
@@ -13,10 +13,10 @@ public static class TracerExtensions
             ? new(txTracer, cancellationToken)
             : new(txTracer, cancellationToken)
             {
-                IsTracingActions = true,
-                IsTracingOpLevelStorage = true,
-                IsTracingInstructions = true, // a little bit costly but almost all are simple calls
-                IsTracingRefunds = true
+                IsTracingActions = txTracer.IsTracingActions,
+                IsTracingOpLevelStorage = txTracer.IsTracingOpLevelStorage,
+                IsTracingInstructions = txTracer.IsTracingInstructions, // a little bit costly but almost all are simple calls
+                IsTracingRefunds = txTracer.IsTracingRefunds
             };
     }
 

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -818,6 +818,11 @@ internal sealed class VirtualMachine<TLogger> : IVirtualMachine where TLogger : 
 #endif
             Instruction instruction = (Instruction)code[programCounter];
 
+            if (_txTracer.IsCancelled)
+            {
+                ThrowOperationCanceledException();
+            }
+
             // Evaluated to constant at compile time and code elided if not tracing
             if (typeof(TTracingInstructions) == typeof(IsTracing))
                 StartInstructionTrace(instruction, vmState, gasAvailable, programCounter, in stack);
@@ -2166,6 +2171,10 @@ internal sealed class VirtualMachine<TLogger> : IVirtualMachine where TLogger : 
         exceptionType = EvmExceptionType.AccessViolation;
     ReturnFailure:
         return GetFailureReturn<TTracingInstructions>(gasAvailable, exceptionType);
+
+        [DoesNotReturn]
+        static void ThrowOperationCanceledException() =>
+            throw new OperationCanceledException("Cancellation Requested");
     }
 
     [SkipLocalsInit]

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -810,6 +810,7 @@ internal sealed class VirtualMachine<TLogger> : IVirtualMachine where TLogger : 
         SkipInit(out StorageCell storageCell);
         object returnData;
         ZeroPaddedSpan slice;
+        bool isCancelable = _txTracer.IsCancelable;
         uint codeLength = (uint)code.Length;
         while ((uint)programCounter < codeLength)
         {
@@ -818,7 +819,7 @@ internal sealed class VirtualMachine<TLogger> : IVirtualMachine where TLogger : 
 #endif
             Instruction instruction = (Instruction)code[programCounter];
 
-            if (_txTracer.IsCancelled)
+            if (isCancelable && _txTracer.IsCancelled)
             {
                 ThrowOperationCanceledException();
             }


### PR DESCRIPTION
## Changes

- Tracing is used to allow for cancellation, however to also introduces overheads from actually capturing all the trace data, even if it just throws it away.
- Instead introduce a IsCancelled property that can be checked once per loop

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
