### PR TITLE
Mcslock reduce threadlocals

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/MCSLockTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/MCSLockTests.cs
@@ -88,27 +88,4 @@ public class MCSLockTests
         var expectedOrder = Enumerable.Range(0, numberOfThreads).ToList();
         CollectionAssert.AreEqual(expectedOrder, executionOrder, "Threads did not acquire lock in the order they were started.");
     }
-
-    [Test]
-    public void NonReentrantTest()
-    {
-        bool reentrancyDetected = false;
-        var thread = new Thread(() =>
-        {
-            using var handle = mcsLock.Acquire();
-            try
-            {
-                using var innerHandle = mcsLock.Acquire(); // Attempt to re-lock
-            }
-            catch
-            {
-                reentrancyDetected = true;
-            }
-        });
-
-        thread.Start();
-        thread.Join();
-
-        Assert.IsTrue(reentrancyDetected, "Reentrancy was not properly detected.");
-    }
 }

--- a/src/Nethermind/Nethermind.Core.Test/McsPriorityLock.cs
+++ b/src/Nethermind/Nethermind.Core.Test/McsPriorityLock.cs
@@ -145,27 +145,4 @@ public class McsPriorityLockTests
         // Some lower priority threads will acquire first; we are asserting that they mostly queue jump
         Assert.That(lowPriorityFirst < (numberOfThreads / 8), Is.True, "High priority threads did not acquire the lock before lower priority ones.");
     }
-
-    [Test]
-    public void NonReentrantTest()
-    {
-        bool reentrancyDetected = false;
-        var thread = new Thread(() =>
-        {
-            using var handle = mcsLock.Acquire();
-            try
-            {
-                using var innerHandle = mcsLock.Acquire(); // Attempt to re-lock
-            }
-            catch
-            {
-                reentrancyDetected = true;
-            }
-        });
-
-        thread.Start();
-        thread.Join();
-
-        Assert.IsTrue(reentrancyDetected, "Reentrancy was not properly detected.");
-    }
 }

--- a/src/Nethermind/Nethermind.Core/Threading/McsLock.cs
+++ b/src/Nethermind/Nethermind.Core/Threading/McsLock.cs
@@ -224,7 +224,7 @@ public class McsLock
         /// </summary>
         public ThreadNode? Next = null;
     }
-    
+
     [StructLayout(LayoutKind.Explicit, Size = 128)]
     internal struct PaddedNode
     {

--- a/src/Nethermind/Nethermind.Core/Threading/McsLock.cs
+++ b/src/Nethermind/Nethermind.Core/Threading/McsLock.cs
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
 using System.Threading;
 
 namespace Nethermind.Core.Threading;
@@ -17,16 +19,16 @@ namespace Nethermind.Core.Threading;
 public class McsLock
 {
     /// <summary>
-    /// Thread-local storage to ensure each thread has its own node instance.
+    /// Reusable queue of nodes to reduce memory allocation overhead.
     /// </summary>
-    internal readonly ThreadLocal<ThreadNode> _node = new(() => new ThreadNode());
+    private ConcurrentQueue<ThreadNode> _nodePool = new();
 
     /// <summary>
     /// Points to the last node in the queue (tail). Used to manage the queue of waiting threads.
     /// </summary>
-    private volatile ThreadNode? _tail;
+    private PaddedNode _tail;
 
-    internal volatile ThreadNode? _currentLockHolder = null;
+    private PaddedNode _currentLockHolder;
 
     /// <summary>
     /// Acquires the lock. If the lock is already held, the calling thread is placed into a queue and
@@ -34,24 +36,27 @@ public class McsLock
     /// </summary>
     public Disposable Acquire()
     {
-        ThreadNode node = _node.Value!;
+        if (!_nodePool.TryDequeue(out ThreadNode? node))
+        {
+            node = new ThreadNode();
+        }
 
         // Check for reentrancy.
-        if (ReferenceEquals(node, _currentLockHolder))
+        if (ReferenceEquals(node, _currentLockHolder.Value))
             ThrowInvalidOperationException();
 
         node.State = (nuint)LockState.Waiting;
 
-        ThreadNode? predecessor = Interlocked.Exchange(ref _tail, node);
+        ThreadNode? predecessor = Interlocked.Exchange(ref _tail.Value, node);
         if (predecessor is not null)
         {
             WaitForUnlock(node, predecessor);
         }
 
         // Set current lock holder.
-        _currentLockHolder = node;
+        _currentLockHolder.Value = node;
 
-        return new Disposable(this);
+        return new Disposable(this, node);
 
         [DoesNotReturn]
         [StackTraceHidden]
@@ -113,11 +118,13 @@ public class McsLock
     /// </summary>
     public readonly ref struct Disposable
     {
+        readonly ThreadNode _node;
         readonly McsLock _lock;
 
-        internal Disposable(McsLock @lock)
+        internal Disposable(McsLock @lock, ThreadNode node)
         {
             _lock = @lock;
+            _node = node;
         }
 
         /// <summary>
@@ -126,17 +133,18 @@ public class McsLock
         /// </summary>
         public void Dispose()
         {
-            ThreadNode node = _lock._node.Value!;
+            ThreadNode node = _node!;
 
             // If there is no next node, it means this thread might be the last in the queue.
             if (node.Next is null)
             {
                 // Attempt to atomically set the tail to null, indicating no thread is waiting.
                 // If it is still 'node', then there are no other waiting threads.
-                if (Interlocked.CompareExchange(ref _lock._tail, null, node) == node)
+                if (Interlocked.CompareExchange(ref _lock._tail.Value, null, node) == node)
                 {
                     // Clear current lock holder.
-                    _lock._currentLockHolder = null;
+                    _lock._currentLockHolder.Value = null;
+                    PoolLock(_lock, node);
                     return;
                 }
 
@@ -148,7 +156,7 @@ public class McsLock
 
             ThreadNode next = node.Next!;
             // Clear current lock holder.
-            _lock._currentLockHolder = null;
+            _lock._currentLockHolder.Value = null;
             // Pass the lock to the next thread by setting its 'Locked' flag to false.
             next.State = (nuint)LockState.ReadyToAcquire;
 
@@ -159,8 +167,15 @@ public class McsLock
             {
                 SignalUnlock(next);
             }
-            // Remove the reference to the next node 
-            node.Next = null;
+
+            PoolLock(_lock, node);
+
+            static void PoolLock(McsLock @lock, ThreadNode node)
+            {
+                node.Next = null;
+                node.State = (nuint)LockState.Waiting;
+                @lock._nodePool.Enqueue(node);
+            }
         }
 
         private static void SpinTillNextNotNull(ThreadNode node)
@@ -208,5 +223,12 @@ public class McsLock
         /// Points to the next node in the queue.
         /// </summary>
         public ThreadNode? Next = null;
+    }
+    
+    [StructLayout(LayoutKind.Explicit, Size = 128)]
+    internal struct PaddedNode
+    {
+        [FieldOffset(64)]
+        public volatile ThreadNode? Value;
     }
 }

--- a/src/Nethermind/Nethermind.Core/Threading/McsPriorityLock.cs
+++ b/src/Nethermind/Nethermind.Core/Threading/McsPriorityLock.cs
@@ -43,8 +43,8 @@ public class McsPriorityLock
     public McsLock.Disposable Acquire()
     {
         // Check for reentrancy.
-        if (_coreLock._node.Value == _coreLock._currentLockHolder)
-            ThrowInvalidOperationException();
+        //if (_coreLock._node.Value == _coreLock._currentLockHolder)
+        //    ThrowInvalidOperationException();
 
         var isPriority = Thread.CurrentThread.Priority > ThreadPriority.Normal;
         if (!isPriority)
@@ -53,12 +53,12 @@ public class McsPriorityLock
 
         return _coreLock.Acquire();
 
-        [DoesNotReturn]
-        [StackTraceHidden]
-        static void ThrowInvalidOperationException()
-        {
-            throw new InvalidOperationException("Lock is not reentrant");
-        }
+        //[DoesNotReturn]
+        //[StackTraceHidden]
+        //static void ThrowInvalidOperationException()
+        //{
+        //    throw new InvalidOperationException("Lock is not reentrant");
+        //}
     }
 
     private McsLock.Disposable NonPriorityAcquire()

--- a/src/Nethermind/Nethermind.Core/Threading/McsPriorityLock.cs
+++ b/src/Nethermind/Nethermind.Core/Threading/McsPriorityLock.cs
@@ -42,23 +42,12 @@ public class McsPriorityLock
     /// </summary>
     public McsLock.Disposable Acquire()
     {
-        // Check for reentrancy.
-        //if (_coreLock._node.Value == _coreLock._currentLockHolder)
-        //    ThrowInvalidOperationException();
-
         var isPriority = Thread.CurrentThread.Priority > ThreadPriority.Normal;
         if (!isPriority)
             // If not a priority thread max of half processors can being to acquire the lock (e.g. block processing)
             return NonPriorityAcquire();
 
         return _coreLock.Acquire();
-
-        //[DoesNotReturn]
-        //[StackTraceHidden]
-        //static void ThrowInvalidOperationException()
-        //{
-        //    throw new InvalidOperationException("Lock is not reentrant");
-        //}
     }
 
     private McsLock.Disposable NonPriorityAcquire()


### PR DESCRIPTION
Contributes to  #7171

## Changes

- Reduce the number of ThreadLocals in use (seems to be issue on Windows over time and lots end up on finalization queue)
- Also add cache padding to the nodes

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No