### PR TITLE
Eth_simulate blob related bugfixes

### DIFF
--- a/src/Nethermind/Nethermind.Evm/BlockExecutionContext.cs
+++ b/src/Nethermind/Nethermind.Evm/BlockExecutionContext.cs
@@ -25,6 +25,12 @@ public readonly struct BlockExecutionContext
         }
     }
 
+    public BlockExecutionContext(BlockHeader blockHeader, UInt256 forceBlobBaseFee)
+    {
+        Header = blockHeader;
+        BlobBaseFee = forceBlobBaseFee;
+    }
+
     public static implicit operator BlockExecutionContext(BlockHeader header)
     {
         return new BlockExecutionContext(header);

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -59,7 +59,12 @@ namespace Nethermind.Evm.TransactionProcessing
             /// <summary>
             /// Commit and later restore state also skip validation, use for CallAndRestore
             /// </summary>
-            CommitAndRestore = Commit | Restore | NoValidation
+            CommitAndRestore = Commit | Restore | NoValidation,
+
+            /// <summary>
+            /// Execute in simulation mode, without making actual changes
+            /// </summary>
+            Simulation = 8
         }
 
         public TransactionProcessor(
@@ -444,7 +449,7 @@ namespace Nethermind.Evm.TransactionProcessing
             out long spentGas,
             out byte statusCode)
         {
-            bool validate = !opts.HasFlag(ExecutionOptions.NoValidation);
+            bool validate = !opts.HasFlag(ExecutionOptions.NoValidation) || opts.HasFlag(ExecutionOptions.Simulation);
 
             substate = null;
             spentGas = tx.GasLimit;

--- a/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
@@ -169,7 +169,7 @@ namespace Nethermind.Facade
             SimulateOutput result = new();
             try
             {
-                if (!_simulateBridgeHelper.TrySimulate(header, payload, new CancellationBlockTracer(tracer, cancellationToken), out string error))
+                if (!_simulateBridgeHelper.TrySimulate(header, payload, simulateOutputTracer, new CancellationBlockTracer(tracer, cancellationToken), out string error))
                 {
                     result.Error = error;
                 }

--- a/src/Nethermind/Nethermind.Facade/Eth/BlockForRpc.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/BlockForRpc.cs
@@ -84,7 +84,8 @@ public class BlockForRpc
         WithdrawalsRoot = block.Header.WithdrawalsRoot;
     }
 
-    public Address Author { get; set; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Address? Author { get; set; }
     public UInt256 Difficulty { get; set; }
     public byte[] ExtraData { get; set; }
     public long GasLimit { get; set; }

--- a/src/Nethermind/Nethermind.Facade/Proxy/Models/Simulate/BlockOverride.cs
+++ b/src/Nethermind/Nethermind.Facade/Proxy/Models/Simulate/BlockOverride.cs
@@ -18,7 +18,8 @@ public class BlockOverride
     public ulong? GasLimit { get; set; }
     public Address? FeeRecipient { get; set; }
     public UInt256? BaseFeePerGas { get; set; }
-
+    public UInt256? BlobBaseFee { get; set; }
+    
     public BlockHeader GetBlockHeader(BlockHeader parent, IBlocksConfig cfg, IReleaseSpec spec)
     {
         ulong newTime = Time ?? checked(parent.Timestamp + cfg.SecondsPerSlot);

--- a/src/Nethermind/Nethermind.Facade/Proxy/Models/Simulate/SimulateBlockResult.cs
+++ b/src/Nethermind/Nethermind.Facade/Proxy/Models/Simulate/SimulateBlockResult.cs
@@ -15,5 +15,5 @@ public class SimulateBlockResult(Block source, bool includeFullTransactionData, 
     : BlockForRpc(source, includeFullTransactionData, specProvider)
 {
     public List<SimulateCallResult> Calls { get; set; } = new();
-    public UInt256 BlobBaseFee { get; set; }
+    //public UInt256 BlobBaseFee { get; set; }
 }

--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateBlockTracer.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateBlockTracer.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Nethermind.Core;
+using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.Evm;
 using Nethermind.Evm.Tracing;
@@ -46,14 +47,6 @@ public class SimulateBlockTracer(bool isTracingLogs, bool includeFullTxData, ISp
         {
             Calls = _txTracers.Select(t => t.TraceResult).ToList(),
         };
-        if (_currentBlock.Header.ExcessBlobGas is not null)
-        {
-            if (!BlobGasCalculator.TryCalculateBlobGasPricePerUnit(_currentBlock.Header.ExcessBlobGas.Value,
-                    out UInt256 blobGasPricePerUnit))
-            {
-                result.BlobBaseFee = blobGasPricePerUnit;
-            }
-        }
 
         Results.Add(result);
     }

--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateReadOnlyBlocksProcessingEnv.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateReadOnlyBlocksProcessingEnv.cs
@@ -15,6 +15,7 @@ using Nethermind.Db;
 using Nethermind.Evm;
 using Nethermind.Evm.Tracing;
 using Nethermind.Evm.TransactionProcessing;
+using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.State;
 using static Nethermind.Consensus.Processing.BlockProcessor;
@@ -72,6 +73,8 @@ public class SimulateReadOnlyBlocksProcessingEnv : ReadOnlyTxProcessingEnvBase, 
         BlockTransactionPicker = new BlockProductionTransactionPicker(specProvider, true);
     }
 
+
+
     public IWorldStateManager WorldStateManager { get; }
     public IVirtualMachine VirtualMachine { get; }
     public IReadOnlyDbProvider DbProvider { get; }
@@ -82,6 +85,11 @@ public class SimulateReadOnlyBlocksProcessingEnv : ReadOnlyTxProcessingEnvBase, 
     public void Dispose()
     {
         DbProvider.Dispose();
+    }
+
+    public void SetBlockBlobBaseFee(UInt256? BlobBaseFee)
+    {
+        ((SimulateTransactionProcessor)_transactionProcessor).BlobBaseFee = BlobBaseFee;
     }
 
     private SimulateBlockValidatorProxy CreateValidator()

--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateTxMutatorTracer.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateTxMutatorTracer.cs
@@ -17,7 +17,7 @@ namespace Nethermind.Facade.Simulate;
 
 internal sealed class SimulateTxMutatorTracer : TxTracer, ITxLogsMutator
 {
-    public const int ExecutionError = -32015;
+    public const int ExecutionError = -32000;
 
     private static readonly Hash256 transferSignature =
         new AbiSignature("Transfer", AbiType.Address, AbiType.Address, AbiType.UInt256).Hash;
@@ -90,7 +90,7 @@ internal sealed class SimulateTxMutatorTracer : TxTracer, ITxLogsMutator
                 Code = ExecutionError, // revert error code stub
                 Message = error
             },
-            ReturnData = null,
+            ReturnData = output,
             Status = StatusCode.Failure
         };
     }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/SimulateTxExecutor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/SimulateTxExecutor.cs
@@ -47,6 +47,11 @@ public class SimulateTxExecutor(IBlockchainBridge blockchainBridge, IBlockFinder
                             callTransactionModel.Type = TxType.EIP1559;
                         }
 
+                        if (callTransactionModel.BlobVersionedHashes is not null)
+                        {
+                            callTransactionModel.Type = TxType.Blob;
+                        }
+
                         bool hadGasLimitInRequest = callTransactionModel.Gas.HasValue;
                         bool hadNonceInRequest = callTransactionModel.Nonce.HasValue;
                         callTransactionModel.EnsureDefaults(_gasCapBudget);


### PR DESCRIPTION
Here we continue development of Eth_simulate feature, last time updated at [5530](https://github.com/NethermindEth/nethermind/pull/5530) 

In this PR we are implementing https://github.com/ethereum/execution-apis/pull/484 proposal. Fixing minor issues related to protocol updates such as:

 - [x] nethermind returns `blobBaseFee` field for a block, this should not be returned as its not part of the block header.
 - [x] nethermind does not return correct blob gas used
 - [x] gas used of call and block do not match
 - [x] nethermind is missing return fields
 - [x] nethermind returns `author` field that should not be there
 
detected by our testing team.