### PR TITLE
Feature/FlushWAL on flush.

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPruningDiskTest.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPruningDiskTest.cs
@@ -132,7 +132,7 @@ public class FullPruningDiskTest
         }
     }
 
-    [Test, MaxTime(Timeout.MaxTestTime), Retry(5)]
+    [Test, MaxTime(Timeout.MaxTestTime * 3)]
     public async Task prune_on_disk_multiple_times()
     {
         using PruningTestBlockchain chain = await PruningTestBlockchain.Create(new PruningConfig { FullPruningMinimumDelayHours = 0 });
@@ -142,7 +142,7 @@ public class FullPruningDiskTest
         }
     }
 
-    [Test, MaxTime(Timeout.MaxTestTime), Retry(5)]
+    [Test, MaxTime(Timeout.MaxTestTime * 3)]
     public async Task prune_on_disk_only_once()
     {
         using PruningTestBlockchain chain = await PruningTestBlockchain.Create(new PruningConfig { FullPruningMinimumDelayHours = 10 });

--- a/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPruningDiskTest.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPruningDiskTest.cs
@@ -132,7 +132,7 @@ public class FullPruningDiskTest
         }
     }
 
-    [Test, MaxTime(Timeout.MaxTestTime * 3)]
+    [Test, MaxTime(Timeout.LongTestTime)]
     public async Task prune_on_disk_multiple_times()
     {
         using PruningTestBlockchain chain = await PruningTestBlockchain.Create(new PruningConfig { FullPruningMinimumDelayHours = 0 });
@@ -142,7 +142,7 @@ public class FullPruningDiskTest
         }
     }
 
-    [Test, MaxTime(Timeout.MaxTestTime * 3)]
+    [Test, MaxTime(Timeout.LongTestTime)]
     public async Task prune_on_disk_only_once()
     {
         using PruningTestBlockchain chain = await PruningTestBlockchain.Create(new PruningConfig { FullPruningMinimumDelayHours = 10 });

--- a/src/Nethermind/Nethermind.Blockchain.Test/Timeout.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Timeout.cs
@@ -4,6 +4,7 @@
 namespace Nethermind.Blockchain.Test;
 internal class Timeout
 {
+    public const int LongTestTime = 60_000;
     public const int MaxTestTime = 10_000;
     public const int MaxWaitTime = 1_000;
 }

--- a/src/Nethermind/Nethermind.Core.Test/TestMemColumnDb.cs
+++ b/src/Nethermind/Nethermind.Core.Test/TestMemColumnDb.cs
@@ -31,4 +31,5 @@ public class TestMemColumnsDb<TKey> : IColumnsDb<TKey>
         return new InMemoryColumnWriteBatch<TKey>(this);
     }
     public void Dispose() { }
+    public void Flush(bool onlyWal = false) { }
 }

--- a/src/Nethermind/Nethermind.Core.Test/TestMemDb.cs
+++ b/src/Nethermind/Nethermind.Core.Test/TestMemDb.cs
@@ -109,7 +109,7 @@ public class TestMemDb : MemDb, ITunableDb
         return new InMemoryWriteBatch(this);
     }
 
-    public override void Flush()
+    public override void Flush(bool onlyWal)
     {
         FlushCount++;
     }

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -128,9 +128,9 @@ public class ColumnDb : IDb
         return _mainDb.KeyExistsWithColumn(key, _columnFamily);
     }
 
-    public void Flush()
+    public void Flush(bool onlyWal)
     {
-        _mainDb.Flush();
+        _mainDb.Flush(onlyWal);
     }
 
     public void Compact()

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -1337,6 +1337,7 @@ public class DbOnTheRocks : IDb, ITunableDb
     {
         try
         {
+            _logger.Warn($"Flushing db {Name}");
             _rocksDbNative.rocksdb_flush(_db.Handle, FlushOptions.DefaultFlushOptions.Handle);
         }
         catch (RocksDbSharpException e)

--- a/src/Nethermind/Nethermind.Db.Rpc/RpcColumnsDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rpc/RpcColumnsDb.cs
@@ -46,5 +46,6 @@ namespace Nethermind.Db.Rpc
             return new InMemoryColumnWriteBatch<T>(this);
         }
         public void Dispose() { }
+        public void Flush(bool onlyWal = false) { }
     }
 }

--- a/src/Nethermind/Nethermind.Db.Rpc/RpcDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rpc/RpcDb.cs
@@ -73,6 +73,8 @@ namespace Nethermind.Db.Rpc
 
         public IDb Innermost => this; // record db is just a helper DB here
         public void Flush() { }
+        public void Flush(bool onlyWal = false) { }
+
         public void Clear() { }
 
         public IEnumerable<KeyValuePair<byte[], byte[]>> GetAll(bool ordered = false) => _recordDb.GetAll();

--- a/src/Nethermind/Nethermind.Db/CompressingDb.cs
+++ b/src/Nethermind/Nethermind.Db/CompressingDb.cs
@@ -137,7 +137,7 @@ namespace Nethermind.Db
 
             public bool KeyExists(ReadOnlySpan<byte> key) => _wrapped.KeyExists(key);
 
-            public void Flush() => _wrapped.Flush();
+            public void Flush(bool onlyWal) => _wrapped.Flush(onlyWal);
 
             public void Clear() => _wrapped.Clear();
 

--- a/src/Nethermind/Nethermind.Db/FullPruning/FullPruningDb.cs
+++ b/src/Nethermind/Nethermind.Db/FullPruning/FullPruningDb.cs
@@ -145,11 +145,11 @@ namespace Nethermind.Db.FullPruning
         public IDb Innermost => this;
 
         // we need to flush both DB's
-        public void Flush()
+        public void Flush(bool onlyWal)
         {
-            _currentDb.Flush();
+            _currentDb.Flush(onlyWal);
             IDb? cloningDb = _pruningContext?.CloningDb;
-            cloningDb?.Flush();
+            cloningDb?.Flush(onlyWal);
         }
 
         // we need to clear both DB's

--- a/src/Nethermind/Nethermind.Db/IDb.cs
+++ b/src/Nethermind/Nethermind.Db/IDb.cs
@@ -23,7 +23,7 @@ namespace Nethermind.Db
     {
         DbMetric GatherMetric(bool includeSharedCache = false) => new DbMetric();
 
-        void Flush() { }
+        void Flush(bool onlyWal = false);
         void Clear() { }
         void Compact() { }
 

--- a/src/Nethermind/Nethermind.Db/MemColumnsDb.cs
+++ b/src/Nethermind/Nethermind.Db/MemColumnsDb.cs
@@ -36,5 +36,6 @@ namespace Nethermind.Db
             return new InMemoryColumnWriteBatch<TKey>(this);
         }
         public void Dispose() { }
+        public void Flush(bool onlyWal = false) { }
     }
 }

--- a/src/Nethermind/Nethermind.Db/MemDb.cs
+++ b/src/Nethermind/Nethermind.Db/MemDb.cs
@@ -77,9 +77,7 @@ namespace Nethermind.Db
 
         public IDb Innermost => this;
 
-        public virtual void Flush()
-        {
-        }
+        public virtual void Flush(bool onlyWal = false) { }
 
         public void Clear()
         {

--- a/src/Nethermind/Nethermind.Db/NullDb.cs
+++ b/src/Nethermind/Nethermind.Db/NullDb.cs
@@ -43,7 +43,8 @@ namespace Nethermind.Db
             return false;
         }
 
-        public void Flush() { }
+        public void Flush(bool onlyWal = false) { }
+
         public void Clear() { }
 
         public IEnumerable<KeyValuePair<byte[], byte[]>> GetAll(bool ordered = false) => Enumerable.Empty<KeyValuePair<byte[], byte[]>>();

--- a/src/Nethermind/Nethermind.Db/ReadOnlyColumnsDb.cs
+++ b/src/Nethermind/Nethermind.Db/ReadOnlyColumnsDb.cs
@@ -44,5 +44,7 @@ namespace Nethermind.Db
                 readOnlyColumn.Value.Dispose();
             }
         }
+
+        public void Flush(bool onlyWal = false) { }
     }
 }

--- a/src/Nethermind/Nethermind.Db/ReadOnlyDb.cs
+++ b/src/Nethermind/Nethermind.Db/ReadOnlyDb.cs
@@ -67,10 +67,10 @@ namespace Nethermind.Db
 
         public bool KeyExists(ReadOnlySpan<byte> key) => _memDb.KeyExists(key) || wrappedDb.KeyExists(key);
 
-        public void Flush()
+        public void Flush(bool onlyWal)
         {
-            wrappedDb.Flush();
-            _memDb.Flush();
+            wrappedDb.Flush(onlyWal);
+            _memDb.Flush(onlyWal);
         }
 
         public void Clear() => throw new InvalidOperationException();

--- a/src/Nethermind/Nethermind.Db/ReadOnlyDb.cs
+++ b/src/Nethermind/Nethermind.Db/ReadOnlyDb.cs
@@ -67,11 +67,7 @@ namespace Nethermind.Db
 
         public bool KeyExists(ReadOnlySpan<byte> key) => _memDb.KeyExists(key) || wrappedDb.KeyExists(key);
 
-        public void Flush(bool onlyWal)
-        {
-            wrappedDb.Flush(onlyWal);
-            _memDb.Flush(onlyWal);
-        }
+        public void Flush(bool onlyWal) { }
 
         public void Clear() => throw new InvalidOperationException();
 

--- a/src/Nethermind/Nethermind.Db/SimpleFilePublicKeyDb.cs
+++ b/src/Nethermind/Nethermind.Db/SimpleFilePublicKeyDb.cs
@@ -86,7 +86,8 @@ namespace Nethermind.Db
             return _cache.ContainsKey(key);
         }
 
-        public void Flush() { }
+        public void Flush(bool onlyWal = false) { }
+
         public void Clear()
         {
             File.Delete(DbPath);

--- a/src/Nethermind/Nethermind.Init/InitializeStateDb.cs
+++ b/src/Nethermind/Nethermind.Init/InitializeStateDb.cs
@@ -121,7 +121,7 @@ public class InitializeStateDb : IStep
             {
                 long minimumWriteBufferSize = (int)Math.Ceiling((minimumWriteBufferMb * 1.MB()) / dbConfig.StateDbWriteBufferNumber);
 
-                if (_logger.IsWarn) _logger.Warn($"Detected {totalWriteBufferMb}MB of maximum write buffer size. Write buffer size should be at least 20% of pruning cache MB or memory pruning may slow down. Try setting `--Db.{nameof(dbConfig.WriteBufferSize)} {minimumWriteBufferSize}`.");
+                if (_logger.IsWarn) _logger.Warn($"Detected {totalWriteBufferMb}MB of maximum write buffer size. Write buffer size should be at least 20% of pruning cache MB or memory pruning may slow down. Try setting `--Db.{nameof(dbConfig.StateDbWriteBufferSize)} {minimumWriteBufferSize}`.");
             }
 
             pruningStrategy = Prune

--- a/src/Nethermind/Nethermind.Init/InitializeStateDb.cs
+++ b/src/Nethermind/Nethermind.Init/InitializeStateDb.cs
@@ -119,9 +119,9 @@ public class InitializeStateDb : IStep
             var minimumWriteBufferMb = 0.2 * pruningConfig.CacheMb;
             if (totalWriteBufferMb < minimumWriteBufferMb)
             {
-                int minimumWriteBufferNumber = (int)Math.Ceiling((minimumWriteBufferMb * 1.MB()) / dbConfig.StateDbWriteBufferSize);
+                long minimumWriteBufferSize = (int)Math.Ceiling((minimumWriteBufferMb * 1.MB()) / dbConfig.StateDbWriteBufferNumber);
 
-                if (_logger.IsWarn) _logger.Warn($"Detected {totalWriteBufferMb}MB of maximum write buffer size. Write buffer size should be at least 20% of pruning cache MB or memory pruning may slow down. Try setting `--Db.{nameof(dbConfig.WriteBufferNumber)} {minimumWriteBufferNumber}`.");
+                if (_logger.IsWarn) _logger.Warn($"Detected {totalWriteBufferMb}MB of maximum write buffer size. Write buffer size should be at least 20% of pruning cache MB or memory pruning may slow down. Try setting `--Db.{nameof(dbConfig.WriteBufferSize)} {minimumWriteBufferSize}`.");
             }
 
             pruningStrategy = Prune

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
@@ -688,7 +688,7 @@ namespace Nethermind.Synchronization.FastSync
                 if (_logger.IsInfo) _logger.Info($"Saving root {syncItem.Hash} of {_branchProgress.CurrentSyncBlock}");
 
                 _logger.Warn($"Flushing initiated");
-                _nodeStorage.Flush();
+                _nodeStorage.Flush(onlyWal: false);
                 _codeDb.Flush();
 
                 Interlocked.Exchange(ref _rootSaved, 1);

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
@@ -687,6 +687,7 @@ namespace Nethermind.Synchronization.FastSync
             {
                 if (_logger.IsInfo) _logger.Info($"Saving root {syncItem.Hash} of {_branchProgress.CurrentSyncBlock}");
 
+                _logger.Warn($"Flushing initiated");
                 _nodeStorage.Flush();
                 _codeDb.Flush();
 

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/TreeSync.cs
@@ -687,7 +687,6 @@ namespace Nethermind.Synchronization.FastSync
             {
                 if (_logger.IsInfo) _logger.Info($"Saving root {syncItem.Hash} of {_branchProgress.CurrentSyncBlock}");
 
-                _logger.Warn($"Flushing initiated");
                 _nodeStorage.Flush(onlyWal: false);
                 _codeDb.Flush();
 

--- a/src/Nethermind/Nethermind.Trie/INodeStorage.cs
+++ b/src/Nethermind/Nethermind.Trie/INodeStorage.cs
@@ -30,7 +30,8 @@ public interface INodeStorage
     /// <summary>
     /// Used by StateSync to make sure values are flushed.
     /// </summary>
-    void Flush();
+    /// <param name="onlyWal"></param>
+    void Flush(bool onlyWal);
     void Compact();
 
     public enum KeyScheme

--- a/src/Nethermind/Nethermind.Trie/INodeStorage.cs
+++ b/src/Nethermind/Nethermind.Trie/INodeStorage.cs
@@ -30,7 +30,7 @@ public interface INodeStorage
     /// <summary>
     /// Used by StateSync to make sure values are flushed.
     /// </summary>
-    /// <param name="onlyWal"></param>
+    /// <param name="onlyWal">True if only WAL file should be flushed, not memtable.</param>
     void Flush(bool onlyWal);
     void Compact();
 

--- a/src/Nethermind/Nethermind.Trie/NodeStorage.cs
+++ b/src/Nethermind/Nethermind.Trie/NodeStorage.cs
@@ -184,11 +184,11 @@ public class NodeStorage : INodeStorage
         _keyValueStore.PutSpan(GetExpectedPath(stackalloc byte[StoragePathLength], address, path, keccak), data, writeFlags);
     }
 
-    public void Flush()
+    public void Flush(bool onlyWal)
     {
         if (_keyValueStore is IDb db)
         {
-            db.Flush();
+            db.Flush(onlyWal);
         }
     }
 

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -504,7 +504,7 @@ namespace Nethermind.Trie.Pruning
 
                 _pruningTask.ContinueWith((_) =>
                 {
-                    OnMemoryPruneCompleted?.Invoke(this, null!);
+                    OnMemoryPruneCompleted?.Invoke(this, EventArgs.Empty);
                 });
             }
         }
@@ -710,11 +710,11 @@ namespace Nethermind.Trie.Pruning
         {
             if (_logger.IsDebug) _logger.Debug($"Beginning new {nameof(BlockCommitSet)} - {blockNumber}");
 
-            if (_lastCommitSet is { } lastCommitSet)
+            if (_lastCommitSet is not null)
             {
-                Debug.Assert(lastCommitSet.IsSealed, "Not sealed when beginning new block");
+                Debug.Assert(_lastCommitSet.IsSealed, "Not sealed when beginning new block");
 
-                if (lastCommitSet.BlockNumber != blockNumber - 1 && blockNumber != 0 && lastCommitSet.BlockNumber != 0)
+                if (_lastCommitSet.BlockNumber != blockNumber - 1 && blockNumber != 0 && _lastCommitSet.BlockNumber != 0)
                 {
                     if (_logger.IsInfo) _logger.Info($"Non consecutive block commit. This is likely a reorg. Last block commit: {_lastCommitSet.BlockNumber}. New block commit: {blockNumber}.");
                 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -457,7 +457,7 @@ namespace Nethermind.Trie.Pruning
                         // otherwise, it may not fit the whole dirty cache.
                         // Additionally, if (WriteBufferSize * (WriteBufferNumber - 1)) is already more than 20% of pruning
                         // cache, it is likely that there are enough space for it on most time, except for syncing maybe.
-                        _nodeStorage.Flush();
+                        _nodeStorage.Flush(onlyWal: false);
                         lock (_dirtyNodesLock)
                         {
                             long start = Stopwatch.GetTimestamp();
@@ -793,8 +793,9 @@ namespace Nethermind.Trie.Pruning
             disposeQueue.CompleteAdding();
             Task.WaitAll(_disposeTasks);
 
-            // Dispose top level last in case something goes wrong, at least the root wont be stored
+            // Dispose top level last in case something goes wrong, at least the root won't be stored
             topLevelWriteBatch.Dispose();
+            _nodeStorage.Flush(onlyWal: true);
 
             long elapsedMilliseconds = (long)Stopwatch.GetElapsedTime(start).TotalMilliseconds;
             Metrics.SnapshotPersistenceTime = elapsedMilliseconds;

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -710,7 +710,7 @@ namespace Nethermind.Trie.Pruning
         {
             if (_logger.IsDebug) _logger.Debug($"Beginning new {nameof(BlockCommitSet)} - {blockNumber}");
 
-            if (_lastCommitSet is {} lastCommitSet)
+            if (_lastCommitSet is { } lastCommitSet)
             {
                 Debug.Assert(lastCommitSet.IsSealed, "Not sealed when beginning new block");
 


### PR DESCRIPTION
- Attempts to make writes more reliable.
- Calls FlushWAl on `Flush()`. This ensure that WAL is written to storage, which normally does not happen as it only is written to OS cache until the OS decided to do so.
  - This is the default rockdb behaviour and means that a crash of the program is recoverable but not a crash of the whole system.
- This change ensure that the writes is recoverable in the event of a system crash. Or something unexpected happens in the OS.
- Also add flush (but only WAL as memtable flush can run in background safely) to persist commit set in triestore. This ensure no funny business going on with missing writes. This adds about 5-10 percent to the pruning time unfortunately.
- Also change write buffer recommendation to increase write buffer size instead of write buffer count. This tend to improve pruning time stability a bit and probably improve the time it take to get back up to speed after memory pruning at expense of memory. But I guess if you increase pruning cache, you have memory to spare anyway.
- Also add logs on which state root is persisted on persist commit set.
- Also when commit set of unexpected number happened, write info log. This generally means a reorg, or something strange is happening if its not a reorg.

## Types of changes

#### What types of changes does your code introduce?

- [X] Optimization

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- [x] Mainnet catch up.
- [x] Mainnet sync
- [x] Mainnet archive