### PR TITLE
Remove tx also from worst sorted values

### DIFF
--- a/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
@@ -443,6 +443,7 @@ namespace Nethermind.TxPool.Collections
         {
             if (_cacheMap.Remove(key))
             {
+                _worstSortedValues.Remove(value);
                 UpdateIsFull();
                 _snapshot = null;
                 return true;


### PR DESCRIPTION
Contributes to https://github.com/NethermindEth/nethermind/issues/6843

## Changes

- When removing from tx pool; also remove from WorstSortedValues; so non-existant values aren't in the WorstSorted txs

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No