### PR TITLE
Fix recreation of light blob tx collection

### DIFF
--- a/src/Nethermind/Nethermind.TxPool/Collections/BlobTxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/BlobTxDistinctSortedPool.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
@@ -65,7 +64,7 @@ public class BlobTxDistinctSortedPool(int capacity, IComparer<Transaction> compa
         return false;
     }
 
-    protected void AddToBlobIndex(Transaction blobTx)
+    private void AddToBlobIndex(Transaction blobTx)
     {
         if (blobTx.BlobVersionedHashes?.Length > 0)
         {

--- a/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
@@ -36,9 +36,8 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool
         long startTime = Stopwatch.GetTimestamp();
         foreach (LightTransaction lightBlobTx in blobTxStorage.GetAll())
         {
-            if (base.TryInsert(lightBlobTx.Hash, lightBlobTx, out _))
+            if (base.InsertCore(lightBlobTx.Hash, lightBlobTx, lightBlobTx.SenderAddress!))
             {
-                AddToBlobIndex(lightBlobTx);
                 numberOfTxsInDb++;
                 numberOfBlobsInDb += lightBlobTx.BlobVersionedHashes?.Length ?? 0;
             }

--- a/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
@@ -36,7 +36,8 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool
         long startTime = Stopwatch.GetTimestamp();
         foreach (LightTransaction lightBlobTx in blobTxStorage.GetAll())
         {
-            if (base.InsertCore(lightBlobTx.Hash, lightBlobTx, lightBlobTx.SenderAddress!))
+            if (lightBlobTx.SenderAddress is not null
+                && base.InsertCore(lightBlobTx.Hash, lightBlobTx, lightBlobTx.SenderAddress))
             {
                 numberOfTxsInDb++;
                 numberOfBlobsInDb += lightBlobTx.BlobVersionedHashes?.Length ?? 0;

--- a/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
@@ -352,7 +352,7 @@ namespace Nethermind.TxPool.Collections
         /// <param name="value">Element to insert.</param>
         /// <param name="removed">Element removed because of exceeding capacity</param>
         /// <returns>If element was inserted. False if element was already present in pool.</returns>
-        public virtual bool TryInsert(TKey key, TValue value, out TValue? removed)
+        public bool TryInsert(TKey key, TValue value, out TValue? removed)
         {
             using var lockRelease = Lock.Acquire();
 


### PR DESCRIPTION
## Changes

- Fix recreation of light blob tx collection

Fixes regression from https://github.com/NethermindEth/nethermind/pull/7572 and https://github.com/NethermindEth/nethermind/pull/7581

it was failing, because we are loading `LightTransactions` from db and trying to add to in-memory collection using `TryInsert`, which in `SortedPool` is calling `IncertCore`, which is overriden in `PersistentBlobTxDistinctSortedPool`. We should use directly `InsertCore` to skip the override which is adding txs to db

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No