### PR TITLE
Switch off gossiped txs during block production

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -1503,6 +1503,10 @@ namespace Nethermind.Blockchain
             if (_logger.IsTrace) _logger.Trace($"Calculated total difficulty for {header} is {header.TotalDifficulty}");
         }
 
+        public void OnBlocksProcessing(IReadOnlyList<Block> blocks) => BlocksProcessing?.Invoke(this, blocks);
+
+        public event EventHandler<IReadOnlyList<Block>>? BlocksProcessing;
+
         public event EventHandler<BlockReplacementEventArgs>? BlockAddedToMain;
 
         public event EventHandler<OnUpdateMainChainArgs>? OnUpdateMainChain;

--- a/src/Nethermind/Nethermind.Blockchain/ChainHeadInfoProvider.cs
+++ b/src/Nethermind/Nethermind.Blockchain/ChainHeadInfoProvider.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Nethermind.Blockchain.Spec;
 using Nethermind.Core;
@@ -34,6 +35,7 @@ namespace Nethermind.Blockchain
             HeadNumber = blockTree.BestKnownNumber;
 
             blockTree.BlockAddedToMain += OnHeadChanged;
+            blockTree.BlocksProcessing += OnHeadProcessing;
         }
 
         public IChainHeadSpecProvider SpecProvider { get; }
@@ -49,6 +51,7 @@ namespace Nethermind.Blockchain
         public UInt256 CurrentPricePerBlobGas { get; internal set; }
 
         public event EventHandler<BlockReplacementEventArgs>? HeadChanged;
+        public event EventHandler<IReadOnlyList<Block>>? HeadProcessing;
 
         private void OnHeadChanged(object? sender, BlockReplacementEventArgs e)
         {
@@ -61,5 +64,8 @@ namespace Nethermind.Blockchain
                     : UInt256.Zero;
             HeadChanged?.Invoke(sender, e);
         }
+
+        private void OnHeadProcessing(object? sender, IReadOnlyList<Block> blocks)
+            => HeadProcessing?.Invoke(sender, blocks);
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/IBlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/IBlockTree.cs
@@ -166,7 +166,10 @@ namespace Nethermind.Blockchain
         /// A block is marked as canon
         /// </summary>
         event EventHandler<BlockReplacementEventArgs> BlockAddedToMain;
-
+        /// <summary>
+        /// Blocks are being processed
+        /// </summary>
+        event EventHandler<IReadOnlyList<Block>> BlocksProcessing;
         /// <summary>
         /// A block is now set as head
         /// </summary>
@@ -185,5 +188,6 @@ namespace Nethermind.Blockchain
         void UpdateBeaconMainChain(BlockInfo[]? blockInfos, long clearBeaconMainChainStartPoint);
 
         void RecalculateTreeLevels();
+        void OnBlocksProcessing(IReadOnlyList<Block> blocks);
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/ReadOnlyBlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/ReadOnlyBlockTree.cs
@@ -10,7 +10,6 @@ using Nethermind.Blockchain.Visitors;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
-using Nethermind.Int256;
 
 namespace Nethermind.Blockchain
 {
@@ -20,10 +19,12 @@ namespace Nethermind.Blockchain
     public class ReadOnlyBlockTree : IReadOnlyBlockTree
     {
         private readonly IBlockTree _wrapped;
+        public event EventHandler<IReadOnlyList<Block>> BlocksProcessing;
 
         public ReadOnlyBlockTree(IBlockTree wrapped)
         {
             _wrapped = wrapped;
+            _wrapped.BlocksProcessing += (e, blocks) => OnBlocksProcessing(blocks);
         }
 
         public ulong NetworkId => _wrapped.NetworkId;
@@ -197,5 +198,7 @@ namespace Nethermind.Blockchain
         public void UpdateMainChain(IReadOnlyList<Block> blocks, bool wereProcessed, bool forceHeadBlock = false) => throw new InvalidOperationException($"{nameof(ReadOnlyBlockTree)} does not expect {nameof(UpdateMainChain)} calls");
 
         public void ForkChoiceUpdated(Hash256? finalizedBlockHash, Hash256? safeBlockBlockHash) => throw new InvalidOperationException($"{nameof(ReadOnlyBlockTree)} does not expect {nameof(ForkChoiceUpdated)} calls");
+
+        public void OnBlocksProcessing(IReadOnlyList<Block> blocks) => BlocksProcessing?.Invoke(this, blocks);
     }
 }

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
@@ -386,6 +386,7 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
 
         ProcessingBranch processingBranch = PrepareProcessingBranch(suggestedBlock, options);
         PrepareBlocksToProcess(suggestedBlock, options, processingBranch);
+        _blockTree.OnBlocksProcessing(processingBranch.Blocks);
 
         _stopwatch.Restart();
         Block[]? processedBlocks = ProcessBranch(processingBranch, options, tracer, out error);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandler.cs
@@ -64,7 +64,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
         public override int MessageIdSpaceSize => 8;
         public override string Name => "eth62";
         protected override TimeSpan InitTimeout => Timeouts.Eth62Status;
-        protected bool CanReceiveTransactions => _txGossipPolicy.ShouldListenToGossipedTransactions;
+        protected bool CanReceiveTransactions => _txGossipPolicy.ShouldListenToGossipedTransactions && _txPool.IsAcceptingTxs;
 
         public override event EventHandler<ProtocolInitializedEventArgs>? ProtocolInitialized;
 

--- a/src/Nethermind/Nethermind.TxPool/IChainHeadInfoProvider.cs
+++ b/src/Nethermind/Nethermind.TxPool/IChainHeadInfoProvider.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
+
 using Nethermind.Core;
 using Nethermind.Core.Specs;
 using Nethermind.Int256;
@@ -23,5 +25,6 @@ namespace Nethermind.TxPool
         public UInt256 CurrentPricePerBlobGas { get; }
 
         event EventHandler<BlockReplacementEventArgs> HeadChanged;
+        event EventHandler<IReadOnlyList<Block>>? HeadProcessing;
     }
 }

--- a/src/Nethermind/Nethermind.TxPool/ITxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxPool.cs
@@ -12,6 +12,8 @@ namespace Nethermind.TxPool
 {
     public interface ITxPool
     {
+        bool IsAcceptingTxs { get; }
+
         int GetPendingTransactionsCount();
         int GetPendingBlobTransactionsCount();
         Transaction[] GetPendingTransactions();

--- a/src/Nethermind/Nethermind.TxPool/NullTxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/NullTxPool.cs
@@ -15,6 +15,7 @@ namespace Nethermind.TxPool
         private NullTxPool() { }
 
         public static NullTxPool Instance { get; } = new();
+        public bool IsAcceptingTxs => true;
 
         public int GetPendingTransactionsCount() => 0;
         public int GetPendingBlobTransactionsCount() => 0;

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -379,7 +379,9 @@ namespace Nethermind.TxPool
         public AcceptTxResult SubmitTx(Transaction tx, TxHandlingOptions handlingOptions)
         {
             Metrics.PendingTransactionsReceived++;
-            if (_notAcceptingTxs && (handlingOptions & TxHandlingOptions.PersistentBroadcast) == 0)
+            if (_notAcceptingTxs &&
+                (handlingOptions & TxHandlingOptions.PersistentBroadcast) == 0 &&
+                !tx.IsSystem())
             {
                 // In block processing mode, we don't accept new transactions unless local
                 Metrics.PendingTransactionsDiscarded++;


### PR DESCRIPTION
## Changes

- Don't accept new tx for pool between Block processing starting and Forkchoice; is additional load on the State db and unknown if the txs will be valid after Forkchoice
- Also removes contention between the Block producer removing completed tx from pool and new txs being added

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [ ] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [ ] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
