### PR TITLE
Fix clear not working

### DIFF
--- a/src/Nethermind/Nethermind.Db.Test/SimpleFilePublicKeyDbTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/SimpleFilePublicKeyDbTests.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-
+using FluentAssertions;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Test.IO;
 using Nethermind.Logging;
@@ -51,6 +51,23 @@ namespace Nethermind.Db.Test
             {
                 Assert.True(filePublicKeyDb[kv.Key].AsSpan().SequenceEqual(kv.Value));
             }
+        }
+
+        [Test]
+        public void Clear()
+        {
+            using TempPath tempPath = TempPath.GetTempFile(SimpleFilePublicKeyDb.DbFileName);
+            tempPath.Dispose();
+
+            SimpleFilePublicKeyDb filePublicKeyDb = new("Test", Path.GetTempPath(), LimboLogs.Instance);
+            using (filePublicKeyDb.StartWriteBatch())
+            {
+                filePublicKeyDb[[1, 2, 3]] = [1, 2, 3];
+            }
+
+            filePublicKeyDb.KeyExists([1, 2, 3]).Should().BeTrue();
+            filePublicKeyDb.Clear();
+            filePublicKeyDb.KeyExists([1, 2, 3]).Should().BeFalse();
         }
     }
 }

--- a/src/Nethermind/Nethermind.Db/SimpleFilePublicKeyDb.cs
+++ b/src/Nethermind/Nethermind.Db/SimpleFilePublicKeyDb.cs
@@ -90,6 +90,7 @@ namespace Nethermind.Db
         public void Clear()
         {
             File.Delete(DbPath);
+            _cache.Clear();
         }
 
         public IEnumerable<KeyValuePair<byte[], byte[]>> GetAll(bool ordered = false) => _cache;


### PR DESCRIPTION
- Fix SimpleFilePublicKeyDb.Clear() not working due to missed `_cache`.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No
