### PR TITLE
Keccak pipelined calculator

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/KeccakCalculatorTest.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/KeccakCalculatorTest.cs
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using FluentAssertions;
+using Nethermind.Core.Crypto;
+using NUnit.Framework;
+
+namespace Nethermind.Evm.Test;
+
+[TestFixture]
+public class KeccakCalculatorTest
+{
+    [Test]
+    public void Consecutive()
+    {
+        var calculator = new KeccakCalculator();
+
+        const int seed = 13;
+        var random = new Random(seed);
+        var payload = new byte[32];
+        var actual = new byte[Hash256.Size];
+
+        const int count = 16;
+
+        ushort[] ids = new ushort[count];
+
+        for (int i = 0; i < count; i++)
+        {
+            random.NextBytes(payload);
+            calculator.TrySchedule(payload, out ids[i]).Should().BeTrue();
+        }
+
+        // Assert
+        random = new Random(seed);
+        for (int i = 0; i < count; i++)
+        {
+            random.NextBytes(payload);
+            Span<byte> expected = ValueKeccak.Compute(payload).BytesAsSpan;
+
+            calculator.Copy(ids[i], actual);
+            expected.SequenceEqual(actual).Should().BeTrue();
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Evm.Test/KeccakCalculatorTest.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/KeccakCalculatorTest.cs
@@ -27,12 +27,13 @@ public class KeccakCalculatorTest
 
         const int count = 128;
 
-        ushort[] ids = new ushort[count];
+        var ids = new OffHeapStack.Slot[count];
 
         for (int i = 0; i < count; i++)
         {
             random.NextBytes(payload);
-            calculator.TrySchedule(payload, out ids[i]).Should().BeTrue();
+            ids[i] = calculator.TrySchedule(payload);
+            ids[i].IsAcquired.Should().BeTrue();
         }
 
         // Reset and assert
@@ -42,7 +43,7 @@ public class KeccakCalculatorTest
             random.NextBytes(payload);
             Span<byte> expected = ValueKeccak.Compute(payload).BytesAsSpan;
 
-            ReadOnlySpan<byte> actual = calculator.Get(ids[i]);
+            ReadOnlySpan<byte> actual = KeccakCalculator.Get(ids[i]);
             expected.SequenceEqual(actual).Should().BeTrue();
         }
 

--- a/src/Nethermind/Nethermind.Evm/KeccakCalculator.cs
+++ b/src/Nethermind/Nethermind.Evm/KeccakCalculator.cs
@@ -5,11 +5,20 @@ using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
+using System.Threading.Tasks;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 
 namespace Nethermind.Evm;
 
+/// <summary>
+/// TODO:
+/// 1. Consider creating a single thread pool work item that communicates by passing a pointer to the work item.
+/// Then a ConcurrentQueue could be used.
+/// 2. Alignment maybe? Why not to align to the word, especially if 1 runner is used
+/// 3. Make the book keeping, so that once the work is done,
+/// it's walked through and checked that it was completed so that calculator can be reused.
+/// </summary>
 public sealed class KeccakCalculator : IThreadPoolWorkItem
 {
     private const byte HashLength = Hash256.Size;

--- a/src/Nethermind/Nethermind.Evm/KeccakCalculator.cs
+++ b/src/Nethermind/Nethermind.Evm/KeccakCalculator.cs
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+
+namespace Nethermind.Evm;
+
+public sealed class KeccakCalculator : IThreadPoolWorkItem
+{
+    private const byte HashLength = Hash256.Size;
+    private const byte MinLength = HashLength;
+
+    private const byte MaxLength = byte.MaxValue - 1;
+    private const byte DoneMarker = byte.MaxValue;
+
+    private const byte LengthPrefix = 1;
+    private const int BufferLength = 8 * 1024;
+
+    private const int NotWorking = 0;
+    private const int Working = 1;
+
+    [StructLayout(LayoutKind.Explicit, Size = Size)]
+    private struct State
+    {
+        private const int Size = CacheLineSize * 3;
+        private const int CacheLineSize = 64;
+
+        [FieldOffset(CacheLineSize * 1)] public ushort WrittenTo;
+        [FieldOffset(CacheLineSize * 2)] public int Status;
+    }
+
+    private State _state;
+
+    private readonly byte[] _buffer = new byte[BufferLength];
+
+    public bool TrySchedule(ReadOnlySpan<byte> bytes, out ushort id)
+    {
+        var writtenTo = _state.WrittenTo;
+
+        if (bytes.Length < MinLength || bytes.Length > MaxLength ||
+            writtenTo + LengthPrefix + bytes.Length > BufferLength)
+        {
+            id = 0;
+            return false;
+        }
+
+        // write length prefix
+        id = writtenTo;
+
+        _buffer[writtenTo] = (byte)bytes.Length;
+
+        bytes.CopyTo(_buffer.AsSpan(writtenTo + LengthPrefix, bytes.Length));
+
+        // Publish
+        Volatile.Write(ref _state.WrittenTo, (ushort)(writtenTo + LengthPrefix + bytes.Length));
+
+        // Ensure the work item
+        if (_state.Status == NotWorking)
+        {
+            Volatile.Write(ref _state.Status, Working);
+            ThreadPool.UnsafeQueueUserWorkItem(this, false);
+        }
+
+        return true;
+    }
+
+    public void Copy(ushort id, Span<byte> destination)
+    {
+        var wait = default(SpinWait);
+
+        while (Volatile.Read(ref _buffer[id]) != DoneMarker)
+        {
+            wait.SpinOnce();
+        }
+
+        _buffer.AsSpan(id + LengthPrefix, HashLength).CopyTo(destination);
+    }
+
+    public void Execute()
+    {
+        var wait = new SpinWait();
+        var buffer = _buffer.AsSpan();
+        var processedTo = 0;
+
+        while (Volatile.Read(ref _state.Status) == Working)
+        {
+            // Consider reading volatile once per loop
+            var writtenTo = Volatile.Read(ref _state.WrittenTo);
+
+            if (processedTo < writtenTo)
+            {
+                ref var length = ref buffer[processedTo];
+
+                Span<byte> span = buffer.Slice(processedTo + LengthPrefix, length);
+
+                // Copy back to the span
+                ValueKeccak.Compute(span).BytesAsSpan.CopyTo(span);
+
+                // Move processed
+                processedTo += LengthPrefix + length;
+
+                // Mark as done writing done marker
+                Volatile.Write(ref length, DoneMarker);
+            }
+            else
+            {
+                wait.SpinOnce();
+            }
+        }
+    }
+
+    public void Clear()
+    {
+        Volatile.Write(ref _state.Status, NotWorking);
+        // TODO: fix the ending
+        _buffer.AsSpan().Clear();
+        _state = default;
+    }
+}

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -1140,17 +1140,17 @@ internal sealed class VirtualMachine<TLogger> : IVirtualMachine where TLogger : 
                         }
                         else
                         {
-                            // The tracing is not set. Try to schedule Keccak
-                            KeccakCalculator? calculator = null;
-                            if (calculator != null && calculator.TrySchedule(bytes, out var id))
-                            {
-                                stack.PushKeccakId(id);
-                            }
-                            else
-                            {
-                                // Scheduling computation wasn't successful. Compute in situ.
-                                stack.PushBytes(ValueKeccak.Compute(bytes).BytesAsSpan);
-                            }
+                            // // The tracing is not set. Try to schedule Keccak
+                            // KeccakCalculator? calculator = null;
+                            // if (calculator != null && calculator.TrySchedule(bytes, out var id))
+                            // {
+                            //     stack.PushKeccakId(id);
+                            // }
+                            // else
+                            // {
+                            // Scheduling computation wasn't successful. Compute in situ.
+                            stack.PushBytes(ValueKeccak.Compute(bytes).BytesAsSpan);
+                            // }
                         }
 
                         break;


### PR DESCRIPTION
This PR proposes a new way of handling `Instruction.KECCAK256`, when it's followed by some instructions that are not result dependent (no immediate pop of the value). It does it by moving the computation to a separate component with a separate thread to compute and placing a special marker in `EvmStack`, so that when the value needs to be retrieved, it's retrieved from the `OffHeapStack`. You can think of it as a **CPU pipeline** enabler, that does something behind the scenes and materialized value on the stack when ready.

The preliminary benchmarks, that compare actual execution with the offloading, show the following difference

| Method           | Mean      | Error    | StdDev   | Ratio |
|----------------- |----------:|---------:|---------:|------:|
| ValueKeccak      | 209.94 ns | 2.212 ns | 2.069 ns |  1.00 |
| KeccakCalculator |  22.80 ns | 0.469 ns | 0.439 ns |  0.11 |

This, of course, does not take into consideration the overhead of checking in `EvmStack` whether or not the value is kept `OffHeap` and detecting what to do. This is just a rough estimation what could be done.

To reflect on a real example, `WrappedEth` was used: https://app.dedaub.com/ethereum/address/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2/disassembled Here are some of the sequences that followed SHA3

```
0x5fa: SHA3      
0x5fb: DUP2      
0x5fc: SWAP1     
0x5fd: SSTORE    
```

```
0x5bd: SHA3      
0x5be: PUSH1     0x0
0x5c0: DUP6      
0x5c1: PUSH20    0xffffffffffffffffffffffffffffffffffffffff
0x5d6: AND       
0x5d7: PUSH20    0xffffffffffffffffffffffffffffffffffffffff
0x5ec: AND       
0x5ed: DUP2      
0x5ee: MSTORE 
```

A terrible case:

```
0x6ce: SHA3      
0x6cf: SLOAD
```

```
  0x773: SHA3      
  0x774: PUSH1     0x0
  0x776: CALLER    
  0x777: PUSH20    0xffffffffffffffffffffffffffffffffffffffff
  0x78c: AND       
  0x78d: PUSH20    0xffffffffffffffffffffffffffffffffffffffff
  0x7a2: AND       
  0x7a3: DUP2      
  0x7a4: MSTORE
```

## Changes

- _List the changes_

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [ ] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
