### PR TITLE
Reduce memory use during Archive Sync

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Receipts/PersistentReceiptStorageTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Receipts/PersistentReceiptStorageTests.cs
@@ -58,6 +58,12 @@ namespace Nethermind.Blockchain.Test.Receipts
             CreateStorage();
         }
 
+        [TearDown]
+        public void TearDown()
+        {
+            _receiptsDb.Dispose();
+        }
+
         private void CreateStorage()
         {
             _decoder = new ReceiptArrayStorageDecoder(_useCompactReceipts);

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
@@ -6,15 +6,16 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Runtime;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Find;
-using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Core.Attributes;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
+using Nethermind.Core.Memory;
 using Nethermind.Evm.Tracing;
 using Nethermind.Evm.Tracing.GethStyle;
 using Nethermind.Evm.Tracing.ParityStyle;
@@ -295,12 +296,25 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
 
     private void RunProcessingLoop()
     {
+        const int BlocksBacklogTriggeringManualGC = 20;
+        const int MaxBlocksWithoutGC = 100;
+
         if (_logger.IsDebug) _logger.Debug($"Starting block processor - {_blockQueue.Count} blocks waiting in the queue.");
 
         FireProcessingQueueEmpty();
 
+        var fireGC = false;
+        var countToGC = 0;
         foreach (BlockRef blockRef in _blockQueue.GetConsumingEnumerable(_loopCancellationSource.Token))
         {
+            if (!fireGC && _blockQueue.Count > BlocksBacklogTriggeringManualGC)
+            {
+                // Long chains in archive sync don't force GC and don't call MallocTrim;
+                // so we trigger it manually
+                fireGC = true;
+                countToGC = MaxBlocksWithoutGC;
+            }
+
             try
             {
                 if (blockRef.IsInDb || blockRef.Block is null)
@@ -338,9 +352,27 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
 
             if (_logger.IsTrace) _logger.Trace($"Now {_blockQueue.Count} blocks waiting in the queue.");
             FireProcessingQueueEmpty();
+
+            if (fireGC)
+            {
+                countToGC--;
+                if (countToGC <= 0)
+                {
+                    fireGC = false;
+                    PerformFullGC();
+                }
+            }
         }
 
         if (_logger.IsInfo) _logger.Info("Block processor queue stopped.");
+    }
+
+    private void PerformFullGC()
+    {
+        if (_logger.IsDebug) _logger.Debug($"Performing Full GC");
+        GCSettings.LargeObjectHeapCompactionMode = GCLargeObjectHeapCompactionMode.CompactOnce;
+        System.GC.Collect(2, GCCollectionMode.Aggressive, blocking: true, compacting: true);
+        MallocHelper.Instance.MallocTrim((uint)1.MiB());
     }
 
     private void FireProcessingQueueEmpty()

--- a/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
@@ -442,6 +442,8 @@ public class TestBlockchain : IDisposable
         {
             CodeDb?.Dispose();
             StateDb?.Dispose();
+            DbProvider.BlobTransactionsDb?.Dispose();
+            DbProvider.ReceiptsDb?.Dispose();
         }
 
         _trieStoreWatcher?.Dispose();

--- a/src/Nethermind/Nethermind.Core.Test/TestMemColumnDb.cs
+++ b/src/Nethermind/Nethermind.Core.Test/TestMemColumnDb.cs
@@ -30,4 +30,5 @@ public class TestMemColumnsDb<TKey> : IColumnsDb<TKey>
     {
         return new InMemoryColumnWriteBatch<TKey>(this);
     }
+    public void Dispose() { }
 }

--- a/src/Nethermind/Nethermind.Db.Rpc/RpcColumnsDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rpc/RpcColumnsDb.cs
@@ -45,5 +45,6 @@ namespace Nethermind.Db.Rpc
         {
             return new InMemoryColumnWriteBatch<T>(this);
         }
+        public void Dispose() { }
     }
 }

--- a/src/Nethermind/Nethermind.Db/IColumnsDb.cs
+++ b/src/Nethermind/Nethermind.Db/IColumnsDb.cs
@@ -7,7 +7,7 @@ using Nethermind.Core;
 
 namespace Nethermind.Db
 {
-    public interface IColumnsDb<TKey> : IDbMeta
+    public interface IColumnsDb<TKey> : IDbMeta, IDisposable
     {
         IDb GetColumnDb(TKey key);
         IEnumerable<TKey> ColumnKeys { get; }

--- a/src/Nethermind/Nethermind.Db/MemColumnsDb.cs
+++ b/src/Nethermind/Nethermind.Db/MemColumnsDb.cs
@@ -35,5 +35,6 @@ namespace Nethermind.Db
         {
             return new InMemoryColumnWriteBatch<TKey>(this);
         }
+        public void Dispose() { }
     }
 }

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -104,7 +104,7 @@ namespace Nethermind.State
                 {
                     if (stack.TryGetSearchedItem(snapshot, out int lastChangeIndexBeforeOriginalSnapshot))
                     {
-                        return _changes[lastChangeIndexBeforeOriginalSnapshot]!.Value;
+                        return _changes[lastChangeIndexBeforeOriginalSnapshot].Value;
                     }
                 }
             }
@@ -112,7 +112,7 @@ namespace Nethermind.State
             return value;
         }
 
-
+        private HashSet<AddressAsKey>? _tempToUpdateRoots;
         /// <summary>
         /// Called by Commit
         /// Used for persistent storage specific logic
@@ -127,12 +127,12 @@ namespace Nethermind.State
             {
                 return;
             }
-            if (_changes[currentPosition] is null)
+            if (_changes[currentPosition].IsNull)
             {
                 throw new InvalidOperationException($"Change at current position {currentPosition} was null when committing {nameof(PartialStorageProviderBase)}");
             }
 
-            HashSet<Address> toUpdateRoots = new();
+            HashSet<AddressAsKey> toUpdateRoots = (_tempToUpdateRoots ??= new());
 
             bool isTracing = tracer.IsTracingStorage;
             Dictionary<StorageCell, ChangeTrace>? trace = null;
@@ -202,7 +202,7 @@ namespace Nethermind.State
                 }
             }
 
-            foreach (Address address in toUpdateRoots)
+            foreach (AddressAsKey address in toUpdateRoots)
             {
                 // since the accounts could be empty accounts that are removing (EIP-158)
                 if (_stateProvider.AccountExists(address))
@@ -215,6 +215,7 @@ namespace Nethermind.State
                     _storages.Remove(address);
                 }
             }
+            toUpdateRoots.Clear();
 
             base.CommitCore(tracer);
             _originalValues.Clear();
@@ -288,7 +289,7 @@ namespace Nethermind.State
             }
         }
 
-        private void SaveToTree(HashSet<Address> toUpdateRoots, Change change)
+        private void SaveToTree(HashSet<AddressAsKey> toUpdateRoots, Change change)
         {
             if (_originalValues.TryGetValue(change.StorageCell, out byte[] initialValue) &&
                 initialValue.AsSpan().SequenceEqual(change.Value))

--- a/src/Nethermind/Nethermind.State/StateProvider.cs
+++ b/src/Nethermind/Nethermind.State/StateProvider.cs
@@ -186,7 +186,7 @@ namespace Nethermind.State
             {
                 // this also works like this in Geth (they don't follow the spec ¯\_(*~*)_/¯)
                 // however we don't do it because of a consensus issue with Geth, just to avoid
-                // hitting non-existing account when substractin Zero-value from the sender
+                // hitting non-existing account when subtracting Zero-value from the sender
                 if (releaseSpec.IsEip158Enabled && !isSubtracting)
                 {
                     Account touched = GetThroughCacheCheckExists();

--- a/src/Nethermind/Nethermind.State/StateProvider.cs
+++ b/src/Nethermind/Nethermind.State/StateProvider.cs
@@ -37,7 +37,7 @@ namespace Nethermind.State
         private readonly ILogger _logger;
         private readonly IKeyValueStore _codeDb;
 
-        private List<Change?> _changes = new(Resettable.StartCapacity);
+        private List<Change> _changes = new(Resettable.StartCapacity);
         internal readonly StateTree _tree;
         private readonly Func<AddressAsKey, Account> _getStateFromTrie;
 
@@ -348,12 +348,12 @@ namespace Nethermind.State
                         }
 
                         _keptInCache.Add(change);
-                        _changes[actualPosition] = null;
+                        _changes[actualPosition] = default;
                         continue;
                     }
                 }
 
-                _changes[currentPosition - i] = null; // TODO: temp, ???
+                _changes[currentPosition - i] = default; // TODO: temp, ???
                 int forChecking = stack.Pop();
                 if (forChecking != currentPosition - i)
                 {
@@ -439,7 +439,7 @@ namespace Nethermind.State
             }
 
             if (_logger.IsTrace) _logger.Trace($"Committing state changes (at {currentPosition})");
-            if (_changes[currentPosition] is null)
+            if (_changes[currentPosition].IsNull)
             {
                 throw new InvalidOperationException($"Change at current position {currentPosition} was null when committing {nameof(StateProvider)}");
             }
@@ -735,7 +735,7 @@ namespace Nethermind.State
         {
             if (_intraTxCache.TryGetValue(address, out Stack<int> value))
             {
-                return _changes[value.Peek()]!.Account;
+                return _changes[value.Peek()].Account;
             }
 
             Account account = GetAndAddToCache(address);
@@ -796,6 +796,7 @@ namespace Nethermind.State
 
         private enum ChangeType
         {
+            Null = 0,
             JustCache,
             Touch,
             Update,
@@ -803,7 +804,7 @@ namespace Nethermind.State
             Delete
         }
 
-        private class Change
+        private readonly struct Change
         {
             public Change(ChangeType type, Address address, Account? account)
             {
@@ -812,9 +813,11 @@ namespace Nethermind.State
                 Account = account;
             }
 
-            public ChangeType ChangeType { get; }
-            public Address Address { get; }
-            public Account? Account { get; }
+            public readonly ChangeType ChangeType;
+            public readonly Address Address;
+            public readonly Account? Account;
+
+            public bool IsNull => ChangeType == ChangeType.Null;
         }
 
         public ArrayPoolList<AddressAsKey>? ChangedAddresses()

--- a/src/Nethermind/Nethermind.Trie/PreCachedTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/PreCachedTrieStore.cs
@@ -88,7 +88,7 @@ public class PreCachedTrieStore : ITrieStore
     public INodeStorage.KeyScheme Scheme => _inner.Scheme;
 }
 
-public class NodeKey : IEquatable<NodeKey>
+public readonly struct NodeKey : IEquatable<NodeKey>
 {
     public readonly Hash256? Address;
     public readonly TreePath Path;
@@ -108,8 +108,8 @@ public class NodeKey : IEquatable<NodeKey>
         Hash = hash;
     }
 
-    public bool Equals(NodeKey? other) =>
-        other is not null && Address == other.Address && Path.Equals(in other.Path) && Hash.Equals(other.Hash);
+    public bool Equals(NodeKey other) =>
+        Address == other.Address && Path.Equals(in other.Path) && Hash.Equals(other.Hash);
 
     public override bool Equals(object? obj) => obj is NodeKey key && Equals(key);
 

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -286,7 +286,7 @@ namespace Nethermind.Trie.Pruning
 
         // Track ALL of the recently re-committed persisted nodes. This is so that we don't accidentally remove
         // recommitted persisted nodes (which will not get re-persisted).
-        private readonly ConcurrentDictionary<HashAndTinyPathAndHash, long> _persistedLastSeen = new(CollectionExtensions.LockPartitions, 4 * 4096);
+        private readonly ConcurrentDictionary<HashAndTinyPathAndHash, long>? _persistedLastSeen;
 
         private bool _lastPersistedReachedReorgBoundary;
         private Task _pruningTask = Task.CompletedTask;
@@ -323,6 +323,10 @@ namespace Nethermind.Trie.Pruning
             _dirtyNodes = new DirtyNodesCache(this);
             _publicStore = new TrieKeyValueStore(this);
 
+            if (pruningStrategy.PruningEnabled)
+            {
+                _persistedLastSeen = new(CollectionExtensions.LockPartitions, 4 * 4096);
+            }
             if (pruningStrategy.TrackedPastKeyCount > 0 && nodeStorage.RequirePath)
             {
                 _pastPathHash = new(pruningStrategy.TrackedPastKeyCount);

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -34,6 +34,9 @@ namespace Nethermind.Trie.Pruning
         {
             private readonly TrieStore _trieStore;
             private readonly bool _storeByHash;
+            private readonly ConcurrentDictionary<Key, TrieNode> _byKeyObjectCache;
+            private readonly ConcurrentDictionary<Hash256AsKey, TrieNode> _byHashObjectCache;
+
             public readonly long KeyMemoryUsage;
 
             public DirtyNodesCache(TrieStore trieStore)
@@ -42,6 +45,15 @@ namespace Nethermind.Trie.Pruning
                 // If the nodestore indicated that path is not required,
                 // we will use a map with hash as its key instead of the full Key to reduce memory usage.
                 _storeByHash = !trieStore._nodeStorage.RequirePath;
+                int initialBuckets = HashHelpers.GetPrime(Math.Max(31, Environment.ProcessorCount * 16));
+                if (_storeByHash)
+                {
+                    _byHashObjectCache = new(CollectionExtensions.LockPartitions, initialBuckets);
+                }
+                else
+                {
+                    _byKeyObjectCache = new(CollectionExtensions.LockPartitions, initialBuckets);
+                }
                 KeyMemoryUsage = _storeByHash ? 0 : Key.MemoryUsage; // 0 because previously it was not counted.
             }
 
@@ -110,11 +122,6 @@ namespace Nethermind.Trie.Pruning
                     _trieStore._logger.Trace($"Creating new node {trieNode}");
                 }
             }
-
-            private static readonly int _initialBuckets = HashHelpers.GetPrime(Math.Max(31, Environment.ProcessorCount * 16));
-
-            private readonly ConcurrentDictionary<Key, TrieNode> _byKeyObjectCache = new(CollectionExtensions.LockPartitions, _initialBuckets);
-            private readonly ConcurrentDictionary<Hash256AsKey, TrieNode> _byHashObjectCache = new(CollectionExtensions.LockPartitions, _initialBuckets);
 
             public bool IsNodeCached(in Key key)
             {
@@ -278,7 +285,16 @@ namespace Nethermind.Trie.Pruning
 
         private INodeStorage.WriteBatch? _currentBatch = null;
 
-        private readonly DirtyNodesCache _dirtyNodes;
+        private DirtyNodesCache? _dirtyNodes;
+        private DirtyNodesCache DirtyNodes => _dirtyNodes ?? CreateCacheAtomic(ref _dirtyNodes);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private DirtyNodesCache CreateCacheAtomic(ref DirtyNodesCache val)
+        {
+            DirtyNodesCache instance = new(this);
+            DirtyNodesCache? prior = Interlocked.CompareExchange(ref val, instance, null);
+            return prior ?? instance;
+        }
 
         // Track some of the persisted path hash. Used to be able to remove keys when it is replaced.
         // If null, disable removing key.
@@ -288,6 +304,7 @@ namespace Nethermind.Trie.Pruning
         // recommitted persisted nodes (which will not get re-persisted).
         private readonly ConcurrentDictionary<HashAndTinyPathAndHash, long>? _persistedLastSeen;
 
+        private ConcurrentDictionary<DirtyNodesCache.Key, bool>? _wasPersisted;
         private bool _lastPersistedReachedReorgBoundary;
         private Task _pruningTask = Task.CompletedTask;
         private readonly CancellationTokenSource _pruningTaskCancellationTokenSource = new();
@@ -320,20 +337,15 @@ namespace Nethermind.Trie.Pruning
             _nodeStorage = nodeStorage ?? throw new ArgumentNullException(nameof(nodeStorage));
             _pruningStrategy = pruningStrategy ?? throw new ArgumentNullException(nameof(pruningStrategy));
             _persistenceStrategy = persistenceStrategy ?? throw new ArgumentNullException(nameof(persistenceStrategy));
-            _dirtyNodes = new DirtyNodesCache(this);
             _publicStore = new TrieKeyValueStore(this);
 
             if (pruningStrategy.PruningEnabled)
             {
                 _persistedLastSeen = new(CollectionExtensions.LockPartitions, 4 * 4096);
-            }
-            if (pruningStrategy.TrackedPastKeyCount > 0 && nodeStorage.RequirePath)
-            {
-                _pastPathHash = new(pruningStrategy.TrackedPastKeyCount);
-            }
-            else
-            {
-                _pastPathHash = null;
+                if (pruningStrategy.TrackedPastKeyCount > 0 && nodeStorage.RequirePath)
+                {
+                    _pastPathHash = new(pruningStrategy.TrackedPastKeyCount);
+                }
             }
         }
 
@@ -390,8 +402,9 @@ namespace Nethermind.Trie.Pruning
         {
             get
             {
-                Metrics.CachedNodesCount = _dirtyNodes.Count;
-                return _dirtyNodes.Count;
+                int count = DirtyNodes.Count;
+                Metrics.CachedNodesCount = count;
+                return count;
             }
         }
 
@@ -464,7 +477,8 @@ namespace Nethermind.Trie.Pruning
             if (_pruningStrategy.PruningEnabled)
             {
                 DirtyNodesCache.Key key = new DirtyNodesCache.Key(address, nodeCommitInfo.Path, node.Keccak);
-                if (_dirtyNodes.TryGetValue(in key, out TrieNode cachedNodeCopy))
+                DirtyNodesCache cache = DirtyNodes;
+                if (cache.TryGetValue(in key, out TrieNode cachedNodeCopy))
                 {
                     Metrics.LoadedFromCacheNodesCount++;
                     if (!ReferenceEquals(cachedNodeCopy, node))
@@ -488,7 +502,7 @@ namespace Nethermind.Trie.Pruning
                 }
                 else
                 {
-                    _dirtyNodes.SaveInCache(key, node);
+                    cache.SaveInCache(key, node);
                 }
             }
 
@@ -518,7 +532,7 @@ namespace Nethermind.Trie.Pruning
             {
                 if (trieType == TrieType.State) // storage tries happen before state commits
                 {
-                    if (_logger.IsTrace) _logger.Trace($"Enqueued blocks {_commitSetQueue.Count}");
+                    if (_logger.IsTrace) _logger.Trace($"Enqueued blocks {_commitSetQueue?.Count ?? 0}");
                     BlockCommitSet set = CurrentPackage;
                     if (set is not null)
                     {
@@ -549,9 +563,10 @@ namespace Nethermind.Trie.Pruning
                     }
 
                     CurrentPackage = null;
-                    if (_pruningStrategy.PruningEnabled && Monitor.IsEntered(_dirtyNodes))
+                    DirtyNodesCache cache = DirtyNodes;
+                    if (_pruningStrategy.PruningEnabled && Monitor.IsEntered(cache))
                     {
-                        Monitor.Exit(_dirtyNodes);
+                        Monitor.Exit(cache);
                     }
                 }
             }
@@ -618,7 +633,7 @@ namespace Nethermind.Trie.Pruning
         public IReadOnlyTrieStore AsReadOnly(INodeStorage? store) =>
             new ReadOnlyTrieStore(this, store);
 
-        public bool IsNodeCached(Hash256? address, in TreePath path, Hash256? hash) => _dirtyNodes.IsNodeCached(new DirtyNodesCache.Key(address, path, hash));
+        public bool IsNodeCached(Hash256? address, in TreePath path, Hash256? hash) => DirtyNodes.IsNodeCached(new DirtyNodesCache.Key(address, path, hash));
 
         public virtual TrieNode FindCachedOrUnknown(Hash256? address, in TreePath path, Hash256? hash) =>
             FindCachedOrUnknown(address, path, hash, false);
@@ -638,10 +653,10 @@ namespace Nethermind.Trie.Pruning
 
         private TrieNode FindCachedOrUnknown(DirtyNodesCache.Key key, bool isReadOnly)
         {
-            return isReadOnly ? _dirtyNodes.FromCachedRlpOrUnknown(key) : _dirtyNodes.FindCachedOrUnknown(key);
+            return isReadOnly ? DirtyNodes.FromCachedRlpOrUnknown(key) : DirtyNodes.FindCachedOrUnknown(key);
         }
 
-        public void Dump() => _dirtyNodes.Dump();
+        public void Dump() => DirtyNodes.Dump();
 
         public void Prune()
         {
@@ -651,9 +666,10 @@ namespace Nethermind.Trie.Pruning
                 {
                     try
                     {
-                        lock (_dirtyNodes)
+                        DirtyNodesCache cache = DirtyNodes;
+                        lock (cache)
                         {
-                            using (_dirtyNodes.AcquireMapLock())
+                            using (cache.AcquireMapLock())
                             {
                                 Stopwatch sw = Stopwatch.StartNew();
                                 if (_logger.IsDebug) _logger.Debug($"Locked {nameof(TrieStore)} for pruning.");
@@ -700,8 +716,11 @@ namespace Nethermind.Trie.Pruning
             {
                 if (_logger.IsDebug) _logger.Debug("Elevated pruning starting");
 
-                using ArrayPoolList<BlockCommitSet> toAddBack = new(_commitSetQueue.Count);
-                using ArrayPoolList<BlockCommitSet> candidateSets = new(_commitSetQueue.Count);
+                int count = _commitSetQueue?.Count ?? 0;
+                if (count == 0) return false;
+
+                using ArrayPoolList<BlockCommitSet> toAddBack = new(count);
+                using ArrayPoolList<BlockCommitSet> candidateSets = new(count);
                 while (_commitSetQueue.TryDequeue(out BlockCommitSet frontSet))
                 {
                     if (frontSet!.BlockNumber >= LatestCommittedBlockNumber - _pruningStrategy.MaxDepth)
@@ -786,7 +805,7 @@ namespace Nethermind.Trie.Pruning
                 if (currentlyPersistingKeccak == keccak) return false;
 
                 // We have it in cache and it is still needed.
-                if (_dirtyNodes.TryGetValue(new DirtyNodesCache.Key(address, fullPath, keccak.ToCommitment()), out TrieNode node) &&
+                if (DirtyNodes.TryGetValue(new DirtyNodesCache.Key(address, fullPath, keccak.ToCommitment()), out TrieNode node) &&
                     !IsNoLongerNeeded(node)) return false;
 
                 // We don't have it in cache, but we know it was re-committed, so if it is still needed, don't remove
@@ -876,14 +895,15 @@ namespace Nethermind.Trie.Pruning
                 : null;
 
             long newMemory = 0;
+            DirtyNodesCache cache = DirtyNodes;
             ActionBlock<TrieNode> pruneAndRecalculateAction =
                 new ActionBlock<TrieNode>(node =>
                 {
                     node.PrunePersistedRecursively(1);
-                    Interlocked.Add(ref newMemory, node.GetMemorySize(false) + _dirtyNodes.KeyMemoryUsage);
+                    Interlocked.Add(ref newMemory, node.GetMemorySize(false) + cache.KeyMemoryUsage);
                 });
 
-            foreach ((DirtyNodesCache.Key key, TrieNode node) in (allNodes ?? _dirtyNodes.AllNodes))
+            foreach ((DirtyNodesCache.Key key, TrieNode node) in (allNodes ?? cache.AllNodes))
             {
                 if (node.IsPersisted)
                 {
@@ -903,7 +923,7 @@ namespace Nethermind.Trie.Pruning
 
                         node.Keccak = keccak;
                     }
-                    _dirtyNodes.Remove(key);
+                    cache.Remove(key);
 
                     Metrics.PrunedPersistedNodesCount++;
                 }
@@ -914,7 +934,7 @@ namespace Nethermind.Trie.Pruning
                     {
                         throw new InvalidOperationException($"Removed {node}");
                     }
-                    _dirtyNodes.Remove(key);
+                    cache.Remove(key);
 
                     Metrics.PrunedTransientNodesCount++;
                 }
@@ -930,7 +950,7 @@ namespace Nethermind.Trie.Pruning
             trackNodesAction?.Completion.Wait();
 
             if (!skipRecalculateMemory) MemoryUsedByDirtyCache = newMemory + (_persistedLastSeen?.Count ?? 0) * 48;
-            Metrics.CachedNodesCount = _dirtyNodes.Count;
+            Metrics.CachedNodesCount = cache.Count;
 
             stopwatch.Stop();
             if (_logger.IsDebug) _logger.Debug($"Finished pruning nodes in {stopwatch.ElapsedMilliseconds}ms {MemoryUsedByDirtyCache / 1.MB()} MB, last persisted block: {LastPersistedBlockNumber} current: {LatestCommittedBlockNumber}.");
@@ -960,7 +980,7 @@ namespace Nethermind.Trie.Pruning
         /// <summary>
         /// This method is here to support testing.
         /// </summary>
-        public void ClearCache() => _dirtyNodes.Clear();
+        public void ClearCache() => DirtyNodes.Clear();
 
         public void Dispose()
         {
@@ -975,8 +995,6 @@ namespace Nethermind.Trie.Pruning
             _pruningTask.Wait();
         }
 
-        #region Private
-
         protected readonly INodeStorage _nodeStorage;
 
         private readonly TrieKeyValueStore _publicStore;
@@ -987,7 +1005,7 @@ namespace Nethermind.Trie.Pruning
 
         private readonly ILogger _logger;
 
-        private readonly ConcurrentQueue<BlockCommitSet> _commitSetQueue = new();
+        private ConcurrentQueue<BlockCommitSet> _commitSetQueue;
 
         private long _memoryUsedByDirtyCache;
 
@@ -1004,6 +1022,14 @@ namespace Nethermind.Trie.Pruning
         private long LatestCommittedBlockNumber { get; set; }
         public INodeStorage.KeyScheme Scheme => _nodeStorage.Scheme;
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static ConcurrentQueue<BlockCommitSet> CreateQueueAtomic(ref ConcurrentQueue<BlockCommitSet> val)
+        {
+            ConcurrentQueue<BlockCommitSet> instance = new();
+            ConcurrentQueue<BlockCommitSet>? prior = Interlocked.CompareExchange(ref val, instance, null);
+            return prior ?? instance;
+        }
+
         private void CreateCommitSet(long blockNumber)
         {
             if (_logger.IsDebug) _logger.Debug($"Beginning new {nameof(BlockCommitSet)} - {blockNumber}");
@@ -1013,7 +1039,7 @@ namespace Nethermind.Trie.Pruning
             Debug.Assert(IsCurrentListSealed, "Not sealed when beginning new block");
 
             BlockCommitSet commitSet = new(blockNumber);
-            _commitSetQueue.Enqueue(commitSet);
+            (_commitSetQueue ?? CreateQueueAtomic(ref _commitSetQueue)).Enqueue(commitSet);
             LatestCommittedBlockNumber = Math.Max(blockNumber, LatestCommittedBlockNumber);
             AnnounceReorgBoundaries();
             DequeueOldCommitSets();
@@ -1113,6 +1139,8 @@ namespace Nethermind.Trie.Pruning
 
         private void DequeueOldCommitSets()
         {
+            if (_commitSetQueue?.IsEmpty ?? true) return;
+
             while (_commitSetQueue.TryPeek(out BlockCommitSet blockCommitSet))
             {
                 if (blockCommitSet.BlockNumber < LatestCommittedBlockNumber - _pruningStrategy.MaxDepth - 1)
@@ -1131,9 +1159,10 @@ namespace Nethermind.Trie.Pruning
         {
             if (CurrentPackage is null)
             {
-                if (_pruningStrategy.PruningEnabled && !Monitor.IsEntered(_dirtyNodes))
+                DirtyNodesCache cache = DirtyNodes;
+                if (_pruningStrategy.PruningEnabled && !Monitor.IsEntered(cache))
                 {
-                    Monitor.Enter(_dirtyNodes);
+                    Monitor.Enter(cache);
                 }
 
                 CreateCommitSet(blockNumber);
@@ -1184,6 +1213,7 @@ namespace Nethermind.Trie.Pruning
             // If we are in archive mode, we don't need to change reorg boundaries.
             if (_pruningStrategy.PruningEnabled)
             {
+                if (_commitSetQueue?.IsEmpty ?? true) return;
                 // here we try to shorten the number of blocks recalculated when restarting (so we force persist)
                 // and we need to speed up the standard announcement procedure so we persists a block
 
@@ -1222,12 +1252,8 @@ namespace Nethermind.Trie.Pruning
             }
         }
 
-        #endregion
-
-        ConcurrentDictionary<DirtyNodesCache.Key, bool>? _wasPersisted;
         public void PersistCache(CancellationToken cancellationToken)
         {
-
             if (_logger.IsInfo) _logger.Info($"Full Pruning Persist Cache started.");
 
             int commitSetCount = 0;
@@ -1253,23 +1279,27 @@ namespace Nethermind.Trie.Pruning
                 PruneCurrentSet();
             }
 
-            // We persist outside of lock first.
-            ClearCommitSetQueue();
+            if (!(_commitSetQueue?.IsEmpty ?? true))
+            {
+                // We persist outside of lock first.
+                ClearCommitSetQueue();
+            }
 
             if (_logger.IsInfo) _logger.Info($"Saving all commit set took {stopwatch.Elapsed} for {commitSetCount} commit sets.");
 
             stopwatch.Restart();
             ConcurrentDictionary<DirtyNodesCache.Key, bool> wasPersisted;
-            lock (_dirtyNodes)
+            DirtyNodesCache cache = DirtyNodes;
+            lock (cache)
             {
-                using (_dirtyNodes.AcquireMapLock())
+                using (cache.AcquireMapLock())
                 {
                     // Double check
                     ClearCommitSetQueue();
 
                     // This should clear most nodes. For some reason, not all.
                     PruneCache(skipRecalculateMemory: true);
-                    KeyValuePair<DirtyNodesCache.Key, TrieNode>[] nodesCopy = _dirtyNodes.AllNodes.ToArray();
+                    KeyValuePair<DirtyNodesCache.Key, TrieNode>[] nodesCopy = cache.AllNodes.ToArray();
 
                     wasPersisted = Interlocked.Exchange(ref _wasPersisted, null) ??
                         new(CollectionExtensions.LockPartitions, nodesCopy.Length);
@@ -1294,9 +1324,9 @@ namespace Nethermind.Trie.Pruning
                     });
                     PruneCache(allNodes: nodesCopy);
 
-                    if (_dirtyNodes.Count != 0)
+                    if (cache.Count != 0)
                     {
-                        if (_logger.IsWarn) _logger.Warn($"{_dirtyNodes.Count} cache entry remains.");
+                        if (_logger.IsWarn) _logger.Warn($"{cache.Count} cache entry remains.");
                     }
                 }
             }
@@ -1322,7 +1352,7 @@ namespace Nethermind.Trie.Pruning
         {
             Hash256 asHash = new Hash256(key);
             return _pruningStrategy.PruningEnabled
-                   && _dirtyNodes.TryGetValue(new DirtyNodesCache.Key(null, TreePath.Empty, asHash), out TrieNode? trieNode)
+                   && DirtyNodes.TryGetValue(new DirtyNodesCache.Key(null, TreePath.Empty, asHash), out TrieNode? trieNode)
                    && trieNode is not null
                    && trieNode.NodeType != NodeType.Unknown
                    && trieNode.FullRlp.IsNotNull

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -929,7 +929,7 @@ namespace Nethermind.Trie.Pruning
             pruneAndRecalculateAction.Completion.Wait();
             trackNodesAction?.Completion.Wait();
 
-            if (!skipRecalculateMemory) MemoryUsedByDirtyCache = newMemory + _persistedLastSeen.Count * 48;
+            if (!skipRecalculateMemory) MemoryUsedByDirtyCache = newMemory + (_persistedLastSeen?.Count ?? 0) * 48;
             Metrics.CachedNodesCount = _dirtyNodes.Count;
 
             stopwatch.Stop();


### PR DESCRIPTION
## Changes

- TxTries and ReceiptTries don't do any pruning so don't need the ConcurrentDictionaries allocated just for Calculating roots

<img width="468" alt="image" src="https://github.com/user-attachments/assets/8fa60162-705c-44ee-81f8-31584e985379">

- Lazy allocate ConcurrenctDictionaries (+DirtyNodes in Trie)
- Change class => struct
- NodeKey class => struct
- Force GCs on archive sync

Seen when processing archive nodes (many blocks at once)

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No