### PR TITLE
Precompile: return out of gas rather than throwing exception

### DIFF
--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -189,7 +189,7 @@ internal sealed class VirtualMachine<TLogger> : IVirtualMachine where TLogger : 
 
                     callResult = ExecutePrecompile(currentState, spec);
 
-                    if (callResult.IsException || !callResult.PrecompileSuccess.Value)
+                    if (!callResult.PrecompileSuccess.Value)
                     {
                         if (currentState.IsPrecompile && currentState.IsTopLevel)
                         {
@@ -578,7 +578,7 @@ internal sealed class VirtualMachine<TLogger> : IVirtualMachine where TLogger : 
 
         if (!UpdateGas(checked(baseGasCost + blobGasCost), ref gasAvailable))
         {
-            return CallResult.OutOfGasException;
+            return new CallResult(default, precompileSuccess: false, shouldRevert: true, EvmExceptionType.OutOfGas);
         }
 
         state.GasAvailable = gasAvailable;

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -189,7 +189,7 @@ internal sealed class VirtualMachine<TLogger> : IVirtualMachine where TLogger : 
 
                     callResult = ExecutePrecompile(currentState, spec);
 
-                    if (!callResult.PrecompileSuccess.Value)
+                    if (callResult.IsException || !callResult.PrecompileSuccess.Value)
                     {
                         if (currentState.IsPrecompile && currentState.IsTopLevel)
                         {
@@ -578,8 +578,7 @@ internal sealed class VirtualMachine<TLogger> : IVirtualMachine where TLogger : 
 
         if (!UpdateGas(checked(baseGasCost + blobGasCost), ref gasAvailable))
         {
-            Metrics.EvmExceptions++;
-            throw new OutOfGasException();
+            return CallResult.OutOfGasException;
         }
 
         state.GasAvailable = gasAvailable;


### PR DESCRIPTION
## Changes

- Precompile: return out of gas rather than throwing exception

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No