### PR TITLE
Revert "Add and parallelise AccessList as part of address prewarming …

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Encoding/AccessListDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/AccessListDecoderTests.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using FluentAssertions;
 using Nethermind.Core.Eip2930;
 using Nethermind.Core.Test.Builders;
-using Nethermind.Int256;
 using Nethermind.Serialization.Rlp;
 using Nethermind.Serialization.Rlp.Eip2930;
 using NUnit.Framework;
@@ -100,16 +99,6 @@ namespace Nethermind.Core.Test.Encoding
             else
             {
                 decoded.Should().BeEquivalentTo(testCase.AccessList, testCase.TestName);
-
-                foreach (var list in decoded)
-                {
-                    var i = 0;
-                    foreach (UInt256 key in list.StorageKeys)
-                    {
-                        key.Should().BeEquivalentTo(list.StorageKeys[i], testCase.TestName);
-                        i++;
-                    }
-                }
             }
         }
 
@@ -128,16 +117,6 @@ namespace Nethermind.Core.Test.Encoding
             else
             {
                 decoded.Should().BeEquivalentTo(testCase.AccessList, testCase.TestName);
-
-                foreach (var list in decoded)
-                {
-                    var i = 0;
-                    foreach (UInt256 key in list.StorageKeys)
-                    {
-                        key.Should().BeEquivalentTo(list.StorageKeys[i], testCase.TestName);
-                        i++;
-                    }
-                }
             }
         }
 

--- a/src/Nethermind/Nethermind.Core/Eip2930/AccessList.cs
+++ b/src/Nethermind/Nethermind.Core/Eip2930/AccessList.cs
@@ -121,24 +121,11 @@ public class AccessList : IEnumerable<(Address Address, AccessList.StorageKeysEn
         private readonly int _index;
         private readonly int _count;
 
-        public int Count => _count;
-
         public StorageKeysEnumerable(AccessList accessList, int index, int count)
         {
             _accessList = accessList;
             _index = index;
             _count = count;
-        }
-
-        public UInt256 this[int index]
-        {
-            get
-            {
-                ArgumentOutOfRangeException.ThrowIfNegative(index);
-                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, _count);
-
-                return _accessList._keys[_index + index];
-            }
         }
 
         StorageKeysEnumerator GetEnumerator() => new(_accessList, _index, _count);

--- a/src/Nethermind/Nethermind.State/IWorldState.cs
+++ b/src/Nethermind/Nethermind.State/IWorldState.cs
@@ -70,7 +70,7 @@ public interface IWorldState : IJournal<Snapshot>, IReadOnlyStateProvider
     Snapshot TakeSnapshot(bool newTransactionStart = false);
 
     Snapshot IJournal<Snapshot>.TakeSnapshot() => TakeSnapshot();
-    void WarmUp(AccessList? accessList, bool isParallelAccess);
+    void WarmUp(AccessList? accessList);
     void WarmUp(Address address);
     /// <summary>
     /// Clear all storage at specified address

--- a/src/Nethermind/Nethermind.State/StateProvider.cs
+++ b/src/Nethermind/Nethermind.State/StateProvider.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Nethermind.Core;
 using Nethermind.Core.Caching;
@@ -658,11 +657,9 @@ namespace Nethermind.State
             };
         }
 
-        public bool WarmUp(Address address, out Account? account)
+        public bool WarmUp(Address address)
         {
-            Debug.Assert(_populatePreBlockCache);
-            account = GetStatePopulatePrewarmCache(address);
-            return account is not null;
+            return GetState(address) is not null;
         }
 
         private Account? GetState(Address address)


### PR DESCRIPTION
…(#7542)"

This reverts commit adaf4aa99944dea0a07ec17573061b013d5df2dd.

## Changes

- Think we are going too fast for the trie and it needs some robustification

```
04 Oct 06:26:30 | Rerunning block after reorg or pruning: 2215903 (0x732fc7...6fb8b9)
04 Oct 06:26:30 | Rerunning block after reorg or pruning: 2215904 (0x2a29d5...c474ab)
04 Oct 06:26:30 | Rerunning block after reorg or pruning: 2215905 (0x3dc177...41602f)
04 Oct 06:26:30 | Rerunning block after reorg or pruning: 2215906 (0xdd4870...a0cfb3)
04 Oct 06:26:30 | Rerunning block after reorg or pruning: 2215907 (0x3c7111...6ce7bf)
04 Oct 06:26:30 | Error pre-warming addresses Nethermind.Trie.TrieException:
Found an Extension 0x9ad3e159909132a8a2364d926ec6ea6783b432cf9f69daf99c7f14f8f13bd3c2 that is missing a child.
   at Nethermind.Trie.PatriciaTree.TraverseExtension(TrieNode node, TraverseContext& traverseContext, TreePath& path) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Trie\PatriciaTree.cs:line 1092
   at Nethermind.Trie.PatriciaTree.TraverseNode(TrieNode node, TraverseContext& traverseContext, TreePath& path) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Trie\PatriciaTree.cs:line 653
   at Nethermind.Trie.PatriciaTree.TraverseBranches(TrieNode node, TreePath& path, TraverseContext traverseContext) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Trie\PatriciaTree.cs:line 956
   at Nethermind.Trie.PatriciaTree.Run(TreePath& updatePathTreePath, CappedArray`1& updateValue, Span`1 updatePath, Boolean isUpdate, Boolean ignoreMissingDelete, Hash256 startRootHash, Boolean isNodeRead) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Trie\PatriciaTree.cs:line 587
   at Nethermind.Trie.PatriciaTree.Get(ReadOnlySpan`1 rawKey, Hash256 rootHash) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Trie\PatriciaTree.cs:line 383
   at Nethermind.State.StateTree.Get(Address address, Hash256 rootHash) in D:\GitHub\nethermind\src\Nethermind\Nethermind.State\StateTree.cs:line 45
   at Nethermind.State.StateProvider.<.ctor>b__48_0(AddressAsKey address) in D:\GitHub\nethermind\src\Nethermind\Nethermind.State\StateProvider.cs:line 657
   at System.Collections.Concurrent.ConcurrentDictionary`2.GetOrAdd(TKey key, Func`2 valueFactory)
   at Nethermind.State.StateProvider.GetStatePopulatePrewarmCache(AddressAsKey addressAsKey) in D:\GitHub\nethermind\src\Nethermind\Nethermind.State\StateProvider.cs:line 688
   at Nethermind.State.StateProvider.WarmUp(Address address, Account& account) in D:\GitHub\nethermind\src\Nethermind\Nethermind.State\StateProvider.cs:line 664
   at Nethermind.State.WorldState.WarmUp(Address address) in D:\GitHub\nethermind\src\Nethermind\Nethermind.State\WorldState.cs:line 169
   at Nethermind.Consensus.Processing.BlockCachePreWarmer.AddressWarmer.<>c__DisplayClass9_0.<WarmupAddresses>b__0(Int32 _) in D:\GitHub\nethermind\src\Nethermind\Nethermind.Consensus\Processing\BlockCachePreWarmer.cs:line 236
   at System.Threading.Tasks.Parallel.<>c__DisplayClass19_0`2.<ForWorker>b__1(RangeWorker& currentWorker, Int64 timeout, Boolean& replicationDelegateYieldedBeforeCompletion)
--- End of stack trace from previous location ---
   at System.Threading.Tasks.Parallel.<>c__DisplayClass19_0`2.<ForWorker>b__1(RangeWorker& currentWorker, Int64 timeout, Boolean& replicationDelegateYieldedBeforeCompletion)
   at System.Threading.Tasks.TaskReplicator.Replica.Execute()
04 Oct 06:26:30 | Rerunning block after reorg or pruning: 2215908 (0x52506b...1bd997)
04 Oct 06:26:30 | Rerunning block after reorg or pruning: 2215909 (0x019888...5e915a)
04 Oct 06:26:30 | Rerunning block after reorg or pruning: 2215910 (0xc2adc7...58a070)
04 Oct 06:26:30 | Rerunning block after reorg or pruning: 2215911 (0x26f51f...cf0090)
04 Oct 06:26:30 | Rerunning block after reorg or pruning: 2215912 (0x3a30c9...ea1bdf)
04 Oct 06:26:30 | Rerunning block after reorg or pruning: 2215913 (0x670c3e...5292f0)
```

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
