### PR TITLE
Validate and log when an unrecognized parameter/flag is used

### DIFF
--- a/src/Nethermind/Nethermind.Config/ExitCodes.cs
+++ b/src/Nethermind/Nethermind.Config/ExitCodes.cs
@@ -16,6 +16,7 @@ public static class ExitCodes
     public const int ConflictingConfigurations = 103;
     public const int LowDiskSpace = 104;
     public const int DuplicatedArguments = 105;
+    public const int UnrecognizedArgument = 106;
 
     // Posix exit code
     // https://tldp.org/LDP/abs/html/exitcodes.html

--- a/src/Nethermind/Nethermind.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Runner/Program.cs
@@ -587,26 +587,26 @@ public static class Program
         return info.ToString();
     }
 
-    private static HashSet<string> GetValidArguments(CommandLineApplication app)
-    {
-        var validArguments = new HashSet<string>();
-        foreach (var option in app.GetOptions())
-        {
-            if (!string.IsNullOrEmpty(option.LongName))
-            {
-                validArguments.Add(option.LongName);
-            }
-            if (!string.IsNullOrEmpty(option.ShortName))
-            {
-                validArguments.Add(option.ShortName);
-            }
-        }
-
-        return validArguments;
-    }
-
     private static bool ValidateArguments(string[] args, CommandLineApplication app)
     {
+        static HashSet<string> GetValidArguments(CommandLineApplication app)
+        {
+            var validArguments = new HashSet<string>();
+            foreach (var option in app.GetOptions())
+            {
+                if (!string.IsNullOrEmpty(option.LongName))
+                {
+                    validArguments.Add(option.LongName);
+                }
+                if (!string.IsNullOrEmpty(option.ShortName))
+                {
+                    validArguments.Add(option.ShortName);
+                }
+            }
+
+            return validArguments;
+        }
+
         // Get all valid options from the configuration files
         var validArguments = GetValidArguments(app);
 

--- a/src/Nethermind/Nethermind.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Runner/Program.cs
@@ -590,7 +590,9 @@ public static class Program
     private static bool ValidateArguments(string[] args, CommandLineApplication app)
     {
         // Get all valid options from the configuration files
-        var validArguments = app.GetOptions().SelectMany(o => new[] { o.LongName, o.ShortName }).ToArray();
+        var validArguments = new HashSet<string>(
+            app.GetOptions().SelectMany(o => new[] { o.LongName, o.ShortName }).Where(name => !string.IsNullOrEmpty(name))
+        );
 
         var argumentsNamesProvided = GetArgumentNames(args).ToList();
         foreach (var argumentName in argumentsNamesProvided)

--- a/src/Nethermind/Nethermind.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Runner/Program.cs
@@ -599,12 +599,10 @@ public static class Program
             }
         }
 
-        static IEnumerable<ReadOnlyMemory<char>> GetDuplicateArguments(IEnumerable<ReadOnlyMemory<char>> argumentsNames)
-        {
-            return argumentsNames.GroupBy(n => n, new MemoryContentsComparer<char>())
+        static IEnumerable<ReadOnlyMemory<char>> GetDuplicateArguments(IEnumerable<ReadOnlyMemory<char>> argumentsNames) =>
+            argumentsNames.GroupBy(n => n, new MemoryContentsComparer<char>())
                 .Where(g => g.Count() > 1)
                 .Select(g => g.Key);
-        }
 
         // Get all valid options from the configuration files
         HashSet<ReadOnlyMemory<char>> validArguments = GetValidArguments(app);

--- a/src/Nethermind/Nethermind.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Runner/Program.cs
@@ -587,12 +587,28 @@ public static class Program
         return info.ToString();
     }
 
+    private static HashSet<string> GetValidArguments(CommandLineApplication app)
+    {
+        var validArguments = new HashSet<string>();
+        foreach (var option in app.GetOptions())
+        {
+            if (!string.IsNullOrEmpty(option.LongName))
+            {
+                validArguments.Add(option.LongName);
+            }
+            if (!string.IsNullOrEmpty(option.ShortName))
+            {
+                validArguments.Add(option.ShortName);
+            }
+        }
+
+        return validArguments;
+    }
+
     private static bool ValidateArguments(string[] args, CommandLineApplication app)
     {
         // Get all valid options from the configuration files
-        var validArguments = new HashSet<string>(
-            app.GetOptions().SelectMany(o => new[] { o.LongName, o.ShortName }).Where(name => !string.IsNullOrEmpty(name))
-        );
+        var validArguments = GetValidArguments(app);
 
         var argumentsNamesProvided = GetArgumentNames(args).ToList();
         foreach (var argumentName in argumentsNamesProvided)

--- a/src/Nethermind/Nethermind.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Runner/Program.cs
@@ -251,27 +251,6 @@ public static class Program
         }
     }
 
-    private static ReadOnlyMemory<char> GetArgumentName(string arg) => arg.StartsWith("--") ? arg.AsMemory(2) : arg.StartsWith('-') ? arg.AsMemory(1) : ReadOnlyMemory<char>.Empty;
-    private static IEnumerable<ReadOnlyMemory<char>> GetArgumentNames(IEnumerable<string> args)
-    {
-        bool lastWasArgument = false;
-        foreach (ReadOnlyMemory<char> potentialArgument in args.Select(GetArgumentName))
-        {
-            if (!lastWasArgument)
-            {
-                bool isCurrentArgument = lastWasArgument = !potentialArgument.IsEmpty;
-                if (isCurrentArgument)
-                {
-                    yield return potentialArgument;
-                }
-            }
-            else
-            {
-                lastWasArgument = false;
-            }
-        }
-    }
-
     private static IEnumerable<ReadOnlyMemory<char>> GetDuplicateArguments(IEnumerable<ReadOnlyMemory<char>> argumentsNames)
     {
         return argumentsNames.GroupBy(n => n, new MemoryContentsComparer<char>())
@@ -605,6 +584,27 @@ public static class Program
             }
 
             return validArguments;
+        }
+
+        static ReadOnlyMemory<char> GetArgumentName(string arg) => arg.StartsWith("--") ? arg.AsMemory(2) : arg.StartsWith('-') ? arg.AsMemory(1) : ReadOnlyMemory<char>.Empty;
+        static IEnumerable<ReadOnlyMemory<char>> GetArgumentNames(IEnumerable<string> args)
+        {
+            bool lastWasArgument = false;
+            foreach (ReadOnlyMemory<char> potentialArgument in args.Select(GetArgumentName))
+            {
+                if (!lastWasArgument)
+                {
+                    bool isCurrentArgument = lastWasArgument = !potentialArgument.IsEmpty;
+                    if (isCurrentArgument)
+                    {
+                        yield return potentialArgument;
+                    }
+                }
+                else
+                {
+                    lastWasArgument = false;
+                }
+            }
         }
 
         // Get all valid options from the configuration files

--- a/src/Nethermind/Nethermind.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Runner/Program.cs
@@ -114,7 +114,7 @@ public static class Program
         _logger.Info("Nethermind starting initialization.");
         _logger.Info($"Client version: {ProductInfo.ClientId}");
 
-        ValidateCommandLineFlags(args);
+        ValidateArguments(args);
 
         string duplicateArgumentsList = string.Join(", ", GetDuplicateArguments(args));
         if (!string.IsNullOrEmpty(duplicateArgumentsList))
@@ -654,7 +654,7 @@ public static class Program
         return options;
     }
 
-    private static void ValidateCommandLineFlags(string[] args)
+    private static void ValidateArguments(string[] args)
     {
         // Get all valid options from the configuration files
         var validParameters = generateValidConfigOptionsHash();

--- a/src/Nethermind/Nethermind.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Runner/Program.cs
@@ -590,14 +590,14 @@ public static class Program
     private static bool ValidateArguments(string[] args, CommandLineApplication app)
     {
         // Get all valid options from the configuration files
-        var validParameters = app.GetOptions().SelectMany(o => new[] { o.LongName, o.ShortName }).ToArray();
+        var validArguments = app.GetOptions().SelectMany(o => new[] { o.LongName, o.ShortName }).ToArray();
 
-        var argumentsNames = GetArgumentNames(args).Select(a => a.ToString()).ToArray();
+        var argumentsNamesProvided = GetArgumentNames(args).Select(a => a.ToString()).ToArray();
 
-        foreach (var argumentName in argumentsNames)
+        foreach (var argumentName in argumentsNamesProvided)
         {
-            // Check if the argument is a valid parameter/option/argument
-            if (!validParameters.Contains(argumentName))
+            // Check if the argument provided is a valid option/argument
+            if (!validArguments.Contains(argumentName))
             {
                 string message = $"Unrecognized argument: {argumentName}.\nRun --help for a list of available options and commands.";
                 throw new ArgumentException(message);

--- a/src/Nethermind/Nethermind.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Runner/Program.cs
@@ -152,8 +152,7 @@ public static class Program
 
         BuildOptionsFromConfigFiles(app);
 
-        bool validArgs = ValidateArguments(args, app);
-        if (!validArgs) return;
+        if (!ValidateArguments(args, app)) return;
 
         app.OnExecute(async () =>
         {

--- a/src/Nethermind/Nethermind.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Runner/Program.cs
@@ -592,15 +592,13 @@ public static class Program
         // Get all valid options from the configuration files
         var validArguments = app.GetOptions().SelectMany(o => new[] { o.LongName, o.ShortName }).ToArray();
 
-        var argumentsNamesProvided = GetArgumentNames(args).Select(a => a.ToString()).ToArray();
-
+        var argumentsNamesProvided = GetArgumentNames(args).ToList();
         foreach (var argumentName in argumentsNamesProvided)
         {
             // Check if the argument provided is a valid option/argument
-            if (!validArguments.Contains(argumentName))
+            if (!validArguments.Contains(argumentName.ToString()))
             {
-                string message = $"Unrecognized argument: {argumentName}.\nRun --help for a list of available options and commands.";
-                throw new ArgumentException(message);
+                throw new ArgumentException($"Unrecognized argument: {argumentName}.\nRun --help for a list of available options and commands.");
             }
         }
 

--- a/src/Nethermind/Nethermind.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Runner/Program.cs
@@ -250,13 +250,6 @@ public static class Program
         }
     }
 
-    private static IEnumerable<ReadOnlyMemory<char>> GetDuplicateArguments(IEnumerable<ReadOnlyMemory<char>> argumentsNames)
-    {
-        return argumentsNames.GroupBy(n => n, new MemoryContentsComparer<char>())
-            .Where(g => g.Count() > 1)
-            .Select(g => g.Key);
-    }
-
     private static IntPtr OnResolvingUnmanagedDll(Assembly _, string nativeLibraryName)
     {
         var alternativePath = nativeLibraryName switch
@@ -604,6 +597,13 @@ public static class Program
                     lastWasArgument = false;
                 }
             }
+        }
+
+        static IEnumerable<ReadOnlyMemory<char>> GetDuplicateArguments(IEnumerable<ReadOnlyMemory<char>> argumentsNames)
+        {
+            return argumentsNames.GroupBy(n => n, new MemoryContentsComparer<char>())
+                .Where(g => g.Count() > 1)
+                .Select(g => g.Key);
         }
 
         // Get all valid options from the configuration files

--- a/src/Nethermind/Nethermind.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Runner/Program.cs
@@ -587,7 +587,7 @@ public static class Program
         return info.ToString();
     }
 
-    private static HashSet<string> generateValidConfigOptionsHash()
+    private static HashSet<string> GenerateValidConfigOptionsHash()
     {
         // Initialize with the default options
         var options = new HashSet<string>
@@ -650,7 +650,7 @@ public static class Program
     private static bool ValidateArguments(string[] args)
     {
         // Get all valid options from the configuration files
-        var validParameters = generateValidConfigOptionsHash();
+        var validParameters = GenerateValidConfigOptionsHash();
 
         foreach (var arg in args)
         {

--- a/src/Nethermind/Nethermind.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Runner/Program.cs
@@ -592,25 +592,25 @@ public static class Program
         // Initialize with the default options
         var options = new HashSet<string>
         {
-            "-?",
-            "-h",
-            "--help",
-            "-v",
-            "--version",
-            "-dd",
-            "--datadir",
-            "-c",
-            "--config",
-            "-d",
-            "--baseDbPath",
-            "-l",
-            "--log",
-            "-cd",
-            "--configsDirectory",
-            "-lcs",
-            "--loggerConfigSource",
-            "-pd",
-            "--pluginsDirectory",
+            "?",
+            "h",
+            "help",
+            "v",
+            "version",
+            "dd",
+            "datadir",
+            "c",
+            "config",
+            "d",
+            "baseDbPath",
+            "l",
+            "log",
+            "cd",
+            "configsDirectory",
+            "lcs",
+            "loggerConfigSource",
+            "pd",
+            "pluginsDirectory",
         };
 
         // Add all the options from the configuration files
@@ -639,7 +639,7 @@ public static class Program
                 ConfigItemAttribute? configItemAttribute = propertyInfo.GetCustomAttribute<ConfigItemAttribute>();
                 if (!(configItemAttribute?.DisabledForCli ?? false))
                 {
-                    options.Add($"--{configType.Name[1..].Replace("Config", string.Empty)}.{propertyInfo.Name}");
+                    options.Add($"{configType.Name[1..].Replace("Config", string.Empty)}.{propertyInfo.Name}");
                 }
             }
         }
@@ -651,13 +651,14 @@ public static class Program
     {
         // Get all valid options from the configuration files
         var validParameters = GenerateValidConfigOptionsHash();
+        var argumentsNames = GetArgumentNames(args).Select(a => a.ToString()).ToArray();
 
-        foreach (var arg in args)
+        foreach (var argumentName in argumentsNames)
         {
-            // Check if the argument is a parameter (starts with --)
-            if (arg.StartsWith("--") && !validParameters.Contains(arg))
+            // Check if the argument is a valid parameter/option/argument
+            if (!validParameters.Contains(argumentName))
             {
-                string message = $"Unrecognized parameter: {arg}.\nRun --help for a list of available options and commands.";
+                string message = $"Unrecognized argument: {argumentName}.\nRun --help for a list of available options and commands.";
                 throw new ArgumentException(message);
             }
         }

--- a/src/Nethermind/Nethermind.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Runner/Program.cs
@@ -560,18 +560,18 @@ public static class Program
 
     private static bool ValidateArguments(string[] args, CommandLineApplication app)
     {
-        static HashSet<string> GetValidArguments(CommandLineApplication app)
+        static HashSet<ReadOnlyMemory<char>> GetValidArguments(CommandLineApplication app)
         {
-            var validArguments = new HashSet<string>();
+            HashSet<ReadOnlyMemory<char>> validArguments = new(new MemoryContentsComparer<char>());
             foreach (var option in app.GetOptions())
             {
                 if (!string.IsNullOrEmpty(option.LongName))
                 {
-                    validArguments.Add(option.LongName);
+                    validArguments.Add(option.LongName.AsMemory());
                 }
                 if (!string.IsNullOrEmpty(option.ShortName))
                 {
-                    validArguments.Add(option.ShortName);
+                    validArguments.Add(option.ShortName.AsMemory());
                 }
             }
 
@@ -607,13 +607,13 @@ public static class Program
         }
 
         // Get all valid options from the configuration files
-        var validArguments = GetValidArguments(app);
+        HashSet<ReadOnlyMemory<char>> validArguments = GetValidArguments(app);
 
-        var argumentsNamesProvided = GetArgumentNames(args).ToList();
-        foreach (var argumentName in argumentsNamesProvided)
+        List<ReadOnlyMemory<char>> argumentsNamesProvided = GetArgumentNames(args).ToList();
+        foreach (ReadOnlyMemory<char> argumentName in argumentsNamesProvided)
         {
             // Check if the argument provided is a valid option/argument
-            if (!validArguments.Contains(argumentName.ToString()))
+            if (!validArguments.Contains(argumentName))
             {
                 throw new ArgumentException($"Unrecognized argument: {argumentName}.\nRun --help for a list of available options and commands.");
             }

--- a/src/Nethermind/Nethermind.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Runner/Program.cs
@@ -609,7 +609,7 @@ public static class Program
         // Get all valid options from the configuration files
         HashSet<ReadOnlyMemory<char>> validArguments = GetValidArguments(app);
 
-        List<ReadOnlyMemory<char>> argumentsNamesProvided = GetArgumentNames(args).ToList();
+        IEnumerable<ReadOnlyMemory<char>> argumentsNamesProvided = GetArgumentNames(args);
         foreach (ReadOnlyMemory<char> argumentName in argumentsNamesProvided)
         {
             // Check if the argument provided is a valid option/argument

--- a/src/Nethermind/Nethermind.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Runner/Program.cs
@@ -615,7 +615,9 @@ public static class Program
             // Check if the argument provided is a valid option/argument
             if (!validArguments.Contains(argumentName))
             {
-                throw new ArgumentException($"Unrecognized argument: {argumentName}.\nRun --help for a list of available options and commands.");
+                _logger.Error($"Failed due to unrecognized argument - [{argumentName}].\nRun --help for a list of available options and commands.");
+                Environment.ExitCode = ExitCodes.UnrecognizedArgument;
+                return false;
             }
         }
 

--- a/src/Nethermind/Nethermind.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Runner/Program.cs
@@ -114,15 +114,8 @@ public static class Program
         _logger.Info("Nethermind starting initialization.");
         _logger.Info($"Client version: {ProductInfo.ClientId}");
 
-        ValidateArguments(args);
-
-        string duplicateArgumentsList = string.Join(", ", GetDuplicateArguments(args));
-        if (!string.IsNullOrEmpty(duplicateArgumentsList))
-        {
-            _logger.Error($"Failed due to duplicated arguments - [{duplicateArgumentsList}] passed while execution");
-            Environment.ExitCode = ExitCodes.DuplicatedArguments;
-            return;
-        }
+        bool validArgs = ValidateArguments(args);
+        if (!validArgs) return;
 
         AppDomain.CurrentDomain.ProcessExit += CurrentDomainOnProcessExit;
         AssemblyLoadContext.Default.ResolvingUnmanagedDll += OnResolvingUnmanagedDll;
@@ -654,7 +647,7 @@ public static class Program
         return options;
     }
 
-    private static void ValidateArguments(string[] args)
+    private static bool ValidateArguments(string[] args)
     {
         // Get all valid options from the configuration files
         var validParameters = generateValidConfigOptionsHash();
@@ -668,5 +661,15 @@ public static class Program
                 throw new ArgumentException(message);
             }
         }
+
+        string duplicateArgumentsList = string.Join(", ", GetDuplicateArguments(args));
+        if (!string.IsNullOrEmpty(duplicateArgumentsList))
+        {
+            _logger.Error($"Failed due to duplicated arguments - [{duplicateArgumentsList}] passed while execution");
+            Environment.ExitCode = ExitCodes.DuplicatedArguments;
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/Nethermind/Nethermind.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Runner/Program.cs
@@ -272,9 +272,9 @@ public static class Program
         }
     }
 
-    private static IEnumerable<ReadOnlyMemory<char>> GetDuplicateArguments(string[] args)
+    private static IEnumerable<ReadOnlyMemory<char>> GetDuplicateArguments(IEnumerable<ReadOnlyMemory<char>> argumentsNames)
     {
-        return GetArgumentNames(args).GroupBy(n => n, new MemoryContentsComparer<char>())
+        return argumentsNames.GroupBy(n => n, new MemoryContentsComparer<char>())
             .Where(g => g.Count() > 1)
             .Select(g => g.Key);
     }
@@ -604,7 +604,7 @@ public static class Program
             }
         }
 
-        string duplicateArgumentsList = string.Join(", ", GetDuplicateArguments(args));
+        string duplicateArgumentsList = string.Join(", ", GetDuplicateArguments(argumentsNamesProvided));
         if (!string.IsNullOrEmpty(duplicateArgumentsList))
         {
             _logger.Error($"Failed due to duplicated arguments - [{duplicateArgumentsList}] passed while execution");


### PR DESCRIPTION
Resolves https://github.com/NethermindEth/nethermind/issues/6942

## Changes
Changes made into `src/Nethermind/Nethermind.Runner/Program.cs`

- Add a function to load all possible flags/params/arguments to be used and put them on a hash
  - The hash is initialized with the default flags allowed in the app and not related to flags in config files
- Add a function to validate current args against the hash generated
- Call the validation function into `Run` so that we initialize the app and validate before start running most of the logic.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [X] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

I did not see any test file for Program.cs files

## Documentation

#### Requires documentation update

- [ ] Yes
- [X] No

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

## Remarks

I recorded a video showing how it works and the error log is displayed when the argument/option/flag used is not valid and when it is valid.
Also, the cases where no flag is provided and when a default app flag (like `--help`) is provided, and when we try using duplicate arguments

https://www.loom.com/share/0ac1011bac1247b992a9fbadba9e5b26?sid=eb48d13b-961e-490e-a1ff-5fe51a2580b0

List of commands used:
```
# Should work
./publish/nethermind --help

# Should work
./publish/nethermind -v

# Should work
./publish/nethermind

# Should work
./publish/nethermind --JsonRpc.WebSocketsPort 8546

# Duplicate argument error
./publish/nethermind --JsonRpc.WebSocketsPort 8546 --JsonRpc.WebSocketsPort 8546

# Unrecognized argument error
./publish/nethermind --JsonRpc.WebsocketsPort 8546
```

