### PR TITLE
Perf PatriciaTree.Run

### DIFF
--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -530,7 +530,15 @@ namespace Nethermind.Trie
         [DebuggerStepThrough]
         public void Set(ReadOnlySpan<byte> rawKey, Rlp? value)
         {
-            Set(rawKey, value is null ? Array.Empty<byte>() : value.Bytes);
+            if (value is null)
+            {
+                Set(rawKey, in CappedArray<byte>.Empty);
+            }
+            else
+            {
+                CappedArray<byte> valueBytes = new(value.Bytes);
+                Set(rawKey, in valueBytes);
+            }
         }
 
         private ref readonly CappedArray<byte> Run(

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -542,12 +542,6 @@ namespace Nethermind.Trie
             Hash256? startRootHash = null,
             bool isNodeRead = false)
         {
-#if DEBUG
-            if (nibblesCount != updatePath.Length)
-            {
-                throw new Exception("Does it ever happen?");
-            }
-#endif
             TraverseContext traverseContext =
                 new(updatePath, ref updatePathTreePath, updateValue, isUpdate, ignoreMissingDelete, isNodeRead: isNodeRead);
 


### PR DESCRIPTION
## Changes

- Don't need to pass count as a parameter as Span is already correctly sized
- Don't need to use count parameter to slice Span as is already correcrly sized
- Use `in CappedArray<byte>.Empty` rather than `Array.Empty<byte>()` which then is coverted to `CappedArray<byte>`
- Shuffle params so pointer sized ones are before Span

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
