### PR TITLE
fix: Use dpkg instead uname to get unified arch in postinst debian script

### DIFF
--- a/scripts/deployment/ppa/debian/postinst
+++ b/scripts/deployment/ppa/debian/postinst
@@ -18,7 +18,7 @@ set -e
 
 case "$1" in
   configure)
-    arch=$(uname -m)
+    arch=$(dpkg --print-architecture)
 
     if [[ "$arch" == arm* ]]; then
       url=to_be_replaced


### PR DESCRIPTION
It seems `uname` changed what it returns doing `uname -m`. 
I'm getting `aarch64` running `uname -m` which results in wrong binary being installed when using nethermind ppa on arm64 machine.

## Changes

- use dpkg instead uname in ppa postinst debian script

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: Ubuntu packaging

## Testing

#### Requires testing

- [ ] Yes
- [x] No



