### PR TITLE
Eth get raw transaction by hash

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
@@ -381,6 +381,19 @@ public partial class EthRpcModule(
         return Task.FromResult(ResultWrapper<TransactionForRpc>.Success(transactionModel));
     }
 
+    public Task<ResultWrapper<>> eth_getRawTransactionByHash(Hash256 transactionHash)
+    {
+        Task<ResultWrapper<TransactionForRpc>> transactionDataTask = Task.FromResult(eth_getTransactionByHash(transactionHash));
+
+        if (transactionDataTask.Result == null){
+            return Task.FromResult(ResultWrapper<string>.Success(null));
+        }
+
+        ResultWrapper<TransactionForRpc> transactionData = transactionDataTask.Result; 
+
+
+    }
+
     public ResultWrapper<TransactionForRpc[]> eth_pendingTransactions()
     {
         Transaction[] transactions = _txPool.GetPendingTransactions();


### PR DESCRIPTION
Fixes Closes Resolves #7370


## Changes

- A new method to get the raw transaction details from transaction hash. 
- The method first gets the Transaction object from _blockchain.getTransaction method (same as eth_getTransactionByHash).
- Then, it converts the hex string values to bytes array for relevant fields (v, r, s, from, to, nonce). 
- RLP Encodes the bytes array. 
- Will implement a way to convert rlp encoded output to hex string (need to confirm if there is an existing way to do that). 
- finally, it will return the string. 

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Will do once the implementation is finalized. 

## Documentation

#### Requires documentation update

- [x] Yes
- [ ] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

_If yes, fill in the details here. Remove if not applicable._

