### PR TITLE
Log when using larger than default pruning cache

### DIFF
--- a/src/Nethermind/Nethermind.Init/InitializeStateDb.cs
+++ b/src/Nethermind/Nethermind.Init/InitializeStateDb.cs
@@ -74,7 +74,7 @@ public class InitializeStateDb : IStep
 
         if (pruningConfig.PruningBoundary < 64)
         {
-            if (_logger.IsWarn) _logger.Warn($"Prunig boundary must be at least 64. Setting to 64.");
+            if (_logger.IsWarn) _logger.Warn($"Pruning boundary must be at least 64. Setting to 64.");
             pruningConfig.PruningBoundary = 64;
         }
 
@@ -96,6 +96,12 @@ public class InitializeStateDb : IStep
                 PruningTriggerPersistenceStrategy triggerPersistenceStrategy = new((IFullPruningDb)getApi.DbProvider!.StateDb, getApi.BlockTree!, getApi.LogManager);
                 getApi.DisposeStack.Push(triggerPersistenceStrategy);
                 persistenceStrategy = persistenceStrategy.Or(triggerPersistenceStrategy);
+            }
+
+            if ((_api.NodeStorageFactory.CurrentKeyScheme != INodeStorage.KeyScheme.Hash || initConfig.StateDbKeyScheme == INodeStorage.KeyScheme.HalfPath)
+                && pruningConfig.CacheMb > 2000)
+            {
+                if (_logger.IsWarn) _logger.Warn($"Detected {pruningConfig.CacheMb}MB of pruning cache config. Pruning cache more than 2000MB is not recommended as it may cause long memory pruning time which affect attestation.");
             }
 
             pruningStrategy = Prune


### PR DESCRIPTION
- Warn when using pruning cache larger than 2GB as the pruning hang can take large amount of time which effect attestation.
- Large pruning cache was mainly used to reduce database growth, but since Ahmad's node running 1GB pruning cache for the past 3 month only grow by 25GB, its probably fine to keep the default for most user.
- One scenario where it still make sense is for RPC provider as more cache does improve block processing performance or when setting much longer pruning boundary where large prune cache is unavoidable. For reference, on mainnet minimum prune cache size is about 450MB for past 128 state to support snap serving.

## Types of changes

#### What types of changes does your code introduce?

- [X] Optimization

## Testing

#### Requires testing

- [X] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

- Tested with setting and not setting te config.