### PR TITLE
Inform test repo on push to master/release branches

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -59,3 +59,16 @@ jobs:
             --build-arg CI=$CI \
             --build-arg COMMIT_HASH=$GITHUB_SHA \
             . --push
+            
+  upgrade_node:
+    name: Update 24/7 node
+    runs-on: [sync-agent-1280gb]
+    needs: [publish-docker]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    steps:
+      - name: Pull images and upgrade container
+        working-directory: /root
+        run: |
+          docker compose stop
+          docker compose pull
+          docker compose up -d

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -61,6 +61,7 @@ jobs:
             . --push
       - name: Trigger notification action on test repo
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/master') || startsWith(github.ref, 'refs/heads/release/'))
+        continue-on-error: true
         uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: receive-push-notification.yml

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -59,16 +59,14 @@ jobs:
             --build-arg CI=$CI \
             --build-arg COMMIT_HASH=$GITHUB_SHA \
             . --push
-            
-  upgrade_node:
-    name: Update 24/7 node
-    runs-on: [sync-agent-1280gb]
-    needs: [publish-docker]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-    steps:
-      - name: Pull images and upgrade container
-        working-directory: /root
-        run: |
-          docker compose stop
-          docker compose pull
-          docker compose up -d
+      - name: Trigger notification action on test repo
+        if: github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/master') || startsWith(github.ref, 'refs/heads/release/'))
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: receive-push-notification.yml
+          repo: NethermindEth/post-merge-smoke-tests
+          ref: "main"
+          token: "${{ steps.gh-app.outputs.token }}"
+          inputs: '{
+            "nethermind_branch": "${{ github.ref}}"
+          }'


### PR DESCRIPTION
Whenever docker image is created for master or release inform test repo, that there is new image to be used in tests (will be used to control if master tests should be triggered or more detailed release tests should be in place)

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [X] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [X] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No
