### PR TITLE
Eliminate bounds checks in Bloom

### DIFF
--- a/src/Nethermind/Nethermind.Core/Bloom.cs
+++ b/src/Nethermind/Nethermind.Core/Bloom.cs
@@ -126,9 +126,10 @@ namespace Nethermind.Core
                 LogEntry logEntry = logEntries[entryIndex];
                 byte[] addressBytes = logEntry.LoggersAddress.Bytes;
                 Set(addressBytes, blockBloom);
-                for (int topicIndex = 0; topicIndex < logEntry.Topics.Length; topicIndex++)
+                Hash256[] topics = logEntry.Topics;
+                for (int topicIndex = 0; topicIndex < topics.Length; topicIndex++)
                 {
-                    Hash256 topic = logEntry.Topics[topicIndex];
+                    Hash256 topic = topics[topicIndex];
                     Set(topic.Bytes, blockBloom);
                 }
             }
@@ -148,9 +149,10 @@ namespace Nethermind.Core
         {
             if (Matches(logEntry.LoggersAddress))
             {
-                for (int topicIndex = 0; topicIndex < logEntry.Topics.Length; topicIndex++)
+                Hash256[] topics = logEntry.Topics;
+                for (int topicIndex = 0; topicIndex < topics.Length; topicIndex++)
                 {
-                    if (!Matches(logEntry.Topics[topicIndex]))
+                    if (!Matches(topics[topicIndex]))
                     {
                         return false;
                     }
@@ -285,9 +287,10 @@ namespace Nethermind.Core
         {
             if (Matches(logEntry.LoggersAddress))
             {
-                for (int topicIndex = 0; topicIndex < logEntry.Topics.Length; topicIndex++)
+                Hash256[] topics = logEntry.Topics;
+                for (int topicIndex = 0; topicIndex < topics.Length; topicIndex++)
                 {
-                    if (!Matches(logEntry.Topics[topicIndex]))
+                    if (!Matches(topics[topicIndex]))
                     {
                         return false;
                     }


### PR DESCRIPTION
## Changes

- Take the `.Topics` array to a local array rather than operating through the property so the Jit can confirm it's `.Length` cannot change per iteration and eliminate the bounds check.

Before the asm contains the `RNGCHKFAIL` exception
```asm
G_M000_IG09:                ;; offset=0x00D7
       xor      rdx, rdx
       xor      r8d, r8d
       jmp      G_M000_IG05
 
G_M000_IG10:                ;; offset=0x00E1
       call     CORINFO_HELP_RNGCHKFAIL
       int3     
 
; Total bytes of code 231
```
After it doesn't (and asm is slightly smaller)
```asm
G_M000_IG09:                ;; offset=0x00CF
       xor      rdx, rdx
       xor      r8d, r8d
       jmp      G_M000_IG05
 
; Total bytes of code 217
```


## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No