### PR TITLE
Memoize Keccaks

### DIFF
--- a/src/Nethermind/Nethermind.Core/Caching/ClockCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/ClockCache.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
 using Nethermind.Core.Threading;
@@ -74,7 +75,8 @@ public sealed class ClockCache<TKey, TValue>(int maxCapacity) : ClockCacheBase<T
             return false;
         }
 
-        int offset = _cacheMap.Count;
+        int offset = _count;
+        Debug.Assert(_cacheMap.Count == _count);
         if (FreeOffsets.Count > 0)
         {
             offset = FreeOffsets.Dequeue();
@@ -86,6 +88,8 @@ public sealed class ClockCache<TKey, TValue>(int maxCapacity) : ClockCacheBase<T
 
         _cacheMap[key] = new LruCacheItem(offset, val);
         KeyToOffset[offset] = key;
+        _count++;
+        Debug.Assert(_cacheMap.Count == _count);
 
         return true;
     }
@@ -93,7 +97,7 @@ public sealed class ClockCache<TKey, TValue>(int maxCapacity) : ClockCacheBase<T
     private int Replace(TKey key)
     {
         int position = Clock;
-        int max = _cacheMap.Count;
+        int max = _count;
         while (true)
         {
             if (position >= max)
@@ -108,6 +112,7 @@ public sealed class ClockCache<TKey, TValue>(int maxCapacity) : ClockCacheBase<T
                 {
                     ThrowInvalidOperationException();
                 }
+                _count--;
                 break;
             }
 
@@ -132,6 +137,7 @@ public sealed class ClockCache<TKey, TValue>(int maxCapacity) : ClockCacheBase<T
 
         if (_cacheMap.Remove(key, out LruCacheItem? ov))
         {
+            _count--;
             KeyToOffset[ov.Offset] = default;
             ClearAccessed(ov.Offset);
             FreeOffsets.Enqueue(ov.Offset);
@@ -157,7 +163,7 @@ public sealed class ClockCache<TKey, TValue>(int maxCapacity) : ClockCacheBase<T
         return _cacheMap.ContainsKey(key);
     }
 
-    public int Count => _cacheMap.Count;
+    public int Count => _count;
 
     private class LruCacheItem(int offset, TValue v)
     {

--- a/src/Nethermind/Nethermind.Core/Caching/ClockCacheBase.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/ClockCacheBase.cs
@@ -21,6 +21,8 @@ public abstract class ClockCacheBase<TKey>
     protected Queue<int> FreeOffsets { get; } = new();
 
     protected int Clock { get; set; } = 0;
+    // Use local count to avoid lock contention with reads on ConcurrentDictionary.Count
+    protected int _count = 0;
 
     protected ClockCacheBase(int maxCapacity)
     {
@@ -35,6 +37,7 @@ public abstract class ClockCacheBase<TKey>
     {
         if (MaxCapacity == 0) return;
 
+        _count = 0;
         Clock = 0;
         FreeOffsets.Clear();
         KeyToOffset.AsSpan().Clear();

--- a/src/Nethermind/Nethermind.Core/Caching/ClockKeyCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/ClockKeyCache.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
 using Nethermind.Core.Threading;
@@ -51,7 +52,8 @@ public sealed class ClockKeyCache<TKey>(int maxCapacity) : ClockCacheBase<TKey>(
             return false;
         }
 
-        offset = _cacheMap.Count;
+        offset = _count;
+        Debug.Assert(_cacheMap.Count == _count);
         if (FreeOffsets.Count > 0)
         {
             offset = FreeOffsets.Dequeue();
@@ -63,6 +65,8 @@ public sealed class ClockKeyCache<TKey>(int maxCapacity) : ClockCacheBase<TKey>(
 
         _cacheMap[key] = offset;
         KeyToOffset[offset] = key;
+        _count++;
+        Debug.Assert(_cacheMap.Count == _count);
 
         return true;
     }
@@ -70,7 +74,7 @@ public sealed class ClockKeyCache<TKey>(int maxCapacity) : ClockCacheBase<TKey>(
     private int Replace(TKey key)
     {
         int position = Clock;
-        int max = _cacheMap.Count;
+        int max = _count;
         while (true)
         {
             if (position >= max)
@@ -85,6 +89,7 @@ public sealed class ClockKeyCache<TKey>(int maxCapacity) : ClockCacheBase<TKey>(
                 {
                     ThrowInvalidOperationException();
                 }
+                _count--;
                 break;
             }
 
@@ -108,6 +113,7 @@ public sealed class ClockKeyCache<TKey>(int maxCapacity) : ClockCacheBase<TKey>(
 
         if (_cacheMap.Remove(key, out int offset))
         {
+            _count--;
             ClearAccessed(offset);
             FreeOffsets.Enqueue(offset);
             return true;
@@ -131,5 +137,5 @@ public sealed class ClockKeyCache<TKey>(int maxCapacity) : ClockCacheBase<TKey>(
         return _cacheMap.ContainsKey(key);
     }
 
-    public int Count => _cacheMap.Count;
+    public int Count => _count;
 }

--- a/src/Nethermind/Nethermind.Core/Caching/LruCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/LruCache.cs
@@ -25,7 +25,7 @@ namespace Nethermind.Core.Caching
             _name = name;
             _maxCapacity = maxCapacity;
             _cacheMap = typeof(TKey) == typeof(byte[])
-                ? new Dictionary<TKey, LinkedListNode<LruCacheItem>>((IEqualityComparer<TKey>)Bytes.EqualityComparer)
+                ? new Dictionary<TKey, LinkedListNode<LruCacheItem>>((IEqualityComparer<TKey>)(object)Bytes.EqualityComparer)
                 : new Dictionary<TKey, LinkedListNode<LruCacheItem>>(startCapacity); // do not initialize it at the full capacity
         }
 

--- a/src/Nethermind/Nethermind.Core/Caching/LruKeyCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/LruKeyCache.cs
@@ -22,7 +22,7 @@ namespace Nethermind.Core.Caching
             _maxCapacity = maxCapacity;
             _name = name ?? throw new ArgumentNullException(nameof(name));
             _cacheMap = typeof(TKey) == typeof(byte[])
-                ? new Dictionary<TKey, LinkedListNode<TKey>>((IEqualityComparer<TKey>)Bytes.EqualityComparer)
+                ? new Dictionary<TKey, LinkedListNode<TKey>>((IEqualityComparer<TKey>)(object)Bytes.EqualityComparer)
                 : new Dictionary<TKey, LinkedListNode<TKey>>(startCapacity); // do not initialize it at the full capacity
         }
 

--- a/src/Nethermind/Nethermind.Core/Crypto/Keccak.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/Keccak.cs
@@ -5,6 +5,8 @@ using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Nethermind.Core.Caching;
+using Nethermind.Core.Extensions;
 
 namespace Nethermind.Core.Crypto
 {
@@ -12,10 +14,11 @@ namespace Nethermind.Core.Crypto
     [DebuggerDisplay("{ToString()}")]
     public static class ValueKeccak
     {
+        private static readonly HashCache _cache = new();
         /// <returns>
         ///     <string>0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470</string>
         /// </returns>
-        public static readonly ValueHash256 OfAnEmptyString = InternalCompute(Array.Empty<byte>());
+        public static readonly ValueHash256 OfAnEmptyString = new("0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470");
 
         /// <returns>
         ///     <string>0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347</string>
@@ -48,6 +51,17 @@ namespace Nethermind.Core.Crypto
             return InternalCompute(System.Text.Encoding.UTF8.GetBytes(input));
         }
 
+        private readonly struct BytesWrapper(byte[] bytes) : IEquatable<BytesWrapper>
+        {
+            internal readonly byte[] _bytes = bytes;
+            public static implicit operator BytesWrapper(byte[] bytes) => new(bytes);
+            public static implicit operator BytesWrapper(ReadOnlySpan<byte> bytes) => new(bytes.ToArray());
+            public bool Equals(BytesWrapper other) => Bytes.EqualityComparer.Equals(_bytes, other._bytes);
+            public override bool Equals(object? obj) => obj is BytesWrapper other && Equals(other);
+            public override int GetHashCode() => Bytes.EqualityComparer.GetHashCode(_bytes);
+        }
+
+        [SkipLocalsInit]
         [DebuggerStepThrough]
         public static ValueHash256 Compute(ReadOnlySpan<byte> input)
         {
@@ -56,16 +70,72 @@ namespace Nethermind.Core.Crypto
                 return OfAnEmptyString;
             }
 
-            Unsafe.SkipInit(out ValueHash256 keccak);
-            KeccakHash.ComputeHashBytesToSpan(input, MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref keccak, 1)));
-            return keccak;
+            Unsafe.SkipInit(out ValueHash256 hash);
+            Unsafe.SkipInit(out BytesWrapper cacheKey);
+            if (input.Length <= 32)
+            {
+                cacheKey = input;
+                if (_cache.TryGet(cacheKey, out hash)) return hash;
+            }
+
+            KeccakHash.ComputeHashBytesToSpan(input, MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref hash, 1)));
+            if (input.Length <= 32)
+            {
+                _cache.Set(cacheKey, hash);
+            }
+            return hash;
         }
 
         internal static ValueHash256 InternalCompute(byte[] input)
         {
-            Unsafe.SkipInit(out ValueHash256 keccak);
-            KeccakHash.ComputeHashBytesToSpan(input, MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref keccak, 1)));
-            return keccak;
+            if (input is null || input.Length == 0)
+            {
+                return OfAnEmptyString;
+            }
+
+            Unsafe.SkipInit(out ValueHash256 hash);
+            if (input.Length <= 32 && _cache.TryGet(input, out hash))
+            {
+                return hash;
+            }
+
+            KeccakHash.ComputeHashBytesToSpan(input, MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref hash, 1)));
+            if (input.Length <= 32)
+            {
+                _cache.Set(input, hash);
+            }
+            return hash;
+        }
+
+        private sealed class HashCache
+        {
+            private const int CacheCount = 16;
+            private const int CacheMax = CacheCount - 1;
+            private readonly ClockCache<BytesWrapper, ValueHash256>[] _caches;
+
+            public HashCache()
+            {
+                _caches = new ClockCache<BytesWrapper, ValueHash256>[CacheCount];
+                for (int i = 0; i < _caches.Length; i++)
+                {
+                    // Cache per nibble to reduce contention as is very parallel
+                    _caches[i] = new ClockCache<BytesWrapper, ValueHash256>(4096);
+                }
+            }
+
+            public bool Set(BytesWrapper bytes, in ValueHash256 hash)
+            {
+                ClockCache<BytesWrapper, ValueHash256> cache = _caches[GetCacheIndex(bytes)];
+                return cache.Set(bytes, hash);
+            }
+
+            private static int GetCacheIndex(BytesWrapper bytes) => bytes._bytes[^1] & CacheMax;
+
+            public bool TryGet(BytesWrapper bytes, out ValueHash256 hash)
+            {
+                ClockCache<BytesWrapper, ValueHash256> cache = _caches[GetCacheIndex(bytes)];
+                return cache.TryGet(bytes, out hash);
+            }
         }
     }
 
@@ -82,17 +152,17 @@ namespace Nethermind.Core.Crypto
         /// <returns>
         ///     <string>0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470</string>
         /// </returns>
-        public static readonly Hash256 OfAnEmptyString = new Hash256(ValueKeccak.InternalCompute(Array.Empty<byte>()));
+        public static readonly Hash256 OfAnEmptyString = new(ValueKeccak.OfAnEmptyString);
 
         /// <returns>
         ///     <string>0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347</string>
         /// </returns>
-        public static readonly Hash256 OfAnEmptySequenceRlp = new Hash256(ValueKeccak.InternalCompute([192]));
+        public static readonly Hash256 OfAnEmptySequenceRlp = new(ValueKeccak.OfAnEmptySequenceRlp);
 
         /// <summary>
         ///     0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421
         /// </summary>
-        public static Hash256 EmptyTreeHash = new Hash256(ValueKeccak.InternalCompute([128]));
+        public static Hash256 EmptyTreeHash = new(ValueKeccak.EmptyTreeHash);
 
         /// <returns>
         ///     <string>0x0000000000000000000000000000000000000000000000000000000000000000</string>

--- a/src/Nethermind/Nethermind.State/StorageTree.cs
+++ b/src/Nethermind/Nethermind.State/StorageTree.cs
@@ -51,7 +51,7 @@ namespace Nethermind.State
         [ThreadStatic]
         private static byte[] _key;
         private static byte[] GetKeyArray() => _key ??= new byte[32];
-        
+
         [SkipLocalsInit]
         private static Span<byte> ComputeKey(in UInt256 index)
         {


### PR DESCRIPTION
Follow up to https://github.com/NethermindEth/nethermind/pull/7328

## Changes

- Memoize Keccaks (.Length <= 32)
    - 16 way partitioned ClockCache (LRU); partitioned to reduce contention (adds are frequent)
    - Though very random same Keccak can be used multiple times, whether from
      - Parallel tx exectuions (same code run twice)
      - Multiple use of same contract keccak(address)
      - Same slot across many contracts in solidity mapping i.e. keccak(slot)
- Reduce ClockCache contention
   - Calling ConcurrentDictionary.Count takes locks and causes contention on read side
   - Use local count that is only changed when have write lock anyway
- More variance in Bytes GetHashCode

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No