### PR TITLE
Fix `+` serialization in JSON RPC

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Data/SerializationTestBase.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Data/SerializationTestBase.cs
@@ -69,7 +69,7 @@ public class SerializationTestBase
         IJsonSerializer serializer = BuildSerializer(converters);
 
         string result = serializer.Serialize(item);
-        Assert.That(result, Is.EqualTo(expectedResult.Replace("+", "\\u002B")), result.Replace("\"", "\\\""));
+        Assert.That(result, Is.EqualTo(expectedResult), result.Replace("\"", "\\\""));
     }
 
     private static IJsonSerializer BuildSerializer(params JsonConverter[] converters) => new EthereumJsonSerializer(converters);

--- a/src/Nethermind/Nethermind.Serialization.Json/EthereumJsonSerializer.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/EthereumJsonSerializer.cs
@@ -56,9 +56,6 @@ namespace Nethermind.Serialization.Json
 
         private static JsonSerializerOptions CreateOptions(bool indented, IEnumerable<JsonConverter> converters = null, int maxDepth = 64)
         {
-            var encoderSettings = new TextEncoderSettings(UnicodeRanges.BasicLatin);
-            encoderSettings.AllowCharacter('+');
-
             var options = new JsonSerializerOptions
             {
                 WriteIndented = indented,
@@ -68,7 +65,7 @@ namespace Nethermind.Serialization.Json
                 DictionaryKeyPolicy = JsonNamingPolicy.CamelCase,
                 PropertyNameCaseInsensitive = true,
                 MaxDepth = maxDepth,
-                Encoder = JavaScriptEncoder.Create(encoderSettings),
+                Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
                 Converters =
                 {
                     new LongConverter(),

--- a/src/Nethermind/Nethermind.Serialization.Json/EthereumJsonSerializer.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/EthereumJsonSerializer.cs
@@ -6,8 +6,10 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Pipelines;
+using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.Unicode;
 using System.Threading.Tasks;
 using Nethermind.Core.Collections;
 
@@ -54,6 +56,9 @@ namespace Nethermind.Serialization.Json
 
         private static JsonSerializerOptions CreateOptions(bool indented, IEnumerable<JsonConverter> converters = null, int maxDepth = 64)
         {
+            var encoderSettings = new TextEncoderSettings(UnicodeRanges.BasicLatin);
+            encoderSettings.AllowCharacter('+');
+
             var options = new JsonSerializerOptions
             {
                 WriteIndented = indented,
@@ -63,6 +68,7 @@ namespace Nethermind.Serialization.Json
                 DictionaryKeyPolicy = JsonNamingPolicy.CamelCase,
                 PropertyNameCaseInsensitive = true,
                 MaxDepth = maxDepth,
+                Encoder = JavaScriptEncoder.Create(encoderSettings),
                 Converters =
                 {
                     new LongConverter(),


### PR DESCRIPTION
Fixes `+` being serialized as `\u002B` in JSON responses to make it consistent with other clients.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No

#### Requires documentation update

- [x] No
