### PR TITLE
Hotfix multiple instances of txdecoder usage

### DIFF
--- a/src/Nethermind/Nethermind.Crypto/TransactionExtensions.cs
+++ b/src/Nethermind/Nethermind.Crypto/TransactionExtensions.cs
@@ -9,12 +9,10 @@ namespace Nethermind.Crypto
 {
     public static class TransactionExtensions
     {
-        private static readonly TxDecoder _txDecoder = TxDecoder.Instance;
-
         public static Hash256 CalculateHash(this Transaction transaction)
         {
             KeccakRlpStream stream = new();
-            _txDecoder.Encode(stream, transaction, RlpBehaviors.SkipTypedWrapping);
+            TxDecoder.Instance.Encode(stream, transaction, RlpBehaviors.SkipTypedWrapping);
             return stream.GetHash();
         }
     }

--- a/src/Nethermind/Nethermind.Crypto/TransactionExtensions.cs
+++ b/src/Nethermind/Nethermind.Crypto/TransactionExtensions.cs
@@ -4,15 +4,17 @@
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Serialization.Rlp;
+using System;
 
 namespace Nethermind.Crypto
 {
     public static class TransactionExtensions
     {
+        private static readonly Lazy<TxDecoder> _txDecoder = new(() => TxDecoder.Instance);
         public static Hash256 CalculateHash(this Transaction transaction)
         {
             KeccakRlpStream stream = new();
-            TxDecoder.Instance.Encode(stream, transaction, RlpBehaviors.SkipTypedWrapping);
+            _txDecoder.Value.Encode(stream, transaction, RlpBehaviors.SkipTypedWrapping);
             return stream.GetHash();
         }
     }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Trace/TraceRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Trace/TraceRpcModule.cs
@@ -38,7 +38,6 @@ namespace Nethermind.JsonRpc.Modules.Trace
         private readonly IReceiptFinder _receiptFinder;
         private readonly ITracer _tracer;
         private readonly IBlockFinder _blockFinder;
-        private readonly TxDecoder _txDecoder = TxDecoder.Instance;
         private readonly IJsonRpcConfig _jsonRpcConfig;
         private readonly TimeSpan _cancellationTokenTimeout;
         private readonly IStateReader _stateReader;
@@ -109,7 +108,7 @@ namespace Nethermind.JsonRpc.Modules.Trace
         /// </summary>
         public ResultWrapper<ParityTxTraceFromReplay> trace_rawTransaction(byte[] data, string[] traceTypes)
         {
-            Transaction tx = _txDecoder.Decode(new RlpStream(data), RlpBehaviors.SkipTypedWrapping);
+            Transaction tx = TxDecoder.Instance.Decode(new RlpStream(data), RlpBehaviors.SkipTypedWrapping);
             return TraceTx(tx, traceTypes, BlockParameter.Latest);
         }
 

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Trace/TraceRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Trace/TraceRpcModule.cs
@@ -20,6 +20,7 @@ using Nethermind.Int256;
 using Nethermind.JsonRpc.Data;
 using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
+using Nethermind.Serialization.Rlp.TxDecoders;
 using Nethermind.State;
 using Nethermind.Trie;
 
@@ -38,6 +39,7 @@ namespace Nethermind.JsonRpc.Modules.Trace
         private readonly IReceiptFinder _receiptFinder;
         private readonly ITracer _tracer;
         private readonly IBlockFinder _blockFinder;
+        private readonly Lazy<TxDecoder> _txDecoder = new(() => TxDecoder.Instance);
         private readonly IJsonRpcConfig _jsonRpcConfig;
         private readonly TimeSpan _cancellationTokenTimeout;
         private readonly IStateReader _stateReader;
@@ -108,7 +110,7 @@ namespace Nethermind.JsonRpc.Modules.Trace
         /// </summary>
         public ResultWrapper<ParityTxTraceFromReplay> trace_rawTransaction(byte[] data, string[] traceTypes)
         {
-            Transaction tx = TxDecoder.Instance.Decode(new RlpStream(data), RlpBehaviors.SkipTypedWrapping);
+            Transaction tx = _txDecoder.Value.Decode(new RlpStream(data), RlpBehaviors.SkipTypedWrapping);
             return TraceTx(tx, traceTypes, BlockParameter.Latest);
         }
 

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
@@ -52,7 +52,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
 
         protected Hash256 _remoteHeadBlockHash;
         protected readonly ITimestamper _timestamper;
-        protected TxDecoder _txDecoder => TxDecoder.Instance;
+        protected readonly Lazy<TxDecoder> _txDecoder = new(() => TxDecoder.Instance);
 
         protected readonly MessageQueue<GetBlockHeadersMessage, IOwnedReadOnlyList<BlockHeader?>> _headersRequests;
         protected readonly MessageQueue<GetBlockBodiesMessage, (OwnedBlockBodies, long)> _bodiesRequests;

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
@@ -52,7 +52,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
 
         protected Hash256 _remoteHeadBlockHash;
         protected readonly ITimestamper _timestamper;
-        protected readonly TxDecoder _txDecoder;
+        protected TxDecoder _txDecoder => TxDecoder.Instance;
 
         protected readonly MessageQueue<GetBlockHeadersMessage, IOwnedReadOnlyList<BlockHeader?>> _headersRequests;
         protected readonly MessageQueue<GetBlockBodiesMessage, (OwnedBlockBodies, long)> _bodiesRequests;
@@ -87,7 +87,6 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
             SyncServer = syncServer ?? throw new ArgumentNullException(nameof(syncServer));
             BackgroundTaskScheduler = new BackgroundTaskSchedulerWrapper(this, backgroundTaskScheduler ?? throw new ArgumentNullException(nameof(BackgroundTaskScheduler)));
             _timestamper = Timestamper.Default;
-            _txDecoder = TxDecoder.Instance;
             _headersRequests = new MessageQueue<GetBlockHeadersMessage, IOwnedReadOnlyList<BlockHeader>>(Send);
             _bodiesRequests = new MessageQueue<GetBlockBodiesMessage, (OwnedBlockBodies, long)>(Send);
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Messages/BlockBodiesMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Messages/BlockBodiesMessageSerializer.cs
@@ -56,7 +56,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages
 
         private class BlockBodyDecoder : IRlpValueDecoder<BlockBody>
         {
-            private readonly TxDecoder _txDecoder = TxDecoder.Instance;
+            private TxDecoder _txDecoder => TxDecoder.Instance;
             private readonly HeaderDecoder _headerDecoder = new();
             private readonly WithdrawalDecoder _withdrawalDecoderDecoder = new();
             private readonly ConsensusRequestDecoder _requestsDecoder = new();

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Messages/BlockBodiesMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Messages/BlockBodiesMessageSerializer.cs
@@ -8,7 +8,6 @@ using Nethermind.Core;
 using Nethermind.Core.Buffers;
 using Nethermind.Core.ConsensusRequests;
 using Nethermind.Serialization.Rlp;
-using Newtonsoft.Json.Linq;
 
 namespace Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages
 {

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Messages/BlockBodiesMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Messages/BlockBodiesMessageSerializer.cs
@@ -1,12 +1,14 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Linq;
 using DotNetty.Buffers;
 using Nethermind.Core;
 using Nethermind.Core.Buffers;
 using Nethermind.Core.ConsensusRequests;
 using Nethermind.Serialization.Rlp;
+using Newtonsoft.Json.Linq;
 
 namespace Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages
 {
@@ -56,7 +58,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages
 
         private class BlockBodyDecoder : IRlpValueDecoder<BlockBody>
         {
-            private TxDecoder _txDecoder => TxDecoder.Instance;
+            private readonly Lazy<TxDecoder> _txDecoder = new(() => TxDecoder.Instance);
             private readonly HeaderDecoder _headerDecoder = new();
             private readonly WithdrawalDecoder _withdrawalDecoderDecoder = new();
             private readonly ConsensusRequestDecoder _requestsDecoder = new();
@@ -72,7 +74,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages
                 + (b.Withdrawals is not null ? Rlp.LengthOfSequence(GetWithdrawalsLength(b.Withdrawals)) : 0)
                 + (b.Requests is not null ? Rlp.LengthOfSequence(GetRequestsLength(b.Requests)) : 0);
 
-            private int GetTxLength(Transaction[] transactions) => transactions.Sum(t => _txDecoder.GetLength(t, RlpBehaviors.None));
+            private int GetTxLength(Transaction[] transactions) => transactions.Sum(t => _txDecoder.Value.GetLength(t, RlpBehaviors.None));
 
             private int GetUnclesLength(BlockHeader[] headers) => headers.Sum(t => _headerDecoder.GetLength(t, RlpBehaviors.None));
 
@@ -91,7 +93,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages
 
                 // quite significant allocations (>0.5%) here based on a sample 3M blocks sync
                 // (just on these delegates)
-                Transaction[] transactions = ctx.DecodeArray(_txDecoder);
+                Transaction[] transactions = ctx.DecodeArray(_txDecoder.Value);
                 BlockHeader[] uncles = ctx.DecodeArray(_headerDecoder);
                 Withdrawal[]? withdrawals = null;
                 ConsensusRequest[]? requests = null;
@@ -114,7 +116,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages
                 stream.StartSequence(GetTxLength(body.Transactions));
                 foreach (Transaction? txn in body.Transactions)
                 {
-                    stream.Encode(txn);
+                    _txDecoder.Value.Encode(stream, txn);
                 }
 
                 stream.StartSequence(GetUnclesLength(body.Uncles));

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Messages/TransactionsMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Messages/TransactionsMessageSerializer.cs
@@ -10,7 +10,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages
 {
     public class TransactionsMessageSerializer : IZeroInnerMessageSerializer<TransactionsMessage>
     {
-        private readonly TxDecoder _decoder = TxDecoder.Instance;
+        private TxDecoder _decoder => TxDecoder.Instance;
 
         public void Serialize(IByteBuffer byteBuffer, TransactionsMessage message)
         {

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Messages/TransactionsMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Messages/TransactionsMessageSerializer.cs
@@ -5,12 +5,14 @@ using DotNetty.Buffers;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Serialization.Rlp;
+using System;
+using System.IO;
 
 namespace Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages
 {
     public class TransactionsMessageSerializer : IZeroInnerMessageSerializer<TransactionsMessage>
     {
-        private TxDecoder _decoder => TxDecoder.Instance;
+        private readonly Lazy<TxDecoder> _txDecoder = new(() => TxDecoder.Instance);
 
         public void Serialize(IByteBuffer byteBuffer, TransactionsMessage message)
         {
@@ -21,7 +23,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages
             nettyRlpStream.StartSequence(contentLength);
             for (int i = 0; i < message.Transactions.Count; i++)
             {
-                nettyRlpStream.Encode(message.Transactions[i], RlpBehaviors.InMempoolForm);
+                _txDecoder.Value.Encode(nettyRlpStream, message.Transactions[i], RlpBehaviors.InMempoolForm);
             }
         }
 
@@ -37,7 +39,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages
             contentLength = 0;
             for (int i = 0; i < message.Transactions.Count; i++)
             {
-                contentLength += _decoder.GetLength(message.Transactions[i], RlpBehaviors.InMempoolForm);
+                contentLength += _txDecoder.Value.GetLength(message.Transactions[i], RlpBehaviors.InMempoolForm);
             }
 
             return Rlp.LengthOfSequence(contentLength);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Messages/TransactionsMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Messages/TransactionsMessageSerializer.cs
@@ -6,7 +6,6 @@ using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Serialization.Rlp;
 using System;
-using System.IO;
 
 namespace Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages
 {

--- a/src/Nethermind/Nethermind.Serialization.Rlp/BlockDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/BlockDecoder.cs
@@ -12,7 +12,7 @@ namespace Nethermind.Serialization.Rlp
     public class BlockDecoder : IRlpValueDecoder<Block>, IRlpStreamDecoder<Block>
     {
         private readonly HeaderDecoder _headerDecoder = new();
-        private readonly TxDecoder _txDecoder = TxDecoder.Instance;
+        private TxDecoder _txDecoder => TxDecoder.Instance;
         private readonly WithdrawalDecoder _withdrawalDecoder = new();
         private readonly ConsensusRequestDecoder _consensusRequestsDecoder = new();
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/BlockDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/BlockDecoder.cs
@@ -12,7 +12,7 @@ namespace Nethermind.Serialization.Rlp
     public class BlockDecoder : IRlpValueDecoder<Block>, IRlpStreamDecoder<Block>
     {
         private readonly HeaderDecoder _headerDecoder = new();
-        private TxDecoder _txDecoder => TxDecoder.Instance;
+        private readonly Lazy<TxDecoder> _txDecoder = new(() => TxDecoder.Instance);
         private readonly WithdrawalDecoder _withdrawalDecoder = new();
         private readonly ConsensusRequestDecoder _consensusRequestsDecoder = new();
 
@@ -180,7 +180,7 @@ namespace Nethermind.Serialization.Rlp
             int txLength = 0;
             for (int i = 0; i < item.Transactions.Length; i++)
             {
-                txLength += _txDecoder.GetLength(item.Transactions[i], rlpBehaviors);
+                txLength += _txDecoder.Value.GetLength(item.Transactions[i], rlpBehaviors);
             }
 
             return txLength;
@@ -338,7 +338,7 @@ namespace Nethermind.Serialization.Rlp
             stream.StartSequence(txsLength);
             for (int i = 0; i < item.Transactions.Length; i++)
             {
-                stream.Encode(item.Transactions[i]);
+                _txDecoder.Value.Encode(stream, item.Transactions[i]);
             }
 
             stream.StartSequence(unclesLength);

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpStream.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpStream.cs
@@ -25,7 +25,6 @@ namespace Nethermind.Serialization.Rlp
         private static readonly HeaderDecoder _headerDecoder = new();
         private static readonly BlockDecoder _blockDecoder = new();
         private static readonly BlockInfoDecoder _blockInfoDecoder = new();
-        private static TxDecoder _txDecoder => TxDecoder.Instance;
         private static readonly WithdrawalDecoder _withdrawalDecoder = new();
         private static readonly ConsensusRequestDecoder _requestsDecoder = new();
         private static readonly LogEntryDecoder _logEntryDecoder = LogEntryDecoder.Instance;
@@ -64,11 +63,6 @@ namespace Nethermind.Serialization.Rlp
         public void Encode(BlockHeader value)
         {
             _headerDecoder.Encode(this, value);
-        }
-
-        public void Encode(Transaction value, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
-        {
-            _txDecoder.Encode(this, value, rlpBehaviors);
         }
 
         public void Encode(Withdrawal value) => _withdrawalDecoder.Encode(this, value);

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpStream.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpStream.cs
@@ -25,7 +25,7 @@ namespace Nethermind.Serialization.Rlp
         private static readonly HeaderDecoder _headerDecoder = new();
         private static readonly BlockDecoder _blockDecoder = new();
         private static readonly BlockInfoDecoder _blockInfoDecoder = new();
-        private static readonly TxDecoder _txDecoder = TxDecoder.Instance;
+        private static TxDecoder _txDecoder => TxDecoder.Instance;
         private static readonly WithdrawalDecoder _withdrawalDecoder = new();
         private static readonly ConsensusRequestDecoder _requestsDecoder = new();
         private static readonly LogEntryDecoder _logEntryDecoder = LogEntryDecoder.Instance;

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoder.cs
@@ -14,15 +14,7 @@ public sealed class TxDecoder : TxDecoder<Transaction>
     public static readonly ObjectPool<Transaction> TxObjectPool = new DefaultObjectPool<Transaction>(new Transaction.PoolPolicy(), Environment.ProcessorCount * 4);
 
 #pragma warning disable CS0618
-    public static TxDecoder Instance
-    {
-        get
-        {
-            var d = Rlp.GetStreamDecoder<Transaction>() as TxDecoder;
-
-            return d;
-        }
-    }
+    public static TxDecoder Instance => Rlp.GetStreamDecoder<Transaction>() as TxDecoder;
 #pragma warning restore CS0618
 
     // Rlp will try to find a public parameterless constructor during static initialization.

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoder.cs
@@ -14,7 +14,15 @@ public sealed class TxDecoder : TxDecoder<Transaction>
     public static readonly ObjectPool<Transaction> TxObjectPool = new DefaultObjectPool<Transaction>(new Transaction.PoolPolicy(), Environment.ProcessorCount * 4);
 
 #pragma warning disable CS0618
-    public static readonly TxDecoder Instance = new();
+    public static TxDecoder Instance
+    {
+        get
+        {
+            var d = Rlp.GetStreamDecoder<Transaction>() as TxDecoder;
+
+            return d;
+        }
+    }
 #pragma warning restore CS0618
 
     // Rlp will try to find a public parameterless constructor during static initialization.

--- a/src/Nethermind/Nethermind.State/Proofs/TxTrie.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/TxTrie.cs
@@ -16,7 +16,7 @@ namespace Nethermind.State.Proofs;
 /// </summary>
 public class TxTrie : PatriciaTrie<Transaction>
 {
-    private static readonly TxDecoder _txDecoder = TxDecoder.Instance;
+    private static TxDecoder _txDecoder => TxDecoder.Instance;
 
     /// <inheritdoc/>
     /// <param name="transactions">The transactions to build the trie of.</param>

--- a/src/Nethermind/Nethermind.State/Proofs/TxTrie.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/TxTrie.cs
@@ -16,7 +16,7 @@ namespace Nethermind.State.Proofs;
 /// </summary>
 public class TxTrie : PatriciaTrie<Transaction>
 {
-    private static TxDecoder _txDecoder => TxDecoder.Instance;
+    private static readonly Lazy<TxDecoder> _txDecoder = new(() => TxDecoder.Instance);
 
     /// <inheritdoc/>
     /// <param name="transactions">The transactions to build the trie of.</param>
@@ -29,7 +29,7 @@ public class TxTrie : PatriciaTrie<Transaction>
 
         foreach (Transaction? transaction in list)
         {
-            CappedArray<byte> buffer = _txDecoder.EncodeToCappedArray(transaction, RlpBehaviors.SkipTypedWrapping, _bufferPool);
+            CappedArray<byte> buffer = _txDecoder.Value.EncodeToCappedArray(transaction, RlpBehaviors.SkipTypedWrapping, _bufferPool);
             CappedArray<byte> keyBuffer = (key++).EncodeToCappedArray(_bufferPool);
 
             Set(keyBuffer.AsSpan(), buffer);

--- a/src/Nethermind/Nethermind.TxPool/BlobTxStorage.cs
+++ b/src/Nethermind/Nethermind.TxPool/BlobTxStorage.cs
@@ -17,7 +17,7 @@ namespace Nethermind.TxPool;
 
 public class BlobTxStorage : IBlobTxStorage
 {
-    private static readonly TxDecoder _txDecoder = TxDecoder.Instance;
+    private static TxDecoder _txDecoder => TxDecoder.Instance;
     private readonly IDb _fullBlobTxsDb;
     private readonly IDb _lightBlobTxsDb;
     private readonly IDb _processedBlobTxsDb;

--- a/src/Nethermind/Nethermind.TxPool/BlobTxStorage.cs
+++ b/src/Nethermind/Nethermind.TxPool/BlobTxStorage.cs
@@ -17,7 +17,7 @@ namespace Nethermind.TxPool;
 
 public class BlobTxStorage : IBlobTxStorage
 {
-    private static TxDecoder _txDecoder => TxDecoder.Instance;
+    private static readonly Lazy<TxDecoder> _txDecoder = new(() => TxDecoder.Instance);
     private readonly IDb _fullBlobTxsDb;
     private readonly IDb _lightBlobTxsDb;
     private readonly IDb _processedBlobTxsDb;
@@ -96,7 +96,7 @@ public class BlobTxStorage : IBlobTxStorage
         if (bytes is not null)
         {
             RlpStream rlpStream = new(bytes);
-            blockBlobTransactions = _txDecoder.DecodeArray(rlpStream, RlpBehaviors.InMempoolForm);
+            blockBlobTransactions = _txDecoder.Value.DecodeArray(rlpStream, RlpBehaviors.InMempoolForm);
             return true;
         }
 
@@ -141,10 +141,10 @@ public class BlobTxStorage : IBlobTxStorage
 
     private void EncodeAndSaveTx(Transaction transaction, IDb db, Span<byte> txHashPrefixed)
     {
-        int length = _txDecoder.GetLength(transaction, RlpBehaviors.InMempoolForm);
+        int length = _txDecoder.Value.GetLength(transaction, RlpBehaviors.InMempoolForm);
         IByteBuffer byteBuffer = PooledByteBufferAllocator.Default.Buffer(length);
         using NettyRlpStream rlpStream = new(byteBuffer);
-        rlpStream.Encode(transaction, RlpBehaviors.InMempoolForm);
+        _txDecoder.Value.Encode(rlpStream, transaction, RlpBehaviors.InMempoolForm);
 
         db.PutSpan(txHashPrefixed, byteBuffer.AsSpan());
     }
@@ -158,7 +158,7 @@ public class BlobTxStorage : IBlobTxStorage
         rlpStream.StartSequence(contentLength);
         foreach (Transaction transaction in blockBlobTransactions)
         {
-            _txDecoder.Encode(rlpStream, transaction, RlpBehaviors.InMempoolForm);
+            _txDecoder.Value.Encode(rlpStream, transaction, RlpBehaviors.InMempoolForm);
         }
 
         db.PutSpan(blockNumber.ToBigEndianSpanWithoutLeadingZeros(out _), byteBuffer.AsSpan());
@@ -169,7 +169,7 @@ public class BlobTxStorage : IBlobTxStorage
         int contentLength = 0;
         foreach (Transaction transaction in blockBlobTransactions)
         {
-            contentLength += _txDecoder.GetLength(transaction, RlpBehaviors.InMempoolForm);
+            contentLength += _txDecoder.Value.GetLength(transaction, RlpBehaviors.InMempoolForm);
         }
 
         return contentLength;

--- a/src/Nethermind/Nethermind.TxPool/TransactionExtensions.cs
+++ b/src/Nethermind/Nethermind.TxPool/TransactionExtensions.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Runtime.CompilerServices;
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
@@ -14,11 +15,11 @@ namespace Nethermind.TxPool
     public static class TransactionExtensions
     {
         private static readonly long MaxSizeOfTxForBroadcast = 4.KiB(); //4KB, as in Geth https://github.com/ethereum/go-ethereum/pull/27618
-        private static readonly ITransactionSizeCalculator _transactionSizeCalculator = new NetworkTransactionSizeCalculator(TxDecoder.Instance);
+        private static readonly Lazy<NetworkTransactionSizeCalculator> _transactionSizeCalculator = new(() => new NetworkTransactionSizeCalculator(TxDecoder.Instance));
 
         public static int GetLength(this Transaction tx)
         {
-            return tx.GetLength(_transactionSizeCalculator);
+            return tx.GetLength(_transactionSizeCalculator.Value);
         }
 
         public static bool CanPayBaseFee(this Transaction tx, UInt256 currentBaseFee) => tx.MaxFeePerGas >= currentBaseFee;


### PR DESCRIPTION
It's a hotfix that assumes another iteration of full clean up

## Changes

- Use the same TxDecoder everywhere

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No
