### PR TITLE
Set dedicated block cache for blob transactions

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
@@ -52,6 +52,8 @@ public class DbConfig : IDbConfig
     public ulong BytesPerSync { get; set; } = 0;
     public double? DataBlockIndexUtilRatio { get; set; }
 
+    public ulong BlobTransactionsDbBlockCacheSize { get; set; } = (ulong)32.MiB();
+
     public ulong ReceiptsDbWriteBufferSize { get; set; } = (ulong)2.MiB();
     public uint ReceiptsDbWriteBufferNumber { get; set; } = 2;
     public ulong ReceiptsDbBlockCacheSize { get; set; } = (ulong)8.MiB();

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/IDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/IDbConfig.cs
@@ -53,6 +53,8 @@ public interface IDbConfig : IConfig
     ulong BytesPerSync { get; set; }
     double? DataBlockIndexUtilRatio { get; set; }
 
+    ulong BlobTransactionsDbBlockCacheSize { get; set; }
+
     ulong ReceiptsDbWriteBufferSize { get; set; }
     uint ReceiptsDbWriteBufferNumber { get; set; }
     ulong ReceiptsDbBlockCacheSize { get; set; }


### PR DESCRIPTION
- Seems to be that the block cache size fluctuate.
- Seems to map with the blob transactions index.
- This set a dedicated block cache for blob transactions so that it does not effect the shared block cache which is used by state.
- The effect of the shared block cache on the block processing is was shown to be not much at all before as the file get os-cached in the first place. There could be a minor difference though.

![Screenshot from 2024-05-16 16-25-40](https://github.com/NethermindEth/nethermind/assets/1841324/32e63292-f6cf-4d8a-91ac-c6e4b0426006)

## Changes

- Set dedicated block cache for blob transaction.

## Types of changes

#### What types of changes does your code introduce?
- [X] Optimization

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

- Manual log shows dedicated cache is used.