### PR TITLE
Intra-block cache

### DIFF
--- a/src/Nethermind/Nethermind.Core/Caching/LruCacheNonConcurrent.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/LruCacheNonConcurrent.cs
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Nethermind.Core.Extensions;
+
+namespace Nethermind.Core.Caching
+{
+    public sealed class LruCacheNonConcurrent<TKey, TValue> where TKey : notnull
+    {
+        private readonly int _maxCapacity;
+        private readonly Dictionary<TKey, LinkedListNode<LruCacheItem>> _cacheMap;
+        private readonly string _name;
+        private LinkedListNode<LruCacheItem>? _leastRecentlyUsed;
+
+        public LruCacheNonConcurrent(int maxCapacity, int startCapacity, string name)
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(maxCapacity, 1);
+
+            _name = name;
+            _maxCapacity = maxCapacity;
+            _cacheMap = typeof(TKey) == typeof(byte[])
+                ? new Dictionary<TKey, LinkedListNode<LruCacheItem>>((IEqualityComparer<TKey>)Bytes.EqualityComparer)
+                : new Dictionary<TKey, LinkedListNode<LruCacheItem>>(startCapacity); // do not initialize it at the full capacity
+        }
+
+        public LruCacheNonConcurrent(int maxCapacity, string name)
+            : this(maxCapacity, 0, name)
+        {
+        }
+
+        public void Clear()
+        {
+            _leastRecentlyUsed = null;
+            _cacheMap.Clear();
+        }
+
+        public TValue Get(TKey key)
+        {
+            if (_cacheMap.TryGetValue(key, out LinkedListNode<LruCacheItem>? node))
+            {
+                TValue value = node.Value.Value;
+                LinkedListNode<LruCacheItem>.MoveToMostRecent(ref _leastRecentlyUsed, node);
+                return value;
+            }
+
+#pragma warning disable 8603
+            // fixed C# 9
+            return default;
+#pragma warning restore 8603
+        }
+
+        public bool TryGet(TKey key, out TValue value)
+        {
+            if (_cacheMap.TryGetValue(key, out LinkedListNode<LruCacheItem>? node))
+            {
+                value = node.Value.Value;
+                LinkedListNode<LruCacheItem>.MoveToMostRecent(ref _leastRecentlyUsed, node);
+                return true;
+            }
+
+#pragma warning disable 8601
+            // fixed C# 9
+            value = default;
+#pragma warning restore 8601
+            return false;
+        }
+
+        public bool Set(TKey key, TValue val)
+        {
+            if (val is null)
+            {
+                return DeleteNoLock(key);
+            }
+
+            if (_cacheMap.TryGetValue(key, out LinkedListNode<LruCacheItem>? node))
+            {
+                node.Value.Value = val;
+                LinkedListNode<LruCacheItem>.MoveToMostRecent(ref _leastRecentlyUsed, node);
+                return false;
+            }
+
+            if (_cacheMap.Count >= _maxCapacity)
+            {
+                Replace(key, val);
+            }
+            else
+            {
+                LinkedListNode<LruCacheItem> newNode = new(new(key, val));
+                LinkedListNode<LruCacheItem>.AddMostRecent(ref _leastRecentlyUsed, newNode);
+                _cacheMap.Add(key, newNode);
+            }
+
+            return true;
+        }
+
+        public bool DeleteNoLock(TKey key)
+        {
+            if (_cacheMap.TryGetValue(key, out LinkedListNode<LruCacheItem>? node))
+            {
+                LinkedListNode<LruCacheItem>.Remove(ref _leastRecentlyUsed, node);
+                _cacheMap.Remove(key);
+                return true;
+            }
+
+            return false;
+        }
+
+        public bool Contains(TKey key)
+        {
+            return _cacheMap.ContainsKey(key);
+        }
+
+        public int Size
+        {
+            get
+            {
+                return _cacheMap.Count;
+            }
+        }
+
+        private void Replace(TKey key, TValue value)
+        {
+            LinkedListNode<LruCacheItem>? node = _leastRecentlyUsed;
+            if (node is null)
+            {
+                ThrowInvalidOperationException();
+            }
+
+            _cacheMap.Remove(node!.Value.Key);
+
+            node.Value = new(key, value);
+            LinkedListNode<LruCacheItem>.MoveToMostRecent(ref _leastRecentlyUsed, node);
+            _cacheMap.Add(key, node);
+
+            [DoesNotReturn]
+            static void ThrowInvalidOperationException()
+            {
+                throw new InvalidOperationException(
+                    $"{nameof(LruCache<TKey, TValue>)} called {nameof(Replace)} when empty.");
+            }
+        }
+
+        private struct LruCacheItem(TKey k, TValue v)
+        {
+            public readonly TKey Key = k;
+            public TValue Value = v;
+        }
+
+        public long MemorySize => CalculateMemorySize(0, _cacheMap.Count);
+
+        public static long CalculateMemorySize(int keyPlusValueSize, int currentItemsCount)
+        {
+            // it may actually be different if the initial capacity not equal to max (depending on the dictionary growth path)
+
+            const int preInit = 48 /* LinkedList */ + 80 /* Dictionary */ + 24;
+            int postInit = 52 /* lazy init of two internal dictionary arrays + dictionary size times (entry size + int) */ + MemorySizes.FindNextPrime(currentItemsCount) * 28 + currentItemsCount * 80 /* LinkedListNode and CacheItem times items count */;
+            return MemorySizes.Align(preInit + postInit + keyPlusValueSize * currentItemsCount);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Core/Caching/LruKeyCacheNonConcurrent.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/LruKeyCacheNonConcurrent.cs
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Nethermind.Core.Extensions;
+
+namespace Nethermind.Core.Caching
+{
+    public sealed class LruKeyCacheNonConcurrent<TKey> where TKey : notnull
+    {
+        private readonly int _maxCapacity;
+        private readonly string _name;
+        private readonly Dictionary<TKey, LinkedListNode<TKey>> _cacheMap;
+        private LinkedListNode<TKey>? _leastRecentlyUsed;
+
+        public LruKeyCacheNonConcurrent(int maxCapacity, int startCapacity, string name)
+        {
+            _maxCapacity = maxCapacity;
+            _name = name ?? throw new ArgumentNullException(nameof(name));
+            _cacheMap = typeof(TKey) == typeof(byte[])
+                ? new Dictionary<TKey, LinkedListNode<TKey>>((IEqualityComparer<TKey>)Bytes.EqualityComparer)
+                : new Dictionary<TKey, LinkedListNode<TKey>>(startCapacity); // do not initialize it at the full capacity
+        }
+
+        public LruKeyCacheNonConcurrent(int maxCapacity, string name)
+            : this(maxCapacity, 0, name)
+        {
+        }
+
+        public void Clear()
+        {
+            _leastRecentlyUsed = null;
+            _cacheMap.Clear();
+        }
+
+        public bool Get(TKey key)
+        {
+            if (_cacheMap.TryGetValue(key, out LinkedListNode<TKey>? node))
+            {
+                LinkedListNode<TKey>.MoveToMostRecent(ref _leastRecentlyUsed, node);
+                return true;
+            }
+
+            return false;
+        }
+
+        public bool Set(TKey key)
+        {
+            if (_cacheMap.TryGetValue(key, out LinkedListNode<TKey>? node))
+            {
+                LinkedListNode<TKey>.MoveToMostRecent(ref _leastRecentlyUsed, node);
+                return false;
+            }
+            else
+            {
+                if (_cacheMap.Count >= _maxCapacity)
+                {
+                    Replace(key);
+                }
+                else
+                {
+                    LinkedListNode<TKey> newNode = new(key);
+                    LinkedListNode<TKey>.AddMostRecent(ref _leastRecentlyUsed, newNode);
+                    _cacheMap.Add(key, newNode);
+                }
+
+                return true;
+            }
+        }
+
+        public void Delete(TKey key)
+        {
+            if (_cacheMap.TryGetValue(key, out LinkedListNode<TKey>? node))
+            {
+                LinkedListNode<TKey>.Remove(ref _leastRecentlyUsed, node);
+                _cacheMap.Remove(key);
+            }
+        }
+
+        private void Replace(TKey key)
+        {
+            LinkedListNode<TKey>? node = _leastRecentlyUsed;
+            if (node is null)
+            {
+                ThrowInvalidOperation();
+            }
+
+            _cacheMap.Remove(node.Value);
+            node.Value = key;
+            LinkedListNode<TKey>.MoveToMostRecent(ref _leastRecentlyUsed, node);
+            _cacheMap.Add(key, node);
+
+            [DoesNotReturn]
+            static void ThrowInvalidOperation()
+            {
+                throw new InvalidOperationException(
+                                    $"{nameof(LruKeyCache<TKey>)} called {nameof(Replace)} when empty.");
+            }
+        }
+
+        public long MemorySize => CalculateMemorySize(0, _cacheMap.Count);
+
+        // TODO: memory size on the KeyCache will be smaller because we do not create LruCacheItems
+        public static long CalculateMemorySize(int keyPlusValueSize, int currentItemsCount)
+        {
+            // it may actually be different if the initial capacity not equal to max (depending on the dictionary growth path)
+
+            const int preInit = 48 /* LinkedList */ + 80 /* Dictionary */ + 24;
+            int postInit = 52 /* lazy init of two internal dictionary arrays + dictionary size times (entry size + int) */ + MemorySizes.FindNextPrime(currentItemsCount) * 28 + currentItemsCount * 80 /* LinkedListNode and CacheItem times items count */;
+            return MemorySizes.Align(preInit + postInit + keyPlusValueSize * currentItemsCount);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Db/Metrics.cs
+++ b/src/Nethermind/Nethermind.Db/Metrics.cs
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.ComponentModel;
 using Nethermind.Core.Attributes;
 
@@ -15,8 +13,16 @@ namespace Nethermind.Db
         public static long CodeDbCache { get; set; }
 
         [CounterMetric]
+        [Description("Number of State Trie cache hits.")]
+        public static long StateTreeCache { get; set; }
+
+        [CounterMetric]
         [Description("Number of State Trie reads.")]
         public static long StateTreeReads { get; set; }
+
+        [CounterMetric]
+        [Description("Number of State Reader reads.")]
+        public static long StateReaderReads { get; set; }
 
         [CounterMetric]
         [Description("Number of Blocks Trie writes.")]
@@ -27,8 +33,16 @@ namespace Nethermind.Db
         public static int StateDbInPruningWrites;
 
         [CounterMetric]
+        [Description("Number of storage trie cache hits.")]
+        public static long StorageTreeCache { get; set; }
+
+        [CounterMetric]
         [Description("Number of storage trie reads.")]
         public static long StorageTreeReads { get; set; }
+
+        [CounterMetric]
+        [Description("Number of storage reader reads.")]
+        public static long StorageReaderReads { get; set; }
 
         [CounterMetric]
         [Description("Number of storage trie writes.")]

--- a/src/Nethermind/Nethermind.Evm/MemoryAllowance.cs
+++ b/src/Nethermind/Nethermind.Evm/MemoryAllowance.cs
@@ -5,6 +5,6 @@ namespace Nethermind.Evm
 {
     public static class MemoryAllowance
     {
-        public static int CodeCacheSize { get; } = 4_096;
+        public static int CodeCacheSize { get; } = 4_096 + 1_024;
     }
 }

--- a/src/Nethermind/Nethermind.Evm/MemoryAllowance.cs
+++ b/src/Nethermind/Nethermind.Evm/MemoryAllowance.cs
@@ -5,6 +5,6 @@ namespace Nethermind.Evm
 {
     public static class MemoryAllowance
     {
-        public static int CodeCacheSize { get; } = 16_384;
+        public static int CodeCacheSize { get; } = 4_096;
     }
 }

--- a/src/Nethermind/Nethermind.State/IWorldState.cs
+++ b/src/Nethermind/Nethermind.State/IWorldState.cs
@@ -101,7 +101,7 @@ public interface IWorldState : IJournal<Snapshot>, IReadOnlyStateProvider
 
     void Commit(IReleaseSpec releaseSpec, bool isGenesis = false);
 
-    void Commit(IReleaseSpec releaseSpec, IWorldStateTracer? traver, bool isGenesis = false);
+    void Commit(IReleaseSpec releaseSpec, IWorldStateTracer? tracer, bool isGenesis = false);
 
     void CommitTree(long blockNumber);
 }

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -311,6 +311,8 @@ namespace Nethermind.State
         public override void ClearStorage(Address address)
         {
             base.ClearStorage(address);
+            // Bit heavy-handed, but we need to clear all the cache for that address
+            _blockCache.Clear();
 
             // here it is important to make sure that we will not reuse the same tree when the contract is revived
             // by means of CREATE 2 - notice that the cached trie may carry information about items that were not

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -19,7 +19,7 @@ namespace Nethermind.State
     /// Manages persistent storage allowing for snapshotting and restoring
     /// Persists data to ITrieStore
     /// </summary>
-    internal class PersistentStorageProvider : PartialStorageProviderBase
+    internal sealed class PersistentStorageProvider : PartialStorageProviderBase
     {
         private readonly ITrieStore _trieStore;
         private readonly StateProvider _stateProvider;
@@ -33,7 +33,7 @@ namespace Nethermind.State
         private readonly ResettableDictionary<StorageCell, byte[]> _originalValues = new();
 
         private readonly ResettableHashSet<StorageCell> _committedThisRound = new();
-        private readonly LruCacheNonConcurrent<StorageCell, byte[]> _blockCache = new(8192, "Storage Cache");
+        private readonly LruCacheNonConcurrent<StorageCell, byte[]> _blockCache = new(4_096, "Storage Cache");
 
         public PersistentStorageProvider(ITrieStore? trieStore, StateProvider? stateProvider, ILogManager? logManager, IStorageTreeFactory? storageTreeFactory = null)
             : base(logManager)

--- a/src/Nethermind/Nethermind.State/StateProvider.cs
+++ b/src/Nethermind/Nethermind.State/StateProvider.cs
@@ -21,14 +21,15 @@ namespace Nethermind.State
     internal class StateProvider
     {
         private const int StartCapacity = Resettable.StartCapacity;
-        private readonly ResettableDictionary<AddressAsKey, Stack<int>> _intraBlockCache = new();
+        private readonly ResettableDictionary<AddressAsKey, Stack<int>> _intraTxCache = new();
         private readonly ResettableHashSet<AddressAsKey> _committedThisRound = new();
         private readonly HashSet<AddressAsKey> _nullAccountReads = new();
         // Only guarding against hot duplicates so filter doesn't need to be too big
         // Note:
         // False negatives are fine as they will just result in a overwrite set
         // False positives would be problematic as the code _must_ be persisted
-        private readonly LruKeyCache<Hash256AsKey> _codeInsertFilter = new(2048, "Code Insert Filter");
+        private readonly LruKeyCacheNonConcurrent<Hash256AsKey> _codeInsertFilter = new(2048, "Code Insert Filter");
+        private readonly LruCacheNonConcurrent<AddressAsKey, Account> _blockCache = new(8192, "Account Cache");
 
         private readonly List<Change> _keptInCache = new();
         private readonly ILogger _logger;
@@ -90,7 +91,7 @@ namespace Nethermind.State
 
         public bool AccountExists(Address address)
         {
-            if (_intraBlockCache.TryGetValue(address, out Stack<int> value))
+            if (_intraTxCache.TryGetValue(address, out Stack<int> value))
             {
                 return _changes[value.Peek()]!.ChangeType != ChangeType.Delete;
             }
@@ -361,7 +362,7 @@ namespace Nethermind.State
             for (int i = 0; i < _currentPosition - snapshot; i++)
             {
                 Change change = _changes[_currentPosition - i];
-                Stack<int> stack = _intraBlockCache[change!.Address];
+                Stack<int> stack = _intraTxCache[change!.Address];
                 if (stack.Count == 1)
                 {
                     if (change.ChangeType == ChangeType.JustCache)
@@ -387,7 +388,7 @@ namespace Nethermind.State
 
                 if (stack.Count == 0)
                 {
-                    _intraBlockCache.Remove(change.Address);
+                    _intraTxCache.Remove(change.Address);
                 }
             }
 
@@ -396,7 +397,7 @@ namespace Nethermind.State
             {
                 _currentPosition++;
                 _changes[_currentPosition] = kept;
-                _intraBlockCache[kept.Address].Push(_currentPosition);
+                _intraTxCache[kept.Address].Push(_currentPosition);
             }
 
             _keptInCache.Clear();
@@ -502,7 +503,7 @@ namespace Nethermind.State
                     continue;
                 }
 
-                Stack<int> stack = _intraBlockCache[change.Address];
+                Stack<int> stack = _intraTxCache[change.Address];
                 int forAssertion = stack.Pop();
                 if (forAssertion != _currentPosition - i)
                 {
@@ -597,7 +598,7 @@ namespace Nethermind.State
             Resettable<Change>.Reset(ref _changes, ref _capacity, ref _currentPosition, StartCapacity);
             _committedThisRound.Reset();
             _nullAccountReads.Clear();
-            _intraBlockCache.Reset();
+            _intraTxCache.Reset();
 
             if (isTracing)
             {
@@ -665,13 +666,22 @@ namespace Nethermind.State
 
         private Account? GetState(Address address)
         {
-            Metrics.StateTreeReads++;
-            Account? account = _tree.Get(address);
+            if (!_blockCache.TryGet(address, out Account? account))
+            {
+                Metrics.StateTreeReads++;
+                account = _tree.Get(address);
+                _blockCache.Set(address, account);
+            }
+            else
+            {
+                Metrics.StateTreeCache++;
+            }
             return account;
         }
 
         private void SetState(Address address, Account? account)
         {
+            _blockCache.Set(address, account);
             _needsStateRootUpdate = true;
             Metrics.StateTreeWrites++;
             _tree.Set(address, account);
@@ -697,7 +707,7 @@ namespace Nethermind.State
 
         private Account? GetThroughCache(Address address)
         {
-            if (_intraBlockCache.TryGetValue(address, out Stack<int> value))
+            if (_intraTxCache.TryGetValue(address, out Stack<int> value))
             {
                 return _changes[value.Peek()]!.Account;
             }
@@ -756,7 +766,7 @@ namespace Nethermind.State
 
         private Stack<int> SetupCache(Address address)
         {
-            ref Stack<int>? value = ref _intraBlockCache.GetValueRefOrAddDefault(address, out bool exists);
+            ref Stack<int>? value = ref _intraTxCache.GetValueRefOrAddDefault(address, out bool exists);
             if (!exists)
             {
                 value = new Stack<int>();
@@ -791,7 +801,8 @@ namespace Nethermind.State
         public void Reset()
         {
             if (_logger.IsTrace) _logger.Trace("Clearing state provider caches");
-            _intraBlockCache.Reset();
+            _blockCache.Clear();
+            _intraTxCache.Reset();
             _committedThisRound.Reset();
             _nullAccountReads.Clear();
             _currentPosition = Resettable.EmptyPosition;

--- a/src/Nethermind/Nethermind.State/StateProvider.cs
+++ b/src/Nethermind/Nethermind.State/StateProvider.cs
@@ -28,8 +28,8 @@ namespace Nethermind.State
         // Note:
         // False negatives are fine as they will just result in a overwrite set
         // False positives would be problematic as the code _must_ be persisted
-        private readonly LruKeyCacheNonConcurrent<Hash256AsKey> _codeInsertFilter = new(2048, "Code Insert Filter");
-        private readonly LruCacheNonConcurrent<AddressAsKey, Account> _blockCache = new(8192, "Account Cache");
+        private readonly LruKeyCacheNonConcurrent<Hash256AsKey> _codeInsertFilter = new(1_024, "Code Insert Filter");
+        private readonly LruCacheNonConcurrent<AddressAsKey, Account> _blockCache = new(4_096, "Account Cache");
 
         private readonly List<Change> _keptInCache = new();
         private readonly ILogger _logger;

--- a/src/Nethermind/Nethermind.State/StateReader.cs
+++ b/src/Nethermind/Nethermind.State/StateReader.cs
@@ -34,7 +34,7 @@ namespace Nethermind.State
                 return Bytes.ZeroByte.Span;
             }
 
-            Metrics.StorageTreeReads++;
+            Metrics.StorageReaderReads++;
 
             StorageTree storage = new StorageTree(_trieStore.GetTrieStore(address.ToAccountPath), Keccak.EmptyTreeHash, _logManager);
             return storage.Get(index, new Hash256(storageRoot));
@@ -68,7 +68,7 @@ namespace Nethermind.State
                 return false;
             }
 
-            Metrics.StateTreeReads++;
+            Metrics.StateReaderReads++;
             return _state.TryGetStruct(address, out account, stateRoot);
         }
     }

--- a/src/Nethermind/Nethermind.State/StorageTree.cs
+++ b/src/Nethermind/Nethermind.State/StorageTree.cs
@@ -59,16 +59,15 @@ namespace Nethermind.State
         {
             if (index < LookupSize)
             {
-                return Get(Lookup[index], storageRoot).ToArray();
+                return GetArray(Lookup[index], storageRoot);
             }
 
             Span<byte> key = stackalloc byte[32];
             ComputeKey(index, ref key);
-            return Get(key, storageRoot).ToArray();
-
+            return GetArray(key, storageRoot);
         }
 
-        public override ReadOnlySpan<byte> Get(ReadOnlySpan<byte> rawKey, Hash256? rootHash = null)
+        public byte[] GetArray(ReadOnlySpan<byte> rawKey, Hash256? rootHash = null)
         {
             ReadOnlySpan<byte> value = base.Get(rawKey, rootHash);
 
@@ -80,6 +79,8 @@ namespace Nethermind.State
             Rlp.ValueDecoderContext rlp = value.AsRlpValueContext();
             return rlp.DecodeByteArray();
         }
+
+        public override ReadOnlySpan<byte> Get(ReadOnlySpan<byte> rawKey, Hash256? rootHash = null) => GetArray(rawKey, rootHash);
 
         [SkipLocalsInit]
         public void Set(in UInt256 index, byte[] value)

--- a/src/Nethermind/Nethermind.State/TransientStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/TransientStorageProvider.cs
@@ -11,7 +11,7 @@ namespace Nethermind.State
     /// EIP-1153 provides a transient store for contracts that doesn't persist
     /// storage across calls. Reverts will rollback any transient state changes.
     /// </summary>
-    internal class TransientStorageProvider : PartialStorageProviderBase
+    internal sealed class TransientStorageProvider : PartialStorageProviderBase
     {
         public TransientStorageProvider(ILogManager? logManager)
             : base(logManager) { }


### PR DESCRIPTION
Resolves #179

I'd solved this a long time ago; however always had issues doing the more ambitious step of sharing the cache between blocks; and parallel pre-caching.

Recognising the perfect can be the enemy of the good; and that we can make a journey with many steps; this introduces just the part of sharing state and storage between tx in the same block; rather than always starting afresh for each tx.

## Changes

- Maintain state and storage cache between the txs in a block

Even though it clears every block in this iteration

*  \> 50% of state reads are cache hits
*  ~ 21% of storage reads are cache hits

<img width="578" alt="image" src="https://github.com/NethermindEth/nethermind/assets/1142958/e77e2d24-8bd5-4a62-8d89-8fc25070c948">


## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No