### PR TITLE
Feature DB File warmer

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
@@ -51,6 +51,7 @@ public class DbConfig : IDbConfig
     public int? UseRibbonFilterStartingFromLevel { get; set; }
     public ulong BytesPerSync { get; set; } = 0;
     public double? DataBlockIndexUtilRatio { get; set; }
+    public bool EnableFileWarmer { get; set; } = false;
 
     public ulong BlobTransactionsDbBlockCacheSize { get; set; } = (ulong)32.MiB();
 
@@ -200,6 +201,7 @@ public class DbConfig : IDbConfig
     public int? StateDbBloomFilterBitsPerKey { get; set; } = 15;
     public int? StateDbUseRibbonFilterStartingFromLevel { get; set; } = 2;
     public double? StateDbDataBlockIndexUtilRatio { get; set; } = 0.5;
+    public bool StateDbEnableFileWarmer { get; set; }
     public IDictionary<string, string>? StateDbAdditionalRocksDbOptions { get; set; }
 
     public uint RecycleLogFileNum { get; set; } = 0;

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/IDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/IDbConfig.cs
@@ -52,6 +52,7 @@ public interface IDbConfig : IConfig
     int? UseRibbonFilterStartingFromLevel { get; set; }
     ulong BytesPerSync { get; set; }
     double? DataBlockIndexUtilRatio { get; set; }
+    bool EnableFileWarmer { get; set; }
 
     ulong BlobTransactionsDbBlockCacheSize { get; set; }
 
@@ -201,6 +202,7 @@ public interface IDbConfig : IConfig
     int? StateDbBloomFilterBitsPerKey { get; set; }
     int? StateDbUseRibbonFilterStartingFromLevel { get; set; }
     double? StateDbDataBlockIndexUtilRatio { get; set; }
+    bool StateDbEnableFileWarmer { get; set; }
     IDictionary<string, string>? StateDbAdditionalRocksDbOptions { get; set; }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/PerTableDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/PerTableDbConfig.cs
@@ -73,6 +73,7 @@ public class PerTableDbConfig
     public int? UseRibbonFilterStartingFromLevel => ReadConfig<int?>(nameof(UseRibbonFilterStartingFromLevel));
     public ulong BytesPerSync => ReadConfig<ulong>(nameof(BytesPerSync));
     public double? DataBlockIndexUtilRatio => ReadConfig<double?>(nameof(DataBlockIndexUtilRatio));
+    public bool EnableFileWarmer => ReadConfig<bool>(nameof(EnableFileWarmer));
 
     private T? ReadConfig<T>(string propertyName)
     {

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -7,6 +7,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions;
+using System.Linq;
 using System.Reflection;
 using System.Threading;
 using ConcurrentCollections;
@@ -183,6 +184,11 @@ public class DbOnTheRocks : IDb, ITunableDb
                 }
             }
 
+            if (_perTableDbConfig.EnableFileWarmer)
+            {
+                WarmupFile(_fullPath, db);
+            }
+
             return db;
         }
         catch (DllNotFoundException e) when (e.Message.Contains("libdl"))
@@ -200,6 +206,83 @@ public class DbOnTheRocks : IDb, ITunableDb
             throw;
         }
 
+    }
+
+    private void WarmupFile(string basePath, RocksDb db)
+    {
+        long availableMemory = GC.GetGCMemoryInfo().TotalAvailableMemoryBytes;
+        _logger.Info($"Warming up database {Name} assuming {availableMemory} bytes of available memory");
+        List<(FileMetadata metadata, DateTime creationTime)> fileMetadatas = new();
+
+        foreach (LiveFileMetadata liveFileMetadata in db.GetLiveFilesMetadata())
+        {
+            string fullPath = Path.Join(basePath, liveFileMetadata.FileMetadata.FileName);
+            try
+            {
+                DateTime creationTime = File.GetCreationTimeUtc(fullPath);
+                fileMetadatas.Add((liveFileMetadata.FileMetadata, creationTime));
+            }
+            catch (IOException)
+            {
+                // Maybe the file is gone or something. We ignore it.
+            }
+        }
+
+        fileMetadatas.Sort((item1, item2) =>
+        {
+            // Sort them by level so that lower level get priority
+            int levelDiff = item1.metadata.FileLevel - item2.metadata.FileLevel;
+            if (levelDiff != 0) return levelDiff;
+
+            // Otherwise, we pick which file is newest.
+            return item2.creationTime.CompareTo(item1.creationTime);
+        });
+
+        long totalSize = 0;
+        fileMetadatas = fileMetadatas.TakeWhile(metadata =>
+        {
+            availableMemory -= (long)metadata.metadata.FileSize;
+            bool take = availableMemory > 0;
+            if (take)
+            {
+                totalSize += (long)metadata.metadata.FileSize;
+            }
+            return take;
+        })
+            // We reverse them again so that lower level goes last so that it is the freshest.
+            // Not all of the available memory is actually available so we are probably over reading things.
+            .Reverse()
+            .ToList();
+
+
+        byte[] buffer = new byte[512.KiB()];
+        long totalRead = 0;
+
+        foreach (var liveFileMetadata in fileMetadatas)
+        {
+            string fullPath = Path.Join(basePath, liveFileMetadata.metadata.FileName);
+            _logger.Info($"{(totalRead * 100 / (double)totalSize):00.00}% Warming up file {fullPath}");
+
+            try
+            {
+                using FileStream stream = File.OpenRead(fullPath);
+                int readCount = buffer.Length;
+                while (readCount == buffer.Length)
+                {
+                    readCount = stream.Read(buffer);
+                    totalRead += readCount;
+                }
+            }
+            catch (FileNotFoundException)
+            {
+                // Happens sometimes. We do nothing here.
+            }
+            catch (IOException e)
+            {
+                // Something unusual, but nothing noteworthy.
+                _logger.Warn($"Exception warming up {fullPath} {e}");
+            }
+        }
     }
 
     private void CreateMarkerIfCorrupt(RocksDbSharpException rocksDbException)

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -256,14 +256,10 @@ public class DbOnTheRocks : IDb, ITunableDb
             .Reverse()
             .ToList();
 
-        ConcurrentQueue<(FileMetadata metadata, DateTime creationTime)> taskQueues = new(fileMetadatas);
-
         long totalRead = 0;
         Parallel.ForEach(fileMetadatas, (task) =>
         {
-            (FileMetadata metadata, DateTime creationTime) = task;
-
-            string fullPath = Path.Join(basePath, metadata.FileName);
+            string fullPath = Path.Join(basePath, task.metadata.FileName);
             _logger.Info($"{(totalRead * 100 / (double)totalSize):00.00}% Warming up file {fullPath}");
 
             try

--- a/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
@@ -134,15 +134,17 @@ namespace Nethermind.Db.Test
         {
             IDbConfig config = new DbConfig();
             config.EnableFileWarmer = true;
-            DbOnTheRocks db = new("testFileWarmer", GetRocksDbSettings("testFileWarmer", "FileWarmerTest"), config, LimboLogs.Instance);
-            for (int i = 0; i < 1000; i++)
             {
-                db[i.ToBigEndianByteArray()] = i.ToBigEndianByteArray();
+                using DbOnTheRocks db = new("testFileWarmer", GetRocksDbSettings("testFileWarmer", "FileWarmerTest"), config, LimboLogs.Instance);
+                for (int i = 0; i < 1000; i++)
+                {
+                    db[i.ToBigEndianByteArray()] = i.ToBigEndianByteArray();
+                }
             }
-            db.Dispose();
 
-            db = new("testFileWarmer", GetRocksDbSettings("testFileWarmer", "FileWarmerTest"), config, LimboLogs.Instance);
-            db.Dispose();
+            {
+                using DbOnTheRocks db = new("testFileWarmer", GetRocksDbSettings("testFileWarmer", "FileWarmerTest"), config, LimboLogs.Instance);
+            }
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
@@ -130,6 +130,22 @@ namespace Nethermind.Db.Test
         }
 
         [Test]
+        public void CanOpenWithFileWarmer()
+        {
+            IDbConfig config = new DbConfig();
+            config.EnableFileWarmer = true;
+            DbOnTheRocks db = new("testFileWarmer", GetRocksDbSettings("testFileWarmer", "FileWarmerTest"), config, LimboLogs.Instance);
+            for (int i = 0; i < 1000; i++)
+            {
+                db[i.ToBigEndianByteArray()] = i.ToBigEndianByteArray();
+            }
+            db.Dispose();
+
+            db = new("testFileWarmer", GetRocksDbSettings("testFileWarmer", "FileWarmerTest"), config, LimboLogs.Instance);
+            db.Dispose();
+        }
+
+        [Test]
         public void Corrupted_exception_on_open_would_create_marker()
         {
             IDbConfig config = new DbConfig();


### PR DESCRIPTION
- As the state is being read, the database will be cached in the OS cache, therefore the block processing improve over time. It takes about 30 minutes of constant block processing (assuming catching up) or about 2 weeks in real time for this effect to continue making consistent testing hard to achieve. Plus if I just want it to run as fast as it could to test for memory issue for example, it take some time.
- This PR introduce a flag that will read the files from DB on start so that the OS cache is filled up early on.
- On a system with 192GB of RAM (max RAM possible on a consumer level hardware at the moment) this can cache the whole state db resulting in a close to 0 iops at ssd level.
- On a system with lower available memory than the size of the db, it will attempt to priority lower level and newer file first, skipping other file entirely. I did not test the effect on such sysstem, but I don't have much hope due to the random nature of the workload.
- Graph is (before, after, before, after). `sudo sysctl -w vm.drop_caches=3` was run between runs.
![Screenshot from 2024-05-20 13-42-48](https://github.com/NethermindEth/nethermind/assets/1841324/ade886bf-321c-4bee-8dc9-11ddb7da5074)

## Types of changes

#### What types of changes does your code introduce?

- [X] New feature (a non-breaking change that adds functionality)
- [X] Optimization

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Tested with forward syncing node from an old backup.