### PR TITLE
Add test for `engine_getBlobsV1` concurrency

### DIFF
--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -680,7 +680,7 @@ namespace Nethermind.TxPool.Test
             }
         }
 
-        [Test][Repeat(10)]
+        [Test][Repeat(3)]
         public void should_handle_indexing_blobs_when_adding_txs_in_parallel([Values(true, false)] bool isPersistentStorage)
         {
             const int txsPerSender = 10;

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -680,7 +680,8 @@ namespace Nethermind.TxPool.Test
             }
         }
 
-        [Test] [Repeat(3)]
+        [Test]
+        [Repeat(3)]
         public void should_handle_indexing_blobs_when_adding_txs_in_parallel([Values(true, false)] bool isPersistentStorage)
         {
             const int txsPerSender = 10;

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -727,7 +727,7 @@ namespace Nethermind.TxPool.Test
                         blobPool.TryGetBlobAndProof(expectedBlobVersionedHash.ToBytes(), out _, out _).Should().BeTrue();
                     }
 
-                    if (i % 2 == 0) blobPool.Remove(tx.Hash, out _).Should().BeTrue();
+                    if (i % 2 == 0) blobPool.TryRemove(tx.Hash, out _).Should().BeTrue();
                 }
             });
 

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -699,11 +699,14 @@ namespace Nethermind.TxPool.Test
 
             byte[] expectedBlobVersionedHash = null;
 
+            foreach (PrivateKey privateKey in TestItem.PrivateKeys)
+            {
+                EnsureSenderBalance(privateKey.Address, UInt256.MaxValue);
+            }
+
             // adding txs in parallel
             Parallel.ForEach(TestItem.PrivateKeys, privateKey =>
             {
-                EnsureSenderBalance(privateKey.Address, UInt256.MaxValue);
-
                 for (int i = 0; i < txsPerSender; i++)
                 {
                     Transaction tx = Build.A.Transaction

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -705,7 +705,7 @@ namespace Nethermind.TxPool.Test
                 EnsureSenderBalance(privateKey.Address, UInt256.MaxValue);
             }
 
-            // adding txs in parallel
+            // adding, getting and removing txs in parallel
             Parallel.ForEach(TestItem.PrivateKeys, privateKey =>
             {
                 for (int i = 0; i < txsPerSender; i++)
@@ -727,11 +727,12 @@ namespace Nethermind.TxPool.Test
                         blobPool.TryGetBlobAndProof(expectedBlobVersionedHash.ToBytes(), out _, out _).Should().BeTrue();
                     }
 
+                    // removing 50% of txs
                     if (i % 2 == 0) blobPool.TryRemove(tx.Hash, out _).Should().BeTrue();
                 }
             });
 
-            // we expect index to have 1 key with poolSize values
+            // we expect index to have 1 key with poolSize/2 values (50% of txs were removed)
             blobPool.BlobIndex.Count.Should().Be(1);
             blobPool.BlobIndex.TryGetValue(expectedBlobVersionedHash, out List<Hash256> values).Should().BeTrue();
             values.Count.Should().Be(poolSize / 2);

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -680,7 +680,7 @@ namespace Nethermind.TxPool.Test
             }
         }
 
-        [Test][Repeat(3)]
+        [Test] [Repeat(3)]
         public void should_handle_indexing_blobs_when_adding_txs_in_parallel([Values(true, false)] bool isPersistentStorage)
         {
             const int txsPerSender = 10;

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -720,15 +720,10 @@ namespace Nethermind.TxPool.Test
                 }
             });
 
+            // we expect index to have 1 key with poolSize values
             blobPool.BlobIndex.Count.Should().Be(1);
-
-            //all txs should be added and indexed
-            for (int i = 0; i < poolSize; i++)
-            {
-                // we expect index to have 1 key with poolSize values
-                blobPool.BlobIndex.TryGetValue(expectedBlobVersionedHash, out List<Hash256> values).Should().BeTrue();
-                values.Count.Should().Be(poolSize);
-            }
+            blobPool.BlobIndex.TryGetValue(expectedBlobVersionedHash, out List<Hash256> values).Should().BeTrue();
+            values.Count.Should().Be(poolSize);
         }
 
         private Transaction GetTx(PrivateKey sender)

--- a/src/Nethermind/Nethermind.TxPool/Collections/BlobTxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/BlobTxDistinctSortedPool.cs
@@ -79,7 +79,7 @@ public class BlobTxDistinctSortedPool(int capacity, IComparer<Transaction> compa
         }
     }
 
-    internal override bool Remove(ValueHash256 hash, out Transaction? tx)
+    protected override bool Remove(ValueHash256 hash, out Transaction? tx)
     {
         if (base.Remove(hash, out tx))
         {

--- a/src/Nethermind/Nethermind.TxPool/Collections/BlobTxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/BlobTxDistinctSortedPool.cs
@@ -120,5 +120,5 @@ public class BlobTxDistinctSortedPool(int capacity, IComparer<Transaction> compa
     /// For tests only - to test sorting
     /// </summary>
     internal void TryGetBlobTxSortingEquivalent(Hash256 hash, out Transaction? lightBlobTx)
-        => base.TryGetValue(hash, out lightBlobTx);
+        => base.TryGetValueNonLocked(hash, out lightBlobTx);
 }

--- a/src/Nethermind/Nethermind.TxPool/Collections/BlobTxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/BlobTxDistinctSortedPool.cs
@@ -79,7 +79,7 @@ public class BlobTxDistinctSortedPool(int capacity, IComparer<Transaction> compa
         }
     }
 
-    protected override bool Remove(ValueHash256 hash, out Transaction? tx)
+    internal override bool Remove(ValueHash256 hash, out Transaction? tx)
     {
         if (base.Remove(hash, out tx))
         {

--- a/src/Nethermind/Nethermind.TxPool/Collections/DistinctValueSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/DistinctValueSortedPool.cs
@@ -57,7 +57,7 @@ namespace Nethermind.TxPool.Collections
             _distinctDictionary[value] = new KeyValuePair<TKey, TValue>(key, value);
         }
 
-        internal override bool Remove(TKey key, out TValue? value)
+        protected override bool Remove(TKey key, out TValue? value)
         {
             if (base.Remove(key, out value))
             {

--- a/src/Nethermind/Nethermind.TxPool/Collections/DistinctValueSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/DistinctValueSortedPool.cs
@@ -57,7 +57,7 @@ namespace Nethermind.TxPool.Collections
             _distinctDictionary[value] = new KeyValuePair<TKey, TValue>(key, value);
         }
 
-        protected override bool Remove(TKey key, out TValue? value)
+        internal override bool Remove(TKey key, out TValue? value)
         {
             if (base.Remove(key, out value))
             {

--- a/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
@@ -89,7 +89,7 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool
         return false;
     }
 
-    protected override bool Remove(ValueHash256 hash, out Transaction? tx)
+    internal override bool Remove(ValueHash256 hash, out Transaction? tx)
     {
         if (base.Remove(hash, out tx))
         {

--- a/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
@@ -89,7 +89,7 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool
         return false;
     }
 
-    internal override bool Remove(ValueHash256 hash, out Transaction? tx)
+    protected override bool Remove(ValueHash256 hash, out Transaction? tx)
     {
         if (base.Remove(hash, out tx))
         {

--- a/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
@@ -64,11 +64,11 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool
         return false;
     }
 
-    public override bool TryGetValue(ValueHash256 hash, [NotNullWhen(true)] out Transaction? fullBlobTx)
+    protected override bool TryGetValueNonLocked(ValueHash256 hash, [NotNullWhen(true)] out Transaction? fullBlobTx)
     {
         // Firstly check if tx is present in in-memory collection of light blob txs (without actual blobs).
         // If not, just return false
-        if (base.TryGetValue(hash, out Transaction? lightTx))
+        if (base.TryGetValueNonLocked(hash, out Transaction? lightTx))
         {
             // tx is present in light collection. Try to get full blob tx from cache
             if (_blobTxCache.TryGet(hash, out fullBlobTx))

--- a/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
@@ -336,14 +336,14 @@ namespace Nethermind.TxPool.Collections
         /// <param name="key">Key to be returned.</param>
         /// <param name="value">Returned element or null.</param>
         /// <returns>If element retrieval succeeded. True if element was present in pool.</returns>
-        public virtual bool TryGetValue(TKey key, [NotNullWhen(true)] out TValue? value)
+        public bool TryGetValue(TKey key, [NotNullWhen(true)] out TValue? value)
         {
             using var lockRelease = Lock.Acquire();
 
             return TryGetValueNonLocked(key, out value);
         }
 
-        protected bool TryGetValueNonLocked(TKey key, [NotNullWhen(true)] out TValue? value) => _cacheMap.TryGetValue(key, out value) && value is not null;
+        protected virtual bool TryGetValueNonLocked(TKey key, [NotNullWhen(true)] out TValue? value) => _cacheMap.TryGetValue(key, out value) && value is not null;
 
         /// <summary>
         /// Tries to insert element.

--- a/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
@@ -470,7 +470,7 @@ namespace Nethermind.TxPool.Collections
         /// <summary>
         /// Actual removal mechanism.
         /// </summary>
-        protected virtual bool Remove(TKey key, out TValue? value)
+        internal virtual bool Remove(TKey key, out TValue? value)
         {
             // Now remove from cache
             if (_cacheMap.Remove(key, out value))

--- a/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
@@ -470,7 +470,7 @@ namespace Nethermind.TxPool.Collections
         /// <summary>
         /// Actual removal mechanism.
         /// </summary>
-        internal virtual bool Remove(TKey key, out TValue? value)
+        protected virtual bool Remove(TKey key, out TValue? value)
         {
             // Now remove from cache
             if (_cacheMap.Remove(key, out value))


### PR DESCRIPTION
## Changes

- Add test for `engine_getBlobsV1` concurrency

1. failing on master
2. passing on https://github.com/NethermindEth/nethermind/pull/7568
3. passing on https://github.com/NethermindEth/nethermind/pull/7572

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No