### PR TITLE
Add and parallelise AccessList as part of address prewarming

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
@@ -91,6 +91,7 @@ public sealed class BlockCachePreWarmer(ReadOnlyTxProcessingEnvFactory envFactor
                 IReadOnlyTxProcessorSource env = _envPool.Get();
                 try
                 {
+                    // Only need one scope as we are taking a parallel safe path
                     using IReadOnlyTxProcessingScope scope = env.Build(stateRoot);
                     int progress = 0;
                     Parallel.For(0, block.Withdrawals.Length, parallelOptions,

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/AccessListDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/AccessListDecoderTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using FluentAssertions;
 using Nethermind.Core.Eip2930;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Int256;
 using Nethermind.Serialization.Rlp;
 using Nethermind.Serialization.Rlp.Eip2930;
 using NUnit.Framework;
@@ -99,6 +100,16 @@ namespace Nethermind.Core.Test.Encoding
             else
             {
                 decoded.Should().BeEquivalentTo(testCase.AccessList, testCase.TestName);
+
+                foreach (var list in decoded)
+                {
+                    var i = 0;
+                    foreach (UInt256 key in list.StorageKeys)
+                    {
+                        key.Should().BeEquivalentTo(list.StorageKeys[i], testCase.TestName);
+                        i++;
+                    }
+                }
             }
         }
 
@@ -117,6 +128,16 @@ namespace Nethermind.Core.Test.Encoding
             else
             {
                 decoded.Should().BeEquivalentTo(testCase.AccessList, testCase.TestName);
+
+                foreach (var list in decoded)
+                {
+                    var i = 0;
+                    foreach (UInt256 key in list.StorageKeys)
+                    {
+                        key.Should().BeEquivalentTo(list.StorageKeys[i], testCase.TestName);
+                        i++;
+                    }
+                }
             }
         }
 

--- a/src/Nethermind/Nethermind.Core/Eip2930/AccessList.cs
+++ b/src/Nethermind/Nethermind.Core/Eip2930/AccessList.cs
@@ -121,6 +121,8 @@ public class AccessList : IEnumerable<(Address Address, AccessList.StorageKeysEn
         private readonly int _index;
         private readonly int _count;
 
+        public int Count => _count;
+
         public StorageKeysEnumerable(AccessList accessList, int index, int count)
         {
             _accessList = accessList;

--- a/src/Nethermind/Nethermind.Core/Eip2930/AccessList.cs
+++ b/src/Nethermind/Nethermind.Core/Eip2930/AccessList.cs
@@ -130,6 +130,17 @@ public class AccessList : IEnumerable<(Address Address, AccessList.StorageKeysEn
             _count = count;
         }
 
+        public UInt256 this[int index]
+        {
+            get
+            {
+                ArgumentOutOfRangeException.ThrowIfNegative(index);
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, _count);
+
+                return _accessList._keys[_index + index];
+            }
+        }
+
         StorageKeysEnumerator GetEnumerator() => new(_accessList, _index, _count);
         IEnumerator<UInt256> IEnumerable<UInt256>.GetEnumerator() => GetEnumerator();
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();

--- a/src/Nethermind/Nethermind.State/IWorldState.cs
+++ b/src/Nethermind/Nethermind.State/IWorldState.cs
@@ -70,7 +70,7 @@ public interface IWorldState : IJournal<Snapshot>, IReadOnlyStateProvider
     Snapshot TakeSnapshot(bool newTransactionStart = false);
 
     Snapshot IJournal<Snapshot>.TakeSnapshot() => TakeSnapshot();
-    void WarmUp(AccessList? accessList);
+    void WarmUp(AccessList? accessList, bool isParallelAccess);
     void WarmUp(Address address);
     /// <summary>
     /// Clear all storage at specified address

--- a/src/Nethermind/Nethermind.State/StateProvider.cs
+++ b/src/Nethermind/Nethermind.State/StateProvider.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Nethermind.Core;
 using Nethermind.Core.Caching;
@@ -657,9 +658,11 @@ namespace Nethermind.State
             };
         }
 
-        public bool WarmUp(Address address)
+        public bool WarmUp(Address address, out Account? account)
         {
-            return GetState(address) is not null;
+            Debug.Assert(_populatePreBlockCache);
+            account = GetStatePopulatePrewarmCache(address);
+            return account is not null;
         }
 
         private Account? GetState(Address address)


### PR DESCRIPTION
## Changes

- Introduce a concurrent safe path for address and storage prewarming where no (non concurrent) storage caches are touched
- In addition prewarm access lists via this path
- Fan out and parallelise sub accesslist storages when there are a lot of them; so as not to cause head of line blocking and seralize prewarming by a large transaction

Resolves a lot of heavy access block issues on higher gas chains (e.g. mainnet) as they mostly use AccessLists; but doesn't completely solve it as on lower gas chains (e.g. Base) access lists aren't as heavily used.

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] No - requires sync and head running testing (in progress)