### PR TITLE
Use .IsEmpty rather than .Count for ConcurrentDictionary

### DIFF
--- a/src/Nethermind/Nethermind.State/PreBlockCaches.cs
+++ b/src/Nethermind/Nethermind.State/PreBlockCaches.cs
@@ -21,7 +21,7 @@ public class PreBlockCaches
 
     public bool Clear()
     {
-        bool isDirty = StorageCache.Count > 0 || StateCache.Count > 0 || RlpCache.Count > 0;
+        bool isDirty = !StorageCache.IsEmpty || !StateCache.IsEmpty || !RlpCache.IsEmpty;
         if (isDirty)
         {
             StorageCache.Clear();


### PR DESCRIPTION
## Changes

- Use fast-path with early exit; rather than having to lock to get exact number

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
