### PR TITLE
Fix forward sync regression, block processing slows down over time

### DIFF
--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -36,7 +36,7 @@ namespace Nethermind.State
         private readonly ResettableDictionary<StorageCell, byte[]> _originalValues = new();
 
         private readonly ResettableHashSet<StorageCell> _committedThisRound = new();
-        private readonly Dictionary<Address, Dictionary<StorageCell, byte[]>> _blockCache = new(4_096);
+        private readonly Dictionary<AddressAsKey, Dictionary<StorageCell, byte[]>> _blockCache = new(4_096);
         private readonly ConcurrentDictionary<StorageCell, byte[]>? _preBlockCache;
         private readonly Func<StorageCell, byte[]> _loadFromTree;
 

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -36,7 +36,7 @@ namespace Nethermind.State
         private readonly ResettableDictionary<StorageCell, byte[]> _originalValues = new();
 
         private readonly ResettableHashSet<StorageCell> _committedThisRound = new();
-        private readonly Dictionary<AddressAsKey, Dictionary<StorageCell, byte[]>> _blockCache = new(4_096);
+        private readonly Dictionary<AddressAsKey, Dictionary<UInt256, byte[]>> _blockCache = new(4_096);
         private readonly ConcurrentDictionary<StorageCell, byte[]>? _preBlockCache;
         private readonly Func<StorageCell, byte[]> _loadFromTree;
 


### PR DESCRIPTION
- It still regress by about 20% when prewarm is disabled. When enable net increase is about 20%. This is with db file warmer on a 196GB ram machine.
- Before, After
![Screenshot from 2024-05-29 10-31-05](https://github.com/NethermindEth/nethermind/assets/1841324/e245ddd4-3c19-4102-92ee-652aeb8eaba4)

## Changes

- Fix

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)
- [X] Optimization
