### PR TITLE
Metrics: Use Kestrel w/o quic

### DIFF
--- a/src/Nethermind/Nethermind.Monitoring/NethermindKestrelMetricServer.cs
+++ b/src/Nethermind/Nethermind.Monitoring/NethermindKestrelMetricServer.cs
@@ -72,7 +72,8 @@ public sealed class NethermindKestrelMetricServer : MetricHandler
 
         // If the caller needs to customize any of this, they can just set up their own web host and inject the middleware.
         var builder = new WebHostBuilder()
-            .UseKestrel()
+            .UseKestrelCore()
+            .UseKestrelHttpsConfiguration()
             .UseIISIntegration()
             .Configure(app =>
             {


### PR DESCRIPTION
Fixes  #7286 

## Changes

- Default Kestrel initialization enables QUIC also, which is buggy. Let's do not activate it(just for metrics)

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No
