### PR TITLE
Reuse ClassLoggers

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/NUnitLogManager.cs
+++ b/src/Nethermind/Nethermind.Core.Test/NUnitLogManager.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Runtime.CompilerServices;
+
 using Nethermind.Logging;
 
 namespace Nethermind.Core.Test
@@ -20,7 +22,7 @@ namespace Nethermind.Core.Test
 
         public ILogger GetClassLogger<T>() => GetClassLogger();
 
-        public ILogger GetClassLogger() => new(_logger);
+        public ILogger GetClassLogger([CallerFilePath] string filePath = "") => new(_logger);
 
         public ILogger GetLogger(string loggerName) => GetClassLogger();
     }

--- a/src/Nethermind/Nethermind.Logging.NLog/NLogManager.cs
+++ b/src/Nethermind/Nethermind.Logging.NLog/NLogManager.cs
@@ -70,7 +70,7 @@ namespace Nethermind.Logging.NLog
         private static ILogger BuildNamedLogger(string loggerName)
             => new(new NLogLogger(loggerName));
         private static ILogger BuildClassLogger(string filePath)
-            => new(new NLogLogger(Path.GetFileNameWithoutExtension(filePath)));
+            => new(new NLogLogger());
 
         public ILogger GetClassLogger(Type type) => s_loggers.GetOrAdd(type, s_loggerBuilder);
 
@@ -80,9 +80,7 @@ namespace Nethermind.Logging.NLog
             s_namedLoggers.GetOrAdd(filePath, s_classLoggerBuilder) :
             new(new NLogLogger());
 
-        public ILogger GetLogger(string loggerName) => !string.IsNullOrEmpty(loggerName) ?
-            s_namedLoggers.GetOrAdd(loggerName, s_namedLoggerBuilder) :
-            new(new NLogLogger());
+        public ILogger GetLogger(string loggerName) => s_namedLoggers.GetOrAdd(loggerName, s_namedLoggerBuilder);
 
         public void SetGlobalVariable(string name, object value)
         {

--- a/src/Nethermind/Nethermind.Logging/ILogManager.cs
+++ b/src/Nethermind/Nethermind.Logging/ILogManager.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Runtime.CompilerServices;
 
 namespace Nethermind.Logging
 {
@@ -9,7 +10,7 @@ namespace Nethermind.Logging
     {
         ILogger GetClassLogger(Type type);
         ILogger GetClassLogger<T>();
-        ILogger GetClassLogger();
+        ILogger GetClassLogger([CallerFilePath] string filePath = "");
         ILogger GetLogger(string loggerName);
 
         void SetGlobalVariable(string name, object value) { }

--- a/src/Nethermind/Nethermind.Logging/LimboLogs.cs
+++ b/src/Nethermind/Nethermind.Logging/LimboLogs.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace Nethermind.Logging
@@ -29,7 +30,7 @@ namespace Nethermind.Logging
 
         public ILogger GetClassLogger<T>() => LimboTraceLogger.Instance;
 
-        public ILogger GetClassLogger() => LimboTraceLogger.Instance;
+        public ILogger GetClassLogger([CallerFilePath] string filePath = "") => LimboTraceLogger.Instance;
 
         public ILogger GetLogger(string loggerName) => LimboTraceLogger.Instance;
     }

--- a/src/Nethermind/Nethermind.Logging/NoErrorLimboLogs.cs
+++ b/src/Nethermind/Nethermind.Logging/NoErrorLimboLogs.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace Nethermind.Logging
@@ -23,7 +24,7 @@ namespace Nethermind.Logging
 
         public ILogger GetClassLogger<T>() => LimboNoErrorLogger.Instance;
 
-        public ILogger GetClassLogger() => LimboNoErrorLogger.Instance;
+        public ILogger GetClassLogger([CallerFilePath] string filePath = "") => LimboNoErrorLogger.Instance;
 
         public ILogger GetLogger(string loggerName) => LimboNoErrorLogger.Instance;
     }

--- a/src/Nethermind/Nethermind.Logging/NullLogManager.cs
+++ b/src/Nethermind/Nethermind.Logging/NullLogManager.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Runtime.CompilerServices;
 
 namespace Nethermind.Logging
 {
@@ -17,7 +18,7 @@ namespace Nethermind.Logging
 
         public ILogger GetClassLogger<T>() => NullLogger.Instance;
 
-        public ILogger GetClassLogger() => NullLogger.Instance;
+        public ILogger GetClassLogger([CallerFilePath] string filePath = "") => NullLogger.Instance;
 
         public ILogger GetLogger(string loggerName) => NullLogger.Instance;
     }

--- a/src/Nethermind/Nethermind.Logging/OneLoggerLogManager.cs
+++ b/src/Nethermind/Nethermind.Logging/OneLoggerLogManager.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Runtime.CompilerServices;
 
 namespace Nethermind.Logging
 {
@@ -18,7 +19,7 @@ namespace Nethermind.Logging
 
         public ILogger GetClassLogger<T>() => _logger;
 
-        public ILogger GetClassLogger() => _logger;
+        public ILogger GetClassLogger([CallerFilePath] string filePath = "") => _logger;
 
         public ILogger GetLogger(string loggerName) => _logger;
     }

--- a/src/Nethermind/Nethermind.Logging/SimpleConsoleLogManager.cs
+++ b/src/Nethermind/Nethermind.Logging/SimpleConsoleLogManager.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Runtime.CompilerServices;
 
 namespace Nethermind.Logging
 {
@@ -23,7 +24,7 @@ namespace Nethermind.Logging
             return new(SimpleConsoleLogger.Instance);
         }
 
-        public ILogger GetClassLogger()
+        public ILogger GetClassLogger([CallerFilePath] string filePath = "")
         {
             return new(SimpleConsoleLogger.Instance);
         }

--- a/src/Nethermind/Nethermind.Logging/TestErrorLogManager.cs
+++ b/src/Nethermind/Nethermind.Logging/TestErrorLogManager.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace Nethermind.Logging;
 
@@ -17,7 +18,7 @@ public class TestErrorLogManager : ILogManager
 
     public ILogger GetClassLogger<T>() => GetClassLogger();
 
-    public ILogger GetClassLogger() => new(new TestErrorLogger(_errors));
+    public ILogger GetClassLogger([CallerFilePath] string filePath = "") => new(new TestErrorLogger(_errors));
 
     public ILogger GetLogger(string loggerName) => GetClassLogger();
 

--- a/src/Nethermind/Nethermind.Logging/TestLogManager.cs
+++ b/src/Nethermind/Nethermind.Logging/TestLogManager.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Runtime.CompilerServices;
 
 namespace Nethermind.Logging
 {
@@ -20,7 +21,7 @@ namespace Nethermind.Logging
 
         public ILogger GetClassLogger<T>() => GetClassLogger();
 
-        public ILogger GetClassLogger() => new(new NUnitLogger(_level));
+        public ILogger GetClassLogger([CallerFilePath] string filePath = "") => new(new NUnitLogger(_level));
 
         public ILogger GetLogger(string loggerName) => GetClassLogger();
 

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
@@ -1583,7 +1583,7 @@ public partial class EngineModuleTests
         var iLogger = Substitute.For<InterfaceLogger>();
         iLogger.IsWarn.Returns(true);
         var logger = new ILogger(iLogger);
-        loggerManager.GetClassLogger().Returns(logger);
+        loggerManager.GetClassLogger(Arg.Any<string>()).Returns(logger);
 
         chain.LogManager = loggerManager;
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncReportTest.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncReportTest.cs
@@ -76,7 +76,7 @@ namespace Nethermind.Synchronization.Test
             iLogger.IsInfo.Returns(true);
             iLogger.IsError.Returns(true);
             ILogger logger = new(iLogger);
-            logManager.GetClassLogger().Returns(logger);
+            logManager.GetClassLogger(Arg.Any<string>()).Returns(logger);
 
             Queue<SyncMode> syncModes = new();
             syncModes.Enqueue(SyncMode.FastHeaders);


### PR DESCRIPTION
## Changes

- Reuse ClassLoggers via ConcurrentDictionary like Typed loggers
- Uses `[CallerFilePath]` for a compile time lookup to avoid using StackTrace to stack walk

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No