### PR TITLE
Keep spinning if next in queue for McsLock

### DIFF
--- a/src/Nethermind/Nethermind.Core/Threading/McsLock.cs
+++ b/src/Nethermind/Nethermind.Core/Threading/McsLock.cs
@@ -86,8 +86,13 @@ public class McsLock
             {
                 // If not next in line (previous waiting) then wait for signal
                 WaitForSignal(node);
-                // Acquired the lock
-                break;
+                if (node.State == (nuint)LockState.ReadyToAcquire)
+                {
+                    // Acquired the lock
+                    break;
+                }
+                // Otherwise reset spinwait
+                sw.Reset();
             }
             else
             {

--- a/src/Nethermind/Nethermind.Core/Threading/McsLock.cs
+++ b/src/Nethermind/Nethermind.Core/Threading/McsLock.cs
@@ -204,7 +204,7 @@ public class McsLock
         }
     }
 
-    private enum LockState : uint
+    public enum LockState : uint
     {
         ReadyToAcquire = 0,
         Waiting = 1,

--- a/src/Nethermind/Nethermind.Core/Threading/McsPriorityLock.cs
+++ b/src/Nethermind/Nethermind.Core/Threading/McsPriorityLock.cs
@@ -43,7 +43,7 @@ public class McsPriorityLock
     public McsLock.Disposable Acquire()
     {
         // Check for reentrancy.
-        if (_coreLock._node.Value == _coreLock._currentLockHolder)
+        if (_coreLock._node.Value!.State != (nuint)McsLock.LockState.Unlocked)
             ThrowInvalidOperationException();
 
         var isPriority = Thread.CurrentThread.Priority > ThreadPriority.Normal;


### PR DESCRIPTION
## Changes

- If thread is next in queue keep spinning rather than waiting for signal
- Singal unlock in background as next in line will still be spinning so additional latency only effects threads waiting for singal; meaning lockholder returns faster

Faster!
<img width="584" alt="image" src="https://github.com/NethermindEth/nethermind/assets/1142958/454d0608-c329-4c24-a8f1-56bc3ea847d8">


## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No