### PR TITLE
Move txPool work from Processing loop event to txPool thread

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
@@ -425,7 +425,10 @@ public class TestBlockchain : IDisposable
         await WaitAsync(_oneAtATime, "Multiple block produced at once.");
         AcceptTxResult[] txResults = transactions.Select(t => TxPool.SubmitTx(t, TxHandlingOptions.None)).ToArray();
         Timestamper.Add(TimeSpan.FromSeconds(1));
+        var headProcessed = new ManualResetEventSlim(false);
+        TxPool.TxPoolHeadChanged += (s, a) => headProcessed.Set();
         await BlockProductionTrigger.BuildBlock();
+        headProcessed.Wait();
         return txResults;
     }
 

--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcSocketsClientTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcSocketsClientTests.cs
@@ -125,7 +125,7 @@ public class JsonRpcSocketsClientTests
                 {
                     using JsonRpcResult result = JsonRpcResult.Single(RandomSuccessResponse(1_000, () => disposeCount++), default);
                     await client.SendJsonRpcResult(result);
-                    await Task.Delay(100);
+                    await Task.Delay(10);
                 }
 
                 disposeCount.Should().Be(messageCount);
@@ -220,7 +220,7 @@ public class JsonRpcSocketsClientTests
                     await stream.WriteEndOfMessageAsync();
                     if (i % 10 == 0)
                     {
-                        await Task.Delay(100);
+                        await Task.Delay(10);
                     }
                 }
                 stream.Close();

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -215,7 +215,7 @@ namespace Nethermind.TxPool.Test
             EnsureSenderBalance(tx.SenderAddress, tx.Value);
 
             var headProcessed = new ManualResetEventSlim(false);
-            txPool.HeadChanged += (s, a) => headProcessed.Set();
+            txPool.TxPoolHeadChanged += (s, a) => headProcessed.Set();
             _blockTree.BlockAddedToMain += Raise.EventWith(_blockTree, new BlockReplacementEventArgs(Build.A.Block.WithGasLimit(10000000).TestObject));
 
             headProcessed.Wait();
@@ -725,7 +725,7 @@ namespace Nethermind.TxPool.Test
             _txPool.SubmitTx(higherPriorityTx, TxHandlingOptions.PersistentBroadcast);
 
             var headProcessed = new ManualResetEventSlim(false);
-            _txPool.HeadChanged += (s, a) => headProcessed.Set();
+            _txPool.TxPoolHeadChanged += (s, a) => headProcessed.Set();
 
             _blockTree.BlockAddedToMain += Raise.EventWith(new BlockReplacementEventArgs(Build.A.Block.TestObject));
 

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -213,7 +213,12 @@ namespace Nethermind.TxPool.Test
             txPool.GetPendingTransactionsCount().Should().Be(0);
             result.Should().Be(AcceptTxResult.InsufficientFunds);
             EnsureSenderBalance(tx.SenderAddress, tx.Value);
+
+            var headProcessed = new ManualResetEventSlim(false);
+            txPool.HeadChanged += (s, a) => headProcessed.Set();
             _blockTree.BlockAddedToMain += Raise.EventWith(_blockTree, new BlockReplacementEventArgs(Build.A.Block.WithGasLimit(10000000).TestObject));
+
+            headProcessed.Wait();
             result = txPool.SubmitTx(tx, TxHandlingOptions.PersistentBroadcast);
             result.Should().Be(AcceptTxResult.InsufficientFunds);
             txPool.GetPendingTransactionsCount().Should().Be(0);
@@ -719,7 +724,12 @@ namespace Nethermind.TxPool.Test
             EnsureSenderBalance(higherPriorityTx);
             _txPool.SubmitTx(higherPriorityTx, TxHandlingOptions.PersistentBroadcast);
 
+            var headProcessed = new ManualResetEventSlim(false);
+            _txPool.HeadChanged += (s, a) => headProcessed.Set();
+
             _blockTree.BlockAddedToMain += Raise.EventWith(new BlockReplacementEventArgs(Build.A.Block.TestObject));
+
+            headProcessed.Wait();
             _txPool.IsKnown(higherPriorityTx.Hash).Should().BeTrue();
             _txPool.IsKnown(transaction.Hash).Should().BeFalse();
         }

--- a/src/Nethermind/Nethermind.TxPool/ITxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxPool.cs
@@ -16,6 +16,8 @@ namespace Nethermind.TxPool
         int GetPendingBlobTransactionsCount();
         Transaction[] GetPendingTransactions();
 
+        public event EventHandler<Block>? TxPoolHeadChanged;
+
         /// <summary>
         /// Non-blob txs grouped by sender address, sorted by nonce and later tx pool sorting
         /// </summary>

--- a/src/Nethermind/Nethermind.TxPool/NullTxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/NullTxPool.cs
@@ -16,6 +16,12 @@ namespace Nethermind.TxPool
 
         public static NullTxPool Instance { get; } = new();
 
+        public event EventHandler<Block>? TxPoolHeadChanged
+        {
+            add { }
+            remove { }
+        }
+
         public int GetPendingTransactionsCount() => 0;
         public int GetPendingBlobTransactionsCount() => 0;
         public Transaction[] GetPendingTransactions() => Array.Empty<Transaction>();

--- a/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
@@ -142,7 +142,7 @@ namespace Nethermind.TxPool
             }
         }
 
-        public void OnNewHead()
+        public void OnNewHead(object? sender, Block block)
         {
             _baseFeeThreshold = CalculateBaseFeeThreshold();
             BroadcastPersistentTxs();

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -191,10 +191,6 @@ namespace Nethermind.TxPool
         {
             try
             {
-                // Clear snapshot
-                _transactionSnapshot = null;
-                _blobTransactionSnapshot = null;
-                _hashCache.ClearCurrentBlockCache();
                 _headBlocksChannel.Writer.TryWrite(e);
             }
             catch (Exception exception)
@@ -211,8 +207,12 @@ namespace Nethermind.TxPool
             {
                 while (await _headBlocksChannel.Reader.WaitToReadAsync())
                 {
+                    _hashCache.ClearCurrentBlockCache();
                     while (_headBlocksChannel.Reader.TryRead(out BlockReplacementEventArgs? args))
                     {
+                        // Clear snapshot
+                        _transactionSnapshot = null;
+                        _blobTransactionSnapshot = null;
                         try
                         {
                             ArrayPoolList<AddressAsKey>? accountChanges = args.Block.AccountChanges;

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -207,12 +207,12 @@ namespace Nethermind.TxPool
             {
                 while (await _headBlocksChannel.Reader.WaitToReadAsync())
                 {
-                    _hashCache.ClearCurrentBlockCache();
                     while (_headBlocksChannel.Reader.TryRead(out BlockReplacementEventArgs? args))
                     {
                         // Clear snapshot
                         _transactionSnapshot = null;
                         _blobTransactionSnapshot = null;
+                        _hashCache.ClearCurrentBlockCache();
                         try
                         {
                             ArrayPoolList<AddressAsKey>? accountChanges = args.Block.AccountChanges;

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -167,7 +167,7 @@ namespace Nethermind.TxPool
             ProcessNewHeads();
         }
 
-        public Transaction[] GetPendingTransactions() => _transactions.GetSnapshot();
+        public Transaction[] GetPendingTransactions() => _transactionSnapshot ??= _transactions.GetSnapshot();
 
         public int GetPendingTransactionsCount() => _transactions.Count;
 

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -59,6 +59,8 @@ namespace Nethermind.TxPool
         private readonly UpdateGroupDelegate _updateBucket;
         private readonly UpdateGroupDelegate _updateBucketAdded;
 
+        public event EventHandler<BlockReplacementEventArgs>? TxPoolHeadChanged;
+
         /// <summary>
         /// Indexes transactions
         /// </summary>
@@ -201,8 +203,6 @@ namespace Nethermind.TxPool
             }
         }
 
-        public event EventHandler<BlockReplacementEventArgs>? HeadChanged;
-
         private void ProcessNewHeads()
         {
             Task.Factory.StartNew(async () =>
@@ -238,7 +238,7 @@ namespace Nethermind.TxPool
                             RemoveProcessedTransactions(args.Block);
                             UpdateBuckets();
                             _broadcaster.OnNewHead();
-                            HeadChanged?.Invoke(this, args);
+                            TxPoolHeadChanged?.Invoke(this, args);
                             Metrics.TransactionCount = _transactions.Count;
                             Metrics.BlobTransactionCount = _blobTransactions.Count;
                         }


### PR DESCRIPTION
## Changes

- Move clearing caches to txPool processing new head rather than main processing informing txPool of new head

2.9% of archive since since its processing blocks so fast 
<img width="433" alt="image" src="https://github.com/user-attachments/assets/3af93b3e-5bd7-4236-9884-f66c2109501d">


## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes (changed existing tests)