### PR TITLE
Add custom runner for Holesky and SnapSync for chiado

### DIFF
--- a/.github/workflows/sync-testnets.yml
+++ b/.github/workflows/sync-testnets.yml
@@ -22,7 +22,7 @@ jobs:
             checkpoint-sync-url: "https://holesky.beaconstate.ethstaker.cc/"
             cl-client: "lighthouse:sigp/lighthouse:latest"
             el-client: "nethermind:nethermindeth/nethermind:master"
-            agent: ubuntu-latest
+            agent: sync-agent-80gb
           - network: "chiado"
             checkpoint-sync-url: "http://139.144.26.89:4000/"
             cl-client: "lighthouse:sigp/lighthouse:latest"
@@ -82,6 +82,7 @@ jobs:
           --el-extra-flag Sync.NonValidatorNode=true --el-extra-flag Sync.DownloadBodiesInFastSync=false \
           --el-extra-flag Sync.DownloadReceiptsInFastSync=false \
           --el-extra-flag JsonRpc.EnabledModules=[Eth,Subscribe,Trace,TxPool,Web3,Personal,Proof,Net,Parity,Health,Rpc,Debug] \
+          --el-extra-flag Sync.SnapSync=true \
           --checkpoint-sync-url=${{ matrix.checkpoint-sync-url }}
           echo 'Running sedge...'
           ./build/sedge run -p $GITHUB_WORKSPACE/sedge


### PR DESCRIPTION
Add custom runner for Holesky as it grew above limits of GH hosted runner and add SnapSync capability for chiado to speed up sync.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [X] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [X] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No