### PR TITLE
Fix/proof generation

### DIFF
--- a/src/Nethermind/Nethermind.Init/InitializeStateDb.cs
+++ b/src/Nethermind/Nethermind.Init/InitializeStateDb.cs
@@ -74,7 +74,7 @@ public class InitializeStateDb : IStep
 
         if (pruningConfig.PruningBoundary < 64)
         {
-            if (_logger.IsWarn) _logger.Warn($"Prunig boundary must be at least 64. Setting to 64.");
+            if (_logger.IsWarn) _logger.Warn($"Pruning boundary must be at least 64. Setting to 64.");
             pruningConfig.PruningBoundary = 64;
         }
 
@@ -96,6 +96,12 @@ public class InitializeStateDb : IStep
                 PruningTriggerPersistenceStrategy triggerPersistenceStrategy = new((IFullPruningDb)getApi.DbProvider!.StateDb, getApi.BlockTree!, getApi.LogManager);
                 getApi.DisposeStack.Push(triggerPersistenceStrategy);
                 persistenceStrategy = persistenceStrategy.Or(triggerPersistenceStrategy);
+            }
+
+            if ((_api.NodeStorageFactory.CurrentKeyScheme != INodeStorage.KeyScheme.Hash || initConfig.StateDbKeyScheme == INodeStorage.KeyScheme.HalfPath)
+                && pruningConfig.CacheMb > 2000)
+            {
+                if (_logger.IsWarn) _logger.Warn($"Detected {pruningConfig.CacheMb}MB of pruning cache config. Pruning cache more than 2000MB is not recommended as it may cause long memory pruning time which affect attestation.");
             }
 
             pruningStrategy = Prune

--- a/src/Nethermind/Nethermind.Synchronization.Test/RangeQueryVisitorTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/RangeQueryVisitorTests.cs
@@ -173,7 +173,7 @@ public class RangeQueryVisitorTests
         }
 
         leafCollector.Leafs.Count.Should().Be(5);
-        visitor.GetProofs().Count.Should().Be(6); // Need to make sure `0x12` is included
+        visitor.GetProofs().Count.Should().Be(6); // Need to make sure `0x11` is included
     }
 
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/RangeQueryVisitorTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/RangeQueryVisitorTests.cs
@@ -174,7 +174,7 @@ public class RangeQueryVisitorTests
 
         leafCollector.Leafs.Count.Should().Be(4);
 
-        ArrayPoolList<byte[]> proofs = visitor.GetProofs();
+        using ArrayPoolList<byte[]> proofs = visitor.GetProofs();
         proofs.Count.Should().Be(6); // Need to make sure `0x11` is included
 
         var proofHashes = proofs.Select((rlp) => Keccak.Compute(rlp)).ToHashSet();

--- a/src/Nethermind/Nethermind.Synchronization.Test/RangeQueryVisitorTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/RangeQueryVisitorTests.cs
@@ -158,10 +158,10 @@ public class RangeQueryVisitorTests
         ];
 
         var stateTree = new StateTree();
-        var account = TestItem.GenerateRandomAccount();
+        var random = new Random(0);
         foreach (var path in paths)
         {
-            stateTree.Set(new Hash256(path), account);
+            stateTree.Set(new Hash256(path), TestItem.GenerateRandomAccount(random));
         }
         stateTree.Commit(0);
 
@@ -178,15 +178,19 @@ public class RangeQueryVisitorTests
         proofs.Count.Should().Be(6); // Need to make sure `0x11` is included
 
         var proofHashes = proofs.Select((rlp) => Keccak.Compute(rlp)).ToHashSet();
+        foreach (Hash256 proofHash in proofHashes)
+        {
+            Console.Out.WriteLine(proofHash);
+        }
 
         string[] proofHashStrs =
         [
-            "0x848936a86befa6693df03877b266a2ccce7e4a65122ca5740a7f5e9d53a56136",
-            "0xa2b09f843c84c34f2444a2cb0d95ba299af66a18581d8ddea8830fbc5802999e",
-            "0x249e8deef5ac40f1e1280b94b137452cb9ab2f2a0b323c5efafff6b3f07c85e3",
-            "0x9f225ad13194e14cb1c8322ddef63a44ffa442cfda5e911b52632caf98f49e46",
-            "0xe380b3732498e98c998d66d1e848f5c0369841905aa343626d73f41e8a67f053",
-            "0x9f225ad13194e14cb1c8322ddef63a44ffa442cfda5e911b52632caf98f49e46"
+            "0x35811c17fd5e33e75276677e27e3fe39653403a4d0df4a2f94af40ac265a4a6f",
+            "0xfd6d9e748837908d14fca3ddf76d06c3f74196543f3d05d8fa0b6d6726037f51",
+            "0xde44831292ba34a2a31566004549c1681dbe3a4042f265be60a9fff3643a3112",
+            "0x665b6b070a219250b89d36feeb07ae350bae619e8660598f9ec98176b19c5d07",
+            "0x07b17db6a32be868e9940568db8b1011c7679e642c2db0237a5a7ebdaadb0e6e",
+            "0xfbd8c8f3cd78599b87fd3ab0cfe127c5b2d488cb913aeec5b80230668fed45c8"
         ];
 
         foreach (var proofHashStr in proofHashStrs)

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapServerTest.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapServerTest.cs
@@ -73,6 +73,21 @@ public class SnapServerTest
     }
 
     [Test]
+    public void TestGetAccountRange_InvalidRange()
+    {
+        Context context = CreateContext();
+        TestItem.Tree.FillStateTreeWithTestAccounts(context.Tree);
+
+        (IOwnedReadOnlyList<PathWithAccount> accounts, IOwnedReadOnlyList<byte[]> proofs) =
+            context.Server.GetAccountRanges(context.Tree.RootHash, Keccak.MaxValue, Keccak.Zero, 4000, CancellationToken.None);
+
+        accounts.Count.Should().Be(0);
+        proofs.Count.Should().Be(0);
+        accounts.Dispose();
+        proofs.Dispose();
+    }
+
+    [Test]
     public void TestNoState()
     {
         Context context = CreateContext(stateRootTracker: CreateConstantStateRootTracker(false));

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapServerTest.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapServerTest.cs
@@ -87,6 +87,38 @@ public class SnapServerTest
     }
 
     [Test]
+    public void TestGetTrieNode_Root()
+    {
+        Context context = CreateContext();
+        TestItem.Tree.FillStateTreeWithTestAccounts(context.Tree);
+
+        using IOwnedReadOnlyList<byte[]> result = context.Server.GetTrieNodes([
+            new PathGroup()
+            {
+                Group = [[]]
+            }
+        ], context.Tree.RootHash, default)!;
+
+        result.Count.Should().Be(1);
+    }
+
+    [Test]
+    public void TestGetTrieNode_Storage_Root()
+    {
+        Context context = CreateContext();
+        TestItem.Tree.FillStateTreeWithTestAccounts(context.Tree);
+
+        using IOwnedReadOnlyList<byte[]> result = context.Server.GetTrieNodes([
+            new PathGroup()
+            {
+                Group = [TestItem.Tree.AccountsWithPaths[0].Path.Bytes.ToArray(), []]
+            }
+        ], context.Tree.RootHash, default)!;
+
+        result.Count.Should().Be(1);
+    }
+
+    [Test]
     public void TestNoState()
     {
         Context context = CreateContext(stateRootTracker: CreateConstantStateRootTracker(false));

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapServerTest.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapServerTest.cs
@@ -82,7 +82,6 @@ public class SnapServerTest
             context.Server.GetAccountRanges(context.Tree.RootHash, Keccak.MaxValue, Keccak.Zero, 4000, CancellationToken.None);
 
         accounts.Count.Should().Be(0);
-        proofs.Count.Should().Be(0);
         accounts.Dispose();
         proofs.Dispose();
     }

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapServer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapServer.cs
@@ -104,8 +104,10 @@ public class SnapServer : ISnapServer
                 default:
                     try
                     {
-                        Hash256 storagePath = new Hash256(ValueKeccak.Zero);
-                        requestedPath[0].CopyTo(storagePath.Bytes); // One of the hive tests does not have complete 32 byte for storage path for some reason.
+                        Hash256 storagePath = new Hash256(
+                            requestedPath[0].Length == Hash256.Size
+                                ? requestedPath[0]
+                                : requestedPath[0].PadRight(Hash256.Size));
                         Account? account = GetAccountByPath(tree, rootHash, requestedPath[0]);
                         if (account is not null)
                         {

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapServer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapServer.cs
@@ -267,6 +267,11 @@ public class SnapServer : ISnapServer
         RangeQueryVisitor.ILeafValueCollector valueCollector,
         CancellationToken cancellationToken)
     {
+        if (startingHash.CompareTo(limitHash) > 0)
+        {
+            return (0, ArrayPoolList<byte[]>.Empty(), false);
+        }
+
         PatriciaTree tree = new(_store, _logManager);
         using RangeQueryVisitor visitor = new(startingHash, limitHash, valueCollector, byteLimit, HardResponseNodeLimit, readFlags: _optimizedReadFlags, cancellationToken);
         VisitingOptions opt = new() { ExpectAccounts = false };

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapServer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapServer.cs
@@ -104,20 +104,18 @@ public class SnapServer : ISnapServer
                 default:
                     try
                     {
-                        Hash256 storagePath = new Hash256(requestedPath[0]);
+                        Hash256 storagePath = new Hash256(ValueKeccak.Zero);
+                        requestedPath[0].CopyTo(storagePath.Bytes); // One of the hive tests does not have complete 32 byte for storage path for some reason.
                         Account? account = GetAccountByPath(tree, rootHash, requestedPath[0]);
                         if (account is not null)
                         {
                             Hash256? storageRoot = account.StorageRoot;
-                            if (!storageRoot.Bytes.SequenceEqual(Keccak.EmptyTreeHash.Bytes))
-                            {
-                                StorageTree sTree = new(_store.GetTrieStore(storagePath), storageRoot, _logManager);
+                            StorageTree sTree = new(_store.GetTrieStore(storagePath), storageRoot, _logManager);
 
-                                for (int reqStorage = 1; reqStorage < requestedPath.Length; reqStorage++)
-                                {
-                                    byte[]? sRlp = sTree.GetNodeByPath(Nibbles.CompactToHexEncode(requestedPath[reqStorage]));
-                                    response.Add(sRlp);
-                                }
+                            for (int reqStorage = 1; reqStorage < requestedPath.Length; reqStorage++)
+                            {
+                                byte[]? sRlp = sTree.GetNodeByPath(Nibbles.CompactToHexEncode(requestedPath[reqStorage]));
+                                response.Add(sRlp);
                             }
                         }
                     }

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapServer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapServer.cs
@@ -267,11 +267,6 @@ public class SnapServer : ISnapServer
         RangeQueryVisitor.ILeafValueCollector valueCollector,
         CancellationToken cancellationToken)
     {
-        if (startingHash.CompareTo(limitHash) > 0)
-        {
-            return (0, ArrayPoolList<byte[]>.Empty(), false);
-        }
-
         PatriciaTree tree = new(_store, _logManager);
         using RangeQueryVisitor visitor = new(startingHash, limitHash, valueCollector, byteLimit, HardResponseNodeLimit, readFlags: _optimizedReadFlags, cancellationToken);
         VisitingOptions opt = new() { ExpectAccounts = false };

--- a/src/Nethermind/Nethermind.Trie/RangeQueryVisitor.cs
+++ b/src/Nethermind/Nethermind.Trie/RangeQueryVisitor.cs
@@ -73,10 +73,6 @@ public class RangeQueryVisitor : ITreeVisitor<TreePathContext>, IDisposable
         else
             _startHash = new TreePath(startHash, 64);
 
-        if (startHash.CompareTo(limitHash) > 0)
-        {
-            throw new InvalidOperationException("limitHash must be after startHash");
-        }
         _cancellationToken = cancellationToken;
         _valueCollector = valueCollector;
         _nodeLimit = nodeLimit;
@@ -141,7 +137,7 @@ public class RangeQueryVisitor : ITreeVisitor<TreePathContext>, IDisposable
             int i = 0;
             while (true)
             {
-                Debug.Assert(_leftmostNodes[i].HasValue);
+                if (!_leftmostNodes[i].HasValue) break;
 
                 TrieNode node = _leftmostNodes[i].Value.Item2;
                 proofs.Add(node.FullRlp.ToArray());
@@ -161,7 +157,7 @@ public class RangeQueryVisitor : ITreeVisitor<TreePathContext>, IDisposable
             int i = 0;
             while (true)
             {
-                Debug.Assert(_rightmostNodes[i] is not null);
+                if (_rightmostNodes[i] is null) break;
 
                 TrieNode node = null;
                 foreach ((TreePath, TrieNode)? entry in _rightmostNodes[i].Data)
@@ -175,7 +171,7 @@ public class RangeQueryVisitor : ITreeVisitor<TreePathContext>, IDisposable
                     }
                 }
 
-                Debug.Assert(node is not null);
+                if (node is null) break;
 
                 proofs.Add(node.FullRlp.ToArray());
                 if (node.IsBranch)

--- a/src/Nethermind/Nethermind.Trie/RangeQueryVisitor.cs
+++ b/src/Nethermind/Nethermind.Trie/RangeQueryVisitor.cs
@@ -73,6 +73,10 @@ public class RangeQueryVisitor : ITreeVisitor<TreePathContext>, IDisposable
         else
             _startHash = new TreePath(startHash, 64);
 
+        if (startHash.CompareTo(limitHash) > 0)
+        {
+            throw new InvalidOperationException("limitHash must be after startHash");
+        }
         _cancellationToken = cancellationToken;
         _valueCollector = valueCollector;
         _nodeLimit = nodeLimit;

--- a/src/Nethermind/Nethermind.Trie/RangeQueryVisitor.cs
+++ b/src/Nethermind/Nethermind.Trie/RangeQueryVisitor.cs
@@ -77,12 +77,6 @@ public class RangeQueryVisitor : ITreeVisitor<TreePathContext>, IDisposable
 
     private bool ShouldVisit(in TreePath path)
     {
-        if (_cancellationToken.IsCancellationRequested)
-        {
-            StoppedEarly = true;
-            return false;
-        }
-
         if (_lastNodeFound)
         {
             StoppedEarly = true;


### PR DESCRIPTION
Fix #7071 

- The assumption that the proof would have its key equal to the prefix of the first leaf is only true if the first leaf is close to the start hash or equal to start hash.
- Geth split ranges of storage trees which mean the start hash can be far from the first leaf. Nethermind does not, so this does not affect nethermind accept for top level tree, which for mainnet is large making this issue unlikely to show up.
- This changes the proof tracking logic to use the type of proof node to know what is the correct level for the next proof node.
- Also fix right proof randomly broken when cancelled.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- [X] Geth can complete snap and healing from nethermind.
- [X] Nethermind can complete snap and healing from nethermind.
- [X] Snap hive test passed.