### PR TITLE
Calculate receipt blooms in parallel

### DIFF
--- a/src/Nethermind/Nethermind.Core/TransactionReceipt.cs
+++ b/src/Nethermind/Nethermind.Core/TransactionReceipt.cs
@@ -9,6 +9,8 @@ namespace Nethermind.Core
 {
     public class TxReceipt
     {
+        private Bloom? _boom;
+
         public TxReceipt()
         {
         }
@@ -60,7 +62,7 @@ namespace Nethermind.Core
         ///     Removed in EIP-658
         /// </summary>
         public Hash256? PostTransactionState { get; set; }
-        public Bloom? Bloom { get; set; }
+        public Bloom? Bloom { get => _boom ?? CalculateBloom(); set => _boom = value; }
         public LogEntry[]? Logs { get; set; }
         public string? Error { get; set; }
 
@@ -70,8 +72,8 @@ namespace Nethermind.Core
         /// </summary>
         public bool SkipStateAndStatusInRlp { get; set; }
 
-        public void CalculateBloom()
-            => Bloom = Logs?.Length == 0 ? Bloom.Empty : new Bloom(Logs);
+        public Bloom CalculateBloom()
+            => _boom = Logs?.Length == 0 ? Bloom.Empty : new Bloom(Logs);
     }
 
     public ref struct TxReceiptStructRef

--- a/src/Nethermind/Nethermind.Core/TransactionReceipt.cs
+++ b/src/Nethermind/Nethermind.Core/TransactionReceipt.cs
@@ -69,6 +69,9 @@ namespace Nethermind.Core
         /// Output is either StateRoot or StatusCode depending on eip configuration.
         /// </summary>
         public bool SkipStateAndStatusInRlp { get; set; }
+
+        public void CalculateBloom()
+            => Bloom = Logs?.Length == 0 ? Bloom.Empty : new Bloom(Logs);
     }
 
     public ref struct TxReceiptStructRef

--- a/src/Nethermind/Nethermind.Evm/Tracing/BlockReceiptsTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/BlockReceiptsTracer.cs
@@ -78,7 +78,7 @@ public class BlockReceiptsTracer : IBlockTracer, ITxTracer, IJournal<int>, ITxTr
         {
             Logs = logEntries,
             TxType = transaction.Type,
-            Bloom = logEntries.Length == 0 ? Bloom.Empty : new Bloom(logEntries),
+            // Bloom calculated in parallel with other receipts
             GasUsedTotal = Block.GasUsed,
             StatusCode = statusCode,
             Recipient = transaction.IsContractCreation ? null : recipient,

--- a/src/Nethermind/Nethermind.Optimism/OptimismBlockReceiptTracer.cs
+++ b/src/Nethermind/Nethermind.Optimism/OptimismBlockReceiptTracer.cs
@@ -53,7 +53,7 @@ public class OptimismBlockReceiptTracer : BlockReceiptsTracer
         {
             Logs = logEntries,
             TxType = transaction.Type,
-            Bloom = logEntries.Length == 0 ? Bloom.Empty : new Bloom(logEntries),
+            // Bloom calculated in parallel with other receipts
             GasUsedTotal = Block.GasUsed,
             StatusCode = statusCode,
             Recipient = transaction.IsContractCreation ? null : recipient,


### PR DESCRIPTION
## Changes

- Calculate the receipt blooms in parallel; saves ~1% on block validation

Before
![image](https://github.com/user-attachments/assets/b146d215-c386-4438-913c-f699b94b707a)
After
![image](https://github.com/user-attachments/assets/d3d85424-dba1-47c7-b692-91441786db5b)


## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
