### PR TITLE
Add flat encoding and requests as a side car

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.Test/ExecutionRequestProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/ExecutionRequestProcessorTests.cs
@@ -76,11 +76,15 @@ public class ExecutionProcessorTests
                 CallOutputTracer tracer = ci.Arg<CallOutputTracer>();
                 if (transaction.To == eip7002Account)
                 {
-                    tracer.ReturnValue = executionWithdrawalRequests.FlatEncodeWithoutType();
+                    Span<byte> buffer = new byte[executionWithdrawalRequests.GetRequestsByteSize()];
+                    executionWithdrawalRequests.FlatEncodeWithoutType(buffer);
+                    tracer.ReturnValue = buffer.ToArray();
                 }
                 else if (transaction.To == eip7251Account)
                 {
-                    tracer.ReturnValue = executionConsolidationRequests.FlatEncodeWithoutType();
+                    Span<byte> buffer = new byte[executionConsolidationRequests.GetRequestsByteSize()];
+                    executionConsolidationRequests.FlatEncodeWithoutType(buffer);
+                    tracer.ReturnValue = buffer.ToArray();
                 }
                 else
                 {
@@ -120,7 +124,7 @@ public class ExecutionProcessorTests
         ]))
         {
             Assert.That(processedRequest.RequestType, Is.EqualTo(expectedRequest.RequestType));
-            Assert.That(processedRequest.RequestData, Is.EqualTo(expectedRequest.RequestData));
+            Assert.That(processedRequest.RequestData.ToArray(), Is.EqualTo(expectedRequest.RequestData.ToArray()));
         }
 
         Assert.That(block.Header.RequestsHash, Is.EqualTo(block.ExecutionRequests.ToArray().CalculateHash()));

--- a/src/Nethermind/Nethermind.Core.Test/Builders/BlockBuilder.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Builders/BlockBuilder.cs
@@ -252,7 +252,7 @@ namespace Nethermind.Core.Test.Builders
         public BlockBuilder WithEmptyRequestsHash()
         {
             TestObjectInternal.Header.RequestsHash = Array.Empty<ExecutionRequest.ExecutionRequest>().CalculateHash();
-            TestObjectInternal.ExecutionRequests = new ArrayPoolList<ExecutionRequest.ExecutionRequest>(0);
+            TestObjectInternal.ExecutionRequests = Array.Empty<ExecutionRequest.ExecutionRequest>();
             return this;
         }
 

--- a/src/Nethermind/Nethermind.Core.Test/Builders/TestItem.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Builders/TestItem.cs
@@ -102,15 +102,15 @@ namespace Nethermind.Core.Test.Builders
 
         public static byte[] SignatureBytes = [.. new Signature("0x9242685bf161793cc25603c231bc2f568eb630ea16aa137d2664ac80388256084f8ae3bd7535248d0bd448298cc2e2071e56992d0774dc340c368ae950852ada1c").Bytes, .. KeccakA.Bytes];
 
-        public static ExecutionRequest.ExecutionRequest ExecutionRequestA = new() { RequestType = 0, RequestData = ([.. PublicKeyA.Bytes.Slice(0, 48), .. KeccakA.Bytes, .. (BitConverter.GetBytes((ulong)1_000_000_000)), .. SignatureBytes, .. BitConverter.GetBytes((ulong)1)]) };
-        public static ExecutionRequest.ExecutionRequest ExecutionRequestB = new() { RequestType = 0, RequestData = ([.. PublicKeyB.Bytes.Slice(0, 48), .. KeccakB.Bytes, .. (BitConverter.GetBytes((ulong)2_000_000_000)), .. SignatureBytes, .. BitConverter.GetBytes((ulong)2)]) };
-        public static ExecutionRequest.ExecutionRequest ExecutionRequestC = new() { RequestType = 0, RequestData = ([.. PublicKeyC.Bytes.Slice(0, 48), .. KeccakC.Bytes, .. (BitConverter.GetBytes((ulong)3_000_000_000)), .. SignatureBytes, .. BitConverter.GetBytes((ulong)3)]) };
-        public static ExecutionRequest.ExecutionRequest ExecutionRequestD = new() { RequestType = 1, RequestData = ([.. AddressA.Bytes, .. PublicKeyA.Bytes.Slice(0, 48), .. (BitConverter.GetBytes((ulong)1_000_000_000))]) };
-        public static ExecutionRequest.ExecutionRequest ExecutionRequestE = new() { RequestType = 1, RequestData = ([.. AddressB.Bytes, .. PublicKeyB.Bytes.Slice(0, 48), .. (BitConverter.GetBytes((ulong)2_000_000_000))]) };
-        public static ExecutionRequest.ExecutionRequest ExecutionRequestF = new() { RequestType = 1, RequestData = ([.. AddressC.Bytes, .. PublicKeyC.Bytes.Slice(0, 48), .. (BitConverter.GetBytes((ulong)3_000_000_000))]) };
-        public static ExecutionRequest.ExecutionRequest ExecutionRequestG = new() { RequestType = 2, RequestData = ([.. AddressA.Bytes, .. PublicKeyA.Bytes.Slice(0, 48), .. PublicKeyB.Bytes.Slice(0, 48)]) };
-        public static ExecutionRequest.ExecutionRequest ExecutionRequestH = new() { RequestType = 2, RequestData = ([.. AddressB.Bytes, .. PublicKeyB.Bytes.Slice(0, 48), .. PublicKeyC.Bytes.Slice(0, 48)]) };
-        public static ExecutionRequest.ExecutionRequest ExecutionRequestI = new() { RequestType = 2, RequestData = ([.. AddressC.Bytes, .. PublicKeyC.Bytes.Slice(0, 48), .. PublicKeyA.Bytes.Slice(0, 48)]) };
+        public static ExecutionRequest.ExecutionRequest ExecutionRequestA = new() { RequestType = 0, RequestData = (byte[])([.. PublicKeyA.Bytes.Slice(0, 48), .. KeccakA.Bytes, .. (BitConverter.GetBytes((ulong)1_000_000_000)), .. SignatureBytes, .. BitConverter.GetBytes((ulong)1)]) };
+        public static ExecutionRequest.ExecutionRequest ExecutionRequestB = new() { RequestType = 0, RequestData = (byte[])([.. PublicKeyB.Bytes.Slice(0, 48), .. KeccakB.Bytes, .. (BitConverter.GetBytes((ulong)2_000_000_000)), .. SignatureBytes, .. BitConverter.GetBytes((ulong)2)]) };
+        public static ExecutionRequest.ExecutionRequest ExecutionRequestC = new() { RequestType = 0, RequestData = (byte[])([.. PublicKeyC.Bytes.Slice(0, 48), .. KeccakC.Bytes, .. (BitConverter.GetBytes((ulong)3_000_000_000)), .. SignatureBytes, .. BitConverter.GetBytes((ulong)3)]) };
+        public static ExecutionRequest.ExecutionRequest ExecutionRequestD = new() { RequestType = 1, RequestData = (byte[])([.. AddressA.Bytes, .. PublicKeyA.Bytes.Slice(0, 48), .. (BitConverter.GetBytes((ulong)1_000_000_000))]) };
+        public static ExecutionRequest.ExecutionRequest ExecutionRequestE = new() { RequestType = 1, RequestData = (byte[])([.. AddressB.Bytes, .. PublicKeyB.Bytes.Slice(0, 48), .. (BitConverter.GetBytes((ulong)2_000_000_000))]) };
+        public static ExecutionRequest.ExecutionRequest ExecutionRequestF = new() { RequestType = 1, RequestData = (byte[])([.. AddressC.Bytes, .. PublicKeyC.Bytes.Slice(0, 48), .. (BitConverter.GetBytes((ulong)3_000_000_000))]) };
+        public static ExecutionRequest.ExecutionRequest ExecutionRequestG = new() { RequestType = 2, RequestData = (byte[])([.. AddressA.Bytes, .. PublicKeyA.Bytes.Slice(0, 48), .. PublicKeyB.Bytes.Slice(0, 48)]) };
+        public static ExecutionRequest.ExecutionRequest ExecutionRequestH = new() { RequestType = 2, RequestData = (byte[])([.. AddressB.Bytes, .. PublicKeyB.Bytes.Slice(0, 48), .. PublicKeyC.Bytes.Slice(0, 48)]) };
+        public static ExecutionRequest.ExecutionRequest ExecutionRequestI = new() { RequestType = 2, RequestData = (byte[])([.. AddressC.Bytes, .. PublicKeyC.Bytes.Slice(0, 48), .. PublicKeyA.Bytes.Slice(0, 48)]) };
 
         public static IPEndPoint IPEndPointA = IPEndPoint.Parse("10.0.0.1");
         public static IPEndPoint IPEndPointB = IPEndPoint.Parse("10.0.0.2");

--- a/src/Nethermind/Nethermind.Core/Block.cs
+++ b/src/Nethermind/Nethermind.Core/Block.cs
@@ -118,7 +118,7 @@ public class Block
     public Hash256? RequestsHash => Header.RequestsHash; // do not add setter here
 
     [JsonIgnore]
-    public ArrayPoolList<ExecutionRequest.ExecutionRequest>? ExecutionRequests { get; set; }
+    public ExecutionRequest.ExecutionRequest[]? ExecutionRequests { get; set; }
 
     [JsonIgnore]
     public ArrayPoolList<AddressAsKey>? AccountChanges { get; set; }

--- a/src/Nethermind/Nethermind.Core/ExecutionRequest/ExecutionRequest.cs
+++ b/src/Nethermind/Nethermind.Core/ExecutionRequest/ExecutionRequest.cs
@@ -94,7 +94,7 @@ public static class ExecutionRequestExtensions
     {
         using (SHA256 sha256 = SHA256.Create())
         {
-            Span<byte> concatenatedHashes = new byte[32*requests.Count()];
+            Span<byte> concatenatedHashes = new byte[32 * requests.Count()];
             int currentPosition = 0;
             // Compute sha256 for each request and concatenate them
             foreach (ExecutionRequest request in requests)

--- a/src/Nethermind/Nethermind.Core/ExecutionRequest/ExecutionRequest.cs
+++ b/src/Nethermind/Nethermind.Core/ExecutionRequest/ExecutionRequest.cs
@@ -4,9 +4,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Data.SqlTypes;
 using System.Security.Cryptography;
-using System.Linq;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 
@@ -24,61 +22,89 @@ public class ExecutionRequest
     public byte RequestType { get; set; }
     public byte[]? RequestData { get; set; }
 
-    public byte[] FlatEncode()
+    public void FlatEncode(Span<byte> buffer)
     {
-        byte[] encoded = new byte[RequestData!.Length + 1];
-        encoded[0] = RequestType;
-        RequestData.CopyTo(encoded, 1);
-        return encoded;
+        if (buffer.Length < RequestData!.Length + 1)
+            throw new ArgumentException("Buffer too small");
+
+        buffer[0] = RequestType;
+        RequestData.CopyTo(buffer.Slice(1));
     }
 
     public override string ToString() => ToString(string.Empty);
 
     public string ToString(string indentation) => @$"{indentation}{nameof(ExecutionRequest)}
             {{{nameof(RequestType)}: {RequestType},
-            {nameof(RequestData)}: {RequestData?.ToHexString()}}}";
+            {nameof(RequestData)}: {RequestData!.ToHexString()}}}";
 }
 
 public static class ExecutionRequestExtensions
 {
-    public static byte[] FlatEncode(this ExecutionRequest[] requests)
+    public static int GetRequestsByteSize(this ExecutionRequest[] requests)
     {
-        List<byte> encoded = new();
+        int size = 0;
         foreach (ExecutionRequest request in requests)
         {
-            encoded.AddRange(request.FlatEncode());
+            size += request.RequestData!.Length + 1;
         }
-        return encoded.ToArray();
+        return size;
     }
 
-    public static byte[] FlatEncodeWithoutType(this ExecutionRequest[] requests)
+    public static void FlatEncode(this ExecutionRequest[] requests, Span<byte> buffer)
     {
-        List<byte> encoded = new();
+        int currentPosition = 0;
+
         foreach (ExecutionRequest request in requests)
         {
-            encoded.AddRange(request.RequestData!);
-        }
-        return encoded.ToArray();
-    }
+            Span<byte> internalBuffer = new byte[request.RequestData!.Length + 1];
+            request.FlatEncode(internalBuffer);
 
-    public static Hash256 CalculateHash(this ExecutionRequest[] requests)
-    {
-        using (SHA256 sha256 = SHA256.Create())
-        {
-            using (SHA256 sha256Inner = SHA256.Create())
+            // Ensure the buffer has enough space to accommodate the new data
+            if (currentPosition + internalBuffer.Length > buffer.Length)
             {
-                foreach (ExecutionRequest request in requests)
-                {
-                    byte[] requestHash = sha256Inner.ComputeHash(request.FlatEncode());
-
-                    // Update the outer hash with the result of each inner hash
-                    sha256.TransformBlock(requestHash, 0, requestHash.Length, null, 0);
-                }
-                // Complete the final hash computation
-                sha256.TransformFinalBlock(new byte[0], 0, 0);
-                return new Hash256(sha256.Hash!);
+                throw new InvalidOperationException("Buffer is not large enough to hold all data of requests");
             }
+
+            // Copy the internalBuffer to the buffer at the current position
+            internalBuffer.CopyTo(buffer.Slice(currentPosition, internalBuffer.Length));
+            currentPosition += internalBuffer.Length;
         }
+    }
+
+    public static void FlatEncodeWithoutType(this ExecutionRequest[] requests, Span<byte> buffer)
+    {
+        int currentPosition = 0;
+
+        foreach (ExecutionRequest request in requests)
+        {
+            // Ensure the buffer has enough space to accommodate the new data
+            if (currentPosition + request.RequestData!.Length > buffer.Length)
+            {
+                throw new InvalidOperationException("Buffer is not large enough to hold all data of requests");
+            }
+
+            // Copy the RequestData to the buffer at the current position
+            request.RequestData.CopyTo(buffer.Slice(currentPosition, request.RequestData.Length));
+            currentPosition += request.RequestData.Length;
+        }
+    }
+
+    public static Hash256 CalculateHash(this IEnumerable<ExecutionRequest> requests)
+    {
+        using var sha256 = SHA256.Create();
+        using var sha256Inner = SHA256.Create();
+        foreach (ExecutionRequest request in requests)
+        {
+            var internalBuffer = new byte[request.RequestData!.Length + 1];
+            request.FlatEncode(internalBuffer);
+            byte[] requestHash = sha256Inner.ComputeHash(internalBuffer);
+
+            // Update the outer hash with the result of each inner hash
+            sha256.TransformBlock(requestHash, 0, requestHash.Length, null, 0);
+        }
+        // Complete the final hash computation
+        sha256.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+        return new Hash256(sha256.Hash!);
     }
 
     public static bool IsSortedByType(this ExecutionRequest[] requests)

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/ExecutionRequestsProcessorMock.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/ExecutionRequestsProcessorMock.cs
@@ -31,11 +31,7 @@ public class ExecutionRequestsProcessorMock : IExecutionRequestsProcessor
         if (block.IsGenesis)
             return;
 
-        block.ExecutionRequests = new ArrayPoolList<ExecutionRequest>(Requests.Length);
-        foreach (var request in Requests)
-        {
-            block.ExecutionRequests.Add(request);
-        }
+        block.ExecutionRequests = Requests;
         block.Header.RequestsHash = Requests.CalculateHash();
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/GetPayloadV4Result.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/GetPayloadV4Result.cs
@@ -12,5 +12,5 @@ public class GetPayloadV4Result(Block block, UInt256 blockFees, BlobsBundleV1 bl
     public ExecutionRequest[]? ExecutionRequests { get; } = ExecutionRequests;
 
     public override string ToString() =>
-        $"{{ExecutionPayload: {ExecutionPayload}, Fees: {BlockValue}, BlobsBundle blobs count: {BlobsBundle.Blobs.Length}, ShouldOverrideBuilder {ShouldOverrideBuilder}, ExecutionRequests : {ExecutionRequests?.FlatEncode()}}}";
+        $"{{ExecutionPayload: {ExecutionPayload}, Fees: {BlockValue}, BlobsBundle blobs count: {BlobsBundle.Blobs.Length}, ShouldOverrideBuilder {ShouldOverrideBuilder}, ExecutionRequests count : {ExecutionRequests?.Length}}}";
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetPayloadV4Handler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetPayloadV4Handler.cs
@@ -24,7 +24,7 @@ public class GetPayloadV4Handler(
 {
     protected override GetPayloadV4Result GetPayloadResultFromBlock(IBlockProductionContext context)
     {
-        return new(context.CurrentBestBlock!, context.BlockFees, new BlobsBundleV1(context.CurrentBestBlock!), context.CurrentBestBlock!.ExecutionRequests!.ToArray())
+        return new(context.CurrentBestBlock!, context.BlockFees, new BlobsBundleV1(context.CurrentBestBlock!), context.CurrentBestBlock!.ExecutionRequests!)
         {
             ShouldOverrideBuilder = censorshipDetector?.GetCensoredBlocks().Contains(new BlockNumberHash(context.CurrentBestBlock!)) ?? false
         };


### PR DESCRIPTION
Closes #7525 
Closes #7524 
Closes #7522
Resolves #7521

## Changes

Implements changes from

* [Update EIP-6110: change request to flat encoding EIPs#8856](https://github.com/ethereum/EIPs/pull/8856)
* [Update EIP-7685: change requests hash to flat hash EIPs#8854](https://github.com/ethereum/EIPs/pull/8854)
* ~[engine: unified list of opaque requests  execution-apis#577](https://github.com/ethereum/execution-apis/pull/577)~
* [engine: Make execution requests a sidecar, take 2 execution-apis#591](https://github.com/ethereum/execution-apis/pull/591)

## Types of changes

- PR modifies two existing engine APIs : `engine_getPayloadV4` and `engine_getPayloadV4`, It incorporates suggestions from [pectra-devnet4 doc](https://notes.ethereum.org/@ethpandaops/pectra-devnet-4), which was to exchange `requests` as a side car and remove them from the block body
- It removes two engine APIs: `engine_getPayloadBodiesByRangeV2` and `engine_getPayloadBodiesByHashV2` and all related objects and handlers, which are now obsolete.
- It introduces  a new processor called `IExecutionRequestsProcess` and gets rid of all kinds of exiting requests processors. 
- Add support for flat request encoding and therefore,  a new way for `RequestsHash` calculation, more info at: https://eips.ethereum.org/EIPS/eip-7685

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [x] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Few more tests are yet to be written after a few rounds of discussions. 

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

## Remarks

Please verify the `requestsHash` calculation, which should be done as follow:

```python3
def compute_requests_hash(requests):
    m = sha256()
    for r in requests:
        m.update(sha256(r))
    return m.digest()

block.header.requests_hash = compute_requests_hash(requests)
```