### PR TITLE
Optimize out DaoTransition call

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Numerics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -427,7 +428,14 @@ public partial class BlockProcessor(
     // TODO: block processor pipeline
     private void ApplyDaoTransition(Block block)
     {
-        if (_specProvider.DaoBlockNumber.HasValue && _specProvider.DaoBlockNumber.Value == block.Header.Number)
+        long? daoBlockNumber = _specProvider.DaoBlockNumber;
+        if (daoBlockNumber.HasValue && daoBlockNumber.Value == block.Header.Number)
+        {
+            ApplyTransition();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        void ApplyTransition()
         {
             if (_logger.IsInfo) _logger.Info("Applying the DAO transition");
             Address withdrawAccount = DaoData.DaoWithdrawalAccount;


### PR DESCRIPTION
## Changes

- Split `ApplyDaoTransition` into a fast inlinable check path and a slower apply path. Isn't a big performance change but it is only activated for 1 block on 1 chain so its bothering me that it shows up in traces 😅

Before
<img width="440" alt="image" src="https://github.com/user-attachments/assets/14f1c2e1-b946-4561-b741-c2b42cfa866f">
After
<img width="451" alt="image" src="https://github.com/user-attachments/assets/bd7b875d-96cb-4048-9d12-d35b15df1052">


## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
