### PR TITLE
Add EOFTest CLI Support

### DIFF
--- a/src/Nethermind/Ethereum.Test.Base/Interfaces/IEofTestRunner.cs
+++ b/src/Nethermind/Ethereum.Test.Base/Interfaces/IEofTestRunner.cs
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Generic;
+
+namespace Ethereum.Test.Base.Interfaces
+{
+    public interface IEofTestRunner
+    {
+        IEnumerable<EthereumTestResult> RunTests();
+    }
+}

--- a/src/Nethermind/Ethereum.Test.Base/LoadEofTestsFileStrategy.cs
+++ b/src/Nethermind/Ethereum.Test.Base/LoadEofTestsFileStrategy.cs
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Ethereum.Test.Base.Interfaces;
+
+namespace Ethereum.Test.Base
+{
+    public class LoadEofTestFileStrategy : ITestLoadStrategy
+    {
+        public IEnumerable<IEthereumTest> Load(string testName, string? wildcard = null)
+        {
+            //in case user wants to give a test file other than the ones in ethereum tests submodule
+            if (File.Exists(testName))
+            {
+                FileTestsSource fileTestsSource = new(testName, wildcard);
+                IEnumerable<EofTest> tests = fileTestsSource.LoadEofTests();
+
+                return tests;
+            }
+
+            string testsDirectory = GetEofTestsDirectory();
+
+            IEnumerable<string> testFiles = Directory.EnumerateFiles(testsDirectory, testName, SearchOption.AllDirectories);
+
+            List<EofTest> eofTests = new();
+
+            //load all tests from found test files in ethereum tests submodule
+            foreach (string testFile in testFiles)
+            {
+                FileTestsSource fileTestsSource = new(testFile, wildcard);
+                try
+                {
+                    IEnumerable<EofTest> tests = fileTestsSource.LoadEofTests();
+
+                    eofTests.AddRange(tests);
+                }
+                catch (Exception e)
+                {
+                    eofTests.Add(new EofTest() { Name = testFile, LoadFailure = $"Failed to load: {e}" });
+                }
+            }
+
+            return eofTests;
+        }
+
+        private string GetEofTestsDirectory()
+        {
+            string currentDirectory = AppDomain.CurrentDomain.BaseDirectory;
+
+            return Path.Combine(currentDirectory.Remove(currentDirectory.LastIndexOf("src")), "src", "tests", "EOFTests");
+        }
+    }
+}

--- a/src/Nethermind/EthereumTests.sln
+++ b/src/Nethermind/EthereumTests.sln
@@ -115,6 +115,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nethermind.Synchronization"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nethermind.Sockets", "Nethermind.Sockets\Nethermind.Sockets.csproj", "{E9D67F92-D848-4DB3-A586-2AC6DE2A3933}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nethermind.EOFParse.Runner", "Nethermind.EOFParse.Runner\Nethermind.EOFParse.Runner.csproj", "{47773DCF-2892-4F87-993F-1A0912CC6420}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -341,6 +343,10 @@ Global
 		{E9D67F92-D848-4DB3-A586-2AC6DE2A3933}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E9D67F92-D848-4DB3-A586-2AC6DE2A3933}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E9D67F92-D848-4DB3-A586-2AC6DE2A3933}.Release|Any CPU.Build.0 = Release|Any CPU
+		{47773DCF-2892-4F87-993F-1A0912CC6420}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{47773DCF-2892-4F87-993F-1A0912CC6420}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{47773DCF-2892-4F87-993F-1A0912CC6420}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{47773DCF-2892-4F87-993F-1A0912CC6420}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Nethermind/Nethermind.EOFParse.Runner/Nethermind.EOFParse.Runner.csproj
+++ b/src/Nethermind/Nethermind.EOFParse.Runner/Nethermind.EOFParse.Runner.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AssemblyName>netheofparse</AssemblyName>
+    <Nullable>annotations</Nullable>
+    <PublishReadyToRun>true</PublishReadyToRun>
+    <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
+    <EnableUnsafeBinaryFormatterSerialization>false</EnableUnsafeBinaryFormatterSerialization>
+    <EnableUnsafeUTF7Encoding>false</EnableUnsafeUTF7Encoding>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommandLineParser"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Nethermind.Evm\Nethermind.Evm.csproj"/>
+    <ProjectReference Include="..\Nethermind.Specs\Nethermind.Specs.csproj"/>
+  </ItemGroup>
+
+</Project>

--- a/src/Nethermind/Nethermind.EOFParse.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.EOFParse.Runner/Program.cs
@@ -2,7 +2,7 @@ using System;
 using System.Linq;
 using CommandLine;
 using Nethermind.Core.Extensions;
-using Nethermind.Evm.EOF;
+using Nethermind.Evm.EvmObjectFormat;
 
 namespace Nethermind.EOFParse.Runner
 {
@@ -44,13 +44,13 @@ namespace Nethermind.EOFParse.Runner
                     var bytecode = Bytes.FromHexString(input);
                     try
                     {
-                        var validationResult = EvmObjectFormat.IsValidEof(bytecode,
-                            EvmObjectFormat.ValidationStrategy.ValidateRuntimeMode, out EofHeader? header);
+                        var validationResult = EofValidator.IsValidEof(bytecode, ValidationStrategy.ValidateRuntimeMode,
+                            out EofContainer? header);
                         if (validationResult)
                         {
-                            var sectionCount = header.Value.CodeSections.Size;
-                            var subcontainerCount = header.Value.ContainerSections?.Size ?? 0;
-                            var dataCount = header.Value.DataSection.Size;
+                            var sectionCount = header.Value.CodeSections.Length;
+                            var subcontainerCount = header.Value.ContainerSections?.Length ?? 0;
+                            var dataCount = header.Value.DataSection.Length;
                             Console.WriteLine($"OK {sectionCount}/{subcontainerCount}/{dataCount}");
                         }
                         else

--- a/src/Nethermind/Nethermind.EOFParse.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.EOFParse.Runner/Program.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Linq;
+using CommandLine;
+using Nethermind.Core.Extensions;
+using Nethermind.Evm.EOF;
+
+namespace Nethermind.EOFParse.Runner
+{
+    internal class Program
+    {
+        public class Options
+        {
+            [Option('i', "input", Required = false,
+                HelpText = "Raw eof input")]
+            public string Input { get; set; }
+
+            [Option('x', "stdin", Required = false,
+                HelpText =
+                    "Interactive testing mode.")]
+            public bool Stdin { get; set; }
+        }
+
+        public static void Main(params string[] args)
+        {
+            ParserResult<Options> result = Parser.Default.ParseArguments<Options>(args);
+            if (result is Parsed<Options> options)
+                Run(options.Value);
+        }
+
+        private static void Run(Options options)
+        {
+            string input = options.Input;
+            if (options.Stdin || input?.Length == 0)
+            {
+                input = Console.ReadLine();
+            }
+
+            while (!string.IsNullOrWhiteSpace(input))
+            {
+                if (!input.StartsWith('#'))
+                {
+                    input = new string(input.Where(c => char.IsLetterOrDigit(c)).ToArray());
+
+                    var bytecode = Bytes.FromHexString(input);
+                    try
+                    {
+                        var validationResult = EvmObjectFormat.IsValidEof(bytecode,
+                            EvmObjectFormat.ValidationStrategy.ValidateRuntimeMode, out EofHeader? header);
+                        if (validationResult)
+                        {
+                            var sectionCount = header.Value.CodeSections.Size;
+                            var subcontainerCount = header.Value.ContainerSections?.Size ?? 0;
+                            var dataCount = header.Value.DataSection.Size;
+                            Console.WriteLine($"OK {sectionCount}/{subcontainerCount}/{dataCount}");
+                        }
+                        else
+                        {
+                            Console.WriteLine($"err: unknown");
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        Console.WriteLine($"err: {e.Message}");
+                    }
+
+
+                    if (!options.Stdin)
+                        break;
+                }
+
+                input = Console.ReadLine();
+            }
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.EOFParse.Runner/Properties/launchSettings.json
+++ b/src/Nethermind/Nethermind.EOFParse.Runner/Properties/launchSettings.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "Valid": {
+      "commandName": "Project",
+      "commandLineArgs": "-i ef00010100040200010006040000000080000260006000fe00"
+    },
+    "Invalid": {
+      "commandName": "Project",
+      "commandLineArgs": "-i ef000101000402000100010400000000800000c0"
+    },
+    "Console": {
+      "commandName": "Project",
+      "commandLineArgs": "-x"
+    },
+    "no args": {
+      "commandName": "Project",
+      "commandLineArgs": ""
+    }
+  }
+}

--- a/src/Nethermind/Nethermind.Test.Runner/EofTestsRunner.cs
+++ b/src/Nethermind/Nethermind.Test.Runner/EofTestsRunner.cs
@@ -1,4 +1,4 @@
- // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
@@ -32,7 +32,7 @@ public class EofTestsRunner(ITestSourceLoader testsSource, string? filter) : Eof
             }
             else
             {
-                var result = new EthereumTestResult(test.Name, "Prague", RunTest(test)) ;
+                var result = new EthereumTestResult(test.Name, "Prague", RunTest(test));
                 testResults.Add(result);
                 if (result.Pass)
                     WriteGreen("PASS");

--- a/src/Nethermind/Nethermind.Test.Runner/EofTestsRunner.cs
+++ b/src/Nethermind/Nethermind.Test.Runner/EofTestsRunner.cs
@@ -1,0 +1,60 @@
+ // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using Ethereum.Test.Base;
+using Ethereum.Test.Base.Interfaces;
+
+namespace Nethermind.Test.Runner;
+
+public class EofTestsRunner(ITestSourceLoader testsSource, string? filter) : EofTestBase, IEofTestRunner
+{
+    private readonly ConsoleColor _defaultColour = Console.ForegroundColor;
+    private readonly ITestSourceLoader _testsSource = testsSource ?? throw new ArgumentNullException(nameof(testsSource));
+
+    public IEnumerable<EthereumTestResult> RunTests()
+    {
+        List<EthereumTestResult> testResults = new();
+        var tests = (IEnumerable<EofTest>)_testsSource.LoadTests();
+        foreach (EofTest test in tests)
+        {
+            if (filter is not null && !Regex.Match(test.Name, $"^({filter})").Success)
+                continue;
+            Setup();
+
+            Console.Write($"{test.Name,-120} ");
+            if (test.LoadFailure is not null)
+            {
+                WriteRed(test.LoadFailure);
+                testResults.Add(new EthereumTestResult(test.Name, test.LoadFailure));
+            }
+            else
+            {
+                var result = new EthereumTestResult(test.Name, "Prague", RunTest(test)) ;
+                testResults.Add(result);
+                if (result.Pass)
+                    WriteGreen("PASS");
+                else
+                    WriteRed("FAIL");
+            }
+        }
+
+        return testResults;
+    }
+
+    private void WriteRed(string text)
+    {
+        Console.ForegroundColor = ConsoleColor.Red;
+        Console.WriteLine(text);
+        Console.ForegroundColor = _defaultColour;
+    }
+
+    private void WriteGreen(string text)
+    {
+        Console.ForegroundColor = ConsoleColor.Green;
+        Console.WriteLine(text);
+        Console.ForegroundColor = _defaultColour;
+    }
+}

--- a/src/Nethermind/Nethermind.Test.Runner/Nethermind.Test.Runner.csproj
+++ b/src/Nethermind/Nethermind.Test.Runner/Nethermind.Test.Runner.csproj
@@ -26,6 +26,9 @@
     <Content Include="blockchainTest1.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="eoftest1.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="statetest1.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/src/Nethermind/Nethermind.Test.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Test.Runner/Program.cs
@@ -23,6 +23,9 @@ namespace Nethermind.Test.Runner
             [Option('b', "blockTest", Required = false, HelpText = "Set test as blockTest. if not, it will be by default assumed a state test.")]
             public bool BlockTest { get; set; }
 
+            [Option('e', "eofTest", Required = false, HelpText = "Set test as eofTest. if not, it will be by default assumed a state test.")]
+            public bool EofTest { get; set; }
+
             [Option('t', "trace", Required = false, HelpText = "Set to always trace (by default traces are only generated for failing tests). [Only for State Test]")]
             public bool TraceAlways { get; set; }
 
@@ -64,8 +67,11 @@ namespace Nethermind.Test.Runner
 
             while (!string.IsNullOrWhiteSpace(input))
             {
+
                 if (options.BlockTest)
                     await RunBlockTest(input, source => new BlockchainTestsRunner(source, options.Filter));
+                else if (options.EofTest)
+                    RunEofTest(input, source => new EofTestsRunner(source, options.Filter));
                 else
                     RunStateTest(input, source => new StateTestsRunner(source, whenTrace, !options.ExcludeMemory, !options.ExcludeStack, options.Filter));
                 if (!options.Stdin)
@@ -84,6 +90,14 @@ namespace Nethermind.Test.Runner
                 ? new TestsSourceLoader(new LoadBlockchainTestFileStrategy(), path)
                 : new TestsSourceLoader(new LoadBlockchainTestsStrategy(), path);
             await testRunnerBuilder(source).RunTestsAsync();
+        }
+
+        private static void RunEofTest(string path, Func<ITestSourceLoader, IEofTestRunner> testRunnerBuilder)
+        {
+            ITestSourceLoader source = Path.HasExtension(path)
+                ? new TestsSourceLoader(new LoadEofTestFileStrategy(), path)
+                : new TestsSourceLoader(new LoadEofTestsStrategy(), path);
+            testRunnerBuilder(source).RunTests();
         }
 
         private static void RunStateTest(string path, Func<ITestSourceLoader, IStateTestRunner> testRunnerBuilder)

--- a/src/Nethermind/Nethermind.Test.Runner/Properties/launchSettings.json
+++ b/src/Nethermind/Nethermind.Test.Runner/Properties/launchSettings.json
@@ -8,6 +8,10 @@
       "commandName": "Project",
       "commandLineArgs": "-b -i blockchainTest1.json"
     },
+    "EOF Test": {
+      "commandName": "Project",
+      "commandLineArgs": "-e -i eoftest1.json"
+    },
     "Regex State Test": {
       "commandName": "Project",
       "commandLineArgs": "-i statetest1.json -f \"randomStatetestmartin-Wed_10_02_29-14338-([0-9]+)\""

--- a/src/Nethermind/Nethermind.Test.Runner/eoftest1.json
+++ b/src/Nethermind/Nethermind.Test.Runner/eoftest1.json
@@ -1,0 +1,23 @@
+{
+  "tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_eof_example.py::test_eof_example[fork_CancunEIP7692-eof_test]": {
+    "vectors": {
+      "0": {
+        "code": "0xef0001010010020004000500060008000204000100008000010100000100010003020300035fe300010050e3000250e43080e300035050e480e4ef",
+        "results": {
+          "Prague": {
+            "result": true
+          }
+        }
+      }
+    },
+    "_info": {
+      "hash": "0xf91c0d32c0e59772417a3e223b57590c91593cb17369253549b946f971c5fcbf",
+      "comment": "`execution-spec-tests` generated test",
+      "filling-transition-tool": "evmone-t8n 0.12.0-6+commit.2d20cc63.dirty",
+      "description": "Test function documentation:\n\n    Example of python EOF classes",
+      "url": "https://github.com/ethereum/execution-spec-tests/blob/99d4c17de5888bb5343c767ef34b2735d2469770/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_eof_example.py#L19",
+      "reference-spec": "https://github.com/ethereum/EIPs/blob/master/EIPS/eip-3540.md",
+      "reference-spec-version": "8dcb0a8c1c0102c87224308028632cc986a61183"
+    }
+  }
+}


### PR DESCRIPTION
## Changes

EEST would very much benefit from a CLI launchable EOF fixtures test.

Here are two CLIs on top of @Demuirgos's EOF test work
(1) adds a -e option to `nethtest` to test a EOFTest
(2) adds a new standalone `netheofparse` CLI to participate in [eofparse](https://github.com/holiman/txparse?tab=readme-ov-file#eof-parser-eofparse) fuzzing.

## Types of changes

#### What types of changes does your code introduce?

- [x] New feature (a non-breaking change that adds functionality)
## Testing

#### Requires testing

- [ ] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [ ] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
