### PR TITLE
eth_simulate does not return eth log when selfdestructive contract sends eth

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/Simulate/EthSimulateTestsBlocksAndTransactions.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/Simulate/EthSimulateTestsBlocksAndTransactions.cs
@@ -278,4 +278,45 @@ public class EthSimulateTestsBlocksAndTransactions
         var logs = result.Data.First().Calls.First().Logs.ToArray();
         Assert.That(logs.First().Address == new Address("0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"));
     }
+
+
+
+    [Test]
+    public async Task Test_eth_simulate_logs_on_selfdestructive_contract_sends_eth()
+    {
+        EthereumJsonSerializer serializer = new();
+        string input = """
+                       {
+                           "traceTransfers": true,
+                           "blockStateCalls": [
+                               {
+                                   "stateOverrides": {
+                                       "0xc200000000000000000000000000000000000000": {
+                                           "code": "0x6080604052348015600f57600080fd5b506004361060285760003560e01c806383197ef014602d575b600080fd5b60336035565b005b600073ffffffffffffffffffffffffffffffffffffffff16fffea26469706673582212208e566fde20a17fff9658b9b1db37e27876fd8934ccf9b2aa308cabd37698681f64736f6c63430008120033",
+                                           "balance": "0x1e8480"
+                                       }
+                                   },
+                                   "calls": [
+                                       {
+                                           "from": "0xc000000000000000000000000000000000000000",
+                                           "to": "0xc200000000000000000000000000000000000000",
+                                           "input": "0x83197ef0"
+                                       }
+                                   ]
+                               }
+                           ]
+                       }
+                       """;
+        var payload = serializer.Deserialize<SimulatePayload<TransactionForRpc>>(input);
+        TestRpcBlockchain chain = await EthRpcSimulateTestsBase.CreateChain();
+        Console.WriteLine($"current test: {nameof(Test_eth_simulate_logs_on_selfdestructive_contract_sends_eth)}");
+        var result = chain.EthRpcModule.eth_simulateV1(payload!, BlockParameter.Latest);
+        var calls = result.Data.First().Calls;
+        var logs = calls.First().Logs.ToArray();
+        Assert.That(logs.Length > 0);
+
+    }
+
+
+
 }


### PR DESCRIPTION
Fixes nethermind does not return eth log when selfdestructive contract sends eth issue. Expected log was:

```
"logs": [
    {
        "address": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
        "topics": [
            "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
            "0x000000000000000000000000c200000000000000000000000000000000000000",
            "0x0000000000000000000000000000000000000000000000000000000000000000"
        ],
        "data": "0x00000000000000000000000000000000000000000000000000000000001e8480",
        "blockNumber": "0x139368a",
        "transactionHash": "0x200fab0bcc81da4a444d4bd94c11132f7343c8ce9f2aa6c30d0844397d28f945",
        "transactionIndex": "0x0",
        "blockHash": "0x6ac1e3302e98cb7d11c007b8ea448c42839b7e095ed28123cab09b267fdb94cb",
        "logIndex": "0x0",
        "removed": false
    }
],
```

## Changes

- EVM logging callback

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
