### PR TITLE
Fix inacccurate memory metric due to concurrent writes

### DIFF
--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -119,6 +119,11 @@ namespace Nethermind.Trie.Pruning
             }
         }
 
+        public void IncrementMemoryUsedByDirtyCache(long nodeMemoryUsage)
+        {
+            Metrics.MemoryUsedByCache = Interlocked.Add(ref _memoryUsedByDirtyCache, nodeMemoryUsage);
+        }
+
         public int CommittedNodesCount
         {
             get => _committedNodesCount;
@@ -129,6 +134,11 @@ namespace Nethermind.Trie.Pruning
             }
         }
 
+        private void IncrementCommittedNodesCount()
+        {
+            Metrics.CommittedNodesCount = Interlocked.Increment(ref _committedNodesCount);
+        }
+
         public int PersistedNodesCount
         {
             get => _persistedNodesCount;
@@ -137,6 +147,11 @@ namespace Nethermind.Trie.Pruning
                 Metrics.PersistedNodeCount = value;
                 _persistedNodesCount = value;
             }
+        }
+
+        private void IncrementPersistedNodesCount()
+        {
+            Metrics.PersistedNodeCount = Interlocked.Increment(ref _persistedNodesCount);
         }
 
         public int CachedNodesCount
@@ -178,7 +193,7 @@ namespace Nethermind.Trie.Pruning
                     PersistNode(address, path, node, blockNumber, writeFlags);
                 }
 
-                CommittedNodesCount++;
+                IncrementCommittedNodesCount();
             }
 
             [MethodImpl(MethodImplOptions.NoInlining)]
@@ -859,6 +874,7 @@ namespace Nethermind.Trie.Pruning
                 currentNode.IsPersisted = true;
                 currentNode.LastSeen = Math.Max(blockNumber, currentNode.LastSeen);
                 PersistedNodesCount++;
+                IncrementPersistedNodesCount();
             }
             else
             {

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStoreDirtyNodesCache.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStoreDirtyNodesCache.cs
@@ -67,7 +67,7 @@ internal class TrieStoreDirtyNodesCache
         if (TryAdd(key, node))
         {
             Metrics.CachedNodesCount = Interlocked.Increment(ref _count);
-            _trieStore.MemoryUsedByDirtyCache += node.GetMemorySize(false) + KeyMemoryUsage;
+            _trieStore.IncrementMemoryUsedByDirtyCache(node.GetMemorySize(false) + KeyMemoryUsage);
         }
     }
 


### PR DESCRIPTION
- Because the commit is now concurrent, the memory used mettrics need to be modified atomically.
- Because it was not atomically modified, it use more memory than tracked causing unintended increased pruning interval.

#### What types of changes does your code introduce?

- [X] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No