### PR TITLE
Faster and not locked VM creation

### DIFF
--- a/.github/workflows/sync-supported-chains.yml
+++ b/.github/workflows/sync-supported-chains.yml
@@ -46,7 +46,6 @@ jobs:
     needs: [setup-matrix]
     strategy:
       fail-fast: false
-      max-parallel: 5 
       matrix:
         config: ${{fromJson(needs.setup-matrix.outputs.matrix)}}
     runs-on: ubuntu-latest
@@ -59,7 +58,7 @@ jobs:
         
       - name: Create a Runner
         id: run-linode-action
-        uses: kamilchodola/linode-github-runner/.github/actions/linode-machine-manager@main
+        uses: kamilchodola/linode-github-runner/.github/actions/linode-machine-manager@kch/add429handling
         with:
           linode_token: ${{ secrets.LINODE_TOKEN }}
           github_token: "${{ secrets.REPOSITORY_DISPATCH_TOKEN }}"
@@ -278,7 +277,7 @@ jobs:
         if: always()
         continue-on-error: true
         id: run-linode-action
-        uses: kamilchodola/linode-github-runner/.github/actions/linode-machine-manager@main
+        uses: kamilchodola/linode-github-runner/.github/actions/linode-machine-manager@kch/add429handling
         with:
           linode_token: ${{ secrets.LINODE_TOKEN }}
           github_token: "${{ secrets.REPOSITORY_DISPATCH_TOKEN }}"
@@ -300,7 +299,7 @@ jobs:
     steps:    
       - name: Destroy VM (make sure is removed if by any unexpected reason it did not removed it on )
         continue-on-error: true
-        uses: kamilchodola/linode-github-runner/.github/actions/linode-machine-manager@main
+        uses: kamilchodola/linode-github-runner/.github/actions/linode-machine-manager@kch/add429handling
         with:
           linode_token: ${{ secrets.LINODE_TOKEN }}
           github_token: "${{ secrets.REPOSITORY_DISPATCH_TOKEN }}"
@@ -312,7 +311,7 @@ jobs:
           repo_name: "nethermind"  
 
       - name: Destroy Runner
-        uses: kamilchodola/linode-github-runner/.github/actions/linode-machine-manager@main
+        uses: kamilchodola/linode-github-runner/.github/actions/linode-machine-manager@kch/add429handling
         with:
           linode_token: ${{ secrets.LINODE_TOKEN }}
           github_token: "${{ secrets.REPOSITORY_DISPATCH_TOKEN }}"

--- a/.github/workflows/sync-supported-chains.yml
+++ b/.github/workflows/sync-supported-chains.yml
@@ -58,7 +58,7 @@ jobs:
         
       - name: Create a Runner
         id: run-linode-action
-        uses: kamilchodola/linode-github-runner/.github/actions/linode-machine-manager@kch/add429handling
+        uses: kamilchodola/linode-github-runner/.github/actions/linode-machine-manager@main
         with:
           linode_token: ${{ secrets.LINODE_TOKEN }}
           github_token: "${{ secrets.REPOSITORY_DISPATCH_TOKEN }}"
@@ -275,9 +275,8 @@ jobs:
 
       - name: Destroy VM
         if: always()
-        continue-on-error: true
         id: run-linode-action
-        uses: kamilchodola/linode-github-runner/.github/actions/linode-machine-manager@kch/add429handling
+        uses: kamilchodola/linode-github-runner/.github/actions/linode-machine-manager@main
         with:
           linode_token: ${{ secrets.LINODE_TOKEN }}
           github_token: "${{ secrets.REPOSITORY_DISPATCH_TOKEN }}"
@@ -296,22 +295,9 @@ jobs:
       matrix:
         config: ${{fromJson(needs.setup-matrix.outputs.matrix)}}
     runs-on: ubuntu-latest
-    steps:    
-      - name: Destroy VM (make sure is removed if by any unexpected reason it did not removed it on )
-        continue-on-error: true
-        uses: kamilchodola/linode-github-runner/.github/actions/linode-machine-manager@kch/add429handling
-        with:
-          linode_token: ${{ secrets.LINODE_TOKEN }}
-          github_token: "${{ secrets.REPOSITORY_DISPATCH_TOKEN }}"
-          action: "destroy-machine"
-          runner_label: t-${{ github.run_id }}-${{ matrix.config.network }}
-          search_phrase: t-${{ github.run_id }}-${{ matrix.config.network }}
-          root_password: ${{ secrets.LINODE_ROOT_PASSWORD }}
-          organization: "NethermindEth"
-          repo_name: "nethermind"  
-
+    steps:
       - name: Destroy Runner
-        uses: kamilchodola/linode-github-runner/.github/actions/linode-machine-manager@kch/add429handling
+        uses: kamilchodola/linode-github-runner/.github/actions/linode-machine-manager@main
         with:
           linode_token: ${{ secrets.LINODE_TOKEN }}
           github_token: "${{ secrets.REPOSITORY_DISPATCH_TOKEN }}"


### PR DESCRIPTION
Mostly is about handling this PR: https://github.com/kamilchodola/linode-github-runner/pull/4

I've needed to lock VM creation for 5 parallel jobs as Linode have a limit of 5 VM creation requests every 15 seconds.
Because of that just VM creation part was taking up to 10 minutes.
Now is reduced to 5 minutes because everything is triggered at once with 20 seconds pooling if 429 exception a raises.

Also as other issues with Linode removal is handled well I can remove a "try again" step for VM removal.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [X] Other: Testing tool imrpovement

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [X] No