### PR TITLE
Add Inbound field to admin_peers rpc call response

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/PeerInfo.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/PeerInfo.cs
@@ -15,7 +15,7 @@ namespace Nethermind.JsonRpc.Modules.Admin
         public string Host { get; set; }
         public int Port { get; set; }
         public string Address { get; set; }
-        public bool IsBootnode { get; set; }
+        public bool IsBootnode { get; set; } // change to BootNode (capitalize "N")?
         public bool IsTrusted { get; set; }
         public bool IsStatic { get; set; }
         public string Enode { get; set; }
@@ -23,6 +23,8 @@ namespace Nethermind.JsonRpc.Modules.Admin
         public string ClientType { get; set; }
         public string EthDetails { get; set; }
         public string LastSignal { get; set; }
+
+        public bool Inbound { get; set; }
 
         public PeerInfo()
         {
@@ -43,13 +45,13 @@ namespace Nethermind.JsonRpc.Modules.Admin
             IsBootnode = peer.Node.IsBootnode;
             IsStatic = peer.Node.IsStatic;
             Enode = peer.Node.ToString(Node.Format.ENode);
+            Inbound = peer.InSession is not null && peer.InSession.Direction == ConnectionDirection.In; // assumes one of InSession/Outsession is always set.?
 
-            if (includeDetails)
-            {
-                ClientType = peer.Node.ClientType.ToString();
-                EthDetails = peer.Node.EthDetails;
-                LastSignal = (peer.InSession ?? peer.OutSession)?.LastPingUtc.ToString(CultureInfo.InvariantCulture);
-            }
+            if (!includeDetails) return;
+
+            ClientType = peer.Node.ClientType.ToString();
+            EthDetails = peer.Node.EthDetails;
+            LastSignal = (peer.InSession ?? peer.OutSession)?.LastPingUtc.ToString(CultureInfo.InvariantCulture);
         }
     }
 }


### PR DESCRIPTION
Closes #7317 


## Changes

- Adds Inbound boolean field which specifies if the peer is inbound or not to the PeerInfo Field

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [x] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing
Previous tests where smoke tests and redundant, followed the pattern.

## Documentation

#### Requires documentation update

- [x] Yes
- [ ] No
`Todo: link to docs pr or change docs in this pr`

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No
