### PR TITLE
Increase Lru tests

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Caching/LruCacheLowObjectTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Caching/LruCacheLowObjectTests.cs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Threading.Tasks;
 using FluentAssertions;
-using Nethermind.Core;
 using Nethermind.Core.Caching;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Int256;
@@ -20,10 +20,10 @@ namespace Nethermind.Core.Test.Caching
             return new Cache(Capacity, "test")!;
         }
 
-        private const int Capacity = 16;
+        private const int Capacity = 32;
 
-        private readonly Account[] _accounts = new Account[Capacity * 2];
-        private readonly Address[] _addresses = new Address[Capacity * 2];
+        private readonly Account[] _accounts = new Account[Capacity * 2 + 1];
+        private readonly Address[] _addresses = new Address[Capacity * 2 + 1];
 
         [SetUp]
         public void Setup()
@@ -100,6 +100,118 @@ namespace Nethermind.Core.Test.Caching
                 }
                 cache.Set(_addresses[i], _accounts[i]);
             }
+        }
+
+        [Test]
+        public void Beyond_capacity_lru_check()
+        {
+            Random random = new();
+            Cache cache = Create();
+            for (var iter = 0; iter < Capacity; iter++)
+            {
+                for (int ii = 0; ii < Capacity; ii++)
+                {
+                    cache.Set(_addresses[ii], _accounts[ii]).Should().BeTrue();
+                }
+
+                for (int i = 1; i < Capacity; i++)
+                {
+                    for (int ii = i - 1; ii < i - 1 + Capacity; ii++)
+                    {
+                        // Fuzz the order of the addresses
+                        var index = random.Next(i - 1, i - 1 + Capacity);
+                        cache.Delete(_addresses[index]).Should().BeTrue();
+                        cache.Set(_addresses[index], _accounts[index]).Should().BeTrue();
+                    }
+                    for (int ii = i - 1; ii < i - 1 + Capacity; ii++)
+                    {
+                        // Fuzz the order of the addresses
+                        var index = random.Next(i - 1, i - 1 + Capacity);
+                        cache.Set(_addresses[index], _accounts[index]).Should().BeFalse();
+                    }
+                    for (int ii = i - 1; ii < i - 1 + Capacity; ii++)
+                    {
+                        // Fuzz the order of the addresses
+                        var index = random.Next(i - 1, i - 1 + Capacity);
+                        cache.Get(_addresses[index]).Should().BeEquivalentTo(_accounts[index]);
+                    }
+                    for (int ii = i; ii < i + Capacity; ii++)
+                    {
+                        if (ii <  i + Capacity - 1)
+                            cache.Set(_addresses[ii], _accounts[ii]).Should().BeFalse();
+                        else
+                            cache.Set(_addresses[ii], _accounts[ii]).Should().BeTrue();
+                    }
+                    for (int ii = i; ii < i + Capacity; ii++)
+                    {
+                        cache.Get(_addresses[ii]).Should().NotBeNull();
+                        cache.Get(_addresses[ii]).Should().BeEquivalentTo(_accounts[ii]);
+                    }
+                    if (i > 0)
+                    {
+                        cache.Get(_addresses[i - 1]).Should().BeNull();
+                    }
+                    cache.Get(_addresses[i + Capacity]).Should().BeNull();
+                }
+
+                cache.Count.Should().Be(Capacity);
+                if (iter % 2 == 0)
+                {
+                    cache.Clear();
+                }
+                else
+                {
+                    for (int ii = Capacity - 1; ii < Capacity * 2 - 1; ii++)
+                    {
+                        cache.Get(_addresses[ii]).Should().BeEquivalentTo(_accounts[ii]);
+                        cache.Delete(_addresses[ii]).Should().BeTrue();
+                    }
+                }
+
+                cache.Count.Should().Be(0);
+            }
+        }
+
+        [Test]
+        public void Beyond_capacity_lru_parallel()
+        {
+            Cache cache = new(Capacity, "test");
+            Parallel.For(0, Environment.ProcessorCount * 8, (iter) =>
+            {
+                for (int ii = 0; ii < Capacity; ii++)
+                {
+                    cache.Set(_addresses[ii], _accounts[ii]);
+                }
+
+                for (int i = 1; i < Capacity; i++)
+                {
+                    for (int ii = i; ii < i + Capacity; ii++)
+                    {
+                        cache.Set(_addresses[ii], _accounts[ii]);
+                    }
+                    for (int ii = i; ii < i + Capacity; ii++)
+                    {
+                        cache.Get(_addresses[ii]);
+                    }
+                    if (i > 0)
+                    {
+                        cache.Get(_addresses[i - 1]);
+                    }
+                    cache.Get(_addresses[i + Capacity]);
+
+                    if (iter % Environment.ProcessorCount == 0)
+                    {
+                        cache.Clear();
+                    }
+                    else
+                    {
+                        for (int ii = i; ii < i + Capacity / 2; ii++)
+                        {
+                            cache.Delete(_addresses[ii]);
+                        }
+                    }
+                }
+            });
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Core.Test/Caching/LruCacheLowObjectTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Caching/LruCacheLowObjectTests.cs
@@ -137,7 +137,7 @@ namespace Nethermind.Core.Test.Caching
                     }
                     for (int ii = i; ii < i + Capacity; ii++)
                     {
-                        if (ii <  i + Capacity - 1)
+                        if (ii < i + Capacity - 1)
                             cache.Set(_addresses[ii], _accounts[ii]).Should().BeFalse();
                         else
                             cache.Set(_addresses[ii], _accounts[ii]).Should().BeTrue();

--- a/src/Nethermind/Nethermind.Core.Test/Caching/LruCacheTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Caching/LruCacheTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Nethermind.Core.Caching;
 using Nethermind.Core.Test.Builders;
@@ -10,18 +11,17 @@ using NUnit.Framework;
 
 namespace Nethermind.Core.Test.Caching
 {
-    [TestFixture(typeof(LruCache<Address, Account>))]
     public class LruCacheTests<TCache>
     {
         private static ICache<Address, Account> Create()
         {
-            return (ICache<Address, Account>)Activator.CreateInstance(typeof(TCache), Capacity, "test")!;
+            return new LruCache<Address, Account>(Capacity, Capacity / 2, "test");
         }
 
-        private const int Capacity = 16;
+        private const int Capacity = 32;
 
-        private readonly Account[] _accounts = new Account[Capacity * 2];
-        private readonly Address[] _addresses = new Address[Capacity * 2];
+        private readonly Account[] _accounts = new Account[Capacity * 2 + 1];
+        private readonly Address[] _addresses = new Address[Capacity * 2 + 1];
 
         [SetUp]
         public void Setup()
@@ -85,6 +85,117 @@ namespace Nethermind.Core.Test.Caching
                 }
                 cache.Set(_addresses[i], _accounts[i]);
             }
+        }
+
+        [Test]
+        public void Beyond_capacity_lru_check()
+        {
+            Random random = new();
+            ICache<Address, Account> cache = Create();
+            for (var iter = 0; iter < Capacity; iter++)
+            {
+                for (int ii = 0; ii < Capacity; ii++)
+                {
+                    cache.Set(_addresses[ii], _accounts[ii]).Should().BeTrue();
+                }
+
+                for (int i = 1; i < Capacity; i++)
+                {
+                    for (int ii = i - 1; ii < i - 1 + Capacity; ii++)
+                    {
+                        // Fuzz the order of the addresses
+                        var index = random.Next(i - 1, i - 1 + Capacity);
+                        cache.Set(_addresses[index], _accounts[index]).Should().BeFalse();
+                    }
+                    for (int ii = i - 1; ii < i - 1 + Capacity; ii++)
+                    {
+                        // Fuzz the order of the addresses
+                        var index = random.Next(i - 1, i - 1 + Capacity);
+                        cache.Delete(_addresses[index]).Should().BeTrue();
+                        cache.Set(_addresses[index], _accounts[index]).Should().BeTrue();
+                    }
+                    for (int ii = i - 1; ii < i - 1 + Capacity; ii++)
+                    {
+                        // Fuzz the order of the addresses
+                        var index = random.Next(i - 1, i - 1 + Capacity);
+                        cache.Get(_addresses[index]).Should().BeEquivalentTo(_accounts[index]);
+                    }
+                    for (int ii = i; ii < i + Capacity; ii++)
+                    {
+                        if (ii <  i + Capacity - 1)
+                            cache.Set(_addresses[ii], _accounts[ii]).Should().BeFalse();
+                        else
+                            cache.Set(_addresses[ii], _accounts[ii]).Should().BeTrue();
+                    }
+                    for (int ii = i; ii < i + Capacity; ii++)
+                    {
+                        cache.Get(_addresses[ii]).Should().NotBeNull();
+                    }
+                    if (i > 0)
+                    {
+                        cache.Get(_addresses[i - 1]).Should().BeNull();
+                    }
+                    cache.Get(_addresses[i + Capacity]).Should().BeNull();
+                }
+
+                cache.Count.Should().Be(Capacity);
+                if (iter % 2 == 0)
+                {
+                    cache.Clear();
+                }
+                else
+                {
+                    for (int ii = Capacity - 1; ii < Capacity * 2 - 1; ii++)
+                    {
+                        cache.Get(_addresses[ii]).Should().BeEquivalentTo(_accounts[ii]);
+                        cache.Delete(_addresses[ii]).Should().BeTrue();
+                    }
+                }
+
+                cache.Count.Should().Be(0);
+            }
+        }
+
+        [Test]
+        public void Beyond_capacity_lru_parallel()
+        {
+            ICache<Address, Account> cache = Create();
+            Parallel.For(0, Environment.ProcessorCount * 8, (iter) =>
+            {
+                for (int ii = 0; ii < Capacity; ii++)
+                {
+                    cache.Set(_addresses[ii], _accounts[ii]);
+                }
+
+                for (int i = 1; i < Capacity; i++)
+                {
+                    for (int ii = i; ii < i + Capacity; ii++)
+                    {
+                        cache.Set(_addresses[ii], _accounts[ii]);
+                    }
+                    for (int ii = i; ii < i + Capacity; ii++)
+                    {
+                        cache.Get(_addresses[ii]);
+                    }
+                    if (i > 0)
+                    {
+                        cache.Get(_addresses[i - 1]);
+                    }
+                    cache.Get(_addresses[i + Capacity]);
+
+                    if (iter % Environment.ProcessorCount == 0)
+                    {
+                        cache.Clear();
+                    }
+                    else
+                    {
+                        for (int ii = i; ii < i + Capacity / 2; ii++)
+                        {
+                            cache.Delete(_addresses[ii]);
+                        }
+                    }
+                }
+            });
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Core.Test/Caching/LruCacheTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Caching/LruCacheTests.cs
@@ -122,7 +122,7 @@ namespace Nethermind.Core.Test.Caching
                     }
                     for (int ii = i; ii < i + Capacity; ii++)
                     {
-                        if (ii <  i + Capacity - 1)
+                        if (ii < i + Capacity - 1)
                             cache.Set(_addresses[ii], _accounts[ii]).Should().BeFalse();
                         else
                             cache.Set(_addresses[ii], _accounts[ii]).Should().BeTrue();

--- a/src/Nethermind/Nethermind.Core.Test/Caching/LruKeyCacheLowObjectTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Caching/LruKeyCacheLowObjectTests.cs
@@ -129,7 +129,7 @@ namespace Nethermind.Core.Test.Caching
                     }
                     for (int ii = i; ii < i + Capacity; ii++)
                     {
-                        if (ii <  i + Capacity - 1)
+                        if (ii < i + Capacity - 1)
                             cache.Set(_addresses[ii]).Should().BeFalse();
                         else
                             cache.Set(_addresses[ii]).Should().BeTrue();
@@ -188,7 +188,7 @@ namespace Nethermind.Core.Test.Caching
                         cache.Get(_addresses[i - 1]);
                     }
                     cache.Get(_addresses[i + Capacity]);
-                
+
                     for (int ii = i; ii < i + Capacity / 2; ii++)
                     {
                         cache.Delete(_addresses[ii]);

--- a/src/Nethermind/Nethermind.Core.Test/Caching/LruKeyCacheLowObjectTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Caching/LruKeyCacheLowObjectTests.cs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Nethermind.Core.Caching;
 using Nethermind.Core.Test.Builders;
@@ -12,10 +14,10 @@ namespace Nethermind.Core.Test.Caching
     [TestFixture]
     public class LruKeyCacheLowObjectTests
     {
-        private const int Capacity = 16;
+        private const int Capacity = 32;
 
-        private readonly Account[] _accounts = new Account[Capacity * 2];
-        private readonly Address[] _addresses = new Address[Capacity * 2];
+        private readonly Account[] _accounts = new Account[Capacity * 2 + 1];
+        private readonly Address[] _addresses = new Address[Capacity * 2 + 1];
 
         [SetUp]
         public void Setup()
@@ -90,6 +92,109 @@ namespace Nethermind.Core.Test.Caching
                 }
                 cache.Set(_addresses[i]);
             }
+        }
+
+        [Test]
+        public void Beyond_capacity_lru_check()
+        {
+            Random random = new();
+            LruKeyCacheLowObject<AddressAsKey> cache = new(Capacity, "test");
+            for (var iter = 0; iter < Capacity; iter++)
+            {
+                for (int ii = 0; ii < Capacity; ii++)
+                {
+                    cache.Set(_addresses[ii]).Should().BeTrue();
+                }
+
+                for (int i = 1; i < Capacity; i++)
+                {
+                    for (int ii = i - 1; ii < i - 1 + Capacity; ii++)
+                    {
+                        // Fuzz the order of the addresses
+                        var index = random.Next(i - 1, i - 1 + Capacity);
+                        cache.Delete(_addresses[index]).Should().BeTrue();
+                        cache.Set(_addresses[index]).Should().BeTrue();
+                    }
+                    for (int ii = i - 1; ii < i - 1 + Capacity; ii++)
+                    {
+                        // Fuzz the order of the addresses
+                        var index = random.Next(i - 1, i - 1 + Capacity);
+                        cache.Set(_addresses[index]).Should().BeFalse();
+                    }
+                    for (int ii = i - 1; ii < i - 1 + Capacity; ii++)
+                    {
+                        // Fuzz the order of the addresses
+                        var index = random.Next(i - 1, i - 1 + Capacity);
+                        cache.Get(_addresses[index]).Should().BeTrue();
+                    }
+                    for (int ii = i; ii < i + Capacity; ii++)
+                    {
+                        if (ii <  i + Capacity - 1)
+                            cache.Set(_addresses[ii]).Should().BeFalse();
+                        else
+                            cache.Set(_addresses[ii]).Should().BeTrue();
+                    }
+                    for (int ii = i; ii < i + Capacity; ii++)
+                    {
+                        cache.Get(_addresses[ii]).Should().BeTrue();
+                    }
+                    if (i > 0)
+                    {
+                        cache.Get(_addresses[i - 1]).Should().BeFalse();
+                    }
+                    cache.Get(_addresses[i + Capacity]).Should().BeFalse();
+                }
+
+                cache.Count.Should().Be(Capacity);
+                if (iter % 2 == 0)
+                {
+                    cache.Clear();
+                }
+                else
+                {
+                    for (int ii = Capacity - 1; ii < Capacity * 2 - 1; ii++)
+                    {
+                        cache.Delete(_addresses[ii]).Should().BeTrue();
+                    }
+                }
+
+                cache.Count.Should().Be(0);
+            }
+        }
+
+        [Test]
+        public void Beyond_capacity_lru_parallel()
+        {
+            LruKeyCacheLowObject<AddressAsKey> cache = new(Capacity, "test");
+            Parallel.For(0, Environment.ProcessorCount * 8, (s) =>
+            {
+                for (int ii = 0; ii < Capacity; ii++)
+                {
+                    cache.Set(_addresses[ii]);
+                }
+
+                for (int i = 1; i < Capacity; i++)
+                {
+                    for (int ii = i; ii < i + Capacity; ii++)
+                    {
+                        cache.Set(_addresses[ii]);
+                    }
+                    for (int ii = i; ii < i + Capacity; ii++)
+                    {
+                        cache.Get(_addresses[ii]);
+                    }
+                    if (i > 0)
+                    {
+                        cache.Get(_addresses[i - 1]);
+                    }
+                    cache.Get(_addresses[i + Capacity]);
+                
+                    for (int ii = i; ii < i + Capacity / 2; ii++)
+                    {
+                        cache.Delete(_addresses[ii]);
+                    }
+                }
+            });
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Core.Test/Caching/LruKeyCacheNonConcurrentTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Caching/LruKeyCacheNonConcurrentTests.cs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Nethermind.Core.Caching;
 using Nethermind.Core.Test.Builders;
@@ -89,6 +91,74 @@ namespace Nethermind.Core.Test.Caching
                     cache.Set(_addresses[i]);
                 }
                 cache.Set(_addresses[i]);
+            }
+        }
+
+        [Test]
+        public void Beyond_capacity_lru_check()
+        {
+            Random random = new();
+            LruKeyCacheNonConcurrent<AddressAsKey> cache = new(Capacity, "test");
+            for (var iter = 0; iter < Capacity; iter++)
+            {
+                for (int ii = 0; ii < Capacity; ii++)
+                {
+                    cache.Set(_addresses[ii]).Should().BeTrue();
+                }
+
+                for (int i = 1; i < Capacity; i++)
+                {
+                    for (int ii = i - 1; ii < i - 1 + Capacity; ii++)
+                    {
+                        // Fuzz the order of the addresses
+                        var index = random.Next(i - 1, i - 1 + Capacity);
+                        cache.Delete(_addresses[index]).Should().BeTrue();
+                        cache.Set(_addresses[index]).Should().BeTrue();
+                    }
+                    for (int ii = i - 1; ii < i - 1 + Capacity; ii++)
+                    {
+                        // Fuzz the order of the addresses
+                        var index = random.Next(i - 1, i - 1 + Capacity);
+                        cache.Set(_addresses[index]).Should().BeFalse();
+                    }
+                    for (int ii = i - 1; ii < i - 1 + Capacity; ii++)
+                    {
+                        // Fuzz the order of the addresses
+                        var index = random.Next(i - 1, i - 1 + Capacity);
+                        cache.Get(_addresses[index]).Should().BeTrue();
+                    }
+                    for (int ii = i; ii < i + Capacity; ii++)
+                    {
+                        if (ii <  i + Capacity - 1)
+                            cache.Set(_addresses[ii]).Should().BeFalse();
+                        else
+                            cache.Set(_addresses[ii]).Should().BeTrue();
+                    }
+                    for (int ii = i; ii < i + Capacity; ii++)
+                    {
+                        cache.Get(_addresses[ii]).Should().BeTrue();
+                    }
+                    if (i > 0)
+                    {
+                        cache.Get(_addresses[i - 1]).Should().BeFalse();
+                    }
+                    cache.Get(_addresses[i + Capacity]).Should().BeFalse();
+                }
+
+                cache.Count.Should().Be(Capacity);
+                if (iter % 2 == 0)
+                {
+                    cache.Clear();
+                }
+                else
+                {
+                    for (int ii = Capacity - 1; ii < Capacity * 2 - 1; ii++)
+                    {
+                        cache.Delete(_addresses[ii]).Should().BeTrue();
+                    }
+                }
+
+                cache.Count.Should().Be(0);
             }
         }
 

--- a/src/Nethermind/Nethermind.Core.Test/Caching/LruKeyCacheNonConcurrentTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Caching/LruKeyCacheNonConcurrentTests.cs
@@ -129,7 +129,7 @@ namespace Nethermind.Core.Test.Caching
                     }
                     for (int ii = i; ii < i + Capacity; ii++)
                     {
-                        if (ii <  i + Capacity - 1)
+                        if (ii < i + Capacity - 1)
                             cache.Set(_addresses[ii]).Should().BeFalse();
                         else
                             cache.Set(_addresses[ii]).Should().BeTrue();

--- a/src/Nethermind/Nethermind.Core.Test/Caching/LruKeyCacheTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Caching/LruKeyCacheTests.cs
@@ -129,7 +129,7 @@ namespace Nethermind.Core.Test.Caching
                     }
                     for (int ii = i; ii < i + Capacity; ii++)
                     {
-                        if (ii <  i + Capacity - 1)
+                        if (ii < i + Capacity - 1)
                             cache.Set(_addresses[ii]).Should().BeFalse();
                         else
                             cache.Set(_addresses[ii]).Should().BeTrue();

--- a/src/Nethermind/Nethermind.Core.Test/Caching/LruKeyCacheTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Caching/LruKeyCacheTests.cs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Nethermind.Core.Caching;
 using Nethermind.Core.Test.Builders;
@@ -12,10 +14,10 @@ namespace Nethermind.Core.Test.Caching
     [TestFixture]
     public class LruKeyCacheTests
     {
-        private const int Capacity = 16;
+        private const int Capacity = 32;
 
-        private readonly Account[] _accounts = new Account[Capacity * 2];
-        private readonly Address[] _addresses = new Address[Capacity * 2];
+        private readonly Account[] _accounts = new Account[Capacity * 2 + 1];
+        private readonly Address[] _addresses = new Address[Capacity * 2 + 1];
 
         [SetUp]
         public void Setup()
@@ -90,6 +92,116 @@ namespace Nethermind.Core.Test.Caching
                 }
                 cache.Set(_addresses[i]);
             }
+        }
+
+        [Test]
+        public void Beyond_capacity_lru_check()
+        {
+            Random random = new();
+            LruKeyCache<AddressAsKey> cache = new(Capacity, "test");
+            for (var iter = 0; iter < Capacity; iter++)
+            {
+                for (int ii = 0; ii < Capacity; ii++)
+                {
+                    cache.Set(_addresses[ii]).Should().BeTrue();
+                }
+
+                for (int i = 1; i < Capacity; i++)
+                {
+                    for (int ii = i - 1; ii < i - 1 + Capacity; ii++)
+                    {
+                        // Fuzz the order of the addresses
+                        var index = random.Next(i - 1, i - 1 + Capacity);
+                        cache.Delete(_addresses[index]).Should().BeTrue();
+                        cache.Set(_addresses[index]).Should().BeTrue();
+                    }
+                    for (int ii = i - 1; ii < i - 1 + Capacity; ii++)
+                    {
+                        // Fuzz the order of the addresses
+                        var index = random.Next(i - 1, i - 1 + Capacity);
+                        cache.Set(_addresses[index]).Should().BeFalse();
+                    }
+                    for (int ii = i - 1; ii < i - 1 + Capacity; ii++)
+                    {
+                        // Fuzz the order of the addresses
+                        var index = random.Next(i - 1, i - 1 + Capacity);
+                        cache.Get(_addresses[index]).Should().BeTrue();
+                    }
+                    for (int ii = i; ii < i + Capacity; ii++)
+                    {
+                        if (ii <  i + Capacity - 1)
+                            cache.Set(_addresses[ii]).Should().BeFalse();
+                        else
+                            cache.Set(_addresses[ii]).Should().BeTrue();
+                    }
+                    for (int ii = i; ii < i + Capacity; ii++)
+                    {
+                        cache.Get(_addresses[ii]).Should().BeTrue();
+                    }
+                    if (i > 0)
+                    {
+                        cache.Get(_addresses[i - 1]).Should().BeFalse();
+                    }
+                    cache.Get(_addresses[i + Capacity]).Should().BeFalse();
+                }
+
+                cache.Count.Should().Be(Capacity);
+                if (iter % 2 == 0)
+                {
+                    cache.Clear();
+                }
+                else
+                {
+                    for (int ii = Capacity - 1; ii < Capacity * 2 - 1; ii++)
+                    {
+                        cache.Delete(_addresses[ii]).Should().BeTrue();
+                    }
+                }
+
+                cache.Count.Should().Be(0);
+            }
+        }
+
+        [Test]
+        public void Beyond_capacity_lru_parallel()
+        {
+            LruKeyCache<AddressAsKey> cache = new(Capacity, Capacity / 2, "test");
+            Parallel.For(0, Environment.ProcessorCount * 8, (iter) =>
+            {
+                for (int ii = 0; ii < Capacity; ii++)
+                {
+                    cache.Set(_addresses[ii]);
+                }
+
+                for (int i = 1; i < Capacity; i++)
+                {
+                    for (int ii = i; ii < i + Capacity; ii++)
+                    {
+                        cache.Set(_addresses[ii]);
+                    }
+                    for (int ii = i; ii < i + Capacity; ii++)
+                    {
+                        cache.Get(_addresses[ii]);
+                    }
+                    if (i > 0)
+                    {
+                        cache.Get(_addresses[i - 1]);
+                    }
+                    cache.Get(_addresses[i + Capacity]);
+
+                    if (iter % Environment.ProcessorCount == 0)
+                    {
+                        cache.Clear();
+                    }
+                    else
+                    {
+                        for (int ii = i; ii < i + Capacity / 2; ii++)
+                        {
+                            cache.Delete(_addresses[ii]);
+                        }
+                    }
+                }
+            });
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Core.Test/Caching/SpanLruCacheTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Caching/SpanLruCacheTests.cs
@@ -136,7 +136,7 @@ namespace Nethermind.Core.Test.Caching
                     }
                     for (int ii = i; ii < i + Capacity; ii++)
                     {
-                        if (ii <  i + Capacity - 1)
+                        if (ii < i + Capacity - 1)
                             cache.Set(_addresses[ii].Bytes, _accounts[ii]).Should().BeFalse();
                         else
                             cache.Set(_addresses[ii].Bytes, _accounts[ii]).Should().BeTrue();

--- a/src/Nethermind/Nethermind.Core/Caching/ICache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/ICache.cs
@@ -24,5 +24,6 @@ namespace Nethermind.Core.Caching
         /// <returns>True if key existed in the cache, otherwise false.</returns>
         bool Delete(TKey key);
         bool Contains(TKey key);
+        int Count { get; }
     }
 }

--- a/src/Nethermind/Nethermind.Core/Caching/ISpanCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/ISpanCache.cs
@@ -31,5 +31,6 @@ namespace Nethermind.Core.Caching
         /// <returns>True if key existed in the cache, otherwise false.</returns>
         bool Delete(ReadOnlySpan<TKey> key);
         bool Contains(ReadOnlySpan<TKey> key);
+        int Count { get; }
     }
 }

--- a/src/Nethermind/Nethermind.Core/Caching/LruCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/LruCache.cs
@@ -160,13 +160,7 @@ namespace Nethermind.Core.Caching
             return array;
         }
 
-        public int Size
-        {
-            get
-            {
-                return _cacheMap.Count;
-            }
-        }
+        public int Count => _cacheMap.Count;
 
         private void Replace(TKey key, TValue value)
         {

--- a/src/Nethermind/Nethermind.Core/Caching/LruCacheLowObject.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/LruCacheLowObject.cs
@@ -144,13 +144,7 @@ namespace Nethermind.Core.Caching
             return _cacheMap.ContainsKey(key);
         }
 
-        public int Size
-        {
-            get
-            {
-                return _cacheMap.Count;
-            }
-        }
+        public int Count => _cacheMap.Count;
 
         private void Replace(TKey key, TValue value)
         {

--- a/src/Nethermind/Nethermind.Core/Caching/LruKeyCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/LruKeyCache.cs
@@ -78,16 +78,20 @@ namespace Nethermind.Core.Caching
             }
         }
 
-        public void Delete(TKey key)
+        public bool Delete(TKey key)
         {
             using var lockRelease = _lock.Acquire();
 
             if (_cacheMap.TryGetValue(key, out LinkedListNode<TKey>? node))
             {
                 LinkedListNode<TKey>.Remove(ref _leastRecentlyUsed, node);
-                _cacheMap.Remove(key);
+                return _cacheMap.Remove(key);
             }
+
+            return false;
         }
+
+        public int Count => _cacheMap.Count;
 
         private void Replace(TKey key)
         {

--- a/src/Nethermind/Nethermind.Core/Caching/LruKeyCacheLowObject.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/LruKeyCacheLowObject.cs
@@ -92,11 +92,11 @@ namespace Nethermind.Core.Caching
             return true;
         }
 
-        public void Delete(TKey key)
+        public bool Delete(TKey key)
         {
             using var lockRelease = _lock.Acquire();
 
-            DeleteNoLock(key);
+            return DeleteNoLock(key);
         }
 
         private bool DeleteNoLock(TKey key)
@@ -121,13 +121,7 @@ namespace Nethermind.Core.Caching
             return _cacheMap.ContainsKey(key);
         }
 
-        public int Size
-        {
-            get
-            {
-                return _cacheMap.Count;
-            }
-        }
+        public int Count => _cacheMap.Count;
 
         private void Replace(TKey key)
         {

--- a/src/Nethermind/Nethermind.Core/Caching/LruKeyCacheNonConcurrent.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/LruKeyCacheNonConcurrent.cs
@@ -70,14 +70,18 @@ namespace Nethermind.Core.Caching
             }
         }
 
-        public void Delete(TKey key)
+        public bool Delete(TKey key)
         {
             if (_cacheMap.TryGetValue(key, out LinkedListNode<TKey>? node))
             {
                 LinkedListNode<TKey>.Remove(ref _leastRecentlyUsed, node);
-                _cacheMap.Remove(key);
+                return _cacheMap.Remove(key);
             }
+
+            return false;
         }
+
+        public int Count => _cacheMap.Count;
 
         private void Replace(TKey key)
         {

--- a/src/Nethermind/Nethermind.Core/Caching/MemCountingCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/MemCountingCache.cs
@@ -196,5 +196,6 @@ namespace Nethermind.Core.Caching
         }
 
         public long MemorySize { get; private set; } = PreInitMemorySize;
+        public int Count => _cacheMap.Count;
     }
 }

--- a/src/Nethermind/Nethermind.Core/Caching/SpanLruCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/SpanLruCache.cs
@@ -133,6 +133,8 @@ namespace Nethermind.Core.Caching
             return _cacheMap.ContainsKey(key);
         }
 
+        public int Count => _cacheMap.Count;
+
         public IDictionary<TKey[], TValue> Clone()
         {
             using var lockRelease = _lock.Acquire();


### PR DESCRIPTION
Fix in https://github.com/NethermindEth/nethermind/pull/7160 broke hive tests; still haven't been able to track down the issue. However more tests is always good.

Break is state root mismatch

```
Processed block 8 (0x51bd5f...3159f4) is invalid: 
- hash: expected 0x63396b16dea8377d79ee68c1c1029a88315138025941d4815c0cfc033dbd5fc7, 
    got 0x51bd5f2998f8e2a5bdba8a15e5a8e8536ccadfd3bb4d776d94c1416b193159f4 
- state root: expected 0x9e0a7957b87f211e0aa26e6f0e4837c6fd23954ed76cce0e0e02c1f15590e157
      got 0xd942379f8376919d331a93825182e628c9ac4ab216cabb1ec495ae36084a833d 
- block extra data : 4e65746865726d696e64, UTF8: Nethermind 
Processed block is not valid 8 (0x63396b16dea8377d79ee68c1c1029a88315138025941d4815c0cfc033dbd5fc7) 
InvalidStateRoot: State root in header does not match. 
```

## Changes

- Increase testing for the Lru tests

## Types of changes

#### What types of changes does your code introduce?

- [x] Other: Additional tests

## Testing

#### Requires testing

- [x] No

#### If yes, did you write tests?

- [x] Yes

