### PR TITLE
Set metrics consistently before request completion

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
@@ -422,7 +422,7 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
             Metrics.LastBlockProcessingTimeInMs = blockProcessingTimeInMicrosecs / 1000;
             Metrics.RecoveryQueueSize = _recoveryQueue.Count;
             Metrics.ProcessingQueueSize = _blockQueue.Count;
-            _stats.UpdateStats(lastProcessed, _blockTree, blockProcessingTimeInMicrosecs);
+            _stats.UpdateStats(lastProcessed, blockProcessingTimeInMicrosecs);
         }
 
         bool updateHead = !options.ContainsFlag(ProcessingOptions.DoNotUpdateHead);
@@ -437,6 +437,8 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
             if (_logger.IsTrace) _logger.Trace($"Marked blocks as processed {lastProcessed}, blocks count: {processedBlocks.Length}");
             _blockTree.MarkChainAsProcessed(processingBranch.Blocks);
         }
+
+        Metrics.BestKnownBlockNumber = _blockTree.BestKnownNumber;
 
         return lastProcessed;
     }

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
@@ -438,7 +438,10 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
             _blockTree.MarkChainAsProcessed(processingBranch.Blocks);
         }
 
-        Metrics.BestKnownBlockNumber = _blockTree.BestKnownNumber;
+        if (!readonlyChain)
+        {
+            Metrics.BestKnownBlockNumber = _blockTree.BestKnownNumber;
+        }
 
         return lastProcessed;
     }

--- a/src/Nethermind/Nethermind.Consensus/Processing/ProcessingStats.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ProcessingStats.cs
@@ -57,7 +57,7 @@ namespace Nethermind.Consensus.Processing
 #endif
         }
 
-        public void UpdateStats(Block? block, IBlockTree blockTreeCtx, long blockProcessingTimeInMicros)
+        public void UpdateStats(Block? block, long blockProcessingTimeInMicros)
         {
             if (block is null)
             {
@@ -82,7 +82,6 @@ namespace Nethermind.Consensus.Processing
             Metrics.GasLimit = block.GasLimit;
 
             Metrics.BlockchainHeight = block.Header.Number;
-            Metrics.BestKnownBlockNumber = blockTreeCtx.BestKnownNumber;
 
             _blockProcessingMicroseconds = _processingStopwatch.ElapsedMicroseconds();
             _runningMicroseconds = _runStopwatch.ElapsedMicroseconds();


### PR DESCRIPTION
## Changes

- Set metrics before request completion so Prometheus more reliably picks up the correct values at request end

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No