### PR TITLE
If worsevalue removed but not found, reinsert new worst item

### DIFF
--- a/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
@@ -442,13 +442,21 @@ namespace Nethermind.TxPool.Collections
         protected virtual bool Remove(TKey key, TValue value)
         {
             // Always remove from worst values; as may have been where it came from and dangling item
-            _worstSortedValues.Remove(value);
+            bool removed = _worstSortedValues.Remove(value);
             // Now remove from cache
             if (_cacheMap.Remove(key))
             {
                 UpdateIsFull();
                 _snapshot = null;
                 return true;
+            }
+            else if (removed)
+            {
+                TGroupKey groupMapping = MapToGroup(value);
+                if (_buckets.TryGetValue(groupMapping, out EnhancedSortedSet<TValue>? bucket))
+                {
+                    UpdateSortedValues(bucket, previousLast: default);
+                }
             }
 
             return false;


### PR DESCRIPTION
Resolves #6843

## Changes

- If a worst value is removed for the group, but wasn't in the group, readd a new worst value for the group

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No
