### PR TITLE
Pre-cache AccessLists

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Processing/ReadOnlyTxProcessingEnv.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ReadOnlyTxProcessingEnv.cs
@@ -22,6 +22,7 @@ namespace Nethermind.Consensus.Processing
         public IBlockTree BlockTree { get; }
         public IBlockhashProvider BlockhashProvider { get; }
         public IVirtualMachine Machine { get; }
+        public ISpecProvider SpecProvider { get; }
 
         public ReadOnlyTxProcessingEnv(
             IWorldStateManager worldStateManager,
@@ -41,7 +42,7 @@ namespace Nethermind.Consensus.Processing
         {
             ArgumentNullException.ThrowIfNull(specProvider);
             ArgumentNullException.ThrowIfNull(worldStateManager);
-
+            SpecProvider = specProvider;
             StateReader = worldStateManager.GlobalStateReader;
             StateProvider = worldStateManager.CreateResettableWorldState(preBlockCaches);
 

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -470,7 +470,6 @@ namespace Nethermind.Evm.TransactionProcessing
                     if (spec.UseTxAccessLists)
                     {
                         state.WarmUp(tx.AccessList); // eip-2930
-                        WorldState.WarmUp(tx.AccessList);
                     }
 
                     if (spec.UseHotAndColdStorage)

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -470,6 +470,7 @@ namespace Nethermind.Evm.TransactionProcessing
                     if (spec.UseTxAccessLists)
                     {
                         state.WarmUp(tx.AccessList); // eip-2930
+                        WorldState.WarmUp(tx.AccessList);
                     }
 
                     if (spec.UseHotAndColdStorage)

--- a/src/Nethermind/Nethermind.State/IWorldState.cs
+++ b/src/Nethermind/Nethermind.State/IWorldState.cs
@@ -5,6 +5,7 @@ using System;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Eip2930;
 using Nethermind.Core.Specs;
 using Nethermind.Int256;
 using Nethermind.State.Tracing;
@@ -68,7 +69,7 @@ public interface IWorldState : IJournal<Snapshot>, IReadOnlyStateProvider
     Snapshot TakeSnapshot(bool newTransactionStart = false);
 
     Snapshot IJournal<Snapshot>.TakeSnapshot() => TakeSnapshot();
-
+    void WarmUp(AccessList? accessList);
     /// <summary>
     /// Clear all storage at specified address
     /// </summary>

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -335,6 +335,11 @@ namespace Nethermind.State
             return value;
         }
 
+        public void WarmUp(in StorageCell storageCell)
+        {
+            LoadFromTree(in storageCell);
+        }
+
         private ReadOnlySpan<byte> LoadFromTree(in StorageCell storageCell)
         {
             ref byte[]? value = ref CollectionsMarshal.GetValueRefOrAddDefault(_blockCache, storageCell, out bool exists);

--- a/src/Nethermind/Nethermind.State/StateProvider.cs
+++ b/src/Nethermind/Nethermind.State/StateProvider.cs
@@ -653,6 +653,11 @@ namespace Nethermind.State
             };
         }
 
+        public void WarmUp(Address address)
+        {
+            GetState(address);
+        }
+
         private Account? GetState(Address address)
         {
             AddressAsKey addressAsKey = address;

--- a/src/Nethermind/Nethermind.State/WorldState.cs
+++ b/src/Nethermind/Nethermind.State/WorldState.cs
@@ -7,6 +7,7 @@ using System.Runtime.CompilerServices;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Eip2930;
 using Nethermind.Core.Specs;
 using Nethermind.Int256;
 using Nethermind.Logging;
@@ -109,7 +110,20 @@ namespace Nethermind.State
             _persistentStorageProvider.Reset();
             _transientStorageProvider.Reset();
         }
-
+        public void WarmUp(AccessList? accessList)
+        {
+            if (accessList?.IsEmpty == false)
+            {
+                foreach ((Address address, AccessList.StorageKeysEnumerable storages) in accessList)
+                {
+                    _stateProvider.WarmUp(address);
+                    foreach (UInt256 storage in storages)
+                    {
+                        _persistentStorageProvider.WarmUp(new StorageCell(address, storage));
+                    }
+                }
+            }
+        }
         public void ClearStorage(Address address)
         {
             _persistentStorageProvider.ClearStorage(address);


### PR DESCRIPTION
## Changes

- Load load the data for access lists. Now we can pre-warm/cache the data in a tx, it makes sense to actually use the access lists to prepopulate those caches.

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
