### PR TITLE
Vectorize Keccak state copy, remove temp array use

### DIFF
--- a/src/Nethermind/Nethermind.Core/Crypto/Keccak.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/Keccak.cs
@@ -113,7 +113,7 @@ namespace Nethermind.Core.Crypto
                 return OfAnEmptyString;
             }
 
-            return new Hash256(KeccakHash.ComputeHashBytes(input));
+            return new Hash256(ValueKeccak.Compute(input));
         }
 
         [DebuggerStepThrough]

--- a/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.cs
@@ -571,19 +571,11 @@ namespace Nethermind.Core.Crypto
             {
                 // XOR the remainder buffer into the state
                 XorVectors(stateBytes, _remainderBuffer.AsSpan(0, _remainderLength));
-
-                // Apply padding
-                stateBytes[_remainderLength] ^= 0x01; // Append bit '1' after the input
-                stateBytes[_roundSize - 1] ^= 0x80;   // Set the last bit of the block to '1'
-
-                Pool.ReturnRemainder(ref _remainderBuffer);
             }
-            else
-            {
-                // No remainder; apply padding directly to state
-                stateBytes[0] ^= 0x01;              // Append bit '1' at the beginning
-                stateBytes[_roundSize - 1] ^= 0x80; // Set the last bit of the block to '1'
-            }
+
+            // Apply terminator markers within the current block
+            stateBytes[_remainderLength] ^= 0x01; // Append bit '1' after the input
+            stateBytes[_roundSize - 1] ^= 0x80;   // Set the last bit of the block to '1'
 
             KeccakF(state);
 


### PR DESCRIPTION
## Changes

- Vectorized Xor to state
- Removed additional temp stackalloc array + copy
- Simplified
- Fast copy to output for 256 and 512 bit sizes

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No
