### PR TITLE
Fix pruning regression

### DIFF
--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -276,7 +276,7 @@ namespace Nethermind.Trie.Pruning
 
         // Track some of the persisted path hash. Used to be able to remove keys when it is replaced.
         // If null, disable removing key.
-        private LruCacheLowObject<HashAndTinyPath, ValueHash256>? _pastPathHash;
+        private LruCache<HashAndTinyPath, ValueHash256>? _pastPathHash;
 
         // Track ALL of the recently re-committed persisted nodes. This is so that we don't accidentally remove
         // recommitted persisted nodes (which will not get re-persisted).


### PR DESCRIPTION
- Don't know why, can't figure it out, but it is reproducable.
- Normally the remove ratio (`rate(nethermind_removed_node_count[$__rate_interval])/rate(nethermind_persisted_node_count[$__rate_interval])`) is around 87%. For some reason, it drops to 20% after around 4000 blocks. This would increase database growth by about 6x.
- Before, after.
![Screenshot_2024-05-29_14-45-51](https://github.com/NethermindEth/nethermind/assets/1841324/1897aa66-e7c3-4f8e-b300-98e45847610d)

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)