### PR TITLE
fix blob index locking

### DIFF
--- a/src/Nethermind/Nethermind.TxPool/Nethermind.TxPool.csproj
+++ b/src/Nethermind/Nethermind.TxPool/Nethermind.TxPool.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="ConcurrentHashSet" />
     <PackageReference Include="NonBlocking" />
   </ItemGroup>
 


### PR DESCRIPTION
## Changes

- Move blob removing under main lock.
- Move list to concurrent set so reading blob index can be thread safe without main lock

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

@marcindsobczak ca you write concurrency test that would fail under old version?