### PR TITLE
Fixed EVM Metrics with a small modexp->exp bug

### DIFF
--- a/src/Nethermind/Nethermind.Evm/Metrics.cs
+++ b/src/Nethermind/Nethermind.Evm/Metrics.cs
@@ -86,8 +86,8 @@ public class Metrics
     [Description("Number of MCOPY opcodes executed.")]
     public static long MCopyOpcode { get; set; }
 
-    [Description("Number of MODEXP precompiles executed.")]
-    public static long ModExpOpcode { get; set; }
+    [Description("Number of EXP opcodes executed.")]
+    public static long ExpOpcode { get; set; }
 
     [Description("Number of BLOCKHASH opcodes executed.")]
     public static long BlockhashOpcode { get; set; }

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -1015,7 +1015,7 @@ internal sealed class VirtualMachine<TLogger> : IVirtualMachine where TLogger : 
                     {
                         gasAvailable -= GasCostOf.Exp;
 
-                        Metrics.ModExpOpcode++;
+                        Metrics.ExpOpcode++;
 
                         if (!stack.PopUInt256(out a)) goto StackUnderflow;
                         bytes = stack.PopWord256();


### PR DESCRIPTION
## Changes

Fixed a small mistake in EVM metrics

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [ ] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

Renamed one metric ModExpOpcode -> ExpOpcode

## Remarks

_Optional. Remove if not applicable._
