### PR TITLE
LoadFromTree improve tracing closure name

### DIFF
--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -60,12 +60,7 @@ namespace Nethermind.State
             _storageTreeFactory = storageTreeFactory ?? new StorageTreeFactory();
             _preBlockCache = preBlockCache;
             _populatePreBlockCache = populatePreBlockCache;
-            _loadFromTree = storageCell =>
-            {
-                StorageTree tree = GetOrCreateStorage(storageCell.Address);
-                Db.Metrics.IncrementStorageTreeReads();
-                return !storageCell.IsHash ? tree.Get(storageCell.Index) : tree.GetArray(storageCell.Hash.Bytes);
-            };
+            _loadFromTree = LoadFromTreeStorage;
         }
 
         public Hash256 StateRoot { get; set; } = null!;
@@ -415,6 +410,13 @@ namespace Nethermind.State
                 value = _loadFromTree(storageCell);
             }
             return value;
+        }
+
+        private byte[] LoadFromTreeStorage(StorageCell storageCell)
+        {
+            StorageTree tree = GetOrCreateStorage(storageCell.Address);
+            Db.Metrics.IncrementStorageTreeReads();
+            return !storageCell.IsHash ? tree.Get(storageCell.Index) : tree.GetArray(storageCell.Hash.Bytes);
         }
 
         private void PushToRegistryOnly(in StorageCell cell, byte[] value)


### PR DESCRIPTION
## Changes

- Set `_loadFromTree` `Func<StorageCell, byte[]>` to method rather than lambda so it shows up in tracing as `LoadFromTreeStorage(StorageCell)` rather than `<.ctor>b__11_0(StorageCell)`

Before

<img width="548" alt="image" src="https://github.com/user-attachments/assets/dbcb8f86-2d66-4987-a11c-3f43086fb56c">

After 
<img width="539" alt="image" src="https://github.com/user-attachments/assets/fc863bb0-4880-4629-a88c-ec420549bdcd">


## Types of changes

#### What types of changes does your code introduce?

- [x] Refactoring

## Testing

#### Requires testing

- [x] No
