### PR TITLE
Remove the redundant target platform

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN arch=$([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "$TARGETARCH") && \
 # A temporary symlink to support the old executable name
 RUN ln -s -r /publish/nethermind /publish/Nethermind.Runner
 
-FROM --platform=$TARGETPLATFORM mcr.microsoft.com/dotnet/aspnet:8.0-noble
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-noble
 
 WORKDIR /nethermind
 

--- a/Dockerfile.chiseled
+++ b/Dockerfile.chiseled
@@ -21,7 +21,7 @@ RUN cd /publish && \
   mkdir logs && \
   mkdir nethermind_db
 
-FROM --platform=$TARGETPLATFORM mcr.microsoft.com/dotnet/aspnet:8.0-noble-chiseled
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-noble-chiseled
 
 WORKDIR /nethermind
 

--- a/Dockerfile.diag
+++ b/Dockerfile.diag
@@ -22,7 +22,7 @@ RUN dotnet tool install -g dotnet-dump && \
     dotnet tool install -g dotnet-trace && \
     dotnet tool install -g JetBrains.dotTrace.GlobalTools
 
-FROM --platform=$TARGETPLATFORM mcr.microsoft.com/dotnet/aspnet:8.0-noble
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-noble
 
 WORKDIR /nethermind
 


### PR DESCRIPTION
## Changes

Removed the redundant `$TARGETPLATFORM` to silence the `RedundantTargetPlatform` warning.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No
