### PR TITLE
Skip eth_getLogs error for NonValidatorNodes

### DIFF
--- a/src/Nethermind/Nethermind.Runner/Ethereum/Steps/StartRpc.cs
+++ b/src/Nethermind/Nethermind.Runner/Ethereum/Steps/StartRpc.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Api;
+using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core;
 using Nethermind.Core.Authentication;
 using Nethermind.Init.Steps;
@@ -50,7 +51,8 @@ namespace Nethermind.Runner.Ethereum.Steps
                     jsonRpcService,
                     jsonRpcConfig,
                     _api.FileSystem,
-                    _api.LogManager);
+                    _api.LogManager,
+                    _api.Config<ISyncConfig>());
 
 
                 if (initConfig.WebSocketsEnabled)


### PR DESCRIPTION
## Changes

- Don't output `Error when handling Id:N, eth_getLogs` for NonValidatorNode as is likely is because they aren't syncing receipts

## Types of changes

#### What types of changes does your code introduce?

- [x] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [x] No