### PR TITLE
Add GenesisTimeoutMs to BlocksConfig

### DIFF
--- a/src/Nethermind/Nethermind.Config/BlocksConfig.cs
+++ b/src/Nethermind/Nethermind.Config/BlocksConfig.cs
@@ -26,7 +26,9 @@ namespace Nethermind.Config
 
         public bool PreWarmStateOnBlockProcessing { get; set; } = true;
 
-        public int BlockProductionTimeoutMs { get; set; } = 4000;
+        public int BlockProductionTimeoutMs { get; set; } = 4_000;
+
+        public int GenesisTimeoutMs { get; set; } = 40_000;
 
         public string ExtraData
         {

--- a/src/Nethermind/Nethermind.Config/IBlocksConfig.cs
+++ b/src/Nethermind/Nethermind.Config/IBlocksConfig.cs
@@ -40,5 +40,8 @@ public interface IBlocksConfig : IConfig
     [ConfigItem(Description = "Block Production timeout, in milliseconds.", DefaultValue = "4000")]
     int BlockProductionTimeoutMs { get; set; }
 
+    [ConfigItem(Description = "Genesis block load timeout, in milliseconds.", DefaultValue = "40000")]
+    int GenesisTimeoutMs { get; set; }
+
     byte[] GetExtraDataBytes();
 }

--- a/src/Nethermind/Nethermind.Init/Steps/LoadGenesisBlock.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/LoadGenesisBlock.cs
@@ -86,7 +86,7 @@ namespace Nethermind.Init.Steps
 
             if (!genesisLoaded)
             {
-                throw new TimeoutException($"Genesis block was not processed after {_genesisProcessedTimeout.TotalSeconds} seconds");
+                throw new TimeoutException($"Genesis block was not processed after {_genesisProcessedTimeout.TotalSeconds} seconds. If you are running custom chain with very big genesis file consider increasing {nameof(BlocksConfig)}.{nameof(IBlocksConfig.GenesisTimeoutMs)}.");
             }
         }
 

--- a/src/Nethermind/Nethermind.Init/Steps/LoadGenesisBlock.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/LoadGenesisBlock.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Api;
 using Nethermind.Blockchain;
+using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Logging;
@@ -19,13 +20,13 @@ namespace Nethermind.Init.Steps
         private readonly IApiWithBlockchain _api;
         private readonly ILogger _logger;
         private IInitConfig? _initConfig;
-
-        readonly TimeSpan _genesisProcessedTimeout = TimeSpan.FromSeconds(40);
+        private readonly TimeSpan _genesisProcessedTimeout;
 
         public LoadGenesisBlock(INethermindApi api)
         {
             _api = api;
             _logger = _api.LogManager.GetClassLogger();
+            _genesisProcessedTimeout = TimeSpan.FromMilliseconds(_api.Config<IBlocksConfig>().GenesisTimeoutMs);
         }
 
         public async Task Execute(CancellationToken _)


### PR DESCRIPTION
Feature requested in #7361

## Changes

- Makes genesis timeout configurable, 40s by default.
- Add hint to the error about when this can be useful.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

## Remarks

- `GenesisHash` is still in `InitConfig` and now it is inconsistent
- Wondered if it should be `Ms` or `S`, but we always have `Ms` in other places so made it that.
