### PR TITLE
Only recalculate storage roots once per block

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
@@ -249,7 +249,7 @@ public partial class BlockProcessor : IBlockProcessor
         _withdrawalProcessor.ProcessWithdrawals(block, spec);
         ReceiptsTracer.EndBlockTrace();
 
-        _stateProvider.Commit(spec);
+        _stateProvider.PostCommit(spec);
 
         if (ShouldComputeStateRoot(block.Header))
         {

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
@@ -235,7 +235,7 @@ public partial class BlockProcessor : IBlockProcessor
         _beaconBlockRootHandler.ApplyContractStateChanges(block, spec, _stateProvider);
         _blockhashStore.ApplyHistoryBlockHashes(block.Header);
 
-        _stateProvider.Commit(spec);
+        _stateProvider.Commit(spec, commitStorageRoots: false);
 
         TxReceipt[] receipts = _blockTransactionsExecutor.ProcessTransactions(block, options, ReceiptsTracer, spec);
 
@@ -249,7 +249,7 @@ public partial class BlockProcessor : IBlockProcessor
         _withdrawalProcessor.ProcessWithdrawals(block, spec);
         ReceiptsTracer.EndBlockTrace();
 
-        _stateProvider.PostCommit(spec);
+        _stateProvider.Commit(spec, commitStorageRoots: true);
 
         if (ShouldComputeStateRoot(block.Header))
         {

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -125,7 +125,7 @@ namespace Nethermind.Evm.TransactionProcessing
             if (!(result = BuyGas(tx, header, spec, tracer, opts, effectiveGasPrice, out UInt256 premiumPerGas, out UInt256 senderReservedGasPayment))) return result;
             if (!(result = IncrementNonce(tx, header, spec, tracer, opts))) return result;
 
-            if (commit) WorldState.Commit(spec, tracer.IsTracingState ? tracer : NullTxTracer.Instance);
+            if (commit) WorldState.Commit(spec, tracer.IsTracingState ? tracer : NullTxTracer.Instance, commitStorageRoots: false);
 
             ExecutionEnvironment env = BuildExecutionEnvironment(tx, in blCtx, spec, effectiveGasPrice);
 
@@ -153,7 +153,7 @@ namespace Nethermind.Evm.TransactionProcessing
             }
             else if (commit)
             {
-                WorldState.Commit(spec, tracer.IsTracingState ? tracer : NullStateTracer.Instance);
+                WorldState.Commit(spec, tracer.IsTracingState ? tracer : NullStateTracer.Instance, commitStorageRoots: false);
             }
 
             if (tracer.IsTracingReceipt)

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -153,7 +153,7 @@ namespace Nethermind.Evm.TransactionProcessing
             }
             else if (commit)
             {
-                WorldState.Commit(spec, tracer.IsTracingState ? tracer : NullStateTracer.Instance, commitStorageRoots: false);
+                WorldState.Commit(spec, tracer.IsTracingState ? tracer : NullStateTracer.Instance, commitStorageRoots: !spec.IsEip658Enabled);
             }
 
             if (tracer.IsTracingReceipt)

--- a/src/Nethermind/Nethermind.State/IWorldState.cs
+++ b/src/Nethermind/Nethermind.State/IWorldState.cs
@@ -99,10 +99,9 @@ public interface IWorldState : IJournal<Snapshot>, IReadOnlyStateProvider
 
     /* snapshots */
 
-    void Commit(IReleaseSpec releaseSpec, bool isGenesis = false);
+    void Commit(IReleaseSpec releaseSpec, bool isGenesis = false, bool commitStorageRoots = true);
 
-    void Commit(IReleaseSpec releaseSpec, IWorldStateTracer? traver, bool isGenesis = false);
+    void Commit(IReleaseSpec releaseSpec, IWorldStateTracer? tracer, bool isGenesis = false, bool commitStorageRoots = true);
 
     void CommitTree(long blockNumber);
-    void PostCommit(IReleaseSpec releaseSpec);
 }

--- a/src/Nethermind/Nethermind.State/IWorldState.cs
+++ b/src/Nethermind/Nethermind.State/IWorldState.cs
@@ -104,4 +104,5 @@ public interface IWorldState : IJournal<Snapshot>, IReadOnlyStateProvider
     void Commit(IReleaseSpec releaseSpec, IWorldStateTracer? traver, bool isGenesis = false);
 
     void CommitTree(long blockNumber);
+    void PostCommit(IReleaseSpec releaseSpec);
 }

--- a/src/Nethermind/Nethermind.State/PartialStorageProviderBase.cs
+++ b/src/Nethermind/Nethermind.State/PartialStorageProviderBase.cs
@@ -145,18 +145,10 @@ namespace Nethermind.State
         /// <summary>
         /// Commit persistent storage
         /// </summary>
-        public void Commit()
+        public void Commit(bool commitStorageRoots = true)
         {
-            Commit(NullStateTracer.Instance);
+            Commit(NullStateTracer.Instance, commitStorageRoots);
         }
-
-        public void PostCommit()
-        {
-            Commit(NullStateTracer.Instance);
-            PostCommitStorages();
-        }
-
-        protected virtual void PostCommitStorages() { }
 
         protected readonly struct ChangeTrace
         {
@@ -180,7 +172,7 @@ namespace Nethermind.State
         /// Commit persistent storage
         /// </summary>
         /// <param name="stateTracer">State tracer</param>
-        public void Commit(IStorageTracer tracer)
+        public void Commit(IStorageTracer tracer, bool commitStorageRoots = true)
         {
             if (_currentPosition == Snapshot.EmptyPosition)
             {
@@ -190,6 +182,16 @@ namespace Nethermind.State
             {
                 CommitCore(tracer);
             }
+
+            if (commitStorageRoots)
+            {
+                CommitStorageRoots();
+            }
+        }
+
+        protected virtual void CommitStorageRoots()
+        {
+            // Commit storage roots
         }
 
         /// <summary>

--- a/src/Nethermind/Nethermind.State/PartialStorageProviderBase.cs
+++ b/src/Nethermind/Nethermind.State/PartialStorageProviderBase.cs
@@ -150,6 +150,14 @@ namespace Nethermind.State
             Commit(NullStateTracer.Instance);
         }
 
+        public void PostCommit()
+        {
+            Commit(NullStateTracer.Instance);
+            PostCommitStorages();
+        }
+
+        protected virtual void PostCommitStorages() { }
+
         protected readonly struct ChangeTrace
         {
             public ChangeTrace(byte[]? before, byte[]? after)

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
@@ -25,6 +26,7 @@ namespace Nethermind.State
         private readonly ILogManager? _logManager;
         internal readonly IStorageTreeFactory _storageTreeFactory;
         private readonly ResettableDictionary<AddressAsKey, StorageTree> _storages = new();
+        private readonly HashSet<Address> _toUpdateRoots = new();
 
         /// <summary>
         /// EIP-1283
@@ -53,6 +55,7 @@ namespace Nethermind.State
             _storages.Reset();
             _originalValues.Clear();
             _committedThisRound.Clear();
+            _toUpdateRoots.Clear();
         }
 
         /// <summary>
@@ -179,16 +182,17 @@ namespace Nethermind.State
                 }
             }
 
-            // TODO: it seems that we are unnecessarily recalculating root hashes all the time in storage?
             foreach (Address address in toUpdateRoots)
             {
                 // since the accounts could be empty accounts that are removing (EIP-158)
                 if (_stateProvider.AccountExists(address))
                 {
-                    Hash256 root = RecalculateRootHash(address);
-
-                    // _logger.Warn($"Recalculating storage root {address}->{root} ({toUpdateRoots.Count})");
-                    _stateProvider.UpdateStorageRoot(address, root);
+                    _toUpdateRoots.Add(address);
+                }
+                else
+                {
+                    _toUpdateRoots.Remove(address);
+                    _storages.Remove(address);
                 }
             }
 
@@ -199,6 +203,75 @@ namespace Nethermind.State
             if (isTracing)
             {
                 ReportChanges(tracer!, trace!);
+            }
+        }
+
+        protected override void PostCommitStorages()
+        {
+            if (_toUpdateRoots.Count == 0)
+            {
+                return;
+            }
+
+            // Is overhead of parallel foreach worth it?
+            if (_toUpdateRoots.Count <= 4)
+            {
+                UpdateRootHashesSingleThread();
+            }
+            else
+            {
+                UpdateRootHashesMultiThread();
+            }
+
+            void UpdateRootHashesSingleThread()
+            {
+                foreach (KeyValuePair<AddressAsKey, StorageTree> kvp in _storages)
+                {
+                    if (!_toUpdateRoots.Contains(kvp.Key))
+                    {
+                        // Remove the storage tree if it was only read and not updated
+                        _storages.Remove(kvp.Key);
+                        continue;
+                    }
+
+                    StorageTree storageTree = kvp.Value;
+                    storageTree.UpdateRootHash();
+                    _stateProvider.UpdateStorageRoot(address: kvp.Key, storageTree.RootHash);
+                }
+
+                _toUpdateRoots.Clear();
+            }
+
+            void UpdateRootHashesMultiThread()
+            {
+                // We can recalculate the roots in parallel as they are all independent tries
+                Parallel.ForEach(_storages, kvp =>
+                {
+                    if (!_toUpdateRoots.Contains(kvp.Key))
+                    {
+                        // Wasn't updated don't recalculate; we don't remove here
+                        // in parallel foreach as it would be unsafe on non-concurrent dictionary
+                        return;
+                    }
+                    StorageTree storageTree = kvp.Value;
+                    storageTree.UpdateRootHash();
+                });
+
+                // Update the storage roots in the main thread non in parallel
+                foreach (KeyValuePair<AddressAsKey, StorageTree> kvp in _storages)
+                {
+                    if (!_toUpdateRoots.Contains(kvp.Key))
+                    {
+                        // Remove the storage tree if it was only read and not updated
+                        _storages.Remove(kvp.Key);
+                        continue;
+                    }
+
+                    // Update the storage root for the Account
+                    _stateProvider.UpdateStorageRoot(address: kvp.Key, kvp.Value.RootHash);
+                }
+
+                _toUpdateRoots.Clear();
             }
         }
 
@@ -223,13 +296,10 @@ namespace Nethermind.State
         /// <param name="blockNumber">Current block number</param>
         public void CommitTrees(long blockNumber)
         {
-            // _logger.Warn($"Storage block commit {blockNumber}");
             foreach (KeyValuePair<AddressAsKey, StorageTree> storage in _storages)
             {
                 storage.Value.Commit(blockNumber);
             }
-
-            // TODO: maybe I could update storage roots only now?
 
             // only needed here as there is no control over cached storage size otherwise
             _storages.Reset();
@@ -305,6 +375,7 @@ namespace Nethermind.State
             // by means of CREATE 2 - notice that the cached trie may carry information about items that were not
             // touched in this block, hence were not zeroed above
             // TODO: how does it work with pruning?
+            _toUpdateRoots.Add(address);
             _storages[address] = new StorageTree(_trieStore.GetTrieStore(address.ToAccountPath), Keccak.EmptyTreeHash, _logManager);
         }
 

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -375,7 +375,7 @@ namespace Nethermind.State
             // by means of CREATE 2 - notice that the cached trie may carry information about items that were not
             // touched in this block, hence were not zeroed above
             // TODO: how does it work with pruning?
-            _toUpdateRoots.Add(address);
+            _toUpdateRoots.Remove(address);
             _storages[address] = new StorageTree(_trieStore.GetTrieStore(address.ToAccountPath), Keccak.EmptyTreeHash, _logManager);
         }
 

--- a/src/Nethermind/Nethermind.State/WorldState.cs
+++ b/src/Nethermind/Nethermind.State/WorldState.cs
@@ -193,23 +193,17 @@ namespace Nethermind.State
             return _trieStore.HasRoot(stateRoot);
         }
 
-        public void Commit(IReleaseSpec releaseSpec, bool isGenesis = false)
+        public void Commit(IReleaseSpec releaseSpec, bool isGenesis = false, bool commitStorageRoots = true)
         {
-            _persistentStorageProvider.Commit();
-            _transientStorageProvider.Commit();
+            _persistentStorageProvider.Commit(commitStorageRoots);
+            _transientStorageProvider.Commit(commitStorageRoots);
             _stateProvider.Commit(releaseSpec, isGenesis);
         }
-        public void Commit(IReleaseSpec releaseSpec, IWorldStateTracer tracer, bool isGenesis = false)
+        public void Commit(IReleaseSpec releaseSpec, IWorldStateTracer tracer, bool isGenesis = false, bool commitStorageRoots = true)
         {
-            _persistentStorageProvider.Commit(tracer);
-            _transientStorageProvider.Commit(tracer);
+            _persistentStorageProvider.Commit(tracer, commitStorageRoots);
+            _transientStorageProvider.Commit(tracer, commitStorageRoots);
             _stateProvider.Commit(releaseSpec, tracer, isGenesis);
-        }
-        public void PostCommit(IReleaseSpec releaseSpec)
-        {
-            _persistentStorageProvider.PostCommit();
-            _transientStorageProvider.PostCommit();
-            _stateProvider.Commit(releaseSpec, isGenesis: false);
         }
 
         public Snapshot TakeSnapshot(bool newTransactionStart = false)

--- a/src/Nethermind/Nethermind.State/WorldState.cs
+++ b/src/Nethermind/Nethermind.State/WorldState.cs
@@ -205,6 +205,12 @@ namespace Nethermind.State
             _transientStorageProvider.Commit(tracer);
             _stateProvider.Commit(releaseSpec, tracer, isGenesis);
         }
+        public void PostCommit(IReleaseSpec releaseSpec)
+        {
+            _persistentStorageProvider.PostCommit();
+            _transientStorageProvider.PostCommit();
+            _stateProvider.Commit(releaseSpec, isGenesis: false);
+        }
 
         public Snapshot TakeSnapshot(bool newTransactionStart = false)
         {


### PR DESCRIPTION
Resolves https://github.com/NethermindEth/nethermind/issues/2324

## Changes

- Only recalculate root hashes for storages once per block than for each tx; if multiple tx use the same contract it is wasteful to recalcuate them multiple times.
- Also means can recalucate all the storage roots in parallel at the end.
- Addresses some long standing TODOs and issue https://github.com/NethermindEth/nethermind/issues/2324


Now 1.5% of block processing when running in Parallel

<img width="547" alt="image" src="https://github.com/NethermindEth/nethermind/assets/1142958/4367b1c1-8e66-4b15-92b4-1c2862686e5e">


## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
