### PR TITLE
Reduce GC pause from 1sec to 500ms for faster blocks

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin/GC/GCKeeper.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/GC/GCKeeper.cs
@@ -150,8 +150,8 @@ public class GCKeeper
         {
             // This should give time to finalize response in Engine API
             // Normally we should get block every 12s (5s on some chains)
-            // Lets say we process block in 2s, then delay 1s, then invoke GC
-            await Task.Delay(1000);
+            // Lets say we process block in 2s, then delay 500ms, then invoke GC
+            await Task.Delay(500);
 
             if (GCSettings.LatencyMode != GCLatencyMode.NoGCRegion)
             {

--- a/src/Nethermind/Nethermind.Merge.Plugin/GC/GCKeeper.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/GC/GCKeeper.cs
@@ -150,8 +150,8 @@ public class GCKeeper
         {
             // This should give time to finalize response in Engine API
             // Normally we should get block every 12s (5s on some chains)
-            // Lets say we process block in 2s, then delay 500ms, then invoke GC
-            await Task.Delay(500);
+            // Lets say we process block in 2s, then delay 250ms, then invoke GC
+            await Task.Delay(250);
 
             if (GCSettings.LatencyMode != GCLatencyMode.NoGCRegion)
             {

--- a/src/Nethermind/Nethermind.Merge.Plugin/GC/GCKeeper.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/GC/GCKeeper.cs
@@ -150,8 +150,8 @@ public class GCKeeper
         {
             // This should give time to finalize response in Engine API
             // Normally we should get block every 12s (5s on some chains)
-            // Lets say we process block in 2s, then delay 250ms, then invoke GC
-            await Task.Delay(250);
+            // Lets say we process block in 2s, then delay 500ms, then invoke GC
+            await Task.Delay(500);
 
             if (GCSettings.LatencyMode != GCLatencyMode.NoGCRegion)
             {


### PR DESCRIPTION
## Changes

- Base has blocks of 2secs to pausing 1sec and triggering GC is too long

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No