### PR TITLE
Fix resources cleanup in eth/* protocols

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/CollectionExtensions.cs
+++ b/src/Nethermind/Nethermind.Core.Test/CollectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Collections.Generic;
@@ -9,14 +9,14 @@ namespace Nethermind.Core.Test;
 public static class CollectionExtensions
 {
     public static TValue AddTo<TValue, TCollection>(this TValue value, ICollection<TCollection> collection)
-        where TValue: TCollection
+        where TValue : TCollection
     {
         collection.Add(value);
         return value;
     }
 
     public static Task<TValue> AddResultTo<TValue, TCollection>(this Task<TValue> task, ICollection<TCollection> disposables)
-        where TValue: TCollection
+        where TValue : TCollection
     {
         return task.ContinueWith(t =>
         {

--- a/src/Nethermind/Nethermind.Core.Test/CollectionExtensions.cs
+++ b/src/Nethermind/Nethermind.Core.Test/CollectionExtensions.cs
@@ -15,14 +15,11 @@ public static class CollectionExtensions
         return value;
     }
 
-    public static Task<TValue> AddResultTo<TValue, TCollection>(this Task<TValue> task, ICollection<TCollection> collection)
+    public static async Task<TValue> AddResultTo<TValue, TCollection>(this Task<TValue> task, ICollection<TCollection> collection)
         where TValue : TCollection
     {
-        return task.ContinueWith(t =>
-        {
-            if (t is { IsCompletedSuccessfully: true, Result: { } value })
-                value.AddTo(collection);
-            return t.Result;
-        });
+        TValue value = await task;
+        if (value != null) collection.Add(value);
+        return value;
     }
 }

--- a/src/Nethermind/Nethermind.Core.Test/CollectionExtensions.cs
+++ b/src/Nethermind/Nethermind.Core.Test/CollectionExtensions.cs
@@ -15,13 +15,13 @@ public static class CollectionExtensions
         return value;
     }
 
-    public static Task<TValue> AddResultTo<TValue, TCollection>(this Task<TValue> task, ICollection<TCollection> disposables)
+    public static Task<TValue> AddResultTo<TValue, TCollection>(this Task<TValue> task, ICollection<TCollection> collection)
         where TValue : TCollection
     {
         return task.ContinueWith(t =>
         {
             if (t is { IsCompletedSuccessfully: true, Result: { } value })
-                value.AddTo(disposables);
+                value.AddTo(collection);
             return t.Result;
         });
     }

--- a/src/Nethermind/Nethermind.Core.Test/CollectionExtensions.cs
+++ b/src/Nethermind/Nethermind.Core.Test/CollectionExtensions.cs
@@ -1,0 +1,28 @@
+﻿// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Nethermind.Core.Test;
+
+public static class CollectionExtensions
+{
+    public static TValue AddTo<TValue, TCollection>(this TValue value, ICollection<TCollection> collection)
+        where TValue: TCollection
+    {
+        collection.Add(value);
+        return value;
+    }
+
+    public static Task<TValue> AddResultTo<TValue, TCollection>(this Task<TValue> task, ICollection<TCollection> disposables)
+        where TValue: TCollection
+    {
+        return task.ContinueWith(t =>
+        {
+            if (t is { IsCompletedSuccessfully: true, Result: { } value })
+                value.AddTo(disposables);
+            return t.Result;
+        });
+    }
+}

--- a/src/Nethermind/Nethermind.Network.Test/MessageDictionaryTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/MessageDictionaryTests.cs
@@ -6,10 +6,13 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Nethermind.Core;
+using Nethermind.Core.Collections;
+using Nethermind.Core.Extensions;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Network.P2P;
 using Nethermind.Network.P2P.Subprotocols;
 using Nethermind.Network.P2P.Subprotocols.Eth.V66.Messages;
+using NSubstitute;
 using NUnit.Framework;
 using GetBlockHeadersMessage = Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages.GetBlockHeadersMessage;
 
@@ -18,7 +21,7 @@ namespace Nethermind.Network.Test;
 public class MessageDictionaryTests
 {
     private readonly List<Eth66Message<GetBlockHeadersMessage>> _recordedRequests = new();
-    private MessageDictionary<Eth66Message<GetBlockHeadersMessage>, BlockHeader[]>
+    private MessageDictionary<Eth66Message<GetBlockHeadersMessage>, IOwnedReadOnlyList<BlockHeader>>
         _testMessageDictionary;
 
     [SetUp]
@@ -31,9 +34,9 @@ public class MessageDictionaryTests
     [Test]
     public void Test_SendAndReceive()
     {
-        Request<Eth66Message<GetBlockHeadersMessage>, BlockHeader[]> request = CreateRequest(111);
+        Request<Eth66Message<GetBlockHeadersMessage>, IOwnedReadOnlyList<BlockHeader>> request = CreateRequest(111);
 
-        BlockHeader[] response = new[] { Build.A.BlockHeader.TestObject };
+        using IOwnedReadOnlyList<BlockHeader> response = new[] { Build.A.BlockHeader.TestObject }.ToPooledList();
 
         _testMessageDictionary.Send(request);
 
@@ -49,9 +52,9 @@ public class MessageDictionaryTests
     [Test]
     public void Test_SendAndReceive_withDifferentRequestId()
     {
-        Request<Eth66Message<GetBlockHeadersMessage>, BlockHeader[]> request = CreateRequest(111);
+        Request<Eth66Message<GetBlockHeadersMessage>, IOwnedReadOnlyList<BlockHeader>> request = CreateRequest(111);
 
-        BlockHeader[] response = new[] { Build.A.BlockHeader.TestObject };
+        using IOwnedReadOnlyList<BlockHeader> response = new[] { Build.A.BlockHeader.TestObject }.ToPooledList();
 
         _testMessageDictionary.Send(request);
 
@@ -67,10 +70,10 @@ public class MessageDictionaryTests
     [Test]
     public void Test_SendAndReceive_outOfOrder()
     {
-        Request<Eth66Message<GetBlockHeadersMessage>, BlockHeader[]> requestBefore = CreateRequest(112);
-        Request<Eth66Message<GetBlockHeadersMessage>, BlockHeader[]> request = CreateRequest(111);
+        Request<Eth66Message<GetBlockHeadersMessage>, IOwnedReadOnlyList<BlockHeader>> requestBefore = CreateRequest(112);
+        Request<Eth66Message<GetBlockHeadersMessage>, IOwnedReadOnlyList<BlockHeader>> request = CreateRequest(111);
 
-        BlockHeader[] response = new[] { Build.A.BlockHeader.TestObject };
+        using IOwnedReadOnlyList<BlockHeader> response = new[] { Build.A.BlockHeader.TestObject }.ToPooledList();
 
         _testMessageDictionary.Send(requestBefore);
         _testMessageDictionary.Send(request);
@@ -100,36 +103,21 @@ public class MessageDictionaryTests
     }
 
     [Test]
-    [Explicit("CI issues - bad test design")]
-    public async Task Test_OldRequest_WillThrowWithTimeout()
+    public void Test_Send_MessageDisposing_OnInvalidId()
     {
-        TimeSpan timeout = TimeSpan.FromMilliseconds(100);
-        Request<Eth66Message<GetBlockHeadersMessage>, BlockHeader[]> request = CreateRequest(0);
-        BlockHeader[] response = new[] { Build.A.BlockHeader.TestObject };
-
-        _testMessageDictionary = new((message) => _recordedRequests.Add(message), timeout);
-
-        request.CompletionSource.Task.IsCompleted.Should().BeFalse();
-        request.CompletionSource.Task.IsFaulted.Should().BeFalse();
-
-        _testMessageDictionary.Send(request);
-
-        await Task.Delay(timeout * 2);
-
-        request.CompletionSource.Task.IsFaulted.Should().BeTrue();
-        request.CompletionSource.Task.Exception.InnerException.Should().BeOfType<TimeoutException>();
-
-        _testMessageDictionary.Invoking((dictionary) => dictionary.Handle(0, response, 100))
+        IOwnedReadOnlyList<BlockHeader> response = Substitute.For<IOwnedReadOnlyList<BlockHeader>>();
+        _testMessageDictionary.Invoking((dictionary) => dictionary.Handle(1234, response, 100))
             .Should()
             .Throw<SubprotocolException>();
+
+        response.Received().Dispose();
     }
 
-    private static Request<Eth66Message<GetBlockHeadersMessage>, BlockHeader[]> CreateRequest(int requestId)
+    private static Request<Eth66Message<GetBlockHeadersMessage>, IOwnedReadOnlyList<BlockHeader>> CreateRequest(int requestId)
     {
-        Request<Eth66Message<GetBlockHeadersMessage>, BlockHeader[]> request =
+        Request<Eth66Message<GetBlockHeadersMessage>, IOwnedReadOnlyList<BlockHeader>> request =
             new(new Network.P2P.Subprotocols.Eth.V66.Messages.GetBlockHeadersMessage(requestId,
                 new GetBlockHeadersMessage()));
         return request;
     }
-
 }

--- a/src/Nethermind/Nethermind.Network.Test/MessageDictionaryTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/MessageDictionaryTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using FluentAssertions;
 using Nethermind.Core;
 using Nethermind.Core.Collections;

--- a/src/Nethermind/Nethermind.Network.Test/P2P/PacketSenderTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/PacketSenderTests.cs
@@ -25,7 +25,7 @@ namespace Nethermind.Network.Test.P2P
             IByteBuffer serialized = UnpooledByteBufferAllocator.Default.Buffer(2);
             var serializer = Substitute.For<IMessageSerializationService>();
 
-            using TestMessage testMessage = new();
+            TestMessage testMessage = new();
             serializer.ZeroSerialize(testMessage).Returns(serialized);
             serialized.SafeRelease();
 
@@ -48,8 +48,11 @@ namespace Nethermind.Network.Test.P2P
         {
             IByteBuffer serialized = UnpooledByteBufferAllocator.Default.Buffer(2);
             var serializer = Substitute.For<IMessageSerializationService>();
-            serializer.ZeroSerialize(PingMessage.Instance).Returns(serialized);
+
+            TestMessage testMessage = new();
+            serializer.ZeroSerialize(testMessage).Returns(serialized);
             serialized.SafeRelease();
+
             IChannelHandlerContext context = Substitute.For<IChannelHandlerContext>();
             IChannel channel = Substitute.For<IChannel>();
             channel.IsWritable.Returns(true);
@@ -58,7 +61,8 @@ namespace Nethermind.Network.Test.P2P
 
             PacketSender packetSender = new(serializer, LimboLogs.Instance, TimeSpan.Zero);
             packetSender.HandlerAdded(context);
-            packetSender.Enqueue(PingMessage.Instance);
+            packetSender.Enqueue(testMessage);
+            testMessage.WasDisposed.Should().BeTrue();
 
             context.Received(0).WriteAndFlushAsync(Arg.Any<IByteBuffer>());
         }
@@ -68,8 +72,11 @@ namespace Nethermind.Network.Test.P2P
         {
             IByteBuffer serialized = UnpooledByteBufferAllocator.Default.Buffer(2);
             var serializer = Substitute.For<IMessageSerializationService>();
-            serializer.ZeroSerialize(PingMessage.Instance).Returns(serialized);
+
+            TestMessage testMessage = new();
+            serializer.ZeroSerialize(testMessage).Returns(serialized);
             serialized.SafeRelease();
+
             IChannelHandlerContext context = Substitute.For<IChannelHandlerContext>();
             IChannel channel = Substitute.For<IChannel>();
             channel.IsWritable.Returns(true);
@@ -80,7 +87,8 @@ namespace Nethermind.Network.Test.P2P
 
             PacketSender packetSender = new(serializer, LimboLogs.Instance, delay);
             packetSender.HandlerAdded(context);
-            packetSender.Enqueue(PingMessage.Instance);
+            packetSender.Enqueue(testMessage);
+            testMessage.WasDisposed.Should().BeTrue();
 
             await context.Received(0).WriteAndFlushAsync(Arg.Any<IByteBuffer>());
 

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandlerTests.cs
@@ -480,7 +480,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
         {
             using BlockHeadersMessage msg = new(Build.A.BlockHeader.TestObjectNTimes(3).ToPooledList());
 
-            Task task = ((ISyncPeer) _handler).GetBlockHeaders(1, 1, 1, CancellationToken.None).AddResultTo(_disposables);
+            Task task = ((ISyncPeer)_handler).GetBlockHeaders(1, 1, 1, CancellationToken.None).AddResultTo(_disposables);
             HandleIncomingStatusMessage();
             HandleZeroMessage(msg, Eth62MessageCode.BlockHeaders);
             await task;

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V63/Eth63ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V63/Eth63ProtocolHandlerTests.cs
@@ -30,7 +30,7 @@ using NUnit.Framework;
 
 namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V63
 {
-    [TestFixture, Parallelizable(ParallelScope.All), FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+    [TestFixture, Parallelizable(ParallelScope.Self)]
     public class Eth63ProtocolHandlerTests
     {
         private Context _ctx = null!;
@@ -41,11 +41,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V63
         {
             _ctx = new();
             _disposables = new();
-
-            // Dispose received messages
-            _ctx.Session
-                .When(s => s.DeliverMessage(Arg.Any<P2PMessage>()))
-                .Do(c => c.Arg<P2PMessage>().AddTo(_disposables));
+            _ctx.Session.When(s => s.DeliverMessage(Arg.Any<P2PMessage>())).Do(c => c.Arg<P2PMessage>().AddTo(_disposables));
         }
 
         [TearDown]

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V63/Eth63ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V63/Eth63ProtocolHandlerTests.cs
@@ -14,6 +14,7 @@ using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Logging;
 using Nethermind.Network.P2P;
+using Nethermind.Network.P2P.Messages;
 using Nethermind.Network.P2P.Subprotocols.Eth.V62;
 using Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages;
 using Nethermind.Network.P2P.Subprotocols.Eth.V63;
@@ -29,26 +30,47 @@ using NUnit.Framework;
 
 namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V63
 {
-    [TestFixture, Parallelizable(ParallelScope.All)]
+    [TestFixture, Parallelizable(ParallelScope.All), FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
     public class Eth63ProtocolHandlerTests
     {
+        private Context _ctx = null!;
+        private CompositeDisposable _disposables = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            _ctx = new();
+            _disposables = new();
+
+            // Dispose received messages
+            _ctx.Session
+                .When(s => s.DeliverMessage(Arg.Any<P2PMessage>()))
+                .Do(c => c.Arg<P2PMessage>().AddTo(_disposables));
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _disposables.Dispose();
+            _ctx.Session.Dispose();
+        }
+
         [Test]
         public async Task Can_request_and_handle_receipts()
         {
-            Context ctx = new();
             TxReceipt[][]? receipts = Enumerable.Repeat(
                 Enumerable.Repeat(Build.A.Receipt.WithAllFieldsFilled.TestObject, 100).ToArray(),
                 1000).ToArray(); // TxReceipt[1000][100]
 
             using ReceiptsMessage receiptsMsg = new(receipts.ToPooledList());
             Packet receiptsPacket =
-                new("eth", Eth63MessageCode.Receipts, ctx._receiptMessageSerializer.Serialize(receiptsMsg));
+                new("eth", Eth63MessageCode.Receipts, _ctx._receiptMessageSerializer.Serialize(receiptsMsg));
 
-            Task<IOwnedReadOnlyList<TxReceipt[]>> task = ctx.ProtocolHandler.GetReceipts(
+            Task<IOwnedReadOnlyList<TxReceipt[]>> task = _ctx.ProtocolHandler.GetReceipts(
                 Enumerable.Repeat(Keccak.Zero, 1000).ToArray(),
                 CancellationToken.None);
 
-            ctx.ProtocolHandler.HandleMessage(receiptsPacket);
+            _ctx.ProtocolHandler.HandleMessage(receiptsPacket);
 
             using var result = await task;
             result.Should().HaveCount(1000);
@@ -57,82 +79,80 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V63
         [Test]
         public async Task Limit_receipt_request()
         {
-            Context ctx = new();
             TxReceipt[] oneBlockReceipt = Enumerable.Repeat(Build.A.Receipt.WithAllFieldsFilled.TestObject, 100).ToArray();
             Packet smallReceiptsPacket =
-                new("eth", Eth63MessageCode.Receipts, ctx._receiptMessageSerializer.Serialize(
+                new("eth", Eth63MessageCode.Receipts, _ctx._receiptMessageSerializer.Serialize(
                     new(RepeatPooled(oneBlockReceipt, 10))
                 ));
             Packet largeReceiptsPacket =
-                new("eth", Eth63MessageCode.Receipts, ctx._receiptMessageSerializer.Serialize(
+                new("eth", Eth63MessageCode.Receipts, _ctx._receiptMessageSerializer.Serialize(
                     new(RepeatPooled(oneBlockReceipt, 1000))
                 ));
 
             GetReceiptsMessage? receiptsMessage = null;
 
-            ctx.Session
+            _ctx.Session
                 .When(session => session.DeliverMessage(Arg.Any<GetReceiptsMessage>()))
-                .Do((info => receiptsMessage = (GetReceiptsMessage)info[0]));
+                .Do(info => receiptsMessage = (GetReceiptsMessage)info[0]);
 
-            Task<IOwnedReadOnlyList<TxReceipt[]>> receiptsTask = ctx.ProtocolHandler.GetReceipts(
-                RepeatPooled(Keccak.Zero, 1000),
-                CancellationToken.None);
+            Task<IOwnedReadOnlyList<TxReceipt[]>> receiptsTask = _ctx.ProtocolHandler
+                .GetReceipts(RepeatPooled(Keccak.Zero, 1000), CancellationToken.None)
+                .AddResultTo(_disposables);
 
-            ctx.ProtocolHandler.HandleMessage(smallReceiptsPacket);
+            _ctx.ProtocolHandler.HandleMessage(smallReceiptsPacket);
             await receiptsTask;
 
             Assert.That(receiptsMessage?.Hashes?.Count, Is.EqualTo(8));
 
-            receiptsTask = ctx.ProtocolHandler.GetReceipts(
-                RepeatPooled(Keccak.Zero, 1000),
-                CancellationToken.None);
+            receiptsTask = _ctx.ProtocolHandler
+                .GetReceipts(RepeatPooled(Keccak.Zero, 1000), CancellationToken.None)
+                .AddResultTo(_disposables);
 
-            ctx.ProtocolHandler.HandleMessage(largeReceiptsPacket);
+            _ctx.ProtocolHandler.HandleMessage(largeReceiptsPacket);
             await receiptsTask;
 
             Assert.That(receiptsMessage?.Hashes?.Count, Is.EqualTo(12));
 
             // Back to 10
-            receiptsTask = ctx.ProtocolHandler.GetReceipts(
-                RepeatPooled(Keccak.Zero, 1000),
-                CancellationToken.None);
+            receiptsTask = _ctx.ProtocolHandler
+                .GetReceipts(RepeatPooled(Keccak.Zero, 1000), CancellationToken.None)
+                .AddResultTo(_disposables);
 
-            ctx.ProtocolHandler.HandleMessage(smallReceiptsPacket);
+            _ctx.ProtocolHandler.HandleMessage(smallReceiptsPacket);
             await receiptsTask;
 
             Assert.That(receiptsMessage?.Hashes?.Count, Is.EqualTo(8));
             receiptsMessage.Dispose();
         }
 
-        private ArrayPoolList<T> RepeatPooled<T>(T txReceipts, int count) => Enumerable.Repeat(txReceipts, count).ToPooledList(count);
+        private ArrayPoolList<T> RepeatPooled<T>(T txReceipts, int count) =>
+            Enumerable.Repeat(txReceipts, count).ToPooledList(count).AddTo(_disposables);
 
         [Test]
         public void Will_not_serve_receipts_requests_above_512()
         {
-            Context ctx = new();
             using GetReceiptsMessage getReceiptsMessage = new(
                 RepeatPooled(Keccak.Zero, 513));
             Packet getReceiptsPacket =
-                new("eth", Eth63MessageCode.GetReceipts, ctx._getReceiptMessageSerializer.Serialize(getReceiptsMessage));
+                new("eth", Eth63MessageCode.GetReceipts, _ctx._getReceiptMessageSerializer.Serialize(getReceiptsMessage));
 
-            ctx.ProtocolHandler.HandleMessage(getReceiptsPacket);
-            ctx.Session.Received().InitiateDisconnect(Arg.Any<DisconnectReason>(), Arg.Any<string>());
+            _ctx.ProtocolHandler.HandleMessage(getReceiptsPacket);
+            _ctx.Session.Received().InitiateDisconnect(Arg.Any<DisconnectReason>(), Arg.Any<string>());
         }
 
         [Test]
         public void Will_not_send_messages_larger_than_2MB()
         {
-            Context ctx = new();
-            ctx.SyncServer.GetReceipts(Arg.Any<Hash256>()).Returns(
+            _ctx.SyncServer.GetReceipts(Arg.Any<Hash256>()).Returns(
                 Enumerable.Repeat(Build.A.Receipt.WithAllFieldsFilled.TestObject, 512).ToArray());
 
             using GetReceiptsMessage getReceiptsMessage = new(
                 RepeatPooled(Keccak.Zero, 512));
             Packet getReceiptsPacket =
-                new("eth", Eth63MessageCode.GetReceipts, ctx._getReceiptMessageSerializer.Serialize(getReceiptsMessage));
+                new("eth", Eth63MessageCode.GetReceipts, _ctx._getReceiptMessageSerializer.Serialize(getReceiptsMessage));
 
-            ctx.ProtocolHandler.HandleMessage(getReceiptsPacket);
-            ctx.Session.Received().DeliverMessage(Arg.Is<ReceiptsMessage>(r => r.TxReceipts.Count == 14));
+            _ctx.ProtocolHandler.HandleMessage(getReceiptsPacket);
+            _ctx.Session.Received().DeliverMessage(Arg.Is<ReceiptsMessage>(r => r.TxReceipts.Count == 14));
         }
 
         private class Context

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V63/NodeDataMessageSeralizerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V63/NodeDataMessageSeralizerTests.cs
@@ -23,14 +23,14 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V63
         [Test]
         public void Roundtrip()
         {
-            ArrayPoolList<byte[]> data = new(3) { TestItem.KeccakA.BytesToArray(), TestItem.KeccakB.BytesToArray(), TestItem.KeccakC.BytesToArray() };
+            using ArrayPoolList<byte[]> data = new(3) { TestItem.KeccakA.BytesToArray(), TestItem.KeccakB.BytesToArray(), TestItem.KeccakC.BytesToArray() };
             Test(data);
         }
 
         [Test]
         public void Zero_roundtrip()
         {
-            ArrayPoolList<byte[]> data = new(3) { TestItem.KeccakA.BytesToArray(), TestItem.KeccakB.BytesToArray(), TestItem.KeccakC.BytesToArray() };
+            using ArrayPoolList<byte[]> data = new(3) { TestItem.KeccakA.BytesToArray(), TestItem.KeccakB.BytesToArray(), TestItem.KeccakC.BytesToArray() };
             Test(data);
         }
 
@@ -43,7 +43,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V63
         [Test]
         public void Roundtrip_with_nulls()
         {
-            ArrayPoolList<byte[]> data = new(3) { TestItem.KeccakA.BytesToArray(), Array.Empty<byte>(), TestItem.KeccakC.BytesToArray() };
+            using ArrayPoolList<byte[]> data = new(3) { TestItem.KeccakA.BytesToArray(), Array.Empty<byte>(), TestItem.KeccakC.BytesToArray() };
             Test(data);
         }
     }

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V65/PooledTxsRequestorTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V65/PooledTxsRequestorTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using FluentAssertions;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
@@ -18,7 +19,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V65
     public class PooledTxsRequestorTests
     {
         private readonly ITxPool _txPool = Substitute.For<ITxPool>();
-        private readonly Action<GetPooledTransactionsMessage> _doNothing = Substitute.For<Action<GetPooledTransactionsMessage>>();
+        private readonly Action<GetPooledTransactionsMessage> _doNothing = msg => msg.Dispose();
         private IPooledTxsRequestor _requestor;
         private IReadOnlyList<Hash256> _request;
         private IList<Hash256> _expected;
@@ -87,7 +88,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V65
 
         private void Send(GetPooledTransactionsMessage msg)
         {
-            _response = msg.Hashes.ToList();
+            using (msg) _response = msg.Hashes.ToList();
         }
     }
 }

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandlerTests.cs
@@ -309,6 +309,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V66
         [TestCase(1, 1)]
         [TestCase(256, 1)]
         [TestCase(257, 2)]
+        [TestCase(512, 2)]
         [TestCase(1000, 4)]
         [TestCase(10000, 40)]
         public void should_request_in_GetPooledTransactionsMessage_up_to_256_txs(int numberOfTransactions, int expectedNumberOfMessages)
@@ -336,14 +337,13 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V66
 
             using NewPooledTransactionHashesMessage hashesMsg = new(hashes);
             HandleIncomingStatusMessage();
-
-            bool callReceived = true;
-            _session.When((session) => session.DeliverMessage(Arg.Is<Network.P2P.Subprotocols.Eth.V66.Messages.GetPooledTransactionsMessage>(m => m.EthMessage.Hashes.Count == maxNumberOfTxsInOneMsg || m.EthMessage.Hashes.Count == numberOfTransactions % maxNumberOfTxsInOneMsg)))
-                .Do(_ => callReceived = true);
-
             HandleZeroMessage(hashesMsg, Eth65MessageCode.NewPooledTransactionHashes);
 
-            callReceived.Should().BeTrue();
+            _session.Received(expectedNumberOfMessages)
+                .DeliverMessage(Arg.Is<Network.P2P.Subprotocols.Eth.V66.Messages.GetPooledTransactionsMessage>(m =>
+                    m.EthMessage.Hashes.Count == maxNumberOfTxsInOneMsg ||
+                    m.EthMessage.Hashes.Count == numberOfTransactions % maxNumberOfTxsInOneMsg
+                ));
         }
 
         private void HandleZeroMessage<T>(T msg, int messageCode) where T : MessageBase

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V66/GetBlockBodiesMessageSerializerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V66/GetBlockBodiesMessageSerializerTests.cs
@@ -16,7 +16,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V66
         {
             Hash256 a = new("0x00000000000000000000000000000000000000000000000000000000deadc0de");
             Hash256 b = new("0x00000000000000000000000000000000000000000000000000000000feedbeef");
-            var ethMessage = new Network.P2P.Subprotocols.Eth.V62.Messages.GetBlockBodiesMessage(new Hash256[] { a, b });
+            using var ethMessage = new Network.P2P.Subprotocols.Eth.V62.Messages.GetBlockBodiesMessage(new Hash256[] { a, b });
             var message = new GetBlockBodiesMessage(1111, ethMessage);
 
             GetBlockBodiesMessageSerializer serializer = new();

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V66/GetBlockHeadersMessageSerializerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V66/GetBlockHeadersMessageSerializerTests.cs
@@ -35,7 +35,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V66
         [Test]
         public void RoundTrip_hash()
         {
-            var ethMessage = new Network.P2P.Subprotocols.Eth.V62.Messages.GetBlockHeadersMessage
+            using var ethMessage = new Network.P2P.Subprotocols.Eth.V62.Messages.GetBlockHeadersMessage
             {
                 StartBlockHash = new Hash256("0x00000000000000000000000000000000000000000000000000000000deadc0de"),
                 StartBlockNumber = 0,

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V66/GetNodeDataMessageSerializerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V66/GetNodeDataMessageSerializerTests.cs
@@ -17,7 +17,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V66
         {
             Hash256[] keys = { new("0x00000000000000000000000000000000000000000000000000000000deadc0de"), new("0x00000000000000000000000000000000000000000000000000000000feedbeef") };
 
-            var ethMessage = new Network.P2P.Subprotocols.Eth.V63.Messages.GetNodeDataMessage(keys.ToPooledList());
+            using var ethMessage = new Network.P2P.Subprotocols.Eth.V63.Messages.GetNodeDataMessage(keys.ToPooledList());
 
             GetNodeDataMessage message = new(1111, ethMessage);
 

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V66/GetPooledTransactionsSerializerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V66/GetPooledTransactionsSerializerTests.cs
@@ -18,7 +18,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V66
             Hash256 a = new("0x00000000000000000000000000000000000000000000000000000000deadc0de");
             Hash256 b = new("0x00000000000000000000000000000000000000000000000000000000feedbeef");
             Hash256[] keys = { a, b };
-            var ethMessage = new Network.P2P.Subprotocols.Eth.V65.Messages.GetPooledTransactionsMessage(keys.ToPooledList());
+            using var ethMessage = new Network.P2P.Subprotocols.Eth.V65.Messages.GetPooledTransactionsMessage(keys.ToPooledList());
 
             GetPooledTransactionsMessage message = new(1111, ethMessage);
 

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V66/GetReceiptsMessageSerializerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V66/GetReceiptsMessageSerializerTests.cs
@@ -19,7 +19,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V66
             Hash256 b = new("0x00000000000000000000000000000000000000000000000000000000feedbeef");
 
             Hash256[] hashes = { a, b };
-            var ethMessage = new Network.P2P.Subprotocols.Eth.V63.Messages.GetReceiptsMessage(hashes.ToPooledList());
+            using var ethMessage = new Network.P2P.Subprotocols.Eth.V63.Messages.GetReceiptsMessage(hashes.ToPooledList());
 
             GetReceiptsMessage message = new(1111, ethMessage);
 

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V66/NodeDataMessageSerializerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V66/NodeDataMessageSerializerTests.cs
@@ -14,8 +14,8 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V66
         [Test]
         public void Roundtrip()
         {
-            ArrayPoolList<byte[]> data = new(2) { new byte[] { 0xde, 0xad, 0xc0, 0xde }, new byte[] { 0xfe, 0xed, 0xbe, 0xef } };
-            var ethMessage = new Network.P2P.Subprotocols.Eth.V63.Messages.NodeDataMessage(data);
+            using ArrayPoolList<byte[]> data = new(2) { new byte[] { 0xde, 0xad, 0xc0, 0xde }, new byte[] { 0xfe, 0xed, 0xbe, 0xef } };
+            using var ethMessage = new Network.P2P.Subprotocols.Eth.V63.Messages.NodeDataMessage(data);
 
             NodeDataMessage message = new(1111, ethMessage);
 

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V66/PooledTransactionsMessageSerializerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V66/PooledTransactionsMessageSerializerTests.cs
@@ -44,7 +44,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V66
                 Hash = new Hash256("0xf39c7dac06a9f3abf09faf5e30439a349d3717611b3ed337cd52b0d192bc72da")
             };
 
-            var ethMessage = new Network.P2P.Subprotocols.Eth.V65.Messages.PooledTransactionsMessage(new ArrayPoolList<Transaction>(2) { tx1, tx2 });
+            using var ethMessage = new Network.P2P.Subprotocols.Eth.V65.Messages.PooledTransactionsMessage(new ArrayPoolList<Transaction>(2) { tx1, tx2 });
 
             PooledTransactionsMessage message = new(1111, ethMessage);
 

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V67/Eth67ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V67/Eth67ProtocolHandlerTests.cs
@@ -102,8 +102,8 @@ public class Eth67ProtocolHandlerTests
     [Test]
     public void Can_ignore_get_node_data()
     {
-        var msg63 = new GetNodeDataMessage(new[] { Keccak.Zero, TestItem.KeccakA }.ToPooledList());
-        var msg66 = new Network.P2P.Subprotocols.Eth.V66.Messages.GetNodeDataMessage(1111, msg63);
+        using var msg63 = new GetNodeDataMessage(new[] { Keccak.Zero, TestItem.KeccakA }.ToPooledList());
+        using var msg66 = new Network.P2P.Subprotocols.Eth.V66.Messages.GetNodeDataMessage(1111, msg63);
 
         HandleIncomingStatusMessage();
         HandleZeroMessage(msg66, Eth66MessageCode.GetNodeData);
@@ -113,8 +113,8 @@ public class Eth67ProtocolHandlerTests
     [Test]
     public void Can_ignore_node_data_and_not_throw_when_receiving_unrequested_node_data()
     {
-        var msg63 = new NodeDataMessage(ArrayPoolList<byte[]>.Empty());
-        var msg66 = new Network.P2P.Subprotocols.Eth.V66.Messages.NodeDataMessage(1111, msg63);
+        using var msg63 = new NodeDataMessage(ArrayPoolList<byte[]>.Empty());
+        using var msg66 = new Network.P2P.Subprotocols.Eth.V66.Messages.NodeDataMessage(1111, msg63);
 
         HandleIncomingStatusMessage();
         System.Action act = () => HandleZeroMessage(msg66, Eth66MessageCode.NodeData);
@@ -124,8 +124,8 @@ public class Eth67ProtocolHandlerTests
     [Test]
     public void Can_handle_eth66_messages_other_than_GetNodeData_and_NodeData() // e.g. GetBlockHeadersMessage
     {
-        var msg62 = new GetBlockHeadersMessage();
-        var msg66 = new Network.P2P.Subprotocols.Eth.V66.Messages.GetBlockHeadersMessage(1111, msg62);
+        using var msg62 = new GetBlockHeadersMessage();
+        using var msg66 = new Network.P2P.Subprotocols.Eth.V66.Messages.GetBlockHeadersMessage(1111, msg62);
 
         HandleIncomingStatusMessage();
         HandleZeroMessage(msg66, Eth66MessageCode.GetBlockHeaders);

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandlerTests.cs
@@ -50,6 +50,7 @@ public class Eth68ProtocolHandlerTests
     private Eth68ProtocolHandler _handler = null!;
     private ITxGossipPolicy _txGossipPolicy = null!;
     private ITimerFactory _timerFactory = null!;
+    private CompositeDisposable _disposables = null!;
 
     [SetUp]
     public void Setup()
@@ -58,9 +59,11 @@ public class Eth68ProtocolHandlerTests
 
         NetworkDiagTracer.IsEnabled = true;
 
+        _disposables = new();
         _session = Substitute.For<ISession>();
         Node node = new(TestItem.PublicKeyA, new IPEndPoint(IPAddress.Broadcast, 30303));
         _session.Node.Returns(node);
+        _session.When(s => s.DeliverMessage(Arg.Any<P2PMessage>())).Do(c => c.Arg<P2PMessage>().AddTo(_disposables));
         _syncManager = Substitute.For<ISyncServer>();
         _transactionPool = Substitute.For<ITxPool>();
         _pooledTxsRequestor = Substitute.For<IPooledTxsRequestor>();
@@ -99,6 +102,7 @@ public class Eth68ProtocolHandlerTests
         _handler?.Dispose();
         _session?.Dispose();
         _syncManager?.Dispose();
+        _disposables.Dispose();
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandlerTests.cs
@@ -94,11 +94,6 @@ public class Eth68ProtocolHandlerTests
     [TearDown]
     public void TearDown()
     {
-        // Dispose received messages
-        _session?.ReceivedCalls()
-            .Where(c => c.GetMethodInfo().Name == nameof(_session.DeliverMessage))
-            .ForEach(c => (c.GetArguments()[0] as P2PMessage)?.Dispose());
-
         _handler?.Dispose();
         _session?.Dispose();
         _syncManager?.Dispose();

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandlerTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using DotNetty.Buffers;
 using FluentAssertions;
@@ -17,6 +18,7 @@ using Nethermind.Core.Timers;
 using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.Network.P2P;
+using Nethermind.Network.P2P.Messages;
 using Nethermind.Network.P2P.Subprotocols;
 using Nethermind.Network.P2P.Subprotocols.Eth;
 using Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages;
@@ -89,6 +91,11 @@ public class Eth68ProtocolHandlerTests
     [TearDown]
     public void TearDown()
     {
+        // Dispose received messages
+        _session?.ReceivedCalls()
+            .Where(c => c.GetMethodInfo().Name == nameof(_session.DeliverMessage))
+            .ForEach(c => (c.GetArguments()[0] as P2PMessage)?.Dispose());
+
         _handler?.Dispose();
         _session?.Dispose();
         _syncManager?.Dispose();
@@ -114,7 +121,7 @@ public class Eth68ProtocolHandlerTests
 
         GenerateLists(txCount, out ArrayPoolList<byte> types, out ArrayPoolList<int> sizes, out ArrayPoolList<Hash256> hashes);
 
-        var msg = new NewPooledTransactionHashesMessage68(types, sizes, hashes);
+        using var msg = new NewPooledTransactionHashesMessage68(types, sizes, hashes);
 
         HandleIncomingStatusMessage();
         HandleZeroMessage(msg, Eth68MessageCode.NewPooledTransactionHashes);
@@ -138,7 +145,7 @@ public class Eth68ProtocolHandlerTests
             types.RemoveAt(sizes.Count - 1);
         }
 
-        var msg = new NewPooledTransactionHashesMessage68(types, sizes, hashes);
+        using var msg = new NewPooledTransactionHashesMessage68(types, sizes, hashes);
 
         HandleIncomingStatusMessage();
         Action action = () => HandleZeroMessage(msg, Eth68MessageCode.NewPooledTransactionHashes);
@@ -151,7 +158,7 @@ public class Eth68ProtocolHandlerTests
         Transaction tx = Build.A.Transaction.WithType(TxType.EIP1559).WithData(new byte[2 * 1024 * 1024])
             .WithHash(TestItem.KeccakA).TestObject;
 
-        var msg = new NewPooledTransactionHashesMessage68(new ArrayPoolList<byte>(1) { (byte)tx.Type },
+        using var msg = new NewPooledTransactionHashesMessage68(new ArrayPoolList<byte>(1) { (byte)tx.Type },
             new ArrayPoolList<int>(1) { tx.GetLength() }, new ArrayPoolList<Hash256>(1) { tx.Hash });
 
         HandleIncomingStatusMessage();
@@ -235,9 +242,9 @@ public class Eth68ProtocolHandlerTests
         int maxNumberOfTxsInOneMsg = sizeOfOneTx < TransactionsMessage.MaxPacketSize ? TransactionsMessage.MaxPacketSize / sizeOfOneTx : 1;
         int messagesCount = numberOfTransactions / maxNumberOfTxsInOneMsg + (numberOfTransactions % maxNumberOfTxsInOneMsg == 0 ? 0 : 1);
 
-        ArrayPoolList<byte> types = new(numberOfTransactions);
-        ArrayPoolList<int> sizes = new(numberOfTransactions);
-        ArrayPoolList<Hash256> hashes = new(numberOfTransactions);
+        using ArrayPoolList<byte> types = new(numberOfTransactions);
+        using ArrayPoolList<int> sizes = new(numberOfTransactions);
+        using ArrayPoolList<Hash256> hashes = new(numberOfTransactions);
 
         for (int i = 0; i < numberOfTransactions; i++)
         {

--- a/src/Nethermind/Nethermind.Network/P2P/MessageDictionary.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/MessageDictionary.cs
@@ -91,6 +91,7 @@ public class MessageDictionary<T66Msg, TData>(Action<T66Msg> send, TimeSpan? old
         }
         else
         {
+            data?.TryDispose();
             throw new SubprotocolException($"Received a response to {nameof(T66Msg)} that has not been requested");
         }
     }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/PooledTxsRequestor.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/PooledTxsRequestor.cs
@@ -17,14 +17,14 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth
     {
         private const int MaxNumberOfTxsInOneMsg = 256;
         private readonly ITxPool _txPool;
-        private readonly ITxPoolConfig _txPoolConfig;
+        private readonly bool _blobSupportEnabled;
 
         private readonly ClockKeyCache<ValueHash256> _pendingHashes = new(MemoryAllowance.TxHashCacheSize);
 
         public PooledTxsRequestor(ITxPool txPool, ITxPoolConfig txPoolConfig)
         {
             _txPool = txPool;
-            _txPoolConfig = txPoolConfig;
+            _blobSupportEnabled = txPoolConfig.BlobsSupport.IsEnabled();
         }
 
         public void RequestTransactions(Action<GetPooledTransactionsMessage> send, IReadOnlyList<Hash256> hashes)
@@ -80,7 +80,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth
                     packetSizeLeft = TransactionsMessage.MaxPacketSize;
                 }
 
-                if (_txPoolConfig.BlobsSupport.IsEnabled() || txType != TxType.Blob)
+                if (_blobSupportEnabled || txType != TxType.Blob)
                 {
                     hashesToRequest.Add(discoveredTxHashesAndSizes[i].Hash);
                     packetSizeLeft -= txSize;

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/PooledTxsRequestor.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/PooledTxsRequestor.cs
@@ -30,78 +30,64 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth
         public void RequestTransactions(Action<GetPooledTransactionsMessage> send, IReadOnlyList<Hash256> hashes)
         {
             ArrayPoolList<Hash256> discoveredTxHashes = AddMarkUnknownHashes(hashes);
-
-            if (discoveredTxHashes.Count != 0)
-            {
-                RequestPooledTransactions(send, discoveredTxHashes);
-            }
+            RequestPooledTransactions(send, discoveredTxHashes);
         }
 
         public void RequestTransactionsEth66(Action<V66.Messages.GetPooledTransactionsMessage> send, IReadOnlyList<Hash256> hashes)
         {
-            using ArrayPoolList<Hash256> discoveredTxHashes = AddMarkUnknownHashes(hashes);
+            ArrayPoolList<Hash256> discoveredTxHashes = AddMarkUnknownHashes(hashes);
 
-            if (discoveredTxHashes.Count != 0)
+            if (discoveredTxHashes.Count <= MaxNumberOfTxsInOneMsg)
             {
-                if (discoveredTxHashes.Count <= MaxNumberOfTxsInOneMsg)
+                RequestPooledTransactionsEth66(send, discoveredTxHashes);
+            }
+            else
+            {
+                using ArrayPoolList<Hash256> _ = discoveredTxHashes;
+                ArrayPoolList<Hash256> hashesToRequest = new(MaxNumberOfTxsInOneMsg);
+                for (int i = 0; i < discoveredTxHashes.Count; i++)
                 {
-                    RequestPooledTransactionsEth66(send, discoveredTxHashes);
-                }
-                else
-                {
-                    ArrayPoolList<Hash256> hashesToRequest = new(MaxNumberOfTxsInOneMsg);
-                    for (int i = 0; i < discoveredTxHashes.Count; i++)
-                    {
-                        if (hashesToRequest.Count % MaxNumberOfTxsInOneMsg == 0 && hashesToRequest.Count > 0)
-                        {
-                            RequestPooledTransactionsEth66(send, hashesToRequest);
-                            hashesToRequest = new(MaxNumberOfTxsInOneMsg);
-                        }
-
-                        hashesToRequest.Add(discoveredTxHashes[i]);
-                    }
-
-                    if (hashesToRequest.Count > 0)
+                    if (hashesToRequest.Count % MaxNumberOfTxsInOneMsg == 0)
                     {
                         RequestPooledTransactionsEth66(send, hashesToRequest);
+                        hashesToRequest = new(MaxNumberOfTxsInOneMsg);
                     }
+
+                    hashesToRequest.Add(discoveredTxHashes[i]);
                 }
+
+                RequestPooledTransactionsEth66(send, hashesToRequest);
             }
         }
 
         public void RequestTransactionsEth68(Action<V66.Messages.GetPooledTransactionsMessage> send, IReadOnlyList<Hash256> hashes, IReadOnlyList<int> sizes, IReadOnlyList<byte> types)
         {
             using ArrayPoolList<(Hash256 Hash, byte Type, int Size)> discoveredTxHashesAndSizes = AddMarkUnknownHashesEth68(hashes, sizes, types);
+            if (discoveredTxHashesAndSizes.Count == 0) return;
 
-            if (discoveredTxHashesAndSizes.Count != 0)
+            int packetSizeLeft = TransactionsMessage.MaxPacketSize;
+            ArrayPoolList<Hash256> hashesToRequest = new(discoveredTxHashesAndSizes.Count);
+
+            for (int i = 0; i < discoveredTxHashesAndSizes.Count; i++)
             {
-                int packetSizeLeft = TransactionsMessage.MaxPacketSize;
-                ArrayPoolList<Hash256> hashesToRequest = new(discoveredTxHashesAndSizes.Count);
+                int txSize = discoveredTxHashesAndSizes[i].Size;
+                TxType txType = (TxType)discoveredTxHashesAndSizes[i].Type;
 
-                for (int i = 0; i < discoveredTxHashesAndSizes.Count; i++)
-                {
-                    int txSize = discoveredTxHashesAndSizes[i].Size;
-                    TxType txType = (TxType)discoveredTxHashesAndSizes[i].Type;
-
-                    if (txSize > packetSizeLeft && hashesToRequest.Count > 0)
-                    {
-                        RequestPooledTransactionsEth66(send, hashesToRequest);
-                        hashesToRequest = new ArrayPoolList<Hash256>(discoveredTxHashesAndSizes.Count);
-                        packetSizeLeft = TransactionsMessage.MaxPacketSize;
-                    }
-
-                    if (_txPoolConfig.BlobsSupport.IsEnabled() || txType != TxType.Blob)
-                    {
-                        hashesToRequest.Add(discoveredTxHashesAndSizes[i].Hash);
-                        packetSizeLeft -= txSize;
-                    }
-                }
-
-                if (hashesToRequest.Count > 0)
+                if (txSize > packetSizeLeft && hashesToRequest.Count > 0)
                 {
                     RequestPooledTransactionsEth66(send, hashesToRequest);
+                    hashesToRequest = new ArrayPoolList<Hash256>(discoveredTxHashesAndSizes.Count);
+                    packetSizeLeft = TransactionsMessage.MaxPacketSize;
+                }
+
+                if (_txPoolConfig.BlobsSupport.IsEnabled() || txType != TxType.Blob)
+                {
+                    hashesToRequest.Add(discoveredTxHashesAndSizes[i].Hash);
+                    packetSizeLeft -= txSize;
                 }
             }
+
+            RequestPooledTransactionsEth66(send, hashesToRequest);
         }
 
         private ArrayPoolList<Hash256> AddMarkUnknownHashes(IReadOnlyList<Hash256> hashes)
@@ -138,13 +124,27 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth
 
         private static void RequestPooledTransactions(Action<GetPooledTransactionsMessage> send, IOwnedReadOnlyList<Hash256> hashesToRequest)
         {
-            send(new GetPooledTransactionsMessage(hashesToRequest));
+            if (hashesToRequest.Count > 0)
+            {
+                send(new(hashesToRequest));
+            }
+            else
+            {
+                hashesToRequest.Dispose();
+            }
         }
 
         private static void RequestPooledTransactionsEth66(Action<V66.Messages.GetPooledTransactionsMessage> send, IOwnedReadOnlyList<Hash256> hashesToRequest)
         {
-            GetPooledTransactionsMessage msg65 = new(hashesToRequest);
-            send(new V66.Messages.GetPooledTransactionsMessage { EthMessage = msg65 });
+            if (hashesToRequest.Count > 0)
+            {
+                GetPooledTransactionsMessage msg65 = new(hashesToRequest);
+                send(new() { EthMessage = msg65 });
+            }
+            else
+            {
+                hashesToRequest.Dispose();
+            }
         }
     }
 }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/PooledTxsRequestor.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/PooledTxsRequestor.cs
@@ -44,19 +44,15 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth
             else
             {
                 using ArrayPoolList<Hash256> _ = discoveredTxHashes;
-                ArrayPoolList<Hash256> hashesToRequest = new(MaxNumberOfTxsInOneMsg);
-                for (int i = 0; i < discoveredTxHashes.Count; i++)
+
+                for (int start = 0; start < discoveredTxHashes.Count; start += MaxNumberOfTxsInOneMsg)
                 {
-                    if (hashesToRequest.Count % MaxNumberOfTxsInOneMsg == 0)
-                    {
-                        RequestPooledTransactionsEth66(send, hashesToRequest);
-                        hashesToRequest = new(MaxNumberOfTxsInOneMsg);
-                    }
+                    var end = Math.Min(start + MaxNumberOfTxsInOneMsg, discoveredTxHashes.Count);
 
-                    hashesToRequest.Add(discoveredTxHashes[i]);
+                    ArrayPoolList<Hash256> hashesToRequest = new(end - start);
+                    hashesToRequest.AddRange(discoveredTxHashes.AsSpan()[start..end]);
+                    RequestPooledTransactionsEth66(send, hashesToRequest);
                 }
-
-                RequestPooledTransactionsEth66(send, hashesToRequest);
             }
         }
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandler.cs
@@ -94,6 +94,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V65
 
         protected virtual void Handle(NewPooledTransactionHashesMessage msg)
         {
+            using var _ = msg;
             AddNotifiedTransactions(msg.Hashes);
 
             Stopwatch stopwatch = Stopwatch.StartNew();

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandler.cs
@@ -170,47 +170,24 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
             return new NodeDataMessage(message.RequestId, nodeDataMessage);
         }
 
-        /// <summary>
-        /// Disposes <paramref name="message"/> if <paramref name="action"/> failed.
-        /// </summary>
-        private void SafeHandle<T>(T message, Action action) where T : P2PMessage
-        {
-            try
-            {
-                action();
-            }
-            finally
-            {
-                message?.Dispose();
-            }
-        }
-
         private void Handle(BlockHeadersMessage message, long size)
         {
-            SafeHandle(message, () =>
-                _headersRequests66.Handle(message.RequestId, message.EthMessage.BlockHeaders, size)
-            );
+            _headersRequests66.Handle(message.RequestId, message.EthMessage.BlockHeaders, size);
         }
 
         private void HandleBodies(BlockBodiesMessage blockBodiesMessage, long size)
         {
-            SafeHandle(blockBodiesMessage, () =>
-                _bodiesRequests66.Handle(blockBodiesMessage.RequestId, (blockBodiesMessage.EthMessage.Bodies, size), size)
-            );
+            _bodiesRequests66.Handle(blockBodiesMessage.RequestId, (blockBodiesMessage.EthMessage.Bodies, size), size);
         }
 
         private void Handle(NodeDataMessage msg, int size)
         {
-            SafeHandle(msg, () =>
-                _nodeDataRequests66.Handle(msg.RequestId, msg.EthMessage.Data, size)
-            );
+            _nodeDataRequests66.Handle(msg.RequestId, msg.EthMessage.Data, size);
         }
 
         private void Handle(ReceiptsMessage msg, long size)
         {
-            SafeHandle(msg, () =>
-                _receiptsRequests66.Handle(msg.RequestId, (msg.EthMessage.TxReceipts, size), size)
-            );
+            _receiptsRequests66.Handle(msg.RequestId, (msg.EthMessage.TxReceipts, size), size);
         }
 
         protected override void Handle(NewPooledTransactionHashesMessage msg)

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandler.cs
@@ -170,24 +170,47 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V66
             return new NodeDataMessage(message.RequestId, nodeDataMessage);
         }
 
+        /// <summary>
+        /// Disposes <paramref name="message"/> if <paramref name="action"/> failed.
+        /// </summary>
+        private void SafeHandle<T>(T message, Action action) where T : P2PMessage
+        {
+            try
+            {
+                action();
+            }
+            finally
+            {
+                message?.Dispose();
+            }
+        }
+
         private void Handle(BlockHeadersMessage message, long size)
         {
-            _headersRequests66.Handle(message.RequestId, message.EthMessage.BlockHeaders, size);
+            SafeHandle(message, () =>
+                _headersRequests66.Handle(message.RequestId, message.EthMessage.BlockHeaders, size)
+            );
         }
 
         private void HandleBodies(BlockBodiesMessage blockBodiesMessage, long size)
         {
-            _bodiesRequests66.Handle(blockBodiesMessage.RequestId, (blockBodiesMessage.EthMessage.Bodies, size), size);
+            SafeHandle(blockBodiesMessage, () =>
+                _bodiesRequests66.Handle(blockBodiesMessage.RequestId, (blockBodiesMessage.EthMessage.Bodies, size), size)
+            );
         }
 
         private void Handle(NodeDataMessage msg, int size)
         {
-            _nodeDataRequests66.Handle(msg.RequestId, msg.EthMessage.Data, size);
+            SafeHandle(msg, () =>
+                _nodeDataRequests66.Handle(msg.RequestId, msg.EthMessage.Data, size)
+            );
         }
 
         private void Handle(ReceiptsMessage msg, long size)
         {
-            _receiptsRequests66.Handle(msg.RequestId, (msg.EthMessage.TxReceipts, size), size);
+            SafeHandle(msg, () =>
+                _receiptsRequests66.Handle(msg.RequestId, (msg.EthMessage.TxReceipts, size), size)
+            );
         }
 
         protected override void Handle(NewPooledTransactionHashesMessage msg)


### PR DESCRIPTION
## Changes

Fixes some of the missing `ArrayPoolList` cleanups in client code and tests.

Fixed:
- eth/66 and SNAP protocols not disposing some messages in case of a `SubprotocolException`.
- eth/65 not disposing `NewPooledTransactionHashesMessage`.
- `PooledTxsRequestor` not disposing some of the allocated `ArrayPoolList`s
- Tests under `Nethermind.Network.Test.P2P.Subprotocols.Eth` failing randomly due to some `ArrayPoolList`s not being disposed. Should be reproducible by either running or debugging tests for multiple protocol versions in a single run.

Also, optimized `ArrayPool` copying in `PooledTxsRequestor.RequestTransactionsEth66`, when multiple batches are sent.

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
