### PR TITLE
Do not trigger tests on master push

### DIFF
--- a/.github/workflows/sync-supported-chains.yml
+++ b/.github/workflows/sync-supported-chains.yml
@@ -321,7 +321,7 @@ jobs:
           repositories: "nethermind,post-merge-smoke-tests"
           
       - name: Trigger notification action on test repo
-        if: github.event.workflow_run.head_branch == 'master' || startsWith(github.event.workflow_run.head_branch, 'release/')
+        if: startsWith(github.event.workflow_run.head_branch, 'release/')
         continue-on-error: true
         uses: benc-uk/workflow-dispatch@v1
         with:


### PR DESCRIPTION
Simple change - idea slightly changed so to reduce costs tests on other repo will be executed with cron for master and on commit on release.
cron to be decided but most probably every second or third day

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [X] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [X] No