### PR TITLE
Fix `TxDecoder` registration

### DIFF
--- a/src/Nethermind/Nethermind.Api/Extensions/INethermindPlugin.cs
+++ b/src/Nethermind/Nethermind.Api/Extensions/INethermindPlugin.cs
@@ -14,7 +14,7 @@ public interface INethermindPlugin : IAsyncDisposable
 
     string Author { get; }
 
-    void InitRlpDecoders(INethermindApi api) { }
+    void InitTxTypesAndRlpDecoders(INethermindApi api) { }
 
     Task Init(INethermindApi nethermindApi) => Task.CompletedTask;
 

--- a/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchain.cs
@@ -431,10 +431,13 @@ public class TestBlockchain : IDisposable
         BlockTree.BlockAddedToMain -= BlockAddedToMain;
         BlockTree.BlockAddedToMain += BlockAddedToMain;
 
-        await WaitAsync(_oneAtATime, "Multiple block produced at once.");
+        await WaitAsync(_oneAtATime, "Multiple block produced at once.").ConfigureAwait(false);
         AcceptTxResult[] txResults = transactions.Select(t => TxPool.SubmitTx(t, TxHandlingOptions.None)).ToArray();
         Timestamper.Add(TimeSpan.FromSeconds(1));
-        await BlockProductionTrigger.BuildBlock();
+        var headProcessed = new SemaphoreSlim(0);
+        TxPool.TxPoolHeadChanged += (s, a) => headProcessed.Release();
+        await BlockProductionTrigger.BuildBlock().ConfigureAwait(false);
+        await headProcessed.WaitAsync().ConfigureAwait(false);
         return txResults;
     }
 

--- a/src/Nethermind/Nethermind.EthStats.Test/EthStatsPluginTests.cs
+++ b/src/Nethermind/Nethermind.EthStats.Test/EthStatsPluginTests.cs
@@ -32,7 +32,7 @@ public class EthStatsPluginTests
     public void Init_eth_stats_plugin_does_not_throw_exception(bool enabled)
     {
         StatsConfig = new EthStatsConfig() { Enabled = enabled };
-        Assert.DoesNotThrow(() => _plugin.InitRlpDecoders(_context));
+        Assert.DoesNotThrow(() => _plugin.InitTxTypesAndRlpDecoders(_context));
         Assert.DoesNotThrowAsync(async () => await _plugin.Init(_context));
         Assert.DoesNotThrowAsync(async () => await _plugin.InitNetworkProtocol());
         Assert.DoesNotThrowAsync(async () => await _plugin.InitRpcModules());

--- a/src/Nethermind/Nethermind.Init/Steps/DatabaseMigrations.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/DatabaseMigrations.cs
@@ -11,7 +11,7 @@ using Nethermind.Init.Steps.Migrations;
 
 namespace Nethermind.Init.Steps
 {
-    [RunnerStepDependencies(typeof(InitRlp), typeof(InitDatabase), typeof(InitializeBlockchain), typeof(InitializeNetwork))]
+    [RunnerStepDependencies(typeof(InitTxTypesAndRlp), typeof(InitDatabase), typeof(InitializeBlockchain), typeof(InitializeNetwork))]
     public sealed class DatabaseMigrations : IStep
     {
         private readonly IApiWithNetwork _api;

--- a/src/Nethermind/Nethermind.Init/Steps/InitCrypto.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitCrypto.cs
@@ -9,7 +9,7 @@ using Nethermind.Crypto;
 
 namespace Nethermind.Init.Steps
 {
-    [RunnerStepDependencies(typeof(InitRlp))]
+    [RunnerStepDependencies(typeof(InitTxTypesAndRlp))]
     public class InitCrypto : IStep
     {
         private readonly IBasicApi _api;

--- a/src/Nethermind/Nethermind.Init/Steps/InitRlp.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitRlp.cs
@@ -30,7 +30,7 @@ namespace Nethermind.Init.Steps
             if (_api.SpecProvider is null) throw new StepDependencyException(nameof(_api.SpecProvider));
 
             // we need to initialize everything transaction related before block tree
-            _api.TxValidator = new TxValidator(_api.SpecProvider!.ChainId);
+            _api.TxValidator = new TxValidator(_api.SpecProvider.ChainId);
 
             Assembly? assembly = Assembly.GetAssembly(typeof(NetworkNodeDecoder));
             if (assembly is not null)

--- a/src/Nethermind/Nethermind.Init/Steps/InitRlp.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitRlp.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Api;
 using Nethermind.Api.Extensions;
+using Nethermind.Consensus.Validators;
 using Nethermind.Core.Attributes;
 using Nethermind.Network;
 using Nethermind.Serialization.Rlp;
@@ -27,6 +28,9 @@ namespace Nethermind.Init.Steps
         public virtual Task Execute(CancellationToken _)
         {
             if (_api.SpecProvider is null) throw new StepDependencyException(nameof(_api.SpecProvider));
+
+            // we need to initialize everything transaction related before block tree
+            _api.TxValidator = new TxValidator(_api.SpecProvider!.ChainId);
 
             Assembly? assembly = Assembly.GetAssembly(typeof(NetworkNodeDecoder));
             if (assembly is not null)

--- a/src/Nethermind/Nethermind.Init/Steps/InitTxTypesAndRlp.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitTxTypesAndRlp.cs
@@ -15,14 +15,9 @@ using Nethermind.Serialization.Rlp;
 namespace Nethermind.Init.Steps
 {
     [RunnerStepDependencies(typeof(ApplyMemoryHint))]
-    public class InitRlp : IStep
+    public class InitTxTypesAndRlp(INethermindApi api) : IStep
     {
-        private readonly INethermindApi _api;
-
-        public InitRlp(INethermindApi api)
-        {
-            _api = api ?? throw new ArgumentNullException(nameof(api));
-        }
+        private readonly INethermindApi _api = api ?? throw new ArgumentNullException(nameof(api));
 
         [Todo(Improve.Refactor, "Automatically scan all the references solutions?")]
         public virtual Task Execute(CancellationToken _)
@@ -40,7 +35,7 @@ namespace Nethermind.Init.Steps
 
             foreach (INethermindPlugin plugin in _api.Plugins)
             {
-                plugin.InitRlpDecoders(_api);
+                plugin.InitTxTypesAndRlpDecoders(_api);
             }
 
             return Task.CompletedTask;

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeBlockTree.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeBlockTree.cs
@@ -20,7 +20,7 @@ using Nethermind.State.Repositories;
 
 namespace Nethermind.Init.Steps
 {
-    [RunnerStepDependencies(typeof(InitRlp), typeof(InitDatabase), typeof(MigrateConfigs), typeof(SetupKeyStore))]
+    [RunnerStepDependencies(typeof(InitTxTypesAndRlp), typeof(InitDatabase), typeof(MigrateConfigs), typeof(SetupKeyStore))]
     public class InitializeBlockTree : IStep
     {
         private readonly IBasicApi _get;

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeBlockchain.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeBlockchain.cs
@@ -92,7 +92,7 @@ namespace Nethermind.Init.Steps
             setApi.TxPoolInfoProvider = new TxPoolInfoProvider(chainHeadInfoProvider.AccountStateProvider, txPool);
             setApi.GasPriceOracle = new GasPriceOracle(getApi.BlockTree!, getApi.SpecProvider, _api.LogManager, blocksConfig.MinGasPrice);
             BlockCachePreWarmer? preWarmer = blocksConfig.PreWarmStateOnBlockProcessing
-                ? new(new(_api.WorldStateManager!, _api.BlockTree!, _api.SpecProvider, _api.LogManager, _api.WorldState), _api.SpecProvider, _api.LogManager, preBlockCaches)
+                ? new(new(_api.WorldStateManager!, _api.BlockTree!, _api.SpecProvider, _api.LogManager, _api.WorldState), _api.SpecProvider!, _api.LogManager, preBlockCaches)
                 : null;
             IBlockProcessor mainBlockProcessor = setApi.MainBlockProcessor = CreateBlockProcessor(preWarmer);
 

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeBlockchain.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeBlockchain.cs
@@ -51,7 +51,6 @@ namespace Nethermind.Init.Steps
         {
             (IApiWithStores getApi, IApiWithBlockchain setApi) = _api.ForBlockchain;
             setApi.TransactionComparerProvider = new TransactionComparerProvider(getApi.SpecProvider!, getApi.BlockTree!.AsReadOnly());
-            setApi.TxValidator = new TxValidator(_api.SpecProvider!.ChainId);
 
             IInitConfig initConfig = getApi.Config<IInitConfig>();
             IBlocksConfig blocksConfig = getApi.Config<IBlocksConfig>();

--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcSocketsClientTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcSocketsClientTests.cs
@@ -125,7 +125,7 @@ public class JsonRpcSocketsClientTests
                 {
                     using JsonRpcResult result = JsonRpcResult.Single(RandomSuccessResponse(1_000, () => disposeCount++), default);
                     await client.SendJsonRpcResult(result);
-                    await Task.Delay(100);
+                    await Task.Delay(10);
                 }
 
                 disposeCount.Should().Be(messageCount);
@@ -220,7 +220,7 @@ public class JsonRpcSocketsClientTests
                     await stream.WriteEndOfMessageAsync();
                     if (i % 10 == 0)
                     {
-                        await Task.Delay(100);
+                        await Task.Delay(10);
                     }
                 }
                 stream.Close();

--- a/src/Nethermind/Nethermind.Optimism.Test/RlpDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Optimism.Test/RlpDecoderTests.cs
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using FluentAssertions;
+using Nethermind.Core;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Serialization.Rlp;
+using NUnit.Framework;
+
+namespace Nethermind.Optimism.Test;
+
+public class RlpDecoderTests
+{
+    [Test]
+    public void Can_decode_non_null_Transaction()
+    {
+        TxDecoder decoder = TxDecoder.Instance;
+        decoder.RegisterDecoder(new OptimismTxDecoder<Transaction>());
+
+        Transaction tx = Build.A.Transaction.WithType(TxType.DepositTx).TestObject;
+
+        RlpStream rlpStream = new(decoder.GetLength(tx, RlpBehaviors.None));
+        decoder.Encode(rlpStream, tx);
+        rlpStream.Reset();
+
+        Transaction? decodedTx = decoder.Decode(rlpStream);
+
+        decodedTx.Should().NotBeNull();
+    }
+
+    [Test]
+    public void Can_decode_non_null_Transaction_through_Rlp()
+    {
+        TxDecoder decoder = TxDecoder.Instance;
+        decoder.RegisterDecoder(new OptimismTxDecoder<Transaction>());
+
+        Transaction tx = Build.A.Transaction.WithType(TxType.DepositTx).TestObject;
+
+        RlpStream rlpStream = new(decoder.GetLength(tx, RlpBehaviors.None));
+        decoder.Encode(rlpStream, tx);
+        rlpStream.Reset();
+
+        Transaction? decodedTx = Rlp.Decode<Transaction?>(rlpStream);
+
+        decodedTx.Should().NotBeNull();
+    }
+}

--- a/src/Nethermind/Nethermind.Optimism/InitializeBlockchainOptimism.cs
+++ b/src/Nethermind/Nethermind.Optimism/InitializeBlockchainOptimism.cs
@@ -11,7 +11,6 @@ using Nethermind.Consensus.Processing;
 using Nethermind.Consensus.Producers;
 using Nethermind.Consensus.Validators;
 using Nethermind.Consensus.Withdrawals;
-using Nethermind.Core;
 using Nethermind.Evm;
 using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Init.Steps;
@@ -29,8 +28,6 @@ public class InitializeBlockchainOptimism(OptimismNethermindApi api) : Initializ
         api.L1CostHelper = new(api.SpecHelper, api.ChainSpec.Optimism.L1BlockAddress);
 
         await base.InitBlockchain();
-
-        api.RegisterTxType(TxType.DepositTx, new OptimismTxDecoder<Transaction>(), Always.Valid);
     }
 
     protected override ITransactionProcessor CreateTransactionProcessor(CodeInfoRepository codeInfoRepository, VirtualMachine virtualMachine)

--- a/src/Nethermind/Nethermind.Optimism/OptimismPlugin.cs
+++ b/src/Nethermind/Nethermind.Optimism/OptimismPlugin.cs
@@ -76,7 +76,7 @@ public class OptimismPlugin : IConsensusPlugin, ISynchronizationPlugin, IInitial
         ILogManager logManager, ChainSpec chainSpec) =>
         new OptimismNethermindApi(configProvider, jsonSerializer, logManager, chainSpec);
 
-    public void InitRlpDecoders(INethermindApi api)
+    public void InitTxTypesAndRlpDecoders(INethermindApi api)
     {
         if (ShouldRunSteps(api))
         {

--- a/src/Nethermind/Nethermind.Optimism/OptimismPlugin.cs
+++ b/src/Nethermind/Nethermind.Optimism/OptimismPlugin.cs
@@ -20,6 +20,8 @@ using Nethermind.Merge.Plugin.InvalidChainTracker;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Consensus.Rewards;
+using Nethermind.Consensus.Validators;
+using Nethermind.Core;
 using Nethermind.Merge.Plugin.Synchronization;
 using Nethermind.Synchronization.ParallelSync;
 using Nethermind.HealthChecks;
@@ -78,6 +80,7 @@ public class OptimismPlugin : IConsensusPlugin, ISynchronizationPlugin, IInitial
     {
         if (ShouldRunSteps(api))
         {
+            api.RegisterTxType(TxType.DepositTx, new OptimismTxDecoder<Transaction>(), Always.Valid);
             Rlp.RegisterDecoders(typeof(OptimismReceiptMessageDecoder).Assembly, true);
         }
     }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoder.cs
@@ -9,18 +9,21 @@ using Nethermind.Serialization.Rlp.TxDecoders;
 
 namespace Nethermind.Serialization.Rlp;
 
+[Rlp.SkipGlobalRegistration]
 public sealed class TxDecoder : TxDecoder<Transaction>
 {
-    public static readonly ObjectPool<Transaction> TxObjectPool = new DefaultObjectPool<Transaction>(new Transaction.PoolPolicy(), Environment.ProcessorCount * 4);
+    public static readonly ObjectPool<Transaction> TxObjectPool;
 
-#pragma warning disable CS0618
-    public static readonly TxDecoder Instance = new();
-#pragma warning restore CS0618
+    public static readonly TxDecoder Instance;
 
-    // Rlp will try to find a public parameterless constructor during static initialization.
-    // The lambda cannot be removed due to static block initialization order.
-    [Obsolete("Use `TxDecoder.Instance` instead")]
-    public TxDecoder() : base(() => TxObjectPool.Get()) { }
+    private TxDecoder(Func<Transaction> transactionFactory) : base(transactionFactory) { }
+
+    static TxDecoder()
+    {
+        TxObjectPool = new DefaultObjectPool<Transaction>(new Transaction.PoolPolicy(), Environment.ProcessorCount * 4);
+        Instance = new TxDecoder(() => TxObjectPool.Get());
+        Rlp.RegisterDecoder(typeof(Transaction), Instance);
+    }
 }
 
 public sealed class SystemTxDecoder : TxDecoder<SystemTransaction>;

--- a/src/Nethermind/Nethermind.TxPool/ITxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxPool.cs
@@ -16,6 +16,8 @@ namespace Nethermind.TxPool
         int GetPendingBlobTransactionsCount();
         Transaction[] GetPendingTransactions();
 
+        public event EventHandler<Block>? TxPoolHeadChanged;
+
         /// <summary>
         /// Non-blob txs grouped by sender address, sorted by nonce and later tx pool sorting
         /// </summary>

--- a/src/Nethermind/Nethermind.TxPool/NullTxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/NullTxPool.cs
@@ -16,6 +16,12 @@ namespace Nethermind.TxPool
 
         public static NullTxPool Instance { get; } = new();
 
+        public event EventHandler<Block>? TxPoolHeadChanged
+        {
+            add { }
+            remove { }
+        }
+
         public int GetPendingTransactionsCount() => 0;
         public int GetPendingBlobTransactionsCount() => 0;
         public Transaction[] GetPendingTransactions() => Array.Empty<Transaction>();

--- a/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
@@ -142,7 +142,7 @@ namespace Nethermind.TxPool
             }
         }
 
-        public void OnNewHead()
+        public void OnNewHead(object? sender, Block block)
         {
             _baseFeeThreshold = CalculateBaseFeeThreshold();
             BroadcastPersistentTxs();

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -59,6 +59,8 @@ namespace Nethermind.TxPool
         private readonly UpdateGroupDelegate _updateBucket;
         private readonly UpdateGroupDelegate _updateBucketAdded;
 
+        public event EventHandler<Block>? TxPoolHeadChanged;
+
         /// <summary>
         /// Indexes transactions
         /// </summary>
@@ -112,6 +114,7 @@ namespace Nethermind.TxPool
             _updateBucketAdded = UpdateBucketWithAddedTransaction;
 
             _broadcaster = new TxBroadcaster(comparer, TimerFactory.Default, txPoolConfig, chainHeadInfoProvider, logManager, transactionsGossipPolicy);
+            TxPoolHeadChanged += _broadcaster.OnNewHead;
 
             _transactions = new TxDistinctSortedPool(MemoryAllowance.MemPoolSize, comparer, logManager);
             _blobTransactions = txPoolConfig.BlobsSupport.IsPersistentStorage()
@@ -164,7 +167,7 @@ namespace Nethermind.TxPool
             ProcessNewHeads();
         }
 
-        public Transaction[] GetPendingTransactions() => _transactions.GetSnapshot();
+        public Transaction[] GetPendingTransactions() => _transactionSnapshot ??= _transactions.GetSnapshot();
 
         public int GetPendingTransactionsCount() => _transactions.Count;
 
@@ -191,10 +194,6 @@ namespace Nethermind.TxPool
         {
             try
             {
-                // Clear snapshot
-                _transactionSnapshot = null;
-                _blobTransactionSnapshot = null;
-                _hashCache.ClearCurrentBlockCache();
                 _headBlocksChannel.Writer.TryWrite(e);
             }
             catch (Exception exception)
@@ -211,8 +210,12 @@ namespace Nethermind.TxPool
             {
                 while (await _headBlocksChannel.Reader.WaitToReadAsync())
                 {
+                    _hashCache.ClearCurrentBlockCache();
                     while (_headBlocksChannel.Reader.TryRead(out BlockReplacementEventArgs? args))
                     {
+                        // Clear snapshot
+                        _transactionSnapshot = null;
+                        _blobTransactionSnapshot = null;
                         try
                         {
                             ArrayPoolList<AddressAsKey>? accountChanges = args.Block.AccountChanges;
@@ -235,7 +238,7 @@ namespace Nethermind.TxPool
                             ReAddReorganisedTransactions(args.PreviousBlock);
                             RemoveProcessedTransactions(args.Block);
                             UpdateBuckets();
-                            _broadcaster.OnNewHead();
+                            TxPoolHeadChanged?.Invoke(this, args.Block);
                             Metrics.TransactionCount = _transactions.Count;
                             Metrics.BlobTransactionCount = _blobTransactions.Count;
                         }
@@ -750,6 +753,7 @@ namespace Nethermind.TxPool
         public void Dispose()
         {
             _timer?.Dispose();
+            TxPoolHeadChanged -= _broadcaster.OnNewHead;
             _broadcaster.Dispose();
             _headInfo.HeadChanged -= OnHeadChange;
             _headBlocksChannel.Writer.Complete();


### PR DESCRIPTION
Proper fix instead of #7496

## Changes

- Prefer manual registration
- Remove fishy public constructor
- Add tests for proper registration

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Added tests to ensure that we're using a single `TxDecoder` global instance.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Registration of these global instances is tricky and very error prone. In an ideal world we would use DI to handle these kind of issues. Let's remember this issue next time DI comes into discussion.