### PR TITLE
Reduce contention in ClockCache

### DIFF
--- a/src/Nethermind/Nethermind.Core/Caching/ClockCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/ClockCache.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
 using Nethermind.Core.Threading;
@@ -74,7 +75,8 @@ public sealed class ClockCache<TKey, TValue>(int maxCapacity) : ClockCacheBase<T
             return false;
         }
 
-        int offset = _cacheMap.Count;
+        int offset = _count;
+        Debug.Assert(_cacheMap.Count == _count);
         if (FreeOffsets.Count > 0)
         {
             offset = FreeOffsets.Dequeue();
@@ -86,6 +88,8 @@ public sealed class ClockCache<TKey, TValue>(int maxCapacity) : ClockCacheBase<T
 
         _cacheMap[key] = new LruCacheItem(offset, val);
         KeyToOffset[offset] = key;
+        _count++;
+        Debug.Assert(_cacheMap.Count == _count);
 
         return true;
     }
@@ -93,7 +97,7 @@ public sealed class ClockCache<TKey, TValue>(int maxCapacity) : ClockCacheBase<T
     private int Replace(TKey key)
     {
         int position = Clock;
-        int max = _cacheMap.Count;
+        int max = _count;
         while (true)
         {
             if (position >= max)
@@ -108,6 +112,7 @@ public sealed class ClockCache<TKey, TValue>(int maxCapacity) : ClockCacheBase<T
                 {
                     ThrowInvalidOperationException();
                 }
+                _count--;
                 break;
             }
 
@@ -132,6 +137,7 @@ public sealed class ClockCache<TKey, TValue>(int maxCapacity) : ClockCacheBase<T
 
         if (_cacheMap.Remove(key, out LruCacheItem? ov))
         {
+            _count--;
             KeyToOffset[ov.Offset] = default;
             ClearAccessed(ov.Offset);
             FreeOffsets.Enqueue(ov.Offset);
@@ -157,7 +163,7 @@ public sealed class ClockCache<TKey, TValue>(int maxCapacity) : ClockCacheBase<T
         return _cacheMap.ContainsKey(key);
     }
 
-    public int Count => _cacheMap.Count;
+    public int Count => _count;
 
     private class LruCacheItem(int offset, TValue v)
     {

--- a/src/Nethermind/Nethermind.Core/Caching/ClockCacheBase.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/ClockCacheBase.cs
@@ -21,6 +21,8 @@ public abstract class ClockCacheBase<TKey>
     protected Queue<int> FreeOffsets { get; } = new();
 
     protected int Clock { get; set; } = 0;
+    // Use local count to avoid lock contention with reads on ConcurrentDictionary.Count
+    protected int _count = 0;
 
     protected ClockCacheBase(int maxCapacity)
     {
@@ -35,6 +37,7 @@ public abstract class ClockCacheBase<TKey>
     {
         if (MaxCapacity == 0) return;
 
+        _count = 0;
         Clock = 0;
         FreeOffsets.Clear();
         KeyToOffset.AsSpan().Clear();

--- a/src/Nethermind/Nethermind.Core/Caching/ClockKeyCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/ClockKeyCache.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
 using Nethermind.Core.Threading;
@@ -51,7 +52,8 @@ public sealed class ClockKeyCache<TKey>(int maxCapacity) : ClockCacheBase<TKey>(
             return false;
         }
 
-        offset = _cacheMap.Count;
+        offset = _count;
+        Debug.Assert(_cacheMap.Count == _count);
         if (FreeOffsets.Count > 0)
         {
             offset = FreeOffsets.Dequeue();
@@ -63,6 +65,8 @@ public sealed class ClockKeyCache<TKey>(int maxCapacity) : ClockCacheBase<TKey>(
 
         _cacheMap[key] = offset;
         KeyToOffset[offset] = key;
+        _count++;
+        Debug.Assert(_cacheMap.Count == _count);
 
         return true;
     }
@@ -70,7 +74,7 @@ public sealed class ClockKeyCache<TKey>(int maxCapacity) : ClockCacheBase<TKey>(
     private int Replace(TKey key)
     {
         int position = Clock;
-        int max = _cacheMap.Count;
+        int max = _count;
         while (true)
         {
             if (position >= max)
@@ -85,6 +89,7 @@ public sealed class ClockKeyCache<TKey>(int maxCapacity) : ClockCacheBase<TKey>(
                 {
                     ThrowInvalidOperationException();
                 }
+                _count--;
                 break;
             }
 
@@ -108,6 +113,7 @@ public sealed class ClockKeyCache<TKey>(int maxCapacity) : ClockCacheBase<TKey>(
 
         if (_cacheMap.Remove(key, out int offset))
         {
+            _count--;
             ClearAccessed(offset);
             FreeOffsets.Enqueue(offset);
             return true;
@@ -131,5 +137,5 @@ public sealed class ClockKeyCache<TKey>(int maxCapacity) : ClockCacheBase<TKey>(
         return _cacheMap.ContainsKey(key);
     }
 
-    public int Count => _cacheMap.Count;
+    public int Count => _count;
 }


### PR DESCRIPTION
## Changes

- Reduce ClockCache contention
   - Calling ConcurrentDictionary.Count takes locks and causes contention on read side
   - Use local count that is only changed when have write lock anyway

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
