### PR TITLE
Fixes for P2P message disposing

### DIFF
--- a/src/Nethermind/Nethermind.Core/Extensions/DisposableExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/DisposableExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
 namespace Nethermind.Core.Extensions;
@@ -14,6 +15,12 @@ public static class DisposableExtensions
         if (item is IDisposable d)
         {
             d.Dispose();
+        }
+
+        if (item is ITuple tuple)
+        {
+            for (var i = 0; i < tuple.Length; i++)
+                tuple[i]?.TryDispose();
         }
     }
 

--- a/src/Nethermind/Nethermind.Core/Extensions/DisposableExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/DisposableExtensions.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
 namespace Nethermind.Core.Extensions;
@@ -15,12 +14,6 @@ public static class DisposableExtensions
         if (item is IDisposable d)
         {
             d.Dispose();
-        }
-
-        if (item is ITuple tuple)
-        {
-            for (var i = 0; i < tuple.Length; i++)
-                tuple[i]?.TryDispose();
         }
     }
 

--- a/src/Nethermind/Nethermind.Network.Test/P2P/PacketSenderTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/PacketSenderTests.cs
@@ -38,7 +38,6 @@ namespace Nethermind.Network.Test.P2P
             PacketSender packetSender = new(serializer, LimboLogs.Instance, TimeSpan.Zero);
             packetSender.HandlerAdded(context);
             packetSender.Enqueue(testMessage);
-            testMessage.WasDisposed.Should().BeTrue();
 
             context.Received(1).WriteAndFlushAsync(Arg.Any<IByteBuffer>());
         }
@@ -62,7 +61,6 @@ namespace Nethermind.Network.Test.P2P
             PacketSender packetSender = new(serializer, LimboLogs.Instance, TimeSpan.Zero);
             packetSender.HandlerAdded(context);
             packetSender.Enqueue(testMessage);
-            testMessage.WasDisposed.Should().BeTrue();
 
             context.Received(0).WriteAndFlushAsync(Arg.Any<IByteBuffer>());
         }
@@ -88,7 +86,6 @@ namespace Nethermind.Network.Test.P2P
             PacketSender packetSender = new(serializer, LimboLogs.Instance, delay);
             packetSender.HandlerAdded(context);
             packetSender.Enqueue(testMessage);
-            testMessage.WasDisposed.Should().BeTrue();
 
             await context.Received(0).WriteAndFlushAsync(Arg.Any<IByteBuffer>());
 
@@ -101,13 +98,6 @@ namespace Nethermind.Network.Test.P2P
         {
             public override int PacketType { get; } = 0;
             public override string Protocol { get; } = "";
-
-            public bool WasDisposed { get; set; }
-            public override void Dispose()
-            {
-                base.Dispose();
-                WasDisposed = true;
-            }
         }
     }
 }

--- a/src/Nethermind/Nethermind.Network/P2P/PacketSender.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/PacketSender.cs
@@ -27,20 +27,12 @@ namespace Nethermind.Network.P2P
 
         public int Enqueue<T>(T message) where T : P2PMessage
         {
-            IByteBuffer buffer;
-            try
+            if (!_context.Channel.IsWritable || !_context.Channel.Active)
             {
-                if (!_context.Channel.IsWritable || !_context.Channel.Active)
-                {
-                    return 0;
-                }
+                return 0;
+            }
 
-                buffer = _messageSerializationService.ZeroSerialize(message);
-            }
-            finally
-            {
-                message.Dispose();
-            }
+            IByteBuffer buffer = _messageSerializationService.ZeroSerialize(message);
             int length = buffer.ReadableBytes;
 
             // Running in background

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroProtocolHandlerBase.cs
@@ -58,6 +58,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
             Task firstTask = await Task.WhenAny(task, Task.Delay(Timeouts.Eth, compositeCancellation.Token));
             if (firstTask.IsCanceled)
             {
+                CleanupTimeoutTask(task);
                 token.ThrowIfCancellationRequested();
             }
 


### PR DESCRIPTION
Resolves #7570 

## Changes

Fixes message disposing when:
- P2P response handling is cancelled or times out;
- used session is already closed.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No