### PR TITLE
Make OnlyStaticPeers load only static peers

### DIFF
--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -461,7 +461,9 @@ public class InitializeNetwork : IStep
             _api.DisposeStack.Push(new NodeSourceToDiscV4Feeder(enrDiscovery, _api.DiscoveryApp, 50));
         }
 
-        CompositeNodeSource nodeSources = new(_api.StaticNodesManager, nodesLoader, enrDiscovery, _api.DiscoveryApp);
+        CompositeNodeSource nodeSources = _networkConfig.OnlyStaticPeers
+            ? new(_api.StaticNodesManager, nodesLoader)
+            : new(_api.StaticNodesManager, nodesLoader, enrDiscovery, _api.DiscoveryApp);
         _api.PeerPool = new PeerPool(nodeSources, _api.NodeStatsManager, peerStorage, _networkConfig, _api.LogManager);
         _api.PeerManager = new PeerManager(
             _api.RlpxPeer,

--- a/src/Nethermind/Nethermind.Network.Test/NodesLoaderTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/NodesLoaderTests.cs
@@ -83,5 +83,19 @@ namespace Nethermind.Network.Test
                 Assert.False(node.IsStatic);
             }
         }
+
+        [Test]
+        public void Can_load_only_static_nodes()
+        {
+            _networkConfig.StaticPeers = enode1String;
+            _networkConfig.Bootnodes = enode2String;
+            _networkConfig.OnlyStaticPeers = true;
+            List<Node> nodes = _loader.LoadInitialList();
+            Assert.That(nodes.Count, Is.EqualTo(1));
+            foreach (Node node in nodes)
+            {
+                Assert.True(node.IsStatic);
+            }
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Network/NodesLoader.cs
+++ b/src/Nethermind/Nethermind.Network/NodesLoader.cs
@@ -43,11 +43,14 @@ namespace Nethermind.Network
             List<Node> allPeers = new();
             LoadPeersFromDb(allPeers);
 
-            LoadConfigPeers(allPeers, _networkConfig.Bootnodes, n =>
+            if (!_networkConfig.OnlyStaticPeers)
             {
-                n.IsBootnode = true;
-                if (_logger.IsDebug) _logger.Debug($"Bootnode     : {n}");
-            });
+                LoadConfigPeers(allPeers, _networkConfig.Bootnodes, n =>
+                {
+                    n.IsBootnode = true;
+                    if (_logger.IsDebug) _logger.Debug($"Bootnode     : {n}");
+                });
+            }
 
             LoadConfigPeers(allPeers, _networkConfig.StaticPeers, n =>
             {


### PR DESCRIPTION
## Changes

- Only add static peer manager and nodes loader to peer pool when OnlyStaticPeers is true.

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Confirmed downloading only from static peers.