### PR TITLE
Fix cannot disable prewarm

### DIFF
--- a/src/Nethermind/Nethermind.Config/IBlocksConfig.cs
+++ b/src/Nethermind/Nethermind.Config/IBlocksConfig.cs
@@ -34,7 +34,7 @@ public interface IBlocksConfig : IConfig
     [ConfigItem(Description = "The block time slot, in seconds.", DefaultValue = "12")]
     ulong SecondsPerSlot { get; set; }
 
-    [ConfigItem(Description = "Try to pre-warm the state when processing blocks. Can lead to 2x speedup in main loop block processing.", DefaultValue = "true")]
+    [ConfigItem(Description = "Try to pre-warm the state when processing blocks. Can lead to 2x speedup in main loop block processing.", DefaultValue = "True")]
     bool PreWarmStateOnBlockProcessing { get; set; }
 
     byte[] GetExtraDataBytes();


### PR DESCRIPTION
- Fix migration config throw error when setting a value because it check the default value via `ToString()` which does not match the string value of the `DefaultValue`.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)
