### PR TITLE
Fix remaining EOF validation issues

### DIFF
--- a/src/Nethermind/Ethereum.Test.Base/EofTest.cs
+++ b/src/Nethermind/Ethereum.Test.Base/EofTest.cs
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Ethereum.Test.Base.Interfaces;
-using System.Collections.Generic;
-using System.Numerics;
+using Nethermind.Evm.EvmObjectFormat;
 
 namespace Ethereum.Test.Base;
 public class Result
@@ -16,6 +15,7 @@ public class Result
 public class VectorTest
 {
     public byte[] Code { get; set; }
+    public ValidationStrategy ContainerKind { get; set; }
 }
 
 public class EofTest : IEthereumTest

--- a/src/Nethermind/Ethereum.Test.Base/EofTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/EofTestBase.cs
@@ -53,6 +53,7 @@ namespace Ethereum.Test.Base
 
             var vector = test.Vector;
             var code = vector.Code;
+            var strategy = vector.ContainerKind;
             var fork = test.Result.Fork switch
             {
                 "Prague" => Nethermind.Specs.Forks.Prague.Instance,
@@ -68,7 +69,7 @@ namespace Ethereum.Test.Base
                 _ => throw new NotSupportedException($"Fork {test.Result.Fork} is not supported")
             };
 
-            bool result = CodeDepositHandler.IsValidWithEofRules(fork, code, 1);
+            bool result = CodeDepositHandler.IsValidWithEofRules(fork, code, 1, strategy);
             return result;
         }
     }

--- a/src/Nethermind/Ethereum.Test.Base/JsonToEthereumTest.cs
+++ b/src/Nethermind/Ethereum.Test.Base/JsonToEthereumTest.cs
@@ -190,15 +190,9 @@ namespace Ethereum.Test.Base
         private static AccountState Convert(AccountStateJson accountStateJson)
         {
             AccountState state = new();
-            state.Balance = accountStateJson.Balance is not null
-                ? Bytes.FromHexString(accountStateJson.Balance).ToUInt256()
-                : 0;
-            state.Code = accountStateJson.Code is not null
-                ? Bytes.FromHexString(accountStateJson.Code)
-                : Array.Empty<byte>();
-            state.Nonce = accountStateJson.Nonce is not null
-                ? Bytes.FromHexString(accountStateJson.Nonce).ToUInt256()
-                : 0;
+            state.Balance = accountStateJson.Balance is not null ? Bytes.FromHexString(accountStateJson.Balance).ToUInt256() : 0;
+            state.Code = accountStateJson.Code is not null ? Bytes.FromHexString(accountStateJson.Code) : Array.Empty<byte>();
+            state.Nonce = accountStateJson.Nonce is not null ? Bytes.FromHexString(accountStateJson.Nonce).ToUInt256() : 0;
             state.Storage = accountStateJson.Storage is not null
                 ? accountStateJson.Storage.ToDictionary(
                     p => Bytes.FromHexString(p.Key).ToUInt256(),
@@ -225,8 +219,7 @@ namespace Ethereum.Test.Base
                                 $"_d{stateJson.Indexes.Data}g{stateJson.Indexes.Gas}v{stateJson.Indexes.Value}_";
                     if (testJson.Info?.Labels?.ContainsKey(iterationNumber.ToString()) ?? false)
                     {
-                        test.Name += testJson.Info?.Labels?[iterationNumber.ToString()]
-                            ?.Replace(":label ", string.Empty);
+                        test.Name += testJson.Info?.Labels?[iterationNumber.ToString()]?.Replace(":label ", string.Empty);
                     }
 
                     test.ForkName = postStateBySpec.Key;
@@ -293,8 +286,7 @@ namespace Ethereum.Test.Base
 
         public static IEnumerable<EofTest> ConvertToEofTests(string json)
         {
-            Dictionary<string, EofTestJson>
-                testsInFile = _serializer.Deserialize<Dictionary<string, EofTestJson>>(json);
+            Dictionary<string, EofTestJson> testsInFile = _serializer.Deserialize<Dictionary<string, EofTestJson>>(json);
             List<EofTest> tests = new();
             foreach (KeyValuePair<string, EofTestJson> namedTest in testsInFile)
             {

--- a/src/Nethermind/Ethereum.Test.Base/JsonToEthereumTest.cs
+++ b/src/Nethermind/Ethereum.Test.Base/JsonToEthereumTest.cs
@@ -12,6 +12,7 @@ using Nethermind.Core.Eip2930;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Crypto;
+using Nethermind.Evm.EvmObjectFormat;
 using Nethermind.Int256;
 using Nethermind.Serialization.Json;
 using Nethermind.Serialization.Rlp;
@@ -189,9 +190,15 @@ namespace Ethereum.Test.Base
         private static AccountState Convert(AccountStateJson accountStateJson)
         {
             AccountState state = new();
-            state.Balance = accountStateJson.Balance is not null ? Bytes.FromHexString(accountStateJson.Balance).ToUInt256() : 0;
-            state.Code = accountStateJson.Code is not null ? Bytes.FromHexString(accountStateJson.Code) : Array.Empty<byte>();
-            state.Nonce = accountStateJson.Nonce is not null ? Bytes.FromHexString(accountStateJson.Nonce).ToUInt256() : 0;
+            state.Balance = accountStateJson.Balance is not null
+                ? Bytes.FromHexString(accountStateJson.Balance).ToUInt256()
+                : 0;
+            state.Code = accountStateJson.Code is not null
+                ? Bytes.FromHexString(accountStateJson.Code)
+                : Array.Empty<byte>();
+            state.Nonce = accountStateJson.Nonce is not null
+                ? Bytes.FromHexString(accountStateJson.Nonce).ToUInt256()
+                : 0;
             state.Storage = accountStateJson.Storage is not null
                 ? accountStateJson.Storage.ToDictionary(
                     p => Bytes.FromHexString(p.Key).ToUInt256(),
@@ -218,7 +225,8 @@ namespace Ethereum.Test.Base
                                 $"_d{stateJson.Indexes.Data}g{stateJson.Indexes.Gas}v{stateJson.Indexes.Value}_";
                     if (testJson.Info?.Labels?.ContainsKey(iterationNumber.ToString()) ?? false)
                     {
-                        test.Name += testJson.Info?.Labels?[iterationNumber.ToString()]?.Replace(":label ", string.Empty);
+                        test.Name += testJson.Info?.Labels?[iterationNumber.ToString()]
+                            ?.Replace(":label ", string.Empty);
                     }
 
                     test.ForkName = postStateBySpec.Key;
@@ -285,7 +293,8 @@ namespace Ethereum.Test.Base
 
         public static IEnumerable<EofTest> ConvertToEofTests(string json)
         {
-            Dictionary<string, EofTestJson> testsInFile = _serializer.Deserialize<Dictionary<string, EofTestJson>>(json);
+            Dictionary<string, EofTestJson>
+                testsInFile = _serializer.Deserialize<Dictionary<string, EofTestJson>>(json);
             List<EofTest> tests = new();
             foreach (KeyValuePair<string, EofTestJson> namedTest in testsInFile)
             {
@@ -309,6 +318,11 @@ namespace Ethereum.Test.Base
                     VectorTestJson vectorJson = pair.Value;
                     VectorTest vector = new();
                     vector.Code = Bytes.FromHexString(vectorJson.Code);
+                    vector.ContainerKind =
+                        ("INITCODE".Equals(vectorJson.ContainerKind)
+                            ? ValidationStrategy.ValidateInitcodeMode
+                            : ValidationStrategy.ValidateRuntimeMode)
+                        | ValidationStrategy.ValidateFullBody;
 
                     foreach (var result in vectorJson.Results)
                     {

--- a/src/Nethermind/Ethereum.Test.Base/VectorTestJson.cs
+++ b/src/Nethermind/Ethereum.Test.Base/VectorTestJson.cs
@@ -8,5 +8,6 @@ namespace Ethereum.Test.Base;
 public class VectorTestJson
 {
     public string Code { get; set; }
+    public string ContainerKind { get; set; }
     public Dictionary<string, TestResultJson> Results { get; set; }
 }

--- a/src/Nethermind/Nethermind.Evm/EvmObjectFormat/Handlers/EofV1.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmObjectFormat/Handlers/EofV1.cs
@@ -440,11 +440,7 @@ internal class Eof1 : IEofVersionHandler
 
                     if (validationStrategy.HasFlag(ValidationStrategy.Validate))
                     {
-                        // Clear the Initcode flag for subcontainer
-                        ValidationStrategy subContainerValidation = validationStrategy & ~ValidationStrategy.ValidateInitcodeMode;
-                        // Set the Runtime flag for subcontainer
-                        subContainerValidation |= ValidationStrategy.ValidateRuntimeMode;
-                        containers.Enqueue((new EofContainer(subsection, header.Value), subContainerValidation));
+                        containers.Enqueue((new EofContainer(subsection, header.Value), worklet.Strategy));
                     }
                 }
                 else
@@ -711,7 +707,7 @@ internal class Eof1 : IEofVersionHandler
                         return false;
                     }
 
-                    containersWorklist.Enqueue(runtimeContainerId + 1, ValidationStrategy.ValidateRuntimeMode);
+                    containersWorklist.Enqueue(runtimeContainerId + 1, ValidationStrategy.ValidateRuntimeMode | ValidationStrategy.ValidateFullBody);
 
                     BitmapHelper.HandleNumbits(EofValidator.ONE_BYTE_LENGTH, invalidJumpDestinations, ref nextPosition);
                 }


### PR DESCRIPTION
## Changes

Fix the remaining EOF validation issues
* Check for required exit from returning code section (RETF or JUMPF)
* prevent JUMPF from non-returning into returning code sections
* consider `ContainerKind` from pyspec tests when running validion tests
* pass the worklet validation mode to validation unadjusted
* validate deep for RETURNCONTRACT

## Types of changes

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No

#### Notes on testing

Tests are the pyspec tess

## Documentation

#### Requires documentation update

- [ ] Yes
- [X] No

#### Requires explanation in Release Notes

- [ ] Yes
- [X] No


