### PR TITLE
Feature/Blocktree suggest pacer

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeSuggestPacerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeSuggestPacerTests.cs
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Threading.Tasks;
+using FluentAssertions;
+using Nethermind.Core;
+using Nethermind.Core.Test.Builders;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Blockchain.Test;
+
+public class BlockTreeSuggestPacerTests
+{
+    [Test]
+    public void WillNotBlockIfInBatchLimit()
+    {
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        blockTree.Head.Returns(Build.A.Block.WithNumber(0).TestObject);
+        using BlockTreeSuggestPacer pacer = new BlockTreeSuggestPacer(blockTree, 10, 5);
+
+        pacer.WaitForQueue(1, default).IsCompleted.Should().BeTrue();
+    }
+
+    [Test]
+    public void WillBlockIfBatchTooLarge()
+    {
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        blockTree.Head.Returns(Build.A.Block.WithNumber(0).TestObject);
+        using BlockTreeSuggestPacer pacer = new BlockTreeSuggestPacer(blockTree, 10, 5);
+
+        pacer.WaitForQueue(11, default).IsCompleted.Should().BeFalse();
+    }
+
+    [Test]
+    public void WillOnlyUnblockOnceHeadReachHighEnough()
+    {
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        blockTree.Head.Returns(Build.A.Block.WithNumber(0).TestObject);
+        using BlockTreeSuggestPacer pacer = new BlockTreeSuggestPacer(blockTree, 10, 5);
+
+        Task waitTask = pacer.WaitForQueue(11, default);
+        waitTask.IsCompleted.Should().BeFalse();
+
+        blockTree.NewHeadBlock += Raise.EventWith(new BlockEventArgs(Build.A.Block.WithNumber(1).TestObject));
+        waitTask.IsCompleted.Should().BeFalse();
+
+        blockTree.NewHeadBlock += Raise.EventWith(new BlockEventArgs(Build.A.Block.WithNumber(5).TestObject));
+        waitTask.IsCompleted.Should().BeFalse();
+
+        blockTree.NewHeadBlock += Raise.EventWith(new BlockEventArgs(Build.A.Block.WithNumber(6).TestObject));
+        waitTask.IsCompleted.Should().BeTrue();
+    }
+}

--- a/src/Nethermind/Nethermind.Blockchain/BlockTreeSuggestPacer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTreeSuggestPacer.cs
@@ -40,14 +40,14 @@ public class BlockTreeSuggestPacer : IDisposable
     public async Task WaitForQueue(long currentBlockNumber, CancellationToken token)
     {
         long currentHeadNumber = _blockTree.Head?.Number ?? 0;
-        if (currentBlockNumber - currentHeadNumber > _stopBatchSize && _dbBatchProcessed == null)
+        if (currentBlockNumber - currentHeadNumber > _stopBatchSize && _dbBatchProcessed is null)
         {
             _blockNumberReachedToUnlock = currentBlockNumber - _stopBatchSize + _resumeBatchSize;
             TaskCompletionSource completionSource = new TaskCompletionSource();
             _dbBatchProcessed = completionSource;
         }
 
-        if (_dbBatchProcessed != null)
+        if (_dbBatchProcessed is not null)
         {
             await using (token.Register(() => _dbBatchProcessed.TrySetCanceled()))
             {

--- a/src/Nethermind/Nethermind.Blockchain/BlockTreeSuggestPacer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTreeSuggestPacer.cs
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Nethermind.Core;
+
+namespace Nethermind.Blockchain;
+
+/// <summary>
+/// Utility class during bulk loading to prevent processing queue from becoming too large
+/// </summary>
+public class BlockTreeSuggestPacer : IDisposable
+{
+    private TaskCompletionSource? _dbBatchProcessed;
+    private long _blockNumberReachedToUnlock = 0;
+    private readonly long _stopBatchSize;
+    private readonly long _resumeBatchSize;
+    private readonly IBlockTree _blockTree;
+
+    public BlockTreeSuggestPacer(IBlockTree blockTree, long stopBatchSize, long resumeBatchSize)
+    {
+        blockTree.NewHeadBlock += BlockTreeOnNewHeadBlock;
+        _blockTree = blockTree;
+        _stopBatchSize = stopBatchSize;
+        _resumeBatchSize = resumeBatchSize;
+    }
+
+    private void BlockTreeOnNewHeadBlock(object sender, BlockEventArgs e)
+    {
+        TaskCompletionSource? completionSource = _dbBatchProcessed;
+        if (completionSource is null) return;
+        if (e.Block.Number < _blockNumberReachedToUnlock) return;
+
+        _dbBatchProcessed = null;
+        completionSource.SetResult();
+    }
+
+    public async Task WaitForQueue(long currentBlockNumber, CancellationToken token)
+    {
+        long currentHeadNumber = _blockTree.Head?.Number ?? 0;
+        if (currentBlockNumber - currentHeadNumber > _stopBatchSize && _dbBatchProcessed == null)
+        {
+            _blockNumberReachedToUnlock = currentBlockNumber - _stopBatchSize + _resumeBatchSize;
+            TaskCompletionSource completionSource = new TaskCompletionSource();
+            _dbBatchProcessed = completionSource;
+        }
+
+        if (_dbBatchProcessed != null)
+        {
+            await using (token.Register(() => _dbBatchProcessed.TrySetCanceled()))
+            {
+                await _dbBatchProcessed.Task;
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        _blockTree.NewHeadBlock -= BlockTreeOnNewHeadBlock;
+    }
+}

--- a/src/Nethermind/Nethermind.Blockchain/Visitors/StartupBlockTreeFixer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Visitors/StartupBlockTreeFixer.cs
@@ -15,7 +15,7 @@ using Nethermind.State;
 
 namespace Nethermind.Blockchain.Visitors
 {
-    public class StartupBlockTreeFixer : IBlockTreeVisitor
+    public class StartupBlockTreeFixer : IBlockTreeVisitor, IDisposable
     {
         public const int DefaultBatchSize = 4000;
         private readonly IBlockTree _blockTree;
@@ -241,6 +241,11 @@ namespace Nethermind.Blockchain.Visitors
                     _logger.Info(
                         $"Found {_blocksToLoad} block tree levels to review for fixes starting from {StartLevelInclusive}");
             }
+        }
+
+        public void Dispose()
+        {
+            _blockTreeSuggestPacer.Dispose();
         }
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Visitors/StartupBlockTreeFixer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Visitors/StartupBlockTreeFixer.cs
@@ -33,11 +33,9 @@ namespace Nethermind.Blockchain.Visitors
         private long? _lastProcessedLevel;
         private long? _processingGapStart;
 
-        private TaskCompletionSource _dbBatchProcessed;
-        private long _currentDbLoadBatchEnd;
         private bool _firstBlockVisited = true;
         private bool _suggestBlocks = true;
-        private readonly long _batchSize;
+        private readonly BlockTreeSuggestPacer _blockTreeSuggestPacer;
 
         public StartupBlockTreeFixer(
             ISyncConfig syncConfig,
@@ -47,34 +45,16 @@ namespace Nethermind.Blockchain.Visitors
             long batchSize = DefaultBatchSize)
         {
             _blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
+            _blockTreeSuggestPacer = new BlockTreeSuggestPacer(_blockTree, batchSize, batchSize / 2);
             _stateReader = stateReader;
             _logger = logger;
 
-            _batchSize = batchSize;
             long assumedHead = _blockTree.Head?.Number ?? 0;
             _startNumber = Math.Max(syncConfig.PivotNumberParsed, assumedHead + 1);
             _blocksToLoad = (assumedHead + 1) >= _startNumber ? (_blockTree.BestKnownNumber - _startNumber + 1) : 0;
 
             _currentLevelNumber = _startNumber - 1; // because we always increment on entering
-            if (_blocksToLoad != 0)
-            {
-                _blockTree.NewHeadBlock += BlockTreeOnNewHeadBlock;
-            }
-
             LogPlannedOperation();
-        }
-
-        private void BlockTreeOnNewHeadBlock(object sender, BlockEventArgs e)
-        {
-            if (_dbBatchProcessed is not null)
-            {
-                if (e.Block.Number == _currentDbLoadBatchEnd)
-                {
-                    TaskCompletionSource completionSource = _dbBatchProcessed;
-                    _dbBatchProcessed = null;
-                    completionSource.SetResult();
-                }
-            }
         }
 
         public bool PreventsAcceptingNewBlocks => true;
@@ -168,9 +148,10 @@ namespace Nethermind.Blockchain.Visitors
 
             if (!_suggestBlocks) return BlockVisitOutcome.None;
 
+            Task waitSuggestQueue = _blockTreeSuggestPacer.WaitForQueue(block.Number, cancellationToken);
+
             long i = block.Number - StartLevelInclusive;
-            if (i % _batchSize == _batchSize - 1 && i != _blocksToLoad - 1 &&
-                _blockTree.Head.Number + _batchSize < block.Number)
+            if (!waitSuggestQueue.IsCompleted)
             {
                 if (_logger.IsInfo)
                 {
@@ -178,12 +159,7 @@ namespace Nethermind.Blockchain.Visitors
                         $"Loaded {i + 1} out of {_blocksToLoad} blocks from DB into processing queue, waiting for processor before loading more.");
                 }
 
-                _dbBatchProcessed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-                await using (cancellationToken.Register(() => _dbBatchProcessed.SetCanceled()))
-                {
-                    _currentDbLoadBatchEnd = block.Number - _batchSize;
-                    await _dbBatchProcessed.Task;
-                }
+                await waitSuggestQueue;
             }
 
             return BlockVisitOutcome.Suggest;

--- a/src/Nethermind/Nethermind.Init/Steps/ReviewBlockTree.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/ReviewBlockTree.cs
@@ -44,7 +44,7 @@ namespace Nethermind.Init.Steps
 
             if (!syncConfig.FastSync)
             {
-                DbBlocksLoader loader = new(_api.BlockTree, _logger);
+                using DbBlocksLoader loader = new(_api.BlockTree, _logger);
                 await _api.BlockTree.Accept(loader, cancellationToken).ContinueWith(t =>
                 {
                     if (t.IsFaulted)
@@ -59,7 +59,7 @@ namespace Nethermind.Init.Steps
             }
             else
             {
-                StartupBlockTreeFixer fixer = new(syncConfig, _api.BlockTree, _api.WorldStateManager!.GlobalStateReader, _logger!);
+                using StartupBlockTreeFixer fixer = new(syncConfig, _api.BlockTree, _api.WorldStateManager!.GlobalStateReader, _logger!);
                 await _api.BlockTree.Accept(fixer, cancellationToken).ContinueWith(t =>
                 {
                     if (t.IsFaulted)


### PR DESCRIPTION
- Extract wait-for-processing-queue logic from `ReviewBlockTree` and `DbBlocksLoader`, to a class `BlockTreeSuggestPacer`.
- This will be used in era.

## Types of changes

#### What types of changes does your code introduce?

- [X] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [X] Yes
- [ ] No

#### If yes, did you write tests?

- [X] Yes
- [ ] No

#### Notes on testing

- Works on era import