### PR TITLE
Use OrdinalIgnoreCase rather than .ToLower()+Op for string

### DIFF
--- a/src/Nethermind/Nethermind.Network.Dns/EnrTreeCrawler.cs
+++ b/src/Nethermind/Nethermind.Network.Dns/EnrTreeCrawler.cs
@@ -15,7 +15,7 @@ public class EnrTreeCrawler
     }
     public IAsyncEnumerable<string> SearchTree(string domain)
     {
-        if (domain.ToLower().StartsWith("enrtree://"))
+        if (domain.StartsWith("enrtree://", StringComparison.OrdinalIgnoreCase))
         {
             domain = domain[10..];
             // Note: we have no verification of a DNS list signer!


### PR DESCRIPTION
## Changes

- Use OrdinalIgnoreCase to not create intermediate string

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No