### PR TITLE
Don't convert tx.Data to array unnecessarily

### DIFF
--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -443,7 +443,7 @@ namespace Nethermind.Evm.TransactionProcessing
 
             codeInfo.AnalyseInBackgroundIfRequired();
 
-            byte[] inputData = tx.IsMessageCall ? tx.Data.AsArray() ?? Array.Empty<byte>() : Array.Empty<byte>();
+            ReadOnlyMemory<byte> inputData = tx.IsMessageCall ? tx.Data ?? default : default;
 
             return new ExecutionEnvironment
             (


### PR DESCRIPTION
## Changes

- Currently it does `ReadOnlyMemory<byte>` -> `byte[]` -> `ReadOnlyMemory<byte>`; can just use the `ReadOnlyMemory<byte>` directly

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No