### PR TITLE
Fix commit in ClientVersionV1 to have only 4 bytes of info following the spec

### DIFF
--- a/src/Nethermind/Nethermind.Core/ProductInfo.cs
+++ b/src/Nethermind/Nethermind.Core/ProductInfo.cs
@@ -4,8 +4,10 @@
 using System;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
+[assembly: InternalsVisibleTo("Nethermind.Merge.Plugin.Test")]
 namespace Nethermind.Core;
 
 public static class ProductInfo
@@ -39,7 +41,7 @@ public static class ProductInfo
 
     public static string ClientCode { get; }
 
-    public static string Commit { get; }
+    public static string Commit { get; internal set; }
 
     public static string Name { get; }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
@@ -1520,6 +1520,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task Should_return_ClientVersionV1()
     {
+        ProductInfo.Commit = "0000000000000000000000000000000000000000000000000000000000000000";
         using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpcModule = CreateEngineModule(chain);
         ResultWrapper<ClientVersionV1[]> result = rpcModule.engine_getClientVersionV1(new ClientVersionV1());

--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/ClientVersionV1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/ClientVersionV1.cs
@@ -16,7 +16,7 @@ public readonly struct ClientVersionV1
         Code = ProductInfo.ClientCode;
         Name = ProductInfo.Name;
         Version = ProductInfo.Version;
-        Commit = ProductInfo.Commit;
+        Commit = ProductInfo.Commit[..8];
     }
 
     public string Code { get; }


### PR DESCRIPTION
Following spec here: https://github.com/ethereum/execution-apis/blob/main/src/engine/identification.md

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No
