### PR TITLE
Fast Call to Non contract addresses

### DIFF
--- a/src/Nethermind/Nethermind.Evm/CodeAnalysis/CodeInfo.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeAnalysis/CodeInfo.cs
@@ -29,6 +29,7 @@ namespace Nethermind.Evm.CodeAnalysis
         }
 
         public bool IsPrecompile => Precompile is not null;
+        public bool IsEmpty => ReferenceEquals(_analyzer, _emptyAnalyzer) && !IsPrecompile;
 
         public CodeInfo(IPrecompile precompile)
         {

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -1872,6 +1872,7 @@ internal sealed class VirtualMachine<TLogger> : IVirtualMachine where TLogger : 
                         }
                         if (ReferenceEquals(returnData, CallResult.BoxedEmpty))
                         {
+                            // Non contract call, clear return data and push success status
                             _returnDataBuffer = default;
                             stack.PushBytes(StatusCode.SuccessBytes.Span);
                             continue;
@@ -2268,6 +2269,7 @@ internal sealed class VirtualMachine<TLogger> : IVirtualMachine where TLogger : 
 
         if (codeInfo.IsEmpty && typeof(TTracingInstructions) != typeof(IsTracing) && !_txTracer.IsTracingActions)
         {
+            // Non contract call, no need to construct call frame can just credit balance and return gas
             UpdateGasUp(gasLimitUl, ref gasAvailable);
             if (!_state.AccountExists(target))
             {


### PR DESCRIPTION
## Changes

- If a call is to a non-contract address; just transfer the value rather than constructing a full call frame 
    - between 1% to 10% of calls per block are to non-contract (i.e. effectively only ETH transfers)

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No