### PR TITLE
Always wait for address prewarmer; even if cancelled

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
@@ -57,10 +57,10 @@ public sealed class BlockCachePreWarmer(ReadOnlyTxProcessingEnvFactory envFactor
 
     private void PreWarmCachesParallel(Block suggestedBlock, Hash256 parentStateRoot, ParallelOptions parallelOptions, AddressWarmer addressWarmer, CancellationToken cancellationToken)
     {
-        if (cancellationToken.IsCancellationRequested) return;
-
         try
         {
+            if (cancellationToken.IsCancellationRequested) return;
+
             if (_logger.IsDebug) _logger.Debug($"Started pre-warming caches for block {suggestedBlock.Number}.");
 
             IReleaseSpec spec = specProvider.GetSpec(suggestedBlock.Header);


### PR DESCRIPTION
## Changes

- Even if cancelled; should wait for all parts to register as cancelled before allowing next block to be processed

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No