### PR TITLE
Enable SnapSync on Gnosis by default

### DIFF
--- a/src/Nethermind/Nethermind.Runner.Test/ConfigFilesTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/ConfigFilesTests.cs
@@ -232,7 +232,10 @@ namespace Nethermind.Runner.Test
         [TestCase("archive", false)]
         [TestCase("mainnet.cfg", true)]
         [TestCase("sepolia.cfg", true)]
-        [TestCase("gnosis.cfg", false)]
+        [TestCase("gnosis.cfg", true)]
+        [TestCase("chiado.cfg", true)]
+        [TestCase("energyweb.cfg", false)]
+        [TestCase("volta.cfg", false)]
         public void Snap_sync_settings_as_expected(string configWildcard, bool enabled)
         {
             Test<ISyncConfig, bool>(configWildcard, c => c.SnapSync, enabled);

--- a/src/Nethermind/Nethermind.Runner/configs/chiado.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/chiado.cfg
@@ -15,6 +15,7 @@
   },
   "Sync": {
     "FastSync": true,
+    "SapSync": true,
     "PivotNumber": 10900000,
     "PivotHash": "0x44b221966e62d3e4cac67e70ee91fb0fa18ad054d3db087e02bb74d672f03848",
     "PivotTotalDifficulty": "231708131825107706987652208063906496124457284",

--- a/src/Nethermind/Nethermind.Runner/configs/chiado.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/chiado.cfg
@@ -15,7 +15,7 @@
   },
   "Sync": {
     "FastSync": true,
-    "SapSync": true,
+    "SnapSync": true,
     "PivotNumber": 10900000,
     "PivotHash": "0x44b221966e62d3e4cac67e70ee91fb0fa18ad054d3db087e02bb74d672f03848",
     "PivotTotalDifficulty": "231708131825107706987652208063906496124457284",

--- a/src/Nethermind/Nethermind.Runner/configs/gnosis.cfg
+++ b/src/Nethermind/Nethermind.Runner/configs/gnosis.cfg
@@ -12,6 +12,7 @@
   },
   "Sync": {
     "FastSync": true,
+    "SnapSync": true,
     "PivotNumber": 35060000,
     "PivotHash": "0xa78ce35526b135ae356e5daa334143a5a8463477db617ff162d88057800cb15a",
     "PivotTotalDifficulty": "8626000110427538733349499292577475819600160930",


### PR DESCRIPTION
Enable SnapSync on Gnosis and Chiado - we have already quite a lot of resynced/new nodes with SnapServing enabled on these chains and it makes it muuuch faster to sync those chains with this setting set to true.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [X] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No