### PR TITLE
Fix for #6960 and new unit tests for testing dependent batches

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/FastHeadersSyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/FastHeadersSyncTests.cs
@@ -439,7 +439,7 @@ namespace Nethermind.Synchronization.Test.FastBlocks
                         c--;
                     }
                 if (!useNulls)
-                    list = list.Where(h => h != null).ToList();
+                    list = list.Where(h => h is not null).ToList();
                 batch.Response = list.ToPooledList();
             }
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/FastHeadersSyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/FastHeadersSyncTests.cs
@@ -403,9 +403,9 @@ namespace Nethermind.Synchronization.Test.FastBlocks
         [TestCase(80, 1, 1, true, false)]
         [TestCase(80, 1, 1, true, true)]
         //All empty reponse
-        [TestCase(0, 192, 1, false,false)]
+        [TestCase(0, 192, 1, false, false)]
         //All null reponse
-        [TestCase(0, 192, 1, false,true)]
+        [TestCase(0, 192, 1, false, true)]
         public async Task Can_insert_all_good_headers_from_dependent_batch_with_missing_or_null_headers(int nullIndex, int count, int increment, bool shouldReport, bool useNulls)
         {
             var peerChain = Build.A.BlockTree().OfChainLength(1000).TestObject;
@@ -439,7 +439,7 @@ namespace Nethermind.Synchronization.Test.FastBlocks
                         c--;
                     }
                 if (!useNulls)
-                    list = list.Where(h=> h != null).ToList();
+                    list = list.Where(h => h != null).ToList();
                 batch.Response = list.ToPooledList();
             }
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/FastHeadersSyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/FastHeadersSyncTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reactive.Linq;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
@@ -147,7 +148,7 @@ namespace Nethermind.Synchronization.Test.FastBlocks
             syncReport.HeadersInQueue.Returns(new MeasuredProgress());
 
             BlockHeader pivot = remoteBlockTree.FindHeader(500, BlockTreeLookupOptions.None)!;
-            ResettableHeaderSyncFeed feed = new(
+            using ResettableHeaderSyncFeed feed = new(
                 blockTree: blockTree,
                 syncPeerPool: Substitute.For<ISyncPeerPool>(),
                 syncConfig: new SyncConfig
@@ -169,7 +170,7 @@ namespace Nethermind.Synchronization.Test.FastBlocks
                     false)!;
             }
 
-            await feed.PrepareRequest();
+            using HeadersSyncBatch? r = await feed.PrepareRequest();
             using HeadersSyncBatch batch1 = (await feed.PrepareRequest())!;
             FulfillBatch(batch1);
 
@@ -194,7 +195,7 @@ namespace Nethermind.Synchronization.Test.FastBlocks
             syncReport.HeadersInQueue.Returns(new MeasuredProgress());
 
             BlockHeader pivot = remoteBlockTree.FindHeader(2000, BlockTreeLookupOptions.None)!;
-            HeadersSyncFeed feed = new(
+            using HeadersSyncFeed feed = new(
                 blockTree: blockTree,
                 syncPeerPool: Substitute.For<ISyncPeerPool>(),
                 syncConfig: new SyncConfig
@@ -248,6 +249,7 @@ namespace Nethermind.Synchronization.Test.FastBlocks
 
             // New batch would be at end of batch 5 (batch 6).
             newBatch.EndNumber.Should().Be(batches[^1].StartNumber - 1);
+            batches.DisposeItems();
         }
 
         [Test]
@@ -378,6 +380,86 @@ namespace Nethermind.Synchronization.Test.FastBlocks
 
             result.Should().NotBeNull();
             result!.EndNumber.Should().Be(499);
+        }
+
+        //Missing headers in the start is not allowed
+        [TestCase(0, 1, 1, true, false)]
+        [TestCase(0, 1, 1, false, true)]
+        //Missing headers in the start is not allowed
+        [TestCase(0, 2, 1, true, false)]
+        [TestCase(0, 2, 1, false, true)]
+        //Missing headers in the start is not allowed
+        [TestCase(0, 2, 191, true, false)]
+        [TestCase(0, 2, 191, false, true)]
+        //Gaps are not allowed
+        [TestCase(1, 1, 1, true, false)]
+        [TestCase(1, 1, 1, true, true)]
+        [TestCase(187, 5, 1, false, false)]
+        [TestCase(187, 5, 1, false, true)]
+        [TestCase(191, 1, 1, false, false)]
+        [TestCase(191, 1, 1, false, true)]
+        [TestCase(190, 1, 1, true, false)]
+        [TestCase(190, 1, 1, true, true)]
+        [TestCase(80, 1, 1, true, false)]
+        [TestCase(80, 1, 1, true, true)]
+        //All empty reponse
+        [TestCase(0, 192, 1, false,false)]
+        //All null reponse
+        [TestCase(0, 192, 1, false,true)]
+        public async Task Can_insert_all_good_headers_from_dependent_batch_with_missing_or_null_headers(int nullIndex, int count, int increment, bool shouldReport, bool useNulls)
+        {
+            var peerChain = Build.A.BlockTree().OfChainLength(1000).TestObject;
+            var syncConfig = new SyncConfig { FastSync = true, PivotNumber = "1000", PivotHash = Keccak.Zero.ToString(), PivotTotalDifficulty = "1000" };
+
+            IBlockTree localBlockTree = Build.A.BlockTree(peerChain.FindBlock(0, BlockTreeLookupOptions.None)!, null).WithSyncConfig(syncConfig).TestObject;
+            const int lowestInserted = 999;
+            localBlockTree.Insert(peerChain.Head!, BlockTreeInsertBlockOptions.SaveHeader);
+
+            ISyncReport report = Substitute.For<ISyncReport>();
+            report.HeadersInQueue.Returns(new MeasuredProgress());
+            report.FastBlocksHeaders.Returns(new MeasuredProgress());
+
+            ISyncPeerPool syncPeerPool = Substitute.For<ISyncPeerPool>();
+            using HeadersSyncFeed feed = new(localBlockTree, syncPeerPool, syncConfig, report, LimboLogs.Instance);
+            feed.InitializeFeed();
+            using HeadersSyncBatch? firstBatch = await feed.PrepareRequest();
+            using HeadersSyncBatch? dependentBatch = await feed.PrepareRequest();
+            dependentBatch!.ResponseSourcePeer = new PeerInfo(Substitute.For<ISyncPeer>());
+
+            void FillBatch(HeadersSyncBatch batch, long start, bool applyNulls)
+            {
+                int c = count;
+                List<BlockHeader?> list = Enumerable.Range((int)start, batch.RequestSize)
+                    .Select(i => peerChain.FindBlock(i, BlockTreeLookupOptions.None)!.Header)
+                    .ToList<BlockHeader?>();
+                if (applyNulls)
+                    for (int i = nullIndex; 0 < c; i += increment)
+                    {
+                        list[i] = null;
+                        c--;
+                    }
+                if (!useNulls)
+                    list = list.Where(h=> h != null).ToList();
+                batch.Response = list.ToPooledList();
+            }
+
+            FillBatch(firstBatch!, lowestInserted - firstBatch!.RequestSize, false);
+            FillBatch(dependentBatch, lowestInserted - dependentBatch.RequestSize * 2, true);
+            long targetHeaderInDependentBatch = dependentBatch.StartNumber;
+
+            feed.HandleResponse(dependentBatch);
+            feed.HandleResponse(firstBatch);
+
+            using HeadersSyncBatch? thirdbatch = await feed.PrepareRequest();
+            FillBatch(thirdbatch!, thirdbatch!.StartNumber, false);
+            feed.HandleResponse(thirdbatch);
+            using HeadersSyncBatch? fourthbatch = await feed.PrepareRequest();
+            FillBatch(fourthbatch!, fourthbatch!.StartNumber, false);
+            feed.HandleResponse(fourthbatch);
+            using HeadersSyncBatch? fifthbatch = await feed.PrepareRequest();
+
+            Assert.That(localBlockTree.LowestInsertedHeader!.Number, Is.LessThanOrEqualTo(targetHeaderInDependentBatch));
+            syncPeerPool.Received(shouldReport ? 1 : 0).ReportBreachOfProtocol(Arg.Any<PeerInfo>(), Arg.Any<DisconnectReason>(), Arg.Any<string>());
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
@@ -4,7 +4,9 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -250,6 +252,7 @@ namespace Nethermind.Synchronization.FastBlocks
 
         protected void ClearDependencies()
         {
+            _dependencies.Values.DisposeItems();
             _dependencies.Clear();
             MarkDirty();
         }
@@ -259,7 +262,9 @@ namespace Nethermind.Synchronization.FastBlocks
             HeadersSyncProgressReport.Update(_pivotNumber);
             HeadersSyncProgressReport.MarkEnd();
             ClearDependencies(); // there may be some dependencies from wrong branches
+            _pending.DisposeItems();
             _pending.Clear(); // there may be pending wrong branches
+            _sent.DisposeItems();
             _sent.Clear(); // we my still be waiting for some bad branches
             HeadersSyncQueueReport.Update(0L);
             HeadersSyncQueueReport.MarkEnd();
@@ -270,14 +275,21 @@ namespace Nethermind.Synchronization.FastBlocks
             long? lowest = LowestInsertedBlockHeader?.Number;
             long processedBatchCount = 0;
             const long maxBatchToProcess = 4;
-            while (lowest.HasValue && processedBatchCount < maxBatchToProcess && _dependencies.TryRemove(lowest.Value - 1, out HeadersSyncBatch? dependentBatch))
+            while (lowest.HasValue && processedBatchCount < maxBatchToProcess && _dependencies.TryRemove(lowest.Value - 1, out HeadersSyncBatch dependentBatch))
             {
-                MarkDirty();
-                InsertHeaders(dependentBatch!);
-                lowest = LowestInsertedBlockHeader?.Number;
-                cancellationToken.ThrowIfCancellationRequested();
+                try
+                {
+                    MarkDirty();
+                    InsertHeaders(dependentBatch);
+                    lowest = LowestInsertedBlockHeader?.Number;
+                    cancellationToken.ThrowIfCancellationRequested();
 
-                processedBatchCount++;
+                    processedBatchCount++;
+                }
+                finally
+                {
+                    dependentBatch.Dispose();  
+                }
             }
         }
 
@@ -449,7 +461,7 @@ namespace Nethermind.Synchronization.FastBlocks
         private static HeadersSyncBatch BuildDependentBatch(HeadersSyncBatch batch, long addedLast, long addedEarliest)
         {
             HeadersSyncBatch dependentBatch = new();
-            dependentBatch.StartNumber = batch.StartNumber;
+            dependentBatch.StartNumber = addedEarliest;
             int count = (int)(addedLast - addedEarliest + 1);
             dependentBatch.RequestSize = count;
             dependentBatch.MinNumber = batch.MinNumber;
@@ -567,26 +579,30 @@ namespace Nethermind.Synchronization.FastBlocks
                             _pending.Enqueue(batch);
                             throw new InvalidOperationException($"Only one header dependency expected ({batch})");
                         }
-
+                        long lastNumber = -1;
                         for (int j = 0; j < batch.Response.Count; j++)
                         {
                             BlockHeader? current = batch.Response[j];
                             if (current is not null)
                             {
+                                if (lastNumber != -1 && lastNumber < current.Number - 1)
+                                {
+                                    //There is a gap in this response,
+                                    //so we save the whole batch for now,
+                                    //and let the next PrepareRequest() handle the disconnect
+                                    addedEarliest = batch.StartNumber;
+                                    addedLast = batch.EndNumber;
+                                    break;
+                                }
                                 addedEarliest = Math.Min(addedEarliest, current.Number);
                                 addedLast = Math.Max(addedLast, current.Number);
-                            }
-                            else
-                            {
-                                break;
+                                lastNumber = current.Number;
                             }
                         }
-
                         HeadersSyncBatch dependentBatch = BuildDependentBatch(batch, addedLast, addedEarliest);
                         _dependencies[header.Number] = dependentBatch;
                         MarkDirty();
                         if (_logger.IsDebug) _logger.Debug($"{batch} -> DEPENDENCY {dependentBatch}");
-
                         // but we cannot do anything with it yet
                         break;
                     }
@@ -636,6 +652,7 @@ namespace Nethermind.Synchronization.FastBlocks
             {
                 if (added <= 0)
                 {
+                    batch.Response?.Dispose();
                     batch.Response = null;
                     _pending.Enqueue(batch);
                 }
@@ -708,6 +725,18 @@ namespace Nethermind.Synchronization.FastBlocks
         {
             _nextHeaderHash = header.ParentHash!;
             _nextHeaderDiff = (header.TotalDifficulty ?? 0) - header.Difficulty;
+        }
+        private bool _disposed = false;
+        public override void Dispose()
+        {
+            if (!_disposed)
+            {
+                _sent.DisposeItems();
+                _pending.DisposeItems();
+                _dependencies.Values.DisposeItems();
+                base.Dispose();
+                _disposed = true;
+            }
         }
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
@@ -288,7 +288,7 @@ namespace Nethermind.Synchronization.FastBlocks
                 }
                 finally
                 {
-                    dependentBatch.Dispose();  
+                    dependentBatch.Dispose();
                 }
             }
         }

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/FastHeadersSyncFeed.cs
@@ -277,7 +277,7 @@ namespace Nethermind.Synchronization.FastBlocks
             const long maxBatchToProcess = 4;
             while (lowest.HasValue && processedBatchCount < maxBatchToProcess && _dependencies.TryRemove(lowest.Value - 1, out HeadersSyncBatch dependentBatch))
             {
-                try
+                using (dependentBatch)
                 {
                     MarkDirty();
                     InsertHeaders(dependentBatch);
@@ -285,10 +285,6 @@ namespace Nethermind.Synchronization.FastBlocks
                     cancellationToken.ThrowIfCancellationRequested();
 
                     processedBatchCount++;
-                }
-                finally
-                {
-                    dependentBatch.Dispose();
                 }
             }
         }


### PR DESCRIPTION
Fixes #6960

`InsertHeaders` now properly handles null when a dependent batch arrives. 

The added unit test also showcases different header batches that is allowed and not. 
Among them are a bit of strange behavior, since we allow a batch to start with null, but not empty.

This is not allowed
**batch 1-3**
header2, header3 

This is allowed
**batch 1-3**
null,header2, header3 

Also this will fix several instances of `ArrayPoolList` not being disposed in `HeaderSyncFeed`.

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

