### PR TITLE
Block beacon header sync until global pivot is updated

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Setup.cs
@@ -90,6 +90,7 @@ public partial class EngineModuleTests
             chain.LogManager);
         invalidChainTracker.SetupBlockchainProcessorInterceptor(chain.BlockchainProcessor);
         chain.BeaconSync = new BeaconSync(chain.BeaconPivot, chain.BlockTree, synchronizationConfig, blockCacheService, chain.PoSSwitcher, chain.LogManager);
+        chain.BeaconSync.AllowBeaconHeaderSync();
         EngineRpcCapabilitiesProvider capabilitiesProvider = new(chain.SpecProvider);
         return new EngineRpcModule(
             new GetPayloadV1Handler(

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
@@ -127,7 +127,6 @@ public class ForkchoiceUpdatedHandler : IForkchoiceUpdatedHandler
 
             if (headBlockHeader is not null)
             {
-                if (_logger.IsInfo) _logger.Error($"here we are");
                 StartNewBeaconHeaderSync(forkchoiceState, headBlockHeader, simpleRequestStr);
                 return ForkchoiceUpdatedV1Result.Syncing;
             }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
@@ -127,6 +127,7 @@ public class ForkchoiceUpdatedHandler : IForkchoiceUpdatedHandler
 
             if (headBlockHeader is not null)
             {
+                if (_logger.IsInfo) _logger.Error($"here we are");
                 StartNewBeaconHeaderSync(forkchoiceState, headBlockHeader, simpleRequestStr);
                 return ForkchoiceUpdatedV1Result.Syncing;
             }
@@ -322,12 +323,12 @@ public class ForkchoiceUpdatedHandler : IForkchoiceUpdatedHandler
 
     private void StartNewBeaconHeaderSync(ForkchoiceStateV1 forkchoiceState, BlockHeader blockHeader, string requestStr)
     {
-        _mergeSyncController.InitBeaconHeaderSync(blockHeader);
+        bool isSyncInitialized = _mergeSyncController.TryInitBeaconHeaderSync(blockHeader);
         _beaconPivot.ProcessDestination = blockHeader;
         _peerRefresher.RefreshPeers(blockHeader.Hash!, blockHeader.ParentHash!, forkchoiceState.FinalizedBlockHash);
         _blockCacheService.FinalizedHash = forkchoiceState.FinalizedBlockHash;
 
-        if (_logger.IsInfo) _logger.Info($"Start a new sync process, Request: {requestStr}.");
+        if (isSyncInitialized && _logger.IsInfo) _logger.Info($"Start a new sync process, Request: {requestStr}.");
     }
 
     private bool IsInconsistent(Hash256 blockHash) => blockHash != Keccak.Zero && !_blockTree.IsMainChain(blockHash);

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconSync.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconSync.cs
@@ -68,7 +68,7 @@ namespace Nethermind.Merge.Plugin.Synchronization
             _isInBeaconModeControl = false;
         }
 
-        public bool ShouldBeInBeaconHeaders(bool canBeInBeaconHeaders = false)
+        public bool ShouldBeInBeaconHeaders(bool canBeInBeaconHeaders = true)
         {
             _canInitBeaconHeaderSync = canBeInBeaconHeaders;
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconSync.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconSync.cs
@@ -23,6 +23,8 @@ namespace Nethermind.Merge.Plugin.Synchronization
         private bool _isInBeaconModeControl = false;
         private readonly ILogger _logger;
 
+        public bool CanInitBeaconHeaders { get; set; } = false;
+
         public BeaconSync(
             IBeaconPivot beaconPivot,
             IBlockTree blockTree,
@@ -50,10 +52,13 @@ namespace Nethermind.Merge.Plugin.Synchronization
             _isInBeaconModeControl = true;
         }
 
-        public void InitBeaconHeaderSync(BlockHeader blockHeader)
+        public bool TryInitBeaconHeaderSync(BlockHeader blockHeader)
         {
+            if (!CanInitBeaconHeaders) return false;
+
             StopBeaconModeControl();
             _beaconPivot.EnsurePivot(blockHeader);
+            return true;
         }
 
         public void StopBeaconModeControl()
@@ -130,7 +135,7 @@ namespace Nethermind.Merge.Plugin.Synchronization
     {
         void StopSyncing();
 
-        void InitBeaconHeaderSync(BlockHeader blockHeader);
+        bool TryInitBeaconHeaderSync(BlockHeader blockHeader);
 
         void StopBeaconModeControl();
     }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconSync.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconSync.cs
@@ -23,7 +23,7 @@ namespace Nethermind.Merge.Plugin.Synchronization
         private bool _isInBeaconModeControl = false;
         private readonly ILogger _logger;
 
-        public bool CanInitBeaconHeaders { get; set; } = false;
+        private bool _canInitBeaconHeaders = false;
 
         public BeaconSync(
             IBeaconPivot beaconPivot,
@@ -54,7 +54,7 @@ namespace Nethermind.Merge.Plugin.Synchronization
 
         public bool TryInitBeaconHeaderSync(BlockHeader blockHeader)
         {
-            if (!CanInitBeaconHeaders) return false;
+            if (!_canInitBeaconHeaders) return false;
 
             StopBeaconModeControl();
             _beaconPivot.EnsurePivot(blockHeader);
@@ -66,8 +66,10 @@ namespace Nethermind.Merge.Plugin.Synchronization
             _isInBeaconModeControl = false;
         }
 
-        public bool ShouldBeInBeaconHeaders()
+        public bool ShouldBeInBeaconHeaders(bool canBeInBeaconHeaders)
         {
+            _canInitBeaconHeaders = canBeInBeaconHeaders;
+
             bool beaconPivotExists = _beaconPivot.BeaconPivotExists();
             bool notInBeaconModeControl = !_isInBeaconModeControl;
             bool notFinishedBeaconHeaderSync = !IsBeaconSyncHeadersFinished();

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconSync.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconSync.cs
@@ -68,7 +68,7 @@ namespace Nethermind.Merge.Plugin.Synchronization
             _isInBeaconModeControl = false;
         }
 
-        public bool ShouldBeInBeaconHeaders(bool canBeInBeaconHeaders)
+        public bool ShouldBeInBeaconHeaders(bool canBeInBeaconHeaders = false)
         {
             _canInitBeaconHeaderSync = canBeInBeaconHeaders;
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconSync.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconSync.cs
@@ -23,7 +23,9 @@ namespace Nethermind.Merge.Plugin.Synchronization
         private bool _isInBeaconModeControl = false;
         private readonly ILogger _logger;
 
-        private bool _canInitBeaconHeaders = false;
+        // beacon header sync can be initialized only when global pivot is already set,
+        // otherwise it might result in conflicting pivots and a deadlock
+        private bool _canInitBeaconHeaderSync = false;
 
         public BeaconSync(
             IBeaconPivot beaconPivot,
@@ -54,7 +56,7 @@ namespace Nethermind.Merge.Plugin.Synchronization
 
         public bool TryInitBeaconHeaderSync(BlockHeader blockHeader)
         {
-            if (!_canInitBeaconHeaders) return false;
+            if (!_canInitBeaconHeaderSync) return false;
 
             StopBeaconModeControl();
             _beaconPivot.EnsurePivot(blockHeader);
@@ -68,7 +70,7 @@ namespace Nethermind.Merge.Plugin.Synchronization
 
         public bool ShouldBeInBeaconHeaders(bool canBeInBeaconHeaders)
         {
-            _canInitBeaconHeaders = canBeInBeaconHeaders;
+            _canInitBeaconHeaderSync = canBeInBeaconHeaders;
 
             bool beaconPivotExists = _beaconPivot.BeaconPivotExists();
             bool notInBeaconModeControl = !_isInBeaconModeControl;

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconSync.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/BeaconSync.cs
@@ -68,10 +68,13 @@ namespace Nethermind.Merge.Plugin.Synchronization
             _isInBeaconModeControl = false;
         }
 
-        public bool ShouldBeInBeaconHeaders(bool canBeInBeaconHeaders = true)
+        public void AllowBeaconHeaderSync()
         {
-            _canInitBeaconHeaderSync = canBeInBeaconHeaders;
+            _canInitBeaconHeaderSync = true;
+        }
 
+        public bool ShouldBeInBeaconHeaders()
+        {
             bool beaconPivotExists = _beaconPivot.BeaconPivotExists();
             bool notInBeaconModeControl = !_isInBeaconModeControl;
             bool notFinishedBeaconHeaderSync = !IsBeaconSyncHeadersFinished();

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/PivotUpdator.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/PivotUpdator.cs
@@ -110,6 +110,7 @@ public class PivotUpdator
             {
                 _syncModeSelector.Changed -= OnSyncModeChanged;
                 _syncConfig.MaxAttemptsToUpdatePivot = 0;
+                _beaconSyncStrategy.AllowBeaconHeaderSync();
                 if (_logger.IsInfo) _logger.Info("Failed to update pivot block, skipping it and using pivot from config file.");
             }
         }
@@ -254,6 +255,7 @@ public class PivotUpdator
         _syncConfig.PivotHash = finalizedBlockHash.ToString();
         _syncConfig.PivotNumber = finalizedBlockNumber.ToString();
         _syncConfig.MaxAttemptsToUpdatePivot = 0;
+        _beaconSyncStrategy.AllowBeaconHeaderSync();
     }
 
 }

--- a/src/Nethermind/Nethermind.Synchronization/IBeaconSyncStrategy.cs
+++ b/src/Nethermind/Nethermind.Synchronization/IBeaconSyncStrategy.cs
@@ -24,7 +24,7 @@ namespace Nethermind.Synchronization
 
     public interface IBeaconSyncStrategy
     {
-        bool ShouldBeInBeaconHeaders(bool canBeInBeaconHeaders = false);
+        bool ShouldBeInBeaconHeaders(bool canBeInBeaconHeaders = true);
         bool ShouldBeInBeaconModeControl();
         bool IsBeaconSyncFinished(BlockHeader? blockHeader);
 

--- a/src/Nethermind/Nethermind.Synchronization/IBeaconSyncStrategy.cs
+++ b/src/Nethermind/Nethermind.Synchronization/IBeaconSyncStrategy.cs
@@ -12,7 +12,9 @@ namespace Nethermind.Synchronization
 
         public static No BeaconSync { get; } = new();
 
-        public bool ShouldBeInBeaconHeaders(bool canBeInBeaconHeaders) => false;
+        public void AllowBeaconHeaderSync() { }
+
+        public bool ShouldBeInBeaconHeaders() => false;
 
         public bool ShouldBeInBeaconModeControl() => false;
 
@@ -24,7 +26,8 @@ namespace Nethermind.Synchronization
 
     public interface IBeaconSyncStrategy
     {
-        bool ShouldBeInBeaconHeaders(bool canBeInBeaconHeaders = true);
+        void AllowBeaconHeaderSync();
+        bool ShouldBeInBeaconHeaders();
         bool ShouldBeInBeaconModeControl();
         bool IsBeaconSyncFinished(BlockHeader? blockHeader);
 

--- a/src/Nethermind/Nethermind.Synchronization/IBeaconSyncStrategy.cs
+++ b/src/Nethermind/Nethermind.Synchronization/IBeaconSyncStrategy.cs
@@ -12,8 +12,7 @@ namespace Nethermind.Synchronization
 
         public static No BeaconSync { get; } = new();
 
-        public bool CanInitBeaconHeaders { get; set; }
-        public bool ShouldBeInBeaconHeaders() => false;
+        public bool ShouldBeInBeaconHeaders(bool canBeInBeaconHeaders) => false;
 
         public bool ShouldBeInBeaconModeControl() => false;
 
@@ -25,8 +24,7 @@ namespace Nethermind.Synchronization
 
     public interface IBeaconSyncStrategy
     {
-        bool CanInitBeaconHeaders { get; set; }
-        bool ShouldBeInBeaconHeaders();
+        bool ShouldBeInBeaconHeaders(bool canBeInBeaconHeaders);
         bool ShouldBeInBeaconModeControl();
         bool IsBeaconSyncFinished(BlockHeader? blockHeader);
 

--- a/src/Nethermind/Nethermind.Synchronization/IBeaconSyncStrategy.cs
+++ b/src/Nethermind/Nethermind.Synchronization/IBeaconSyncStrategy.cs
@@ -12,6 +12,7 @@ namespace Nethermind.Synchronization
 
         public static No BeaconSync { get; } = new();
 
+        public bool CanInitBeaconHeaders { get; set; }
         public bool ShouldBeInBeaconHeaders() => false;
 
         public bool ShouldBeInBeaconModeControl() => false;
@@ -24,6 +25,7 @@ namespace Nethermind.Synchronization
 
     public interface IBeaconSyncStrategy
     {
+        bool CanInitBeaconHeaders { get; set; }
         bool ShouldBeInBeaconHeaders();
         bool ShouldBeInBeaconModeControl();
         bool IsBeaconSyncFinished(BlockHeader? blockHeader);

--- a/src/Nethermind/Nethermind.Synchronization/IBeaconSyncStrategy.cs
+++ b/src/Nethermind/Nethermind.Synchronization/IBeaconSyncStrategy.cs
@@ -24,7 +24,7 @@ namespace Nethermind.Synchronization
 
     public interface IBeaconSyncStrategy
     {
-        bool ShouldBeInBeaconHeaders(bool canBeInBeaconHeaders);
+        bool ShouldBeInBeaconHeaders(bool canBeInBeaconHeaders = false);
         bool ShouldBeInBeaconModeControl();
         bool IsBeaconSyncFinished(BlockHeader? blockHeader);
 

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
@@ -338,8 +338,8 @@ namespace Nethermind.Synchronization.ParallelSync
 
         private bool ShouldBeInBeaconHeaders(bool shouldBeInUpdatingPivot)
         {
-            bool shouldBeNotInUpdatingPivot = !shouldBeInUpdatingPivot;
             bool shouldBeInBeaconHeaders = _beaconSyncStrategy.ShouldBeInBeaconHeaders();
+            bool shouldBeNotInUpdatingPivot = !shouldBeInUpdatingPivot;
 
             bool result = shouldBeInBeaconHeaders &&
                           shouldBeNotInUpdatingPivot;

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
@@ -344,6 +344,8 @@ namespace Nethermind.Synchronization.ParallelSync
             bool result = shouldBeInBeaconHeaders &&
                           shouldBeNotInUpdatingPivot;
 
+            _beaconSyncStrategy.CanInitBeaconHeaders = shouldBeNotInUpdatingPivot;
+
             if (_logger.IsTrace)
             {
                 LogDetailedSyncModeChecks("BEACON HEADERS",

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
@@ -339,7 +339,7 @@ namespace Nethermind.Synchronization.ParallelSync
         private bool ShouldBeInBeaconHeaders(bool shouldBeInUpdatingPivot)
         {
             bool shouldBeNotInUpdatingPivot = !shouldBeInUpdatingPivot;
-            bool shouldBeInBeaconHeaders = _beaconSyncStrategy.ShouldBeInBeaconHeaders(shouldBeNotInUpdatingPivot);
+            bool shouldBeInBeaconHeaders = _beaconSyncStrategy.ShouldBeInBeaconHeaders();
 
             bool result = shouldBeInBeaconHeaders &&
                           shouldBeNotInUpdatingPivot;

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
@@ -338,13 +338,11 @@ namespace Nethermind.Synchronization.ParallelSync
 
         private bool ShouldBeInBeaconHeaders(bool shouldBeInUpdatingPivot)
         {
-            bool shouldBeInBeaconHeaders = _beaconSyncStrategy.ShouldBeInBeaconHeaders();
             bool shouldBeNotInUpdatingPivot = !shouldBeInUpdatingPivot;
+            bool shouldBeInBeaconHeaders = _beaconSyncStrategy.ShouldBeInBeaconHeaders(shouldBeNotInUpdatingPivot);
 
             bool result = shouldBeInBeaconHeaders &&
                           shouldBeNotInUpdatingPivot;
-
-            _beaconSyncStrategy.CanInitBeaconHeaders = shouldBeNotInUpdatingPivot;
 
             if (_logger.IsTrace)
             {


### PR DESCRIPTION
Fixes #6304

## Changes

- block a start of beacon header sync until global pivot is updated

Beacon header sync can be initialized only when global pivot is already set, otherwise it might result in conflicting pivots and a deadlock

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_