### PR TITLE
Eof/valdiation fixes

### DIFF
--- a/src/Nethermind/Ethereum.Blockchain.Pyspec.Test/PragueEofTests.cs
+++ b/src/Nethermind/Ethereum.Blockchain.Pyspec.Test/PragueEofTests.cs
@@ -13,7 +13,7 @@ namespace Ethereum.Blockchain.Pyspec.Test;
 public class PragueEofTests : EofTestBase
 {
     [TestCaseSource(nameof(LoadTests))]
-    public void Test(EofTest test) => RunTest(test);
+    public void Test(EofTest test) => Assert.That(RunTest(test));
 
     private static IEnumerable<EofTest> LoadTests()
     {

--- a/src/Nethermind/Nethermind.Evm/EvmObjectFormat/EofCodeValidator.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmObjectFormat/EofCodeValidator.cs
@@ -52,7 +52,7 @@ public static class EofValidator
     {
         if (IsEof(code, out byte version) && _eofVersionHandlers.TryGetValue(version, out IEofVersionHandler handler))
         {
-            return handler.TryParseEofHeader(code, out header);
+            return handler.TryParseEofHeader(code, ValidationStrategy.Validate, out header);
         }
 
         header = null;

--- a/src/Nethermind/Nethermind.Evm/EvmObjectFormat/Handlers/EofV1.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmObjectFormat/Handlers/EofV1.cs
@@ -252,6 +252,12 @@ internal class Eof1 : IEofVersionHandler
                         return false;
                     }
 
+                    if (sectionSizes.DataSectionSize is not null)
+                    {
+                        if (Logger.IsTrace) Logger.Trace($"EOF: Eof{VERSION}, Container section is out of order");
+                        return false;
+                    }
+
                     if (container.Length < pos + EofValidator.TWO_BYTE_LENGTH)
                     {
                         if (Logger.IsTrace) Logger.Trace($"EOF: Eof{VERSION}, Code is too small to be valid code");

--- a/src/Nethermind/Nethermind.Evm/EvmObjectFormat/Handlers/EofV1.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmObjectFormat/Handlers/EofV1.cs
@@ -167,6 +167,12 @@ internal class Eof1 : IEofVersionHandler
             switch (separator)
             {
                 case Separator.KIND_TYPE:
+                    if (sectionSizes.TypeSectionSize != null)
+                    {
+                        if (Logger.IsTrace) Logger.Trace($"EOF: Eof{VERSION}, Multiple type sections");
+                        return false;
+                    }
+
                     if (container.Length < pos + EofValidator.TWO_BYTE_LENGTH)
                     {
                         if (Logger.IsTrace) Logger.Trace($"EOF: Eof{VERSION}, Code is too small to be valid code");
@@ -183,6 +189,12 @@ internal class Eof1 : IEofVersionHandler
                     pos += EofValidator.TWO_BYTE_LENGTH;
                     break;
                 case Separator.KIND_CODE:
+                    if (sectionSizes.CodeSectionSize != null)
+                    {
+                        if (Logger.IsTrace) Logger.Trace($"EOF: Eof{VERSION}, Multiple code sections");
+                        return false;
+                    }
+
                     if (sectionSizes.TypeSectionSize is null)
                     {
                         if (Logger.IsTrace) Logger.Trace($"EOF: Eof{VERSION}, Code is not well fromated");
@@ -228,6 +240,12 @@ internal class Eof1 : IEofVersionHandler
                     pos += EofValidator.TWO_BYTE_LENGTH + EofValidator.TWO_BYTE_LENGTH * numberOfCodeSections;
                     break;
                 case Separator.KIND_CONTAINER:
+                    if (sectionSizes.ContainerSectionSize != null)
+                    {
+                        if (Logger.IsTrace) Logger.Trace($"EOF: Eof{VERSION}, Multiple container sections");
+                        return false;
+                    }
+
                     if (sectionSizes.CodeSectionSize is null)
                     {
                         if (Logger.IsTrace) Logger.Trace($"EOF: Eof{VERSION}, Code is not well fromated");
@@ -273,6 +291,12 @@ internal class Eof1 : IEofVersionHandler
                     pos += EofValidator.TWO_BYTE_LENGTH + EofValidator.TWO_BYTE_LENGTH * numberOfContainerSections;
                     break;
                 case Separator.KIND_DATA:
+                    if (sectionSizes.DataSectionSize != null)
+                    {
+                        if (Logger.IsTrace) Logger.Trace($"EOF: Eof{VERSION}, Multiple data sections");
+                        return false;
+                    }
+
                     if (sectionSizes.CodeSectionSize is null)
                     {
                         if (Logger.IsTrace) Logger.Trace($"EOF: Eof{VERSION}, Code is not well fromated");

--- a/src/Nethermind/Nethermind.Evm/EvmObjectFormat/Handlers/EofV1.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmObjectFormat/Handlers/EofV1.cs
@@ -316,6 +316,12 @@ internal class Eof1 : IEofVersionHandler
             : new CompoundSectionHeader(codeSectionSubHeader.EndOffset, containerSections);
         var dataSectionSubHeader = new SectionHeader(containerSectionSubHeader?.EndOffset ?? codeSectionSubHeader.EndOffset, sectionSizes.DataSectionSize.Value);
 
+        if (dataSectionSubHeader.EndOffset < containerMemory.Length)
+        {
+            if (Logger.IsTrace) Logger.Trace($"EOF: Eof{VERSION}, Extra data after end of container, starting at {dataSectionSubHeader.EndOffset}");
+            return false;
+        }
+
         header = new EofHeader
         {
             Version = VERSION,

--- a/src/Nethermind/Nethermind.Evm/EvmObjectFormat/IEofVersionHandler.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmObjectFormat/IEofVersionHandler.cs
@@ -7,6 +7,6 @@ using System.Diagnostics.CodeAnalysis;
 namespace Nethermind.Evm.EvmObjectFormat;
 interface IEofVersionHandler
 {
-    bool TryParseEofHeader(ReadOnlyMemory<byte> code, [NotNullWhen(true)] out EofHeader? header);
+    bool TryParseEofHeader(ReadOnlyMemory<byte> code, ValidationStrategy strategy, [NotNullWhen(true)] out EofHeader? header);
     bool TryGetEofContainer(ReadOnlyMemory<byte> code, ValidationStrategy strategy, [NotNullWhen(true)] out EofContainer? header);
 }

--- a/src/Nethermind/Nethermind.Evm/Instruction.cs
+++ b/src/Nethermind/Nethermind.Evm/Instruction.cs
@@ -195,7 +195,7 @@ namespace Nethermind.Evm
         EXCHANGE = 0xe8, // random value opcode spec has collision
         RETURNDATALOAD = 0xf7,
 
-        // opcode value not spec-ed 
+        // opcode value not spec-ed
         EXTCALL = 0xf8,
         EXTDELEGATECALL = 0xf9, // DelegateCallEnabled
         EXTSTATICCALL = 0xfb, // StaticCallEnabled
@@ -240,6 +240,7 @@ namespace Nethermind.Evm
                 Instruction.CALL => !IsEofContext,
                 Instruction.CALLCODE => !IsEofContext,
                 Instruction.DELEGATECALL => !IsEofContext,
+                Instruction.STATICCALL => !IsEofContext,
                 Instruction.SELFDESTRUCT => !IsEofContext,
                 Instruction.JUMP => !IsEofContext,
                 Instruction.JUMPI => !IsEofContext,
@@ -255,7 +256,7 @@ namespace Nethermind.Evm
             };
         }
 
-        //Note() : Extensively test this, refactor it, 
+        //Note() : Extensively test this, refactor it,
         public static (ushort? InputCount, ushort? OutputCount, ushort? immediates) StackRequirements(this Instruction instruction) => instruction switch
         {
             Instruction.STOP => (0, 0, 0),


### PR DESCRIPTION
## Changes

Fixes several small EOF validation testing failures

* Types of changes
* Don't allow out of order subcontainer header
* Require full length data header except in EOFCREATE usage.
* Don't allow repeat header sections
* Reject containers with excess data
* Check container sizes
* Require code sections to end with terminal operator
* Prohibit STATICALL in EOF container code

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

Testing is handled by Ethereum Execution Specification Tests, which are in an external repo.
