### PR TITLE
Add metrics for `engine_getBlobsV1`

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetBlobsHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetBlobsHandler.cs
@@ -38,7 +38,6 @@ public class GetBlobsHandler(ITxPool txPool) : IAsyncHandler<byte[][], GetBlobsV
             else
             {
                 yield return null;
-
             }
         }
     }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetBlobsHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetBlobsHandler.cs
@@ -35,8 +35,11 @@ public class GetBlobsHandler(ITxPool txPool) : IAsyncHandler<byte[][], GetBlobsV
                 Metrics.NumberOfSentBlobs++;
                 yield return new BlobAndProofV1(blob, proof);
             }
+            else
+            {
+                yield return null;
 
-            yield return null;
+            }
         }
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Metrics.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Metrics.cs
@@ -23,5 +23,13 @@ namespace Nethermind.Merge.Plugin
         [GaugeMetric]
         [Description("Number of Transactions included in the Last GetPayload Request")]
         public static int NumberOfTransactionsInGetPayload { get; set; }
+
+        [GaugeMetric]
+        [Description("Number of Blobs requested by engine_getBlobsV1")]
+        public static int NumberOfRequestedBlobs { get; set; }
+
+        [GaugeMetric]
+        [Description("Number of Blobs sent by engine_getBlobsV1")]
+        public static int NumberOfSentBlobs { get; set; }
     }
 }


### PR DESCRIPTION
## Changes

- adding metrics about `engine_getBlobsV1` - `NumberOfRequestedBlobs` and `NumberOfSentBlobs`

Already added to grafana

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No