### PR TITLE
Prewarm txns in order (of processing)

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
@@ -134,7 +134,7 @@ public class BlockCachePreWarmer(ReadOnlyTxProcessingEnvFactory envFactory, ISpe
                         scope.WorldState.WarmUp(tx.AccessList); // eip-2930
                     }
                     TransactionResult result = scope.TransactionProcessor.Trace(systemTransaction, new BlockExecutionContext(block.Header.Clone()), NullTxTracer.Instance);
-                    if (_logger.IsTrace) _logger.Trace($"Finished pre-warming cache for tx {tx.Hash} with {result}");
+                    if (_logger.IsTrace) _logger.Trace($"Finished pre-warming cache for tx[{i}] {tx.Hash} with {result}");
                 }
                 catch (Exception ex)
                 {

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
@@ -98,8 +98,13 @@ public class BlockCachePreWarmer(ReadOnlyTxProcessingEnvFactory envFactory, ISpe
         void WarmupTransactions(ParallelOptions parallelOptions, IReleaseSpec spec, Block block, Hash256 stateRoot)
         {
             if (parallelOptions.CancellationToken.IsCancellationRequested) return;
-            Parallel.For(0, block.Transactions.Length, parallelOptions, i =>
+
+            int progress = 0;
+            Parallel.For(1, block.Transactions.Length, parallelOptions, _ =>
             {
+                // Process transactions in order, rather than the partitioning scheme from Parallel.For
+                int i = Interlocked.Increment(ref progress);
+
                 // If the transaction has already been processed or being processed, exit early
                 if (block.TransactionProcessed >= i) return;
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
@@ -30,7 +30,7 @@ public class BlockCachePreWarmer(ReadOnlyTxProcessingEnvFactory envFactory, ISpe
         {
             if (targetWorldState.ClearCache())
             {
-                if (_logger.IsWarn) _logger.Warn("Cashes are not empty. Clearing them.");
+                if (_logger.IsWarn) _logger.Warn("Caches are not empty. Clearing them.");
             }
 
             if (!IsGenesisBlock(parentStateRoot) && Environment.ProcessorCount > 2 && !cancellationToken.IsCancellationRequested)
@@ -111,8 +111,7 @@ public class BlockCachePreWarmer(ReadOnlyTxProcessingEnvFactory envFactory, ISpe
             if (parallelOptions.CancellationToken.IsCancellationRequested) return;
 
             int progress = 0;
-            // We want to start at 1 which is the second transaction, giving total count one less than the length
-            Parallel.For(1, block.Transactions.Length, parallelOptions, _ =>
+            Parallel.For(0, block.Transactions.Length, parallelOptions, _ =>
             {
                 using ThreadExtensions.Disposable handle = Thread.CurrentThread.BoostPriority();
                 IReadOnlyTxProcessorSource env = _envPool.Get();
@@ -121,8 +120,8 @@ public class BlockCachePreWarmer(ReadOnlyTxProcessingEnvFactory envFactory, ISpe
                 try
                 {
                     // Process transactions in sequential order, rather than partitioning scheme from Parallel.For
-                    // Interlocked.Increment returns the incremented value, so it will start at 1
-                    int i = Interlocked.Increment(ref progress);
+                    // Interlocked.Increment returns the incremented value, so subtract 1 to start at 0
+                    int i = Interlocked.Increment(ref progress) - 1;
                     // If the transaction has already been processed or being processed, exit early
                     if (block.TransactionProcessed > i) return;
 


### PR DESCRIPTION
Contributes to https://github.com/NethermindEth/nethermind/issues/7171

## Changes

- Process transactions in order (the order that they will be required by main thread), rather than the partitioning scheme from Parallel.For

Partially resolves slow down on Windows

![image](https://github.com/user-attachments/assets/fb4f66d9-b593-443f-aab1-5463e0352902)


Before

<img width="299" alt="image" src="https://github.com/user-attachments/assets/10610ece-ac6b-4d04-a386-187e2e27a458">

After

<img width="298" alt="image" src="https://github.com/user-attachments/assets/a378d1b3-4fd9-4538-baa0-9d40c54fd0e1">


## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No

#### If yes, did you write tests?

- [x] No
