### PR TITLE
Use Reth's method of calculating MGas/s

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockchainProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockchainProcessorTests.cs
@@ -123,6 +123,16 @@ namespace Nethermind.Blockchain.Test
                 public event EventHandler<BlockEventArgs>? BlockProcessing;
 
                 public event EventHandler<BlockProcessedEventArgs>? BlockProcessed;
+                public event EventHandler<Block>? EvmProcessingStarted
+                {
+                    add { }
+                    remove { }
+                }
+                public event EventHandler<Block>? EvmProcessingComplete
+                {
+                    add { }
+                    remove { }
+                }
 
                 public event EventHandler<TxProcessedEventArgs>? TransactionProcessed
                 {

--- a/src/Nethermind/Nethermind.Consensus/Processing/IBlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/IBlockProcessor.cs
@@ -43,6 +43,16 @@ namespace Nethermind.Consensus.Processing
         event EventHandler<BlockProcessedEventArgs> BlockProcessed;
 
         /// <summary>
+        /// Fired when a block's transactions are been processed.
+        /// </summary>
+        event EventHandler<Block> EvmProcessingStarted;
+
+        /// <summary>
+        /// Fired after a block's transactions have been processed.
+        /// </summary>
+        event EventHandler<Block> EvmProcessingComplete;
+
+        /// <summary>
         /// Fired after a transaction has been processed (even if inside the block).
         /// </summary>
         event EventHandler<TxProcessedEventArgs> TransactionProcessed;

--- a/src/Nethermind/Nethermind.Consensus/Processing/NullBlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/NullBlockProcessor.cs
@@ -43,5 +43,15 @@ namespace Nethermind.Consensus.Processing
             add { }
             remove { }
         }
+        public event EventHandler<Block>? EvmProcessingStarted
+        {
+            add { }
+            remove { }
+        }
+        public event EventHandler<Block>? EvmProcessingComplete
+        {
+            add { }
+            remove { }
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
@@ -325,4 +325,14 @@ public class TestBlockProcessorInterceptor : IBlockProcessor
         add => _blockProcessorImplementation.TransactionProcessed += value;
         remove => _blockProcessorImplementation.TransactionProcessed -= value;
     }
+    public event EventHandler<Block>? EvmProcessingStarted
+    {
+        add => _blockProcessorImplementation.EvmProcessingStarted += value;
+        remove => _blockProcessorImplementation.EvmProcessingStarted -= value;
+    }
+    public event EventHandler<Block>? EvmProcessingComplete
+    {
+        add => _blockProcessorImplementation.EvmProcessingComplete += value;
+        remove => _blockProcessorImplementation.EvmProcessingComplete -= value;
+    }
 }


### PR DESCRIPTION
## Changes

- Measure Evm transaction processing time, rather than block end to end
- Is now "Evm throughput" in logs

<img width="778" alt="image" src="https://github.com/user-attachments/assets/6162dfb1-19cc-45b0-8cee-34904257721e">


## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No
