### PR TITLE
Cleanup/remove lookup by hash

### DIFF
--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -161,7 +161,6 @@ public class InitializeNetwork : IStep
         _api.DisposeStack.Push(_api.Synchronizer);
 
         ISyncServer syncServer = _api.SyncServer = new SyncServer(
-            _api.TrieStore!.TrieNodeRlpStore,
             _api.DbProvider.CodeDb,
             _api.BlockTree,
             _api.ReceiptStorage!,

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/NetModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/NetModuleTests.cs
@@ -49,7 +49,6 @@ namespace Nethermind.JsonRpc.Test.Modules
             syncConfig.PivotHash.Returns(Keccak.MaxValue.ToString());
             ISyncServer syncServer = new SyncServer(
                 Substitute.For<IReadOnlyKeyValueStore>(),
-                Substitute.For<IReadOnlyKeyValueStore>(),
                 blockTree,
                 Substitute.For<IReceiptFinder>(),
                 Substitute.For<IBlockValidator>(),

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTestsBase.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTestsBase.cs
@@ -228,7 +228,6 @@ namespace Nethermind.Synchronization.Test.FastSync
             public string Name => "Mock";
 
             private readonly IDb _codeDb;
-            private readonly IReadOnlyKeyValueStore _stateDb;
             private readonly ISnapServer _snapServer;
 
             private Hash256[]? _filter;
@@ -253,7 +252,6 @@ namespace Nethermind.Synchronization.Test.FastSync
                 alwaysAvailableRootTracker.HasStateRoot(Arg.Any<Hash256>()).Returns(true);
                 IReadOnlyTrieStore trieStore = new TrieStore(new NodeStorage(stateDb), Nethermind.Trie.Pruning.No.Pruning,
                     Persist.EveryBlock, LimboLogs.Instance).AsReadOnly();
-                _stateDb = trieStore.TrieNodeRlpStore;
                 _snapServer = new SnapServer(
                     trieStore,
                     codeDb,
@@ -292,7 +290,7 @@ namespace Nethermind.Synchronization.Test.FastSync
 
                     if (_filter is null || _filter.Contains(item))
                     {
-                        responses[i] = _codeDb[item.Bytes] ?? _stateDb[item.Bytes]!;
+                        responses[i] = _codeDb[item.Bytes]!;
                     }
 
                     i++;

--- a/src/Nethermind/Nethermind.Synchronization.Test/OldStyleFullSynchronizerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/OldStyleFullSynchronizerTests.cs
@@ -87,7 +87,6 @@ namespace Nethermind.Synchronization.Test
                 stateReader,
                 LimboLogs.Instance);
             _syncServer = new SyncServer(
-                trieStore.TrieNodeRlpStore,
                 _codeDb,
                 _blockTree,
                 _receiptStorage,
@@ -374,18 +373,6 @@ namespace Nethermind.Synchronization.Test
             resetEvent.WaitOne(_standardTimeoutUnit);
 
             await miner2.Received().GetBlockHeaders(6, 1, 0, default);
-        }
-
-        [Test]
-        public void Can_retrieve_node_values()
-        {
-            _stateDb.Set(TestItem.KeccakA, TestItem.RandomDataA);
-            IOwnedReadOnlyList<byte[]?> data = _syncServer.GetNodeData(new[] { TestItem.KeccakA, TestItem.KeccakB }, CancellationToken.None);
-
-            Assert.That(data, Is.Not.Null);
-            Assert.That(data.Count, Is.EqualTo(2), "data.Length");
-            Assert.That(data[0], Is.EqualTo(TestItem.RandomDataA), "data[0]");
-            Assert.That(data[1], Is.EqualTo(null), "data[1]");
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncServerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncServerTests.cs
@@ -92,7 +92,6 @@ public class SyncServerTests
         IBlockValidator blockValidator = validationOk ? Always.Valid : Always.Invalid;
         ctx.SyncServer = new SyncServer(
             new MemDb(),
-            new MemDb(),
             localBlockTree,
             NullReceiptStorage.Instance,
             blockValidator,
@@ -133,7 +132,6 @@ public class SyncServerTests
         BlockTree localBlockTree = Build.A.BlockTree().OfChainLength(9).TestObject;
 
         ctx.SyncServer = new SyncServer(
-            new MemDb(),
             new MemDb(),
             localBlockTree,
             NullReceiptStorage.Instance,
@@ -181,7 +179,6 @@ public class SyncServerTests
         }
 
         ctx.SyncServer = new SyncServer(
-            new MemDb(),
             new MemDb(),
             localBlockTree,
             NullReceiptStorage.Instance,
@@ -249,7 +246,6 @@ public class SyncServerTests
             LimboLogs.Instance);
 
         ctx.SyncServer = new SyncServer(
-            new MemDb(),
             new MemDb(),
             localBlockTree,
             NullReceiptStorage.Instance,
@@ -473,7 +469,6 @@ public class SyncServerTests
 
         ctx.SyncServer = new SyncServer(
             new MemDb(),
-            new MemDb(),
             localBlockTree,
             NullReceiptStorage.Instance,
             blockValidator,
@@ -513,7 +508,6 @@ public class SyncServerTests
 
         ctx.SyncServer = new SyncServer(
             new MemDb(),
-            new MemDb(),
             localBlockTree,
             NullReceiptStorage.Instance,
             blockValidator,
@@ -545,7 +539,6 @@ public class SyncServerTests
         ISealValidator sealValidator = Substitute.For<ISealValidator>();
         ctx.SyncServer = new SyncServer(
             new MemDb(),
-            new MemDb(),
             localBlockTree,
             NullReceiptStorage.Instance,
             Always.Valid,
@@ -571,7 +564,6 @@ public class SyncServerTests
         BlockTree remoteBlockTree = Build.A.BlockTree().OfChainLength(10).TestObject;
         BlockTree localBlockTree = Build.A.BlockTree().OfChainLength(9).TestObject;
         ctx.SyncServer = new SyncServer(
-            new MemDb(),
             new MemDb(),
             localBlockTree,
             NullReceiptStorage.Instance,
@@ -607,7 +599,6 @@ public class SyncServerTests
         Context ctx = new();
         BlockTree blockTree = Build.A.BlockTree().OfChainLength(9).TestObject;
         ctx.SyncServer = new SyncServer(
-            new MemDb(),
             new MemDb(),
             blockTree,
             NullReceiptStorage.Instance,
@@ -649,7 +640,6 @@ public class SyncServerTests
         BlockTree localBlockTree = Build.A.BlockTree().OfChainLength(9).TestObject;
         ctx.SyncServer = new SyncServer(
             new MemDb(),
-            new MemDb(),
             localBlockTree,
             NullReceiptStorage.Instance,
             Always.Valid,
@@ -677,41 +667,6 @@ public class SyncServerTests
         await Task.WhenAll(peers.Select(p => ((SyncPeerMock)p.SyncPeer).Close()).ToArray());
     }
 
-    [Test]
-    public void GetNodeData_returns_cached_trie_nodes()
-    {
-        Context ctx = new();
-        BlockTree localBlockTree = Build.A.BlockTree().OfChainLength(600).TestObject;
-        ISealValidator sealValidator = Substitute.For<ISealValidator>();
-        MemDb stateDb = new();
-        TrieStore trieStore = new(stateDb, Prune.WhenCacheReaches(10.MB()), NoPersistence.Instance, LimboLogs.Instance);
-        ctx.SyncServer = new SyncServer(
-            trieStore.TrieNodeRlpStore,
-            new MemDb(),
-            localBlockTree,
-            NullReceiptStorage.Instance,
-            Always.Valid,
-            sealValidator,
-            ctx.PeerPool,
-            StaticSelector.Full,
-            new SyncConfig(),
-            Policy.FullGossip,
-            MainnetSpecProvider.Instance,
-            LimboLogs.Instance);
-
-        Hash256 nodeKey = TestItem.KeccakA;
-        TrieNode node = new(NodeType.Leaf, nodeKey, TestItem.KeccakB.Bytes);
-        IScopedTrieStore scopedTrieStore = trieStore.GetTrieStore(null);
-        using (ICommitter committer = scopedTrieStore.BeginCommit(TrieType.State, 1, node))
-        {
-            TreePath path = TreePath.Empty;
-            committer.CommitNode(ref path, new NodeCommitInfo(node));
-        }
-
-        stateDb.KeyExists(nodeKey).Should().BeFalse();
-        ctx.SyncServer.GetNodeData(new[] { nodeKey }, CancellationToken.None, NodeDataType.All).Should().BeEquivalentTo(new[] { TestItem.KeccakB.BytesToArray() });
-    }
-
     private class Context
     {
         public Context()
@@ -723,7 +678,6 @@ public class SyncServerTests
             BlockTree = Substitute.For<IBlockTree>();
             StaticSelector selector = StaticSelector.Full;
             SyncServer = new SyncServer(
-                new MemDb(),
                 new MemDb(),
                 BlockTree,
                 NullReceiptStorage.Instance,

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncThreadTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncThreadTests.cs
@@ -381,7 +381,6 @@ namespace Nethermind.Synchronization.Test
 
             ISyncModeSelector selector = synchronizer.SyncModeSelector;
             SyncServer syncServer = new(
-                trieStore.TrieNodeRlpStore,
                 codeDb,
                 tree,
                 receiptStorage,

--- a/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
@@ -402,7 +402,6 @@ public class SynchronizerTests
             }
 
             SyncServer = new SyncServer(
-                trieStore.TrieNodeRlpStore,
                 codeDb,
                 BlockTree,
                 NullReceiptStorage.Instance,

--- a/src/Nethermind/Nethermind.Synchronization.Test/Trie/HealingTreeTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/Trie/HealingTreeTests.cs
@@ -84,8 +84,6 @@ public class HealingTreeTests
             k => new TrieNode(NodeType.Leaf) { Key = path });
         trieStore.GetTrieStore(Arg.Any<Hash256?>())
             .Returns((callInfo) => new ScopedTrieStore(trieStore, (Hash256?)callInfo[0]));
-        TestMemDb db = new();
-        trieStore.TrieNodeRlpStore.Returns(db);
 
         ITrieNodeRecovery<GetTrieNodesRequest> recovery = Substitute.For<ITrieNodeRecovery<GetTrieNodesRequest>>();
         recovery.CanRecover.Returns(isMainThread);

--- a/src/Nethermind/Nethermind.Synchronization/SyncServer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SyncServer.cs
@@ -40,7 +40,6 @@ namespace Nethermind.Synchronization
         private readonly IReceiptFinder _receiptFinder;
         private readonly IBlockValidator _blockValidator;
         private readonly ISealValidator _sealValidator;
-        private readonly IReadOnlyKeyValueStore _stateDb;
         private readonly IReadOnlyKeyValueStore _codeDb;
         private readonly IGossipPolicy _gossipPolicy;
         private readonly ISpecProvider _specProvider;
@@ -54,7 +53,6 @@ namespace Nethermind.Synchronization
         private BlockHeader? _pivotHeader;
 
         public SyncServer(
-            IReadOnlyKeyValueStore stateDb,
             IReadOnlyKeyValueStore codeDb,
             IBlockTree blockTree,
             IReceiptFinder receiptFinder,
@@ -73,7 +71,6 @@ namespace Nethermind.Synchronization
             _pool = pool ?? throw new ArgumentNullException(nameof(pool));
             _syncModeSelector = syncModeSelector ?? throw new ArgumentNullException(nameof(syncModeSelector));
             _sealValidator = sealValidator ?? throw new ArgumentNullException(nameof(sealValidator));
-            _stateDb = stateDb ?? throw new ArgumentNullException(nameof(stateDb));
             _codeDb = codeDb ?? throw new ArgumentNullException(nameof(codeDb));
             _blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
             _receiptFinder = receiptFinder ?? throw new ArgumentNullException(nameof(receiptFinder));
@@ -375,7 +372,7 @@ namespace Nethermind.Synchronization
                 values.Add(null);
                 if ((includedTypes & NodeDataType.State) == NodeDataType.State)
                 {
-                    values[i] = _stateDb[keys[i].Bytes];
+                    values[i] = null; // We can no longer serve by hash
                 }
 
                 if (values[i] is null && (includedTypes & NodeDataType.Code) == NodeDataType.Code)

--- a/src/Nethermind/Nethermind.Trie/PreCachedTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/PreCachedTrieStore.cs
@@ -55,8 +55,6 @@ public class PreCachedTrieStore : ITrieStore
         remove => _inner.ReorgBoundaryReached -= value;
     }
 
-    public IReadOnlyKeyValueStore TrieNodeRlpStore => _inner.TrieNodeRlpStore;
-
     public void Set(Hash256? address, in TreePath path, in ValueHash256 keccak, byte[] rlp)
     {
         _preBlockCache[new(address, in path, in keccak)] = rlp;

--- a/src/Nethermind/Nethermind.Trie/Pruning/ITrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/ITrieStore.cs
@@ -19,9 +19,6 @@ namespace Nethermind.Trie.Pruning
 
         event EventHandler<ReorgBoundaryReached>? ReorgBoundaryReached;
 
-        // Used for serving via hash
-        IReadOnlyKeyValueStore TrieNodeRlpStore { get; }
-
         // Used by healing
         void Set(Hash256? address, in TreePath path, in ValueHash256 keccak, byte[] rlp);
 


### PR DESCRIPTION
- Remove lookup by hash. 
- Because we can't implement them with halfpath.
- And I think most network nowadays should have significant nethermind version that serve snap

## Types of changes

#### What types of changes does your code introduce?

- [ ] Refactoring

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No
