### PR TITLE
Fix frequent warning on invalid Discovery packet size

### DIFF
--- a/src/Nethermind/Nethermind.Network.Discovery/NettyDiscoveryBaseHandler.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/NettyDiscoveryBaseHandler.cs
@@ -30,9 +30,11 @@ public abstract class NettyDiscoveryBaseHandler : SimpleChannelInboundHandler<Da
 
     protected bool ValidatePacket(DatagramPacket packet)
     {
+        // Potential cases where this can happen:
+        // - Neighbors response containing 16+ nodes in a single packet
         if (packet.Content.ReadableBytes is 0 or > MaxPacketSize)
         {
-            if (_logger.IsWarn) _logger.Warn($"Skipping discovery packet of invalid size: {packet.Content.ReadableBytes}");
+            if (_logger.IsDebug) _logger.Debug($"Skipping discovery packet of invalid size: {packet.Content.ReadableBytes}");
             return false;
         }
 

--- a/src/Nethermind/Nethermind.Network.Discovery/NettyDiscoveryHandler.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/NettyDiscoveryHandler.cs
@@ -83,7 +83,7 @@ public class NettyDiscoveryHandler : NettyDiscoveryBaseHandler, IMsgSender
         int size = msgBuffer.ReadableBytes;
         if (size > MaxPacketSize)
         {
-            if (_logger.IsWarn) _logger.Warn($"Attempting to send message larger than 1280 bytes. This is out of spec and may not work for all client. Msg: ${discoveryMsg}");
+            if (_logger.IsWarn) _logger.Warn($"Attempting to send message larger than 1280 bytes. This is out of spec and may not work for all clients. Msg: ${discoveryMsg}");
         }
 
         if (discoveryMsg is PingMsg pingMessage)


### PR DESCRIPTION
Fixes frequent warning on invalid Discovery packet size in some cases.

## Changes

- Reduced "invalid incoming packet size" log level to Debug.
- Fixed typo.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
