### PR TITLE
Remove removed past PathHashes

### DIFF
--- a/src/Nethermind/Nethermind.Init/InitializeStateDb.cs
+++ b/src/Nethermind/Nethermind.Init/InitializeStateDb.cs
@@ -111,7 +111,7 @@ public class InitializeStateDb : IStep
                 .WhenCacheReaches(pruningConfig.CacheMb.MB())
                 // Use of ratio, as the effectiveness highly correlate with the amount of keys per snapshot save which
                 // depends on CacheMb. 0.05 is the minimum where it can keep track the whole snapshot.. most of the time.
-                // With the default 2000MB cache and 0.1 ratio, it can keep track of just over 1M keys.
+                // With the default 1000MB cache and 0.1 ratio, it can keep track of just over 1M keys.
                 .TrackingPastKeys((int)(pruningConfig.CacheMb.MB() * pruningConfig.TrackedPastKeyCountMemoryRatio / KeyEntryMemorySize))
                 .KeepingLastNState(pruningConfig.PruningBoundary);
         }

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -768,7 +768,7 @@ namespace Nethermind.Trie.Pruning
         {
             if (persistedHashes is null) return;
 
-            bool CanRemove(Hash256? address, TinyTreePath path, in TreePath fullPath, ValueHash256 keccak, Hash256? currentlyPersistingKeccak)
+            bool CanRemove(Hash256? address, TinyTreePath path, in TreePath fullPath, in ValueHash256 keccak, Hash256? currentlyPersistingKeccak)
             {
                 // Multiple current hash that we don't keep track for simplicity. Just ignore this case.
                 if (currentlyPersistingKeccak is null) return false;
@@ -792,13 +792,14 @@ namespace Nethermind.Trie.Pruning
             void DoAct(KeyValuePair<HashAndTinyPath, Hash256> keyValuePair)
             {
                 HashAndTinyPath key = keyValuePair.Key;
-                if (_pastPathHash.TryGet(new(key.addr, in key.path), out ValueHash256 prevHash))
+                if (_pastPathHash.TryGet(key, out ValueHash256 prevHash))
                 {
                     TreePath fullPath = key.path.ToTreePath(); // Micro op to reduce double convert
                     if (CanRemove(key.addr, key.path, fullPath, prevHash, keyValuePair.Value))
                     {
                         Metrics.RemovedNodeCount++;
                         writeBatch.Remove(key.addr, fullPath, prevHash);
+                        _pastPathHash.Delete(key);
                     }
                 }
             }


### PR DESCRIPTION
## Changes

- When memory pruning an item; remove its entry from the LruCache (as its just been pruned)
- Shrink the size of the LruCache by default from 2.1M items to 1M items

Otherwise after a couple prunes the cache quickly grows to the maximum 2.1M items; some of which will never be used again.

<img width="661" alt="image" src="https://github.com/NethermindEth/nethermind/assets/1142958/953c1f23-93a0-4e34-9a71-f2fb26c70cb6">


## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [ ] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [ ] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
