### PR TITLE
Fix block metrics + reduce metric contention

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Processing/ProcessingStats.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ProcessingStats.cs
@@ -38,6 +38,13 @@ namespace Nethermind.Consensus.Processing
         private long _runMicroseconds;
         private long _reportMs;
         private Block? _lastBlock;
+        private long _sloadOpcodeProcessing;
+        private long _sstoreOpcodeProcessing;
+        private long _callsProcessing;
+        private long _emptyCallsProcessing;
+        private long _codeDbCacheProcessing;
+        private long _contractAnalysedProcessing;
+        private long _createsProcessing;
 
         public ProcessingStats(ILogger logger)
         {
@@ -86,6 +93,13 @@ namespace Nethermind.Consensus.Processing
             {
                 _lastReportMs = _reportMs;
                 _lastBlock = block;
+                _sloadOpcodeProcessing = Evm.Metrics.ThreadLocalSLoadOpcode;
+                _sstoreOpcodeProcessing = Evm.Metrics.ThreadLocalSStoreOpcode;
+                _callsProcessing = Evm.Metrics.ThreadLocalCalls;
+                _emptyCallsProcessing = Evm.Metrics.ThreadLocalEmptyCalls;
+                _codeDbCacheProcessing =  Db.Metrics.ThreadLocalCodeDbCache;
+                _contractAnalysedProcessing =  Evm.Metrics.ThreadLocalContractsAnalysed;
+                _createsProcessing = Evm.Metrics.ThreadLocalCreates;
                 GenerateReport();
             }
         }
@@ -132,13 +146,13 @@ namespace Nethermind.Consensus.Processing
             {
                 double totalMicroseconds = _blockProcessingMicroseconds;
                 long chunkTx = Metrics.Transactions - _lastTotalTx;
-                long chunkCalls = Evm.Metrics.Calls - _lastTotalCalls;
-                long chunkEmptyCalls = Evm.Metrics.EmptyCalls - _lastTotalEmptyCalls;
-                long chunkCreates = Evm.Metrics.Creates - _lastTotalCreates;
-                long chunkSload = Evm.Metrics.SloadOpcode - _lastTotalSLoad;
-                long chunkSstore = Evm.Metrics.SstoreOpcode - _lastTotalSStore;
-                long contractsAnalysed = Evm.Metrics.ContractsAnalysed - _lastContractsAnalysed;
-                long cachedContractsUsed = Db.Metrics.CodeDbCache - _lastCachedContractsUsed;
+                long chunkCalls = _callsProcessing - _lastTotalCalls;
+                long chunkEmptyCalls = _emptyCallsProcessing - _lastTotalEmptyCalls;
+                long chunkCreates = _createsProcessing - _lastTotalCreates;
+                long chunkSload = _sloadOpcodeProcessing - _lastTotalSLoad;
+                long chunkSstore = _sstoreOpcodeProcessing - _lastTotalSStore;
+                long contractsAnalysed = _contractAnalysedProcessing - _lastContractsAnalysed;
+                long cachedContractsUsed = _codeDbCacheProcessing - _lastCachedContractsUsed;
                 double totalMgasPerSecond = totalMicroseconds == 0 ? -1 : Metrics.Mgas / totalMicroseconds * 1_000_000.0;
                 double totalTxPerSecond = totalMicroseconds == 0 ? -1 : Metrics.Transactions / totalMicroseconds * 1_000_000.0;
                 double totalBlocksPerSecond = totalMicroseconds == 0 ? -1 : _totalBlocks / totalMicroseconds * 1_000_000.0;
@@ -239,17 +253,17 @@ namespace Nethermind.Consensus.Processing
                 }
             }
 
-            _lastCachedContractsUsed = Db.Metrics.CodeDbCache;
-            _lastContractsAnalysed = Evm.Metrics.ContractsAnalysed;
+            _lastCachedContractsUsed = _codeDbCacheProcessing;
+            _lastContractsAnalysed = _contractAnalysedProcessing;
             _lastBlockNumber = Metrics.Blocks;
             _lastTotalMGas = Metrics.Mgas;
             _lastElapsedRunningMicroseconds = _runningMicroseconds;
             _lastTotalTx = Metrics.Transactions;
-            _lastTotalCalls = Evm.Metrics.Calls;
-            _lastTotalEmptyCalls = Evm.Metrics.EmptyCalls;
-            _lastTotalCreates = Evm.Metrics.Creates;
-            _lastTotalSLoad = Evm.Metrics.SloadOpcode;
-            _lastTotalSStore = Evm.Metrics.SstoreOpcode;
+            _lastTotalCalls = _callsProcessing;
+            _lastTotalEmptyCalls = _emptyCallsProcessing;
+            _lastTotalCreates = _createsProcessing;
+            _lastTotalSLoad = _sloadOpcodeProcessing;
+            _lastTotalSStore = _sstoreOpcodeProcessing;
             _lastSelfDestructs = currentSelfDestructs;
             _chunkProcessingMicroseconds = 0;
         }

--- a/src/Nethermind/Nethermind.Consensus/Processing/ProcessingStats.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ProcessingStats.cs
@@ -97,8 +97,8 @@ namespace Nethermind.Consensus.Processing
                 _sstoreOpcodeProcessing = Evm.Metrics.ThreadLocalSStoreOpcode;
                 _callsProcessing = Evm.Metrics.ThreadLocalCalls;
                 _emptyCallsProcessing = Evm.Metrics.ThreadLocalEmptyCalls;
-                _codeDbCacheProcessing =  Db.Metrics.ThreadLocalCodeDbCache;
-                _contractAnalysedProcessing =  Evm.Metrics.ThreadLocalContractsAnalysed;
+                _codeDbCacheProcessing = Db.Metrics.ThreadLocalCodeDbCache;
+                _contractAnalysedProcessing = Evm.Metrics.ThreadLocalContractsAnalysed;
                 _createsProcessing = Evm.Metrics.ThreadLocalCreates;
                 GenerateReport();
             }

--- a/src/Nethermind/Nethermind.Db/Metrics.cs
+++ b/src/Nethermind/Nethermind.Db/Metrics.cs
@@ -25,6 +25,7 @@ namespace Nethermind.Db
             }
         }
         private static ThreadLocal<long> _codeDbCache = new(trackAllValues: true);
+        [Description("Number of Code DB cache reads on thread.")]
         public static long ThreadLocalCodeDbCache => _codeDbCache.Value;
         public static void IncrementCodeDbCache() => _codeDbCache.Value++;
 
@@ -61,6 +62,7 @@ namespace Nethermind.Db
             }
         }
         private static ThreadLocal<long> _stateTreeReads = new(trackAllValues: true);
+        [Description("Number of State Trie reads on thread.")]
         public static long ThreadLocalStateTreeReads => _stateTreeReads.Value;
         public static void IncrementStateTreeReads() => _stateTreeReads.Value++;
 
@@ -121,6 +123,7 @@ namespace Nethermind.Db
             }
         }
         private static ThreadLocal<long> _storageTreeReads = new(trackAllValues: true);
+        [Description("Number of storage trie reads on thread.")]
         public static long ThreadLocalStorageTreeReads => _storageTreeReads.Value;
         public static void IncrementStorageTreeReads() => _storageTreeReads.Value++;
 

--- a/src/Nethermind/Nethermind.Db/Metrics.cs
+++ b/src/Nethermind/Nethermind.Db/Metrics.cs
@@ -12,23 +12,74 @@ namespace Nethermind.Db
     {
         [CounterMetric]
         [Description("Number of Code DB cache reads.")]
-        public static long CodeDbCache { get; set; }
+        public static long CodeDbCache
+        {
+            get
+            {
+                long total = 0;
+                foreach (var value in _codeDbCache.Values)
+                {
+                    total += value;
+                }
+                return total;
+            }
+        }
+        private static ThreadLocal<long> _codeDbCache = new(trackAllValues: true);
+        public static long ThreadLocalCodeDbCache => _codeDbCache.Value;
+        public static void IncrementCodeDbCache() => _codeDbCache.Value++;
 
         [CounterMetric]
         [Description("Number of State Trie cache hits.")]
-        public static long StateTreeCache => _stateTreeCacheHits;
-        private static long _stateTreeCacheHits;
-        public static void IncrementTreeCacheHits() => Interlocked.Increment(ref _stateTreeCacheHits);
+        public static long StateTreeCache
+        {
+            get
+            {
+                long total = 0;
+                foreach (var value in _stateTreeCacheHits.Values)
+                {
+                    total += value;
+                }
+                return total;
+            }
+        }
+
+        private static ThreadLocal<long> _stateTreeCacheHits = new(trackAllValues: true);
+        public static void IncrementStateTreeCacheHits() => _stateTreeCacheHits.Value++;
 
         [CounterMetric]
         [Description("Number of State Trie reads.")]
-        public static long StateTreeReads { get; set; }
+        public static long StateTreeReads
+        {
+            get
+            {
+                long total = 0;
+                foreach (var value in _stateTreeReads.Values)
+                {
+                    total += value;
+                }
+                return total;
+            }
+        }
+        private static ThreadLocal<long> _stateTreeReads = new(trackAllValues: true);
+        public static long ThreadLocalStateTreeReads => _stateTreeReads.Value;
+        public static void IncrementStateTreeReads() => _stateTreeReads.Value++;
 
         [CounterMetric]
         [Description("Number of State Reader reads.")]
-        public static long StateReaderReads => _stateReaderReads;
-        private static long _stateReaderReads;
-        public static void IncrementStateReaderReads() => Interlocked.Increment(ref _stateReaderReads);
+        public static long StateReaderReads
+        {
+            get
+            {
+                long total = 0;
+                foreach (var value in _stateReaderReads.Values)
+                {
+                    total += value;
+                }
+                return total;
+            }
+        }
+        private static ThreadLocal<long> _stateReaderReads = new(trackAllValues: true);
+        public static void IncrementStateReaderReads() => _stateReaderReads.Value++;
 
         [CounterMetric]
         [Description("Number of Blocks Trie writes.")]
@@ -40,11 +91,38 @@ namespace Nethermind.Db
 
         [CounterMetric]
         [Description("Number of storage trie cache hits.")]
-        public static long StorageTreeCache { get; set; }
+        public static long StorageTreeCache
+        {
+            get
+            {
+                long total = 0;
+                foreach (var value in _storageTreeCache.Values)
+                {
+                    total += value;
+                }
+                return total;
+            }
+        }
+        private static ThreadLocal<long> _storageTreeCache = new(trackAllValues: true);
+        public static void IncrementStorageTreeCache() => _storageTreeCache.Value++;
 
         [CounterMetric]
         [Description("Number of storage trie reads.")]
-        public static long StorageTreeReads { get; set; }
+        public static long StorageTreeReads
+        {
+            get
+            {
+                long total = 0;
+                foreach (var value in _storageTreeReads.Values)
+                {
+                    total += value;
+                }
+                return total;
+            }
+        }
+        private static ThreadLocal<long> _storageTreeReads = new(trackAllValues: true);
+        public static long ThreadLocalStorageTreeReads => _storageTreeReads.Value;
+        public static void IncrementStorageTreeReads() => _storageTreeReads.Value++;
 
         [CounterMetric]
         [Description("Number of storage reader reads.")]

--- a/src/Nethermind/Nethermind.Evm/Metrics.cs
+++ b/src/Nethermind/Nethermind.Evm/Metrics.cs
@@ -35,6 +35,7 @@ public class Metrics
         }
     }
     private static ThreadLocal<long> _calls = new(trackAllValues: true);
+    [Description("Number of calls to other contracts on thread.")]
     public static long ThreadLocalCalls => _calls.Value;
     public static void IncrementCalls() => _calls.Value++;
 
@@ -53,6 +54,7 @@ public class Metrics
         }
     }
     private static ThreadLocal<long> _sLoadOpcode = new(trackAllValues: true);
+    [Description("Number of SLOAD opcodes executed on thread.")]
     public static long ThreadLocalSLoadOpcode => _sLoadOpcode.Value;
     public static void IncrementSLoadOpcode() => _sLoadOpcode.Value++;
 
@@ -71,6 +73,7 @@ public class Metrics
         }
     }
     private static ThreadLocal<long> _sStoreOpcode = new(trackAllValues: true);
+    [Description("Number of SSTORE opcodes executed on thread.")]
     public static long ThreadLocalSStoreOpcode => _sStoreOpcode.Value;
     public static void IncrementSStoreOpcode() => _sStoreOpcode.Value++;
 
@@ -128,6 +131,7 @@ public class Metrics
         }
     }
     private static ThreadLocal<long> _emptyCalls = new(trackAllValues: true);
+    [Description("Number of calls made to addresses without code on thread.")]
     public static long ThreadLocalEmptyCalls => _emptyCalls.Value;
     public static void IncrementEmptyCalls() => _emptyCalls.Value++;
 
@@ -146,6 +150,7 @@ public class Metrics
         }
     }
     private static ThreadLocal<long> _creates = new(trackAllValues: true);
+    [Description("Number of contract create calls on thread.")]
     public static long ThreadLocalCreates => _creates.Value;
     public static void IncrementCreates() => _creates.Value++;
 
@@ -163,6 +168,7 @@ public class Metrics
         }
     }
     private static ThreadLocal<long> _contractsAnalysed = new(trackAllValues: true);
+    [Description("Number of contracts' code analysed for jump destinations on thread.")]
     public static long ThreadLocalContractsAnalysed => _contractsAnalysed.Value;
     public static void IncrementContractsAnalysed() => _contractsAnalysed.Value++;
 

--- a/src/Nethermind/Nethermind.Evm/Metrics.cs
+++ b/src/Nethermind/Nethermind.Evm/Metrics.cs
@@ -22,15 +22,57 @@ public class Metrics
 
     [CounterMetric]
     [Description("Number of calls to other contracts.")]
-    public static long Calls { get; set; }
+    public static long Calls
+    {
+        get
+        {
+            long total = 0;
+            foreach (var value in _calls.Values)
+            {
+                total += value;
+            }
+            return total;
+        }
+    }
+    private static ThreadLocal<long> _calls = new(trackAllValues: true);
+    public static long ThreadLocalCalls => _calls.Value;
+    public static void IncrementCalls() => _calls.Value++;
 
     [CounterMetric]
     [Description("Number of SLOAD opcodes executed.")]
-    public static long SloadOpcode { get; set; }
+    public static long SloadOpcode
+    {
+        get
+        {
+            long total = 0;
+            foreach (var value in _sLoadOpcode.Values)
+            {
+                total += value;
+            }
+            return total;
+        }
+    }
+    private static ThreadLocal<long> _sLoadOpcode = new(trackAllValues: true);
+    public static long ThreadLocalSLoadOpcode => _sLoadOpcode.Value;
+    public static void IncrementSLoadOpcode() => _sLoadOpcode.Value++;
 
     [CounterMetric]
     [Description("Number of SSTORE opcodes executed.")]
-    public static long SstoreOpcode { get; set; }
+    public static long SstoreOpcode
+    {
+        get
+        {
+            long total = 0;
+            foreach (var value in _sStoreOpcode.Values)
+            {
+                total += value;
+            }
+            return total;
+        }
+    }
+    private static ThreadLocal<long> _sStoreOpcode = new(trackAllValues: true);
+    public static long ThreadLocalSStoreOpcode => _sStoreOpcode.Value;
+    public static void IncrementSStoreOpcode() => _sStoreOpcode.Value++;
 
     [Description("Number of TLOAD opcodes executed.")]
     public static long TloadOpcode { get; set; }
@@ -73,15 +115,56 @@ public class Metrics
 
     [CounterMetric]
     [Description("Number of calls made to addresses without code.")]
-    public static long EmptyCalls { get; set; }
+    public static long EmptyCalls
+    {
+        get
+        {
+            long total = 0;
+            foreach (var value in _emptyCalls.Values)
+            {
+                total += value;
+            }
+            return total;
+        }
+    }
+    private static ThreadLocal<long> _emptyCalls = new(trackAllValues: true);
+    public static long ThreadLocalEmptyCalls => _emptyCalls.Value;
+    public static void IncrementEmptyCalls() => _emptyCalls.Value++;
 
     [CounterMetric]
     [Description("Number of contract create calls.")]
-    public static long Creates { get; set; }
-    private static long _contractsAnalysed;
+    public static long Creates
+    {
+        get
+        {
+            long total = 0;
+            foreach (var value in _creates.Values)
+            {
+                total += value;
+            }
+            return total;
+        }
+    }
+    private static ThreadLocal<long> _creates = new(trackAllValues: true);
+    public static long ThreadLocalCreates => _creates.Value;
+    public static void IncrementCreates() => _creates.Value++;
+
     [Description("Number of contracts' code analysed for jump destinations.")]
-    public static long ContractsAnalysed => _contractsAnalysed;
-    public static void IncrementContractsAnalysed() => Interlocked.Increment(ref _contractsAnalysed);
+    public static long ContractsAnalysed
+    {
+        get
+        {
+            long total = 0;
+            foreach (var value in _contractsAnalysed.Values)
+            {
+                total += value;
+            }
+            return total;
+        }
+    }
+    private static ThreadLocal<long> _contractsAnalysed = new(trackAllValues: true);
+    public static long ThreadLocalContractsAnalysed => _contractsAnalysed.Value;
+    public static void IncrementContractsAnalysed() => _contractsAnalysed.Value++;
 
     internal static long Transactions { get; set; }
     internal static float AveGasPrice { get; set; }

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -583,7 +583,7 @@ internal sealed class VirtualMachine<TLogger> : IVirtualMachine where TLogger : 
         }
         else
         {
-            Db.Metrics.CodeDbCache++;
+            Db.Metrics.IncrementCodeDbCache();
         }
 
         return cachedCodeInfo;
@@ -771,7 +771,7 @@ internal sealed class VirtualMachine<TLogger> : IVirtualMachine where TLogger : 
         {
             if (!vmState.IsTopLevel)
             {
-                Metrics.EmptyCalls++;
+                Metrics.IncrementEmptyCalls();
             }
             goto Empty;
         }
@@ -1872,7 +1872,7 @@ internal sealed class VirtualMachine<TLogger> : IVirtualMachine where TLogger : 
                 case Instruction.CREATE:
                 case Instruction.CREATE2:
                     {
-                        Metrics.Creates++;
+                        Metrics.IncrementCreates();
                         if (!spec.Create2OpcodeEnabled && instruction == Instruction.CREATE2) goto InvalidInstruction;
 
                         if (vmState.IsStatic) goto StaticCallViolation;
@@ -2186,7 +2186,7 @@ internal sealed class VirtualMachine<TLogger> : IVirtualMachine where TLogger : 
         returnData = null;
         ref readonly ExecutionEnvironment env = ref vmState.Env;
 
-        Metrics.Calls++;
+        Metrics.IncrementCalls();
 
         if (instruction == Instruction.DELEGATECALL && !spec.DelegateCallEnabled ||
             instruction == Instruction.STATICCALL && !spec.StaticCallEnabled) return EvmExceptionType.BadInstruction;
@@ -2350,7 +2350,7 @@ internal sealed class VirtualMachine<TLogger> : IVirtualMachine where TLogger : 
             {
                 _state.AddToBalance(target, transferValue, spec);
             }
-            Metrics.EmptyCalls++;
+            Metrics.IncrementEmptyCalls();
 
             returnData = CallResult.BoxedEmpty;
             return EvmExceptionType.None;
@@ -2631,7 +2631,7 @@ internal sealed class VirtualMachine<TLogger> : IVirtualMachine where TLogger : 
         where TTracingInstructions : struct, IIsTracing
         where TTracingStorage : struct, IIsTracing
     {
-        Metrics.SloadOpcode++;
+        Metrics.IncrementSLoadOpcode();
         gasAvailable -= spec.GetSLoadCost();
 
         if (!stack.PopUInt256(out UInt256 result)) return EvmExceptionType.StackUnderflow;
@@ -2659,7 +2659,7 @@ internal sealed class VirtualMachine<TLogger> : IVirtualMachine where TLogger : 
         where TTracingRefunds : struct, IIsTracing
         where TTracingStorage : struct, IIsTracing
     {
-        Metrics.SstoreOpcode++;
+        Metrics.IncrementSStoreOpcode();
 
         if (vmState.IsStatic) return EvmExceptionType.StaticCallViolation;
         // fail fast before the first storage read if gas is not enough even for reset

--- a/src/Nethermind/Nethermind.State/StateProvider.cs
+++ b/src/Nethermind/Nethermind.State/StateProvider.cs
@@ -649,7 +649,7 @@ namespace Nethermind.State
             _tree = stateTree ?? new StateTree(trieStore, logManager);
             _getStateFromTrie = address =>
             {
-                Metrics.StateTreeReads++;
+                Metrics.IncrementStateTreeReads();
                 return _tree.Get(address);
             };
         }
@@ -665,19 +665,19 @@ namespace Nethermind.State
             ref Account? account = ref CollectionsMarshal.GetValueRefOrAddDefault(_blockCache, addressAsKey, out bool exists);
             if (!exists)
             {
-                long priorReads = Metrics.StateTreeReads;
+                long priorReads = Metrics.ThreadLocalStateTreeReads;
                 account = _preBlockCache is not null
                     ? _preBlockCache.GetOrAdd(addressAsKey, _getStateFromTrie)
                     : _getStateFromTrie(addressAsKey);
 
-                if (Metrics.StateTreeReads == priorReads)
+                if (Metrics.ThreadLocalStateTreeReads == priorReads)
                 {
-                    Metrics.IncrementTreeCacheHits();
+                    Metrics.IncrementStateTreeCacheHits();
                 }
             }
             else
             {
-                Metrics.IncrementTreeCacheHits();
+                Metrics.IncrementStateTreeCacheHits();
             }
             return account;
         }

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -800,7 +800,7 @@ namespace Nethermind.TxPool
                 }
                 else
                 {
-                    Db.Metrics.IncrementTreeCacheHits();
+                    Db.Metrics.IncrementStateTreeCacheHits();
                 }
 
                 return true;


### PR DESCRIPTION
## Changes

- Use `ThreadLocal<long>` for contended metrics (cpu cache contention)
- Report using the processing thread's local for block metric in logs (so is only block, and not all threads work)

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] Optimization

## Testing

#### Requires testing

- [x] No
