### PR TITLE
Add dual array concat overload

### DIFF
--- a/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
@@ -277,6 +277,14 @@ namespace Nethermind.Core.Extensions
             return result;
         }
 
+        public static byte[] Concat(byte[] part1, byte[] part2)
+        {
+            byte[] result = new byte[part1.Length + part2.Length];
+            part1.CopyTo(result, 0);
+            part2.CopyTo(result.AsSpan(part1.Length));
+            return result;
+        }
+
         public static byte[] Concat(params byte[][] parts)
         {
             int totalLength = 0;


### PR DESCRIPTION

## Changes

- Add dual array overload vs `params byte[][]` where it uses two for loops. Is used by 17 call sites

<img width="421" alt="image" src="https://github.com/user-attachments/assets/9029f149-f9de-43bd-a795-70e0569d5389">


## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
