### PR TITLE
Avx512 Keccak

### DIFF
--- a/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.cs
@@ -94,9 +94,13 @@ namespace Nethermind.Core.Crypto
         private static void KeccakF(Span<ulong> st)
         {
             if (Avx512F.IsSupported)
+            {
                 KeccakF1600Avx512F(st);
+            }
             else
+            {
                 KeccakF1600(st);
+            }
         }
 
         private static void KeccakF1600(Span<ulong> st)

--- a/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.cs
@@ -639,20 +639,13 @@ namespace Nethermind.Core.Crypto
             for (int round = 0; round < round_consts.Length; round++)
             {
                 // Theta step
-                Vector512<ulong> c0 = Vector512.Create(state[0], state[5], state[10], state[15], state[20], 0UL, 0UL, 0UL);
-                Vector512<ulong> c1 = Vector512.Create(state[1], state[6], state[11], state[16], state[21], 0UL, 0UL, 0UL);
-                Vector512<ulong> c2 = Vector512.Create(state[2], state[7], state[12], state[17], state[22], 0UL, 0UL, 0UL);
-                Vector512<ulong> c3 = Vector512.Create(state[3], state[8], state[13], state[18], state[23], 0UL, 0UL, 0UL);
-                Vector512<ulong> c4 = Vector512.Create(state[4], state[9], state[14], state[19], state[24], 0UL, 0UL, 0UL);
+                Vector512<ulong> c0 = Vector512.Create(state[0], state[1], state[2], state[3], state[4], 0UL, 0UL, 0UL);
+                Vector512<ulong> c1 = Vector512.Create(state[5], state[6], state[7], state[8], state[9], 0UL, 0UL, 0UL);
+                Vector512<ulong> c2 = Vector512.Create(state[10], state[11], state[12], state[13], state[14], 0UL, 0UL, 0UL);
+                Vector512<ulong> c3 = Vector512.Create(state[15], state[16], state[17], state[18], state[19], 0UL, 0UL, 0UL);
+                Vector512<ulong> c4 = Vector512.Create(state[20], state[21], state[22], state[23], state[24], 0UL, 0UL, 0UL);
 
-                // Compute bVec as horizontal XORs
-                ulong b0 = c0.GetElement(0) ^ c0.GetElement(1) ^ c0.GetElement(2) ^ c0.GetElement(3) ^ c0.GetElement(4);
-                ulong b1 = c1.GetElement(0) ^ c1.GetElement(1) ^ c1.GetElement(2) ^ c1.GetElement(3) ^ c1.GetElement(4);
-                ulong b2 = c2.GetElement(0) ^ c2.GetElement(1) ^ c2.GetElement(2) ^ c2.GetElement(3) ^ c2.GetElement(4);
-                ulong b3 = c3.GetElement(0) ^ c3.GetElement(1) ^ c3.GetElement(2) ^ c3.GetElement(3) ^ c3.GetElement(4);
-                ulong b4 = c4.GetElement(0) ^ c4.GetElement(1) ^ c4.GetElement(2) ^ c4.GetElement(3) ^ c4.GetElement(4);
-
-                Vector512<ulong> bVec = Vector512.Create(b0, b1, b2, b3, b4, 0UL, 0UL, 0UL);
+                Vector512<ulong> bVec =  Vector512.Xor(Vector512.Xor(Vector512.Xor(c0, c1), Vector512.Xor(c2, c3)), c4);
 
                 // Compute tVec
                 Vector512<ulong> bVecRot1 = Avx512F.PermuteVar8x64(bVec, Vector512.Create(1UL, 2UL, 3UL, 4UL, 0UL, 5UL, 6UL, 7UL));

--- a/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.cs
@@ -645,7 +645,7 @@ namespace Nethermind.Core.Crypto
                 Vector512<ulong> c3 = Vector512.Create(state[15], state[16], state[17], state[18], state[19], 0UL, 0UL, 0UL);
                 Vector512<ulong> c4 = Vector512.Create(state[20], state[21], state[22], state[23], state[24], 0UL, 0UL, 0UL);
 
-                Vector512<ulong> bVec =  Vector512.Xor(Vector512.Xor(Vector512.Xor(c0, c1), Vector512.Xor(c2, c3)), c4);
+                Vector512<ulong> bVec = Vector512.Xor(Vector512.Xor(Vector512.Xor(c0, c1), Vector512.Xor(c2, c3)), c4);
 
                 // Compute tVec
                 Vector512<ulong> bVecRot1 = Avx512F.PermuteVar8x64(bVec, Vector512.Create(1UL, 2UL, 3UL, 4UL, 0UL, 5UL, 6UL, 7UL));

--- a/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.cs
@@ -707,11 +707,8 @@ namespace Nethermind.Core.Crypto
                     Vector512<ulong> row1 = Avx512F.PermuteVar8x64(row, Vector512.Create(1UL, 2UL, 3UL, 4UL, 0UL, 5UL, 6UL, 7UL));
                     Vector512<ulong> row2 = Avx512F.PermuteVar8x64(row, Vector512.Create(2UL, 3UL, 4UL, 0UL, 1UL, 5UL, 6UL, 7UL));
 
-                    // Compute (~row1) & row2
-                    Vector512<ulong> tempVec = Avx512F.AndNot(row1, row2);
-
-                    // Update the row: state[i + j] ^= tempVec[j]
-                    Vector512<ulong> updatedRow = Avx512F.Xor(row, tempVec);
+                    // Compute A = row XOR ((NOT row1) AND row2) using TernaryLogic
+                    Vector512<ulong> updatedRow = Avx512F.TernaryLogic(row, row1, row2, 0xD2);
 
                     // Store the updated row back to the state array
                     state[i] = updatedRow.GetElement(0);

--- a/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.cs
@@ -641,12 +641,22 @@ namespace Nethermind.Core.Crypto
                 _ = state[24];
             }
 
-            Vector512<ulong> mask = Vector512.Create(ulong.MaxValue, ulong.MaxValue, ulong.MaxValue, ulong.MaxValue, ulong.MaxValue, 0UL, 0UL, 0UL);
-            Vector512<ulong> c0 = Vector512.BitwiseAnd(mask, Unsafe.As<ulong, Vector512<ulong>>(ref MemoryMarshal.GetReference(state)));
-            Vector512<ulong> c1 = Vector512.BitwiseAnd(mask, Unsafe.As<ulong, Vector512<ulong>>(ref Unsafe.Add(ref MemoryMarshal.GetReference(state), 5)));
-            Vector512<ulong> c2 = Vector512.BitwiseAnd(mask, Unsafe.As<ulong, Vector512<ulong>>(ref Unsafe.Add(ref MemoryMarshal.GetReference(state), 10)));
-            Vector512<ulong> c3 = Vector512.BitwiseAnd(mask, Unsafe.As<ulong, Vector512<ulong>>(ref Unsafe.Add(ref MemoryMarshal.GetReference(state), 15)));
+            // Can straight load and over-read for start elements
+            Vector512<ulong> c0 = Unsafe.As<ulong, Vector512<ulong>>(ref MemoryMarshal.GetReference(state));
+            Vector512<ulong> c1 = Unsafe.As<ulong, Vector512<ulong>>(ref Unsafe.Add(ref MemoryMarshal.GetReference(state), 5));
+            Vector512<ulong> c2 = Unsafe.As<ulong, Vector512<ulong>>(ref Unsafe.Add(ref MemoryMarshal.GetReference(state), 10));
+            Vector512<ulong> c3 = Unsafe.As<ulong, Vector512<ulong>>(ref Unsafe.Add(ref MemoryMarshal.GetReference(state), 15));
+            // Can't over-read for the last elements (8 items in vector 5 to be remaining)
+            // so read them directly as ulongs
             Vector512<ulong> c4 = Vector512.Create(state[20], state[21], state[22], state[23], state[24], 0UL, 0UL, 0UL);
+            {
+                // Clear the over-read values from first vectors
+                Vector512<ulong> mask = Vector512.Create(ulong.MaxValue, ulong.MaxValue, ulong.MaxValue, ulong.MaxValue, ulong.MaxValue, 0UL, 0UL, 0UL);
+                c0 = Vector512.BitwiseAnd(mask, c0);
+                c1 = Vector512.BitwiseAnd(mask, c1);
+                c2 = Vector512.BitwiseAnd(mask, c2);
+                c3 = Vector512.BitwiseAnd(mask, c3);
+            }
 
             ulong[] roundConstants = RoundConstants;
             for (int round = 0; round < roundConstants.Length; round++)
@@ -654,7 +664,7 @@ namespace Nethermind.Core.Crypto
                 // Theta step
                 Vector512<ulong> bVec = Vector512.Xor(Vector512.Xor(Vector512.Xor(c0, c1), Vector512.Xor(c2, c3)), c4);
 
-                // Compute tVec
+                // Compute Theta Vector
                 Vector512<ulong> bVecRot1 = Avx512F.PermuteVar8x64(bVec, Vector512.Create(1UL, 2UL, 3UL, 4UL, 0UL, 5UL, 6UL, 7UL));
                 Vector512<ulong> bVecRot4 = Avx512F.PermuteVar8x64(bVec, Vector512.Create(4UL, 0UL, 1UL, 2UL, 3UL, 5UL, 6UL, 7UL));
 
@@ -663,13 +673,13 @@ namespace Nethermind.Core.Crypto
                 Vector512<ulong> bVecRot1ShiftedRight = Avx512F.ShiftRightLogical(bVecRot1, 63);
                 Vector512<ulong> bVecRot1Rotated = Avx512F.Or(bVecRot1ShiftedLeft, bVecRot1ShiftedRight);
 
-                Vector512<ulong> tVec = Avx512F.Xor(bVecRot4, bVecRot1Rotated);
+                Vector512<ulong> thetaVec = Avx512F.Xor(bVecRot4, bVecRot1Rotated);
 
-                c0 = Avx512F.Xor(c0, tVec);
-                c1 = Avx512F.Xor(c1, tVec);
-                c2 = Avx512F.Xor(c2, tVec);
-                c3 = Avx512F.Xor(c3, tVec);
-                c4 = Avx512F.Xor(c4, tVec);
+                c0 = Avx512F.Xor(c0, thetaVec);
+                c1 = Avx512F.Xor(c1, thetaVec);
+                c2 = Avx512F.Xor(c2, thetaVec);
+                c3 = Avx512F.Xor(c3, thetaVec);
+                c4 = Avx512F.Xor(c4, thetaVec);
 
                 // Rho step
                 Vector512<ulong> rhoVec0 = Vector512.Create(0UL, 1UL, 62UL, 28UL, 27UL, 0UL, 0UL, 0UL);
@@ -688,17 +698,36 @@ namespace Nethermind.Core.Crypto
                 c4 = Avx512F.RotateLeftVariable(c4, rhoVec4);
 
                 // Pi step
-                var c0New = Vector512.Create(c0.GetElement(0), c1.GetElement(1), c2.GetElement(2), c3.GetElement(3), c4.GetElement(4), 0UL, 0UL, 0UL);
-                var c1New = Vector512.Create(c0.GetElement(3), c1.GetElement(4), c2.GetElement(0), c3.GetElement(1), c4.GetElement(2), 0UL, 0UL, 0UL);
-                var c2New = Vector512.Create(c0.GetElement(1), c1.GetElement(2), c2.GetElement(3), c3.GetElement(4), c4.GetElement(0), 0UL, 0UL, 0UL);
-                var c3New = Vector512.Create(c0.GetElement(4), c1.GetElement(0), c2.GetElement(1), c3.GetElement(2), c4.GetElement(3), 0UL, 0UL, 0UL);
-                var c4New = Vector512.Create(c0.GetElement(2), c1.GetElement(3), c2.GetElement(4), c3.GetElement(0), c4.GetElement(1), 0UL, 0UL, 0UL);
+                Vector512<ulong> c0Pi = Avx512F.PermuteVar8x64x2(c0, Vector512.Create(0UL, 8 + 1, 2, 3, 4, 5, 6, 7), c1);
+                c0Pi = Avx512F.PermuteVar8x64x2(c0Pi, Vector512.Create(0UL, 1, 8 + 2, 3, 4, 5, 6, 7), c2);
+                c0Pi = Avx512F.PermuteVar8x64x2(c0Pi, Vector512.Create(0UL, 1, 2, 8 + 3, 4, 5, 6, 7), c3);
+                c0Pi = Avx512F.PermuteVar8x64x2(c0Pi, Vector512.Create(0UL, 1, 2, 3, 8 + 4, 5, 6, 7), c4);
 
-                c0 = c0New;
-                c1 = c1New;
-                c2 = c2New;
-                c3 = c3New;
-                c4 = c4New;
+                Vector512<ulong> c1Pi = Avx512F.PermuteVar8x64x2(c0, Vector512.Create(3UL, 8 + 4, 2, 3, 4, 5, 6, 7), c1);
+                c1Pi = Avx512F.PermuteVar8x64x2(c1Pi, Vector512.Create(0UL, 1, 8 + 0, 3, 4, 5, 6, 7), c2);
+                c1Pi = Avx512F.PermuteVar8x64x2(c1Pi, Vector512.Create(0UL, 1, 2, 8 + 1, 4, 5, 6, 7), c3);
+                c1Pi = Avx512F.PermuteVar8x64x2(c1Pi, Vector512.Create(0UL, 1, 2, 3, 8 + 2, 5, 6, 7), c4);
+
+                Vector512<ulong> c2Pi = Avx512F.PermuteVar8x64x2(c0, Vector512.Create(1UL, 8 + 2, 2, 3, 4, 5, 6, 7), c1);
+                c2Pi = Avx512F.PermuteVar8x64x2(c2Pi, Vector512.Create(0UL, 1, 8 + 3, 3, 4, 5, 6, 7), c2);
+                c2Pi = Avx512F.PermuteVar8x64x2(c2Pi, Vector512.Create(0UL, 1, 2, 8 + 4, 4, 5, 6, 7), c3);
+                c2Pi = Avx512F.PermuteVar8x64x2(c2Pi, Vector512.Create(0UL, 1, 2, 3, 8 + 0, 5, 6, 7), c4);
+
+                Vector512<ulong> c3Pi = Avx512F.PermuteVar8x64x2(c0, Vector512.Create(4UL, 8 + 0, 2, 3, 4, 5, 6, 7), c1);
+                c3Pi = Avx512F.PermuteVar8x64x2(c3Pi, Vector512.Create(0UL, 1, 8 + 1, 3, 4, 5, 6, 7), c2);
+                c3Pi = Avx512F.PermuteVar8x64x2(c3Pi, Vector512.Create(0UL, 1, 2, 8 + 2, 4, 5, 6, 7), c3);
+                c3Pi = Avx512F.PermuteVar8x64x2(c3Pi, Vector512.Create(0UL, 1, 2, 3, 8 + 3, 5, 6, 7), c4);
+
+                Vector512<ulong> c4Pi = Avx512F.PermuteVar8x64x2(c0, Vector512.Create(2UL, 8 + 3, 2, 3, 4, 5, 6, 7), c1);
+                c4Pi = Avx512F.PermuteVar8x64x2(c4Pi, Vector512.Create(0UL, 1, 8 + 4, 3, 4, 5, 6, 7), c2);
+                c4Pi = Avx512F.PermuteVar8x64x2(c4Pi, Vector512.Create(0UL, 1, 2, 8 + 0, 4, 5, 6, 7), c3);
+                c4Pi = Avx512F.PermuteVar8x64x2(c4Pi, Vector512.Create(0UL, 1, 2, 3, 8 + 1, 5, 6, 7), c4);
+
+                c0 = c0Pi;
+                c1 = c1Pi;
+                c2 = c2Pi;
+                c3 = c3Pi;
+                c4 = c4Pi;
 
                 // Chi step
                 Vector512<ulong> permute1 = Vector512.Create(1UL, 2UL, 3UL, 4UL, 0UL, 5UL, 6UL, 7UL);
@@ -714,10 +743,12 @@ namespace Nethermind.Core.Crypto
                 c0 = Vector512.Xor(c0, Vector512.Create(roundConstants[round], 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL));
             }
 
+            // Can over-write for first elements
             Unsafe.As<ulong, Vector512<ulong>>(ref MemoryMarshal.GetReference(state)) = c0;
             Unsafe.As<ulong, Vector512<ulong>>(ref Unsafe.Add(ref MemoryMarshal.GetReference(state), 5)) = c1;
             Unsafe.As<ulong, Vector512<ulong>>(ref Unsafe.Add(ref MemoryMarshal.GetReference(state), 10)) = c2;
             Unsafe.As<ulong, Vector512<ulong>>(ref Unsafe.Add(ref MemoryMarshal.GetReference(state), 15)) = c3;
+            // Can't over-write for last elements (8 items in vector 5 to be written)
             state[20] = c4.GetElement(0);
             state[21] = c4.GetElement(1);
             state[22] = c4.GetElement(2);


### PR DESCRIPTION
## Changes

- Implement Keccak using Avx512 intrinsics

Inner loop is as follows, with no stack writes or stack spills 
```asm
G_M000_IG04:                ;; offset=0x0284
       vpxorq   zmm15, zmm6, zmm7
       vpxorq   zmm14, zmm8, zmm9
       vpxorq   zmm14, zmm15, zmm14
       vpxorq   zmm14, zmm14, zmm10
       vpermq   zmm15, zmm0, zmm14
       vpsllq   zmm0, zmm15, 1
       vpsrlq   zmm15, zmm15, 63
       vporq    zmm0, zmm0, zmm15
       vpermq   zmm14, zmm1, zmm14
       vpxorq   zmm0, zmm14, zmm0
       vpxorq   zmm6, zmm6, zmm0
       vpxorq   zmm7, zmm7, zmm0
       vpxorq   zmm8, zmm8, zmm0
       vpxorq   zmm9, zmm9, zmm0
       vpxorq   zmm10, zmm10, zmm0
       vprolvq  zmm6, zmm6, zmm2
       vprolvq  zmm7, zmm7, zmm3
       vprolvq  zmm8, zmm8, zmm4
       vprolvq  zmm9, zmm9, zmm5
       vprolvq  zmm10, zmm10, zmm16
       vmovaps  zmm0, zmm6
       vpermt2q zmm0, zmm17, zmm7
       vpermt2q zmm0, zmm18, zmm8
       vpermt2q zmm0, zmm19, zmm9
       vpermt2q zmm0, zmm20, zmm10
       vmovaps  zmm14, zmm6
       vpermt2q zmm14, zmm21, zmm7
       vpermt2q zmm14, zmm22, zmm8
       vpermt2q zmm14, zmm23, zmm9
       vpermt2q zmm14, zmm24, zmm10
       vmovaps  zmm15, zmm6
       vpermt2q zmm15, zmm25, zmm7
       vpermt2q zmm15, zmm26, zmm8
       vpermt2q zmm15, zmm27, zmm9
       vpermt2q zmm15, zmm28, zmm10
       vmovaps  zmm1, zmm6
       vpermt2q zmm1, zmm29, zmm7
       vpermt2q zmm1, zmm30, zmm8
       vpermt2q zmm1, zmm31, zmm9
       vpermt2q zmm1, zmm11, zmm10
       vpermt2q zmm6, zmm12, zmm7
       vpermt2q zmm6, zmm13, zmm8
       vmovups  zmm8, zmmword ptr [rsp+0xA0]
       vpermt2q zmm6, zmm8, zmm9
       vmovups  zmm9, zmmword ptr [rsp+0x60]
       vpermt2q zmm6, zmm9, zmm10
       vmovups  zmm7, zmmword ptr [reloc @RWD64]
       vpermq   zmm10, zmm7, zmm0
       vmovups  zmm7, zmmword ptr [reloc @RWD1792]
       vpermq   zmm7, zmm7, zmm0
       vpternlogq zmm0, zmm10, zmm7, -46
       vmovaps  zmm7, zmm0
       vmovups  zmm0, zmmword ptr [reloc @RWD64]
       vpermq   zmm0, zmm0, zmm14
       vmovups  zmm10, zmmword ptr [reloc @RWD1792]
       vpermq   zmm10, zmm10, zmm14
       vpternlogq zmm14, zmm0, zmm10, -46
       vmovups  zmm0, zmmword ptr [reloc @RWD64]
       vpermq   zmm0, zmm0, zmm15
       vmovups  zmm10, zmmword ptr [reloc @RWD1792]
       vpermq   zmm10, zmm10, zmm15

G_M000_IG05:                ;; offset=0x0418
       vpternlogq zmm15, zmm0, zmm10, -46
       vmovups  zmm0, zmmword ptr [reloc @RWD64]
       vpermq   zmm0, zmm0, zmm1
       vmovups  zmm10, zmmword ptr [reloc @RWD1792]
       vpermq   zmm10, zmm10, zmm1
       vpternlogq zmm1, zmm0, zmm10, -46
       vmovaps  zmm10, zmm1
       vmovups  zmm0, zmmword ptr [reloc @RWD64]
       vpermq   zmm0, zmm0, zmm6
       vmovups  zmm1, zmmword ptr [reloc @RWD1792]
       vpermq   zmm1, zmm1, zmm6
       vpternlogq zmm6, zmm0, zmm1, -46
       mov      r8d, edx
       vmovd    xmm0, qword ptr [rcx+8*r8+0x10]
       xor      r8d, r8d
       vpinsrq  xmm0, xmm0, r8, 1
       vxorps   xmm1, xmm1, xmm1
       vinserti128 ymm0, ymm0, xmm1, 1
       vxorps   ymm1, ymm1, ymm1
       vinserti64x4 zmm0, zmm0, ymm1, 1
       vpxorq   zmm7, zmm7, zmm0
       inc      edx
       cmp      eax, edx
       vmovups  zmm0, zmmword ptr [rsp+0x120]
       vmovups  zmm1, zmmword ptr [rsp+0xE0]
       jg       G_M000_IG08
```

5% faster on Zen4 which doesn't have proper Avx512; should be faster on Zen5

| Method  | ScenarioIndex | Mean     | Error   | StdDev   | Ratio | RatioSD | Ops/s |
|-------- |-------------- |---------:|--------:|---------:|------:|--------:|------------:|
| Current | 1             | 374.6 ns | 6.53 ns |  9.57 ns |  1.00 |    0.00 |          2,669,514 |
| Avx512F | 1             | 356.7 ns | 6.76 ns | 10.12 ns |  0.95 |    0.02 |          2,803,476 |

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [ ] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No