### PR TITLE
Remove subroutines (eip2315 withdrawn)

### DIFF
--- a/src/Nethermind/Nethermind.Benchmark/Evm/JumpDestinationsBenchmark.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Evm/JumpDestinationsBenchmark.cs
@@ -29,7 +29,7 @@ namespace Nethermind.Benchmarks.Evm
         [Benchmark]
         public bool Current()
         {
-            return _codeInfo.ValidateJump(0, false);
+            return _codeInfo.ValidateJump(0);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
@@ -177,11 +177,6 @@ namespace Nethermind.Core.Specs
         bool IsEip2200Enabled { get; }
 
         /// <summary>
-        /// Berlin subroutines -> https://github.com/ethereum/EIPs/issues/2315
-        /// </summary>
-        bool IsEip2315Enabled { get; }
-
-        /// <summary>
         /// Berlin BLS crypto precompiles
         /// </summary>
         bool IsEip2537Enabled { get; }
@@ -335,8 +330,6 @@ namespace Nethermind.Core.Specs
         public bool StaticCallEnabled => IsEip214Enabled;
 
         public bool ShiftOpcodesEnabled => IsEip145Enabled;
-
-        public bool SubroutinesEnabled => IsEip2315Enabled;
 
         public bool RevertOpcodeEnabled => IsEip140Enabled;
 

--- a/src/Nethermind/Nethermind.Evm.Test/CodeAnalysis/CodeInfoTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/CodeAnalysis/CodeInfoTests.cs
@@ -28,23 +28,7 @@ namespace Nethermind.Evm.Test.CodeAnalysis
 
             CodeInfo codeInfo = new(code);
 
-            codeInfo.ValidateJump(destination, false).Should().Be(isValid);
-        }
-
-        [TestCase(-1, false)]
-        [TestCase(0, true)]
-        [TestCase(1, false)]
-        public void Validates_when_only_begin_sub_present(int destination, bool isValid)
-        {
-            byte[] code =
-            {
-                (byte)Instruction.BEGINSUB
-            };
-
-            CodeInfo codeInfo = new(code);
-
-
-            codeInfo.ValidateJump(destination, true).Should().Be(isValid);
+            codeInfo.ValidateJump(destination).Should().Be(isValid);
         }
 
         [Test]
@@ -58,23 +42,7 @@ namespace Nethermind.Evm.Test.CodeAnalysis
 
             CodeInfo codeInfo = new(code);
 
-            codeInfo.ValidateJump(1, true).Should().BeFalse();
-            codeInfo.ValidateJump(1, false).Should().BeFalse();
-        }
-
-        [Test]
-        public void Validates_when_push_with_data_like_begin_sub()
-        {
-            byte[] code =
-            {
-                (byte)Instruction.PUSH1,
-                (byte)Instruction.BEGINSUB
-            };
-
-            CodeInfo codeInfo = new(code);
-
-            codeInfo.ValidateJump(1, true).Should().BeFalse();
-            codeInfo.ValidateJump(1, false).Should().BeFalse();
+            codeInfo.ValidateJump(1).Should().BeFalse();
         }
 
         [Test]
@@ -89,7 +57,7 @@ namespace Nethermind.Evm.Test.CodeAnalysis
 
             CodeInfo codeInfo = new(code);
 
-            codeInfo.ValidateJump(11, false).Should().BeTrue();
+            codeInfo.ValidateJump(11).Should().BeTrue();
         }
 
         [Test]
@@ -104,7 +72,7 @@ namespace Nethermind.Evm.Test.CodeAnalysis
 
             CodeInfo codeInfo = new(code);
 
-            codeInfo.ValidateJump(31, false).Should().BeTrue();
+            codeInfo.ValidateJump(31).Should().BeTrue();
         }
 
         [Test]
@@ -117,7 +85,7 @@ namespace Nethermind.Evm.Test.CodeAnalysis
 
             CodeInfo codeInfo = new(code);
 
-            codeInfo.ValidateJump(10, false).Should().BeTrue();
+            codeInfo.ValidateJump(10).Should().BeTrue();
         }
 
         [Test]
@@ -130,7 +98,7 @@ namespace Nethermind.Evm.Test.CodeAnalysis
 
             CodeInfo codeInfo = new(code);
 
-            codeInfo.ValidateJump(10, false).Should().BeFalse();
+            codeInfo.ValidateJump(10).Should().BeFalse();
         }
 
         [Test]
@@ -140,7 +108,7 @@ namespace Nethermind.Evm.Test.CodeAnalysis
 
             CodeInfo codeInfo = new(code);
 
-            codeInfo.ValidateJump(10, false).Should().BeTrue();
+            codeInfo.ValidateJump(10).Should().BeTrue();
         }
 
         [Test]
@@ -150,7 +118,7 @@ namespace Nethermind.Evm.Test.CodeAnalysis
 
             CodeInfo codeInfo = new(code);
 
-            codeInfo.ValidateJump(10, false).Should().BeFalse();
+            codeInfo.ValidateJump(10).Should().BeFalse();
         }
 
         [Test]
@@ -164,8 +132,8 @@ namespace Nethermind.Evm.Test.CodeAnalysis
 
             CodeInfo codeInfo = new(code);
 
-            codeInfo.ValidateJump(10, false).Should().BeFalse();
-            codeInfo.ValidateJump(11, false).Should().BeFalse(); // 0x5b but not JUMPDEST but data
+            codeInfo.ValidateJump(10).Should().BeFalse();
+            codeInfo.ValidateJump(11).Should().BeFalse(); // 0x5b but not JUMPDEST but data
         }
 
         [TestCase(1)]
@@ -231,15 +199,15 @@ namespace Nethermind.Evm.Test.CodeAnalysis
 
             for (i = 0; i < Vector256<byte>.Count * 2 + Vector128<byte>.Count; i++)
             {
-                codeInfo.ValidateJump(i, false).Should().BeTrue();
+                codeInfo.ValidateJump(i).Should().BeTrue();
             }
             for (; i < Vector256<byte>.Count * 3; i++)
             {
-                codeInfo.ValidateJump(i, false).Should().BeFalse();
+                codeInfo.ValidateJump(i).Should().BeFalse();
             }
             for (; i < code.Length; i++)
             {
-                codeInfo.ValidateJump(i, false).Should().BeFalse(); // Are 0x5b but not JUMPDEST but data
+                codeInfo.ValidateJump(i).Should().BeFalse(); // Are 0x5b but not JUMPDEST but data
             }
         }
     }

--- a/src/Nethermind/Nethermind.Evm.Test/InstructionTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/InstructionTests.cs
@@ -20,42 +20,5 @@ namespace Nethermind.Evm.Test
         {
             Instruction.PREVRANDAO.GetName(true, Cancun.Instance).Should().Be("PREVRANDAO");
         }
-
-        [Test]
-        public void Return_tload_name_for_beginsub_opcode_for_eip1153()
-        {
-            Instruction.BEGINSUB.GetName(true, Cancun.Instance).Should().Be("TLOAD");
-        }
-
-        [Test]
-        public void Return_beginsub_name_for_beginsub_opcode_for_eip1153()
-        {
-            Instruction.BEGINSUB.GetName(true, Shanghai.Instance).Should().Be("BEGINSUB");
-        }
-
-        [Test]
-        public void Return_returnsub_name_for_returnsub_opcode_for_eip1153()
-        {
-            Instruction.RETURNSUB.GetName(true, Shanghai.Instance).Should().Be("RETURNSUB");
-        }
-
-        [Test]
-        public void Return_tstore_name_for_returnsub_opcode_for_eip1153()
-        {
-            Instruction.RETURNSUB.GetName(true, Cancun.Instance).Should().Be("TSTORE");
-        }
-
-
-        [Test]
-        public void Return_mcopy_name_for_mcopy_opcode_post_eip_5656()
-        {
-            Instruction.MCOPY.GetName(true, Cancun.Instance).Should().Be("MCOPY");
-        }
-
-        [Test]
-        public void Return_jumpsub_name_for_mcopy_opcode_pre_eip_5656()
-        {
-            Instruction.MCOPY.GetName(true, Shanghai.Instance).Should().Be("JUMPSUB");
-        }
     }
 }

--- a/src/Nethermind/Nethermind.Evm/ByteCodeBuilderExtensions.cs
+++ b/src/Nethermind/Nethermind.Evm/ByteCodeBuilderExtensions.cs
@@ -101,10 +101,6 @@ namespace Nethermind.Evm
             => @this.Op(Instruction.SWAP1 + i - 1);
         public static Prepare DUPx(this Prepare @this, byte i)
             => @this.Op(Instruction.DUP1 + i - 1);
-        public static Prepare BEGINSUB(this Prepare @this)
-            => @this.Op(Instruction.BEGINSUB);
-        public static Prepare RETURNSUB(this Prepare @this)
-            => @this.Op(Instruction.RETURNSUB);
         public static Prepare INVALID(this Prepare @this)
             => @this.Op(Instruction.INVALID);
         #endregion
@@ -116,9 +112,6 @@ namespace Nethermind.Evm
         public static Prepare EXTCODEHASH(this Prepare @this, Address? address = null)
             => @this.PushSingle(address)
                     .Op(Instruction.EXTCODEHASH);
-        public static Prepare JUMPSUB(this Prepare @this, UInt256? pos = null)
-            => @this.PushSingle(pos)
-                    .Op(Instruction.JUMPSUB);
         public static Prepare PUSHx(this Prepare @this, byte[] args)
             => @this.PushData(args);
         public static Prepare MLOAD(this Prepare @this, UInt256? pos = null)

--- a/src/Nethermind/Nethermind.Evm/CodeAnalysis/CodeInfo.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeAnalysis/CodeInfo.cs
@@ -37,9 +37,9 @@ namespace Nethermind.Evm.CodeAnalysis
             _analyzer = _emptyAnalyzer;
         }
 
-        public bool ValidateJump(int destination, bool isSubroutine)
+        public bool ValidateJump(int destination)
         {
-            return _analyzer.ValidateJump(destination, isSubroutine);
+            return _analyzer.ValidateJump(destination);
         }
 
         void IThreadPoolWorkItem.Execute()

--- a/src/Nethermind/Nethermind.Evm/CodeAnalysis/JumpDestinationAnalyzer.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeAnalysis/JumpDestinationAnalyzer.cs
@@ -11,10 +11,9 @@ namespace Nethermind.Evm.CodeAnalysis
 {
     public sealed class JumpDestinationAnalyzer(ReadOnlyMemory<byte> code)
     {
-        private const int PUSH1 = 0x60;
+        private const int PUSH1 = (int)Instruction.PUSH1;
         private const int PUSHx = PUSH1 - 1;
-        private const int JUMPDEST = 0x5b;
-        private const int BEGINSUB = 0x5c;
+        private const int JUMPDEST = (int)Instruction.JUMPDEST;
         private const int BitShiftPerInt64 = 6;
 
         private static readonly long[]? _emptyJumpDestinationBitmap = new long[1];
@@ -22,23 +21,15 @@ namespace Nethermind.Evm.CodeAnalysis
 
         private ReadOnlyMemory<byte> MachineCode { get; } = code;
 
-        public bool ValidateJump(int destination, bool isSubroutine)
+        public bool ValidateJump(int destination)
         {
             ReadOnlySpan<byte> machineCode = MachineCode.Span;
             _jumpDestinationBitmap ??= CreateJumpDestinationBitmap(machineCode);
 
-            var result = false;
             // Cast to uint to change negative numbers to very int high numbers
             // Then do length check, this both reduces check by 1 and eliminates the bounds
             // check from accessing the span.
-            if ((uint)destination < (uint)machineCode.Length && IsJumpDestination(_jumpDestinationBitmap, destination))
-            {
-                // Store byte to int, as less expensive operations at word size
-                int codeByte = machineCode[destination];
-                result = isSubroutine ? codeByte == BEGINSUB : codeByte == JUMPDEST;
-            }
-
-            return result;
+            return (uint)destination < (uint)machineCode.Length && IsJumpDestination(_jumpDestinationBitmap, destination);
         }
 
         /// <summary>
@@ -90,12 +81,8 @@ namespace Nethermind.Evm.CodeAnalysis
                     {
                         // Check the bytes for any JUMPDESTs.
                         Vector128<sbyte> dest = Sse2.CompareEqual(data, Vector128.Create((sbyte)JUMPDEST));
-                        // Check the bytes for any BEGINSUBs.
-                        Vector128<sbyte> sub = Sse2.CompareEqual(data, Vector128.Create((sbyte)BEGINSUB));
-                        // Merge the two results.
-                        Vector128<sbyte> combined = Sse2.Or(dest, sub);
                         // Extract the checks as a set of int flags.
-                        int flags = Sse2.MoveMask(combined);
+                        int flags = Sse2.MoveMask(dest);
                         // Shift up flags by depending which side of long we are on, and merge to current set.
                         currentFlags |= (long)flags << (programCounter & (32 + 16));
                         // Forward programCounter by Vector128 stride.
@@ -110,7 +97,7 @@ namespace Nethermind.Evm.CodeAnalysis
                 // access here.
                 int op = Unsafe.Add(ref MemoryMarshal.GetReference(code), programCounter);
 
-                if ((uint)op - JUMPDEST <= BEGINSUB - JUMPDEST)
+                if (op == JUMPDEST)
                 {
                     // Accumulate Jump Destinations to register, shift will wrap and single bit
                     // so can shift by the whole programCounter.

--- a/src/Nethermind/Nethermind.Evm/Instruction.cs
+++ b/src/Nethermind/Nethermind.Evm/Instruction.cs
@@ -81,9 +81,6 @@ namespace Nethermind.Evm
         MSIZE = 0x59,
         GAS = 0x5a,
         JUMPDEST = 0x5b,
-        BEGINSUB = 0x5c,
-        RETURNSUB = 0x5d,
-        JUMPSUB = 0x5e,
         MCOPY = 0x5e,
 
         PUSH0 = 0x5f, // EIP-3855
@@ -182,9 +179,6 @@ namespace Nethermind.Evm
             instruction switch
             {
                 Instruction.PREVRANDAO when !isPostMerge => "DIFFICULTY",
-                Instruction.TLOAD or Instruction.BEGINSUB => spec?.TransientStorageEnabled == true ? "TLOAD" : "BEGINSUB",
-                Instruction.TSTORE or Instruction.RETURNSUB => spec?.TransientStorageEnabled == true ? "TSTORE" : "RETURNSUB",
-                Instruction.JUMPSUB or Instruction.MCOPY => spec?.IsEip5656Enabled == true ? "MCOPY" : "JUMPSUB",
                 _ => FastEnum.IsDefined(instruction) ? FastEnum.GetName(instruction) : null
             };
     }

--- a/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecBasedSpecProviderTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecBasedSpecProviderTests.cs
@@ -771,7 +771,6 @@ public class ChainSpecBasedSpecProviderTests
         TestTransitions((ForkActivation)20280L, r => { r.IsEip2028Enabled = true; });
         TestTransitions((ForkActivation)22000L, r => { r.IsEip2200Enabled = true; });
         TestTransitions((ForkActivation)23000L, r => { r.IsEip1283Enabled = r.IsEip1344Enabled = true; });
-        TestTransitions((ForkActivation)24000L, r => { r.IsEip2315Enabled = r.ValidateChainId = r.ValidateReceipts = true; });
         TestTransitions((ForkActivation)29290L, r => { r.IsEip2929Enabled = r.IsEip2565Enabled = true; });
         TestTransitions((ForkActivation)29300L, r => { r.IsEip2930Enabled = true; });
         TestTransitions((ForkActivation)31980L, r => { r.IsEip3198Enabled = true; });

--- a/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecBasedSpecProviderTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecBasedSpecProviderTests.cs
@@ -772,6 +772,7 @@ public class ChainSpecBasedSpecProviderTests
         TestTransitions((ForkActivation)22000L, r => { r.IsEip2200Enabled = true; });
         TestTransitions((ForkActivation)23000L, r => { r.IsEip1283Enabled = r.IsEip1344Enabled = true; });
         TestTransitions((ForkActivation)29290L, r => { r.IsEip2929Enabled = r.IsEip2565Enabled = true; });
+        TestTransitions((ForkActivation)24000L, r => { r.ValidateChainId = r.ValidateReceipts = true; });
         TestTransitions((ForkActivation)29300L, r => { r.IsEip2930Enabled = true; });
         TestTransitions((ForkActivation)31980L, r => { r.IsEip3198Enabled = true; });
         TestTransitions((ForkActivation)35290L, r => { r.IsEip3529Enabled = true; });

--- a/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecBasedSpecProviderTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecBasedSpecProviderTests.cs
@@ -771,8 +771,8 @@ public class ChainSpecBasedSpecProviderTests
         TestTransitions((ForkActivation)20280L, r => { r.IsEip2028Enabled = true; });
         TestTransitions((ForkActivation)22000L, r => { r.IsEip2200Enabled = true; });
         TestTransitions((ForkActivation)23000L, r => { r.IsEip1283Enabled = r.IsEip1344Enabled = true; });
-        TestTransitions((ForkActivation)29290L, r => { r.IsEip2929Enabled = r.IsEip2565Enabled = true; });
         TestTransitions((ForkActivation)24000L, r => { r.ValidateChainId = r.ValidateReceipts = true; });
+        TestTransitions((ForkActivation)29290L, r => { r.IsEip2929Enabled = r.IsEip2565Enabled = true; });
         TestTransitions((ForkActivation)29300L, r => { r.IsEip2930Enabled = true; });
         TestTransitions((ForkActivation)31980L, r => { r.IsEip3198Enabled = true; });
         TestTransitions((ForkActivation)35290L, r => { r.IsEip3529Enabled = true; });

--- a/src/Nethermind/Nethermind.Specs.Test/GoerliSpecProviderTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/GoerliSpecProviderTests.cs
@@ -16,7 +16,6 @@ namespace Nethermind.Specs.Test
         [TestCase(4_460_644, true)]
         public void Berlin_eips(long blockNumber, bool isEnabled)
         {
-            _specProvider.GetSpec((ForkActivation)blockNumber).IsEip2315Enabled.Should().Be(false);
             _specProvider.GetSpec((ForkActivation)blockNumber).IsEip2537Enabled.Should().Be(false);
             _specProvider.GetSpec((ForkActivation)blockNumber).IsEip2565Enabled.Should().Be(isEnabled);
             _specProvider.GetSpec((ForkActivation)blockNumber).IsEip2929Enabled.Should().Be(isEnabled);

--- a/src/Nethermind/Nethermind.Specs.Test/MainnetSpecProviderTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/MainnetSpecProviderTests.cs
@@ -17,7 +17,6 @@ namespace Nethermind.Specs.Test
         [TestCase(12_244_000, true)]
         public void Berlin_eips(long blockNumber, bool isEnabled)
         {
-            _specProvider.GetSpec((ForkActivation)blockNumber).IsEip2315Enabled.Should().Be(false);
             _specProvider.GetSpec((ForkActivation)blockNumber).IsEip2537Enabled.Should().Be(false);
             _specProvider.GetSpec((ForkActivation)blockNumber).IsEip2565Enabled.Should().Be(isEnabled);
             _specProvider.GetSpec((ForkActivation)blockNumber).IsEip2929Enabled.Should().Be(isEnabled);

--- a/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
@@ -97,9 +97,7 @@ namespace Nethermind.Specs.Test
 
         public bool IsEip2200Enabled => _spec.IsEip2200Enabled;
 
-        public bool IsEip2315Enabled => _spec.IsEip2315Enabled;
-
-        public bool IsEip2537Enabled => _spec.IsEip2315Enabled;
+        public bool IsEip2537Enabled => _spec.IsEip2537Enabled;
 
         public bool IsEip2565Enabled => _spec.IsEip2565Enabled;
 

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
@@ -194,7 +194,6 @@ namespace Nethermind.Specs.ChainSpecStyle
             releaseSpec.IsEip2200Enabled = (chainSpec.Parameters.Eip2200Transition ?? long.MaxValue) <= releaseStartBlock || (chainSpec.Parameters.Eip1706Transition ?? long.MaxValue) <= releaseStartBlock && releaseSpec.IsEip1283Enabled;
             releaseSpec.IsEip1559Enabled = (chainSpec.Parameters.Eip1559Transition ?? long.MaxValue) <= releaseStartBlock;
             releaseSpec.Eip1559TransitionBlock = chainSpec.Parameters.Eip1559Transition ?? long.MaxValue;
-            releaseSpec.IsEip2315Enabled = (chainSpec.Parameters.Eip2315Transition ?? long.MaxValue) <= releaseStartBlock;
             releaseSpec.IsEip2537Enabled = (chainSpec.Parameters.Eip2537Transition ?? long.MaxValue) <= releaseStartBlock ||
                                            (chainSpec.Parameters.Eip2537TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
             releaseSpec.IsEip2565Enabled = (chainSpec.Parameters.Eip2565Transition ?? long.MaxValue) <= releaseStartBlock;

--- a/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
@@ -47,7 +47,6 @@ namespace Nethermind.Specs
         public bool IsEip1108Enabled { get; set; }
         public bool IsEip1884Enabled { get; set; }
         public bool IsEip2200Enabled { get; set; }
-        public bool IsEip2315Enabled { get; set; }
         public bool IsEip2537Enabled { get; set; }
         public bool IsEip2565Enabled { get; set; }
         public bool IsEip2929Enabled { get; set; }

--- a/src/Nethermind/Nethermind.Specs/SystemTransactionReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs/SystemTransactionReleaseSpec.cs
@@ -93,9 +93,7 @@ namespace Nethermind.Specs
 
         public bool IsEip2200Enabled => _spec.IsEip2200Enabled;
 
-        public bool IsEip2315Enabled => _spec.IsEip2315Enabled;
-
-        public bool IsEip2537Enabled => _spec.IsEip2315Enabled;
+        public bool IsEip2537Enabled => _spec.IsEip2537Enabled;
 
         public bool IsEip2565Enabled => _spec.IsEip2565Enabled;
 


### PR DESCRIPTION
## Changes

- "[EIP-2315](https://eips.ethereum.org/EIPS/eip-2315): Simple Subroutines for the EVM" was withdrawn; is dead code now.

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
