### PR TITLE
JSON RPC: fix missing params when all are optional

### DIFF
--- a/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
+++ b/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
@@ -131,7 +131,7 @@ public class Startup
             }
         });
 
-        app.Run(async (ctx) =>
+        app.Run(async ctx =>
         {
             if (ctx.Request.Method == "GET")
             {


### PR DESCRIPTION
Related to #6824

## Changes

- Handle missing params correctly.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

## Remarks

Now it handles correctly

```
{"method":"admin_peers","id":1,"jsonrpc":"2.0"}
```
