### PR TITLE
Perf/allow multiple sync allocation per peer

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
@@ -143,4 +143,7 @@ public interface ISyncConfig : IConfig
 
     [ConfigItem(Description = "_Technical._ MultiSyncModeSelector sync mode timer loop interval. Used for testing.", DefaultValue = "1000", HiddenFromDocs = true)]
     int MultiSyncModeSelectorLoopTimerMs { get; set; }
+
+    [ConfigItem(Description = "_Technical._ Specify concurrent request per peer for syncing.", DefaultValue = "2", HiddenFromDocs = true)]
+    int AllocationSlots { get; set; }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
@@ -65,6 +65,7 @@ namespace Nethermind.Blockchain.Synchronization
         public int MallocTrimIntervalSec { get; set; } = 300;
         public bool? SnapServingEnabled { get; set; } = null;
         public int MultiSyncModeSelectorLoopTimerMs { get; set; } = 1000;
+        public int AllocationSlots { get; set; } = 2;
         public bool TrieHealing { get; set; } = true;
 
         public override string ToString()

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -105,7 +105,14 @@ public class InitializeNetwork : IStep
         int maxPeersCount = _networkConfig.ActivePeersMaxCount;
         int maxPriorityPeersCount = _networkConfig.PriorityPeersMaxCount;
         Network.Metrics.PeerLimit = maxPeersCount;
-        SyncPeerPool apiSyncPeerPool = new(_api.BlockTree, _api.NodeStatsManager!, _api.BetterPeerStrategy, _api.LogManager, maxPeersCount, maxPriorityPeersCount);
+        SyncPeerPool apiSyncPeerPool = new(
+            _api.BlockTree,
+            _api.NodeStatsManager!,
+            _api.BetterPeerStrategy,
+            _api.LogManager,
+            maxPeersCount,
+            maxPriorityPeersCount,
+            _syncConfig.AllocationSlots);
 
         _api.SyncPeerPool = apiSyncPeerPool;
         _api.PeerDifficultyRefreshPool = apiSyncPeerPool;

--- a/src/Nethermind/Nethermind.Synchronization.Test/PeerInfoTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/PeerInfoTests.cs
@@ -97,9 +97,9 @@ namespace Nethermind.Synchronization.Test
         public void Can_allocate()
         {
             PeerInfo peerInfo = new(Substitute.For<ISyncPeer>());
-            peerInfo.IsAllocated(_contexts).Should().BeFalse();
+            peerInfo.IsAllocationFull(_contexts).Should().BeFalse();
             peerInfo.TryAllocate(_contexts);
-            peerInfo.IsAllocated(_contexts).Should().BeTrue();
+            peerInfo.IsAllocationFull(_contexts).Should().BeTrue();
             peerInfo.CanBeAllocated(_contexts).Should().BeFalse();
         }
 
@@ -107,11 +107,11 @@ namespace Nethermind.Synchronization.Test
         public void Can_free()
         {
             PeerInfo peerInfo = new(Substitute.For<ISyncPeer>());
-            peerInfo.IsAllocated(_contexts).Should().BeFalse();
+            peerInfo.IsAllocationFull(_contexts).Should().BeFalse();
             peerInfo.TryAllocate(_contexts);
-            peerInfo.IsAllocated(_contexts).Should().BeTrue();
+            peerInfo.IsAllocationFull(_contexts).Should().BeTrue();
             peerInfo.Free(_contexts);
-            peerInfo.IsAllocated(_contexts).Should().BeFalse();
+            peerInfo.IsAllocationFull(_contexts).Should().BeFalse();
             peerInfo.CanBeAllocated(_contexts).Should().BeTrue();
         }
 
@@ -120,16 +120,16 @@ namespace Nethermind.Synchronization.Test
         {
             PeerInfo peerInfo = new(Substitute.For<ISyncPeer>());
             peerInfo.TryAllocate(AllocationContexts.Blocks);
-            peerInfo.IsAllocated(AllocationContexts.Bodies).Should().BeTrue();
-            peerInfo.IsAllocated(AllocationContexts.Headers).Should().BeTrue();
-            peerInfo.IsAllocated(AllocationContexts.Receipts).Should().BeTrue();
+            peerInfo.IsAllocationFull(AllocationContexts.Bodies).Should().BeTrue();
+            peerInfo.IsAllocationFull(AllocationContexts.Headers).Should().BeTrue();
+            peerInfo.IsAllocationFull(AllocationContexts.Receipts).Should().BeTrue();
             peerInfo.CanBeAllocated(AllocationContexts.Bodies).Should().BeFalse();
             peerInfo.CanBeAllocated(AllocationContexts.Headers).Should().BeFalse();
             peerInfo.CanBeAllocated(AllocationContexts.Receipts).Should().BeFalse();
 
             peerInfo.Free(AllocationContexts.Receipts);
-            peerInfo.IsAllocated(AllocationContexts.Receipts).Should().BeFalse();
-            peerInfo.IsAllocated(AllocationContexts.Bodies).Should().BeTrue();
+            peerInfo.IsAllocationFull(AllocationContexts.Receipts).Should().BeFalse();
+            peerInfo.IsAllocationFull(AllocationContexts.Bodies).Should().BeTrue();
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Synchronization.Test/PeerInfoTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/PeerInfoTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
@@ -113,7 +114,7 @@ namespace Nethermind.Synchronization.Test
             Dictionary<AllocationContexts, int> newAllowances = PeerInfo.DefaultAllowances.ToDictionary();
             newAllowances[_contexts] = 5;
 
-            PeerInfo peerInfo = new(Substitute.For<ISyncPeer>(), newAllowances);
+            PeerInfo peerInfo = new(Substitute.For<ISyncPeer>(), newAllowances.ToFrozenDictionary());
 
             for (int i = 0; i < 5; i++)
             {

--- a/src/Nethermind/Nethermind.Synchronization/Peers/AllocationContexts.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/AllocationContexts.cs
@@ -6,15 +6,15 @@ using System;
 namespace Nethermind.Synchronization.Peers
 {
     [Flags]
-    public enum AllocationContexts
+    public enum AllocationContexts: uint
     {
         None = 0,
         Headers = 1,
         Bodies = 2,
         Receipts = 4,
-        Blocks = 7,
+        Blocks = Headers | Bodies | Receipts,
         State = 8,
         Snap = 16,
-        All = Headers | Bodies | Receipts | Blocks | State | Snap
+        All = Headers | Bodies | Receipts | Blocks | State | Snap,
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization/Peers/AllocationContexts.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/AllocationContexts.cs
@@ -6,7 +6,7 @@ using System;
 namespace Nethermind.Synchronization.Peers
 {
     [Flags]
-    public enum AllocationContexts: uint
+    public enum AllocationContexts : uint
     {
         None = 0,
         Headers = 1,

--- a/src/Nethermind/Nethermind.Synchronization/Peers/PeerInfo.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/PeerInfo.cs
@@ -249,7 +249,7 @@ namespace Nethermind.Synchronization.Peers
                 return cachedContext;
             }
 
-            cachedContext = Enum.GetValues<AllocationContexts>()
+            cachedContext = FastEnum.GetValues<AllocationContexts>()
                 .Where(aCtx => IsOnlyOneContext(aCtx) && (contexts & aCtx) != 0)
                 .ToArray();
 

--- a/src/Nethermind/Nethermind.Synchronization/Peers/PeerInfo.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/PeerInfo.cs
@@ -20,7 +20,7 @@ namespace Nethermind.Synchronization.Peers
 {
     public class PeerInfo
     {
-        private static readonly Dictionary<AllocationContexts, int> DefaultAllowances = new Dictionary<AllocationContexts, int>()
+        public static readonly Dictionary<AllocationContexts, int> DefaultAllowances = new Dictionary<AllocationContexts, int>()
         {
             {AllocationContexts.Headers, 1},
             {AllocationContexts.Bodies, 1},
@@ -250,7 +250,7 @@ namespace Nethermind.Synchronization.Peers
             }
 
             cachedContext = Enum.GetValues<AllocationContexts>()
-                .Where(aCtx => IsNotCompositeContexts(aCtx) && (contexts & aCtx) != 0)
+                .Where(aCtx => IsOnlyOneContext(aCtx) && (contexts & aCtx) != 0)
                 .ToArray();
 
             SeparatedContextsCache.TryAdd(contexts, cachedContext);
@@ -259,7 +259,7 @@ namespace Nethermind.Synchronization.Peers
 
         private static ConcurrentDictionary<AllocationContexts, AllocationContexts[]> SeparatedContextsCache = new ConcurrentDictionary<AllocationContexts, AllocationContexts[]>();
 
-        bool IsNotCompositeContexts(AllocationContexts x)
+        public static bool IsOnlyOneContext(AllocationContexts x)
         {
             return (x & (x - 1)) == 0;
         }

--- a/src/Nethermind/Nethermind.Synchronization/Peers/PeerInfo.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/PeerInfo.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Frozen;
 using NonBlocking;
 using System.Collections.Generic;
 using System.Linq;
@@ -20,24 +21,22 @@ namespace Nethermind.Synchronization.Peers
 {
     public class PeerInfo
     {
-        public static readonly Dictionary<AllocationContexts, int> DefaultAllowances = new Dictionary<AllocationContexts, int>()
+        public static readonly FrozenDictionary<AllocationContexts, int> DefaultAllowances = new Dictionary<AllocationContexts, int>()
         {
             {AllocationContexts.Headers, 1},
             {AllocationContexts.Bodies, 1},
             {AllocationContexts.Receipts, 1},
             {AllocationContexts.State, 1},
             {AllocationContexts.Snap, 1},
-        };
+        }.ToFrozenDictionary();
 
-        private readonly Dictionary<AllocationContexts, int> _allocationAllowances;
+        private readonly FrozenDictionary<AllocationContexts, int> _allocationAllowances;
 
-        public PeerInfo(ISyncPeer syncPeer, Dictionary<AllocationContexts, int>? allocationAllowances = null)
+        public PeerInfo(ISyncPeer syncPeer, FrozenDictionary<AllocationContexts, int>? allocationAllowances = null)
         {
             SyncPeer = syncPeer;
-
-            allocationAllowances ??= DefaultAllowances;
-            AllocationSlots = new ConcurrentDictionary<AllocationContexts, int>(allocationAllowances);
-            _allocationAllowances = allocationAllowances;
+            _allocationAllowances = allocationAllowances?.ToFrozenDictionary() ?? DefaultAllowances;
+            AllocationSlots = new ConcurrentDictionary<AllocationContexts, int>(_allocationAllowances);
         }
 
         public NodeClientType PeerClientType => SyncPeer?.ClientType ?? NodeClientType.Unknown;

--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
@@ -244,7 +244,7 @@ namespace Nethermind.Synchronization.Peers
                 return;
             }
 
-            PeerInfo peerInfo = new(syncPeer);
+            PeerInfo peerInfo = new(syncPeer, _allocationAllowances);
             _peers.TryAdd(syncPeer.Node.Id, peerInfo);
             UpdatePeerCountMetric(peerInfo.PeerClientType, 1);
 
@@ -679,7 +679,7 @@ namespace Nethermind.Synchronization.Peers
             {
                 // We don't want to disconnect on timeout. It could be that we are downloading from the peer,
                 // or we have some connection issue
-                ReportWeakPeer(new PeerInfo(syncPeer), AllocationContexts.All);
+                ReportWeakPeer(new PeerInfo(syncPeer, _allocationAllowances), AllocationContexts.All);
             }
             else
             {

--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -39,7 +40,7 @@ namespace Nethermind.Synchronization.Peers
         private readonly BlockingCollection<RefreshTotalDiffTask> _peerRefreshQueue = new();
 
         private readonly ConcurrentDictionary<PublicKey, PeerInfo> _peers = new();
-        private readonly Dictionary<AllocationContexts, int> _allocationAllowances;
+        private readonly FrozenDictionary<AllocationContexts, int> _allocationAllowances;
 
         private readonly ConcurrentDictionary<PublicKey, CancellationTokenSource> _refreshCancelTokens = new();
         private readonly ConcurrentDictionary<SyncPeerAllocation, object?> _replaceableAllocations = new();
@@ -77,17 +78,18 @@ namespace Nethermind.Synchronization.Peers
             _allocationsUpgradeIntervalInMs = allocationsUpgradeIntervalInMsInMs;
             _logger = logManager?.GetClassLogger() ?? throw new ArgumentNullException(nameof(logManager));
 
-            _allocationAllowances = new Dictionary<AllocationContexts, int>();
+            Dictionary<AllocationContexts, int> allocationAllowances = new();
             foreach (AllocationContexts ctx in Enum.GetValues<AllocationContexts>())
             {
                 if (PeerInfo.IsOnlyOneContext(ctx))
                 {
-                    _allocationAllowances[ctx] = allocationSlots;
+                    allocationAllowances[ctx] = allocationSlots;
                 }
             }
 
             // These is a problem with header where it reliably hangs when setting a high enough allowance. So we disable it for now.
-            _allocationAllowances[AllocationContexts.Headers] = 1;
+            allocationAllowances[AllocationContexts.Headers] = 1;
+            _allocationAllowances = allocationAllowances.ToFrozenDictionary();
 
             if (_logger.IsDebug) _logger.Debug($"PeerMaxCount: {PeerMaxCount}, PriorityPeerMaxCount: {PriorityPeerMaxCount}");
         }
@@ -678,7 +680,7 @@ namespace Nethermind.Synchronization.Peers
             if (_logger.IsTrace) _logger.Trace($"Refresh failed reported: {syncPeer.Node:c}, {reason}, {exception}");
             _stats.ReportSyncEvent(syncPeer.Node, syncPeer.IsInitialized ? NodeStatsEventType.SyncFailed : NodeStatsEventType.SyncInitFailed);
 
-            if (exception is OperationCanceledException || exception is TimeoutException)
+            if (exception is OperationCanceledException or TimeoutException)
             {
                 // We don't want to disconnect on timeout. It could be that we are downloading from the peer,
                 // or we have some connection issue

--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
@@ -86,6 +86,9 @@ namespace Nethermind.Synchronization.Peers
                 }
             }
 
+            // These is a problem with header where it reliably hangs when setting a high enough allowance. So we disable it for now.
+            _allocationAllowances[AllocationContexts.Headers] = 1;
+
             if (_logger.IsDebug) _logger.Debug($"PeerMaxCount: {PeerMaxCount}, PriorityPeerMaxCount: {PriorityPeerMaxCount}");
         }
 


### PR DESCRIPTION
- At the moment, during sync, we have exactly one request per peer at any moment (per request type), for sync, which is behind an allocation system.
- This PR allows it to be more than one which is useful to account for the latency and processing overhead by the server.
- Add a config `--Sync.AllocationSlots` default to 2 to configure how allocation per peer.
- Disabled for headers as there seems to be a bug with it. 
- Useful for when you have one peer that you know is fast (because it ran locally), but can be faster with concurrent requests.
- Graph is 8, 4, 2, 1 allocation slots, syncing from another nethermind nodes, with background task parallelism set to 64 (unthrottled). 
![Screenshot_2024-06-12_20-19-20](https://github.com/NethermindEth/nethermind/assets/1841324/c0356cd5-ba50-44af-86d2-ae64794e1d87)
- When the background thread is set back to 1 on the server, 2 allocation slots only improve throughput slightly
- Graph is 4, 2, 1.
- ![Screenshot_2024-06-13_16-27-55](https://github.com/NethermindEth/nethermind/assets/1841324/3de8b399-96a9-4d52-9d1d-a988a0a733ed)


## Types of changes

#### What types of changes does your code introduce?

- [X] Optimization

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No
