### PR TITLE
ArrayPoolList.ReduceCount clear only remaining length

### DIFF
--- a/src/Nethermind/Nethermind.Core/Collections/ArrayPoolList.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/ArrayPoolList.cs
@@ -145,7 +145,7 @@ public sealed class ArrayPoolList<T> : IList<T>, IList, IOwnedReadOnlyList<T>
         else if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
         {
             // Release any references to the objects in the array that are no longer in use.
-            Array.Clear(_array, count, oldCount);
+            Array.Clear(_array, count, oldCount - count);
         }
 
         void ThrowOnlyReduce(int count)


### PR DESCRIPTION
Resolves https://github.com/NethermindEth/nethermind/issues/6996

## Changes

- Subtract new count from old count to get length to clear

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No
