### PR TITLE
Bls Signature refactoring & performance

### DIFF
--- a/src/Nethermind/Directory.Packages.props
+++ b/src/Nethermind/Directory.Packages.props
@@ -47,7 +47,7 @@
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
-    <PackageVersion Include="Nethermind.Crypto.Bls" Version="1.0.3" />
+    <PackageVersion Include="Nethermind.Crypto.Bls" Version="1.0.4" />
     <PackageVersion Include="Nethermind.Crypto.Pairings" Version="1.1.1" />
     <PackageVersion Include="Nethermind.Crypto.SecP256k1" Version="1.2.2" />
     <PackageVersion Include="Nethermind.DotNetty.Buffers" Version="1.0.1" />

--- a/src/Nethermind/Nethermind.Crypto/BlsSigner.cs
+++ b/src/Nethermind/Nethermind.Crypto/BlsSigner.cs
@@ -123,6 +123,9 @@ public static class BlsSigner
             _point = new(buf);
         }
 
+        public void FromSk(Bls.SecretKey sk)
+            => _point.FromSk(sk);
+
         public bool TryDecode(ReadOnlySpan<byte> publicKeyBytes, out Bls.ERROR err)
             => _point.TryDecode(publicKeyBytes, out err);
 

--- a/src/Nethermind/Nethermind.Shutter/Contracts/ValidatorRegistryContract.cs
+++ b/src/Nethermind/Nethermind.Shutter/Contracts/ValidatorRegistryContract.cs
@@ -12,6 +12,7 @@ using Nethermind.Logging;
 using System.Collections.Generic;
 using Nethermind.Core.Extensions;
 using Update = (byte[] Message, byte[] Signature);
+using Nethermind.Crypto;
 
 namespace Nethermind.Shutter.Contracts;
 
@@ -46,7 +47,7 @@ public class ValidatorRegistryContract(
         {
             Update update = GetUpdate(header, updates - i - 1);
 
-            if (update.Message.Length != 46 || update.Signature.Length != 96)
+            if (update.Message.Length != Message.Sz || update.Signature.Length != BlsSigner.Signature.Sz)
             {
                 if (_logger.IsDebug) _logger.Debug("Registration message was wrong length.");
                 continue;
@@ -108,6 +109,7 @@ public class ValidatorRegistryContract(
 
     private readonly ref struct Message
     {
+        public const int Sz = 46;
         public readonly byte Version;
         public readonly ulong ChainId;
         public readonly ReadOnlySpan<byte> ContractAddress;
@@ -117,7 +119,7 @@ public class ValidatorRegistryContract(
 
         public Message(Span<byte> encodedMessage)
         {
-            if (encodedMessage.Length != 46)
+            if (encodedMessage.Length != Sz)
             {
                 throw new ArgumentException("Validator registry contract message was wrong length.");
             }

--- a/src/Nethermind/Nethermind.Shutter/ShutterCrypto.cs
+++ b/src/Nethermind/Nethermind.Shutter/ShutterCrypto.cs
@@ -222,7 +222,12 @@ public static class ShutterCrypto
         ValueHash256 h = ValueKeccak.Compute(msgBytes);
 
         G1Affine pk = new(stackalloc long[G1Affine.Sz]);
-        pk.Decode(pkBytes);
+
+        if (!pk.TryDecode(pkBytes, out _))
+        {
+            return false;
+        }
+
         return BlsSigner.Verify(pk, sigBytes, h.Bytes);
     }
 

--- a/src/Nethermind/Nethermind.Shutter/ShutterCrypto.cs
+++ b/src/Nethermind/Nethermind.Shutter/ShutterCrypto.cs
@@ -219,12 +219,11 @@ public static class ShutterCrypto
     [SkipLocalsInit]
     public static bool CheckValidatorRegistrySignature(ReadOnlySpan<byte> pkBytes, ReadOnlySpan<byte> sigBytes, ReadOnlySpan<byte> msgBytes)
     {
-        BlsSigner.Signature sig = new(sigBytes);
         ValueHash256 h = ValueKeccak.Compute(msgBytes);
 
         G1Affine pk = new(stackalloc long[G1Affine.Sz]);
         pk.Decode(pkBytes);
-        return BlsSigner.Verify(pk, sig, h.Bytes);
+        return BlsSigner.Verify(pk, sigBytes, h.Bytes);
     }
 
     public static EncryptedMessage Encrypt(ReadOnlySpan<byte> msg, G1 identity, G2 eonKey, ReadOnlySpan<byte> sigma)


### PR DESCRIPTION
## Changes

- Refactor BlsSigner to allow public key aggregation without allocating large buffer
- Change signature class to allow direct aggregation
- Use improved blst bindings
- Bugfix: not throwing exception when Shutter validator registry file has invalid public key

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [ ] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
