### PR TITLE
Use string for additional rocksdb config

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
@@ -26,7 +26,7 @@ public class DbConfig : IDbConfig
     public bool? DisableCompression { get; set; } = false;
     public bool? UseLz4 { get; set; } = false;
     public ulong? CompactionReadAhead { get; set; } = (ulong)256.KiB();
-    public IDictionary<string, string>? AdditionalRocksDbOptions { get; set; }
+    public string? AdditionalRocksDbOptions { get; set; }
     public ulong? MaxBytesForLevelBase { get; set; } = (ulong)256.MiB();
     public ulong TargetFileSizeBase { get; set; } = (ulong)64.MiB();
     public int TargetFileSizeMultiplier { get; set; } = 1;
@@ -66,7 +66,7 @@ public class DbConfig : IDbConfig
     public bool? ReceiptsDbUseDirectIoForFlushAndCompactions { get; set; }
     public ulong? ReceiptsDbCompactionReadAhead { get; set; }
     public ulong ReceiptsDbTargetFileSizeBase { get; set; } = (ulong)256.MiB();
-    public IDictionary<string, string>? ReceiptsDbAdditionalRocksDbOptions { get; set; }
+    public string? ReceiptsDbAdditionalRocksDbOptions { get; set; }
 
     public ulong BlocksDbWriteBufferSize { get; set; } = (ulong)64.MiB();
     public uint BlocksDbWriteBufferNumber { get; set; } = 2;
@@ -78,7 +78,7 @@ public class DbConfig : IDbConfig
     public bool? BlocksDbUseDirectReads { get; set; }
     public bool? BlocksDbUseDirectIoForFlushAndCompactions { get; set; }
     public ulong? BlocksDbCompactionReadAhead { get; set; }
-    public IDictionary<string, string>? BlocksDbAdditionalRocksDbOptions { get; set; }
+    public string? BlocksDbAdditionalRocksDbOptions { get; set; }
 
     public ulong HeadersDbWriteBufferSize { get; set; } = (ulong)8.MiB();
     public uint HeadersDbWriteBufferNumber { get; set; } = 2;
@@ -90,7 +90,7 @@ public class DbConfig : IDbConfig
     public bool? HeadersDbUseDirectReads { get; set; }
     public bool? HeadersDbUseDirectIoForFlushAndCompactions { get; set; }
     public ulong? HeadersDbCompactionReadAhead { get; set; }
-    public IDictionary<string, string>? HeadersDbAdditionalRocksDbOptions { get; set; }
+    public string? HeadersDbAdditionalRocksDbOptions { get; set; }
     public ulong? HeadersDbMaxBytesForLevelBase { get; set; } = (ulong)128.MiB();
 
     public ulong BlockNumbersDbWriteBufferSize { get; set; } = (ulong)8.MiB();
@@ -106,7 +106,7 @@ public class DbConfig : IDbConfig
     public bool? BlockNumbersDbUseDirectReads { get; set; }
     public bool? BlockNumbersDbUseDirectIoForFlushAndCompactions { get; set; }
     public ulong? BlockNumbersDbCompactionReadAhead { get; set; }
-    public IDictionary<string, string>? BlockNumbersDbAdditionalRocksDbOptions { get; set; }
+    public string? BlockNumbersDbAdditionalRocksDbOptions { get; set; }
     public ulong? BlockNumbersDbMaxBytesForLevelBase { get; set; } = (ulong)16.MiB();
 
     public ulong BlockInfosDbWriteBufferSize { get; set; } = (ulong)4.MiB();
@@ -119,7 +119,7 @@ public class DbConfig : IDbConfig
     public bool? BlockInfosDbUseDirectReads { get; set; }
     public bool? BlockInfosDbUseDirectIoForFlushAndCompactions { get; set; }
     public ulong? BlockInfosDbCompactionReadAhead { get; set; }
-    public IDictionary<string, string>? BlockInfosDbAdditionalRocksDbOptions { get; set; }
+    public string? BlockInfosDbAdditionalRocksDbOptions { get; set; }
 
     public ulong PendingTxsDbWriteBufferSize { get; set; } = (ulong)4.MiB();
     public uint PendingTxsDbWriteBufferNumber { get; set; } = 4;
@@ -131,7 +131,7 @@ public class DbConfig : IDbConfig
     public bool? PendingTxsDbUseDirectReads { get; set; }
     public bool? PendingTxsDbUseDirectIoForFlushAndCompactions { get; set; }
     public ulong? PendingTxsDbCompactionReadAhead { get; set; }
-    public IDictionary<string, string>? PendingTxsDbAdditionalRocksDbOptions { get; set; }
+    public string? PendingTxsDbAdditionalRocksDbOptions { get; set; }
 
     public ulong CodeDbWriteBufferSize { get; set; } = (ulong)1.MiB();
     public uint CodeDbWriteBufferNumber { get; set; } = 2;
@@ -146,7 +146,7 @@ public class DbConfig : IDbConfig
     public bool? CodeUseDirectReads { get; set; }
     public bool? CodeUseDirectIoForFlushAndCompactions { get; set; }
     public ulong? CodeCompactionReadAhead { get; set; }
-    public IDictionary<string, string>? CodeDbAdditionalRocksDbOptions { get; set; }
+    public string? CodeDbAdditionalRocksDbOptions { get; set; }
 
     public ulong BloomDbWriteBufferSize { get; set; } = (ulong)1.KiB();
     public uint BloomDbWriteBufferNumber { get; set; } = 4;
@@ -154,7 +154,7 @@ public class DbConfig : IDbConfig
     public bool BloomDbCacheIndexAndFilterBlocks { get; set; } = false;
     public int? BloomDbMaxOpenFiles { get; set; }
     public long? BloomDbMaxBytesPerSec { get; set; }
-    public IDictionary<string, string>? BloomDbAdditionalRocksDbOptions { get; set; }
+    public string? BloomDbAdditionalRocksDbOptions { get; set; }
 
     public ulong MetadataDbWriteBufferSize { get; set; } = (ulong)1.KiB();
     public uint MetadataDbWriteBufferNumber { get; set; } = 4;
@@ -166,7 +166,7 @@ public class DbConfig : IDbConfig
     public bool? MetadataUseDirectReads { get; set; }
     public bool? MetadataUseDirectIoForFlushAndCompactions { get; set; }
     public ulong? MetadataCompactionReadAhead { get; set; }
-    public IDictionary<string, string>? MetadataDbAdditionalRocksDbOptions { get; set; }
+    public string? MetadataDbAdditionalRocksDbOptions { get; set; }
 
     public ulong StateDbWriteBufferSize { get; set; } = (ulong)64.MB();
     public uint StateDbWriteBufferNumber { get; set; } = 4;
@@ -202,7 +202,7 @@ public class DbConfig : IDbConfig
     public int? StateDbUseRibbonFilterStartingFromLevel { get; set; } = 2;
     public double? StateDbDataBlockIndexUtilRatio { get; set; } = 0.5;
     public bool StateDbEnableFileWarmer { get; set; } = false;
-    public IDictionary<string, string>? StateDbAdditionalRocksDbOptions { get; set; }
+    public string? StateDbAdditionalRocksDbOptions { get; set; }
 
     public uint RecycleLogFileNum { get; set; } = 0;
     public bool WriteAheadLogSync { get; set; } = false;

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/IDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/IDbConfig.cs
@@ -27,7 +27,7 @@ public interface IDbConfig : IConfig
     bool? DisableCompression { get; set; }
     bool? UseLz4 { get; set; }
     ulong? CompactionReadAhead { get; set; }
-    IDictionary<string, string>? AdditionalRocksDbOptions { get; set; }
+    string? AdditionalRocksDbOptions { get; set; }
     ulong? MaxBytesForLevelBase { get; set; }
     ulong TargetFileSizeBase { get; set; }
     int TargetFileSizeMultiplier { get; set; }
@@ -67,7 +67,7 @@ public interface IDbConfig : IConfig
     bool? ReceiptsDbUseDirectIoForFlushAndCompactions { get; set; }
     ulong? ReceiptsDbCompactionReadAhead { get; set; }
     ulong ReceiptsDbTargetFileSizeBase { get; set; }
-    IDictionary<string, string>? ReceiptsDbAdditionalRocksDbOptions { get; set; }
+    string? ReceiptsDbAdditionalRocksDbOptions { get; set; }
 
     ulong BlocksDbWriteBufferSize { get; set; }
     uint BlocksDbWriteBufferNumber { get; set; }
@@ -79,7 +79,7 @@ public interface IDbConfig : IConfig
     bool? BlocksDbUseDirectReads { get; set; }
     bool? BlocksDbUseDirectIoForFlushAndCompactions { get; set; }
     ulong? BlocksDbCompactionReadAhead { get; set; }
-    IDictionary<string, string>? BlocksDbAdditionalRocksDbOptions { get; set; }
+    string? BlocksDbAdditionalRocksDbOptions { get; set; }
 
     ulong HeadersDbWriteBufferSize { get; set; }
     uint HeadersDbWriteBufferNumber { get; set; }
@@ -91,7 +91,7 @@ public interface IDbConfig : IConfig
     bool? HeadersDbUseDirectReads { get; set; }
     bool? HeadersDbUseDirectIoForFlushAndCompactions { get; set; }
     ulong? HeadersDbCompactionReadAhead { get; set; }
-    IDictionary<string, string>? HeadersDbAdditionalRocksDbOptions { get; set; }
+    string? HeadersDbAdditionalRocksDbOptions { get; set; }
     ulong? HeadersDbMaxBytesForLevelBase { get; set; }
 
     ulong BlockNumbersDbWriteBufferSize { get; set; }
@@ -107,7 +107,7 @@ public interface IDbConfig : IConfig
     bool? BlockNumbersDbUseDirectReads { get; set; }
     bool? BlockNumbersDbUseDirectIoForFlushAndCompactions { get; set; }
     ulong? BlockNumbersDbCompactionReadAhead { get; set; }
-    IDictionary<string, string>? BlockNumbersDbAdditionalRocksDbOptions { get; set; }
+    string? BlockNumbersDbAdditionalRocksDbOptions { get; set; }
     ulong? BlockNumbersDbMaxBytesForLevelBase { get; set; }
 
     ulong BlockInfosDbWriteBufferSize { get; set; }
@@ -120,7 +120,7 @@ public interface IDbConfig : IConfig
     bool? BlockInfosDbUseDirectReads { get; set; }
     bool? BlockInfosDbUseDirectIoForFlushAndCompactions { get; set; }
     ulong? BlockInfosDbCompactionReadAhead { get; set; }
-    IDictionary<string, string>? BlockInfosDbAdditionalRocksDbOptions { get; set; }
+    string? BlockInfosDbAdditionalRocksDbOptions { get; set; }
 
     ulong PendingTxsDbWriteBufferSize { get; set; }
     uint PendingTxsDbWriteBufferNumber { get; set; }
@@ -132,7 +132,7 @@ public interface IDbConfig : IConfig
     bool? PendingTxsDbUseDirectReads { get; set; }
     bool? PendingTxsDbUseDirectIoForFlushAndCompactions { get; set; }
     ulong? PendingTxsDbCompactionReadAhead { get; set; }
-    IDictionary<string, string>? PendingTxsDbAdditionalRocksDbOptions { get; set; }
+    string? PendingTxsDbAdditionalRocksDbOptions { get; set; }
 
     ulong CodeDbWriteBufferSize { get; set; }
     uint CodeDbWriteBufferNumber { get; set; }
@@ -147,7 +147,7 @@ public interface IDbConfig : IConfig
     bool? CodeUseDirectReads { get; set; }
     bool? CodeUseDirectIoForFlushAndCompactions { get; set; }
     ulong? CodeCompactionReadAhead { get; set; }
-    IDictionary<string, string>? CodeDbAdditionalRocksDbOptions { get; set; }
+    string? CodeDbAdditionalRocksDbOptions { get; set; }
 
     ulong BloomDbWriteBufferSize { get; set; }
     uint BloomDbWriteBufferNumber { get; set; }
@@ -155,7 +155,7 @@ public interface IDbConfig : IConfig
     bool BloomDbCacheIndexAndFilterBlocks { get; set; }
     int? BloomDbMaxOpenFiles { get; set; }
     long? BloomDbMaxBytesPerSec { get; set; }
-    IDictionary<string, string>? BloomDbAdditionalRocksDbOptions { get; set; }
+    string? BloomDbAdditionalRocksDbOptions { get; set; }
 
     ulong MetadataDbWriteBufferSize { get; set; }
     uint MetadataDbWriteBufferNumber { get; set; }
@@ -167,7 +167,7 @@ public interface IDbConfig : IConfig
     bool? MetadataUseDirectReads { get; set; }
     bool? MetadataUseDirectIoForFlushAndCompactions { get; set; }
     ulong? MetadataCompactionReadAhead { get; set; }
-    IDictionary<string, string>? MetadataDbAdditionalRocksDbOptions { get; set; }
+    string? MetadataDbAdditionalRocksDbOptions { get; set; }
 
     ulong StateDbWriteBufferSize { get; set; }
     uint StateDbWriteBufferNumber { get; set; }
@@ -203,7 +203,7 @@ public interface IDbConfig : IConfig
     int? StateDbUseRibbonFilterStartingFromLevel { get; set; }
     double? StateDbDataBlockIndexUtilRatio { get; set; }
     bool StateDbEnableFileWarmer { get; set; }
-    IDictionary<string, string>? StateDbAdditionalRocksDbOptions { get; set; }
+    string? StateDbAdditionalRocksDbOptions { get; set; }
 
     /// <summary>
     /// Enables DB Statistics - https://github.com/facebook/rocksdb/wiki/Statistics

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/PerTableDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/PerTableDbConfig.cs
@@ -34,7 +34,7 @@ public class PerTableDbConfig
 
     public ulong WriteBufferNumber => _settings.WriteBufferNumber ?? ReadConfig<uint>(nameof(WriteBufferNumber));
 
-    public IDictionary<string, string>? AdditionalRocksDbOptions => ReadConfig<IDictionary<string, string>?>(nameof(AdditionalRocksDbOptions));
+    public string? AdditionalRocksDbOptions => ReadConfig<string?>(nameof(AdditionalRocksDbOptions));
 
     public int? MaxOpenFiles => ReadConfig<int?>(nameof(MaxOpenFiles));
     public long? MaxBytesPerSec => ReadConfig<long?>(nameof(MaxBytesPerSec));

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -707,8 +707,14 @@ public class DbOnTheRocks : IDb, ITunableDb
         if (dbConfig.AdditionalRocksDbOptions is not null)
         {
             IntPtr optsPtr = Marshal.StringToHGlobalAnsi(dbConfig.AdditionalRocksDbOptions);
-            _rocksDbNative.rocksdb_get_options_from_string(options.Handle, optsPtr, options.Handle);
-            Marshal.FreeHGlobal(optsPtr);
+            try
+            {
+                _rocksDbNative.rocksdb_get_options_from_string(options.Handle, optsPtr, options.Handle);
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(optsPtr);
+            }
         }
 
         #endregion

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -704,7 +704,7 @@ public class DbOnTheRocks : IDb, ITunableDb
         }
         options.SetStatsDumpPeriodSec(dbConfig.StatsDumpPeriodSec);
 
-        if (dbConfig.AdditionalRocksDbOptions != null)
+        if (dbConfig.AdditionalRocksDbOptions is not null)
         {
             IntPtr optsPtr = Marshal.StringToHGlobalAnsi(dbConfig.AdditionalRocksDbOptions);
             _rocksDbNative.rocksdb_get_options_from_string(options.Handle, optsPtr, options.Handle);

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
@@ -99,12 +100,6 @@ public class DbOnTheRocks : IDb, ITunableDb
         _rocksDbNative = rocksDbNative ?? RocksDbSharp.Native.Instance;
         _perTableDbConfig = new PerTableDbConfig(dbConfig, _settings);
         _db = Init(basePath, dbSettings.DbPath, dbConfig, logManager, columnFamilies, dbSettings.DeleteOnStart, sharedCache);
-
-        if (_perTableDbConfig.AdditionalRocksDbOptions is not null)
-        {
-            ApplyOptions(_perTableDbConfig.AdditionalRocksDbOptions);
-        }
-
         _iteratorManager = new IteratorManager(_db, null, _readAheadReadOptions);
     }
 
@@ -708,6 +703,14 @@ public class DbOnTheRocks : IDb, ITunableDb
             options.EnableStatistics();
         }
         options.SetStatsDumpPeriodSec(dbConfig.StatsDumpPeriodSec);
+
+        if (dbConfig.AdditionalRocksDbOptions != null)
+        {
+            IntPtr optsPtr = Marshal.StringToHGlobalAnsi(dbConfig.AdditionalRocksDbOptions);
+            _rocksDbNative.rocksdb_get_options_from_string(options.Handle, optsPtr, options.Handle);
+            Marshal.FreeHGlobal(optsPtr);
+        }
+
         #endregion
 
         #region read-write options


### PR DESCRIPTION
- Turns out, you can use string to access options that is not available from the C (and therefore c#) binding.
- Notable options are `compaction_pri=kByCompensatedSize` which prioritize removing items.
- No significant impact on state db though. 
- Still, easy flag for experimentation.

## Types of changes

#### What types of changes does your code introduce?

- [X] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [ ] Yes
- [X] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No