### PR TITLE
Don't boost priority of forkchoice if syncing

### DIFF
--- a/src/Nethermind/Nethermind.Core/Threading/ThreadExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Threading/ThreadExtensions.cs
@@ -10,7 +10,7 @@ public static class ThreadExtensions
 {
     public readonly struct Disposable : IDisposable
     {
-        private readonly Thread _thread;
+        private readonly Thread? _thread;
         private readonly ThreadPriority _previousPriority;
 
         internal Disposable(Thread thread)
@@ -22,7 +22,10 @@ public static class ThreadExtensions
 
         public void Dispose()
         {
-            _thread.Priority = _previousPriority;
+            if (_thread is not null && Thread.CurrentThread == _thread)
+            {
+                _thread.Priority = _previousPriority;
+            }
         }
     }
 


### PR DESCRIPTION
## Changes

- Don't boost priority of forkchoice if syncing.
    - Apart from being no advantage
    - If syncing may go async and switch threads

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No