### PR TITLE
Recheck if empty under lock, early exit

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
@@ -19,7 +19,7 @@ using Nethermind.Core.Eip2930;
 
 namespace Nethermind.Consensus.Processing;
 
-public class BlockCachePreWarmer(ReadOnlyTxProcessingEnvFactory envFactory, ISpecProvider specProvider, ILogManager logManager, IWorldState? targetWorldState = null) : IBlockCachePreWarmer
+public sealed class BlockCachePreWarmer(ReadOnlyTxProcessingEnvFactory envFactory, ISpecProvider specProvider, ILogManager logManager, PreBlockCaches? preBlockCaches = null) : IBlockCachePreWarmer
 {
     private readonly ObjectPool<IReadOnlyTxProcessorSource> _envPool = new DefaultObjectPool<IReadOnlyTxProcessorSource>(new ReadOnlyTxProcessingEnvPooledObjectPolicy(envFactory), Environment.ProcessorCount);
     private readonly ObjectPool<SystemTransaction> _systemTransactionPool = new DefaultObjectPool<SystemTransaction>(new DefaultPooledObjectPolicy<SystemTransaction>(), Environment.ProcessorCount);
@@ -27,9 +27,9 @@ public class BlockCachePreWarmer(ReadOnlyTxProcessingEnvFactory envFactory, ISpe
 
     public Task PreWarmCaches(Block suggestedBlock, Hash256? parentStateRoot, AccessList? systemTxAccessList, CancellationToken cancellationToken = default)
     {
-        if (targetWorldState is not null)
+        if (preBlockCaches is not null)
         {
-            if (targetWorldState.ClearCache())
+            if (preBlockCaches.ClearCaches())
             {
                 if (_logger.IsWarn) _logger.Warn("Caches are not empty. Clearing them.");
             }
@@ -40,10 +40,10 @@ public class BlockCachePreWarmer(ReadOnlyTxProcessingEnvFactory envFactory, ISpe
                 ParallelOptions parallelOptions = new() { MaxDegreeOfParallelism = physicalCoreCount - 1, CancellationToken = cancellationToken };
 
                 // Run address warmer ahead of transactions warmer, but queue to ThreadPool so it doesn't block the txs
-                ThreadPool.UnsafeQueueUserWorkItem(
-                    new AddressWarmer(parallelOptions, suggestedBlock, parentStateRoot, systemTxAccessList, this), preferLocal: false);
+                var addressWarmer = new AddressWarmer(parallelOptions, suggestedBlock, parentStateRoot, systemTxAccessList, this);
+                ThreadPool.UnsafeQueueUserWorkItem(addressWarmer, preferLocal: false);
                 // Do not pass cancellation token to the task, we don't want exceptions to be thrown in main processing thread
-                return Task.Run(() => PreWarmCachesParallel(suggestedBlock, parentStateRoot, parallelOptions, cancellationToken));
+                return Task.Run(() => PreWarmCachesParallel(suggestedBlock, parentStateRoot, parallelOptions, addressWarmer, cancellationToken));
             }
         }
 
@@ -53,11 +53,9 @@ public class BlockCachePreWarmer(ReadOnlyTxProcessingEnvFactory envFactory, ISpe
     // Parent state root is null for genesis block
     private static bool IsGenesisBlock(Hash256? parentStateRoot) => parentStateRoot is null;
 
-    public void ClearCaches() => targetWorldState?.ClearCache();
+    public bool ClearCaches() => preBlockCaches?.ClearCaches() ?? false;
 
-    public Task ClearCachesInBackground() => targetWorldState?.ClearCachesInBackground() ?? Task.CompletedTask;
-
-    private void PreWarmCachesParallel(Block suggestedBlock, Hash256 parentStateRoot, ParallelOptions parallelOptions, CancellationToken cancellationToken)
+    private void PreWarmCachesParallel(Block suggestedBlock, Hash256 parentStateRoot, ParallelOptions parallelOptions, AddressWarmer addressWarmer, CancellationToken cancellationToken)
     {
         if (cancellationToken.IsCancellationRequested) return;
 
@@ -68,6 +66,9 @@ public class BlockCachePreWarmer(ReadOnlyTxProcessingEnvFactory envFactory, ISpe
             IReleaseSpec spec = specProvider.GetSpec(suggestedBlock.Header);
             WarmupTransactions(parallelOptions, spec, suggestedBlock, parentStateRoot);
             WarmupWithdrawals(parallelOptions, spec, suggestedBlock, parentStateRoot);
+
+            // Don't compete task until address warmer is also done.
+            addressWarmer.Wait();
 
             if (_logger.IsDebug) _logger.Debug($"Finished pre-warming caches for block {suggestedBlock.Number}.");
         }
@@ -152,19 +153,23 @@ public class BlockCachePreWarmer(ReadOnlyTxProcessingEnvFactory envFactory, ISpe
     private class AddressWarmer(ParallelOptions parallelOptions, Block block, Hash256 stateRoot, AccessList? systemTxAccessList, BlockCachePreWarmer preWarmer)
         : IThreadPoolWorkItem
     {
-        private readonly ParallelOptions ParallelOptions = parallelOptions;
         private readonly Block Block = block;
         private readonly Hash256 StateRoot = stateRoot;
         private readonly BlockCachePreWarmer PreWarmer = preWarmer;
         private readonly AccessList? SystemTxAccessList = systemTxAccessList;
+        private readonly ManualResetEventSlim _doneEvent = new(initialState: false);
+
+        public void Wait() => _doneEvent.Wait();
 
         void IThreadPoolWorkItem.Execute()
         {
+            if (parallelOptions.CancellationToken.IsCancellationRequested) return;
+
             IReadOnlyTxProcessorSource env = PreWarmer._envPool.Get();
             try
             {
                 using IReadOnlyTxProcessingScope scope = env.Build(StateRoot);
-                WarmupAddresses(ParallelOptions, Block, scope);
+                WarmupAddresses(parallelOptions, Block, scope);
             }
             catch (Exception ex)
             {
@@ -173,6 +178,7 @@ public class BlockCachePreWarmer(ReadOnlyTxProcessingEnvFactory envFactory, ISpe
             finally
             {
                 PreWarmer._envPool.Return(env);
+                _doneEvent.Set();
             }
         }
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
@@ -57,8 +57,9 @@ public partial class BlockProcessor(
     private readonly IRewardCalculator _rewardCalculator = rewardCalculator ?? throw new ArgumentNullException(nameof(rewardCalculator));
     private readonly IBlockProcessor.IBlockTransactionsExecutor _blockTransactionsExecutor = blockTransactionsExecutor ?? throw new ArgumentNullException(nameof(blockTransactionsExecutor));
     private readonly IBlockhashStore _blockhashStore = blockHashStore ?? throw new ArgumentNullException(nameof(blockHashStore));
+    private Task _clearTask = Task.CompletedTask;
     private const int MaxUncommittedBlocks = 64;
-    private readonly Action<Task> _clearCaches = _ => preWarmer.ClearCaches();
+    private readonly Action<Task> _clearCaches = _ => preWarmer?.ClearCaches();
 
     /// <summary>
     /// We use a single receipt tracer for all blocks. Internally receipt tracer forwards most of the calls
@@ -93,10 +94,13 @@ public partial class BlockProcessor(
         int blocksCount = suggestedBlocks.Count;
         Block[] processedBlocks = new Block[blocksCount];
 
+        Task? preWarmTask = null;
         try
         {
             for (int i = 0; i < blocksCount; i++)
             {
+                preWarmTask = null;
+                WaitForCacheClear();
                 Block suggestedBlock = suggestedBlocks[i];
                 if (blocksCount > 64 && i % 8 == 0)
                 {
@@ -111,7 +115,6 @@ public partial class BlockProcessor(
                 Block processedBlock;
                 TxReceipt[] receipts;
 
-                Task? preWarmTask = null;
                 bool skipPrewarming = preWarmer is null || suggestedBlock.Transactions.Length < 3;
                 if (!skipPrewarming)
                 {
@@ -124,8 +127,11 @@ public partial class BlockProcessor(
                 }
                 else
                 {
+                    if (preWarmer?.ClearCaches() ?? false)
+                    {
+                        if (_logger.IsWarn) _logger.Warn("Low txs, caches are not empty. Clearing them.");
+                    }
                     // Even though we skip prewarming we still need to ensure the caches are cleared
-                    preWarmer?.ClearCaches();
                     (processedBlock, receipts) = ProcessOne(suggestedBlock, options, blockTracer);
                 }
 
@@ -133,11 +139,7 @@ public partial class BlockProcessor(
 
                 // be cautious here as AuRa depends on processing
                 PreCommitBlock(newBranchStateRoot, suggestedBlock.Number);
-                if (preWarmTask is not null)
-                {
-                    // Can start clearing caches in background
-                    preWarmTask = preWarmTask.ContinueWith(_clearCaches, TaskContinuationOptions.RunContinuationsAsynchronously);
-                }
+                QueueClearCaches(preWarmer, preWarmTask);
 
                 if (notReadOnly)
                 {
@@ -172,13 +174,26 @@ public partial class BlockProcessor(
         }
         catch (Exception ex) // try to restore at all cost
         {
-            _logger.Trace($"Encountered exception {ex} while processing blocks.");
+            if (_logger.IsWarn) _logger.Warn($"Encountered exception {ex} while processing blocks.");
+            QueueClearCaches(preWarmer, preWarmTask);
+            preWarmTask?.GetAwaiter().GetResult();
             RestoreBranch(previousBranchStateRoot);
             throw;
         }
-        finally
+    }
+
+    private void WaitForCacheClear() => _clearTask.GetAwaiter().GetResult();
+
+    private void QueueClearCaches(IBlockCachePreWarmer preWarmer, Task? preWarmTask)
+    {
+        if (preWarmTask is not null)
         {
-            preWarmer?.ClearCaches();
+            // Can start clearing caches in background
+            _clearTask = preWarmTask.ContinueWith(_clearCaches, TaskContinuationOptions.RunContinuationsAsynchronously);
+        }
+        else if (preWarmer is not null)
+        {
+            _clearTask = Task.Run(() => preWarmer.ClearCaches());
         }
     }
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
@@ -126,6 +126,8 @@ public partial class BlockProcessor(
                 }
                 else
                 {
+                    // Even though we skip prewarming we still need to ensure the caches are cleared
+                    preWarmer?.ClearCaches();
                     (processedBlock, receipts) = ProcessOne(suggestedBlock, options, blockTracer);
                 }
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
@@ -512,6 +512,7 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
         }
         catch (InvalidBlockException ex)
         {
+            if (_logger.IsWarn) _logger.Warn($"Issue processing block {ex.InvalidBlock} {ex}");
             invalidBlockHash = ex.InvalidBlock.Hash;
             error = ex.Message;
             Block? invalidBlock = processingBranch.BlocksToProcess.FirstOrDefault(b => b.Hash == invalidBlockHash);
@@ -540,10 +541,6 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
                     options,
                     new GethLikeBlockMemoryTracer(GethTraceOptions.Default),
                     DumpOptions.Geth);
-            }
-            else
-            {
-                if (_logger.IsError) _logger.Error($"Unexpected situation occurred during the handling of an invalid block {ex.InvalidBlock}", ex);
             }
 
             processedBlocks = null;

--- a/src/Nethermind/Nethermind.Consensus/Processing/IBlockCachePreWarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/IBlockCachePreWarmer.cs
@@ -12,5 +12,5 @@ namespace Nethermind.Consensus.Processing;
 public interface IBlockCachePreWarmer
 {
     Task PreWarmCaches(Block suggestedBlock, Hash256 parentStateRoot, AccessList? systemTxAccessList, CancellationToken cancellationToken = default);
-    void ClearCaches();
+    bool ClearCaches();
 }

--- a/src/Nethermind/Nethermind.Consensus/Processing/IBlockCachePreWarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/IBlockCachePreWarmer.cs
@@ -13,5 +13,4 @@ public interface IBlockCachePreWarmer
 {
     Task PreWarmCaches(Block suggestedBlock, Hash256 parentStateRoot, AccessList? systemTxAccessList, CancellationToken cancellationToken = default);
     void ClearCaches();
-    Task ClearCachesInBackground();
 }

--- a/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
@@ -121,6 +121,8 @@ public class TestBlockchain : IDisposable
 
     public static TransactionBuilder<Transaction> BuildSimpleTransaction => Builders.Build.A.Transaction.SignedAndResolved(TestItem.PrivateKeyA).To(AccountB);
 
+    private PreBlockCaches PreBlockCaches { get; } = new();
+
     protected virtual async Task<TestBlockchain> Build(ISpecProvider? specProvider = null, UInt256? initialValues = null, bool addBlockOnStart = true)
     {
         Timestamper = new ManualTimestamper(new DateTime(2020, 2, 15, 12, 50, 30, DateTimeKind.Utc));
@@ -129,7 +131,7 @@ public class TestBlockchain : IDisposable
         EthereumEcdsa = new EthereumEcdsa(SpecProvider.ChainId);
         DbProvider = await CreateDbProvider();
         TrieStore = new TrieStore(StateDb, LogManager);
-        State = new WorldState(TrieStore, DbProvider.CodeDb, LogManager, new PreBlockCaches());
+        State = new WorldState(TrieStore, DbProvider.CodeDb, LogManager, PreBlockCaches);
 
         // Eip4788 precompile state account
         if (specProvider?.GenesisSpec?.IsBeaconBlockRootAvailable ?? false)
@@ -381,7 +383,7 @@ public class TestBlockchain : IDisposable
             preWarmer: CreateBlockCachePreWarmer());
 
     protected virtual IBlockCachePreWarmer CreateBlockCachePreWarmer() =>
-        new BlockCachePreWarmer(new ReadOnlyTxProcessingEnvFactory(WorldStateManager, BlockTree, SpecProvider, LogManager, WorldStateManager.GlobalWorldState), SpecProvider, LogManager, WorldStateManager.GlobalWorldState);
+        new BlockCachePreWarmer(new ReadOnlyTxProcessingEnvFactory(WorldStateManager, BlockTree, SpecProvider, LogManager, WorldStateManager.GlobalWorldState), SpecProvider, LogManager, PreBlockCaches);
 
     public async Task WaitForNewHead()
     {

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeBlockchain.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeBlockchain.cs
@@ -93,7 +93,7 @@ namespace Nethermind.Init.Steps
             setApi.TxPoolInfoProvider = new TxPoolInfoProvider(chainHeadInfoProvider.AccountStateProvider, txPool);
             setApi.GasPriceOracle = new GasPriceOracle(getApi.BlockTree!, getApi.SpecProvider, _api.LogManager, blocksConfig.MinGasPrice);
             BlockCachePreWarmer? preWarmer = blocksConfig.PreWarmStateOnBlockProcessing
-                ? new(new(_api.WorldStateManager!, _api.BlockTree!, _api.SpecProvider, _api.LogManager, _api.WorldState), _api.SpecProvider, _api.LogManager, _api.WorldState)
+                ? new(new(_api.WorldStateManager!, _api.BlockTree!, _api.SpecProvider, _api.LogManager, _api.WorldState), _api.SpecProvider, _api.LogManager, preBlockCaches)
                 : null;
             IBlockProcessor mainBlockProcessor = setApi.MainBlockProcessor = CreateBlockProcessor(preWarmer);
 

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TraceRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TraceRpcModuleTests.cs
@@ -13,9 +13,7 @@ using Nethermind.Core.Specs;
 using Nethermind.Specs;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Int256;
-using Nethermind.JsonRpc.Modules.Eth;
 using Nethermind.JsonRpc.Modules.Trace;
-using Nethermind.Logging;
 using NUnit.Framework;
 using Nethermind.Blockchain.Find;
 using Nethermind.Consensus.Processing;
@@ -25,7 +23,6 @@ using Nethermind.Consensus.Validators;
 using Nethermind.Core.Crypto;
 using Nethermind.Db;
 using Nethermind.Evm;
-using Nethermind.Evm.Tracing.ParityStyle;
 using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Facade.Eth;
 using Nethermind.Serialization.Json;
@@ -36,7 +33,6 @@ using Nethermind.JsonRpc.Modules;
 
 namespace Nethermind.JsonRpc.Test.Modules;
 
-[Parallelizable(ParallelScope.All)]
 [TestFixture]
 public class TraceRpcModuleTests
 {

--- a/src/Nethermind/Nethermind.State/IWorldState.cs
+++ b/src/Nethermind/Nethermind.State/IWorldState.cs
@@ -113,8 +113,4 @@ public interface IWorldState : IJournal<Snapshot>, IReadOnlyStateProvider
 
     void CommitTree(long blockNumber);
     ArrayPoolList<AddressAsKey>? GetAccountChanges();
-
-    bool ClearCache() => false;
-
-    Task ClearCachesInBackground() => Task.CompletedTask;
 }

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -330,7 +330,6 @@ namespace Nethermind.State
             _toUpdateRoots.Clear();
             // only needed here as there is no control over cached storage size otherwise
             _storages.Clear();
-            _preBlockCache?.NoResizeClear();
         }
 
         private StorageTree GetOrCreateStorage(Address address)

--- a/src/Nethermind/Nethermind.State/PreBlockCaches.cs
+++ b/src/Nethermind/Nethermind.State/PreBlockCaches.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Numerics;
 using System.Runtime.InteropServices;
-using System.Threading.Tasks;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Trie;
@@ -20,7 +19,6 @@ public class PreBlockCaches
     private static int LockPartitions => CollectionExtensions.LockPartitions;
 
     private readonly Func<bool>[] _clearCaches;
-    private readonly Action _clearAllCaches;
 
     private readonly ConcurrentDictionary<StorageCell, byte[]> _storageCache = new(LockPartitions, InitialCapacity);
     private readonly ConcurrentDictionary<AddressAsKey, Account> _stateCache = new(LockPartitions, InitialCapacity);
@@ -36,16 +34,12 @@ public class PreBlockCaches
             _rlpCache.NoResizeClear,
             _precompileCache.NoResizeClear
         ];
-
-        _clearAllCaches = () => ClearImmediate();
     }
 
     public ConcurrentDictionary<StorageCell, byte[]> StorageCache => _storageCache;
     public ConcurrentDictionary<AddressAsKey, Account> StateCache => _stateCache;
     public ConcurrentDictionary<NodeKey, byte[]?> RlpCache => _rlpCache;
     public ConcurrentDictionary<PrecompileCacheKey, (ReadOnlyMemory<byte>, bool)> PrecompileCache => _precompileCache;
-
-    public Task ClearCachesInBackground() => Task.Run(_clearAllCaches);
 
     public bool ClearImmediate()
     {

--- a/src/Nethermind/Nethermind.State/PreBlockCaches.cs
+++ b/src/Nethermind/Nethermind.State/PreBlockCaches.cs
@@ -41,7 +41,7 @@ public class PreBlockCaches
     public ConcurrentDictionary<NodeKey, byte[]?> RlpCache => _rlpCache;
     public ConcurrentDictionary<PrecompileCacheKey, (ReadOnlyMemory<byte>, bool)> PrecompileCache => _precompileCache;
 
-    public bool ClearImmediate()
+    public bool ClearCaches()
     {
         bool isDirty = false;
         foreach (Func<bool> clearCache in _clearCaches)

--- a/src/Nethermind/Nethermind.State/StateProvider.cs
+++ b/src/Nethermind/Nethermind.State/StateProvider.cs
@@ -857,7 +857,6 @@ namespace Nethermind.State
             }
 
             _tree.Commit(blockNumber);
-            _preBlockCache?.NoResizeClear();
         }
 
         public static void CommitBranch()

--- a/src/Nethermind/Nethermind.State/WorldState.cs
+++ b/src/Nethermind/Nethermind.State/WorldState.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Runtime.CompilerServices;
-using System.Threading.Tasks;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
@@ -271,7 +270,5 @@ namespace Nethermind.State
         ArrayPoolList<AddressAsKey>? IWorldState.GetAccountChanges() => _stateProvider.ChangedAddresses();
 
         PreBlockCaches? IPreBlockCaches.Caches => PreBlockCaches;
-
-        public bool ClearCache() => PreBlockCaches?.ClearImmediate() == true;
     }
 }

--- a/src/Nethermind/Nethermind.State/WorldState.cs
+++ b/src/Nethermind/Nethermind.State/WorldState.cs
@@ -273,7 +273,5 @@ namespace Nethermind.State
         PreBlockCaches? IPreBlockCaches.Caches => PreBlockCaches;
 
         public bool ClearCache() => PreBlockCaches?.ClearImmediate() == true;
-
-        public Task ClearCachesInBackground() => PreBlockCaches?.ClearCachesInBackground() ?? Task.CompletedTask;
     }
 }

--- a/src/Nethermind/Nethermind.Trie/PreCachedTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/PreCachedTrieStore.cs
@@ -42,7 +42,6 @@ public class PreCachedTrieStore : ITrieStore
     public void FinishBlockCommit(TrieType trieType, long blockNumber, Hash256? address, TrieNode? root, WriteFlags writeFlags = WriteFlags.None)
     {
         _inner.FinishBlockCommit(trieType, blockNumber, address, root, writeFlags);
-        _preBlockCache.NoResizeClear();
     }
 
     public bool IsPersisted(Hash256? address, in TreePath path, in ValueHash256 keccak)


### PR DESCRIPTION
## Changes

- Once the ConcurrentDIctionary lock is acquired, recheck if the collection is empty before trying to clear it
- Remove some additional clears of preWarm cache as over clearing them
- Allow prewarm cache to clear in background on prewarm continuation; only forcing at start of next block if not cleared

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No