### PR TITLE
Return 401 rather than 403 for auth'd endpoint

### DIFF
--- a/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
+++ b/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
@@ -133,23 +133,35 @@ public class Startup
 
         app.Run(async ctx =>
         {
-            if (ctx.Request.Method == "GET")
+            var method = ctx.Request.Method;
+            if (method is not "POST" and not "GET")
+            {
+                return;
+            }
+
+            if (!jsonRpcUrlCollection.TryGetValue(ctx.Connection.LocalPort, out JsonRpcUrl jsonRpcUrl) ||
+                !jsonRpcUrl.RpcEndpoint.HasFlag(RpcEndpoint.Http))
+            {
+                return;
+            }
+
+            if (jsonRpcUrl.IsAuthenticated)
+            {
+                if (!await rpcAuthentication!.Authenticate(ctx.Request.Headers.Authorization))
+                {
+                    await PushErrorResponse(StatusCodes.Status401Unauthorized, ErrorCodes.InvalidRequest, "Authentication error");
+                    return;
+                }
+            }
+
+            if (method == "GET")
             {
                 await ctx.Response.WriteAsync("Nethermind JSON RPC");
             }
-
-            if (ctx.Request.Method == "POST" &&
-                jsonRpcUrlCollection.TryGetValue(ctx.Connection.LocalPort, out JsonRpcUrl jsonRpcUrl) &&
-                jsonRpcUrl.RpcEndpoint.HasFlag(RpcEndpoint.Http))
+            else
             {
                 if (jsonRpcUrl.MaxRequestBodySize is not null)
                     ctx.Features.Get<IHttpMaxRequestBodySizeFeature>().MaxRequestBodySize = jsonRpcUrl.MaxRequestBodySize;
-
-                if (jsonRpcUrl.IsAuthenticated && !await rpcAuthentication!.Authenticate(ctx.Request.Headers.Authorization))
-                {
-                    await PushErrorResponse(StatusCodes.Status403Forbidden, ErrorCodes.InvalidRequest, "Authentication error");
-                    return;
-                }
 
                 Stopwatch stopwatch = Stopwatch.StartNew();
                 CountingPipeReader request = new(ctx.Request.BodyReader);


### PR DESCRIPTION
## Changes

- Return 401 rather than 403 for auth'd endpoint (when no auth)
- Also return 401 for GET requests as Base uses this to detect when EL is online

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No
