### PR TITLE
EXTCODESIZE+POP

### DIFF
--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -1261,6 +1261,14 @@ internal sealed class VirtualMachine<TLogger> : IVirtualMachine where TLogger : 
                         {
                             bool optimizeAccess = false;
                             Instruction nextInstruction = (Instruction)code[programCounter];
+                            // Thrown away result
+                            if (nextInstruction == Instruction.POP)
+                            {
+                                programCounter++;
+                                // Add gas cost for POP
+                                gasAvailable -= GasCostOf.VeryLow;
+                                break;
+                            }
                             // code.length is zero
                             if (nextInstruction == Instruction.ISZERO)
                             {

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -1266,7 +1266,7 @@ internal sealed class VirtualMachine<TLogger> : IVirtualMachine where TLogger : 
                             {
                                 programCounter++;
                                 // Add gas cost for POP
-                                gasAvailable -= GasCostOf.VeryLow;
+                                gasAvailable -= GasCostOf.Base;
                                 break;
                             }
                             // code.length is zero


### PR DESCRIPTION
## Changes

- EXTCODESIZE+POP => NOP; is a common pattern on a large patch of blocks in archive sync (Think it was an exploit). However don't actually need to access any data in this combination.

<img width="469" alt="image" src="https://github.com/user-attachments/assets/42cb1b78-8bba-46bd-a44f-49bbec188bbc">


## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No