### PR TITLE
Reset state per block during archive sync

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
@@ -143,6 +143,7 @@ public partial class BlockProcessor : IBlockProcessor
                 }
 
                 preBlockStateRoot = processedBlock.StateRoot;
+                _stateProvider.Reset(resizeCollections: true);
             }
 
             if (options.ContainsFlag(ProcessingOptions.DoNotUpdateHead))

--- a/src/Nethermind/Nethermind.Core/Resettables/ResettableDictionary.cs
+++ b/src/Nethermind/Nethermind.Core/Resettables/ResettableDictionary.cs
@@ -111,10 +111,16 @@ namespace Nethermind.Core.Resettables
         public ICollection<TKey> Keys => _wrapped.Keys;
         public ICollection<TValue> Values => _wrapped.Values;
 
-        public void Reset()
+        public void Reset(bool resizeCollections = true)
         {
             if (_wrapped.Count == 0)
             {
+                return;
+            }
+
+            if (!resizeCollections)
+            {
+                _wrapped.Clear();
                 return;
             }
 

--- a/src/Nethermind/Nethermind.Core/Resettables/ResettableHashSet.cs
+++ b/src/Nethermind/Nethermind.Core/Resettables/ResettableHashSet.cs
@@ -61,10 +61,15 @@ namespace Nethermind.Core.Resettables
         public int Count => _wrapped.Count;
         public bool IsReadOnly => false;
 
-        public void Reset()
+        public void Reset(bool resizeCollections = true)
         {
             if (_wrapped.Count == 0)
             {
+                return;
+            }
+            if (!resizeCollections)
+            {
+                _wrapped.Clear();
                 return;
             }
 

--- a/src/Nethermind/Nethermind.State/IWorldState.cs
+++ b/src/Nethermind/Nethermind.State/IWorldState.cs
@@ -55,7 +55,7 @@ public interface IWorldState : IJournal<Snapshot>, IReadOnlyStateProvider
     /// <summary>
     /// Reset all storage
     /// </summary>
-    void Reset();
+    void Reset(bool resizeCollections = false);
 
     /// <summary>
     /// Creates a restartable snapshot.

--- a/src/Nethermind/Nethermind.State/PartialStorageProviderBase.cs
+++ b/src/Nethermind/Nethermind.State/PartialStorageProviderBase.cs
@@ -209,7 +209,7 @@ namespace Nethermind.State
         /// <summary>
         /// Reset the storage state
         /// </summary>
-        public virtual void Reset()
+        public virtual void Reset(bool resizeCollections = true)
         {
             if (_logger.IsTrace) _logger.Trace("Resetting storage");
 

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -68,11 +68,11 @@ namespace Nethermind.State
         /// <summary>
         /// Reset the storage state
         /// </summary>
-        public override void Reset()
+        public override void Reset(bool resizeCollections = true)
         {
             base.Reset();
             _blockCache.Clear();
-            _storages.Reset();
+            _storages.Reset(resizeCollections);
             _originalValues.Clear();
             _committedThisRound.Clear();
             _toUpdateRoots.Clear();

--- a/src/Nethermind/Nethermind.State/StateProvider.cs
+++ b/src/Nethermind/Nethermind.State/StateProvider.cs
@@ -819,12 +819,12 @@ namespace Nethermind.State
             }
         }
 
-        public void Reset()
+        public void Reset(bool resizeCollections = true)
         {
             if (_logger.IsTrace) _logger.Trace("Clearing state provider caches");
             _blockCache.Clear();
-            _intraTxCache.Reset();
-            _committedThisRound.Reset();
+            _intraTxCache.Reset(resizeCollections);
+            _committedThisRound.Reset(resizeCollections);
             _nullAccountReads.Clear();
             _currentPosition = Resettable.EmptyPosition;
             Array.Clear(_changes, 0, _changes.Length);

--- a/src/Nethermind/Nethermind.State/WorldState.cs
+++ b/src/Nethermind/Nethermind.State/WorldState.cs
@@ -104,11 +104,11 @@ namespace Nethermind.State
         {
             _transientStorageProvider.Set(storageCell, newValue);
         }
-        public void Reset()
+        public void Reset(bool resizeCollections = false)
         {
-            _stateProvider.Reset();
-            _persistentStorageProvider.Reset();
-            _transientStorageProvider.Reset();
+            _stateProvider.Reset(resizeCollections);
+            _persistentStorageProvider.Reset(resizeCollections);
+            _transientStorageProvider.Reset(resizeCollections);
         }
         public void WarmUp(AccessList? accessList)
         {


### PR DESCRIPTION
Resolves #7083 

## Changes

- Reset world state per block when processing a long chain

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [ ] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [ ] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
