### PR TITLE
Remove 5 flow control exceptions

### DIFF
--- a/src/Nethermind/Nethermind.Evm/EvmPooledMemory.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmPooledMemory.cs
@@ -247,11 +247,12 @@ public struct EvmPooledMemory : IEvmMemory
         }
     }
 
-    public static long Div32Ceiling(in UInt256 length)
+    public static long Div32Ceiling(in UInt256 length, out bool outOfGas)
     {
         if (length.IsLargerThanULong())
         {
-            ThrowOutOfGasException();
+            outOfGas = true;
+            return 0;
         }
 
         ulong result = length.u0;
@@ -264,10 +265,23 @@ public struct EvmPooledMemory : IEvmMemory
 
         if (result > int.MaxValue)
         {
+            outOfGas = true;
+            return 0;
+        }
+
+        outOfGas = false;
+        return (long)result;
+    }
+
+    public static long Div32Ceiling(in UInt256 length)
+    {
+        long result = Div32Ceiling(in length, out bool outOfGas);
+        if (outOfGas)
+        {
             ThrowOutOfGasException();
         }
 
-        return (long)result;
+        return result;
     }
 
     private void UpdateSize(in UInt256 location, in UInt256 length, bool rentIfNeeded = true)

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -56,6 +56,8 @@ public class VirtualMachine : IVirtualMachine
         255, 255, 255, 255, 255, 255, 255, 255
     };
 
+    internal static readonly PrecompileExecutionFailureException PrecompileExecutionFailureException = new();
+
     private readonly IVirtualMachine _evm;
 
     public VirtualMachine(
@@ -172,6 +174,7 @@ internal sealed class VirtualMachine<TLogger> : IVirtualMachine where TLogger : 
 
         while (true)
         {
+            Exception? failure = null;
             if (!currentState.IsContinuation)
             {
                 _returnDataBuffer = Array.Empty<byte>();
@@ -193,9 +196,9 @@ internal sealed class VirtualMachine<TLogger> : IVirtualMachine where TLogger : 
                     {
                         if (currentState.IsPrecompile && currentState.IsTopLevel)
                         {
-                            Metrics.EvmExceptions++;
+                            failure = VirtualMachine.PrecompileExecutionFailureException;
                             // TODO: when direct / calls are treated same we should not need such differentiation
-                            throw new PrecompileExecutionFailureException();
+                            goto Failure;
                         }
 
                         // TODO: testing it as it seems the way to pass zkSNARKs tests
@@ -316,102 +319,112 @@ internal sealed class VirtualMachine<TLogger> : IVirtualMachine where TLogger : 
                 }
 
                 Address callCodeOwner = currentState.Env.ExecutingAccount;
-                using EvmState previousState = currentState;
-                currentState = _stateStack.Pop();
-                currentState.IsContinuation = true;
-                currentState.GasAvailable += previousState.GasAvailable;
-                bool previousStateSucceeded = true;
-
-                if (!callResult.ShouldRevert)
+                using (EvmState previousState = currentState)
                 {
-                    long gasAvailableForCodeDeposit = previousState.GasAvailable; // TODO: refactor, this is to fix 61363 Ropsten
-                    if (previousState.ExecutionType.IsAnyCreate())
+                    currentState = _stateStack.Pop();
+                    currentState.IsContinuation = true;
+                    currentState.GasAvailable += previousState.GasAvailable;
+                    bool previousStateSucceeded = true;
+
+                    if (!callResult.ShouldRevert)
                     {
-                        previousCallResult = callCodeOwner.Bytes;
-                        previousCallOutputDestination = UInt256.Zero;
-                        _returnDataBuffer = Array.Empty<byte>();
-                        previousCallOutput = ZeroPaddedSpan.Empty;
-
-                        long codeDepositGasCost = CodeDepositHandler.CalculateCost(callResult.Output.Length, spec);
-                        bool invalidCode = CodeDepositHandler.CodeIsInvalid(spec, callResult.Output);
-                        if (gasAvailableForCodeDeposit >= codeDepositGasCost && !invalidCode)
+                        long gasAvailableForCodeDeposit = previousState.GasAvailable; // TODO: refactor, this is to fix 61363 Ropsten
+                        if (previousState.ExecutionType.IsAnyCreate())
                         {
-                            ReadOnlyMemory<byte> code = callResult.Output;
-                            _codeInfoRepository.InsertCode(_state, code, callCodeOwner, spec);
+                            previousCallResult = callCodeOwner.Bytes;
+                            previousCallOutputDestination = UInt256.Zero;
+                            _returnDataBuffer = Array.Empty<byte>();
+                            previousCallOutput = ZeroPaddedSpan.Empty;
 
-                            currentState.GasAvailable -= codeDepositGasCost;
+                            long codeDepositGasCost = CodeDepositHandler.CalculateCost(callResult.Output.Length, spec);
+                            bool invalidCode = CodeDepositHandler.CodeIsInvalid(spec, callResult.Output);
+                            if (gasAvailableForCodeDeposit >= codeDepositGasCost && !invalidCode)
+                            {
+                                ReadOnlyMemory<byte> code = callResult.Output;
+                                _codeInfoRepository.InsertCode(_state, code, callCodeOwner, spec);
+
+                                currentState.GasAvailable -= codeDepositGasCost;
+
+                                if (typeof(TTracingActions) == typeof(IsTracing))
+                                {
+                                    _txTracer.ReportActionEnd(previousState.GasAvailable - codeDepositGasCost, callCodeOwner, callResult.Output);
+                                }
+                            }
+                            else if (spec.FailOnOutOfGasCodeDeposit || invalidCode)
+                            {
+                                currentState.GasAvailable -= gasAvailableForCodeDeposit;
+                                worldState.Restore(previousState.Snapshot);
+                                if (!previousState.IsCreateOnPreExistingAccount)
+                                {
+                                    _state.DeleteAccount(callCodeOwner);
+                                }
+
+                                previousCallResult = BytesZero;
+                                previousStateSucceeded = false;
+
+                                if (typeof(TTracingActions) == typeof(IsTracing))
+                                {
+                                    _txTracer.ReportActionError(invalidCode ? EvmExceptionType.InvalidCode : EvmExceptionType.OutOfGas);
+                                }
+                            }
+                            else if (typeof(TTracingActions) == typeof(IsTracing))
+                            {
+                                _txTracer.ReportActionEnd(0L, callCodeOwner, callResult.Output);
+                            }
+                        }
+                        else
+                        {
+                            _returnDataBuffer = callResult.Output;
+                            previousCallResult = callResult.PrecompileSuccess.HasValue ? (callResult.PrecompileSuccess.Value ? StatusCode.SuccessBytes : StatusCode.FailureBytes) : StatusCode.SuccessBytes;
+                            previousCallOutput = callResult.Output.Span.SliceWithZeroPadding(0, Math.Min(callResult.Output.Length, (int)previousState.OutputLength));
+                            previousCallOutputDestination = (ulong)previousState.OutputDestination;
+                            if (previousState.IsPrecompile)
+                            {
+                                // parity induced if else for vmtrace
+                                if (_txTracer.IsTracingInstructions)
+                                {
+                                    _txTracer.ReportMemoryChange(previousCallOutputDestination, previousCallOutput);
+                                }
+                            }
 
                             if (typeof(TTracingActions) == typeof(IsTracing))
                             {
-                                _txTracer.ReportActionEnd(previousState.GasAvailable - codeDepositGasCost, callCodeOwner, callResult.Output);
+                                _txTracer.ReportActionEnd(previousState.GasAvailable, _returnDataBuffer);
                             }
                         }
-                        else if (spec.FailOnOutOfGasCodeDeposit || invalidCode)
-                        {
-                            currentState.GasAvailable -= gasAvailableForCodeDeposit;
-                            worldState.Restore(previousState.Snapshot);
-                            if (!previousState.IsCreateOnPreExistingAccount)
-                            {
-                                _state.DeleteAccount(callCodeOwner);
-                            }
 
-                            previousCallResult = BytesZero;
-                            previousStateSucceeded = false;
-
-                            if (typeof(TTracingActions) == typeof(IsTracing))
-                            {
-                                _txTracer.ReportActionError(invalidCode ? EvmExceptionType.InvalidCode : EvmExceptionType.OutOfGas);
-                            }
-                        }
-                        else if (typeof(TTracingActions) == typeof(IsTracing))
+                        if (previousStateSucceeded)
                         {
-                            _txTracer.ReportActionEnd(0L, callCodeOwner, callResult.Output);
+                            previousState.CommitToParent(currentState);
                         }
                     }
                     else
                     {
+                        worldState.Restore(previousState.Snapshot);
                         _returnDataBuffer = callResult.Output;
-                        previousCallResult = callResult.PrecompileSuccess.HasValue ? (callResult.PrecompileSuccess.Value ? StatusCode.SuccessBytes : StatusCode.FailureBytes) : StatusCode.SuccessBytes;
+                        previousCallResult = StatusCode.FailureBytes;
                         previousCallOutput = callResult.Output.Span.SliceWithZeroPadding(0, Math.Min(callResult.Output.Length, (int)previousState.OutputLength));
                         previousCallOutputDestination = (ulong)previousState.OutputDestination;
-                        if (previousState.IsPrecompile)
-                        {
-                            // parity induced if else for vmtrace
-                            if (_txTracer.IsTracingInstructions)
-                            {
-                                _txTracer.ReportMemoryChange(previousCallOutputDestination, previousCallOutput);
-                            }
-                        }
+
 
                         if (typeof(TTracingActions) == typeof(IsTracing))
                         {
-                            _txTracer.ReportActionEnd(previousState.GasAvailable, _returnDataBuffer);
+                            _txTracer.ReportActionRevert(previousState.GasAvailable, callResult.Output);
                         }
-                    }
-
-                    if (previousStateSucceeded)
-                    {
-                        previousState.CommitToParent(currentState);
-                    }
-                }
-                else
-                {
-                    worldState.Restore(previousState.Snapshot);
-                    _returnDataBuffer = callResult.Output;
-                    previousCallResult = StatusCode.FailureBytes;
-                    previousCallOutput = callResult.Output.Span.SliceWithZeroPadding(0, Math.Min(callResult.Output.Length, (int)previousState.OutputLength));
-                    previousCallOutputDestination = (ulong)previousState.OutputDestination;
-
-
-                    if (typeof(TTracingActions) == typeof(IsTracing))
-                    {
-                        _txTracer.ReportActionRevert(previousState.GasAvailable, callResult.Output);
                     }
                 }
             }
             catch (Exception ex) when (ex is EvmException or OverflowException)
             {
-                if (typeof(TLogger) == typeof(IsTracing)) _logger.Trace($"exception ({ex.GetType().Name}) in {currentState.ExecutionType} at depth {currentState.Env.CallDepth} - restoring snapshot");
+                failure = ex;
+                goto Failure;
+            }
+
+            continue;
+
+        Failure:
+            {
+                if (typeof(TLogger) == typeof(IsTracing)) _logger.Trace($"exception ({failure.GetType().Name}) in {currentState.ExecutionType} at depth {currentState.Env.CallDepth} - restoring snapshot");
 
                 _state.Restore(currentState.Snapshot);
 
@@ -420,18 +433,18 @@ internal sealed class VirtualMachine<TLogger> : IVirtualMachine where TLogger : 
                 if (txTracer.IsTracingInstructions)
                 {
                     txTracer.ReportOperationRemainingGas(0);
-                    txTracer.ReportOperationError(ex is EvmException evmException ? evmException.ExceptionType : EvmExceptionType.Other);
+                    txTracer.ReportOperationError(failure is EvmException evmException ? evmException.ExceptionType : EvmExceptionType.Other);
                 }
 
                 if (typeof(TTracingActions) == typeof(IsTracing))
                 {
-                    EvmException evmException = ex as EvmException;
+                    EvmException evmException = failure as EvmException;
                     _txTracer.ReportActionError(evmException?.ExceptionType ?? EvmExceptionType.Other);
                 }
 
                 if (currentState.IsTopLevel)
                 {
-                    return new TransactionSubstate(ex is OverflowException ? EvmExceptionType.Other : (ex as EvmException).ExceptionType, isTracing);
+                    return new TransactionSubstate(failure is OverflowException ? EvmExceptionType.Other : (failure as EvmException).ExceptionType, isTracing);
                 }
 
                 previousCallResult = StatusCode.FailureBytes;

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -57,6 +57,7 @@ public class VirtualMachine : IVirtualMachine
     };
 
     internal static readonly PrecompileExecutionFailureException PrecompileExecutionFailureException = new();
+    internal static readonly OutOfGasException PrecompileOutOfGasException = new();
 
     private readonly IVirtualMachine _evm;
 
@@ -194,6 +195,11 @@ internal sealed class VirtualMachine<TLogger> : IVirtualMachine where TLogger : 
 
                     if (!callResult.PrecompileSuccess.Value)
                     {
+                        if (callResult.IsException)
+                        {
+                            failure = VirtualMachine.PrecompileOutOfGasException;
+                            goto Failure;
+                        }
                         if (currentState.IsPrecompile && currentState.IsTopLevel)
                         {
                             failure = VirtualMachine.PrecompileExecutionFailureException;

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -2714,7 +2714,8 @@ internal sealed class VirtualMachine<TLogger> : IVirtualMachine where TLogger : 
 
     private static bool UpdateMemoryCost(EvmState vmState, ref long gasAvailable, in UInt256 position, in UInt256 length)
     {
-        long memoryCost = vmState.Memory.CalculateMemoryCost(in position, length);
+        long memoryCost = vmState.Memory.CalculateMemoryCost(in position, length, out bool outOfGas);
+        if (outOfGas) return false;
         return memoryCost == 0L || UpdateGas(memoryCost, ref gasAvailable);
     }
 

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -591,8 +591,7 @@ internal sealed class VirtualMachine<TLogger> : IVirtualMachine where TLogger : 
 
         if (!UpdateGas(checked(baseGasCost + blobGasCost), ref gasAvailable))
         {
-            Metrics.EvmExceptions++;
-            throw new OutOfGasException();
+            return new(default, false, true, EvmExceptionType.OutOfGas);
         }
 
         state.GasAvailable = gasAvailable;


### PR DESCRIPTION
Mostly white space changes

## Changes

- Switch to a return code and two gotos (some white space changes from containing a `using` so `goto` can be used)

![image](https://github.com/user-attachments/assets/f94afb01-831e-4852-936d-aa8fb2519c57)

<img width="453" alt="image" src="https://github.com/user-attachments/assets/7daf61a4-9aea-4067-b1dc-59b951517831">

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
