### PR TITLE
Fix low object LruCaches

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Caching/LruCacheLowObjectTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Caching/LruCacheLowObjectTests.cs
@@ -41,7 +41,7 @@ namespace Nethermind.Core.Test.Caching
             Cache cache = Create();
             for (int i = 0; i < Capacity; i++)
             {
-                cache.Set(_addresses[i], _accounts[i]);
+                cache.Set(_addresses[i], _accounts[i]).Should().BeTrue();
             }
 
             Account? account = cache.Get(_addresses[Capacity - 1]);
@@ -52,8 +52,8 @@ namespace Nethermind.Core.Test.Caching
         public void Can_reset()
         {
             Cache cache = Create();
-            cache.Set(_addresses[0], _accounts[0]);
-            cache.Set(_addresses[0], _accounts[1]);
+            cache.Set(_addresses[0], _accounts[0]).Should().BeTrue();
+            cache.Set(_addresses[0], _accounts[1]).Should().BeFalse();
             cache.Get(_addresses[0]).Should().Be(_accounts[1]);
         }
 
@@ -68,10 +68,10 @@ namespace Nethermind.Core.Test.Caching
         public void Can_clear()
         {
             Cache cache = Create();
-            cache.Set(_addresses[0], _accounts[0]);
+            cache.Set(_addresses[0], _accounts[0]).Should().BeTrue();
             cache.Clear();
             cache.Get(_addresses[0]).Should().BeNull();
-            cache.Set(_addresses[0], _accounts[1]);
+            cache.Set(_addresses[0], _accounts[1]).Should().BeTrue();
             cache.Get(_addresses[0]).Should().Be(_accounts[1]);
         }
 
@@ -81,11 +81,25 @@ namespace Nethermind.Core.Test.Caching
             Cache cache = Create();
             for (int i = 0; i < Capacity * 2; i++)
             {
-                cache.Set(_addresses[i], _accounts[i]);
+                cache.Set(_addresses[i], _accounts[i]).Should().BeTrue();
             }
 
             Account? account = cache.Get(_addresses[Capacity]);
             account.Should().Be(_accounts[Capacity]);
+        }
+
+        [Test]
+        public void Beyond_capacity_lru()
+        {
+            Cache cache = Create();
+            for (int i = 0; i < Capacity * 2; i++)
+            {
+                for (int ii = 0; ii < Capacity / 2; ii++)
+                {
+                    cache.Set(_addresses[i], _accounts[i]);
+                }
+                cache.Set(_addresses[i], _accounts[i]);
+            }
         }
 
         [Test]
@@ -114,7 +128,7 @@ namespace Nethermind.Core.Test.Caching
             Cache cache = Create();
             for (int i = 0; i < Capacity; i++)
             {
-                cache.Set(_addresses[i], _accounts[i]);
+                cache.Set(_addresses[i], _accounts[i]).Should().BeTrue();
             }
 
             cache.Clear();
@@ -124,7 +138,7 @@ namespace Nethermind.Core.Test.Caching
             // fill again
             for (int i = 0; i < Capacity; i++)
             {
-                cache.Set(_addresses[i], _accounts[MapForRefill(i)]);
+                cache.Set(_addresses[i], _accounts[MapForRefill(i)]).Should().BeTrue();
             }
 
             // validate
@@ -145,8 +159,10 @@ namespace Nethermind.Core.Test.Caching
 
             for (int i = 0; i < iterations; i++)
             {
-                cache.Set(i, i);
-                cache.Delete(i - itemsToKeep);
+                cache.Set(i, i).Should().BeTrue();
+                var remove = i - itemsToKeep;
+                if (remove >= 0)
+                    cache.Delete(remove).Should().BeTrue();
             }
 
             int count = 0;

--- a/src/Nethermind/Nethermind.Core.Test/Caching/LruCacheTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Caching/LruCacheTests.cs
@@ -39,7 +39,7 @@ namespace Nethermind.Core.Test.Caching
             ICache<Address, Account> cache = Create();
             for (int i = 0; i < Capacity; i++)
             {
-                cache.Set(_addresses[i], _accounts[i]);
+                cache.Set(_addresses[i], _accounts[i]).Should().BeTrue();
             }
 
             Account? account = cache.Get(_addresses[Capacity - 1]);
@@ -50,8 +50,8 @@ namespace Nethermind.Core.Test.Caching
         public void Can_reset()
         {
             ICache<Address, Account> cache = Create();
-            cache.Set(_addresses[0], _accounts[0]);
-            cache.Set(_addresses[0], _accounts[1]);
+            cache.Set(_addresses[0], _accounts[0]).Should().BeTrue();
+            cache.Set(_addresses[0], _accounts[1]).Should().BeFalse();
             cache.Get(_addresses[0]).Should().Be(_accounts[1]);
         }
 
@@ -66,11 +66,25 @@ namespace Nethermind.Core.Test.Caching
         public void Can_clear()
         {
             ICache<Address, Account> cache = Create();
-            cache.Set(_addresses[0], _accounts[0]);
+            cache.Set(_addresses[0], _accounts[0]).Should().BeTrue();
             cache.Clear();
             cache.Get(_addresses[0]).Should().BeNull();
-            cache.Set(_addresses[0], _accounts[1]);
+            cache.Set(_addresses[0], _accounts[1]).Should().BeTrue();
             cache.Get(_addresses[0]).Should().Be(_accounts[1]);
+        }
+
+        [Test]
+        public void Beyond_capacity_lru()
+        {
+            ICache<Address, Account> cache = Create();
+            for (int i = 0; i < Capacity * 2; i++)
+            {
+                for (int ii = 0; ii < Capacity / 2; ii++)
+                {
+                    cache.Set(_addresses[i], _accounts[i]);
+                }
+                cache.Set(_addresses[i], _accounts[i]);
+            }
         }
 
         [Test]
@@ -79,7 +93,7 @@ namespace Nethermind.Core.Test.Caching
             ICache<Address, Account> cache = Create();
             for (int i = 0; i < Capacity * 2; i++)
             {
-                cache.Set(_addresses[i], _accounts[i]);
+                cache.Set(_addresses[i], _accounts[i]).Should().BeTrue();
             }
 
             Account? account = cache.Get(_addresses[Capacity]);

--- a/src/Nethermind/Nethermind.Core.Test/Caching/LruKeyCacheLowObjectTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Caching/LruKeyCacheLowObjectTests.cs
@@ -79,6 +79,20 @@ namespace Nethermind.Core.Test.Caching
         }
 
         [Test]
+        public void Beyond_capacity_lru()
+        {
+            LruKeyCacheLowObject<AddressAsKey> cache = new(Capacity, "test");
+            for (int i = 0; i < Capacity * 2; i++)
+            {
+                for (int ii = 0; ii < Capacity / 2; ii++)
+                {
+                    cache.Set(_addresses[i]);
+                }
+                cache.Set(_addresses[i]);
+            }
+        }
+
+        [Test]
         public void Can_delete()
         {
             LruKeyCacheLowObject<AddressAsKey> cache = new(Capacity, "test");

--- a/src/Nethermind/Nethermind.Core.Test/Caching/LruKeyCacheNonConcurrentTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Caching/LruKeyCacheNonConcurrentTests.cs
@@ -10,7 +10,7 @@ using NUnit.Framework;
 namespace Nethermind.Core.Test.Caching
 {
     [TestFixture]
-    public class LruKeyCacheTests
+    public class LruKeyCacheNonConcurrentTests
     {
         private const int Capacity = 16;
 
@@ -30,7 +30,7 @@ namespace Nethermind.Core.Test.Caching
         [Test]
         public void At_capacity()
         {
-            LruKeyCache<Address> cache = new(Capacity, "test");
+            LruKeyCacheNonConcurrent<Address> cache = new(Capacity, "test");
             for (int i = 0; i < Capacity; i++)
             {
                 cache.Set(_addresses[i]).Should().BeTrue();
@@ -42,7 +42,7 @@ namespace Nethermind.Core.Test.Caching
         [Test]
         public void Can_reset()
         {
-            LruKeyCache<Address> cache = new(Capacity, "test");
+            LruKeyCacheNonConcurrent<Address> cache = new(Capacity, "test");
             cache.Set(_addresses[0]).Should().BeTrue();
             cache.Set(_addresses[0]).Should().BeFalse();
             cache.Get(_addresses[0]).Should().BeTrue();
@@ -51,14 +51,14 @@ namespace Nethermind.Core.Test.Caching
         [Test]
         public void Can_ask_before_first_set()
         {
-            LruKeyCache<Address> cache = new(Capacity, "test");
+            LruKeyCacheNonConcurrent<Address> cache = new(Capacity, "test");
             cache.Get(_addresses[0]).Should().BeFalse();
         }
 
         [Test]
         public void Can_clear()
         {
-            LruKeyCache<Address> cache = new(Capacity, "test");
+            LruKeyCacheNonConcurrent<Address> cache = new(Capacity, "test");
             cache.Set(_addresses[0]).Should().BeTrue();
             cache.Clear();
             cache.Get(_addresses[0]).Should().BeFalse();
@@ -69,10 +69,10 @@ namespace Nethermind.Core.Test.Caching
         [Test]
         public void Beyond_capacity()
         {
-            LruKeyCache<Address> cache = new(Capacity, "test");
+            LruKeyCacheNonConcurrent<Address> cache = new(Capacity, "test");
             for (int i = 0; i < Capacity * 2; i++)
             {
-                cache.Set(_addresses[i]).Should().BeTrue();
+                cache.Set(_addresses[i]);
             }
 
             cache.Get(_addresses[Capacity]).Should().BeTrue();
@@ -81,7 +81,7 @@ namespace Nethermind.Core.Test.Caching
         [Test]
         public void Beyond_capacity_lru()
         {
-            LruKeyCache<AddressAsKey> cache = new(Capacity, "test");
+            LruKeyCacheNonConcurrent<AddressAsKey> cache = new(Capacity, "test");
             for (int i = 0; i < Capacity * 2; i++)
             {
                 for (int ii = 0; ii < Capacity / 2; ii++)
@@ -95,7 +95,7 @@ namespace Nethermind.Core.Test.Caching
         [Test]
         public void Can_delete()
         {
-            LruKeyCache<Address> cache = new(Capacity, "test");
+            LruKeyCacheNonConcurrent<Address> cache = new(Capacity, "test");
             cache.Set(_addresses[0]).Should().BeTrue();
             cache.Delete(_addresses[0]);
             cache.Get(_addresses[0]).Should().BeFalse();

--- a/src/Nethermind/Nethermind.Core.Test/Caching/SpanLruCacheTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Caching/SpanLruCacheTests.cs
@@ -40,7 +40,7 @@ namespace Nethermind.Core.Test.Caching
             ISpanCache<byte, Account> cache = Create();
             for (int i = 0; i < Capacity; i++)
             {
-                cache.Set(_addresses[i].Bytes, _accounts[i]);
+                cache.Set(_addresses[i].Bytes, _accounts[i]).Should().BeTrue();
             }
 
             Account? account = cache.Get(_addresses[Capacity - 1].Bytes);
@@ -51,8 +51,8 @@ namespace Nethermind.Core.Test.Caching
         public void Can_reset()
         {
             ISpanCache<byte, Account> cache = Create();
-            cache.Set(_addresses[0].Bytes, _accounts[0]);
-            cache.Set(_addresses[0].Bytes, _accounts[1]);
+            cache.Set(_addresses[0].Bytes, _accounts[0]).Should().BeTrue();
+            cache.Set(_addresses[0].Bytes, _accounts[1]).Should().BeFalse();
             cache.Get(_addresses[0].Bytes).Should().Be(_accounts[1]);
         }
 
@@ -67,10 +67,10 @@ namespace Nethermind.Core.Test.Caching
         public void Can_clear()
         {
             ISpanCache<byte, Account> cache = Create();
-            cache.Set(_addresses[0].Bytes, _accounts[0]);
+            cache.Set(_addresses[0].Bytes, _accounts[0]).Should().BeTrue();
             cache.Clear();
             cache.Get(_addresses[0].Bytes).Should().BeNull();
-            cache.Set(_addresses[0].Bytes, _accounts[1]);
+            cache.Set(_addresses[0].Bytes, _accounts[1]).Should().BeTrue();
             cache.Get(_addresses[0].Bytes).Should().Be(_accounts[1]);
         }
 
@@ -80,11 +80,25 @@ namespace Nethermind.Core.Test.Caching
             ISpanCache<byte, Account> cache = Create();
             for (int i = 0; i < Capacity * 2; i++)
             {
-                cache.Set(_addresses[i].Bytes, _accounts[i]);
+                cache.Set(_addresses[i].Bytes, _accounts[i]).Should().BeTrue();
             }
 
             Account? account = cache.Get(_addresses[Capacity].Bytes);
             account.Should().Be(_accounts[Capacity]);
+        }
+
+        [Test]
+        public void Beyond_capacity_lru()
+        {
+            ISpanCache<byte, Account> cache = Create();
+            for (int i = 0; i < Capacity * 2; i++)
+            {
+                for (int ii = 0; ii < Capacity / 2; ii++)
+                {
+                    cache.Set(_addresses[i].Bytes, _accounts[i]);
+                }
+                cache.Set(_addresses[i].Bytes, _accounts[i]);
+            }
         }
 
         [Test]
@@ -101,7 +115,7 @@ namespace Nethermind.Core.Test.Caching
         public void Can_delete()
         {
             ISpanCache<byte, Account> cache = Create();
-            cache.Set(_addresses[0].Bytes, _accounts[0]);
+            cache.Set(_addresses[0].Bytes, _accounts[0]).Should().BeTrue();
             cache.Delete(_addresses[0].Bytes).Should().BeTrue();
             cache.Get(_addresses[0].Bytes).Should().Be(null);
             cache.Delete(_addresses[0].Bytes).Should().BeFalse();

--- a/src/Nethermind/Nethermind.Core/Caching/LinkedListNode.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/LinkedListNode.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
@@ -21,7 +22,10 @@ internal sealed class LinkedListNode<T>
     {
         if (node.Next == node)
         {
-            Debug.Assert(leastRecentlyUsed == node, "this should only be true for a list with only one node");
+            if (leastRecentlyUsed != node)
+            {
+                InvalidNotSingleNodeList();
+            }
             // Do nothing only one node
         }
         else
@@ -33,10 +37,16 @@ internal sealed class LinkedListNode<T>
 
     public static void Remove(ref LinkedListNode<T>? leastRecentlyUsed, LinkedListNode<T> node)
     {
-        Debug.Assert(leastRecentlyUsed is not null, "This method shouldn't be called on empty list!");
+        if (leastRecentlyUsed is null)
+        {
+            InvalidRemoveFromEmptyList();
+        }
         if (node.Next == node)
         {
-            Debug.Assert(leastRecentlyUsed == node, "this should only be true for a list with only one node");
+            if (leastRecentlyUsed != node)
+            {
+                InvalidNotSingleNodeList();
+            }
             leastRecentlyUsed = null;
         }
         else
@@ -48,6 +58,20 @@ internal sealed class LinkedListNode<T>
                 leastRecentlyUsed = node.Next;
             }
         }
+
+        [DoesNotReturn]
+        [StackTraceHidden]
+        static void InvalidRemoveFromEmptyList()
+        {
+            throw new InvalidOperationException("This method shouldn't be called on empty list");
+        }
+    }
+
+    [DoesNotReturn]
+    [StackTraceHidden]
+    static void InvalidNotSingleNodeList()
+    {
+        throw new InvalidOperationException("This should only be true for a list with only one node");
     }
 
     public static void AddMostRecent([NotNull] ref LinkedListNode<T>? leastRecentlyUsed, LinkedListNode<T> node)

--- a/src/Nethermind/Nethermind.Core/Caching/LruCacheLowObject.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/LruCacheLowObject.cs
@@ -163,9 +163,13 @@ namespace Nethermind.Core.Caching
             ref var node = ref _items[offset];
 
             _cacheMap.Remove(node.Key);
+            node = new(key, value)
+            {
+                Next = node.Next,
+                Prev = node.Prev
+            };
 
             MoveToMostRecent(ref node, offset);
-            node = new(key, value);
             _cacheMap.Add(key, offset);
 
             [DoesNotReturn]
@@ -181,7 +185,10 @@ namespace Nethermind.Core.Caching
         {
             if (node.Next == offset)
             {
-                Debug.Assert(_leastRecentlyUsed == offset, "this should only be true for a list with only one node");
+                if (_leastRecentlyUsed != offset)
+                {
+                    InvalidNotSingleNodeList();
+                }
                 // Do nothing only one node
             }
             else
@@ -193,10 +200,16 @@ namespace Nethermind.Core.Caching
 
         private void Remove(ref LruCacheItem node, int offset)
         {
-            Debug.Assert(_leastRecentlyUsed >= 0, "This method shouldn't be called on empty list!");
+            if (_leastRecentlyUsed < 0)
+            {
+                InvalidRemoveFromEmptyList();
+            }
             if (node.Next == offset)
             {
-                Debug.Assert(_leastRecentlyUsed == offset, "this should only be true for a list with only one node");
+                if (_leastRecentlyUsed != offset)
+                {
+                    InvalidNotSingleNodeList();
+                }
                 _leastRecentlyUsed = -1;
             }
             else
@@ -208,6 +221,18 @@ namespace Nethermind.Core.Caching
                     _leastRecentlyUsed = node.Next;
                 }
             }
+
+            static void InvalidRemoveFromEmptyList()
+            {
+                throw new InvalidOperationException("This method shouldn't be called on empty list");
+            }
+        }
+
+        [DoesNotReturn]
+        [StackTraceHidden]
+        static void InvalidNotSingleNodeList()
+        {
+            throw new InvalidOperationException("This should only be true for a list with only one node");
         }
 
         private void AddMostRecent(ref LruCacheItem node, int offset)

--- a/src/Nethermind/Nethermind.Core/Caching/LruKeyCacheLowObject.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/LruKeyCacheLowObject.cs
@@ -140,9 +140,13 @@ namespace Nethermind.Core.Caching
             ref var node = ref _items[offset];
 
             _cacheMap.Remove(node.Key);
+            node = new(key)
+            {
+                Next = node.Next,
+                Prev = node.Prev
+            };
 
             MoveToMostRecent(ref node, offset);
-            node = new(key);
             _cacheMap.Add(key, offset);
 
             [DoesNotReturn]
@@ -156,7 +160,10 @@ namespace Nethermind.Core.Caching
         {
             if (node.Next == offset)
             {
-                Debug.Assert(_leastRecentlyUsed == offset, "this should only be true for a list with only one node");
+                if (_leastRecentlyUsed != offset)
+                {
+                    InvalidNotSingleNodeList();
+                }
                 // Do nothing only one node
             }
             else
@@ -168,10 +175,16 @@ namespace Nethermind.Core.Caching
 
         private void Remove(ref LruCacheItem node, int offset)
         {
-            Debug.Assert(_leastRecentlyUsed >= 0, "This method shouldn't be called on empty list!");
+            if (_leastRecentlyUsed < 0)
+            {
+                InvalidRemoveFromEmptyList();
+            }
             if (node.Next == offset)
             {
-                Debug.Assert(_leastRecentlyUsed == offset, "this should only be true for a list with only one node");
+                if (_leastRecentlyUsed != offset)
+                {
+                    InvalidNotSingleNodeList();
+                }
                 _leastRecentlyUsed = -1;
             }
             else
@@ -183,6 +196,18 @@ namespace Nethermind.Core.Caching
                     _leastRecentlyUsed = node.Next;
                 }
             }
+
+            static void InvalidRemoveFromEmptyList()
+            {
+                throw new InvalidOperationException("This method shouldn't be called on empty list");
+            }
+        }
+
+        [DoesNotReturn]
+        [StackTraceHidden]
+        static void InvalidNotSingleNodeList()
+        {
+            throw new InvalidOperationException("This should only be true for a list with only one node");
         }
 
         private void AddMostRecent(ref LruCacheItem node, int offset)

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
@@ -66,8 +66,8 @@ namespace Nethermind.Synchronization.FastSync
         private readonly ReaderWriterLockSlim _syncStateLock = new();
         private readonly ConcurrentDictionary<StateSyncBatch, object?> _pendingRequests = new();
         private Dictionary<StateSyncItem.NodeKey, HashSet<DependentItem>> _dependencies = new();
-        private readonly LruKeyCache<StateSyncItem.NodeKey> _alreadySavedNode = new(AlreadySavedCapacity, "saved nodes");
-        private readonly LruKeyCache<ValueHash256> _alreadySavedCode = new(AlreadySavedCapacity, "saved nodes");
+        private readonly LruKeyCacheLowObject<StateSyncItem.NodeKey> _alreadySavedNode = new(AlreadySavedCapacity, "saved nodes");
+        private readonly LruKeyCacheLowObject<ValueHash256> _alreadySavedCode = new(AlreadySavedCapacity, "saved nodes");
 
         private BranchProgress _branchProgress;
         private int _hintsToResetRoot;


### PR DESCRIPTION
## Changes

- Replace was overriting `.Next` and `.Prev` after item had been moved. Carry those values through to new node

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes
