### PR TITLE
Fix/json rpc dangling whitespace

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/SequenceTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/SequenceTests.cs
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Buffers;
+using FluentAssertions;
+using Nethermind.Core.Extensions;
+using NUnit.Framework;
+
+namespace Nethermind.Core.Test;
+
+public class SequenceTests
+{
+    [Test]
+    public void Sequence_whitespace_slice()
+    {
+        var end = new TestReadOnlySequenceSegment("\r\nabc"u8.ToArray(), 2);
+        var start = new TestReadOnlySequenceSegment("  "u8.ToArray(), 0, end);
+        ReadOnlySequence<byte> sequence = new ReadOnlySequence<byte>(start, 0, end, 5);
+
+        sequence.SliceToNonWhitespace().ToArray().Should().Equal("abc"u8.ToArray());
+    }
+
+    private class TestReadOnlySequenceSegment : ReadOnlySequenceSegment<byte>
+    {
+        public TestReadOnlySequenceSegment(Memory<byte> memory, long runningIndex = 0, ReadOnlySequenceSegment<byte>? next = null)
+        {
+            Memory = memory;
+            Next = next;
+            RunningIndex = runningIndex;
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Core.Test/SequenceTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/SequenceTests.cs
@@ -18,7 +18,7 @@ public class SequenceTests
         var start = new TestReadOnlySequenceSegment("  "u8.ToArray(), 0, end);
         ReadOnlySequence<byte> sequence = new ReadOnlySequence<byte>(start, 0, end, 5);
 
-        sequence.SliceLeadingWhitespace().ToArray().Should().Equal("abc"u8.ToArray());
+        sequence.TrimStart().ToArray().Should().Equal("abc"u8.ToArray());
     }
 
     private class TestReadOnlySequenceSegment : ReadOnlySequenceSegment<byte>

--- a/src/Nethermind/Nethermind.Core.Test/SequenceTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/SequenceTests.cs
@@ -18,7 +18,7 @@ public class SequenceTests
         var start = new TestReadOnlySequenceSegment("  "u8.ToArray(), 0, end);
         ReadOnlySequence<byte> sequence = new ReadOnlySequence<byte>(start, 0, end, 5);
 
-        sequence.SliceToNonWhitespace().ToArray().Should().Equal("abc"u8.ToArray());
+        sequence.SliceLeadingWhitespace().ToArray().Should().Equal("abc"u8.ToArray());
     }
 
     private class TestReadOnlySequenceSegment : ReadOnlySequenceSegment<byte>

--- a/src/Nethermind/Nethermind.Core/Extensions/ReadOnlySequenceExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/ReadOnlySequenceExtensions.cs
@@ -10,13 +10,14 @@ public static class ReadOnlySequenceExtensions
 {
     private static readonly byte[] WhitespaceChars = " \t\r\n"u8.ToArray();
 
-    public static ReadOnlySequence<byte> SliceLeadingWhitespace(this ReadOnlySequence<byte> sequence)
+    public static ReadOnlySequence<byte> TrimStart(this ReadOnlySequence<byte> sequence, byte[]? chars = null)
     {
         SequencePosition position = sequence.Start;
+        ReadOnlySpan<byte> charsSpan = chars ?? WhitespaceChars;
         while (sequence.TryGet(ref position, out ReadOnlyMemory<byte> memory))
         {
             ReadOnlySpan<byte> span = memory.Span;
-            int index = span.IndexOfAnyExcept(WhitespaceChars);
+            int index = span.IndexOfAnyExcept(charsSpan);
 
             if (index != 0)
             {

--- a/src/Nethermind/Nethermind.Core/Extensions/ReadOnlySequenceExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/ReadOnlySequenceExtensions.cs
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Buffers;
+
+namespace Nethermind.Core.Extensions;
+
+public static class ReadOnlySequenceExtensions
+{
+    private static readonly byte[] WhitespaceChars = " \t\r\n"u8.ToArray();
+
+    public static ReadOnlySequence<byte> SliceToNonWhitespace(this ReadOnlySequence<byte> sequence)
+    {
+        SequencePosition position = sequence.Start;
+        while (sequence.TryGet(ref position, out ReadOnlyMemory<byte> memory))
+        {
+            ReadOnlySpan<byte> span = memory.Span;
+            int index = span.IndexOfAnyExcept(WhitespaceChars);
+
+            if (index != 0)
+            {
+                // if index == -1, then the whole span is whitespace
+                sequence = sequence.Slice(index != -1 ? index : span.Length);
+            }
+            else
+            {
+                return sequence;
+            }
+        }
+
+        return sequence;
+    }
+}

--- a/src/Nethermind/Nethermind.Core/Extensions/ReadOnlySequenceExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/ReadOnlySequenceExtensions.cs
@@ -10,7 +10,7 @@ public static class ReadOnlySequenceExtensions
 {
     private static readonly byte[] WhitespaceChars = " \t\r\n"u8.ToArray();
 
-    public static ReadOnlySequence<byte> SliceToNonWhitespace(this ReadOnlySequence<byte> sequence)
+    public static ReadOnlySequence<byte> SliceLeadingWhitespace(this ReadOnlySequence<byte> sequence)
     {
         SequencePosition position = sequence.Start;
         while (sequence.TryGet(ref position, out ReadOnlyMemory<byte> memory))

--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcProcessorTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcProcessorTests.cs
@@ -208,7 +208,7 @@ public class JsonRpcProcessorTests(bool returnErrors)
     [Test]
     public async Task Can_process_batch_request_with_two_requests()
     {
-        IList<JsonRpcResult> result = await ProcessAsync("{\"id\":67,\"jsonrpc\":\"2.0\",\"method\":\"eth_getTransactionCount\",\"params\":[\"0x7f01d9b227593e033bf8d6fc86e634d27aa85568\",\"0x668c24\"]}{\"id\":68,\"jsonrpc\":\"2.0\",\"method\":\"eth_getTransactionCount\",\"params\":[\"0x7f01d9b227593e033bf8d6fc86e634d27aa85568\",\"0x668c24\"]}");
+        IList<JsonRpcResult> result = await ProcessAsync("{\"id\":67,\"jsonrpc\":\"2.0\",\"method\":\"eth_getTransactionCount\",\"params\":[\"0x7f01d9b227593e033bf8d6fc86e634d27aa85568\",\"0x668c24\"]}\r\n{\"id\":68,\"jsonrpc\":\"2.0\",\"method\":\"eth_getTransactionCount\",\"params\":[\"0x7f01d9b227593e033bf8d6fc86e634d27aa85568\",\"0x668c24\"]}");
         result.Should().HaveCount(2);
         result[0].Response.Should().NotBeNull();
         result[0].BatchedResponses.Should().BeNull();

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
@@ -242,7 +242,7 @@ public class JsonRpcProcessor : IJsonRpcProcessor
                     break;
                 }
 
-                buffer = buffer.SliceLeadingWhitespace();
+                buffer = buffer.TrimStart();
             }
 
             // Checks if the deserialization failed

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
@@ -242,7 +242,7 @@ public class JsonRpcProcessor : IJsonRpcProcessor
                     break;
                 }
 
-                buffer = buffer.SliceToNonWhitespace();
+                buffer = buffer.SliceLeadingWhitespace();
             }
 
             // Checks if the deserialization failed

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
@@ -241,6 +241,8 @@ public class JsonRpcProcessor : IJsonRpcProcessor
                     yield return deserializationFailureResult.Value;
                     break;
                 }
+
+                buffer = buffer.SliceToNonWhitespace();
             }
 
             // Checks if the deserialization failed


### PR DESCRIPTION
Fixes #7025

## Changes

- There can be leftover whitespace when reading json bytes from buffer. For example trailing CR LF when using websockets. Now they are sliced and ignored when parsing json.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No


## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No